### PR TITLE
Blocktree structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,51 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
@@ -34,6 +75,22 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "config"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
+dependencies = [
+ "lazy_static 1.4.0",
+ "nom",
+ "rust-ini",
+ "serde 1.0.158",
+ "serde-hjson",
+ "serde_json",
+ "toml",
+ "yaml-rust",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -69,6 +126,32 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "futures"
@@ -126,7 +209,7 @@ checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -170,16 +253,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
+name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "log"
@@ -195,6 +351,14 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "monad-blocktree"
+version = "0.1.0"
+dependencies = [
+ "monad-consensus",
+ "ptree",
+]
 
 [[package]]
 name = "monad-consensus"
@@ -233,6 +397,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+dependencies = [
+ "num-traits 0.2.15",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+dependencies = [
+ "num-traits 0.2.15",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,7 +465,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -278,6 +490,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptree"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de80796b316aec75344095a6d2ef68ec9b8f573b9e7adc821149ba3598e270"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "config",
+ "directories",
+ "petgraph",
+ "serde 1.0.158",
+ "serde-value",
+ "tint",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +513,55 @@ checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
+name = "regex"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "rust-ini"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
+
+[[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "secp256k1"
@@ -302,6 +579,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "serde"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
+
+[[package]]
+name = "serde"
+version = "1.0.158"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde-hjson"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
+dependencies = [
+ "lazy_static 1.4.0",
+ "num-traits 0.1.43",
+ "regex",
+ "serde 0.8.23",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde 1.0.158",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.158"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.8",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde 1.0.158",
 ]
 
 [[package]]
@@ -325,10 +661,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -354,7 +707,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -366,8 +719,37 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "test-case-core",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.8",
+]
+
+[[package]]
+name = "tint"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af24570664a3074673dbbf69a65bdae0ae0b72f2949b1adfbacb736ee4d6896"
+dependencies = [
+ "lazy_static 0.2.11",
 ]
 
 [[package]]
@@ -391,6 +773,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde 1.0.158",
+]
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +798,34 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -475,6 +894,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,5 +920,5 @@ checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     "monad-crypto",
     "monad-executor",
     "monad-validator",
+    "monad-blocktree",
 ]

--- a/monad-blocktree/Cargo.toml
+++ b/monad-blocktree/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "monad-blocktree"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+monad-consensus = {path = "../monad-consensus"}
+ptree = "0.4.0"

--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -1,0 +1,506 @@
+use monad_consensus::types::block::Block;
+use monad_consensus::types::voting::VotingQuorum;
+use monad_consensus::BlockId;
+use monad_consensus::Round;
+use ptree::print_tree;
+use std::collections::HashMap;
+use std::fmt;
+use std::result::Result as StdResult;
+
+use ptree::builder::TreeBuilder;
+
+type Result<T> = StdResult<T, BlockTreeError>;
+
+#[derive(Debug, PartialEq)]
+#[non_exhaustive]
+pub enum BlockTreeError {
+    ParentNotPresent(String),
+    BlockNotExist(String),
+}
+
+impl fmt::Display for BlockTreeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ParentNotPresent(s) => write!(f, "Parent not present: {}", s),
+            Self::BlockNotExist(s) => write!(f, "Block not exist: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for BlockTreeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
+
+pub struct BlockTreeBlock<T>
+where
+    T: VotingQuorum,
+{
+    block: Block<T>,
+    children: Vec<BlockId>,
+}
+
+impl<T: VotingQuorum> BlockTreeBlock<T> {
+    const CHILD_INDENT: &str = "    ";
+    fn new(b: Block<T>) -> Self {
+        BlockTreeBlock {
+            block: b,
+            children: Vec::new(),
+        }
+    }
+
+    fn tree_fmt(
+        &self,
+        tree: &BlockTree<T>,
+        f: &mut fmt::Formatter<'_>,
+        indent: &String,
+    ) -> std::fmt::Result {
+        write!(
+            f,
+            "{}({:?}){:?}\n",
+            indent,
+            self.block.round.0,
+            self.block.get_id()
+        )?;
+        let mut child_indent: String = indent.clone();
+        child_indent.push_str(Self::CHILD_INDENT);
+        for bid in self.children.iter() {
+            let block = tree.tree.get(bid).unwrap();
+            block.tree_fmt(tree, f, &child_indent)?;
+        }
+        Ok(())
+    }
+
+    fn build_ptree<'a>(
+        &self,
+        tree: &BlockTree<T>,
+        tree_print: &'a mut TreeBuilder,
+    ) -> &'a mut TreeBuilder {
+        let mut result =
+            tree_print.begin_child(format!("({}){:?}", self.block.round.0, self.block.get_id()));
+        for bid in self.children.iter() {
+            let block = tree.tree.get(bid).unwrap();
+            result = block.build_ptree(tree, result);
+        }
+        result.end_child()
+    }
+}
+
+pub struct BlockTree<T>
+where
+    T: VotingQuorum,
+{
+    root: BlockId,
+    tree: HashMap<BlockId, BlockTreeBlock<T>>,
+    high_round: Round,
+}
+
+impl<T: VotingQuorum> std::fmt::Debug for BlockTree<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let root = self.tree.get(&self.root).unwrap();
+        root.tree_fmt(&self, f, &"".to_owned())?;
+        Ok(())
+    }
+}
+
+impl<T: VotingQuorum> BlockTree<T> {
+    pub fn new(genesis_block: Block<T>) -> Self {
+        let bid = genesis_block.get_id();
+        let round = genesis_block.round;
+        let mut tree = HashMap::new();
+        tree.insert(bid, BlockTreeBlock::new(genesis_block));
+        Self {
+            root: bid,
+            tree: tree,
+            high_round: round,
+        }
+    }
+
+    /// let n = new_root_block.round
+    /// Pruning all blocks with lower round than `n` is accurate and complete
+    /// 1)  Nodes that aren't descendents of `n` are added before `n` and have round number smaller than `n`
+    ///     It only prunes blocks not part of the `new_root` subtree -> accurate
+    /// 2)  When prune is called on round `n` block, only round `n+1` block is added (as `n`'s children)
+    ///     All the blocks that remains shouldn't be pruned -> complete
+    ///
+    /// Returns the blocks in increasing rounds
+    pub fn prune(&mut self, new_root: &BlockId) -> Result<Vec<Block<T>>> {
+        // retain the new root block, remove all other committable block to avoid copying
+        let mut commit: Vec<Block<T>> = Vec::new();
+        if &self.root == new_root {
+            return Ok(commit);
+        }
+        let new_root_block = &self
+            .tree
+            .get(new_root)
+            .ok_or(BlockTreeError::BlockNotExist(format!("{:?}", new_root)))?
+            .block;
+        let new_root_round = new_root_block.round;
+        commit.push(new_root_block.clone());
+
+        let mut cur = new_root_block.qc.info.vote.id;
+        while cur != self.root {
+            let block = self.tree.remove(&cur).unwrap();
+            cur = block.block.qc.info.vote.id;
+            commit.push(block.block);
+        }
+        self.root = *new_root;
+
+        // garbage collect old blocks
+        // remove any blocks lower than round `n`
+        // should only keep `n`, `n+1` blocks
+        self.tree.retain(|_, b| b.block.round >= new_root_round);
+
+        commit.reverse();
+        Ok(commit)
+    }
+
+    pub fn add(&mut self, b: Block<T>) -> Result<()> {
+        // blocks must be inserted in increasing rounds
+        assert!(b.round > self.high_round);
+
+        let new_bid = b.get_id();
+        let new_round = b.round;
+        let parent_bid = &b.qc.info.vote.id;
+        self.tree
+            .get_mut(parent_bid)
+            .ok_or(BlockTreeError::ParentNotPresent(format!(
+                "{:?}",
+                parent_bid
+            )))?
+            .children
+            .push(new_bid);
+        self.tree.insert(new_bid, BlockTreeBlock::new(b));
+        self.high_round = new_round;
+        Ok(())
+    }
+
+    pub fn debug_print(&self) -> std::io::Result<()> {
+        let mut tree = TreeBuilder::new("BlockTree".to_owned());
+        let root = self.tree.get(&self.root).unwrap();
+        root.build_ptree(&self, &mut tree);
+
+        print_tree(&tree.build())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use monad_consensus::mock_types::mock_signature::MockSignatures;
+    use monad_consensus::types::block::{Block as ConsensusBlock, TransactionList};
+    use monad_consensus::types::ledger::LedgerCommitInfo;
+    use monad_consensus::types::quorum_certificate::{QcInfo, QuorumCertificate};
+    use monad_consensus::types::voting::VoteInfo;
+    use monad_consensus::{BlockId, NodeId, Round};
+
+    use super::BlockTree;
+    use super::BlockTreeError;
+
+    type Block = ConsensusBlock<MockSignatures>;
+    type QC = QuorumCertificate<MockSignatures>;
+
+    #[test]
+    fn test_prune() {
+        let txlist = TransactionList(vec![]);
+        let g = Block::new(
+            NodeId(0),
+            Round(0),
+            &txlist,
+            &QC::new(
+                QcInfo {
+                    vote: VoteInfo::default(),
+                    ledger_commit: LedgerCommitInfo::default(),
+                },
+                MockSignatures(),
+            ),
+        );
+
+        let v1 = VoteInfo {
+            id: g.get_id(),
+            round: Round(0),
+            parent_id: BlockId::default(),
+            parent_round: Round::default(),
+        };
+
+        let b1 = Block::new(
+            NodeId(0),
+            Round(1),
+            &txlist,
+            &QC::new(
+                QcInfo {
+                    vote: v1,
+                    ledger_commit: LedgerCommitInfo::default(),
+                },
+                MockSignatures(),
+            ),
+        );
+
+        let v2 = VoteInfo {
+            id: b1.get_id(),
+            round: Round(1),
+            parent_id: g.get_id(),
+            parent_round: Round(0),
+        };
+
+        let b2 = Block::new(
+            NodeId(0),
+            Round(2),
+            &txlist,
+            &QC::new(
+                QcInfo {
+                    vote: v2,
+                    ledger_commit: LedgerCommitInfo::default(),
+                },
+                MockSignatures(),
+            ),
+        );
+
+        let v3 = VoteInfo {
+            id: g.get_id(),
+            round: Round(0),
+            parent_id: BlockId::default(),
+            parent_round: Round::default(),
+        };
+
+        let b3 = Block::new(
+            NodeId(0),
+            Round(3),
+            &txlist,
+            &QC::new(
+                QcInfo {
+                    vote: v3,
+                    ledger_commit: LedgerCommitInfo::default(),
+                },
+                MockSignatures(),
+            ),
+        );
+
+        let v4 = VoteInfo {
+            id: g.get_id(),
+            round: Round(0),
+            parent_id: BlockId::default(),
+            parent_round: Round::default(),
+        };
+
+        let b4 = Block::new(
+            NodeId(0),
+            Round(4),
+            &txlist,
+            &QC::new(
+                QcInfo {
+                    vote: v4,
+                    ledger_commit: LedgerCommitInfo::default(),
+                },
+                MockSignatures(),
+            ),
+        );
+
+        let v5 = VoteInfo {
+            id: b3.get_id(),
+            round: Round(3),
+            parent_id: g.get_id(),
+            parent_round: Round(0),
+        };
+
+        let b5 = Block::new(
+            NodeId(0),
+            Round(5),
+            &txlist,
+            &QC::new(
+                QcInfo {
+                    vote: v5,
+                    ledger_commit: LedgerCommitInfo::default(),
+                },
+                MockSignatures(),
+            ),
+        );
+
+        let v6 = VoteInfo {
+            id: b5.get_id(),
+            round: Round(5),
+            parent_id: b3.get_id(),
+            parent_round: Round(3),
+        };
+
+        let b6 = Block::new(
+            NodeId(0),
+            Round(6),
+            &txlist,
+            &QC::new(
+                QcInfo {
+                    vote: v6,
+                    ledger_commit: LedgerCommitInfo::default(),
+                },
+                MockSignatures(),
+            ),
+        );
+
+        let v7 = VoteInfo {
+            id: b6.get_id(),
+            round: Round(6),
+            parent_id: b5.get_id(),
+            parent_round: Round(5),
+        };
+
+        let b7 = Block::new(
+            NodeId(0),
+            Round(7),
+            &txlist,
+            &QC::new(
+                QcInfo {
+                    vote: v7,
+                    ledger_commit: LedgerCommitInfo::default(),
+                },
+                MockSignatures(),
+            ),
+        );
+
+        // Initial blocktree
+        //        g
+        //   /    |     \
+        //  b1    b3    b4
+        //  |     |
+        //  b2    b5
+        //        |
+        //        b6
+        let mut blocktree = BlockTree::<MockSignatures>::new(g.clone());
+
+        assert!(blocktree.add(b1.clone()).is_ok());
+        assert!(blocktree.add(b2.clone()).is_ok());
+        assert!(blocktree.add(b3.clone()).is_ok());
+        assert!(blocktree.add(b4.clone()).is_ok());
+        assert!(blocktree.add(b5.clone()).is_ok());
+        assert!(blocktree.add(b6.clone()).is_ok());
+        println!("{:?}", blocktree);
+
+        // pruning on the old root should return no committable blocks
+        let commit = blocktree.prune(&g.get_id()).unwrap();
+        assert_eq!(commit.len(), 0);
+
+        let commit = blocktree.prune(&b5.get_id()).unwrap();
+        assert_eq!(
+            Vec::from_iter(commit.iter().map(|b| b.get_id())),
+            vec![b3.get_id(), b5.get_id()]
+        );
+        println!("{:?}", blocktree);
+
+        // Pruned blocktree
+        //     b5
+        //     |
+        //     b6
+
+        // try pruning all other nodes should return err
+        matches!(
+            blocktree.prune(&g.get_id()).unwrap_err(),
+            BlockTreeError::BlockNotExist(_)
+        );
+        matches!(
+            blocktree.prune(&b1.get_id()).unwrap_err(),
+            BlockTreeError::BlockNotExist(_)
+        );
+        matches!(
+            blocktree.prune(&b2.get_id()).unwrap_err(),
+            BlockTreeError::BlockNotExist(_)
+        );
+        matches!(
+            blocktree.prune(&b4.get_id()).unwrap_err(),
+            BlockTreeError::BlockNotExist(_)
+        );
+
+        // Pruned blocktree after insertion
+        //     b5
+        //   /    \
+        //  b6    b8
+        //  |
+        //  b7
+
+        assert!(blocktree.add(b7.clone()).is_ok());
+
+        let v8 = VoteInfo {
+            id: b5.get_id(),
+            round: Round(5),
+            parent_id: b3.get_id(),
+            parent_round: Round(3),
+        };
+
+        let b8 = Block::new(
+            NodeId(0),
+            Round(8),
+            &txlist,
+            &QC::new(
+                QcInfo {
+                    vote: v8,
+                    ledger_commit: LedgerCommitInfo::default(),
+                },
+                MockSignatures(),
+            ),
+        );
+
+        assert!(blocktree.add(b8.clone()).is_ok());
+        println!("{:?}", blocktree);
+    }
+
+    #[test]
+    fn test_add_parent_not_exist() {
+        let txlist = TransactionList(vec![]);
+        let g = Block::new(
+            NodeId(0),
+            Round(0),
+            &txlist,
+            &QC::new(
+                QcInfo {
+                    vote: VoteInfo::default(),
+                    ledger_commit: LedgerCommitInfo::default(),
+                },
+                MockSignatures(),
+            ),
+        );
+
+        let v1 = VoteInfo {
+            id: g.get_id(),
+            round: Round(0),
+            parent_id: BlockId::default(),
+            parent_round: Round::default(),
+        };
+
+        let b1 = Block::new(
+            NodeId(0),
+            Round(1),
+            &txlist,
+            &QC::new(
+                QcInfo {
+                    vote: v1,
+                    ledger_commit: LedgerCommitInfo::default(),
+                },
+                MockSignatures(),
+            ),
+        );
+
+        let v2 = VoteInfo {
+            id: b1.get_id(),
+            round: Round(1),
+            parent_id: g.get_id(),
+            parent_round: Round(0),
+        };
+
+        let b2 = Block::new(
+            NodeId(0),
+            Round(2),
+            &txlist,
+            &QC::new(
+                QcInfo {
+                    vote: v2,
+                    ledger_commit: LedgerCommitInfo::default(),
+                },
+                MockSignatures(),
+            ),
+        );
+
+        let mut blocktree = BlockTree::new(g);
+        matches!(
+            blocktree.add(b2.clone()).unwrap_err(),
+            BlockTreeError::ParentNotPresent(_)
+        );
+    }
+}

--- a/monad-blocktree/src/lib.rs
+++ b/monad-blocktree/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod blocktree;

--- a/monad-consensus/src/lib.rs
+++ b/monad-consensus/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod mock_types;
 pub mod types;
 pub mod validation;
 
@@ -6,11 +7,11 @@ use std::ops::Sub;
 
 use zerocopy::AsBytes;
 
-type Hash = [u8; 32];
+pub type Hash = [u8; 32];
 
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, AsBytes)]
-pub struct Round(u64);
+pub struct Round(pub u64);
 
 impl AsRef<[u8]> for Round {
     fn as_ref(&self) -> &[u8] {
@@ -36,7 +37,7 @@ impl Sub for Round {
 
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, AsBytes)]
-pub struct NodeId(u16);
+pub struct NodeId(pub u16);
 
 impl AsRef<[u8]> for NodeId {
     fn as_ref(&self) -> &[u8] {
@@ -45,5 +46,15 @@ impl AsRef<[u8]> for NodeId {
 }
 
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Default, PartialEq, Eq, Hash)]
 pub struct BlockId(pub Hash);
+
+impl std::fmt::Debug for BlockId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:>02x}{:>02x}..{:>02x}{:>02x}",
+            self.0[0], self.0[1], self.0[30], self.0[31]
+        )
+    }
+}

