### PR TITLE
Refactor Partition and Replay transformers

### DIFF
--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -13,7 +13,7 @@ use monad_executor::{
     xfmr_pipe, PeerId,
 };
 use monad_state::{MonadMessage, MonadState};
-use monad_testutil::swarm::{get_configs, run_nodes, run_nodes_until_step};
+use monad_testutil::swarm::{get_configs, run_nodes, run_nodes_until};
 use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
 use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
 
@@ -67,7 +67,7 @@ fn delayed_message_test(seed: u64) {
 
     println!("delayed node ID: {:?}", first_node);
 
-    run_nodes_until_step::<
+    run_nodes_until::<
         MonadState<
             ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
             NopSignature,
@@ -95,11 +95,11 @@ fn delayed_message_test(seed: u64) {
             Transformer::Latency(LatencyTransformer(Duration::from_millis(1))),
             Transformer::Partition(PartitionTransformer(filter_peers)),
             Transformer::Replay(ReplayTransformer::new(
-                200,
+                Duration::from_secs(1),
                 TransformerReplayOrder::Random(seed),
             ))
         ),
-        400,
+        Duration::from_secs(2),
     );
 }
 

--- a/monad-state/tests/order.rs
+++ b/monad-state/tests/order.rs
@@ -13,7 +13,7 @@ use monad_executor::{
     xfmr_pipe, PeerId,
 };
 use monad_state::{MonadMessage, MonadState};
-use monad_testutil::swarm::{get_configs, run_nodes_until_step};
+use monad_testutil::swarm::{get_configs, run_nodes_until};
 use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
 use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -62,7 +62,7 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
 
     println!("delayed node ID: {:?}", first_node);
 
-    run_nodes_until_step::<
+    run_nodes_until::<
         MonadState<
             ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator>,
             NopSignature,
@@ -89,8 +89,11 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
         xfmr_pipe!(
             Transformer::Latency(LatencyTransformer(Duration::from_millis(1))),
             Transformer::Partition(PartitionTransformer(filter_peers)),
-            Transformer::Replay(ReplayTransformer::new(50, direction))
+            Transformer::Replay(ReplayTransformer::new(
+                Duration::from_millis(500),
+                direction
+            ))
         ),
-        400,
+        Duration::from_secs(1),
     );
 }

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -156,14 +156,14 @@ pub fn run_nodes<S, ST, SCT, RS, RSC, LGR, P, TVT, ME>(
     );
 }
 
-pub fn run_nodes_until_step<S, ST, SCT, RS, RSC, LGR, P, TVT, ME>(
+pub fn run_nodes_until<S, ST, SCT, RS, RSC, LGR, P, TVT, ME>(
     pubkeys: Vec<PubKey>,
     state_configs: Vec<MonadConfig<SCT, TVT>>,
     router_scheduler_config: RSC,
     logger_config: LGR::Config,
 
     pipeline: P,
-    step: i32,
+    until: Duration,
 ) where
     S: State<Config = MonadConfig<SCT, TVT>>,
     ST: MessageSignature,
@@ -207,13 +207,7 @@ pub fn run_nodes_until_step<S, ST, SCT, RS, RSC, LGR, P, TVT, ME>(
         pipeline,
     );
 
-    let mut cnt = 0;
-    while let Some((_duration, _id, _event)) = nodes.step() {
-        cnt += 1;
-        if cnt > step {
-            break;
-        }
-    }
+    while nodes.step_until(until).is_some() {}
 
     node_ledger_verification(
         &nodes


### PR DESCRIPTION
The Partition and Replay transformers worked by counting the # of messages that passed through, and then branching depending on that number. This commit changes their behavior to be more declarative - they operate on absolute ticks now, which is less brittle.