### PR TITLE
consensus_state commit rule test

### DIFF
--- a/monad-state/tests/single_node.rs
+++ b/monad-state/tests/single_node.rs
@@ -1,12 +1,11 @@
-use std::time::Duration;
-
-use monad_executor::mock_swarm::LatencyTransformer;
-
 mod base;
 
 #[cfg(feature = "proto")]
 #[test]
 fn two_nodes() {
+    use monad_executor::mock_swarm::LatencyTransformer;
+    use std::time::Duration;
+
     tracing_subscriber::fmt::init();
 
     base::run_nodes(


### PR DESCRIPTION
Adding two tests to test the commit rule: specifically how `ledger_commit_info.commit_state_hash` is populated.