### PR TITLE
Add evidence interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4668,6 +4668,7 @@ name = "monad-executor"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "log",
  "monad-consensus-types",
  "monad-crypto",
  "monad-mempool-controller",

--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -6,6 +6,7 @@ use monad_consensus::{
 };
 use monad_consensus_types::{
     block::Block,
+    evidence::Evidence,
     payload::{FullTransactionList, TransactionList},
     quorum_certificate::QuorumCertificate,
     signature::SignatureCollection,
@@ -39,6 +40,7 @@ pub enum ConsensusCommand<ST, SCT: SignatureCollection> {
     /// Checkpoints periodically can upload/backup the ledger and garbage clean
     /// persisted events if necessary
     CheckpointSave(Checkpoint<SCT>),
+    AddEvidence(Evidence),
     // TODO add command for updating validator_set/round
     // - to handle this command, we need to call message_state.set_round()
 }
@@ -87,4 +89,6 @@ pub struct FetchedFullTxs<ST, SCT> {
     pub author: NodeId,
     pub p: ProposalMessage<ST, SCT>,
     pub txns: Option<FullTransactionList>,
+    pub signature: Vec<u8>,
+    pub sender: NodeId,
 }

--- a/monad-consensus-types/src/evidence.rs
+++ b/monad-consensus-types/src/evidence.rs
@@ -1,0 +1,37 @@
+use monad_types::{Hash, NodeId, Round};
+use sha2::Digest;
+use zerocopy::AsBytes;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum EvidencePresence {
+    Found,
+    NotFound,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+#[repr(u8)]
+pub enum EvidenceType {
+    Equivocation = 0,
+    DDoS = 1,
+    Amnesia = 2,
+    InvalidProposal = 3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Evidence {
+    pub evidence_type: EvidenceType,
+    pub round: Round,
+    pub malicious_node: NodeId,
+    pub signed_invalid_msg: Vec<u8>,
+}
+
+impl Evidence {
+    pub fn get_hash(&self) -> Hash {
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(self.round.as_bytes());
+        hasher.update([self.evidence_type as u8]);
+        hasher.update(self.malicious_node.0.bytes());
+        hasher.update(&self.signed_invalid_msg);
+        Hash(hasher.finalize().into())
+    }
+}

--- a/monad-consensus-types/src/lib.rs
+++ b/monad-consensus-types/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod convert;
 
 pub mod block;
+pub mod evidence;
 pub mod ledger;
 pub mod multi_sig;
 pub mod payload;

--- a/monad-driver/src/lib.rs
+++ b/monad-driver/src/lib.rs
@@ -10,7 +10,10 @@ mod tests {
     };
     use monad_crypto::secp256k1::{KeyPair, SecpSignature};
     use monad_executor::{
-        executor::{checkpoint::MockCheckpoint, ledger::MockLedger, mock::MockMempool},
+        executor::{
+            checkpoint::MockCheckpoint, evpool::MockEvidencePool, ledger::MockLedger,
+            mock::MockMempool,
+        },
         Executor, State,
     };
     use monad_state::{MonadConfig, MonadState};
@@ -51,6 +54,7 @@ mod tests {
                     mempool: MockMempool::default(),
                     ledger: MockLedger::default(),
                     checkpoint: MockCheckpoint::default(),
+                    evpool: MockEvidencePool::default(),
                     timer: monad_executor::executor::timer::TokioTimer::default(),
                 };
 

--- a/monad-executor/Cargo.toml
+++ b/monad-executor/Cargo.toml
@@ -20,6 +20,7 @@ monad-types = { path = "../monad-types" }
 monad-wal = { path = "../monad-wal" }
 
 futures = { workspace = true }
+log = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 thiserror = { workspace = true }

--- a/monad-executor/src/executor/evpool.rs
+++ b/monad-executor/src/executor/evpool.rs
@@ -1,0 +1,70 @@
+use std::collections::{HashMap, VecDeque};
+
+use log::info;
+use monad_consensus_types::evidence::Evidence;
+use monad_types::Hash;
+
+use crate::{EvidenceCommand, Executor};
+
+#[derive(Default)]
+pub struct MockEvidencePool {
+    evidence_list: VecDeque<Evidence>,
+    evidence_store: HashMap<Hash, Evidence>,
+}
+
+impl MockEvidencePool {
+    fn add_evidence(&mut self, ev: Evidence) {
+        let hash = ev.get_hash();
+        self.evidence_store.insert(hash, ev.clone());
+        self.evidence_list.push_back(ev);
+    }
+}
+
+impl Executor for MockEvidencePool {
+    type Command = EvidenceCommand;
+    fn exec(&mut self, commands: Vec<Self::Command>) {
+        for command in commands {
+            match command {
+                EvidenceCommand::AddEvidence(ev) => {
+                    let hash = ev.get_hash();
+                    if self.evidence_store.contains_key(&hash) {
+                        info!("Evidence already exists");
+                        continue;
+                    }
+                    self.add_evidence(ev);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use monad_consensus_types::evidence::{Evidence, EvidenceType};
+    use monad_testutil::signing::get_key;
+    use monad_types::{NodeId, Round};
+
+    use super::*;
+
+    #[test]
+    fn test_add_evidence() {
+        let mut evpool = MockEvidencePool::default();
+        let pk = get_key(0).pubkey();
+        let ev = Evidence {
+            round: Round(1),
+            evidence_type: EvidenceType::InvalidProposal,
+            malicious_node: NodeId(pk),
+            signed_invalid_msg: Default::default(),
+        };
+        let hash = ev.get_hash();
+        evpool.exec(vec![EvidenceCommand::AddEvidence(ev)]);
+        assert!(evpool.evidence_store.contains_key(&hash));
+        assert_eq!(evpool.evidence_list.len(), 1);
+        assert_eq!(evpool.evidence_list[0].round, Round(1));
+        assert_eq!(
+            evpool.evidence_list[0].evidence_type,
+            EvidenceType::InvalidProposal
+        );
+    }
+}

--- a/monad-executor/src/executor/mod.rs
+++ b/monad-executor/src/executor/mod.rs
@@ -1,5 +1,6 @@
 pub mod checkpoint;
 pub mod epoch;
+pub mod evpool;
 pub mod ledger;
 pub mod mock;
 pub mod parent;

--- a/monad-executor/src/state.rs
+++ b/monad-executor/src/state.rs
@@ -1,6 +1,9 @@
 use std::hash::Hash;
 
-use monad_consensus_types::payload::{FullTransactionList, TransactionList};
+use monad_consensus_types::{
+    evidence::Evidence,
+    payload::{FullTransactionList, TransactionList},
+};
 use monad_crypto::secp256k1::PubKey;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -59,6 +62,9 @@ pub enum LedgerCommand<B> {
 pub enum CheckpointCommand<C> {
     Save(C),
 }
+pub enum EvidenceCommand {
+    AddEvidence(Evidence),
+}
 
 pub trait Executor {
     type Command;
@@ -75,6 +81,7 @@ where
     MempoolCommand(MempoolCommand<M::Event>),
     LedgerCommand(LedgerCommand<B>),
     CheckpointCommand(CheckpointCommand<C>),
+    EvidenceCommand(EvidenceCommand),
 }
 
 impl<M, OM, B, C> Command<M, OM, B, C>
@@ -89,12 +96,14 @@ where
         Vec<MempoolCommand<M::Event>>,
         Vec<LedgerCommand<B>>,
         Vec<CheckpointCommand<C>>,
+        Vec<EvidenceCommand>,
     ) {
         let mut router_cmds = Vec::new();
         let mut timer_cmds = Vec::new();
         let mut mempool_cmds = Vec::new();
         let mut ledger_cmds = Vec::new();
         let mut checkpoint_cmds = Vec::new();
+        let mut evidence_cmds = Vec::new();
         for command in commands {
             match command {
                 Command::RouterCommand(cmd) => router_cmds.push(cmd),
@@ -102,6 +111,7 @@ where
                 Command::MempoolCommand(cmd) => mempool_cmds.push(cmd),
                 Command::LedgerCommand(cmd) => ledger_cmds.push(cmd),
                 Command::CheckpointCommand(cmd) => checkpoint_cmds.push(cmd),
+                Command::EvidenceCommand(cmd) => evidence_cmds.push(cmd),
             }
         }
         (
@@ -110,6 +120,7 @@ where
             mempool_cmds,
             ledger_cmds,
             checkpoint_cmds,
+            evidence_cmds,
         )
     }
 }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -20,8 +20,8 @@ use monad_crypto::{
 };
 use monad_executor::{
     executor::{
-        checkpoint::MockCheckpoint, ledger::MockLedger, mock::MockMempool, parent::ParentExecutor,
-        timer::TokioTimer,
+        checkpoint::MockCheckpoint, evpool::MockEvidencePool, ledger::MockLedger,
+        mock::MockMempool, parent::ParentExecutor, timer::TokioTimer,
     },
     Executor, State,
 };
@@ -284,6 +284,7 @@ async fn run(
         mempool: MockMempool::default(),
         ledger: MockLedger::default(),
         checkpoint: MockCheckpoint::default(),
+        evpool: MockEvidencePool::default(),
     };
 
     let (mut state, init_commands) = MonadState::init(MonadConfig {

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -36,6 +36,8 @@ message ProtoFetchedFullTxs {
   monad_proto.basic.ProtoNodeId author = 1;
   monad_proto.message.ProtoProposalMessageAggSig p = 2;
   bytes full_txs = 3;
+  bytes signature = 4;
+  monad_proto.basic.ProtoNodeId sender = 5;
 }
 
 message ProtoAdvanceEpochEvent {

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -18,7 +18,8 @@ use monad_executor::{
     timed_event::TimedEvent,
     PeerId, State,
 };
-use monad_state::{MonadConfig, MonadEvent, MonadMessage, MonadState};
+use monad_state::{MonadConfig, MonadEvent, MonadMessage, MonadState, VerifiedMonadMessage};
+use monad_types::Serializable;
 use monad_validator::{
     leader_election::LeaderElection,
     simple_round_robin::SimpleRoundRobin,
@@ -170,7 +171,9 @@ pub fn node_ledger_verification<
             PL,
         ),
     >,
-) {
+) where
+    VerifiedMonadMessage<ST, SCT>: Serializable,
+{
     let num_b = states
         .values()
         .map(|v| v.0.ledger().get_blocks().len())


### PR DESCRIPTION
Currently, the `EvidencePool` is implemented as an `Executor`. There are now three `EvidenceCommands` in work that the executor can process:
`AddEvidence` is called when the consensus process found out any abnormalities;
`FetchEvidenceList` is to add the evidence into the buffer for block inclusion;
`DeleteEvidence` is for deleting the expired evidence before Round x.