### PR TITLE
Fix `TestSigner`

### DIFF
--- a/monad-consensus/tests/message.rs
+++ b/monad-consensus/tests/message.rs
@@ -141,8 +141,8 @@ fn test_vote_message() {
 
     let expected_vote_info_hash = vm.ledger_commit_info.vote_info_hash;
 
-    let msg = Sha256Hash::hash_object(&vm.vote_info);
-    let svm = TestSigner::sign_object(vm, msg.as_ref(), &keypair);
+    let msg = Sha256Hash::hash_object(&vm);
+    let svm = TestSigner::sign_object::<Sha256Hash, _>(vm, &keypair);
 
     assert_eq!(
         svm.author_signature().recover_pubkey(msg.as_ref()).unwrap(),

--- a/monad-consensus/tests/proposal.rs
+++ b/monad-consensus/tests/proposal.rs
@@ -4,7 +4,7 @@ use monad_consensus_types::{
     ledger::LedgerCommitInfo,
     payload::{ExecutionArtifacts, Payload, TransactionList},
     quorum_certificate::{QcInfo, QuorumCertificate},
-    validation::{Error, Hasher, Sha256Hash},
+    validation::{Error, Sha256Hash},
     voting::VoteInfo,
 };
 use monad_crypto::secp256k1::{PubKey, SecpSignature};
@@ -66,8 +66,7 @@ fn test_proposal_hash() {
         last_round_tc: None,
     };
 
-    let msg = Sha256Hash::hash_object(&proposal);
-    let sp = TestSigner::sign_object(proposal, msg.as_ref(), &keypair);
+    let sp = TestSigner::sign_object::<Sha256Hash, _>(proposal, &keypair);
 
     let vset = ValidatorSet::new(vlist).unwrap();
     assert!(sp.verify::<Sha256Hash, _>(&vset, &keypair.pubkey()).is_ok());
@@ -95,8 +94,7 @@ fn test_proposal_missing_tc() {
         last_round_tc: None,
     };
 
-    let msg = Sha256Hash::hash_object(&proposal);
-    let sp = TestSigner::sign_object(proposal, msg.as_ref(), &keypair);
+    let sp = TestSigner::sign_object::<Sha256Hash, _>(proposal, &keypair);
 
     let vset = ValidatorSet::new(vlist).unwrap();
     assert_eq!(
@@ -131,8 +129,7 @@ fn test_proposal_author_not_sender() {
         last_round_tc: None,
     };
 
-    let msg = Sha256Hash::hash_object(&proposal);
-    let sp = TestSigner::sign_object(proposal, msg.as_ref(), &author_keypair);
+    let sp = TestSigner::sign_object::<Sha256Hash, _>(proposal, &author_keypair);
 
     let vset = ValidatorSet::new(vlist).unwrap();
     assert_eq!(
@@ -161,8 +158,7 @@ fn test_proposal_invalid_author() {
         last_round_tc: None,
     };
 
-    let msg = Sha256Hash::hash_object(&proposal);
-    let sp = TestSigner::sign_object(proposal, msg.as_ref(), &non_valdiator_keypair);
+    let sp = TestSigner::sign_object::<Sha256Hash, _>(proposal, &non_valdiator_keypair);
 
     let vset = ValidatorSet::new(vlist).unwrap();
     assert_eq!(
@@ -191,8 +187,7 @@ fn test_proposal_invalid_qc() {
         last_round_tc: None,
     };
 
-    let msg = Sha256Hash::hash_object(&proposal);
-    let sp = TestSigner::sign_object(proposal, msg.as_ref(), &non_staked_keypair);
+    let sp = TestSigner::sign_object::<Sha256Hash, _>(proposal, &non_staked_keypair);
 
     let vset = ValidatorSet::new(vlist).unwrap();
     assert_eq!(

--- a/monad-consensus/tests/vote_state.rs
+++ b/monad-consensus/tests/vote_state.rs
@@ -4,12 +4,8 @@ use monad_consensus::{
     vote_state::VoteState,
 };
 use monad_consensus_types::{
-    ledger::LedgerCommitInfo,
-    multi_sig::MultiSig,
-    quorum_certificate::QuorumCertificate,
-    signature::SignatureCollection,
-    validation::{Hasher, Sha256Hash},
-    voting::VoteInfo,
+    ledger::LedgerCommitInfo, multi_sig::MultiSig, quorum_certificate::QuorumCertificate,
+    signature::SignatureCollection, validation::Sha256Hash, voting::VoteInfo,
 };
 use monad_crypto::secp256k1::{KeyPair, SecpSignature};
 use monad_testutil::signing::*;
@@ -35,10 +31,7 @@ fn create_signed_vote_message(
         ledger_commit_info: lci,
     };
 
-    let msg = Sha256Hash::hash_object(&vm.ledger_commit_info);
-    let svm = TestSigner::sign_object(vm, msg.as_ref(), keypair);
-
-    svm
+    TestSigner::sign_object::<Sha256Hash, _>(vm, keypair)
 }
 
 fn setup_ctx(

--- a/monad-testutil/src/signing.rs
+++ b/monad-testutil/src/signing.rs
@@ -7,7 +7,7 @@ use monad_consensus_types::{
     payload::{ExecutionArtifacts, Payload, TransactionList},
     quorum_certificate::{genesis_vote_info, QuorumCertificate},
     signature::SignatureCollection,
-    validation::Hasher,
+    validation::{Hashable, Hasher},
 };
 use monad_crypto::{
     secp256k1::{Error, KeyPair, PubKey, SecpSignature},
@@ -122,8 +122,12 @@ pub struct TestSigner<S> {
 }
 
 impl TestSigner<SecpSignature> {
-    pub fn sign_object<T>(o: T, msg: &[u8], key: &KeyPair) -> Unverified<SecpSignature, T> {
-        let sig = key.sign(msg);
+    pub fn sign_object<H: Hasher, T: Hashable>(
+        o: T,
+        key: &KeyPair,
+    ) -> Unverified<SecpSignature, T> {
+        let msg = H::hash_object(&o);
+        let sig = key.sign(msg.as_ref());
 
         Unverified::new(o, sig)
     }


### PR DESCRIPTION
Using the `TestSigner` is more complex than it needs to be. The test code needs to hash the object it wants to sign first, then pass the msg hash to the `TestSigner`.

Instead of passing in the object and msg hash, the `sign_object` method accepts a `Hasher` generic and hash the object in the function, and then create the signature on the message hash.

All the use cases right now are create valid signatures. If one wants to create an invalid signature, it can sign the object with a different keypair. It produces the same verification error (`InvalidAuthor`) as if the msg hash is wrong.

Closes #189 