### PR TITLE
`Pacemaker` and `Safety` stubs

### DIFF
--- a/monad-consensus/src/pacemaker.rs
+++ b/monad-consensus/src/pacemaker.rs
@@ -16,7 +16,7 @@ use crate::{
     },
 };
 
-struct Pacemaker<T: SignatureCollection> {
+pub struct Pacemaker<T: SignatureCollection> {
     delta: Duration,
 
     current_round: Round,
@@ -120,7 +120,7 @@ where
     }
 
     #[must_use]
-    fn process_remote_timeout<L: LeaderElection>(
+    pub fn process_remote_timeout<L: LeaderElection>(
         &mut self,
         validators: &ValidatorSet<L>,
         safety: &mut Safety,
@@ -175,7 +175,7 @@ where
     }
 
     #[must_use]
-    fn advance_round_tc(&mut self, tc: TimeoutCertificate) -> Option<PacemakerCommand<T>> {
+    pub fn advance_round_tc(&mut self, tc: TimeoutCertificate) -> Option<PacemakerCommand<T>> {
         if tc.round < self.current_round {
             return None;
         }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use monad_blocktree::blocktree::BlockTree;
 use monad_consensus::{
-    pacemaker::PacemakerTimerExpire,
+    pacemaker::{Pacemaker, PacemakerTimerExpire},
     signatures::aggregate_signature::AggregateSignatures,
     types::{
         ledger::{InMemoryLedger, Ledger},
@@ -14,6 +14,7 @@ use monad_consensus::{
     validation::{
         hashing::{Hasher, Sha256Hash},
         protocol::{verify_proposal, verify_timeout_message, verify_vote_message},
+        safety::Safety,
         signing::{Unverified, Verified},
     },
     vote_state::VoteState,
@@ -140,7 +141,7 @@ impl State for MonadState {
                         match timeout {
                             Ok(p) => self
                                 .consensus_state
-                                .handle_timeout_message(&p, &self.validator_set),
+                                .handle_timeout_message(p, &self.validator_set),
                             Err(_) => todo!(),
                         }
                     }
@@ -243,6 +244,9 @@ where
 
     ledger: L,
 
+    pacemaker: Pacemaker<T>,
+    safety: Safety,
+
     // TODO this might be in synchronizer only
     round: Round,
 }
@@ -285,10 +289,10 @@ where
 
     fn handle_timeout_message<V: LeaderElection>(
         &mut self,
-        p: &Verified<TimeoutMessage<T>>,
+        p: Verified<TimeoutMessage<T>>,
         validators: &ValidatorSet<V>,
     ) -> Vec<ConsensusCommand> {
-        todo!();
+        todo!()
     }
 
     // If the qc has a commit_state_hash, commit the parent block and prune the


### PR DESCRIPTION
Small PR that introduces Pacemaker and Safety members into ConsensusState - will submit a subsequent PR for the `handle_timeout_message` implementation, but putting this PR out there to unblock other progress.