### PR TITLE
handle incoming votes from higher rounds in handle_vote_message

### DIFF
--- a/monad-consensus/src/vote_state.rs
+++ b/monad-consensus/src/vote_state.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use monad_types::{Hash, NodeId};
+use monad_types::{Hash, NodeId, Round};
 use monad_validator::{leader_election::LeaderElection, validator_set::ValidatorSet};
 
 use crate::{
@@ -14,19 +14,17 @@ use crate::{
 
 // accumulate votes and create a QC if enough votes are received
 // only one QC should be created in a round using the first supermajority of votes received
-// At the end of a round, this state should be reset.
+// At the end of a round, older rounds can be cleaned up
 pub struct VoteState<T> {
-    pending_vote_sigs: HashMap<Hash, T>,
-    pending_vote_keys: HashMap<Hash, Vec<NodeId>>,
-    qc_created: bool,
+    pending_votes: BTreeMap<Round, HashMap<Hash, (T, Vec<NodeId>)>>,
+    qc_created: BTreeSet<Round>,
 }
 
 impl<T> Default for VoteState<T> {
     fn default() -> Self {
         VoteState {
-            pending_vote_sigs: HashMap::new(),
-            pending_vote_keys: HashMap::new(),
-            qc_created: false,
+            pending_votes: BTreeMap::new(),
+            qc_created: BTreeSet::new(),
         }
     }
 }
@@ -41,41 +39,149 @@ where
         v: &Verified<T::SignatureType, VoteMessage>,
         validators: &ValidatorSet<V>,
     ) -> Option<QuorumCertificate<T>> {
-        if self.qc_created {
+        let round = v.vote_info.round;
+
+        if self.qc_created.contains(&round) {
             return None;
         }
 
         let vote_idx = H::hash_object(&v.ledger_commit_info);
-        let sigs = self.pending_vote_sigs.entry(vote_idx).or_insert(T::new());
 
-        sigs.add_signature(*v.author_signature());
-
-        self.pending_vote_keys
+        let round_pending_votes = self.pending_votes.entry(round).or_insert(HashMap::new());
+        let pending_entry = round_pending_votes
             .entry(vote_idx)
-            .or_default()
-            .push(*v.author());
+            .or_insert((T::new(), Vec::new()));
 
-        let pubkeys = &self.pending_vote_keys[&vote_idx];
+        pending_entry.0.add_signature(*v.author_signature());
+        pending_entry.1.push(*v.author());
 
-        if validators.has_super_majority_votes(pubkeys) {
-            assert!(!self.qc_created);
+        if validators.has_super_majority_votes(&pending_entry.1) {
+            assert!(!self.qc_created.contains(&round));
             let qc = QuorumCertificate::<T>::new(
                 QcInfo {
                     vote: v.vote_info,
                     ledger_commit: v.ledger_commit_info,
                 },
-                sigs.clone(),
+                pending_entry.0.clone(),
             );
-            self.qc_created = true;
+            self.qc_created.insert(round);
             return Some(qc);
         }
 
         None
     }
 
-    pub fn start_new_round(&mut self) {
-        self.qc_created = false;
-        self.pending_vote_sigs.clear();
-        self.pending_vote_keys.clear();
+    pub fn start_new_round(&mut self, new_round: Round) {
+        self.qc_created.retain(|k| *k >= new_round);
+        self.pending_votes.retain(|k, _| *k >= new_round);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::signatures::aggregate_signature::AggregateSignatures;
+    use crate::types::ledger::LedgerCommitInfo;
+    use crate::types::message::VoteMessage;
+    use crate::types::voting::VoteInfo;
+    use crate::validation::hashing::Sha256Hash;
+    use crate::validation::signing::Verified;
+    use monad_crypto::secp256k1::{KeyPair, SecpSignature};
+    use monad_testutil::signing::*;
+    use monad_testutil::validators::MockLeaderElection;
+    use monad_types::{BlockId, Round};
+    use monad_validator::validator::Validator;
+    use monad_validator::validator_set::ValidatorSet;
+
+    use super::VoteState;
+
+    fn create_valset(num_nodes: u32) -> (Vec<KeyPair>, ValidatorSet<MockLeaderElection>) {
+        let keys = create_keys(num_nodes);
+
+        let mut nodes = Vec::new();
+        for i in 0..num_nodes {
+            nodes.push(Validator {
+                pubkey: keys[i as usize].pubkey().clone(),
+                stake: 1,
+            });
+        }
+
+        let valset = ValidatorSet::<MockLeaderElection>::new(nodes).unwrap();
+        (keys, valset)
+    }
+
+    fn create_signed_vote_message(
+        keypair: &KeyPair,
+        vote_round: Round,
+    ) -> Verified<SecpSignature, VoteMessage> {
+        let vi = VoteInfo {
+            id: BlockId([0x00_u8; 32]),
+            round: vote_round,
+            parent_id: BlockId([0x00_u8; 32]),
+            parent_round: Round(0),
+        };
+
+        let lci = LedgerCommitInfo::new::<Sha256Hash>(Some(Default::default()), &vi);
+
+        let vm = VoteMessage {
+            vote_info: vi,
+            ledger_commit_info: lci,
+        };
+
+        let svm = Verified::new::<Sha256Hash>(vm, &keypair);
+
+        svm
+    }
+
+    #[test]
+    fn clean_older_votes() {
+        let mut votestate = VoteState::<AggregateSignatures<SecpSignature>>::default();
+        let (keys, valset) = create_valset(4);
+
+        // add one vote for rounds 0-3
+        for i in 0..4 {
+            let svm = create_signed_vote_message(&keys[0], Round(i.try_into().unwrap()));
+            let _qc = votestate.process_vote::<_, Sha256Hash>(&svm, &valset);
+        }
+
+        assert_eq!(votestate.pending_votes.len(), 4);
+
+        // add supermajority number of votes for round 4, expecting older rounds to be
+        // removed
+        for i in 0..4 {
+            let svm = create_signed_vote_message(&keys[i], Round(4));
+            let _qc = votestate.process_vote::<_, Sha256Hash>(&svm, &valset);
+        }
+        votestate.start_new_round(Round(5));
+
+        assert_eq!(votestate.pending_votes.len(), 0);
+    }
+
+    #[test]
+    fn handle_future_votes() {
+        let mut votestate = VoteState::<AggregateSignatures<SecpSignature>>::default();
+        let (keys, valset) = create_valset(4);
+
+        // add one vote for rounds 0-3 and 5-8
+        for i in 0..4 {
+            let svm = create_signed_vote_message(&keys[0], Round(i.try_into().unwrap()));
+            let _qc = votestate.process_vote::<_, Sha256Hash>(&svm, &valset);
+        }
+
+        for i in 5..9 {
+            let svm = create_signed_vote_message(&keys[0], Round(i.try_into().unwrap()));
+            let _qc = votestate.process_vote::<_, Sha256Hash>(&svm, &valset);
+        }
+
+        assert_eq!(votestate.pending_votes.len(), 8);
+
+        // add supermajority number of votes for round 4, expecting older rounds to be
+        // removed
+        for i in 0..4 {
+            let svm = create_signed_vote_message(&keys[i], Round(4));
+            let _qc = votestate.process_vote::<_, Sha256Hash>(&svm, &valset);
+        }
+        votestate.start_new_round(Round(5));
+
+        assert_eq!(votestate.pending_votes.len(), 4);
     }
 }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -490,7 +490,7 @@ where
         v: &Verified<T::SignatureType, VoteMessage>,
         validators: &mut ValidatorSet<V>,
     ) -> Vec<ConsensusCommand<S, T>> {
-        if self.pacemaker.get_current_round() != v.vote_info.round {
+        if v.vote_info.round < self.pacemaker.get_current_round() {
             return Default::default();
         }
 
@@ -581,7 +581,8 @@ where
         &mut self,
         last_round_tc: Option<TimeoutCertificate<S>>,
     ) -> Vec<ConsensusCommand<S, T>> {
-        self.vote_state.start_new_round();
+        self.vote_state
+            .start_new_round(self.pacemaker.get_current_round());
 
         let txns: TransactionList = self.mempool.get_transactions(10000);
         let b = Block::new::<H>(


### PR DESCRIPTION
this is a conservative approach to handling votes from future rounds -- it just accepts anything and when a round is completed, start_new_round() will clean up votes from older rounds. 
There is probably a way to improve this by considering how many rounds ahead can actually be received and which future rounds a node can actually be leader for. Will note this for a future PR to optimize if we feel its needed. 