### PR TITLE
Benchmark: append raw data blobs through WAL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2757,6 +2757,7 @@ dependencies = [
 name = "monad-wal"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "monad-consensus",
  "monad-crypto",
  "monad-executor",

--- a/monad-wal/Cargo.toml
+++ b/monad-wal/Cargo.toml
@@ -5,14 +5,27 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+# this is necessary for criterion bench options
+# https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+[lib]
+bench = false
+
 [dependencies]
 monad-executor = { version = "0.1.0", path = "../monad-executor" }
 
 [dev-dependencies]
+criterion = "0.4.0"
+tempfile = "3.5.0"
+
 monad-consensus = { path = "../monad-consensus"}
 monad-crypto = { path = "../monad-crypto" }
 monad-executor = { path = "../monad-executor" }
 monad-state = { path = "../monad-state", features = ["proto"] }
 monad-testutil = { path = "../monad-testutil" }
 monad-types = { path = "../monad-types" }
-tempfile = "3.5.0"
+
+
+[[bench]]
+name = "raw_bench"
+harness = false
+

--- a/monad-wal/benches/raw_bench.rs
+++ b/monad-wal/benches/raw_bench.rs
@@ -1,0 +1,124 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::error::Error;
+use std::fmt::Debug;
+use std::fs::create_dir_all;
+use tempfile::{tempdir, TempDir};
+
+use monad_executor::{Deserializable, Serializable};
+use monad_wal::wal::*;
+
+const VOTE_SIZE: usize = 400;
+const BLOCK_SIZE: usize = 32 * 10000;
+const N_VALIDATORS: usize = 400;
+
+// benchmark file io append only, without serde overhead
+#[derive(Debug, Clone)]
+struct Datablob {
+    data: Vec<u8>,
+}
+
+impl Datablob {
+    fn new(byte_len: usize) -> Self {
+        Datablob {
+            data: vec![0xbf; byte_len],
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ReadError {}
+
+impl std::fmt::Display for ReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <Self as Debug>::fmt(self, f)
+    }
+}
+
+impl Error for ReadError {}
+
+impl Serializable for Datablob {
+    fn serialize(&self) -> Vec<u8> {
+        self.data.clone()
+    }
+}
+
+impl Deserializable for Datablob {
+    type ReadError = ReadError;
+
+    fn deserialize(message: &[u8]) -> Result<Self, Self::ReadError> {
+        Ok(Datablob {
+            data: message.to_vec(),
+        })
+    }
+}
+struct Bencher {
+    data: Datablob,
+    logger: WALogger<Datablob>,
+    _tmpdir: TempDir,
+}
+
+impl Bencher {
+    fn new(byte_len: usize) -> Bencher {
+        let tmpdir = tempdir().unwrap();
+        create_dir_all(tmpdir.path()).unwrap();
+        let file_path = tmpdir.path().join("wal");
+        Bencher {
+            data: Datablob::new(byte_len),
+            logger: WALogger::<Datablob>::new(file_path).unwrap().0,
+            _tmpdir: tmpdir,
+        }
+    }
+
+    fn append(&mut self) {
+        self.logger.push(&self.data).unwrap()
+    }
+    fn append_two_write(&mut self) {
+        self.logger.push_two_write(&self.data).unwrap()
+    }
+}
+
+fn bench_block(c: &mut Criterion) {
+    let mut bencher = Bencher::new(BLOCK_SIZE);
+
+    c.bench_function("block", |b| b.iter(|| bencher.append()));
+}
+
+fn bench_block_two_write(c: &mut Criterion) {
+    let mut bencher = Bencher::new(BLOCK_SIZE);
+
+    c.bench_function("block_two_write", |b| b.iter(|| bencher.append_two_write()));
+}
+
+fn bench_vote(c: &mut Criterion) {
+    let mut bencher = Bencher::new(VOTE_SIZE);
+
+    c.bench_function("vote", |b| {
+        b.iter(|| {
+            for _ in 0..N_VALIDATORS {
+                bencher.append()
+            }
+        })
+    });
+}
+
+fn bench_vote_two_write(c: &mut Criterion) {
+    let mut bencher = Bencher::new(VOTE_SIZE);
+
+    c.bench_function("vote_two_write", |b| {
+        b.iter(|| {
+            for _ in 0..N_VALIDATORS {
+                bencher.append_two_write()
+            }
+        })
+    });
+}
+
+criterion_group!(
+    bench,
+    bench_block,
+    bench_block_two_write,
+    bench_vote,
+    bench_vote_two_write,
+);
+
+criterion_main!(bench);

--- a/monad-wal/src/aof.rs
+++ b/monad-wal/src/aof.rs
@@ -26,6 +26,14 @@ impl AppendOnlyFile {
         self.file.write_all(data)
     }
 
+    pub fn sync_all(&self) -> io::Result<()> {
+        self.file.sync_all()
+    }
+
+    pub fn sync_data(&self) -> io::Result<()> {
+        self.file.sync_data()
+    }
+
     pub fn set_len(&mut self, len: u64) -> io::Result<()> {
         self.file.set_len(len)
     }

--- a/monad-wal/src/wal.rs
+++ b/monad-wal/src/wal.rs
@@ -70,6 +70,7 @@ where
 
         self.file_handle.write_all(&len_buf)?;
         self.file_handle.write_all(&msg_buf)?;
+        self.file_handle.sync_all()?;
         Ok(())
     }
 
@@ -78,6 +79,7 @@ where
         let mut buf = msg_buf.len().to_be_bytes().to_vec();
         buf.append(&mut msg_buf);
         self.file_handle.write_all(&buf)?;
+        self.file_handle.sync_all()?;
         Ok(())
     }
 


### PR DESCRIPTION
- Benchmark three ways of pushing the message header and payload
    - write(header), write(payload), flush
    - copy header + payload to one buffer, write(header + payload), flush
    - (nightly feature) write_vectored(header + payload), flush
- Benchmark result [page](https://www.notion.so/monad-labs/Append-only-file-benchmark-a837d777cd2d4837a0531ed392343199?pvs=4) 