### PR TITLE
Weighted round robin leader election

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -76,9 +76,18 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "monad-crypto"
@@ -88,6 +97,13 @@ dependencies = [
  "secp256k1",
  "sha2",
  "tiny-keccak",
+]
+
+[[package]]
+name = "monad-validator"
+version = "0.1.0"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 
 members = [
     "monad-crypto",
+    "monad-validator",
 ]

--- a/monad-validator/Cargo.toml
+++ b/monad-validator/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "monad-validator"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+log = "0.4"

--- a/monad-validator/src/leader_election.rs
+++ b/monad-validator/src/leader_election.rs
@@ -1,0 +1,10 @@
+use super::validator::Address;
+
+// VotingPower is i64
+pub trait LeaderElection {
+    fn new() -> Self;
+    fn start_new_epoch(&mut self, voting_powers: Vec<(Address, i64)>);
+    fn increment_view(&mut self, view: i64);
+    fn get_leader(&self) -> &Address;
+    fn update_voting_power(&mut self, addr: &Address, new_voting_power: i64) -> bool;
+}

--- a/monad-validator/src/lib.rs
+++ b/monad-validator/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod leader_election;
+pub mod validator;
+pub mod weighted_round_robin;

--- a/monad-validator/src/validator.rs
+++ b/monad-validator/src/validator.rs
@@ -1,0 +1,21 @@
+use std::fmt::Debug;
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub struct Address(pub i64); // placeholder type for Address
+#[derive(Clone, Copy, Debug)]
+pub struct PubKey(pub i64); // placeholder type
+#[derive(Clone, Copy)]
+pub struct Stake(pub i64);
+
+#[derive(Clone, Copy)]
+pub struct Validator {
+    pub address: Address,
+    pub pubkey: PubKey,
+    pub stake: Stake,
+}
+
+impl Debug for Validator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "validator {:?}", self.address.0)
+    }
+}

