### PR TITLE
Implement Debug trait manually for some types

### DIFF
--- a/monad-consensus/src/types/block.rs
+++ b/monad-consensus/src/types/block.rs
@@ -6,16 +6,33 @@ use crate::types::quorum_certificate::QuorumCertificate;
 use crate::types::signature::SignatureCollection;
 use crate::validation::hashing::{Hashable, Hasher};
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct TransactionList(pub Vec<u8>);
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+impl std::fmt::Debug for TransactionList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Txns").field(&self.0).finish()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
 pub struct Block<T> {
     pub author: NodeId,
     pub round: Round,
     pub payload: TransactionList,
     pub qc: QuorumCertificate<T>,
     id: BlockId,
+}
+
+impl<T> std::fmt::Debug for Block<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Block")
+            .field("author", &self.author)
+            .field("round", &self.round)
+            .field("qc_info", &self.qc.info)
+            .field("id", &self.id)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<T: SignatureCollection> Hashable for Block<T> {

--- a/monad-consensus/src/types/consensus_message.rs
+++ b/monad-consensus/src/types/consensus_message.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use monad_crypto::{secp256k1::KeyPair, Signature};
 
 use crate::{
@@ -10,11 +12,21 @@ use crate::{
 
 use super::signature::SignatureCollection;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum ConsensusMessage<ST, SCT> {
     Proposal(ProposalMessage<ST, SCT>),
     Vote(VoteMessage),
     Timeout(TimeoutMessage<ST, SCT>),
+}
+
+impl<ST: Debug, SCT: Debug> Debug for ConsensusMessage<ST, SCT> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &*self {
+            ConsensusMessage::Proposal(p) => f.debug_tuple("").field(&p).finish(),
+            ConsensusMessage::Vote(v) => f.debug_tuple("").field(&v).finish(),
+            ConsensusMessage::Timeout(t) => f.debug_tuple("").field(&t).finish(),
+        }
+    }
 }
 
 impl<ST, SCT> Hashable for ConsensusMessage<ST, SCT>

--- a/monad-consensus/src/types/ledger.rs
+++ b/monad-consensus/src/types/ledger.rs
@@ -5,10 +5,33 @@ use crate::{
     validation::hashing::{Hashable, Hasher},
 };
 
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Copy, Clone, Default, PartialEq, Eq)]
 pub struct LedgerCommitInfo {
     pub commit_state_hash: Option<Hash>,
     pub vote_info_hash: Hash,
+}
+
+impl std::fmt::Debug for LedgerCommitInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.commit_state_hash {
+            Some(c) => write!(
+                f,
+                "commit: {:02x}{:02x}..{:02x}{:02x} ",
+                c[0], c[1], c[30], c[31]
+            ),
+            None => write!(f, "commit: []"),
+        }?;
+
+        write!(
+            f,
+            "vote: {:02x}{:02x}..{:02x}{:02x}",
+            self.vote_info_hash[0],
+            self.vote_info_hash[1],
+            self.vote_info_hash[30],
+            self.vote_info_hash[31]
+        )?;
+        Ok(())
+    }
 }
 
 impl LedgerCommitInfo {

--- a/monad-consensus/src/types/message.rs
+++ b/monad-consensus/src/types/message.rs
@@ -10,10 +10,19 @@ use super::{
     voting::VoteInfo,
 };
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct VoteMessage {
     pub vote_info: VoteInfo,
     pub ledger_commit_info: LedgerCommitInfo,
+}
+
+impl std::fmt::Debug for VoteMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VoteMessage")
+            .field("info", &self.vote_info)
+            .field("lc", &self.ledger_commit_info)
+            .finish()
+    }
 }
 
 impl Hashable for VoteMessage {

--- a/monad-consensus/src/types/quorum_certificate.rs
+++ b/monad-consensus/src/types/quorum_certificate.rs
@@ -8,17 +8,35 @@ use crate::validation::hashing::Hasher;
 pub const GENESIS_PRIME_QC_HASH: Hash = [0xAA; 32];
 
 #[non_exhaustive]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct QuorumCertificate<T> {
     pub info: QcInfo,
     pub signatures: T,
     signature_hash: Hash,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+impl<T: std::fmt::Debug> std::fmt::Debug for QuorumCertificate<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QC")
+            .field("info", &self.info)
+            .field("sigs", &self.signatures)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct QcInfo {
     pub vote: VoteInfo,
     pub ledger_commit: LedgerCommitInfo,
+}
+
+impl std::fmt::Debug for QcInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QcInfo")
+            .field("v", &self.vote)
+            .field("lc", &self.ledger_commit)
+            .finish()
+    }
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/monad-consensus/src/types/voting.rs
+++ b/monad-consensus/src/types/voting.rs
@@ -4,12 +4,23 @@ use monad_types::*;
 
 use crate::validation::hashing::{Hashable, Hasher};
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct VoteInfo {
     pub id: BlockId,
     pub round: Round,
     pub parent_id: BlockId,
     pub parent_round: Round,
+}
+
+impl std::fmt::Debug for VoteInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VoteInfo")
+            .field("id", &self.id)
+            .field("r", &self.round)
+            .field("pid", &self.parent_id)
+            .field("pr", &self.parent_round)
+            .finish()
+    }
 }
 
 impl Hashable for VoteInfo {

--- a/monad-crypto/src/secp256k1.rs
+++ b/monad-crypto/src/secp256k1.rs
@@ -5,7 +5,7 @@ use crate::Signature;
 
 use zeroize::Zeroize;
 
-#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct PubKey(secp256k1::PublicKey);
 pub struct KeyPair(secp256k1::KeyPair);
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -17,6 +17,18 @@ pub struct Error(secp256k1::Error);
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl std::fmt::Debug for PubKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let ser = self.bytes();
+        write!(
+            f,
+            "{:02x}{:02x}..{:02x}{:02x}",
+            ser[0], ser[1], ser[30], ser[31]
+        )?;
+        Ok(())
     }
 }
 

