### PR TITLE
RFC: Switch `TimeoutCertificate` to `SignatureCollection`

### DIFF
--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -56,6 +56,7 @@ impl<S: MessageSignature, SC: SignatureCollection> From<PacemakerCommand<S, SC>>
 {
     fn from(cmd: PacemakerCommand<S, SC>) -> Self {
         match cmd {
+            PacemakerCommand::PrepareTimeout(_) => unreachable!(),
             PacemakerCommand::Broadcast(message) => ConsensusCommand::Publish {
                 target: RouterTarget::Broadcast,
                 message: ConsensusMessage::Timeout(message),

--- a/monad-consensus-types/src/convert/timeout.rs
+++ b/monad-consensus-types/src/convert/timeout.rs
@@ -4,7 +4,7 @@ use super::signing::{message_signature_to_proto, proto_to_message_signature};
 use crate::{
     message_signature::MessageSignature,
     signature_collection::SignatureCollection,
-    timeout::{HighQcRound, HighQcRoundSigTuple, TimeoutCertificate, TimeoutInfo},
+    timeout::{HighQcRound, HighQcRoundSigColTuple, TimeoutCertificate, TimeoutInfo},
 };
 
 impl From<&HighQcRound> for ProtoHighQcRound {
@@ -29,16 +29,16 @@ impl TryFrom<ProtoHighQcRound> for HighQcRound {
     }
 }
 
-impl<S: MessageSignature> From<&HighQcRoundSigTuple<S>> for ProtoHighQcRoundSigTuple {
-    fn from(value: &HighQcRoundSigTuple<S>) -> Self {
+impl<S: MessageSignature> From<&HighQcRoundSigColTuple<S>> for ProtoHighQcRoundSigTuple {
+    fn from(value: &HighQcRoundSigColTuple<S>) -> Self {
         Self {
             high_qc_round: Some((&value.high_qc_round).into()),
-            author_signature: Some(message_signature_to_proto(&value.author_signature)),
+            author_signature: Some(message_signature_to_proto(&value.sigs)),
         }
     }
 }
 
-impl<S: MessageSignature> TryFrom<ProtoHighQcRoundSigTuple> for HighQcRoundSigTuple<S> {
+impl<S: MessageSignature> TryFrom<ProtoHighQcRoundSigTuple> for HighQcRoundSigColTuple<S> {
     type Error = ProtoError;
     fn try_from(value: ProtoHighQcRoundSigTuple) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -48,7 +48,7 @@ impl<S: MessageSignature> TryFrom<ProtoHighQcRoundSigTuple> for HighQcRoundSigTu
                     "Unverified<HighQcRound>.obj".to_owned(),
                 ))?
                 .try_into()?,
-            author_signature: proto_to_message_signature(value.author_signature.ok_or(
+            sigs: proto_to_message_signature(value.author_signature.ok_or(
                 Self::Error::MissingRequiredField(
                     "Unverified<HighQcRound>.author_signature".to_owned(),
                 ),

--- a/monad-consensus-types/src/timeout.rs
+++ b/monad-consensus-types/src/timeout.rs
@@ -1,16 +1,54 @@
+use std::collections::HashMap;
+
 use monad_types::*;
 use zerocopy::AsBytes;
 
 use super::quorum_certificate::QuorumCertificate;
-use crate::validation::{Hashable, Hasher};
+use crate::{
+    signature_collection::{
+        SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
+    },
+    validation::{Hashable, Hasher},
+    voting::ValidatorMapping,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TimeoutInfo<T> {
-    pub round: Round,
-    pub high_qc: QuorumCertificate<T>,
+pub struct Timeout<SCT: SignatureCollection> {
+    pub tminfo: TimeoutInfo<SCT>,
+    pub last_round_tc: Option<TimeoutCertificate<SCT>>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+impl<SCT: SignatureCollection> Hashable for Timeout<SCT> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // similar to ProposalMessage, not hashing over last_round_tc
+        self.tminfo.hash(state);
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TimeoutInfo<SCT> {
+    pub round: Round,
+    pub high_qc: QuorumCertificate<SCT>,
+}
+
+impl<SCT: SignatureCollection> Hashable for TimeoutInfo<SCT> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.update(self.round);
+        state.update(self.high_qc.info.vote.id.0.as_bytes());
+        state.update(self.high_qc.get_hash());
+    }
+}
+
+impl<SCT: SignatureCollection> TimeoutInfo<SCT> {
+    pub fn timeout_digest<H: Hasher>(&self) -> Hash {
+        let mut hasher = H::new();
+        hasher.update(self.round.as_bytes());
+        hasher.update(self.high_qc.info.vote.round.as_bytes());
+        hasher.hash()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct HighQcRound {
     pub qc_round: Round,
 }
@@ -22,18 +60,50 @@ impl Hashable for HighQcRound {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct HighQcRoundSigTuple<S> {
+pub struct HighQcRoundSigColTuple<SCT> {
     pub high_qc_round: HighQcRound,
-    pub author_signature: S,
+    pub sigs: SCT,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TimeoutCertificate<S> {
+pub struct TimeoutCertificate<SCT> {
     pub round: Round,
-    pub high_qc_rounds: Vec<HighQcRoundSigTuple<S>>,
+    pub high_qc_rounds: Vec<HighQcRoundSigColTuple<SCT>>,
 }
 
-impl<S> TimeoutCertificate<S> {
+impl<SCT: SignatureCollection> TimeoutCertificate<SCT> {
+    pub fn new<H: Hasher>(
+        round: Round,
+        high_qc_round_sig_tuple: &[(NodeId, TimeoutInfo<SCT>, SCT::SignatureType)],
+        validator_mapping: &ValidatorMapping<SignatureCollectionKeyPairType<SCT>>,
+    ) -> Result<Self, SignatureCollectionError<SCT::SignatureType>> {
+        let mut sigs = HashMap::new();
+        for (node_id, tmo_info, sig) in high_qc_round_sig_tuple {
+            let high_qc_round = HighQcRound {
+                qc_round: tmo_info.high_qc.info.vote.round,
+            };
+            let tminfo_digest = tmo_info.timeout_digest::<H>();
+            let entry = sigs
+                .entry(high_qc_round)
+                .or_insert((tminfo_digest, Vec::new()));
+            assert_eq!(entry.0, tminfo_digest);
+            entry.1.push((*node_id, *sig));
+        }
+        let mut high_qc_rounds = Vec::new();
+
+        for (high_qc_round, (tminfo_digest, sigs)) in sigs.into_iter() {
+            let sct = SCT::new(sigs, validator_mapping, tminfo_digest.as_ref())?;
+            high_qc_rounds.push(HighQcRoundSigColTuple::<SCT> {
+                high_qc_round,
+                sigs: sct,
+            });
+        }
+        Ok(Self {
+            round,
+            high_qc_rounds,
+        })
+    }
+
     pub fn max_round(&self) -> Round {
         self.high_qc_rounds
             .iter()

--- a/monad-consensus/src/messages/message.rs
+++ b/monad-consensus/src/messages/message.rs
@@ -3,7 +3,7 @@ use monad_consensus_types::{
     certificate_signature::CertificateSignature,
     message_signature::MessageSignature,
     signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
-    timeout::{TimeoutCertificate, TimeoutInfo},
+    timeout::{Timeout, TimeoutCertificate},
     validation::{Hashable, Hasher},
     voting::Vote,
 };
@@ -51,15 +51,27 @@ impl<SCT: SignatureCollection> VoteMessage<SCT> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TimeoutMessage<S, T> {
-    pub tminfo: TimeoutInfo<T>,
-    pub last_round_tc: Option<TimeoutCertificate<S>>,
+pub struct TimeoutMessage<SCT: SignatureCollection> {
+    pub timeout: Timeout<SCT>,
+    pub sig: SCT::SignatureType,
 }
 
-impl<S: MessageSignature, T: SignatureCollection> Hashable for TimeoutMessage<S, T> {
+impl<SCT: SignatureCollection> TimeoutMessage<SCT> {
+    pub fn new<H: Hasher>(
+        timeout: Timeout<SCT>,
+        key: &SignatureCollectionKeyPairType<SCT>,
+    ) -> Self {
+        let tmo_hash = timeout.timeout_digest();
+        let sig = <SCT::SignatureType as CertificateSignature>::sign(tmo_hash.as_ref(), key);
+
+        Self { timeout, sig }
+    }
+}
+
+impl<SCT: SignatureCollection> Hashable for TimeoutMessage<SCT> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        state.update(self.tminfo.round);
-        state.update(self.tminfo.high_qc.info.vote.round);
+        self.timeout.hash(state);
+        self.sig.hash(state);
     }
 }
 

--- a/monad-consensus/src/pacemaker.rs
+++ b/monad-consensus/src/pacemaker.rs
@@ -1,10 +1,10 @@
 use std::{collections::HashMap, time::Duration};
 
 use monad_consensus_types::{
-    message_signature::MessageSignature,
     quorum_certificate::QuorumCertificate,
-    signature_collection::SignatureCollection,
-    timeout::{HighQcRound, HighQcRoundSigTuple, TimeoutCertificate},
+    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
+    timeout::{Timeout, TimeoutCertificate},
+    voting::ValidatorMapping,
 };
 use monad_types::{NodeId, Round};
 use monad_validator::validator_set::ValidatorSetType;
@@ -15,14 +15,14 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub struct Pacemaker<S, T> {
+pub struct Pacemaker<SCT: SignatureCollection> {
     delta: Duration,
 
     current_round: Round,
-    last_round_tc: Option<TimeoutCertificate<S>>,
+    last_round_tc: Option<TimeoutCertificate<SCT>>,
 
     // only need to store for current round
-    pending_timeouts: HashMap<NodeId, (TimeoutMessage<S, T>, S)>,
+    pending_timeouts: HashMap<NodeId, TimeoutMessage<SCT>>,
 
     // used to not duplicate broadcast/tc
     phase: PhaseHonest,
@@ -36,8 +36,9 @@ enum PhaseHonest {
 }
 
 #[derive(Debug)]
-pub enum PacemakerCommand<S, T> {
-    Broadcast(TimeoutMessage<S, T>),
+pub enum PacemakerCommand<SCT: SignatureCollection> {
+    PrepareTimeout(Timeout<SCT>),
+    Broadcast(TimeoutMessage<SCT>),
     Schedule {
         duration: Duration,
         on_timeout: PacemakerTimerExpire,
@@ -48,15 +49,11 @@ pub enum PacemakerCommand<S, T> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PacemakerTimerExpire;
 
-impl<S, T> Pacemaker<S, T>
-where
-    S: MessageSignature,
-    T: SignatureCollection,
-{
+impl<SCT: SignatureCollection> Pacemaker<SCT> {
     pub fn new(
         delta: Duration,
         current_round: Round,
-        last_round_tc: Option<TimeoutCertificate<S>>,
+        last_round_tc: Option<TimeoutCertificate<SCT>>,
     ) -> Self {
         Self {
             delta,
@@ -77,7 +74,7 @@ where
     }
 
     #[must_use]
-    fn start_timer(&mut self, new_round: Round) -> PacemakerCommand<S, T> {
+    fn start_timer(&mut self, new_round: Round) -> PacemakerCommand<SCT> {
         assert!(new_round > self.current_round);
 
         self.phase = PhaseHonest::Zero;
@@ -95,8 +92,8 @@ where
     fn local_timeout_round(
         &self,
         safety: &mut Safety,
-        high_qc: &QuorumCertificate<T>,
-    ) -> Vec<PacemakerCommand<S, T>> {
+        high_qc: &QuorumCertificate<SCT>,
+    ) -> Vec<PacemakerCommand<SCT>> {
         let mut cmds = vec![PacemakerCommand::ScheduleReset];
         let maybe_broadcast = safety
             .make_timeout(self.current_round, high_qc.clone(), &self.last_round_tc)
@@ -107,7 +104,8 @@ where
                     &self.last_round_tc,
                 )
                 .expect("invalid timeout");
-                PacemakerCommand::Broadcast(TimeoutMessage {
+
+                PacemakerCommand::PrepareTimeout(Timeout {
                     tminfo: timeout_info,
                     last_round_tc: self.last_round_tc.clone(),
                 })
@@ -120,9 +118,9 @@ where
     pub fn handle_event(
         &mut self,
         safety: &mut Safety,
-        high_qc: &QuorumCertificate<T>,
+        high_qc: &QuorumCertificate<SCT>,
         _event: PacemakerTimerExpire,
-    ) -> Vec<PacemakerCommand<S, T>> {
+    ) -> Vec<PacemakerCommand<SCT>> {
         self.phase = PhaseHonest::One;
         self.local_timeout_round(safety, high_qc)
     }
@@ -131,23 +129,22 @@ where
     pub fn process_remote_timeout<VST: ValidatorSetType>(
         &mut self,
         validators: &VST,
+        validator_mapping: &ValidatorMapping<SignatureCollectionKeyPairType<SCT>>,
         safety: &mut Safety,
-        high_qc: &QuorumCertificate<T>,
+        high_qc: &QuorumCertificate<SCT>,
         author: NodeId,
-        signature: S,
-        tmo: TimeoutMessage<S, T>,
-    ) -> (Option<TimeoutCertificate<S>>, Vec<PacemakerCommand<S, T>>) {
+        tmo: TimeoutMessage<SCT>,
+    ) -> (Option<TimeoutCertificate<SCT>>, Vec<PacemakerCommand<SCT>>) {
         let mut ret_commands = Vec::new();
 
-        let tm_info = &tmo.tminfo;
+        let tm_info = &tmo.timeout.tminfo;
         if tm_info.round < self.current_round {
             return (None, ret_commands);
         }
         assert_eq!(tm_info.round, self.current_round);
 
         // it's fine to overwrite if already exists
-        self.pending_timeouts
-            .insert(author, (tmo.clone(), signature));
+        self.pending_timeouts.insert(author, tmo.clone);
 
         let timeouts: Vec<NodeId> = self.pending_timeouts.keys().copied().collect();
 
@@ -158,22 +155,17 @@ where
         }
         let mut ret_tc = None;
         if self.phase == PhaseHonest::One && validators.has_super_majority_votes(&timeouts) {
-            ret_tc = Some(TimeoutCertificate {
-                round: tm_info.round,
-                high_qc_rounds: self
-                    .pending_timeouts
-                    .values()
-                    .map(|(tmo, signature)| {
-                        assert_eq!(tmo.tminfo.round, tm_info.round);
-                        HighQcRoundSigTuple {
-                            high_qc_round: HighQcRound {
-                                qc_round: tmo.tminfo.high_qc.info.vote.round,
-                            },
-                            author_signature: *signature,
-                        }
-                    })
-                    .collect(),
-            });
+            // change how to create timeout certificate
+            // FIXME: error handling when creating certificate
+
+            ret_tc = Some(TimeoutCertificate::new(
+                tm_info.round,
+                self.pending_timeouts
+                    .iter()
+                    .map(|(node_id, tmo_msg)| (node_id, tmo_msg.timeout.tminfo, tmo_msg.sig)),
+                validator_mapping,
+            ));
+
             self.phase = PhaseHonest::Supermajority;
         }
 
@@ -183,8 +175,8 @@ where
     #[must_use]
     pub fn advance_round_tc(
         &mut self,
-        tc: &TimeoutCertificate<S>,
-    ) -> Option<PacemakerCommand<S, T>> {
+        tc: &TimeoutCertificate<SCT>,
+    ) -> Option<PacemakerCommand<SCT>> {
         if tc.round < self.current_round {
             return None;
         }
@@ -196,8 +188,8 @@ where
     #[must_use]
     pub fn advance_round_qc(
         &mut self,
-        qc: &QuorumCertificate<T>,
-    ) -> Option<PacemakerCommand<S, T>> {
+        qc: &QuorumCertificate<SCT>,
+    ) -> Option<PacemakerCommand<SCT>> {
         if qc.info.vote.round < self.current_round {
             return None;
         }

--- a/monad-consensus/tests/message.rs
+++ b/monad-consensus/tests/message.rs
@@ -7,7 +7,7 @@ use monad_consensus_types::{
     payload::{ExecutionArtifacts, Payload, TransactionList},
     quorum_certificate::{QcInfo, QuorumCertificate},
     signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
-    timeout::{HighQcRound, HighQcRoundSigTuple, TimeoutCertificate, TimeoutInfo},
+    timeout::{HighQcRound, HighQcRoundSigColTuple, TimeoutCertificate, TimeoutInfo},
     validation::{Hasher, Sha256Hash},
     voting::{Vote, VoteInfo},
 };
@@ -108,9 +108,9 @@ fn max_high_qc() {
     .map(|x| {
         let msg = Sha256Hash::hash_object(x);
         let keypair = get_key(0);
-        HighQcRoundSigTuple {
+        HighQcRoundSigColTuple {
             high_qc_round: *x,
-            author_signature: keypair.sign(msg.as_ref()),
+            sigs: keypair.sign(msg.as_ref()),
         }
     })
     .collect();

--- a/monad-consensus/tests/protobuf.rs
+++ b/monad-consensus/tests/protobuf.rs
@@ -15,7 +15,7 @@ use monad_consensus_types::{
     payload::{ExecutionArtifacts, TransactionList},
     quorum_certificate::{QcInfo, QuorumCertificate},
     signature_collection::SignatureCollection,
-    timeout::{HighQcRound, HighQcRoundSigTuple, TimeoutCertificate, TimeoutInfo},
+    timeout::{HighQcRound, HighQcRoundSigColTuple, TimeoutCertificate, TimeoutInfo},
     validation::{Hasher, Sha256Hash},
     voting::{Vote, VoteInfo},
 };
@@ -170,9 +170,9 @@ test_all_combination!(test_timeout_message, |num_keys| {
 
     let mut high_qc_rounds = Vec::new();
     for keypair in keypairs.iter() {
-        high_qc_rounds.push(HighQcRoundSigTuple {
+        high_qc_rounds.push(HighQcRoundSigColTuple {
             high_qc_round,
-            author_signature: keypair.sign(high_qc_round_hash.as_ref()),
+            sigs: keypair.sign(high_qc_round_hash.as_ref()),
         });
     }
 
@@ -252,9 +252,9 @@ test_all_combination!(test_proposal_tc, |num_keys| {
     let mut high_qc_rounds = Vec::new();
 
     for keypair in keypairs.iter() {
-        high_qc_rounds.push(HighQcRoundSigTuple {
+        high_qc_rounds.push(HighQcRoundSigColTuple {
             high_qc_round,
-            author_signature: keypair.sign(high_qc_round_hash.as_ref()),
+            sigs: keypair.sign(high_qc_round_hash.as_ref()),
         });
     }
 

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -27,7 +27,7 @@ impl AsRef<[u8]> for Hash {
 }
 
 #[repr(transparent)]
-#[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd, AsBytes)]
+#[derive(Copy, Clone, Eq, Hash, Ord, PartialEq, PartialOrd, AsBytes)]
 pub struct Round(pub u64);
 
 impl AsRef<[u8]> for Round {

--- a/monad-wal/benches/event_bench.rs
+++ b/monad-wal/benches/event_bench.rs
@@ -16,7 +16,7 @@ use monad_consensus_types::{
     payload::{ExecutionArtifacts, TransactionList},
     quorum_certificate::{QcInfo, QuorumCertificate},
     signature_collection::SignatureCollection,
-    timeout::{HighQcRound, HighQcRoundSigTuple, TimeoutCertificate, TimeoutInfo},
+    timeout::{HighQcRound, HighQcRoundSigColTuple, TimeoutCertificate, TimeoutInfo},
     validation::{Hasher, Sha256Hash},
     voting::{Vote, VoteInfo},
 };
@@ -190,9 +190,9 @@ fn bench_timeout(c: &mut Criterion) {
 
     let mut high_qc_rounds = Vec::new();
     for keypair in keypairs.iter() {
-        high_qc_rounds.push(HighQcRoundSigTuple {
+        high_qc_rounds.push(HighQcRoundSigColTuple {
             high_qc_round,
-            author_signature: keypair.sign(high_qc_round_hash.as_ref()),
+            sigs: keypair.sign(high_qc_round_hash.as_ref()),
         });
     }
 


### PR DESCRIPTION
Review #256 instead

`TimeoutCertificate` was created with a vector of signatures over the current round and the high qc round. The size of the certificate is thus proportional to the number of signers on it.

We note that nodes are likely to be locked on a small number of high qcs, so we can leverage aggregate signatures to make TC more compact and potentially faster to verify.

`TimeoutMessage` now carries a signature created with the certificate keypair. We bucket the timeout signatures by `high_qc_round` and aggregate signatures in the same bucket when constructing the TC.

Closes #196 