### PR TITLE
Deprecate executor-level acks

### DIFF
--- a/monad-executor/src/state.rs
+++ b/monad-executor/src/state.rs
@@ -15,15 +15,8 @@ pub enum RouterCommand<M, OM>
 where
     M: Message,
 {
-    Publish {
-        to: PeerId,
-        message: OM,
-        on_ack: M::Event,
-    },
-    Unpublish {
-        to: PeerId,
-        id: M::Id,
-    },
+    Publish { to: PeerId, message: OM },
+    Unpublish { to: PeerId, id: M::Id },
 }
 
 pub enum TimerCommand<E> {

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -15,14 +15,6 @@ message ProtoPeerId {
 }
 
 // this type doesn't have a pair rust type
-// conversion is done in ProtoMonadEvent
-message ProtoAckEvent {
-  ProtoPeerId peer = 1;
-  monad_proto.signing.ProtoSignature id = 2;
-  monad_proto.basic.ProtoRound round = 3;
-}
-
-// this type doesn't have a pair rust type
 // conversion is done in ProtoConsensusEvent
 message ProtoMessageWithSender {
   monad_proto.basic.ProtoPubkey sender = 1;
@@ -49,7 +41,6 @@ message ProtoConsensusEvent {
 
 message ProtoMonadEvent{
   oneof event {
-    ProtoAckEvent ack = 1;
     ProtoConsensusEvent consensus_event = 2;
   }
 }

--- a/monad-state/src/message.rs
+++ b/monad-state/src/message.rs
@@ -130,27 +130,6 @@ where
 
         commands
     }
-
-    pub fn handle_ack(
-        &mut self,
-        round: Round,
-        peer: PeerId,
-        id: M::Id,
-    ) -> Option<MessageActionUnpublish<M>> {
-        let max_round = self.max_round();
-        if round >= self.min_round() && round <= max_round {
-            let back_idx = self.max_rounds_cached() - 1;
-            let key = (peer, id);
-
-            assert!(self.messages[(back_idx - (max_round - round).0) as usize].remove(&key));
-            Some(MessageActionUnpublish {
-                to: key.0,
-                id: key.1,
-            })
-        } else {
-            None
-        }
-    }
 }
 
 #[cfg(test)]
@@ -216,31 +195,5 @@ mod tests {
                 id: TestMessage,
             }],
         )
-    }
-
-    #[test]
-    fn handle_ack() {
-        let mut state = MessageState::<TestMessage, TestMessage>::new(5, Vec::new());
-        let _ = state.send(PeerId(node_id().0), TestMessage);
-
-        let evicted = state.handle_ack(Round(0), PeerId(node_id().0), TestMessage);
-        assert_eq!(
-            evicted,
-            Some(MessageActionUnpublish {
-                to: PeerId(node_id().0),
-                id: TestMessage,
-            }),
-        )
-    }
-
-    #[test]
-    fn evicted_handle_ack() {
-        let mut state = MessageState::<TestMessage, TestMessage>::new(5, Vec::new());
-        let _ = state.send(PeerId(node_id().0), TestMessage);
-
-        let _ = state.set_round(Round(10), Vec::new());
-
-        let evicted = state.handle_ack(Round(0), PeerId(node_id().0), TestMessage);
-        assert_eq!(evicted, None,)
     }
 }

--- a/monad-state/tests/protobuf.rs
+++ b/monad-state/tests/protobuf.rs
@@ -8,7 +8,6 @@ mod test {
     use monad_consensus::validation::hashing::{Hasher, Sha256Hash};
     use monad_consensus::{pacemaker::PacemakerTimerExpire, validation::signing::Unverified};
     use monad_crypto::secp256k1::{KeyPair, SecpSignature};
-    use monad_executor::PeerId;
     use monad_state::{
         convert::interface::{deserialize_event, serialize_event},
         ConsensusEvent, MonadEvent,
@@ -16,24 +15,6 @@ mod test {
     use monad_testutil::signing::get_key;
     use monad_types::BlockId;
     use monad_types::{Hash, Round};
-
-    #[test]
-    fn test_ack_event() {
-        let keypair = get_key(1);
-        let pubkey = keypair.pubkey();
-        let msg_hash = Hash([0x01_u8; 32]);
-        let event: MonadEvent<SecpSignature, AggregateSignatures<SecpSignature>> =
-            MonadEvent::Ack {
-                peer: PeerId(pubkey),
-                id: keypair.sign(msg_hash.as_ref()),
-                round: Round(10),
-            };
-
-        let buf = serialize_event(&event);
-        let rx_event = deserialize_event(&buf);
-
-        assert_eq!(event, rx_event.unwrap());
-    }
 
     #[test]
     fn test_consensus_timeout_event() {

--- a/monad-viz/src/main.rs
+++ b/monad-viz/src/main.rs
@@ -228,32 +228,6 @@ impl Program<Message> for &Sim {
                             ..Default::default()
                         })
                     }
-                    NodeEvent::Ack {
-                        tx_time,
-                        rx_time,
-                        tx_peer,
-                        message_id,
-                    } => {
-                        if tx_time == Duration::from_secs_f32(tick) || rx_peer == tx_peer {
-                            continue;
-                        }
-                        let (x1, y1) = points[node_indices[tx_peer]];
-                        let (x2, y2) = points[node_indices[rx_peer]];
-                        let ratio =
-                            (tick - tx_time.as_secs_f32()) / (rx_time - tx_time).as_secs_f32();
-                        let (x, y) = (x1 + (x2 - x1) * ratio, y1 + (y2 - y1) * ratio);
-
-                        let circle = Path::circle(frame.center() + Vector::new(x, y), 4.0);
-                        frame.fill(&circle, Color::from_rgb(255.0, 0.0, 255.0));
-
-                        frame.fill_text(Text {
-                            content: "ACK".to_owned(),
-                            position: frame.center() + Vector::new(x + 5.0, y - 5.0),
-                            size: 20.0,
-                            color: Color::BLACK,
-                            ..Default::default()
-                        })
-                    }
                     NodeEvent::Timer {
                         scheduled_time,
                         trip_time,

--- a/monad-wal/benches/event_bench.rs
+++ b/monad-wal/benches/event_bench.rs
@@ -214,33 +214,12 @@ fn bench_local_timeout(c: &mut Criterion) {
     });
 }
 
-fn bench_ack(c: &mut Criterion) {
-    let msg_hash = Hash([0xab_u8; 32].into());
-    let keypair: KeyPair = get_key(1);
-    let event: MonadEvent<SecpSignature, AggregateSignatures<SecpSignature>> = MonadEvent::Ack {
-        peer: PeerId(keypair.pubkey()),
-        id: keypair.sign(msg_hash.as_ref()),
-        round: Round(1),
-    };
-
-    let mut bencher = MonadEventBencher::new(event);
-
-    c.bench_function("bench_ack", |b| {
-        b.iter(|| {
-            for _ in 0..N_VALIDATORS {
-                bencher.append();
-            }
-        })
-    });
-}
-
 criterion_group!(
     bench,
     bench_proposal,
     bench_vote,
     bench_timeout,
     bench_local_timeout,
-    bench_ack
 );
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Removes the on_ack event in RouterCommand::Publish in preparation for RouterCommand::Broadcast. We previously had on_ack support so that nodes would not retransmit acked messages on restart - but this complicates the implementation significantly.

TODO we need to call MessageState::set_round in monad-state to gc old messages to not leak memory over many rounds.