--- a/monad-validator/src/weighted_round_robin.rs
+++ b/monad-validator/src/weighted_round_robin.rs
@@ -1,0 +1,304 @@
+use super::{leader_election::LeaderElection, validator::Address};
+use log::warn;
+use std::cmp::Ordering;
+use std::fmt::Debug;
+
+#[derive(Eq, Clone, Copy, Debug)]
+struct Voter {
+    address: Address,
+    voting_power: i64,
+    priority: i64,
+}
+
+// ordering Voters first on priority, then on address
+// higher priority -> smaller in Ord
+impl Ord for Voter {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (self.priority, self.address)
+            .cmp(&(other.priority, other.address))
+            .reverse()
+    }
+}
+
+impl PartialOrd for Voter {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for Voter {
+    fn eq(&self, other: &Self) -> bool {
+        self.address == other.address
+    }
+}
+
+impl Voter {
+    pub fn verified(&self) -> bool {
+        self.voting_power > 0
+    }
+}
+pub struct WeightedRoundRobin {
+    voters: Vec<Voter>,
+    leader: usize, // voter idx
+    total_voting_power: i64,
+}
+
+impl LeaderElection for WeightedRoundRobin {
+    fn new() -> Self {
+        Self {
+            voters: Vec::new(),
+            leader: 0,
+            total_voting_power: 0,
+        }
+    }
+
+    fn start_new_epoch(&mut self, voting_powers: Vec<(Address, i64)>) {
+        self.voters.reserve(voting_powers.len());
+        self.total_voting_power = 0;
+        for (addr, vp) in voting_powers.into_iter() {
+            let voter = Voter {
+                address: addr,
+                voting_power: vp,
+                priority: vp,
+            };
+            if !voter.verified() {
+                warn!("ignoring voter {:?} with zero voting power", voter.address);
+                continue;
+            }
+            self.voters.push(voter);
+            self.total_voting_power += vp;
+        }
+
+        if !self.voters.is_empty() {
+            self.voters.sort();
+            self.increment_one_view();
+        }
+    }
+
+    fn increment_view(&mut self, view: i64) {
+        self.panic_if_empty();
+        for _ in 0..view {
+            self.increment_one_view();
+        }
+    }
+
+    fn get_leader(&self) -> &Address {
+        self.panic_if_empty();
+        &self.voters[self.leader].address
+    }
+
+    fn update_voting_power(&mut self, addr: &Address, new_voting_power: i64) -> bool {
+        self.panic_if_empty();
+        let v = match self.voters.iter_mut().filter(|v| addr == &v.address).next() {
+            Some(v) => v,
+            None => return false,
+        };
+        self.total_voting_power -= v.voting_power;
+        self.total_voting_power += new_voting_power;
+        v.voting_power = new_voting_power;
+        v.priority = -self.total_voting_power;
+        true
+    }
+}
+
+impl WeightedRoundRobin {
+    fn get_highest_priority_validator(&self) -> usize {
+        self.panic_if_empty();
+        self.voters
+            .iter()
+            .enumerate()
+            .min_by(|(_, vx), (_, vy)| vx.cmp(vy))
+            .map(|(idx, _)| idx)
+            .unwrap()
+    }
+
+    fn increment_one_view(&mut self) {
+        for v in self.voters.iter_mut() {
+            v.priority += v.voting_power;
+        }
+        println!("voters: {:?}", self.voters);
+        self.leader = self.get_highest_priority_validator();
+        self.voters[self.leader].priority -= self.total_voting_power;
+    }
+
+    fn panic_if_empty(&self) {
+        if self.voters.is_empty() {
+            panic!("empty validators");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::validator::PubKey;
+
+    use super::super::leader_election::LeaderElection;
+    use super::super::validator::{Address, Stake, Validator};
+
+    use super::WeightedRoundRobin;
+
+    fn collect_voting_powers(validators: &Vec<Validator>) -> Vec<(Address, i64)> {
+        validators.iter().map(|v| (v.address, v.stake.0)).collect()
+    }
+
+    // expected schedule (basic round robin)
+    #[test]
+    fn test_basic_round_robin() {
+        let v1 = Validator {
+            address: Address(1),
+            pubkey: PubKey(1),
+            stake: Stake(1),
+        };
+        let v2 = Validator {
+            address: Address(2),
+            pubkey: PubKey(2),
+            stake: Stake(1),
+        };
+        let validators = vec![v1, v2];
+        let mut wrr: WeightedRoundRobin = LeaderElection::new();
+        wrr.start_new_epoch(collect_voting_powers(&validators));
+
+        assert!(wrr.get_leader() == &v2.address);
+        wrr.increment_view(1);
+        assert!(wrr.get_leader() == &v1.address);
+        wrr.increment_view(1);
+        assert!(wrr.get_leader() == &v2.address);
+        wrr.increment_view(1);
+        assert!(wrr.get_leader() == &v1.address);
+    }
+
+    // expected schedule (weighted round robin)
+    #[test]
+    fn test_weighted_round_robin() {
+        let v1 = Validator {
+            address: Address(1),
+            pubkey: PubKey(1),
+            stake: Stake(1),
+        };
+        let v2 = Validator {
+            address: Address(2),
+            pubkey: PubKey(2),
+            stake: Stake(2),
+        };
+        let validators = vec![v1, v2];
+        let mut wrr: WeightedRoundRobin = LeaderElection::new();
+        wrr.start_new_epoch(collect_voting_powers(&validators));
+
+        // expected schedule: (v2, v2, v1), (v2, v2, v1)...
+        assert!(wrr.get_leader() == &v2.address);
+        wrr.increment_view(1);
+        assert!(wrr.get_leader() == &v2.address);
+        wrr.increment_view(1);
+        assert!(wrr.get_leader() == &v1.address);
+        wrr.increment_view(1);
+
+        assert!(wrr.get_leader() == &v2.address);
+        wrr.increment_view(1);
+        assert!(wrr.get_leader() == &v2.address);
+        wrr.increment_view(1);
+        assert!(wrr.get_leader() == &v1.address);
+    }
+
+    // two instances agree on the same schedule
+    #[test]
+    fn test_agreement() {
+        let v1 = Validator {
+            address: Address(1),
+            pubkey: PubKey(1),
+            stake: Stake(1),
+        };
+        let v2 = Validator {
+            address: Address(2),
+            pubkey: PubKey(2),
+            stake: Stake(3),
+        };
+        let validators = vec![v1, v2];
+        let mut wrr1: WeightedRoundRobin = LeaderElection::new();
+        let mut wrr2: WeightedRoundRobin = LeaderElection::new();
+        wrr1.start_new_epoch(collect_voting_powers(&validators));
+        wrr2.start_new_epoch(collect_voting_powers(&validators));
+
+        for _ in 0..20 {
+            assert!(wrr1.get_leader() == wrr2.get_leader());
+            wrr1.increment_view(1);
+            wrr2.increment_view(1);
+        }
+    }
+
+    // advancing n views equivalent to incrementing 1 view n times
+    #[test]
+    fn test_increment_views_equivalent() {
+        let v1 = Validator {
+            address: Address(1),
+            pubkey: PubKey(1),
+            stake: Stake(1),
+        };
+        let v2 = Validator {
+            address: Address(2),
+            pubkey: PubKey(2),
+            stake: Stake(3),
+        };
+        let validators = vec![v1, v2];
+        let mut wrr1: WeightedRoundRobin = LeaderElection::new();
+        let mut wrr2: WeightedRoundRobin = LeaderElection::new();
+        wrr1.start_new_epoch(collect_voting_powers(&validators));
+        wrr2.start_new_epoch(collect_voting_powers(&validators));
+
+        for _ in 0..20 {
+            assert!(wrr1.get_leader() == wrr2.get_leader());
+            wrr1.increment_view(1);
+            wrr1.increment_view(1);
+            wrr2.increment_view(2);
+        }
+    }
+
+    // update stake
+    #[test]
+    fn test_update_stake() {
+        let mut v1 = Validator {
+            address: Address(1),
+            pubkey: PubKey(1),
+            stake: Stake(10),
+        };
+        let v2 = Validator {
+            address: Address(2),
+            pubkey: PubKey(2),
+            stake: Stake(10),
+        };
+
+        let validators = vec![v1, v2];
+        let mut wrr: WeightedRoundRobin = LeaderElection::new();
+        wrr.start_new_epoch(collect_voting_powers(&validators));
+
+        assert!(wrr.get_leader() == &v2.address);
+        wrr.increment_view(1);
+        assert!(wrr.get_leader() == &v1.address);
+        wrr.increment_view(1);
+
+        // now v1 gets slashed to 5
+        v1.stake = Stake(5);
+        assert!(wrr.update_voting_power(&v1.address, v1.stake.0));
+        assert!(wrr.total_voting_power == 15);
+
+        // we do not change the proposer intra-view; v2 is still the proposer
+        assert!(wrr.get_leader() == &v2.address);
+        wrr.increment_view(1);
+        // "compensating" v2/"slashing" v1 by giving v2 one more round
+        assert!(wrr.get_leader() == &v2.address);
+        wrr.increment_view(1);
+
+        // schedule after (v2, v2, v1), (v2, v2, v1)...
+        assert!(wrr.get_leader() == &v2.address);
+        wrr.increment_view(1);
+        assert!(wrr.get_leader() == &v2.address);
+        wrr.increment_view(1);
+        assert!(wrr.get_leader() == &v1.address);
+        wrr.increment_view(1);
+
+        assert!(wrr.get_leader() == &v2.address);
+        wrr.increment_view(1);
+        assert!(wrr.get_leader() == &v2.address);
+        wrr.increment_view(1);
+        assert!(wrr.get_leader() == &v1.address);
+    }
+}


### PR DESCRIPTION
A weighted round robin leader election for validators. It assumes that the validator list is stable is in an epoch. In every view, it deterministically produces the leader, with the average probability of selection proportional to its stake. Validator stakes can be updated and will take effect on the next view.

Some WIP docs https://www.notion.so/monad-labs/LeaderElection-6f6d4bed2c0c4d058b8770fcc1a1eef4?pvs=4