### PR TITLE
Move `(De)serializable` traits to new `monad-traits` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3472,7 +3472,7 @@ dependencies = [
  "monad-consensus",
  "monad-crypto",
  "monad-executor",
- "monad-types",
+ "monad-traits",
  "tracing",
 ]
 
@@ -3509,6 +3509,7 @@ dependencies = [
  "monad-proto",
  "monad-testutil",
  "monad-tracing-counter",
+ "monad-traits",
  "monad-types",
  "monad-validator",
  "monad-wal",
@@ -3547,6 +3548,10 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "monad-traits"
+version = "0.1.0"
 
 [[package]]
 name = "monad-types"
@@ -3592,6 +3597,7 @@ dependencies = [
  "monad-executor",
  "monad-state",
  "monad-testutil",
+ "monad-traits",
  "monad-types",
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "monad-state",
     "monad-testutil",
     "monad-tracing-counter",
+    "monad-traits",
     "monad-types",
     "monad-validator",
     "monad-viz",

--- a/monad-p2p/Cargo.toml
+++ b/monad-p2p/Cargo.toml
@@ -12,7 +12,7 @@ bench = false
 monad-consensus = { path = "../monad-consensus" }
 monad-crypto = { path = "../monad-crypto", features = ["libp2p-identity"] }
 monad-executor = { path = "../monad-executor" }
-monad-types = { path = "../monad-types" }
+monad-traits = { path = "../monad-traits" }
 
 async-trait = { workspace = true }
 futures = { workspace = true }

--- a/monad-p2p/src/behavior/codec.rs
+++ b/monad-p2p/src/behavior/codec.rs
@@ -2,7 +2,7 @@ use std::{io::ErrorKind, marker::PhantomData, sync::Arc};
 
 use async_trait::async_trait;
 use monad_executor::{Message, PeerId};
-use monad_types::{Deserializable, Serializable};
+use monad_traits::{Deserializable, Serializable};
 
 use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use libp2p::request_response::Codec;

--- a/monad-p2p/src/behavior/mod.rs
+++ b/monad-p2p/src/behavior/mod.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use libp2p::{request_response::ProtocolSupport, swarm::NetworkBehaviour};
-use monad_types::{Deserializable, Serializable};
+use monad_traits::{Deserializable, Serializable};
 
 mod codec;
 pub use codec::WrappedMessage;

--- a/monad-p2p/src/lib.rs
+++ b/monad-p2p/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
 
 use futures::{FutureExt, Stream, StreamExt};
 use monad_executor::{Executor, Message, RouterCommand};
-use monad_types::{Deserializable, Serializable};
+use monad_traits::{Deserializable, Serializable};
 
 use libp2p::{request_response::RequestId, swarm::SwarmBuilder, Transport};
 
@@ -319,7 +319,7 @@ mod tests {
 
     use crate::Service;
     use monad_executor::Message;
-    use monad_types::{Deserializable, Serializable};
+    use monad_traits::{Deserializable, Serializable};
 
     use futures::StreamExt;
 

--- a/monad-state/Cargo.toml
+++ b/monad-state/Cargo.toml
@@ -14,6 +14,7 @@ monad-consensus = { path = "../monad-consensus" }
 monad-crypto = { path = "../monad-crypto" }
 monad-executor = { path = "../monad-executor" }
 monad-proto = { path = "../monad-proto", optional = true }
+monad-traits = { path = "../monad-traits" }
 monad-types = { path = "../monad-types" }
 monad-validator = { path = "../monad-validator" }
 monad-wal = { path = "../monad-wal" }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -85,7 +85,7 @@ where
 }
 
 #[cfg(feature = "proto")]
-impl monad_types::Deserializable
+impl monad_traits::Deserializable
     for MonadEvent<
         monad_crypto::secp256k1::SecpSignature,
         monad_consensus::signatures::aggregate_signature::AggregateSignatures<
@@ -101,7 +101,7 @@ impl monad_types::Deserializable
 }
 
 #[cfg(feature = "proto")]
-impl monad_types::Serializable
+impl monad_traits::Serializable
     for MonadEvent<
         monad_crypto::secp256k1::SecpSignature,
         monad_consensus::signatures::aggregate_signature::AggregateSignatures<
@@ -123,7 +123,7 @@ pub struct VerifiedMonadMessage<ST, SCT>(Verified<ST, ConsensusMessage<ST, SCT>>
 pub struct MonadMessage<ST, SCT>(Unverified<ST, ConsensusMessage<ST, SCT>>);
 
 #[cfg(feature = "proto")]
-impl<S: Signature> monad_types::Serializable
+impl<S: Signature> monad_traits::Serializable
     for VerifiedMonadMessage<
         S,
         monad_consensus::signatures::aggregate_signature::AggregateSignatures<S>,
@@ -135,7 +135,7 @@ impl<S: Signature> monad_types::Serializable
 }
 
 #[cfg(feature = "proto")]
-impl<S: Signature> monad_types::Deserializable
+impl<S: Signature> monad_traits::Deserializable
     for MonadMessage<S, monad_consensus::signatures::aggregate_signature::AggregateSignatures<S>>
 {
     type ReadError = monad_proto::error::ProtoError;

--- a/monad-traits/Cargo.toml
+++ b/monad-traits/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "monad-traits"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/monad-traits/src/lib.rs
+++ b/monad-traits/src/lib.rs
@@ -1,0 +1,11 @@
+use std::error::Error;
+
+pub trait Serializable {
+    fn serialize(&self) -> Vec<u8>;
+}
+
+pub trait Deserializable: Sized {
+    type ReadError: Error + Send + Sync;
+
+    fn deserialize(message: &[u8]) -> Result<Self, Self::ReadError>;
+}

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "proto")]
 pub mod convert;
 
