### PR TITLE
Add a PeerId filter list to MockSwarm

### DIFF
--- a/monad-executor/src/executor/mock.rs
+++ b/monad-executor/src/executor/mock.rs
@@ -738,6 +738,7 @@ mod tests {
                 .zip(state_configs)
                 .collect(),
             |_from, _to| Duration::from_millis(50),
+            Vec::new(),
         );
 
         while let Some((duration, id, event)) = nodes.step() {

--- a/monad-state/tests/base.rs
+++ b/monad-state/tests/base.rs
@@ -66,6 +66,7 @@ pub fn run_nodes(num_nodes: u16, num_blocks: usize) {
     let mut nodes = Nodes::<MonadState<SignatureType, SignatureCollectionType>, _>::new(
         pubkeys.into_iter().zip(state_configs).collect(),
         |_node_1, _node_2| Duration::from_millis(1),
+        Vec::new(),
     );
 
     while let Some((duration, id, event)) = nodes.step() {
@@ -104,6 +105,7 @@ pub fn run_nodes_msg_delays(num_nodes: u16, num_blocks: usize) {
             }
             Duration::from_millis(ck as u64 % 600)
         },
+        Vec::new(),
     );
 
     while let Some((duration, id, event)) = nodes.step() {

--- a/monad-viz/src/graph.rs
+++ b/monad-viz/src/graph.rs
@@ -76,13 +76,17 @@ where
             init_compute_latency: compute_latency.clone(),
             max_tick,
 
-            nodes: Nodes::new(configs, compute_latency),
+            nodes: Nodes::new(configs, compute_latency, Vec::new()),
             current_tick: Duration::from_secs(0),
         }
     }
 
     fn reset(&mut self) {
-        self.nodes = Nodes::new((self.init_configs_gen)(), self.init_compute_latency.clone());
+        self.nodes = Nodes::new(
+            (self.init_configs_gen)(),
+            self.init_compute_latency.clone(),
+            Vec::new(),
+        );
         self.current_tick = self.min_tick();
     }
 }


### PR DESCRIPTION
filter list prevents nodes in the list from receiving messages