### PR TITLE
Fix `test_proposal_invalid_qc` test

### DIFF
--- a/monad-consensus/tests/proposal.rs
+++ b/monad-consensus/tests/proposal.rs
@@ -98,14 +98,16 @@ fn test_proposal_missing_tc() {
 }
 
 #[test]
-fn test_proposal_invalid_qc() {
+fn test_proposal_author_not_sender() {
     let mut vlist = Vec::new();
 
-    let keypair = get_key(6);
+    let author_keypair = get_key(6);
+    let sender_keypair = get_key(7);
 
-    vlist.push((NodeId(keypair.pubkey()), Stake(0)));
+    vlist.push((NodeId(author_keypair.pubkey()), Stake(0)));
+    vlist.push((NodeId(sender_keypair.pubkey()), Stake(0)));
 
-    let author = node_id();
+    let author = NodeId(author_keypair.pubkey());
     let proposal = ProposalMessage {
         block: setup_block(
             author,
@@ -121,12 +123,72 @@ fn test_proposal_invalid_qc() {
     };
 
     let msg = Sha256Hash::hash_object(&proposal);
-    let sp = TestSigner::sign_object(proposal, msg.as_ref(), &get_key(7));
+    let sp = TestSigner::sign_object(proposal, msg.as_ref(), &author_keypair);
 
     let vset = ValidatorSet::new(vlist).unwrap();
     assert_eq!(
-        sp.verify::<Sha256Hash, _>(&vset, &keypair.pubkey())
+        sp.verify::<Sha256Hash, _>(&vset, &sender_keypair.pubkey())
             .unwrap_err(),
+        Error::AuthorNotSender
+    );
+}
+
+#[test]
+fn test_proposal_invalid_author() {
+    let mut vlist = Vec::new();
+    let author_keypair = get_key(6);
+    let non_valdiator_keypair = get_key(7);
+
+    vlist.push((NodeId(author_keypair.pubkey()), Stake(0)));
+
+    let author = NodeId(author_keypair.pubkey());
+    let proposal = ProposalMessage {
+        block: setup_block(
+            author,
+            Round(234),
+            Round(233),
+            &[author_keypair.pubkey(), non_valdiator_keypair.pubkey()],
+        ),
+        last_round_tc: None,
+    };
+
+    let msg = Sha256Hash::hash_object(&proposal);
+    let sp = TestSigner::sign_object(proposal, msg.as_ref(), &non_valdiator_keypair);
+
+    let vset = ValidatorSet::new(vlist).unwrap();
+    assert_eq!(
+        sp.verify::<Sha256Hash, _>(&vset, &author.0).unwrap_err(),
         Error::InvalidAuthor
+    );
+}
+
+#[test]
+fn test_proposal_invalid_qc() {
+    let mut vlist = Vec::new();
+    let non_staked_keypair = get_key(6);
+    let staked_keypair = get_key(7);
+
+    vlist.push((NodeId(non_staked_keypair.pubkey()), Stake(0)));
+    vlist.push((NodeId(staked_keypair.pubkey()), Stake(1)));
+
+    let author = NodeId(non_staked_keypair.pubkey());
+    let proposal = ProposalMessage {
+        block: setup_block(
+            author,
+            Round(234),
+            Round(233),
+            &[non_staked_keypair.pubkey()],
+        ),
+        last_round_tc: None,
+    };
+
+    let msg = Sha256Hash::hash_object(&proposal);
+    let sp = TestSigner::sign_object(proposal, msg.as_ref(), &non_staked_keypair);
+
+    let vset = ValidatorSet::new(vlist).unwrap();
+    assert_eq!(
+        sp.verify::<Sha256Hash, _>(&vset, &non_staked_keypair.pubkey())
+            .unwrap_err(),
+        Error::InsufficientStake
     );
 }


### PR DESCRIPTION
The previous test was a misnomer. The proposal has valid qc but the message was not signed by the sender.

This PR renames the test to
`test_proposal_author_not_sender` and adds a new test where the qc doesn't have enough stake. The MockSignature constructor and verify functions are corrected to produce the expected behavior