### PR TITLE
Add StateRoot hashes to consensus and seq_num to blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4856,6 +4856,7 @@ dependencies = [
  "monad-validator",
  "monad-wal",
  "sha2 0.10.7",
+ "zerocopy",
 ]
 
 [[package]]

--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -343,6 +343,7 @@ mod test {
         let payload = Payload {
             txns: TransactionList(vec![]),
             header: ExecutionArtifacts::zero(),
+            seq_num: 0,
         };
         let g = Block::new::<Sha256Hash>(
             node_id(),
@@ -603,6 +604,7 @@ mod test {
         let payload = Payload {
             txns: TransactionList(vec![]),
             header: ExecutionArtifacts::zero(),
+            seq_num: 0,
         };
         let g = Block::new::<Sha256Hash>(
             node_id(),
@@ -694,6 +696,7 @@ mod test {
             &Payload {
                 txns: txlist,
                 header: ExecutionArtifacts::zero(),
+                seq_num: 0,
             },
             &QC::new::<HasherType>(
                 QcInfo {
@@ -722,6 +725,7 @@ mod test {
             &Payload {
                 txns: TransactionList(vec![1]),
                 header: ExecutionArtifacts::zero(),
+                seq_num: 0,
             },
             &QC::new::<HasherType>(
                 QcInfo {
@@ -738,6 +742,7 @@ mod test {
             &Payload {
                 txns: TransactionList(vec![2]),
                 header: ExecutionArtifacts::zero(),
+                seq_num: 0,
             },
             &QC::new::<HasherType>(
                 QcInfo {
@@ -761,6 +766,7 @@ mod test {
             &Payload {
                 txns: TransactionList(vec![3]),
                 header: ExecutionArtifacts::zero(),
+                seq_num: 0,
             },
             &QC::new::<HasherType>(
                 QcInfo {
@@ -805,6 +811,7 @@ mod test {
             &Payload {
                 txns: txlist,
                 header: ExecutionArtifacts::zero(),
+                seq_num: 0,
             },
             &QC::new::<HasherType>(
                 QcInfo {
@@ -833,6 +840,7 @@ mod test {
             &Payload {
                 txns: TransactionList(vec![1]),
                 header: ExecutionArtifacts::zero(),
+                seq_num: 0,
             },
             &QC::new::<HasherType>(
                 QcInfo {
@@ -863,6 +871,7 @@ mod test {
         let payload = Payload {
             txns: TransactionList(vec![]),
             header: ExecutionArtifacts::zero(),
+            seq_num: 0,
         };
         let g = Block::new::<Sha256Hash>(
             node_id(),
@@ -991,6 +1000,7 @@ mod test {
         let payload = Payload {
             txns: TransactionList(vec![]),
             header: ExecutionArtifacts::zero(),
+            seq_num: 0,
         };
         let g = Block::new::<Sha256Hash>(
             node_id(),
@@ -1097,6 +1107,7 @@ mod test {
         let payload = Payload {
             txns: TransactionList(vec![]),
             header: ExecutionArtifacts::zero(),
+            seq_num: 0,
         };
         let g = Block::new::<Sha256Hash>(
             node_id(),
@@ -1251,6 +1262,7 @@ mod test {
         let payload = Payload {
             txns: TransactionList(vec![]),
             header: ExecutionArtifacts::zero(),
+            seq_num: 0,
         };
         let g = Block::new::<Sha256Hash>(
             node_id(),

--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -80,6 +80,7 @@ pub struct FetchedTxs<ST, SCT> {
     // they're included here just to be extra safe
     pub node_id: NodeId,
     pub round: Round,
+    pub seq_num: u64,
     pub high_qc: QuorumCertificate<SCT>,
     pub last_round_tc: Option<TimeoutCertificate<ST>>,
 

--- a/monad-consensus-types/src/convert/block.rs
+++ b/monad-consensus-types/src/convert/block.rs
@@ -166,6 +166,7 @@ impl From<&Payload> for ProtoPayload {
         ProtoPayload {
             txns: Some((&(value.txns)).into()),
             header: Some((&(value.header)).into()),
+            seq_num: value.seq_num,
         }
     }
 }
@@ -184,6 +185,7 @@ impl TryFrom<ProtoPayload> for Payload {
                     "Payload.header".to_owned(),
                 ))?
                 .try_into()?,
+            seq_num: value.seq_num,
         })
     }
 }

--- a/monad-consensus/tests/block.rs
+++ b/monad-consensus/tests/block.rs
@@ -33,6 +33,7 @@ fn block_hash_id() {
         &Payload {
             txns,
             header: ExecutionArtifacts::zero(),
+            seq_num: 0,
         },
         &qc,
     );

--- a/monad-consensus/tests/message.rs
+++ b/monad-consensus/tests/message.rs
@@ -81,6 +81,7 @@ fn proposal_msg_hash() {
         &Payload {
             txns,
             header: ExecutionArtifacts::zero(),
+            seq_num: 0,
         },
         &qc,
     );

--- a/monad-consensus/tests/proposal.rs
+++ b/monad-consensus/tests/proposal.rs
@@ -44,6 +44,7 @@ fn setup_block(
         &Payload {
             txns,
             header: ExecutionArtifacts::zero(),
+            seq_num: 0,
         },
         &qc,
     )

--- a/monad-driver/src/lib.rs
+++ b/monad-driver/src/lib.rs
@@ -126,6 +126,7 @@ mod tests {
                         certkey,
                         validators: config_validators.clone(),
                         delta: Duration::from_millis(2),
+                        state_root_delay: 0,
                         genesis_block: genesis_block.clone(),
                         genesis_vote_info: genesis_vote_info(genesis_block.get_id()),
                         genesis_signatures: genesis_sigs.clone(),

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -64,6 +64,7 @@ pub struct Config {
         SignatureCollectionPubKeyType<SignatureCollectionType>,
     )>,
     pub delta: Duration,
+    pub state_root_delay: u64,
     pub genesis_block: Block<SignatureCollectionType>,
     pub genesis_vote_info: VoteInfo,
     pub genesis_signatures: SignatureCollectionType,
@@ -135,6 +136,7 @@ async fn main() {
             Duration::from_secs(10),
             Duration::from_secs(1),
             Duration::from_secs(60),
+            0,
         )
         .map(|config| {
             let maybe_provider = args.otel_endpoint.as_ref().map(|endpoint| {
@@ -183,6 +185,7 @@ fn testnet(
     simulation_length: Duration,
     delta: Duration,
     keepalive: Duration,
+    state_root_delay: u64,
 ) -> impl Iterator<Item = Config> {
     let secrets = std::iter::repeat_with(rand::random::<[u8; 32]>)
         .map(Box::new)
@@ -230,6 +233,7 @@ fn testnet(
             &Payload {
                 txns: genesis_txn,
                 header: genesis_execution_header,
+                seq_num: 0,
             },
             &genesis_prime_qc,
         )
@@ -273,6 +277,7 @@ fn testnet(
             libp2p_keepalive: keepalive,
             genesis_peers: peers.clone(),
             delta,
+            state_root_delay,
             genesis_block: genesis_block.clone(),
             genesis_vote_info: genesis_vote_info(genesis_block.get_id()),
             genesis_signatures: genesis_signatures.clone(),
@@ -326,6 +331,7 @@ async fn run(
         key: keypair,
         certkey: certkeypair,
         delta: config.delta,
+        state_root_delay: config.state_root_delay,
         genesis_block: config.genesis_block,
         genesis_vote_info: config.genesis_vote_info,
         genesis_signatures: config.genesis_signatures,

--- a/monad-proto/proto/block.proto
+++ b/monad-proto/proto/block.proto
@@ -21,6 +21,7 @@ message ProtoTransactionList {
 message ProtoPayload {
   ProtoTransactionList txns = 1;
   ProtoExecutionArtifacts header = 2;
+  uint64 seq_num = 3;
 }
 
 message ProtoBlockAggSig {

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -30,6 +30,7 @@ message ProtoFetchedTxs {
   optional monad_proto.timeout.ProtoTimeoutCertificate last_round_tc = 4;
 
   bytes tx_hashes = 5;
+  uint64 seq_num = 6;
 }
 
 message ProtoFetchedFullTxs {

--- a/monad-state/src/convert/event.rs
+++ b/monad-state/src/convert/event.rs
@@ -41,6 +41,7 @@ impl<S: MessageSignature + CertificateSignatureRecoverable> From<&ConsensusEvent
                     last_round_tc: fetched.last_round_tc.as_ref().map(Into::into),
 
                     tx_hashes: fetched.txns.0.clone(),
+                    seq_num: fetched.seq_num,
                 })
             }
             TypeConsensusEvent::FetchedFullTxs(fetched_full) => {
@@ -114,6 +115,7 @@ impl<S: MessageSignature + CertificateSignatureRecoverable> TryFrom<ProtoConsens
                             "ConsensusEvent::fetched_txs.round".to_owned(),
                         ))?
                         .try_into()?,
+                    seq_num: fetched_txs.seq_num,
                     high_qc: fetched_txs
                         .high_qc
                         .ok_or(ProtoError::MissingRequiredField(

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -241,6 +241,7 @@ pub struct MonadConfig<SCT: SignatureCollection, TV> {
     pub certkey: SignatureCollectionKeyPairType<SCT>,
 
     pub delta: Duration,
+    pub state_root_delay: u64,
     pub genesis_block: Block<SCT>,
     pub genesis_vote_info: VoteInfo,
     pub genesis_signatures: SCT,
@@ -310,6 +311,7 @@ where
                 config.genesis_block,
                 genesis_qc,
                 config.delta,
+                config.state_root_delay,
                 config.key,
                 config.certkey,
             ),
@@ -349,6 +351,7 @@ where
                                 &Payload {
                                     txns: fetched.txns,
                                     header: ExecutionArtifacts::zero(), // TODO this needs to be fetched
+                                    seq_num: fetched.seq_num,
                                 },
                                 &fetched.high_qc,
                             );

--- a/monad-testutil/Cargo.toml
+++ b/monad-testutil/Cargo.toml
@@ -21,3 +21,4 @@ monad-validator = {path = "../monad-validator" }
 monad-wal = {path = "../monad-wal" }
 
 sha2 = { workspace = true }
+zerocopy = { workspace = true }

--- a/monad-testutil/src/block.rs
+++ b/monad-testutil/src/block.rs
@@ -85,6 +85,7 @@ pub fn setup_block<SCT: SignatureCollection>(
         &Payload {
             txns,
             header: execution_header,
+            seq_num: 0,
         },
         &qc,
     )

--- a/monad-testutil/src/proposal.rs
+++ b/monad-testutil/src/proposal.rs
@@ -20,6 +20,7 @@ use monad_validator::{leader_election::LeaderElection, validator_set::ValidatorS
 
 pub struct ProposalGen<ST, SCT> {
     round: Round,
+    seq_num: u64,
     qc: QuorumCertificate<SCT>,
     high_qc: QuorumCertificate<SCT>,
     last_tc: Option<TimeoutCertificate<ST>>,
@@ -33,6 +34,7 @@ where
     pub fn new(genesis_qc: QuorumCertificate<SCT>) -> Self {
         ProposalGen {
             round: Round(0),
+            seq_num: 0,
             qc: genesis_qc.clone(),
             high_qc: genesis_qc,
             last_tc: None,
@@ -69,6 +71,7 @@ where
             &Payload {
                 txns,
                 header: execution_header,
+                seq_num: self.seq_num,
             },
             qc,
         );
@@ -81,6 +84,7 @@ where
             last_round_tc: self.last_tc.clone(),
         };
         self.last_tc = None;
+        self.seq_num += 1;
 
         Verified::new::<Sha256Hash>(proposal, leader_key)
     }

--- a/monad-testutil/src/signing.rs
+++ b/monad-testutil/src/signing.rs
@@ -14,6 +14,7 @@ use monad_consensus_types::{
 use monad_crypto::secp256k1::{Error as SecpError, KeyPair, PubKey, SecpSignature};
 use monad_types::{Hash, NodeId, Round};
 use sha2::{Digest, Sha256};
+use zerocopy::AsBytes;
 
 #[derive(Clone, Default, Debug)]
 pub struct MockSignatures {
@@ -88,6 +89,7 @@ pub fn hash<T: SignatureCollection>(b: &Block<T>) -> Hash {
     hasher.update(b.payload.header.receipts_root);
     hasher.update(b.payload.header.logs_bloom);
     hasher.update(b.payload.header.gas_used);
+    hasher.update(b.payload.seq_num.as_bytes());
     hasher.update(b.qc.info.vote.id.0);
     hasher.update(b.qc.signatures.get_hash::<Sha256Hash>());
 
@@ -140,6 +142,7 @@ where
         &Payload {
             txns: genesis_txn,
             header: ExecutionArtifacts::zero(),
+            seq_num: 0,
         },
         &genesis_prime_qc,
     );

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -78,6 +78,7 @@ pub fn get_configs<SCT: SignatureCollection>(
                 .map(|(node_id, sctpubkey)| (node_id.0, *sctpubkey))
                 .collect::<Vec<_>>(),
             delta,
+            state_root_delay: 0,
             genesis_block: genesis_block.clone(),
             genesis_vote_info: genesis_vote_info(genesis_block.get_id()),
             genesis_signatures: genesis_sigs.clone(),

--- a/monad-viz/src/config.rs
+++ b/monad-viz/src/config.rs
@@ -87,6 +87,7 @@ impl SimulationConfig<MS, NoSerRouterScheduler<MM>, TransformerPipeline<MM>, Per
                     .collect::<Vec<_>>(),
 
                 delta: self.delta,
+                state_root_delay: 0,
                 genesis_block: genesis_block.clone(),
                 genesis_vote_info: genesis_vote_info(genesis_block.get_id()),
                 genesis_signatures: genesis_sigs.clone(),

--- a/monad-viz/src/replay_graph.rs
+++ b/monad-viz/src/replay_graph.rs
@@ -51,6 +51,7 @@ impl ReplayConfig<MS> for RepConfig {
                     .map(|(node_id, sctpubkey)| (node_id.0, *sctpubkey))
                     .collect::<Vec<_>>(),
                 delta: self.delta,
+                state_root_delay: 0,
                 genesis_block: genesis_block.clone(),
                 genesis_vote_info: genesis_vote_info(genesis_block.get_id()),
                 genesis_signatures: genesis_sigs.clone(),


### PR DESCRIPTION
In order for proposals to be validated, the state root hash of a previously executed block needs to be checked. The root hash to be checked is a fixed delta relative to the current block being proposed.

There is a difference between the number of blocks executed and the round number in blocks. Because of timeouts, we can be on round 1000 while the block in the proposal is only the 3rd proposed block. The state-root is relative to executed blocks, not rounds, so a sequence number is introduced to identify which state-root hash to check.

The state-root to check could also be determined via the ordering of state root hashes (queue) but sequence id helps solve the problem of identifying which hash to use if a proposal from a high round arrives which does not extend a known branch of the blocktree. If the round is much higher but the sequence number is still within a range of available state root hashes, the node can still validate the proposal, accept the proposal and blocksync the missing blocks. Without the sequence number, its unknown how many blocks are missing and whether this node has the state roots necessary to verify those blocks and therefore whether blocksync is sufficient to catch up or if a more involved state sync is necessary.


Upcoming PR will add the validator for state root hashes. 
We will still need a way to set the sequence number properly when a node coldstarts, but how that works will depend on the coldstart implementation, so not considering it now. 