### PR TITLE
Change PeerId underlying type to PubKey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,8 @@ name = "monad-executor"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "monad-crypto",
+ "monad-testutil",
  "tokio",
 ]
 
@@ -404,6 +406,7 @@ dependencies = [
  "monad-consensus",
  "monad-crypto",
  "monad-executor",
+ "monad-testutil",
  "monad-types",
  "monad-validator",
 ]

--- a/monad-consensus/tests/vote_state.rs
+++ b/monad-consensus/tests/vote_state.rs
@@ -40,19 +40,6 @@ fn create_signed_vote_message(vote_hash: &str, keypair: &KeyPair) -> Unverified<
     svm
 }
 
-fn create_keys(num_keys: u32) -> Vec<KeyPair> {
-    assert!(num_keys < 255);
-    let mut res = Vec::new();
-    for i in 0..num_keys {
-        let k: [u8; 32] = [(i + 1) as u8; 32];
-        let keypair = KeyPair::from_slice(&k).unwrap();
-
-        res.push(keypair);
-    }
-
-    res
-}
-
 fn setup_ctx(
     num_nodes: u32,
 ) -> (

--- a/monad-executor/Cargo.toml
+++ b/monad-executor/Cargo.toml
@@ -7,5 +7,9 @@ edition = "2021"
 
 [dependencies]
 futures = "0.3"
+monad-crypto = { path = "../monad-crypto" }
 
 tokio = { version = "1.26", features = ["time"], optional = true }
+
+[dev-dependencies]
+monad-testutil = { path = "../monad-testutil"}

--- a/monad-executor/src/state.rs
+++ b/monad-executor/src/state.rs
@@ -1,7 +1,9 @@
 use std::hash::Hash;
 
+use monad_crypto::secp256k1::PubKey;
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PeerId(pub u64);
+pub struct PeerId(pub PubKey);
 pub enum RouterCommand<E, M>
 where
     M: Message<Event = E>,

--- a/monad-state/Cargo.toml
+++ b/monad-state/Cargo.toml
@@ -13,3 +13,5 @@ monad-executor = { path = "../monad-executor" }
 monad-types = { path = "../monad-types" }
 monad-validator = { path = "../monad-validator" }
 
+[dev-dependencies]
+monad-testutil = { path = "../monad-testutil"}

--- a/monad-state/src/message.rs
+++ b/monad-state/src/message.rs
@@ -132,6 +132,7 @@ where
 #[cfg(test)]
 mod tests {
     use monad_executor::{Message, PeerId};
+    use monad_testutil::signing::node_id;
     use monad_types::Round;
 
     use crate::message::{MessageActionUnpublish, MessageState};
@@ -181,22 +182,22 @@ mod tests {
     #[test]
     fn send() {
         let mut state = MessageState::<TestMessage>::new(5, Vec::new());
-        let action = state.send(PeerId(0), TestMessage);
+        let action = state.send(PeerId(node_id().0), TestMessage);
 
-        assert_eq!(action.to, PeerId(0));
+        assert_eq!(action.to, PeerId(node_id().0));
         assert_eq!(action.message, TestMessage);
     }
 
     #[test]
     fn set_round_eviction() {
         let mut state = MessageState::<TestMessage>::new(5, Vec::new());
-        let _ = state.send(PeerId(0), TestMessage);
+        let _ = state.send(PeerId(node_id().0), TestMessage);
 
         let evicted = state.set_round(Round(10), Vec::new());
         assert_eq!(
             evicted,
             vec![MessageActionUnpublish {
-                to: PeerId(0),
+                to: PeerId(node_id().0),
                 id: TestMessage,
             }],
         )
@@ -205,13 +206,13 @@ mod tests {
     #[test]
     fn handle_ack() {
         let mut state = MessageState::<TestMessage>::new(5, Vec::new());
-        let _ = state.send(PeerId(0), TestMessage);
+        let _ = state.send(PeerId(node_id().0), TestMessage);
 
-        let evicted = state.handle_ack(Round(0), PeerId(0), TestMessage);
+        let evicted = state.handle_ack(Round(0), PeerId(node_id().0), TestMessage);
         assert_eq!(
             evicted,
             Some(MessageActionUnpublish {
-                to: PeerId(0),
+                to: PeerId(node_id().0),
                 id: TestMessage,
             }),
         )
@@ -220,11 +221,11 @@ mod tests {
     #[test]
     fn evicted_handle_ack() {
         let mut state = MessageState::<TestMessage>::new(5, Vec::new());
-        let _ = state.send(PeerId(0), TestMessage);
+        let _ = state.send(PeerId(node_id().0), TestMessage);
 
         let _ = state.set_round(Round(10), Vec::new());
 
-        let evicted = state.handle_ack(Round(0), PeerId(0), TestMessage);
+        let evicted = state.handle_ack(Round(0), PeerId(node_id().0), TestMessage);
         assert_eq!(evicted, None,)
     }
 }

--- a/monad-testutil/src/signing.rs
+++ b/monad-testutil/src/signing.rs
@@ -43,6 +43,19 @@ pub fn node_id() -> NodeId {
     NodeId(keypair.pubkey())
 }
 
+pub fn create_keys(num_keys: u32) -> Vec<KeyPair> {
+    assert!(num_keys < 255);
+    let mut res = Vec::new();
+    for i in 0..num_keys {
+        let k: [u8; 32] = [(i + 1) as u8; 32];
+        let keypair = KeyPair::from_slice(&k).unwrap();
+
+        res.push(keypair);
+    }
+
+    res
+}
+
 pub struct Signer;
 impl Signer {
     pub fn sign_object<T: Signable>(o: T, msg: &[u8], key: &KeyPair) -> <T as Signable>::Output {


### PR DESCRIPTION
This change makes PeerId consistent with NodeId in the rest of the consensus code. Nodes are always expected to be identified by their PubKey