### PR TITLE
Add StateRootValidator trait and fix seq_num calculation

### DIFF
--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -333,6 +333,10 @@ impl<T: SignatureCollection> BlockTree<T> {
         }
     }
 
+    pub fn get_seq_num(&self, block_id: BlockId) -> Option<u64> {
+        self.tree.get(&block_id).map(|b| b.block.payload.seq_num)
+    }
+
     pub fn tree(&self) -> &HashMap<BlockId, BlockTreeBlock<T>> {
         &self.tree
     }

--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -13,7 +13,7 @@ use monad_consensus_types::{
     timeout::TimeoutCertificate,
 };
 use monad_executor::RouterTarget;
-use monad_types::{BlockId, Epoch, NodeId, Round};
+use monad_types::{BlockId, Epoch, Hash, NodeId, Round};
 
 pub enum ConsensusCommand<ST, SCT: SignatureCollection> {
     Publish {
@@ -47,6 +47,7 @@ pub enum ConsensusCommand<ST, SCT: SignatureCollection> {
     /// Checkpoints periodically can upload/backup the ledger and garbage clean
     /// persisted events if necessary
     CheckpointSave(Checkpoint<SCT>),
+    StateRootHash(Block<SCT>),
     // TODO add command for updating validator_set/round
     // - to handle this command, we need to call message_state.set_round()
 }
@@ -85,6 +86,7 @@ pub struct FetchedTxs<ST, SCT> {
     pub node_id: NodeId,
     pub round: Round,
     pub seq_num: u64,
+    pub state_root_hash: Hash,
     pub high_qc: QuorumCertificate<SCT>,
     pub last_round_tc: Option<TimeoutCertificate<ST>>,
 

--- a/monad-consensus-state/src/wrapper.rs
+++ b/monad-consensus-state/src/wrapper.rs
@@ -4,18 +4,20 @@ use monad_consensus_types::{
 
 use crate::ConsensusState;
 
-struct ConsensusStateWrapper<S: MessageSignature, SC: SignatureCollection, TV> {
-    consensus_state: ConsensusState<S, SC, TV>,
+struct ConsensusStateWrapper<S: MessageSignature, SC: SignatureCollection, TV, SV> {
+    consensus_state: ConsensusState<S, SC, TV, SV>,
 }
 
-impl<S: MessageSignature, SC: SignatureCollection, TV> Drop for ConsensusStateWrapper<S, SC, TV> {
+impl<S: MessageSignature, SC: SignatureCollection, TV, SV> Drop
+    for ConsensusStateWrapper<S, SC, TV, SV>
+{
     fn drop(&mut self) {
         eprintln!("{:?}", self);
     }
 }
 
-impl<S: MessageSignature, SC: SignatureCollection, TV> std::fmt::Debug
-    for ConsensusStateWrapper<S, SC, TV>
+impl<S: MessageSignature, SC: SignatureCollection, TV, SV> std::fmt::Debug
+    for ConsensusStateWrapper<S, SC, TV, SV>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ConsensusState")

--- a/monad-consensus-types/src/block.rs
+++ b/monad-consensus-types/src/block.rs
@@ -11,6 +11,7 @@ use crate::{
 pub trait BlockType: Clone + PartialEq + Eq {
     fn get_id(&self) -> BlockId;
     fn get_parent_id(&self) -> BlockId;
+    fn get_seq_num(&self) -> u64;
 }
 
 #[derive(Clone)]
@@ -77,5 +78,9 @@ impl<T: SignatureCollection> BlockType for Block<T> {
 
     fn get_parent_id(&self) -> BlockId {
         self.qc.info.vote.id
+    }
+
+    fn get_seq_num(&self) -> u64 {
+        self.payload.seq_num
     }
 }

--- a/monad-driver/src/lib.rs
+++ b/monad-driver/src/lib.rs
@@ -7,7 +7,7 @@ mod tests {
     use monad_consensus_state::ConsensusState;
     use monad_consensus_types::{
         block::BlockType, certificate_signature::CertificateKeyPair, multi_sig::MultiSig,
-        quorum_certificate::genesis_vote_info,
+        payload::NopStateRoot, quorum_certificate::genesis_vote_info,
         signature_collection::SignatureCollectionKeyPairType, transaction_validator::MockValidator,
         validation::Sha256Hash, voting::ValidatorMapping,
     };
@@ -29,8 +29,14 @@ mod tests {
     type SignatureType = SecpSignature;
     type SignatureCollectionType = MultiSig<SignatureType>;
     type TransactionValidatorType = MockValidator;
+    type StateRootValidatorType = NopStateRoot;
     type S = MonadState<
-        ConsensusState<SignatureType, SignatureCollectionType, TransactionValidatorType>,
+        ConsensusState<
+            SignatureType,
+            SignatureCollectionType,
+            TransactionValidatorType,
+            StateRootValidatorType,
+        >,
         SignatureType,
         SignatureCollectionType,
         ValidatorSet,

--- a/monad-executor/src/executor/mod.rs
+++ b/monad-executor/src/executor/mod.rs
@@ -3,6 +3,7 @@ pub mod epoch;
 pub mod ledger;
 pub mod mock;
 pub mod parent;
+pub mod state_root_hash;
 
 #[cfg(feature = "tokio")]
 pub mod mempool;

--- a/monad-executor/src/executor/parent.rs
+++ b/monad-executor/src/executor/parent.rs
@@ -33,8 +33,14 @@ where
 {
     type Command = Command<M, OM, B, C>;
     fn exec(&mut self, commands: Vec<Command<M, OM, B, C>>) {
-        let (router_cmds, timer_cmds, mempool_cmds, ledger_cmds, checkpoint_cmds) =
-            Command::split_commands(commands);
+        let (
+            router_cmds,
+            timer_cmds,
+            mempool_cmds,
+            ledger_cmds,
+            checkpoint_cmds,
+            _state_root_hash_cmds,
+        ) = Command::split_commands(commands);
         self.router.exec(router_cmds);
         self.timer.exec(timer_cmds);
         self.mempool.exec(mempool_cmds);

--- a/monad-executor/src/executor/state_root_hash.rs
+++ b/monad-executor/src/executor/state_root_hash.rs
@@ -1,0 +1,84 @@
+use std::{
+    marker::PhantomData,
+    ops::DerefMut,
+    pin::Pin,
+    task::{Context, Poll, Waker},
+};
+
+use futures::Stream;
+use monad_consensus_types::block::BlockType;
+use monad_types::Hash;
+use rand::RngCore;
+use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
+
+use crate::{Executor, StateRootHashCommand};
+
+pub struct MockStateRootHash<O, E> {
+    update: Option<(u64, Hash)>,
+    generate_event: Option<Box<dyn (FnOnce(u64, Hash) -> E) + Send + Sync>>,
+    waker: Option<Waker>,
+    phantom: PhantomData<O>,
+}
+
+impl<O, E> MockStateRootHash<O, E> {
+    pub fn ready(&self) -> bool {
+        self.update.is_some()
+    }
+}
+
+impl<O, E> Default for MockStateRootHash<O, E> {
+    fn default() -> Self {
+        Self {
+            update: None,
+            generate_event: None,
+            waker: None,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<O: BlockType, E> Executor for MockStateRootHash<O, E> {
+    type Command = StateRootHashCommand<O, E>;
+    fn exec(&mut self, commands: Vec<Self::Command>) {
+        let mut wake = false;
+
+        for command in commands {
+            match command {
+                StateRootHashCommand::LedgerCommit(block, func) => {
+                    let seq_num = block.get_seq_num();
+                    let mut gen = ChaChaRng::seed_from_u64(seq_num);
+                    let mut hash = Hash([0; 32]);
+                    gen.fill_bytes(&mut hash.0);
+
+                    self.update = Some((seq_num, hash));
+                    self.generate_event = Some(func);
+                    wake = true;
+                }
+            }
+        }
+        if wake {
+            if let Some(waker) = self.waker.take() {
+                waker.wake()
+            };
+        }
+    }
+}
+
+impl<O, E> Stream for MockStateRootHash<O, E>
+where
+    Self: Unpin,
+{
+    type Item = E;
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.deref_mut();
+
+        if let Some((seqnum, hash)) = this.update.take() {
+            if let Some(cb) = this.generate_event.take() {
+                return Poll::Ready(Some(cb(seqnum, hash)));
+            }
+        }
+
+        self.waker = Some(cx.waker().clone());
+        Poll::Pending
+    }
+}

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -9,7 +9,8 @@ use futures_util::{FutureExt, StreamExt};
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
-    multi_sig::MultiSig, transaction_validator::MockValidator, validation::Sha256Hash,
+    multi_sig::MultiSig, payload::NopStateRoot, transaction_validator::MockValidator,
+    validation::Sha256Hash,
 };
 use monad_crypto::secp256k1::SecpSignature;
 use monad_executor::{
@@ -44,8 +45,14 @@ type HasherType = Sha256Hash;
 type SignatureType = SecpSignature;
 type SignatureCollectionType = MultiSig<SignatureType>;
 type TransactionValidatorType = MockValidator;
+type StateRootValidatorType = NopStateRoot;
 type MonadState = monad_state::MonadState<
-    ConsensusState<SignatureType, SignatureCollectionType, TransactionValidatorType>,
+    ConsensusState<
+        SignatureType,
+        SignatureCollectionType,
+        TransactionValidatorType,
+        StateRootValidatorType,
+    >,
     SignatureType,
     SignatureCollectionType,
     ValidatorSet,

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -31,6 +31,7 @@ message ProtoFetchedTxs {
 
   bytes tx_hashes = 5;
   uint64 seq_num = 6;
+  monad_proto.basic.ProtoHash state_root_hash = 7;
 }
 
 message ProtoFetchedFullTxs {
@@ -54,6 +55,11 @@ message ProtoLoadEpochEvent {
   monad_proto.validator_set.ProtoValidatorSetData upcoming_validator_set = 3;
 }
 
+message ProtoStateUpdateEvent {
+  uint64 seq_num = 1;
+  monad_proto.basic.ProtoHash state_root_hash = 2;
+}
+
 message ProtoConsensusEvent {
   oneof event {
     ProtoMessageWithSender message = 1;
@@ -63,6 +69,7 @@ message ProtoConsensusEvent {
     ProtoAdvanceEpochEvent advance_epoch = 5;
     ProtoLoadEpochEvent load_epoch = 6;
     ProtoFetchedBlock fetched_block = 7;
+    ProtoStateUpdateEvent state_update = 8;
   }
 }
 

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -2,7 +2,9 @@ use std::{collections::HashSet, time::Duration};
 
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_consensus_types::{
+    multi_sig::MultiSig, payload::NopStateRoot, transaction_validator::MockValidator,
+};
 use monad_crypto::NopSignature;
 use monad_executor::{
     executor::mock::{MockMempool, NoSerRouterConfig, NoSerRouterScheduler},
@@ -22,7 +24,7 @@ use crate::RandomizedTest;
 fn random_latency_test(seed: u64) {
     run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, NopStateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,
@@ -69,7 +71,7 @@ fn delayed_message_test(seed: u64) {
 
     run_nodes_until::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, NopStateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/benches/two_node_benchmark.rs
+++ b/monad-state/benches/two_node_benchmark.rs
@@ -3,7 +3,9 @@ use std::time::Duration;
 use criterion::{criterion_group, criterion_main, Criterion};
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_consensus_types::{
+    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+};
 use monad_crypto::NopSignature;
 use monad_executor::{
     executor::mock::{MockMempool, NoSerRouterConfig, NoSerRouterScheduler},
@@ -25,7 +27,7 @@ criterion_main!(benches);
 fn two_nodes() {
     run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/block_sync.rs
+++ b/monad-state/tests/block_sync.rs
@@ -2,7 +2,9 @@ use std::{collections::HashSet, time::Duration};
 
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_consensus_types::{
+    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+};
 use monad_crypto::NopSignature;
 use monad_executor::{
     executor::mock::{MockMempool, NoSerRouterConfig, NoSerRouterScheduler},
@@ -39,7 +41,7 @@ fn black_out() {
 
     run_nodes_until::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,
@@ -94,7 +96,7 @@ fn extreme_delay() {
 
     run_nodes_until::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/many_nodes.rs
+++ b/monad-state/tests/many_nodes.rs
@@ -2,7 +2,9 @@ use std::time::{Duration, Instant};
 
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_consensus_types::{
+    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+};
 use monad_crypto::NopSignature;
 use monad_executor::{
     executor::mock::{MockMempool, NoSerRouterConfig, NoSerRouterScheduler},
@@ -24,7 +26,7 @@ fn many_nodes() {
 
     run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,
@@ -60,7 +62,7 @@ fn many_nodes_quic() {
 
     run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/many_nodes_metrics.rs
+++ b/monad-state/tests/many_nodes_metrics.rs
@@ -2,7 +2,9 @@ use std::time::Duration;
 
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_consensus_types::{
+    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+};
 use monad_crypto::NopSignature;
 use monad_executor::{
     executor::mock::{MockMempool, NoSerRouterConfig, NoSerRouterScheduler},
@@ -37,7 +39,7 @@ fn many_nodes_metrics() {
 
     run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/msg_delays.rs
+++ b/monad-state/tests/msg_delays.rs
@@ -2,7 +2,9 @@ use std::time::Duration;
 
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_consensus_types::{
+    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+};
 use monad_crypto::NopSignature;
 use monad_executor::{
     executor::mock::{MockMempool, NoSerRouterConfig, NoSerRouterScheduler},
@@ -20,7 +22,7 @@ fn two_nodes() {
 
     run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/order.rs
+++ b/monad-state/tests/order.rs
@@ -2,7 +2,9 @@ use std::{collections::HashSet, env, time::Duration};
 
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_consensus_types::{
+    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+};
 use monad_crypto::NopSignature;
 use monad_executor::{
     executor::mock::{MockMempool, NoSerRouterConfig, NoSerRouterScheduler},
@@ -64,7 +66,7 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
 
     run_nodes_until::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/rand_lat.rs
+++ b/monad-state/tests/rand_lat.rs
@@ -2,7 +2,9 @@ use std::env;
 
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_consensus_types::{
+    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+};
 use monad_crypto::NopSignature;
 use monad_executor::{
     executor::mock::{MockMempool, NoSerRouterConfig, NoSerRouterScheduler},
@@ -57,7 +59,7 @@ fn nodes_with_random_latency(seed: u64) {
 
     run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/replay.rs
+++ b/monad-state/tests/replay.rs
@@ -3,7 +3,8 @@ use std::{collections::HashMap, fs::create_dir_all, time::Duration};
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
-    block::BlockType, multi_sig::MultiSig, transaction_validator::MockValidator,
+    block::BlockType, multi_sig::MultiSig, payload::NopStateRoot,
+    transaction_validator::MockValidator,
 };
 use monad_crypto::secp256k1::SecpSignature;
 use monad_executor::{
@@ -22,6 +23,7 @@ use tempfile::tempdir;
 type SignatureType = SecpSignature;
 type SignatureCollectionType = MultiSig<SignatureType>;
 type TransactionValidatorType = MockValidator;
+type StateRootValidatorType = NopStateRoot;
 
 #[test]
 fn test_replay() {
@@ -68,7 +70,12 @@ pub fn recover_nodes_msg_delays(num_nodes: u16, num_blocks_before: usize, num_bl
 
     let mut nodes = Nodes::<
         MonadState<
-            ConsensusState<SignatureType, SignatureCollectionType, TransactionValidatorType>,
+            ConsensusState<
+                SignatureType,
+                SignatureCollectionType,
+                TransactionValidatorType,
+                StateRootValidatorType,
+            >,
             SignatureType,
             SignatureCollectionType,
             ValidatorSet,
@@ -146,7 +153,12 @@ pub fn recover_nodes_msg_delays(num_nodes: u16, num_blocks_before: usize, num_bl
 
     let mut nodes_recovered = Nodes::<
         MonadState<
-            ConsensusState<SignatureType, SignatureCollectionType, TransactionValidatorType>,
+            ConsensusState<
+                SignatureType,
+                SignatureCollectionType,
+                TransactionValidatorType,
+                StateRootValidatorType,
+            >,
             SignatureType,
             SignatureCollectionType,
             ValidatorSet,

--- a/monad-state/tests/single_node.rs
+++ b/monad-state/tests/single_node.rs
@@ -2,7 +2,9 @@ use std::time::{Duration, Instant};
 
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_consensus_types::{
+    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+};
 use monad_crypto::NopSignature;
 use monad_executor::{
     executor::mock::{MockMempool, NoSerRouterConfig, NoSerRouterScheduler},
@@ -24,7 +26,7 @@ fn two_nodes() {
 
     run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,
@@ -60,7 +62,7 @@ fn two_nodes_quic() {
 
     run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/single_node_metrics.rs
+++ b/monad-state/tests/single_node_metrics.rs
@@ -2,7 +2,9 @@ use std::time::Duration;
 
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_consensus_types::{
+    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+};
 use monad_crypto::NopSignature;
 use monad_executor::{
     executor::mock::{MockMempool, NoSerRouterConfig, NoSerRouterScheduler},
@@ -37,7 +39,7 @@ fn two_nodes() {
 
     run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/two_nodes_bls.rs
+++ b/monad-state/tests/two_nodes_bls.rs
@@ -2,7 +2,9 @@ use std::time::Duration;
 
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{bls::BlsSignatureCollection, transaction_validator::MockValidator};
+use monad_consensus_types::{
+    bls::BlsSignatureCollection, payload::StateRoot, transaction_validator::MockValidator,
+};
 use monad_crypto::secp256k1::SecpSignature;
 use monad_executor::{
     executor::mock::{MockMempool, NoSerRouterConfig, NoSerRouterScheduler},
@@ -23,7 +25,7 @@ fn two_nodes_bls() {
 
     run_nodes::<
         MonadState<
-            ConsensusState<SignatureType, SignatureCollectionType, MockValidator>,
+            ConsensusState<SignatureType, SignatureCollectionType, MockValidator, StateRoot>,
             SignatureType,
             SignatureCollectionType,
             ValidatorSet,

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -9,7 +9,7 @@ use monad_consensus_types::{
     certificate_signature::{CertificateKeyPair, CertificateSignature},
     ledger::LedgerCommitInfo,
     multi_sig::MultiSig,
-    payload::{ExecutionArtifacts, Payload, TransactionList},
+    payload::{ExecutionArtifacts, NopStateRoot, Payload, TransactionList},
     quorum_certificate::{genesis_vote_info, QuorumCertificate},
     signature_collection::{
         SignatureCollection, SignatureCollectionKeyPairType, SignatureCollectionPubKeyType,
@@ -38,8 +38,14 @@ type HasherType = Sha256Hash;
 type SignatureType = SecpSignature;
 type SignatureCollectionType = MultiSig<SignatureType>;
 type TransactionValidatorType = MockValidator;
+type StateRootValidatorType = NopStateRoot;
 type MonadState = monad_state::MonadState<
-    ConsensusState<SignatureType, SignatureCollectionType, TransactionValidatorType>,
+    ConsensusState<
+        SignatureType,
+        SignatureCollectionType,
+        TransactionValidatorType,
+        StateRootValidatorType,
+    >,
     SignatureType,
     SignatureCollectionType,
     ValidatorSet,

--- a/monad-testutil/examples/logs_gen.rs
+++ b/monad-testutil/examples/logs_gen.rs
@@ -2,7 +2,9 @@ use std::{path::PathBuf, time::Duration};
 
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_consensus_types::{
+    multi_sig::MultiSig, payload::NopStateRoot, transaction_validator::MockValidator,
+};
 use monad_crypto::NopSignature;
 use monad_executor::{
     executor::mock::{MockMempool, NoSerRouterConfig, NoSerRouterScheduler},
@@ -19,7 +21,7 @@ use monad_wal::wal::{WALogger, WALoggerConfig};
 type SignatureType = NopSignature;
 type SignatureCollectionType = MultiSig<SignatureType>;
 type MS = MonadState<
-    ConsensusState<SignatureType, SignatureCollectionType, MockValidator>,
+    ConsensusState<SignatureType, SignatureCollectionType, MockValidator, NopStateRoot>,
     SignatureType,
     SignatureCollectionType,
     ValidatorSet,

--- a/monad-testutil/src/block.rs
+++ b/monad-testutil/src/block.rs
@@ -33,6 +33,9 @@ impl BlockType for MockBlock {
     fn get_parent_id(&self) -> monad_types::BlockId {
         self.parent_block_id
     }
+    fn get_seq_num(&self) -> u64 {
+        0
+    }
 }
 
 impl std::fmt::Debug for MockBlock {

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -48,7 +48,7 @@ pub fn get_configs<ST: MessageSignature, SCT: SignatureCollection, TVT: Clone>(
                 .map(|(node_id, sctpubkey)| (node_id.0, *sctpubkey))
                 .collect::<Vec<_>>(),
             delta,
-            state_root_delay: 0,
+            state_root_delay: 4,
             genesis_block: genesis_block.clone(),
             genesis_vote_info: genesis_vote_info(genesis_block.get_id()),
             genesis_signatures: genesis_sigs.clone(),

--- a/monad-viz/src/main.rs
+++ b/monad-viz/src/main.rs
@@ -26,6 +26,7 @@ use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
     block::{Block, BlockType},
     multi_sig::MultiSig,
+    payload::NopStateRoot,
     transaction_validator::MockValidator,
 };
 use monad_crypto::NopSignature;
@@ -47,6 +48,7 @@ use replay_graph::{RepConfig, ReplayNodesSimulation};
 type SignatureType = NopSignature;
 type SignatureCollectionType = MultiSig<SignatureType>;
 type TransactionValidatorType = MockValidator;
+type StateRootValidatorType = NopStateRoot;
 type NS<'a> = NodeState<
     'a,
     PeerId,
@@ -55,7 +57,12 @@ type NS<'a> = NodeState<
     MonadEvent<SignatureType, SignatureCollectionType>,
 >;
 type MS = MonadState<
-    ConsensusState<SignatureType, SignatureCollectionType, TransactionValidatorType>,
+    ConsensusState<
+        SignatureType,
+        SignatureCollectionType,
+        TransactionValidatorType,
+        StateRootValidatorType,
+    >,
     SignatureType,
     SignatureCollectionType,
     ValidatorSet,
@@ -148,6 +155,7 @@ impl Application for Viz {
                             SignatureType,
                             SignatureCollectionType,
                             TransactionValidatorType,
+                            StateRootValidatorType,
                         >,
                         SignatureType,
                         SignatureCollectionType,
@@ -182,6 +190,7 @@ impl Application for Viz {
                             SignatureType,
                             SignatureCollectionType,
                             TransactionValidatorType,
+                            StateRootValidatorType,
                         >,
                         SignatureType,
                         SignatureCollectionType,


### PR DESCRIPTION
Get seq_num directly from the block being extended in the branch of the blocktree when creating a proposal instead of storing it in consensus-state. 

The state-root executor will at some point turn into, or merge with, the file ledger executor. 