### PR TITLE
Change the id of NopSignature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3602,7 +3602,6 @@ dependencies = [
  "libp2p-identity",
  "monad-proto",
  "multihash",
- "rand 0.8.5",
  "secp256k1",
  "sha2 0.10.6",
  "tiny-keccak",

--- a/monad-crypto/Cargo.toml
+++ b/monad-crypto/Cargo.toml
@@ -14,7 +14,6 @@ monad-proto = { path = "../monad-proto", optional = true }
 blst = { workspace = true }
 libp2p-identity = { workspace = true, features = ["secp256k1"], optional = true }
 multihash = { workspace = true, features = ["identity"], optional = true }
-rand = { workspace = true }
 secp256k1 = { workspace = true, features = ["global-context", "recovery"] }
 sha2 = { workspace = true }
 zerocopy = { workspace = true }


### PR DESCRIPTION
Previously, the id of the NopSignature was using a random number generated at runtime. This is not ideal, as it makes the MonadEvent impossible to compare when we replay the event log during the visualization. Thus, in order to provide a consistent way of doing equality comparisons, we now use the hash of the message as the id in the signature function.