### PR TITLE
Add random latency transformer for testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3383,6 +3383,8 @@ dependencies = [
  "monad-testutil",
  "monad-types",
  "monad-wal",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "tokio",
 ]
 

--- a/monad-executor/Cargo.toml
+++ b/monad-executor/Cargo.toml
@@ -17,6 +17,8 @@ monad-wal = { path = "../monad-wal" }
 
 futures = "0.3"
 tokio = { version = "1.26", features = ["time"], optional = true }
+rand = "0.8.5"
+rand_chacha = "0.3.1"
 
 [dev-dependencies]
 monad-testutil = { path = "../monad-testutil"}

--- a/monad-state/tests/rand_lat.rs
+++ b/monad-state/tests/rand_lat.rs
@@ -1,0 +1,25 @@
+use test_case::test_case;
+
+mod base;
+
+#[test_case(1; "seed1")]
+#[test_case(2; "seed2")]
+#[test_case(3; "seed3")]
+#[test_case(4; "seed4")]
+#[test_case(5; "seed5")]
+#[test_case(6; "seed6")]
+#[test_case(7; "seed7")]
+#[test_case(8; "seed8")]
+#[test_case(9; "seed9")]
+#[test_case(10; "seed10")]
+fn nodes_with_random_latency(seed: u64) {
+    use monad_executor::mock_swarm::RandLatencyTransformer;
+    use std::time::Duration;
+
+    base::run_nodes(
+        4,
+        2048,
+        Duration::from_millis(250),
+        RandLatencyTransformer::new(seed, 330),
+    );
+}


### PR DESCRIPTION
RandomLatencyTransformer is seeded with a u64 for reproducible tests. rand_chacha lib is used for SeedableRng for reproducibility across builds and architectures.