### PR TITLE
Add stake verification to QC and TC

### DIFF
--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -315,6 +315,7 @@ mod test {
         block::{Block as ConsensusBlock, TransactionList},
         ledger::LedgerCommitInfo,
         quorum_certificate::{QcInfo, QuorumCertificate},
+        signature::SignatureCollection,
         validation::Sha256Hash,
         voting::VoteInfo,
     };
@@ -350,7 +351,7 @@ mod test {
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -370,7 +371,7 @@ mod test {
                     vote: v1,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -390,7 +391,7 @@ mod test {
                     vote: v2,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -410,7 +411,7 @@ mod test {
                     vote: v3,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -430,7 +431,7 @@ mod test {
                     vote: v4,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -450,7 +451,7 @@ mod test {
                     vote: v5,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -470,7 +471,7 @@ mod test {
                     vote: v6,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -490,7 +491,7 @@ mod test {
                     vote: v7,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -582,7 +583,7 @@ mod test {
                     vote: v8,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -607,7 +608,7 @@ mod test {
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -627,7 +628,7 @@ mod test {
                     vote: v1,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -647,7 +648,7 @@ mod test {
                     vote: v2,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -691,7 +692,7 @@ mod test {
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -711,7 +712,7 @@ mod test {
                     vote: v1,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -724,7 +725,7 @@ mod test {
                     vote: v1,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -744,7 +745,7 @@ mod test {
                     vote: v2,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -790,7 +791,7 @@ mod test {
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -810,7 +811,7 @@ mod test {
                     vote: v1,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -845,7 +846,7 @@ mod test {
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -865,7 +866,7 @@ mod test {
                     vote: v1,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -885,7 +886,7 @@ mod test {
                     vote: v2,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -898,7 +899,7 @@ mod test {
                     vote: v2,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -911,7 +912,7 @@ mod test {
                     vote: v2,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -970,7 +971,7 @@ mod test {
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
         let v4 = VoteInfo {
@@ -989,7 +990,7 @@ mod test {
                     vote: v4,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -1009,7 +1010,7 @@ mod test {
                     vote: v5,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -1029,7 +1030,7 @@ mod test {
                     vote: v6,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -1073,7 +1074,7 @@ mod test {
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -1093,7 +1094,7 @@ mod test {
                     vote: v2,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -1113,7 +1114,7 @@ mod test {
                     vote: v3,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -1133,7 +1134,7 @@ mod test {
                     vote: v4,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -1153,7 +1154,7 @@ mod test {
                     vote: v5,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -1173,7 +1174,7 @@ mod test {
                     vote: v6,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -1223,7 +1224,7 @@ mod test {
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -1243,7 +1244,7 @@ mod test {
                     vote: v1,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 
@@ -1263,7 +1264,7 @@ mod test {
                     vote: v4,
                     ledger_commit: LedgerCommitInfo::default(),
                 },
-                MockSignatures,
+                MockSignatures::new(),
             ),
         );
 

--- a/monad-consensus-types/src/validation.rs
+++ b/monad-consensus-types/src/validation.rs
@@ -13,6 +13,8 @@ pub enum Error {
     AuthorNotSender,
     /// There are high qc rounds larger than the TC round
     InvalidTcRound,
+    /// The SignatureCollection doesn't have supermajority of the stake signed
+    InsufficientStake,
 }
 
 pub trait Hashable {

--- a/monad-consensus/tests/block.rs
+++ b/monad-consensus/tests/block.rs
@@ -2,6 +2,7 @@ use monad_consensus_types::{
     block::{Block, TransactionList},
     ledger::LedgerCommitInfo,
     quorum_certificate::{QcInfo, QuorumCertificate},
+    signature::SignatureCollection,
     validation::{Hasher, Sha256Hash},
     voting::VoteInfo,
 };
@@ -23,7 +24,7 @@ fn block_hash_id() {
             },
             ledger_commit: LedgerCommitInfo::default(),
         },
-        MockSignatures,
+        MockSignatures::new(),
     );
 
     let block = Block::<MockSignatures>::new::<Sha256Hash>(author, round, &txns, &qc);

--- a/monad-consensus/tests/message.rs
+++ b/monad-consensus/tests/message.rs
@@ -3,6 +3,7 @@ use monad_consensus_types::{
     block::{Block, TransactionList},
     ledger::LedgerCommitInfo,
     quorum_certificate::{QcInfo, QuorumCertificate},
+    signature::SignatureCollection,
     timeout::{HighQcRound, HighQcRoundSigTuple, TimeoutCertificate, TimeoutInfo},
     validation::{Hasher, Sha256Hash},
     voting::VoteInfo,
@@ -28,7 +29,7 @@ fn timeout_msg_hash() {
                 },
                 ledger_commit: Default::default(),
             },
-            MockSignatures,
+            MockSignatures::new(),
         ),
     };
 
@@ -67,7 +68,7 @@ fn proposal_msg_hash() {
             },
             ledger_commit: LedgerCommitInfo::default(),
         },
-        MockSignatures,
+        MockSignatures::new(),
     );
 
     let block = Block::<MockSignatures>::new::<Sha256Hash>(author, round, &txns, &qc);

--- a/monad-consensus/tests/proposal.rs
+++ b/monad-consensus/tests/proposal.rs
@@ -1,4 +1,4 @@
-use monad_consensus::{messages::message::ProposalMessage, validation::signing::ValidatorMember};
+use monad_consensus::messages::message::ProposalMessage;
 use monad_consensus_types::{
     block::{Block, TransactionList},
     ledger::LedgerCommitInfo,
@@ -6,16 +6,21 @@ use monad_consensus_types::{
     validation::{Error, Hasher, Sha256Hash},
     voting::VoteInfo,
 };
-use monad_crypto::secp256k1::SecpSignature;
+use monad_crypto::secp256k1::{PubKey, SecpSignature};
 use monad_testutil::signing::{get_key, node_id, MockSignatures, TestSigner};
 use monad_types::*;
+use monad_validator::validator_set::{ValidatorSet, ValidatorSetType};
 
-fn setup_block(author: NodeId, block_round: u64, qc_round: u64) -> Block<MockSignatures> {
+fn setup_block(
+    author: NodeId,
+    block_round: Round,
+    qc_round: Round,
+    signers: &[PubKey],
+) -> Block<MockSignatures> {
     let txns = TransactionList(vec![1, 2, 3, 4]);
-    let round = Round(block_round);
     let vi = VoteInfo {
         id: BlockId(Hash([0x00_u8; 32])),
-        round: Round(qc_round),
+        round: qc_round,
         parent_id: BlockId(Hash([0x00_u8; 32])),
         parent_round: Round(0),
     };
@@ -24,51 +29,69 @@ fn setup_block(author: NodeId, block_round: u64, qc_round: u64) -> Block<MockSig
             vote: vi,
             ledger_commit: LedgerCommitInfo::new::<Sha256Hash>(Some(Default::default()), &vi),
         },
-        MockSignatures,
+        MockSignatures::with_pubkeys(signers),
     );
 
-    Block::<MockSignatures>::new::<Sha256Hash>(author, round, &txns, &qc)
+    Block::<MockSignatures>::new::<Sha256Hash>(author, block_round, &txns, &qc)
 }
 
 #[test]
 fn test_proposal_hash() {
-    let mut vset = ValidatorMember::new();
+    let mut vlist = Vec::new();
+    let keypair = get_key(6);
+
+    vlist.push((NodeId(keypair.pubkey()), Stake(1)));
 
     let author = node_id();
     let proposal: ProposalMessage<SecpSignature, MockSignatures> = ProposalMessage {
-        block: setup_block(author, 234, 233),
+        block: setup_block(
+            author,
+            Round(234),
+            Round(233),
+            vlist
+                .iter()
+                .map(|(node_id, _)| node_id.0)
+                .collect::<Vec<_>>()
+                .as_ref(),
+        ),
         last_round_tc: None,
     };
-
-    let keypair = get_key(0);
-
-    vset.insert(NodeId(keypair.pubkey()), Stake(0));
 
     let msg = Sha256Hash::hash_object(&proposal);
     let sp = TestSigner::sign_object(proposal, msg.as_ref(), &keypair);
 
-    assert!(sp.verify::<Sha256Hash>(&vset, &keypair.pubkey()).is_ok());
+    let vset = ValidatorSet::new(vlist).unwrap();
+    assert!(sp.verify::<Sha256Hash, _>(&vset, &keypair.pubkey()).is_ok());
 }
 
 #[test]
 fn test_proposal_missing_tc() {
-    let mut vset = ValidatorMember::new();
+    let mut vlist = Vec::new();
+    let keypair = get_key(6);
+
+    vlist.push((NodeId(keypair.pubkey()), Stake(0)));
 
     let author = node_id();
     let proposal = ProposalMessage {
-        block: setup_block(author, 234, 232),
+        block: setup_block(
+            author,
+            Round(234),
+            Round(232),
+            vlist
+                .iter()
+                .map(|(node_id, _)| node_id.0)
+                .collect::<Vec<_>>()
+                .as_ref(),
+        ),
         last_round_tc: None,
     };
-
-    let keypair = get_key(6);
-
-    vset.insert(NodeId(keypair.pubkey()), Stake(0));
 
     let msg = Sha256Hash::hash_object(&proposal);
     let sp = TestSigner::sign_object(proposal, msg.as_ref(), &keypair);
 
+    let vset = ValidatorSet::new(vlist).unwrap();
     assert_eq!(
-        sp.verify::<Sha256Hash>(&vset, &keypair.pubkey())
+        sp.verify::<Sha256Hash, _>(&vset, &keypair.pubkey())
             .unwrap_err(),
         Error::NotWellFormed
     );
@@ -76,23 +99,33 @@ fn test_proposal_missing_tc() {
 
 #[test]
 fn test_proposal_invalid_qc() {
-    let mut vset = ValidatorMember::new();
-
-    let author = node_id();
-    let proposal = ProposalMessage {
-        block: setup_block(author, 234, 233),
-        last_round_tc: None,
-    };
+    let mut vlist = Vec::new();
 
     let keypair = get_key(6);
 
-    vset.insert(NodeId(keypair.pubkey()), Stake(0));
+    vlist.push((NodeId(keypair.pubkey()), Stake(0)));
+
+    let author = node_id();
+    let proposal = ProposalMessage {
+        block: setup_block(
+            author,
+            Round(234),
+            Round(233),
+            vlist
+                .iter()
+                .map(|(node_id, _)| node_id.0)
+                .collect::<Vec<_>>()
+                .as_ref(),
+        ),
+        last_round_tc: None,
+    };
 
     let msg = Sha256Hash::hash_object(&proposal);
     let sp = TestSigner::sign_object(proposal, msg.as_ref(), &get_key(7));
 
+    let vset = ValidatorSet::new(vlist).unwrap();
     assert_eq!(
-        sp.verify::<Sha256Hash>(&vset, &keypair.pubkey())
+        sp.verify::<Sha256Hash, _>(&vset, &keypair.pubkey())
             .unwrap_err(),
         Error::InvalidAuthor
     );

--- a/monad-consensus/tests/qc.rs
+++ b/monad-consensus/tests/qc.rs
@@ -1,6 +1,7 @@
 use monad_consensus_types::{
     ledger::LedgerCommitInfo,
     quorum_certificate::{QcInfo, QuorumCertificate, Rank},
+    signature::SignatureCollection,
     voting::VoteInfo,
 };
 use monad_testutil::signing::MockSignatures;
@@ -31,14 +32,14 @@ fn comparison() {
             vote: vi_1,
             ledger_commit: ci,
         },
-        MockSignatures,
+        MockSignatures::new(),
     );
     let mut qc_2 = QuorumCertificate::<MockSignatures>::new(
         QcInfo {
             vote: vi_2,
             ledger_commit: ci,
         },
-        MockSignatures,
+        MockSignatures::new(),
     );
 
     assert!(Rank(qc_1.info) < Rank(qc_2.info));

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -364,7 +364,7 @@ where
                         unverified_message,
                     } => {
                         let verified_message = match unverified_message
-                            .verify::<HasherType>(self.validator_set.get_members(), &sender)
+                            .verify::<HasherType, _>(&self.validator_set, &sender)
                         {
                             Ok(m) => m,
                             Err(e) => todo!("{e:?}"),

--- a/monad-testutil/src/signing.rs
+++ b/monad-testutil/src/signing.rs
@@ -15,12 +15,23 @@ use monad_crypto::{
 use monad_types::{Hash, NodeId, Round};
 
 #[derive(Clone, Default, Debug)]
-pub struct MockSignatures;
+pub struct MockSignatures {
+    pubkey: Vec<PubKey>,
+}
+
+impl MockSignatures {
+    pub fn with_pubkeys(pubkeys: &[PubKey]) -> Self {
+        Self {
+            pubkey: pubkeys.to_vec(),
+        }
+    }
+}
+
 impl SignatureCollection for MockSignatures {
     type SignatureType = SecpSignature;
 
     fn new() -> Self {
-        MockSignatures {}
+        MockSignatures { pubkey: Vec::new() }
     }
 
     fn get_hash(&self) -> Hash {
@@ -34,7 +45,7 @@ impl SignatureCollection for MockSignatures {
     }
 
     fn get_pubkeys(&self, _msg: &[u8]) -> Result<Vec<PubKey>, Error> {
-        Ok(Vec::new())
+        Ok(self.pubkey.clone())
     }
 
     fn num_signatures(&self) -> usize {


### PR DESCRIPTION
The current certificate verification only verifies the SignatureCollection and doesn't check whether +2/3 stake has signed the message. Any SignatureCollection is treated as valid so long as the signature is valid. This is wrong and this PR patches that, and adds two stake validation test. 

Verify_qc/tc now takes in the ValidatorSet for staking information.