### PR TITLE
Add mempool-ipc-path cli option to monad-node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4852,6 +4852,7 @@ dependencies = [
  "monad-consensus-types",
  "monad-crypto",
  "monad-executor",
+ "monad-mempool-controller",
  "monad-p2p",
  "monad-state",
  "monad-types",

--- a/monad-node/Cargo.toml
+++ b/monad-node/Cargo.toml
@@ -10,6 +10,7 @@ monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto", features = ["libp2p-identity"] }
 monad-executor = { path = "../monad-executor", features = ["tokio"] }
+monad-mempool-controller = { path = "../monad-mempool-controller" }
 monad-p2p = { path = "../monad-p2p", features = ["tokio"] }
 monad-state = { path = "../monad-state", features = ["proto"] }
 monad-types = { path = "../monad-types" }

--- a/monad-node/src/state.rs
+++ b/monad-node/src/state.rs
@@ -25,6 +25,7 @@ pub struct NodeState {
     pub certkey: KeyPair,
 
     pub otel_context: Option<opentelemetry::Context>,
+    pub mempool_ipc_path: Option<PathBuf>,
 }
 
 impl NodeState {
@@ -57,6 +58,7 @@ impl NodeState {
             certkey,
 
             otel_context,
+            mempool_ipc_path: cli.mempool_ipc_path,
         })
     }
 }


### PR DESCRIPTION
By passing ControllerConfig to the MonadMempool constructor, we can optionally set the mempool_ipc_path property.