### PR TITLE
Implement Drop trait for ConsensusState for debug prints

### DIFF
--- a/monad-consensus/src/pacemaker.rs
+++ b/monad-consensus/src/pacemaker.rs
@@ -14,6 +14,7 @@ use crate::{
     validation::{message::well_formed, safety::Safety},
 };
 
+#[derive(Debug)]
 pub struct Pacemaker<S, T> {
     delta: Duration,
 

--- a/monad-consensus/src/validation/safety.rs
+++ b/monad-consensus/src/validation/safety.rs
@@ -13,6 +13,7 @@ use monad_types::*;
 
 use std::cmp;
 
+#[derive(Debug)]
 pub struct Safety {
     highest_vote_round: Round,
     highest_qc_round: Round,

--- a/monad-consensus/src/vote_state.rs
+++ b/monad-consensus/src/vote_state.rs
@@ -13,6 +13,7 @@ use crate::messages::message::VoteMessage;
 // accumulate votes and create a QC if enough votes are received
 // only one QC should be created in a round using the first supermajority of votes received
 // At the end of a round, older rounds can be cleaned up
+#[derive(Debug)]
 pub struct VoteState<T> {
     pending_votes: BTreeMap<Round, HashMap<Hash, (T, HashSet<NodeId>)>>,
     qc_created: BTreeSet<Round>,

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -443,6 +443,26 @@ struct ConsensusState<S, T> {
     keypair: KeyPair,
 }
 
+struct ConsensusStateWrapper<S: Signature, T: SignatureCollection> {
+    consensus_state: ConsensusState<S, T>,
+}
+
+impl<S: Signature, T: SignatureCollection> std::fmt::Debug for ConsensusStateWrapper<S, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConsensusState")
+            .field(
+                "pending_block_tree",
+                &self.consensus_state.pending_block_tree,
+            )
+            .field("vote_state", &self.consensus_state.vote_state)
+            .field("high_qc", &self.consensus_state.high_qc)
+            .field("pacemaker", &self.consensus_state.pacemaker)
+            .field("safety", &self.consensus_state.safety)
+            .field("nodeid", &self.consensus_state.nodeid)
+            .finish_non_exhaustive()
+    }
+}
+
 impl<S, T> ConsensusState<S, T>
 where
     S: Signature,
@@ -664,6 +684,12 @@ where
                 txns: TransactionList(txns),
             }
         }))]
+    }
+}
+
+impl<S: Signature, T: SignatureCollection> Drop for ConsensusStateWrapper<S, T> {
+    fn drop(&mut self) {
+        eprintln!("{:?}", self);
     }
 }
 


### PR DESCRIPTION
Drop trait allows an implementer to run code on destruction. We can use this to implement a debug print to stderr that will be called on a panic as the stack unwinds.