-use std::error::Error;
 use std::ops::Add;
 use std::ops::AddAssign;
 use std::ops::Deref;
@@ -87,14 +86,4 @@ impl std::fmt::Debug for BlockId {
             self.0[0], self.0[1], self.0[30], self.0[31]
         )
     }
-}
-
-pub trait Serializable {
-    fn serialize(&self) -> Vec<u8>;
-}
-
-pub trait Deserializable: Sized {
-    type ReadError: Error + Send + Sync;
-
-    fn deserialize(message: &[u8]) -> Result<Self, Self::ReadError>;
 }

--- a/monad-wal/Cargo.toml
+++ b/monad-wal/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 bench = false
 
 [dependencies]
-monad-types = { path = "../monad-types" }
+monad-traits = { path = "../monad-traits" }
 
 [dev-dependencies]
 monad-consensus = { path = "../monad-consensus" }

--- a/monad-wal/benches/event_bench.rs
+++ b/monad-wal/benches/event_bench.rs
@@ -31,7 +31,7 @@ use monad_testutil::{
     block::setup_block,
     signing::{create_keys, get_key},
 };
-use monad_types::Serializable;
+use monad_traits::Serializable;
 use monad_types::{BlockId, Hash, NodeId, Round};
 use monad_wal::wal::{WALogger, WALoggerConfig};
 use monad_wal::PersistenceLogger;

--- a/monad-wal/benches/raw_bench.rs
+++ b/monad-wal/benches/raw_bench.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use std::fs::create_dir_all;
 use tempfile::{tempdir, TempDir};
 
-use monad_types::{Deserializable, Serializable};
+use monad_traits::{Deserializable, Serializable};
 use monad_wal::wal::*;
 use monad_wal::PersistenceLogger;
 

--- a/monad-wal/src/wal.rs
+++ b/monad-wal/src/wal.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use std::path::PathBuf;
 use std::{fmt::Debug, io};
 
-use monad_types::{Deserializable, Serializable};
+use monad_traits::{Deserializable, Serializable};
 
 use crate::aof::AppendOnlyFile;
 use crate::PersistenceLogger;

--- a/monad-wal/tests/replay.rs
+++ b/monad-wal/tests/replay.rs
@@ -3,7 +3,7 @@ mod test {
     use std::{array::TryFromSliceError, fs::OpenOptions};
 
     use monad_executor::{Message, State};
-    use monad_types::{Deserializable, Serializable};
+    use monad_traits::{Deserializable, Serializable};
     use monad_wal::wal::{WALogger, WALoggerConfig};
     use monad_wal::PersistenceLogger;
 


### PR DESCRIPTION
The two traits were originally defined in `monad-types`, which depends on `monad-crypto` crate. The `monad-crypto` crate can use the traits, so lifting them to a separate crate to avoid circular dependencies.