### PR TITLE
Lift `Unverified` out of `ConsensusMessage`, `handle_timeout_message` implementation

### DIFF
--- a/monad-consensus/src/pacemaker.rs
+++ b/monad-consensus/src/pacemaker.rs
@@ -138,11 +138,7 @@ where
         // it's fine to overwrite if already exists
         self.pending_timeouts.insert(tmo.0.author, tmo.clone());
 
-        let timeouts = self
-            .pending_timeouts
-            .keys()
-            .map(|node_id| node_id.clone()) // TODO: maybe has_honest_vote should take &Vec<&NodeId>
-            .collect();
+        let timeouts = self.pending_timeouts.keys().copied().collect();
 
         if self.phase == Phase::ZeroHonest && validators.has_honest_vote(&timeouts) {
             ret_commands.push(PacemakerCommand::Unschedule);
@@ -175,12 +171,12 @@ where
     }
 
     #[must_use]
-    pub fn advance_round_tc(&mut self, tc: TimeoutCertificate) -> Option<PacemakerCommand<T>> {
+    pub fn advance_round_tc(&mut self, tc: &TimeoutCertificate) -> Option<PacemakerCommand<T>> {
         if tc.round < self.current_round {
             return None;
         }
         let round = tc.round;
-        self.last_round_tc = Some(tc);
+        self.last_round_tc = Some(tc.clone());
         Some(self.start_timer(round + Round(1)))
     }
 

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -2,29 +2,29 @@ use std::time::Duration;
 
 use monad_blocktree::blocktree::BlockTree;
 use monad_consensus::{
-    pacemaker::{Pacemaker, PacemakerTimerExpire},
+    pacemaker::{Pacemaker, PacemakerCommand, PacemakerTimerExpire},
     signatures::aggregate_signature::AggregateSignatures,
     types::{
         ledger::{InMemoryLedger, Ledger},
         message::{ProposalMessage, TimeoutMessage, VoteMessage},
         quorum_certificate::{QuorumCertificate, Rank},
-        signature::SignatureCollection,
+        signature::{ConsensusSignature, SignatureCollection},
         timeout::TimeoutCertificate,
     },
     validation::{
         hashing::{Hasher, Sha256Hash},
         protocol::{verify_proposal, verify_timeout_message, verify_vote_message},
         safety::Safety,
-        signing::{Unverified, Verified},
+        signing::{Signable, Signed, Unverified, Verified},
     },
     vote_state::VoteState,
 };
 use monad_executor::{Command, Message, PeerId, RouterCommand, State, TimerCommand};
-use monad_types::Round;
+use monad_types::{NodeId, Round};
 use monad_validator::leader_election::LeaderElection;
 use monad_validator::{validator_set::ValidatorSet, weighted_round_robin::WeightedRoundRobin};
 
-use message::{MessageActionPublish, MessageState};
+use message::MessageState;
 
 mod message;
 
@@ -45,10 +45,11 @@ pub enum MonadEvent {
         id: <MonadMessage as Message>::Id,
         round: Round,
     },
-    ConsensusEvent(ConsensusEvent),
+    ConsensusEvent(ConsensusEvent<SignatureType>),
 }
 
-type MonadMessage = ConsensusMessage;
+#[derive(Debug, Clone)]
+pub struct MonadMessage(Unverified<ConsensusMessage<SignatureType>>);
 
 impl Message for MonadMessage {
     type Event = MonadEvent;
@@ -72,7 +73,7 @@ impl Message for MonadMessage {
     }
 
     fn event(self, _from: PeerId) -> Self::Event {
-        Self::Event::ConsensusEvent(ConsensusEvent::UnverifiedMessage(self))
+        Self::Event::ConsensusEvent(ConsensusEvent::UnverifiedMessage(self.0))
     }
 }
 
