### PR TITLE
Fetch txs from mempool and validate on proposal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4632,6 +4632,7 @@ dependencies = [
  "monad-p2p",
  "monad-state",
  "monad-testutil",
+ "monad-types",
  "monad-wal",
  "tempfile",
  "tokio",
@@ -4642,6 +4643,7 @@ name = "monad-executor"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "monad-consensus-types",
  "monad-crypto",
  "monad-proto",
  "monad-testutil",
@@ -4768,6 +4770,7 @@ dependencies = [
  "futures",
  "libp2p",
  "monad-consensus",
+ "monad-consensus-types",
  "monad-crypto",
  "monad-executor",
  "monad-types",

--- a/monad-consensus-types/src/convert/mod.rs
+++ b/monad-consensus-types/src/convert/mod.rs
@@ -3,4 +3,5 @@ pub mod ledger;
 pub mod quorum_certificate;
 pub mod signing;
 pub mod timeout;
+pub mod transaction;
 pub mod voting;

--- a/monad-consensus-types/src/convert/transaction.rs
+++ b/monad-consensus-types/src/convert/transaction.rs
@@ -1,0 +1,83 @@
+use monad_proto::{
+    error::ProtoError,
+    proto::transaction::{
+        proto_transaction_collection::Txns, ProtoEthereumTransactions, ProtoMockTransactions,
+        ProtoTransactionCollection,
+    },
+};
+
+use crate::transaction::{EthereumTransactions, MockTransactions};
+
+impl From<MockTransactions> for ProtoMockTransactions {
+    fn from(_: MockTransactions) -> Self {
+        ProtoMockTransactions {}
+    }
+}
+
+impl From<MockTransactions> for ProtoTransactionCollection {
+    fn from(value: MockTransactions) -> Self {
+        Self {
+            txns: Some(Txns::MockTxns(value.into())),
+        }
+    }
+}
+
+impl From<ProtoMockTransactions> for MockTransactions {
+    fn from(_: ProtoMockTransactions) -> Self {
+        Self {}
+    }
+}
+
+impl TryFrom<ProtoTransactionCollection> for MockTransactions {
+    type Error = ProtoError;
+
+    fn try_from(value: ProtoTransactionCollection) -> Result<Self, Self::Error> {
+        let txns = value.txns.ok_or(Self::Error::MissingRequiredField(
+            "ProtoTransactionCollection.txns".to_owned(),
+        ))?;
+
+        match txns {
+            Txns::MockTxns(txns) => Ok(txns.into()),
+            _ => Err(Self::Error::MissingRequiredField(
+                "ProtoTransactionCollection.txns.mock_txns".to_owned(),
+            )),
+        }
+    }
+}
+
+impl From<EthereumTransactions> for ProtoEthereumTransactions {
+    fn from(_value: EthereumTransactions) -> Self {
+        Self {}
+    }
+}
+
+impl From<EthereumTransactions> for ProtoTransactionCollection {
+    fn from(value: EthereumTransactions) -> Self {
+        Self {
+            txns: Some(Txns::EthTxns(value.into())),
+        }
+    }
+}
+
+impl From<ProtoEthereumTransactions> for EthereumTransactions {
+    fn from(_: ProtoEthereumTransactions) -> Self {
+        Self {}
+    }
+}
+
+impl TryFrom<ProtoTransactionCollection> for EthereumTransactions {
+    type Error = ProtoError;
+
+    fn try_from(value: ProtoTransactionCollection) -> Result<Self, Self::Error> {
+        let txns = value.txns.ok_or(Self::Error::MissingRequiredField(
+            "ProtoTransactionCollection.txns".to_owned(),
+        ))?;
+
+        match txns {
+            Txns::EthTxns(txns) => Ok(txns.into()),
+            _ => Err(Self::Error::MissingRequiredField(
+                "ProtoTransactionCollection.txns.eth_txns".to_owned(),
+            )),
+        }
+    }
+}

--- a/monad-consensus-types/src/lib.rs
+++ b/monad-consensus-types/src/lib.rs
@@ -7,5 +7,6 @@ pub mod multi_sig;
 pub mod quorum_certificate;
 pub mod signature;
 pub mod timeout;
+pub mod transaction;
 pub mod validation;
 pub mod voting;

--- a/monad-consensus-types/src/mod.rs
+++ b/monad-consensus-types/src/mod.rs
@@ -1,8 +1,0 @@
-pub mod block;
-pub mod consensus_message;
-pub mod ledger;
-pub mod message;
-pub mod quorum_certificate;
-pub mod signature;
-pub mod timeout;
-pub mod voting;

--- a/monad-consensus-types/src/transaction.rs
+++ b/monad-consensus-types/src/transaction.rs
@@ -1,0 +1,36 @@
+use core::fmt::Debug;
+
+use monad_proto::{error::ProtoError, proto::transaction::ProtoTransactionCollection};
+
+pub trait TransactionCollection:
+    Copy
+    + Clone
+    + Eq
+    + Default
+    + Send
+    + Sync
+    + std::fmt::Debug
+    + Into<ProtoTransactionCollection>
+    + TryFrom<ProtoTransactionCollection, Error = ProtoError>
+    + 'static
+{
+    fn validate(self) -> bool;
+}
+
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
+pub struct MockTransactions;
+
+impl TransactionCollection for MockTransactions {
+    fn validate(self) -> bool {
+        true
+    }
+}
+
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
+pub struct EthereumTransactions;
+
+impl TransactionCollection for EthereumTransactions {
+    fn validate(self) -> bool {
+        unimplemented!()
+    }
+}

--- a/monad-driver/Cargo.toml
+++ b/monad-driver/Cargo.toml
@@ -10,6 +10,7 @@ monad-crypto = { path = "../monad-crypto", features = ["libp2p-identity"] }
 monad-executor = { path = "../monad-executor", features = ["tokio"] }
 monad-p2p = { path = "../monad-p2p", features = ["tokio"] }
 monad-state = { path = "../monad-state", features = ["proto"] }
+monad-types = { path = "../monad-types" }
 
 futures = { workspace = true }
 libp2p = { workspace = true }

--- a/monad-driver/src/lib.rs
+++ b/monad-driver/src/lib.rs
@@ -4,7 +4,8 @@ mod tests {
 
     use futures::StreamExt;
     use monad_consensus_types::{
-        multi_sig::MultiSig, quorum_certificate::genesis_vote_info, validation::Sha256Hash,
+        multi_sig::MultiSig, quorum_certificate::genesis_vote_info, transaction::MockTransactions,
+        validation::Sha256Hash,
     };
     use monad_crypto::secp256k1::{KeyPair, SecpSignature};
     use monad_executor::{
@@ -21,7 +22,8 @@ mod tests {
 
     type SignatureType = SecpSignature;
     type SignatureCollectionType = MultiSig<SignatureType>;
-    type S = MonadState<SignatureType, SignatureCollectionType>;
+    type TransactionCollectionType = MockTransactions;
+    type S = MonadState<SignatureType, SignatureCollectionType, TransactionCollectionType>;
     type PersistenceLoggerType = MockWALogger<<S as State>::Event>;
 
     #[tokio::test]

--- a/monad-executor/Cargo.toml
+++ b/monad-executor/Cargo.toml
@@ -12,9 +12,10 @@ bench = false
 
 [dependencies]
 monad-crypto = { path = "../monad-crypto" }
+monad-consensus-types = { path = "../monad-consensus-types" }
 monad-proto = { path = "../monad-proto", optional = true }
+monad-types = { path = "../monad-types" }
 monad-wal = { path = "../monad-wal" }
-monad-types = { path = "../monad-types"  }
 
 futures = { workspace = true }
 rand = { workspace = true }
@@ -24,7 +25,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 monad-testutil = { path = "../monad-testutil" }
-
 
 tokio = { workspace = true, features = ["macros", "rt"] }
 

--- a/monad-executor/src/lib.rs
+++ b/monad-executor/src/lib.rs
@@ -13,8 +13,9 @@ pub mod convert;
 
 // driver loop
 async fn run<S: State>(
-    mut executor: impl Executor<Command = Command<S::Message, S::OutboundMessage, S::Block>>
-        + Stream<Item = S::Event>
+    mut executor: impl Executor<
+            Command = Command<S::Message, S::OutboundMessage, S::Block, S::TransactionCollection>,
+        > + Stream<Item = S::Event>
         + Unpin,
     config: S::Config,
     init_events: Vec<S::Event>,

--- a/monad-executor/src/replay_nodes.rs
+++ b/monad-executor/src/replay_nodes.rs
@@ -90,7 +90,12 @@ where
         node_id: &PeerId,
         tick: Duration,
         cmds: Vec<
-            Command<<S as State>::Message, <S as State>::OutboundMessage, <S as State>::Block>,
+            Command<
+                <S as State>::Message,
+                <S as State>::OutboundMessage,
+                <S as State>::Block,
+                <S as State>::TransactionCollection,
+            >,
         >,
     ) {
         let mut to_publish = Vec::new();
@@ -142,7 +147,9 @@ where
                 msg_queue.push(PendingMsg {
                     send_id: *node_id,
                     send_tick: tick,
-                    event: message.clone().event(*node_id),
+                    event: message
+                        .clone()
+                        .event::<<S as State>::TransactionCollection>(*node_id),
                     message: message.clone(),
                 });
             }

--- a/monad-mempool-types/build.rs
+++ b/monad-mempool-types/build.rs
@@ -3,5 +3,7 @@ extern crate protobuf_src;
 
 fn main() {
     std::env::set_var("PROTOC", protobuf_src::protoc());
-    prost_build::Config::new().compile_protos(&["proto/tx.proto"], &["proto/"]).unwrap();
+    prost_build::Config::new()
+        .compile_protos(&["proto/tx.proto"], &["proto/"])
+        .unwrap();
 }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -16,6 +16,7 @@ use monad_consensus_types::{
     multi_sig::MultiSig,
     quorum_certificate::{genesis_vote_info, QuorumCertificate},
     signature::SignatureCollection,
+    transaction::MockTransactions,
     validation::{Hasher, Sha256Hash},
     voting::VoteInfo,
 };
@@ -35,7 +36,9 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 type HasherType = Sha256Hash;
 type SignatureType = SecpSignature;
 type SignatureCollectionType = MultiSig<SignatureType>;
-type MonadState = monad_state::MonadState<SignatureType, SignatureCollectionType>;
+type TransactionCollectionType = MockTransactions;
+type MonadState =
+    monad_state::MonadState<SignatureType, SignatureCollectionType, TransactionCollectionType>;
 type MonadConfig = <MonadState as State>::Config;
 
 pub struct Config {

--- a/monad-p2p/Cargo.toml
+++ b/monad-p2p/Cargo.toml
@@ -10,6 +10,7 @@ bench = false
 
 [dependencies]
 monad-consensus = { path = "../monad-consensus" }
+monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto", features = ["libp2p-identity"] }
 monad-executor = { path = "../monad-executor" }
 monad-types = { path = "../monad-types" }

--- a/monad-p2p/src/behavior/codec.rs
+++ b/monad-p2p/src/behavior/codec.rs
@@ -1,6 +1,7 @@
 use std::{io::ErrorKind, marker::PhantomData, sync::Arc};
 
 use async_trait::async_trait;
+use monad_consensus_types::transaction::TransactionCollection;
 use monad_executor::{Message, PeerId};
 use monad_types::{Deserializable, Serializable};
 
@@ -43,7 +44,7 @@ where
         }
     }
 
-    pub fn event(self, peer_id: PeerId) -> M::Event {
+    pub fn event<TC: TransactionCollection>(self, peer_id: PeerId) -> M::Event<TC> {
         match self {
             WrappedMessage::Receive(m) => m.event(peer_id),
             WrappedMessage::Send(om) => om.into().event(peer_id),

--- a/monad-proto/build.rs
+++ b/monad-proto/build.rs
@@ -15,6 +15,7 @@ fn main() {
                 "proto/quorum_certificate.proto",
                 "proto/signing.proto",
                 "proto/timeout.proto",
+                "proto/transaction.proto",
                 "proto/voting.proto",
             ],
             &["proto/"],

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -9,6 +9,7 @@ import "pacemaker.proto";
 import "quorum_certificate.proto";
 import "signing.proto";
 import "timeout.proto";
+import "transaction.proto";
 
 message ProtoPeerId {
   monad_proto.basic.ProtoPubkey pubkey = 1;
@@ -31,11 +32,18 @@ message ProtoFetchedTxs {
   monad_proto.block.ProtoTransactionList txns = 5;
 }
 
+message ProtoFetchedFullTxs {
+  monad_proto.basic.ProtoNodeId author = 1;
+  monad_proto.message.ProtoProposalMessageAggSig p = 2;
+  monad_proto.transaction.ProtoTransactionCollection txns = 3;
+}
+
 message ProtoConsensusEvent {
   oneof event {
     ProtoMessageWithSender message = 1;
     monad_proto.pacemaker.ProtoPacemakerTimerExpire timeout = 2;
     ProtoFetchedTxs fetched_txs = 3;
+    ProtoFetchedFullTxs fetched_full_txs = 4;
   }
 }
 

--- a/monad-proto/proto/transaction.proto
+++ b/monad-proto/proto/transaction.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package monad_proto.transaction;
+
+message ProtoTransactionCollection {
+    oneof txns {
+        ProtoEthereumTransactions eth_txns = 1;
+        ProtoMockTransactions mock_txns = 2;
+    }
+}
+
+message ProtoEthereumTransactions {
+
+}
+
+message ProtoMockTransactions {
+
+}

--- a/monad-proto/src/lib.rs
+++ b/monad-proto/src/lib.rs
@@ -21,6 +21,7 @@ pub mod proto {
     include_proto!(quorum_certificate);
     include_proto!(block);
     include_proto!(message);
+    include_proto!(transaction);
     include_proto!(event);
     include_proto!(pacemaker);
 }

--- a/monad-state/src/convert/event.rs
+++ b/monad-state/src/convert/event.rs
@@ -1,19 +1,21 @@
 use monad_consensus::pacemaker::PacemakerTimerExpire;
 use monad_consensus_types::multi_sig::MultiSig;
+use monad_consensus_types::transaction::TransactionCollection;
 use monad_crypto::Signature;
 use monad_proto::error::ProtoError;
 use monad_proto::proto::event::*;
 use monad_proto::proto::pacemaker::ProtoPacemakerTimerExpire;
 
 use crate::ConsensusEvent as TypeConsensusEvent;
+use crate::FetchedFullTxs;
 use crate::FetchedTxs;
 use crate::MonadEvent as TypeMonadEvent;
 
-pub(super) type MonadEvent<S> = TypeMonadEvent<S, MultiSig<S>>;
-pub(super) type ConsensusEvent<S> = TypeConsensusEvent<S, MultiSig<S>>;
+pub(super) type MonadEvent<S, T> = TypeMonadEvent<S, MultiSig<S>, T>;
+pub(super) type ConsensusEvent<S, T> = TypeConsensusEvent<S, MultiSig<S>, T>;
 
-impl<S: Signature> From<&ConsensusEvent<S>> for ProtoConsensusEvent {
-    fn from(value: &ConsensusEvent<S>) -> Self {
+impl<S: Signature, T: TransactionCollection> From<&ConsensusEvent<S, T>> for ProtoConsensusEvent {
+    fn from(value: &ConsensusEvent<S, T>) -> Self {
         let event = match value {
             TypeConsensusEvent::Message {
                 sender,
@@ -35,12 +37,19 @@ impl<S: Signature> From<&ConsensusEvent<S>> for ProtoConsensusEvent {
                     txns: Some((&fetched.txns).into()),
                 })
             }
+            TypeConsensusEvent::FetchedFullTxs(fetched_full) => {
+                proto_consensus_event::Event::FetchedFullTxs(ProtoFetchedFullTxs {
+                    author: Some((&fetched_full.author).into()),
+                    p: Some((&fetched_full.p).into()),
+                    txns: Some(fetched_full.txns.into()),
+                })
+            }
         };
         Self { event: Some(event) }
     }
 }
 
-impl<S: Signature> TryFrom<ProtoConsensusEvent> for ConsensusEvent<S> {
+impl<S: Signature, T: TransactionCollection> TryFrom<ProtoConsensusEvent> for ConsensusEvent<S, T> {
     type Error = ProtoError;
 
     fn try_from(value: ProtoConsensusEvent) -> Result<Self, Self::Error> {
@@ -94,6 +103,28 @@ impl<S: Signature> TryFrom<ProtoConsensusEvent> for ConsensusEvent<S> {
                         .try_into()?,
                 })
             }
+            Some(proto_consensus_event::Event::FetchedFullTxs(fetched_full_txs)) => {
+                ConsensusEvent::FetchedFullTxs(FetchedFullTxs {
+                    author: fetched_full_txs
+                        .author
+                        .ok_or(ProtoError::MissingRequiredField(
+                            "ConsensusEvent::fetched_full_txs.author".to_owned(),
+                        ))?
+                        .try_into()?,
+                    p: fetched_full_txs
+                        .p
+                        .ok_or(ProtoError::MissingRequiredField(
+                            "ConsensusEvent::fetched_full_txs.p".to_owned(),
+                        ))?
+                        .try_into()?,
+                    txns: fetched_full_txs
+                        .txns
+                        .ok_or(ProtoError::MissingRequiredField(
+                            "ConsensusEvent::fetched_full_txs.txns".to_owned(),
+                        ))?
+                        .try_into()?,
+                })
+            }
             None => Err(ProtoError::MissingRequiredField(
                 "ConsensusEvent.event".to_owned(),
             ))?,
@@ -102,8 +133,8 @@ impl<S: Signature> TryFrom<ProtoConsensusEvent> for ConsensusEvent<S> {
     }
 }
 
-impl<S: Signature> From<&MonadEvent<S>> for ProtoMonadEvent {
-    fn from(value: &MonadEvent<S>) -> Self {
+impl<S: Signature, T: TransactionCollection> From<&MonadEvent<S, T>> for ProtoMonadEvent {
+    fn from(value: &MonadEvent<S, T>) -> Self {
         let event = match value {
             TypeMonadEvent::ConsensusEvent(msg) => {
                 proto_monad_event::Event::ConsensusEvent(msg.into())
@@ -113,10 +144,10 @@ impl<S: Signature> From<&MonadEvent<S>> for ProtoMonadEvent {
     }
 }
 
-impl<S: Signature> TryFrom<ProtoMonadEvent> for MonadEvent<S> {
+impl<S: Signature, T: TransactionCollection> TryFrom<ProtoMonadEvent> for MonadEvent<S, T> {
     type Error = ProtoError;
     fn try_from(value: ProtoMonadEvent) -> Result<Self, Self::Error> {
-        let event: MonadEvent<S> = match value.event {
+        let event: MonadEvent<S, T> = match value.event {
             Some(proto_monad_event::Event::ConsensusEvent(event)) => {
                 MonadEvent::ConsensusEvent(event.try_into()?)
             }

--- a/monad-state/src/convert/interface.rs
+++ b/monad-state/src/convert/interface.rs
@@ -1,14 +1,17 @@
 use super::event::MonadEvent;
+use monad_consensus_types::transaction::TransactionCollection;
 use monad_crypto::Signature;
 use monad_proto::{error::ProtoError, proto::event::ProtoMonadEvent};
 use prost::Message;
 
-pub fn serialize_event(event: &MonadEvent<impl Signature>) -> Vec<u8> {
+pub fn serialize_event(event: &MonadEvent<impl Signature, impl TransactionCollection>) -> Vec<u8> {
     let proto_event: ProtoMonadEvent = event.into();
     proto_event.encode_to_vec()
 }
 
-pub fn deserialize_event<S: Signature>(data: &[u8]) -> Result<MonadEvent<S>, ProtoError> {
+pub fn deserialize_event<S: Signature, T: TransactionCollection>(
+    data: &[u8],
+) -> Result<MonadEvent<S, T>, ProtoError> {
     let event = ProtoMonadEvent::decode(data)?;
     event.try_into()
 }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::marker::PhantomData;
 use std::time::Duration;
 
 use monad_blocktree::blocktree::BlockTree;
@@ -14,6 +15,7 @@ use monad_consensus_types::{
     quorum_certificate::{QuorumCertificate, Rank},
     signature::SignatureCollection,
     timeout::TimeoutCertificate,
+    transaction::{MockTransactions, TransactionCollection},
     validation::{Hasher, Sha256Hash},
     voting::VoteInfo,
 };
@@ -42,21 +44,23 @@ mod message;
 type LeaderElectionType = WeightedRoundRobin;
 type HasherType = Sha256Hash;
 
-pub struct MonadState<ST, SCT>
+pub struct MonadState<ST, SCT, TC>
 where
     ST: Signature,
     SCT: SignatureCollection<SignatureType = ST>,
+    TC: TransactionCollection,
 {
     message_state: MessageState<MonadMessage<ST, SCT>, VerifiedMonadMessage<ST, SCT>>,
 
-    consensus_state: ConsensusState<ST, SCT>,
+    consensus_state: ConsensusState<ST, SCT, TC>,
     validator_set: ValidatorSet<LeaderElectionType>,
 }
 
-impl<ST, SCT> MonadState<ST, SCT>
+impl<ST, SCT, TC> MonadState<ST, SCT, TC>
 where
     ST: Signature,
     SCT: SignatureCollection<SignatureType = ST>,
+    TC: TransactionCollection,
 {
     pub fn pubkey(&self) -> PubKey {
         self.consensus_state.nodeid.0
@@ -68,18 +72,20 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MonadEvent<ST, SCT>
+pub enum MonadEvent<ST, SCT, TC>
 where
     ST: Signature,
     SCT: SignatureCollection<SignatureType = ST>,
+    TC: TransactionCollection,
 {
-    ConsensusEvent(ConsensusEvent<ST, SCT>),
+    ConsensusEvent(ConsensusEvent<ST, SCT, TC>),
 }
 
 impl monad_types::Deserializable
     for MonadEvent<
         monad_crypto::NopSignature,
         monad_consensus_types::multi_sig::MultiSig<monad_crypto::NopSignature>,
+        MockTransactions,
     >
 {
     type ReadError = monad_proto::error::ProtoError;
@@ -93,6 +99,7 @@ impl monad_types::Serializable
     for MonadEvent<
         monad_crypto::NopSignature,
         monad_consensus_types::multi_sig::MultiSig<monad_crypto::NopSignature>,
+        MockTransactions,
     >
 {
     fn serialize(&self) -> Vec<u8> {
@@ -101,11 +108,14 @@ impl monad_types::Serializable
 }
 
 #[cfg(feature = "proto")]
-impl monad_types::Deserializable
+impl<T> monad_types::Deserializable
     for MonadEvent<
         monad_crypto::secp256k1::SecpSignature,
         monad_consensus_types::multi_sig::MultiSig<monad_crypto::secp256k1::SecpSignature>,
+        T,
     >
+where
+    T: TransactionCollection,
 {
     type ReadError = monad_proto::error::ProtoError;
 
@@ -115,11 +125,14 @@ impl monad_types::Deserializable
 }
 
 #[cfg(feature = "proto")]
-impl monad_types::Serializable
+impl<T> monad_types::Serializable
     for MonadEvent<
         monad_crypto::secp256k1::SecpSignature,
         monad_consensus_types::multi_sig::MultiSig<monad_crypto::secp256k1::SecpSignature>,
+        T,
     >
+where
+    T: TransactionCollection,
 {
     fn serialize(&self) -> Vec<u8> {
         crate::convert::interface::serialize_event(self)
@@ -173,14 +186,14 @@ where
     ST: Signature,
     SCT: SignatureCollection<SignatureType = ST>,
 {
-    type Event = MonadEvent<ST, SCT>;
+    type Event<TC: TransactionCollection> = MonadEvent<ST, SCT, TC>;
     type Id = ST;
 
     fn id(&self) -> Self::Id {
         *self.0.author_signature()
     }
 
-    fn event(self, from: PeerId) -> Self::Event {
+    fn event<TC: TransactionCollection>(self, from: PeerId) -> Self::Event<TC> {
         // MUST assert that output is valid and came from the `from` PeerId
         // `from` must somehow be guaranteed to be staked at this point so that subsequent
         // malformed stuff (that gets added to event log) can be slashed? TODO
@@ -202,22 +215,26 @@ pub struct MonadConfig<SCT> {
     pub genesis_signatures: SCT,
 }
 
-impl<ST, SCT> State for MonadState<ST, SCT>
+impl<ST, SCT, TC> State for MonadState<ST, SCT, TC>
 where
     ST: Signature,
     SCT: SignatureCollection<SignatureType = ST>,
+    TC: TransactionCollection,
 {
     type Config = MonadConfig<SCT>;
-    type Event = MonadEvent<ST, SCT>;
+    type Event = MonadEvent<ST, SCT, TC>;
     type Message = MonadMessage<ST, SCT>;
     type OutboundMessage = VerifiedMonadMessage<ST, SCT>;
     type Block = Block<SCT>;
+    type TransactionCollection = TC;
 
     fn init(
         config: Self::Config,
     ) -> (
         Self,
-        Vec<Command<Self::Message, Self::OutboundMessage, Self::Block>>,
+        Vec<
+            Command<Self::Message, Self::OutboundMessage, Self::Block, Self::TransactionCollection>,
+        >,
     ) {
         // create my keys and validator structs
         // FIXME stake should be configurable
@@ -236,7 +253,7 @@ where
             config.genesis_signatures,
         );
 
-        let mut monad_state: MonadState<ST, SCT> = Self {
+        let mut monad_state: MonadState<ST, SCT, TC> = Self {
             message_state: MessageState::new(
                 10,
                 validator_list
@@ -264,10 +281,11 @@ where
     fn update(
         &mut self,
         event: Self::Event,
-    ) -> Vec<Command<Self::Message, Self::OutboundMessage, Self::Block>> {
+    ) -> Vec<Command<Self::Message, Self::OutboundMessage, Self::Block, Self::TransactionCollection>>
+    {
         match event {
             MonadEvent::ConsensusEvent(consensus_event) => {
-                let consensus_commands: Vec<ConsensusCommand<ST, SCT>> = match consensus_event {
+                let consensus_commands: Vec<ConsensusCommand<ST, SCT, TC>> = match consensus_event {
                     ConsensusEvent::Timeout(pacemaker_expire) => self
                         .consensus_state
                         .pacemaker
@@ -303,6 +321,22 @@ where
                                 message: ConsensusMessage::Proposal(p),
                             })
                         }
+
+                        cmds
+                    }
+                    ConsensusEvent::FetchedFullTxs(fetched_txs) => {
+                        let mut cmds = vec![ConsensusCommand::FetchFullTxsReset];
+
+                        cmds.extend(
+                            self.consensus_state
+                                .handle_proposal_message_full::<HasherType, LeaderElectionType>(
+                                    fetched_txs.author,
+                                    fetched_txs.p,
+                                    fetched_txs.txns,
+                                    &mut self.validator_set,
+                                ),
+                        );
+
                         cmds
                     }
                     ConsensusEvent::Message {
@@ -319,11 +353,9 @@ where
                         match verified_message {
                             ConsensusMessage::Proposal(msg) => self
                                 .consensus_state
-                                .handle_proposal_message::<HasherType, _>(
-                                    author,
-                                    msg,
-                                    &mut self.validator_set,
-                                ),
+                                .handle_proposal_message::<HasherType, LeaderElectionType>(
+                                author, msg,
+                            ),
                             ConsensusMessage::Vote(msg) => self
                                 .consensus_state
                                 .handle_vote_message::<HasherType, LeaderElectionType>(
@@ -343,6 +375,7 @@ where
                         }
                     }
                 };
+
                 let mut cmds = Vec::new();
                 for consensus_command in consensus_commands {
                     match consensus_command {
@@ -377,6 +410,14 @@ where
                         ConsensusCommand::FetchTxsReset => {
                             cmds.push(Command::MempoolCommand(MempoolCommand::FetchReset))
                         }
+                        ConsensusCommand::FetchFullTxs(cb) => cmds.push(Command::MempoolCommand(
+                            MempoolCommand::FetchFullTxs(Box::new(|txs| {
+                                Self::Event::ConsensusEvent(ConsensusEvent::FetchedFullTxs(cb(txs)))
+                            })),
+                        )),
+                        ConsensusCommand::FetchFullTxsReset => {
+                            cmds.push(Command::MempoolCommand(MempoolCommand::FetchFullReset))
+                        }
                         ConsensusCommand::RequestSync { blockid: _ } => {
                             // TODO: respond with the Proposal matching the blockID.
                             //       right now, all 'missed' proposals are actually in-flight
@@ -394,7 +435,7 @@ where
 }
 
 #[derive(Clone, PartialEq, Eq)]
-pub enum ConsensusEvent<ST, SCT> {
+pub enum ConsensusEvent<ST, SCT, TC> {
     Message {
         sender: PubKey,
         unverified_message: Unverified<ST, ConsensusMessage<ST, SCT>>,
@@ -402,9 +443,10 @@ pub enum ConsensusEvent<ST, SCT> {
     Timeout(PacemakerTimerExpire),
 
     FetchedTxs(FetchedTxs<ST, SCT>),
+    FetchedFullTxs(FetchedFullTxs<ST, SCT, TC>),
 }
 
-impl<S: Debug, T: Debug> Debug for ConsensusEvent<S, T> {
+impl<S: Debug, SC: Debug, T: Debug> Debug for ConsensusEvent<S, SC, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ConsensusEvent::Message {
@@ -417,6 +459,12 @@ impl<S: Debug, T: Debug> Debug for ConsensusEvent<S, T> {
                 .finish(),
             ConsensusEvent::Timeout(p) => p.fmt(f),
             ConsensusEvent::FetchedTxs(p) => p.fmt(f),
+            ConsensusEvent::FetchedFullTxs(p) => f
+                .debug_struct("FetchedFullTxs")
+                .field("author", &p.author)
+                .field("proposal", &p.p)
+                .field("txns", &p.txns)
+                .finish(),
         }
     }
 }
@@ -433,7 +481,14 @@ pub struct FetchedTxs<ST, SCT> {
     txns: TransactionList,
 }
 
-pub enum ConsensusCommand<ST, SCT: SignatureCollection> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FetchedFullTxs<ST, SCT, TC> {
+    author: NodeId,
+    p: ProposalMessage<ST, SCT>,
+    txns: TC,
+}
+
+pub enum ConsensusCommand<ST, SCT: SignatureCollection, TC: TransactionCollection> {
     Publish {
         target: RouterTarget,
         message: ConsensusMessage<ST, SCT>,
@@ -445,6 +500,8 @@ pub enum ConsensusCommand<ST, SCT: SignatureCollection> {
     ScheduleReset,
     FetchTxs(Box<dyn (FnOnce(Vec<u8>) -> FetchedTxs<ST, SCT>) + Send + Sync>),
     FetchTxsReset,
+    FetchFullTxs(Box<dyn (FnOnce(TC) -> FetchedFullTxs<ST, SCT, TC>) + Send + Sync>),
+    FetchFullTxsReset,
     LedgerCommit(Block<SCT>),
     RequestSync {
         blockid: BlockId,
@@ -453,25 +510,28 @@ pub enum ConsensusCommand<ST, SCT: SignatureCollection> {
     // - to handle this command, we need to call message_state.set_round()
 }
 
-struct ConsensusState<S, T> {
-    pending_block_tree: BlockTree<T>,
-    vote_state: VoteState<T>,
-    high_qc: QuorumCertificate<T>,
+struct ConsensusState<S, SC, T> {
+    pending_block_tree: BlockTree<SC>,
+    vote_state: VoteState<SC>,
+    high_qc: QuorumCertificate<SC>,
 
-    pacemaker: Pacemaker<S, T>,
+    pacemaker: Pacemaker<S, SC>,
     safety: Safety,
 
+    transaction_type: PhantomData<T>,
     nodeid: NodeId,
 
     // TODO deprecate
     keypair: KeyPair,
 }
 
-struct ConsensusStateWrapper<S: Signature, T: SignatureCollection> {
-    consensus_state: ConsensusState<S, T>,
+struct ConsensusStateWrapper<S: Signature, SC: SignatureCollection, T: TransactionCollection> {
+    consensus_state: ConsensusState<S, SC, T>,
 }
 
-impl<S: Signature, T: SignatureCollection> std::fmt::Debug for ConsensusStateWrapper<S, T> {
+impl<S: Signature, SC: SignatureCollection, T: TransactionCollection> std::fmt::Debug
+    for ConsensusStateWrapper<S, SC, T>
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ConsensusState")
             .field(
@@ -487,15 +547,16 @@ impl<S: Signature, T: SignatureCollection> std::fmt::Debug for ConsensusStateWra
     }
 }
 
-impl<S, T> ConsensusState<S, T>
+impl<S, SC, T> ConsensusState<S, SC, T>
 where
     S: Signature,
-    T: SignatureCollection,
+    SC: SignatureCollection,
+    T: TransactionCollection,
 {
     pub fn new(
         my_pubkey: PubKey,
-        genesis_block: Block<T>,
-        genesis_qc: QuorumCertificate<T>,
+        genesis_block: Block<SC>,
+        genesis_qc: QuorumCertificate<SC>,
         delta: Duration,
 
         // TODO deprecate
@@ -507,6 +568,7 @@ where
             high_qc: genesis_qc,
             pacemaker: Pacemaker::new(delta, Round(1), None),
             safety: Safety::default(),
+            transaction_type: PhantomData,
             nodeid: NodeId(my_pubkey),
 
             keypair,
@@ -516,10 +578,25 @@ where
     fn handle_proposal_message<H: Hasher, V: LeaderElection>(
         &mut self,
         author: NodeId,
-        p: ProposalMessage<S, T>,
+        p: ProposalMessage<S, SC>,
+    ) -> Vec<ConsensusCommand<S, SC, T>> {
+        vec![ConsensusCommand::FetchFullTxs(Box::new(move |txns| {
+            FetchedFullTxs { author, p, txns }
+        }))]
+    }
+
+    fn handle_proposal_message_full<H: Hasher, V: LeaderElection>(
+        &mut self,
+        author: NodeId,
+        p: ProposalMessage<S, SC>,
+        txns: T,
         validators: &mut ValidatorSet<V>,
-    ) -> Vec<ConsensusCommand<S, T>> {
-        let mut cmds = Vec::new();
+    ) -> Vec<ConsensusCommand<S, SC, T>> {
+        let mut cmds = vec![];
+
+        if !txns.validate() {
+            return cmds;
+        }
 
         let process_certificate_cmds = self.process_certificate_qc(&p.block.qc);
         cmds.extend(process_certificate_cmds);
@@ -550,7 +627,9 @@ where
             return cmds;
         }
 
-        let vote_msg = self.safety.make_vote::<S, T, H>(&p.block, &p.last_round_tc);
+        let vote_msg = self
+            .safety
+            .make_vote::<S, SC, H>(&p.block, &p.last_round_tc);
 
         if let Some(v) = vote_msg {
             let next_leader = validators.get_leader(round + Round(1));
@@ -567,15 +646,15 @@ where
     fn handle_vote_message<H: Hasher, V: LeaderElection>(
         &mut self,
         author: NodeId,
-        signature: T::SignatureType,
+        signature: SC::SignatureType,
         v: VoteMessage,
         validators: &mut ValidatorSet<V>,
-    ) -> Vec<ConsensusCommand<S, T>> {
+    ) -> Vec<ConsensusCommand<S, SC, T>> {
         if v.vote_info.round < self.pacemaker.get_current_round() {
             return Default::default();
         }
 
-        let qc: Option<QuorumCertificate<T>> = self
+        let qc: Option<QuorumCertificate<SC>> = self
             .vote_state
             .process_vote::<V, H>(&author, &signature, &v, validators);
 
@@ -594,9 +673,9 @@ where
         &mut self,
         author: NodeId,
         signature: S,
-        tm: TimeoutMessage<S, T>,
+        tm: TimeoutMessage<S, SC>,
         validators: &mut ValidatorSet<V>,
-    ) -> Vec<ConsensusCommand<S, T>> {
+    ) -> Vec<ConsensusCommand<S, SC, T>> {
         let mut cmds = Vec::new();
         if tm.tminfo.round < self.pacemaker.get_current_round() {
             return cmds;
@@ -643,7 +722,7 @@ where
     // block tree
     // Update our highest seen qc (high_qc) if the incoming qc is of higher rank
     #[must_use]
-    fn process_qc(&mut self, qc: &QuorumCertificate<T>) -> Vec<ConsensusCommand<S, T>> {
+    fn process_qc(&mut self, qc: &QuorumCertificate<SC>) -> Vec<ConsensusCommand<S, SC, T>> {
         if Rank(qc.info) <= Rank(self.high_qc.info) {
             return Vec::new();
         }
@@ -664,7 +743,7 @@ where
                 cmds.extend(
                     blocks_to_commit
                         .into_iter()
-                        .map(ConsensusCommand::<S, T>::LedgerCommit),
+                        .map(ConsensusCommand::<S, SC, T>::LedgerCommit),
                 );
             }
         }
@@ -673,7 +752,10 @@ where
 
     // TODO consider changing return type to Option<T>
     #[must_use]
-    fn process_certificate_qc(&mut self, qc: &QuorumCertificate<T>) -> Vec<ConsensusCommand<S, T>> {
+    fn process_certificate_qc(
+        &mut self,
+        qc: &QuorumCertificate<SC>,
+    ) -> Vec<ConsensusCommand<S, SC, T>> {
         let mut cmds = Vec::new();
         cmds.extend(self.process_qc(qc));
 
@@ -691,7 +773,7 @@ where
     fn process_new_round_event(
         &mut self,
         last_round_tc: Option<TimeoutCertificate<S>>,
-    ) -> Vec<ConsensusCommand<S, T>> {
+    ) -> Vec<ConsensusCommand<S, SC, T>> {
         self.vote_state
             .start_new_round(self.pacemaker.get_current_round());
 
@@ -711,14 +793,18 @@ where
     }
 }
 
-impl<S: Signature, T: SignatureCollection> Drop for ConsensusStateWrapper<S, T> {
+impl<S: Signature, SC: SignatureCollection, T: TransactionCollection> Drop
+    for ConsensusStateWrapper<S, SC, T>
+{
     fn drop(&mut self) {
         eprintln!("{:?}", self);
     }
 }
 
-impl<S: Signature, T: SignatureCollection> From<PacemakerCommand<S, T>> for ConsensusCommand<S, T> {
-    fn from(cmd: PacemakerCommand<S, T>) -> Self {
+impl<S: Signature, SC: SignatureCollection, T: TransactionCollection> From<PacemakerCommand<S, SC>>
+    for ConsensusCommand<S, SC, T>
+{
+    fn from(cmd: PacemakerCommand<S, SC>) -> Self {
         match cmd {
             PacemakerCommand::Broadcast(message) => ConsensusCommand::Publish {
                 target: RouterTarget::Broadcast,
@@ -750,6 +836,7 @@ mod test {
     use monad_consensus_types::quorum_certificate::{genesis_vote_info, QuorumCertificate};
     use monad_consensus_types::signature::SignatureCollection;
     use monad_consensus_types::timeout::TimeoutInfo;
+    use monad_consensus_types::transaction::MockTransactions;
     use monad_consensus_types::validation::Sha256Hash;
     use monad_consensus_types::voting::VoteInfo;
     use monad_crypto::secp256k1::KeyPair;
@@ -760,14 +847,21 @@ mod test {
     use monad_types::{BlockId, Hash, NodeId, Round, Stake};
     use monad_validator::{validator_set::ValidatorSet, weighted_round_robin::WeightedRoundRobin};
 
-    use crate::{ConsensusCommand, ConsensusMessage, ConsensusState};
+    use crate::{
+        ConsensusCommand, ConsensusMessage, ConsensusState, LeaderElectionType,
+        TransactionCollection,
+    };
 
-    fn setup<ST: Signature, SCT: SignatureCollection<SignatureType = ST>>(
+    fn setup<
+        ST: Signature,
+        SCT: SignatureCollection<SignatureType = ST>,
+        TC: TransactionCollection,
+    >(
         num_states: u32,
     ) -> (
         Vec<KeyPair>,
         ValidatorSet<WeightedRoundRobin>,
-        Vec<ConsensusState<ST, SCT>>,
+        Vec<ConsensusState<ST, SCT, TC>>,
     ) {
         let keys = create_keys(num_states);
         let pubkeys = keys.iter().map(KeyPair::pubkey).collect::<Vec<_>>();
@@ -792,7 +886,7 @@ mod test {
             .enumerate()
             .map(|(i, k)| {
                 let default_key = KeyPair::from_bytes([127; 32]).unwrap();
-                ConsensusState::<ST, SCT>::new(
+                ConsensusState::<ST, SCT, TC>::new(
                     k.pubkey(),
                     genesis_block.clone(),
                     genesis_qc.clone(),
@@ -808,7 +902,8 @@ mod test {
     // 2f+1 votes for a VoteInfo leads to a QC locking -- ie, high_qc is set to that QC.
     #[test]
     fn lock_qc_high() {
-        let (keys, mut valset, mut states) = setup::<NopSignature, MultiSig<NopSignature>>(4);
+        let (keys, mut valset, mut states) =
+            setup::<NopSignature, MultiSig<NopSignature>, MockTransactions>(4);
 
         let state = &mut states[0];
         assert_eq!(state.high_qc.info.vote.round, Round(0));
@@ -858,7 +953,8 @@ mod test {
     // When a node locally timesout on a round, it no longer produces votes in that round
     #[test]
     fn timeout_stops_voting() {
-        let (keys, mut valset, mut states) = setup::<NopSignature, MultiSig<NopSignature>>(4);
+        let (keys, mut valset, mut states) =
+            setup::<NopSignature, MultiSig<NopSignature>, MockTransactions>(4);
         let state = &mut states[0];
         let mut propgen = ProposalGen::new(state.high_qc.clone());
         let p1 = propgen.next_proposal(&keys, &mut valset, &Default::default());
@@ -873,8 +969,8 @@ mod test {
         // check no vote commands result from receiving the proposal for round 1
 
         let (author, _, verified_message) = p1.destructure();
-        let cmds =
-            state.handle_proposal_message::<Sha256Hash, _>(author, verified_message, &mut valset);
+        let cmds = state
+            .handle_proposal_message::<Sha256Hash, LeaderElectionType>(author, verified_message);
         let result = cmds.iter().find(|&c| {
             matches!(
                 c,
@@ -890,15 +986,20 @@ mod test {
 
     #[test]
     fn enter_proposalmsg_round() {
-        let (keys, mut valset, mut states) = setup::<NopSignature, MultiSig<NopSignature>>(4);
+        let (keys, mut valset, mut states) =
+            setup::<NopSignature, MultiSig<NopSignature>, MockTransactions>(4);
 
         let state = &mut states[0];
         let mut propgen = ProposalGen::new(state.high_qc.clone());
 
         let p1 = propgen.next_proposal(&keys, &mut valset, &Default::default());
         let (author, _, verified_message) = p1.destructure();
-        let cmds =
-            state.handle_proposal_message::<Sha256Hash, _>(author, verified_message, &mut valset);
+        let cmds = state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
+            author,
+            verified_message,
+            MockTransactions::default(),
+            &mut valset,
+        );
         let result = cmds.iter().find(|&c| {
             matches!(
                 c,
@@ -914,8 +1015,12 @@ mod test {
 
         let p2 = propgen.next_proposal(&keys, &mut valset, &Default::default());
         let (author, _, verified_message) = p2.destructure();
-        let cmds =
-            state.handle_proposal_message::<Sha256Hash, _>(author, verified_message, &mut valset);
+        let cmds = state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
+            author,
+            verified_message,
+            MockTransactions::default(),
+            &mut valset,
+        );
         let result = cmds.iter().find(|&c| {
             matches!(
                 c,
@@ -934,14 +1039,20 @@ mod test {
         }
         let p7 = propgen.next_proposal(&keys, &mut valset, &Default::default());
         let (author, _, verified_message) = p7.destructure();
-        state.handle_proposal_message::<Sha256Hash, _>(author, verified_message, &mut valset);
+        state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
+            author,
+            verified_message,
+            MockTransactions::default(),
+            &mut valset,
+        );
 
         assert_eq!(state.pacemaker.get_current_round(), Round(7));
     }
 
     #[test]
     fn old_qc_in_timeout_message() {
-        let (keys, mut valset, mut states) = setup::<NopSignature, MultiSig<NopSignature>>(4);
+        let (keys, mut valset, mut states) =
+            setup::<NopSignature, MultiSig<NopSignature>, MockTransactions>(4);
         let state = &mut states[0];
         let mut propgen = ProposalGen::new(state.high_qc.clone());
 
@@ -950,9 +1061,10 @@ mod test {
         for i in 1..5 {
             let p = propgen.next_proposal(&keys, &mut valset, &Default::default());
             let (author, _, verified_message) = p.clone().destructure();
-            let cmds = state.handle_proposal_message::<Sha256Hash, _>(
+            let cmds = state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
                 author,
                 verified_message,
+                MockTransactions::default(),
                 &mut valset,
             );
             let result = cmds.iter().find(|&c| {
@@ -988,14 +1100,19 @@ mod test {
 
     #[test]
     fn duplicate_proposals() {
-        let (keys, mut valset, mut states) = setup::<NopSignature, MultiSig<NopSignature>>(4);
+        let (keys, mut valset, mut states) =
+            setup::<NopSignature, MultiSig<NopSignature>, MockTransactions>(4);
         let state = &mut states[0];
         let mut propgen = ProposalGen::new(state.high_qc.clone());
 
         let p1 = propgen.next_proposal(&keys, &mut valset, &Default::default());
         let (author, _, verified_message) = p1.clone().destructure();
-        let cmds =
-            state.handle_proposal_message::<Sha256Hash, _>(author, verified_message, &mut valset);
+        let cmds = state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
+            author,
+            verified_message,
+            MockTransactions::default(),
+            &mut valset,
+        );
         let result = cmds.iter().find(|&c| {
             matches!(
                 c,
@@ -1009,8 +1126,12 @@ mod test {
 
         // send duplicate of p1, expect it to be ignored and no output commands
         let (author, _, verified_message) = p1.destructure();
-        let cmds =
-            state.handle_proposal_message::<Sha256Hash, _>(author, verified_message, &mut valset);
+        let cmds = state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
+            author,
+            verified_message,
+            MockTransactions::default(),
+            &mut valset,
+        );
         assert!(cmds.is_empty());
     }
 
@@ -1024,15 +1145,20 @@ mod test {
     }
 
     fn out_of_order_proposals(perms: Vec<usize>) {
-        let (keys, mut valset, mut states) = setup::<NopSignature, MultiSig<NopSignature>>(4);
+        let (keys, mut valset, mut states) =
+            setup::<NopSignature, MultiSig<NopSignature>, MockTransactions>(4);
         let state = &mut states[0];
         let mut propgen = ProposalGen::new(state.high_qc.clone());
 
         // first proposal
         let p1 = propgen.next_proposal(&keys, &mut valset, &Default::default());
         let (author, _, verified_message) = p1.destructure();
-        let cmds =
-            state.handle_proposal_message::<Sha256Hash, _>(author, verified_message, &mut valset);
+        let cmds = state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
+            author,
+            verified_message,
+            MockTransactions::default(),
+            &mut valset,
+        );
         let result = cmds.iter().find(|&c| {
             matches!(
                 c,
@@ -1049,8 +1175,12 @@ mod test {
         // second proposal
         let p2 = propgen.next_proposal(&keys, &mut valset, &Default::default());
         let (author, _, verified_message) = p2.destructure();
-        let cmds =
-            state.handle_proposal_message::<Sha256Hash, _>(author, verified_message, &mut valset);
+        let cmds = state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
+            author,
+            verified_message,
+            MockTransactions::default(),
+            &mut valset,
+        );
         let result = cmds.iter().find(|&c| {
             matches!(
                 c,
@@ -1072,7 +1202,12 @@ mod test {
         // last proposal arrvies
         let p_fut = propgen.next_proposal(&keys, &mut valset, &Default::default());
         let (author, _, verified_message) = p_fut.destructure();
-        state.handle_proposal_message::<Sha256Hash, _>(author, verified_message, &mut valset);
+        state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
+            author,
+            verified_message,
+            MockTransactions::default(),
+            &mut valset,
+        );
 
         // confirm the size of the pending_block_tree (genesis, p1, p2, p_fut)
         assert_eq!(state.pending_block_tree.size(), 4);
@@ -1081,11 +1216,14 @@ mod test {
         let mut cmds = Vec::new();
         for i in &perms {
             let (author, _, verified_message) = missing_proposals[*i].clone().destructure();
-            cmds.extend(state.handle_proposal_message::<Sha256Hash, _>(
-                author,
-                verified_message,
-                &mut valset,
-            ));
+            cmds.extend(
+                state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
+                    author,
+                    verified_message,
+                    MockTransactions::default(),
+                    &mut valset,
+                ),
+            );
         }
 
         let _self_id = PeerId(state.nodeid.0);
@@ -1117,11 +1255,14 @@ mod test {
                     target: RouterTarget::PointToPoint(_self_id),
                     message: ConsensusMessage::Proposal(m),
                 } => {
-                    proposals.extend(state.handle_proposal_message::<Sha256Hash, _>(
-                        m.block.author,
-                        m.clone(),
-                        &mut valset,
-                    ));
+                    proposals.extend(
+                        state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
+                            m.block.author,
+                            m.clone(),
+                            MockTransactions::default(),
+                            &mut valset,
+                        ),
+                    );
                 }
                 _ => more_proposals = false,
             }
@@ -1133,7 +1274,12 @@ mod test {
         // last proposal arrvies
         let p_last = propgen.next_proposal(&keys, &mut valset, &Default::default());
         let (author, _, verified_message) = p_last.destructure();
-        state.handle_proposal_message::<Sha256Hash, _>(author, verified_message, &mut valset);
+        state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
+            author,
+            verified_message,
+            MockTransactions::default(),
+            &mut valset,
+        );
 
         assert_eq!(state.pending_block_tree.size(), 3);
         assert_eq!(
@@ -1146,7 +1292,8 @@ mod test {
 
     #[test]
     fn test_commit_rule_consecutive() {
-        let (keys, mut valset, mut states) = setup::<NopSignature, MultiSig<NopSignature>>(4);
+        let (keys, mut valset, mut states) =
+            setup::<NopSignature, MultiSig<NopSignature>, MockTransactions>(4);
 
         let state = &mut states[0];
         let mut propgen = ProposalGen::new(state.high_qc.clone());
@@ -1154,8 +1301,12 @@ mod test {
         // round 1 proposal
         let p1 = propgen.next_proposal(&keys, &mut valset, &Default::default());
         let (author, _, verified_message) = p1.destructure();
-        let p1_cmds =
-            state.handle_proposal_message::<Sha256Hash, _>(author, verified_message, &mut valset);
+        let p1_cmds = state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
+            author,
+            verified_message,
+            MockTransactions::default(),
+            &mut valset,
+        );
 
         let p1_votes = p1_cmds
             .into_iter()
@@ -1174,8 +1325,12 @@ mod test {
         // round 2 proposal
         let p2 = propgen.next_proposal(&keys, &mut valset, &Default::default());
         let (author, _, verified_message) = p2.destructure();
-        let p2_cmds =
-            state.handle_proposal_message::<Sha256Hash, _>(author, verified_message, &mut valset);
+        let p2_cmds = state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
+            author,
+            verified_message,
+            MockTransactions::default(),
+            &mut valset,
+        );
 
         let lc = p2_cmds
             .iter()
@@ -1200,8 +1355,12 @@ mod test {
         let p3 = propgen.next_proposal(&keys, &mut valset, &Default::default());
         let (author, _, verified_message) = p3.destructure();
 
-        let p2_cmds =
-            state.handle_proposal_message::<Sha256Hash, _>(author, verified_message, &mut valset);
+        let p2_cmds = state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
+            author,
+            verified_message,
+            MockTransactions::default(),
+            &mut valset,
+        );
         let lc = p2_cmds
             .iter()
             .find(|c| matches!(c, ConsensusCommand::LedgerCommit(_)));
@@ -1211,7 +1370,8 @@ mod test {
     #[test]
     fn test_commit_rule_non_consecutive() {
         use monad_consensus::pacemaker::PacemakerCommand::Broadcast;
-        let (keys, mut valset, mut states) = setup::<NopSignature, MultiSig<NopSignature>>(4);
+        let (keys, mut valset, mut states) =
+            setup::<NopSignature, MultiSig<NopSignature>, MockTransactions>(4);
 
         let state = &mut states[0];
         let mut propgen = ProposalGen::new(state.high_qc.clone());
@@ -1219,13 +1379,22 @@ mod test {
         // round 1 proposal
         let p1 = propgen.next_proposal(&keys, &mut valset, &Default::default());
         let (author, _, verified_message) = p1.destructure();
-        state.handle_proposal_message::<Sha256Hash, _>(author, verified_message, &mut valset);
+        state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
+            author,
+            verified_message,
+            MockTransactions::default(),
+            &mut valset,
+        );
 
         // round 2 proposal
         let p2 = propgen.next_proposal(&keys, &mut valset, &Default::default());
         let (author, _, verified_message) = p2.destructure();
-        let p2_cmds =
-            state.handle_proposal_message::<Sha256Hash, _>(author, verified_message, &mut valset);
+        let p2_cmds = state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
+            author,
+            verified_message,
+            MockTransactions::default(),
+            &mut valset,
+        );
 
         let p2_votes = p2_cmds
             .into_iter()
@@ -1266,8 +1435,12 @@ mod test {
         assert_eq!(p3.block.qc.info.vote.round, Round(1));
         assert_eq!(p3.block.round, Round(3));
         let (author, _, verified_message) = p3.destructure();
-        let p3_cmds =
-            state.handle_proposal_message::<Sha256Hash, _>(author, verified_message, &mut valset);
+        let p3_cmds = state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
+            author,
+            verified_message,
+            MockTransactions::default(),
+            &mut valset,
+        );
 
         let p3_votes = p3_cmds
             .into_iter()
@@ -1289,7 +1462,8 @@ mod test {
     // not incorrectly committed
     #[test]
     fn test_malicious_proposal_to_next_leader() {
-        let (keys, mut valset, mut states) = setup::<NopSignature, MultiSig<NopSignature>>(4);
+        let (keys, mut valset, mut states) =
+            setup::<NopSignature, MultiSig<NopSignature>, MockTransactions>(4);
 
         let (first_state, xs) = states.split_first_mut().unwrap();
         let (second_state, xs) = xs.split_first_mut().unwrap();
@@ -1307,9 +1481,10 @@ mod test {
         let mp1 = mal_proposal_gen.next_proposal(&keys, &mut valset, &TransactionList(vec![5]));
 
         let (author, _, verified_message) = cp1.destructure();
-        let cmds1 = first_state.handle_proposal_message::<Sha256Hash, _>(
+        let cmds1 = first_state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
             author,
             verified_message.clone(),
+            MockTransactions::default(),
             &mut valset,
         );
         let p1_votes = cmds1
@@ -1323,9 +1498,10 @@ mod test {
             })
             .collect::<Vec<_>>()[0];
 
-        let cmds3 = third_state.handle_proposal_message::<Sha256Hash, _>(
+        let cmds3 = third_state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
             author,
             verified_message.clone(),
+            MockTransactions::default(),
             &mut valset,
         );
         let p3_votes = cmds3
@@ -1339,9 +1515,10 @@ mod test {
             })
             .collect::<Vec<_>>()[0];
 
-        let cmds4 = fourth_state.handle_proposal_message::<Sha256Hash, _>(
+        let cmds4 = fourth_state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
             author,
             verified_message,
+            MockTransactions::default(),
             &mut valset,
         );
         let p4_votes = cmds4
@@ -1356,9 +1533,10 @@ mod test {
             .collect::<Vec<_>>()[0];
 
         let (author, _, verified_message) = mp1.destructure();
-        let cmds2 = second_state.handle_proposal_message::<Sha256Hash, _>(
+        let cmds2 = second_state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
             author,
             verified_message,
+            MockTransactions::default(),
             &mut valset,
         );
         let p2_votes = cmds2
@@ -1397,9 +1575,10 @@ mod test {
         // points to a different proposal (second_state has the malicious proposal in its blocktree)
         let cp2 = correct_proposal_gen.next_proposal(&keys, &mut valset, &Default::default());
         let (author, _, verified_message) = cp2.destructure();
-        let cmds2 = second_state.handle_proposal_message::<Sha256Hash, _>(
+        let cmds2 = second_state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
             author,
             verified_message.clone(),
+            MockTransactions::default(),
             &mut valset,
         );
         let res = cmds2.into_iter().find(|c| {
@@ -1413,9 +1592,10 @@ mod test {
         assert!(res.is_some());
 
         // first_state has the correct block in its blocktree, so it should not request anything
-        let cmds1 = first_state.handle_proposal_message::<Sha256Hash, _>(
+        let cmds1 = first_state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
             author,
             verified_message,
+            MockTransactions::default(),
             &mut valset,
         );
         let res = cmds1.into_iter().find(|c| {
@@ -1431,14 +1611,16 @@ mod test {
         // next correct proposal is created and we send it to the first two states.
         let cp3 = correct_proposal_gen.next_proposal(&keys, &mut valset, &Default::default());
         let (author, _, verified_message) = cp3.destructure();
-        let cmds2 = second_state.handle_proposal_message::<Sha256Hash, _>(
+        let cmds2 = second_state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
             author,
             verified_message.clone(),
+            MockTransactions::default(),
             &mut valset,
         );
-        let cmds1 = first_state.handle_proposal_message::<Sha256Hash, _>(
+        let cmds1 = first_state.handle_proposal_message_full::<Sha256Hash, LeaderElectionType>(
             author,
             verified_message,
+            MockTransactions::default(),
             &mut valset,
         );
 

--- a/monad-state/src/message.rs
+++ b/monad-state/src/message.rs
@@ -125,6 +125,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use monad_consensus_types::transaction::TransactionCollection;
     use monad_executor::{Message, PeerId, RouterTarget};
     use monad_testutil::signing::node_id;
     use monad_types::Round;
@@ -135,14 +136,14 @@ mod tests {
     struct TestMessage;
 
     impl Message for TestMessage {
-        type Event = TestMessage;
+        type Event<TC: TransactionCollection> = TestMessage;
         type Id = TestMessage;
 
         fn id(&self) -> Self::Id {
             self.clone()
         }
 
-        fn event(self, _from: PeerId) -> Self::Event {
+        fn event<TC: TransactionCollection>(self, _from: PeerId) -> Self::Event<TC> {
             unreachable!()
         }
     }

--- a/monad-state/tests/protobuf.rs
+++ b/monad-state/tests/protobuf.rs
@@ -2,6 +2,7 @@
 mod test {
     use monad_consensus::messages::{consensus_message::ConsensusMessage, message::VoteMessage};
     use monad_consensus::{pacemaker::PacemakerTimerExpire, validation::signing::Unverified};
+    use monad_consensus_types::transaction::MockTransactions;
     use monad_consensus_types::{
         ledger::LedgerCommitInfo,
         multi_sig::MultiSig,
@@ -22,6 +23,7 @@ mod test {
         let event = MonadEvent::ConsensusEvent(ConsensusEvent::<
             SecpSignature,
             MultiSig<SecpSignature>,
+            MockTransactions,
         >::Timeout(PacemakerTimerExpire {}));
 
         let buf = serialize_event(&event);
@@ -59,7 +61,7 @@ mod test {
         });
 
         let buf = serialize_event(&event);
-        let rx_event = deserialize_event(&buf);
+        let rx_event = deserialize_event::<SecpSignature, MockTransactions>(&buf);
 
         assert_eq!(event, rx_event.unwrap());
     }

--- a/monad-state/tests/replay.rs
+++ b/monad-state/tests/replay.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 #[cfg(feature = "proto")]
 mod test {
+    use monad_consensus_types::transaction::MockTransactions;
     use monad_testutil::swarm::{get_configs, node_ledger_verification};
     use std::collections::HashMap;
     use std::fs::create_dir_all;
@@ -17,6 +18,7 @@ mod test {
 
     type SignatureType = SecpSignature;
     type SignatureCollectionType = MultiSig<SignatureType>;
+    type TransactionCollectionType = MockTransactions;
 
     #[test]
     fn test_replay() {
@@ -50,9 +52,9 @@ mod test {
             .collect::<Vec<_>>();
 
         let mut nodes = Nodes::<
-            MonadState<SignatureType, SignatureCollectionType>,
+            MonadState<SignatureType, SignatureCollectionType, TransactionCollectionType>,
             _,
-            WALogger<TimedEvent<MonadEvent<SignatureType, SignatureCollectionType>>>,
+            WALogger<TimedEvent<MonadEvent<SignatureType, SignatureCollectionType, _>>>,
         >::new(
             peers,
             XorLatencyTransformer(Duration::from_millis(u8::MAX as u64)),
@@ -105,9 +107,9 @@ mod test {
 
         let mut nodes_recovered =
             Nodes::<
-                MonadState<SignatureType, SignatureCollectionType>,
+                MonadState<SignatureType, SignatureCollectionType, TransactionCollectionType>,
                 _,
-                WALogger<TimedEvent<MonadEvent<SignatureType, SignatureCollectionType>>>,
+                WALogger<TimedEvent<MonadEvent<SignatureType, SignatureCollectionType, _>>>,
             >::new(peers_clone, LatencyTransformer(Duration::from_millis(1)));
 
         let node_ledger_recovered = nodes_recovered

--- a/monad-testutil/examples/logs_gen.rs
+++ b/monad-testutil/examples/logs_gen.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use monad_consensus_types::multi_sig::MultiSig;
+use monad_consensus_types::transaction::MockTransactions;
 use monad_crypto::NopSignature;
 use monad_executor::{
     mock_swarm::{Nodes, Transformer},
@@ -12,10 +13,11 @@ use monad_state::{MonadEvent, MonadState};
 use monad_testutil::swarm::get_configs;
 use monad_wal::wal::{WALogger, WALoggerConfig};
 
-type MS = MonadState<SignatureType, SignatureCollectionType>;
-type MM = <MS as State>::Message;
 type SignatureType = NopSignature;
 type SignatureCollectionType = MultiSig<SignatureType>;
+type TransactionCollection = MockTransactions;
+type MS = MonadState<SignatureType, SignatureCollectionType, TransactionCollection>;
+type MM = <MS as State>::Message;
 
 pub fn generate_log<T: Transformer<MM>>(
     num_nodes: u16,
@@ -25,7 +27,9 @@ pub fn generate_log<T: Transformer<MM>>(
 ) where
     T: Clone,
 {
-    type WALoggerType = WALogger<TimedEvent<MonadEvent<SignatureType, SignatureCollectionType>>>;
+    type WALoggerType = WALogger<
+        TimedEvent<MonadEvent<SignatureType, SignatureCollectionType, TransactionCollection>>,
+    >;
     let (pubkeys, state_configs) = get_configs(num_nodes, delta);
     let binding = pubkeys.clone();
     let file_path_vec = binding.iter().map(|pubkey| WALoggerConfig {

--- a/monad-viz/Cargo.toml
+++ b/monad-viz/Cargo.toml
@@ -14,8 +14,8 @@ monad-crypto = { path = "../monad-crypto" }
 monad-executor = { path = "../monad-executor" }
 monad-state = { path = "../monad-state" }
 monad-testutil = { path = "../monad-testutil" }
-monad-wal = { path = "../monad-wal" }
 monad-types = { path = "../monad-types" }
+monad-wal = { path = "../monad-wal" }
 
 iced = { version = "0.9", features = ["canvas"] }
 iced_native = { version = "0.10" }

--- a/monad-wal/benches/event_bench.rs
+++ b/monad-wal/benches/event_bench.rs
@@ -1,4 +1,7 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+#[cfg(target_os = "linux")]
+use criterion::criterion_main;
+
+use criterion::{criterion_group, Criterion};
 use std::fs::create_dir_all;
 use tempfile::{tempdir, TempDir};
 
@@ -20,8 +23,8 @@ use monad_consensus_types::{
     voting::VoteInfo,
 };
 
+use monad_consensus_types::transaction::MockTransactions;
 use monad_crypto::secp256k1::{KeyPair, SecpSignature};
-use monad_executor::PeerId;
 use monad_state::{ConsensusEvent, MonadEvent};
 use monad_testutil::{
     block::setup_block,
@@ -34,7 +37,7 @@ use monad_wal::PersistenceLogger;
 
 const N_VALIDATORS: usize = 400;
 
-type BenchEvent = MonadEvent<SecpSignature, MultiSig<SecpSignature>>;
+type BenchEvent = MonadEvent<SecpSignature, MultiSig<SecpSignature>, MockTransactions>;
 struct MonadEventBencher {
     event: BenchEvent,
     logger: WALogger<BenchEvent>,
@@ -198,7 +201,7 @@ fn bench_timeout(c: &mut Criterion) {
 }
 
 fn bench_local_timeout(c: &mut Criterion) {
-    let event: MonadEvent<SecpSignature, MultiSig<SecpSignature>> =
+    let event: MonadEvent<SecpSignature, MultiSig<SecpSignature>, MockTransactions> =
         MonadEvent::ConsensusEvent(ConsensusEvent::Timeout(PacemakerTimerExpire {}));
 
     let mut bencher = MonadEventBencher::new(event);


### PR DESCRIPTION
Currently, we have no way of validating the transactions provided in proposals. This is a draft for a proposed solution which involves creating a new TransactionCollection generic and adding an additional command to fetch the full transactions from the mempool so that they can be validated for proposals.

Todo:
- [x] Change Vec<TransactionCollection> to TransactionCollection
- [x] Finish protobuf serialization / deserialization