### PR TITLE
Fix PeerId/PubKey conversions, add more tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,6 +1645,7 @@ dependencies = [
  "secp256k1",
  "sha2 0.10.6",
  "tiny-keccak",
+ "zeroize",
 ]
 
 [[package]]

--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -197,10 +197,10 @@ mod test {
     type QC = QuorumCertificate<MockSignatures>;
 
     fn node_id() -> NodeId {
-        let privkey =
+        let mut privkey =
             hex::decode("6fe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
                 .unwrap();
-        let keypair = KeyPair::from_slice(&privkey).unwrap();
+        let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
         NodeId(keypair.pubkey())
     }
 

--- a/monad-consensus/tests/message.rs
+++ b/monad-consensus/tests/message.rs
@@ -83,9 +83,9 @@ fn proposal_msg_hash() {
 
     let txns = TransactionList(vec![1, 2, 3, 4]);
 
-    let privkey =
+    let mut privkey =
         hex::decode("6fe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530").unwrap();
-    let keypair = KeyPair::from_slice(&privkey).unwrap();
+    let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
     let author = NodeId(keypair.pubkey());
     let round = Round(234);
     let qc = QuorumCertificate::<MockSignatures>::new(
@@ -155,9 +155,9 @@ fn test_vote_message() {
         ledger_commit_info: lci,
     };
 
-    let privkey =
+    let mut privkey =
         hex::decode("6fe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530").unwrap();
-    let keypair = KeyPair::from_slice(&privkey).unwrap();
+    let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
 
     let expected_vote_info_hash = vm.ledger_commit_info.vote_info_hash.clone();
 

--- a/monad-crypto/Cargo.toml
+++ b/monad-crypto/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 rand = "0.8.5"
 secp256k1 = { version = "0.26", features = ["global-context", "recovery"] }
 sha2 = "0.10"
+zeroize = "1.3"
 
 libp2p-identity = { version = "0.1", features = ["secp256k1"], optional = true }
 multihash = { version = "0.17", features = ["identity"], optional = true }

--- a/monad-p2p/Cargo.toml
+++ b/monad-p2p/Cargo.toml
@@ -12,4 +12,4 @@ monad-crypto = { path = "../monad-crypto", features = ["libp2p-identity"] }
 futures = "0.3"
 async-trait = "0.1"
 
-libp2p = { version = "0.51", features = ["macros", "mplex", "noise", "identify", "request-response"] }
+libp2p = { version = "0.51", features = ["macros", "mplex", "noise", "identify", "request-response", "secp256k1"] }

--- a/monad-p2p/src/behavior/mod.rs
+++ b/monad-p2p/src/behavior/mod.rs
@@ -20,10 +20,10 @@ impl<M> Behavior<M>
 where
     M: Message + Serializable,
 {
-    pub(crate) fn new(identity: &libp2p::identity::Keypair) -> Self {
+    pub(crate) fn new(pubkey: &libp2p::identity::PublicKey) -> Self {
         let identify = libp2p::identify::Behaviour::new(libp2p::identify::Config::new(
             IDENTIFY_PROTO_NAME.to_string(),
-            identity.public(),
+            pubkey.clone(),
         ));
 
         let mut request_response_config = libp2p::request_response::Config::default();

--- a/monad-p2p/src/lib.rs
+++ b/monad-p2p/src/lib.rs
@@ -28,10 +28,11 @@ where
             .authenticate(libp2p::noise::NoiseAuthenticated::xx(identity).unwrap())
             .multiplex(libp2p::mplex::MplexConfig::new())
             .boxed();
-        let local_peer_id: libp2p::PeerId = identity.public().into();
 
-        let behavior = Behavior::new(identity);
+        let pubkey = identity.public();
+        let behavior = Behavior::new(&pubkey);
 
+        let local_peer_id: libp2p::PeerId = pubkey.into();
         let mut swarm = SwarmBuilder::without_executor(transport, behavior, local_peer_id).build();
         swarm.listen_on("/memory/0".parse().unwrap()).unwrap();
 

--- a/monad-testutil/src/signing.rs
+++ b/monad-testutil/src/signing.rs
@@ -54,9 +54,9 @@ pub fn hash<T: SignatureCollection>(b: &Block<T>) -> Hash {
 }
 
 pub fn node_id() -> NodeId {
-    let privkey =
+    let mut privkey =
         hex::decode("6fe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530").unwrap();
-    let keypair = KeyPair::from_slice(&privkey).unwrap();
+    let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
     NodeId(keypair.pubkey())
 }
 
@@ -64,8 +64,8 @@ pub fn create_keys(num_keys: u32) -> Vec<KeyPair> {
     assert!(num_keys < 255);
     let mut res = Vec::new();
     for i in 0..num_keys {
-        let k: [u8; 32] = [(i + 1) as u8; 32];
-        let keypair = KeyPair::from_slice(&k).unwrap();
+        let mut k: [u8; 32] = [(i + 1) as u8; 32];
+        let keypair = KeyPair::from_bytes(&mut k).unwrap();
 
         res.push(keypair);
     }
@@ -78,7 +78,7 @@ pub fn get_genesis_config<H: Hasher, T: SignatureCollection>(keys: &Vec<KeyPair>
     let genesis_prime_qc = QuorumCertificate::<T>::genesis_prime_qc::<H>();
     let genesis_block = Block::<T>::new::<H>(
         // FIXME init from genesis config, don't use random key
-        NodeId(KeyPair::from_slice(&[0xBE_u8; 32]).unwrap().pubkey()),
+        NodeId(KeyPair::from_bytes(&mut [0xBE_u8; 32]).unwrap().pubkey()),
         Round(0),
         &genesis_txn,
         &genesis_prime_qc,
@@ -109,6 +109,6 @@ impl TestSigner<SecpSignature> {
 }
 
 pub fn get_key(seed: &str) -> KeyPair {
-    let privkey = hex::decode(seed.repeat(64)).unwrap();
-    KeyPair::from_slice(&privkey).unwrap()
+    let mut privkey = hex::decode(seed.repeat(64)).unwrap();
+    KeyPair::from_bytes(&mut privkey).unwrap()
 }

--- a/monad-testutil/src/validators.rs
+++ b/monad-testutil/src/validators.rs
@@ -8,8 +8,8 @@ pub struct MockLeaderElection {
 
 impl LeaderElection for MockLeaderElection {
     fn new() -> Self {
-        let key: [u8; 32] = [128; 32];
-        let keypair = KeyPair::from_slice(&key).unwrap();
+        let mut key: [u8; 32] = [128; 32];
+        let keypair = KeyPair::from_bytes(&mut key).unwrap();
         let leader = keypair.pubkey();
         MockLeaderElection {
             leader: NodeId(leader),

--- a/monad-validator/src/validator_set.rs
+++ b/monad-validator/src/validator_set.rs
@@ -121,7 +121,7 @@ mod test {
         let mut privkey =
             hex::decode("6fe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
                 .unwrap();
-        let keypair1 = KeyPair::from_slice(&privkey).unwrap();
+        let keypair1 = KeyPair::from_bytes(&mut privkey).unwrap();
 
         let v1 = Validator {
             pubkey: keypair1.pubkey().clone(),
@@ -136,7 +136,7 @@ mod test {
         privkey = hex::decode("afe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
             .unwrap();
         let v2 = Validator {
-            pubkey: KeyPair::from_slice(&privkey).unwrap().pubkey(),
+            pubkey: KeyPair::from_bytes(&mut privkey).unwrap().pubkey(),
             stake: 2,
         };
 
@@ -147,31 +147,35 @@ mod test {
         let vs = ValidatorSet::<WeightedRoundRobin>::new(validators).unwrap();
         assert!(vs.is_member(&NodeId(keypair1.pubkey())));
 
-        let pkey3 = hex::decode("cfe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
-            .unwrap();
-        let pubkey3 = KeyPair::from_slice(&pkey3).unwrap().pubkey();
+        let mut pkey3 =
+            hex::decode("cfe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
+                .unwrap();
+        let pubkey3 = KeyPair::from_bytes(&mut pkey3).unwrap().pubkey();
         assert!(!vs.is_member(&NodeId(pubkey3)));
     }
 
     #[test]
     fn test_super_maj() {
-        let pkey1 = hex::decode("6fe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
-            .unwrap();
-        let pkey2 = hex::decode("afe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
-            .unwrap();
+        let mut pkey1 =
+            hex::decode("6fe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
+                .unwrap();
+        let mut pkey2 =
+            hex::decode("afe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
+                .unwrap();
         let v1 = Validator {
-            pubkey: KeyPair::from_slice(&pkey1).unwrap().pubkey(),
+            pubkey: KeyPair::from_bytes(&mut pkey1).unwrap().pubkey(),
             stake: 1,
         };
 
         let v2 = Validator {
-            pubkey: KeyPair::from_slice(&pkey2).unwrap().pubkey(),
+            pubkey: KeyPair::from_bytes(&mut pkey2).unwrap().pubkey(),
             stake: 3,
         };
 
-        let pkey3 = hex::decode("cfe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
-            .unwrap();
-        let pubkey3 = KeyPair::from_slice(&pkey3).unwrap().pubkey();
+        let mut pkey3 =
+            hex::decode("cfe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
+                .unwrap();
+        let pubkey3 = KeyPair::from_bytes(&mut pkey3).unwrap().pubkey();
 
         let validators = vec![v1.clone(), v2.clone()];
         let vs = ValidatorSet::<WeightedRoundRobin>::new(validators).unwrap();
@@ -183,17 +187,19 @@ mod test {
 
     #[test]
     fn test_honest_vote() {
-        let pkey1 = hex::decode("6fe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
-            .unwrap();
-        let pkey2 = hex::decode("afe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
-            .unwrap();
+        let mut pkey1 =
+            hex::decode("6fe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
+                .unwrap();
+        let mut pkey2 =
+            hex::decode("afe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
+                .unwrap();
         let v1 = Validator {
-            pubkey: KeyPair::from_slice(&pkey1).unwrap().pubkey(),
+            pubkey: KeyPair::from_bytes(&mut pkey1).unwrap().pubkey(),
             stake: 1,
         };
 
         let v2 = Validator {
-            pubkey: KeyPair::from_slice(&pkey2).unwrap().pubkey(),
+            pubkey: KeyPair::from_bytes(&mut pkey2).unwrap().pubkey(),
             stake: 2,
         };
 
@@ -205,17 +211,19 @@ mod test {
 
     #[test]
     fn test_get_leader() {
-        let pkey1 = hex::decode("6fe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
-            .unwrap();
-        let pubkey1 = KeyPair::from_slice(&pkey1).unwrap().pubkey();
+        let mut pkey1 =
+            hex::decode("6fe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
+                .unwrap();
+        let pubkey1 = KeyPair::from_bytes(&mut pkey1).unwrap().pubkey();
         let v1 = Validator {
             pubkey: pubkey1,
             stake: 1,
         };
 
-        let pkey2 = hex::decode("afe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
-            .unwrap();
-        let pubkey2 = KeyPair::from_slice(&pkey2).unwrap().pubkey();
+        let mut pkey2 =
+            hex::decode("afe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
+                .unwrap();
+        let pubkey2 = KeyPair::from_bytes(&mut pkey2).unwrap().pubkey();
         let v2 = Validator {
             pubkey: pubkey2,
             stake: 1,

--- a/monad-validator/src/weighted_round_robin.rs
+++ b/monad-validator/src/weighted_round_robin.rs
@@ -159,11 +159,11 @@ mod tests {
     #[test]
     fn test_basic_round_robin() {
         let v1 = Validator {
-            pubkey: KeyPair::from_slice(&get_key1()).unwrap().pubkey(),
+            pubkey: KeyPair::from_bytes(&mut get_key1()).unwrap().pubkey(),
             stake: 1,
         };
         let v2 = Validator {
-            pubkey: KeyPair::from_slice(&get_key2()).unwrap().pubkey(),
+            pubkey: KeyPair::from_bytes(&mut get_key2()).unwrap().pubkey(),
             stake: 1,
         };
         let validators = vec![v1, v2];
@@ -183,11 +183,11 @@ mod tests {
     #[test]
     fn test_weighted_round_robin() {
         let v1 = Validator {
-            pubkey: KeyPair::from_slice(&get_key1()).unwrap().pubkey(),
+            pubkey: KeyPair::from_bytes(&mut get_key1()).unwrap().pubkey(),
             stake: 1,
         };
         let v2 = Validator {
-            pubkey: KeyPair::from_slice(&get_key2()).unwrap().pubkey(),
+            pubkey: KeyPair::from_bytes(&mut get_key2()).unwrap().pubkey(),
             stake: 2,
         };
         let validators = vec![v1, v2];
@@ -213,11 +213,11 @@ mod tests {
     #[test]
     fn test_agreement() {
         let v1 = Validator {
-            pubkey: KeyPair::from_slice(&get_key1()).unwrap().pubkey(),
+            pubkey: KeyPair::from_bytes(&mut get_key1()).unwrap().pubkey(),
             stake: 1,
         };
         let v2 = Validator {
-            pubkey: KeyPair::from_slice(&get_key2()).unwrap().pubkey(),
+            pubkey: KeyPair::from_bytes(&mut get_key2()).unwrap().pubkey(),
             stake: 3,
         };
         let validators = vec![v1, v2];
@@ -237,11 +237,11 @@ mod tests {
     #[test]
     fn test_increment_views_equivalent() {
         let v1 = Validator {
-            pubkey: KeyPair::from_slice(&get_key1()).unwrap().pubkey(),
+            pubkey: KeyPair::from_bytes(&mut get_key1()).unwrap().pubkey(),
             stake: 1,
         };
         let v2 = Validator {
-            pubkey: KeyPair::from_slice(&get_key2()).unwrap().pubkey(),
+            pubkey: KeyPair::from_bytes(&mut get_key2()).unwrap().pubkey(),
             stake: 3,
         };
         let validators = vec![v1, v2];
@@ -262,11 +262,11 @@ mod tests {
     #[test]
     fn test_update_stake() {
         let mut v1 = Validator {
-            pubkey: KeyPair::from_slice(&get_key1()).unwrap().pubkey(),
+            pubkey: KeyPair::from_bytes(&mut get_key1()).unwrap().pubkey(),
             stake: 10,
         };
         let v2 = Validator {
-            pubkey: KeyPair::from_slice(&get_key2()).unwrap().pubkey(),
+            pubkey: KeyPair::from_bytes(&mut get_key2()).unwrap().pubkey(),
             stake: 10,
         };
 


### PR DESCRIPTION
It turns out that `libp2p::PeerId` is actually protobuf-encoded, meaning that we weren't actually mapping our Pubkeys to the canonical PeerId.

This PR fixes that, and also adds another more exhaustive test that catches this.