@@ -99,66 +100,95 @@ impl State for MonadState {
                 .collect(),
 
             MonadEvent::ConsensusEvent(consensus_event) => {
-                let consensus_commands: Vec<ConsensusCommand> = match consensus_event {
-                    ConsensusEvent::Timeout(pacemaker_expire) => {
-                        todo!()
-                    }
-                    ConsensusEvent::UnverifiedMessage(ConsensusMessage::Proposal(msg)) => {
-                        let proposal = verify_proposal::<Sha256Hash, SignatureType>(
-                            self.validator_set.get_members(),
-                            msg,
-                        );
-
-                        match proposal {
-                            Ok(p) => self
-                                .consensus_state
-                                .handle_proposal_message(&p, &self.validator_set),
-                            Err(_) => todo!(),
+                let consensus_commands: Vec<ConsensusCommand<AggregateSignatures>> =
+                    match consensus_event {
+                        ConsensusEvent::Timeout(pacemaker_expire) => {
+                            todo!()
                         }
-                    }
-                    ConsensusEvent::UnverifiedMessage(ConsensusMessage::Vote(msg)) => {
-                        let vote = verify_vote_message::<Sha256Hash>(
-                            self.validator_set.get_members(),
-                            msg,
-                        );
+                        ConsensusEvent::UnverifiedMessage(msg) => {
+                            match UnverifiedConsensusMessage::from(msg) {
+                                UnverifiedConsensusMessage::Proposal(msg) => {
+                                    let proposal = verify_proposal::<Sha256Hash, SignatureType>(
+                                        self.validator_set.get_members(),
+                                        msg,
+                                    );
 
-                        match vote {
-                            Ok(p) => self
-                                .consensus_state
-                                .handle_vote_message::<Sha256Hash, LeaderElectionType>(
-                                    &p,
-                                    &mut self.validator_set,
-                                ),
-                            Err(_) => todo!(),
-                        }
-                    }
-                    ConsensusEvent::UnverifiedMessage(ConsensusMessage::Timeout(msg)) => {
-                        let timeout = verify_timeout_message::<Sha256Hash, SignatureType>(
-                            self.validator_set.get_members(),
-                            msg,
-                        );
+                                    match proposal {
+                                        Ok(p) => self
+                                            .consensus_state
+                                            .handle_proposal_message(&p, &self.validator_set),
+                                        Err(_) => todo!(),
+                                    }
+                                }
+                                UnverifiedConsensusMessage::Vote(msg) => {
+                                    let vote = verify_vote_message::<Sha256Hash>(
+                                        self.validator_set.get_members(),
+                                        msg,
+                                    );
 
-                        match timeout {
-                            Ok(p) => self
-                                .consensus_state
-                                .handle_timeout_message(p, &self.validator_set),
-                            Err(_) => todo!(),
+                                    match vote {
+                                        Ok(p) => self
+                                            .consensus_state
+                                            .handle_vote_message::<Sha256Hash, LeaderElectionType>(
+                                                &p,
+                                                &mut self.validator_set,
+                                            ),
+                                        Err(_) => todo!(),
+                                    }
+                                }
+                                UnverifiedConsensusMessage::Timeout(msg) => {
+                                    let timeout = verify_timeout_message::<Sha256Hash, SignatureType>(
+                                        self.validator_set.get_members(),
+                                        msg,
+                                    );
+
+                                    match timeout {
+                                        Ok(p) => self
+                                            .consensus_state
+                                            .handle_timeout_message(p, &self.validator_set),
+                                        Err(_) => todo!(),
+                                    }
+                                }
+                            }
                         }
-                    }
-                };
+                    };
                 let mut cmds = Vec::new();
                 for consensus_command in consensus_commands {
                     match consensus_command {
                         ConsensusCommand::Send { to, message } => {
-                            cmds.push(self.message_state.send(to, message).into())
+                            let message = MonadMessage(
+                                message.signed_object(todo!("author"), todo!("signature")),
+                            );
+                            let publish_action = self.message_state.send(to, message);
+                            let id = publish_action.message.id();
+                            cmds.push(Command::RouterCommand(RouterCommand::Publish {
+                                to: publish_action.to.clone(),
+                                message: publish_action.message,
+                                on_ack: MonadEvent::Ack {
+                                    peer: publish_action.to,
+                                    id,
+                                    round: self.message_state.round(),
+                                },
+                            }))
                         }
                         ConsensusCommand::Broadcast { message } => {
-                            cmds.extend(
-                                self.message_state
-                                    .broadcast(message)
-                                    .into_iter()
-                                    .map(Into::into),
+                            let message = MonadMessage(
+                                message.signed_object(todo!("author"), todo!("signature")),
                             );
+                            cmds.extend(self.message_state.broadcast(message).into_iter().map(
+                                |publish_action| {
+                                    let id = publish_action.message.id();
+                                    Command::RouterCommand(RouterCommand::Publish {
+                                        to: publish_action.to.clone(),
+                                        message: publish_action.message,
+                                        on_ack: MonadEvent::Ack {
+                                            peer: publish_action.to,
+                                            id,
+                                            round: self.message_state.round(),
+                                        },
+                                    })
+                                },
+                            ));
                         }
                         ConsensusCommand::Schedule {
                             duration,
@@ -181,32 +211,78 @@ impl State for MonadState {
 }
 
 #[derive(Debug, Clone)]
-pub enum ConsensusEvent {
-    UnverifiedMessage(ConsensusMessage),
+pub enum ConsensusEvent<T: SignatureCollection> {
+    UnverifiedMessage(Unverified<ConsensusMessage<T>>),
     Timeout(PacemakerTimerExpire),
 }
 
 #[derive(Debug, Clone)]
-pub enum ConsensusMessage {
-    Proposal(Unverified<ProposalMessage<SignatureType>>),
-    Vote(Unverified<VoteMessage>),
-    Timeout(Unverified<TimeoutMessage<SignatureType>>),
+pub enum ConsensusMessage<T: SignatureCollection> {
+    Proposal(ProposalMessage<T>),
+    Vote(VoteMessage),
+    Timeout(TimeoutMessage<T>),
 }
 
-impl ConsensusMessage {
+impl<T: SignatureCollection> Signable for ConsensusMessage<T> {
+    type Output = Unverified<ConsensusMessage<T>>;
+    fn signed_object(self, author: NodeId, signature: ConsensusSignature) -> Self::Output {
+        Unverified(Signed {
+            obj: self,
+            author,
+            author_signature: signature,
+        })
+    }
+}
+
+impl<T: SignatureCollection> ConsensusMessage<T> {
     fn round(&self) -> Round {
         todo!()
     }
 }
 
+#[derive(Debug, Clone)]
+pub enum UnverifiedConsensusMessage<T: SignatureCollection> {
+    Proposal(Unverified<ProposalMessage<T>>),
+    Vote(Unverified<VoteMessage>),
+    Timeout(Unverified<TimeoutMessage<T>>),
+}
+
+impl<T: SignatureCollection> From<Unverified<ConsensusMessage<T>>>
+    for UnverifiedConsensusMessage<T>
+{
+    fn from(unverified: Unverified<ConsensusMessage<T>>) -> Self {
+        match unverified.0.obj {
+            ConsensusMessage::Proposal(proposal) => {
+                UnverifiedConsensusMessage::Proposal(Unverified(Signed {
+                    obj: proposal,
+                    author: unverified.0.author,
+                    author_signature: unverified.0.author_signature,
+                }))
+            }
+            ConsensusMessage::Vote(vote) => UnverifiedConsensusMessage::Vote(Unverified(Signed {
+                obj: vote,
+                author: unverified.0.author,
+                author_signature: unverified.0.author_signature,
+            })),
+            ConsensusMessage::Timeout(timeout) => {
+                UnverifiedConsensusMessage::Timeout(Unverified(Signed {
+                    obj: timeout,
+                    author: unverified.0.author,
+                    author_signature: unverified.0.author_signature,
+                }))
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
-pub enum ConsensusCommand {
+pub enum ConsensusCommand<T: SignatureCollection> {
     Send {
         to: PeerId,
-        message: ConsensusMessage,
+        message: ConsensusMessage<T>,
     },
     Broadcast {
-        message: ConsensusMessage,
+        message: ConsensusMessage<T>,
     },
     Schedule {
         duration: Duration,
@@ -215,22 +291,6 @@ pub enum ConsensusCommand {
     Unschedule,
     // TODO add command for updating validator_set/round
     // - to handle this command, we need to call message_state.set_round()
-}
-
-impl From<MessageActionPublish<ConsensusMessage>> for Command<MonadEvent, MonadMessage> {
-    fn from(publish: MessageActionPublish<ConsensusMessage>) -> Self {
-        let id = publish.message.id();
-        let round = publish.message.round();
-        Command::RouterCommand(RouterCommand::Publish {
-            to: publish.to.clone(),
-            message: publish.message,
-            on_ack: MonadEvent::Ack {
-                peer: publish.to,
-                id,
-                round,
-            },
-        })
-    }
 }
 
 struct ConsensusState<T, L>
@@ -260,7 +320,7 @@ where
         &mut self,
         p: &Verified<ProposalMessage<T>>,
         validators: &ValidatorSet<V>,
-    ) -> Vec<ConsensusCommand> {
+    ) -> Vec<ConsensusCommand<T>> {
         todo!();
     }
 
@@ -268,7 +328,7 @@ where
         &mut self,
         v: &Verified<VoteMessage>,
         validators: &mut ValidatorSet<V>,
-    ) -> Vec<ConsensusCommand> {
+    ) -> Vec<ConsensusCommand<T>> {
         let mut retval = Vec::new();
         if self.round != v.0.obj.vote_info.round {
             return retval;
@@ -291,8 +351,37 @@ where
         &mut self,
         p: Verified<TimeoutMessage<T>>,
         validators: &ValidatorSet<V>,
-    ) -> Vec<ConsensusCommand> {
-        todo!()
+    ) -> Vec<ConsensusCommand<T>> {
+        let mut cmds = Vec::new();
+
+        let process_certificate_cmds = self.process_certificate_qc(&p.0.obj.tminfo.high_qc);
+        cmds.extend(process_certificate_cmds);
+
+        if let Some(last_round_tc) = p.0.obj.last_round_tc.as_ref() {
+            let advance_round_cmds = self
+                .pacemaker
+                .advance_round_tc(last_round_tc)
+                .map(Into::into)
+                .into_iter();
+            cmds.extend(advance_round_cmds);
+        }
+
+        let (tc, remote_timeout_cmds) =
+            self.pacemaker
+                .process_remote_timeout(validators, &mut self.safety, &self.high_qc, p);
+        cmds.extend(remote_timeout_cmds.into_iter().map(Into::into));
+        if let Some(tc) = tc {
+            let advance_round_cmds = self
+                .pacemaker
+                .advance_round_tc(&tc)
+                .into_iter()
+                .map(Into::into);
+            cmds.extend(advance_round_cmds);
+
+            self.process_new_round_event(&Some(tc));
+        }
+
+        cmds
     }
 
     // If the qc has a commit_state_hash, commit the parent block and prune the
@@ -316,7 +405,7 @@ where
     }
 
     #[must_use]
-    fn process_certificate_qc(&mut self, qc: &QuorumCertificate<T>) -> Vec<ConsensusCommand> {
+    fn process_certificate_qc(&mut self, qc: &QuorumCertificate<T>) -> Vec<ConsensusCommand<T>> {
         let retval = Vec::new();
         self.process_qc(qc);
 
@@ -328,7 +417,25 @@ where
     fn process_new_round_event(
         &self,
         last_round_tc: &Option<TimeoutCertificate>,
-    ) -> Vec<ConsensusCommand> {
+    ) -> Vec<ConsensusCommand<T>> {
         todo!();
+    }
+}
+
+impl<T: SignatureCollection> From<PacemakerCommand<T>> for ConsensusCommand<T> {
+    fn from(cmd: PacemakerCommand<T>) -> Self {
+        match cmd {
+            PacemakerCommand::Broadcast(message) => ConsensusCommand::Broadcast {
+                message: ConsensusMessage::Timeout(message),
+            },
+            PacemakerCommand::Schedule {
+                duration,
+                on_timeout,
+            } => ConsensusCommand::Schedule {
+                duration,
+                on_timeout,
+            },
+            PacemakerCommand::Unschedule => ConsensusCommand::Unschedule,
+        }
     }
 }

--- a/monad-state/src/message.rs
+++ b/monad-state/src/message.rs
@@ -60,6 +60,10 @@ where
         self.round
     }
 
+    pub fn round(&self) -> Round {
+        self.round
+    }
+
     pub fn set_round(
         &mut self,
         round: Round,


### PR DESCRIPTION
Implementation of `handle_timeout_message`

This required moving some types around for `ConsensusMessage` to get the `Unverified` type to work out.

Not the prettiest but we can clean this up a lot further.