### PR TITLE
`monad_crypto::PubKey` <--> `libp2p_identity::PeerId` Conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "asn1_der"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +228,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest 0.10.6",
+]
+
+[[package]]
+name = "blake2b_simd"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.2",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake2s_simd"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637f448b9e61dfadbdcbae9a885fadee1f3eaffb1f8d3c1965d3ade8bdfd44f"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.2",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake3"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ae2468a89544a466886840aa467a25b766499f4f04bf7d9fcd10ecee9fccef"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.2",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -359,6 +412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
+
+[[package]]
 name = "copypasta"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +472,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -954,6 +1023,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array",
+ "hmac",
+]
+
+[[package]]
 name = "hound"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1128,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "lazy-bytes-cast"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,7 +1171,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "bitflags",
  "cfg-if",
  "ryu",
@@ -1206,14 +1305,17 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a8ea433ae0cea7e3315354305237b9897afe45278b2118a7a57ca744e70fd27"
 dependencies = [
+ "asn1_der",
  "bs58",
  "ed25519-dalek",
+ "libsecp256k1",
  "log",
  "multiaddr",
  "multihash",
  "prost",
  "quick-protobuf",
  "rand 0.8.5",
+ "sha2 0.10.6",
  "thiserror",
  "zeroize",
 ]
@@ -1318,6 +1420,54 @@ dependencies = [
  "heck",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
+dependencies = [
+ "arrayref",
+ "base64",
+ "digest 0.9.0",
+ "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.8.5",
+ "serde 1.0.160",
+ "sha2 0.9.9",
+ "typenum",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
+dependencies = [
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -1489,6 +1639,8 @@ name = "monad-crypto"
 version = "0.1.0"
 dependencies = [
  "hex",
+ "libp2p-identity",
+ "multihash",
  "rand 0.8.5",
  "secp256k1",
  "sha2 0.10.6",
@@ -1512,6 +1664,7 @@ dependencies = [
  "async-trait",
  "futures",
  "libp2p",
+ "monad-crypto",
  "monad-executor",
 ]
 
@@ -1624,10 +1777,14 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
 dependencies = [
+ "blake2b_simd",
+ "blake2s_simd",
+ "blake3",
  "core2",
  "digest 0.10.6",
  "multihash-derive",
  "sha2 0.10.6",
+ "sha3",
  "unsigned-varint",
 ]
 
@@ -2487,6 +2644,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
+dependencies = [
+ "digest 0.10.6",
+ "keccak",
 ]
 
 [[package]]

--- a/monad-consensus/src/types/block.rs
+++ b/monad-consensus/src/types/block.rs
@@ -20,7 +20,7 @@ pub struct Block<T> {
 
 impl<T: SignatureCollection> Hashable for Block<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        state.update(self.author.0.into_bytes().as_bytes());
+        state.update(&self.author.0.bytes());
         state.update(self.round.as_bytes());
         state.update(self.payload.0.as_bytes());
         state.update(self.qc.info.vote.id.0.as_bytes());

--- a/monad-crypto/Cargo.toml
+++ b/monad-crypto/Cargo.toml
@@ -10,6 +10,12 @@ rand = "0.8.5"
 secp256k1 = { version = "0.26", features = ["global-context", "recovery"] }
 sha2 = "0.10"
 
+libp2p-identity = { version = "0.1", features = ["secp256k1"], optional = true }
+multihash = { version = "0.17", features = ["identity"], optional = true }
+
 [dev-dependencies]
 hex = "0.4"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
+
+[features]
+libp2p-identity = ["dep:libp2p-identity", "dep:multihash"]

--- a/monad-p2p/Cargo.toml
+++ b/monad-p2p/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 monad-executor = { path = "../monad-executor" }
+monad-crypto = { path = "../monad-crypto", features = ["libp2p-identity"] }
 
 futures = "0.3"
 async-trait = "0.1"

--- a/monad-proto/src/types/basic.rs
+++ b/monad-proto/src/types/basic.rs
@@ -10,7 +10,7 @@ include!(concat!(env!("OUT_DIR"), "/monad_proto.basic.rs"));
 impl From<&NodeId> for ProtoNodeId {
     fn from(nodeid: &NodeId) -> Self {
         ProtoNodeId {
-            id: nodeid.0.into_bytes(),
+            id: nodeid.0.bytes(),
         }
     }
 }

--- a/monad-testutil/src/signing.rs
+++ b/monad-testutil/src/signing.rs
@@ -44,7 +44,7 @@ use sha2::Digest;
 
 pub fn hash<T: SignatureCollection>(b: &Block<T>) -> Hash {
     let mut hasher = sha2::Sha256::new();
-    hasher.update(b.author.0.into_bytes());
+    hasher.update(b.author.0.bytes());
     hasher.update(b.round);
     hasher.update(&b.payload.0);
     hasher.update(b.qc.info.vote.id.0);

--- a/monad-viz/src/main.rs
+++ b/monad-viz/src/main.rs
@@ -52,10 +52,10 @@ async fn main() {
             config_gen,
             |node_1, node_2| {
                 let mut ck = 0;
-                for b in node_1.0.into_bytes() {
+                for b in node_1.0.bytes() {
                     ck ^= b;
                 }
-                for b in node_2.0.into_bytes() {
+                for b in node_2.0.bytes() {
                     ck ^= b;
                 }
                 Duration::from_millis(ck as u64 % 100)


### PR DESCRIPTION
I think the test I added makes this PR pretty safe... but eventually we probably want a better way of doing these conversions