### PR TITLE
Return reference to the vector in ledger

### DIFF
--- a/monad-consensus/src/types/ledger.rs
+++ b/monad-consensus/src/types/ledger.rs
@@ -42,8 +42,8 @@ pub struct InMemoryLedger<T> {
 }
 
 impl<T: SignatureCollection> InMemoryLedger<T> {
-    pub fn get_blocks(&self) -> Vec<Block<T>> {
-        self.blockchain.clone()
+    pub fn get_blocks(&self) -> &Vec<Block<T>> {
+        &self.blockchain
     }
 }
 

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -50,7 +50,7 @@ impl MonadState {
         self.consensus_state.nodeid.0
     }
 
-    pub fn ledger(&self) -> Vec<Block<SignatureType>> {
+    pub fn ledger(&self) -> &Vec<Block<SignatureType>> {
         self.consensus_state.ledger.get_blocks()
     }
 }


### PR DESCRIPTION
monad-state test runs about 200ms faster after this change