--- a/monad-executor/src/state.rs
+++ b/monad-executor/src/state.rs
@@ -2,8 +2,15 @@ use std::{error::Error, hash::Hash};
 
 use monad_crypto::secp256k1::PubKey;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PeerId(pub PubKey);
+
+impl std::fmt::Debug for PeerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 pub enum RouterCommand<S>
 where
     S: State,

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -349,13 +349,29 @@ where
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum ConsensusEvent<S, T> {
     Message {
         sender: PubKey,
         unverified_message: Unverified<S, ConsensusMessage<S, T>>,
     },
     Timeout(PacemakerTimerExpire),
+}
+
+impl<S: Debug, T: Debug> Debug for ConsensusEvent<S, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &*self {
+            ConsensusEvent::Message {
+                sender,
+                unverified_message,
+            } => f
+                .debug_struct("Message")
+                .field("sender", &sender)
+                .field("msg", &unverified_message)
+                .finish(),
+            ConsensusEvent::Timeout(p) => p.fmt(f),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -8,7 +8,7 @@ use zerocopy::AsBytes;
 pub type Hash = [u8; 32];
 
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, AsBytes)]
+#[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd, AsBytes)]
 pub struct Round(pub u64);
 
 impl AsRef<[u8]> for Round {
@@ -39,9 +39,21 @@ impl AddAssign for Round {
     }
 }
 
+impl std::fmt::Debug for Round {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 #[repr(transparent)]
-#[derive(Copy, Clone, Hash, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct NodeId(pub PubKey);
+
+impl std::fmt::Debug for NodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 #[repr(transparent)]
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
Implement a debug fmt for some types with summarized details to make debug prints easier to read

some example output of pretty print debug output for consensus events from a two node test

```
[ID: 041b..dd07] -- [tick: 12ms] ==> Message {
    sender: 041b..dd07,
    msg: Unverified {
        obj: (
            ProposalMessage {
                block: Block {
                    author: 041b..dd07,
                    round: 7,
                    qc_info: QcInfo {
                        v: VoteInfo {
                            id: a3d7..ea5b,
                            r: 6,
                            pid: 8558..8cc3,
                            pr: 5,
                        },
                        lc: commit: a3d7..ea5b vote: 5375..fc71,
                    },
                    id: 0344..8a59,
                    ..
                },
                last_round_tc: None,
            },
        ),
        author_signature: NopSignature {
            pubkey: 041b..dd07,
            id: 2317528046,
        },
    },
}
[ID: 044d..4d07] -- [tick: 13ms] ==> Message {
    sender: 044d..4d07,
    msg: Unverified {
        obj: (
            VoteMessage {
                info: VoteInfo {
                    id: 0344..8a59,
                    r: 7,
                    pid: a3d7..ea5b,
                    pr: 6,
                },
                lc: commit: 0344..8a59 vote: 4723..65c5,
            },
        ),
        author_signature: NopSignature {
            pubkey: 044d..4d07,
            id: 4109603779,
        },
    },
}
```