### PR TITLE
Add ExecutionArtifacts to the consensus Block

### DIFF
--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -312,8 +312,9 @@ mod test {
     use std::collections::HashSet;
 
     use monad_consensus_types::{
-        block::{Block as ConsensusBlock, TransactionList},
+        block::Block as ConsensusBlock,
         ledger::LedgerCommitInfo,
+        payload::{ExecutionArtifacts, Payload, TransactionList},
         quorum_certificate::{QcInfo, QuorumCertificate},
         signature::SignatureCollection,
         validation::Sha256Hash,
@@ -336,11 +337,14 @@ mod test {
 
     #[test]
     fn test_prune() {
-        let txlist = TransactionList(vec![]);
+        let payload = Payload {
+            txns: TransactionList(vec![]),
+            header: ExecutionArtifacts::zero(),
+        };
         let g = Block::new::<Sha256Hash>(
             node_id(),
             Round(0),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: VoteInfo {
@@ -365,7 +369,7 @@ mod test {
         let b1 = Block::new::<Sha256Hash>(
             node_id(),
             Round(1),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v1,
@@ -385,7 +389,7 @@ mod test {
         let b2 = Block::new::<Sha256Hash>(
             node_id(),
             Round(2),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v2,
@@ -405,7 +409,7 @@ mod test {
         let b3 = Block::new::<Sha256Hash>(
             node_id(),
             Round(3),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v3,
@@ -425,7 +429,7 @@ mod test {
         let b4 = Block::new::<Sha256Hash>(
             node_id(),
             Round(4),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v4,
@@ -445,7 +449,7 @@ mod test {
         let b5 = Block::new::<Sha256Hash>(
             node_id(),
             Round(5),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v5,
@@ -465,7 +469,7 @@ mod test {
         let b6 = Block::new::<Sha256Hash>(
             node_id(),
             Round(6),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v6,
@@ -485,7 +489,7 @@ mod test {
         let b7 = Block::new::<Sha256Hash>(
             node_id(),
             Round(7),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v7,
@@ -577,7 +581,7 @@ mod test {
         let b8 = Block::new::<Sha256Hash>(
             node_id(),
             Round(8),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v8,
@@ -593,11 +597,14 @@ mod test {
 
     #[test]
     fn test_add_parent_not_exist() {
-        let txlist = TransactionList(vec![]);
+        let payload = Payload {
+            txns: TransactionList(vec![]),
+            header: ExecutionArtifacts::zero(),
+        };
         let g = Block::new::<Sha256Hash>(
             node_id(),
             Round(0),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: VoteInfo {
@@ -622,7 +629,7 @@ mod test {
         let b1 = Block::new::<Sha256Hash>(
             node_id(),
             Round(1),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v1,
@@ -642,7 +649,7 @@ mod test {
         let b2 = Block::new::<Sha256Hash>(
             node_id(),
             Round(2),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v2,
@@ -681,7 +688,10 @@ mod test {
         let g = Block::new::<Sha256Hash>(
             node_id(),
             Round(0),
-            &txlist,
+            &Payload {
+                txns: txlist,
+                header: ExecutionArtifacts::zero(),
+            },
             &QC::new(
                 QcInfo {
                     vote: VoteInfo {
@@ -706,7 +716,10 @@ mod test {
         let b1 = Block::new::<Sha256Hash>(
             node_id(),
             Round(1),
-            &TransactionList(vec![1]),
+            &Payload {
+                txns: TransactionList(vec![1]),
+                header: ExecutionArtifacts::zero(),
+            },
             &QC::new(
                 QcInfo {
                     vote: v1,
@@ -719,7 +732,10 @@ mod test {
         let b2 = Block::new::<Sha256Hash>(
             node_id(),
             Round(1),
-            &TransactionList(vec![2]),
+            &Payload {
+                txns: TransactionList(vec![2]),
+                header: ExecutionArtifacts::zero(),
+            },
             &QC::new(
                 QcInfo {
                     vote: v1,
@@ -739,7 +755,10 @@ mod test {
         let b3 = Block::new::<Sha256Hash>(
             node_id(),
             Round(2),
-            &TransactionList(vec![3]),
+            &Payload {
+                txns: TransactionList(vec![3]),
+                header: ExecutionArtifacts::zero(),
+            },
             &QC::new(
                 QcInfo {
                     vote: v2,
@@ -780,7 +799,10 @@ mod test {
         let g = Block::new::<Sha256Hash>(
             node_id(),
             Round(0),
-            &txlist,
+            &Payload {
+                txns: txlist,
+                header: ExecutionArtifacts::zero(),
+            },
             &QC::new(
                 QcInfo {
                     vote: VoteInfo {
@@ -805,7 +827,10 @@ mod test {
         let b1 = Block::new::<Sha256Hash>(
             node_id(),
             Round(1),
-            &TransactionList(vec![1]),
+            &Payload {
+                txns: TransactionList(vec![1]),
+                header: ExecutionArtifacts::zero(),
+            },
             &QC::new(
                 QcInfo {
                     vote: v1,
@@ -832,10 +857,14 @@ mod test {
 
     #[test]
     fn paths_to_root() {
+        let payload = Payload {
+            txns: TransactionList(vec![]),
+            header: ExecutionArtifacts::zero(),
+        };
         let g = Block::new::<Sha256Hash>(
             node_id(),
             Round(0),
-            &TransactionList(Vec::new()),
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: VoteInfo {
@@ -860,7 +889,7 @@ mod test {
         let b1 = Block::new::<Sha256Hash>(
             node_id(),
             Round(1),
-            &TransactionList(Vec::new()),
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v1,
@@ -880,7 +909,7 @@ mod test {
         let b2 = Block::new::<Sha256Hash>(
             node_id(),
             Round(2),
-            &TransactionList(Vec::new()),
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v2,
@@ -893,7 +922,7 @@ mod test {
         let b3 = Block::new::<Sha256Hash>(
             node_id(),
             Round(3),
-            &TransactionList(Vec::new()),
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v2,
@@ -906,7 +935,7 @@ mod test {
         let b4 = Block::new::<Sha256Hash>(
             node_id(),
             Round(4),
-            &TransactionList(Vec::new()),
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v2,
@@ -956,11 +985,14 @@ mod test {
     fn unrooted_transition_to_rooted() {
         let mut blocktree = BlockTree::<MockSignatures>::new_unrooted(Round(4));
 
-        let txlist = TransactionList(vec![]);
+        let payload = Payload {
+            txns: TransactionList(vec![]),
+            header: ExecutionArtifacts::zero(),
+        };
         let g = Block::new::<Sha256Hash>(
             node_id(),
             Round(0),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: VoteInfo {
@@ -984,7 +1016,7 @@ mod test {
         let b4 = Block::new::<Sha256Hash>(
             node_id(),
             Round(4),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v4,
@@ -1004,7 +1036,7 @@ mod test {
         let b5 = Block::new::<Sha256Hash>(
             node_id(),
             Round(5),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v5,
@@ -1024,7 +1056,7 @@ mod test {
         let b6 = Block::new::<Sha256Hash>(
             node_id(),
             Round(6),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v6,
@@ -1059,11 +1091,14 @@ mod test {
     fn unrooted_many_potential_roots() {
         let mut blocktree = BlockTree::<MockSignatures>::new_unrooted(Round(4));
 
-        let txlist = TransactionList(vec![]);
+        let payload = Payload {
+            txns: TransactionList(vec![]),
+            header: ExecutionArtifacts::zero(),
+        };
         let g = Block::new::<Sha256Hash>(
             node_id(),
             Round(0),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: VoteInfo {
@@ -1088,7 +1123,7 @@ mod test {
         let b2 = Block::new::<Sha256Hash>(
             node_id(),
             Round(4),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v2,
@@ -1108,7 +1143,7 @@ mod test {
         let b3 = Block::new::<Sha256Hash>(
             node_id(),
             Round(4),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v3,
@@ -1128,7 +1163,7 @@ mod test {
         let b4 = Block::new::<Sha256Hash>(
             node_id(),
             Round(4),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v4,
@@ -1148,7 +1183,7 @@ mod test {
         let b5 = Block::new::<Sha256Hash>(
             node_id(),
             Round(5),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v5,
@@ -1168,7 +1203,7 @@ mod test {
         let b6 = Block::new::<Sha256Hash>(
             node_id(),
             Round(6),
-            &txlist,
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v6,
@@ -1210,10 +1245,14 @@ mod test {
 
     #[test]
     fn test_has_parent() {
+        let payload = Payload {
+            txns: TransactionList(vec![]),
+            header: ExecutionArtifacts::zero(),
+        };
         let g = Block::new::<Sha256Hash>(
             node_id(),
             Round(0),
-            &TransactionList(Vec::new()),
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: VoteInfo {
@@ -1238,7 +1277,7 @@ mod test {
         let b1 = Block::new::<Sha256Hash>(
             node_id(),
             Round(1),
-            &TransactionList(Vec::new()),
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v1,
@@ -1258,7 +1297,7 @@ mod test {
         let b4 = Block::new::<Sha256Hash>(
             node_id(),
             Round(4),
-            &TransactionList(Vec::new()),
+            &payload,
             &QC::new(
                 QcInfo {
                     vote: v4,

--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -5,7 +5,8 @@ use monad_consensus::{
     pacemaker::{PacemakerCommand, PacemakerTimerExpire},
 };
 use monad_consensus_types::{
-    block::{Block, FullTransactionList, TransactionList},
+    block::Block,
+    payload::{FullTransactionList, TransactionList},
     quorum_certificate::QuorumCertificate,
     signature::SignatureCollection,
     timeout::TimeoutCertificate,

--- a/monad-consensus-types/src/convert/block.rs
+++ b/monad-consensus-types/src/convert/block.rs
@@ -1,9 +1,16 @@
 use monad_crypto::Signature;
-use monad_proto::{error::ProtoError, proto::block::*};
+use monad_proto::{
+    error::ProtoError,
+    proto::{
+        basic::{ProtoBloom, ProtoGas},
+        block::*,
+    },
+};
 
 use crate::{
-    block::{Block, TransactionList},
+    block::Block,
     multi_sig::MultiSig,
+    payload::{Bloom, ExecutionArtifacts, Gas, Payload, TransactionList},
     validation::Sha256Hash,
 };
 
@@ -64,5 +71,119 @@ impl<S: Signature> TryFrom<ProtoBlockAggSig> for Block<MultiSig<S>> {
                 ))?
                 .try_into()?,
         ))
+    }
+}
+
+impl From<&Gas> for ProtoGas {
+    fn from(value: &Gas) -> Self {
+        Self { gas: value.0 }
+    }
+}
+
+impl TryFrom<ProtoGas> for Gas {
+    type Error = ProtoError;
+    fn try_from(value: ProtoGas) -> Result<Self, Self::Error> {
+        Ok(Self(value.gas))
+    }
+}
+
+impl From<&Bloom> for ProtoBloom {
+    fn from(value: &Bloom) -> Self {
+        Self {
+            bloom: value.0.to_vec(),
+        }
+    }
+}
+
+impl TryFrom<ProtoBloom> for Bloom {
+    type Error = ProtoError;
+    fn try_from(value: ProtoBloom) -> Result<Self, Self::Error> {
+        Ok(Self(value.bloom.try_into().map_err(|e: Vec<_>| {
+            Self::Error::WrongHashLen(format!("{}", e.len()))
+        })?))
+    }
+}
+
+impl From<&ExecutionArtifacts> for ProtoExecutionArtifacts {
+    fn from(value: &ExecutionArtifacts) -> Self {
+        Self {
+            parent_hash: Some((&(value.parent_hash)).into()),
+            state_root: Some((&(value.state_root)).into()),
+            transactions_root: Some((&(value.transactions_root)).into()),
+            receipts_root: Some((&(value.receipts_root)).into()),
+            logs_bloom: Some((&(value.logs_bloom)).into()),
+            gas_used: Some((&(value.gas_used)).into()),
+        }
+    }
+}
+
+impl TryFrom<ProtoExecutionArtifacts> for ExecutionArtifacts {
+    type Error = ProtoError;
+    fn try_from(value: ProtoExecutionArtifacts) -> Result<Self, Self::Error> {
+        Ok(Self {
+            parent_hash: value
+                .parent_hash
+                .ok_or(Self::Error::MissingRequiredField(
+                    "ExecutionArtifacts.parent_hash".to_owned(),
+                ))?
+                .try_into()?,
+            state_root: value
+                .state_root
+                .ok_or(Self::Error::MissingRequiredField(
+                    "ExecutionArtifacts.state_root".to_owned(),
+                ))?
+                .try_into()?,
+            transactions_root: value
+                .transactions_root
+                .ok_or(Self::Error::MissingRequiredField(
+                    "ExecutionArtifacts.transactions_root".to_owned(),
+                ))?
+                .try_into()?,
+            receipts_root: value
+                .receipts_root
+                .ok_or(Self::Error::MissingRequiredField(
+                    "ExecutionArtifacts.receipts_root".to_owned(),
+                ))?
+                .try_into()?,
+            logs_bloom: value
+                .logs_bloom
+                .ok_or(Self::Error::MissingRequiredField(
+                    "ExecutionArtifacts.logs_bloom".to_owned(),
+                ))?
+                .try_into()?,
+            gas_used: value
+                .gas_used
+                .ok_or(Self::Error::MissingRequiredField(
+                    "ExecutionArtifacts.gas_used".to_owned(),
+                ))?
+                .try_into()?,
+        })
+    }
+}
+
+impl From<&Payload> for ProtoPayload {
+    fn from(value: &Payload) -> Self {
+        ProtoPayload {
+            txns: Some((&(value.txns)).into()),
+            header: Some((&(value.header)).into()),
+        }
+    }
+}
+
+impl TryFrom<ProtoPayload> for Payload {
+    type Error = ProtoError;
+    fn try_from(value: ProtoPayload) -> Result<Self, Self::Error> {
+        Ok(Self {
+            txns: value
+                .txns
+                .ok_or(Self::Error::MissingRequiredField("Payload.txns".to_owned()))?
+                .try_into()?,
+            header: value
+                .header
+                .ok_or(Self::Error::MissingRequiredField(
+                    "Payload.header".to_owned(),
+                ))?
+                .try_into()?,
+        })
     }
 }

--- a/monad-consensus-types/src/lib.rs
+++ b/monad-consensus-types/src/lib.rs
@@ -4,6 +4,7 @@ pub mod convert;
 pub mod block;
 pub mod ledger;
 pub mod multi_sig;
+pub mod payload;
 pub mod quorum_certificate;
 pub mod signature;
 pub mod timeout;

--- a/monad-consensus-types/src/payload.rs
+++ b/monad-consensus-types/src/payload.rs
@@ -1,0 +1,97 @@
+use monad_types::Hash;
+use zerocopy::AsBytes;
+
+use crate::validation::{Hashable, Hasher};
+
+const BLOOM_SIZE: usize = 256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Bloom(pub [u8; BLOOM_SIZE]);
+
+impl Bloom {
+    pub fn zero() -> Self {
+        Bloom([0x00_u8; BLOOM_SIZE])
+    }
+}
+
+impl AsRef<[u8]> for Bloom {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+#[repr(transparent)]
+#[derive(Debug, Default, Copy, Clone, Eq, Ord, PartialEq, PartialOrd, AsBytes)]
+pub struct Gas(pub u64);
+
+impl AsRef<[u8]> for Gas {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExecutionArtifacts {
+    pub parent_hash: Hash,
+    pub state_root: Hash,
+    pub transactions_root: Hash,
+    pub receipts_root: Hash,
+    pub logs_bloom: Bloom,
+    pub gas_used: Gas,
+}
+
+impl ExecutionArtifacts {
+    pub fn zero() -> Self {
+        ExecutionArtifacts {
+            parent_hash: Default::default(),
+            state_root: Default::default(),
+            transactions_root: Default::default(),
+            receipts_root: Default::default(),
+            logs_bloom: Bloom::zero(),
+            gas_used: Gas(0),
+        }
+    }
+}
+
+impl Hashable for ExecutionArtifacts {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.update(self.parent_hash);
+        state.update(self.state_root);
+        state.update(self.transactions_root);
+        state.update(self.receipts_root);
+        state.update(self.logs_bloom);
+        state.update(self.gas_used.as_bytes());
+    }
+}
+
+#[derive(Clone, Default, PartialEq, Eq)]
+// TODO rename to TransactionHashList or something
+pub struct TransactionList(pub Vec<u8>);
+
+impl std::fmt::Debug for TransactionList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("TxnHashes").field(&self.0).finish()
+    }
+}
+
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct FullTransactionList(pub Vec<u8>);
+
+impl std::fmt::Debug for FullTransactionList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Txns").field(&self.0).finish()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct Payload {
+    pub txns: TransactionList,
+    pub header: ExecutionArtifacts,
+}
+
+impl Hashable for Payload {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.update(self.txns.0.as_bytes());
+        self.header.hash(state);
+    }
+}

--- a/monad-consensus-types/src/transaction_validator.rs
+++ b/monad-consensus-types/src/transaction_validator.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-use crate::block::FullTransactionList;
+use crate::payload::FullTransactionList;
 
 pub trait TransactionValidator {
     fn validate(&self, txs: &FullTransactionList) -> bool;

--- a/monad-consensus/tests/block.rs
+++ b/monad-consensus/tests/block.rs
@@ -1,6 +1,7 @@
 use monad_consensus_types::{
-    block::{Block, TransactionList},
+    block::Block,
     ledger::LedgerCommitInfo,
+    payload::{ExecutionArtifacts, Payload, TransactionList},
     quorum_certificate::{QcInfo, QuorumCertificate},
     signature::SignatureCollection,
     validation::{Hasher, Sha256Hash},
@@ -27,7 +28,15 @@ fn block_hash_id() {
         MockSignatures::new(),
     );
 
-    let block = Block::<MockSignatures>::new::<Sha256Hash>(author, round, &txns, &qc);
+    let block = Block::<MockSignatures>::new::<Sha256Hash>(
+        author,
+        round,
+        &Payload {
+            txns,
+            header: ExecutionArtifacts::zero(),
+        },
+        &qc,
+    );
 
     let h1 = Sha256Hash::hash_object(&block);
     let h2: Hash = hash(&block);

--- a/monad-consensus/tests/message.rs
+++ b/monad-consensus/tests/message.rs
@@ -1,7 +1,8 @@
 use monad_consensus::messages::message::{ProposalMessage, TimeoutMessage, VoteMessage};
 use monad_consensus_types::{
-    block::{Block, TransactionList},
+    block::Block,
     ledger::LedgerCommitInfo,
+    payload::{ExecutionArtifacts, Payload, TransactionList},
     quorum_certificate::{QcInfo, QuorumCertificate},
     signature::SignatureCollection,
     timeout::{HighQcRound, HighQcRoundSigTuple, TimeoutCertificate, TimeoutInfo},
@@ -71,7 +72,15 @@ fn proposal_msg_hash() {
         MockSignatures::new(),
     );
 
-    let block = Block::<MockSignatures>::new::<Sha256Hash>(author, round, &txns, &qc);
+    let block = Block::<MockSignatures>::new::<Sha256Hash>(
+        author,
+        round,
+        &Payload {
+            txns,
+            header: ExecutionArtifacts::zero(),
+        },
+        &qc,
+    );
 
     let proposal: ProposalMessage<SecpSignature, MockSignatures> = ProposalMessage {
         block: block.clone(),

--- a/monad-consensus/tests/proposal.rs
+++ b/monad-consensus/tests/proposal.rs
@@ -1,7 +1,8 @@
 use monad_consensus::messages::message::ProposalMessage;
 use monad_consensus_types::{
-    block::{Block, TransactionList},
+    block::Block,
     ledger::LedgerCommitInfo,
+    payload::{ExecutionArtifacts, Payload, TransactionList},
     quorum_certificate::{QcInfo, QuorumCertificate},
     validation::{Error, Hasher, Sha256Hash},
     voting::VoteInfo,
@@ -32,7 +33,15 @@ fn setup_block(
         MockSignatures::with_pubkeys(signers),
     );
 
-    Block::<MockSignatures>::new::<Sha256Hash>(author, block_round, &txns, &qc)
+    Block::<MockSignatures>::new::<Sha256Hash>(
+        author,
+        block_round,
+        &Payload {
+            txns,
+            header: ExecutionArtifacts::zero(),
+        },
+        &qc,
+    )
 }
 
 #[test]

--- a/monad-consensus/tests/protobuf.rs
+++ b/monad-consensus/tests/protobuf.rs
@@ -11,9 +11,9 @@ mod test {
         validation::signing::Verified,
     };
     use monad_consensus_types::{
-        block::TransactionList,
         ledger::LedgerCommitInfo,
         multi_sig::MultiSig,
+        payload::{ExecutionArtifacts, TransactionList},
         quorum_certificate::{QcInfo, QuorumCertificate},
         signature::SignatureCollection,
         timeout::{HighQcRound, HighQcRoundSigTuple, TimeoutCertificate, TimeoutInfo},
@@ -149,6 +149,7 @@ mod test {
             233,
             232,
             TransactionList(vec![1, 2, 3, 4]),
+            ExecutionArtifacts::zero(),
             &keypairs,
         );
         let proposal: ConsensusMessage<SecpSignature, MultiSig<SecpSignature>> =
@@ -176,6 +177,7 @@ mod test {
             233,
             231,
             TransactionList(vec![1, 2, 3, 4]),
+            ExecutionArtifacts::zero(),
             &keypairs,
         );
 

--- a/monad-executor/src/executor/mempool.rs
+++ b/monad-executor/src/executor/mempool.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use futures::{Stream, StreamExt};
-use monad_consensus_types::block::{FullTransactionList, TransactionList};
+use monad_consensus_types::payload::{FullTransactionList, TransactionList};
 use monad_mempool_controller::{Controller, ControllerConfig};
 use monad_mempool_messenger::MessengerError;
 use thiserror::Error;

--- a/monad-executor/src/executor/mock.rs
+++ b/monad-executor/src/executor/mock.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use futures::{Stream, StreamExt};
-use monad_consensus_types::block::{FullTransactionList, TransactionList};
+use monad_consensus_types::payload::{FullTransactionList, TransactionList};
 
 use super::{checkpoint::MockCheckpoint, epoch::MockEpoch, ledger::MockLedger};
 use crate::{

--- a/monad-executor/src/state.rs
+++ b/monad-executor/src/state.rs
@@ -1,6 +1,6 @@
 use std::hash::Hash;
 
-use monad_consensus_types::block::{FullTransactionList, TransactionList};
+use monad_consensus_types::payload::{FullTransactionList, TransactionList};
 use monad_crypto::secp256k1::PubKey;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -4,9 +4,10 @@ use clap::Parser;
 use futures_util::{FutureExt, StreamExt};
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
-    block::{Block, TransactionList},
+    block::Block,
     ledger::LedgerCommitInfo,
     multi_sig::MultiSig,
+    payload::{ExecutionArtifacts, Payload, TransactionList},
     quorum_certificate::{genesis_vote_info, QuorumCertificate},
     signature::SignatureCollection,
     transaction_validator::MockValidator,
@@ -201,11 +202,15 @@ fn testnet(
     let genesis_block = {
         let genesis_txn = TransactionList::default();
         let genesis_prime_qc = QuorumCertificate::genesis_prime_qc::<HasherType>();
+        let genesis_execution_header = ExecutionArtifacts::zero();
         Block::new::<HasherType>(
             // FIXME init from genesis config, don't use random key
             NodeId(KeyPair::from_bytes(&mut [0xBE_u8; 32]).unwrap().pubkey()),
             Round(0),
-            &genesis_txn,
+            &Payload {
+                txns: genesis_txn,
+                header: genesis_execution_header,
+            },
             &genesis_prime_qc,
         )
     };

--- a/monad-proto/proto/basic.proto
+++ b/monad-proto/proto/basic.proto
@@ -29,3 +29,11 @@ message ProtoEpoch {
 message ProtoStake {
   int64 stake = 1;
 }
+
+message ProtoGas {
+  uint64 gas = 1;
+}
+
+message ProtoBloom {
+  bytes bloom = 1;
+}

--- a/monad-proto/proto/block.proto
+++ b/monad-proto/proto/block.proto
@@ -5,13 +5,27 @@ package monad_proto.block;
 import "basic.proto";
 import "quorum_certificate.proto";
 
+message ProtoExecutionArtifacts {
+  monad_proto.basic.ProtoHash parent_hash = 1;
+  monad_proto.basic.ProtoHash state_root = 2;
+  monad_proto.basic.ProtoHash transactions_root = 3;
+  monad_proto.basic.ProtoHash receipts_root = 4;
+  monad_proto.basic.ProtoBloom logs_bloom = 5;
+  monad_proto.basic.ProtoGas gas_used = 6;
+}
+
 message ProtoTransactionList {
   bytes data = 1;
+}
+
+message ProtoPayload {
+  ProtoTransactionList txns = 1;
+  ProtoExecutionArtifacts header = 2;
 }
 
 message ProtoBlockAggSig {
   monad_proto.basic.ProtoNodeId author = 1;
   monad_proto.basic.ProtoRound round = 2;
-  ProtoTransactionList payload = 3;
+  ProtoPayload payload = 3;
   monad_proto.quorum_certificate.ProtoQuorumCertificateAggSig qc = 4;
 }

--- a/monad-state/src/convert/event.rs
+++ b/monad-state/src/convert/event.rs
@@ -1,7 +1,7 @@
 use monad_consensus::pacemaker::PacemakerTimerExpire;
 use monad_consensus_types::{
-    block::{FullTransactionList, TransactionList},
     multi_sig::MultiSig,
+    payload::{FullTransactionList, TransactionList},
 };
 use monad_crypto::Signature;
 use monad_proto::{

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -12,8 +12,12 @@ use monad_consensus_state::{
     ConsensusProcess,
 };
 use monad_consensus_types::{
-    block::Block, quorum_certificate::QuorumCertificate, signature::SignatureCollection,
-    validation::Sha256Hash, voting::VoteInfo,
+    block::Block,
+    payload::{ExecutionArtifacts, Payload},
+    quorum_certificate::QuorumCertificate,
+    signature::SignatureCollection,
+    validation::Sha256Hash,
+    voting::VoteInfo,
 };
 use monad_crypto::{
     secp256k1::{KeyPair, PubKey},
@@ -324,7 +328,10 @@ where
                             let b = Block::new::<HasherType>(
                                 fetched.node_id,
                                 fetched.round,
-                                &fetched.txns,
+                                &Payload {
+                                    txns: fetched.txns,
+                                    header: ExecutionArtifacts::zero(), // TODO this needs to be fetched
+                                },
                                 &fetched.high_qc,
                             );
 

--- a/monad-testutil/src/block.rs
+++ b/monad-testutil/src/block.rs
@@ -1,7 +1,8 @@
 use monad_consensus_types::{
-    block::{Block, TransactionList},
+    block::Block,
     ledger::LedgerCommitInfo,
     multi_sig::MultiSig,
+    payload::{ExecutionArtifacts, Payload, TransactionList},
     quorum_certificate::{QcInfo, QuorumCertificate},
     signature::SignatureCollection,
     validation::{Hasher, Sha256Hash},
@@ -15,6 +16,7 @@ pub fn setup_block(
     block_round: u64,
     qc_round: u64,
     txns: TransactionList,
+    execution_header: ExecutionArtifacts,
     keypairs: &[KeyPair],
 ) -> Block<MultiSig<SecpSignature>> {
     let txns = txns;
@@ -41,5 +43,13 @@ pub fn setup_block(
 
     let qc = QuorumCertificate::<MultiSig<SecpSignature>>::new(qcinfo, aggsig);
 
-    Block::<MultiSig<SecpSignature>>::new::<Sha256Hash>(author, round, &txns, &qc)
+    Block::<MultiSig<SecpSignature>>::new::<Sha256Hash>(
+        author,
+        round,
+        &Payload {
+            txns,
+            header: execution_header,
+        },
+        &qc,
+    )
 }

--- a/monad-wal/benches/event_bench.rs
+++ b/monad-wal/benches/event_bench.rs
@@ -12,9 +12,9 @@ use monad_consensus::{
     validation::signing::Unverified,
 };
 use monad_consensus_types::{
-    block::TransactionList,
     ledger::LedgerCommitInfo,
     multi_sig::MultiSig,
+    payload::{ExecutionArtifacts, TransactionList},
     quorum_certificate::{QcInfo, QuorumCertificate},
     signature::SignatureCollection,
     timeout::{HighQcRound, HighQcRoundSigTuple, TimeoutCertificate, TimeoutInfo},
@@ -67,7 +67,14 @@ fn bench_proposal(c: &mut Criterion) {
     let keypairs = create_keys(1);
     let author_keypair = &keypairs[0];
 
-    let blk = setup_block(NodeId(author_keypair.pubkey()), 10, 9, txns, &keypairs);
+    let blk = setup_block(
+        NodeId(author_keypair.pubkey()),
+        10,
+        9,
+        txns,
+        ExecutionArtifacts::zero(),
+        &keypairs,
+    );
 
     let proposal = ConsensusMessage::Proposal(ProposalMessage {
         block: blk,


### PR DESCRIPTION
The results of executing a block will be retrieved via executor at some point by consensus and will need to be included in block proposals. These are the execution artifacts.