### PR TITLE
Fix monad-p2p send-to-self bug

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,7 @@ jobs:
         -D clippy::suspicious
         -D clippy::style
         -D clippy::clone_on_copy
+        -D clippy::redundant_clone
         -D clippy::iter_kv_map
         -D clippy::unnecessary_cast
         -D clippy::filter_next

--- a/monad-executor/src/state.rs
+++ b/monad-executor/src/state.rs
@@ -72,5 +72,6 @@ pub trait Message: Clone + Unpin {
     type Id: Eq + Hash + Clone + Unpin;
 
     fn id(&self) -> Self::Id;
+    // TODO PeerId -> &PeerId
     fn event(self, from: PeerId) -> Self::Event;
 }


### PR DESCRIPTION
This PR adds support for sending to self, as well as a test.

Implemented using a simple FIFO queue of events that came from self.

For context, this would previously fail because libp2p doesn't allow self-dialing.

Depends on #70 