### PR TITLE
Refactoring `VoteMessage`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4630,6 +4630,7 @@ dependencies = [
  "monad-types",
  "prost",
  "sha2 0.10.7",
+ "test-case",
  "zerocopy",
 ]
 

--- a/monad-consensus-types/Cargo.toml
+++ b/monad-consensus-types/Cargo.toml
@@ -15,4 +15,12 @@ sha2 = { workspace = true }
 zerocopy = { workspace = true }
 
 [features]
-proto = ["dep:monad-proto", "dep:prost", "monad-crypto/proto", "monad-types/proto"]
+proto = [
+    "dep:monad-proto",
+    "dep:prost",
+    "monad-crypto/proto",
+    "monad-types/proto",
+]
+
+[dev-dependencies]
+test-case = { workspace = true }

--- a/monad-consensus-types/src/certificate_signature.rs
+++ b/monad-consensus-types/src/certificate_signature.rs
@@ -6,7 +6,7 @@ use monad_crypto::{
 use crate::{message_signature::MessageSignature, validation::Hashable};
 
 pub trait CertificateKeyPair: Send + Sized + Sync + 'static {
-    type PubKeyType: std::cmp::Eq + std::hash::Hash;
+    type PubKeyType: std::cmp::Eq + std::hash::Hash + Copy;
     type Error: std::error::Error + Send + Sync;
 
     fn from_bytes(secret: impl AsMut<[u8]>) -> Result<Self, Self::Error>;

--- a/monad-consensus-types/src/convert/signing.rs
+++ b/monad-consensus-types/src/convert/signing.rs
@@ -44,15 +44,13 @@ pub fn proto_to_message_signature<S: MessageSignature>(
     S::deserialize(&proto.sig).map_err(|e| ProtoError::CryptoError(format!("{}", e)))
 }
 
-pub(crate) fn certificate_signature_to_proto(
-    signature: &impl CertificateSignature,
-) -> ProtoSignature {
+pub fn certificate_signature_to_proto(signature: &impl CertificateSignature) -> ProtoSignature {
     ProtoSignature {
         sig: signature.serialize(),
     }
 }
 
-pub(crate) fn proto_to_certificate_signature<S: CertificateSignature>(
+pub fn proto_to_certificate_signature<S: CertificateSignature>(
     proto: ProtoSignature,
 ) -> Result<S, ProtoError> {
     S::deserialize(&proto.sig).map_err(|e| ProtoError::CryptoError(format!("{}", e)))

--- a/monad-consensus-types/src/convert/voting.rs
+++ b/monad-consensus-types/src/convert/voting.rs
@@ -1,7 +1,7 @@
 use monad_proto::{error::ProtoError, proto::voting::*};
 use monad_types::Round;
 
-use crate::voting::VoteInfo;
+use crate::voting::{Vote, VoteInfo};
 
 impl From<&VoteInfo> for ProtoVoteInfo {
     fn from(vi: &VoteInfo) -> Self {
@@ -29,6 +29,36 @@ impl TryFrom<ProtoVoteInfo> for VoteInfo {
                 ))?
                 .try_into()?,
             parent_round: Round(proto_vi.parent_round),
+        })
+    }
+}
+
+impl From<&Vote> for ProtoVote {
+    fn from(value: &Vote) -> Self {
+        ProtoVote {
+            vote_info: Some((&value.vote_info).into()),
+            ledger_commit_info: Some((&value.ledger_commit_info).into()),
+        }
+    }
+}
+
+impl TryFrom<ProtoVote> for Vote {
+    type Error = ProtoError;
+
+    fn try_from(value: ProtoVote) -> Result<Self, Self::Error> {
+        Ok(Self {
+            vote_info: value
+                .vote_info
+                .ok_or(Self::Error::MissingRequiredField(
+                    "Vote.vote_info".to_owned(),
+                ))?
+                .try_into()?,
+            ledger_commit_info: value
+                .ledger_commit_info
+                .ok_or(Self::Error::MissingRequiredField(
+                    "Vote.ledger_commit_info".to_owned(),
+                ))?
+                .try_into()?,
         })
     }
 }

--- a/monad-consensus-types/src/quorum_certificate.rs
+++ b/monad-consensus-types/src/quorum_certificate.rs
@@ -68,8 +68,8 @@ pub fn genesis_vote_info(genesis_block_id: BlockId) -> VoteInfo {
     }
 }
 
