### PR TITLE
Create a proper genesis block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,7 @@ dependencies = [
  "egui",
  "egui-macroquad",
  "macroquad",
+ "monad-consensus",
  "monad-crypto",
  "monad-executor",
  "monad-state",

--- a/monad-consensus/src/types/block.rs
+++ b/monad-consensus/src/types/block.rs
@@ -24,7 +24,7 @@ impl<T: SignatureCollection> Hashable for &Block<T> {
         state.update(self.round.as_bytes());
         state.update(self.payload.0.as_bytes());
         state.update(self.qc.info.vote.id.0.as_bytes());
-        state.update(self.qc.signature_hash.as_bytes());
+        state.update(self.qc.get_hash().as_bytes());
     }
 }
 
@@ -42,11 +42,7 @@ impl<T: SignatureCollection> Block<T> {
             qc: qc.clone(),
             id: Default::default(),
         };
-        if round == Round(0) {
-            // FIXME lol
-        } else {
-            b.id = BlockId(H::hash_object(&b));
-        }
+        b.id = BlockId(H::hash_object(&b));
         b
     }
 

--- a/monad-consensus/src/types/quorum_certificate.rs
+++ b/monad-consensus/src/types/quorum_certificate.rs
@@ -3,13 +3,16 @@ use monad_types::*;
 use crate::types::ledger::*;
 use crate::types::signature::SignatureCollection;
 use crate::types::voting::*;
+use crate::validation::hashing::Hasher;
+
+pub const GENESIS_PRIME_QC_HASH: Hash = [0xAA; 32];
 
 #[non_exhaustive]
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Debug)]
 pub struct QuorumCertificate<T> {
     pub info: QcInfo,
     pub signatures: T,
-    pub signature_hash: Hash,
+    signature_hash: Hash,
 }
 
 #[derive(Copy, Clone, Debug, Default)]
@@ -41,6 +44,15 @@ impl Ord for Rank {
     }
 }
 
+pub fn genesis_vote_info(genesis_block_id: BlockId) -> VoteInfo {
+    VoteInfo {
+        id: genesis_block_id,
+        round: Round(0),
+        parent_id: BlockId(GENESIS_PRIME_QC_HASH),
+        parent_round: Round(0),
+    }
+}
+
 impl<T: SignatureCollection> QuorumCertificate<T> {
     pub fn new(info: QcInfo, signatures: T) -> Self {
         let hash = signatures.get_hash();
@@ -49,5 +61,51 @@ impl<T: SignatureCollection> QuorumCertificate<T> {
             signatures,
             signature_hash: hash,
         }
+    }
+
+    // This is the QC that will be included in the genesis block
+    pub fn genesis_prime_qc<H: Hasher>() -> Self {
+        let vote_info = VoteInfo {
+            id: BlockId(GENESIS_PRIME_QC_HASH),
+            round: Round(0),
+            parent_id: BlockId(GENESIS_PRIME_QC_HASH),
+            parent_round: Round(0),
+        };
+        let lci = LedgerCommitInfo::new::<H>(None, &vote_info);
+
+        let sigs = T::new();
+        let sig_hash = sigs.get_hash();
+
+        QuorumCertificate {
+            info: QcInfo {
+                vote: vote_info,
+                ledger_commit: lci,
+            },
+            signatures: sigs,
+            signature_hash: sig_hash,
+        }
+    }
+
+    // This is the QC that will be used in the block of the first proposal
+    // and will be the initial qc_high for all nodes
+    // All initial genesis nodes will have to create signatures for the genesis lci
+    pub fn genesis_qc<H: Hasher>(genesis_vote_info: VoteInfo, genesis_signatures: T) -> Self {
+        let vote_info = genesis_vote_info;
+        let lci = LedgerCommitInfo::new::<H>(None, &vote_info);
+
+        let sig_hash = genesis_signatures.get_hash();
+
+        QuorumCertificate {
+            info: QcInfo {
+                vote: vote_info,
+                ledger_commit: lci,
+            },
+            signatures: genesis_signatures,
+            signature_hash: sig_hash,
+        }
+    }
+
+    pub fn get_hash(&self) -> Hash {
+        self.signature_hash
     }
 }

--- a/monad-consensus/src/types/signature.rs
+++ b/monad-consensus/src/types/signature.rs
@@ -4,7 +4,7 @@ use monad_crypto::{
 };
 use monad_types::Hash;
 
-pub trait SignatureCollection: Clone + Default {
+pub trait SignatureCollection: Clone + Default + std::fmt::Debug {
     type SignatureType: Signature;
 
     fn new() -> Self;

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -165,11 +165,6 @@ where
     H: Hasher,
     V: SignatureCollection,
 {
-    if qc.info.vote.round == Round(0) {
-        // FIXME lol
-        return Ok(());
-    }
-
     if let Some(tc) = tc {
         for a in tc.high_qc_rounds.iter() {
             // TODO fix this hashing..

--- a/monad-viz/Cargo.toml
+++ b/monad-viz/Cargo.toml
@@ -11,6 +11,7 @@ egui-macroquad = "0.15"
 macroquad = { version = "0.3.25", default-features = false }
 
 monad-executor = { path = "../monad-executor" }
+monad-consensus = { path = "../monad-consensus" }
 monad-crypto = { path = "../monad-crypto" }
 monad-state = { path = "../monad-state" }
 monad-testutil = { path = "../monad-testutil" }


### PR DESCRIPTION
The initial genesis block will have a genesis-prime qc with some constant hashes for qc block id's. The block id of the genesis block will then be constant.
The initial config will contain the genesis block used and a collection of signatures from all genesis validators over the genesis-prime qc. This collection of signatures is used to create the genesis qc (the qc which certifies the genesis-block) -- this genesis qc will be the initial qc_high for all nodes and is attached to the first block created for round 1.