### PR TITLE
QuicRouterScheduler implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4134,7 +4134,7 @@ dependencies = [
  "libp2p-tls",
  "log",
  "parking_lot 0.12.1",
- "quinn-proto",
+ "quinn-proto 0.9.4",
  "rand 0.8.5",
  "rustls 0.20.8",
  "thiserror",
@@ -4650,6 +4650,8 @@ dependencies = [
  "libp2p-identity",
  "monad-proto",
  "multihash",
+ "rcgen 0.11.1",
+ "rustls 0.21.5",
  "secp256k1",
  "sha2 0.10.7",
  "tiny-keccak",
@@ -4815,6 +4817,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-quic"
+version = "0.1.0"
+dependencies = [
+ "monad-crypto",
+ "monad-executor",
+ "quinn-proto 0.11.0",
+]
+
+[[package]]
 name = "monad-randomized-tests"
 version = "0.1.0"
 dependencies = [
@@ -4845,6 +4856,7 @@ dependencies = [
  "monad-crypto",
  "monad-executor",
  "monad-proto",
+ "monad-quic",
  "monad-testutil",
  "monad-tracing-counter",
  "monad-types",
@@ -5818,6 +5830,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
+dependencies = [
+ "base64 0.21.2",
+ "serde 1.0.175",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6319,6 +6341,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn-proto"
+version = "0.11.0"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=307d80b9#307d80b9398d4e1e305c0131f2c3989090ec9432"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "ring",
+ "rustc-hash",
+ "rustls 0.21.5",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6469,7 +6507,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
- "pem",
+ "pem 1.1.1",
  "ring",
  "time",
  "x509-parser 0.13.2",
@@ -6482,7 +6520,19 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
- "pem",
+ "pem 1.1.1",
+ "ring",
+ "time",
+ "yasna",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4954fbc00dcd4d8282c987710e50ba513d351400dbdd00e803a05172a90d8976"
+dependencies = [
+ "pem 2.0.1",
  "ring",
  "time",
  "yasna",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "monad-node",
     "monad-p2p",
     "monad-proto",
+    "monad-quic",
     "monad-randomized-tests",
     "monad-state",
     "monad-testground",
@@ -62,10 +63,17 @@ prost-build = "0.11.9"
 prost-types = "0.11.8"
 protobuf-src = "1.1.0"
 ptree = "0.4.0"
+
+# the important commit: "307d80b9398d4e1e305c0131f2c3989090ec9432"
+# we can use latest release once it includes that
+quinn-proto = { git = "https://github.com/quinn-rs/quinn.git", rev = "307d80b9" }
+
 rand = "0.8.5"
 rand_chacha = "0.3.1"
+rcgen = "0.11"
 ref-cast = "1.0"
 rustls-pemfile = "1.0.3"
+rustls = "0.21"
 secp256k1 = "0.26"
 serde = "1.0.160"
 sha2 = "0.10.6"
@@ -80,5 +88,6 @@ tracing = "0.1.37"
 tracing-core = "0.1.30"
 tracing-opentelemetry = "0.19"
 tracing-subscriber = "0.3.17"
+x509-parser = "0.15"
 zerocopy = "0.6.1"
 zeroize = "1.3"

--- a/monad-crypto/Cargo.toml
+++ b/monad-crypto/Cargo.toml
@@ -19,6 +19,9 @@ sha2 = { workspace = true }
 zerocopy = { workspace = true }
 zeroize = { workspace = true }
 
+rcgen = { workspace = true, optional = true }
+rustls = { workspace = true, optional = true }
+
 [dev-dependencies]
 hex = { workspace = true }
 tiny-keccak = { workspace = true, features = ["keccak"] }
@@ -26,3 +29,4 @@ tiny-keccak = { workspace = true, features = ["keccak"] }
 [features]
 libp2p-identity = ["dep:libp2p-identity", "dep:multihash"]
 proto = ["dep:monad-proto"]
+rustls = ["dep:rcgen", "dep:rustls"]

--- a/monad-crypto/src/lib.rs
+++ b/monad-crypto/src/lib.rs
@@ -3,6 +3,9 @@ use crate::secp256k1::PubKey;
 #[cfg(feature = "proto")]
 pub mod convert;
 
+#[cfg(feature = "rustls")]
+pub mod rustls;
+
 pub mod bls12_381;
 pub mod secp256k1;
 

--- a/monad-crypto/src/rustls.rs
+++ b/monad-crypto/src/rustls.rs
@@ -1,0 +1,73 @@
+use std::{error::Error, sync::Arc};
+
+use rustls::{
+    client::{ServerCertVerified, ServerCertVerifier},
+    server::ClientCertVerifier,
+};
+
+fn make_certificate() -> Result<(rustls::Certificate, rustls::PrivateKey), Box<dyn Error>> {
+    let rcgen_key = rcgen::KeyPair::generate(&rcgen::PKCS_ED25519)?;
+    let key = rustls::PrivateKey(rcgen_key.serialize_der());
+
+    let mut params = rcgen::CertificateParams::new(Vec::new());
+    params.alg = &rcgen::PKCS_ED25519;
+    params.key_pair = Some(rcgen_key);
+
+    let certificate =
+        rustls::Certificate(rcgen::Certificate::from_params(params)?.serialize_der()?);
+
+    Ok((certificate, key))
+}
+
+pub struct UnsafeTlsVerifier;
+
+impl UnsafeTlsVerifier {
+    pub fn make_server_config() -> rustls::ServerConfig {
+        let (certificate, cert_keypair) =
+            make_certificate().expect("making certificate should always succed");
+        rustls::ServerConfig::builder()
+            .with_safe_defaults()
+            .with_client_cert_verifier(Arc::new(Self))
+            .with_single_cert(vec![certificate], cert_keypair)
+            .expect("building ServerConfig should always succed")
+    }
+
+    pub fn make_client_config() -> rustls::ClientConfig {
+        let (certificate, cert_keypair) =
+            make_certificate().expect("making certificate should always succed");
+        rustls::ClientConfig::builder()
+            .with_safe_defaults()
+            .with_custom_certificate_verifier(Arc::new(Self))
+            .with_client_auth_cert(vec![certificate], cert_keypair)
+            .expect("building ClientConfig should always succeed")
+    }
+}
+
+impl ClientCertVerifier for UnsafeTlsVerifier {
+    fn client_auth_root_subjects(&self) -> &[rustls::DistinguishedName] {
+        &[]
+    }
+
+    fn verify_client_cert(
+        &self,
+        _end_entity: &rustls::Certificate,
+        _intermediates: &[rustls::Certificate],
+        _now: std::time::SystemTime,
+    ) -> Result<rustls::server::ClientCertVerified, rustls::Error> {
+        Ok(rustls::server::ClientCertVerified::assertion())
+    }
+}
+
+impl ServerCertVerifier for UnsafeTlsVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::Certificate,
+        _intermediates: &[rustls::Certificate],
+        _server_name: &rustls::ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: std::time::SystemTime,
+    ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+}

--- a/monad-quic/Cargo.toml
+++ b/monad-quic/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "monad-quic"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+monad-crypto = { path = "../monad-crypto", features = ["rustls"] }
+monad-executor = { path = "../monad-executor" }
+
+quinn-proto = { workspace = true }

--- a/monad-quic/src/gossip.rs
+++ b/monad-quic/src/gossip.rs
@@ -1,0 +1,108 @@
+use std::collections::{HashMap, VecDeque};
+
+use monad_executor::{PeerId, RouterTarget};
+
+pub enum GossipEvent {
+    /// Send gossip_message to peer
+    Send(PeerId, Vec<u8>), // send gossip_message
+
+    /// Emit app_message to executor (NOTE: not gossip_message)
+    Emit(PeerId, Vec<u8>),
+}
+
+/// Gossip converts:
+/// - outbound application messages to outbound gossip messages (tag whatever necessary metadata)
+/// - inbound gossip messages to inbound application messages + outbound gossip messages
+///
+/// NOTE that this must gracefully handle outbound application to self (should immediately Emit, not Send)
+///
+/// `message` and `gossip_message` are both typed as bytes intentionally, because that's the atomic
+/// unit of transfer.
+pub trait Gossip {
+    type Config;
+
+    fn new(config: Self::Config) -> Self;
+
+    fn send(&mut self, to: RouterTarget, message: &[u8]);
+    fn handle_gossip_message(&mut self, from: PeerId, gossip_message: &[u8]);
+    fn poll(&mut self) -> Option<GossipEvent>;
+}
+
+pub struct MockGossipConfig {
+    pub all_peers: Vec<PeerId>,
+}
+
+pub struct MockGossip {
+    config: MockGossipConfig,
+
+    read_buffers: HashMap<PeerId, VecDeque<u8>>,
+    events: VecDeque<GossipEvent>,
+}
+
+type MessageLenType = u32;
+const MESSAGE_HEADER_LEN: usize = std::mem::size_of::<MessageLenType>();
+
+impl Gossip for MockGossip {
+    type Config = MockGossipConfig;
+
+    fn new(config: Self::Config) -> Self {
+        Self {
+            config,
+
+            read_buffers: Default::default(),
+            events: VecDeque::default(),
+        }
+    }
+
+    fn send(&mut self, to: RouterTarget, message: &[u8]) {
+        let mut gossip_message = Vec::from((message.len() as MessageLenType).to_le_bytes());
+        gossip_message.extend_from_slice(message);
+        match to {
+            RouterTarget::Broadcast => {
+                for peer in &self.config.all_peers {
+                    self.events
+                        .push_back(GossipEvent::Send(*peer, gossip_message.clone()))
+                }
+            }
+            RouterTarget::PointToPoint(to) => {
+                self.events.push_back(GossipEvent::Send(to, gossip_message))
+            }
+        }
+    }
+
+    fn handle_gossip_message(&mut self, from: PeerId, gossip_message: &[u8]) {
+        let read_buffer = self.read_buffers.entry(from).or_default();
+        read_buffer.extend(gossip_message.iter());
+        while {
+            let buffer_len = read_buffer.len();
+            if buffer_len < MESSAGE_HEADER_LEN {
+                false
+            } else {
+                let message_len = MessageLenType::from_le_bytes(
+                    read_buffer
+                        .iter()
+                        .copied()
+                        .take(MESSAGE_HEADER_LEN)
+                        .collect::<Vec<_>>()
+                        .try_into()
+                        .unwrap(),
+                );
+                buffer_len >= MESSAGE_HEADER_LEN + message_len as usize
+            }
+        } {
+            let message_len = MessageLenType::from_le_bytes(
+                read_buffer
+                    .drain(..MESSAGE_HEADER_LEN)
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+            ) as usize;
+            let emit: Vec<u8> = read_buffer.drain(..message_len).collect();
+            self.events.push_back(GossipEvent::Emit(from, emit))
+        }
+    }
+
+    fn poll(&mut self) -> Option<GossipEvent> {
+        self.events.pop_front()
+    }
+}

--- a/monad-quic/src/lib.rs
+++ b/monad-quic/src/lib.rs
@@ -1,0 +1,420 @@
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use monad_crypto::rustls::UnsafeTlsVerifier;
+use monad_executor::{
+    executor::mock::{RouterEvent, RouterScheduler},
+    PeerId, RouterTarget,
+};
+use quinn_proto::{
+    ClientConfig, Connection, ConnectionHandle, DatagramEvent, Dir, EndpointConfig, StreamId,
+    TransportConfig,
+};
+
+pub mod gossip;
+use gossip::{Gossip, GossipEvent};
+
+mod timeout_queue;
+use timeout_queue::TimeoutQueue;
+
+pub struct QuicRouterSchedulerConfig<GC> {
+    pub zero_instant: Instant,
+
+    pub all_peers: BTreeSet<PeerId>,
+    pub me: PeerId,
+
+    pub gossip_config: GC,
+}
+
+pub struct QuicRouterScheduler<G: Gossip> {
+    zero_instant: Instant,
+
+    me: PeerId,
+    endpoint: quinn_proto::Endpoint,
+    connections: HashMap<ConnectionHandle, Connection>,
+    outbound_connections: HashMap<PeerId, ConnectionHandle>,
+    outbound_writeable_streams: HashMap<PeerId, StreamId>,
+    inbound_readable_streams: HashMap<PeerId, StreamId>,
+
+    peer_ids: HashMap<PeerId, SocketAddr>,
+    addresses: HashMap<SocketAddr, PeerId>,
+
+    gossip: G,
+
+    timeouts: TimeoutQueue,
+
+    pending_events: BTreeMap<Duration, Vec<RouterEvent<Vec<u8>, Vec<u8>>>>,
+    pending_outbound_messages: HashMap<PeerId, VecDeque<Vec<u8>>>,
+}
+
+const SERVER_NAME: &str = "MONAD";
+
+impl<G: Gossip> RouterScheduler for QuicRouterScheduler<G> {
+    type Config = QuicRouterSchedulerConfig<G::Config>;
+    type M = Vec<u8>;
+    type Serialized = Vec<u8>;
+
+    fn new(config: Self::Config) -> Self {
+        let mut endpoint = quinn_proto::Endpoint::new(
+            Arc::new(EndpointConfig::default()),
+            Some(Arc::new(
+                quinn_proto::ServerConfig::with_crypto(Arc::new(
+                    UnsafeTlsVerifier::make_server_config(),
+                )), // TODO use_retry ?
+            )),
+            false,
+        );
+
+        let mut connections = HashMap::new();
+        let mut outbound_connections = HashMap::new();
+        let mut peer_ids = HashMap::new();
+        for (idx, peer) in config
+            .all_peers
+            .iter()
+            .enumerate()
+            .filter(|(_, peer)| peer != &&config.me)
+        {
+            let sock_addr =
+                SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 3000 + idx as u16));
+            peer_ids.insert(*peer, sock_addr);
+
+            let mut client_config =
+                ClientConfig::new(Arc::new(UnsafeTlsVerifier::make_client_config()));
+            client_config.transport_config(Arc::new(
+                TransportConfig::default(), // TODO ?
+            ));
+
+            let (connection_handle, connection) = endpoint
+                .connect(config.zero_instant, client_config, sock_addr, SERVER_NAME)
+                .expect("mock quic should never fail to connect");
+            connections.insert(connection_handle, connection);
+            outbound_connections.insert(*peer, connection_handle);
+        }
+        let addresses = peer_ids.iter().map(|(x, y)| (*y, *x)).collect();
+
+        let mut scheduler = Self {
+            zero_instant: config.zero_instant,
+
+            me: config.me,
+            endpoint,
+            connections,
+            outbound_connections,
+            outbound_writeable_streams: HashMap::new(),
+            inbound_readable_streams: HashMap::new(),
+
+            peer_ids,
+            addresses,
+
+            gossip: G::new(config.gossip_config),
+
+            timeouts: Default::default(),
+            pending_events: Default::default(),
+            pending_outbound_messages: HashMap::new(),
+        };
+
+        let mut handles: Vec<_> = scheduler.connections.keys().cloned().collect();
+        handles.sort();
+        for handle in &handles {
+            scheduler.poll_connection(Duration::ZERO, handle);
+            // don't need to poll_gossip, because no read events may be generated here
+        }
+
+        scheduler
+    }
+
+    fn inbound(
+        &mut self,
+        time: std::time::Duration,
+        from: monad_executor::PeerId,
+        message: Self::Serialized,
+    ) {
+        if from == self.me {
+            self.gossip.handle_gossip_message(from, &message);
+            self.poll_gossip(time);
+        } else if let Some(maybe_event) = self.endpoint.handle(
+            self.zero_instant + time,
+            *self.peer_ids.get(&from).expect("peer_id should exist"),
+            None,
+            None, // TODO ecn codepoint?
+            message.into_iter().collect(),
+        ) {
+            match maybe_event {
+                DatagramEvent::ConnectionEvent(connection_handle, event) => {
+                    let connection = self
+                        .connections
+                        .get_mut(&connection_handle)
+                        .expect("connection should exist");
+
+                    connection.handle_event(event);
+
+                    self.poll_connection(time, &connection_handle);
+                    self.poll_gossip(time);
+                }
+                DatagramEvent::NewConnection(connection_handle, connection) => {
+                    let replaced = self.connections.insert(connection_handle, connection);
+                    assert!(replaced.is_none());
+
+                    self.poll_connection(time, &connection_handle);
+                    self.poll_gossip(time);
+                    return;
+                }
+                DatagramEvent::Response(quinn_proto::Transmit {
+                    destination,
+                    ecn,
+                    contents,
+                    segment_size: _,
+                    src_ip: _,
+                }) => {
+                    assert_eq!(ecn, None);
+                    let to = *self
+                        .addresses
+                        .get(&destination)
+                        .expect("address should exist");
+                    assert!(
+                        time >= self
+                            .pending_events
+                            .last_key_value()
+                            .map(|(time, _)| *time)
+                            .unwrap_or(Duration::ZERO)
+                    );
+                    self.pending_events
+                        .entry(time)
+                        .or_default()
+                        .push(RouterEvent::Tx(to, contents.into()))
+                }
+            };
+        }
+    }
+
+    fn outbound<OM: Into<Self::M>>(&mut self, time: Duration, to: RouterTarget, message: OM) {
+        let message = message.into();
+        self.gossip.send(to, &message);
+        self.poll_gossip(time);
+    }
+
+    fn peek_tick(&self) -> Option<Duration> {
+        self.peek_event().map(|(tick, _)| tick)
+    }
+
+    fn step_until(&mut self, until: Duration) -> Option<RouterEvent<Self::M, Self::Serialized>> {
+        while let Some((min_tick, event_type)) = self.peek_event() {
+            if min_tick > until {
+                break;
+            }
+            match event_type {
+                QuicEventType::Event => {
+                    let mut entry = self.pending_events.first_entry().unwrap();
+                    assert_eq!(min_tick, *entry.key());
+                    let events = entry.get_mut();
+                    let event = events.pop().expect("events should never be empty");
+
+                    if events.is_empty() {
+                        self.pending_events.pop_first().unwrap();
+                    }
+                    return Some(event);
+                }
+                QuicEventType::Timeout => {
+                    let (timeout_tick, connection_handle) =
+                        self.timeouts.pop().expect("invariant broken");
+                    assert_eq!(min_tick, timeout_tick);
+
+                    let connection = self
+                        .connections
+                        .get_mut(&connection_handle)
+                        .expect("connection should exist");
+
+                    connection.handle_timeout(self.zero_instant + timeout_tick);
+                    self.poll_connection(timeout_tick, &connection_handle);
+                    self.poll_gossip(timeout_tick);
+                }
+            }
+        }
+        None
+    }
+}
+
+enum QuicEventType {
+    Timeout,
+    Event,
+}
+
+impl<G: Gossip> QuicRouterScheduler<G> {
+    fn peek_event(&self) -> Option<(Duration, QuicEventType)> {
+        self.timeouts
+            .peek_tick()
+            .map(|tick| (tick, QuicEventType::Timeout))
+            .into_iter()
+            .chain(
+                self.pending_events
+                    .first_key_value()
+                    .map(|(tick, _)| (*tick, QuicEventType::Event)),
+            )
+            .min_by_key(|(tick, _)| *tick)
+    }
+
+    /// should be followed up with a self.poll_gossip (because connection events may be generated)
+    fn poll_connection(&mut self, time: Duration, connection_handle: &ConnectionHandle) {
+        let mut should_poll = true;
+        while should_poll {
+            should_poll = false;
+            let connection = self
+                .connections
+                .get_mut(connection_handle)
+                .expect("connection should exist");
+
+            let remote_peer_id = self
+                .addresses
+                .get(&connection.remote_address())
+                .expect("address should exist");
+
+            while let Some(transmit) = connection.poll_transmit(self.zero_instant + time, 1)
+            // TODO what do we set MAX_DATAGRAMS to?
+            {
+                let to = *self
+                    .addresses
+                    .get(&transmit.destination)
+                    .expect("address should exist");
+                self.pending_events
+                    .entry(time)
+                    .or_default()
+                    .push(RouterEvent::Tx(to, transmit.contents.into()))
+            }
+
+            if let Some(timeout) = connection.poll_timeout() {
+                self.timeouts
+                    .insert(timeout - self.zero_instant, connection_handle)
+            }
+
+            while let Some(endpoint_event) = connection.poll_endpoint_events() {
+                if let Some(connection_event) = self
+                    .endpoint
+                    .handle_event(*connection_handle, endpoint_event)
+                {
+                    connection.handle_event(connection_event);
+
+                    should_poll = true;
+                }
+            }
+
+            if let Some(stream_id) = self.outbound_writeable_streams.get(remote_peer_id) {
+                let pending_outbound = self
+                    .pending_outbound_messages
+                    .entry(*remote_peer_id)
+                    .or_default();
+                while let Some(gossip_message) = pending_outbound.pop_front() {
+                    let num_sent = connection
+                        .send_stream(*stream_id)
+                        .write(&gossip_message)
+                        .expect("expect no write error for mock quic");
+                    assert_eq!(gossip_message.len(), num_sent);
+                }
+            }
+
+            while let Some(event) = connection.poll() {
+                match event {
+                    quinn_proto::Event::HandshakeDataReady => (),
+                    quinn_proto::Event::Connected => {
+                        if connection.side().is_client() {
+                            let stream_id = connection
+                                .streams()
+                                .open(Dir::Uni)
+                                .expect("creating stream_id failed");
+
+                            let maybe_removed = self
+                                .outbound_writeable_streams
+                                .insert(*remote_peer_id, stream_id);
+                            assert!(maybe_removed.is_none());
+                            should_poll = true;
+                            break;
+                        }
+                    }
+                    quinn_proto::Event::ConnectionLost { reason } => {
+                        todo!("time: {:?}, {reason:?}", time)
+                    }
+                    quinn_proto::Event::Stream(stream_event) => match stream_event {
+                        quinn_proto::StreamEvent::Opened { dir } => {
+                            let stream_id = connection
+                                .streams()
+                                .accept(dir)
+                                .expect("stream id should exist");
+                            let replaced = self
+                                .inbound_readable_streams
+                                .insert(*remote_peer_id, stream_id);
+                            assert!(replaced.is_none());
+
+                            let mut recv_stream = connection.recv_stream(stream_id);
+                            let mut chunks = recv_stream.read(true).expect("failed to read chunks");
+                            while let Ok(Some(chunk)) = chunks.next(
+                                10_000, // TODO ?
+                            ) {
+                                self.gossip
+                                    .handle_gossip_message(*remote_peer_id, &chunk.bytes);
+                            }
+                            let _should_transmit = chunks.finalize();
+                        }
+                        quinn_proto::StreamEvent::Readable { id } => {
+                            let stream_id = *self
+                                .inbound_readable_streams
+                                .get(remote_peer_id)
+                                .expect("readable stream should be registered as inbound stream");
+                            let mut recv_stream = connection.recv_stream(stream_id);
+                            let mut chunks = recv_stream.read(true).expect("failed to read chunks");
+                            while let Ok(Some(chunk)) = chunks.next(
+                                10_000, // TODO ?
+                            ) {
+                                self.gossip
+                                    .handle_gossip_message(*remote_peer_id, &chunk.bytes);
+                            }
+                            let _should_transmit = chunks.finalize();
+                        }
+                        quinn_proto::StreamEvent::Writable { id } => todo!(),
+                        quinn_proto::StreamEvent::Finished { id } => todo!(),
+                        quinn_proto::StreamEvent::Stopped { id, error_code } => todo!(),
+                        quinn_proto::StreamEvent::Available { dir } => todo!(),
+                    },
+                    quinn_proto::Event::DatagramReceived => todo!(),
+                }
+            }
+        }
+    }
+
+    fn poll_gossip(&mut self, time: Duration) {
+        while let Some(event) = self.gossip.poll() {
+            match event {
+                GossipEvent::Send(peer_id, gossip_message) => {
+                    if peer_id == self.me {
+                        self.pending_events
+                            .entry(time)
+                            .or_default()
+                            .push(RouterEvent::Tx(peer_id, gossip_message))
+                    } else {
+                        let maybe_connection_handle =
+                            self.outbound_connections.get(&peer_id).copied();
+                        self.pending_outbound_messages
+                            .entry(peer_id)
+                            .or_default()
+                            .push_back(gossip_message);
+                        if let Some(connection_handle) = maybe_connection_handle {
+                            self.poll_connection(time, &connection_handle);
+                        }
+                    }
+                }
+                GossipEvent::Emit(peer_id, message) => {
+                    assert!(
+                        time >= self
+                            .pending_events
+                            .last_key_value()
+                            .map(|(time, _)| *time)
+                            .unwrap_or(Duration::ZERO)
+                    );
+                    let event = RouterEvent::Rx(peer_id, message);
+                    self.pending_events.entry(time).or_default().push(event)
+                }
+            }
+        }
+    }
+}

--- a/monad-quic/src/timeout_queue.rs
+++ b/monad-quic/src/timeout_queue.rs
@@ -1,0 +1,51 @@
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    time::Duration,
+};
+
+use quinn_proto::ConnectionHandle;
+
+#[derive(Default)]
+pub(crate) struct TimeoutQueue {
+    timeouts: BTreeMap<Duration, BTreeSet<ConnectionHandle>>,
+    connection_timeouts: HashMap<ConnectionHandle, Duration>,
+}
+
+impl TimeoutQueue {
+    pub fn peek_tick(&self) -> Option<Duration> {
+        let (tick, _) = self.timeouts.first_key_value()?;
+        Some(*tick)
+    }
+
+    pub fn pop(&mut self) -> Option<(Duration, ConnectionHandle)> {
+        let mut entry = self.timeouts.first_entry()?;
+
+        let timeout_tick = *entry.key();
+        let handles = entry.get_mut();
+        let handle = handles.pop_first().expect("invariant broken");
+        self.connection_timeouts
+            .remove(&handle)
+            .expect("invariant broken");
+        if handles.is_empty() {
+            self.timeouts.pop_first().expect("invariant broken");
+        }
+
+        Some((timeout_tick, handle))
+    }
+
+    pub fn insert(&mut self, tick: Duration, handle: &ConnectionHandle) {
+        let tick_timeouts = self.timeouts.entry(tick).or_default();
+        if tick_timeouts.contains(handle) {
+            return;
+        }
+        tick_timeouts.insert(*handle);
+        if let Some(removed) = self.connection_timeouts.insert(*handle, tick) {
+            let old_timeouts = self.timeouts.get_mut(&removed).expect("invariant broken");
+            let deleted = old_timeouts.remove(handle);
+            assert!(deleted);
+            if old_timeouts.is_empty() {
+                self.timeouts.remove(&removed).expect("invariant broken");
+            }
+        }
+    }
+}

--- a/monad-state/Cargo.toml
+++ b/monad-state/Cargo.toml
@@ -24,6 +24,7 @@ prost = { workspace = true, optional = true }
 ref-cast = { workspace = true }
 
 [dev-dependencies]
+monad-quic = { path = "../monad-quic" }
 monad-testutil = { path = "../monad-testutil"}
 monad-tracing-counter = { path = "../monad-tracing-counter" }
 monad-wal = { path = "../monad-wal" }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -210,6 +210,21 @@ impl<MS: MessageSignature, CS: CertificateSignatureRecoverable> monad_types::Des
     }
 }
 
