### PR TITLE
protobuf for ConsensusMessage

### DIFF
--- a/monad-consensus/src/types/consensus_message.rs
+++ b/monad-consensus/src/types/consensus_message.rs
@@ -1,0 +1,26 @@
+use crate::types::message::{ProposalMessage, TimeoutMessage, VoteMessage};
+use crate::validation::signing::{Unverified, Verified};
+
+#[derive(Debug, Clone)]
+pub enum SignedConsensusMessage<S, T> {
+    Proposal(Unverified<S, ProposalMessage<S, T>>),
+    Vote(Unverified<S, VoteMessage>),
+    Timeout(Unverified<S, TimeoutMessage<S, T>>),
+}
+
+#[derive(Debug, Clone)]
+pub enum VerifiedConsensusMessage<S, T> {
+    Proposal(Verified<S, ProposalMessage<S, T>>),
+    Vote(Verified<S, VoteMessage>),
+    Timeout(Verified<S, TimeoutMessage<S, T>>),
+}
+
+impl<S, T> From<VerifiedConsensusMessage<S, T>> for SignedConsensusMessage<S, T> {
+    fn from(value: VerifiedConsensusMessage<S, T>) -> Self {
+        match value {
+            VerifiedConsensusMessage::Proposal(msg) => Self::Proposal(msg.into()),
+            VerifiedConsensusMessage::Vote(msg) => Self::Vote(msg.into()),
+            VerifiedConsensusMessage::Timeout(msg) => Self::Timeout(msg.into()),
+        }
+    }
+}

--- a/monad-consensus/src/types/mod.rs
+++ b/monad-consensus/src/types/mod.rs
@@ -1,4 +1,5 @@
 pub mod block;
+pub mod consensus_message;
 pub mod ledger;
 pub mod mempool;
 pub mod message;

--- a/monad-proto/src/proto/message.proto
+++ b/monad-proto/src/proto/message.proto
@@ -38,3 +38,11 @@ message ProtoUnverifiedProposalMessageAggSig {
   ProtoProposalMessageAggSig proposal = 1;
   monad_proto.signing.ProtoSecpSignature author_signature = 2;
 }
+
+message ProtoUnverifiedConsensusMessage {
+  oneof OneofMessage {
+    ProtoUnverifiedProposalMessageAggSig proposal = 1;
+    ProtoUnverifiedTimeoutMessage timeout = 2;
+    ProtoUnverifiedVoteMessage vote = 3;
+  }
+}

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -7,6 +7,7 @@ use monad_consensus::{
     signatures::aggregate_signature::AggregateSignatures,
     types::{
         block::{Block, TransactionList},
+        consensus_message::{SignedConsensusMessage, VerifiedConsensusMessage},
         ledger::{InMemoryLedger, Ledger},
         mempool::{Mempool, SimulationMempool},
         message::{ProposalMessage, TimeoutMessage, VoteMessage},
@@ -18,7 +19,7 @@ use monad_consensus::{
     validation::{
         hashing::{Hasher, Sha256Hash},
         safety::Safety,
-        signing::{Unverified, Verified},
+        signing::Verified,
     },
     vote_state::VoteState,
 };
@@ -358,30 +359,6 @@ impl<T: SignatureCollection> ConsensusMessage<SignatureType, T> {
             ConsensusMessage::Timeout(msg) => {
                 VerifiedConsensusMessage::Timeout(Verified::new::<H>(msg, keypair))
             }
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum SignedConsensusMessage<S, T> {
-    Proposal(Unverified<S, ProposalMessage<S, T>>),
-    Vote(Unverified<S, VoteMessage>),
-    Timeout(Unverified<S, TimeoutMessage<S, T>>),
-}
-
-#[derive(Debug, Clone)]
-pub enum VerifiedConsensusMessage<S, T> {
-    Proposal(Verified<S, ProposalMessage<S, T>>),
-    Vote(Verified<S, VoteMessage>),
-    Timeout(Verified<S, TimeoutMessage<S, T>>),
-}
-
-impl<S, T> From<VerifiedConsensusMessage<S, T>> for SignedConsensusMessage<S, T> {
-    fn from(value: VerifiedConsensusMessage<S, T>) -> Self {
-        match value {
-            VerifiedConsensusMessage::Proposal(msg) => Self::Proposal(msg.into()),
-            VerifiedConsensusMessage::Vote(msg) => Self::Vote(msg.into()),
-            VerifiedConsensusMessage::Timeout(msg) => Self::Timeout(msg.into()),
         }
     }
 }


### PR DESCRIPTION
- Protobuf for (Signed/Verified)ConsensusMessage
- Deprecating serde functions for individual message types
- Moving ConsensusMessage to `monad-consensus` crate to avoid circular dependency between `monad-state` and `monad-proto`