### PR TITLE
Add seeded randomness In mock_swarm's event

### DIFF
--- a/monad-consensus-types/src/test_utils.rs
+++ b/monad-consensus-types/src/test_utils.rs
@@ -40,10 +40,7 @@ pub(crate) fn setup_sigcol_test<SCT: SignatureCollection>(
         .collect::<Vec<_>>();
     let keys = create_certificate_keys::<SCT>(num);
 
-    let voting_keys = node_ids
-        .into_iter()
-        .zip(keys.into_iter())
-        .collect::<Vec<_>>();
+    let voting_keys = node_ids.into_iter().zip(keys).collect::<Vec<_>>();
 
     let voting_identity = voting_keys
         .iter()

--- a/monad-executor/src/mock_swarm.rs
+++ b/monad-executor/src/mock_swarm.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::Reverse,
-    collections::{BTreeMap, BTreeSet, BinaryHeap},
+    collections::{BTreeMap, BinaryHeap},
     time::Duration,
 };
 
@@ -8,6 +8,8 @@ use futures::StreamExt;
 use monad_crypto::secp256k1::PubKey;
 use monad_types::{Deserializable, Serializable};
 use monad_wal::PersistenceLogger;
+use rand::Rng;
+use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
 use tracing::info_span;
 
 use crate::{
@@ -39,7 +41,40 @@ where
         Some(self.cmp(other))
     }
 }
+pub enum NextTickEvent {
+    Internal { pid: PeerId, tick: Duration },
+    External { tick: Duration },
+}
 
+pub struct NodesConfig<S, RS, T, LGR>
+where
+    S: State,
+    RS: RouterScheduler,
+    T: Pipeline<RS::Serialized>,
+    LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
+{
+    pub peers: Vec<(PubKey, S::Config, LGR::Config, RS::Config)>,
+    pub pipeline: T,
+    pub seed: u64,
+    pub bias: f64,
+}
+
+impl<S, RS, T, LGR> Default for NodesConfig<S, RS, T, LGR>
+where
+    S: State,
+    RS: RouterScheduler,
+    T: Pipeline<RS::Serialized>,
+    LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
+{
+    fn default() -> Self {
+        Self {
+            peers: vec![],
+            pipeline: T::default(),
+            seed: 1,
+            bias: 1.0,
+        }
+    }
+}
 pub struct Nodes<S, RS, T, LGR, ME>
 where
     S: State,
@@ -51,6 +86,9 @@ where
     states: BTreeMap<PeerId, (MockExecutor<S, RS, ME>, S, LGR)>,
     pipeline: T,
     scheduled_messages: BinaryHeap<Reverse<(Duration, LinkMessage<RS::Serialized>)>>,
+    rng_gen: ChaChaRng,
+    ie_bias: f64,
+    pref_ie: bool,
 }
 
 impl<S, RS, T, LGR, ME> Nodes<S, RS, T, LGR, ME>
