### PR TITLE
Add new crate for running randomized tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,6 +2064,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghost"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77ac7b51b8e6313251737fcef4b1c01a2ea102bde68415b62c0ee9268fec357"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "gimli"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2572,6 +2583,15 @@ dependencies = [
  "waitgroup",
  "webrtc-srtp",
  "webrtc-util",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0539b5de9241582ce6bd6b0ba7399313560151e58c9aaf8b74b711b1bdce644"
+dependencies = [
+ "ghost",
 ]
 
 [[package]]
@@ -3450,6 +3470,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-randomized-tests"
+version = "0.1.0"
+dependencies = [
+ "inventory",
+ "monad-executor",
+ "monad-state",
+ "monad-testutil",
+ "simple-xml-builder",
+]
+
+[[package]]
 name = "monad-state"
 version = "0.1.0"
 dependencies = [
@@ -3482,9 +3513,13 @@ version = "0.1.0"
 dependencies = [
  "monad-consensus",
  "monad-crypto",
+ "monad-executor",
  "monad-state",
  "monad-types",
  "monad-validator",
+ "monad-wal",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sha2 0.10.6",
 ]
 
@@ -5292,6 +5327,15 @@ name = "simd-adler32"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
+
+[[package]]
+name = "simple-xml-builder"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a50cb1e76f89e3c076f7ae0a609c4b0033c26034f740eddbeb761b64b2f42980"
+dependencies = [
+ "indexmap",
+]
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "monad-node",
     "monad-p2p",
     "monad-proto",
+    "monad-randomized-tests",
     "monad-state",
     "monad-testutil",
     "monad-tracing-counter",

--- a/monad-randomized-tests/Cargo.toml
+++ b/monad-randomized-tests/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "monad-randomized-tests"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+inventory = "0.3.6"
+simple-xml-builder = "1.1.0"
+monad-executor = { path = "../monad-executor" }
+monad-state = { path = "../monad-state" }
+monad-testutil = { path = "../monad-testutil" }
+
+[[bin]]
+name = "randomized-tests"
+path = "src/main.rs"

--- a/monad-randomized-tests/gocd_util/run_bench.sh
+++ b/monad-randomized-tests/gocd_util/run_bench.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cargo bench 2>&1 | tee bench_output.txt

--- a/monad-randomized-tests/gocd_util/run_tests.sh
+++ b/monad-randomized-tests/gocd_util/run_tests.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cargo run --bin randomized-tests $GO_PIPELINE_COUNTER

--- a/monad-randomized-tests/src/main.rs
+++ b/monad-randomized-tests/src/main.rs
@@ -1,0 +1,134 @@
+use simple_xml_builder::XMLElement;
+use std::collections::HashMap;
+use std::env;
+use std::fs::File;
+use std::panic;
+use std::time::{Duration, Instant};
+
+pub mod testcases;
+
+#[derive(Debug)]
+pub struct RandomizedTest {
+    pub name: &'static str,
+    pub func: fn(u64),
+}
+
+#[derive(Debug)]
+pub struct TestResults {
+    pub pass: bool,
+    pub time: Duration,
+}
+
+#[derive(Debug)]
+struct TestsuiteError();
+
+impl std::fmt::Display for TestsuiteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "tests failed")
+    }
+}
+
+impl std::error::Error for TestsuiteError {}
+
+fn setup() {
+    println!("Running randomized testcases");
+}
+
+fn summarize(
+    seed: u64,
+    results: HashMap<String, TestResults>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let num_tests = results.len();
+    let passed = results.values().filter(|x| x.pass).count();
+    let failed = num_tests - passed;
+    println!(
+        "tests run: {}, passed: {}, failed: {}",
+        num_tests, passed, failed,
+    );
+    println!("{:#?}", results);
+
+    let file = File::create("tests_results.xml")?;
+    let mut testsuite = XMLElement::new("testsuite");
+    testsuite.add_attribute("name", "Randomized tests");
+    testsuite.add_attribute("tests", num_tests);
+    testsuite.add_attribute("failures", failed);
+    testsuite.add_attribute("errors", 0);
+    testsuite.add_attribute("skipped", 0);
+    testsuite.add_attribute("assertions", 0);
+    testsuite.add_attribute("time", 0);
+    testsuite.add_attribute("timestamp", 0);
+    testsuite.add_attribute("file", format!("monad-randomized-tests;seed={}", seed));
+
+    for tc in results {
+        let mut testcase = XMLElement::new("testcase");
+        testcase.add_attribute("name", tc.0);
+        testcase.add_attribute("time", tc.1.time.as_millis());
+
+        if !tc.1.pass {
+            let failure = XMLElement::new("failure");
+            testcase.add_child(failure);
+        }
+
+        testsuite.add_child(testcase);
+    }
+
+    testsuite.write(file)?;
+
+    if failed > 0 {
+        Err(Box::new(TestsuiteError()))
+    } else {
+        Ok(())
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    println!("{:?}", args);
+
+    let arg = match args.get(1) {
+        Some(seed) => seed,
+        None => {
+            println!("need a seed arg");
+            return;
+        }
+    };
+
+    let seed = match arg.parse::<u64>() {
+        Ok(x) => x,
+        Err(e) => {
+            println!("cannot parse seed arg, {}", e);
+            return;
+        }
+    };
+
+    let mut results = HashMap::new();
+
+    setup();
+
+    for t in inventory::iter::<RandomizedTest> {
+        let start = Instant::now();
+        let result = panic::catch_unwind(|| (t.func)(seed));
+        let elapsed = start.elapsed();
+
+        results.insert(
+            String::from(t.name),
+            TestResults {
+                pass: result.is_ok(),
+                time: elapsed,
+            },
+        );
+    }
+
+    let r = summarize(seed, results);
+    match r {
+        Ok(()) => {
+            std::process::exit(0);
+        }
+        Err(e) => {
+            println!("testsuite failed, {}", e);
+            std::process::exit(-1);
+        }
+    }
+}
+
+inventory::collect!(RandomizedTest);

--- a/monad-randomized-tests/src/testcases/mod.rs
+++ b/monad-randomized-tests/src/testcases/mod.rs
@@ -1,0 +1,1 @@
+pub mod tests;

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -1,0 +1,57 @@
+use crate::RandomizedTest;
+use monad_executor::{
+    mock_swarm::{LatencyTransformer, RandLatencyTransformer, Transformer},
+    PeerId,
+};
+use monad_testutil::swarm::{get_configs, run_nodes, run_one_delayed_node};
+use monad_testutil::swarm::{PartitionThenReplayTransformer, TransformerReplayOrder};
+use std::collections::HashSet;
+use std::time::Duration;
+
+fn random_latency_test(seed: u64) {
+    run_nodes(
+        4,
+        2048,
+        Duration::from_millis(250),
+        RandLatencyTransformer::new(seed, 330),
+    );
+}
+
+fn delayed_message_test(seed: u64) {
+    let num_nodes = 4;
+    let delta = Duration::from_millis(2);
+    let (pubkeys, state_configs) = get_configs(num_nodes, delta);
+
+    assert!(num_nodes >= 2, "test requires 2 or more nodes");
+
+    let first_node = PeerId(*pubkeys.first().unwrap());
+
+    let mut filter_peers = HashSet::new();
+    filter_peers.insert(first_node);
+
+    println!("delayed node ID: {:?}", first_node);
+
+    run_one_delayed_node(
+        vec![
+            LatencyTransformer(Duration::from_millis(1)).boxed(),
+            PartitionThenReplayTransformer::new(
+                filter_peers,
+                200,
+                TransformerReplayOrder::Random(seed),
+            )
+            .boxed(),
+        ],
+        pubkeys,
+        state_configs,
+    );
+}
+
+inventory::submit!(RandomizedTest {
+    name: "random_latency",
+    func: random_latency_test,
+});
+
+inventory::submit!(RandomizedTest {
+    name: "delayed_message",
+    func: delayed_message_test,
+});

--- a/monad-state/benches/two_node_benchmark.rs
+++ b/monad-state/benches/two_node_benchmark.rs
@@ -3,10 +3,7 @@ use std::time::Duration;
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use monad_executor::mock_swarm::LatencyTransformer;
-
-#[path = "../tests/base.rs"]
-mod base;
-use base::run_nodes;
+use monad_testutil::swarm::run_nodes;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("two nodes", |b| b.iter(|| two_nodes()));

--- a/monad-state/tests/many_nodes.rs
+++ b/monad-state/tests/many_nodes.rs
@@ -1,14 +1,13 @@
 use std::time::Duration;
 
 use monad_executor::mock_swarm::LatencyTransformer;
-
-mod base;
+use monad_testutil::swarm::run_nodes;
 
 #[test]
 fn many_nodes() {
     tracing_subscriber::fmt::init();
 
-    base::run_nodes(
+    run_nodes(
         100,
         1024,
         Duration::from_millis(2),

--- a/monad-state/tests/many_nodes_metrics.rs
+++ b/monad-state/tests/many_nodes_metrics.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use monad_executor::mock_swarm::LatencyTransformer;
+use monad_testutil::swarm::run_nodes;
 use monad_tracing_counter::counter::CounterLayer;
 use monad_tracing_counter::counter::MetricFilter;
 use monad_tracing_counter::counter_status;
@@ -9,7 +10,6 @@ use tracing_core::LevelFilter;
 use tracing_subscriber::filter::Targets;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::Registry;
-mod base;
 
 #[test]
 fn many_nodes() {
@@ -26,7 +26,7 @@ fn many_nodes() {
 
     tracing::subscriber::set_global_default(subscriber).expect("unable to set global subscriber");
 
-    base::run_nodes(
+    run_nodes(
         100,
         1024,
         Duration::from_millis(2),

--- a/monad-state/tests/msg_delays.rs
+++ b/monad-state/tests/msg_delays.rs
@@ -1,14 +1,13 @@
 use std::time::Duration;
 
 use monad_executor::mock_swarm::XorLatencyTransformer;
-
-mod base;
+use monad_testutil::swarm::run_nodes;
 
 #[test]
 fn two_nodes() {
     tracing_subscriber::fmt::init();
 
-    base::run_nodes(
+    run_nodes(
         4,
         40,
         Duration::from_millis(101),

--- a/monad-state/tests/order.rs
+++ b/monad-state/tests/order.rs
@@ -2,12 +2,11 @@ use std::collections::HashSet;
 use std::time::Duration;
 
 use monad_executor::mock_swarm::{LatencyTransformer, Transformer};
+use monad_testutil::swarm::{get_configs, run_one_delayed_node};
+use monad_testutil::swarm::{PartitionThenReplayTransformer, TransformerReplayOrder};
 use test_case::test_case;
 
-use crate::base::{PartitionThenReplayTransformer, TransformerReplayOrder};
 use monad_executor::PeerId;
-
-mod base;
 
 #[test_case(TransformerReplayOrder::Forward; "in order")]
 #[test_case(TransformerReplayOrder::Reverse; "reverse order")]
@@ -19,7 +18,7 @@ mod base;
 fn all_messages_delayed(direction: TransformerReplayOrder) {
     let num_nodes = 4;
     let delta = Duration::from_millis(2);
-    let (pubkeys, state_configs) = base::get_configs(num_nodes, delta);
+    let (pubkeys, state_configs) = get_configs(num_nodes, delta);
 
     assert!(num_nodes >= 2, "test requires 2 or more nodes");
 
@@ -30,7 +29,7 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
 
     println!("delayed node ID: {:?}", first_node);
 
-    base::run_one_delayed_node(
+    run_one_delayed_node(
         vec![
             LatencyTransformer(Duration::from_millis(1)).boxed(),
             PartitionThenReplayTransformer::new(filter_peers, 200, direction).boxed(),

--- a/monad-state/tests/rand_lat.rs
+++ b/monad-state/tests/rand_lat.rs
@@ -1,6 +1,5 @@
+use monad_testutil::swarm::run_nodes;
 use test_case::test_case;
-
-mod base;
 
 #[test_case(1; "seed1")]
 #[test_case(2; "seed2")]
@@ -16,7 +15,7 @@ fn nodes_with_random_latency(seed: u64) {
     use monad_executor::mock_swarm::RandLatencyTransformer;
     use std::time::Duration;
 
-    base::run_nodes(
+    run_nodes(
         4,
         2048,
         Duration::from_millis(250),

--- a/monad-state/tests/replay.rs
+++ b/monad-state/tests/replay.rs
@@ -1,11 +1,7 @@
-mod base;
-
 #[cfg(test)]
 #[cfg(feature = "proto")]
 mod test {
-    use super::base;
-
-    use base::{get_configs, node_ledger_verification};
+    use monad_testutil::swarm::{get_configs, node_ledger_verification};
     use std::collections::HashMap;
     use std::fs::create_dir_all;
     use std::time::Duration;

--- a/monad-state/tests/single_node.rs
+++ b/monad-state/tests/single_node.rs
@@ -1,4 +1,4 @@
-mod base;
+use monad_testutil::swarm::run_nodes;
 
 #[test]
 fn two_nodes() {
@@ -7,7 +7,7 @@ fn two_nodes() {
 
     tracing_subscriber::fmt::init();
 
-    base::run_nodes(
+    run_nodes(
         2,
         1024,
         Duration::from_millis(2),

--- a/monad-state/tests/single_node_metrics.rs
+++ b/monad-state/tests/single_node_metrics.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use monad_executor::mock_swarm::LatencyTransformer;
+use monad_testutil::swarm::run_nodes;
 use monad_tracing_counter::counter::CounterLayer;
 use monad_tracing_counter::counter::MetricFilter;
 use monad_tracing_counter::counter_status;
@@ -9,7 +10,6 @@ use tracing_core::LevelFilter;
 use tracing_subscriber::filter::Targets;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::Registry;
-mod base;
 
 #[test]
 fn two_nodes() {
@@ -26,7 +26,7 @@ fn two_nodes() {
 
     tracing::subscriber::set_global_default(subscriber).expect("unable to set global subscriber");
 
-    base::run_nodes(
+    run_nodes(
         2,
         1024,
         Duration::from_millis(2),

--- a/monad-testutil/Cargo.toml
+++ b/monad-testutil/Cargo.toml
@@ -13,8 +13,12 @@ bench = false
 [dependencies]
 monad-consensus = { path = "../monad-consensus" }
 monad-crypto = {path = "../monad-crypto"}
+monad-executor = {path = "../monad-executor"}
 monad-state = {path = "../monad-state"}
 monad-types = {path = "../monad-types"}
 monad-validator = {path = "../monad-validator"}
+monad-wal = {path = "../monad-wal"}
+rand = "0.8.5"
+rand_chacha = "0.3.1"
 
 sha2 = "0.10.6"

--- a/monad-testutil/src/lib.rs
+++ b/monad-testutil/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod block;
 pub mod proposal;
 pub mod signing;
+pub mod swarm;
 pub mod validators;

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -3,6 +3,7 @@ use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
 use std::{collections::BTreeMap, collections::HashSet, time::Duration};
 
+use crate::signing::{create_keys, get_genesis_config};
 use monad_consensus::{
     signatures::aggregate_signature::AggregateSignatures,
     types::{quorum_certificate::genesis_vote_info, signature::SignatureCollection},
@@ -15,7 +16,6 @@ use monad_executor::{
     PeerId, State,
 };
 use monad_state::{MonadConfig, MonadEvent, MonadMessage, MonadState};
-use monad_testutil::signing::{create_keys, get_genesis_config};
 use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
 use monad_wal::PersistenceLogger;
 


### PR DESCRIPTION
Create a new binary that takes in a seed to run randomized tests. Intent of this patch is to make a compatible test harness for CI tools to run.

Refactored the base test code from monad-state into monad-testutil for reuse.