### PR TITLE
Remove stake funcs from SignatureCollection trait

### DIFF
--- a/monad-consensus/src/signatures/aggregate_signature.rs
+++ b/monad-consensus/src/signatures/aggregate_signature.rs
@@ -4,48 +4,17 @@ use sha2::Digest;
 #[derive(Clone, Debug)]
 pub struct AggregateSignatures {
     pub sigs: Vec<ConsensusSignature>,
-    voting_stake: i64,
-    max_stake: i64,
 }
 
 impl Default for AggregateSignatures {
     fn default() -> Self {
-        Self {
-            sigs: Vec::new(),
-            voting_stake: 0,
-            max_stake: 10000,
-        }
+        Self { sigs: Vec::new() }
     }
-}
-
-fn div_ceil(a: i64) -> i64 {
-    // algorithm doesn't work for negative dividend
-    if a < 0 {
-        panic!("cannot have negative dividend")
-    }
-    if i64::MAX - a < 3 - 1 {
-        panic!("dividend value results in integer overflow")
-    }
-
-    (a + (3 - 1)) / 3
 }
 
 impl SignatureCollection for AggregateSignatures {
-    fn new(max_stake: i64) -> Self {
-        AggregateSignatures {
-            sigs: Vec::new(),
-            voting_stake: 0,
-            max_stake,
-        }
-    }
-
-    fn verify_quorum(&self) -> bool {
-        let super_majority = div_ceil(2 * self.max_stake);
-        self.voting_stake >= super_majority
-    }
-
-    fn current_stake(&self) -> i64 {
-        self.voting_stake
+    fn new() -> Self {
+        AggregateSignatures { sigs: Vec::new() }
     }
 
     fn get_hash(&self) -> crate::Hash {
@@ -58,50 +27,11 @@ impl SignatureCollection for AggregateSignatures {
         hasher.finalize().into()
     }
 
-    fn add_signature(&mut self, s: ConsensusSignature, vote_stake: i64) {
+    fn add_signature(&mut self, s: ConsensusSignature) {
         self.sigs.push(s);
-        self.voting_stake += vote_stake;
     }
 
     fn get_signatures(&self) -> Vec<&ConsensusSignature> {
         self.sigs.iter().collect()
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use crate::{signatures::aggregate_signature::div_ceil, types::signature::SignatureCollection};
-
-    use super::AggregateSignatures;
-
-    #[test]
-    fn div_ceil_test() {
-        assert_eq!(3, div_ceil(8));
-        assert_eq!(1, div_ceil(1));
-        assert_eq!(0, div_ceil(0));
-    }
-
-    #[test]
-    fn super_maj_test() {
-        let mut s = AggregateSignatures::new(4);
-
-        s.voting_stake = 2;
-        assert!(!s.verify_quorum());
-
-        s.voting_stake = 3;
-        assert!(s.verify_quorum());
-
-        s.voting_stake = 4;
-        assert!(s.verify_quorum());
-
-        s.voting_stake = 5;
-        assert!(s.verify_quorum());
-    }
-
-    #[test]
-    #[should_panic]
-    fn negative_dividend() {
-        let s = AggregateSignatures::new(-4);
-        s.verify_quorum();
     }
 }

--- a/monad-consensus/src/types/signature.rs
+++ b/monad-consensus/src/types/signature.rs
@@ -5,20 +5,13 @@ use monad_crypto::secp256k1::Signature;
 pub struct ConsensusSignature(pub Signature);
 
 pub trait SignatureCollection: Default + Clone {
-    fn new(max_stake: i64) -> Self;
-
-    // is voting power >= 2f+1
-    fn verify_quorum(&self) -> bool;
-
-    // TODO get the return type from monad-validators later
-    fn current_stake(&self) -> i64;
+    fn new() -> Self;
 
     // hash of all the signatures
     fn get_hash(&self) -> Hash;
 
-    // add the signature from a signed vote message and its voting power to the
-    // aggregate
-    fn add_signature(&mut self, s: ConsensusSignature, stake: i64);
+    // add the signature from a signed vote message
+    fn add_signature(&mut self, s: ConsensusSignature);
 
     fn get_signatures(&self) -> Vec<&ConsensusSignature>;
 }

--- a/monad-testutil/src/signing.rs
+++ b/monad-testutil/src/signing.rs
@@ -9,23 +9,15 @@ use monad_crypto::secp256k1::KeyPair;
 #[derive(Clone, Default, Debug)]
 pub struct MockSignatures;
 impl SignatureCollection for MockSignatures {
-    fn new(_stake: i64) -> Self {
+    fn new() -> Self {
         MockSignatures {}
-    }
-
-    fn verify_quorum(&self) -> bool {
-        true
-    }
-
-    fn current_stake(&self) -> i64 {
-        0
     }
 
     fn get_hash(&self) -> Hash {
         Default::default()
     }
 
-    fn add_signature(&mut self, _s: ConsensusSignature, _vote_power: i64) {}
+    fn add_signature(&mut self, _s: ConsensusSignature) {}
 
     fn get_signatures(&self) -> Vec<&ConsensusSignature> {
         Default::default()


### PR DESCRIPTION
It doesn't make sense for SignatureCollection to keep track of vote weights. The validatorset should be responsible for taking in a SignatureCollection and determining the vote weight.