### PR TITLE
Simplify MockExecutor event polling

### DIFF
--- a/monad-executor/src/mock_swarm.rs
+++ b/monad-executor/src/mock_swarm.rs
@@ -1,10 +1,9 @@
 use std::{
     cmp::Reverse,
-    collections::{BTreeMap, BTreeSet, BinaryHeap},
+    collections::{BTreeMap, BinaryHeap},
     time::Duration,
 };
 
-use futures::StreamExt;
 use monad_crypto::secp256k1::PubKey;
 use monad_types::{Deserializable, Serializable};
 use monad_wal::PersistenceLogger;
@@ -53,6 +52,11 @@ where
     scheduled_messages: BinaryHeap<Reverse<(Duration, LinkMessage<RS::Serialized>)>>,
 }
 
+enum SwarmEventType {
+    ExecutorEvent(PeerId),
+    ScheduledMessage,
+}
+
 impl<S, RS, T, LGR, ME> Nodes<S, RS, T, LGR, ME>
 where
     S: State,
@@ -76,10 +80,6 @@ where
 
         let mut states = BTreeMap::new();
 
-        let all_peers: BTreeSet<_> = peers
-            .iter()
-            .map(|(pubkey, _, _, _)| PeerId(*pubkey))
-            .collect();
         for (pubkey, state_config, logger_config, router_scheduler_config) in peers {
             let mut executor: MockExecutor<S, RS, ME> =
                 MockExecutor::new(RS::new(router_scheduler_config));
@@ -102,96 +102,91 @@ where
         }
     }
 
