### PR TITLE
Split voting key from signing key

### DIFF
--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -318,7 +318,7 @@ mod test {
         validation::Sha256Hash,
         voting::VoteInfo,
     };
-    use monad_crypto::secp256k1::KeyPair;
+    use monad_crypto::{secp256k1::KeyPair, GenericKeyPair};
     use monad_testutil::signing::MockSignatures;
     use monad_types::{BlockId, Hash, NodeId, Round};
 

--- a/monad-consensus-types/src/convert/block.rs
+++ b/monad-consensus-types/src/convert/block.rs
@@ -1,10 +1,10 @@
-use monad_crypto::Signature;
+use monad_crypto::{GenericSignature, Signature};
 use monad_proto::{error::ProtoError, proto::block::*};
 
 use crate::{
     block::{Block, TransactionList},
     multi_sig::MultiSig,
-    validation::Sha256Hash,
+    validation::{Hashable, Sha256Hash},
 };
 
 impl From<&TransactionList> for ProtoTransactionList {
@@ -22,7 +22,7 @@ impl TryFrom<ProtoTransactionList> for TransactionList {
     }
 }
 
-impl<S: Signature> From<&Block<MultiSig<S>>> for ProtoBlockAggSig {
+impl<S: Signature + GenericSignature + Hashable> From<&Block<MultiSig<S>>> for ProtoBlockAggSig {
     fn from(value: &Block<MultiSig<S>>) -> Self {
         Self {
             author: Some((&value.author).into()),
@@ -33,7 +33,7 @@ impl<S: Signature> From<&Block<MultiSig<S>>> for ProtoBlockAggSig {
     }
 }
 
-impl<S: Signature> TryFrom<ProtoBlockAggSig> for Block<MultiSig<S>> {
+impl<S: Signature + GenericSignature + Hashable> TryFrom<ProtoBlockAggSig> for Block<MultiSig<S>> {
     type Error = ProtoError;
 
     fn try_from(value: ProtoBlockAggSig) -> Result<Self, Self::Error> {

--- a/monad-consensus-types/src/convert/quorum_certificate.rs
+++ b/monad-consensus-types/src/convert/quorum_certificate.rs
@@ -1,9 +1,10 @@
-use monad_crypto::Signature;
+use monad_crypto::{GenericSignature, Signature};
 use monad_proto::{error::ProtoError, proto::quorum_certificate::*};
 
 use crate::{
     multi_sig::MultiSig,
     quorum_certificate::{QcInfo, QuorumCertificate as ConsensusQC},
+    validation::Hashable,
 };
 
 type QuorumCertificate<S> = ConsensusQC<MultiSig<S>>;
@@ -35,7 +36,10 @@ impl TryFrom<ProtoQcInfo> for QcInfo {
     }
 }
 
-impl<S: Signature> From<&QuorumCertificate<S>> for ProtoQuorumCertificateAggSig {
+// TODO: generalize over signature collection
+impl<S: Signature + GenericSignature + Hashable> From<&QuorumCertificate<S>>
+    for ProtoQuorumCertificateAggSig
+{
     fn from(value: &QuorumCertificate<S>) -> Self {
         Self {
             info: Some((&value.info).into()),
@@ -44,7 +48,9 @@ impl<S: Signature> From<&QuorumCertificate<S>> for ProtoQuorumCertificateAggSig 
     }
 }
 
-impl<S: Signature> TryFrom<ProtoQuorumCertificateAggSig> for QuorumCertificate<S> {
+impl<S: Signature + GenericSignature + Hashable> TryFrom<ProtoQuorumCertificateAggSig>
+    for QuorumCertificate<S>
+{
     type Error = ProtoError;
 
     fn try_from(value: ProtoQuorumCertificateAggSig) -> Result<Self, Self::Error> {

--- a/monad-consensus-types/src/convert/timeout.rs
+++ b/monad-consensus-types/src/convert/timeout.rs
@@ -1,6 +1,6 @@
 use monad_crypto::{
     convert::{proto_to_signature, signature_to_proto},
-    Signature,
+    GenericSignature, Signature,
 };
 use monad_proto::{error::ProtoError, proto::timeout::*};
 
@@ -10,6 +10,7 @@ use crate::{
         HighQcRound, HighQcRoundSigTuple as TypeHighQcRoundSigTuple,
         TimeoutCertificate as ConsensusTC, TimeoutInfo as ConsensusTmoInfo,
     },
+    validation::Hashable,
 };
 
 type HighQcRoundSigTuple<S> = TypeHighQcRoundSigTuple<S>;
@@ -99,7 +100,7 @@ impl<S: Signature> TryFrom<ProtoTimeoutCertificate> for TimeoutCertificate<S> {
     }
 }
 
-impl<S: Signature> From<&TimeoutInfo<S>> for ProtoTimeoutInfoAggSig {
+impl<S: Signature + GenericSignature + Hashable> From<&TimeoutInfo<S>> for ProtoTimeoutInfoAggSig {
     fn from(value: &TimeoutInfo<S>) -> Self {
         Self {
             round: Some((&value.round).into()),
@@ -108,7 +109,9 @@ impl<S: Signature> From<&TimeoutInfo<S>> for ProtoTimeoutInfoAggSig {
     }
 }
 
-impl<S: Signature> TryFrom<ProtoTimeoutInfoAggSig> for TimeoutInfo<S> {
+impl<S: Signature + GenericSignature + Hashable> TryFrom<ProtoTimeoutInfoAggSig>
+    for TimeoutInfo<S>
+{
     type Error = ProtoError;
 
     fn try_from(value: ProtoTimeoutInfoAggSig) -> Result<Self, Self::Error> {

--- a/monad-consensus-types/src/convert/voting.rs
+++ b/monad-consensus-types/src/convert/voting.rs
@@ -1,7 +1,7 @@
 use monad_proto::{error::ProtoError, proto::voting::*};
 use monad_types::Round;
 
-use crate::voting::VoteInfo;
+use crate::voting::{Vote, VoteInfo};
 
 impl From<&VoteInfo> for ProtoVoteInfo {
     fn from(vi: &VoteInfo) -> Self {
@@ -29,6 +29,36 @@ impl TryFrom<ProtoVoteInfo> for VoteInfo {
                 ))?
                 .try_into()?,
             parent_round: Round(proto_vi.parent_round),
+        })
+    }
+}
+
+impl From<&Vote> for ProtoVote {
+    fn from(value: &Vote) -> Self {
+        ProtoVote {
+            vote_info: Some((&value.vote_info).into()),
+            ledger_commit_info: Some((&value.ledger_commit_info).into()),
+        }
+    }
+}
+
+impl TryFrom<ProtoVote> for Vote {
+    type Error = ProtoError;
+
+    fn try_from(value: ProtoVote) -> Result<Self, Self::Error> {
+        Ok(Self {
+            vote_info: value
+                .vote_info
+                .ok_or(Self::Error::MissingRequiredField(
+                    "VoteMessage.vote_info".to_owned(),
+                ))?
+                .try_into()?,
+            ledger_commit_info: value
+                .ledger_commit_info
+                .ok_or(Self::Error::MissingRequiredField(
+                    "VoteMessage.ledger_commit_info".to_owned(),
+                ))?
+                .try_into()?,
         })
     }
 }

--- a/monad-consensus-types/src/signature.rs
+++ b/monad-consensus-types/src/signature.rs
@@ -1,7 +1,9 @@
 use std::fmt::Debug;
 
-use monad_crypto::{bls12_381::BlsPubKey, Signature};
+use monad_crypto::{bls12_381::BlsPubKey, GenericSignature};
 use monad_types::{Hash, NodeId};
+
+use crate::validation::Hashable;
 
 #[derive(Clone, Debug)]
 pub struct SignatureBuilder<SCT: SignatureCollection> {
@@ -33,9 +35,13 @@ impl<SCT: SignatureCollection> IntoIterator for SignatureBuilder<SCT> {
     }
 }
 
+pub type SignatureCollectionKeyPairType<SCT> =
+    <<SCT as SignatureCollection>::SignatureType as GenericSignature>::KeyPairType;
+
 pub trait SignatureCollection: Clone + Send + Sync + std::fmt::Debug + 'static {
     type SignatureError: std::error::Error + Send + Sync;
-    type SignatureType: Signature + Copy;
+    type SignatureType: GenericSignature + Copy + Hashable;
+    // need Hashable to create signtaure over the SignatureCollection
 
     /// the new() function verifies:
     ///   1. nodeId idx is in range

--- a/monad-consensus-types/src/validation.rs
+++ b/monad-consensus-types/src/validation.rs
@@ -1,3 +1,4 @@
+use monad_crypto::{secp256k1::SecpSignature, NopSignature};
 use monad_types::Hash;
 use sha2::Digest;
 
@@ -43,5 +44,19 @@ impl Hasher for Sha256Hash {
     }
     fn hash(self) -> Hash {
         Hash(self.0.finalize().into())
+    }
+}
+
+impl Hashable for SecpSignature {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let slice = unsafe { std::mem::transmute::<Self, [u8; 65]>(*self) };
+        state.update(slice);
+    }
+}
+
+impl Hashable for NopSignature {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let slice = unsafe { std::mem::transmute::<Self, [u8; 72]>(*self) };
+        state.update(slice);
     }
 }

--- a/monad-consensus/src/convert/interface.rs
+++ b/monad-consensus/src/convert/interface.rs
@@ -1,17 +1,18 @@
-use monad_crypto::Signature;
+use monad_consensus_types::validation::Hashable;
+use monad_crypto::{GenericSignature, Signature};
 use monad_proto::{error::ProtoError, proto::message::ProtoUnverifiedConsensusMessage};
 use prost::Message;
 
 use super::message::{UnverifiedConsensusMessage, VerifiedConsensusMessage};
 
 pub fn serialize_verified_consensus_message(
-    msg: &VerifiedConsensusMessage<impl Signature>,
+    msg: &VerifiedConsensusMessage<impl Signature + GenericSignature + Hashable>,
 ) -> Vec<u8> {
     let proto_msg: ProtoUnverifiedConsensusMessage = msg.into();
     proto_msg.encode_to_vec()
 }
 
-pub fn deserialize_unverified_consensus_message<S: Signature>(
+pub fn deserialize_unverified_consensus_message<S: Signature + GenericSignature + Hashable>(
     data: &[u8],
 ) -> Result<UnverifiedConsensusMessage<S>, ProtoError> {
     let msg = ProtoUnverifiedConsensusMessage::decode(data)?;

--- a/monad-consensus/src/convert/message.rs
+++ b/monad-consensus/src/convert/message.rs
@@ -1,9 +1,9 @@
 use std::ops::Deref;
 
-use monad_consensus_types::multi_sig::MultiSig;
+use monad_consensus_types::{multi_sig::MultiSig, validation::Hashable};
 use monad_crypto::{
     convert::{proto_to_signature, signature_to_proto},
-    Signature,
+    GenericSignature, Signature,
 };
 use monad_proto::{error::ProtoError, proto::message::*};
 
@@ -12,48 +12,46 @@ use crate::{
         consensus_message::ConsensusMessage,
         message::{
             ProposalMessage as ConsensusTypePropMsg, TimeoutMessage as ConsensusTypeTmoMsg,
-            VoteMessage,
+            VoteMessage as ConsensusTypeVoteMessage,
         },
     },
     validation::signing::{Unverified, Verified},
 };
 
+type VoteMessage<S> = ConsensusTypeVoteMessage<MultiSig<S>>;
 type TimeoutMessage<S> = ConsensusTypeTmoMsg<S, MultiSig<S>>;
 type ProposalMessage<S> = ConsensusTypePropMsg<S, MultiSig<S>>;
 pub(crate) type VerifiedConsensusMessage<S> = Verified<S, ConsensusMessage<S, MultiSig<S>>>;
 pub(crate) type UnverifiedConsensusMessage<S> = Unverified<S, ConsensusMessage<S, MultiSig<S>>>;
 
-impl From<&VoteMessage> for ProtoVoteMessage {
-    fn from(value: &VoteMessage) -> Self {
+impl<S: Signature + GenericSignature + Hashable> From<&VoteMessage<S>> for ProtoVoteMessage {
+    fn from(value: &VoteMessage<S>) -> Self {
         ProtoVoteMessage {
-            vote_info: Some((&value.vote_info).into()),
-            ledger_commit_info: Some((&value.ledger_commit_info).into()),
+            vote: Some((&value.vote).into()),
+            sig: Some(signature_to_proto(&value.sig)),
         }
     }
 }
 
-impl TryFrom<ProtoVoteMessage> for VoteMessage {
+impl<S: Signature + GenericSignature + Hashable> TryFrom<ProtoVoteMessage> for VoteMessage<S> {
     type Error = ProtoError;
 
     fn try_from(value: ProtoVoteMessage) -> Result<Self, Self::Error> {
         Ok(Self {
-            vote_info: value
-                .vote_info
+            vote: value
+                .vote
                 .ok_or(Self::Error::MissingRequiredField(
-                    "VoteMessage.vote_info".to_owned(),
+                    "VoteMessageSigned.vote".to_owned(),
                 ))?
                 .try_into()?,
-            ledger_commit_info: value
-                .ledger_commit_info
-                .ok_or(Self::Error::MissingRequiredField(
-                    "VoteMessage.ledger_commit_info".to_owned(),
-                ))?
-                .try_into()?,
+            sig: proto_to_signature(value.sig.ok_or(Self::Error::MissingRequiredField(
+                "VoteMessageSigned.vote".to_owned(),
+            ))?)?,
         })
     }
 }
 
-impl<S: Signature> From<&TimeoutMessage<S>> for ProtoTimeoutMessage {
+impl<S: Signature + GenericSignature + Hashable> From<&TimeoutMessage<S>> for ProtoTimeoutMessage {
     fn from(value: &TimeoutMessage<S>) -> Self {
         ProtoTimeoutMessage {
             tminfo: Some((&value.tminfo).into()),
@@ -62,7 +60,9 @@ impl<S: Signature> From<&TimeoutMessage<S>> for ProtoTimeoutMessage {
     }
 }
 
-impl<S: Signature> TryFrom<ProtoTimeoutMessage> for TimeoutMessage<S> {
+impl<S: Signature + GenericSignature + Hashable> TryFrom<ProtoTimeoutMessage>
+    for TimeoutMessage<S>
+{
     type Error = ProtoError;
     fn try_from(value: ProtoTimeoutMessage) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -78,7 +78,9 @@ impl<S: Signature> TryFrom<ProtoTimeoutMessage> for TimeoutMessage<S> {
     }
 }
 
-impl<S: Signature> From<&ProposalMessage<S>> for ProtoProposalMessageAggSig {
+impl<S: Signature + GenericSignature + Hashable> From<&ProposalMessage<S>>
+    for ProtoProposalMessageAggSig
+{
     fn from(value: &ProposalMessage<S>) -> Self {
         Self {
             block: Some((&value.block).into()),
@@ -87,7 +89,9 @@ impl<S: Signature> From<&ProposalMessage<S>> for ProtoProposalMessageAggSig {
     }
 }
 
-impl<S: Signature> TryFrom<ProtoProposalMessageAggSig> for ProposalMessage<S> {
+impl<S: Signature + GenericSignature + Hashable> TryFrom<ProtoProposalMessageAggSig>
+    for ProposalMessage<S>
+{
     type Error = ProtoError;
 
     fn try_from(value: ProtoProposalMessageAggSig) -> Result<Self, Self::Error> {
@@ -103,7 +107,9 @@ impl<S: Signature> TryFrom<ProtoProposalMessageAggSig> for ProposalMessage<S> {
     }
 }
 
-impl<S: Signature> From<&VerifiedConsensusMessage<S>> for ProtoUnverifiedConsensusMessage {
+impl<S: Signature + GenericSignature + Hashable> From<&VerifiedConsensusMessage<S>>
+    for ProtoUnverifiedConsensusMessage
+{
     fn from(value: &VerifiedConsensusMessage<S>) -> Self {
         let oneof_message = match value.deref() {
             ConsensusMessage::Proposal(msg) => {
@@ -123,7 +129,9 @@ impl<S: Signature> From<&VerifiedConsensusMessage<S>> for ProtoUnverifiedConsens
     }
 }
 
-impl<S: Signature> TryFrom<ProtoUnverifiedConsensusMessage> for UnverifiedConsensusMessage<S> {
+impl<S: Signature + GenericSignature + Hashable> TryFrom<ProtoUnverifiedConsensusMessage>
+    for UnverifiedConsensusMessage<S>
+{
     type Error = ProtoError;
 
     fn try_from(value: ProtoUnverifiedConsensusMessage) -> Result<Self, Self::Error> {

--- a/monad-consensus/src/messages/consensus_message.rs
+++ b/monad-consensus/src/messages/consensus_message.rs
@@ -12,13 +12,13 @@ use crate::{
 };
 
 #[derive(Clone, PartialEq, Eq)]
-pub enum ConsensusMessage<ST, SCT> {
+pub enum ConsensusMessage<ST, SCT: SignatureCollection> {
     Proposal(ProposalMessage<ST, SCT>),
-    Vote(VoteMessage),
+    Vote(VoteMessage<SCT>),
     Timeout(TimeoutMessage<ST, SCT>),
 }
 
-impl<ST: Debug, SCT: Debug> Debug for ConsensusMessage<ST, SCT> {
+impl<ST: Debug, SCT: Debug + SignatureCollection> Debug for ConsensusMessage<ST, SCT> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ConsensusMessage::Proposal(p) => f.debug_tuple("").field(&p).finish(),

--- a/monad-consensus/src/messages/message.rs
+++ b/monad-consensus/src/messages/message.rs
@@ -1,31 +1,42 @@
 use monad_consensus_types::{
     block::Block,
-    ledger::LedgerCommitInfo,
     signature::SignatureCollection,
     timeout::{TimeoutCertificate, TimeoutInfo},
     validation::{Hashable, Hasher},
-    voting::VoteInfo,
+    voting::Vote,
 };
 use monad_crypto::Signature;
 
-#[derive(Copy, Clone, PartialEq, Eq)]
-pub struct VoteMessage {
-    pub vote_info: VoteInfo,
-    pub ledger_commit_info: LedgerCommitInfo,
+#[derive(PartialEq, Eq)]
+pub struct VoteMessage<SCT: SignatureCollection> {
+    pub vote: Vote,
+    pub sig: SCT::SignatureType,
 }
 
-impl std::fmt::Debug for VoteMessage {
+impl<SCT: SignatureCollection> Copy for VoteMessage<SCT> {}
+
+impl<SCT: SignatureCollection> Clone for VoteMessage<SCT> {
+    fn clone(&self) -> Self {
+        Self {
+            vote: self.vote,
+            sig: self.sig,
+        }
+    }
+}
+
+impl<SCT: SignatureCollection> std::fmt::Debug for VoteMessage<SCT> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("VoteMessage")
-            .field("info", &self.vote_info)
-            .field("lc", &self.ledger_commit_info)
+        f.debug_struct("VoteMessageSigned")
+            .field("vote", &self.vote)
+            .field("sig", &self.sig)
             .finish()
     }
 }
 
-impl Hashable for VoteMessage {
+impl<SCT: SignatureCollection> Hashable for VoteMessage<SCT> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.ledger_commit_info.hash(state)
+        self.vote.hash(state);
+        self.sig.hash(state);
     }
 }
 

--- a/monad-consensus/src/validation/safety.rs
+++ b/monad-consensus/src/validation/safety.rs
@@ -7,11 +7,9 @@ use monad_consensus_types::{
     signature::SignatureCollection,
     timeout::{TimeoutCertificate, TimeoutInfo},
     validation::Hasher,
-    voting::VoteInfo,
+    voting::{Vote, VoteInfo},
 };
 use monad_types::*;
-
-use crate::messages::message::VoteMessage;
 
 #[derive(Debug)]
 pub struct Safety {
@@ -90,7 +88,7 @@ impl Safety {
         &mut self,
         block: &Block<T>,
         last_tc: &Option<TimeoutCertificate<S>>,
-    ) -> Option<VoteMessage> {
+    ) -> Option<Vote> {
         let qc_round = block.qc.info.vote.round;
         if self.safe_to_vote(block.round, qc_round, last_tc) {
             self.update_highest_qc_round(qc_round);
@@ -111,7 +109,7 @@ impl Safety {
 
             let ledger_commit_info = LedgerCommitInfo::new::<H>(commit_hash, &vote_info);
 
-            return Some(VoteMessage {
+            return Some(Vote {
                 vote_info,
                 ledger_commit_info,
             });

--- a/monad-consensus/tests/message.rs
+++ b/monad-consensus/tests/message.rs
@@ -1,24 +1,100 @@
-use monad_consensus::messages::message::{ProposalMessage, TimeoutMessage, VoteMessage};
-use monad_consensus_types::{
-    block::{Block, TransactionList},
-    ledger::LedgerCommitInfo,
-    quorum_certificate::{QcInfo, QuorumCertificate},
-    timeout::{HighQcRound, HighQcRoundSigTuple, TimeoutCertificate, TimeoutInfo},
-    validation::{Hasher, Sha256Hash},
-    voting::VoteInfo,
-};
-use monad_crypto::secp256k1::{KeyPair, SecpSignature};
-use monad_testutil::signing::*;
-use monad_types::*;
-use sha2::Digest;
-use test_case::test_case;
-use zerocopy::AsBytes;
+#[cfg(test)]
+mod tests {
+    use monad_consensus::messages::message::{ProposalMessage, TimeoutMessage};
+    use monad_consensus_types::{
+        block::{Block, TransactionList},
+        ledger::LedgerCommitInfo,
+        quorum_certificate::{QcInfo, QuorumCertificate},
+        timeout::{HighQcRound, HighQcRoundSigTuple, TimeoutCertificate, TimeoutInfo},
+        validation::{Hasher, Sha256Hash},
+        voting::{Vote, VoteInfo},
+    };
+    use monad_crypto::{
+        secp256k1::{KeyPair, SecpSignature},
+        GenericKeyPair,
+    };
+    use monad_testutil::signing::*;
+    use monad_types::*;
+    use sha2::Digest;
+    use test_case::test_case;
+    use zerocopy::AsBytes;
 
-#[test]
-fn timeout_msg_hash() {
-    let ti = TimeoutInfo {
-        round: Round(10),
-        high_qc: QuorumCertificate::<MockSignatures>::new(
+    // TODO: make another test for vote message
+    // FIXME: this test is same as `monad-consensus-types::voting::test::voteinfo_hash`
+    #[test_case(None ; "None commit_state")]
+    #[test_case(Some(Default::default()) ; "Some commit_state")]
+    fn vote_hash(cs: Option<Hash>) {
+        let lci = LedgerCommitInfo {
+            commit_state_hash: cs,
+            vote_info_hash: Default::default(),
+        };
+
+        let v = Vote {
+            vote_info: VoteInfo {
+                id: BlockId(Hash([0x00_u8; 32])),
+                round: Round(0),
+                parent_id: BlockId(Hash([0x00_u8; 32])),
+                parent_round: Round(0),
+            },
+            ledger_commit_info: lci,
+        };
+
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(v.vote_info.id.0.as_bytes());
+        hasher.update(v.vote_info.round.as_bytes());
+        hasher.update(v.vote_info.parent_id.0.as_bytes());
+        hasher.update(v.vote_info.parent_round.as_bytes());
+        let h1: Hash = Hash(hasher.finalize_reset().into());
+
+        let h2 = Sha256Hash::hash_object(&v.vote_info);
+
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn timeout_msg_hash() {
+        let ti = TimeoutInfo {
+            round: Round(10),
+            high_qc: QuorumCertificate::<MockSignatures>::new(
+                QcInfo {
+                    vote: VoteInfo {
+                        id: BlockId(Hash([0x00_u8; 32])),
+                        round: Round(0),
+                        parent_id: BlockId(Hash([0x00_u8; 32])),
+                        parent_round: Round(0),
+                    },
+                    ledger_commit: Default::default(),
+                },
+                MockSignatures::with_pubkeys(&[]),
+            ),
+        };
+
+        let tm: TimeoutMessage<SecpSignature, MockSignatures> = TimeoutMessage {
+            tminfo: ti,
+            last_round_tc: None,
+        };
+
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(tm.tminfo.round);
+        hasher.update(tm.tminfo.high_qc.info.vote.round);
+        let h1: Hash = Hash(hasher.finalize_reset().into());
+
+        let h2 = Sha256Hash::hash_object(&tm);
+
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn proposal_msg_hash() {
+        use monad_testutil::signing::hash;
+
+        let txns = TransactionList(vec![1, 2, 3, 4]);
+
+        let mut privkey: [u8; 32] = [127; 32];
+        let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
+        let author = NodeId(keypair.pubkey());
+        let round = Round(234);
+        let qc = QuorumCertificate::<MockSignatures>::new(
             QcInfo {
                 vote: VoteInfo {
                     id: BlockId(Hash([0x00_u8; 32])),
@@ -26,152 +102,84 @@ fn timeout_msg_hash() {
                     parent_id: BlockId(Hash([0x00_u8; 32])),
                     parent_round: Round(0),
                 },
-                ledger_commit: Default::default(),
+                ledger_commit: LedgerCommitInfo::default(),
             },
             MockSignatures::with_pubkeys(&[]),
-        ),
-    };
+        );
 
-    let tm: TimeoutMessage<SecpSignature, MockSignatures> = TimeoutMessage {
-        tminfo: ti,
-        last_round_tc: None,
-    };
+        let block = Block::<MockSignatures>::new::<Sha256Hash>(author, round, &txns, &qc);
 
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(tm.tminfo.round);
-    hasher.update(tm.tminfo.high_qc.info.vote.round);
-    let h1: Hash = Hash(hasher.finalize_reset().into());
+        let proposal: ProposalMessage<SecpSignature, MockSignatures> = ProposalMessage {
+            block: block.clone(),
+            last_round_tc: None,
+        };
 
-    let h2 = Sha256Hash::hash_object(&tm);
+        let h1 = Sha256Hash::hash_object(&proposal);
+        let h2 = hash(&block);
 
-    assert_eq!(h1, h2);
-}
+        assert_eq!(h1, h2);
+    }
 
-#[test]
-fn proposal_msg_hash() {
-    use monad_testutil::signing::hash;
+    #[test]
+    fn max_high_qc() {
+        let high_qc_rounds = vec![
+            HighQcRound { qc_round: Round(1) },
+            HighQcRound { qc_round: Round(3) },
+            HighQcRound { qc_round: Round(1) },
+        ]
+        .iter()
+        .map(|x| {
+            let msg = Sha256Hash::hash_object(x);
+            let keypair = get_key(0);
+            HighQcRoundSigTuple {
+                high_qc_round: *x,
+                author_signature: keypair.sign(msg.as_ref()),
+            }
+        })
+        .collect();
 
-    let txns = TransactionList(vec![1, 2, 3, 4]);
+        let tc = TimeoutCertificate {
+            round: Round(2),
+            high_qc_rounds,
+        };
 
-    let mut privkey: [u8; 32] = [127; 32];
-    let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
-    let author = NodeId(keypair.pubkey());
-    let round = Round(234);
-    let qc = QuorumCertificate::<MockSignatures>::new(
-        QcInfo {
-            vote: VoteInfo {
+        assert_eq!(tc.max_round(), Round(3));
+    }
+
+    #[test]
+    fn test_vote_message() {
+        let lci = LedgerCommitInfo {
+            commit_state_hash: Some(Default::default()),
+            vote_info_hash: Default::default(),
+        };
+
+        let vm = Vote {
+            vote_info: VoteInfo {
                 id: BlockId(Hash([0x00_u8; 32])),
                 round: Round(0),
                 parent_id: BlockId(Hash([0x00_u8; 32])),
                 parent_round: Round(0),
             },
-            ledger_commit: LedgerCommitInfo::default(),
-        },
-        MockSignatures::with_pubkeys(&[]),
-    );
+            ledger_commit_info: lci,
+        };
 
-    let block = Block::<MockSignatures>::new::<Sha256Hash>(author, round, &txns, &qc);
+        let mut privkey: [u8; 32] = [127; 32];
+        let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
 
-    let proposal: ProposalMessage<SecpSignature, MockSignatures> = ProposalMessage {
-        block: block.clone(),
-        last_round_tc: None,
-    };
+        let _expected_vote_info_hash = vm.ledger_commit_info.vote_info_hash;
 
-    let h1 = Sha256Hash::hash_object(&proposal);
-    let h2 = hash(&block);
+        let msg = Sha256Hash::hash_object(&vm.vote_info);
+        let svm = TestSigner::sign_object(vm, msg.as_ref(), &keypair);
 
-    assert_eq!(h1, h2);
-}
+        assert_eq!(
+            svm.author_signature().recover_pubkey(msg.as_ref()).unwrap(),
+            keypair.pubkey()
+        );
 
-#[test]
-fn max_high_qc() {
-    let high_qc_rounds = vec![
-        HighQcRound { qc_round: Round(1) },
-        HighQcRound { qc_round: Round(3) },
-        HighQcRound { qc_round: Round(1) },
-    ]
-    .iter()
-    .map(|x| {
-        let msg = Sha256Hash::hash_object(x);
-        let keypair = get_key(0);
-        HighQcRoundSigTuple {
-            high_qc_round: *x,
-            author_signature: keypair.sign(msg.as_ref()),
-        }
-    })
-    .collect();
-
-    let tc = TimeoutCertificate {
-        round: Round(2),
-        high_qc_rounds,
-    };
-
-    assert_eq!(tc.max_round(), Round(3));
-}
-
-#[test]
-fn test_vote_message() {
-    let lci = LedgerCommitInfo {
-        commit_state_hash: Some(Default::default()),
-        vote_info_hash: Default::default(),
-    };
-
-    let vm = VoteMessage {
-        vote_info: VoteInfo {
-            id: BlockId(Hash([0x00_u8; 32])),
-            round: Round(0),
-            parent_id: BlockId(Hash([0x00_u8; 32])),
-            parent_round: Round(0),
-        },
-        ledger_commit_info: lci,
-    };
-
-    let mut privkey: [u8; 32] = [127; 32];
-    let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
-
-    let expected_vote_info_hash = vm.ledger_commit_info.vote_info_hash;
-
-    let msg = Sha256Hash::hash_object(&vm.vote_info);
-    let svm = TestSigner::sign_object(vm, msg.as_ref(), &keypair);
-
-    assert_eq!(
-        svm.author_signature().recover_pubkey(msg.as_ref()).unwrap(),
-        keypair.pubkey()
-    );
-
-    // TODO fix this test.. would be best if we could do this as a unit test
-    // assert_eq!(
-    //     svm.obj.ledger_commit_info.vote_info_hash,
-    //     expected_vote_info_hash
-    // );
-}
-
-#[test_case(None ; "None commit_state")]
-#[test_case(Some(Default::default()) ; "Some commit_state")]
-fn vote_msg_hash(cs: Option<Hash>) {
-    let lci = LedgerCommitInfo {
-        commit_state_hash: cs,
-        vote_info_hash: Default::default(),
-    };
-
-    let vm = VoteMessage {
-        vote_info: VoteInfo {
-            id: BlockId(Hash([0x00_u8; 32])),
-            round: Round(0),
-            parent_id: BlockId(Hash([0x00_u8; 32])),
-            parent_round: Round(0),
-        },
-        ledger_commit_info: lci,
-    };
-
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(vm.vote_info.id.0.as_bytes());
-    hasher.update(vm.vote_info.round.as_bytes());
-    hasher.update(vm.vote_info.parent_id.0.as_bytes());
-    hasher.update(vm.vote_info.parent_round.as_bytes());
-    let h1: Hash = Hash(hasher.finalize_reset().into());
-
-    let h2 = Sha256Hash::hash_object(&vm.vote_info);
-
-    assert_eq!(h1, h2);
+        // TODO fix this test.. would be best if we could do this as a unit test
+        // assert_eq!(
+        //     svm.obj.ledger_commit_info.vote_info_hash,
+        //     expected_vote_info_hash
+        // );
+    }
 }

--- a/monad-consensus/tests/proposal.rs
+++ b/monad-consensus/tests/proposal.rs
@@ -6,7 +6,10 @@ use monad_consensus_types::{
     validation::{Error, Hasher, Sha256Hash},
     voting::VoteInfo,
 };
-use monad_crypto::secp256k1::{PubKey, SecpSignature};
+use monad_crypto::{
+    secp256k1::{PubKey, SecpSignature},
+    GenericKeyPair,
+};
 use monad_testutil::{
     signing::{get_key, MockSignatures, TestSigner},
     validators::create_keys_w_validators,
@@ -40,7 +43,7 @@ fn setup_block(
 
 #[test]
 fn test_proposal_hash() {
-    let (keypairs, _blskeys, vset, vprop) = create_keys_w_validators(1);
+    let (keypairs, _blskeys, _, vset, vprop) = create_keys_w_validators::<MockSignatures>(1);
     let author = NodeId(keypairs[0].pubkey());
 
     let proposal: ProposalMessage<SecpSignature, MockSignatures> = ProposalMessage {
@@ -56,6 +59,7 @@ fn test_proposal_hash() {
         ),
         last_round_tc: None,
     };
+
     let msg = Sha256Hash::hash_object(&proposal);
     let sp = TestSigner::sign_object(proposal, msg.as_ref(), &keypairs[0]);
 
@@ -66,7 +70,7 @@ fn test_proposal_hash() {
 
 #[test]
 fn test_proposal_missing_tc() {
-    let (keypairs, _blskeys, vset, vprop) = create_keys_w_validators(1);
+    let (keypairs, _blskeys, _, vset, vprop) = create_keys_w_validators::<MockSignatures>(1);
     let author = NodeId(keypairs[0].pubkey());
 
     let proposal = ProposalMessage {
@@ -95,7 +99,7 @@ fn test_proposal_missing_tc() {
 
 #[test]
 fn test_proposal_invalid_qc() {
-    let (keypairs, _blskeys, vset, vprop) = create_keys_w_validators(1);
+    let (keypairs, _blskeys, _, vset, vprop) = create_keys_w_validators::<MockSignatures>(1);
     let author = NodeId(keypairs[0].pubkey());
 
     let proposal = ProposalMessage {

--- a/monad-executor/src/executor/mock.rs
+++ b/monad-executor/src/executor/mock.rs
@@ -319,7 +319,7 @@ mod tests {
     use std::{collections::HashSet, fmt::Debug, time::Duration};
 
     use futures::{FutureExt, StreamExt};
-    use monad_crypto::secp256k1::KeyPair;
+    use monad_crypto::{secp256k1::KeyPair, GenericKeyPair};
     use monad_testutil::signing::{create_keys, node_id};
     use monad_types::{Deserializable, Serializable};
     use monad_wal::mock::{MockWALogger, MockWALoggerConfig};

--- a/monad-proto/proto/message.proto
+++ b/monad-proto/proto/message.proto
@@ -9,8 +9,8 @@ import "timeout.proto";
 import "voting.proto";
 
 message ProtoVoteMessage {
-  monad_proto.voting.ProtoVoteInfo vote_info = 1;
-  monad_proto.ledger.ProtoLedgerCommitInfo ledger_commit_info = 2;
+  monad_proto.voting.ProtoVote vote = 1;
+  monad_proto.signing.ProtoSignature sig = 2;
 }
 
 message ProtoTimeoutMessage {

--- a/monad-proto/proto/voting.proto
+++ b/monad-proto/proto/voting.proto
@@ -3,10 +3,16 @@ syntax = "proto3";
 package monad_proto.voting;
 
 import "basic.proto";
+import "ledger.proto";
 
 message ProtoVoteInfo {
   monad_proto.basic.ProtoBlockId id = 1;
   uint64 round = 2;
   monad_proto.basic.ProtoBlockId parent_id = 3;
   uint64 parent_round = 4;
+}
+
+message ProtoVote {
+  ProtoVoteInfo vote_info = 1;
+  monad_proto.ledger.ProtoLedgerCommitInfo ledger_commit_info = 2;
 }

--- a/monad-state/src/convert/event.rs
+++ b/monad-state/src/convert/event.rs
@@ -2,8 +2,9 @@ use monad_consensus::pacemaker::PacemakerTimerExpire;
 use monad_consensus_types::{
     block::{FullTransactionList, TransactionList},
     multi_sig::MultiSig,
+    validation::Hashable,
 };
-use monad_crypto::Signature;
+use monad_crypto::{GenericSignature, Signature};
 use monad_proto::{
     error::ProtoError,
     proto::{event::*, pacemaker::ProtoPacemakerTimerExpire},
@@ -16,7 +17,7 @@ use crate::{
 pub(super) type MonadEvent<S> = TypeMonadEvent<S, MultiSig<S>>;
 pub(super) type ConsensusEvent<S> = TypeConsensusEvent<S, MultiSig<S>>;
 
-impl<S: Signature> From<&ConsensusEvent<S>> for ProtoConsensusEvent {
+impl<S: Signature + GenericSignature + Hashable> From<&ConsensusEvent<S>> for ProtoConsensusEvent {
     fn from(value: &ConsensusEvent<S>) -> Self {
         let event = match value {
             TypeConsensusEvent::Message {
@@ -51,7 +52,9 @@ impl<S: Signature> From<&ConsensusEvent<S>> for ProtoConsensusEvent {
     }
 }
 
-impl<S: Signature> TryFrom<ProtoConsensusEvent> for ConsensusEvent<S> {
+impl<S: Signature + GenericSignature + Hashable> TryFrom<ProtoConsensusEvent>
+    for ConsensusEvent<S>
+{
     type Error = ProtoError;
 
     fn try_from(value: ProtoConsensusEvent) -> Result<Self, Self::Error> {
@@ -125,7 +128,7 @@ impl<S: Signature> TryFrom<ProtoConsensusEvent> for ConsensusEvent<S> {
     }
 }
 
-impl<S: Signature> From<&MonadEvent<S>> for ProtoMonadEvent {
+impl<S: Signature + GenericSignature + Hashable> From<&MonadEvent<S>> for ProtoMonadEvent {
     fn from(value: &MonadEvent<S>) -> Self {
         let event = match value {
             TypeMonadEvent::ConsensusEvent(msg) => {
@@ -136,7 +139,7 @@ impl<S: Signature> From<&MonadEvent<S>> for ProtoMonadEvent {
     }
 }
 
-impl<S: Signature> TryFrom<ProtoMonadEvent> for MonadEvent<S> {
+impl<S: Signature + GenericSignature + Hashable> TryFrom<ProtoMonadEvent> for MonadEvent<S> {
     type Error = ProtoError;
     fn try_from(value: ProtoMonadEvent) -> Result<Self, Self::Error> {
         let event: MonadEvent<S> = match value.event {

--- a/monad-state/src/convert/interface.rs
+++ b/monad-state/src/convert/interface.rs
@@ -1,15 +1,20 @@
-use monad_crypto::Signature;
+use monad_consensus_types::validation::Hashable;
+use monad_crypto::{GenericSignature, Signature};
 use monad_proto::{error::ProtoError, proto::event::ProtoMonadEvent};
 use prost::Message;
 
 use super::event::MonadEvent;
 
-pub fn serialize_event(event: &MonadEvent<impl Signature>) -> Vec<u8> {
+pub fn serialize_event(
+    event: &MonadEvent<impl Signature + GenericSignature + Hashable>,
+) -> Vec<u8> {
     let proto_event: ProtoMonadEvent = event.into();
     proto_event.encode_to_vec()
 }
 
-pub fn deserialize_event<S: Signature>(data: &[u8]) -> Result<MonadEvent<S>, ProtoError> {
+pub fn deserialize_event<S: Signature + GenericSignature + Hashable>(
+    data: &[u8],
+) -> Result<MonadEvent<S>, ProtoError> {
     let event = ProtoMonadEvent::decode(data)?;
     event.try_into()
 }

--- a/monad-testutil/src/block.rs
+++ b/monad-testutil/src/block.rs
@@ -1,27 +1,23 @@
 use monad_consensus_types::{
     block::{Block, TransactionList},
     ledger::LedgerCommitInfo,
-    multi_sig::MultiSig,
     quorum_certificate::{QcInfo, QuorumCertificate},
-    signature::{SignatureBuilder, SignatureCollection},
+    signature::{SignatureBuilder, SignatureCollection, SignatureCollectionKeyPairType},
     validation::{Hasher, Sha256Hash},
     voting::VoteInfo,
 };
-use monad_crypto::{
-    secp256k1::{KeyPair, SecpSignature},
-    Signature,
-};
+use monad_crypto::GenericSignature;
 use monad_types::{BlockId, Hash, NodeId, Round};
 use monad_validator::validator_property::{ValidatorSetProperty, ValidatorSetPropertyType};
 
-pub fn setup_block(
+pub fn setup_block<'a, SCT: SignatureCollection>(
     author: NodeId,
     block_round: u64,
     qc_round: u64,
     txns: TransactionList,
-    keypairs: &[KeyPair],
+    voters: impl Iterator<Item = (NodeId, &'a SignatureCollectionKeyPairType<SCT>)>,
     validators_property: &ValidatorSetProperty,
-) -> Block<MultiSig<SecpSignature>> {
+) -> Block<SCT> {
     let txns = txns;
     let round = Round(block_round);
 
@@ -40,21 +36,22 @@ pub fn setup_block(
     let qcinfo_hash = Sha256Hash::hash_object(&qcinfo.ledger_commit);
 
     let mut builder = SignatureBuilder::new();
-    for keypair in keypairs.iter() {
-        let idx = validators_property
-            .get_index(&NodeId(keypair.pubkey()))
-            .unwrap();
-        builder.add_signature(idx, SecpSignature::sign(qcinfo_hash.as_ref(), keypair));
+    for (node_id, keypair) in voters {
+        let idx = validators_property.get_index(&node_id).unwrap();
+        builder.add_signature(
+            idx,
+            <SCT::SignatureType as GenericSignature>::sign(qcinfo_hash.as_ref(), keypair),
+        );
     }
 
-    let aggsig = MultiSig::new(
+    let aggsig = SCT::new(
         builder,
         validators_property.get_voting_list(),
         qcinfo_hash.as_ref(),
     )
     .unwrap();
 
-    let qc = QuorumCertificate::<MultiSig<SecpSignature>>::new(qcinfo, aggsig);
+    let qc = QuorumCertificate::<SCT>::new(qcinfo, aggsig);
 
-    Block::<MultiSig<SecpSignature>>::new::<Sha256Hash>(author, round, &txns, &qc)
+    Block::<SCT>::new::<Sha256Hash>(author, round, &txns, &qc)
 }

--- a/monad-testutil/src/validators.rs
+++ b/monad-testutil/src/validators.rs
@@ -1,4 +1,5 @@
-use monad_crypto::{bls12_381::BlsKeyPair, secp256k1::KeyPair};
+use monad_consensus_types::signature::{SignatureCollection, SignatureCollectionKeyPairType};
+use monad_crypto::{bls12_381::BlsKeyPair, secp256k1::KeyPair, GenericKeyPair};
 use monad_types::{NodeId, Round, Stake};
 use monad_validator::{
     leader_election::LeaderElection,
@@ -6,7 +7,7 @@ use monad_validator::{
     validator_set::{ValidatorSet, ValidatorSetType},
 };
 
-use crate::signing::{create_keys, create_keys_bls};
+use crate::signing::{create_keys, create_keys_bls, create_voting_keys};
 
 pub struct MockLeaderElection {
     leader: NodeId,
@@ -27,16 +28,18 @@ impl LeaderElection for MockLeaderElection {
     }
 }
 
-pub fn create_keys_w_validators(
+pub fn create_keys_w_validators<SCT: SignatureCollection>(
     num_nodes: u32,
 ) -> (
     Vec<KeyPair>,
     Vec<BlsKeyPair>,
+    Vec<SignatureCollectionKeyPairType<SCT>>,
     ValidatorSet,
     ValidatorSetProperty,
 ) {
     let keys = create_keys(num_nodes);
     let blskeys = create_keys_bls(num_nodes);
+    let voting_keys = create_voting_keys::<SCT>(num_nodes);
 
     let staking_list = keys
         .iter()
@@ -54,5 +57,5 @@ pub fn create_keys_w_validators(
     let validators_property =
         ValidatorSetProperty::new(prop_list).expect("create validator set property");
 
-    (keys, blskeys, validators, validators_property)
+    (keys, blskeys, voting_keys, validators, validators_property)
 }

--- a/monad-validator/src/validator_property.rs
+++ b/monad-validator/src/validator_property.rs
@@ -78,6 +78,7 @@ impl ValidatorSetPropertyType for ValidatorSetProperty {
 
 #[cfg(test)]
 mod test {
+    use monad_crypto::GenericKeyPair;
     use monad_testutil::signing::{create_keys, create_keys_bls, get_key, get_key_bls};
     use monad_types::NodeId;
 

--- a/monad-validator/src/validator_set.rs
+++ b/monad-validator/src/validator_set.rs
@@ -110,7 +110,7 @@ impl ValidatorSetType for ValidatorSet {
 
 #[cfg(test)]
 mod test {
-    use monad_crypto::secp256k1::KeyPair;
+    use monad_crypto::{secp256k1::KeyPair, GenericKeyPair};
     use monad_testutil::signing::{create_keys, get_key};
     use monad_types::{NodeId, Stake};
 

--- a/monad-viz/src/config.rs
+++ b/monad-viz/src/config.rs
@@ -9,13 +9,17 @@ use monad_consensus_types::{
     quorum_certificate::genesis_vote_info, transaction_validator::MockValidator,
     validation::Sha256Hash,
 };
-use monad_crypto::secp256k1::{KeyPair, PubKey};
+use monad_crypto::{
+    secp256k1::{KeyPair, PubKey},
+    GenericKeyPair,
+};
 use monad_executor::{
     mock_swarm::{LatencyTransformer, Layer, LayerTransformer, XorLatencyTransformer},
     State,
 };
 use monad_state::MonadConfig;
 use monad_testutil::{signing::get_genesis_config, validators::create_keys_w_validators};
+use monad_types::NodeId;
 use monad_wal::{mock::MockWALoggerConfig, PersistenceLogger};
 
 use crate::{graph::SimulationConfig, PersistenceLoggerType, SignatureCollectionType, MM, MS};
@@ -53,20 +57,29 @@ impl SimulationConfig<MS, LayerTransformer<MM>, PersistenceLoggerType> for SimCo
         <MS as State>::Config,
         <PersistenceLoggerType as PersistenceLogger>::Config,
     )> {
-        let (keys, blskeys, validators, validators_prop) = create_keys_w_validators(self.num_nodes);
+        let (keys, blskeys, votekeys, validators, validators_prop) =
+            create_keys_w_validators::<SignatureCollectionType>(self.num_nodes);
 
         let pubkeys = keys.iter().map(KeyPair::pubkey).collect::<Vec<_>>();
+        let voters = pubkeys
+            .iter()
+            .map(|pk| NodeId(*pk))
+            .zip(votekeys.iter())
+            .collect::<Vec<_>>();
+
         let (genesis_block, genesis_sigs) = get_genesis_config::<Sha256Hash, SignatureCollectionType>(
-            keys.iter(),
+            voters.into_iter(),
             &validators_prop,
         );
 
         let state_configs = keys
             .into_iter()
             .zip(std::iter::repeat(pubkeys.clone()))
-            .map(|(key, pubkeys)| MonadConfig {
+            .zip(votekeys.into_iter())
+            .map(|((key, pubkeys), voting_key)| MonadConfig {
                 transaction_validator: MockValidator,
                 key,
+                voting_key,
                 validators: pubkeys
                     .iter()
                     .cloned()


### PR DESCRIPTION
`ConsensusState` holds only one keypair, which is used for both signing messages and votes. In a future PR on `BlsSignatureCollections`, we want to switch between two voting keypairs, based on the `SignatureCollection` we use.

This PR adds a `voting_key` field to `ConsensusState` that's dedicated to signing votes. VoteMessage holds the vote signature over the ledger commit info. The signature in `Verified<_>` is now over the entire VoteMessage.