### PR TITLE
Refactor crypto traits; add Secp prefix to primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,6 +3399,7 @@ dependencies = [
  "hex",
  "libp2p-identity",
  "monad-proto",
+ "monad-traits",
  "multihash",
  "rand 0.8.5",
  "secp256k1",

--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -231,7 +231,8 @@ mod test {
     use monad_consensus::types::quorum_certificate::{QcInfo, QuorumCertificate};
     use monad_consensus::types::voting::VoteInfo;
     use monad_consensus::validation::hashing::Sha256Hash;
-    use monad_crypto::secp256k1::KeyPair;
+    use monad_crypto::secp256k1::SecpKeyPair;
+    use monad_crypto::KeyPair;
     use monad_testutil::signing::MockSignatures;
     use monad_types::{BlockId, Hash, NodeId, Round};
 
@@ -243,7 +244,7 @@ mod test {
 
     fn node_id() -> NodeId {
         let mut privkey: [u8; 32] = [127; 32];
-        let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
+        let keypair = SecpKeyPair::from_bytes(&mut privkey).unwrap();
         NodeId(keypair.pubkey())
     }
 

--- a/monad-consensus/src/convert/block.rs
+++ b/monad-consensus/src/convert/block.rs
@@ -1,4 +1,7 @@
-use monad_crypto::Signature;
+use monad_crypto::{
+    secp256k1::{SecpError, SecpPubKey},
+    Signature,
+};
 use monad_proto::error::ProtoError;
 use monad_proto::proto::block::*;
 
@@ -34,7 +37,9 @@ impl<S: Signature> From<&Block<AggregateSignatures<S>>> for ProtoBlockAggSig {
     }
 }
 
-impl<S: Signature> TryFrom<ProtoBlockAggSig> for Block<AggregateSignatures<S>> {
+impl<S: Signature<PubKey = SecpPubKey, Error = SecpError>> TryFrom<ProtoBlockAggSig>
+    for Block<AggregateSignatures<S>>
+{
     type Error = ProtoError;
 
     fn try_from(value: ProtoBlockAggSig) -> Result<Self, Self::Error> {

--- a/monad-consensus/src/convert/interface.rs
+++ b/monad-consensus/src/convert/interface.rs
@@ -1,4 +1,7 @@
-use monad_crypto::Signature;
+use monad_crypto::{
+    secp256k1::{SecpError, SecpPubKey},
+    Signature,
+};
 use prost::Message;
 
 use monad_proto::error::ProtoError;
@@ -13,7 +16,9 @@ pub fn serialize_verified_consensus_message(
     proto_msg.encode_to_vec()
 }
 
-pub fn deserialize_unverified_consensus_message<S: Signature>(
+pub fn deserialize_unverified_consensus_message<
+    S: Signature<PubKey = SecpPubKey, Error = SecpError>,
+>(
     data: &[u8],
 ) -> Result<UnverifiedConsensusMessage<S>, ProtoError> {
     let msg = ProtoUnverifiedConsensusMessage::decode(data)?;

--- a/monad-consensus/src/convert/message.rs
+++ b/monad-consensus/src/convert/message.rs
@@ -1,6 +1,7 @@
 use std::ops::Deref;
 
 use monad_crypto::convert::{proto_to_signature, signature_to_proto};
+use monad_crypto::secp256k1::{SecpError, SecpPubKey};
 use monad_crypto::Signature;
 use monad_proto::error::ProtoError;
 use monad_proto::proto::message::*;
@@ -58,7 +59,9 @@ impl<S: Signature> From<&TimeoutMessage<S>> for ProtoTimeoutMessage {
     }
 }
 
-impl<S: Signature> TryFrom<ProtoTimeoutMessage> for TimeoutMessage<S> {
+impl<S: Signature<PubKey = SecpPubKey, Error = SecpError>> TryFrom<ProtoTimeoutMessage>
+    for TimeoutMessage<S>
+{
     type Error = ProtoError;
     fn try_from(value: ProtoTimeoutMessage) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -83,7 +86,9 @@ impl<S: Signature> From<&ProposalMessage<S>> for ProtoProposalMessageAggSig {
     }
 }
 
-impl<S: Signature> TryFrom<ProtoProposalMessageAggSig> for ProposalMessage<S> {
+impl<S: Signature<PubKey = SecpPubKey, Error = SecpError>> TryFrom<ProtoProposalMessageAggSig>
+    for ProposalMessage<S>
+{
     type Error = ProtoError;
 
     fn try_from(value: ProtoProposalMessageAggSig) -> Result<Self, Self::Error> {
@@ -119,7 +124,9 @@ impl<S: Signature> From<&VerifiedConsensusMessage<S>> for ProtoUnverifiedConsens
     }
 }
 
-impl<S: Signature> TryFrom<ProtoUnverifiedConsensusMessage> for UnverifiedConsensusMessage<S> {
+impl<S: Signature<PubKey = SecpPubKey, Error = SecpError>> TryFrom<ProtoUnverifiedConsensusMessage>
+    for UnverifiedConsensusMessage<S>
+{
     type Error = ProtoError;
 
     fn try_from(value: ProtoUnverifiedConsensusMessage) -> Result<Self, Self::Error> {

--- a/monad-consensus/src/convert/quorum_certificate.rs
+++ b/monad-consensus/src/convert/quorum_certificate.rs
@@ -1,4 +1,7 @@
-use monad_crypto::Signature;
+use monad_crypto::{
+    secp256k1::{SecpError, SecpPubKey},
+    Signature,
+};
 use monad_proto::error::ProtoError;
 use monad_proto::proto::quorum_certificate::*;
 
@@ -45,7 +48,9 @@ impl<S: Signature> From<&QuorumCertificate<S>> for ProtoQuorumCertificateAggSig 
     }
 }
 
-impl<S: Signature> TryFrom<ProtoQuorumCertificateAggSig> for QuorumCertificate<S> {
+impl<S: Signature<PubKey = SecpPubKey, Error = SecpError>> TryFrom<ProtoQuorumCertificateAggSig>
+    for QuorumCertificate<S>
+{
     type Error = ProtoError;
 
     fn try_from(value: ProtoQuorumCertificateAggSig) -> Result<Self, Self::Error> {

--- a/monad-consensus/src/convert/timeout.rs
+++ b/monad-consensus/src/convert/timeout.rs
@@ -1,5 +1,6 @@
 use monad_crypto::{
     convert::{proto_to_signature, signature_to_proto},
+    secp256k1::{SecpError, SecpPubKey},
     Signature,
 };
 use monad_proto::error::ProtoError;
@@ -109,7 +110,9 @@ impl<S: Signature> From<&TimeoutInfo<S>> for ProtoTimeoutInfoAggSig {
     }
 }
 
-impl<S: Signature> TryFrom<ProtoTimeoutInfoAggSig> for TimeoutInfo<S> {
+impl<S: Signature<PubKey = SecpPubKey, Error = SecpError>> TryFrom<ProtoTimeoutInfoAggSig>
+    for TimeoutInfo<S>
+{
     type Error = ProtoError;
 
     fn try_from(value: ProtoTimeoutInfoAggSig) -> Result<Self, Self::Error> {

--- a/monad-consensus/src/signatures/aggregate_signature.rs
+++ b/monad-consensus/src/signatures/aggregate_signature.rs
@@ -1,5 +1,5 @@
 use monad_crypto::{
-    secp256k1::{Error, PubKey},
+    secp256k1::{SecpError, SecpPubKey},
     Signature,
 };
 use monad_types::Hash;
@@ -18,7 +18,9 @@ impl<S: Signature> Default for AggregateSignatures<S> {
     }
 }
 
-impl<S: Signature> SignatureCollection for AggregateSignatures<S> {
+impl<S: Signature<PubKey = SecpPubKey, Error = SecpError>> SignatureCollection
+    for AggregateSignatures<S>
+{
     type SignatureType = S;
 
     fn new() -> Self {
@@ -39,7 +41,7 @@ impl<S: Signature> SignatureCollection for AggregateSignatures<S> {
         self.sigs.push(sig);
     }
 
-    fn verify_signatures(&self, msg: &[u8]) -> Result<(), Error> {
+    fn verify_signatures(&self, msg: &[u8]) -> Result<(), SecpError> {
         for s in self.sigs.iter() {
             let pubkey = s.recover_pubkey(msg)?;
             s.verify(msg, &pubkey)?;
@@ -47,10 +49,10 @@ impl<S: Signature> SignatureCollection for AggregateSignatures<S> {
         Ok(())
     }
 
-    fn get_pubkeys(&self, msg: &[u8]) -> Result<Vec<PubKey>, Error> {
+    fn get_pubkeys(&self, msg: &[u8]) -> Result<Vec<SecpPubKey>, SecpError> {
         self.sigs
             .iter()
-            .map(|s| -> Result<PubKey, Error> { s.recover_pubkey(msg) })
+            .map(|s| -> Result<SecpPubKey, SecpError> { s.recover_pubkey(msg) })
             .collect()
     }
 

--- a/monad-consensus/src/types/consensus_message.rs
+++ b/monad-consensus/src/types/consensus_message.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use monad_crypto::{secp256k1::KeyPair, Signature};
+use monad_crypto::{secp256k1::SecpKeyPair, Signature};
 
 use crate::{
     types::message::{ProposalMessage, TimeoutMessage, VoteMessage},
@@ -52,10 +52,10 @@ where
 
 impl<ST, SCT> ConsensusMessage<ST, SCT>
 where
-    ST: Signature,
+    ST: Signature<KeyPair = SecpKeyPair>,
     SCT: SignatureCollection<SignatureType = ST>,
 {
-    pub fn sign<H: Hasher>(self, keypair: &KeyPair) -> Verified<ST, ConsensusMessage<ST, SCT>> {
+    pub fn sign<H: Hasher>(self, keypair: &SecpKeyPair) -> Verified<ST, ConsensusMessage<ST, SCT>> {
         Verified::new::<H>(self, keypair)
     }
 }

--- a/monad-consensus/src/types/signature.rs
+++ b/monad-consensus/src/types/signature.rs
@@ -1,5 +1,5 @@
 use monad_crypto::{
-    secp256k1::{Error, PubKey},
+    secp256k1::{SecpError, SecpPubKey},
     Signature,
 };
 use monad_types::Hash;
@@ -15,9 +15,9 @@ pub trait SignatureCollection: Clone + Default + Send + Sync + std::fmt::Debug +
     // add the signature from a signed vote message
     fn add_signature(&mut self, s: Self::SignatureType);
 
-    fn verify_signatures(&self, msg: &[u8]) -> Result<(), Error>;
+    fn verify_signatures(&self, msg: &[u8]) -> Result<(), SecpError>;
 
-    fn get_pubkeys(&self, msg: &[u8]) -> Result<Vec<PubKey>, Error>;
+    fn get_pubkeys(&self, msg: &[u8]) -> Result<Vec<SecpPubKey>, SecpError>;
 
     fn num_signatures(&self) -> usize;
 }

--- a/monad-consensus/src/vote_state.rs
+++ b/monad-consensus/src/vote_state.rs
@@ -92,7 +92,8 @@ mod test {
     use crate::types::voting::VoteInfo;
     use crate::validation::hashing::Sha256Hash;
     use crate::validation::signing::Verified;
-    use monad_crypto::secp256k1::{KeyPair, SecpSignature};
+    use monad_crypto::secp256k1::{SecpKeyPair, SecpSignature};
+    use monad_crypto::KeyPair;
     use monad_testutil::signing::get_key;
     use monad_testutil::signing::*;
     use monad_testutil::validators::MockLeaderElection;
@@ -103,7 +104,7 @@ mod test {
 
     use super::VoteState;
 
-    fn create_valset(num_nodes: u32) -> (Vec<KeyPair>, ValidatorSet<MockLeaderElection>) {
+    fn create_valset(num_nodes: u32) -> (Vec<SecpKeyPair>, ValidatorSet<MockLeaderElection>) {
         let keys = create_keys(num_nodes);
 
         let mut nodes = Vec::new();
@@ -119,7 +120,7 @@ mod test {
     }
 
     fn create_signed_vote_message(
-        keypair: &KeyPair,
+        keypair: &SecpKeyPair,
         vote_round: Round,
     ) -> Verified<SecpSignature, VoteMessage> {
         let vi = VoteInfo {

--- a/monad-consensus/tests/message.rs
+++ b/monad-consensus/tests/message.rs
@@ -10,7 +10,8 @@ use monad_consensus::types::timeout::{
     HighQcRound, HighQcRoundSigTuple, TimeoutCertificate, TimeoutInfo,
 };
 use monad_consensus::validation::hashing::*;
-use monad_crypto::secp256k1::{KeyPair, SecpSignature};
+use monad_crypto::secp256k1::{SecpKeyPair, SecpSignature};
+use monad_crypto::{KeyPair, Signature};
 use monad_testutil::signing::*;
 use monad_types::*;
 use sha2::Digest;
@@ -86,7 +87,7 @@ fn proposal_msg_hash() {
     let txns = TransactionList(vec![1, 2, 3, 4]);
 
     let mut privkey: [u8; 32] = [127; 32];
-    let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
+    let keypair = SecpKeyPair::from_bytes(&mut privkey).unwrap();
     let author = NodeId(keypair.pubkey());
     let round = Round(234);
     let qc = QuorumCertificate::<MockSignatures>::new(
@@ -159,7 +160,7 @@ fn test_vote_message() {
     };
 
     let mut privkey: [u8; 32] = [127; 32];
-    let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
+    let keypair = SecpKeyPair::from_bytes(&mut privkey).unwrap();
 
     let expected_vote_info_hash = vm.ledger_commit_info.vote_info_hash;
 

--- a/monad-consensus/tests/proposal.rs
+++ b/monad-consensus/tests/proposal.rs
@@ -7,6 +7,7 @@ use monad_consensus::validation::error::Error;
 use monad_consensus::validation::hashing::*;
 use monad_consensus::validation::signing::ValidatorMember;
 use monad_crypto::secp256k1::SecpSignature;
+use monad_crypto::KeyPair;
 use monad_testutil::signing::{get_key, node_id, MockSignatures, TestSigner};
 use monad_types::*;
 use monad_validator::validator::Validator;

--- a/monad-consensus/tests/protobuf.rs
+++ b/monad-consensus/tests/protobuf.rs
@@ -21,13 +21,14 @@ mod test {
             signing::{ValidatorMember, Verified},
         },
     };
-    use monad_crypto::secp256k1::{KeyPair, SecpSignature};
+    use monad_crypto::secp256k1::{SecpKeyPair, SecpSignature};
+    use monad_crypto::KeyPair;
     use monad_testutil::block::setup_block;
     use monad_testutil::signing::{create_keys, get_key};
     use monad_types::{BlockId, Hash, NodeId, Round};
     use monad_validator::validator::Validator;
 
-    fn setup_validator_member(keypairs: &[KeyPair]) -> ValidatorMember {
+    fn setup_validator_member(keypairs: &[SecpKeyPair]) -> ValidatorMember {
         let mut vmember = ValidatorMember::new();
         for keypair in keypairs.iter() {
             vmember.insert(

--- a/monad-consensus/tests/vote_state.rs
+++ b/monad-consensus/tests/vote_state.rs
@@ -11,7 +11,8 @@ use monad_consensus::validation::hashing::{Hasher, Sha256Hash};
 use monad_consensus::validation::signing::Unverified;
 use monad_consensus::validation::signing::Verified;
 use monad_consensus::vote_state::VoteState;
-use monad_crypto::secp256k1::{KeyPair, SecpSignature};
+use monad_crypto::secp256k1::{SecpKeyPair, SecpSignature};
+use monad_crypto::KeyPair;
 use monad_testutil::signing::*;
 use monad_testutil::validators::MockLeaderElection;
 use monad_types::Hash;
@@ -19,7 +20,7 @@ use monad_validator::validator::Validator;
 use monad_validator::validator_set::ValidatorSet;
 
 fn create_signed_vote_message(
-    keypair: &KeyPair,
+    keypair: &SecpKeyPair,
     vote_round: Round,
 ) -> Unverified<SecpSignature, VoteMessage> {
     let vi = VoteInfo {
@@ -45,7 +46,7 @@ fn create_signed_vote_message(
 fn setup_ctx(
     num_nodes: u32,
 ) -> (
-    Vec<KeyPair>,
+    Vec<SecpKeyPair>,
     ValidatorSet<MockLeaderElection>,
     Vec<Verified<SecpSignature, VoteMessage>>,
 ) {

--- a/monad-crypto/Cargo.toml
+++ b/monad-crypto/Cargo.toml
@@ -10,6 +10,7 @@ bench = false
 
 [dependencies]
 monad-proto = { path = "../monad-proto", optional = true }
+monad-traits = { path = "../monad-traits" }
 
 libp2p-identity = { workspace = true, features = ["secp256k1"], optional = true }
 multihash = { workspace = true, features = ["identity"], optional = true }

--- a/monad-crypto/src/convert/mod.rs
+++ b/monad-crypto/src/convert/mod.rs
@@ -4,21 +4,22 @@ use monad_proto::error::ProtoError;
 use monad_proto::proto::basic::ProtoPubkey;
 use monad_proto::proto::signing::ProtoSignature;
 
-use crate::{PubKey, Signature};
+use crate::secp256k1::SecpPubKey;
+use crate::Signature;
 
-impl From<&PubKey> for ProtoPubkey {
-    fn from(value: &PubKey) -> Self {
+impl From<&SecpPubKey> for ProtoPubkey {
+    fn from(value: &SecpPubKey) -> Self {
         Self {
             pubkey: value.bytes(),
         }
     }
 }
 
-impl TryFrom<ProtoPubkey> for PubKey {
+impl TryFrom<ProtoPubkey> for SecpPubKey {
     type Error = ProtoError;
 
     fn try_from(value: ProtoPubkey) -> Result<Self, Self::Error> {
-        PubKey::from_slice(value.pubkey.as_bytes())
+        Self::from_slice(value.pubkey.as_bytes())
             .map_err(|e| ProtoError::Secp256k1Error(format!("{}", e)))
     }
 }

--- a/monad-crypto/src/nop.rs
+++ b/monad-crypto/src/nop.rs
@@ -1,0 +1,56 @@
+use crate::secp256k1::{SecpError, SecpKeyPair, SecpPubKey};
+use crate::{KeyPair, Signature};
+use monad_traits::{Deserializable, Serializable};
+use rand::Rng;
+
+// This implementation won't sign or verify anything, but its still required to return a PubKey
+// It's Hash must also be unique (Signature's Hash is used as a MonadMessage ID) for some period
+// of time (the executor message window size?)
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct NopSignature {
+    pubkey: SecpPubKey,
+    id: u32,
+}
+
+impl Signature for NopSignature {
+    type KeyPair = SecpKeyPair;
+    type PubKey = SecpPubKey;
+    type Error = SecpError;
+
+    fn sign(_msg: &[u8], keypair: &SecpKeyPair) -> Self {
+        let mut rng = rand::thread_rng();
+
+        NopSignature {
+            pubkey: keypair.pubkey(),
+            id: rng.gen::<u32>(),
+        }
+    }
+
+    fn verify(&self, _msg: &[u8], _pubkey: &SecpPubKey) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn recover_pubkey(&self, _msg: &[u8]) -> Result<SecpPubKey, Self::Error> {
+        Ok(self.pubkey)
+    }
+}
+
+impl Serializable for NopSignature {
+    fn serialize(&self) -> Vec<u8> {
+        self.id
+            .to_le_bytes()
+            .into_iter()
+            .chain(self.pubkey.bytes().into_iter())
+            .collect()
+    }
+}
+
+impl Deserializable for NopSignature {
+    type ReadError = SecpError;
+
+    fn deserialize(signature: &[u8]) -> Result<Self, Self::ReadError> {
+        let id = u32::from_le_bytes(signature[..4].try_into().unwrap());
+        let pubkey = SecpPubKey::from_slice(&signature[4..])?;
+        Ok(Self { pubkey, id })
+    }
+}

--- a/monad-crypto/src/secp256k1.rs
+++ b/monad-crypto/src/secp256k1.rs
@@ -1,26 +1,29 @@
 use secp256k1::Secp256k1;
 use sha2::Digest;
-
-use crate::Signature;
-
 use zeroize::Zeroize;
 
+use monad_traits::{Deserializable, Serializable};
+
+use crate::{Compressable, KeyPair, PubKey, Signature};
+
 #[derive(Copy, Clone)]
-pub struct PubKey(secp256k1::PublicKey);
-pub struct KeyPair(secp256k1::KeyPair);
+pub struct SecpPubKey(secp256k1::PublicKey);
+pub struct SecpKeyPair(secp256k1::KeyPair);
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SecpSignature(secp256k1::ecdsa::RecoverableSignature);
 
 #[derive(Debug, Clone)]
-pub struct Error(secp256k1::Error);
+pub struct SecpError(secp256k1::Error);
 
-impl std::fmt::Display for Error {
+impl std::fmt::Display for SecpError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl std::fmt::Debug for PubKey {
+impl std::error::Error for SecpError {}
+
+impl std::fmt::Debug for SecpPubKey {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let ser = self.bytes();
         write!(
@@ -32,89 +35,38 @@ impl std::fmt::Debug for PubKey {
     }
 }
 
-impl std::cmp::PartialEq for PubKey {
+impl std::cmp::PartialEq for SecpPubKey {
     fn eq(&self, other: &Self) -> bool {
         self.0.eq_fast_unstable(&other.0)
     }
 }
 
-impl std::cmp::Eq for PubKey {}
+impl std::cmp::Eq for SecpPubKey {}
 
-impl std::cmp::Ord for PubKey {
+impl std::cmp::Ord for SecpPubKey {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.0.cmp_fast_unstable(&other.0)
     }
 }
 
-impl std::cmp::PartialOrd for PubKey {
+impl std::cmp::PartialOrd for SecpPubKey {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl std::hash::Hash for PubKey {
+impl std::hash::Hash for SecpPubKey {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let slice = unsafe { std::mem::transmute::<Self, [u8; 64]>(*self) };
         slice.hash(state)
     }
 }
 
-fn msg_hash(msg: &[u8]) -> secp256k1::Message {
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(msg);
-    let hash = hasher.finalize();
-
-    secp256k1::Message::from_slice(&hash).expect("32 bytes")
-}
-
-impl KeyPair {
-    pub fn from_bytes(mut secret: impl AsMut<[u8]>) -> Result<Self, Error> {
-        let secret = secret.as_mut();
-        let keypair = secp256k1::KeyPair::from_seckey_slice(secp256k1::SECP256K1, secret)
-            .map(Self)
-            .map_err(Error);
-        secret.zeroize();
-        keypair
-    }
-
-    #[cfg(feature = "libp2p-identity")]
-    /// Special implementation for creating both a (monad_crypto::KeyPair, lib2p::KeyPair)
-    /// TODO Once we've unified those, hopefully we can deprecate this
-    pub fn libp2p_from_bytes(
-        mut secret: impl AsMut<[u8]>,
-    ) -> Result<(Self, libp2p_identity::secp256k1::Keypair), Error> {
-        let secret = secret.as_mut();
-        let monad_keypair = {
-            let secret = &*secret; // explicitly use immutable reference
-            secp256k1::KeyPair::from_seckey_slice(secp256k1::SECP256K1, secret)
-                .map(Self)
-                .map_err(Error)?
-        };
-        let libp2p_keypair = libp2p_identity::secp256k1::SecretKey::from_bytes(secret)
-            .expect("monad_keypair parse succeeded, libp2p parse shouldn't fail")
-            .into();
-
-        Ok((monad_keypair, libp2p_keypair))
-    }
-
-    pub fn sign(&self, msg: &[u8]) -> SecpSignature {
-        SecpSignature(Secp256k1::sign_ecdsa_recoverable(
-            secp256k1::SECP256K1,
-            &msg_hash(msg),
-            &self.0.secret_key(),
-        ))
-    }
-
-    pub fn pubkey(&self) -> PubKey {
-        PubKey(self.0.public_key())
-    }
-}
-
-impl PubKey {
-    pub fn from_slice(pubkey: &[u8]) -> Result<Self, Error> {
+impl SecpPubKey {
+    pub fn from_slice(pubkey: &[u8]) -> Result<Self, SecpError> {
         secp256k1::PublicKey::from_slice(pubkey)
             .map(Self)
-            .map_err(Error)
+            .map_err(SecpError)
     }
 
     pub fn bytes(&self) -> Vec<u8> {
@@ -125,25 +77,110 @@ impl PubKey {
         self.0.serialize().to_vec()
     }
 
-    pub fn verify(&self, msg: &[u8], signature: &SecpSignature) -> Result<(), Error> {
+    pub fn verify(&self, msg: &[u8], signature: &SecpSignature) -> Result<(), SecpError> {
         Secp256k1::verify_ecdsa(
             secp256k1::SECP256K1,
             &msg_hash(msg),
             &signature.0.to_standard(),
             &self.0,
         )
-        .map_err(Error)
+        .map_err(SecpError)
+    }
+}
+
+impl Serializable for SecpPubKey {
+    fn serialize(&self) -> Vec<u8> {
+        self.bytes()
+    }
+}
+
+impl Deserializable for SecpPubKey {
+    type ReadError = SecpError;
+
+    fn deserialize(message: &[u8]) -> Result<Self, Self::ReadError> {
+        Self::from_slice(message)
+    }
+}
+
+impl Compressable for SecpPubKey {
+    type UncompressError = SecpError;
+
+    fn compress(&self) -> Vec<u8> {
+        self.bytes_compressed()
+    }
+
+    fn uncompress(msg: &[u8]) -> Result<Self, Self::UncompressError> {
+        Self::from_slice(msg)
+    }
+}
+
+impl PubKey for SecpPubKey {}
+
+fn msg_hash(msg: &[u8]) -> secp256k1::Message {
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(msg);
+    let hash = hasher.finalize();
+
+    secp256k1::Message::from_slice(&hash).expect("32 bytes")
+}
+
+impl KeyPair for SecpKeyPair {
+    type Signature = SecpSignature;
+    type PubKey = SecpPubKey;
+    type Error = SecpError;
+
+    fn from_bytes(mut secret: impl AsMut<[u8]>) -> Result<Self, Self::Error> {
+        let secret = secret.as_mut();
+        let keypair = secp256k1::KeyPair::from_seckey_slice(secp256k1::SECP256K1, secret)
+            .map(Self)
+            .map_err(SecpError);
+        secret.zeroize();
+        keypair
+    }
+
+    fn sign(&self, msg: &[u8]) -> Self::Signature {
+        SecpSignature(Secp256k1::sign_ecdsa_recoverable(
+            secp256k1::SECP256K1,
+            &msg_hash(msg),
+            &self.0.secret_key(),
+        ))
+    }
+
+    fn pubkey(&self) -> Self::PubKey {
+        SecpPubKey(self.0.public_key())
+    }
+}
+
+impl SecpKeyPair {
+    #[cfg(feature = "libp2p-identity")]
+    /// Special implementation for creating both a (monad_crypto::KeyPair, lib2p::KeyPair)
+    /// TODO Once we've unified those, hopefully we can deprecate this
+    pub fn libp2p_from_bytes(
+        mut secret: impl AsMut<[u8]>,
+    ) -> Result<(Self, libp2p_identity::secp256k1::Keypair), SecpError> {
+        let secret = secret.as_mut();
+        let monad_keypair = {
+            let secret = &*secret; // explicitly use immutable reference
+            secp256k1::KeyPair::from_seckey_slice(secp256k1::SECP256K1, secret)
+                .map(Self)
+                .map_err(SecpError)?
+        };
+        let libp2p_keypair = libp2p_identity::secp256k1::SecretKey::from_bytes(secret)
+            .expect("monad_keypair parse succeeded, libp2p parse shouldn't fail")
+            .into();
+
+        Ok((monad_keypair, libp2p_keypair))
     }
 }
 
 impl SecpSignature {
-    pub fn recover_pubkey(&self, msg: &[u8]) -> Result<PubKey, Error> {
+    fn recover_pubkey(&self, msg: &[u8]) -> Result<SecpPubKey, SecpError> {
         Secp256k1::recover_ecdsa(secp256k1::SECP256K1, &msg_hash(msg), &self.0)
-            .map(PubKey)
-            .map_err(Error)
+            .map(SecpPubKey)
+            .map_err(SecpError)
     }
 
-    pub fn serialize(&self) -> [u8; 65] {
+    fn serialize(&self) -> [u8; 65] {
         // recid is 0..3, fit in a single byte (see secp256k1 https://docs.rs/secp256k1/0.27.0/src/secp256k1/ecdsa/recovery.rs.html#39)
         let (recid, sig) = self.0.serialize_compact();
         assert!((0..=3).contains(&recid.to_i32()));
@@ -152,15 +189,48 @@ impl SecpSignature {
         sig_vec.try_into().unwrap()
     }
 
-    pub fn deserialize(data: &[u8]) -> Result<Self, Error> {
+    fn deserialize(data: &[u8]) -> Result<Self, SecpError> {
         if data.len() != 64 + 1 {
-            return Err(Error(secp256k1::Error::InvalidSignature));
+            return Err(SecpError(secp256k1::Error::InvalidSignature));
         }
         let sig_data = &data[..64];
-        let recid = secp256k1::ecdsa::RecoveryId::from_i32(data[64] as i32).map_err(Error)?;
+        let recid = secp256k1::ecdsa::RecoveryId::from_i32(data[64] as i32).map_err(SecpError)?;
         Ok(SecpSignature(
-            secp256k1::ecdsa::RecoverableSignature::from_compact(sig_data, recid).map_err(Error)?,
+            secp256k1::ecdsa::RecoverableSignature::from_compact(sig_data, recid)
+                .map_err(SecpError)?,
         ))
+    }
+}
+
+impl Signature for SecpSignature {
+    type Error = SecpError;
+    type KeyPair = SecpKeyPair;
+    type PubKey = SecpPubKey;
+
+    fn sign(msg: &[u8], keypair: &Self::KeyPair) -> Self {
+        keypair.sign(msg)
+    }
+
+    fn verify(&self, msg: &[u8], pubkey: &Self::PubKey) -> Result<(), Self::Error> {
+        pubkey.verify(msg, self)
+    }
+
+    fn recover_pubkey(&self, msg: &[u8]) -> Result<Self::PubKey, Self::Error> {
+        self.recover_pubkey(msg)
+    }
+}
+
+impl Serializable for SecpSignature {
+    fn serialize(&self) -> Vec<u8> {
+        self.serialize().to_vec()
+    }
+}
+
+impl Deserializable for SecpSignature {
+    type ReadError = SecpError;
+
+    fn deserialize(message: &[u8]) -> Result<Self, Self::ReadError> {
+        Self::deserialize(message)
     }
 }
 
@@ -185,7 +255,7 @@ impl From<libp2p_identity::DecodingError> for PeerIdError {
 }
 
 #[cfg(feature = "libp2p-identity")]
-impl TryFrom<libp2p_identity::PeerId> for PubKey {
+impl TryFrom<libp2p_identity::PeerId> for SecpPubKey {
     type Error = PeerIdError;
     fn try_from(peer_id: libp2p_identity::PeerId) -> Result<Self, Self::Error> {
         let bytes = peer_id.to_bytes();
@@ -210,8 +280,8 @@ impl TryFrom<libp2p_identity::PeerId> for PubKey {
 }
 
 #[cfg(feature = "libp2p-identity")]
-impl From<&PubKey> for libp2p_identity::PeerId {
-    fn from(pubkey: &PubKey) -> Self {
+impl From<&SecpPubKey> for libp2p_identity::PeerId {
+    fn from(pubkey: &SecpPubKey) -> Self {
         let pubkey = libp2p_identity::secp256k1::PublicKey::decode(&pubkey.bytes_compressed())
             .expect("internal pubkey -> peer_id should never fail");
 
@@ -222,44 +292,38 @@ impl From<&PubKey> for libp2p_identity::PeerId {
     }
 }
 
-impl Signature for SecpSignature {
-    fn sign(msg: &[u8], keypair: &KeyPair) -> Self {
-        keypair.sign(msg)
-    }
-
-    fn verify(&self, msg: &[u8], pubkey: &PubKey) -> Result<(), Error> {
-        pubkey.verify(msg, self)
-    }
-
-    fn recover_pubkey(&self, msg: &[u8]) -> Result<PubKey, Error> {
-        self.recover_pubkey(msg)
-    }
-
-    fn serialize(&self) -> Vec<u8> {
-        self.serialize().to_vec()
-    }
-
-    fn deserialize(signature: &[u8]) -> Result<Self, Error> {
-        Self::deserialize(signature)
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use crate::{Compressable, KeyPair};
     use tiny_keccak::Hasher;
 
-    use super::{KeyPair, PubKey, SecpSignature};
+    use super::{Deserializable, Serializable};
+    use super::{SecpKeyPair, SecpPubKey, SecpSignature};
 
     #[test]
     fn test_pubkey_roundtrip() {
         let mut privkey: [u8; 32] = [127; 32];
-        let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
+        let keypair = SecpKeyPair::from_bytes(&mut privkey).unwrap();
 
-        let pubkey_bytes = keypair.pubkey().bytes();
+        let pubkey_bytes = keypair.pubkey().serialize();
         assert_eq!(
             pubkey_bytes,
-            PubKey::from_slice(&pubkey_bytes).unwrap().bytes()
+            SecpPubKey::deserialize(&pubkey_bytes).unwrap().serialize()
         );
+    }
+
+    #[test]
+    fn test_pubkey_roundtrip_compressed() {
+        let mut privkey: [u8; 32] = [127; 32];
+        let keypair = SecpKeyPair::from_bytes(&mut privkey).unwrap();
+
+        let pubkey_bytes_compressed = keypair.pubkey().compress();
+        assert_eq!(
+            pubkey_bytes_compressed,
+            SecpPubKey::uncompress(&pubkey_bytes_compressed)
+                .unwrap()
+                .compress()
+        )
     }
 
     #[test]
@@ -267,7 +331,7 @@ mod tests {
         let mut privkey =
             hex::decode("6fe42879ece8a11c0df224953ded12cd3c19d0353aaf80057bddfd4d4fc90530")
                 .unwrap();
-        let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
+        let keypair = SecpKeyPair::from_bytes(&mut privkey).unwrap();
 
         let mut hasher = tiny_keccak::Keccak::v256();
         // pubkey() returns 65 bytes, ignore first one
@@ -284,7 +348,7 @@ mod tests {
     #[test]
     fn test_verify() {
         let mut privkey: [u8; 32] = [127; 32];
-        let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
+        let keypair = SecpKeyPair::from_bytes(&mut privkey).unwrap();
 
         let msg = b"hello world";
         let signature = keypair.sign(msg);
@@ -296,7 +360,7 @@ mod tests {
     #[test]
     fn test_recovery() {
         let mut privkey: [u8; 32] = [127; 32];
-        let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
+        let keypair = SecpKeyPair::from_bytes(&mut privkey).unwrap();
 
         let msg = b"hello world";
         let signature = keypair.sign(msg);
@@ -309,7 +373,7 @@ mod tests {
     #[test]
     fn test_signature_serde() {
         let mut privkey: [u8; 32] = [127; 32];
-        let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
+        let keypair = SecpKeyPair::from_bytes(&mut privkey).unwrap();
 
         let msg = b"hello world";
         let signature = keypair.sign(msg);
@@ -324,11 +388,11 @@ mod tests {
     // THIS MUST PASS!! don't comment this test out >:(
     fn test_pubkey_peerid_roundtrip() {
         let mut privkey: [u8; 32] = [127; 32];
-        let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
+        let keypair = SecpKeyPair::from_bytes(&mut privkey).unwrap();
 
         let pubkey = keypair.pubkey();
         let peer_id: libp2p_identity::PeerId = (&pubkey).into();
-        assert_eq!(pubkey, PubKey::try_from(peer_id).unwrap());
+        assert_eq!(pubkey, SecpPubKey::try_from(peer_id).unwrap());
     }
 
     #[cfg(feature = "libp2p-identity")]
@@ -336,7 +400,7 @@ mod tests {
     // THIS MUST PASS!! don't comment this test out >:(
     fn test_keypair_pubkey_peerid_roundtrip() {
         let mut privkey: [u8; 32] = [127; 32];
-        let (monad_keypair, libp2p_keypair) = KeyPair::libp2p_from_bytes(&mut privkey).unwrap();
+        let (monad_keypair, libp2p_keypair) = SecpKeyPair::libp2p_from_bytes(&mut privkey).unwrap();
 
         let monad_pubkey = monad_keypair.pubkey();
         let libp2p_pubkey = libp2p_identity::Keypair::from(libp2p_keypair).public();
@@ -354,7 +418,7 @@ mod tests {
 
         assert_eq!(monad_peer_id, libp2p_peer_id);
 
-        assert_eq!(monad_pubkey, PubKey::try_from(monad_peer_id).unwrap());
-        assert_eq!(monad_pubkey, PubKey::try_from(libp2p_peer_id).unwrap());
+        assert_eq!(monad_pubkey, SecpPubKey::try_from(monad_peer_id).unwrap());
+        assert_eq!(monad_pubkey, SecpPubKey::try_from(libp2p_peer_id).unwrap());
     }
 }

--- a/monad-driver/src/lib.rs
+++ b/monad-driver/src/lib.rs
@@ -7,7 +7,8 @@ mod tests {
         signatures::aggregate_signature::AggregateSignatures,
         types::quorum_certificate::genesis_vote_info, validation::hashing::Sha256Hash,
     };
-    use monad_crypto::secp256k1::{KeyPair, SecpSignature};
+    use monad_crypto::secp256k1::{SecpKeyPair, SecpSignature};
+    use monad_crypto::KeyPair;
     use monad_executor::{
         executor::{ledger::MockLedger, mempool::MockMempool},
         Executor, State,
@@ -35,7 +36,7 @@ mod tests {
         let mut node_configs = (0..NUM_NODES)
             .map(|i| {
                 let mut k: [u8; 32] = [(i + 1) as u8; 32];
-                let (key, key_libp2p) = KeyPair::libp2p_from_bytes(&mut k).unwrap();
+                let (key, key_libp2p) = SecpKeyPair::libp2p_from_bytes(&mut k).unwrap();
 
                 let executor = monad_executor::executor::parent::ParentExecutor {
                     router: monad_p2p::Service::without_executor(key_libp2p.into()),
@@ -72,11 +73,12 @@ mod tests {
 
         let pubkeys = node_configs
             .iter()
-            .map(|(key, _, _)| KeyPair::pubkey(key))
+            .map(|(key, _, _)| SecpKeyPair::pubkey(key))
             .collect::<Vec<_>>();
-        let (genesis_block, genesis_sigs) = get_genesis_config::<Sha256Hash, SignatureCollectionType>(
-            node_configs.iter().map(|(key, _, _)| key),
-        );
+        let (genesis_block, genesis_sigs) =
+            get_genesis_config::<Sha256Hash, SignatureCollectionType, SignatureType>(
+                node_configs.iter().map(|(key, _, _)| key),
+            );
 
         let state_configs = node_configs
             .into_iter()

--- a/monad-executor/src/executor/mock.rs
+++ b/monad-executor/src/executor/mock.rs
@@ -415,7 +415,8 @@ mod tests {
 
     use futures::{FutureExt, StreamExt};
 
-    use monad_crypto::secp256k1::KeyPair;
+    use monad_crypto::secp256k1::SecpKeyPair;
+    use monad_crypto::KeyPair;
     use monad_testutil::signing::{create_keys, node_id};
     use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
 
@@ -924,7 +925,7 @@ mod tests {
     fn test_nodes() {
         let pubkeys = create_keys(NUM_NODES as u32)
             .iter()
-            .map(KeyPair::pubkey)
+            .map(SecpKeyPair::pubkey)
             .map(PeerId)
             .collect::<Vec<_>>();
         let state_configs = (0..NUM_NODES)

--- a/monad-executor/src/mock_swarm.rs
+++ b/monad-executor/src/mock_swarm.rs
@@ -8,7 +8,7 @@ use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaChaRng;
 
 use futures::StreamExt;
-use monad_crypto::secp256k1::PubKey;
+use monad_crypto::secp256k1::SecpPubKey;
 use monad_wal::PersistenceLogger;
 use tracing::info_span;
 
@@ -201,7 +201,7 @@ where
 
     MockExecutor<S>: Unpin,
 {
-    pub fn new(peers: Vec<(PubKey, S::Config, LGR::Config)>, transformer: T) -> Self {
+    pub fn new(peers: Vec<(SecpPubKey, S::Config, LGR::Config)>, transformer: T) -> Self {
         assert!(!peers.is_empty());
 
         let mut states = BTreeMap::new();

--- a/monad-executor/src/state.rs
+++ b/monad-executor/src/state.rs
@@ -1,9 +1,9 @@
 use std::hash::Hash;
 
-use monad_crypto::secp256k1::PubKey;
+use monad_crypto::secp256k1::SecpPubKey;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PeerId(pub PubKey);
+pub struct PeerId(pub SecpPubKey);
 
 impl std::fmt::Debug for PeerId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/monad-p2p/src/lib.rs
+++ b/monad-p2p/src/lib.rs
@@ -242,7 +242,7 @@ where
                 libp2p::swarm::SwarmEvent::Behaviour(behavior::BehaviorEvent::RequestResponse(
                     libp2p::request_response::Event::Message { peer, message },
                 )) => {
-                    let pubkey = match monad_crypto::secp256k1::PubKey::try_from(peer) {
+                    let pubkey = match monad_crypto::secp256k1::SecpPubKey::try_from(peer) {
                         Ok(pubkey) => pubkey,
                         Err(_) => {
                             // We don't need to respond if the peer isn't using a valid secp256k1 key

--- a/monad-state/src/convert/event.rs
+++ b/monad-state/src/convert/event.rs
@@ -2,6 +2,8 @@ use monad_consensus::pacemaker::PacemakerTimerExpire;
 use monad_consensus::signatures::aggregate_signature::AggregateSignatures;
 use monad_crypto::convert::proto_to_signature;
 use monad_crypto::convert::signature_to_proto;
+use monad_crypto::secp256k1::SecpError;
+use monad_crypto::secp256k1::SecpPubKey;
 use monad_crypto::Signature;
 use monad_proto::error::ProtoError;
 use monad_proto::proto::event::*;
@@ -42,7 +44,9 @@ impl<S: Signature> From<&ConsensusEvent<S>> for ProtoConsensusEvent {
     }
 }
 
-impl<S: Signature> TryFrom<ProtoConsensusEvent> for ConsensusEvent<S> {
+impl<S: Signature<PubKey = SecpPubKey, Error = SecpError>> TryFrom<ProtoConsensusEvent>
+    for ConsensusEvent<S>
+{
     type Error = ProtoError;
 
     fn try_from(value: ProtoConsensusEvent) -> Result<Self, Self::Error> {
@@ -104,7 +108,9 @@ impl<S: Signature> TryFrom<ProtoConsensusEvent> for ConsensusEvent<S> {
     }
 }
 
-impl<S: Signature> From<&MonadEvent<S>> for ProtoMonadEvent {
+impl<S: Signature<PubKey = SecpPubKey, Error = SecpError>> From<&MonadEvent<S>>
+    for ProtoMonadEvent
+{
     fn from(value: &MonadEvent<S>) -> Self {
         let event = match value {
             TypeMonadEvent::Ack { peer, id, round } => {
@@ -122,7 +128,9 @@ impl<S: Signature> From<&MonadEvent<S>> for ProtoMonadEvent {
     }
 }
 
-impl<S: Signature> TryFrom<ProtoMonadEvent> for MonadEvent<S> {
+impl<S: Signature<PubKey = SecpPubKey, Error = SecpError>> TryFrom<ProtoMonadEvent>
+    for MonadEvent<S>
+{
     type Error = ProtoError;
     fn try_from(value: ProtoMonadEvent) -> Result<Self, Self::Error> {
         let event: MonadEvent<S> = match value.event {

--- a/monad-state/src/convert/interface.rs
+++ b/monad-state/src/convert/interface.rs
@@ -1,14 +1,21 @@
 use super::event::MonadEvent;
-use monad_crypto::Signature;
+use monad_crypto::{
+    secp256k1::{SecpError, SecpPubKey},
+    Signature,
+};
 use monad_proto::{error::ProtoError, proto::event::ProtoMonadEvent};
 use prost::Message;
 
-pub fn serialize_event(event: &MonadEvent<impl Signature>) -> Vec<u8> {
+pub fn serialize_event(
+    event: &MonadEvent<impl Signature<PubKey = SecpPubKey, Error = SecpError>>,
+) -> Vec<u8> {
     let proto_event: ProtoMonadEvent = event.into();
     proto_event.encode_to_vec()
 }
 
-pub fn deserialize_event<S: Signature>(data: &[u8]) -> Result<MonadEvent<S>, ProtoError> {
+pub fn deserialize_event<S: Signature<PubKey = SecpPubKey, Error = SecpError>>(
+    data: &[u8],
+) -> Result<MonadEvent<S>, ProtoError> {
     let event = ProtoMonadEvent::decode(data)?;
     event.try_into()
 }

--- a/monad-state/tests/protobuf.rs
+++ b/monad-state/tests/protobuf.rs
@@ -7,7 +7,8 @@ mod test {
     use monad_consensus::types::voting::VoteInfo;
     use monad_consensus::validation::hashing::{Hasher, Sha256Hash};
     use monad_consensus::{pacemaker::PacemakerTimerExpire, validation::signing::Unverified};
-    use monad_crypto::secp256k1::{KeyPair, SecpSignature};
+    use monad_crypto::secp256k1::{SecpKeyPair, SecpSignature};
+    use monad_crypto::KeyPair;
     use monad_executor::PeerId;
     use monad_state::{
         convert::interface::{deserialize_event, serialize_event},
@@ -50,7 +51,7 @@ mod test {
 
     #[test]
     fn test_consensus_message_event() {
-        let keypair: KeyPair = get_key(0);
+        let keypair: SecpKeyPair = get_key(0);
         let vi = VoteInfo {
             id: BlockId(Hash([42_u8; 32])),
             round: Round(1),

--- a/monad-state/tests/replay.rs
+++ b/monad-state/tests/replay.rs
@@ -92,8 +92,10 @@ mod test {
         // drop the nodes -> close the files
         drop(nodes);
 
-        let (pubkeys_clone, state_configs_clone) =
-            get_configs::<SignatureCollectionType>(num_nodes, Duration::from_millis(2));
+        let (pubkeys_clone, state_configs_clone) = get_configs::<
+            SignatureCollectionType,
+            SignatureType,
+        >(num_nodes, Duration::from_millis(2));
 
         let peers_clone = pubkeys_clone
             .into_iter()

--- a/monad-testutil/src/block.rs
+++ b/monad-testutil/src/block.rs
@@ -8,8 +8,9 @@ use monad_consensus::types::signature::SignatureCollection;
 use monad_consensus::types::voting::VoteInfo;
 use monad_consensus::validation::hashing::Hasher;
 use monad_consensus::validation::hashing::Sha256Hash;
-use monad_crypto::secp256k1::KeyPair;
+use monad_crypto::secp256k1::SecpKeyPair;
 use monad_crypto::secp256k1::SecpSignature;
+use monad_crypto::KeyPair;
 use monad_types::BlockId;
 use monad_types::Hash;
 use monad_types::NodeId;
@@ -20,7 +21,7 @@ pub fn setup_block(
     block_round: u64,
     qc_round: u64,
     txns: TransactionList,
-    keypairs: &[KeyPair],
+    keypairs: &[SecpKeyPair],
 ) -> Block<AggregateSignatures<SecpSignature>> {
     let txns = txns;
     let round = Round(block_round);

--- a/monad-testutil/src/proposal.rs
+++ b/monad-testutil/src/proposal.rs
@@ -8,8 +8,8 @@ use monad_consensus::types::timeout::{HighQcRound, HighQcRoundSigTuple, TimeoutI
 use monad_consensus::types::voting::VoteInfo;
 use monad_consensus::validation::hashing::{Hashable, Hasher, Sha256Hash};
 use monad_consensus::validation::signing::Verified;
-use monad_crypto::secp256k1::KeyPair;
-use monad_crypto::Signature;
+use monad_crypto::secp256k1::{SecpKeyPair, SecpPubKey};
+use monad_crypto::{KeyPair, Signature};
 use monad_types::{NodeId, Round};
 use monad_validator::{leader_election::LeaderElection, validator_set::ValidatorSet};
 
@@ -23,7 +23,7 @@ pub struct ProposalGen<S, T> {
 impl<S, T> ProposalGen<S, T>
 where
     T: SignatureCollection<SignatureType = S>,
-    S: Signature,
+    S: Signature<KeyPair = SecpKeyPair, PubKey = SecpPubKey>,
 {
     pub fn new(genesis_qc: QuorumCertificate<T>) -> Self {
         ProposalGen {
@@ -36,7 +36,7 @@ where
 
     pub fn next_proposal<L: LeaderElection>(
         &mut self,
-        keys: &Vec<KeyPair>,
+        keys: &Vec<SecpKeyPair>,
         valset: &mut ValidatorSet<L>,
     ) -> Verified<T::SignatureType, ProposalMessage<T::SignatureType, T>> {
         // high_qc is the highest qc seen in a proposal
@@ -78,7 +78,7 @@ where
     // before adding the state's key to keys
     pub fn next_tc<L: LeaderElection>(
         &mut self,
-        keys: &Vec<KeyPair>,
+        keys: &Vec<SecpKeyPair>,
         valset: &mut ValidatorSet<L>,
     ) -> Vec<Verified<T::SignatureType, TimeoutMessage<S, T>>> {
         let node_ids = keys
@@ -125,7 +125,7 @@ where
         tmo_msgs
     }
 
-    fn get_next_qc(&self, keys: &Vec<KeyPair>, block: &Block<T>) -> QuorumCertificate<T> {
+    fn get_next_qc(&self, keys: &Vec<SecpKeyPair>, block: &Block<T>) -> QuorumCertificate<T> {
         let vi = VoteInfo {
             id: block.get_id(),
             round: block.round,

--- a/monad-testutil/src/validators.rs
+++ b/monad-testutil/src/validators.rs
@@ -1,7 +1,7 @@
-use monad_crypto::secp256k1::KeyPair;
+use monad_crypto::secp256k1::SecpKeyPair;
+use monad_crypto::KeyPair;
 use monad_types::{NodeId, Round};
 use monad_validator::leader_election::LeaderElection;
-
 pub struct MockLeaderElection {
     leader: NodeId,
 }
@@ -9,7 +9,7 @@ pub struct MockLeaderElection {
 impl LeaderElection for MockLeaderElection {
     fn new() -> Self {
         let mut key: [u8; 32] = [128; 32];
-        let keypair = KeyPair::from_bytes(&mut key).unwrap();
+        let keypair = SecpKeyPair::from_bytes(&mut key).unwrap();
         let leader = keypair.pubkey();
         MockLeaderElection {
             leader: NodeId(leader),

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -6,7 +6,7 @@ use std::ops::AddAssign;
 use std::ops::Deref;
 use std::ops::Sub;
 
-use monad_crypto::secp256k1::PubKey;
+use monad_crypto::secp256k1::SecpPubKey;
 use zerocopy::AsBytes;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
@@ -66,7 +66,7 @@ impl std::fmt::Debug for Round {
 
 #[repr(transparent)]
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
-pub struct NodeId(pub PubKey);
+pub struct NodeId(pub SecpPubKey);
 
 impl std::fmt::Debug for NodeId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/monad-validator/src/validator.rs
+++ b/monad-validator/src/validator.rs
@@ -1,10 +1,10 @@
 use std::fmt::Debug;
 
-use monad_crypto::secp256k1::PubKey;
+use monad_crypto::secp256k1::SecpPubKey;
 
 #[derive(Clone, Copy)]
 pub struct Validator {
-    pub pubkey: PubKey,
+    pub pubkey: SecpPubKey,
     pub stake: i64,
 }
 

--- a/monad-validator/src/validator_set.rs
+++ b/monad-validator/src/validator_set.rs
@@ -124,13 +124,14 @@ mod test {
     use crate::{validator::Validator, weighted_round_robin::WeightedRoundRobin};
 
     use super::ValidatorSet;
-    use monad_crypto::secp256k1::KeyPair;
+    use monad_crypto::secp256k1::SecpKeyPair;
+    use monad_crypto::KeyPair;
     use monad_types::{NodeId, Round};
 
     #[test]
     fn test_membership() {
         let mut privkey: [u8; 32] = [100; 32];
-        let keypair1 = KeyPair::from_bytes(&mut privkey).unwrap();
+        let keypair1 = SecpKeyPair::from_bytes(&mut privkey).unwrap();
 
         let v1 = Validator {
             pubkey: keypair1.pubkey(),
@@ -144,7 +145,7 @@ mod test {
 
         privkey = [101; 32];
         let v2 = Validator {
-            pubkey: KeyPair::from_bytes(&mut privkey).unwrap().pubkey(),
+            pubkey: SecpKeyPair::from_bytes(&mut privkey).unwrap().pubkey(),
             stake: 2,
         };
 
@@ -156,7 +157,7 @@ mod test {
         assert!(vs.is_member(&NodeId(keypair1.pubkey())));
 
         let mut pkey3: [u8; 32] = [102; 32];
-        let pubkey3 = KeyPair::from_bytes(&mut pkey3).unwrap().pubkey();
+        let pubkey3 = SecpKeyPair::from_bytes(&mut pkey3).unwrap().pubkey();
         assert!(!vs.is_member(&NodeId(pubkey3)));
     }
 
@@ -165,17 +166,17 @@ mod test {
         let mut pkey1: [u8; 32] = [100; 32];
         let mut pkey2: [u8; 32] = [101; 32];
         let v1 = Validator {
-            pubkey: KeyPair::from_bytes(&mut pkey1).unwrap().pubkey(),
+            pubkey: SecpKeyPair::from_bytes(&mut pkey1).unwrap().pubkey(),
             stake: 1,
         };
 
         let v2 = Validator {
-            pubkey: KeyPair::from_bytes(&mut pkey2).unwrap().pubkey(),
+            pubkey: SecpKeyPair::from_bytes(&mut pkey2).unwrap().pubkey(),
             stake: 3,
         };
 
         let mut pkey3: [u8; 32] = [102; 32];
-        let pubkey3 = KeyPair::from_bytes(&mut pkey3).unwrap().pubkey();
+        let pubkey3 = SecpKeyPair::from_bytes(&mut pkey3).unwrap().pubkey();
 
         let validators = vec![v1, v2];
         let vs = ValidatorSet::<WeightedRoundRobin>::new(validators).unwrap();
@@ -190,12 +191,12 @@ mod test {
         let mut pkey1: [u8; 32] = [100; 32];
         let mut pkey2: [u8; 32] = [101; 32];
         let v1 = Validator {
-            pubkey: KeyPair::from_bytes(&mut pkey1).unwrap().pubkey(),
+            pubkey: SecpKeyPair::from_bytes(&mut pkey1).unwrap().pubkey(),
             stake: 1,
         };
 
         let v2 = Validator {
-            pubkey: KeyPair::from_bytes(&mut pkey2).unwrap().pubkey(),
+            pubkey: SecpKeyPair::from_bytes(&mut pkey2).unwrap().pubkey(),
             stake: 2,
         };
 
@@ -208,14 +209,14 @@ mod test {
     #[test]
     fn test_get_leader() {
         let mut pkey1: [u8; 32] = [100; 32];
-        let pubkey1 = KeyPair::from_bytes(&mut pkey1).unwrap().pubkey();
+        let pubkey1 = SecpKeyPair::from_bytes(&mut pkey1).unwrap().pubkey();
         let v1 = Validator {
             pubkey: pubkey1,
             stake: 1,
         };
 
         let mut pkey2: [u8; 32] = [101; 32];
-        let pubkey2 = KeyPair::from_bytes(&mut pkey2).unwrap().pubkey();
+        let pubkey2 = SecpKeyPair::from_bytes(&mut pkey2).unwrap().pubkey();
         let v2 = Validator {
             pubkey: pubkey2,
             stake: 1,

--- a/monad-validator/src/weighted_round_robin.rs
+++ b/monad-validator/src/weighted_round_robin.rs
@@ -132,7 +132,8 @@ impl WeightedRoundRobin {
 
 #[cfg(test)]
 mod tests {
-    use monad_crypto::secp256k1::KeyPair;
+    use monad_crypto::secp256k1::SecpKeyPair;
+    use monad_crypto::KeyPair;
     use monad_types::{NodeId, Round};
 
     use super::super::leader_election::LeaderElection;
@@ -159,11 +160,11 @@ mod tests {
     #[test]
     fn test_basic_round_robin() {
         let v1 = Validator {
-            pubkey: KeyPair::from_bytes(&mut get_key1()).unwrap().pubkey(),
+            pubkey: SecpKeyPair::from_bytes(&mut get_key1()).unwrap().pubkey(),
             stake: 1,
         };
         let v2 = Validator {
-            pubkey: KeyPair::from_bytes(&mut get_key2()).unwrap().pubkey(),
+            pubkey: SecpKeyPair::from_bytes(&mut get_key2()).unwrap().pubkey(),
             stake: 1,
         };
         let validators = vec![v1, v2];
@@ -183,11 +184,11 @@ mod tests {
     #[test]
     fn test_weighted_round_robin() {
         let v1 = Validator {
-            pubkey: KeyPair::from_bytes(&mut get_key1()).unwrap().pubkey(),
+            pubkey: SecpKeyPair::from_bytes(&mut get_key1()).unwrap().pubkey(),
             stake: 1,
         };
         let v2 = Validator {
-            pubkey: KeyPair::from_bytes(&mut get_key2()).unwrap().pubkey(),
+            pubkey: SecpKeyPair::from_bytes(&mut get_key2()).unwrap().pubkey(),
             stake: 2,
         };
         let validators = vec![v1, v2];
@@ -213,11 +214,11 @@ mod tests {
     #[test]
     fn test_agreement() {
         let v1 = Validator {
-            pubkey: KeyPair::from_bytes(&mut get_key1()).unwrap().pubkey(),
+            pubkey: SecpKeyPair::from_bytes(&mut get_key1()).unwrap().pubkey(),
             stake: 1,
         };
         let v2 = Validator {
-            pubkey: KeyPair::from_bytes(&mut get_key2()).unwrap().pubkey(),
+            pubkey: SecpKeyPair::from_bytes(&mut get_key2()).unwrap().pubkey(),
             stake: 3,
         };
         let validators = vec![v1, v2];
@@ -237,11 +238,11 @@ mod tests {
     #[test]
     fn test_increment_views_equivalent() {
         let v1 = Validator {
-            pubkey: KeyPair::from_bytes(&mut get_key1()).unwrap().pubkey(),
+            pubkey: SecpKeyPair::from_bytes(&mut get_key1()).unwrap().pubkey(),
             stake: 1,
         };
         let v2 = Validator {
-            pubkey: KeyPair::from_bytes(&mut get_key2()).unwrap().pubkey(),
+            pubkey: SecpKeyPair::from_bytes(&mut get_key2()).unwrap().pubkey(),
             stake: 3,
         };
         let validators = vec![v1, v2];
@@ -262,11 +263,11 @@ mod tests {
     #[test]
     fn test_update_stake() {
         let mut v1 = Validator {
-            pubkey: KeyPair::from_bytes(&mut get_key1()).unwrap().pubkey(),
+            pubkey: SecpKeyPair::from_bytes(&mut get_key1()).unwrap().pubkey(),
             stake: 10,
         };
         let v2 = Validator {
-            pubkey: KeyPair::from_bytes(&mut get_key2()).unwrap().pubkey(),
+            pubkey: SecpKeyPair::from_bytes(&mut get_key2()).unwrap().pubkey(),
             stake: 10,
         };
 

--- a/monad-viz/src/config.rs
+++ b/monad-viz/src/config.rs
@@ -8,7 +8,8 @@ use iced_lazy::Component;
 use monad_consensus::{
     types::quorum_certificate::genesis_vote_info, validation::hashing::Sha256Hash,
 };
-use monad_crypto::secp256k1::{KeyPair, PubKey};
+use monad_crypto::secp256k1::{SecpKeyPair, SecpPubKey};
+use monad_crypto::KeyPair;
 use monad_executor::mock_swarm::{
     LatencyTransformer, Layer, LayerTransformer, XorLatencyTransformer,
 };
@@ -18,7 +19,9 @@ use monad_testutil::signing::{create_keys, get_genesis_config};
 use monad_wal::mock::MockWALoggerConfig;
 use monad_wal::PersistenceLogger;
 
-use crate::{graph::SimulationConfig, PersistenceLoggerType, SignatureCollectionType, MM, MS};
+use crate::{
+    graph::SimulationConfig, PersistenceLoggerType, SignatureCollectionType, SignatureType, MM, MS,
+};
 
 #[derive(Debug, Clone)]
 pub struct SimConfig {
@@ -49,14 +52,14 @@ impl SimulationConfig<MS, LayerTransformer<MM>, PersistenceLoggerType> for SimCo
     fn nodes(
         &self,
     ) -> Vec<(
-        PubKey,
+        SecpPubKey,
         <MS as State>::Config,
         <PersistenceLoggerType as PersistenceLogger>::Config,
     )> {
         let keys = create_keys(self.num_nodes);
-        let pubkeys = keys.iter().map(KeyPair::pubkey).collect::<Vec<_>>();
+        let pubkeys = keys.iter().map(SecpKeyPair::pubkey).collect::<Vec<_>>();
         let (genesis_block, genesis_sigs) =
-            get_genesis_config::<Sha256Hash, SignatureCollectionType>(keys.iter());
+            get_genesis_config::<Sha256Hash, SignatureCollectionType, SignatureType>(keys.iter());
 
         let state_configs = keys
             .into_iter()

--- a/monad-viz/src/graph.rs
+++ b/monad-viz/src/graph.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use monad_crypto::secp256k1::PubKey;
+use monad_crypto::secp256k1::SecpPubKey;
 use monad_executor::{
     executor::mock::MockExecutor,
     mock_swarm::{Nodes, Transformer},
@@ -59,7 +59,7 @@ where
 {
     fn max_tick(&self) -> Duration;
     fn transformer(&self) -> &T;
-    fn nodes(&self) -> Vec<(PubKey, S::Config, LGR::Config)>;
+    fn nodes(&self) -> Vec<(SecpPubKey, S::Config, LGR::Config)>;
 }
 
 pub struct NodesSimulation<S, T, LGR, C>

--- a/monad-viz/src/main.rs
+++ b/monad-viz/src/main.rs
@@ -17,7 +17,7 @@ use iced::{
 };
 
 use monad_consensus::signatures::aggregate_signature::AggregateSignatures;
-use monad_crypto::NopSignature;
+use monad_crypto::nop::NopSignature;
 use monad_executor::mock_swarm::{
     LatencyTransformer, Layer, LayerTransformer, XorLatencyTransformer,
 };

--- a/monad-wal/benches/event_bench.rs
+++ b/monad-wal/benches/event_bench.rs
@@ -24,7 +24,8 @@ use monad_consensus::{
         signing::Unverified,
     },
 };
-use monad_crypto::secp256k1::{KeyPair, SecpSignature};
+use monad_crypto::secp256k1::{SecpKeyPair, SecpSignature};
+use monad_crypto::KeyPair;
 use monad_executor::PeerId;
 use monad_state::{ConsensusEvent, MonadEvent};
 use monad_testutil::{
@@ -91,7 +92,7 @@ fn bench_proposal(c: &mut Criterion) {
 }
 
 fn bench_vote(c: &mut Criterion) {
-    let keypair: KeyPair = get_key(1);
+    let keypair: SecpKeyPair = get_key(1);
     let vi = VoteInfo {
         id: BlockId(Hash([42_u8; 32].into())),
         round: Round(1),
@@ -216,7 +217,7 @@ fn bench_local_timeout(c: &mut Criterion) {
 
 fn bench_ack(c: &mut Criterion) {
     let msg_hash = Hash([0xab_u8; 32].into());
-    let keypair: KeyPair = get_key(1);
+    let keypair: SecpKeyPair = get_key(1);
     let event: MonadEvent<SecpSignature, AggregateSignatures<SecpSignature>> = MonadEvent::Ack {
         peer: PeerId(keypair.pubkey()),
         id: keypair.sign(msg_hash.as_ref()),


### PR DESCRIPTION
We are incorporating more signature scheme e.g. bls. The old Signature trait is specifically associated with secp types. This PR makes it more generic so we can implement the traits for other signatures.

To avoid mixing keys and signatures from different curves/signature algos, the signatures are associated with some KeyPair and PubKey types. We don't associate KeyPair with Signature because different signing algorithms (e.g. ECSDA vs nop) can generate different sigantures with same key.