### PR TITLE
`Transformer` abstraction for mock_swarm configuration

### DIFF
--- a/monad-executor/src/executor/mock.rs
+++ b/monad-executor/src/executor/mock.rs
@@ -359,7 +359,7 @@ mod tests {
 
     use crate::{
         executor::mock::MockExecutor,
-        mock_swarm::Nodes,
+        mock_swarm::{LatencyTransformer, Nodes},
         state::{Command, Executor, PeerId, RouterCommand, State, TimerCommand},
         Message,
     };
@@ -737,8 +737,7 @@ mod tests {
                 .map(|peer_id| peer_id.0)
                 .zip(state_configs)
                 .collect(),
-            |_from, _to| Duration::from_millis(50),
-            Vec::new(),
+            LatencyTransformer(Duration::from_millis(50)),
         );
 
         while let Some((duration, id, event)) = nodes.step() {

--- a/monad-executor/src/mock_swarm.rs
+++ b/monad-executor/src/mock_swarm.rs
@@ -1,28 +1,116 @@
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 
 use futures::StreamExt;
 use monad_crypto::secp256k1::PubKey;
 
-use crate::{executor::mock::MockExecutor, Executor, PeerId, State};
+use crate::{executor::mock::MockExecutor, Executor, Message, PeerId, State};
 
-pub struct Nodes<S: State, L: Fn(&PeerId, &PeerId) -> Duration> {
-    states: HashMap<PeerId, (MockExecutor<S>, S)>,
-    compute_latency: L,
-    filter_list: Vec<PeerId>,
+pub enum LinkMessageType<M: Message> {
+    Message(M),
+    Ack(M::Id),
 }
 
-impl<S, L> Nodes<S, L>
+pub struct LinkMessage<M: Message> {
+    pub from: PeerId,
+    pub to: PeerId,
+    pub message: LinkMessageType<M>,
+
+    /// absolute time
+    pub from_tick: Duration,
+}
+
+pub trait Transformer<M: Message> {
+    #[must_use]
+    /// note that the output Duration should be a delay, not an absolute time
+    // TODO smallvec? resulting Vec will almost always be len 1
+    fn transform(&mut self, message: LinkMessage<M>) -> Vec<(Duration, LinkMessage<M>)>;
+
+    fn boxed(self) -> Box<dyn Transformer<M>>
+    where
+        Self: Sized + 'static,
+    {
+        Box::new(self)
+    }
+}
+
+/// adds constant latency
+#[derive(Clone)]
+pub struct LatencyTransformer(pub Duration);
+impl<M: Message> Transformer<M> for LatencyTransformer {
+    fn transform(&mut self, message: LinkMessage<M>) -> Vec<(Duration, LinkMessage<M>)> {
+        vec![(self.0, message)]
+    }
+}
+
+/// adds constant latency (parametrizable cap) to each link determined by xor(peer_id_1, peer_id_2)
+#[derive(Clone)]
+pub struct XorLatencyTransformer(pub Duration);
+impl<M: Message> Transformer<M> for XorLatencyTransformer {
+    fn transform(&mut self, message: LinkMessage<M>) -> Vec<(Duration, LinkMessage<M>)> {
+        let mut ck: u8 = 0;
+        for b in message.from.0.bytes() {
+            ck ^= b;
+        }
+        for b in message.to.0.bytes() {
+            ck ^= b;
+        }
+        vec![(self.0.mul_f32(ck as f32 / u8::MAX as f32), message)]
+    }
+}
+
+/// blacklists given nodes
+#[derive(Clone)]
+pub struct BlacklistTransformer(pub HashSet<PeerId>);
+impl<M: Message> Transformer<M> for BlacklistTransformer {
+    fn transform(&mut self, message: LinkMessage<M>) -> Vec<(Duration, LinkMessage<M>)> {
+        let mut output = Vec::new();
+        if !self.0.contains(&message.from) && !self.0.contains(&message.to) {
+            output.push((Duration::ZERO, message))
+        }
+        output
+    }
+}
+
+// using dynamic dispatch so that we can change these at runtime... such as in monad-viz
+type LayerTransformer<M> = Vec<Box<dyn Transformer<M>>>;
+
+impl<M: Message> Transformer<M> for LayerTransformer<M> {
+    fn transform(&mut self, message: LinkMessage<M>) -> Vec<(Duration, LinkMessage<M>)> {
+        self.iter_mut().fold(
+            // accumulator is transformed set of messages before/after each layer
+            vec![(Duration::ZERO, message)],
+            |messages, layer| {
+                messages
+                    .into_iter()
+                    .flat_map(|(base_duration, message)| {
+                        // transform each message by applying the layer to each
+                        layer
+                            .transform(message)
+                            .into_iter()
+                            .map(move |(duration, message)| (base_duration + duration, message))
+                    })
+                    .collect()
+            },
+        )
+    }
+}
+
+pub struct Nodes<S: State, T: Transformer<S::Message>> {
+    states: HashMap<PeerId, (MockExecutor<S>, S)>,
+    transformer: T,
+}
+
+impl<S, T> Nodes<S, T>
 where
     S: State,
-    L: Fn(&PeerId, &PeerId) -> Duration,
+    T: Transformer<S::Message>,
 
     MockExecutor<S>: Unpin,
 {
-    pub fn new(
-        peers: Vec<(PubKey, S::Config)>,
-        compute_latency: L,
-        filter_list: Vec<PeerId>,
-    ) -> Self {
+    pub fn new(peers: Vec<(PubKey, S::Config)>, transformer: T) -> Self {
         assert!(!peers.is_empty());
 
         let mut states = HashMap::new();
@@ -36,8 +124,7 @@ where
 
         let mut nodes = Self {
             states,
-            compute_latency,
-            filter_list,
+            transformer,
         };
 
         for peer_id in nodes.states.keys().cloned().collect::<Vec<_>>() {
@@ -82,46 +169,58 @@ where
     }
 
     fn simulate_peer(&mut self, peer_id: &PeerId, tick: Duration) {
-        let (mut executor, state) = self.states.remove(peer_id).unwrap();
+        let outbounds = {
+            let mut outbounds = Vec::new();
+            let (mut executor, state) = self.states.remove(peer_id).unwrap();
 
-        while let Some((to, outbound_message)) = executor.receive_message() {
-            if self.filter_list.contains(&to) {
-                continue;
+            while let Some((to, outbound_message)) = executor.receive_message() {
+                let transformed = self.transformer.transform(LinkMessage {
+                    from: *peer_id,
+                    to,
+                    message: LinkMessageType::Message(outbound_message.into()),
+
+                    from_tick: tick,
+                });
+
+                outbounds.extend(transformed.into_iter());
+            }
+            while let Some((to, message_id)) = executor.receive_ack() {
+                let transformed = self.transformer.transform(LinkMessage {
+                    from: *peer_id,
+                    to,
+                    message: LinkMessageType::Ack(message_id),
+
+                    from_tick: tick,
+                });
+
+                outbounds.extend(transformed.into_iter());
             }
 
-            let to_state = if &to == peer_id {
-                &mut executor
-            } else {
-                &mut self.states.get_mut(&to).unwrap().0
-            };
+            self.states.insert(*peer_id, (executor, state));
+            outbounds
+        };
 
-            to_state.send_message(
-                tick + (self.compute_latency)(peer_id, &to),
-                *peer_id,
-                outbound_message.into(),
-                tick,
-            );
-        }
-        while let Some((to, message_id)) = executor.receive_ack() {
-            if self.filter_list.contains(&to) {
-                continue;
+        for (
+            delay,
+            LinkMessage {
+                from,
+                to,
+                message,
+                from_tick,
+            },
+        ) in outbounds
+        {
+            let to_state = &mut self.states.get_mut(&to).unwrap().0;
+
+            match message {
+                LinkMessageType::Message(m) => {
+                    to_state.send_message(tick + delay, from, m, from_tick)
+                }
+                LinkMessageType::Ack(m_id) => {
+                    to_state.send_ack(tick + delay, from, m_id, from_tick)
+                }
             }
-
-            let to_state = if &to == peer_id {
-                &mut executor
-            } else {
-                &mut self.states.get_mut(&to).unwrap().0
-            };
-
-            to_state.send_ack(
-                tick + (self.compute_latency)(peer_id, &to),
-                *peer_id,
-                message_id,
-                tick,
-            );
         }
-
-        self.states.insert(*peer_id, (executor, state));
     }
 
     pub fn states(&self) -> &HashMap<PeerId, (MockExecutor<S>, S)> {

--- a/monad-state/tests/msg_delays.rs
+++ b/monad-state/tests/msg_delays.rs
@@ -1,8 +1,17 @@
+use std::time::Duration;
+
+use monad_executor::mock_swarm::XorLatencyTransformer;
+
 mod base;
 
 #[test]
 fn two_nodes() {
     tracing_subscriber::fmt::init();
 
-    base::run_nodes_msg_delays(4, 40);
+    base::run_nodes(
+        4,
+        40,
+        Duration::from_millis(101),
+        XorLatencyTransformer(Duration::from_millis(u8::MAX as u64)),
+    );
 }

--- a/monad-state/tests/single_node.rs
+++ b/monad-state/tests/single_node.rs
@@ -1,8 +1,17 @@
+use std::time::Duration;
+
+use monad_executor::mock_swarm::LatencyTransformer;
+
 mod base;
 
 #[test]
 fn two_nodes() {
     tracing_subscriber::fmt::init();
 
-    base::run_nodes(2, 1024);
+    base::run_nodes(
+        2,
+        1024,
+        Duration::from_millis(2),
+        LatencyTransformer(Duration::from_millis(1)),
+    );
 }

--- a/monad-viz/src/main.rs
+++ b/monad-viz/src/main.rs
@@ -14,6 +14,7 @@ use monad_consensus::{
 };
 use monad_crypto::secp256k1::KeyPair;
 use monad_crypto::NopSignature;
+use monad_executor::mock_swarm::XorLatencyTransformer;
 use monad_state::{MonadConfig, MonadState};
 use monad_testutil::signing::{create_keys, get_genesis_config};
 
@@ -53,18 +54,10 @@ async fn main() {
 
             pubkeys.into_iter().zip(state_configs).collect()
         };
+
         NodesSimulation::<MonadState<SignatureType, SignatureCollectionType>, _, _>::new(
             config_gen,
-            |node_1, node_2| {
-                let mut ck = 0;
-                for b in node_1.0.bytes() {
-                    ck ^= b;
-                }
-                for b in node_2.0.bytes() {
-                    ck ^= b;
-                }
-                Duration::from_millis(ck as u64 % 100)
-            },
+            XorLatencyTransformer(Duration::from_millis(100)),
             Duration::from_secs(4),
         )
     };


### PR DESCRIPTION
Adds the concepts of a `Transformer` - something that can alter the delivery of messages.
Transformers can be composed together.
With the abstraction provided, it'll be easy for us to add stuff to control bandwidth, rearrange specific messages arbitrarily, etc.

Probably easiest to understand reading from the code... will mark out relevant sections.