### PR TITLE
Fix node_ledger_verification function and order test

### DIFF
--- a/monad-state/tests/order.rs
+++ b/monad-state/tests/order.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::time::Duration;
 
+use monad_executor::mock_swarm::{LatencyTransformer, Transformer};
 use test_case::test_case;
 
 use crate::base::PartitionThenReplayTransformer;
@@ -25,14 +26,17 @@ fn all_messages_delayed(direction: bool) {
     println!("delayed node ID: {:?}", first_node);
 
     base::run_one_delayed_node(
-        4,
-        PartitionThenReplayTransformer {
-            peers: filter_peers,
-            filtered_msgs: Vec::new(),
-            cnt: 0,
-            cnt_limit: 200,
-            reverse: direction,
-        },
+        vec![
+            LatencyTransformer(Duration::from_millis(1)).boxed(),
+            PartitionThenReplayTransformer {
+                peers: filter_peers,
+                filtered_msgs: Vec::new(),
+                cnt: 0,
+                cnt_limit: 200,
+                reverse: direction,
+            }
+            .boxed(),
+        ],
         pubkeys,
         state_configs,
     );

--- a/monad-state/tests/replay.rs
+++ b/monad-state/tests/replay.rs
@@ -147,6 +147,6 @@ mod test {
             })
             .collect::<Vec<_>>();
 
-        node_ledger_verification(nodes_recovered.states(), num_block_after);
+        node_ledger_verification(nodes_recovered.states());
     }
 }


### PR DESCRIPTION
Tests were not checking the full amount of blocks in the ledger and were not ensuring that the ledgers are within 1 length of each other.

Order test had an issue with the Transformer config because of 0 latency messages -- resolved by adding a non-zero latency transformer