### PR TITLE
Improve message type safety

### DIFF
--- a/monad-executor/src/executor/parent.rs
+++ b/monad-executor/src/executor/parent.rs
@@ -4,7 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use crate::{Command, Executor, RouterCommand, TimerCommand};
+use crate::{Command, Executor, Message, RouterCommand, TimerCommand};
 
 use futures::Stream;
 use futures::StreamExt;
@@ -14,13 +14,14 @@ pub struct ParentExecutor<R, T> {
     pub timer: T,
 }
 
-impl<E, R, T> Executor for ParentExecutor<R, T>
+impl<E, M, R, T> Executor for ParentExecutor<R, T>
 where
-    R: Executor<Command = RouterCommand<E>>,
+    M: Message<Event = E>,
+    R: Executor<Command = RouterCommand<E, M>>,
     T: Executor<Command = TimerCommand<E>>,
 {
-    type Command = Command<E>;
-    fn exec(&mut self, commands: Vec<Command<E>>) {
+    type Command = Command<E, M>;
+    fn exec(&mut self, commands: Vec<Command<E, M>>) {
         let (router_cmds, timer_cmds) = Command::split_commands(commands);
         self.router.exec(router_cmds);
         self.timer.exec(timer_cmds);

--- a/monad-executor/src/lib.rs
+++ b/monad-executor/src/lib.rs
@@ -1,13 +1,15 @@
 use futures::{Stream, StreamExt};
 
 mod state;
-use state::*;
+pub use state::*;
 
-mod executor;
+pub mod executor;
 
 // driver loop
 async fn run<S: State>(
-    mut executor: impl Executor<Command = Command<S::Event>> + Stream<Item = S::Event> + Unpin,
+    mut executor: impl Executor<Command = Command<S::Event, S::Message>>
+        + Stream<Item = S::Event>
+        + Unpin,
     init_events: Vec<S::Event>,
 ) {
     let (mut state, mut init_commands) = S::init();


### PR DESCRIPTION
The only important changes are in `monad-executor/src/state.rs`, basically replacing the `Codec` trait with the `Message` trait.

This change improves the readability of the monad-state changes I'm working on.