### PR TITLE
`ConsensusCommand` abstraction

### DIFF
--- a/monad-consensus/src/pacemaker.rs
+++ b/monad-consensus/src/pacemaker.rs
@@ -45,6 +45,7 @@ pub enum PacemakerCommand<T: SignatureCollection> {
     Unschedule,
 }
 
+#[derive(Debug, Clone)]
 pub struct PacemakerTimerExpire {
     round: Round,
 }

--- a/monad-consensus/src/types/message.rs
+++ b/monad-consensus/src/types/message.rs
@@ -38,7 +38,7 @@ impl Hashable for &VoteMessage {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct TimeoutMessage<T>
 where
     T: SignatureCollection,


### PR DESCRIPTION
This PR creates a `ConsensusCommand` which is a superset of the normal commands.

All consensus commands can be mapped to normal commands using what's in MonadState - an example of this is the `Broadcast` command which is mapped using `message_state`.

This file is getting kinda big... will split it up into smaller ones at some point