### PR TITLE
Add block-sync and associated testcases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4569,7 +4569,9 @@ dependencies = [
  "monad-consensus",
  "monad-consensus-state",
  "monad-consensus-types",
+ "monad-crypto",
  "monad-executor",
+ "monad-testutil",
  "monad-types",
  "monad-validator",
 ]

--- a/monad-block-sync/Cargo.toml
+++ b/monad-block-sync/Cargo.toml
@@ -12,3 +12,7 @@ monad-consensus-types = { path = "../monad-consensus-types" }
 monad-executor = { path = "../monad-executor" }
 monad-types = { path = "../monad-types" }
 monad-validator = { path = "../monad-validator" }
+
+[dev-dependencies]
+monad-testutil = { path = "../monad-testutil" }
+monad-crypto = { path = "../monad-crypto" }

--- a/monad-block-sync/src/lib.rs
+++ b/monad-block-sync/src/lib.rs
@@ -1,7 +1,7 @@
 use monad_consensus::messages::{
     consensus_message::ConsensusMessage, message::RequestBlockSyncMessage,
 };
-use monad_consensus_state::command::ConsensusCommand;
+use monad_consensus_state::command::{ConsensusCommand, FetchedBlock};
 use monad_consensus_types::{
     message_signature::MessageSignature, signature_collection::SignatureCollection,
 };
@@ -9,12 +9,15 @@ use monad_executor::{PeerId, RouterTarget};
 use monad_types::{BlockId, NodeId};
 use monad_validator::validator_set::ValidatorSetType;
 
-pub struct BlockSyncState {}
+#[derive(Debug)]
+pub struct BlockSyncState {
+    round_robin_validator_selector: usize,
+}
 
-pub trait BlockSyncProcess<ST, SCT, VT>
+pub trait BlockSyncProcess<ST, SC, VT>
 where
     ST: MessageSignature,
-    SCT: SignatureCollection,
+    SC: SignatureCollection,
     VT: ValidatorSetType,
 {
     fn new() -> Self;
@@ -23,31 +26,36 @@ where
         &mut self,
         blockid: BlockId,
         validators: &VT,
-    ) -> (RouterTarget, ConsensusMessage<ST, SCT>);
+    ) -> (RouterTarget, ConsensusMessage<ST, SC>);
 
     fn handle_request_block_sync_message(
         &mut self,
         author: NodeId,
         s: RequestBlockSyncMessage,
-        validators: &VT,
-    ) -> Vec<ConsensusCommand<ST, SCT>>;
+    ) -> Vec<ConsensusCommand<ST, SC>>;
 }
 
-impl<ST, SCT, VT> BlockSyncProcess<ST, SCT, VT> for BlockSyncState
+impl<ST, SC, VT> BlockSyncProcess<ST, SC, VT> for BlockSyncState
 where
     ST: MessageSignature,
