### PR TITLE
Configurable monad-p2p authentication and timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2738,6 +2738,7 @@ dependencies = [
  "libp2p-metrics",
  "libp2p-mplex",
  "libp2p-noise",
+ "libp2p-plaintext",
  "libp2p-quic",
  "libp2p-request-response",
  "libp2p-swarm",
@@ -2920,6 +2921,22 @@ dependencies = [
  "thiserror",
  "x25519-dalek 1.1.1",
  "zeroize",
+]
+
+[[package]]
+name = "libp2p-plaintext"
+version = "0.39.1"
+source = "git+https://github.com/monad-crypto/rust-libp2p.git?rev=a2a5160b#a2a5160b2b44d7a63c3dd52db4441f28ec6ce7cc"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "futures",
+ "libp2p-core",
+ "libp2p-identity",
+ "log",
+ "quick-protobuf",
+ "unsigned-varint",
+ "void",
 ]
 
 [[package]]

--- a/monad-p2p/Cargo.toml
+++ b/monad-p2p/Cargo.toml
@@ -20,7 +20,7 @@ futures = "0.3"
 async-trait = "0.1"
 tracing = "0.1"
 
-libp2p = { workspace = true, features = ["macros", "mplex", "noise", "identify", "request-response", "secp256k1"] }
+libp2p = { workspace = true, features = ["macros", "mplex", "noise", "plaintext", "identify", "request-response", "secp256k1"] }
 
 [features]
 tokio = ["libp2p/tcp", "libp2p/tokio"]

--- a/monad-p2p/src/behavior/mod.rs
+++ b/monad-p2p/src/behavior/mod.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use libp2p::{request_response::ProtocolSupport, swarm::NetworkBehaviour};
 use monad_types::{Deserializable, Serializable};
 
@@ -16,8 +18,6 @@ where
 }
 const IDENTIFY_PROTO_NAME: &str = "/monad/identify/0.0.1";
 const REQUEST_RESPONSE_PROTO_NAME: &str = "/monad/req-res/0.0.1";
-const REQUEST_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
-const REQUEST_RESPONSE_KEEPALIVE: std::time::Duration = std::time::Duration::from_secs(1);
 
 impl<M, OM> Behavior<M, OM>
 where
@@ -25,7 +25,7 @@ where
     <M as Deserializable>::ReadError: 'static,
     OM: Serializable + Send + Sync + 'static,
 {
-    pub(crate) fn new(pubkey: &libp2p::identity::PublicKey) -> Self {
+    pub(crate) fn new(pubkey: &libp2p::identity::PublicKey, timeout: Duration) -> Self {
         let identify = libp2p::identify::Behaviour::new(libp2p::identify::Config::new(
             IDENTIFY_PROTO_NAME.to_string(),
             pubkey.clone(),
@@ -33,8 +33,8 @@ where
 
         let mut request_response_config = libp2p::request_response::Config::default();
         request_response_config
-            .set_request_timeout(REQUEST_RESPONSE_TIMEOUT)
-            .set_connection_keep_alive(REQUEST_RESPONSE_KEEPALIVE);
+            .set_request_timeout(timeout)
+            .set_connection_keep_alive(timeout);
         let request_response = libp2p::request_response::Behaviour::new(
             codec::ReliableMessageCodec::default(),
             [(


### PR DESCRIPTION
Adds the option to configure the monad-p2p request/response timeouts and authentication modes (eg None/Noise).