### PR TITLE
Change BlockTree be either Rooted or Unrooted on creation

### DIFF
--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -540,7 +540,7 @@ where
             .add(p.block.clone())
             .expect("Failed to add block to blocktree");
 
-        if !self.pending_block_tree.has_parent(&p.block.qc) {
+        if !self.pending_block_tree.has_parent(&p.block) {
             cmds.push(ConsensusCommand::RequestSync {
                 blockid: p.block.get_parent_id(),
             });


### PR DESCRIPTION
The purpose of Rooted vs Unrooted BlockTree is to support starting a node from the first proposal it receives on the network (unrooted mode) vs starting from a known genesis block (rooted).

A rooted BlockTree is created with a genesis block which all subsequent added blocks are expected to extend. A branch is not valid unless there is a path to the root from the leaf.

An Unrooted BlockTree is created with no blocks. Instead there is an expected round number of the root. Blocks added at that round number are potential roots of a valid branch. When a leaf has a valid path to any of the roots, that branch is committed on prune and the other roots are discarded. The leaf of the valid branch becomes the new root.