--- a/monad-consensus/src/mock_types/mock_signature.rs
+++ b/monad-consensus/src/mock_types/mock_signature.rs
@@ -1,0 +1,21 @@
+use crate::types::signature::ConsensusSignature;
+use crate::types::voting::VotingQuorum;
+use crate::Hash;
+
+#[derive(Clone, Default, Debug)]
+pub struct MockSignatures();
+impl VotingQuorum for MockSignatures {
+    fn verify_quorum(&self) -> bool {
+        true
+    }
+
+    fn current_voting_power(&self) -> i64 {
+        0
+    }
+
+    fn get_hash(&self) -> Hash {
+        Default::default()
+    }
+
+    fn add_signature(&mut self, _s: ConsensusSignature) {}
+}

--- a/monad-consensus/src/mock_types/mod.rs
+++ b/monad-consensus/src/mock_types/mod.rs
@@ -1,0 +1,1 @@
+pub mod mock_signature;

--- a/monad-consensus/src/types/block.rs
+++ b/monad-consensus/src/types/block.rs
@@ -1,3 +1,5 @@
+use sha2::Digest;
+
 use crate::types::quorum_certificate::QuorumCertificate;
 use crate::types::voting::VotingQuorum;
 use crate::validation::signing::Hashable;
@@ -15,7 +17,7 @@ where
     pub round: Round,
     pub payload: TransactionList,
     pub qc: QuorumCertificate<T>,
