### PR TITLE
End-to-end node example

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,3 +41,4 @@ jobs:
         -D clippy::needless_question_mark
         -D clippy::bool_comparison
         -D unused_imports
+        -D unused_parens

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,6 +2669,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-node"
+version = "0.1.0"
+dependencies = [
+ "futures-util",
+ "monad-consensus",
+ "monad-crypto",
+ "monad-executor",
+ "monad-p2p",
+ "monad-state",
+ "monad-types",
+ "rand 0.8.5",
+ "tokio",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "monad-p2p"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "monad-crypto",
     "monad-executor",
     "monad-driver",
+    "monad-node",
     "monad-p2p",
     "monad-proto",
     "monad-state",

--- a/monad-node/Cargo.toml
+++ b/monad-node/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "monad-node"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+monad-consensus = { path = "../monad-consensus" }
+monad-crypto = { path = "../monad-crypto", features = ["libp2p-identity"] }
+monad-executor = { path = "../monad-executor", features = ["tokio"] }
+monad-p2p = { path = "../monad-p2p", features = ["tokio"] }
+monad-state = { path = "../monad-state", features = ["proto"] }
+monad-types = { path = "../monad-types" }
+
+futures-util = "0.3"
+rand = "0.8"
+tokio = { version = "1.28", features = ["macros", "rt-multi-thread"] }
+tracing-subscriber = "0.3"

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -1,0 +1,156 @@
+use std::time::Duration;
+
+use monad_consensus::{
+    signatures::aggregate_signature::AggregateSignatures,
+    types::{
+        block::{Block, TransactionList},
+        ledger::LedgerCommitInfo,
+        quorum_certificate::{genesis_vote_info, QuorumCertificate},
+        signature::SignatureCollection,
+        voting::VoteInfo,
+    },
+    validation::hashing::{Hasher, Sha256Hash},
+};
+use monad_crypto::secp256k1::{KeyPair, PubKey, SecpSignature};
+use monad_crypto::Signature;
+use monad_executor::{
+    executor::{parent::ParentExecutor, timer::TokioTimer},
+    Executor, State,
+};
+use monad_p2p::Multiaddr;
+
+use futures_util::StreamExt;
+use monad_types::{NodeId, Round};
+
+type HasherType = Sha256Hash;
+type SignatureType = SecpSignature;
+type SignatureCollectionType = AggregateSignatures<SignatureType>;
+type MonadState = monad_state::MonadState<SignatureType, SignatureCollectionType>;
+type MonadConfig = <MonadState as State>::Config;
+
+pub struct Config {
+    // boxed for no implicit copies
+    pub secret_key: Box<[u8; 32]>,
+
+    pub bind_address: Multiaddr,
+
+    pub genesis_peers: Vec<(Multiaddr, PubKey)>,
+    pub delta: Duration,
+    pub genesis_block: Block<SignatureCollectionType>,
+    pub genesis_vote_info: VoteInfo,
+    pub genesis_signatures: SignatureCollectionType,
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    futures_util::future::select_all(testnet(4, Duration::from_secs(1)).map(|config| {
+        let fut = { run(config) };
+        Box::pin(fut)
+    }))
+    .await;
+}
+
+fn testnet(num_nodes: usize, delta: Duration) -> impl Iterator<Item = Config> {
+    let secrets = std::iter::repeat_with(rand::random::<[u8; 32]>)
+        .map(Box::new)
+        .take(num_nodes)
+        .collect::<Vec<_>>();
+    let keys: Vec<_> = secrets
+        .iter()
+        .cloned() // It's ok to copy these secrets because this is just used for testnet config gen
+        .map(|mut secret| KeyPair::libp2p_from_bytes(secret.as_mut_slice()).unwrap())
+        .collect();
+
+    let addresses = (0..num_nodes)
+        .map(|idx| {
+            format!("/ip4/127.0.0.1/tcp/{}", 4700 + idx)
+                .parse()
+                .unwrap()
+        })
+        .collect::<Vec<Multiaddr>>();
+
+    let peers = addresses
+        .iter()
+        .cloned()
+        .zip(keys.iter().map(|(keypair, _)| keypair.pubkey()))
+        .collect::<Vec<_>>();
+
+    let genesis_block = {
+        let genesis_txn = TransactionList::default();
+        let genesis_prime_qc = QuorumCertificate::genesis_prime_qc::<HasherType>();
+        Block::new::<HasherType>(
+            // FIXME init from genesis config, don't use random key
+            NodeId(KeyPair::from_bytes(&mut [0xBE_u8; 32]).unwrap().pubkey()),
+            Round(0),
+            &genesis_txn,
+            &genesis_prime_qc,
+        )
+    };
+    let genesis_signatures = {
+        let genesis_lci =
+            LedgerCommitInfo::new::<HasherType>(None, &genesis_vote_info(genesis_block.get_id()));
+        let msg = HasherType::hash_object(&genesis_lci);
+        let mut signatures = SignatureCollectionType::new();
+        for signature in keys
+            .iter()
+            .map(|(key, _)| SignatureType::sign(msg.as_ref(), key))
+        {
+            signatures.add_signature(signature)
+        }
+        signatures
+    };
+
+    addresses
+        .into_iter()
+        .zip(secrets.into_iter())
+        .map(move |(bind_address, secret_key)| Config {
+            secret_key,
+            bind_address,
+            genesis_peers: peers.clone(),
+            delta,
+            genesis_block: genesis_block.clone(),
+            genesis_vote_info: genesis_vote_info(genesis_block.get_id()),
+            genesis_signatures: genesis_signatures.clone(),
+        })
+}
+
+async fn run(mut config: Config) {
+    let (keypair, libp2p_keypair) =
+        KeyPair::libp2p_from_bytes(config.secret_key.as_mut_slice()).expect("invalid key");
+
+    let mut router =
+        monad_p2p::Service::with_tokio_executor(libp2p_keypair.into(), config.bind_address).await;
+    for (address, peer) in &config.genesis_peers {
+        router.add_peer(&peer.into(), address.clone())
+    }
+
+    let mut executor = ParentExecutor {
+        router,
+        timer: TokioTimer::default(),
+    };
+
+    let (mut state, init_commands) = MonadState::init(MonadConfig {
+        validators: config
+            .genesis_peers
+            .into_iter()
+            .map(|(_, peer)| peer)
+            .collect(),
+        key: keypair,
+        delta: config.delta,
+        genesis_block: config.genesis_block,
+        genesis_vote_info: config.genesis_vote_info,
+        genesis_signatures: config.genesis_signatures,
+    });
+    executor.exec(init_commands);
+
+    // FIXME hack so all tcp sockets are bound before they try and send mesages
+    // we can delete this once we support retry at the monad-p2p executor level
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    while let Some(event) = executor.next().await {
+        let commands = state.update(event);
+        executor.exec(commands);
+    }
+}

--- a/monad-p2p/Cargo.toml
+++ b/monad-p2p/Cargo.toml
@@ -22,4 +22,4 @@ async-trait = "0.1"
 libp2p = { version = "0.51", features = ["macros", "mplex", "noise", "identify", "request-response", "secp256k1"] }
 
 [features]
-tokio = ["libp2p/tokio"]
+tokio = ["libp2p/tcp", "libp2p/tokio"]

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -214,6 +214,7 @@ where
 
     fn init(config: Self::Config) -> (Self, Vec<Command<Self::Message, Self::OutboundMessage>>) {
         // create my keys and validator structs
+        // FIXME stake should be configurable
         let validator_list = config
             .validators
             .into_iter()


### PR DESCRIPTION
End-to-end example of glueing everything together (monad-p2p, monad-state, etc)

Will add CLI options in a later PR for writing genesis configs to a file, reading genesis configs from a file, etc.