### PR TITLE
move monad-executor::{ser/de} to monad-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,6 +2664,7 @@ dependencies = [
  "monad-crypto",
  "monad-proto",
  "monad-testutil",
+ "monad-types",
  "tokio",
 ]
 
@@ -2677,6 +2678,7 @@ dependencies = [
  "monad-consensus",
  "monad-crypto",
  "monad-executor",
+ "monad-types",
 ]
 
 [[package]]

--- a/monad-executor/Cargo.toml
+++ b/monad-executor/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1.26", features = ["time"], optional = true }
 
 [dev-dependencies]
 monad-testutil = { path = "../monad-testutil"}
+monad-types = { path = "../monad-types" }
 
 [features]
 proto = ["dep:monad-proto", "monad-crypto/proto"]

--- a/monad-executor/src/executor/mock.rs
+++ b/monad-executor/src/executor/mock.rs
@@ -356,6 +356,7 @@ mod tests {
 
     use monad_crypto::secp256k1::KeyPair;
     use monad_testutil::signing::{create_keys, node_id};
+    use monad_types::{Deserializable, Serializable};
 
     use crate::{
         executor::mock::MockExecutor,

--- a/monad-executor/src/state.rs
+++ b/monad-executor/src/state.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, hash::Hash};
+use std::hash::Hash;
 
 use monad_crypto::secp256k1::PubKey;
 
@@ -75,16 +75,6 @@ pub trait State: Sized {
 
     fn init(config: Self::Config) -> (Self, Vec<Command<Self::Message, Self::OutboundMessage>>);
     fn update(&mut self, event: Self::Event) -> Vec<Command<Self::Message, Self::OutboundMessage>>;
-}
-
-pub trait Serializable {
-    fn serialize(&self) -> Vec<u8>;
-}
-
-pub trait Deserializable: Sized {
-    type ReadError: Error + Send + Sync;
-
-    fn deserialize(message: &[u8]) -> Result<Self, Self::ReadError>;
 }
 
 pub trait Message: Clone {

--- a/monad-p2p/Cargo.toml
+++ b/monad-p2p/Cargo.toml
@@ -14,6 +14,7 @@ bench = false
 monad-consensus = { path = "../monad-consensus" }
 monad-crypto = { path = "../monad-crypto", features = ["libp2p-identity"] }
 monad-executor = { path = "../monad-executor" }
+monad-types = { path = "../monad-types" }
 
 futures = "0.3"
 async-trait = "0.1"

--- a/monad-p2p/src/behavior/codec.rs
+++ b/monad-p2p/src/behavior/codec.rs
@@ -1,7 +1,8 @@
 use std::{io::ErrorKind, marker::PhantomData, sync::Arc};
 
 use async_trait::async_trait;
-use monad_executor::{Deserializable, Message, PeerId, Serializable};
+use monad_executor::{Message, PeerId};
+use monad_types::{Deserializable, Serializable};
 
 use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use libp2p::request_response::Codec;

--- a/monad-p2p/src/behavior/mod.rs
+++ b/monad-p2p/src/behavior/mod.rs
@@ -1,5 +1,5 @@
 use libp2p::{request_response::ProtocolSupport, swarm::NetworkBehaviour};
-use monad_executor::{Deserializable, Serializable};
+use monad_types::{Deserializable, Serializable};
 
 mod codec;
 pub use codec::WrappedMessage;

--- a/monad-p2p/src/lib.rs
+++ b/monad-p2p/src/lib.rs
@@ -6,7 +6,8 @@ use std::{
 };
 
 use futures::{FutureExt, Stream, StreamExt};
-use monad_executor::{Deserializable, Executor, Message, RouterCommand, Serializable};
+use monad_executor::{Executor, Message, RouterCommand};
+use monad_types::{Deserializable, Serializable};
 
 use libp2p::{request_response::RequestId, swarm::SwarmBuilder, Multiaddr, Transport};
 
@@ -274,7 +275,8 @@ mod tests {
     };
 
     use crate::Service;
-    use monad_executor::{Deserializable, Message, Serializable};
+    use monad_executor::Message;
+    use monad_types::{Deserializable, Serializable};
 
     use futures::StreamExt;
 

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -87,7 +87,7 @@ where
 }
 
 #[cfg(feature = "proto")]
-impl monad_executor::Deserializable
+impl monad_types::Deserializable
     for MonadEvent<
         monad_crypto::secp256k1::SecpSignature,
         monad_consensus::signatures::aggregate_signature::AggregateSignatures<
@@ -103,7 +103,7 @@ impl monad_executor::Deserializable
 }
 
 #[cfg(feature = "proto")]
-impl monad_executor::Serializable
+impl monad_types::Serializable
     for MonadEvent<
         monad_crypto::secp256k1::SecpSignature,
         monad_consensus::signatures::aggregate_signature::AggregateSignatures<
