### PR TITLE
Fix Docker integration test for 90+ nodes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,7 @@ Dockerfile
 
 **/.git
 **/target
+
+**/*.data
+**/*.data.old
+**/*.svg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ resolver = "2"
 [profile.dev]
 opt-level = 1
 
+[profile.release]
+debug = true
+
 [workspace.dependencies]
 libp2p = { git = "https://github.com/monad-crypto/rust-libp2p.git", rev = "a2a5160b" }
 libp2p-identity = { git = "https://github.com/monad-crypto/rust-libp2p.git", rev = "a2a5160b" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,5 @@ RUN apt install -y iproute2
 COPY --from=builder /usr/local/cargo/bin/monad-node /usr/local/bin/monad-node
 COPY --from=builder /usr/src/monad-bft/tc.sh .
 
-ENV RUST_LOG=trace
+ENV RUST_LOG=monad_consensus=DEBUG
 CMD ["bash", "tc.sh"]

--- a/monad-p2p/src/behavior/mod.rs
+++ b/monad-p2p/src/behavior/mod.rs
@@ -25,7 +25,11 @@ where
     <M as Deserializable>::ReadError: 'static,
     OM: Serializable + Send + Sync + 'static,
 {
-    pub(crate) fn new(pubkey: &libp2p::identity::PublicKey, timeout: Duration) -> Self {
+    pub(crate) fn new(
+        pubkey: &libp2p::identity::PublicKey,
+        timeout: Duration,
+        keepalive: Duration,
+    ) -> Self {
         let identify = libp2p::identify::Behaviour::new(libp2p::identify::Config::new(
             IDENTIFY_PROTO_NAME.to_string(),
             pubkey.clone(),
@@ -34,7 +38,7 @@ where
         let mut request_response_config = libp2p::request_response::Config::default();
         request_response_config
             .set_request_timeout(timeout)
-            .set_connection_keep_alive(timeout);
+            .set_connection_keep_alive(keepalive);
         let request_response = libp2p::request_response::Behaviour::new(
             codec::ReliableMessageCodec::default(),
             [(

--- a/monad-p2p/src/lib.rs
+++ b/monad-p2p/src/lib.rs
@@ -55,7 +55,7 @@ where
             .boxed();
 
         let pubkey = identity.public();
-        let behavior = Behavior::new(&pubkey, Duration::from_secs(1));
+        let behavior = Behavior::new(&pubkey, Duration::from_secs(1), Duration::from_secs(10));
 
         let local_peer_id: libp2p::PeerId = pubkey.into();
         let mut swarm = SwarmBuilder::without_executor(transport, behavior, local_peer_id).build();
@@ -82,6 +82,7 @@ where
         identity: libp2p::identity::Keypair,
         address: Multiaddr,
         timeout: Duration,
+        keepalive: Duration,
         auth: Auth,
     ) -> Self {
         use libp2p::multiaddr::Protocol;
@@ -116,7 +117,7 @@ where
         };
 
         let pubkey = identity.public();
-        let behavior = Behavior::new(&pubkey, timeout);
+        let behavior = Behavior::new(&pubkey, timeout, keepalive);
 
         let local_peer_id: libp2p::PeerId = pubkey.into();
         let mut swarm = SwarmBuilder::with_tokio_executor(transport, behavior, local_peer_id)


### PR DESCRIPTION
Our libp2p keepalive timeout had to be extended, because we have N:N connections but only 1:N and N:1 connections are active at once.