### PR TITLE
Run nightly RustFmt in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,13 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v2
-      - name: Check
-        run: cargo check --all-targets --all-features --verbose
-      - name: Run tests
-        run: cargo test --all-targets --all-features --verbose
+      - run: rustup toolchain install nightly --profile minimal --component rustfmt
       - name: Format
-        run: cargo fmt --all --check --verbose
+        run: cargo +nightly fmt --all --check --verbose
+      - uses: Swatinem/rust-cache@v2
       - name: Lint
         run: cargo clippy --all-targets --all-features --
           -D clippy::suspicious
@@ -40,3 +37,7 @@ jobs:
           -A clippy::type_complexity
           -A clippy::int_plus_one
           -A clippy::uninlined-format-args
+      - name: Check
+        run: cargo check --all-targets --all-features --verbose
+      - name: Run tests
+        run: cargo test --all-targets --all-features --verbose

--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -251,11 +251,15 @@ impl<T: SignatureCollection> BlockTree<T> {
             RootKind::Unrooted(r) => block_tree_block.block.round == r,
         };
         loop {
-            let Some(i) = self.tree.get(bid) else { return false };
+            let Some(i) = self.tree.get(bid) else {
+                return false;
+            };
             if root_match(i) {
                 return true;
             }
-            let Some(parent_id) = &i.parent else {return false };
+            let Some(parent_id) = &i.parent else {
+                return false;
+            };
             bid = parent_id;
         }
     }


### PR DESCRIPTION
Stable Rust doesn't support the RustFmt features we're using

[Source](https://github.com/monad-crypto/monad-bft/actions/runs/5649751777/job/15304751203)