### PR TITLE
Remove obsolete function + add comments

### DIFF
--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -167,6 +167,9 @@ impl State for MonadState {
                                 on_ack: MonadEvent::Ack {
                                     peer: publish_action.to,
                                     id,
+
+                                    // TODO verify that this is the correct round()?
+                                    // should we be extracting this from `message` instead?
                                     round: self.message_state.round(),
                                 },
                             }))
@@ -184,6 +187,9 @@ impl State for MonadState {
                                         on_ack: MonadEvent::Ack {
                                             peer: publish_action.to,
                                             id,
+
+                                            // TODO verify that this is the correct round()?
+                                            // should we be extracting this from `message` instead?
                                             round: self.message_state.round(),
                                         },
                                     })
@@ -231,12 +237,6 @@ impl<T: SignatureCollection> Signable for ConsensusMessage<T> {
             author,
             author_signature: signature,
         })
-    }
-}
-
-impl<T: SignatureCollection> ConsensusMessage<T> {
-    fn round(&self) -> Round {
-        todo!()
     }
 }
 


### PR DESCRIPTION
This should have been part of the last PR..

We now just get the `round` from `message_state` - I'm not actually entirely sure this is correct, but leaving a comment so we can revisit later.