### PR TITLE
Make Ser/De generic over signatures

### DIFF
--- a/monad-consensus/src/convert/interface.rs
+++ b/monad-consensus/src/convert/interface.rs
@@ -1,3 +1,4 @@
+use monad_crypto::Signature;
 use prost::Message;
 
 use monad_proto::error::ProtoError;
@@ -5,14 +6,16 @@ use monad_proto::proto::message::ProtoUnverifiedConsensusMessage;
 
 use super::message::{UnverifiedConsensusMessage, VerifiedConsensusMessage};
 
-pub fn serialize_verified_consensus_message(msg: &VerifiedConsensusMessage) -> Vec<u8> {
+pub fn serialize_verified_consensus_message(
+    msg: &VerifiedConsensusMessage<impl Signature>,
+) -> Vec<u8> {
     let proto_msg: ProtoUnverifiedConsensusMessage = msg.into();
     proto_msg.encode_to_vec()
 }
 
-pub fn deserialize_unverified_consensus_message(
+pub fn deserialize_unverified_consensus_message<S: Signature>(
     data: &[u8],
-) -> Result<UnverifiedConsensusMessage, ProtoError> {
+) -> Result<UnverifiedConsensusMessage<S>, ProtoError> {
     let msg = ProtoUnverifiedConsensusMessage::decode(data)?;
     msg.try_into()
 }

--- a/monad-consensus/src/convert/quorum_certificate.rs
+++ b/monad-consensus/src/convert/quorum_certificate.rs
@@ -1,11 +1,13 @@
+use monad_crypto::Signature;
 use monad_proto::error::ProtoError;
 use monad_proto::proto::quorum_certificate::*;
 
-use crate::types::quorum_certificate::{QcInfo, QuorumCertificate as ConsensusQC};
+use crate::{
+    signatures::aggregate_signature::AggregateSignatures,
+    types::quorum_certificate::{QcInfo, QuorumCertificate as ConsensusQC},
+};
 
-use super::signing::AggSecpSignature;
-
-type QuorumCertificate = ConsensusQC<AggSecpSignature>;
+type QuorumCertificate<S> = ConsensusQC<AggregateSignatures<S>>;
 
 impl From<&QcInfo> for ProtoQcInfo {
     fn from(qcinfo: &QcInfo) -> Self {
@@ -34,8 +36,8 @@ impl TryFrom<ProtoQcInfo> for QcInfo {
     }
 }
 
-impl From<&QuorumCertificate> for ProtoQuorumCertificateAggSig {
-    fn from(value: &QuorumCertificate) -> Self {
+impl<S: Signature> From<&QuorumCertificate<S>> for ProtoQuorumCertificateAggSig {
+    fn from(value: &QuorumCertificate<S>) -> Self {
         Self {
             info: Some((&value.info).into()),
             signatures: Some((&value.signatures).into()),
@@ -43,7 +45,7 @@ impl From<&QuorumCertificate> for ProtoQuorumCertificateAggSig {
     }
 }
 
-impl TryFrom<ProtoQuorumCertificateAggSig> for QuorumCertificate {
+impl<S: Signature> TryFrom<ProtoQuorumCertificateAggSig> for QuorumCertificate<S> {
     type Error = ProtoError;
 
     fn try_from(value: ProtoQuorumCertificateAggSig) -> Result<Self, Self::Error> {

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::ops::Deref;
 
+use monad_crypto::convert::signature_to_proto;
 use monad_crypto::secp256k1::{KeyPair, PubKey};
 use monad_crypto::Signature;
 #[cfg(feature = "proto")]
@@ -331,8 +332,8 @@ fn get_pubkey(msg: &[u8], sig: &impl Signature) -> Result<PubKey, Error> {
 }
 
 #[cfg(feature = "proto")]
-impl From<&UnverifiedConsensusMessage> for ProtoUnverifiedConsensusMessage {
-    fn from(value: &UnverifiedConsensusMessage) -> Self {
+impl<S: Signature> From<&UnverifiedConsensusMessage<S>> for ProtoUnverifiedConsensusMessage {
+    fn from(value: &UnverifiedConsensusMessage<S>) -> Self {
         let oneof_message = match &value.obj {
             ConsensusMessage::Proposal(msg) => {
                 proto_unverified_consensus_message::OneofMessage::Proposal(msg.into())
@@ -345,7 +346,7 @@ impl From<&UnverifiedConsensusMessage> for ProtoUnverifiedConsensusMessage {
             }
         };
         Self {
-            author_signature: Some(value.author_signature().into()),
+            author_signature: Some(signature_to_proto(value.author_signature())),
             oneof_message: Some(oneof_message),
         }
     }

--- a/monad-consensus/tests/protobuf.rs
+++ b/monad-consensus/tests/protobuf.rs
@@ -21,7 +21,7 @@ mod test {
             signing::{ValidatorMember, Verified},
         },
     };
-    use monad_crypto::secp256k1::KeyPair;
+    use monad_crypto::secp256k1::{KeyPair, SecpSignature};
     use monad_testutil::block::setup_block;
     use monad_testutil::signing::{create_keys, get_key};
     use monad_types::{BlockId, Hash, NodeId, Round};
@@ -53,10 +53,11 @@ mod test {
             commit_state_hash: None,
             vote_info_hash: Hash([42_u8; 32]),
         };
-        let votemsg = ConsensusMessage::Vote(VoteMessage {
-            vote_info: vi,
-            ledger_commit_info: lci,
-        });
+        let votemsg: ConsensusMessage<SecpSignature, AggregateSignatures<SecpSignature>> =
+            ConsensusMessage::Vote(VoteMessage {
+                vote_info: vi,
+                ledger_commit_info: lci,
+            });
         let keypairs = vec![get_key(0)];
         let author_keypair = &keypairs[0];
         let validators = setup_validator_member(&keypairs);
@@ -154,10 +155,11 @@ mod test {
             TransactionList(vec![1, 2, 3, 4]),
             &keypairs,
         );
-        let proposal = ConsensusMessage::Proposal(ProposalMessage {
-            block: blk,
-            last_round_tc: None,
-        });
+        let proposal: ConsensusMessage<SecpSignature, AggregateSignatures<SecpSignature>> =
+            ConsensusMessage::Proposal(ProposalMessage {
+                block: blk,
+                last_round_tc: None,
+            });
         let verified_msg = Verified::new::<Sha256Hash>(proposal, author_keypair);
 
         let rx_buf = serialize_verified_consensus_message(&verified_msg);

--- a/monad-crypto/src/secp256k1.rs
+++ b/monad-crypto/src/secp256k1.rs
@@ -235,8 +235,12 @@ impl Signature for SecpSignature {
         self.recover_pubkey(msg)
     }
 
-    fn serialize(&self) -> [u8; 65] {
-        self.serialize()
+    fn serialize(&self) -> Vec<u8> {
+        self.serialize().to_vec()
+    }
+
+    fn deserialize(signature: &[u8]) -> Result<Self, Error> {
+        Self::deserialize(signature)
     }
 }
 

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -18,7 +18,7 @@ message ProtoPeerId {
 // conversion is done in ProtoMonadEvent
 message ProtoAckEvent {
   ProtoPeerId peer = 1;
-  monad_proto.signing.ProtoSecpSignature id = 2;
+  monad_proto.signing.ProtoSignature id = 2;
   monad_proto.basic.ProtoRound round = 3;
 }
 

--- a/monad-proto/proto/message.proto
+++ b/monad-proto/proto/message.proto
@@ -29,5 +29,5 @@ message ProtoUnverifiedConsensusMessage {
     ProtoTimeoutMessage timeout = 2;
     ProtoVoteMessage vote = 3;
   }
-  monad_proto.signing.ProtoSecpSignature author_signature = 4;
+  monad_proto.signing.ProtoSignature author_signature = 4;
 }

--- a/monad-proto/proto/signing.proto
+++ b/monad-proto/proto/signing.proto
@@ -2,11 +2,11 @@ syntax = "proto3";
 
 package monad_proto.signing;
 
-message ProtoSecpSignature {
+message ProtoSignature {
   bytes sig = 1;
 }
 
 // AggregateSignatures
 message ProtoAggSig {
-  repeated ProtoSecpSignature sigs = 1;
+  repeated ProtoSignature sigs = 1;
 }

--- a/monad-proto/proto/timeout.proto
+++ b/monad-proto/proto/timeout.proto
@@ -13,7 +13,7 @@ message ProtoHighQcRound {
 
 message ProtoHighQcRoundSigTuple {
   ProtoHighQcRound high_qc_round = 1;
-  monad_proto.signing.ProtoSecpSignature author_signature = 2;
+  monad_proto.signing.ProtoSignature author_signature = 2;
 }
 
 message ProtoTimeoutCertificate {

--- a/monad-state/src/convert/interface.rs
+++ b/monad-state/src/convert/interface.rs
@@ -1,13 +1,14 @@
 use super::event::MonadEvent;
+use monad_crypto::Signature;
 use monad_proto::{error::ProtoError, proto::event::ProtoMonadEvent};
 use prost::Message;
 
-pub fn serialize_event(event: &MonadEvent) -> Vec<u8> {
+pub fn serialize_event(event: &MonadEvent<impl Signature>) -> Vec<u8> {
     let proto_event: ProtoMonadEvent = event.into();
     proto_event.encode_to_vec()
 }
 
-pub fn deserialize_event(data: &[u8]) -> Result<MonadEvent, ProtoError> {
+pub fn deserialize_event<S: Signature>(data: &[u8]) -> Result<MonadEvent<S>, ProtoError> {
     let event = ProtoMonadEvent::decode(data)?;
     event.try_into()
 }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -130,12 +130,10 @@ pub struct VerifiedMonadMessage<ST, SCT>(Verified<ST, ConsensusMessage<ST, SCT>>
 pub struct MonadMessage<ST, SCT>(Unverified<ST, ConsensusMessage<ST, SCT>>);
 
 #[cfg(feature = "proto")]
-impl monad_types::Serializable
+impl<S: Signature> monad_types::Serializable
     for VerifiedMonadMessage<
-        monad_crypto::secp256k1::SecpSignature,
-        monad_consensus::signatures::aggregate_signature::AggregateSignatures<
-            monad_crypto::secp256k1::SecpSignature,
-        >,
+        S,
+        monad_consensus::signatures::aggregate_signature::AggregateSignatures<S>,
     >
 {
     fn serialize(&self) -> Vec<u8> {
@@ -144,13 +142,8 @@ impl monad_types::Serializable
 }
 
 #[cfg(feature = "proto")]
-impl monad_types::Deserializable
-    for MonadMessage<
-        monad_crypto::secp256k1::SecpSignature,
-        monad_consensus::signatures::aggregate_signature::AggregateSignatures<
-            monad_crypto::secp256k1::SecpSignature,
-        >,
-    >
+impl<S: Signature> monad_types::Deserializable
+    for MonadMessage<S, monad_consensus::signatures::aggregate_signature::AggregateSignatures<S>>
 {
     type ReadError = monad_proto::error::ProtoError;
 

--- a/monad-wal/benches/event_bench.rs
+++ b/monad-wal/benches/event_bench.rs
@@ -10,7 +10,6 @@ use monad_consensus::types::timeout::{
     HighQcRound, HighQcRoundSigTuple, TimeoutCertificate, TimeoutInfo,
 };
 use monad_consensus::{
-    convert::signing::AggSecpSignature,
     signatures::aggregate_signature::AggregateSignatures,
     types::{
         block::TransactionList,
@@ -39,7 +38,7 @@ use monad_wal::PersistenceLogger;
 
 const N_VALIDATORS: usize = 400;
 
-type BenchEvent = MonadEvent<SecpSignature, AggSecpSignature>;
+type BenchEvent = MonadEvent<SecpSignature, AggregateSignatures<SecpSignature>>;
 struct MonadEventBencher {
     event: BenchEvent,
     logger: WALogger<BenchEvent>,
@@ -203,7 +202,7 @@ fn bench_timeout(c: &mut Criterion) {
 }
 
 fn bench_local_timeout(c: &mut Criterion) {
-    let event: MonadEvent<SecpSignature, AggSecpSignature> =
+    let event: MonadEvent<SecpSignature, AggregateSignatures<SecpSignature>> =
         MonadEvent::ConsensusEvent(ConsensusEvent::Timeout(PacemakerTimerExpire {}));
 
     let mut bencher = MonadEventBencher::new(event);
@@ -218,7 +217,7 @@ fn bench_local_timeout(c: &mut Criterion) {
 fn bench_ack(c: &mut Criterion) {
     let msg_hash = Hash([0xab_u8; 32].into());
     let keypair: KeyPair = get_key(1);
-    let event: MonadEvent<SecpSignature, AggSecpSignature> = MonadEvent::Ack {
+    let event: MonadEvent<SecpSignature, AggregateSignatures<SecpSignature>> = MonadEvent::Ack {
         peer: PeerId(keypair.pubkey()),
         id: keypair.sign(msg_hash.as_ref()),
         round: Round(1),


### PR DESCRIPTION
Instead of only allowing the Ser/De of Secp Signatures, support Ser/De of generic signatures.