### PR TITLE
Use Signature trait for sigs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,7 @@ name = "monad-crypto"
 version = "0.1.0"
 dependencies = [
  "hex",
+ "rand",
  "secp256k1",
  "sha2",
  "tiny-keccak",
@@ -502,6 +503,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +564,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/monad-consensus/src/signatures/aggregate_signature.rs
+++ b/monad-consensus/src/signatures/aggregate_signature.rs
@@ -1,20 +1,26 @@
+use monad_crypto::{
+    secp256k1::{Error, PubKey},
+    Signature,
+};
 use monad_types::Hash;
 
-use crate::types::signature::{ConsensusSignature, SignatureCollection};
+use crate::types::signature::SignatureCollection;
 use sha2::Digest;
 
 #[derive(Clone, Debug)]
-pub struct AggregateSignatures {
-    pub sigs: Vec<ConsensusSignature>,
+pub struct AggregateSignatures<S> {
+    pub sigs: Vec<S>,
 }
 
-impl Default for AggregateSignatures {
+impl<S: Signature> Default for AggregateSignatures<S> {
     fn default() -> Self {
         Self { sigs: Vec::new() }
     }
 }
 
-impl SignatureCollection for AggregateSignatures {
+impl<S: Signature> SignatureCollection for AggregateSignatures<S> {
+    type SignatureType = S;
+
     fn new() -> Self {
         AggregateSignatures { sigs: Vec::new() }
     }
@@ -23,17 +29,32 @@ impl SignatureCollection for AggregateSignatures {
         let mut hasher = sha2::Sha256::new();
 
         for v in self.sigs.iter() {
-            hasher.update(v.0.serialize());
+            hasher.update(v.serialize());
         }
 
         hasher.finalize().into()
     }
 
-    fn add_signature(&mut self, s: ConsensusSignature) {
-        self.sigs.push(s);
+    fn add_signature(&mut self, sig: Self::SignatureType) {
+        self.sigs.push(sig);
     }
 
-    fn get_signatures(&self) -> Vec<&ConsensusSignature> {
-        self.sigs.iter().collect()
+    fn verify_signatures(&self, msg: &[u8]) -> Result<(), Error> {
+        for s in self.sigs.iter() {
+            let pubkey = s.recover_pubkey(msg)?;
+            s.verify(msg, &pubkey)?;
+        }
+        Ok(())
+    }
+
+    fn get_pubkeys(&self, msg: &[u8]) -> Result<Vec<PubKey>, Error> {
+        self.sigs
+            .iter()
+            .map(|s| -> Result<PubKey, Error> { s.recover_pubkey(msg) })
+            .collect()
+    }
+
+    fn num_signatures(&self) -> usize {
+        self.sigs.len()
     }
 }

--- a/monad-consensus/src/types/message.rs
+++ b/monad-consensus/src/types/message.rs
@@ -1,3 +1,5 @@
+use monad_crypto::Signature;
+
 use crate::validation::hashing::{Hashable, Hasher};
 
 use super::{
@@ -14,13 +16,13 @@ pub struct VoteMessage {
     pub ledger_commit_info: LedgerCommitInfo,
 }
 
-#[derive(Debug, Clone)]
-pub struct TimeoutMessage<T> {
+#[derive(Clone, Debug)]
+pub struct TimeoutMessage<S, T> {
     pub tminfo: TimeoutInfo<T>,
-    pub last_round_tc: Option<TimeoutCertificate>,
+    pub last_round_tc: Option<TimeoutCertificate<S>>,
 }
 
-impl<T: SignatureCollection> Hashable for &TimeoutMessage<T> {
+impl<S: Signature, T: SignatureCollection> Hashable for &TimeoutMessage<S, T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.update(&self.tminfo.round);
         state.update(&self.tminfo.high_qc.info.vote.round);
@@ -28,12 +30,12 @@ impl<T: SignatureCollection> Hashable for &TimeoutMessage<T> {
 }
 
 #[derive(Clone, Debug)]
-pub struct ProposalMessage<T> {
+pub struct ProposalMessage<S, T> {
     pub block: Block<T>,
-    pub last_round_tc: Option<TimeoutCertificate>,
+    pub last_round_tc: Option<TimeoutCertificate<S>>,
 }
 
-impl<T: SignatureCollection> Hashable for &ProposalMessage<T> {
+impl<S: Signature, T: SignatureCollection> Hashable for &ProposalMessage<S, T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         (&self.block).hash(state);
     }

--- a/monad-consensus/src/types/signature.rs
+++ b/monad-consensus/src/types/signature.rs
@@ -1,17 +1,23 @@
-use monad_crypto::secp256k1::Signature;
+use monad_crypto::{
+    secp256k1::{Error, PubKey},
+    Signature,
+};
 use monad_types::Hash;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct ConsensusSignature(pub Signature);
+pub trait SignatureCollection: Clone + Default {
+    type SignatureType: Signature;
 
-pub trait SignatureCollection: Default + Clone {
     fn new() -> Self;
 
     // hash of all the signatures
     fn get_hash(&self) -> Hash;
 
     // add the signature from a signed vote message
-    fn add_signature(&mut self, s: ConsensusSignature);
+    fn add_signature(&mut self, s: Self::SignatureType);
 
-    fn get_signatures(&self) -> Vec<&ConsensusSignature>;
+    fn verify_signatures(&self, msg: &[u8]) -> Result<(), Error>;
+
+    fn get_pubkeys(&self, msg: &[u8]) -> Result<Vec<PubKey>, Error>;
+
+    fn num_signatures(&self) -> usize;
 }

--- a/monad-consensus/src/types/timeout.rs
+++ b/monad-consensus/src/types/timeout.rs
@@ -4,7 +4,7 @@ use monad_types::*;
 
 use crate::validation::hashing::{Hashable, Hasher};
 
-use super::{quorum_certificate::QuorumCertificate, signature::ConsensusSignature};
+use super::quorum_certificate::QuorumCertificate;
 
 #[derive(Clone, Debug)]
 pub struct TimeoutInfo<T> {
@@ -24,12 +24,12 @@ impl Hashable for &HighQcRound {
 }
 
 #[derive(Clone, Debug)]
-pub struct TimeoutCertificate {
+pub struct TimeoutCertificate<S> {
     pub round: Round,
-    pub high_qc_rounds: Vec<(HighQcRound, ConsensusSignature)>,
+    pub high_qc_rounds: Vec<(HighQcRound, S)>,
 }
 
-impl TimeoutCertificate {
+impl<S> TimeoutCertificate<S> {
     pub fn max_round(&self) -> Round {
         self.high_qc_rounds
             .iter()

--- a/monad-consensus/src/validation/message.rs
+++ b/monad-consensus/src/validation/message.rs
@@ -5,10 +5,10 @@ use crate::validation::error::Error;
 
 // (DiemBFT v4, p.12)
 // https://developers.diem.com/papers/diem-consensus-state-machine-replication-in-the-diem-blockchain/2021-08-17.pdf
-pub fn well_formed(
+pub fn well_formed<S>(
     round: Round,
     qc_round: Round,
-    tc: &Option<TimeoutCertificate>,
+    tc: &Option<TimeoutCertificate<S>>,
 ) -> Result<(), Error> {
     let prev_round = round - Round(1);
     let valid_qc_round = qc_round == prev_round;

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 use std::ops::Deref;
 
-use monad_crypto::secp256k1::PubKey;
+use monad_crypto::secp256k1::{PubKey, SecpSignature};
+use monad_crypto::Signature;
 use monad_types::Hash;
 use monad_types::NodeId;
 use monad_types::Round;
@@ -11,7 +12,6 @@ use crate::types::message::ProposalMessage;
 use crate::types::message::TimeoutMessage;
 use crate::types::message::VoteMessage;
 use crate::types::quorum_certificate::QuorumCertificate;
-use crate::types::signature::ConsensusSignature;
 use crate::types::signature::SignatureCollection;
 use crate::types::timeout::TimeoutCertificate;
 use crate::validation::error::Error;
@@ -20,22 +20,22 @@ use crate::validation::hashing::Hasher;
 use crate::validation::message::well_formed;
 
 #[derive(Clone, Debug)]
-pub struct Verified<M> {
+pub struct Verified<S, M> {
     obj: M,
     author: NodeId,
-    author_signature: ConsensusSignature,
+    author_signature: S,
 }
 
-impl<M> Verified<M> {
+impl<S: Signature, M> Verified<S, M> {
     pub fn author(&self) -> &NodeId {
         &self.author
     }
-    pub fn author_signature(&self) -> &ConsensusSignature {
+    pub fn author_signature(&self) -> &S {
         &self.author_signature
     }
 }
 
-impl<M> Deref for Verified<M> {
+impl<S, M> Deref for Verified<S, M> {
     type Target = M;
 
     fn deref(&self) -> &Self::Target {
@@ -44,36 +44,40 @@ impl<M> Deref for Verified<M> {
 }
 
 #[derive(Clone, Debug)]
-pub struct Unverified<M> {
+pub struct Unverified<S, M> {
     obj: M,
-    author_signature: ConsensusSignature,
+    author_signature: S,
 }
 
-impl<M> Unverified<M> {
-    pub fn new(obj: M, signature: ConsensusSignature) -> Self {
+impl<S: Signature, M> Unverified<S, M> {
+    pub fn new(obj: M, signature: S) -> Self {
         Self {
             obj,
             author_signature: signature,
         }
     }
 
-    pub fn author_signature(&self) -> &ConsensusSignature {
+    pub fn author_signature(&self) -> &S {
         &self.author_signature
     }
 }
 
-impl<T: SignatureCollection> Unverified<ProposalMessage<T>> {
+impl<S, T> Unverified<S, ProposalMessage<S, T>>
+where
+    S: Signature,
+    T: SignatureCollection,
+{
     // A verified proposal is one which is well-formed and has valid
     // signatures for the present TC or QC
     pub fn verify<H: Hasher>(
         self,
         validators: &ValidatorMember,
         sender: &PubKey,
-    ) -> Result<Verified<ProposalMessage<T>>, Error> {
+    ) -> Result<Verified<S, ProposalMessage<S, T>>, Error> {
         self.well_formed_proposal()?;
         let msg = H::hash_object(&self.obj);
         let author = verify_author(validators, sender, &msg, &self.author_signature)?;
-        verify_certificates::<H, _>(validators, &self.obj.last_round_tc, &self.obj.block.qc)?;
+        verify_certificates::<S, H, _>(validators, &self.obj.last_round_tc, &self.obj.block.qc)?;
 
         let result = Verified {
             obj: self.obj,
@@ -93,14 +97,14 @@ impl<T: SignatureCollection> Unverified<ProposalMessage<T>> {
     }
 }
 
-impl Unverified<VoteMessage> {
+impl<S: Signature> Unverified<S, VoteMessage> {
     // A verified vote message has a valid signature
     // Return type must keep the signature with the message as it is used later by the protocol
     pub fn verify<H: Hasher>(
         self,
         validators: &ValidatorMember,
         sender: &PubKey,
-    ) -> Result<Verified<VoteMessage>, Error> {
+    ) -> Result<Verified<S, VoteMessage>, Error> {
         let msg = H::hash_object(&self.obj.ledger_commit_info);
 
         let author = verify_author(validators, sender, &msg, &self.author_signature)?;
@@ -115,16 +119,20 @@ impl Unverified<VoteMessage> {
     }
 }
 
-impl<T: SignatureCollection> Unverified<TimeoutMessage<T>> {
+impl<S, T> Unverified<S, TimeoutMessage<S, T>>
+where
+    S: Signature,
+    T: SignatureCollection,
+{
     pub fn verify<H: Hasher>(
         self,
         validators: &ValidatorMember,
         sender: &PubKey,
-    ) -> Result<Verified<TimeoutMessage<T>>, Error> {
+    ) -> Result<Verified<S, TimeoutMessage<S, T>>, Error> {
         self.well_formed_timeout()?;
         let msg = H::hash_object(&self.obj);
         let author = verify_author(validators, sender, &msg, &self.author_signature)?;
-        verify_certificates::<H, _>(
+        verify_certificates::<S, H, _>(
             validators,
             &self.obj.last_round_tc,
             &self.obj.tminfo.high_qc,
@@ -147,12 +155,13 @@ impl<T: SignatureCollection> Unverified<TimeoutMessage<T>> {
     }
 }
 
-fn verify_certificates<H, V>(
+fn verify_certificates<S, H, V>(
     validators: &ValidatorMember,
-    tc: &Option<TimeoutCertificate>,
+    tc: &Option<TimeoutCertificate<S>>,
     qc: &QuorumCertificate<V>,
 ) -> Result<(), Error>
 where
+    S: Signature,
     H: Hasher,
     V: SignatureCollection,
 {
@@ -161,32 +170,36 @@ where
         return Ok(());
     }
 
-    let msg_sig = if let Some(tc) = tc {
-        tc.high_qc_rounds
-            .iter()
-            .map(|a| {
-                // TODO fix this..
-                let mut h = H::new();
-                h.update(tc.round);
-                h.update(a.0.qc_round);
+    if let Some(tc) = tc {
+        for a in tc.high_qc_rounds.iter() {
+            // TODO fix this hashing..
+            let mut h = H::new();
+            h.update(tc.round);
+            h.update(a.0.qc_round);
+            let msg = h.hash();
 
-                (h.hash(), &a.1)
-            })
-            .collect::<Vec<(Hash, &ConsensusSignature)>>()
-    } else {
-        qc.signatures
-            .get_signatures()
-            .into_iter()
-            .map(|s| (H::hash_object(&qc.info.ledger_commit), s))
-            .collect::<Vec<(Hash, &ConsensusSignature)>>()
-    };
+            let pubkey = get_pubkey(&msg, &a.1)?;
+            pubkey.valid_pubkey(validators)?;
 
-    for (hash, sig) in msg_sig {
-        get_pubkey(&hash, sig)?
-            .valid_pubkey(validators)?
-            .verify(&hash, &sig.0)
-            .map_err(|_| Error::InvalidSignature)?;
+            a.1.verify(&msg, &pubkey)
+                .map_err(|_| Error::InvalidSignature)?;
+        }
     }
+
+    let qc_msg = H::hash_object(&qc.info.ledger_commit);
+    let pubkeys = qc
+        .signatures
+        .get_pubkeys(&qc_msg)
+        .map_err(|_| Error::InvalidSignature)?;
+
+    for p in pubkeys.iter() {
+        p.valid_pubkey(validators)?;
+    }
+
+    qc.signatures
+        .verify_signatures(&qc_msg)
+        .map_err(|_| Error::InvalidSignature)?;
+
     Ok(())
 }
 
@@ -194,11 +207,10 @@ fn verify_author(
     validators: &ValidatorMember,
     sender: &PubKey,
     msg: &Hash,
-    sig: &ConsensusSignature,
+    sig: &impl Signature,
 ) -> Result<PubKey, Error> {
     let pubkey = get_pubkey(msg, sig)?.valid_pubkey(validators)?;
-    pubkey
-        .verify(msg, &sig.0)
+    sig.verify(msg, &pubkey)
         .map_err(|_| Error::InvalidSignature)?;
     if sender != &pubkey {
         Err(Error::AuthorNotSender)
@@ -208,10 +220,8 @@ fn verify_author(
 }
 
 // Extract the PubKey from the Signature if possible
-fn get_pubkey(msg: &[u8], sig: &ConsensusSignature) -> Result<PubKey, Error> {
-    sig.0
-        .recover_pubkey(msg)
-        .map_err(|_| Error::InvalidSignature)
+fn get_pubkey(msg: &[u8], sig: &impl Signature) -> Result<PubKey, Error> {
+    sig.recover_pubkey(msg).map_err(|_| Error::InvalidSignature)
 }
 
 pub type ValidatorMember = HashMap<NodeId, Validator>;

--- a/monad-consensus/src/vote_state.rs
+++ b/monad-consensus/src/vote_state.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use monad_crypto::Signature;
 use monad_types::{Hash, NodeId};
 use monad_validator::{leader_election::LeaderElection, validator_set::ValidatorSet};
 
@@ -28,7 +29,7 @@ where
     #[must_use]
     pub fn process_vote<V: LeaderElection, H: Hasher>(
         &mut self,
-        v: &Verified<VoteMessage>,
+        v: &Verified<T::SignatureType, VoteMessage>,
         validators: &ValidatorSet<V>,
     ) -> Option<QuorumCertificate<T>> {
         if self.qc_created {
@@ -37,6 +38,7 @@ where
 
         let vote_idx = H::hash_object(&v.ledger_commit_info);
         let sigs = self.pending_vote_sigs.entry(vote_idx).or_insert(T::new());
+
         sigs.add_signature(*v.author_signature());
 
         self.pending_vote_keys

--- a/monad-consensus/tests/proposal.rs
+++ b/monad-consensus/tests/proposal.rs
@@ -4,7 +4,8 @@ use monad_consensus::types::quorum_certificate::QuorumCertificate;
 use monad_consensus::validation::error::Error;
 use monad_consensus::validation::hashing::*;
 use monad_consensus::validation::signing::ValidatorMember;
-use monad_testutil::signing::{get_key, node_id, MockSignatures, Signer};
+use monad_crypto::secp256k1::SecpSignature;
+use monad_testutil::signing::{get_key, node_id, MockSignatures, TestSigner};
 use monad_types::*;
 use monad_validator::validator::Validator;
 
@@ -22,7 +23,7 @@ fn test_proposal_hash() {
     let mut vset = ValidatorMember::new();
 
     let author = node_id();
-    let proposal = ProposalMessage {
+    let proposal: ProposalMessage<SecpSignature, MockSignatures> = ProposalMessage {
         block: setup_block(author, 234, 233),
         last_round_tc: None,
     };
@@ -38,7 +39,7 @@ fn test_proposal_hash() {
     );
 
     let msg = Sha256Hash::hash_object(&proposal);
-    let sp = Signer::sign_object(proposal, &msg, &keypair);
+    let sp = TestSigner::sign_object(proposal, &msg, &keypair);
 
     assert!(sp.verify::<Sha256Hash>(&vset, &keypair.pubkey()).is_ok());
 }
@@ -64,7 +65,7 @@ fn test_proposal_missing_tc() {
     );
 
     let msg = Sha256Hash::hash_object(&proposal);
-    let sp = Signer::sign_object(proposal, &msg, &keypair);
+    let sp = TestSigner::sign_object(proposal, &msg, &keypair);
 
     assert_eq!(
         sp.verify::<Sha256Hash>(&vset, &keypair.pubkey())
@@ -94,7 +95,7 @@ fn test_proposal_invalid_qc() {
     );
 
     let msg = Sha256Hash::hash_object(&proposal);
-    let sp = Signer::sign_object(proposal, &msg, &get_key("7"));
+    let sp = TestSigner::sign_object(proposal, &msg, &get_key("7"));
 
     assert_eq!(
         sp.verify::<Sha256Hash>(&vset, &keypair.pubkey())

--- a/monad-crypto/Cargo.toml
+++ b/monad-crypto/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rand = "0.8.5"
 secp256k1 = { version = "0.26", features = ["global-context", "recovery"] }
 sha2 = "0.10"
 


### PR DESCRIPTION
removed the ConsensusSignature and implemented SecpSignature in monad-crypto, which implements the Signature trait. 

There is still a weird dependency on secp251k1 in the generic Signature trait because a signature is created by signing a message with a key, and we don't have an abstraction for the keypair yet.
I think we can address that in the future and still use the trait with the dependency for now since it allows us to skip signing in the tests and makes them much faster