-impl<T: SignatureCollection> QuorumCertificate<T> {
-    pub fn new<H: Hasher>(info: QcInfo, signatures: T) -> Self {
+impl<SCT: SignatureCollection> QuorumCertificate<SCT> {
+    pub fn new<H: Hasher>(info: QcInfo, signatures: SCT) -> Self {
         let hash = signatures.get_hash::<H>();
         QuorumCertificate {
             info,
@@ -88,7 +88,7 @@ impl<T: SignatureCollection> QuorumCertificate<T> {
         };
         let lci = LedgerCommitInfo::new::<H>(None, &vote_info);
 
-        let sigs = T::new(Vec::new(), &ValidatorMapping::new(std::iter::empty()), &[])
+        let sigs = SCT::new(Vec::new(), &ValidatorMapping::new(std::iter::empty()), &[])
             .expect("genesis qc sigs");
         let sig_hash = sigs.get_hash::<H>();
 
@@ -105,7 +105,7 @@ impl<T: SignatureCollection> QuorumCertificate<T> {
     // This is the QC that will be used in the block of the first proposal
     // and will be the initial qc_high for all nodes
     // All initial genesis nodes will have to create signatures for the genesis lci
-    pub fn genesis_qc<H: Hasher>(genesis_vote_info: VoteInfo, genesis_signatures: T) -> Self {
+    pub fn genesis_qc<H: Hasher>(genesis_vote_info: VoteInfo, genesis_signatures: SCT) -> Self {
         let vote_info = genesis_vote_info;
         let lci = LedgerCommitInfo::new::<H>(None, &vote_info);
 

--- a/monad-consensus-types/src/transaction_validator.rs
+++ b/monad-consensus-types/src/transaction_validator.rs
@@ -19,7 +19,7 @@ impl TransactionValidator for MockValidator {
 pub struct EthereumValidator;
 
 impl TransactionValidator for EthereumValidator {
-    fn validate(&self, txs: &FullTransactionList) -> bool {
+    fn validate(&self, _txs: &FullTransactionList) -> bool {
         unimplemented!()
     }
 }

--- a/monad-consensus/src/validation/safety.rs
+++ b/monad-consensus/src/validation/safety.rs
@@ -7,11 +7,9 @@ use monad_consensus_types::{
     signature_collection::SignatureCollection,
     timeout::{TimeoutCertificate, TimeoutInfo},
     validation::Hasher,
-    voting::VoteInfo,
+    voting::{Vote, VoteInfo},
 };
 use monad_types::*;
-
-use crate::messages::message::VoteMessage;
 
 #[derive(Debug)]
 pub struct Safety {
@@ -90,7 +88,7 @@ impl Safety {
         &mut self,
         block: &Block<T>,
         last_tc: &Option<TimeoutCertificate<S>>,
-    ) -> Option<VoteMessage> {
+    ) -> Option<Vote> {
         let qc_round = block.qc.info.vote.round;
         if self.safe_to_vote(block.round, qc_round, last_tc) {
             self.update_highest_qc_round(qc_round);
@@ -111,7 +109,7 @@ impl Safety {
 
             let ledger_commit_info = LedgerCommitInfo::new::<H>(commit_hash, &vote_info);
 
-            return Some(VoteMessage {
+            return Some(Vote {
                 vote_info,
                 ledger_commit_info,
             });

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -226,15 +226,15 @@ where
     }
 }
 
-impl<S: MessageSignature> Unverified<S, VoteMessage> {
+impl<S: MessageSignature, SCT: SignatureCollection> Unverified<S, VoteMessage<SCT>> {
     // A verified vote message has a valid signature
     // Return type must keep the signature with the message as it is used later by the protocol
     pub fn verify<H: Hasher>(
         self,
         validators: &HashMap<NodeId, Stake>,
         sender: &PubKey,
-    ) -> Result<Verified<S, VoteMessage>, Error> {
-        let msg = H::hash_object(&self.obj.ledger_commit_info);
+    ) -> Result<Verified<S, VoteMessage<SCT>>, Error> {
+        let msg = H::hash_object(&self.obj);
 
         let author = verify_author(validators, sender, &msg, &self.author_signature)?;
 

--- a/monad-driver/src/lib.rs
+++ b/monad-driver/src/lib.rs
@@ -117,12 +117,13 @@ mod tests {
         let state_configs = node_configs
             .into_iter()
             .zip(std::iter::repeat(pubkeys.clone()))
-            .map(|((key, _, exec, logger_config), _)| {
+            .map(|((key, certkey, exec, logger_config), _)| {
                 (
                     exec,
                     MonadConfig {
                         transaction_validator: TransactionValidatorType {},
                         key,
+                        certkey,
                         validators: config_validators.clone(),
                         delta: Duration::from_millis(2),
                         genesis_block: genesis_block.clone(),

--- a/monad-proto/proto/message.proto
+++ b/monad-proto/proto/message.proto
@@ -11,8 +11,8 @@ import "voting.proto";
 
 
 message ProtoVoteMessage {
-  monad_proto.voting.ProtoVoteInfo vote_info = 1;
-  monad_proto.ledger.ProtoLedgerCommitInfo ledger_commit_info = 2;
+  monad_proto.voting.ProtoVote vote = 1;
+  monad_proto.signing.ProtoSignature sig = 2;
 }
 
 message ProtoRequestBlockSyncMessage {

--- a/monad-proto/proto/voting.proto
+++ b/monad-proto/proto/voting.proto
@@ -3,10 +3,16 @@ syntax = "proto3";
 package monad_proto.voting;
 
 import "basic.proto";
+import "ledger.proto";
 
 message ProtoVoteInfo {
   monad_proto.basic.ProtoBlockId id = 1;
   uint64 round = 2;
   monad_proto.basic.ProtoBlockId parent_id = 3;
   uint64 parent_round = 4;
+}
+
+message ProtoVote {
+  ProtoVoteInfo vote_info = 1;
+  monad_proto.ledger.ProtoLedgerCommitInfo ledger_commit_info = 2;
 }

--- a/monad-testutil/src/signing.rs
+++ b/monad-testutil/src/signing.rs
@@ -40,7 +40,7 @@ impl MockSignatures {
 }
 
 impl Hashable for MockSignatures {
-    fn hash<H: Hasher>(&self, state: &mut H) {}
+    fn hash<H: Hasher>(&self, _state: &mut H) {}
 }
 
 impl SignatureCollection for MockSignatures {
@@ -48,11 +48,11 @@ impl SignatureCollection for MockSignatures {
     type SignatureType = SecpSignature;
 
     fn new(
-        sigs: Vec<(NodeId, Self::SignatureType)>,
-        validator_mapping: &monad_consensus_types::voting::ValidatorMapping<
+        _sigs: Vec<(NodeId, Self::SignatureType)>,
+        _validator_mapping: &monad_consensus_types::voting::ValidatorMapping<
             <Self::SignatureType as monad_consensus_types::certificate_signature::CertificateSignature>::KeyPairType,
         >,
-        msg: &[u8],
+        _msg: &[u8],
     ) -> Result<Self, Self::SignatureError> {
         Ok(Self { pubkey: Vec::new() })
     }
@@ -63,10 +63,10 @@ impl SignatureCollection for MockSignatures {
 
     fn verify(
         &self,
-        validator_mapping: &monad_consensus_types::voting::ValidatorMapping<
+        _validator_mapping: &monad_consensus_types::voting::ValidatorMapping<
             <Self::SignatureType as monad_consensus_types::certificate_signature::CertificateSignature>::KeyPairType,
         >,
-        msg: &[u8],
+        _msg: &[u8],
     ) -> Result<Vec<NodeId>, Self::SignatureError> {
         Ok(self.pubkey.iter().map(|pubkey| NodeId(*pubkey)).collect())
     }
@@ -115,7 +115,9 @@ pub fn create_certificate_keys<SCT: SignatureCollection>(
 ) -> Vec<SignatureCollectionKeyPairType<SCT>> {
     let mut res = Vec::new();
     for i in 0..num_keys {
-        let keypair = get_certificate_key::<SCT>(i.into());
+        // (i+1) makes sure that the MessageKeyPair != CertificateKeyPair
+        // so we don't accidentally mis-sign stuff without test noticing
+        let keypair = get_certificate_key::<SCT>(i as u64 + 1);
         res.push(keypair);
     }
     res

--- a/monad-viz/src/replay_graph.rs
+++ b/monad-viz/src/replay_graph.rs
@@ -40,16 +40,16 @@ impl ReplayConfig<MS> for RepConfig {
 
         let state_configs = keys
             .into_iter()
-            .zip(std::iter::repeat(pubkeys.clone()))
-            .map(|(key, pubkeys)| MonadConfig {
+            .zip(cert_keys.into_iter())
+            .map(|(key, certkey)| MonadConfig {
                 transaction_validator: MockValidator,
-
                 key,
-                validators: pubkeys
+                certkey,
+                validators: validator_mapping
+                    .map
                     .iter()
-                    .cloned()
-                    .zip(cert_keys.iter().map(|k| k.pubkey()))
-                    .collect(),
+                    .map(|(node_id, sctpubkey)| (node_id.0, *sctpubkey))
+                    .collect::<Vec<_>>(),
                 delta: self.delta,
                 genesis_block: genesis_block.clone(),
                 genesis_vote_info: genesis_vote_info(genesis_block.get_id()),


### PR DESCRIPTION
`VoteMessage` now carries a `CertificateSignature` on the `Vote`, and another `MessageSignature` is created around the entire `VoteMessage`

Removes the link we had between `MessageSignature` and `SignatureCollection`. Validators keeps two keypairs, one for signing messages, the other for signing votes and timeouts (to be implemented).

Closes #203 