### PR TITLE
Use `waker` in executors

### DIFF
--- a/monad-executor/Cargo.toml
+++ b/monad-executor/Cargo.toml
@@ -22,5 +22,7 @@ tokio = { version = "1.26", features = ["time"], optional = true }
 monad-testutil = { path = "../monad-testutil"}
 monad-types = { path = "../monad-types" }
 
+tokio = { version = "1.26", features = ["macros", "rt"] }
+
 [features]
 proto = ["dep:monad-proto", "monad-crypto/proto"]

--- a/monad-executor/src/executor/mempool.rs
+++ b/monad-executor/src/executor/mempool.rs
@@ -1,7 +1,7 @@
 use std::{
     ops::DerefMut,
     pin::Pin,
-    task::{Context, Poll},
+    task::{Context, Poll, Waker},
 };
 
 use crate::{Executor, MempoolCommand};
@@ -10,6 +10,7 @@ use futures::Stream;
 
 pub struct MockMempool<E> {
     fetch_txs_state: Option<Box<dyn FnOnce(Vec<u8>) -> E>>,
+    waker: Option<Waker>,
 }
 
 impl<E> MockMempool<E> {
@@ -22,16 +23,29 @@ impl<E> Default for MockMempool<E> {
     fn default() -> Self {
         Self {
             fetch_txs_state: None,
+            waker: None,
         }
     }
 }
 impl<E> Executor for MockMempool<E> {
     type Command = MempoolCommand<E>;
     fn exec(&mut self, commands: Vec<Self::Command>) {
+        let mut wake = false;
         for command in commands {
-            match command {
-                MempoolCommand::FetchTxs(cb) => self.fetch_txs_state = Some(cb),
-                MempoolCommand::FetchReset => self.fetch_txs_state = None,
+            self.fetch_txs_state = match command {
+                MempoolCommand::FetchTxs(cb) => {
+                    wake = true;
+                    Some(cb)
+                }
+                MempoolCommand::FetchReset => {
+                    wake = false;
+                    None
+                }
+            }
+        }
+        if wake {
+            if let Some(waker) = self.waker.take() {
+                waker.wake();
             }
         }
     }
@@ -41,12 +55,87 @@ where
     Self: Unpin,
 {
     type Item = E;
-    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.deref_mut();
 
-        Poll::Ready(this.fetch_txs_state.take().map(
-            // run cb with empty tx list
-            |cb| cb(Vec::new()),
-        ))
+        if let Some(cb) = this.fetch_txs_state.take() {
+            return Poll::Ready(Some(cb(Vec::new())));
+        }
+
+        self.waker = Some(cx.waker().clone());
+        Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt;
+
+    use super::*;
+
+    #[test]
+    fn test_fetch() {
+        let mut mempool = MockMempool::default();
+        mempool.exec(vec![MempoolCommand::FetchTxs(Box::new(|_| {}))]);
+        assert!(futures::executor::block_on(mempool.next()).is_some());
+        assert!(!mempool.ready());
+    }
+
+    #[test]
+    fn test_double_fetch() {
+        let mut mempool = MockMempool::default();
+        mempool.exec(vec![MempoolCommand::FetchTxs(Box::new(|_| {}))]);
+        mempool.exec(vec![MempoolCommand::FetchTxs(Box::new(|_| {}))]);
+        assert!(futures::executor::block_on(mempool.next()).is_some());
+        assert!(!mempool.ready());
+    }
+
+    #[test]
+    fn test_reset() {
+        let mut mempool = MockMempool::default();
+        mempool.exec(vec![MempoolCommand::FetchTxs(Box::new(|_| {}))]);
+        mempool.exec(vec![MempoolCommand::FetchReset]);
+        assert!(!mempool.ready());
+    }
+
+    #[test]
+    fn test_inline_double_fetch() {
+        let mut mempool = MockMempool::default();
+        mempool.exec(vec![
+            MempoolCommand::FetchTxs(Box::new(|_| {})),
+            MempoolCommand::FetchTxs(Box::new(|_| {})),
+        ]);
+        assert!(futures::executor::block_on(mempool.next()).is_some());
+        assert!(!mempool.ready());
+    }
+
+    #[test]
+    fn test_inline_reset() {
+        let mut mempool = MockMempool::default();
+        mempool.exec(vec![
+            MempoolCommand::FetchTxs(Box::new(|_| {})),
+            MempoolCommand::FetchReset,
+        ]);
+        assert!(!mempool.ready());
+    }
+
+    #[test]
+    fn test_inline_reset_fetch() {
+        let mut mempool = MockMempool::default();
+        mempool.exec(vec![
+            MempoolCommand::FetchReset,
+            MempoolCommand::FetchTxs(Box::new(|_| {})),
+        ]);
+        assert!(futures::executor::block_on(mempool.next()).is_some());
+        assert!(!mempool.ready());
+    }
+
+    #[test]
+    fn test_noop_exec() {
+        let mut mempool = MockMempool::default();
+        mempool.exec(vec![MempoolCommand::FetchTxs(Box::new(|_| {}))]);
+        mempool.exec(Vec::new());
+        assert!(futures::executor::block_on(mempool.next()).is_some());
+        assert!(!mempool.ready());
     }
 }

--- a/monad-executor/src/executor/timer.rs
+++ b/monad-executor/src/executor/timer.rs
@@ -1,7 +1,7 @@
 use std::{
     ops::DerefMut,
     pin::Pin,
-    task::{Context, Poll},
+    task::{Context, Poll, Waker},
 };
 
 use crate::{Executor, TimerCommand};
@@ -10,27 +10,41 @@ use futures::{FutureExt, Stream};
 
 pub struct TokioTimer<E> {
     state: Option<(Pin<Box<tokio::time::Sleep>>, E)>,
+    waker: Option<Waker>,
 }
 impl<E> Default for TokioTimer<E> {
     fn default() -> Self {
-        Self { state: None }
+        Self {
+            state: None,
+            waker: None,
+        }
     }
 }
 impl<E> Executor for TokioTimer<E> {
     type Command = TimerCommand<E>;
     fn exec(&mut self, commands: Vec<TimerCommand<E>>) {
-        let mut timer = None;
+        let mut wake = false;
         for command in commands {
-            match command {
+            self.state = match command {
                 TimerCommand::Schedule {
                     duration,
                     on_timeout,
-                } => timer = Some((duration, on_timeout)),
-                TimerCommand::ScheduleReset => timer = None,
+                } => {
+                    wake = true;
+                    Some((Box::pin(tokio::time::sleep(duration)), on_timeout))
+                }
+                TimerCommand::ScheduleReset => {
+                    wake = false;
+                    None
+                }
             }
         }
 
-        self.state = timer.map(|(duration, e)| (Box::pin(tokio::time::sleep(duration)), e));
+        if wake {
+            if let Some(waker) = self.waker.take() {
+                waker.wake();
+            }
+        }
     }
 }
 impl<E> Stream for TokioTimer<E>
@@ -40,11 +54,137 @@ where
     type Item = E;
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.deref_mut();
-        match this.state.as_mut() {
-            None => Poll::Ready(None),
-            Some((sleep, _)) => sleep
-                .poll_unpin(cx)
-                .map(|()| this.state.take().map(|(_, event)| event)),
+
+        if let Some((sleep, _)) = this.state.as_mut() {
+            if sleep.poll_unpin(cx).is_ready() {
+                return Poll::Ready(Some(this.state.take().expect("event must exist").1));
+            }
         }
+
+        self.waker = Some(cx.waker().clone());
+        Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use futures::StreamExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_schedule() {
+        let mut timer = TokioTimer::default();
+        assert_eq!(futures::poll!(timer.next()), Poll::Pending);
+
+        timer.exec(vec![TimerCommand::Schedule {
+            duration: Duration::from_millis(0),
+            on_timeout: (),
+        }]);
+
+        assert_eq!(timer.next().await, Some(()));
+        assert_eq!(futures::poll!(timer.next()), Poll::Pending);
+    }
+
+    #[tokio::test]
+    async fn test_double_schedule() {
+        let mut timer = TokioTimer::default();
+        assert_eq!(futures::poll!(timer.next()), Poll::Pending);
+
+        timer.exec(vec![TimerCommand::Schedule {
+            duration: Duration::from_millis(0),
+            on_timeout: (),
+        }]);
+        timer.exec(vec![TimerCommand::Schedule {
+            duration: Duration::from_millis(0),
+            on_timeout: (),
+        }]);
+
+        assert_eq!(timer.next().await, Some(()));
+        assert_eq!(futures::poll!(timer.next()), Poll::Pending);
+    }
+
+    #[tokio::test]
+    async fn test_reset() {
+        let mut timer = TokioTimer::default();
+        assert_eq!(futures::poll!(timer.next()), Poll::Pending);
+
+        timer.exec(vec![TimerCommand::Schedule {
+            duration: Duration::from_millis(0),
+            on_timeout: (),
+        }]);
+        timer.exec(vec![TimerCommand::ScheduleReset]);
+
+        assert_eq!(futures::poll!(timer.next()), Poll::Pending);
+    }
+
+    #[tokio::test]
+    async fn test_inline_double_schedule() {
+        let mut timer = TokioTimer::default();
+        assert_eq!(futures::poll!(timer.next()), Poll::Pending);
+
+        timer.exec(vec![
+            TimerCommand::Schedule {
+                duration: Duration::from_millis(0),
+                on_timeout: (),
+            },
+            TimerCommand::Schedule {
+                duration: Duration::from_millis(0),
+                on_timeout: (),
+            },
+        ]);
+
+        assert_eq!(timer.next().await, Some(()));
+        assert_eq!(futures::poll!(timer.next()), Poll::Pending);
+    }
+
+    #[tokio::test]
+    async fn test_inline_reset() {
+        let mut timer = TokioTimer::default();
+        assert_eq!(futures::poll!(timer.next()), Poll::Pending);
+
+        timer.exec(vec![
+            TimerCommand::Schedule {
+                duration: Duration::from_millis(0),
+                on_timeout: (),
+            },
+            TimerCommand::ScheduleReset,
+        ]);
+
+        assert_eq!(futures::poll!(timer.next()), Poll::Pending);
+    }
+
+    #[tokio::test]
+    async fn test_inline_reset_schedule() {
+        let mut timer = TokioTimer::default();
+        assert_eq!(futures::poll!(timer.next()), Poll::Pending);
+
+        timer.exec(vec![
+            TimerCommand::ScheduleReset,
+            TimerCommand::Schedule {
+                duration: Duration::from_millis(0),
+                on_timeout: (),
+            },
+        ]);
+
+        assert_eq!(timer.next().await, Some(()));
+        assert_eq!(futures::poll!(timer.next()), Poll::Pending);
+    }
+
+    #[tokio::test]
+    async fn test_noop_exec() {
+        let mut timer = TokioTimer::default();
+        assert_eq!(futures::poll!(timer.next()), Poll::Pending);
+
+        timer.exec(vec![TimerCommand::Schedule {
+            duration: Duration::from_millis(1),
+            on_timeout: (),
+        }]);
+        timer.exec(Vec::new());
+
+        assert_eq!(timer.next().await, Some(()));
+        assert_eq!(futures::poll!(timer.next()), Poll::Pending);
     }
 }


### PR DESCRIPTION
Previously we wouldn't actually call the `waker` in our futures - this PR fixes that.