@@ -125,7 +125,7 @@ pub struct VerifiedMonadMessage<ST, SCT>(Verified<ST, ConsensusMessage<ST, SCT>>
 pub struct MonadMessage<ST, SCT>(Unverified<ST, ConsensusMessage<ST, SCT>>);
 
 #[cfg(feature = "proto")]
-impl monad_executor::Serializable
+impl monad_types::Serializable
     for VerifiedMonadMessage<
         monad_crypto::secp256k1::SecpSignature,
         monad_consensus::signatures::aggregate_signature::AggregateSignatures<
@@ -139,7 +139,7 @@ impl monad_executor::Serializable
 }
 
 #[cfg(feature = "proto")]
-impl monad_executor::Deserializable
+impl monad_types::Deserializable
     for MonadMessage<
         monad_crypto::secp256k1::SecpSignature,
         monad_consensus::signatures::aggregate_signature::AggregateSignatures<

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "proto")]
 pub mod convert;
 
+use std::error::Error;
 use std::ops::Add;
 use std::ops::AddAssign;
 use std::ops::Deref;
@@ -86,4 +87,14 @@ impl std::fmt::Debug for BlockId {
             self.0[0], self.0[1], self.0[30], self.0[31]
         )
     }
+}
+
+pub trait Serializable {
+    fn serialize(&self) -> Vec<u8>;
+}
+
+pub trait Deserializable: Sized {
+    type ReadError: Error + Send + Sync;
+
+    fn deserialize(message: &[u8]) -> Result<Self, Self::ReadError>;
 }

--- a/monad-wal/Cargo.toml
+++ b/monad-wal/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 bench = false
 
 [dependencies]
-monad-executor = { path = "../monad-executor" }
+monad-types = { path = "../monad-types" }
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/monad-wal/benches/event_bench.rs
+++ b/monad-wal/benches/event_bench.rs
@@ -26,12 +26,13 @@ use monad_consensus::{
     },
 };
 use monad_crypto::secp256k1::{KeyPair, SecpSignature};
-use monad_executor::{PeerId, Serializable};
+use monad_executor::PeerId;
 use monad_state::{ConsensusEvent, MonadEvent};
 use monad_testutil::{
     block::setup_block,
     signing::{create_keys, get_key},
 };
+use monad_types::Serializable;
 use monad_types::{BlockId, Hash, NodeId, Round};
 use monad_wal::wal::WALogger;
 use monad_wal::PersistenceLogger;

--- a/monad-wal/benches/raw_bench.rs
+++ b/monad-wal/benches/raw_bench.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use std::fs::create_dir_all;
 use tempfile::{tempdir, TempDir};
 
-use monad_executor::{Deserializable, Serializable};
+use monad_types::{Deserializable, Serializable};
 use monad_wal::wal::*;
 use monad_wal::PersistenceLogger;
 

--- a/monad-wal/src/lib.rs
+++ b/monad-wal/src/lib.rs
@@ -5,7 +5,7 @@ pub mod wal;
 use std::path::PathBuf;
 use std::{error::Error, fmt::Debug};
 
-use monad_executor::{Deserializable, Serializable};
+use monad_types::{Deserializable, Serializable};
 
 // the persistence layer only accepts one type of message
 // we can refactor M to Verified/Unverified type if we write to WAL after verifying the message

--- a/monad-wal/src/mock.rs
+++ b/monad-wal/src/mock.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use monad_executor::{Deserializable, Serializable};
+use monad_types::{Deserializable, Serializable};
 
 use crate::PersistenceLogger;
 

--- a/monad-wal/src/wal.rs
+++ b/monad-wal/src/wal.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use std::path::PathBuf;
 use std::{fmt::Debug, io};
 
-use monad_executor::{Deserializable, Serializable};
+use monad_types::{Deserializable, Serializable};
 
 use crate::aof::AppendOnlyFile;
 use crate::PersistenceLogger;

--- a/monad-wal/tests/replay.rs
+++ b/monad-wal/tests/replay.rs
@@ -2,7 +2,8 @@
 mod test {
     use std::{array::TryFromSliceError, fs::OpenOptions, path::PathBuf};
 
-    use monad_executor::{Deserializable, Message, Serializable, State};
+    use monad_executor::{Message, State};
+    use monad_types::{Deserializable, Serializable};
     use monad_wal::wal::WALogger;
     use monad_wal::PersistenceLogger;
 


### PR DESCRIPTION
Moving Serializable/Deserializable trait from `monad-executor` to `monad-types`
Preparing for #94: `monad-wal` depends on the traits and `monad-executor::mock_swarm` will depend on `monad-wal`. Moving the traits to `monad-types` to avoid circular dependency