### PR TITLE
monad-sim

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+.dockerignore
+
+**/.git
+**/target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,10 +171,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.70"
+name = "anstream"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "arc-swap"
@@ -412,7 +461,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.160",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -513,9 +562,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
 
 [[package]]
 name = "bytemuck"
@@ -605,26 +654,26 @@ dependencies = [
 
 [[package]]
 name = "ciborium"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
- "serde 1.0.160",
+ "serde 1.0.163",
 ]
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half",
@@ -660,14 +709,50 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "bitflags",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex 0.4.1",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -678,6 +763,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "clipboard-win"
@@ -696,6 +787,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,9 +808,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
 dependencies = [
  "lazy_static 1.4.0",
- "nom 5.1.2",
+ "nom 5.1.3",
  "rust-ini",
- "serde 1.0.160",
+ "serde 1.0.163",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -814,7 +911,7 @@ dependencies = [
  "atty",
  "cast",
  "ciborium",
- "clap",
+ "clap 3.2.25",
  "criterion-plot",
  "itertools",
  "lazy_static 1.4.0",
@@ -823,7 +920,7 @@ dependencies = [
  "plotters",
  "rayon",
  "regex",
- "serde 1.0.160",
+ "serde 1.0.163",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -1165,13 +1262,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1234,7 +1331,7 @@ dependencies = [
  "curve25519-dalek 3.2.0",
  "ed25519",
  "rand 0.7.3",
- "serde 1.0.160",
+ "serde 1.0.163",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -1410,12 +1507,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.6.2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1914,6 +2011,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,18 +2039,18 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "68c16e1bfd491478ab155fd8b4896b86f9ede344949b641e61501e07c2b8b4d5"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "keccak"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
 ]
@@ -1990,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libloading"
@@ -2013,8 +2122,7 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 [[package]]
 name = "libp2p"
 version = "0.51.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f210d259724eae82005b5c48078619b7745edb7b76de370b03f8ba59ea103097"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "bytes",
  "futures",
@@ -2043,8 +2151,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c54073648b20bb47335164544a4e5694434f44530f47a4f6618f5f585f3ff5"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -2055,8 +2162,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caa33f1d26ed664c4fe2cca81a08c8e07d4c1c04f2f4ac7655c2dd85467fda0"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -2067,8 +2173,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.39.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7f8b7d65c070a5a1b5f8f0510648189da08f787b8963f8e21219e0710733af"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "either",
  "fnv",
@@ -2095,11 +2200,11 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146ff7034daae62077c415c2376b8057368042df6ab95f5432ad5e88568b1554"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "futures",
  "libp2p-core",
+ "libp2p-identity",
  "log",
  "parking_lot",
  "smallvec 1.10.0",
@@ -2109,8 +2214,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40d1da1f75baf824cfdc80f6aced51f7cbf8dc14e32363e9443570a80d4ee337"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -2131,8 +2235,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identity"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a8ea433ae0cea7e3315354305237b9897afe45278b2118a7a57ca744e70fd27"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -2141,7 +2244,6 @@ dependencies = [
  "log",
  "multiaddr",
  "multihash",
- "prost",
  "quick-protobuf",
  "rand 0.8.5",
  "sha2 0.10.6",
@@ -2152,8 +2254,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.43.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19983e1f949f979a928f2c603de1cf180cc0dc23e4ac93a62651ccb18341460b"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "data-encoding",
  "futures",
@@ -2173,11 +2274,11 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42ec91e227d7d0dafa4ce88b333cdf5f277253873ab087555c92798db2ddd46"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "libp2p-core",
  "libp2p-identify",
+ "libp2p-identity",
  "libp2p-swarm",
  "prometheus-client",
 ]
@@ -2185,13 +2286,13 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d34780b514b159e6f3fd70ba3e72664ec89da28dca2d1e7856ee55e2c7031ba"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "futures",
  "libp2p-core",
+ "libp2p-identity",
  "log",
  "nohash-hasher",
  "parking_lot",
@@ -2203,8 +2304,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c87c2803deffeae94108072a0387f8c9ff494af68a4908454c11c811e27b5e5"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
@@ -2226,8 +2326,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.7.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b26abd81cd2398382a1edfe739b539775be8a90fa6914f39b2ab49571ec735"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "bytes",
  "futures",
@@ -2248,26 +2347,22 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872b9d63fed44d9f81110c30be6c7ca5593a093576d2a95c5d018051e294d2e9"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "async-trait",
- "bytes",
  "futures",
  "instant",
  "libp2p-core",
+ "libp2p-identity",
  "libp2p-swarm",
- "log",
  "rand 0.8.5",
  "smallvec 1.10.0",
- "unsigned-varint",
 ]
 
 [[package]]
 name = "libp2p-swarm"
 version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd1e223f02fcd7e3790f9b954e2e81791810e3512daeb27fa97df7652e946bc2"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "either",
  "fnv",
@@ -2287,25 +2382,24 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fba456131824ab6acd4c7bf61e9c0f0a3014b5fc9868ccb8e10d344594cdc4f"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "heck",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "libp2p-tcp"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d33698596d7722d85d3ab0c86c2c322254fce1241e91208e3679b4eb3026cf"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
  "libc",
  "libp2p-core",
+ "libp2p-identity",
  "log",
  "socket2",
  "tokio",
@@ -2314,8 +2408,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff08d13d0dc66e5e9ba6279c1de417b84fa0d0adc3b03e5732928c180ec02781"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -2326,15 +2419,14 @@ dependencies = [
  "rustls 0.20.8",
  "thiserror",
  "webpki 0.22.0",
- "x509-parser 0.14.0",
+ "x509-parser 0.15.0",
  "yasna",
 ]
 
 [[package]]
 name = "libp2p-webrtc"
 version = "0.4.0-alpha.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba48592edbc2f60b4bc7c10d65445b0c3964c07df26fdf493b6880d33be36f8"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -2352,7 +2444,8 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.5",
  "rcgen 0.9.3",
