### PR TITLE
Add RouterScheduler abstraction

### DIFF
--- a/monad-executor/src/timed_event.rs
+++ b/monad-executor/src/timed_event.rs
@@ -2,7 +2,7 @@ use std::{array::TryFromSliceError, fmt::Debug, time::Duration};
 
 use monad_types::{Deserializable, Serializable};
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct TimedEvent<M> {
     pub timestamp: Duration, // ticks Duration in milliseconds
     pub event: M,

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -157,12 +157,12 @@ impl monad_types::Serializable
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VerifiedMonadMessage<ST, SCT>(Verified<ST, ConsensusMessage<ST, SCT>>);
 
 #[derive(RefCast)]
 #[repr(transparent)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MonadMessage<ST, SCT>(Unverified<ST, ConsensusMessage<ST, SCT>>);
 
 #[cfg(feature = "proto")]

--- a/monad-state/tests/replay.rs
+++ b/monad-state/tests/replay.rs
@@ -7,10 +7,11 @@ mod test {
     use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
     use monad_crypto::secp256k1::SecpSignature;
     use monad_executor::{
+        executor::mock::NoSerRouterScheduler,
         mock_swarm::{Nodes, XorLatencyTransformer},
         timed_event::TimedEvent,
     };
-    use monad_state::{MonadEvent, MonadState};
+    use monad_state::{MonadEvent, MonadMessage, MonadState};
     use monad_testutil::swarm::{get_configs, node_ledger_verification};
     use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
     use monad_wal::wal::{WALogger, WALoggerConfig};
@@ -59,6 +60,7 @@ mod test {
                 ValidatorSet,
                 SimpleRoundRobin,
             >,
+            NoSerRouterScheduler<MonadMessage<SignatureType, SignatureCollectionType>>,
             _,
             WALogger<TimedEvent<MonadEvent<SignatureType, SignatureCollectionType>>>,
         >::new(
@@ -119,6 +121,7 @@ mod test {
                 ValidatorSet,
                 SimpleRoundRobin,
             >,
+            NoSerRouterScheduler<MonadMessage<SignatureType, SignatureCollectionType>>,
             _,
             WALogger<TimedEvent<MonadEvent<SignatureType, SignatureCollectionType>>>,
         >::new(

--- a/monad-testutil/examples/logs_gen.rs
+++ b/monad-testutil/examples/logs_gen.rs
@@ -4,6 +4,7 @@ use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
 use monad_crypto::NopSignature;
 use monad_executor::{
+    executor::mock::NoSerRouterScheduler,
     mock_swarm::{Nodes, Transformer},
     timed_event::TimedEvent,
     State,
@@ -44,7 +45,7 @@ pub fn generate_log<T: Transformer<MM>>(
         .zip(file_path_vec)
         .map(|((a, b), c)| (a, b, c))
         .collect::<Vec<_>>();
-    let mut nodes = Nodes::<MS, T, WALoggerType>::new(peers, transformer);
+    let mut nodes = Nodes::<MS, NoSerRouterScheduler<MM>, T, WALoggerType>::new(peers, transformer);
 
     while let Some((duration, id, event)) = nodes.step() {
         if nodes

--- a/monad-viz/src/config.rs
+++ b/monad-viz/src/config.rs
@@ -11,6 +11,7 @@ use monad_consensus_types::{
 };
 use monad_crypto::secp256k1::{KeyPair, PubKey};
 use monad_executor::{
+    executor::mock::NoSerRouterScheduler,
     mock_swarm::{LatencyTransformer, Layer, LayerTransformer, XorLatencyTransformer},
     State,
 };
@@ -45,7 +46,9 @@ impl SimConfig {
     }
 }
 
-impl SimulationConfig<MS, LayerTransformer<MM>, PersistenceLoggerType> for SimConfig {
+impl SimulationConfig<MS, NoSerRouterScheduler<MM>, LayerTransformer<MM>, PersistenceLoggerType>
+    for SimConfig
+{
     fn nodes(
         &self,
     ) -> Vec<(

--- a/monad-viz/src/main.rs
+++ b/monad-viz/src/main.rs
@@ -27,11 +27,12 @@ use monad_consensus_types::{
 };
 use monad_crypto::NopSignature;
 use monad_executor::{
+    executor::mock::NoSerRouterScheduler,
     mock_swarm::{LatencyTransformer, Layer, LayerTransformer, XorLatencyTransformer},
     timed_event::TimedEvent,
     PeerId, State,
 };
-use monad_state::{MonadEvent, MonadState};
+use monad_state::{MonadEvent, MonadMessage, MonadState};
 use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
 use monad_wal::{
     mock::MockWALogger,
@@ -60,7 +61,13 @@ type MS = MonadState<
 type MM = <MS as State>::Message;
 type PersistenceLoggerType =
     MockWALogger<TimedEvent<MonadEvent<SignatureType, SignatureCollectionType>>>;
-type Sim = NodesSimulation<MS, LayerTransformer<MM>, PersistenceLoggerType, SimConfig>;
+type Sim = NodesSimulation<
+    MS,
+    NoSerRouterScheduler<MM>,
+    LayerTransformer<MM>,
+    PersistenceLoggerType,
+    SimConfig,
+>;
 type ReplaySim = ReplayNodesSimulation<MS, RepConfig>;
 
 #[derive(Parser, Default)]
@@ -171,6 +178,7 @@ impl Application for Viz {
                         ValidatorSet,
                         SimpleRoundRobin,
                     >,
+                    NoSerRouterScheduler<MonadMessage<SignatureType, SignatureCollectionType>>,
                     _,
                     _,
                     _,

--- a/monad-viz/src/replay_graph.rs
+++ b/monad-viz/src/replay_graph.rs
@@ -5,10 +5,7 @@ use monad_consensus_types::{
     validation::Sha256Hash,
 };
 use monad_crypto::secp256k1::{KeyPair, PubKey};
-use monad_executor::{
-    executor::mock::MockExecutor, replay_nodes::ReplayNodes, timed_event::TimedEvent, Message,
-    PeerId, State,
-};
+use monad_executor::{replay_nodes::ReplayNodes, timed_event::TimedEvent, Message, PeerId, State};
 use monad_state::MonadConfig;
 use monad_testutil::signing::{create_keys, get_genesis_config};
 use monad_types::{Deserializable, Serializable};
@@ -68,7 +65,6 @@ where
 impl<S, C> ReplayNodesSimulation<S, C>
 where
     S: monad_executor::State,
-    MockExecutor<S>: Unpin,
     S::Event: Serializable + Deserializable + Debug + Eq,
     C: ReplayConfig<S>,
 {
@@ -125,7 +121,6 @@ impl<S, C> Graph for ReplayNodesSimulation<S, C>
 where
     S: monad_executor::State,
     S::Event: Serializable + Deserializable + Eq + Debug,
-    MockExecutor<S>: Unpin,
     C: ReplayConfig<S>,
 {
     type State = S;


### PR DESCRIPTION
Refactors MockSwarm to support a generic RouterScheduler. This is in preparation for adding a QUIC RouterScheduler that can work with MockSwarm.