-    SCT: SignatureCollection,
+    SC: SignatureCollection,
     VT: ValidatorSetType,
 {
     fn new() -> Self {
-        BlockSyncState {}
+        BlockSyncState {
+            round_robin_validator_selector: 0,
+        }
     }
+
     fn request_block_sync(
         &mut self,
         blockid: BlockId,
         validators: &VT,
-    ) -> (RouterTarget, ConsensusMessage<ST, SCT>) {
-        let target = RouterTarget::PointToPoint(PeerId(validators.get_list()[0].0));
+    ) -> (RouterTarget, ConsensusMessage<ST, SC>) {
+        let target = RouterTarget::PointToPoint(PeerId(
+            validators.get_list()[self.round_robin_validator_selector % validators.len()].0,
+        ));
+        self.round_robin_validator_selector += 1;
         let message =
             ConsensusMessage::RequestBlockSync(RequestBlockSyncMessage { block_id: blockid });
         (target, message)
@@ -57,8 +65,107 @@ where
         &mut self,
         author: NodeId,
         s: RequestBlockSyncMessage,
-        validators: &VT,
-    ) -> Vec<ConsensusCommand<ST, SCT>> {
-        vec![]
+    ) -> Vec<ConsensusCommand<ST, SC>> {
+        vec![ConsensusCommand::LedgerFetch(
+            s.block_id,
+            Box::new(move |block| FetchedBlock {
+                requester: author,
+                block,
+            }),
+        )]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use monad_consensus::messages::{
+        consensus_message::ConsensusMessage, message::RequestBlockSyncMessage,
+    };
+    use monad_consensus_state::command::ConsensusCommand;
+    use monad_consensus_types::multi_sig::MultiSig;
+    use monad_crypto::{secp256k1::PubKey, NopSignature};
+    use monad_executor::RouterTarget;
+    use monad_testutil::{signing::get_key, validators::create_keys_w_validators};
+    use monad_types::{BlockId, Hash, NodeId};
+    use monad_validator::validator_set::{ValidatorSet, ValidatorSetType};
+
+    use crate::{BlockSyncProcess, BlockSyncState};
+    type ST = NopSignature;
+    type SC = MultiSig<ST>;
+    type VT = ValidatorSet;
+
+    fn verify_target_and_message(
+        target: &RouterTarget,
+        message: &ConsensusMessage<ST, SC>,
+        desired_pubkey: PubKey,
+        desired_block_id: BlockId,
+    ) {
+        match message {
+            ConsensusMessage::RequestBlockSync(rbsm) => {
+                let block_id = rbsm.block_id;
+                assert_eq!(block_id, desired_block_id);
+            }
+            _ => panic!("request_block_sync didn't produce a valid ConsensusMessage type"),
+        }
+
+        match target {
+            RouterTarget::PointToPoint(node) => {
+                assert_eq!(node.0, desired_pubkey);
+            }
+            _ => panic!("request_block_sync didn't produce a valid routing target"),
+        }
+    }
+
+    #[test]
+    fn test_request_block_sync_basic_functionality() {
+        let mut process: BlockSyncState = BlockSyncProcess::<ST, SC, VT>::new();
+        let (_, _, valset, _) = create_keys_w_validators::<SC>(4);
+
+        let (target, message): (RouterTarget, ConsensusMessage<ST, SC>) =
+            process.request_block_sync(BlockId(Hash([0x00_u8; 32])), &valset);
+
+        verify_target_and_message(
+            &target,
+            &message,
+            valset.get_list()[0].0,
+            BlockId(Hash([0x00_u8; 32])),
+        );
+    }
+
+    #[test]
+    fn test_request_block_sync_round_robin() {
+        let mut process: BlockSyncState = BlockSyncProcess::<ST, SC, VT>::new();
+        let (_, _, valset, _) = create_keys_w_validators::<SC>(4);
+
+        let (mut target, mut message): (RouterTarget, ConsensusMessage<ST, SC>) =
+            process.request_block_sync(BlockId(Hash([0x00_u8; 32])), &valset);
+        for i in 0..15 {
+            verify_target_and_message(
+                &target,
+                &message,
+                valset.get_list()[i % 4].0,
+                BlockId(Hash([0x00_u8; 32])),
+            );
+            (target, message) = process.request_block_sync(BlockId(Hash([0x00_u8; 32])), &valset);
+        }
+    }
+
+    #[test]
+    fn test_handle_request_block_sync_message_basic_functionality() {
+        let mut process: BlockSyncState = BlockSyncProcess::<ST, SC, VT>::new();
+        let keypair = get_key(6);
+        let command: Vec<ConsensusCommand<ST, SC>> =
+            <BlockSyncState as BlockSyncProcess<ST, SC, VT>>::handle_request_block_sync_message(
+                &mut process,
+                NodeId(keypair.pubkey()),
+                RequestBlockSyncMessage {
+                    block_id: BlockId(Hash([0x00_u8; 32])),
+                },
+            );
+        assert_eq!(command.len(), 1);
+        let res = command
+            .iter()
+            .find(|c| matches!(c, ConsensusCommand::LedgerFetch(_, _)));
+        assert!(res.is_some());
     }
 }

--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -40,6 +40,7 @@ pub enum ConsensusCommand<ST, SCT: SignatureCollection> {
         BlockId,
         Box<dyn (FnOnce(Option<Block<SCT>>) -> FetchedBlock<SCT>) + Send + Sync>,
     ),
+    LedgerFetchReset,
     /// Checkpoints periodically can upload/backup the ledger and garbage clean
     /// persisted events if necessary
     CheckpointSave(Checkpoint<SCT>),
@@ -96,5 +97,6 @@ pub struct FetchedFullTxs<ST, SCT> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FetchedBlock<SCT> {
+    pub requester: NodeId,
     pub block: Option<Block<SCT>>,
 }

--- a/monad-executor/src/executor/parent.rs
+++ b/monad-executor/src/executor/parent.rs
@@ -48,6 +48,7 @@ where
     R: Stream<Item = E> + Unpin,
     T: Stream<Item = E> + Unpin,
     M: Stream<Item = E> + Unpin,
+    L: Stream<Item = E> + Unpin,
     Self: Unpin,
 {
     type Item = E;
@@ -59,6 +60,7 @@ where
             this.router.by_ref().boxed_local(),
             this.timer.by_ref().boxed_local(),
             this.mempool.by_ref().boxed_local(),
+            this.ledger.by_ref().boxed_local(),
         ])
         .poll_next_unpin(cx)
     }