@@ -71,16 +109,12 @@ where
     S::Event: Unpin,
     S::Block: Unpin,
 {
-    pub fn new(peers: Vec<(PubKey, S::Config, LGR::Config, RS::Config)>, pipeline: T) -> Self {
-        assert!(!peers.is_empty());
+    pub fn new(config: NodesConfig<S, RS, T, LGR>) -> Self {
+        assert!(!config.peers.is_empty());
 
         let mut states = BTreeMap::new();
 
-        let all_peers: BTreeSet<_> = peers
-            .iter()
-            .map(|(pubkey, _, _, _)| PeerId(*pubkey))
-            .collect();
-        for (pubkey, state_config, logger_config, router_scheduler_config) in peers {
+        for (pubkey, state_config, logger_config, router_scheduler_config) in config.peers {
             let mut executor: MockExecutor<S, RS, ME> =
                 MockExecutor::new(RS::new(router_scheduler_config));
             let (wal, replay_events) = LGR::new(logger_config).unwrap();
@@ -94,15 +128,20 @@ where
 
             states.insert(PeerId(pubkey), (executor, state, wal));
         }
-
+        let mut gen = ChaChaRng::seed_from_u64(config.seed);
+        let ie_bias = config.bias;
+        let pref_ie = gen.gen_bool(config.bias);
         Self {
             states,
-            pipeline,
+            pipeline: config.pipeline,
             scheduled_messages: Default::default(),
+            rng_gen: gen,
+            ie_bias,
+            pref_ie,
         }
     }
 
-    pub fn next_tick(&mut self) -> Option<Duration> {
+    pub fn peek_next_tick(&mut self) -> Option<NextTickEvent> {
         let min_event = self
             .states
             .iter_mut()
@@ -111,87 +150,104 @@ where
                 Some((id, executor, state, wal, tick))
             })
             .min_by_key(|(_, _, _, _, tick)| *tick);
-        let maybe_min_event_tick = min_event
-            .as_ref()
-            .map(|(_, _, _, _, min_event_tick)| min_event_tick);
+
+        let maybe_min_event_tick = min_event.as_ref().map(|(_, _, _, _, tick)| *tick);
+
         let maybe_min_scheduled_tick = self
             .scheduled_messages
             .peek()
-            .map(|Reverse((min_scheduled_tick, _))| min_scheduled_tick);
-        maybe_min_event_tick
-            .into_iter()
-            .chain(maybe_min_scheduled_tick)
-            .min()
-            .copied()
+            .map(|Reverse((min_scheduled_tick, _))| *min_scheduled_tick);
+
+        match (maybe_min_event_tick, maybe_min_scheduled_tick) {
+            (None, None) => None,
+            (None, Some(min_scheduled_tick)) => Some(NextTickEvent::External {
+                tick: min_scheduled_tick,
+            }),
+            (Some(min_event_tick), None) => Some(NextTickEvent::Internal {
+                pid: *min_event.unwrap().0,
+                tick: min_event_tick,
+            }),
+            (Some(min_event_tick), Some(min_scheduled_tick)) => {
+                if min_event_tick < min_scheduled_tick
+                    || (min_event_tick == min_scheduled_tick && self.pref_ie)
+                {
+                    Some(NextTickEvent::Internal {
+                        pid: *min_event.unwrap().0,
+                        tick: min_event_tick,
+                    })
+                } else {
+                    Some(NextTickEvent::External {
+                        tick: min_scheduled_tick,
+                    })
+                }
+            }
+        }
+    }
+
+    fn generate_next_preference(&mut self) {
+        self.pref_ie = self.rng_gen.gen_bool(self.ie_bias);
+    }
+
+    pub fn next_tick(&mut self) -> Option<Duration> {
+        match self.peek_next_tick() {
+            Some(NextTickEvent::Internal { pid: _, tick }) => Some(tick),
+            Some(NextTickEvent::External { tick }) => Some(tick),
+            None => None,
+        }
     }
 
     pub fn step(&mut self) -> Option<(Duration, PeerId, S::Event)> {
         loop {
-            let min_event = self
-                .states
-                .iter_mut()
-                .filter_map(|(id, (executor, state, wal))| {
-                    let tick = executor.peek_event_tick()?;
-                    Some((id, executor, state, wal, tick))
-                })
-                .min_by_key(|(_, _, _, _, tick)| *tick);
-            let maybe_min_event_tick = min_event
-                .as_ref()
-                .map(|(_, _, _, _, min_event_tick)| min_event_tick);
-            let maybe_min_scheduled_tick = self
-                .scheduled_messages
-                .peek()
-                .map(|Reverse((min_scheduled_tick, _))| min_scheduled_tick);
-            let poll_event = match (maybe_min_event_tick, maybe_min_scheduled_tick) {
-                (None, None) => break,
-                (None, Some(_)) => false,
-                (Some(_), None) => true,
-                (Some(min_event_tick), Some(min_scheduled_tick)) => {
-                    min_event_tick <= min_scheduled_tick
-                }
-            };
+            match self.peek_next_tick() {
+                Some(NextTickEvent::Internal { pid, tick }) => {
+                    self.generate_next_preference();
+                    let (executor, state, wal) = self
+                        .states
+                        .get_mut(&pid)
+                        .expect("logic error, must be nonempty");
+                    let executor_event: MockExecutorEvent<
+                        <S as State>::Event,
+                        <RS as RouterScheduler>::Serialized,
+                    > = futures::executor::block_on(executor.next()).unwrap();
+                    match executor_event {
+                        MockExecutorEvent::Event(event) => {
+                            let timed_event = TimedEvent {
+                                timestamp: tick,
+                                event: event.clone(),
+                            };
+                            wal.push(&timed_event).unwrap(); // FIXME: propagate the error
+                            let node_span = info_span!("node", id = ?pid);
+                            let _guard = node_span.enter();
+                            let commands = state.update(event.clone());
 
-            if poll_event {
-                let (id, executor, state, wal, tick) =
-                    min_event.expect("logic error, must be nonempty");
-                let id = *id;
-                let executor_event = futures::executor::block_on(executor.next()).unwrap();
-                match executor_event {
-                    MockExecutorEvent::Event(event) => {
-                        let timed_event = TimedEvent {
-                            timestamp: tick,
-                            event: event.clone(),
-                        };
-                        wal.push(&timed_event).unwrap(); // FIXME: propagate the error
-                        let node_span = info_span!("node", id = ?id);
-                        let _guard = node_span.enter();
-                        let commands = state.update(event.clone());
+                            executor.exec(commands);
 
-                        executor.exec(commands);
-
-                        return Some((tick, id, event));
-                    }
-                    MockExecutorEvent::Send(to, serialized) => {
-                        let lm = LinkMessage {
-                            from: id,
-                            to,
-                            message: serialized,
-
-                            from_tick: tick,
-                        };
-                        let transformed = self.pipeline.process(lm);
-                        for (delay, msg) in transformed {
-                            self.scheduled_messages.push(Reverse((tick + delay, msg)));
+                            return Some((tick, pid, event));
+                        }
+                        MockExecutorEvent::Send(to, serialized) => {
+                            let lm = LinkMessage {
+                                from: pid,
+                                to,
+                                message: serialized,
+                                from_tick: tick,
+                            };
+                            let transformed = self.pipeline.process(lm);
+                            for (delay, msg) in transformed {
+                                self.scheduled_messages.push(Reverse((tick + delay, msg)));
+                            }
                         }
                     }
                 }
-            } else {
-                let Reverse((scheduled_tick, message)) = self
-                    .scheduled_messages
-                    .pop()
-                    .expect("logic error, must be nonempty");
-                let (executor, _, _) = self.states.get_mut(&message.to).unwrap();
-                executor.send_message(scheduled_tick, message.from, message.message);
+                Some(NextTickEvent::External { tick: _ }) => {
+                    self.generate_next_preference();
+                    let Reverse((scheduled_tick, message)) = self
+                        .scheduled_messages
+                        .pop()
+                        .expect("logic error, must be nonempty");
+                    let (executor, _, _) = self.states.get_mut(&message.to).unwrap();
+                    executor.send_message(scheduled_tick, message.from, message.message);
+                }
+                None => break,
             }
         }
 

--- a/monad-viz/src/graph.rs
+++ b/monad-viz/src/graph.rs
@@ -3,7 +3,7 @@ use std::{cmp::Reverse, collections::HashMap, fmt::Debug, time::Duration};
 use monad_crypto::secp256k1::PubKey;
 use monad_executor::{
     executor::mock::{MockExecutor, MockableExecutor, RouterScheduler},
-    mock_swarm::{LinkMessage, Nodes},
+    mock_swarm::{LinkMessage, Nodes, NodesConfig},
     timed_event::TimedEvent,
     transformer::Pipeline,
     Message, PeerId,
@@ -98,10 +98,15 @@ where
     MockExecutor<S, RS, ME>: Unpin,
 {
     pub fn new(config: C) -> Self {
-        Self {
-            nodes: Nodes::new(config.nodes(), config.pipeline().clone()),
-            current_tick: Duration::ZERO,
+        let nodes_config = NodesConfig {
+            peers: config.nodes(),
+            pipeline: config.pipeline().clone(),
+            ..Default::default()
+        };
 
+        Self {
+            nodes: Nodes::new(nodes_config),
+            current_tick: Duration::ZERO,
             config,
         }
     }
@@ -118,7 +123,12 @@ where
     }
 
     fn reset(&mut self) {
-        self.nodes = Nodes::new(self.config.nodes(), self.config.pipeline().clone());
+        let nodes_config = NodesConfig {
+            peers: self.config.nodes(),
+            pipeline: self.config.pipeline().clone(),
+            ..Default::default()
+        };
+        self.nodes = Nodes::new(nodes_config);
         self.current_tick = self.min_tick();
     }
 }


### PR DESCRIPTION
When selecting external or internal events for next processing event, mock_swarm
always preferred internal. This is not a desirable because it limit the testing capability
of mock_swarm.

This commit allows mock_swarm to select event at random
(internal vs external) if arrived at the same time. This modification allows for some tougher testing environment

Currently, the random selection capability is disabled by setting preference to exclusively internal event, as lack of block-sync / checkpoint capability can cause certain integration tests to fail (which is a good)


As a side effect, too many parameter is added to the Nodes during initialization, and some may prefer default parameter too. To introduce better parameter management, NodesConfig is used to managing the init parameter passed to Nodes.