### PR TITLE
Remove `proto` feature

### DIFF
--- a/monad-consensus-types/Cargo.toml
+++ b/monad-consensus-types/Cargo.toml
@@ -8,22 +8,14 @@ edition = "2021"
 [dependencies]
 bitvec = { workspace = true, features = ["serde"] }
 log = { workspace = true }
-prost = { workspace = true, optional = true }
+prost = { workspace = true }
 serde_cbor = { workspace = true }
 sha2 = { workspace = true }
 zerocopy = { workspace = true }
 
 monad-crypto = { path = "../monad-crypto" }
-monad-proto = { path = "../monad-proto", optional = true }
+monad-proto = { path = "../monad-proto" }
 monad-types = { path = "../monad-types" }
-
-[features]
-proto = [
-    "dep:monad-proto",
-    "dep:prost",
-    "monad-crypto/proto",
-    "monad-types/proto",
-]
 
 [dev-dependencies]
 monad-testutil = { path = "../monad-testutil" }

--- a/monad-consensus-types/src/lib.rs
+++ b/monad-consensus-types/src/lib.rs
@@ -1,9 +1,7 @@
-#[cfg(feature = "proto")]
-pub mod convert;
-
 pub mod block;
 pub mod bls;
 pub mod certificate_signature;
+pub mod convert;
 pub mod ledger;
 pub mod message_signature;
 pub mod multi_sig;

--- a/monad-consensus/Cargo.toml
+++ b/monad-consensus/Cargo.toml
@@ -10,12 +10,12 @@ bench = false
 
 [dependencies]
 monad-crypto = { path = "../monad-crypto" }