- "serde 1.0.160",
+ "serde 1.0.163",
+ "sha2 0.10.6",
  "stun",
  "thiserror",
  "tinytemplate",
@@ -2375,7 +2468,7 @@ dependencies = [
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
- "serde 1.0.160",
+ "serde 1.0.163",
  "sha2 0.9.9",
  "typenum",
 ]
@@ -2417,9 +2510,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "lock_api"
@@ -2442,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
+checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
 dependencies = [
  "hashbrown 0.13.2",
 ]
@@ -2569,15 +2662,6 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
@@ -2672,6 +2756,7 @@ dependencies = [
 name = "monad-node"
 version = "0.1.0"
 dependencies = [
+ "clap 4.2.7",
  "futures-util",
  "monad-consensus",
  "monad-crypto",
@@ -2681,6 +2766,7 @@ dependencies = [
  "monad-types",
  "rand 0.8.5",
  "tokio",
+ "tracing",
  "tracing-subscriber",
 ]
 
@@ -2695,6 +2781,7 @@ dependencies = [
  "monad-crypto",
  "monad-executor",
  "monad-types",
+ "tracing",
 ]
 
 [[package]]
@@ -2798,7 +2885,7 @@ dependencies = [
  "multibase",
  "multihash",
  "percent-encoding",
- "serde 1.0.160",
+ "serde 1.0.163",
  "static_assertions",
  "unsigned-varint",
  "url",
@@ -2855,8 +2942,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "multistream-select"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8552ab875c1313b97b8d20cb857b9fd63e2d1d6a0a1b53ce9821e575405f27a"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "bytes",
  "futures",
@@ -2958,9 +3044,9 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
-version = "5.1.2"
+version = "5.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
 dependencies = [
  "lexical-core",
  "memchr",
@@ -3296,9 +3382,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "platforms"
@@ -3344,7 +3430,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.7.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -3554,7 +3640,7 @@ dependencies = [
  "config",
  "directories",
  "petgraph",
- "serde 1.0.160",
+ "serde 1.0.163",
  "serde-value",
  "tint",
 ]
@@ -3615,8 +3701,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1693116345026436eb2f10b677806169c1a1260c1c60eaaffe3fb5a29ae23d8b"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -3645,9 +3730,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -3907,7 +3992,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "rand 0.8.5",
- "serde 1.0.160",
+ "serde 1.0.163",
  "thiserror",
  "webrtc-util",
 ]
@@ -3944,9 +4029,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.14"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
@@ -3984,8 +4069,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26338f5e09bb721b85b135ea05af7767c90b52f6de4f087d4f4a3a9d64e7dc04"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
 dependencies = [
  "futures",
  "pin-project",
@@ -4103,9 +4187,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
@@ -4129,14 +4213,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
- "serde 1.0.160",
+ "serde 1.0.163",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4151,7 +4235,7 @@ checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.160",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -4204,9 +4288,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.6",
  "keccak",
@@ -4528,27 +4612,27 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
- "serde 1.0.160",
+ "serde 1.0.163",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -4577,7 +4661,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde 1.0.160",
+ "serde 1.0.163",
  "serde_json",
 ]
 
@@ -4598,9 +4682,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4646,15 +4730,16 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.160",
+ "serde 1.0.163",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.38"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9cf6a813d3f40c88b0b6b6f29a5c95c6cdbf97c1f9cc53fb820200f5ad814d"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
+ "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4844,8 +4929,6 @@ checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
 dependencies = [
  "asynchronous-codec",
  "bytes",
- "futures-io",
- "futures-util",
 ]
 
 [[package]]
@@ -4866,10 +4949,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "uuid"
-version = "1.3.1"
+name = "utf8parse"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
 dependencies = [
  "getrandom 0.2.9",
 ]
@@ -4931,9 +5020,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5b6cb788c4e39112fbe1822277ef6fb3c55cd86b95cb3d3c4c1c9597e4ac74b4"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4941,24 +5030,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "35e522ed4105a9d626d885b35d62501b30d9666283a5c8be12c14a8bdafe7822"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "358a79a0cb89d21db8120cbfb91392335913e4890665b1a7981d9e956903b434"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4966,22 +5055,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "a901d592cafaa4d711bc324edfaff879ac700b19c3dfd60058d2b445be2691eb"
 
 [[package]]
 name = "wayland-client"
@@ -5058,9 +5147,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "16b5f940c7edfdc6d12126d98c9ef4d1b3d470011c47c76a6581df47ad9ba721"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5118,7 +5207,7 @@ dependencies = [
  "rtp",
  "rustls 0.19.1",
  "sdp",
- "serde 1.0.160",
+ "serde 1.0.163",
  "serde_json",
  "sha2 0.10.6",
  "stun",
@@ -5181,7 +5270,7 @@ dependencies = [
  "ring",
  "rustls 0.19.1",
  "sec1",
- "serde 1.0.160",
+ "serde 1.0.163",
  "sha1",
  "sha2 0.10.6",
  "signature",
@@ -5205,7 +5294,7 @@ dependencies = [
  "crc",
  "log",
  "rand 0.8.5",
- "serde 1.0.160",
+ "serde 1.0.163",
  "serde_json",
  "stun",
  "thiserror",
@@ -5627,12 +5716,11 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+checksum = "bab0c2f54ae1d92f4fcb99c0b7ccf0b1e3451cbd395e5f115ccbdbcb18d4f634"
 dependencies = [
  "asn1-rs 0.5.2",
- "base64",
  "data-encoding",
  "der-parser 8.2.0",
  "lazy_static 1.4.0",
@@ -5654,9 +5742,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.4"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+checksum = "dc95a04ea24f543cd9be5aab44f963fa35589c99e18415c38fb2b17e133bf8d2"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ members = [
     "monad-blocktree",
     "monad-consensus",
     "monad-crypto",
-    "monad-executor",
     "monad-driver",
+    "monad-executor", 
     "monad-node",
     "monad-p2p",
     "monad-proto",
@@ -19,3 +19,7 @@ members = [
 
 [profile.dev]
 opt-level = 1
+
+[workspace.dependencies]
+libp2p = { git = "https://github.com/monad-crypto/rust-libp2p.git", rev = "a2a5160b" }
+libp2p-identity = { git = "https://github.com/monad-crypto/rust-libp2p.git", rev = "a2a5160b" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM rust:1-buster AS chef 
+RUN cargo install cargo-chef 
+WORKDIR app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare  --recipe-path recipe.json
+
+FROM chef AS builder
+
+WORKDIR /usr/src/monad-bft
+RUN apt update
+RUN apt install -y python3
+
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --recipe-path recipe.json
+# Build application
+COPY . .
+RUN cargo install --path monad-node
+RUN python3 tc-gen.py > tc.sh
+
+
+FROM debian:buster-slim
+WORKDIR /usr/src/monad-bft
+
+RUN apt update
+RUN apt install -y iproute2
+COPY --from=builder /usr/local/cargo/bin/monad-node /usr/local/bin/monad-node
+COPY --from=builder /usr/src/monad-bft/tc.sh .
+
+ENV RUST_LOG=trace
+CMD ["bash", "tc.sh"]

--- a/monad-crypto/Cargo.toml
+++ b/monad-crypto/Cargo.toml
@@ -18,7 +18,7 @@ secp256k1 = { version = "0.26", features = ["global-context", "recovery"] }
 sha2 = "0.10"
 zeroize = "1.3"
 
-libp2p-identity = { version = "0.1", features = ["secp256k1"], optional = true }
+libp2p-identity = { workspace = true, features = ["secp256k1"], optional = true }
 multihash = { version = "0.17", features = ["identity"], optional = true }
 zerocopy = "0.6.1"
 

--- a/monad-driver/Cargo.toml
+++ b/monad-driver/Cargo.toml
@@ -13,7 +13,7 @@ monad-p2p = { path = "../monad-p2p", features = ["tokio"] }
 monad-state = { path = "../monad-state", features = ["proto"] }
 
 futures = "0.3"
-libp2p = { version = "0.51" }
+libp2p = { workspace = true }
 tokio = { version = "1.28", features = ["rt", "macros"] }
 
 [dev-dependencies]

--- a/monad-node/Cargo.toml
+++ b/monad-node/Cargo.toml
@@ -13,7 +13,9 @@ monad-p2p = { path = "../monad-p2p", features = ["tokio"] }
 monad-state = { path = "../monad-state", features = ["proto"] }
 monad-types = { path = "../monad-types" }
 
+clap = { version = "4.2", features = ["derive"] }
 futures-util = "0.3"
 rand = "0.8"
 tokio = { version = "1.28", features = ["macros", "rt-multi-thread"] }
+tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/monad-p2p/Cargo.toml
+++ b/monad-p2p/Cargo.toml
@@ -18,8 +18,9 @@ monad-types = { path = "../monad-types" }
 
 futures = "0.3"
 async-trait = "0.1"
+tracing = "0.1"
 
-libp2p = { version = "0.51", features = ["macros", "mplex", "noise", "identify", "request-response", "secp256k1"] }
+libp2p = { workspace = true, features = ["macros", "mplex", "noise", "identify", "request-response", "secp256k1"] }
 
 [features]
 tokio = ["libp2p/tcp", "libp2p/tokio"]

--- a/monad-p2p/src/behavior/mod.rs
+++ b/monad-p2p/src/behavior/mod.rs
@@ -11,7 +11,7 @@ where
     <M as Deserializable>::ReadError: 'static,
     OM: Serializable + Send + Sync + 'static,
 {
-    pub identify: libp2p::identify::Behaviour,
+    // pub identify: libp2p::identify::Behaviour,
     pub request_response: libp2p::request_response::Behaviour<codec::ReliableMessageCodec<M, OM>>,
 }
 const IDENTIFY_PROTO_NAME: &str = "/monad/identify/0.0.1";
@@ -45,7 +45,7 @@ where
         );
 
         Self {
-            identify,
+            // identify,
             request_response,
         }
     }

--- a/tc-gen.py
+++ b/tc-gen.py
@@ -1,0 +1,154 @@
+#!/usr/bin/python3
+
+device = "lo"
+regions = [
+    {
+        "name": "us",
+        "latencies_ms": [10, 50, 100],
+        "nodes": [
+            {
+                "up_Mbps": 100,
+                "down_Mbps": 100,
+            },
+        ],
+    },
+    {
+        "name": "europe",
+        "latencies_ms": [50, 10, 50],
+        "nodes": [
+            {
+                "up_Mbps": 100,
+                "down_Mbps": 100,
+            },
+        ],
+    },
+    {
+        "name": "asia",
+        "latencies_ms": [100, 50, 10],
+        "nodes": [
+            {
+                "up_Mbps": 100,
+                "down_Mbps": 100,
+            },
+        ],
+    },
+]
+# regions = [
+#     {
+#         "name": "asia",
+#         "latencies_ms": [50],
+#         "nodes": [
+#             {
+#                 "up_Mbps": 100,
+#                 "down_Mbps": 100,
+#             },
+#             {
+#                 "up_Mbps": 100,
+#                 "down_Mbps": 100,
+#             },
+#         ],
+#     },
+# ]
+
+commands = []
+node_ips = []
+
+commands.append("set -x")
+commands.append("# INBOUND")
+commands.append(
+    "tc qdisc add dev {} handle ffff: ingress".format(
+        device,
+    )
+)
+for region_idx, region in enumerate(regions):
+    for node in region["nodes"]:
+        # inbound
+        commands.append(
+            "tc filter add dev {} parent ffff: u32 match ip dst 127.{}.0.0/16 police rate {}mbit burst {}".format(
+                device,
+                100 + region_idx,
+                node["down_Mbps"],
+                1_000_000, # 100 KB
+            )
+        )
+
+commands.append("")
+commands.append("")
+commands.append("")
+commands.append("# OUTBOUND")
+commands.append("tc qdisc add dev {} root handle 1: htb".format(device))
+
+node_idx = 0
+for region_idx, region in enumerate(regions):
+    commands.append("")
+    commands.append("")
+    commands.append("# REGION: {}".format(region["name"]))
+    for node in region["nodes"]:
+        commands.append("")
+        commands.append("# -> FROM_NODE: {}".format(node_idx))
+        # outbound
+        commands.append(
+            "tc class add dev {} parent 1: classid 1:{} htb rate {}mbit".format(
+                device,
+                node_idx + 1,
+                node["up_Mbps"],
+            )
+        )
+        node_ip = "127.{}.0.{}".format(100 + region_idx, node_idx + 1)
+        commands.append(
+            "tc filter add dev {} protocol ip parent 1: prio 1 u32 match ip src {}/32 flowid 1:{}".format(
+                device,
+                node_ip,
+                node_idx + 1,
+            )
+        )
+        node_ips.append(node_ip)
+
+        drr_qdisc = 10 * (node_idx + 1)
+        commands.append(
+            "tc qdisc add dev {} parent 1:{} handle {}: drr".format(
+                device, node_idx + 1, drr_qdisc
+            )
+        )
+
+        for r_idx, r_delay in enumerate(region["latencies_ms"]):
+            commands.append("")
+            commands.append("# ---> TO: {}".format(regions[r_idx]["name"]))
+            commands.append(
+                "tc class add dev {} parent {}: classid {}:{} drr".format(
+                    device,
+                    drr_qdisc,
+                    drr_qdisc,
+                    r_idx + 1,
+                )
+            )
+            commands.append(
+                "tc filter add dev {} protocol ip parent {}: prio 1 u32 match ip dst 127.{}.0.0/16 flowid {}:{}".format(
+                    device,
+                    drr_qdisc,
+                    100 + r_idx,
+                    drr_qdisc,
+                    r_idx + 1,
+                )
+            )
+
+            netem_qdisc = 10 * drr_qdisc + r_idx
+            commands.append(
+                "tc qdisc add dev {} parent {}:{} handle {}: netem delay {}ms".format(
+                    device,
+                    drr_qdisc,
+                    r_idx + 1,
+                    netem_qdisc,
+                    r_delay,
+                )
+            )
+
+        node_idx += 1
+
+
+commands.append("")
+commands.append("")
+commands.append("monad-node --addresses {}".format(" ".join(node_ips)))
+
+for command in commands:
+    print(command)


### PR DESCRIPTION
I think we should create a separate `crates/` dir and put all our crates in there, so that we can split out stuff like `tc-gen.py` into its own folder (maybe `tools/`)?

Will also create a github action for this stuff later.

Test can be run via:
```bash
docker run --cap-add=NET_ADMIN --rm -it $(docker build -q .)
```