### PR TITLE
Allow FetchTx to determine the max number of txns in proposal

### DIFF
--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -25,7 +25,10 @@ pub enum ConsensusCommand<ST, SCT: SignatureCollection> {
         on_timeout: PacemakerTimerExpire,
     },
     ScheduleReset,
-    FetchTxs(Box<dyn (FnOnce(TransactionList) -> FetchedTxs<ST, SCT>) + Send + Sync>),
+    FetchTxs(
+        usize,
+        Box<dyn (FnOnce(TransactionList) -> FetchedTxs<ST, SCT>) + Send + Sync>,
+    ),
     FetchTxsReset,
     FetchFullTxs(
         TransactionList,

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -447,16 +447,18 @@ where
         let high_qc = self.high_qc.clone();
         let seq_num = self.seq_num;
 
-        vec![ConsensusCommand::FetchTxs(Box::new(move |txns| {
-            FetchedTxs {
+        vec![ConsensusCommand::FetchTxs(
+            // FIXME get from config
+            10000,
+            Box::new(move |txns| FetchedTxs {
                 node_id,
                 round,
                 seq_num,
                 high_qc,
                 last_round_tc,
                 txns,
-            }
-        }))]
+            }),
+        )]
     }
 }
 

--- a/monad-executor/src/executor/mempool.rs
+++ b/monad-executor/src/executor/mempool.rs
@@ -32,7 +32,7 @@ enum ControllerTaskError {
 
 #[derive(Debug)]
 enum ControllerTaskCommand {
-    FetchTxs,
+    FetchTxs(usize),
     FetchFullTxs(TransactionList),
 }
 
@@ -86,8 +86,8 @@ impl<E> MonadMempool<E> {
                     };
 
                     match task {
-                        ControllerTaskCommand::FetchTxs => {
-                            let proposal = controller.create_proposal().await;
+                        ControllerTaskCommand::FetchTxs(num_max_txs) => {
+                            let proposal = controller.create_proposal(num_max_txs).await;
 
                             tx.send(ControllerTaskResult::FetchTxs(TransactionList(proposal)))
                                 .await?;
@@ -123,9 +123,9 @@ impl<E> Executor for MonadMempool<E> {
 
         for command in commands {
             match command {
-                MempoolCommand::FetchTxs(cb) => {
+                MempoolCommand::FetchTxs(num_max_txs, cb) => {
                     self.fetch_txs_state = Some(cb);
-                    task_command = Some(ControllerTaskCommand::FetchTxs);
+                    task_command = Some(ControllerTaskCommand::FetchTxs(num_max_txs));
                 }
                 MempoolCommand::FetchReset => {
                     self.fetch_txs_state = None;

--- a/monad-executor/src/executor/mock.rs
+++ b/monad-executor/src/executor/mock.rs
@@ -451,7 +451,7 @@ impl<E> Executor for MockMempool<E> {
 
         for command in commands {
             match command {
-                MempoolCommand::FetchTxs(cb) => {
+                MempoolCommand::FetchTxs(max_num_txs, cb) => {
                     self.fetch_txs_state = Some(cb);
                     wake = true;
                 }
@@ -829,7 +829,7 @@ mod tests {
     #[test]
     fn test_fetch() {
         let mut mempool = MockMempool::<()>::default();
-        mempool.exec(vec![MempoolCommand::FetchTxs(Box::new(|_| {}))]);
+        mempool.exec(vec![MempoolCommand::FetchTxs(0, Box::new(|_| {}))]);
         assert!(futures::executor::block_on(mempool.next()).is_some());
         assert!(!mempool.ready());
     }
@@ -837,8 +837,8 @@ mod tests {
     #[test]
     fn test_double_fetch() {
         let mut mempool = MockMempool::<()>::default();
-        mempool.exec(vec![MempoolCommand::FetchTxs(Box::new(|_| {}))]);
-        mempool.exec(vec![MempoolCommand::FetchTxs(Box::new(|_| {}))]);
+        mempool.exec(vec![MempoolCommand::FetchTxs(0, Box::new(|_| {}))]);
+        mempool.exec(vec![MempoolCommand::FetchTxs(0, Box::new(|_| {}))]);
         assert!(futures::executor::block_on(mempool.next()).is_some());
         assert!(!mempool.ready());
     }
@@ -846,7 +846,7 @@ mod tests {
     #[test]
     fn test_reset() {
         let mut mempool = MockMempool::<()>::default();
-        mempool.exec(vec![MempoolCommand::FetchTxs(Box::new(|_| {}))]);
+        mempool.exec(vec![MempoolCommand::FetchTxs(0, Box::new(|_| {}))]);
         mempool.exec(vec![MempoolCommand::FetchReset]);
         assert!(!mempool.ready());
     }
@@ -855,8 +855,8 @@ mod tests {
     fn test_inline_double_fetch() {
         let mut mempool = MockMempool::<()>::default();
         mempool.exec(vec![
-            MempoolCommand::FetchTxs(Box::new(|_| {})),
-            MempoolCommand::FetchTxs(Box::new(|_| {})),
+            MempoolCommand::FetchTxs(0, Box::new(|_| {})),
+            MempoolCommand::FetchTxs(0, Box::new(|_| {})),
         ]);
         assert!(futures::executor::block_on(mempool.next()).is_some());
         assert!(!mempool.ready());
@@ -866,7 +866,7 @@ mod tests {
     fn test_inline_reset() {
         let mut mempool = MockMempool::<()>::default();
         mempool.exec(vec![
-            MempoolCommand::FetchTxs(Box::new(|_| {})),
+            MempoolCommand::FetchTxs(0, Box::new(|_| {})),
             MempoolCommand::FetchReset,
         ]);
         assert!(!mempool.ready());
@@ -877,7 +877,7 @@ mod tests {
         let mut mempool = MockMempool::<()>::default();
         mempool.exec(vec![
             MempoolCommand::FetchReset,
-            MempoolCommand::FetchTxs(Box::new(|_| {})),
+            MempoolCommand::FetchTxs(0, Box::new(|_| {})),
         ]);
         assert!(futures::executor::block_on(mempool.next()).is_some());
         assert!(!mempool.ready());
@@ -886,7 +886,7 @@ mod tests {
     #[test]
     fn test_noop_exec() {
         let mut mempool = MockMempool::<()>::default();
-        mempool.exec(vec![MempoolCommand::FetchTxs(Box::new(|_| {}))]);
+        mempool.exec(vec![MempoolCommand::FetchTxs(0, Box::new(|_| {}))]);
         mempool.exec(Vec::new());
         assert!(futures::executor::block_on(mempool.next()).is_some());
         assert!(!mempool.ready());

--- a/monad-executor/src/state.rs
+++ b/monad-executor/src/state.rs
@@ -47,7 +47,7 @@ pub enum MempoolCommand<E> {
     /// FetchReset should ALMOST ALWAYS be emitted by the state machine after handling E
     /// This is to prevent E from firing twice on replay
     // TODO create test to demonstrate faulty behavior if written improperly
-    FetchTxs(Box<dyn (FnOnce(TransactionList) -> E) + Send + Sync>),
+    FetchTxs(usize, Box<dyn (FnOnce(TransactionList) -> E) + Send + Sync>),
     FetchReset,
     FetchFullTxs(
         TransactionList,

--- a/monad-mempool-controller/src/lib.rs
+++ b/monad-mempool-controller/src/lib.rs
@@ -319,8 +319,8 @@ impl Controller {
         Ok(())
     }
 
-    pub async fn create_proposal(&self) -> Vec<u8> {
-        let proposal = self.pool.lock().await.create_proposal();
+    pub async fn create_proposal(&self, tx_limit: usize) -> Vec<u8> {
+        let proposal = self.pool.lock().await.create_proposal(tx_limit);
 
         encode_list::<Vec<u8>, _>(
             proposal
@@ -449,10 +449,10 @@ mod test {
         // Allow time for controllers to receive the messages
         tokio::time::sleep(Duration::from_secs(2)).await;
 
-        let sender_proposal = sender_controller.create_proposal().await;
+        let sender_proposal = sender_controller.create_proposal(NUM_TX.into()).await;
 
         for (controller, _) in &controllers {
-            let proposal = controller.create_proposal().await;
+            let proposal = controller.create_proposal(NUM_TX.into()).await;
             assert_eq!(sender_proposal, proposal);
         }
     }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -493,11 +493,14 @@ where
                         ConsensusCommand::ScheduleReset => {
                             cmds.push(Command::TimerCommand(TimerCommand::ScheduleReset))
                         }
-                        ConsensusCommand::FetchTxs(cb) => cmds.push(Command::MempoolCommand(
-                            MempoolCommand::FetchTxs(Box::new(|txs| {
-                                Self::Event::ConsensusEvent(ConsensusEvent::FetchedTxs(cb(txs)))
-                            })),
-                        )),
+                        ConsensusCommand::FetchTxs(max_txns, cb) => {
+                            cmds.push(Command::MempoolCommand(MempoolCommand::FetchTxs(
+                                max_txns,
+                                Box::new(|txs| {
+                                    Self::Event::ConsensusEvent(ConsensusEvent::FetchedTxs(cb(txs)))
+                                }),
+                            )))
+                        }
                         ConsensusCommand::FetchTxsReset => {
                             cmds.push(Command::MempoolCommand(MempoolCommand::FetchReset))
                         }


### PR DESCRIPTION
Removes the parameter on the mempool side so the only limit comes from consensus side via the fetch command.

The hardcoded 10000 tx limit will be put into config in future PR