### PR TITLE
Persistence and replay layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2754,6 +2754,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-wal"
+version = "0.1.0"
+dependencies = [
+ "monad-consensus",
+ "monad-crypto",
+ "monad-executor",
+ "monad-state",
+ "monad-testutil",
+ "monad-types",
+ "tempfile",
+]
+
+[[package]]
 name = "multiaddr"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "monad-types",
     "monad-validator",
     "monad-viz",
+    "monad-wal",
 ]
 
 [profile.dev]

--- a/monad-wal/Cargo.toml
+++ b/monad-wal/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "monad-wal"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+monad-executor = { version = "0.1.0", path = "../monad-executor" }
+
+[dev-dependencies]
+monad-consensus = { path = "../monad-consensus"}
+monad-crypto = { path = "../monad-crypto" }
+monad-executor = { path = "../monad-executor" }
+monad-state = { path = "../monad-state", features = ["proto"] }
+monad-testutil = { path = "../monad-testutil" }
+monad-types = { path = "../monad-types" }
+tempfile = "3.5.0"

--- a/monad-wal/src/aof.rs
+++ b/monad-wal/src/aof.rs
@@ -1,0 +1,32 @@
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub(crate) struct AppendOnlyFile {
+    file: File,
+}
+
+impl AppendOnlyFile {
+    pub fn new(file_path: PathBuf) -> io::Result<Self> {
+        // open the file in r+ (read append mode)
+        let file = OpenOptions::new()
+            .read(true)
+            .append(true)
+            .create(true)
+            .open(file_path)?;
+        Ok(Self { file })
+    }
+
+    pub fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.file.read_exact(buf)
+    }
+
+    pub fn write_all(&mut self, data: &[u8]) -> io::Result<()> {
+        self.file.write_all(data)
+    }
+
+    pub fn set_len(&mut self, len: u64) -> io::Result<()> {
+        self.file.set_len(len)
+    }
+}

--- a/monad-wal/src/lib.rs
+++ b/monad-wal/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod aof;
+pub mod wal;

--- a/monad-wal/src/wal.rs
+++ b/monad-wal/src/wal.rs
@@ -1,0 +1,94 @@
+use std::io;
+use std::marker::PhantomData;
+use std::path::PathBuf;
+
+use monad_executor::{Deserializable, Serializable};
+
+use crate::aof::AppendOnlyFile;
+
+#[derive(Debug)]
+pub enum WALError<M: Deserializable> {
+    IOError(io::Error),
+    DeserError(<M as Deserializable>::ReadError),
+}
+
+impl<M> From<io::Error> for WALError<M>
+where
+    M: Deserializable,
+{
+    fn from(value: io::Error) -> Self {
+        Self::IOError(value)
+    }
+}
+
+// the logger only accepts one type of message
+// we can refactor M to Verified/Unverified type if we write to WAL after verifying the message
+#[derive(Debug)]
+pub struct WALogger<M: Serializable + Deserializable> {
+    _marker: PhantomData<M>,
+    file_handle: AppendOnlyFile,
+}
+
+impl<M> WALogger<M>
+where
+    M: Serializable + Deserializable,
+{
+    // this definition of the new function means that we can only have one type of message in this WAL
+    // should enforce this in `push`/have WALogger parametrized by the message type
+    pub fn new(file_path: PathBuf) -> Result<(Self, Vec<M>), WALError<M>> {
+        // read the events to replay, then append-only
+        let file = AppendOnlyFile::new(file_path)?;
+        let mut logger = Self {
+            _marker: PhantomData,
+            file_handle: file,
+        };
+        let mut msg_vec = Vec::new();
+        // load msgs from file one at a time
+        let mut read_offset = 0;
+        loop {
+            match logger.load_one() {
+                Ok((msg, offset)) => {
+                    msg_vec.push(msg);
+                    read_offset += offset;
+                }
+                Err(WALError::IOError(err)) => match err.kind() {
+                    io::ErrorKind::UnexpectedEof => {
+                        // truncate the file to end of last message
+                        logger.file_handle.set_len(read_offset)?;
+                        return Ok((logger, msg_vec));
+                    }
+                    _ => return Err(WALError::IOError(err)),
+                },
+                Err(err) => return Err(err),
+            }
+        }
+    }
+
+    pub fn push_two_write(&mut self, message: &M) -> Result<(), WALError<M>> {
+        let msg_buf = message.serialize();
+        let len_buf = msg_buf.len().to_be_bytes().to_vec();
+
+        self.file_handle.write_all(&len_buf)?;
+        self.file_handle.write_all(&msg_buf)?;
+        Ok(())
+    }
+
+    pub fn push(&mut self, message: &M) -> Result<(), WALError<M>> {
+        let mut msg_buf = message.serialize();
+        let mut buf = msg_buf.len().to_be_bytes().to_vec();
+        buf.append(&mut msg_buf);
+        self.file_handle.write_all(&buf)?;
+        Ok(())
+    }
+
+    fn load_one(&mut self) -> Result<(M, u64), WALError<M>> {
+        let mut len_buf = [0u8; 8];
+        self.file_handle.read_exact(&mut len_buf)?;
+        let len = usize::from_be_bytes(len_buf);
+        let mut buf = vec![0u8; len];
+        self.file_handle.read_exact(&mut buf)?;
+        let offset = (len_buf.len() + buf.len()) as u64;
+        let msg = M::deserialize(&buf).map_err(WALError::DeserError)?;
+        Ok((msg, offset))
+    }
+}

