### PR TITLE
rename VotingQuorum trait

### DIFF
--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -1,5 +1,5 @@
 use monad_consensus::types::block::Block;
-use monad_consensus::types::voting::VotingQuorum;
+use monad_consensus::types::signature::SignatureCollection;
 use monad_consensus::BlockId;
 use monad_consensus::Round;
 use ptree::print_tree;
@@ -35,13 +35,13 @@ impl std::error::Error for BlockTreeError {
 
 pub struct BlockTreeBlock<T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     block: Block<T>,
     children: Vec<BlockId>,
 }
 
-impl<T: VotingQuorum> BlockTreeBlock<T> {
+impl<T: SignatureCollection> BlockTreeBlock<T> {
     const CHILD_INDENT: &str = "    ";
     fn new(b: Block<T>) -> Self {
         BlockTreeBlock {
@@ -89,14 +89,14 @@ impl<T: VotingQuorum> BlockTreeBlock<T> {
 
 pub struct BlockTree<T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     root: BlockId,
     tree: HashMap<BlockId, BlockTreeBlock<T>>,
     high_round: Round,
 }
 
-impl<T: VotingQuorum> std::fmt::Debug for BlockTree<T> {
+impl<T: SignatureCollection> std::fmt::Debug for BlockTree<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let root = self.tree.get(&self.root).unwrap();
         root.tree_fmt(&self, f, &"".to_owned())?;
@@ -104,7 +104,7 @@ impl<T: VotingQuorum> std::fmt::Debug for BlockTree<T> {
     }
 }
 
-impl<T: VotingQuorum> BlockTree<T> {
+impl<T: SignatureCollection> BlockTree<T> {
     pub fn new(genesis_block: Block<T>) -> Self {
         let bid = genesis_block.get_id();
         let round = genesis_block.round;

--- a/monad-consensus/src/types/block.rs
+++ b/monad-consensus/src/types/block.rs
@@ -1,7 +1,7 @@
 use sha2::Digest;
 
 use crate::types::quorum_certificate::QuorumCertificate;
-use crate::types::voting::VotingQuorum;
+use crate::types::signature::SignatureCollection;
 use crate::validation::hashing::Hashable;
 use crate::*;
 
@@ -11,7 +11,7 @@ pub struct TransactionList(pub Vec<u8>);
 #[derive(Clone, Default, Debug)]
 pub struct Block<T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     pub author: NodeId,
     pub round: Round,
@@ -22,7 +22,7 @@ where
 
 pub struct BlockIter<'a, T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     pub b: &'a Block<T>,
     pub index: usize,
@@ -30,7 +30,7 @@ where
 
 impl<'a, T> Iterator for BlockIter<'a, T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     type Item = &'a [u8];
 
@@ -51,7 +51,7 @@ where
 
 impl<'a, T> Hashable<'a> for &'a Block<T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     type DataIter = BlockIter<'a, T>;
 
@@ -60,7 +60,7 @@ where
     }
 }
 
-impl<T: VotingQuorum> Block<T> {
+impl<T: SignatureCollection> Block<T> {
     pub fn new(
         author: NodeId,
         round: Round,

--- a/monad-consensus/src/types/message.rs
+++ b/monad-consensus/src/types/message.rs
@@ -6,9 +6,9 @@ use super::block::BlockIter;
 use super::{
     block::Block,
     ledger::LedgerCommitInfo,
-    signature::ConsensusSignature,
+    signature::{ConsensusSignature, SignatureCollection},
     timeout::{TimeoutCertificate, TimeoutInfo},
-    voting::{VoteInfo, VotingQuorum},
+    voting::VoteInfo,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -60,7 +60,7 @@ impl<'a> Hashable<'a> for &'a VoteMessage {
 #[derive(Clone)]
 pub struct TimeoutMessage<T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     pub tminfo: TimeoutInfo<T>,
     pub last_round_tc: Option<TimeoutCertificate>,
@@ -68,7 +68,7 @@ where
 
 pub struct TimeoutMessageIter<'a, T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     tm: &'a TimeoutMessage<T>,
     index: usize,
@@ -76,7 +76,7 @@ where
 
 impl<'a, T> Iterator for TimeoutMessageIter<'a, T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     type Item = &'a [u8];
 
@@ -94,7 +94,7 @@ where
 
 impl<T> Signable for TimeoutMessage<T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     type Output = Unverified<TimeoutMessage<T>>;
 
@@ -109,7 +109,7 @@ where
 
 impl<'a, T> Hashable<'a> for &'a TimeoutMessage<T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     type DataIter = TimeoutMessageIter<'a, T>;
 
@@ -121,7 +121,7 @@ where
 #[derive(Clone, Debug)]
 pub struct ProposalMessage<T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     pub block: Block<T>,
     pub last_round_tc: Option<TimeoutCertificate>,
@@ -129,7 +129,7 @@ where
 
 impl<'a, T> Hashable<'a> for &'a ProposalMessage<T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     type DataIter = BlockIter<'a, T>;
 
@@ -143,7 +143,7 @@ where
 
 impl<T> Signable for ProposalMessage<T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     type Output = Unverified<ProposalMessage<T>>;
 

--- a/monad-consensus/src/types/quorum_certificate.rs
+++ b/monad-consensus/src/types/quorum_certificate.rs
@@ -1,14 +1,15 @@
+use crate::types::ledger::*;
+use crate::types::signature::{ConsensusSignature, SignatureCollection};
+use crate::types::voting::*;
 use crate::validation::hashing::Hashable;
 use crate::validation::signing::{Signable, Signed, Unverified};
 use crate::*;
-
-use super::{ledger::*, signature::ConsensusSignature, voting::*};
 
 #[non_exhaustive]
 #[derive(Clone, Default, Debug)]
 pub struct QuorumCertificate<T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     pub info: QcInfo,
     pub signatures: T,
@@ -17,7 +18,7 @@ where
 
 pub struct QcIter<'a, T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     pub qc: &'a QuorumCertificate<T>,
     pub index: usize,
@@ -25,7 +26,7 @@ where
 
 impl<'a, T> Iterator for QcIter<'a, T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     type Item = &'a [u8];
 
@@ -42,7 +43,7 @@ where
 
 impl<'a, T> Hashable<'a> for &'a QuorumCertificate<T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     type DataIter = QcIter<'a, T>;
 
@@ -53,7 +54,7 @@ where
 
 impl<T> Signable for QuorumCertificate<T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     type Output = Unverified<QuorumCertificate<T>>;
 
@@ -95,7 +96,7 @@ impl Ord for Rank {
     }
 }
 
-impl<T: VotingQuorum> QuorumCertificate<T> {
+impl<T: SignatureCollection> QuorumCertificate<T> {
     pub fn new(info: QcInfo, signatures: T) -> Self {
         let hash = signatures.get_hash();
         QuorumCertificate {

--- a/monad-consensus/src/types/signature.rs
+++ b/monad-consensus/src/types/signature.rs
@@ -1,4 +1,24 @@
+use crate::Hash;
 use monad_crypto::secp256k1::Signature;
 
 #[derive(Clone, Debug)]
 pub struct ConsensusSignature(pub Signature);
+
+pub trait SignatureCollection: Default + Clone {
+    fn new(max_stake: i64) -> Self;
+
+    // is voting power >= 2f+1
+    fn verify_quorum(&self) -> bool;
+
+    // TODO get the return type from monad-validators later
+    fn current_stake(&self) -> i64;
+
+    // hash of all the signatures
+    fn get_hash(&self) -> Hash;
+
+    // add the signature from a signed vote message and its voting power to the
+    // aggregate
+    fn add_signature(&mut self, s: ConsensusSignature, stake: i64);
+
+    fn get_signatures(&self) -> Vec<&ConsensusSignature>;
+}

--- a/monad-consensus/src/types/timeout.rs
+++ b/monad-consensus/src/types/timeout.rs
@@ -3,13 +3,14 @@ use crate::validation::signing::{Signable, Signed, Unverified};
 use crate::*;
 
 use super::{
-    quorum_certificate::QuorumCertificate, signature::ConsensusSignature, voting::VotingQuorum,
+    quorum_certificate::QuorumCertificate, signature::ConsensusSignature,
+    signature::SignatureCollection,
 };
 
 #[derive(Clone, Debug)]
 pub struct TimeoutInfo<T>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     pub round: Round,
     pub high_qc: QuorumCertificate<T>,

--- a/monad-consensus/src/types/voting.rs
+++ b/monad-consensus/src/types/voting.rs
@@ -1,23 +1,5 @@
-use crate::types::signature::ConsensusSignature;
 use crate::validation::hashing::Hashable;
 use crate::*;
-
-pub trait VotingQuorum: Default + Clone {
-    // is voting power >= 2f+1
-    fn verify_quorum(&self) -> bool;
-
-    // TODO get the return type from monad-validators later
-    fn current_voting_power(&self) -> i64;
-
-    // hash of all the signatures
-    fn get_hash(&self) -> Hash;
-
-    // add the signature from a signed vote message and its voting power to the
-    // aggregate
-    fn add_signature(&mut self, s: ConsensusSignature, vote_power: i64);
-
-    fn get_signatures(&self) -> Vec<&ConsensusSignature>;
-}
 
 use sha2::Digest;
 

--- a/monad-consensus/src/validation/message.rs
+++ b/monad-consensus/src/validation/message.rs
@@ -1,12 +1,12 @@
 use crate::*;
 
 use crate::types::message::{ProposalMessage, TimeoutMessage};
+use crate::types::signature::SignatureCollection;
 use crate::types::timeout::TimeoutCertificate;
-use crate::types::voting::VotingQuorum;
 use crate::validation::error::Error;
 use crate::validation::signing::Unverified;
 
-pub fn well_formed_proposal<T: VotingQuorum>(
+pub fn well_formed_proposal<T: SignatureCollection>(
     p: &Unverified<ProposalMessage<T>>,
 ) -> Result<(), Error> {
     well_formed(
@@ -16,7 +16,7 @@ pub fn well_formed_proposal<T: VotingQuorum>(
     )
 }
 
-pub fn well_formed_timeout<T: VotingQuorum>(
+pub fn well_formed_timeout<T: SignatureCollection>(
     t: &Unverified<TimeoutMessage<T>>,
 ) -> Result<(), Error> {
     well_formed(

--- a/monad-consensus/src/validation/protocol.rs
+++ b/monad-consensus/src/validation/protocol.rs
@@ -5,8 +5,8 @@ use crate::types::message::TimeoutMessage;
 use crate::types::message::VoteMessage;
 use crate::types::quorum_certificate::QuorumCertificate;
 use crate::types::signature::ConsensusSignature;
+use crate::types::signature::SignatureCollection;
 use crate::types::timeout::TimeoutCertificate;
-use crate::types::voting::VotingQuorum;
 use crate::validation::error::Error;
 use crate::validation::hashing::Hasher;
 use crate::validation::message::{well_formed_proposal, well_formed_timeout};
@@ -50,7 +50,7 @@ pub fn verify_proposal<H, T>(
     p: Unverified<ProposalMessage<T>>,
 ) -> Result<Verified<ProposalMessage<T>>, Error>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
     H: Hasher,
 {
     well_formed_proposal(&p)?;
@@ -100,7 +100,7 @@ pub fn verify_timeout_message<H, T>(
 ) -> Result<Verified<TimeoutMessage<T>>, Error>
 where
     H: Hasher,
-    T: VotingQuorum,
+    T: SignatureCollection,
 {
     well_formed_timeout(&t)?;
     let msg = h.hash_object(&t.0.obj);
@@ -128,7 +128,7 @@ fn verify_certificates<H, V>(
 ) -> Result<(), Error>
 where
     H: Hasher,
-    V: VotingQuorum,
+    V: SignatureCollection,
 {
     let msg_sig = if let Some(tc) = tc {
         tc.high_qc_rounds

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -2,7 +2,7 @@ use message::MessageState;
 use monad_blocktree::blocktree::BlockTree;
 use monad_consensus::types::message::{TimeoutMessage, VoteMessage};
 use monad_consensus::types::quorum_certificate::QuorumCertificate;
-use monad_consensus::types::voting::VotingQuorum;
+use monad_consensus::types::signature::SignatureCollection;
 use monad_consensus::validation::hashing::Sha256Hash;
 use monad_consensus::validation::protocol::{
     verify_proposal, verify_timeout_message, verify_vote_message,
@@ -170,7 +170,7 @@ impl State for MonadState {
 
 struct ConsensusState<T, V>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
     V: LeaderElection,
 {
     pending_block_tree: BlockTree<T>,
@@ -181,7 +181,7 @@ where
 
 impl<T, V> ConsensusState<T, V>
 where
-    T: VotingQuorum,
+    T: SignatureCollection,
     V: LeaderElection,
 {
     fn handle_proposal_message(

--- a/monad-testutil/src/signing.rs
+++ b/monad-testutil/src/signing.rs
@@ -1,6 +1,6 @@
 use monad_consensus::types::block::Block;
 use monad_consensus::types::signature::ConsensusSignature;
-use monad_consensus::types::voting::VotingQuorum;
+use monad_consensus::types::signature::SignatureCollection;
 use monad_consensus::validation::hashing::Hashable;
 use monad_consensus::validation::signing::Signable;
 use monad_consensus::{Hash, NodeId};
@@ -8,12 +8,16 @@ use monad_crypto::secp256k1::KeyPair;
 
 #[derive(Clone, Default, Debug)]
 pub struct MockSignatures;
-impl VotingQuorum for MockSignatures {
+impl SignatureCollection for MockSignatures {
+    fn new(_stake: i64) -> Self {
+        MockSignatures {}
+    }
+
     fn verify_quorum(&self) -> bool {
         true
     }
 
-    fn current_voting_power(&self) -> i64 {
+    fn current_stake(&self) -> i64 {
         0
     }
 
@@ -30,7 +34,7 @@ impl VotingQuorum for MockSignatures {
 
 use sha2::Digest;
 
-pub fn hash<T: VotingQuorum>(b: &Block<T>) -> Hash {
+pub fn hash<T: SignatureCollection>(b: &Block<T>) -> Hash {
     let mut hasher = sha2::Sha256::new();
     hasher.update(b.author);
     hasher.update(b.round);


### PR DESCRIPTION
rename VotingQuorum to SignatureCollection which describes it better. add new() function to the trait. rename voting power to stake to be consistent with monad-validator

---
in a future PR, I will remove the verify_quorum and current_stake functions because they don't make sense to attach to this trait. The validator_set should be able to take in a SignatureCollection and return the stake and quorum etc.