+#[cfg(feature = "proto")]
+impl<MS: MessageSignature, CS: CertificateSignatureRecoverable> monad_types::Deserializable<Vec<u8>>
+    for MonadMessage<MS, monad_consensus_types::multi_sig::MultiSig<CS>>
+{
+    type ReadError = monad_proto::error::ProtoError;
+
+    fn deserialize(message: &Vec<u8>) -> Result<Self, Self::ReadError> {
+        Ok(MonadMessage(
+            monad_consensus::convert::interface::deserialize_unverified_consensus_message(
+                message.as_ref(),
+            )?,
+        ))
+    }
+}
+
 impl<ST, SCT: SignatureCollection> From<VerifiedMonadMessage<ST, SCT>> for MonadMessage<ST, SCT> {
     fn from(value: VerifiedMonadMessage<ST, SCT>) -> Self {
         MonadMessage(value.0.into())

--- a/monad-state/tests/many_nodes.rs
+++ b/monad-state/tests/many_nodes.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
@@ -8,6 +8,10 @@ use monad_executor::{
     executor::mock::{MockMempool, NoSerRouterConfig, NoSerRouterScheduler},
     transformer::{LatencyTransformer, Transformer, TransformerPipeline},
     xfmr_pipe,
+};
+use monad_quic::{
+    gossip::{MockGossip, MockGossipConfig},
+    QuicRouterScheduler, QuicRouterSchedulerConfig,
 };
 use monad_state::{MonadMessage, MonadState};
 use monad_testutil::swarm::run_nodes;
@@ -47,5 +51,45 @@ fn many_nodes() {
         100,
         1024,
         Duration::from_millis(2),
+    );
+}
+
+#[test]
+fn many_nodes_quic() {
+    let zero_instant = Instant::now();
+
+    run_nodes::<
+        MonadState<
+            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
+            NopSignature,
+            MultiSig<NopSignature>,
+            ValidatorSet,
+            SimpleRoundRobin,
+            BlockSyncState,
+        >,
+        NopSignature,
+        MultiSig<NopSignature>,
+        QuicRouterScheduler<MockGossip>,
+        _,
+        MockWALogger<_>,
+        _,
+        MockValidator,
+        MockMempool<_>,
+    >(
+        MockValidator,
+        |all_peers, me| QuicRouterSchedulerConfig {
+            zero_instant,
+            all_peers: all_peers.iter().cloned().collect(),
+            me,
+
+            gossip_config: MockGossipConfig { all_peers },
+        },
+        MockWALoggerConfig,
+        xfmr_pipe!(Transformer::Latency::<Vec<u8>>(LatencyTransformer(
+            Duration::from_millis(1)
+        ))),
+        40,
+        10,
+        Duration::from_millis(10),
     );
 }

--- a/monad-state/tests/many_nodes_metrics.rs
+++ b/monad-state/tests/many_nodes_metrics.rs
@@ -21,7 +21,7 @@ use tracing_core::LevelFilter;
 use tracing_subscriber::{filter::Targets, prelude::*, Registry};
 
 #[test]
-fn many_nodes() {
+fn many_nodes_metrics() {
     let fmt_layer = tracing_subscriber::fmt::layer();
     let counter_layer = CounterLayer::new();
 

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -94,7 +94,7 @@ pub fn run_nodes<S, ST, SCT, RS, RSC, LGR, P, TVT, ME>(
     ST: MessageSignature,
     SCT: SignatureCollection,
 
-    RS: RouterScheduler<M = S::Message>,
+    RS: RouterScheduler,
     S::Message: Deserializable<RS::M>,
     S::OutboundMessage: Serializable<RS::M>,
     RS::Serialized: Eq,
@@ -170,7 +170,7 @@ pub fn run_nodes_until<S, ST, SCT, RS, RSC, LGR, P, TVT, ME>(
     ST: MessageSignature,
     SCT: SignatureCollection,
 
-    RS: RouterScheduler<M = S::Message>,
+    RS: RouterScheduler,
     S::Message: Deserializable<RS::M>,
     S::OutboundMessage: Serializable<RS::M>,
     RS::Serialized: Eq,


### PR DESCRIPTION
This commit contains an implementation of a QuicRouterScheduler built on top of quinn-proto. QuicRouterScheduler is generic over Gossip - right now we only have a MockGossip that does a simple broadcast. Reconnect logic hasn't been implemented yet, so blackout tests will fail. After that's fixed, we can port further tests to use the QuicRouterScheduler.