### PR TITLE
Set dev profile to opt-1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ members = [
     "monad-types",
     "monad-validator",
 ]
+
+[profile.dev]
+opt-level = 1


### PR DESCRIPTION
monad-state node tests run orders of magnitude faster with just opt-1 optimizations