-    id: Hash,
+    id: BlockId,
 }
 
 pub struct BlockIter<'a, T>
@@ -73,10 +75,16 @@ impl<T: VotingQuorum> Block<T> {
             id: Default::default(),
         };
         // TODO: new() can take in a Hasher and populate id
+        let mut hasher = sha2::Sha256::new();
+        for m in (&b).msg_parts() {
+            hasher.update(m);
+        }
+        b.id = BlockId(hasher.finalize().into());
+
         b
     }
 
-    pub fn get_id(&self) -> Hash {
+    pub fn get_id(&self) -> BlockId {
         self.id
     }
 }

--- a/monad-consensus/src/types/quorum_certificate.rs
+++ b/monad-consensus/src/types/quorum_certificate.rs
@@ -107,33 +107,15 @@ impl<T: VotingQuorum> QuorumCertificate<T> {
 
 #[cfg(test)]
 mod tests {
+    use crate::mock_types::mock_signature::MockSignatures;
     use crate::types::ledger::LedgerCommitInfo;
-    use crate::types::signature::ConsensusSignature;
-    use crate::types::voting::{VoteInfo, VotingQuorum};
+    use crate::types::voting::VoteInfo;
 
     use crate::*;
 
     use super::QcInfo;
     use super::QuorumCertificate;
     use super::Rank;
-
-    #[derive(Clone, Default, Debug)]
-    struct MockSignatures();
-    impl VotingQuorum for MockSignatures {
-        fn verify_quorum(&self) -> bool {
-            true
-        }
-
-        fn current_voting_power(&self) -> i64 {
-            0
-        }
-
-        fn get_hash(&self) -> crate::Hash {
-            Default::default()
-        }
-
-        fn add_signature(&mut self, _s: ConsensusSignature) {}
-    }
 
     #[test]
     fn comparison() {


### PR DESCRIPTION
A tree structure to store pending blocks. A block contains a QC for its parent, i.e. its parent block is `block.qc.vote_info.id`. `prune` moves the root to the given block and deallocates all non-descendant blocks. 

Modifies `consensus-types` to expose some type/fields