### PR TITLE
Add initial skeleton for Checkpoints and Epochs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4895,6 +4895,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "monad-crypto",
+ "monad-proto",
  "monad-types",
 ]
 

--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -12,7 +12,7 @@ use monad_consensus_types::{
 };
 use monad_crypto::Signature;
 use monad_executor::RouterTarget;
-use monad_types::{BlockId, NodeId, Round};
+use monad_types::{BlockId, Epoch, NodeId, Round};
 
 pub enum ConsensusCommand<ST, SCT: SignatureCollection> {
     Publish {
@@ -32,6 +32,9 @@ pub enum ConsensusCommand<ST, SCT: SignatureCollection> {
     RequestSync {
         blockid: BlockId,
     },
+    /// Checkpoints periodically can upload/backup the ledger and garbage clean
+    /// persisted events if necessary
+    CheckpointSave(Checkpoint<SCT>),
     // TODO add command for updating validator_set/round
     // - to handle this command, we need to call message_state.set_round()
 }
@@ -55,6 +58,12 @@ impl<S: Signature, SC: SignatureCollection> From<PacemakerCommand<S, SC>>
             PacemakerCommand::ScheduleReset => ConsensusCommand::ScheduleReset,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Checkpoint<SCT> {
+    block: Block<SCT>,
+    epoch: Epoch,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/monad-driver/src/lib.rs
+++ b/monad-driver/src/lib.rs
@@ -10,7 +10,7 @@ mod tests {
     };
     use monad_crypto::secp256k1::{KeyPair, SecpSignature};
     use monad_executor::{
-        executor::{ledger::MockLedger, mempool::MockMempool},
+        executor::{checkpoint::MockCheckpoint, ledger::MockLedger, mempool::MockMempool},
         Executor, State,
     };
     use monad_state::{MonadConfig, MonadState};
@@ -50,6 +50,7 @@ mod tests {
                     router: monad_p2p::Service::without_executor(key_libp2p.into()),
                     mempool: MockMempool::default(),
                     ledger: MockLedger::default(),
+                    checkpoint: MockCheckpoint::default(),
                     timer: monad_executor::executor::timer::TokioTimer::default(),
                 };
 

--- a/monad-executor/src/executor/checkpoint.rs
+++ b/monad-executor/src/executor/checkpoint.rs
@@ -1,0 +1,25 @@
+use crate::{CheckpointCommand, Executor};
+
+pub struct MockCheckpoint<C> {
+    pub checkpoint: Option<C>,
+}
+
+impl<C> Default for MockCheckpoint<C> {
+    fn default() -> Self {
+        Self { checkpoint: None }
+    }
+}
+
+impl<C> Executor for MockCheckpoint<C> {
+    type Command = CheckpointCommand<C>;
+    fn exec(&mut self, commands: Vec<Self::Command>) {
+        for command in commands {
+            match command {
+                CheckpointCommand::Save(c) => {
+                    self.checkpoint = Some(c);
+                    println!("checkpoint saved");
+                }
+            }
+        }
+    }
+}

--- a/monad-executor/src/executor/epoch.rs
+++ b/monad-executor/src/executor/epoch.rs
@@ -1,0 +1,32 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::Stream;
+
+pub struct MockEpoch<E> {
+    state: Option<E>,
+}
+
+impl<E> MockEpoch<E> {
+    pub fn ready(&self) -> bool {
+        self.state.is_some()
+    }
+}
+
+impl<E> Default for MockEpoch<E> {
+    fn default() -> Self {
+        Self { state: None }
+    }
+}
+
+impl<E> Stream for MockEpoch<E>
+where
+    Self: Unpin,
+{
+    type Item = E;
+    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Pending
+    }
+}

--- a/monad-executor/src/executor/mod.rs
+++ b/monad-executor/src/executor/mod.rs
@@ -1,3 +1,5 @@
+pub mod checkpoint;
+pub mod epoch;
 pub mod ledger;
 pub mod mempool;
 pub mod mock;

--- a/monad-executor/src/executor/parent.rs
+++ b/monad-executor/src/executor/parent.rs
@@ -7,39 +7,43 @@ use std::{
 use futures::{Stream, StreamExt};
 
 use crate::{
-    Command, Executor, LedgerCommand, MempoolCommand, Message, RouterCommand, TimerCommand,
+    CheckpointCommand, Command, Executor, LedgerCommand, MempoolCommand, Message, RouterCommand,
+    TimerCommand,
 };
 
-pub struct ParentExecutor<R, T, M, L> {
+pub struct ParentExecutor<R, T, M, L, C> {
     pub router: R,
     pub timer: T,
     pub mempool: M,
     pub ledger: L,
+    pub checkpoint: C,
     // if you add an executor here, you must add it to BOTH exec AND poll_next !
 }
 
-impl<RE, TE, ME, LE, M, OM, B> Executor for ParentExecutor<RE, TE, ME, LE>
+impl<RE, TE, ME, LE, CE, M, OM, B, C> Executor for ParentExecutor<RE, TE, ME, LE, CE>
 where
     RE: Executor<Command = RouterCommand<M, OM>>,
     TE: Executor<Command = TimerCommand<M::Event>>,
 
-    ME: Executor<Command = MempoolCommand<M::Event>>,
+    CE: Executor<Command = CheckpointCommand<C>>,
     LE: Executor<Command = LedgerCommand<B>>,
+    ME: Executor<Command = MempoolCommand<M::Event>>,
 
     M: Message,
 {
-    type Command = Command<M, OM, B>;
-    fn exec(&mut self, commands: Vec<Command<M, OM, B>>) {
-        let (router_cmds, timer_cmds, mempool_cmds, ledger_cmds) =
+    type Command = Command<M, OM, B, C>;
+    fn exec(&mut self, commands: Vec<Command<M, OM, B, C>>) {
+        let (router_cmds, timer_cmds, mempool_cmds, ledger_cmds, checkpoint_cmds) =
             Command::split_commands(commands);
         self.router.exec(router_cmds);
         self.timer.exec(timer_cmds);
         self.mempool.exec(mempool_cmds);
         self.ledger.exec(ledger_cmds);
+        self.checkpoint.exec(checkpoint_cmds);
     }
 }
 
-impl<E, R, T, M, L> Stream for ParentExecutor<R, T, M, L>
+impl<E, R, T, M, L, C> Stream for ParentExecutor<R, T, M, L, C>
 where
     R: Stream<Item = E> + Unpin,
     T: Stream<Item = E> + Unpin,
@@ -60,7 +64,7 @@ where
     }
 }
 
-impl<R, T, M, L> ParentExecutor<R, T, M, L> {
+impl<R, T, M, L, C> ParentExecutor<R, T, M, L, C> {
     pub fn ledger(&self) -> &L {
         &self.ledger
     }

--- a/monad-executor/src/lib.rs
+++ b/monad-executor/src/lib.rs
@@ -13,7 +13,7 @@ pub mod convert;
 
 // driver loop
 async fn run<S: State>(
-    mut executor: impl Executor<Command = Command<S::Message, S::OutboundMessage, S::Block>>
+    mut executor: impl Executor<Command = Command<S::Message, S::OutboundMessage, S::Block, S::Checkpoint>>
         + Stream<Item = S::Event>
         + Unpin,
     config: S::Config,

--- a/monad-executor/src/mock_swarm.rs
+++ b/monad-executor/src/mock_swarm.rs
@@ -197,6 +197,7 @@ where
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
 
     MockExecutor<S>: Unpin,
+    S::Event: Unpin,
 {
     pub fn new(peers: Vec<(PubKey, S::Config, LGR::Config)>, transformer: T) -> Self {
         assert!(!peers.is_empty());

--- a/monad-executor/src/replay_nodes.rs
+++ b/monad-executor/src/replay_nodes.rs
@@ -93,7 +93,12 @@ where
         node_id: &PeerId,
         tick: Duration,
         cmds: Vec<
-            Command<<S as State>::Message, <S as State>::OutboundMessage, <S as State>::Block>,
+            Command<
+                <S as State>::Message,
+                <S as State>::OutboundMessage,
+                <S as State>::Block,
+                <S as State>::Checkpoint,
+            >,
         >,
     ) {
         let mut to_publish = Vec::new();

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -19,7 +19,8 @@ use monad_crypto::{
 };
 use monad_executor::{
     executor::{
-        ledger::MockLedger, mempool::MockMempool, parent::ParentExecutor, timer::TokioTimer,
+        checkpoint::MockCheckpoint, ledger::MockLedger, mempool::MockMempool,
+        parent::ParentExecutor, timer::TokioTimer,
     },
     Executor, State,
 };
@@ -277,6 +278,7 @@ async fn run(
         timer: TokioTimer::default(),
         mempool: MockMempool::default(),
         ledger: MockLedger::default(),
+        checkpoint: MockCheckpoint::default(),
     };
 
     let (mut state, init_commands) = MonadState::init(MonadConfig {

--- a/monad-proto/build.rs
+++ b/monad-proto/build.rs
@@ -15,6 +15,7 @@ fn main() {
                 "proto/quorum_certificate.proto",
                 "proto/signing.proto",
                 "proto/timeout.proto",
+                "proto/validator_set.proto",
                 "proto/voting.proto",
             ],
             &["proto/"],

--- a/monad-proto/proto/basic.proto
+++ b/monad-proto/proto/basic.proto
@@ -22,3 +22,10 @@ message ProtoBlockId  {
   ProtoHash bid = 1;
 }
 
+message ProtoEpoch {
+  uint64 epoch = 1;
+}
+
+message ProtoStake {
+  int64 stake = 1;
+}

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -9,6 +9,7 @@ import "pacemaker.proto";
 import "quorum_certificate.proto";
 import "signing.proto";
 import "timeout.proto";
+import "validator_set.proto";
 
 message ProtoPeerId {
   monad_proto.basic.ProtoPubkey pubkey = 1;
@@ -37,12 +38,24 @@ message ProtoFetchedFullTxs {
   bytes full_txs = 3;
 }
 
+message ProtoAdvanceEpochEvent {
+  monad_proto.validator_set.ProtoValidatorSetData validator_set = 1;
+}
+
+message ProtoLoadEpochEvent {
+    monad_proto.basic.ProtoEpoch epoch = 1;
+    monad_proto.validator_set.ProtoValidatorSetData validator_set = 2;
+    monad_proto.validator_set.ProtoValidatorSetData upcoming_validator_set = 3;
+}
+
 message ProtoConsensusEvent {
   oneof event {
     ProtoMessageWithSender message = 1;
     monad_proto.pacemaker.ProtoPacemakerTimerExpire timeout = 2;
     ProtoFetchedTxs fetched_txs = 3;
     ProtoFetchedFullTxs fetched_full_txs = 4;
+    ProtoAdvanceEpochEvent advance_epoch = 5;
+    ProtoLoadEpochEvent load_epoch = 6;
   }
 }
 

--- a/monad-proto/proto/validator_set.proto
+++ b/monad-proto/proto/validator_set.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package monad_proto.validator_set;
+
+import "basic.proto";
+
+message ValidatorMapEntry {
+    monad_proto.basic.ProtoNodeId key = 1;
+    monad_proto.basic.ProtoStake value = 2;
+}
+
+message ProtoValidatorSetData {
+    repeated ValidatorMapEntry validators = 1;
+}

--- a/monad-proto/src/lib.rs
+++ b/monad-proto/src/lib.rs
@@ -23,4 +23,5 @@ pub mod proto {
     include_proto!(message);
     include_proto!(event);
     include_proto!(pacemaker);
+    include_proto!(validator_set);
 }

--- a/monad-types/src/convert/mod.rs
+++ b/monad-types/src/convert/mod.rs
@@ -1,9 +1,9 @@
 use monad_proto::{
     error::ProtoError,
-    proto::basic::{ProtoBlockId, ProtoHash, ProtoNodeId, ProtoRound},
+    proto::basic::{ProtoBlockId, ProtoEpoch, ProtoHash, ProtoNodeId, ProtoRound, ProtoStake},
 };
 
-use crate::{BlockId, Hash, NodeId, Round};
+use crate::{BlockId, Epoch, Hash, NodeId, Round, Stake};
 
 impl From<&NodeId> for ProtoNodeId {
     fn from(nodeid: &NodeId) -> Self {
@@ -75,5 +75,31 @@ impl TryFrom<ProtoBlockId> for BlockId {
                 ))?
                 .try_into()?,
         ))
+    }
+}
+
+impl From<&Epoch> for ProtoEpoch {
+    fn from(value: &Epoch) -> Self {
+        ProtoEpoch { epoch: value.0 }
+    }
+}
+
+impl TryFrom<ProtoEpoch> for Epoch {
+    type Error = ProtoError;
+    fn try_from(value: ProtoEpoch) -> Result<Self, Self::Error> {
+        Ok(Self(value.epoch))
+    }
+}
+
+impl From<&Stake> for ProtoStake {
+    fn from(value: &Stake) -> Self {
+        ProtoStake { stake: value.0 }
+    }
+}
+
+impl TryFrom<ProtoStake> for Stake {
+    type Error = ProtoError;
+    fn try_from(value: ProtoStake) -> Result<Self, Self::Error> {
+        Ok(Self(value.stake))
     }
 }

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -65,6 +65,24 @@ impl std::fmt::Debug for Round {
 }
 
 #[repr(transparent)]
+#[derive(Copy, Clone, Hash, Eq, PartialEq, PartialOrd, Ord)]
+pub struct Epoch(pub u64);
+
+impl Add for Epoch {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl std::fmt::Debug for Epoch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[repr(transparent)]
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct NodeId(pub PubKey);
 

--- a/monad-validator/Cargo.toml
+++ b/monad-validator/Cargo.toml
@@ -10,6 +10,7 @@ bench = false
 
 [dependencies]
 monad-crypto = { path = "../monad-crypto" }
+monad-proto = { path = "../monad-proto" }
 monad-types = { path = "../monad-types" }
 
 log = { workspace = true }

--- a/monad-validator/src/validator_set.rs
+++ b/monad-validator/src/validator_set.rs
@@ -3,6 +3,10 @@ use std::{
     error, fmt,
 };
 
+use monad_proto::{
+    error::ProtoError,
+    proto::validator_set::{ProtoValidatorSetData, ValidatorMapEntry},
+};
 use monad_types::{NodeId, Stake};
 
 pub type Result<T> = std::result::Result<T, ValidatorSetError>;
@@ -39,11 +43,53 @@ pub trait ValidatorSetType {
     fn has_honest_vote(&self, addrs: &[NodeId]) -> bool;
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatorData(pub Vec<(NodeId, Stake)>);
+
 #[derive(Debug)]
 pub struct ValidatorSet {
     validators: HashMap<NodeId, Stake>,
     validator_list: Vec<NodeId>,
     total_stake: Stake,
+}
+
+impl From<&ValidatorData> for ProtoValidatorSetData {
+    fn from(value: &ValidatorData) -> Self {
+        let vlist = value
+            .0
+            .iter()
+            .map(|(node, stake)| ValidatorMapEntry {
+                key: Some(node.into()),
+                value: Some(stake.into()),
+            })
+            .collect::<Vec<ValidatorMapEntry>>();
+        Self { validators: vlist }
+    }
+}
+
+impl TryFrom<ProtoValidatorSetData> for ValidatorData {
+    type Error = ProtoError;
+    fn try_from(value: ProtoValidatorSetData) -> std::result::Result<Self, Self::Error> {
+        let mut vlist = ValidatorData(Vec::new());
+        for v in value.validators {
+            let a = v
+                .key
+                .ok_or(Self::Error::MissingRequiredField(
+                    "ValildatorMapEntry.key".to_owned(),
+                ))?
+                .try_into()?;
+            let b = v
+                .value
+                .ok_or(Self::Error::MissingRequiredField(
+                    "ValildatorMapEntry.value".to_owned(),
+                ))?
+                .try_into()?;
+
+            vlist.0.push((a, b));
+        }
+
+        Ok(vlist)
+    }
 }
 
 impl ValidatorSetType for ValidatorSet {

--- a/monad-validator/src/weighted_round_robin.rs
+++ b/monad-validator/src/weighted_round_robin.rs
@@ -40,7 +40,7 @@ impl Voter {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WeightedRoundRobin {
     voters: Vec<Voter>,
     leader: usize, // voter idx

--- a/monad-viz/src/graph.rs
+++ b/monad-viz/src/graph.rs
@@ -82,6 +82,7 @@ impl<S, T, LGR, C> NodesSimulation<S, T, LGR, C>
 where
     S: monad_executor::State,
     MockExecutor<S>: Unpin,
+    S::Event: Unpin,
     T: Transformer<S::Message> + Clone,
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
     C: SimulationConfig<S, T, LGR>,
@@ -117,6 +118,7 @@ impl<S, T, LGR, C> Graph for NodesSimulation<S, T, LGR, C>
 where
     S: monad_executor::State,
     MockExecutor<S>: Unpin,
+    S::Event: Unpin,
     T: Transformer<S::Message> + Clone,
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
     C: SimulationConfig<S, T, LGR>,

--- a/monad-wal/tests/replay.rs
+++ b/monad-wal/tests/replay.rs
@@ -74,12 +74,20 @@ mod test {
         type OutboundMessage = MockMessage;
         type Message = MockMessage;
         type Block = ();
+        type Checkpoint = ();
 
         fn init(
             _config: Self::Config,
         ) -> (
             Self,
-            Vec<monad_executor::Command<Self::Message, Self::OutboundMessage, Self::Block>>,
+            Vec<
+                monad_executor::Command<
+                    Self::Message,
+                    Self::OutboundMessage,
+                    Self::Block,
+                    Self::Checkpoint,
+                >,
+            >,
         ) {
             let state = VecState { events: Vec::new() };
             (state, Vec::new())
@@ -88,8 +96,14 @@ mod test {
         fn update(
             &mut self,
             event: Self::Event,
-        ) -> Vec<monad_executor::Command<Self::Message, Self::OutboundMessage, Self::Block>>
-        {
+        ) -> Vec<
+            monad_executor::Command<
+                Self::Message,
+                Self::OutboundMessage,
+                Self::Block,
+                Self::Checkpoint,
+            >,
+        > {
             self.events.push(event);
             Vec::new()
         }


### PR DESCRIPTION
Checkpoints and Epochs involve side effects so they require an executor as well as Events and Commands. A Checkpoint is created via a command from consensus state when necessary. Loading checkpoints and reacting to Epoch changes are external input from Events.

This change adds the supporting types for the above but doesn't implement any behaviour so there should be no functional changes to how things work yet. Future changes will flesh out the particular details for checkpoint and epoch implementations.

Adding new events requires updating the serialization types as well.