### PR TITLE
Lift out Verified<T> around ConsensusMessage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,6 +1849,7 @@ dependencies = [
  "monad-testutil",
  "monad-types",
  "monad-validator",
+ "ref-cast",
 ]
 
 [[package]]
@@ -2655,6 +2656,26 @@ dependencies = [
  "getrandom 0.2.9",
  "redox_syscall 0.2.16",
  "thiserror",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43faa91b1c8b36841ee70e97188a869d37ae21759da6846d4be66de5bf7b12c"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/monad-consensus/tests/vote_state.rs
+++ b/monad-consensus/tests/vote_state.rs
@@ -100,8 +100,13 @@ fn test_votes(num_nodes: u32) {
     let mut voteset = VoteState::<AggregateSignatures<SecpSignature>>::default();
     let mut qcs = Vec::new();
     for i in 0..num_nodes {
-        let qc =
-            voteset.process_vote::<MockLeaderElection, Sha256Hash>(&votes[i as usize], &valset);
+        let v = &votes[i as usize];
+        let qc = voteset.process_vote::<MockLeaderElection, Sha256Hash>(
+            v.author(),
+            v.author_signature(),
+            &v,
+            &valset,
+        );
         qcs.push(qc);
     }
     let valid_qc: Vec<&Option<QuorumCertificate<AggregateSignatures<SecpSignature>>>> =
@@ -125,8 +130,13 @@ fn test_reset(num_nodes: u32, num_rounds: u32) {
 
     for k in 0..num_rounds {
         for i in 0..num_nodes {
-            let qc =
-                voteset.process_vote::<MockLeaderElection, Sha256Hash>(&votes[i as usize], &valset);
+            let v = &votes[i as usize];
+            let qc = voteset.process_vote::<MockLeaderElection, Sha256Hash>(
+                v.author(),
+                v.author_signature(),
+                &v,
+                &valset,
+            );
             qcs.push(qc);
         }
 
@@ -152,8 +162,13 @@ fn test_minority(num_nodes: u32) {
     let majority = 2 * num_nodes / 3 + 1;
 
     for i in 0..majority - 1 {
-        let qc =
-            voteset.process_vote::<MockLeaderElection, Sha256Hash>(&votes[i as usize], &valset);
+        let v = &votes[i as usize];
+        let qc = voteset.process_vote::<MockLeaderElection, Sha256Hash>(
+            v.author(),
+            v.author_signature(),
+            &v,
+            &valset,
+        );
         qcs.push(qc);
     }
 

--- a/monad-executor/src/executor/mock.rs
+++ b/monad-executor/src/executor/mock.rs
@@ -229,7 +229,7 @@ where
         }
 
         for (to, message, on_ack) in to_publish {
-            let id = message.clone().into().id();
+            let id = message.as_ref().id();
             if to_unpublish.contains(&(to, id.clone())) {
                 continue;
             }
@@ -440,6 +440,11 @@ mod tests {
 
     #[derive(Clone)]
     struct LongAckMessage(u64);
+    impl AsRef<Self> for LongAckMessage {
+        fn as_ref(&self) -> &Self {
+            &self
+        }
+    }
     impl Message for LongAckMessage {
         type Event = LongAckEvent;
         type Id = u64;
@@ -683,6 +688,11 @@ mod tests {
     #[derive(Clone)]
     struct SimpleChainMessage {
         round: u64,
+    }
+    impl AsRef<Self> for SimpleChainMessage {
+        fn as_ref(&self) -> &Self {
+            &self
+        }
     }
 
     impl Message for SimpleChainMessage {

--- a/monad-executor/src/state.rs
+++ b/monad-executor/src/state.rs
@@ -63,7 +63,7 @@ where
 pub trait State: Sized {
     type Config;
     type Event: Clone;
-    type OutboundMessage: Into<Self::Message> + Clone;
+    type OutboundMessage: Into<Self::Message> + AsRef<Self::Message>;
     type Message: Message<Event = Self::Event>;
 
     fn init(config: Self::Config) -> (Self, Vec<Command<Self>>);

--- a/monad-p2p/src/lib.rs
+++ b/monad-p2p/src/lib.rs
@@ -233,9 +233,10 @@ mod tests {
             Ok(TestMessage(u64::from_le_bytes(message)))
         }
     }
+
     impl AsRef<TestMessage> for TestMessage {
         fn as_ref(&self) -> &TestMessage {
-            &self
+            self
         }
     }
 

--- a/monad-proto/src/proto/message.proto
+++ b/monad-proto/src/proto/message.proto
@@ -14,19 +14,9 @@ message ProtoVoteMessage {
   monad_proto.ledger.ProtoLedgerCommitInfo ledger_commit_info = 2;
 }
 
-message ProtoUnverifiedVoteMessage {
-  ProtoVoteMessage vote_msg = 1;
-  monad_proto.signing.ProtoSecpSignature author_signature = 2;
-}
-
 message ProtoTimeoutMessage {
   monad_proto.timeout.ProtoTimeoutInfoAggSig tminfo = 1;
   optional monad_proto.timeout.ProtoTimeoutCertificate last_round_tc = 2;
-}
-
-message ProtoUnverifiedTimeoutMessage {
-  ProtoTimeoutMessage tmo_msg = 1;
-  monad_proto.signing.ProtoSecpSignature author_signature = 2;
 }
 
 message ProtoProposalMessageAggSig {
@@ -34,15 +24,11 @@ message ProtoProposalMessageAggSig {
   optional monad_proto.timeout.ProtoTimeoutCertificate last_round_tc = 2;
 }
 
-message ProtoUnverifiedProposalMessageAggSig {
-  ProtoProposalMessageAggSig proposal = 1;
-  monad_proto.signing.ProtoSecpSignature author_signature = 2;
-}
-
 message ProtoUnverifiedConsensusMessage {
   oneof OneofMessage {
-    ProtoUnverifiedProposalMessageAggSig proposal = 1;
-    ProtoUnverifiedTimeoutMessage timeout = 2;
-    ProtoUnverifiedVoteMessage vote = 3;
+    ProtoProposalMessageAggSig proposal = 1;
+    ProtoTimeoutMessage timeout = 2;
+    ProtoVoteMessage vote = 3;
   }
+  monad_proto.signing.ProtoSecpSignature author_signature = 4;
 }

--- a/monad-state/Cargo.toml
+++ b/monad-state/Cargo.toml
@@ -20,6 +20,8 @@ monad-validator = { path = "../monad-validator" }
 
 monad-proto = { path = "../monad-proto", optional = true }
 
+ref-cast = "1.0"
+
 [features]
 proto = ["dep:monad-proto"]
 


### PR DESCRIPTION
Had to lift out `Verified<T>` in order to support `impl AsRef<MonadMessage> for OutboundMonadMessage { ... }`.

I think this makes more sense conceptually anyways... verification should wrap the entire enum instead of being inside the enum - this also simplifies a good deal of code.
