### PR TITLE
`SignatureCollection` test cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4625,10 +4625,14 @@ dependencies = [
 name = "monad-consensus-types"
 version = "0.1.0"
 dependencies = [
+ "log",
  "monad-crypto",
  "monad-proto",
+ "monad-testutil",
  "monad-types",
  "prost",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sha2 0.10.7",
  "test-case",
  "zerocopy",

--- a/monad-consensus-types/Cargo.toml
+++ b/monad-consensus-types/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+log = { workspace = true }
 monad-crypto = { path = "../monad-crypto" }
 monad-proto = { path = "../monad-proto", optional = true }
 monad-types = { path = "../monad-types" }
@@ -23,4 +24,7 @@ proto = [
 ]
 
 [dev-dependencies]
+monad-testutil = { path = "../monad-testutil" }
+rand = { workspace = true }
+rand_chacha = { workspace = true }
 test-case = { workspace = true }

--- a/monad-consensus-types/src/certificate_signature.rs
+++ b/monad-consensus-types/src/certificate_signature.rs
@@ -6,7 +6,7 @@ use monad_crypto::{
 use crate::{message_signature::MessageSignature, validation::Hashable};
 
 pub trait CertificateKeyPair: Send + Sized + Sync + 'static {
-    type PubKeyType: std::cmp::Eq + std::hash::Hash + Copy;
+    type PubKeyType: std::cmp::Eq + std::fmt::Debug + std::hash::Hash + Copy;
     type Error: std::error::Error + Send + Sync;
 
     fn from_bytes(secret: impl AsMut<[u8]>) -> Result<Self, Self::Error>;

--- a/monad-consensus-types/src/lib.rs
+++ b/monad-consensus-types/src/lib.rs
@@ -9,6 +9,8 @@ pub mod multi_sig;
 pub mod payload;
 pub mod quorum_certificate;
 pub mod signature_collection;
+#[cfg(test)]
+pub mod test_utils;
 pub mod timeout;
 pub mod transaction_validator;
 pub mod validation;

--- a/monad-consensus-types/src/signature_collection.rs
+++ b/monad-consensus-types/src/signature_collection.rs
@@ -11,15 +11,44 @@ pub type SignatureCollectionKeyPairType<SCT> =
 pub type SignatureCollectionPubKeyType<SCT> =
     <SignatureCollectionKeyPairType<SCT> as CertificateKeyPair>::PubKeyType;
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum SignatureCollectionError<S> {
+    NodeIdNotInMapping(Vec<(NodeId, S)>),
+    // only possible for non-deterministic signature
+    ConflictingSignatures((NodeId, S, S)),
+    // verification error
+    InvalidSignatures(Vec<S>),
+}
+
+impl<S: CertificateSignature> std::fmt::Display for SignatureCollectionError<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SignatureCollectionError::NodeIdNotInMapping(v) => {
+                write!(f, "NodeId not in validator mapping: {v:?}")
+            }
+            SignatureCollectionError::ConflictingSignatures((node_id, s1, s2)) => {
+                write!(
+                    f,
+                    "Conflicting signatures from {node_id:?}\ns1: {s1:?}\ns2: {s2:?}"
+                )
+            }
+            SignatureCollectionError::InvalidSignatures(sig) => {
+                write!(f, "Invalid signature ({sig:?})")
+            }
+        }
+    }
+}
+
+impl<S: CertificateSignature> std::error::Error for SignatureCollectionError<S> {}
+
 pub trait SignatureCollection: Clone + Hashable + Send + Sync + std::fmt::Debug + 'static {
-    type SignatureError: std::error::Error + Send + Sync;
     type SignatureType: CertificateSignature;
 
     fn new(
         sigs: Vec<(NodeId, Self::SignatureType)>,
         validator_mapping: &ValidatorMapping<SignatureCollectionKeyPairType<Self>>,
         msg: &[u8],
-    ) -> Result<Self, Self::SignatureError>;
+    ) -> Result<Self, SignatureCollectionError<Self::SignatureType>>;
 
     // hash of all the signatures
     fn get_hash<H: Hasher>(&self) -> Hash;