--- a/monad-executor/src/mock_swarm.rs
+++ b/monad-executor/src/mock_swarm.rs
@@ -69,6 +69,7 @@ where
 
     MockExecutor<S, RS, ME>: Unpin,
     S::Event: Unpin,
+    S::Block: Unpin,
 {
     pub fn new(peers: Vec<(PubKey, S::Config, LGR::Config, RS::Config)>, pipeline: T) -> Self {
         assert!(!peers.is_empty());

--- a/monad-executor/src/replay_nodes.rs
+++ b/monad-executor/src/replay_nodes.rs
@@ -106,17 +106,14 @@ where
 
         for command in cmds {
             match command {
-                Command::LedgerCommand(cmd) => match cmd {
-                    LedgerCommand::LedgerCommit(b) => {
-                        let block = self
-                            .replay_nodes_info
-                            .get_mut(node_id)
-                            .unwrap()
-                            .mut_blockchain();
-                        block.push(b);
-                    }
-                    LedgerCommand::LedgerFetch(b_id, cb) => {}
-                },
+                Command::LedgerCommand(LedgerCommand::LedgerCommit(b)) => {
+                    let block = self
+                        .replay_nodes_info
+                        .get_mut(node_id)
+                        .unwrap()
+                        .mut_blockchain();
+                    block.push(b);
+                }
                 Command::RouterCommand(cmd) => match cmd {
                     RouterCommand::Publish { target, message } => {
                         to_publish.push((target, message));

--- a/monad-executor/src/state.rs
+++ b/monad-executor/src/state.rs
@@ -59,6 +59,7 @@ pub enum MempoolCommand<E> {
 pub enum LedgerCommand<B, E> {
     LedgerCommit(B),
     LedgerFetch(BlockId, Box<dyn (FnOnce(Option<B>) -> E) + Send + Sync>),
+    LedgerFetchReset,
 }
 
 pub enum CheckpointCommand<C> {

--- a/monad-executor/src/transformer.rs
+++ b/monad-executor/src/transformer.rs
@@ -124,15 +124,15 @@ impl<M> Transform<M> for DropTransformer {
 }
 
 #[derive(Clone, Debug)]
-pub struct PeriodicTranformer {
+pub struct PeriodicTransformer {
     pub start: u32,    // when period start
     pub duration: u32, // how long does it last
     cnt: u32,          // monotonically inreasing counter
 }
 
-impl PeriodicTranformer {
+impl PeriodicTransformer {
     pub fn new(start: u32, duration: u32) -> Self {
-        PeriodicTranformer {
+        PeriodicTransformer {
             start,
             duration,
             cnt: 0,
@@ -140,7 +140,7 @@ impl PeriodicTranformer {
     }
 }
 
-impl<M> Transform<M> for PeriodicTranformer {
+impl<M> Transform<M> for PeriodicTransformer {
     fn transform(&mut self, message: LinkMessage<M>) -> TransformerStream<M> {
         self.cnt += 1;
         if self.cnt < self.start || self.cnt >= self.start + self.duration {
@@ -224,7 +224,7 @@ pub enum Transformer<M> {
     RandLatency(RandLatencyTransformer),
     Partition(PartitionTransformer),
     Drop(DropTransformer),
-    Periodic(PeriodicTranformer),
+    Periodic(PeriodicTransformer),
     Replay(ReplayTransformer<M>),
 }
 
@@ -335,7 +335,7 @@ mod test {
     use crate::{
         mock_swarm::LinkMessage,
         transformer::{
-            DropTransformer, PartitionTransformer, PeriodicTranformer, RandLatencyTransformer,
+            DropTransformer, PartitionTransformer, PeriodicTransformer, RandLatencyTransformer,
             ReplayTransformer, TransformerStream, XorLatencyTransformer,
         },
         PeerId,
@@ -437,7 +437,7 @@ mod test {
         let keys = create_keys(2);
         let mut peers = HashSet::new();
         peers.insert(PeerId(keys[0].pubkey()));
-        let mut t = PeriodicTranformer::new(3, 5);
+        let mut t = PeriodicTransformer::new(3, 5);
         let m = get_mock_message();
         for _ in 0..2 {
             let TransformerStream::Complete(c) = t.transform(m.clone()) else {
@@ -517,7 +517,7 @@ mod test {
         let mut pipe = xfmr_pipe![
             Transformer::Latency(LatencyTransformer(Duration::from_millis(30))),
             Transformer::Partition(PartitionTransformer(peers)),
-            Transformer::Periodic(PeriodicTranformer::new(3, 5)),
+            Transformer::Periodic(PeriodicTransformer::new(3, 5)),
             Transformer::Latency(LatencyTransformer(Duration::from_millis(30)))
         ];
         for _ in 0..1000 {

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -40,7 +40,8 @@ message ProtoFetchedFullTxs {
 }
 
 message ProtoFetchedBlock {
-  monad_proto.block.ProtoBlockAggSig block = 1;
+  monad_proto.basic.ProtoNodeId requester = 1;
+  monad_proto.block.ProtoBlockAggSig block = 2;
 }
 
 message ProtoAdvanceEpochEvent {

--- a/monad-state/src/convert/event.rs
+++ b/monad-state/src/convert/event.rs
@@ -57,6 +57,7 @@ impl<S: MessageSignature + CertificateSignatureRecoverable> From<&ConsensusEvent
             }
             TypeConsensusEvent::FetchedBlock(fetched_block) => {
                 proto_consensus_event::Event::FetchedBlock(ProtoFetchedBlock {
+                    requester: Some((&fetched_block.requester).into()),
                     block: fetched_block.block.as_ref().map(|b| b.into()),
                 })
             }
@@ -148,6 +149,12 @@ impl<S: MessageSignature + CertificateSignatureRecoverable> TryFrom<ProtoConsens
             }
             Some(proto_consensus_event::Event::FetchedBlock(fetched_block)) => {
                 ConsensusEvent::FetchedBlock(FetchedBlock {
+                    requester: fetched_block
+                        .requester
+                        .ok_or(ProtoError::MissingRequiredField(
+                            "ConsensusEvent::fetched_block.requester".to_owned(),
+                        ))?
+                        .try_into()?,
                     block: Some(
                         fetched_block
                             .block

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -105,7 +105,7 @@ pub fn run_nodes<S, ST, SCT, RS, RSC, LGR, P, TVT, ME>(
 
     MockExecutor<S, RS, ME>: Unpin,
     S::Event: Unpin,
-    S::Block: PartialEq,
+    S::Block: PartialEq + Unpin,
 
     RSC: Fn(Vec<PeerId>, PeerId) -> RS::Config,
 
@@ -180,7 +180,7 @@ pub fn run_nodes_until_step<S, ST, SCT, RS, RSC, LGR, P, TVT, ME>(
 
     MockExecutor<S, RS, ME>: Unpin,
     S::Event: Unpin,
-    S::Block: PartialEq,
+    S::Block: PartialEq + Unpin,
 
     RSC: Fn(Vec<PeerId>, PeerId) -> RS::Config,
 

--- a/monad-validator/src/validator_set.rs
+++ b/monad-validator/src/validator_set.rs
@@ -36,6 +36,8 @@ pub trait ValidatorSetType {
         Self: Sized;
     fn get_members(&self) -> &HashMap<NodeId, Stake>;
     fn get_list(&self) -> &Vec<NodeId>;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool;
     fn is_member(&self, addr: &NodeId) -> bool;
     fn has_super_majority_votes<'a, I>(&self, addrs: I) -> bool
     where
@@ -121,6 +123,14 @@ impl ValidatorSetType for ValidatorSet {
 
     fn get_list(&self) -> &Vec<NodeId> {
         &self.validator_list
+    }
+
+    fn len(&self) -> usize {
+        self.validator_list.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.validator_list.is_empty()
     }
 
     fn is_member(&self, addr: &NodeId) -> bool {

--- a/monad-viz/src/graph.rs
+++ b/monad-viz/src/graph.rs
@@ -93,6 +93,7 @@ where
 
     S::Event: Serializable<Vec<u8>> + Deserializable<[u8]> + Unpin + Debug,
     S::OutboundMessage: Serializable<S::Message>,
+    S::Block: Unpin,
     RS::Serialized: Eq,
     MockExecutor<S, RS, ME>: Unpin,
 {
@@ -134,6 +135,7 @@ where
     S::Event: Serializable<Vec<u8>> + Deserializable<[u8]> + Unpin + Debug,
     S::Message: Deserializable<RS::M>,
     S::OutboundMessage: Serializable<RS::M>,
+    S::Block: Unpin,
     RS::Serialized: Eq,
     MockExecutor<S, RS, ME>: Unpin,
 {


### PR DESCRIPTION
block-sync is a way for blocks to catch up from missing block, caused by either extreme network delay, lost node, or malicious leader censoring certain node by provide byzantine proposal.

Once a proposal is fully handled, if the pending block generated by the current proposal doesn't contain a path to root, it will try to request the closest (to the current pending block) block from a validator in round-robin fashion until either the block is retrieved or the original proposal finally arrived.