-    pub fn next_tick(&mut self) -> Option<Duration> {
+    fn peek_event(&self) -> Option<(Duration, SwarmEventType)> {
         let min_event = self
             .states
-            .iter_mut()
+            .iter()
             .filter_map(|(id, (executor, state, wal))| {
-                let tick = executor.peek_event_tick()?;
+                let tick = executor.peek_tick()?;
                 Some((id, executor, state, wal, tick))
             })
             .min_by_key(|(_, _, _, _, tick)| *tick);
-        let maybe_min_event_tick = min_event
-            .as_ref()
-            .map(|(_, _, _, _, min_event_tick)| min_event_tick);
-        let maybe_min_scheduled_tick = self
-            .scheduled_messages
-            .peek()
-            .map(|Reverse((min_scheduled_tick, _))| min_scheduled_tick);
+        let maybe_min_event_tick = min_event.as_ref().map(|(id, _, _, _, min_event_tick)| {
+            (*min_event_tick, SwarmEventType::ExecutorEvent(**id))
+        });
+        let maybe_min_scheduled_tick =
+            self.scheduled_messages
+                .peek()
+                .map(|Reverse((min_scheduled_tick, _))| {
+                    (*min_scheduled_tick, SwarmEventType::ScheduledMessage)
+                });
         maybe_min_event_tick
             .into_iter()
             .chain(maybe_min_scheduled_tick)
-            .min()
-            .copied()
+            .min_by_key(|(tick, _)| *tick)
+    }
+
+    pub fn peek_tick(&self) -> Option<Duration> {
+        self.peek_event().map(|(tick, _)| tick)
     }
 
     pub fn step(&mut self) -> Option<(Duration, PeerId, S::Event)> {
-        loop {
-            let min_event = self
-                .states
-                .iter_mut()
-                .filter_map(|(id, (executor, state, wal))| {
-                    let tick = executor.peek_event_tick()?;
-                    Some((id, executor, state, wal, tick))
-                })
-                .min_by_key(|(_, _, _, _, tick)| *tick);
-            let maybe_min_event_tick = min_event
-                .as_ref()
-                .map(|(_, _, _, _, min_event_tick)| min_event_tick);
-            let maybe_min_scheduled_tick = self
-                .scheduled_messages
-                .peek()
-                .map(|Reverse((min_scheduled_tick, _))| min_scheduled_tick);
-            let poll_event = match (maybe_min_event_tick, maybe_min_scheduled_tick) {
-                (None, None) => break,
-                (None, Some(_)) => false,
-                (Some(_), None) => true,
-                (Some(min_event_tick), Some(min_scheduled_tick)) => {
-                    min_event_tick <= min_scheduled_tick
-                }
-            };
+        self.step_until(Duration::MAX)
+    }
 
-            if poll_event {
-                let (id, executor, state, wal, tick) =
-                    min_event.expect("logic error, must be nonempty");
-                let id = *id;
-                let executor_event = futures::executor::block_on(executor.next()).unwrap();
-                match executor_event {
-                    MockExecutorEvent::Event(event) => {
-                        let timed_event = TimedEvent {
-                            timestamp: tick,
-                            event: event.clone(),
-                        };
-                        wal.push(&timed_event).unwrap(); // FIXME: propagate the error
-                        let node_span = info_span!("node", id = ?id);
-                        let _guard = node_span.enter();
-                        let commands = state.update(event.clone());
+    pub fn step_until(&mut self, until: Duration) -> Option<(Duration, PeerId, S::Event)> {
+        while let Some((tick, event_type)) = self.peek_event() {
+            if tick > until {
+                break;
+            }
 
-                        executor.exec(commands);
+            match event_type {
+                SwarmEventType::ExecutorEvent(id) => {
+                    let (executor, state, wal) = self
+                        .states
+                        .get_mut(&id)
+                        .expect("logic error, should be nonempty");
+                    let executor_event = executor.step_until(tick);
+                    match executor_event {
+                        None => continue,
+                        Some(MockExecutorEvent::Event(event)) => {
+                            let timed_event = TimedEvent {
+                                timestamp: tick,
+                                event: event.clone(),
+                            };
+                            wal.push(&timed_event).unwrap(); // FIXME: propagate the error
+                            let node_span = info_span!("node", id = ?id);
+                            let _guard = node_span.enter();
+                            let commands = state.update(event.clone());
 
-                        return Some((tick, id, event));
-                    }
-                    MockExecutorEvent::Send(to, serialized) => {
-                        let lm = LinkMessage {
-                            from: id,
-                            to,
-                            message: serialized,
+                            executor.exec(commands);
 
-                            from_tick: tick,
-                        };
-                        let transformed = self.pipeline.process(lm);
-                        for (delay, msg) in transformed {
-                            self.scheduled_messages.push(Reverse((tick + delay, msg)));
+                            return Some((tick, id, event));
+                        }
+                        Some(MockExecutorEvent::Send(to, serialized)) => {
+                            let lm = LinkMessage {
+                                from: id,
+                                to,
+                                message: serialized,
+
+                                from_tick: tick,
+                            };
+                            let transformed = self.pipeline.process(lm);
+                            for (delay, msg) in transformed {
+                                self.scheduled_messages.push(Reverse((tick + delay, msg)));
+                            }
                         }
                     }
                 }
-            } else {
-                let Reverse((scheduled_tick, message)) = self
-                    .scheduled_messages
-                    .pop()
-                    .expect("logic error, must be nonempty");
-                let (executor, _, _) = self.states.get_mut(&message.to).unwrap();
-                executor.send_message(scheduled_tick, message.from, message.message);
+                SwarmEventType::ScheduledMessage => {
+                    let Reverse((scheduled_tick, message)) = self
+                        .scheduled_messages
+                        .pop()
+                        .expect("logic error, should be nonempty");
+                    assert_eq!(tick, scheduled_tick);
+                    let (executor, _, _) = self.states.get_mut(&message.to).unwrap();
+                    executor.send_message(scheduled_tick, message.from, message.message);
+                }
             }
         }
 


### PR DESCRIPTION
Our MockExecutor event polling was convoluted - this commit simplifies
it. At a high-level, we replace the Stream implementation of
MockExecutor with a step_until function. This allows for more granular
polling of MockExecutor without an unintuitive overloading of
Stream::poll_next.