@@ -28,8 +57,142 @@ pub trait SignatureCollection: Clone + Hashable + Send + Sync + std::fmt::Debug 
         &self,
         validator_mapping: &ValidatorMapping<SignatureCollectionKeyPairType<Self>>,
         msg: &[u8],
-    ) -> Result<Vec<NodeId>, Self::SignatureError>;
+    ) -> Result<Vec<NodeId>, SignatureCollectionError<Self::SignatureType>>;
 
     // TODO: deprecate this function: only used by tests
     fn num_signatures(&self) -> usize;
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashSet;
+
+    use monad_testutil::signing::get_key;
+    use monad_types::{Hash, NodeId};
+
+    use crate::{
+        certificate_signature::CertificateSignature,
+        signature_collection::{SignatureCollection, SignatureCollectionError},
+        test_utils::{get_certificate_key, setup_sigcol_test},
+        voting::ValidatorMapping,
+    };
+
+    macro_rules! test_all_signature_collection {
+        ($test_name:ident, $test_code:block) => {
+            mod $test_name {
+                use monad_crypto::{secp256k1::SecpSignature, NopSignature};
+
+                use super::*;
+                use crate::multi_sig::*;
+
+                fn invoke<T: SignatureCollection>() {
+                    $test_code
+                }
+
+                #[test]
+                fn multi_sig_secp() {
+                    invoke::<MultiSig<SecpSignature>>();
+                }
+
+                #[test]
+                fn multi_sig_nop() {
+                    invoke::<MultiSig<NopSignature>>();
+                }
+            }
+        };
+    }
+
+    test_all_signature_collection!(test_num_signatures, {
+        let validator_mapping = ValidatorMapping::new(std::iter::empty());
+        let hash = Hash([0_u8; 32]);
+        let sigs = T::new(Vec::new(), &validator_mapping, hash.as_ref()).unwrap();
+        assert_eq!(sigs.num_signatures(), 0);
+    });
+
+    test_all_signature_collection!(test_creation, {
+        let (voting_keys, valmap) = setup_sigcol_test::<T>(5);
+
+        let msg_hash = Hash([129_u8; 32]);
+        let mut sigs = Vec::new();
+
+        for (node_id, certkey) in voting_keys.iter() {
+            let sig = <T::SignatureType as CertificateSignature>::sign(msg_hash.as_ref(), certkey);
+            sigs.push((*node_id, sig));
+        }
+
+        assert!(T::new(sigs, &valmap, msg_hash.as_ref()).is_ok());
+    });
+
+    test_all_signature_collection!(test_node_id_not_in_validator_mapping, {
+        let (voting_keys, valmap) = setup_sigcol_test::<T>(5);
+
+        let non_validator_node_id = NodeId(get_key(100).pubkey());
+        let non_validator_cert_key = get_certificate_key::<T>(100);
+
+        assert!(!valmap.map.contains_key(&non_validator_node_id));
+
+        let msg_hash = Hash([129_u8; 32]);
+        let mut sigs = Vec::new();
+
+        for (node_id, certkey) in voting_keys.iter() {
+            let sig = <T::SignatureType as CertificateSignature>::sign(msg_hash.as_ref(), certkey);
+            sigs.push((*node_id, sig));
+        }
+
+        let non_validator_sig = <T::SignatureType as CertificateSignature>::sign(
+            msg_hash.as_ref(),
+            &non_validator_cert_key,
+        );
+        sigs.push((non_validator_node_id, non_validator_sig));
+
+        assert_eq!(
+            T::new(sigs, &valmap, msg_hash.as_ref()).unwrap_err(),
+            SignatureCollectionError::NodeIdNotInMapping(vec![(
+                non_validator_node_id,
+                non_validator_sig
+            )])
+        );
+    });
+
+    test_all_signature_collection!(test_duplicate_sig, {
+        let (voting_keys, valmap) = setup_sigcol_test::<T>(5);
+
+        let msg_hash = Hash([129_u8; 32]);
+        let mut sigs = Vec::new();
+
+        for (node_id, certkey) in voting_keys.iter() {
+            let sig = <T::SignatureType as CertificateSignature>::sign(msg_hash.as_ref(), certkey);
+            sigs.push((*node_id, sig));
+        }
+
+        // duplicate the last signature
+        sigs.push(*sigs.last().unwrap());
+        assert_eq!(sigs[sigs.len() - 1], sigs[sigs.len() - 2]);
+        let sigcol = T::new(sigs, &valmap, msg_hash.as_ref()).unwrap();
+
+        // duplicate signature is removed
+        assert_eq!(sigcol.num_signatures(), voting_keys.len());
+    });
+
+    test_all_signature_collection!(test_verify, {
+        let (voting_keys, valmap) = setup_sigcol_test::<T>(5);
+
+        let msg_hash = Hash([129_u8; 32]);
+        let mut sigs = Vec::new();
+
+        for (node_id, certkey) in voting_keys.iter() {
+            let sig = <T::SignatureType as CertificateSignature>::sign(msg_hash.as_ref(), certkey);
+            sigs.push((*node_id, sig));
+        }
+
+        let sigcol = T::new(sigs, &valmap, msg_hash.as_ref()).unwrap();
+
+        let signers = sigcol.verify(&valmap, msg_hash.as_ref()).unwrap();
+
+        let signers_set = signers.iter().collect::<HashSet<_>>();
+        let expected_set = valmap.map.keys().collect::<HashSet<_>>();
+        assert_eq!(signers_set, expected_set);
+    });
+
+    // invalid verification goes in specific impls
 }