-monad-proto = { path = "../monad-proto", optional = true }
+monad-proto = { path = "../monad-proto" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-types = { path = "../monad-types" }
 monad-validator = { path = "../monad-validator" }
 
-prost = { workspace = true, optional = true }
+prost = { workspace = true }
 zerocopy = { workspace = true }
 
 [dev-dependencies]
@@ -24,6 +24,3 @@ monad-testutil = { path = "../monad-testutil" }
 sha2 = { workspace = true }
 test-case = { workspace = true }
 tracing = { workspace = true }
-
-[features]
-proto = ["dep:monad-proto", "dep:prost", "monad-crypto/proto", "monad-consensus-types/proto", "monad-types/proto"]

--- a/monad-consensus/src/lib.rs
+++ b/monad-consensus/src/lib.rs
@@ -1,6 +1,4 @@
-#[cfg(feature = "proto")]
 pub mod convert;
-
 pub mod messages;
 pub mod pacemaker;
 pub mod validation;

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -9,18 +9,15 @@ use monad_consensus_types::{
     validation::{Error, Hashable, Hasher},
     voting::ValidatorMapping,
 };
-#[cfg(feature = "proto")]
 use monad_crypto::secp256k1::{KeyPair, PubKey};
-#[cfg(feature = "proto")]
 use monad_proto::proto::message::{
     proto_unverified_consensus_message, ProtoUnverifiedConsensusMessage,
 };
 use monad_types::{Hash, NodeId, Stake};
 use monad_validator::validator_set::ValidatorSetType;
 
-#[cfg(feature = "proto")]
-use crate::convert::message::UnverifiedConsensusMessage;
 use crate::{
+    convert::message::UnverifiedConsensusMessage,
     messages::{
         consensus_message::ConsensusMessage,
         message::{
@@ -451,7 +448,6 @@ fn get_pubkey(msg: &[u8], sig: &impl MessageSignature) -> Result<PubKey, Error> 
     sig.recover_pubkey(msg).map_err(|_| Error::InvalidSignature)
 }
 
-#[cfg(feature = "proto")]
 impl<MS: MessageSignature, SCT: SignatureCollection> From<&UnverifiedConsensusMessage<MS, SCT>>
     for ProtoUnverifiedConsensusMessage
 {

--- a/monad-consensus/tests/protobuf.rs
+++ b/monad-consensus/tests/protobuf.rs
@@ -1,287 +1,279 @@
-#[cfg(all(test, feature = "proto"))]
-mod test {
-    use monad_consensus::{
-        convert::interface::{
-            deserialize_unverified_consensus_message, serialize_verified_consensus_message,
-        },
-        messages::{
-            consensus_message::ConsensusMessage,
-            message::{ProposalMessage, TimeoutMessage, VoteMessage},
-        },
-        validation::signing::Verified,
-    };
-    use monad_consensus_types::{
-        certificate_signature::CertificateSignature,
-        ledger::LedgerCommitInfo,
-        multi_sig::MultiSig,
-        payload::{ExecutionArtifacts, TransactionList},
-        quorum_certificate::{QcInfo, QuorumCertificate},
-        signature_collection::SignatureCollection,
-        timeout::{HighQcRound, HighQcRoundSigTuple, TimeoutCertificate, TimeoutInfo},
-        validation::{Hasher, Sha256Hash},
-        voting::{Vote, VoteInfo},
-    };
-    use monad_testutil::{block::setup_block, validators::create_keys_w_validators};
-    use monad_types::{BlockId, Hash, NodeId, Round};
+use monad_consensus::{
+    convert::interface::{
+        deserialize_unverified_consensus_message, serialize_verified_consensus_message,
+    },
+    messages::{
+        consensus_message::ConsensusMessage,
+        message::{ProposalMessage, TimeoutMessage, VoteMessage},
+    },
+    validation::signing::Verified,
+};
+use monad_consensus_types::{
+    certificate_signature::CertificateSignature,
+    ledger::LedgerCommitInfo,
+    multi_sig::MultiSig,
+    payload::{ExecutionArtifacts, TransactionList},
+    quorum_certificate::{QcInfo, QuorumCertificate},
+    signature_collection::SignatureCollection,
+    timeout::{HighQcRound, HighQcRoundSigTuple, TimeoutCertificate, TimeoutInfo},
+    validation::{Hasher, Sha256Hash},
+    voting::{Vote, VoteInfo},
+};
+use monad_testutil::{block::setup_block, validators::create_keys_w_validators};
+use monad_types::{BlockId, Hash, NodeId, Round};
 
-    macro_rules! test_all_combination {
-        ($test_name:ident, $test_code:expr) => {
-            mod $test_name {
-                use monad_consensus_types::{
-                    bls::BlsSignatureCollection, message_signature::MessageSignature,
-                };
-                use monad_crypto::{secp256k1::SecpSignature, NopSignature};
-                use test_case::test_case;
+macro_rules! test_all_combination {
+    ($test_name:ident, $test_code:expr) => {
+        mod $test_name {
+            use monad_consensus_types::{
+                bls::BlsSignatureCollection, message_signature::MessageSignature,
+            };
+            use monad_crypto::{secp256k1::SecpSignature, NopSignature};
+            use test_case::test_case;
 
-                use super::*;
+            use super::*;
 
-                fn invoke<ST: MessageSignature, SCT: SignatureCollection>(num_keys: u32) {
-                    // to supress linter warning about unused ST
-                    let _: Option<ST> = None;
-                    $test_code(num_keys)
-                }
-
-                #[test_case(1; "1 sig")]
-                #[test_case(5; "5 sigs")]
-                #[test_case(100; "100 sigs")]
-                fn secp_multi_sig_secp(num_keys: u32) {
-                    invoke::<SecpSignature, MultiSig<SecpSignature>>(num_keys);
-                }
-
-                #[test_case(1; "1 sig")]
-                #[test_case(5; "5 sigs")]
-                #[test_case(100; "100 sigs")]
-                fn secp_multi_sig_nop(num_keys: u32) {
-                    invoke::<SecpSignature, MultiSig<NopSignature>>(num_keys);
-                }
-
-                #[test_case(1; "1 sig")]
-                #[test_case(5; "5 sigs")]
-                #[test_case(100; "100 sigs")]
-                fn secp_bls(num_keys: u32) {
-                    invoke::<SecpSignature, BlsSignatureCollection>(num_keys);
-                }
-
-                #[test_case(1; "1 sig")]
-                #[test_case(5; "5 sigs")]
-                #[test_case(100; "100 sigs")]
-                fn nop_multi_sig_secp(num_keys: u32) {
-                    invoke::<NopSignature, MultiSig<SecpSignature>>(num_keys);
-                }
-
-                #[test_case(1; "1 sig")]
-                #[test_case(5; "5 sigs")]
-                #[test_case(100; "100 sigs")]
-                fn nop_multi_sig_nop(num_keys: u32) {
-                    invoke::<NopSignature, MultiSig<NopSignature>>(num_keys);
-                }
-
-                #[test_case(1; "1 sig")]
-                #[test_case(5; "5 sigs")]
-                #[test_case(100; "100 sigs")]
-                fn nop_bls(num_keys: u32) {
-                    invoke::<NopSignature, BlsSignatureCollection>(num_keys);
-                }
+            fn invoke<ST: MessageSignature, SCT: SignatureCollection>(num_keys: u32) {
+                // to supress linter warning about unused ST
+                let _: Option<ST> = None;
+                $test_code(num_keys)
             }
-        };
+
+            #[test_case(1; "1 sig")]
+            #[test_case(5; "5 sigs")]
+            #[test_case(100; "100 sigs")]
+            fn secp_multi_sig_secp(num_keys: u32) {
+                invoke::<SecpSignature, MultiSig<SecpSignature>>(num_keys);
+            }
+
+            #[test_case(1; "1 sig")]
+            #[test_case(5; "5 sigs")]
+            #[test_case(100; "100 sigs")]
+            fn secp_multi_sig_nop(num_keys: u32) {
+                invoke::<SecpSignature, MultiSig<NopSignature>>(num_keys);
+            }
+
+            #[test_case(1; "1 sig")]
+            #[test_case(5; "5 sigs")]
+            #[test_case(100; "100 sigs")]
+            fn secp_bls(num_keys: u32) {
+                invoke::<SecpSignature, BlsSignatureCollection>(num_keys);
+            }
+
+            #[test_case(1; "1 sig")]
+            #[test_case(5; "5 sigs")]
+            #[test_case(100; "100 sigs")]
+            fn nop_multi_sig_secp(num_keys: u32) {
+                invoke::<NopSignature, MultiSig<SecpSignature>>(num_keys);
+            }
+
+            #[test_case(1; "1 sig")]
+            #[test_case(5; "5 sigs")]
+            #[test_case(100; "100 sigs")]
+            fn nop_multi_sig_nop(num_keys: u32) {
+                invoke::<NopSignature, MultiSig<NopSignature>>(num_keys);
+            }
+
+            #[test_case(1; "1 sig")]
+            #[test_case(5; "5 sigs")]
+            #[test_case(100; "100 sigs")]
+            fn nop_bls(num_keys: u32) {
+                invoke::<NopSignature, BlsSignatureCollection>(num_keys);
+            }
+        }
+    };
+}
+
+// TODO: revisit to cleanup
+test_all_combination!(test_vote_message, |num_keys| {
+    let (keypairs, certkeys, validators, validator_mapping) =
+        create_keys_w_validators::<SCT>(num_keys);
+    let vi = VoteInfo {
+        id: BlockId(Hash([42_u8; 32])),
+        round: Round(1),
+        parent_id: BlockId(Hash([43_u8; 32])),
+        parent_round: Round(2),
+    };
+    let lci = LedgerCommitInfo {
+        commit_state_hash: None,
+        vote_info_hash: Hash([42_u8; 32]),
+    };
+
+    let vote = Vote {
+        vote_info: vi,
+        ledger_commit_info: lci,
+    };
+
+    let votemsg: ConsensusMessage<ST, SCT> =
+        ConsensusMessage::Vote(VoteMessage::new::<Sha256Hash>(vote, &certkeys[0]));
+
+    let author_keypair = &keypairs[0];
+
+    let verified_votemsg = Verified::new::<Sha256Hash>(votemsg, author_keypair);
+
+    let rx_buf = serialize_verified_consensus_message(&verified_votemsg);
+    let rx_msg = deserialize_unverified_consensus_message(rx_buf.as_ref()).unwrap();
+
+    let verified_rx_vote = rx_msg
+        .verify::<Sha256Hash, _>(&validators, &validator_mapping, &author_keypair.pubkey())
+        .unwrap();
+
+    assert_eq!(verified_votemsg, verified_rx_vote);
+});
+
+test_all_combination!(test_timeout_message, |num_keys| {
+    let (keypairs, cert_keys, validators, validator_mapping) =
+        create_keys_w_validators::<SCT>(num_keys);
+
+    let author_keypair = &keypairs[0];
+
+    let vi = VoteInfo {
+        id: BlockId(Hash([42_u8; 32])),
+        round: Round(1),
+        parent_id: BlockId(Hash([43_u8; 32])),
+        parent_round: Round(2),
+    };
+    let lci = LedgerCommitInfo::new::<Sha256Hash>(None, &vi);
+
+    let qcinfo = QcInfo {
+        vote: vi,
+        ledger_commit: lci,
+    };
+
+    let qcinfo_hash = Sha256Hash::hash_object(&qcinfo.ledger_commit);
+
+    let mut sigs = Vec::new();
+
+    for i in 0..cert_keys.len() {
+        let node_id = NodeId(keypairs[i].pubkey());
+        let sig =
+            <SCT::SignatureType as CertificateSignature>::sign(qcinfo_hash.as_ref(), &cert_keys[i]);
+        sigs.push((node_id, sig));
     }
 
-    // TODO: revisit to cleanup
-    test_all_combination!(test_vote_message, |num_keys| {
-        let (keypairs, certkeys, validators, validator_mapping) =
-            create_keys_w_validators::<SCT>(num_keys);
-        let vi = VoteInfo {
-            id: BlockId(Hash([42_u8; 32])),
-            round: Round(1),
-            parent_id: BlockId(Hash([43_u8; 32])),
-            parent_round: Round(2),
-        };
-        let lci = LedgerCommitInfo {
-            commit_state_hash: None,
-            vote_info_hash: Hash([42_u8; 32]),
-        };
+    let sigcol = SCT::new(sigs, &validator_mapping, qcinfo_hash.as_ref()).unwrap();
 
-        let vote = Vote {
-            vote_info: vi,
-            ledger_commit_info: lci,
-        };
+    let qc = QuorumCertificate::new::<Sha256Hash>(qcinfo, sigcol);
 
-        let votemsg: ConsensusMessage<ST, SCT> =
-            ConsensusMessage::Vote(VoteMessage::new::<Sha256Hash>(vote, &certkeys[0]));
+    let tmo_info = TimeoutInfo {
+        round: Round(3),
+        high_qc: qc,
+    };
 
-        let author_keypair = &keypairs[0];
+    let high_qc_round = HighQcRound { qc_round: Round(1) };
+    // FIXME: is there a cleaner way to do the high qc hash?
+    let tc_round = Round(2);
+    let mut hasher = Sha256Hash::new();
+    hasher.update(tc_round);
+    hasher.update(high_qc_round.qc_round);
+    let high_qc_round_hash = hasher.hash();
 
-        let verified_votemsg = Verified::new::<Sha256Hash>(votemsg, author_keypair);
-
-        let rx_buf = serialize_verified_consensus_message(&verified_votemsg);
-        let rx_msg = deserialize_unverified_consensus_message(rx_buf.as_ref()).unwrap();
-
-        let verified_rx_vote = rx_msg
-            .verify::<Sha256Hash, _>(&validators, &validator_mapping, &author_keypair.pubkey())
-            .unwrap();
-
-        assert_eq!(verified_votemsg, verified_rx_vote);
-    });
-
-    test_all_combination!(test_timeout_message, |num_keys| {
-        let (keypairs, cert_keys, validators, validator_mapping) =
-            create_keys_w_validators::<SCT>(num_keys);
-
-        let author_keypair = &keypairs[0];
-
-        let vi = VoteInfo {
-            id: BlockId(Hash([42_u8; 32])),
-            round: Round(1),
-            parent_id: BlockId(Hash([43_u8; 32])),
-            parent_round: Round(2),
-        };
-        let lci = LedgerCommitInfo::new::<Sha256Hash>(None, &vi);
-
-        let qcinfo = QcInfo {
-            vote: vi,
-            ledger_commit: lci,
-        };
-
-        let qcinfo_hash = Sha256Hash::hash_object(&qcinfo.ledger_commit);
-
-        let mut sigs = Vec::new();
-
-        for i in 0..cert_keys.len() {
-            let node_id = NodeId(keypairs[i].pubkey());
-            let sig = <SCT::SignatureType as CertificateSignature>::sign(
-                qcinfo_hash.as_ref(),
-                &cert_keys[i],
-            );
-            sigs.push((node_id, sig));
-        }
-
-        let sigcol = SCT::new(sigs, &validator_mapping, qcinfo_hash.as_ref()).unwrap();
-
-        let qc = QuorumCertificate::new::<Sha256Hash>(qcinfo, sigcol);
-
-        let tmo_info = TimeoutInfo {
-            round: Round(3),
-            high_qc: qc,
-        };
-
-        let high_qc_round = HighQcRound { qc_round: Round(1) };
-        // FIXME: is there a cleaner way to do the high qc hash?
-        let tc_round = Round(2);
-        let mut hasher = Sha256Hash::new();
-        hasher.update(tc_round);
-        hasher.update(high_qc_round.qc_round);
-        let high_qc_round_hash = hasher.hash();
-
-        let mut high_qc_rounds = Vec::new();
-        for keypair in keypairs.iter() {
-            high_qc_rounds.push(HighQcRoundSigTuple {
-                high_qc_round,
-                author_signature: keypair.sign(high_qc_round_hash.as_ref()),
-            });
-        }
-
-        let tc = TimeoutCertificate {
-            round: tc_round,
-            high_qc_rounds,
-        };
-
-        let tmo_message = ConsensusMessage::Timeout(TimeoutMessage {
-            tminfo: tmo_info,
-            last_round_tc: Some(tc),
+    let mut high_qc_rounds = Vec::new();
+    for keypair in keypairs.iter() {
+        high_qc_rounds.push(HighQcRoundSigTuple {
+            high_qc_round,
+            author_signature: keypair.sign(high_qc_round_hash.as_ref()),
         });
-        let verified_tmo_message = Verified::new::<Sha256Hash>(tmo_message, author_keypair);
+    }
 
-        let rx_buf = serialize_verified_consensus_message(&verified_tmo_message);
-        let rx_msg = deserialize_unverified_consensus_message(rx_buf.as_ref()).unwrap();
+    let tc = TimeoutCertificate {
+        round: tc_round,
+        high_qc_rounds,
+    };
 
-        let verified_rx_tmo_messaage = rx_msg.verify::<Sha256Hash, _>(
-            &validators,
-            &validator_mapping,
-            &author_keypair.pubkey(),
-        );
-
-        assert_eq!(verified_tmo_message, verified_rx_tmo_messaage.unwrap());
+    let tmo_message = ConsensusMessage::Timeout(TimeoutMessage {
+        tminfo: tmo_info,
+        last_round_tc: Some(tc),
     });
+    let verified_tmo_message = Verified::new::<Sha256Hash>(tmo_message, author_keypair);
 
-    test_all_combination!(test_proposal_qc, |num_keys| {
-        let (keypairs, cert_keys, validators, validator_map) =
-            create_keys_w_validators::<SCT>(num_keys);
+    let rx_buf = serialize_verified_consensus_message(&verified_tmo_message);
+    let rx_msg = deserialize_unverified_consensus_message(rx_buf.as_ref()).unwrap();
 
-        let author_keypair = &keypairs[0];
-        let blk = setup_block(
-            NodeId(author_keypair.pubkey()),
-            Round(233),
-            Round(232),
-            TransactionList(vec![1, 2, 3, 4]),
-            ExecutionArtifacts::zero(),
-            &cert_keys,
-            &validator_map,
-        );
-        let proposal: ConsensusMessage<ST, SCT> = ConsensusMessage::Proposal(ProposalMessage {
-            block: blk,
-            last_round_tc: None,
+    let verified_rx_tmo_messaage =
+        rx_msg.verify::<Sha256Hash, _>(&validators, &validator_mapping, &author_keypair.pubkey());
+
+    assert_eq!(verified_tmo_message, verified_rx_tmo_messaage.unwrap());
+});
+
+test_all_combination!(test_proposal_qc, |num_keys| {
+    let (keypairs, cert_keys, validators, validator_map) =
+        create_keys_w_validators::<SCT>(num_keys);
+
+    let author_keypair = &keypairs[0];
+    let blk = setup_block(
+        NodeId(author_keypair.pubkey()),
+        Round(233),
+        Round(232),
+        TransactionList(vec![1, 2, 3, 4]),
+        ExecutionArtifacts::zero(),
+        &cert_keys,
+        &validator_map,
+    );
+    let proposal: ConsensusMessage<ST, SCT> = ConsensusMessage::Proposal(ProposalMessage {
+        block: blk,
+        last_round_tc: None,
+    });
+    let verified_msg = Verified::new::<Sha256Hash>(proposal, author_keypair);
+
+    let rx_buf = serialize_verified_consensus_message(&verified_msg);
+    let rx_msg = deserialize_unverified_consensus_message(&rx_buf).unwrap();
+
+    let verified_rx_msg =
+        rx_msg.verify::<Sha256Hash, _>(&validators, &validator_map, &author_keypair.pubkey());
+
+    assert_eq!(verified_msg, verified_rx_msg.unwrap());
+});
+
+test_all_combination!(test_proposal_tc, |num_keys| {
+    let (keypairs, cert_keys, validators, validator_map) =
+        create_keys_w_validators::<SCT>(num_keys);
+
+    let author_keypair = &keypairs[0];
+    let blk = setup_block::<SCT>(
+        NodeId(author_keypair.pubkey()),
+        Round(233),
+        Round(231),
+        TransactionList(vec![1, 2, 3, 4]),
+        ExecutionArtifacts::zero(),
+        &cert_keys,
+        &validator_map,
+    );
+
+    let tc_round = Round(232);
+    let high_qc_round = HighQcRound {
+        qc_round: Round(231),
+    };
+    let mut hasher = Sha256Hash::new();
+    hasher.update(tc_round);
+    hasher.update(high_qc_round.qc_round);
+    let high_qc_round_hash = hasher.hash();
+
+    let mut high_qc_rounds = Vec::new();
+
+    for keypair in keypairs.iter() {
+        high_qc_rounds.push(HighQcRoundSigTuple {
+            high_qc_round,
+            author_signature: keypair.sign(high_qc_round_hash.as_ref()),
         });
-        let verified_msg = Verified::new::<Sha256Hash>(proposal, author_keypair);
+    }
 
-        let rx_buf = serialize_verified_consensus_message(&verified_msg);
-        let rx_msg = deserialize_unverified_consensus_message(&rx_buf).unwrap();
+    let tc = TimeoutCertificate {
+        round: Round(232),
+        high_qc_rounds,
+    };
 
-        let verified_rx_msg =
-            rx_msg.verify::<Sha256Hash, _>(&validators, &validator_map, &author_keypair.pubkey());
-
-        assert_eq!(verified_msg, verified_rx_msg.unwrap());
+    let msg = ConsensusMessage::Proposal(ProposalMessage {
+        block: blk,
+        last_round_tc: Some(tc),
     });
+    let verified_msg = Verified::new::<Sha256Hash>(msg, author_keypair);
 
-    test_all_combination!(test_proposal_tc, |num_keys| {
-        let (keypairs, cert_keys, validators, validator_map) =
-            create_keys_w_validators::<SCT>(num_keys);
+    let rx_buf = serialize_verified_consensus_message(&verified_msg);
+    let rx_msg = deserialize_unverified_consensus_message(&rx_buf).unwrap();
 
-        let author_keypair = &keypairs[0];
-        let blk = setup_block::<SCT>(
-            NodeId(author_keypair.pubkey()),
-            Round(233),
-            Round(231),
-            TransactionList(vec![1, 2, 3, 4]),
-            ExecutionArtifacts::zero(),
-            &cert_keys,
-            &validator_map,
-        );
+    let verified_rx_msg =
+        rx_msg.verify::<Sha256Hash, _>(&validators, &validator_map, &author_keypair.pubkey());
 
-        let tc_round = Round(232);
-        let high_qc_round = HighQcRound {
-            qc_round: Round(231),
-        };
-        let mut hasher = Sha256Hash::new();
-        hasher.update(tc_round);
-        hasher.update(high_qc_round.qc_round);
-        let high_qc_round_hash = hasher.hash();
-
-        let mut high_qc_rounds = Vec::new();
-
-        for keypair in keypairs.iter() {
-            high_qc_rounds.push(HighQcRoundSigTuple {
-                high_qc_round,
-                author_signature: keypair.sign(high_qc_round_hash.as_ref()),
-            });
-        }
-
-        let tc = TimeoutCertificate {
-            round: Round(232),
-            high_qc_rounds,
-        };
-
-        let msg = ConsensusMessage::Proposal(ProposalMessage {
-            block: blk,
-            last_round_tc: Some(tc),
-        });
-        let verified_msg = Verified::new::<Sha256Hash>(msg, author_keypair);
-
-        let rx_buf = serialize_verified_consensus_message(&verified_msg);
-        let rx_msg = deserialize_unverified_consensus_message(&rx_buf).unwrap();
-
-        let verified_rx_msg =
-            rx_msg.verify::<Sha256Hash, _>(&validators, &validator_map, &author_keypair.pubkey());
-
-        assert_eq!(verified_msg, verified_rx_msg.unwrap());
-    });
-}
+    assert_eq!(verified_msg, verified_rx_msg.unwrap());
+});

--- a/monad-crypto/Cargo.toml
+++ b/monad-crypto/Cargo.toml
@@ -9,10 +9,12 @@ edition = "2021"
 bench = false
 
 [dependencies]
-monad-proto = { path = "../monad-proto", optional = true }
+monad-proto = { path = "../monad-proto" }
 
 blst = { workspace = true }
-libp2p-identity = { workspace = true, features = ["secp256k1"], optional = true }
+libp2p-identity = { workspace = true, features = [
+    "secp256k1",
+], optional = true }
 multihash = { workspace = true, features = ["identity"], optional = true }
 secp256k1 = { workspace = true, features = ["global-context", "recovery"] }
 sha2 = { workspace = true }
@@ -28,5 +30,4 @@ tiny-keccak = { workspace = true, features = ["keccak"] }
 
 [features]
 libp2p-identity = ["dep:libp2p-identity", "dep:multihash"]
-proto = ["dep:monad-proto"]
 rustls = ["dep:rcgen", "dep:rustls"]

--- a/monad-crypto/src/lib.rs
+++ b/monad-crypto/src/lib.rs
@@ -1,12 +1,10 @@
 use crate::secp256k1::PubKey;
 
-#[cfg(feature = "proto")]
-pub mod convert;
-
 #[cfg(feature = "rustls")]
 pub mod rustls;
 
 pub mod bls12_381;
+pub mod convert;
 pub mod secp256k1;
 
 // This implementation won't sign or verify anything, but its still required to return a PubKey

--- a/monad-driver/Cargo.toml
+++ b/monad-driver/Cargo.toml
@@ -11,7 +11,7 @@ monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto", features = ["libp2p-identity"] }
 monad-executor = { path = "../monad-executor", features = ["tokio"] }
 monad-p2p = { path = "../monad-p2p", features = ["tokio"] }
-monad-state = { path = "../monad-state", features = ["proto"] }
+monad-state = { path = "../monad-state" }
 monad-testutil = { path = "../monad-testutil" }
 monad-types = { path = "../monad-types" }
 monad-validator = { path = "../monad-validator" }

--- a/monad-executor/Cargo.toml
+++ b/monad-executor/Cargo.toml
@@ -15,7 +15,7 @@ monad-crypto = { path = "../monad-crypto" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-mempool-controller = { path = "../monad-mempool-controller" }
 monad-mempool-messenger = { path = "../monad-mempool-messenger" }
-monad-proto = { path = "../monad-proto", optional = true }
+monad-proto = { path = "../monad-proto" }
 monad-types = { path = "../monad-types" }
 monad-wal = { path = "../monad-wal" }
 
@@ -30,6 +30,3 @@ tracing = { workspace = true }
 monad-testutil = { path = "../monad-testutil" }
 
 tokio = { workspace = true, features = ["macros", "rt"] }
-
-[features]
-proto = ["dep:monad-proto", "monad-crypto/proto"]

--- a/monad-executor/src/lib.rs
+++ b/monad-executor/src/lib.rs
@@ -9,7 +9,6 @@ pub mod replay_nodes;
 pub mod timed_event;
 pub mod transformer;
 
-#[cfg(feature = "proto")]
 pub mod convert;
 
 // driver loop

--- a/monad-node/Cargo.toml
+++ b/monad-node/Cargo.toml
@@ -12,7 +12,7 @@ monad-crypto = { path = "../monad-crypto", features = ["libp2p-identity"] }
 monad-executor = { path = "../monad-executor", features = ["tokio"] }
 monad-mempool-controller = { path = "../monad-mempool-controller" }
 monad-p2p = { path = "../monad-p2p", features = ["tokio"] }
-monad-state = { path = "../monad-state", features = ["proto"] }
+monad-state = { path = "../monad-state" }
 monad-types = { path = "../monad-types" }
 monad-validator = { path = "../monad-validator" }
 

--- a/monad-state/Cargo.toml
+++ b/monad-state/Cargo.toml
@@ -16,16 +16,16 @@ monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
 monad-executor = { path = "../monad-executor" }
-monad-proto = { path = "../monad-proto", optional = true }
+monad-proto = { path = "../monad-proto" }
 monad-types = { path = "../monad-types" }
 monad-validator = { path = "../monad-validator" }
 
-prost = { workspace = true, optional = true }
+prost = { workspace = true }
 ref-cast = { workspace = true }
 
 [dev-dependencies]
 monad-quic = { path = "../monad-quic" }
-monad-testutil = { path = "../monad-testutil"}
+monad-testutil = { path = "../monad-testutil" }
 monad-tracing-counter = { path = "../monad-tracing-counter" }
 monad-wal = { path = "../monad-wal" }
 
@@ -38,9 +38,6 @@ test-case = { workspace = true }
 tracing = { workspace = true }
 tracing-core = { workspace = true }
 tracing-subscriber = { workspace = true }
-
-[features]
-proto = ["dep:monad-proto", "dep:prost", "monad-consensus/proto", "monad-consensus-types/proto", "monad-crypto/proto", "monad-types/proto", "monad-executor/proto"]
 
 [[bench]]
 name = "two_node_benchmark"

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -39,7 +39,6 @@ use monad_validator::{
 };
 use ref_cast::RefCast;
 
-#[cfg(feature = "proto")]
 pub mod convert;
 
 mod message;
@@ -143,7 +142,6 @@ impl monad_types::Serializable<Vec<u8>>
     }
 }
 
-#[cfg(feature = "proto")]
 impl monad_types::Deserializable<[u8]>
     for MonadEvent<
         monad_crypto::secp256k1::SecpSignature,
@@ -157,7 +155,6 @@ impl monad_types::Deserializable<[u8]>
     }
 }
 
-#[cfg(feature = "proto")]
 impl monad_types::Serializable<Vec<u8>>
     for MonadEvent<
         monad_crypto::secp256k1::SecpSignature,
@@ -169,7 +166,6 @@ impl monad_types::Serializable<Vec<u8>>
     }
 }
 
-#[cfg(feature = "proto")]
 impl monad_types::Deserializable<[u8]>
     for MonadEvent<
         monad_crypto::secp256k1::SecpSignature,
@@ -183,7 +179,6 @@ impl monad_types::Deserializable<[u8]>
     }
 }
 
-#[cfg(feature = "proto")]
 impl monad_types::Serializable<Vec<u8>>
     for MonadEvent<
         monad_crypto::secp256k1::SecpSignature,
@@ -205,7 +200,6 @@ pub struct VerifiedMonadMessage<ST, SCT: SignatureCollection>(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MonadMessage<ST, SCT: SignatureCollection>(Unverified<ST, ConsensusMessage<ST, SCT>>);
 
-#[cfg(feature = "proto")]
 impl<MS: MessageSignature, SCT: SignatureCollection> monad_types::Serializable<Vec<u8>>
     for VerifiedMonadMessage<MS, SCT>
 {
@@ -222,7 +216,6 @@ impl<MS: MessageSignature, SCT: SignatureCollection>
     }
 }
 
-#[cfg(feature = "proto")]
 impl<MS: MessageSignature, SCT: SignatureCollection> monad_types::Deserializable<[u8]>
     for MonadMessage<MS, SCT>
 {
@@ -235,7 +228,6 @@ impl<MS: MessageSignature, SCT: SignatureCollection> monad_types::Deserializable
     }
 }
 
-#[cfg(feature = "proto")]
 impl<MS: MessageSignature, CS: CertificateSignatureRecoverable> monad_types::Deserializable<Vec<u8>>
     for MonadMessage<MS, monad_consensus_types::multi_sig::MultiSig<CS>>
 {

--- a/monad-state/tests/protobuf.rs
+++ b/monad-state/tests/protobuf.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "proto")]
-
 use monad_consensus::{
     messages::{consensus_message::ConsensusMessage, message::VoteMessage},
     pacemaker::PacemakerTimerExpire,

--- a/monad-state/tests/replay.rs
+++ b/monad-state/tests/replay.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "proto")]
-
 use std::{collections::HashMap, fs::create_dir_all, time::Duration};
 
 use monad_block_sync::BlockSyncState;

--- a/monad-testground/Cargo.toml
+++ b/monad-testground/Cargo.toml
@@ -10,7 +10,7 @@ monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto", features = ["libp2p-identity"] }
 monad-executor = { path = "../monad-executor", features = ["tokio"] }
 monad-p2p = { path = "../monad-p2p", features = ["tokio"] }
-monad-state = { path = "../monad-state", features = ["proto"] }
+monad-state = { path = "../monad-state" }
 monad-types = { path = "../monad-types" }
 monad-validator = { path = "../monad-validator" }
 

--- a/monad-testutil/Cargo.toml
+++ b/monad-testutil/Cargo.toml
@@ -11,12 +11,12 @@ bench = false
 [dependencies]
 monad-consensus = { path = "../monad-consensus" }
 monad-consensus-types = { path = "../monad-consensus-types" }
-monad-crypto = {path = "../monad-crypto" }
-monad-executor = {path = "../monad-executor" }
-monad-state = {path = "../monad-state", features = ["proto"]}
-monad-types = {path = "../monad-types" }
-monad-validator = {path = "../monad-validator" }
-monad-wal = {path = "../monad-wal" }
+monad-crypto = { path = "../monad-crypto" }
+monad-executor = { path = "../monad-executor" }
+monad-state = { path = "../monad-state" }
+monad-types = { path = "../monad-types" }
+monad-validator = { path = "../monad-validator" }
+monad-wal = { path = "../monad-wal" }
 
 sha2 = { workspace = true }
 zerocopy = { workspace = true }

--- a/monad-types/Cargo.toml
+++ b/monad-types/Cargo.toml
@@ -10,9 +10,6 @@ bench = false
 
 [dependencies]
 monad-crypto = { path = "../monad-crypto" }
-monad-proto = { path = "../monad-proto", optional = true }
+monad-proto = { path = "../monad-proto" }
 
 zerocopy = { workspace = true }
-
-[features]
-proto = ["dep:monad-proto", "monad-crypto/proto"]

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "proto")]
 pub mod convert;
 
 use std::{

--- a/monad-wal/Cargo.toml
+++ b/monad-wal/Cargo.toml
@@ -16,7 +16,7 @@ monad-consensus = { path = "../monad-consensus" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
 monad-executor = { path = "../monad-executor" }
-monad-state = { path = "../monad-state", features = ["proto"] }
+monad-state = { path = "../monad-state" }
 monad-testutil = { path = "../monad-testutil" }
 monad-types = { path = "../monad-types" }
 


### PR DESCRIPTION
The `proto` feature was introduced to allow individual crate to compile without the protobuf dependencies. After the event persistence logger, the top level alaways require the proto feature, and we seldom need individual crate compilation without the protobufs. Actually some compilations break because not all proto-dependent code is correctly put behind feature gates.

This PR removes the `proto` feature.