### PR TITLE
Tracing counter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,8 +3320,10 @@ dependencies = [
  "monad-consensus",
  "monad-crypto",
  "monad-testutil",
+ "monad-tracing-counter",
  "monad-types",
  "ptree",
+ "tracing",
 ]
 
 [[package]]
@@ -3386,6 +3388,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3441,6 +3444,7 @@ dependencies = [
  "monad-executor",
  "monad-proto",
  "monad-testutil",
+ "monad-tracing-counter",
  "monad-types",
  "monad-validator",
  "monad-wal",
@@ -3451,6 +3455,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "tracing",
+ "tracing-core",
  "tracing-subscriber",
 ]
 
@@ -3464,6 +3469,17 @@ dependencies = [
  "monad-types",
  "monad-validator",
  "sha2 0.10.6",
+]
+
+[[package]]
+name = "monad-tracing-counter"
+version = "0.1.0"
+dependencies = [
+ "lazy_static 1.4.0",
+ "once_cell",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "monad-proto",
     "monad-state",
     "monad-testutil",
+    "monad-tracing-counter",
     "monad-types",
     "monad-validator",
     "monad-viz",

--- a/monad-blocktree/Cargo.toml
+++ b/monad-blocktree/Cargo.toml
@@ -12,8 +12,10 @@ bench = false
 
 [dependencies]
 monad-consensus = { path = "../monad-consensus" }
+monad-tracing-counter = { path = "../monad-tracing-counter" }
 monad-types = { path = "../monad-types" }
 ptree = "0.4.0"
+tracing = "0.1.37"
 
 [dev-dependencies]
 monad-testutil = { path = "../monad-testutil" }

--- a/monad-executor/Cargo.toml
+++ b/monad-executor/Cargo.toml
@@ -16,9 +16,10 @@ monad-proto = { path = "../monad-proto", optional = true }
 monad-wal = { path = "../monad-wal" }
 
 futures = "0.3"
-tokio = { version = "1.26", features = ["time"], optional = true }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
+tokio = { version = "1.26", features = ["time"], optional = true }
+tracing = "0.1.37"
 
 [dev-dependencies]
 monad-testutil = { path = "../monad-testutil"}

--- a/monad-executor/src/mock_swarm.rs
+++ b/monad-executor/src/mock_swarm.rs
@@ -10,6 +10,7 @@ use rand_chacha::ChaChaRng;
 use futures::StreamExt;
 use monad_crypto::secp256k1::PubKey;
 use monad_wal::PersistenceLogger;
+use tracing::info_span;
 
 use crate::{executor::mock::MockExecutor, Executor, Message, PeerId, State};
 
@@ -255,6 +256,8 @@ where
             let id = *id;
             let event = futures::executor::block_on(executor.next()).unwrap();
             wal.push(&event).unwrap(); // FIXME: propagate the error
+            let node_span = info_span!("node", id = ?id);
+            let _guard = node_span.enter();
             let commands = state.update(event.clone());
 
             executor.exec(commands);

--- a/monad-state/Cargo.toml
+++ b/monad-state/Cargo.toml
@@ -22,17 +22,19 @@ monad-wal = { path = "../monad-wal" }
 monad-proto = { path = "../monad-proto", optional = true }
 
 ref-cast = "1.0"
-tracing = "0.1"
 prost = { version = "0.11.9", optional = true }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
+tracing = "0.1.35"
+tracing-core = "0.1.30"
 
 [features]
 proto = ["dep:monad-proto", "dep:prost", "monad-consensus/proto", "monad-crypto/proto", "monad-types/proto", "monad-executor/proto"]
 
 [dev-dependencies]
 monad-testutil = { path = "../monad-testutil"}
-tracing-subscriber = "0.3"
+monad-tracing-counter = { path = "../monad-tracing-counter" }
+tracing-subscriber = "0.3.17"
 criterion = "0.4"
 tempfile = "3.5.0"
 itertools = "0.10.5"

--- a/monad-state/tests/single_node_metrics.rs
+++ b/monad-state/tests/single_node_metrics.rs
@@ -1,0 +1,37 @@
+use std::time::Duration;
+
+use monad_executor::mock_swarm::LatencyTransformer;
+use monad_tracing_counter::counter::CounterLayer;
+use monad_tracing_counter::counter::MetricFilter;
+use monad_tracing_counter::counter_status;
+
+use tracing_core::LevelFilter;
+use tracing_subscriber::filter::Targets;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::Registry;
+mod base;
+
+#[test]
+fn two_nodes() {
+    let fmt_layer = tracing_subscriber::fmt::layer();
+    let counter_layer = CounterLayer::new();
+
+    let subscriber = Registry::default()
+        .with(
+            fmt_layer
+                .with_filter(MetricFilter {})
+                .with_filter(Targets::new().with_default(LevelFilter::INFO)),
+        )
+        .with(counter_layer);
+
+    tracing::subscriber::set_global_default(subscriber).expect("unable to set global subscriber");
+
+    base::run_nodes(
+        2,
+        1024,
+        Duration::from_millis(2),
+        LatencyTransformer(Duration::from_millis(1)),
+    );
+
+    counter_status!();
+}

--- a/monad-tracing-counter/Cargo.toml
+++ b/monad-tracing-counter/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "monad-tracing-counter"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+lazy_static = "1.4.0"
+once_cell = "1.17.1"
+tracing = "0.1.35"
+tracing-core = "0.1.31"
+tracing-subscriber = "0.3.17"
+

--- a/monad-tracing-counter/src/counter.rs
+++ b/monad-tracing-counter/src/counter.rs
@@ -1,0 +1,223 @@
+use std::collections::HashMap;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::RwLock;
+use std::sync::RwLockReadGuard;
+use std::sync::RwLockWriteGuard;
+use tracing_core::field::Visit;
+use tracing_core::{span, Event, Interest, Metadata, Subscriber as CoreSubscriber};
+use tracing_subscriber::layer::Filter;
+const METRIC_PREFIX_MONOTONIC_COUNTER: &str = "monotonic_counter.";
+const METRIC_STATUS: &str = "metric_status";
+
+#[macro_export]
+macro_rules! counter_status {
+    () => {{
+        use tracing::trace;
+        trace!(metric_status = true)
+    }};
+}
+
+#[macro_export]
+macro_rules! inc_count {
+    ($($k:ident).+) => {{
+        use tracing::trace;
+        trace!(monotonic_counter.$($k).+ = 1);
+    }};
+}
+
+#[derive(Clone)]
+pub struct MetricFilter;
+
+impl<S> Filter<S> for MetricFilter {
+    fn enabled(
+        &self,
+        meta: &Metadata<'_>,
+        _cx: &tracing_subscriber::layer::Context<'_, S>,
+    ) -> bool {
+        for field in meta.fields() {
+            if field.name().starts_with(METRIC_PREFIX_MONOTONIC_COUNTER)
+                || field.name() == METRIC_STATUS
+            {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+struct Visitor<'a> {
+    counts: &'a RwLock<HashMap<String, AtomicUsize>>,
+    prefix: RwLockReadGuard<'a, String>,
+}
+
+impl<'a> Visitor<'a> {
+    fn increment(&self, key: &String, value: usize) {
+        {
+            let lock = self.counts.read().unwrap();
+            if let Some(metric) = lock.get(key) {
+                metric.fetch_add(value, Ordering::Release);
+                return;
+            }
+        }
+        let mut lock = self.counts.write().unwrap();
+        let metric = lock
+            .entry(key.to_string())
+            .or_insert_with(|| AtomicUsize::new(0));
+        metric.fetch_add(value, Ordering::Release);
+    }
+
+    fn status(&self) {
+        let lock = self.counts.read().unwrap();
+        let mut freq = lock
+            .iter()
+            .map(|(k, v)| (k, v.load(Ordering::Acquire)))
+            .collect::<Vec<_>>();
+        freq.sort_by_key(|&(k, _v)| k);
+        println!("Counter service: {:?}", freq);
+    }
+}
+
+impl<'a> Visit for Visitor<'a> {
+    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {
+        // noop
+    }
+
+    fn record_i64(&mut self, field: &tracing_core::Field, value: i64) {
+        if let Some(metric) = field.name().strip_prefix(METRIC_PREFIX_MONOTONIC_COUNTER) {
+            let metric = self.prefix.clone() + metric;
+            self.increment(&metric, value as usize)
+        }
+    }
+
+    fn record_u64(&mut self, field: &tracing_core::Field, value: u64) {
+        if let Some(metric) = field.name().strip_prefix(METRIC_PREFIX_MONOTONIC_COUNTER) {
+            let metric = self.prefix.clone() + metric;
+            self.increment(&metric, value as usize)
+        }
+    }
+
+    fn record_bool(&mut self, field: &tracing_core::Field, _value: bool) {
+        if field.name() == "metric_status" {
+            self.status()
+        }
+    }
+}
+
+pub struct CounterLayer {
+    counts: RwLock<HashMap<String, AtomicUsize>>,
+    spans: RwLock<HashMap<span::Id, String>>,
+    prefix: RwLock<String>,
+}
+
+impl CounterLayer {
+    pub fn new() -> Self {
+        Self {
+            counts: RwLock::new(HashMap::new()),
+            spans: RwLock::new(HashMap::new()),
+            prefix: RwLock::new(String::new()),
+        }
+    }
+
+    fn visitor(&self) -> Visitor<'_> {
+        Visitor {
+            counts: &self.counts,
+            prefix: self.prefix.read().unwrap(),
+        }
+    }
+
+    fn span_vistor(&self, span_id: &span::Id) -> NewSpanVisitor<'_> {
+        NewSpanVisitor {
+            spans: self.spans.write().unwrap(),
+            span_id: span_id.clone(),
+        }
+    }
+}
+
+impl Default for CounterLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct NewSpanVisitor<'a> {
+    spans: RwLockWriteGuard<'a, HashMap<span::Id, String>>,
+    span_id: span::Id,
+}
+
+impl<'a> Visit for NewSpanVisitor<'a> {
+    fn record_debug(&mut self, field: &tracing_core::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "id" {
+            self.spans
+                .insert(self.span_id.clone(), format!("{:?}:", value));
+        }
+    }
+}
+
+impl<S> tracing_subscriber::Layer<S> for CounterLayer
+where
+    S: CoreSubscriber,
+    Self: 'static,
+{
+    fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
+        let mut interest = Interest::sometimes();
+        for key in metadata.fields() {
+            if key.name().starts_with(METRIC_PREFIX_MONOTONIC_COUNTER)
+                || key.name() == METRIC_STATUS
+            {
+                interest = Interest::always();
+            }
+        }
+
+        interest
+    }
+
+    fn on_new_span(
+        &self,
+        attrs: &span::Attributes<'_>,
+        id: &span::Id,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if attrs.metadata().name() == "node" {
+            let values = attrs.values();
+            let mut visitor = self.span_vistor(id);
+            values.record(&mut visitor);
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let mut visitor = self.visitor();
+        event.record(&mut visitor);
+    }
+
+    fn on_enter(&self, id: &span::Id, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let spans_r = self.spans.read().unwrap();
+
+        if let Some(span_info) = spans_r.get(id) {
+            self.prefix.write().unwrap().push_str(span_info);
+        }
+    }
+
+    fn on_exit(&self, id: &span::Id, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let spans_r = self.spans.read().unwrap();
+        if let Some(span_info) = spans_r.get(id) {
+            let mut lock_prefix = self.prefix.write().unwrap();
+            let new_prefix = lock_prefix.trim_end_matches(span_info);
+            *lock_prefix = new_prefix.to_string();
+        }
+    }
+
+    fn on_close(&self, id: span::Id, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+        // span id management
+        self.spans.write().unwrap().remove(&id);
+    }
+
+    fn on_id_change(
+        &self,
+        _old: &span::Id,
+        _new: &span::Id,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        // TODO: move prefix to a different id
+    }
+}

--- a/monad-tracing-counter/src/lib.rs
+++ b/monad-tracing-counter/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod counter;


### PR DESCRIPTION
A counter implementation that composes with `tracing` and adopts the same interface as `tracing-opentelemetry::MetricsLayer`
- The counter is a `tracing-subscriber` layer that keeps track of the event counts
- The interface is the same as `tracing-opentelemetry::MetricsLayer` so it could be swapped with the `tracing-opentelemetry` backend. 
    - Only the `monotonic_counter` interface is implemented
- Instead of periodically pushing to a data upstream, the `counter_status!` macro print the current tally
 - Added a per-layer filter for the format layer to avoid printing all the counter logs
 - Level filter needs to be specified as a per-layer filter as well, can add support for passing that in through the `RUST_LOG` env var
 - `cargo test two_nodes --test single_node_metrics -- --nocapture`
 - Specifying span with name "node" and key "id" adds a prefix to the counter metrics collected within the span. (e.g. `info_span!("node", id = "1234")` prefixes "1234" to all metrics collected in the span)
 - Performance overhead: running two nodes for 10240 blocks
    - 0.47s -> 0.54s ~ 15% when blocktree is instrumented (emitting 2 metrics per node per block produced) if all the `println!` are suppressed