### PR TITLE
Make monad-testutil functions generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4806,8 +4806,15 @@ name = "monad-randomized-tests"
 version = "0.1.0"
 dependencies = [
  "inventory",
+ "monad-block-sync",
+ "monad-consensus-state",
+ "monad-consensus-types",
+ "monad-crypto",
  "monad-executor",
+ "monad-state",
  "monad-testutil",
+ "monad-validator",
+ "monad-wal",
  "simple-xml-builder",
 ]
 

--- a/monad-consensus-types/src/block.rs
+++ b/monad-consensus-types/src/block.rs
@@ -8,12 +8,12 @@ use crate::{
     validation::{Hashable, Hasher},
 };
 
-pub trait BlockType: Clone {
+pub trait BlockType: Clone + PartialEq + Eq {
     fn get_id(&self) -> BlockId;
     fn get_parent_id(&self) -> BlockId;
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct Block<T> {
     pub author: NodeId,
     pub round: Round,
@@ -21,6 +21,13 @@ pub struct Block<T> {
     pub qc: QuorumCertificate<T>,
     id: BlockId,
 }
+
+impl<T> PartialEq for Block<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+impl<T> Eq for Block<T> {}
 
 impl<T> std::fmt::Debug for Block<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/monad-executor/src/executor/mock.rs
+++ b/monad-executor/src/executor/mock.rs
@@ -43,6 +43,7 @@ pub struct NoSerRouterScheduler<M> {
     events: VecDeque<(Duration, RouterEvent<M, M>)>,
 }
 
+#[derive(Clone)]
 pub struct NoSerRouterConfig {
     pub all_peers: BTreeSet<PeerId>,
 }

--- a/monad-randomized-tests/Cargo.toml
+++ b/monad-randomized-tests/Cargo.toml
@@ -6,8 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+monad-block-sync = { path = "../monad-block-sync" }
+monad-consensus-state = { path = "../monad-consensus-state" }
+monad-consensus-types = { path = "../monad-consensus-types" }
+monad-crypto = { path = "../monad-crypto" }
 monad-executor = { path = "../monad-executor" }
+monad-state = { path = "../monad-state" }
 monad-testutil = { path = "../monad-testutil" }
+monad-validator = { path = "../monad-validator" }
+monad-wal = { path = "../monad-wal" }
 
 inventory = "0.3.6"
 simple-xml-builder = "1.1.0"

--- a/monad-state/benches/two_node_benchmark.rs
+++ b/monad-state/benches/two_node_benchmark.rs
@@ -1,11 +1,19 @@
 use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, Criterion};
+use monad_block_sync::BlockSyncState;
+use monad_consensus_state::ConsensusState;
+use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_crypto::NopSignature;
 use monad_executor::{
+    executor::mock::{NoSerRouterConfig, NoSerRouterScheduler},
     transformer::{LatencyTransformer, Transformer, TransformerPipeline},
     xfmr_pipe,
 };
+use monad_state::{MonadMessage, MonadState};
 use monad_testutil::swarm::run_nodes;
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
+use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("two nodes", |b| b.iter(two_nodes));
@@ -15,12 +23,33 @@ criterion_group!(benches, criterion_benchmark);
 criterion_main!(benches);
 
 fn two_nodes() {
-    run_nodes(
-        2,
-        1024,
-        Duration::from_millis(2),
+    run_nodes::<
+        MonadState<
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            NopSignature,
+            MultiSig<NopSignature>,
+            ValidatorSet,
+            SimpleRoundRobin,
+            BlockSyncState,
+        >,
+        NopSignature,
+        MultiSig<NopSignature>,
+        NoSerRouterScheduler<MonadMessage<_, _>>,
+        _,
+        MockWALogger<_>,
+        _,
+        MockValidator,
+    >(
+        MockValidator,
+        |all_peers, _| NoSerRouterConfig {
+            all_peers: all_peers.into_iter().collect(),
+        },
+        MockWALoggerConfig,
         xfmr_pipe!(Transformer::Latency(LatencyTransformer(
             Duration::from_millis(1)
         ))),
+        2,
+        1024,
+        Duration::from_millis(2),
     );
 }

--- a/monad-state/tests/many_nodes.rs
+++ b/monad-state/tests/many_nodes.rs
@@ -1,21 +1,50 @@
 use std::time::Duration;
 
+use monad_block_sync::BlockSyncState;
+use monad_consensus_state::ConsensusState;
+use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_crypto::NopSignature;
 use monad_executor::{
+    executor::mock::{NoSerRouterConfig, NoSerRouterScheduler},
     transformer::{LatencyTransformer, Transformer, TransformerPipeline},
     xfmr_pipe,
 };
+use monad_state::{MonadMessage, MonadState};
 use monad_testutil::swarm::run_nodes;
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
+use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
 
 #[test]
 fn many_nodes() {
     tracing_subscriber::fmt::init();
 
-    run_nodes(
-        100,
-        1024,
-        Duration::from_millis(2),
+    run_nodes::<
+        MonadState<
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            NopSignature,
+            MultiSig<NopSignature>,
+            ValidatorSet,
+            SimpleRoundRobin,
+            BlockSyncState,
+        >,
+        NopSignature,
+        MultiSig<NopSignature>,
+        NoSerRouterScheduler<MonadMessage<_, _>>,
+        _,
+        MockWALogger<_>,
+        _,
+        MockValidator,
+    >(
+        MockValidator,
+        |all_peers, _| NoSerRouterConfig {
+            all_peers: all_peers.into_iter().collect(),
+        },
+        MockWALoggerConfig,
         xfmr_pipe!(Transformer::Latency(LatencyTransformer(
             Duration::from_millis(1)
         ))),
+        100,
+        1024,
+        Duration::from_millis(2),
     );
 }

--- a/monad-state/tests/many_nodes_metrics.rs
+++ b/monad-state/tests/many_nodes_metrics.rs
@@ -1,14 +1,22 @@
 use std::time::Duration;
 
+use monad_block_sync::BlockSyncState;
+use monad_consensus_state::ConsensusState;
+use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_crypto::NopSignature;
 use monad_executor::{
+    executor::mock::{NoSerRouterConfig, NoSerRouterScheduler},
     transformer::{LatencyTransformer, Transformer, TransformerPipeline},
     xfmr_pipe,
 };
+use monad_state::{MonadMessage, MonadState};
 use monad_testutil::swarm::run_nodes;
 use monad_tracing_counter::{
     counter::{CounterLayer, MetricFilter},
     counter_status,
 };
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
+use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
 use tracing_core::LevelFilter;
 use tracing_subscriber::{filter::Targets, prelude::*, Registry};
 
@@ -27,13 +35,36 @@ fn many_nodes() {
 
     tracing::subscriber::set_global_default(subscriber).expect("unable to set global subscriber");
 
-    run_nodes(
+    run_nodes::<
+        MonadState<
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            NopSignature,
+            MultiSig<NopSignature>,
+            ValidatorSet,
+            SimpleRoundRobin,
+            BlockSyncState,
+        >,
+        NopSignature,
+        MultiSig<NopSignature>,
+        NoSerRouterScheduler<MonadMessage<_, _>>,
+        _,
+        MockWALogger<_>,
+        _,
+        MockValidator,
+    >(
+        MockValidator,
+        |all_peers, _| NoSerRouterConfig {
+            all_peers: all_peers.into_iter().collect(),
+        },
+        MockWALoggerConfig,
+        xfmr_pipe!(Transformer::<
+            MonadMessage<NopSignature, MultiSig<NopSignature>>,
+        >::Latency(LatencyTransformer(
+            Duration::from_millis(1)
+        ))),
         100,
         1024,
         Duration::from_millis(2),
-        xfmr_pipe!(Transformer::Latency(LatencyTransformer(
-            Duration::from_millis(1)
-        ))),
     );
 
     counter_status!();

--- a/monad-state/tests/msg_delays.rs
+++ b/monad-state/tests/msg_delays.rs
@@ -1,21 +1,50 @@
 use std::time::Duration;
 
+use monad_block_sync::BlockSyncState;
+use monad_consensus_state::ConsensusState;
+use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_crypto::NopSignature;
 use monad_executor::{
+    executor::mock::{NoSerRouterConfig, NoSerRouterScheduler},
     transformer::{Transformer, TransformerPipeline, XorLatencyTransformer},
     xfmr_pipe,
 };
+use monad_state::{MonadMessage, MonadState};
 use monad_testutil::swarm::run_nodes;
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
+use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
 
 #[test]
 fn two_nodes() {
     tracing_subscriber::fmt::init();
 
-    run_nodes(
-        4,
-        40,
-        Duration::from_millis(101),
+    run_nodes::<
+        MonadState<
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            NopSignature,
+            MultiSig<NopSignature>,
+            ValidatorSet,
+            SimpleRoundRobin,
+            BlockSyncState,
+        >,
+        NopSignature,
+        MultiSig<NopSignature>,
+        NoSerRouterScheduler<MonadMessage<_, _>>,
+        _,
+        MockWALogger<_>,
+        _,
+        MockValidator,
+    >(
+        MockValidator,
+        |all_peers, _| NoSerRouterConfig {
+            all_peers: all_peers.into_iter().collect(),
+        },
+        MockWALoggerConfig,
         xfmr_pipe!(Transformer::XorLatency(XorLatencyTransformer(
             Duration::from_millis(u8::MAX as u64)
         ))),
+        4,
+        40,
+        Duration::from_millis(101),
     );
 }

--- a/monad-state/tests/replay.rs
+++ b/monad-state/tests/replay.rs
@@ -31,7 +31,11 @@ fn test_replay() {
 }
 
 pub fn recover_nodes_msg_delays(num_nodes: u16, num_blocks_before: usize, num_block_after: usize) {
-    let (pubkeys, state_configs) = get_configs(num_nodes, Duration::from_millis(101));
+    let (pubkeys, state_configs) = get_configs::<SignatureType, SignatureCollectionType, _>(
+        TransactionValidatorType {},
+        num_nodes,
+        Duration::from_millis(101),
+    );
 
     // create the log file path
     let mut logger_configs = Vec::new();
@@ -116,7 +120,11 @@ pub fn recover_nodes_msg_delays(num_nodes: u16, num_blocks_before: usize, num_bl
     drop(nodes);
 
     let (pubkeys_clone, state_configs_clone) =
-        get_configs::<SignatureCollectionType>(num_nodes, Duration::from_millis(2));
+        get_configs::<SignatureType, SignatureCollectionType, _>(
+            TransactionValidatorType {},
+            num_nodes,
+            Duration::from_millis(2),
+        );
 
     let peers_clone = pubkeys_clone
         .iter()
@@ -187,5 +195,11 @@ pub fn recover_nodes_msg_delays(num_nodes: u16, num_blocks_before: usize, num_bl
         }
     }
 
-    node_ledger_verification(nodes_recovered.states());
+    node_ledger_verification(
+        &nodes_recovered
+            .states()
+            .values()
+            .map(|(executor, _state, _logger)| executor.ledger().get_blocks().clone())
+            .collect(),
+    );
 }

--- a/monad-state/tests/single_node.rs
+++ b/monad-state/tests/single_node.rs
@@ -1,21 +1,50 @@
 use std::time::Duration;
 
+use monad_block_sync::BlockSyncState;
+use monad_consensus_state::ConsensusState;
+use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_crypto::NopSignature;
 use monad_executor::{
+    executor::mock::{NoSerRouterConfig, NoSerRouterScheduler},
     transformer::{LatencyTransformer, Transformer, TransformerPipeline},
     xfmr_pipe,
 };
+use monad_state::{MonadMessage, MonadState};
 use monad_testutil::swarm::run_nodes;
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
+use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
 
 #[test]
 fn two_nodes() {
     tracing_subscriber::fmt::init();
 
-    run_nodes(
+    run_nodes::<
+        MonadState<
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            NopSignature,
+            MultiSig<NopSignature>,
+            ValidatorSet,
+            SimpleRoundRobin,
+            BlockSyncState,
+        >,
+        NopSignature,
+        MultiSig<NopSignature>,
+        NoSerRouterScheduler<MonadMessage<_, _>>,
+        _,
+        MockWALogger<_>,
+        _,
+        MockValidator,
+    >(
+        MockValidator,
+        |all_peers, _| NoSerRouterConfig {
+            all_peers: all_peers.into_iter().collect(),
+        },
+        MockWALoggerConfig,
+        xfmr_pipe!(Transformer::Latency::<
+            MonadMessage<NopSignature, MultiSig<NopSignature>>,
+        >(LatencyTransformer(Duration::from_millis(1)))),
         2,
         1024,
         Duration::from_millis(2),
-        xfmr_pipe!(Transformer::Latency(LatencyTransformer(
-            Duration::from_millis(1)
-        ),)),
     );
 }

--- a/monad-state/tests/single_node_metrics.rs
+++ b/monad-state/tests/single_node_metrics.rs
@@ -1,14 +1,22 @@
 use std::time::Duration;
 
+use monad_block_sync::BlockSyncState;
+use monad_consensus_state::ConsensusState;
+use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_crypto::NopSignature;
 use monad_executor::{
+    executor::mock::{NoSerRouterConfig, NoSerRouterScheduler},
     transformer::{LatencyTransformer, Transformer, TransformerPipeline},
     xfmr_pipe,
 };
+use monad_state::{MonadMessage, MonadState};
 use monad_testutil::swarm::run_nodes;
 use monad_tracing_counter::{
     counter::{CounterLayer, MetricFilter},
     counter_status,
 };
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
+use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
 use tracing_core::LevelFilter;
 use tracing_subscriber::{filter::Targets, prelude::*, Registry};
 
@@ -27,14 +35,34 @@ fn two_nodes() {
 
     tracing::subscriber::set_global_default(subscriber).expect("unable to set global subscriber");
 
-    run_nodes(
-        2,
-        1024,
-        Duration::from_millis(2),
+    run_nodes::<
+        MonadState<
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            NopSignature,
+            MultiSig<NopSignature>,
+            ValidatorSet,
+            SimpleRoundRobin,
+            BlockSyncState,
+        >,
+        NopSignature,
+        MultiSig<NopSignature>,
+        NoSerRouterScheduler<MonadMessage<_, _>>,
+        _,
+        MockWALogger<_>,
+        _,
+        MockValidator,
+    >(
+        MockValidator,
+        |all_peers, _| NoSerRouterConfig {
+            all_peers: all_peers.into_iter().collect(),
+        },
+        MockWALoggerConfig,
         xfmr_pipe!(Transformer::Latency(LatencyTransformer(
             Duration::from_millis(1)
         ))),
+        2,
+        1024,
+        Duration::from_millis(2),
     );
-
     counter_status!();
 }

--- a/monad-testutil/Cargo.toml
+++ b/monad-testutil/Cargo.toml
@@ -9,9 +9,7 @@ edition = "2021"
 bench = false
 
 [dependencies]
-monad-block-sync = { path = "../monad-block-sync" }
 monad-consensus = { path = "../monad-consensus" }
-monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = {path = "../monad-crypto" }
 monad-executor = {path = "../monad-executor" }
@@ -22,3 +20,7 @@ monad-wal = {path = "../monad-wal" }
 
 sha2 = { workspace = true }
 zerocopy = { workspace = true }
+
+[dev-dependencies]
+monad-block-sync = { path = "../monad-block-sync" }
+monad-consensus-state = { path = "../monad-consensus-state" }

--- a/monad-testutil/examples/logs_gen.rs
+++ b/monad-testutil/examples/logs_gen.rs
@@ -37,7 +37,8 @@ pub fn generate_log<T: Pipeline<MM>>(
     T: Clone,
 {
     type WALoggerType = WALogger<TimedEvent<MonadEvent<SignatureType, SignatureCollectionType>>>;
-    let (pubkeys, state_configs) = get_configs(num_nodes, delta);
+    let (pubkeys, state_configs) =
+        get_configs::<NopSignature, MultiSig<NopSignature>, _>(MockValidator, num_nodes, delta);
     let file_path_vec = pubkeys.iter().map(|pubkey| WALoggerConfig {
         file_path: PathBuf::from(format!("{:?}.log", pubkey)),
         sync: false,


### PR DESCRIPTION
Previously, monad-testutil had type aliases defined at the top of the file, which the functions referenced directly. This commit changes all of those functions to be properly generic.

One consequence of this is that the generic type specification bleeds up into all of the tests that depend on moand-testutil. This was a conscious decision - because the alternative would be to define additional helper functions in monad-testutil with default values for some of the generic parameters. I chose not to take that approach because as we start to test more and more permutations of different executors/validators/signatures/etc, the usefulness of preset common defaults will start to degrade.