### PR TITLE
Update MockLedger to support Ledger Fetch

### DIFF
--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -1,6 +1,9 @@
 use std::{collections::HashMap, fmt, result::Result as StdResult};
 
-use monad_consensus_types::{block::Block, signature_collection::SignatureCollection};
+use monad_consensus_types::{
+    block::{Block, BlockType},
+    signature_collection::SignatureCollection,
+};
 use monad_tracing_counter::inc_count;
 use monad_types::{BlockId, Round};
 use ptree::{builder::TreeBuilder, print_tree};
@@ -312,7 +315,7 @@ mod test {
     use std::collections::HashSet;
 
     use monad_consensus_types::{
-        block::Block as ConsensusBlock,
+        block::{Block as ConsensusBlock, BlockType},
         ledger::LedgerCommitInfo,
         payload::{ExecutionArtifacts, Payload, TransactionList},
         quorum_certificate::{QcInfo, QuorumCertificate},

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -11,7 +11,7 @@ use monad_consensus::{
     vote_state::VoteState,
 };
 use monad_consensus_types::{
-    block::Block,
+    block::{Block, BlockType},
     message_signature::MessageSignature,
     payload::FullTransactionList,
     quorum_certificate::{QuorumCertificate, Rank},
@@ -433,6 +433,7 @@ mod test {
         validation::signing::Verified,
     };
     use monad_consensus_types::{
+        block::BlockType,
         certificate_signature::CertificateSignatureRecoverable,
         ledger::LedgerCommitInfo,
         message_signature::MessageSignature,

--- a/monad-consensus-types/src/block.rs
+++ b/monad-consensus-types/src/block.rs
@@ -8,6 +8,11 @@ use crate::{
     validation::{Hashable, Hasher},
 };
 
+pub trait BlockType: Clone {
+    fn get_id(&self) -> BlockId;
+    fn get_parent_id(&self) -> BlockId;
+}
+
 #[derive(Clone, PartialEq, Eq)]
 pub struct Block<T> {
     pub author: NodeId,
@@ -56,12 +61,14 @@ impl<T: SignatureCollection> Block<T> {
         b.id = BlockId(H::hash_object(&b));
         b
     }
+}
 
-    pub fn get_id(&self) -> BlockId {
+impl<T: SignatureCollection> BlockType for Block<T> {
+    fn get_id(&self) -> BlockId {
         self.id
     }
 
-    pub fn get_parent_id(&self) -> BlockId {
+    fn get_parent_id(&self) -> BlockId {
         self.qc.info.vote.id
     }
 }

--- a/monad-consensus/src/validation/safety.rs
+++ b/monad-consensus/src/validation/safety.rs
@@ -1,7 +1,7 @@
 use std::cmp;
 
 use monad_consensus_types::{
-    block::Block,
+    block::{Block, BlockType},
     ledger::LedgerCommitInfo,
     quorum_certificate::{QcInfo, QuorumCertificate},
     signature_collection::SignatureCollection,

--- a/monad-driver/src/lib.rs
+++ b/monad-driver/src/lib.rs
@@ -6,7 +6,7 @@ mod tests {
     use monad_block_sync::BlockSyncState;
     use monad_consensus_state::ConsensusState;
     use monad_consensus_types::{
-        certificate_signature::CertificateKeyPair, multi_sig::MultiSig,
+        block::BlockType, certificate_signature::CertificateKeyPair, multi_sig::MultiSig,
         quorum_certificate::genesis_vote_info,
         signature_collection::SignatureCollectionKeyPairType, transaction_validator::MockValidator,
         validation::Sha256Hash, voting::ValidatorMapping,

--- a/monad-executor/src/executor/ledger.rs
+++ b/monad-executor/src/executor/ledger.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     marker::Unpin,
     ops::DerefMut,
     pin::Pin,
@@ -6,41 +7,42 @@ use std::{
 };
 
 use futures::Stream;
+use monad_consensus_types::block::BlockType;
+use monad_types::BlockId;
 
 use crate::{Executor, LedgerCommand};
 
-pub struct MockLedger<O, E> {
+pub struct MockLedger<O: BlockType, E> {
     blockchain: Vec<O>,
-    ledger_fetch_cb: Option<Box<dyn (FnOnce(Option<O>) -> E) + Send + Sync>>,
+    block_index: HashMap<BlockId, usize>,
+    ledger_fetch_cb: Option<(BlockId, Box<dyn (FnOnce(Option<O>) -> E) + Send + Sync>)>,
     waker: Option<Waker>,
 }
 
-impl<O, E> MockLedger<O, E>
-where
-    O: Clone,
-{
+impl<O: BlockType, E> MockLedger<O, E> {
     pub fn ready(&self) -> bool {
         self.ledger_fetch_cb.is_some()
     }
 }
 
-impl<O, E> Default for MockLedger<O, E> {
+impl<O: BlockType, E> Default for MockLedger<O, E> {
     fn default() -> Self {
         Self {
             blockchain: Vec::new(),
+            block_index: HashMap::new(),
             ledger_fetch_cb: None,
             waker: None,
         }
     }
 }
 
-impl<O, E> MockLedger<O, E> {
+impl<O: BlockType, E> MockLedger<O, E> {
     pub fn get_blocks(&self) -> &Vec<O> {
         &self.blockchain
     }
 }
 
-impl<O, E> Executor for MockLedger<O, E> {
+impl<O: BlockType, E> Executor for MockLedger<O, E> {
     type Command = LedgerCommand<O, E>;
     fn exec(&mut self, commands: Vec<Self::Command>) {
         let mut wake = false;
@@ -48,10 +50,14 @@ impl<O, E> Executor for MockLedger<O, E> {
         for command in commands {
             match command {
                 LedgerCommand::LedgerCommit(block) => {
+                    // it is assumed the consensus verified that block is valid, thus commiting shouldn't cause issue
+                    // only concern might be hash collision
+                    self.block_index
+                        .insert(block.get_id(), self.blockchain.len());
                     self.blockchain.push(block);
                 }
                 LedgerCommand::LedgerFetch(block_id, cb) => {
-                    self.ledger_fetch_cb = Some(cb);
+                    self.ledger_fetch_cb = Some((block_id, cb));
                     wake = true;
                 }
             }
@@ -67,23 +73,158 @@ impl<O, E> Executor for MockLedger<O, E> {
 impl<O, E> Stream for MockLedger<O, E>
 where
     Self: Unpin,
-    O: Clone,
+    O: Clone + BlockType,
 {
     type Item = E;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.deref_mut();
 
-        if let Some(cb) = this.ledger_fetch_cb.take() {
-            return Poll::Ready(match self.blockchain.len() {
-                0 => Some(cb(None)),
-                // TODO, introduce better data structure for retrieving based on BlockId
-                // right now just want to present the rough flow.
-                n => Some(cb(Some(self.blockchain[n - 1].clone()))),
-            });
+        if let Some((block_id, cb)) = this.ledger_fetch_cb.take() {
+            return Poll::Ready(Some(cb({
+                if let Some(i) = self.block_index.get(&block_id) {
+                    Some(self.blockchain[*i].clone())
+                } else {
+                    None
+                }
+            })));
         }
 
         self.waker = Some(cx.waker().clone());
         Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::{FutureExt, StreamExt};
+    use monad_testutil::block::MockBlock;
+
+    use crate::{executor::ledger::MockLedger, Executor, LedgerCommand};
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct MockLedgerEvent {
+        pub block: Option<MockBlock>,
+    }
+
+    #[test]
+    fn test_basic_stream_functionality() {
+        let mut mock_ledger = MockLedger::<MockBlock, MockLedgerEvent>::default();
+        assert_eq!(mock_ledger.next().now_or_never(), None); // nothing should be within the pipeline
+        let block = MockBlock {
+            block_id: monad_types::BlockId(monad_types::Hash([0x00_u8; 32])),
+            parent_block_id: monad_types::BlockId(monad_types::Hash([0x01_u8; 32])),
+        };
+        mock_ledger.exec(vec![LedgerCommand::LedgerCommit(block)]);
+        assert_eq!(mock_ledger.next().now_or_never(), None); // ledger commit shouldn't cause any event
+
+        mock_ledger.exec(vec![LedgerCommand::LedgerFetch(
+            monad_types::BlockId(monad_types::Hash([0x00_u8; 32])),
+            Box::new(|block: Option<MockBlock>| MockLedgerEvent { block }),
+        )]);
+        let retrieved = mock_ledger.next().now_or_never();
+        assert_ne!(retrieved, None); // there should be a response
+        let mock_ledger_event = retrieved.unwrap().unwrap().block.unwrap();
+        assert_eq!(
+            mock_ledger_event.block_id,
+            monad_types::BlockId(monad_types::Hash([0x00_u8; 32])),
+        );
+        assert_eq!(
+            mock_ledger_event.parent_block_id,
+            monad_types::BlockId(monad_types::Hash([0x01_u8; 32])),
+        );
+    }
+
+    #[test]
+    fn test_seeking_exist() {
+        let mut mock_ledger = MockLedger::<MockBlock, MockLedgerEvent>::default();
+        assert_eq!(mock_ledger.next().now_or_never(), None); // nothing should be within the pipeline
+        mock_ledger.exec(vec![
+            LedgerCommand::LedgerCommit(MockBlock {
+                block_id: monad_types::BlockId(monad_types::Hash([0x01_u8; 32])),
+                parent_block_id: monad_types::BlockId(monad_types::Hash([0x00_u8; 32])),
+            }),
+            LedgerCommand::LedgerCommit(MockBlock {
+                block_id: monad_types::BlockId(monad_types::Hash([0x02_u8; 32])),
+                parent_block_id: monad_types::BlockId(monad_types::Hash([0x01_u8; 32])),
+            }),
+            LedgerCommand::LedgerCommit(MockBlock {
+                block_id: monad_types::BlockId(monad_types::Hash([0x03_u8; 32])),
+                parent_block_id: monad_types::BlockId(monad_types::Hash([0x02_u8; 32])),
+            }),
+            LedgerCommand::LedgerCommit(MockBlock {
+                block_id: monad_types::BlockId(monad_types::Hash([0x04_u8; 32])),
+                parent_block_id: monad_types::BlockId(monad_types::Hash([0x03_u8; 32])),
+            }),
+        ]);
+        assert_eq!(mock_ledger.next().now_or_never(), None); // ledger commit shouldn't cause any event
+
+        mock_ledger.exec(vec![LedgerCommand::LedgerFetch(
+            monad_types::BlockId(monad_types::Hash([0x02_u8; 32])),
+            Box::new(|block: Option<MockBlock>| MockLedgerEvent { block }),
+        )]);
+        let retrieved = mock_ledger.next().now_or_never();
+        assert_ne!(retrieved, None); // there should be a response
+        let mock_ledger_event = retrieved.unwrap().unwrap().block.unwrap();
+        assert_eq!(
+            mock_ledger_event.block_id,
+            monad_types::BlockId(monad_types::Hash([0x02_u8; 32])),
+        );
+        assert_eq!(
+            mock_ledger_event.parent_block_id,
+            monad_types::BlockId(monad_types::Hash([0x01_u8; 32])),
+        );
+
+        // similarly, calling retrieve again always be viable
+        mock_ledger.exec(vec![LedgerCommand::LedgerFetch(
+            monad_types::BlockId(monad_types::Hash([0x02_u8; 32])),
+            Box::new(|block: Option<MockBlock>| MockLedgerEvent { block }),
+        )]);
+        let retrieved = mock_ledger.next().now_or_never();
+        assert_ne!(retrieved, None); // there should be a response
+        let mock_ledger_event = retrieved.unwrap().unwrap().block.unwrap();
+        assert_eq!(
+            mock_ledger_event.block_id,
+            monad_types::BlockId(monad_types::Hash([0x02_u8; 32])),
+        );
+        assert_eq!(
+            mock_ledger_event.parent_block_id,
+            monad_types::BlockId(monad_types::Hash([0x01_u8; 32])),
+        );
+    }
+    #[test]
+    fn test_seeking_non_exist() {
+        let mut mock_ledger = MockLedger::<MockBlock, MockLedgerEvent>::default();
+        assert_eq!(mock_ledger.next().now_or_never(), None); // nothing should be within the pipeline
+
+        mock_ledger.exec(vec![
+            LedgerCommand::LedgerCommit(MockBlock {
+                block_id: monad_types::BlockId(monad_types::Hash([0x01_u8; 32])),
+                parent_block_id: monad_types::BlockId(monad_types::Hash([0x00_u8; 32])),
+            }),
+            LedgerCommand::LedgerCommit(MockBlock {
+                block_id: monad_types::BlockId(monad_types::Hash([0x02_u8; 32])),
+                parent_block_id: monad_types::BlockId(monad_types::Hash([0x01_u8; 32])),
+            }),
+            LedgerCommand::LedgerCommit(MockBlock {
+                block_id: monad_types::BlockId(monad_types::Hash([0x03_u8; 32])),
+                parent_block_id: monad_types::BlockId(monad_types::Hash([0x02_u8; 32])),
+            }),
+            LedgerCommand::LedgerCommit(MockBlock {
+                block_id: monad_types::BlockId(monad_types::Hash([0x04_u8; 32])),
+                parent_block_id: monad_types::BlockId(monad_types::Hash([0x03_u8; 32])),
+            }),
+        ]);
+        assert_eq!(mock_ledger.next().now_or_never(), None); // ledger commit shouldn't cause any event
+
+        mock_ledger.exec(vec![LedgerCommand::LedgerFetch(
+            monad_types::BlockId(monad_types::Hash([0x10_u8; 32])),
+            Box::new(|block: Option<MockBlock>| MockLedgerEvent { block }),
+        )]);
+        let retrieved = mock_ledger.next().now_or_never();
+        assert_ne!(retrieved, None); // there should be a response
+        let mock_ledger_event = retrieved.unwrap().unwrap().block;
+
+        assert_eq!(mock_ledger_event, None);
     }
 }

--- a/monad-executor/src/executor/mock.rs
+++ b/monad-executor/src/executor/mock.rs
@@ -477,7 +477,10 @@ mod tests {
 
     use futures::{FutureExt, StreamExt};
     use monad_crypto::secp256k1::KeyPair;
-    use monad_testutil::signing::{create_keys, node_id};
+    use monad_testutil::{
+        block::MockBlock,
+        signing::{create_keys, node_id},
+    };
     use monad_types::{Deserializable, Serializable};
     use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
 
@@ -652,7 +655,7 @@ mod tests {
         type Event = SimpleChainEvent;
         type OutboundMessage = SimpleChainMessage;
         type Message = SimpleChainMessage;
-        type Block = ();
+        type Block = MockBlock;
         type Checkpoint = ();
 
         fn init(

--- a/monad-executor/src/state.rs
+++ b/monad-executor/src/state.rs
@@ -1,6 +1,9 @@
 use std::hash::Hash;
 
-use monad_consensus_types::payload::{FullTransactionList, TransactionList};
+use monad_consensus_types::{
+    block::BlockType,
+    payload::{FullTransactionList, TransactionList},
+};
 use monad_crypto::secp256k1::PubKey;
 use monad_types::BlockId;
 
@@ -121,7 +124,7 @@ pub trait State: Sized {
     type Event: Clone;
     type OutboundMessage: Into<Self::Message> + AsRef<Self::Message>;
     type Message: Message<Event = Self::Event>;
-    type Block;
+    type Block: BlockType;
     type Checkpoint;
 
     fn init(

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -5,7 +5,7 @@ use futures_util::{FutureExt, StreamExt};
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
-    block::Block,
+    block::{Block, BlockType},
     certificate_signature::{CertificateKeyPair, CertificateSignature},
     ledger::LedgerCommitInfo,
     multi_sig::MultiSig,

--- a/monad-state/tests/replay.rs
+++ b/monad-state/tests/replay.rs
@@ -5,7 +5,9 @@ mod test {
 
     use monad_block_sync::BlockSyncState;
     use monad_consensus_state::ConsensusState;
-    use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+    use monad_consensus_types::{
+        block::BlockType, multi_sig::MultiSig, transaction_validator::MockValidator,
+    };
     use monad_crypto::secp256k1::SecpSignature;
     use monad_executor::{
         executor::mock::NoSerRouterScheduler,

--- a/monad-testutil/src/block.rs
+++ b/monad-testutil/src/block.rs
@@ -1,5 +1,5 @@
 use monad_consensus_types::{
-    block::Block,
+    block::{Block, BlockType},
     certificate_signature::CertificateSignature,
     ledger::LedgerCommitInfo,
     multi_sig::MultiSig,
@@ -11,6 +11,37 @@ use monad_consensus_types::{
 };
 use monad_crypto::secp256k1::{KeyPair, SecpSignature};
 use monad_types::{BlockId, Hash, NodeId, Round};
+
+// test utility if you only wish for simple block
+#[derive(Clone, PartialEq, Eq)]
+pub struct MockBlock {
+    pub block_id: BlockId,
+    pub parent_block_id: BlockId,
+}
+
+impl Default for MockBlock {
+    fn default() -> Self {
+        MockBlock {
+            block_id: monad_types::BlockId(monad_types::Hash([0x00_u8; 32])),
+            parent_block_id: monad_types::BlockId(monad_types::Hash([0x01_u8; 32])),
+        }
+    }
+}
+
+impl BlockType for MockBlock {
+    fn get_id(&self) -> monad_types::BlockId {
+        self.block_id
+    }
+    fn get_parent_id(&self) -> monad_types::BlockId {
+        self.parent_block_id
+    }
+}
+
+impl std::fmt::Debug for MockBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MockBlock").finish()
+    }
+}
 
 pub fn setup_block(
     author: NodeId,

--- a/monad-testutil/src/proposal.rs
+++ b/monad-testutil/src/proposal.rs
@@ -3,7 +3,7 @@ use monad_consensus::{
     validation::signing::Verified,
 };
 use monad_consensus_types::{
-    block::Block,
+    block::{Block, BlockType},
     certificate_signature::{CertificateSignature, CertificateSignatureRecoverable},
     ledger::LedgerCommitInfo,
     message_signature::MessageSignature,

--- a/monad-testutil/src/signing.rs
+++ b/monad-testutil/src/signing.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use monad_consensus::validation::signing::Unverified;
 use monad_consensus_types::{
-    block::Block,
+    block::{Block, BlockType},
     certificate_signature::{CertificateKeyPair, CertificateSignature},
     ledger::LedgerCommitInfo,
     payload::{ExecutionArtifacts, Payload, TransactionList},

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -6,6 +6,7 @@ use std::{
 use monad_block_sync::{BlockSyncProcess, BlockSyncState};
 use monad_consensus_state::{ConsensusProcess, ConsensusState};
 use monad_consensus_types::{
+    block::BlockType,
     certificate_signature::{CertificateKeyPair, CertificateSignatureRecoverable},
     message_signature::MessageSignature,
     multi_sig::MultiSig,

--- a/monad-viz/src/config.rs
+++ b/monad-viz/src/config.rs
@@ -6,7 +6,7 @@ use iced::{
 };
 use iced_lazy::Component;
 use monad_consensus_types::{
-    quorum_certificate::genesis_vote_info, transaction_validator::MockValidator,
+    block::BlockType, quorum_certificate::genesis_vote_info, transaction_validator::MockValidator,
     validation::Sha256Hash,
 };
 use monad_crypto::secp256k1::{KeyPair, PubKey};

--- a/monad-viz/src/main.rs
+++ b/monad-viz/src/main.rs
@@ -24,7 +24,9 @@ use iced::{
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
-    block::Block, multi_sig::MultiSig, transaction_validator::MockValidator,
+    block::{Block, BlockType},
+    multi_sig::MultiSig,
+    transaction_validator::MockValidator,
 };
 use monad_crypto::NopSignature;
 use monad_executor::{

--- a/monad-viz/src/replay_graph.rs
+++ b/monad-viz/src/replay_graph.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, fmt::Debug, time::Duration, vec};
 
 use monad_consensus_types::{
-    quorum_certificate::genesis_vote_info, transaction_validator::MockValidator,
+    block::BlockType, quorum_certificate::genesis_vote_info, transaction_validator::MockValidator,
     validation::Sha256Hash,
 };
 use monad_crypto::secp256k1::{KeyPair, PubKey};

--- a/monad-wal/tests/replay.rs
+++ b/monad-wal/tests/replay.rs
@@ -3,6 +3,7 @@ mod test {
     use std::{array::TryFromSliceError, fs::OpenOptions};
 
     use monad_executor::{Message, State};
+    use monad_testutil::block::MockBlock;
     use monad_types::{Deserializable, Serializable};
     use monad_wal::{
         wal::{WALogger, WALoggerConfig},
@@ -73,7 +74,7 @@ mod test {
         type Event = TestEvent;
         type OutboundMessage = MockMessage;
         type Message = MockMessage;
-        type Block = ();
+        type Block = MockBlock;
         type Checkpoint = ();
 
         fn init(


### PR DESCRIPTION
Provide Ledger with fetch historical block capability, 
as a consequence enforced a trait on Block

Preparation for Block-Sync