--- a/monad-wal/tests/replay.rs
+++ b/monad-wal/tests/replay.rs
@@ -1,0 +1,215 @@
+#[cfg(test)]
+mod test {
+    use std::{array::TryFromSliceError, fs::OpenOptions, path::PathBuf};
+
+    use monad_executor::{Deserializable, Message, Serializable, State};
+    use monad_wal::wal::WALogger;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct TestEvent {
+        data: i32,
+    }
+
+    impl Serializable for TestEvent {
+        fn serialize(&self) -> Vec<u8> {
+            self.data.to_be_bytes().to_vec()
+        }
+    }
+
+    impl Deserializable for TestEvent {
+        type ReadError = TryFromSliceError;
+
+        fn deserialize(message: &[u8]) -> Result<Self, Self::ReadError> {
+            let buf: [u8; 4] = message.try_into()?;
+            Ok(Self {
+                data: i32::from_be_bytes(buf),
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    struct VecState {
+        events: Vec<TestEvent>,
+        wal: WALogger<TestEvent>,
+    }
+
+    impl VecState {
+        fn persist_event(&mut self, event: &TestEvent) {
+            self.wal.push(event).unwrap()
+        }
+    }
+
+    impl PartialEq for VecState {
+        fn eq(&self, other: &Self) -> bool {
+            self.events.eq(&other.events)
+        }
+    }
+
+    impl Eq for VecState {}
+
+    struct VecStateConfig {
+        wal_path: PathBuf,
+    }
+
+    #[derive(Clone)]
+    struct MockMessage;
+
+    impl Message for MockMessage {
+        type Event = TestEvent;
+
+        type Id = i32;
+
+        fn id(&self) -> Self::Id {
+            0
+        }
+
+        fn event(self, _from: monad_executor::PeerId) -> Self::Event {
+            TestEvent { data: 0 }
+        }
+    }
+
+    impl AsRef<MockMessage> for MockMessage {
+        fn as_ref(&self) -> &MockMessage {
+            &self
+        }
+    }
+
+    impl State for VecState {
+        type Config = VecStateConfig;
+        type Event = TestEvent;
+        type OutboundMessage = MockMessage;
+        type Message = MockMessage;
+
+        fn init(
+            config: Self::Config,
+        ) -> (
+            Self,
+            Vec<monad_executor::Command<Self::Message, Self::OutboundMessage>>,
+        ) {
+            let (wal, events): (WALogger<_>, Vec<TestEvent>) =
+                WALogger::new(config.wal_path).unwrap();
+            let mut state = VecState {
+                events: Vec::new(),
+                wal: wal,
+            };
+            for e in events {
+                state.update(e);
+            }
+            (state, Vec::new())
+        }
+
+        fn update(
+            &mut self,
+            event: Self::Event,
+        ) -> Vec<monad_executor::Command<Self::Message, Self::OutboundMessage>> {
+            self.events.push(event);
+            Vec::new()
+        }
+    }
+
+    fn generate_test_events(num: i32) -> Vec<TestEvent> {
+        (0..num).map(|i| TestEvent { data: i }).collect()
+    }
+
+    enum TestConfig {
+        Full,
+        IncompletePayload,
+        IncompleteHeader,
+    }
+
+    fn test_replay_configurable(test_config: TestConfig) {
+        // setup
+        use std::fs;
+        use std::fs::create_dir_all;
+        use tempfile::tempdir;
+
+        let events1 = generate_test_events(10);
+        let events1_len = events1.len();
+        let events2 = generate_test_events(7);
+
+        let tmpdir = tempdir().unwrap();
+        create_dir_all(tmpdir.path()).unwrap();
+        let log1_path = tmpdir.path().join("wal1");
+        let config1 = VecStateConfig {
+            wal_path: log1_path.clone(),
+        };
+
+        let (mut state1, _) = VecState::init(config1);
+
+        // driver loop (simulate executor by iterating events)
+        for (i, e) in events1.into_iter().enumerate() {
+            state1.persist_event(&e);
+            // simulate node failure when appending event by truncating the file
+            // state is not updated
+            if i == events1_len - 1 {
+                let file_len = fs::metadata(&log1_path).unwrap().len();
+                let payload_len = e.serialize().len() as u64;
+
+                let truncated_len = match test_config {
+                    TestConfig::Full => file_len,
+                    TestConfig::IncompletePayload => file_len - 1,
+                    TestConfig::IncompleteHeader => file_len - payload_len - 1,
+                };
+
+                let file = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(&log1_path)
+                    .unwrap();
+                file.set_len(truncated_len).unwrap();
+
+                if truncated_len < file_len {
+                    break;
+                }
+            }
+
+            state1.update(e);
+        }
+
+        // init another state from the wal, assert equal
+        let log1_len = fs::metadata(&log1_path).unwrap().len();
+        let log2_path = tmpdir.path().join("wal2");
+        let copied = fs::copy(&log1_path, &log2_path).unwrap();
+        assert_eq!(log1_len, copied);
+
+        let config2 = VecStateConfig {
+            wal_path: log2_path.clone(),
+        };
+
+        let (mut state2, _) = VecState::init(config2);
+        assert_eq!(state1, state2);
+
+        // another driver loop
+        for e in events2.into_iter() {
+            state2.persist_event(&e);
+            state2.update(e);
+        }
+
+        // init 3rd state from wal (to test the wal is in the right state even if it had incomplete messages)
+        let log2_len = fs::metadata(&log2_path).unwrap().len();
+        let log3_path = tmpdir.path().join("wal3");
+        let copied = fs::copy(&log2_path, &log3_path).unwrap();
+        assert_eq!(log2_len, copied);
+
+        let config3 = VecStateConfig {
+            wal_path: log3_path,
+        };
+        let (state3, _) = VecState::init(config3);
+        assert_eq!(state2, state3);
+    }
+
+    #[test]
+    fn test_replay() {
+        test_replay_configurable(TestConfig::Full);
+    }
+
+    #[test]
+    fn test_replay_incomplete_payload() {
+        test_replay_configurable(TestConfig::IncompletePayload);
+    }
+
+    #[test]
+    fn test_replay_incomplete_header() {
+        test_replay_configurable(TestConfig::IncompleteHeader);
+    }
+}


### PR DESCRIPTION
- A generic write ahead logger that can persist anything Serializable and Deserializable: an 8-byte (should probably use a smaller one) header is added to record length of the message payload
- Replay test: assert identical state can be reconstructed from the log file 
- `WAL.push` has three implementations, benchmark coming in a later PR