--- a/monad-consensus-types/src/test_utils.rs
+++ b/monad-consensus-types/src/test_utils.rs
@@ -1,0 +1,56 @@
+use monad_testutil::signing::create_keys;
+use monad_types::NodeId;
+use sha2::{Digest, Sha256};
+
+use crate::{
+    certificate_signature::CertificateKeyPair,
+    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
+    voting::ValidatorMapping,
+};
+
+pub(crate) fn get_certificate_key<SCT: SignatureCollection>(
+    seed: u64,
+) -> SignatureCollectionKeyPairType<SCT> {
+    let mut hasher = Sha256::new();
+    hasher.update(seed.to_le_bytes());
+    let mut hash = hasher.finalize();
+    <SignatureCollectionKeyPairType<SCT> as CertificateKeyPair>::from_bytes(&mut hash).unwrap()
+}
+
+pub(crate) fn create_certificate_keys<SCT: SignatureCollection>(
+    num: u32,
+) -> Vec<SignatureCollectionKeyPairType<SCT>> {
+    let mut res = Vec::new();
+    for i in 0..num {
+        let keypair = get_certificate_key::<SCT>(i.into());
+        res.push(keypair);
+    }
+    res
+}
+
+pub(crate) fn setup_sigcol_test<SCT: SignatureCollection>(
+    num: u32,
+) -> (
+    Vec<(NodeId, SignatureCollectionKeyPairType<SCT>)>,
+    ValidatorMapping<SignatureCollectionKeyPairType<SCT>>,
+) {
+    let node_ids = create_keys(num)
+        .into_iter()
+        .map(|k| NodeId(k.pubkey()))
+        .collect::<Vec<_>>();
+    let keys = create_certificate_keys::<SCT>(num);
+
+    let voting_keys = node_ids
+        .into_iter()
+        .zip(keys.into_iter())
+        .collect::<Vec<_>>();
+
+    let voting_identity = voting_keys
+        .iter()
+        .map(|(node_id, key)| (*node_id, key.pubkey()))
+        .collect::<Vec<_>>();
+
+    let validator_mapping = ValidatorMapping::new(voting_identity);
+
+    (voting_keys, validator_mapping)
+}


### PR DESCRIPTION
Add general `SignatureCollection` test cases and `MultiSig<S>` specific tests for invalid signatures.

Modified SignatureCollection trait to support general error reporting

Closes #171 