### PR TITLE
Serializable trait refactor

### DIFF
--- a/monad-executor/src/executor/parent.rs
+++ b/monad-executor/src/executor/parent.rs
@@ -14,14 +14,15 @@ pub struct ParentExecutor<R, T> {
     pub timer: T,
 }
 
-impl<E, M, R, T> Executor for ParentExecutor<R, T>
+impl<E, M, OM, R, T> Executor for ParentExecutor<R, T>
 where
     M: Message<Event = E>,
-    R: Executor<Command = RouterCommand<E, M>>,
+    OM: Into<M>,
+    R: Executor<Command = RouterCommand<E, M, OM>>,
     T: Executor<Command = TimerCommand<E>>,
 {
-    type Command = Command<E, M>;
-    fn exec(&mut self, commands: Vec<Command<E, M>>) {
+    type Command = Command<E, M, OM>;
+    fn exec(&mut self, commands: Vec<Command<E, M, OM>>) {
         let (router_cmds, timer_cmds) = Command::split_commands(commands);
         self.router.exec(router_cmds);
         self.timer.exec(timer_cmds);

--- a/monad-executor/src/lib.rs
+++ b/monad-executor/src/lib.rs
@@ -9,7 +9,7 @@ pub mod mock_swarm;
 
 // driver loop
 async fn run<S: State>(
-    mut executor: impl Executor<Command = Command<S::Event, S::Message>>
+    mut executor: impl Executor<Command = Command<S::Event, S::Message, S::OutboundMessage>>
         + Stream<Item = S::Event>
         + Unpin,
     config: S::Config,

--- a/monad-p2p/src/behavior/codec.rs
+++ b/monad-p2p/src/behavior/codec.rs
@@ -1,7 +1,7 @@
 use std::{io::ErrorKind, marker::PhantomData, sync::Arc};
 
 use async_trait::async_trait;
-use monad_executor::{Message, Serializable};
+use monad_executor::{Deserializable, Message, Serializable};
 
 use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use libp2p::request_response::Codec;
@@ -28,7 +28,7 @@ where
 #[async_trait]
 impl<M> Codec for ReliableMessageCodec<M>
 where
-    M: Message + Serializable,
+    M: Message + Serializable + Deserializable,
 {
     type Protocol = String;
     // TODO can we avoid Arc?

--- a/monad-p2p/src/behavior/mod.rs
+++ b/monad-p2p/src/behavior/mod.rs
@@ -1,12 +1,12 @@
 use libp2p::{request_response::ProtocolSupport, swarm::NetworkBehaviour};
-use monad_executor::{Message, Serializable};
+use monad_executor::{Deserializable, Message, Serializable};
 
 mod codec;
 
 #[derive(NetworkBehaviour)]
 pub(crate) struct Behavior<M>
 where
-    M: Message + Serializable,
+    M: Message + Serializable + Deserializable,
 {
     pub identify: libp2p::identify::Behaviour,
     pub request_response: libp2p::request_response::Behaviour<codec::ReliableMessageCodec<M>>,
@@ -18,7 +18,7 @@ const REQUEST_RESPONSE_KEEPALIVE: std::time::Duration = std::time::Duration::fro
 
 impl<M> Behavior<M>
 where
-    M: Message + Serializable,
+    M: Message + Serializable + Deserializable,
 {
     pub(crate) fn new(pubkey: &libp2p::identity::PublicKey) -> Self {
         let identify = libp2p::identify::Behaviour::new(libp2p::identify::Config::new(


### PR DESCRIPTION
- split Serializable trait into Serializable and Deserializable: we want to serialize VerifiedMessage only and deserialize should produce Signed/Unverified message
- not sure how this might affect #3 