### PR TITLE
RFC: Refactoring `VoteMessage`

### DIFF
--- a/monad-consensus-types/src/voting.rs
+++ b/monad-consensus-types/src/voting.rs
@@ -5,6 +5,7 @@ use zerocopy::AsBytes;
 
 use crate::{
     certificate_signature::CertificateKeyPair,
+    ledger::LedgerCommitInfo,
     validation::{Hashable, Hasher},
 };
 
@@ -27,6 +28,12 @@ impl<VKT: CertificateKeyPair> IntoIterator for ValidatorMapping<VKT> {
     fn into_iter(self) -> Self::IntoIter {
         self.map.into_iter()
     }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct Vote {
+    pub vote_info: VoteInfo,
+    pub ledger_commit_info: LedgerCommitInfo,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq)]

--- a/monad-consensus/src/messages/consensus_message.rs
+++ b/monad-consensus/src/messages/consensus_message.rs
@@ -16,7 +16,7 @@ use crate::{
 #[derive(Clone, PartialEq, Eq)]
 pub enum ConsensusMessage<ST, SCT> {
     Proposal(ProposalMessage<ST, SCT>),
-    Vote(VoteMessage),
+    Vote(VoteMessage<SCT>),
     Timeout(TimeoutMessage<ST, SCT>),
 }
 

--- a/monad-consensus/src/messages/message.rs
+++ b/monad-consensus/src/messages/message.rs
@@ -5,13 +5,13 @@ use monad_consensus_types::{
     signature_collection::SignatureCollection,
     timeout::{TimeoutCertificate, TimeoutInfo},
     validation::{Hashable, Hasher},
-    voting::VoteInfo,
+    voting::{Vote, VoteInfo},
 };
 
 #[derive(Copy, Clone, PartialEq, Eq)]
-pub struct VoteMessage {
-    pub vote_info: VoteInfo,
-    pub ledger_commit_info: LedgerCommitInfo,
+pub struct VoteMessage<SCT: SignatureCollection> {
+    pub vote: Vote,
+    pub sig: SCT::SignatureType,
 }
 
 impl std::fmt::Debug for VoteMessage {

--- a/monad-consensus/src/validation/safety.rs
+++ b/monad-consensus/src/validation/safety.rs
@@ -7,7 +7,7 @@ use monad_consensus_types::{
     signature_collection::SignatureCollection,
     timeout::{TimeoutCertificate, TimeoutInfo},
     validation::Hasher,
-    voting::VoteInfo,
+    voting::{Vote, VoteInfo},
 };
 use monad_types::*;
 
@@ -90,7 +90,7 @@ impl Safety {
         &mut self,
         block: &Block<T>,
         last_tc: &Option<TimeoutCertificate<S>>,
-    ) -> Option<VoteMessage> {
+    ) -> Option<Vote> {
         let qc_round = block.qc.info.vote.round;
         if self.safe_to_vote(block.round, qc_round, last_tc) {
             self.update_highest_qc_round(qc_round);
@@ -111,7 +111,7 @@ impl Safety {
 
             let ledger_commit_info = LedgerCommitInfo::new::<H>(commit_hash, &vote_info);
 
-            return Some(VoteMessage {
+            return Some(Vote {
                 vote_info,
                 ledger_commit_info,
             });

--- a/monad-consensus/src/vote_state.rs
+++ b/monad-consensus/src/vote_state.rs
@@ -38,8 +38,7 @@ where
     pub fn process_vote<H: Hasher, VT: ValidatorSetType>(
         &mut self,
         author: &NodeId,
-        signature: &SCT::SignatureType,
-        v: &VoteMessage,
+        v: &VoteMessage<SCT>,
         validators: &VT,
         validator_mapping: &ValidatorMapping<SignatureCollectionKeyPairType<SCT>>,
     ) -> Option<QuorumCertificate<SCT>> {
@@ -61,7 +60,7 @@ where
             .entry(vote_idx)
             .or_insert((Vec::new(), HashSet::new()));
 
-        pending_entry.0.push((*author, *signature));
+        pending_entry.0.push((*author, v.sig));
         pending_entry.1.insert(*author);
 
         if validators.has_super_majority_votes(&pending_entry.1) {

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -395,7 +395,6 @@ where
                             ConsensusMessage::Vote(msg) => {
                                 self.consensus.handle_vote_message::<HasherType, _, _>(
                                     author,
-                                    signature,
                                     msg,
                                     &self.validator_set,
                                     &self.validator_mapping,


### PR DESCRIPTION
Removes the link we had between `MessageSignature` and `SignatureCollection`. Validators keeps two keypairs, one for signing messages, the other for signing votes and timeouts (to be implemented).

`VoteMessage` now carries a `CertificateSignature` on the `Vote`, and another `MessageSignature` is created around the entire `VoteMessage`