### PR TITLE
Allow for generic RouterScheduler in MockSwarm

### DIFF
--- a/monad-p2p/src/behavior/codec.rs
+++ b/monad-p2p/src/behavior/codec.rs
@@ -126,7 +126,7 @@ where
     where
         T: AsyncWrite + Unpin + Send,
     {
-        let bytes = req.serialize();
+        let bytes = Serializable::<Vec<u8>>::serialize(req.as_ref());
         io.write_all((bytes.len() as LengthEncoding).to_le_bytes().as_slice())
             .await?;
         io.write_all(&bytes).await?;

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -185,6 +185,15 @@ impl<MS: MessageSignature, CS: CertificateSignatureRecoverable> monad_types::Ser
     }
 }
 
+impl<MS: MessageSignature, CS: CertificateSignatureRecoverable>
+    monad_types::Serializable<MonadMessage<MS, monad_consensus_types::multi_sig::MultiSig<CS>>>
+    for VerifiedMonadMessage<MS, monad_consensus_types::multi_sig::MultiSig<CS>>
+{
+    fn serialize(&self) -> MonadMessage<MS, monad_consensus_types::multi_sig::MultiSig<CS>> {
+        MonadMessage(self.0.clone().into())
+    }
+}
+
 #[cfg(feature = "proto")]
 impl<MS: MessageSignature, CS: CertificateSignatureRecoverable> monad_types::Deserializable<[u8]>
     for MonadMessage<MS, monad_consensus_types::multi_sig::MultiSig<CS>>

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -3,6 +3,7 @@ pub mod convert;
 
 use std::{
     error::Error,
+    io,
     ops::{Add, AddAssign, Deref, Sub, SubAssign},
 };
 
@@ -148,8 +149,22 @@ pub trait Serializable<S> {
     fn serialize(&self) -> S;
 }
 
+impl<S: Clone> Serializable<S> for S {
+    fn serialize(&self) -> S {
+        self.clone()
+    }
+}
+
 pub trait Deserializable<S: ?Sized>: Sized {
     type ReadError: Error + Send + Sync;
 
     fn deserialize(message: &S) -> Result<Self, Self::ReadError>;
+}
+
+impl<S: Clone> Deserializable<S> for S {
+    type ReadError = io::Error;
+
+    fn deserialize(message: &S) -> Result<Self, Self::ReadError> {
+        Ok(message.clone())
+    }
 }

--- a/monad-viz/src/graph.rs
+++ b/monad-viz/src/graph.rs
@@ -63,7 +63,7 @@ where
 {
     fn max_tick(&self) -> Duration;
     fn pipeline(&self) -> &T;
-    fn nodes(&self) -> Vec<(PubKey, S::Config, LGR::Config)>;
+    fn nodes(&self) -> Vec<(PubKey, S::Config, LGR::Config, RS::Config)>;
 }
 
 pub struct NodesSimulation<S, RS, T, LGR, C>
@@ -84,8 +84,10 @@ where
 impl<S, RS, T, LGR, C> NodesSimulation<S, RS, T, LGR, C>
 where
     S: monad_executor::State,
-    RS: RouterScheduler<M = S::Message>,
+    RS: RouterScheduler,
     RS::Serialized: Eq,
+    S::Message: Deserializable<RS::M>,
+    S::OutboundMessage: Serializable<RS::M>,
     MockExecutor<S, RS>: Unpin,
     S::Event: Unpin,
     T: Pipeline<RS::Serialized> + Clone,
@@ -122,8 +124,10 @@ where
 impl<S, RS, T, LGR, C> Graph for NodesSimulation<S, RS, T, LGR, C>
 where
     S: monad_executor::State,
-    RS: RouterScheduler<M = S::Message>,
+    RS: RouterScheduler,
     RS::Serialized: Eq,
+    S::Message: Deserializable<RS::M>,
+    S::OutboundMessage: Serializable<RS::M>,
     MockExecutor<S, RS>: Unpin,
     S::Event: Unpin,
     T: Pipeline<RS::Serialized> + Clone,

--- a/monad-viz/src/main.rs
+++ b/monad-viz/src/main.rs
@@ -30,7 +30,7 @@ use monad_consensus_types::{
 };
 use monad_crypto::NopSignature;
 use monad_executor::{
-    executor::mock::NoSerRouterScheduler,
+    executor::mock::{NoSerRouterScheduler, RouterScheduler},
     timed_event::TimedEvent,
     transformer::{LatencyTransformer, Transformer, TransformerPipeline, XorLatencyTransformer},
     xfmr_pipe, PeerId, State,
@@ -65,6 +65,7 @@ type MS = MonadState<
 type MM = <MS as State>::Message;
 type PersistenceLoggerType =
     MockWALogger<TimedEvent<MonadEvent<SignatureType, SignatureCollectionType>>>;
+type Rsc = <NoSerRouterScheduler<MM> as RouterScheduler>::Config;
 type Sim = NodesSimulation<
     MS,
     NoSerRouterScheduler<MM>,

--- a/monad-wal/benches/event_bench.rs
+++ b/monad-wal/benches/event_bench.rs
@@ -54,7 +54,10 @@ impl MonadEventBencher {
             file_path,
             sync: false,
         };
-        println!("size of event: {}", event.serialize().len());
+        println!(
+            "size of event: {}",
+            Serializable::<Vec<u8>>::serialize(&event).len()
+        );
         Self {
             event,
             logger: WALogger::<BenchEvent>::new(config).unwrap().0,

--- a/monad-wal/tests/replay.rs
+++ b/monad-wal/tests/replay.rs
@@ -153,7 +153,7 @@ mod test {
             // state is not updated
             if i == input1_len - 1 {
                 let file_len = fs::metadata(&log1_path).unwrap().len();
-                let payload_len = e.serialize().len() as u64;
+                let payload_len = Serializable::<Vec<u8>>::serialize(&e).len() as u64;
 
                 let truncated_len = match test_config {
                     TestConfig::Full => file_len,


### PR DESCRIPTION
Previously MockSwarm would not allow for truly generic RouterScheduler - it would require RouterScheduler's message type to be equivalent to State's message type.