### PR TITLE
Swarm Simulation Test

### DIFF
--- a/monad-executor/src/state.rs
+++ b/monad-executor/src/state.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct PeerId;
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PeerId(pub u64);
 pub enum RouterCommand<E, M>
 where
     M: Message<Event = E>,
@@ -65,5 +65,5 @@ pub trait Message: Sized + Clone + Unpin {
     fn deserialize(from: PeerId, message: &[u8]) -> Result<Self, Self::ReadError>;
     fn serialize(&self) -> Vec<u8>;
     fn id(&self) -> Self::Id;
-    fn event(self) -> Self::Event;
+    fn event(self, from: PeerId) -> Self::Event;
 }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -37,7 +37,7 @@ impl Message for MonadMessage {
         self.clone()
     }
 
-    fn event(self) -> Self::Event {
+    fn event(self, _from: PeerId) -> Self::Event {
         todo!()
     }
 }

--- a/monad-state/src/message.rs
+++ b/monad-state/src/message.rs
@@ -146,7 +146,7 @@ mod tests {
             self.clone()
         }
 
-        fn event(self) -> Self::Event {
+        fn event(self, _from: PeerId) -> Self::Event {
             todo!()
         }
     }
@@ -171,22 +171,22 @@ mod tests {
     #[test]
     fn send() {
         let mut state = MessageState::<TestMessage>::new(5, Vec::new());
-        let action = state.send(PeerId, TestMessage);
+        let action = state.send(PeerId(0), TestMessage);
 
-        assert_eq!(action.to, PeerId);
+        assert_eq!(action.to, PeerId(0));
         assert_eq!(action.message, TestMessage);
     }
 
     #[test]
     fn set_round_eviction() {
         let mut state = MessageState::<TestMessage>::new(5, Vec::new());
-        let _ = state.send(PeerId, TestMessage);
+        let _ = state.send(PeerId(0), TestMessage);
 
         let evicted = state.set_round(10, Vec::new());
         assert_eq!(
             evicted,
             vec![MessageActionUnpublish {
-                to: PeerId,
+                to: PeerId(0),
                 id: TestMessage,
             }],
         )
@@ -195,13 +195,13 @@ mod tests {
     #[test]
     fn handle_ack() {
         let mut state = MessageState::<TestMessage>::new(5, Vec::new());
-        let _ = state.send(PeerId, TestMessage);
+        let _ = state.send(PeerId(0), TestMessage);
 
-        let evicted = state.handle_ack(0, PeerId, TestMessage);
+        let evicted = state.handle_ack(0, PeerId(0), TestMessage);
         assert_eq!(
             evicted,
             Some(MessageActionUnpublish {
-                to: PeerId,
+                to: PeerId(0),
                 id: TestMessage,
             }),
         )
@@ -210,11 +210,11 @@ mod tests {
     #[test]
     fn evicted_handle_ack() {
         let mut state = MessageState::<TestMessage>::new(5, Vec::new());
-        let _ = state.send(PeerId, TestMessage);
+        let _ = state.send(PeerId(0), TestMessage);
 
         let _ = state.set_round(10, Vec::new());
 
-        let evicted = state.handle_ack(0, PeerId, TestMessage);
+        let evicted = state.handle_ack(0, PeerId(0), TestMessage);
         assert_eq!(evicted, None,)
     }
 }


### PR DESCRIPTION
This PR adds a mock swarm simulation tests that sequences and executes events on N nodes (and fixes some bugs found in the process).

Mostly just a POC to illustrate, still some cleanup to do but that can be done later in a subsequent PR.

Important future note: the `inbound_messages` and `inbound_ack` fields should actually be priority queues in order for the mock executor to be correct, but that can be fixed later.