### PR TITLE
Tracing Example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,6 +2619,7 @@ dependencies = [
  "monad-validator",
  "sha2 0.10.6",
  "test-case",
+ "tracing",
  "zerocopy",
 ]
 
@@ -2702,6 +2703,8 @@ dependencies = [
  "monad-types",
  "monad-validator",
  "ref-cast",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2940,6 +2943,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3087,6 +3100,12 @@ name = "os_str_bytes"
 version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owned_ttf_parser"
@@ -4159,6 +4178,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static 1.4.0",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4454,6 +4482,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4605,6 +4643,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static 1.4.0",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec 1.10.0",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4774,6 +4838,12 @@ checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
 dependencies = [
  "getrandom 0.2.9",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/monad-consensus/Cargo.toml
+++ b/monad-consensus/Cargo.toml
@@ -18,6 +18,7 @@ monad-validator = { path = "../monad-validator" }
 sha2 = "0.10.6"
 test-case = "3.0.0"
 zerocopy = "0.6.1"
+tracing = "0.1"
 
 [dev-dependencies]
 monad-testutil = { path = "../monad-testutil"}

--- a/monad-consensus/src/types/ledger.rs
+++ b/monad-consensus/src/types/ledger.rs
@@ -5,6 +5,8 @@ use crate::{
     validation::hashing::{Hashable, Hasher},
 };
 
+use tracing::{event, Level};
+
 #[derive(Copy, Clone, Default, PartialEq, Eq)]
 pub struct LedgerCommitInfo {
     pub commit_state_hash: Option<Hash>,
@@ -80,6 +82,11 @@ impl<T: SignatureCollection> Ledger for InMemoryLedger<T> {
     }
 
     fn add_blocks(&mut self, blocks: Vec<Block<Self::Signatures>>) {
+        event!(
+            Level::DEBUG,
+            num_blocks = blocks.len(),
+            "appending to ledger"
+        );
         self.blockchain.extend(blocks);
     }
 }

--- a/monad-state/Cargo.toml
+++ b/monad-state/Cargo.toml
@@ -21,12 +21,14 @@ monad-validator = { path = "../monad-validator" }
 monad-proto = { path = "../monad-proto", optional = true }
 
 ref-cast = "1.0"
+tracing = "0.1"
 
 [features]
 proto = ["dep:monad-proto"]
 
 [dev-dependencies]
 monad-testutil = { path = "../monad-testutil"}
+tracing-subscriber = "0.3"
 criterion = "0.4"
 
 [[bench]]

--- a/monad-state/tests/base.rs
+++ b/monad-state/tests/base.rs
@@ -5,8 +5,8 @@ use monad_consensus::{
     types::quorum_certificate::genesis_vote_info, validation::hashing::Sha256Hash,
 };
 use monad_crypto::{secp256k1::KeyPair, secp256k1::PubKey, NopSignature};
-use monad_executor::{mock_swarm::Nodes, State};
-use monad_state::{ConsensusEvent, MonadConfig, MonadEvent, MonadState};
+use monad_executor::mock_swarm::Nodes;
+use monad_state::{MonadConfig, MonadState};
 use monad_testutil::signing::{create_keys, get_genesis_config};
 use monad_types::BlockId;
 
@@ -61,6 +61,8 @@ fn node_ledger_verification(node_blocks: &Vec<Vec<BlockId>>) {
 }
 
 pub fn run_nodes(num_nodes: u16, num_blocks: usize) {
+    tracing_subscriber::fmt::init();
+
     let (pubkeys, state_configs) = get_configs(num_nodes, 2);
 
     let mut nodes = Nodes::<MonadState<SignatureType, SignatureCollectionType>, _>::new(
@@ -90,6 +92,8 @@ pub fn run_nodes(num_nodes: u16, num_blocks: usize) {
 }
 
 pub fn run_nodes_msg_delays(num_nodes: u16, num_blocks: usize) {
+    tracing_subscriber::fmt::init();
+
     let (pubkeys, state_configs) = get_configs(num_nodes, 101);
 
     let mut nodes = Nodes::<MonadState<SignatureType, SignatureCollectionType>, _>::new(


### PR DESCRIPTION
Example usage of tracing library - we can add instrumentation as needed in further PRs.

Usage is running the tests/binaries as is - with `tracing_subscriber::fmt::init()` called once on init.

The default log level is INFO, but can be configured by setting `RUST_LOG={trace, debug, ...}`.