### PR TITLE
Make monad-p2p a RouterCommand executor

### DIFF
--- a/monad-executor/src/executor/mock.rs
+++ b/monad-executor/src/executor/mock.rs
@@ -190,7 +190,7 @@ impl<S> Executor for MockExecutor<S>
 where
     S: State,
 {
-    type Command = Command<S>;
+    type Command = Command<S::Message, S::OutboundMessage>;
     fn exec(&mut self, commands: Vec<Self::Command>) {
         // we must have processed received messages at this point, so we can send out acks
         self.outbound_ack.extend(
@@ -385,7 +385,9 @@ mod tests {
         type OutboundMessage = LongAckMessage;
         type Message = LongAckMessage;
 
-        fn init(_config: Self::Config) -> (Self, Vec<Command<Self>>) {
+        fn init(
+            _config: Self::Config,
+        ) -> (Self, Vec<Command<Self::Message, Self::OutboundMessage>>) {
             let init_self = Self {
                 num_ack: 0,
                 num_timeouts: 0,
@@ -405,7 +407,10 @@ mod tests {
 
             (init_self, init_cmds)
         }
-        fn update(&mut self, event: Self::Event) -> Vec<Command<Self>> {
+        fn update(
+            &mut self,
+            event: Self::Event,
+        ) -> Vec<Command<Self::Message, Self::OutboundMessage>> {
             let mut commands = Vec::new();
             match event {
                 LongAckEvent::IncrementNumAck => {
@@ -618,7 +623,9 @@ mod tests {
         type OutboundMessage = SimpleChainMessage;
         type Message = SimpleChainMessage;
 
-        fn init(config: Self::Config) -> (Self, Vec<Command<Self>>) {
+        fn init(
+            config: Self::Config,
+        ) -> (Self, Vec<Command<Self::Message, Self::OutboundMessage>>) {
             let (pubkeys, me) = config;
 
             let init_cmds = pubkeys
@@ -645,7 +652,10 @@ mod tests {
 
             (init_self, init_cmds)
         }
-        fn update(&mut self, event: Self::Event) -> Vec<Command<Self>> {
+        fn update(
+            &mut self,
+            event: Self::Event,
+        ) -> Vec<Command<Self::Message, Self::OutboundMessage>> {
             let mut commands = Vec::new();
             match event {
                 SimpleChainEvent::Vote { peer, round } => {

--- a/monad-executor/src/executor/parent.rs
+++ b/monad-executor/src/executor/parent.rs
@@ -4,7 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use crate::{Command, Executor, RouterCommand, State, TimerCommand};
+use crate::{Command, Executor, Message, RouterCommand, TimerCommand};
 
 use futures::Stream;
 use futures::StreamExt;
@@ -14,14 +14,15 @@ pub struct ParentExecutor<R, T> {
     pub timer: T,
 }
 
-impl<S, R, T> Executor for ParentExecutor<R, T>
+impl<R, T, M, OM> Executor for ParentExecutor<R, T>
 where
-    S: State,
-    R: Executor<Command = RouterCommand<S>>,
-    T: Executor<Command = TimerCommand<S::Event>>,
+    R: Executor<Command = RouterCommand<M, OM>>,
+    T: Executor<Command = TimerCommand<M::Event>>,
+
+    M: Message,
 {
-    type Command = Command<S>;
-    fn exec(&mut self, commands: Vec<Command<S>>) {
+    type Command = Command<M, OM>;
+    fn exec(&mut self, commands: Vec<Command<M, OM>>) {
         let (router_cmds, timer_cmds) = Command::split_commands(commands);
         self.router.exec(router_cmds);
         self.timer.exec(timer_cmds);

--- a/monad-executor/src/lib.rs
+++ b/monad-executor/src/lib.rs
@@ -9,7 +9,9 @@ pub mod mock_swarm;
 
 // driver loop
 async fn run<S: State>(
-    mut executor: impl Executor<Command = Command<S>> + Stream<Item = S::Event> + Unpin,
+    mut executor: impl Executor<Command = Command<S::Message, S::OutboundMessage>>
+        + Stream<Item = S::Event>
+        + Unpin,
     config: S::Config,
     init_events: Vec<S::Event>,
 ) {

--- a/monad-p2p/src/behavior/mod.rs
+++ b/monad-p2p/src/behavior/mod.rs
@@ -2,6 +2,7 @@ use libp2p::{request_response::ProtocolSupport, swarm::NetworkBehaviour};
 use monad_executor::{Deserializable, Serializable};
 
 mod codec;
+pub use codec::WrappedMessage;
 
 #[derive(NetworkBehaviour)]
 pub(crate) struct Behavior<M, OM>
@@ -9,8 +10,6 @@ where
     M: Deserializable + Send + Sync + 'static,
     <M as Deserializable>::ReadError: 'static,
     OM: Serializable + Send + Sync + 'static,
-
-    M: Serializable, // FIXME
 {
     pub identify: libp2p::identify::Behaviour,
     pub request_response: libp2p::request_response::Behaviour<codec::ReliableMessageCodec<M, OM>>,
@@ -25,8 +24,6 @@ where
     M: Deserializable + Send + Sync + 'static,
     <M as Deserializable>::ReadError: 'static,
     OM: Serializable + Send + Sync + 'static,
-
-    M: Serializable, // FIXME
 {
     pub(crate) fn new(pubkey: &libp2p::identity::PublicKey) -> Self {
         let identify = libp2p::identify::Behaviour::new(libp2p::identify::Config::new(

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -177,7 +177,7 @@ where
     type Message = MonadMessage<ST, SCT>;
     type OutboundMessage = VerifiedMonadMessage<ST, SCT>;
 
-    fn init(config: Self::Config) -> (Self, Vec<Command<Self>>) {
+    fn init(config: Self::Config) -> (Self, Vec<Command<Self::Message, Self::OutboundMessage>>) {
         // create my keys and validator structs
         let validator_list = config
             .validators
@@ -219,7 +219,7 @@ where
         (monad_state, init_cmds)
     }
 
-    fn update(&mut self, event: Self::Event) -> Vec<Command<Self>> {
+    fn update(&mut self, event: Self::Event) -> Vec<Command<Self::Message, Self::OutboundMessage>> {
         match event {
             MonadEvent::Ack { peer, id, round } => self
                 .message_state


### PR DESCRIPTION
Very simple change - this makes monad-p2p work out of the box with `monad_executor::executor::parent::ParentExecutor`.

This means that after our ser/de stuff is done, we pretty straightforwardly test our consensus on a libp2p-backed test executor.

One unknown: rust-libp2p uses [futures_timer](https://docs.rs/futures-timer/latest/futures_timer/) to drive its timeouts, whereas we use a tokio timer in monad-executor - I don't love the asymmetry there