### PR TITLE
Rename AggregateSignature<S> to MultiSig<S>

### DIFF
--- a/monad-consensus/src/convert/block.rs
+++ b/monad-consensus/src/convert/block.rs
@@ -3,7 +3,7 @@ use monad_proto::error::ProtoError;
 use monad_proto::proto::block::*;
 
 use crate::{
-    signatures::aggregate_signature::AggregateSignatures,
+    signatures::multi_sig::MultiSig,
     types::block::{Block, TransactionList},
     validation::hashing::Sha256Hash,
 };
@@ -23,8 +23,8 @@ impl TryFrom<ProtoTransactionList> for TransactionList {
     }
 }
 
-impl<S: Signature> From<&Block<AggregateSignatures<S>>> for ProtoBlockAggSig {
-    fn from(value: &Block<AggregateSignatures<S>>) -> Self {
+impl<S: Signature> From<&Block<MultiSig<S>>> for ProtoBlockAggSig {
+    fn from(value: &Block<MultiSig<S>>) -> Self {
         Self {
             author: Some((&value.author).into()),
             round: Some((&value.round).into()),
@@ -34,7 +34,7 @@ impl<S: Signature> From<&Block<AggregateSignatures<S>>> for ProtoBlockAggSig {
     }
 }
 
-impl<S: Signature> TryFrom<ProtoBlockAggSig> for Block<AggregateSignatures<S>> {
+impl<S: Signature> TryFrom<ProtoBlockAggSig> for Block<MultiSig<S>> {
     type Error = ProtoError;
 
     fn try_from(value: ProtoBlockAggSig) -> Result<Self, Self::Error> {

--- a/monad-consensus/src/convert/message.rs
+++ b/monad-consensus/src/convert/message.rs
@@ -5,19 +5,17 @@ use monad_crypto::Signature;
 use monad_proto::error::ProtoError;
 use monad_proto::proto::message::*;
 
-use crate::signatures::aggregate_signature::AggregateSignatures;
+use crate::signatures::multi_sig::MultiSig;
 use crate::types::consensus_message::ConsensusMessage;
 use crate::types::message::{
     ProposalMessage as ConsensusTypePropMsg, TimeoutMessage as ConsensusTypeTmoMsg, VoteMessage,
 };
 use crate::validation::signing::{Unverified, Verified};
 
-type TimeoutMessage<S> = ConsensusTypeTmoMsg<S, AggregateSignatures<S>>;
-type ProposalMessage<S> = ConsensusTypePropMsg<S, AggregateSignatures<S>>;
-pub(crate) type VerifiedConsensusMessage<S> =
-    Verified<S, ConsensusMessage<S, AggregateSignatures<S>>>;
-pub(crate) type UnverifiedConsensusMessage<S> =
-    Unverified<S, ConsensusMessage<S, AggregateSignatures<S>>>;
+type TimeoutMessage<S> = ConsensusTypeTmoMsg<S, MultiSig<S>>;
+type ProposalMessage<S> = ConsensusTypePropMsg<S, MultiSig<S>>;
+pub(crate) type VerifiedConsensusMessage<S> = Verified<S, ConsensusMessage<S, MultiSig<S>>>;
+pub(crate) type UnverifiedConsensusMessage<S> = Unverified<S, ConsensusMessage<S, MultiSig<S>>>;
 
 impl From<&VoteMessage> for ProtoVoteMessage {
     fn from(value: &VoteMessage) -> Self {

--- a/monad-consensus/src/convert/quorum_certificate.rs
+++ b/monad-consensus/src/convert/quorum_certificate.rs
@@ -3,11 +3,11 @@ use monad_proto::error::ProtoError;
 use monad_proto::proto::quorum_certificate::*;
 
 use crate::{
-    signatures::aggregate_signature::AggregateSignatures,
+    signatures::multi_sig::MultiSig,
     types::quorum_certificate::{QcInfo, QuorumCertificate as ConsensusQC},
 };
 
-type QuorumCertificate<S> = ConsensusQC<AggregateSignatures<S>>;
+type QuorumCertificate<S> = ConsensusQC<MultiSig<S>>;
 
 impl From<&QcInfo> for ProtoQcInfo {
     fn from(qcinfo: &QcInfo) -> Self {

--- a/monad-consensus/src/convert/signing.rs
+++ b/monad-consensus/src/convert/signing.rs
@@ -3,10 +3,10 @@ use monad_crypto::Signature;
 use monad_proto::error::ProtoError;
 use monad_proto::proto::signing::*;
 
-use crate::signatures::aggregate_signature::AggregateSignatures;
+use crate::signatures::multi_sig::MultiSig;
 
-impl<S: Signature> From<&AggregateSignatures<S>> for ProtoAggSig {
-    fn from(value: &AggregateSignatures<S>) -> Self {
+impl<S: Signature> From<&MultiSig<S>> for ProtoMultiSig {
+    fn from(value: &MultiSig<S>) -> Self {
         Self {
             sigs: value
                 .sigs
@@ -17,10 +17,10 @@ impl<S: Signature> From<&AggregateSignatures<S>> for ProtoAggSig {
     }
 }
 
-impl<S: Signature> TryFrom<ProtoAggSig> for AggregateSignatures<S> {
+impl<S: Signature> TryFrom<ProtoMultiSig> for MultiSig<S> {
     type Error = ProtoError;
 
-    fn try_from(value: ProtoAggSig) -> Result<Self, Self::Error> {
+    fn try_from(value: ProtoMultiSig) -> Result<Self, Self::Error> {
         Ok(Self {
             sigs: value
                 .sigs

--- a/monad-consensus/src/convert/timeout.rs
+++ b/monad-consensus/src/convert/timeout.rs
@@ -6,7 +6,7 @@ use monad_proto::error::ProtoError;
 use monad_proto::proto::timeout::*;
 
 use crate::{
-    signatures::aggregate_signature::AggregateSignatures,
+    signatures::multi_sig::MultiSig,
     types::timeout::{
         HighQcRound, HighQcRoundSigTuple as TypeHighQcRoundSigTuple,
         TimeoutCertificate as ConsensusTC, TimeoutInfo as ConsensusTmoInfo,
@@ -15,7 +15,7 @@ use crate::{
 
 type HighQcRoundSigTuple<S> = TypeHighQcRoundSigTuple<S>;
 type TimeoutCertificate<S> = ConsensusTC<S>;
-type TimeoutInfo<S> = ConsensusTmoInfo<AggregateSignatures<S>>;
+type TimeoutInfo<S> = ConsensusTmoInfo<MultiSig<S>>;
 
 impl From<&HighQcRound> for ProtoHighQcRound {
     fn from(value: &HighQcRound) -> Self {

--- a/monad-consensus/src/signatures/mod.rs
+++ b/monad-consensus/src/signatures/mod.rs
@@ -1,1 +1,1 @@
-pub mod aggregate_signature;
+pub mod multi_sig;

--- a/monad-consensus/src/signatures/multi_sig.rs
+++ b/monad-consensus/src/signatures/multi_sig.rs
@@ -8,21 +8,21 @@ use crate::types::signature::SignatureCollection;
 use sha2::Digest;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct AggregateSignatures<S> {
+pub struct MultiSig<S> {
     pub sigs: Vec<S>,
 }
 
-impl<S: Signature> Default for AggregateSignatures<S> {
+impl<S: Signature> Default for MultiSig<S> {
     fn default() -> Self {
         Self { sigs: Vec::new() }
     }
 }
 
-impl<S: Signature> SignatureCollection for AggregateSignatures<S> {
+impl<S: Signature> SignatureCollection for MultiSig<S> {
     type SignatureType = S;
 
     fn new() -> Self {
-        AggregateSignatures { sigs: Vec::new() }
+        MultiSig { sigs: Vec::new() }
     }
 
     fn get_hash(&self) -> Hash {

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -372,7 +372,7 @@ impl ValidatorPubKey for PubKey {
 
 #[cfg(test)]
 mod test {
-    use crate::signatures::aggregate_signature::AggregateSignatures;
+    use crate::signatures::multi_sig::MultiSig;
     use crate::types::ledger::LedgerCommitInfo;
     use crate::types::quorum_certificate::{QcInfo, QuorumCertificate};
     use crate::types::signature::SignatureCollection;
@@ -441,7 +441,7 @@ mod test {
         let msg = Sha256Hash::hash_object(&lci);
         let s = keypair.sign(msg.as_ref());
 
-        let mut sigs = AggregateSignatures::new();
+        let mut sigs = MultiSig::new();
         sigs.add_signature(s);
 
         let vi2 = VoteInfo {
@@ -459,6 +459,6 @@ mod test {
             sigs,
         );
 
-        assert!(verify_qc::<AggregateSignatures<SecpSignature>, Sha256Hash>(&vset, &qc).is_err());
+        assert!(verify_qc::<MultiSig<SecpSignature>, Sha256Hash>(&vset, &qc).is_err());
     }
 }

--- a/monad-consensus/src/vote_state.rs
+++ b/monad-consensus/src/vote_state.rs
@@ -86,7 +86,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::signatures::aggregate_signature::AggregateSignatures;
+    use crate::signatures::multi_sig::MultiSig;
     use crate::types::ledger::LedgerCommitInfo;
     use crate::types::message::VoteMessage;
     use crate::types::voting::VoteInfo;
@@ -137,7 +137,7 @@ mod test {
 
     #[test]
     fn clean_older_votes() {
-        let mut votestate = VoteState::<AggregateSignatures<SecpSignature>>::default();
+        let mut votestate = VoteState::<MultiSig<SecpSignature>>::default();
         let (keys, valset) = create_valset(4);
 
         // add one vote for rounds 0-3
@@ -171,7 +171,7 @@ mod test {
 
     #[test]
     fn handle_future_votes() {
-        let mut votestate = VoteState::<AggregateSignatures<SecpSignature>>::default();
+        let mut votestate = VoteState::<MultiSig<SecpSignature>>::default();
         let (keys, valset) = create_valset(4);
 
         // add one vote for rounds 0-3 and 5-8
@@ -215,7 +215,7 @@ mod test {
 
     #[test]
     fn vote_idx_doesnt_match() {
-        let mut vote_state = VoteState::<AggregateSignatures<SecpSignature>>::default();
+        let mut vote_state = VoteState::<MultiSig<SecpSignature>>::default();
         let keypair = get_key(6);
         let val = (NodeId(keypair.pubkey()), Stake(1));
 
@@ -282,7 +282,7 @@ mod test {
 
     #[test]
     fn duplicate_votes() {
-        let mut votestate = VoteState::<AggregateSignatures<SecpSignature>>::default();
+        let mut votestate = VoteState::<MultiSig<SecpSignature>>::default();
         let (keys, valset) = create_valset(4);
 
         // create a vote for round 0 from one node, but add it supermajority number of times

--- a/monad-consensus/tests/protobuf.rs
+++ b/monad-consensus/tests/protobuf.rs
@@ -5,7 +5,7 @@ mod test {
     };
     use monad_consensus::types::timeout::HighQcRoundSigTuple;
     use monad_consensus::{
-        signatures::aggregate_signature::AggregateSignatures,
+        signatures::multi_sig::MultiSig,
         types::{
             block::TransactionList,
             consensus_message::ConsensusMessage,
@@ -46,7 +46,7 @@ mod test {
             commit_state_hash: None,
             vote_info_hash: Hash([42_u8; 32]),
         };
-        let votemsg: ConsensusMessage<SecpSignature, AggregateSignatures<SecpSignature>> =
+        let votemsg: ConsensusMessage<SecpSignature, MultiSig<SecpSignature>> =
             ConsensusMessage::Vote(VoteMessage {
                 vote_info: vi,
                 ledger_commit_info: lci,
@@ -88,7 +88,7 @@ mod test {
 
         let qcinfo_hash = Sha256Hash::hash_object(&qcinfo.ledger_commit);
 
-        let mut aggsig = AggregateSignatures::new();
+        let mut aggsig = MultiSig::new();
         for keypair in keypairs.iter() {
             aggsig.add_signature(keypair.sign(qcinfo_hash.as_ref()));
         }
@@ -148,7 +148,7 @@ mod test {
             TransactionList(vec![1, 2, 3, 4]),
             &keypairs,
         );
-        let proposal: ConsensusMessage<SecpSignature, AggregateSignatures<SecpSignature>> =
+        let proposal: ConsensusMessage<SecpSignature, MultiSig<SecpSignature>> =
             ConsensusMessage::Proposal(ProposalMessage {
                 block: blk,
                 last_round_tc: None,

--- a/monad-consensus/tests/vote_state.rs
+++ b/monad-consensus/tests/vote_state.rs
@@ -1,6 +1,6 @@
 use test_case::test_case;
 
-use monad_consensus::signatures::aggregate_signature::AggregateSignatures;
+use monad_consensus::signatures::multi_sig::MultiSig;
 use monad_consensus::types::ledger::LedgerCommitInfo;
 use monad_consensus::types::message::VoteMessage;
 use monad_consensus::types::quorum_certificate::QuorumCertificate;
@@ -70,7 +70,7 @@ fn setup_ctx(
 }
 
 fn verify_qcs(
-    qcs: Vec<&Option<QuorumCertificate<AggregateSignatures<SecpSignature>>>>,
+    qcs: Vec<&Option<QuorumCertificate<MultiSig<SecpSignature>>>>,
     expected_qcs: u32,
     expected_sigs: u32,
 ) {
@@ -93,7 +93,7 @@ fn verify_qcs(
 fn test_votes(num_nodes: u32) {
     let (_, valset, votes) = setup_ctx(num_nodes);
 
-    let mut voteset = VoteState::<AggregateSignatures<SecpSignature>>::default();
+    let mut voteset = VoteState::<MultiSig<SecpSignature>>::default();
     let mut qcs = Vec::new();
     for i in 0..num_nodes {
         let v = &votes[i as usize];
@@ -105,7 +105,7 @@ fn test_votes(num_nodes: u32) {
         );
         qcs.push(qc);
     }
-    let valid_qc: Vec<&Option<QuorumCertificate<AggregateSignatures<SecpSignature>>>> =
+    let valid_qc: Vec<&Option<QuorumCertificate<MultiSig<SecpSignature>>>> =
         qcs.iter().filter(|a| a.is_some()).collect();
 
     // number of expected signatures is 2/3 + 1 for num_nodes because all weights were equal
@@ -121,7 +121,7 @@ fn test_votes(num_nodes: u32) {
 fn test_reset(num_nodes: u32, num_rounds: u32) {
     let (_, valset, votes) = setup_ctx(num_nodes);
 
-    let mut voteset = VoteState::<AggregateSignatures<SecpSignature>>::default();
+    let mut voteset = VoteState::<MultiSig<SecpSignature>>::default();
     let mut qcs = Vec::new();
 
     for k in 0..num_rounds {
@@ -139,7 +139,7 @@ fn test_reset(num_nodes: u32, num_rounds: u32) {
         voteset.start_new_round(Round(k.into()) + Round(1));
     }
 
-    let valid_qc: Vec<&Option<QuorumCertificate<AggregateSignatures<SecpSignature>>>> =
+    let valid_qc: Vec<&Option<QuorumCertificate<MultiSig<SecpSignature>>>> =
         qcs.iter().filter(|a| a.is_some()).collect();
 
     let num_expected_sigs = 2 * num_nodes / 3 + 1;
@@ -152,7 +152,7 @@ fn test_reset(num_nodes: u32, num_rounds: u32) {
 fn test_minority(num_nodes: u32) {
     let (_, valset, votes) = setup_ctx(num_nodes);
 
-    let mut voteset = VoteState::<AggregateSignatures<SecpSignature>>::default();
+    let mut voteset = VoteState::<MultiSig<SecpSignature>>::default();
     let mut qcs = Vec::new();
 
     let majority = 2 * num_nodes / 3 + 1;
@@ -168,7 +168,7 @@ fn test_minority(num_nodes: u32) {
         qcs.push(qc);
     }
 
-    let valid_qc: Vec<&Option<QuorumCertificate<AggregateSignatures<SecpSignature>>>> =
+    let valid_qc: Vec<&Option<QuorumCertificate<MultiSig<SecpSignature>>>> =
         qcs.iter().filter(|a| a.is_some()).collect();
 
     assert_eq!(valid_qc.len(), 0);

--- a/monad-driver/src/lib.rs
+++ b/monad-driver/src/lib.rs
@@ -4,8 +4,8 @@ mod tests {
 
     use futures::StreamExt;
     use monad_consensus::{
-        signatures::aggregate_signature::AggregateSignatures,
-        types::quorum_certificate::genesis_vote_info, validation::hashing::Sha256Hash,
+        signatures::multi_sig::MultiSig, types::quorum_certificate::genesis_vote_info,
+        validation::hashing::Sha256Hash,
     };
     use monad_crypto::secp256k1::{KeyPair, SecpSignature};
     use monad_executor::{
@@ -21,7 +21,7 @@ mod tests {
     use tempfile::tempdir;
 
     type SignatureType = SecpSignature;
-    type SignatureCollectionType = AggregateSignatures<SignatureType>;
+    type SignatureCollectionType = MultiSig<SignatureType>;
     type S = MonadState<SignatureType, SignatureCollectionType>;
     type PersistenceLoggerType = MockWALogger<<S as State>::Event>;
 

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -6,7 +6,7 @@ use tracing::event;
 use tracing::Level;
 
 use monad_consensus::{
-    signatures::aggregate_signature::AggregateSignatures,
+    signatures::multi_sig::MultiSig,
     types::{
         block::{Block, TransactionList},
         ledger::LedgerCommitInfo,
@@ -29,7 +29,7 @@ use monad_types::{NodeId, Round};
 
 type HasherType = Sha256Hash;
 type SignatureType = SecpSignature;
-type SignatureCollectionType = AggregateSignatures<SignatureType>;
+type SignatureCollectionType = MultiSig<SignatureType>;
 type MonadState = monad_state::MonadState<SignatureType, SignatureCollectionType>;
 type MonadConfig = <MonadState as State>::Config;
 

--- a/monad-proto/proto/quorum_certificate.proto
+++ b/monad-proto/proto/quorum_certificate.proto
@@ -13,5 +13,5 @@ message ProtoQcInfo{
 
 message ProtoQuorumCertificateAggSig {
   ProtoQcInfo info = 1;
-  monad_proto.signing.ProtoAggSig signatures = 2;
+  monad_proto.signing.ProtoMultiSig signatures = 2;
 }

--- a/monad-proto/proto/signing.proto
+++ b/monad-proto/proto/signing.proto
@@ -7,6 +7,6 @@ message ProtoSignature {
 }
 
 // AggregateSignatures
-message ProtoAggSig {
+message ProtoMultiSig {
   repeated ProtoSignature sigs = 1;
 }

--- a/monad-state/src/convert/event.rs
+++ b/monad-state/src/convert/event.rs
@@ -1,5 +1,5 @@
 use monad_consensus::pacemaker::PacemakerTimerExpire;
-use monad_consensus::signatures::aggregate_signature::AggregateSignatures;
+use monad_consensus::signatures::multi_sig::MultiSig;
 use monad_crypto::Signature;
 use monad_proto::error::ProtoError;
 use monad_proto::proto::event::*;
@@ -9,8 +9,8 @@ use crate::ConsensusEvent as TypeConsensusEvent;
 use crate::FetchedTxs;
 use crate::MonadEvent as TypeMonadEvent;
 
-pub(super) type MonadEvent<S> = TypeMonadEvent<S, AggregateSignatures<S>>;
-pub(super) type ConsensusEvent<S> = TypeConsensusEvent<S, AggregateSignatures<S>>;
+pub(super) type MonadEvent<S> = TypeMonadEvent<S, MultiSig<S>>;
+pub(super) type ConsensusEvent<S> = TypeConsensusEvent<S, MultiSig<S>>;
 
 impl<S: Signature> From<&ConsensusEvent<S>> for ProtoConsensusEvent {
     fn from(value: &ConsensusEvent<S>) -> Self {

--- a/monad-state/tests/protobuf.rs
+++ b/monad-state/tests/protobuf.rs
@@ -1,6 +1,6 @@
 #[cfg(all(test, feature = "proto"))]
 mod test {
-    use monad_consensus::signatures::aggregate_signature::AggregateSignatures;
+    use monad_consensus::signatures::multi_sig::MultiSig;
     use monad_consensus::types::consensus_message::ConsensusMessage;
     use monad_consensus::types::ledger::LedgerCommitInfo;
     use monad_consensus::types::message::VoteMessage;
@@ -20,7 +20,7 @@ mod test {
     fn test_consensus_timeout_event() {
         let event = MonadEvent::ConsensusEvent(ConsensusEvent::<
             SecpSignature,
-            AggregateSignatures<SecpSignature>,
+            MultiSig<SecpSignature>,
         >::Timeout(PacemakerTimerExpire {}));
 
         let buf = serialize_event(&event);
@@ -42,7 +42,7 @@ mod test {
             commit_state_hash: None,
             vote_info_hash: Hash([42_u8; 32]),
         };
-        let votemsg: ConsensusMessage<SecpSignature, AggregateSignatures<SecpSignature>> =
+        let votemsg: ConsensusMessage<SecpSignature, MultiSig<SecpSignature>> =
             ConsensusMessage::Vote(VoteMessage {
                 vote_info: vi,
                 ledger_commit_info: lci,

--- a/monad-state/tests/replay.rs
+++ b/monad-state/tests/replay.rs
@@ -7,7 +7,7 @@ mod test {
     use std::time::Duration;
     use tempfile::tempdir;
 
-    use monad_consensus::signatures::aggregate_signature::AggregateSignatures;
+    use monad_consensus::signatures::multi_sig::MultiSig;
     use monad_crypto::secp256k1::SecpSignature;
     use monad_executor::mock_swarm::Nodes;
     use monad_executor::mock_swarm::XorLatencyTransformer;
@@ -15,7 +15,7 @@ mod test {
     use monad_wal::wal::{WALogger, WALoggerConfig};
 
     type SignatureType = SecpSignature;
-    type SignatureCollectionType = AggregateSignatures<SignatureType>;
+    type SignatureCollectionType = MultiSig<SignatureType>;
 
     #[test]
     fn test_replay() {

--- a/monad-testutil/src/block.rs
+++ b/monad-testutil/src/block.rs
@@ -1,4 +1,4 @@
-use monad_consensus::signatures::aggregate_signature::AggregateSignatures;
+use monad_consensus::signatures::multi_sig::MultiSig;
 use monad_consensus::types::block::Block;
 use monad_consensus::types::block::TransactionList;
 use monad_consensus::types::ledger::LedgerCommitInfo;
@@ -21,7 +21,7 @@ pub fn setup_block(
     qc_round: u64,
     txns: TransactionList,
     keypairs: &[KeyPair],
-) -> Block<AggregateSignatures<SecpSignature>> {
+) -> Block<MultiSig<SecpSignature>> {
     let txns = txns;
     let round = Round(block_round);
 
@@ -39,12 +39,12 @@ pub fn setup_block(
     };
     let qcinfo_hash = Sha256Hash::hash_object(&qcinfo.ledger_commit);
 
-    let mut aggsig = AggregateSignatures::new();
+    let mut aggsig = MultiSig::new();
     for keypair in keypairs.iter() {
         aggsig.add_signature(keypair.sign(qcinfo_hash.as_ref()));
     }
 
-    let qc = QuorumCertificate::<AggregateSignatures<SecpSignature>>::new(qcinfo, aggsig);
+    let qc = QuorumCertificate::<MultiSig<SecpSignature>>::new(qcinfo, aggsig);
 
-    Block::<AggregateSignatures<SecpSignature>>::new::<Sha256Hash>(author, round, &txns, &qc)
+    Block::<MultiSig<SecpSignature>>::new::<Sha256Hash>(author, round, &txns, &qc)
 }

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeMap, collections::HashSet, time::Duration};
 
 use crate::signing::{create_keys, get_genesis_config};
 use monad_consensus::{
-    signatures::aggregate_signature::AggregateSignatures,
+    signatures::multi_sig::MultiSig,
     types::{quorum_certificate::genesis_vote_info, signature::SignatureCollection},
     validation::hashing::Sha256Hash,
 };
@@ -20,7 +20,7 @@ use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
 use monad_wal::PersistenceLogger;
 
 type SignatureType = NopSignature;
-type SignatureCollectionType = AggregateSignatures<SignatureType>;
+type SignatureCollectionType = MultiSig<SignatureType>;
 type MS = MonadState<SignatureType, SignatureCollectionType>;
 type MC = MonadConfig<SignatureCollectionType>;
 type MM = <MS as State>::Message;

--- a/monad-viz/src/main.rs
+++ b/monad-viz/src/main.rs
@@ -16,7 +16,7 @@ use iced::{
     Vector,
 };
 
-use monad_consensus::signatures::aggregate_signature::AggregateSignatures;
+use monad_consensus::signatures::multi_sig::MultiSig;
 use monad_crypto::NopSignature;
 use monad_executor::mock_swarm::{
     LatencyTransformer, Layer, LayerTransformer, XorLatencyTransformer,
@@ -26,7 +26,7 @@ use monad_state::{MonadEvent, MonadState};
 use monad_wal::mock::MockWALogger;
 
 type SignatureType = NopSignature;
-type SignatureCollectionType = AggregateSignatures<SignatureType>;
+type SignatureCollectionType = MultiSig<SignatureType>;
 type MS = MonadState<SignatureType, SignatureCollectionType>;
 type MM = <MS as State>::Message;
 type PersistenceLoggerType = MockWALogger<MonadEvent<SignatureType, SignatureCollectionType>>;

--- a/monad-wal/benches/event_bench.rs
+++ b/monad-wal/benches/event_bench.rs
@@ -10,7 +10,7 @@ use monad_consensus::types::timeout::{
     HighQcRound, HighQcRoundSigTuple, TimeoutCertificate, TimeoutInfo,
 };
 use monad_consensus::{
-    signatures::aggregate_signature::AggregateSignatures,
+    signatures::multi_sig::MultiSig,
     types::{
         block::TransactionList,
         consensus_message::ConsensusMessage,
@@ -38,7 +38,7 @@ use monad_wal::PersistenceLogger;
 
 const N_VALIDATORS: usize = 400;
 
-type BenchEvent = MonadEvent<SecpSignature, AggregateSignatures<SecpSignature>>;
+type BenchEvent = MonadEvent<SecpSignature, MultiSig<SecpSignature>>;
 struct MonadEventBencher {
     event: BenchEvent,
     logger: WALogger<BenchEvent>,
@@ -145,7 +145,7 @@ fn bench_timeout(c: &mut Criterion) {
 
     let qcinfo_hash = Sha256Hash::hash_object(&qcinfo.ledger_commit);
 
-    let mut aggsig = AggregateSignatures::new();
+    let mut aggsig = MultiSig::new();
     for keypair in keypairs.iter() {
         aggsig.add_signature(keypair.sign(qcinfo_hash.as_ref()));
     }
@@ -202,7 +202,7 @@ fn bench_timeout(c: &mut Criterion) {
 }
 
 fn bench_local_timeout(c: &mut Criterion) {
-    let event: MonadEvent<SecpSignature, AggregateSignatures<SecpSignature>> =
+    let event: MonadEvent<SecpSignature, MultiSig<SecpSignature>> =
         MonadEvent::ConsensusEvent(ConsensusEvent::Timeout(PacemakerTimerExpire {}));
 
     let mut bencher = MonadEventBencher::new(event);


### PR DESCRIPTION
The AggregateSignature\<S\> struct is a vector of a signature rather than a constant size aggregate signature. It should be named MultiSig. The renaming prevents confusion with bls aggregate signature.