### PR TITLE
Add seq_num into VoteInfo and therefore QC

### DIFF
--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -392,6 +392,7 @@ mod test {
                         round: Round(0),
                         parent_id: BlockId(Hash([0x00_u8; 32])),
                         parent_round: Round(0),
+                        seq_num: 0,
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
@@ -404,6 +405,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b1 = Block::new::<Sha256Hash>(
@@ -424,6 +426,7 @@ mod test {
             round: Round(1),
             parent_id: g.get_id(),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b2 = Block::new::<Sha256Hash>(
@@ -444,6 +447,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b3 = Block::new::<Sha256Hash>(
@@ -464,6 +468,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b4 = Block::new::<Sha256Hash>(
@@ -484,6 +489,7 @@ mod test {
             round: Round(3),
             parent_id: g.get_id(),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b5 = Block::new::<Sha256Hash>(
@@ -504,6 +510,7 @@ mod test {
             round: Round(5),
             parent_id: b3.get_id(),
             parent_round: Round(3),
+            seq_num: 0,
         };
 
         let b6 = Block::new::<Sha256Hash>(
@@ -524,6 +531,7 @@ mod test {
             round: Round(6),
             parent_id: b5.get_id(),
             parent_round: Round(5),
+            seq_num: 0,
         };
 
         let b7 = Block::new::<Sha256Hash>(
@@ -616,6 +624,7 @@ mod test {
             round: Round(5),
             parent_id: b3.get_id(),
             parent_round: Round(3),
+            seq_num: 0,
         };
 
         let b8 = Block::new::<Sha256Hash>(
@@ -653,6 +662,7 @@ mod test {
                         round: Round(0),
                         parent_id: BlockId(Hash([0x00_u8; 32])),
                         parent_round: Round(0),
+                        seq_num: 0,
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
@@ -665,6 +675,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b1 = Block::new::<Sha256Hash>(
@@ -685,6 +696,7 @@ mod test {
             round: Round(1),
             parent_id: g.get_id(),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b2 = Block::new::<Sha256Hash>(
@@ -741,6 +753,7 @@ mod test {
                         round: Round(0),
                         parent_id: BlockId(Hash([0x00_u8; 32])),
                         parent_round: Round(0),
+                        seq_num: 0,
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
@@ -753,6 +766,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b1 = Block::new::<Sha256Hash>(
@@ -794,6 +808,7 @@ mod test {
             round: Round(1),
             parent_id: g.get_id(),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b3 = Block::new::<Sha256Hash>(
@@ -856,6 +871,7 @@ mod test {
                         round: Round(0),
                         parent_id: BlockId(Hash([0x00_u8; 32])),
                         parent_round: Round(0),
+                        seq_num: 0,
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
@@ -868,6 +884,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b1 = Block::new::<Sha256Hash>(
@@ -920,6 +937,7 @@ mod test {
                         round: Round(0),
                         parent_id: BlockId(Hash([0x00_u8; 32])),
                         parent_round: Round(0),
+                        seq_num: 0,
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
@@ -932,6 +950,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b1 = Block::new::<Sha256Hash>(
@@ -952,6 +971,7 @@ mod test {
             round: Round(1),
             parent_id: g.get_id(),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b2 = Block::new::<Sha256Hash>(
@@ -1049,6 +1069,7 @@ mod test {
                         round: Round(0),
                         parent_id: BlockId(Hash([0x00_u8; 32])),
                         parent_round: Round(0),
+                        seq_num: 0,
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
@@ -1060,6 +1081,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b4 = Block::new::<Sha256Hash>(
@@ -1080,6 +1102,7 @@ mod test {
             round: Round(4),
             parent_id: g.get_id(),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b5 = Block::new::<Sha256Hash>(
@@ -1100,6 +1123,7 @@ mod test {
             round: Round(5),
             parent_id: b4.get_id(),
             parent_round: Round(4),
+            seq_num: 0,
         };
 
         let b6 = Block::new::<Sha256Hash>(
@@ -1156,6 +1180,7 @@ mod test {
                         round: Round(0),
                         parent_id: BlockId(Hash([0x00_u8; 32])),
                         parent_round: Round(0),
+                        seq_num: 0,
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
@@ -1168,6 +1193,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b2 = Block::new::<Sha256Hash>(
@@ -1188,6 +1214,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b3 = Block::new::<Sha256Hash>(
@@ -1208,6 +1235,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b4 = Block::new::<Sha256Hash>(
@@ -1228,6 +1256,7 @@ mod test {
             round: Round(4),
             parent_id: g.get_id(),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b5 = Block::new::<Sha256Hash>(
@@ -1248,6 +1277,7 @@ mod test {
             round: Round(5),
             parent_id: b4.get_id(),
             parent_round: Round(4),
+            seq_num: 0,
         };
 
         let b6 = Block::new::<Sha256Hash>(
@@ -1311,6 +1341,7 @@ mod test {
                         round: Round(0),
                         parent_id: BlockId(Hash([0x00_u8; 32])),
                         parent_round: Round(0),
+                        seq_num: 0,
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
@@ -1323,6 +1354,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b1 = Block::new::<Sha256Hash>(
@@ -1343,6 +1375,7 @@ mod test {
             round: Round(3),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(3),
+            seq_num: 0,
         };
 
         let b4 = Block::new::<Sha256Hash>(
@@ -1390,6 +1423,7 @@ mod test {
                         round: Round(0),
                         parent_id: BlockId(Hash([0x00_u8; 32])),
                         parent_round: Round(0),
+                        seq_num: 0,
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
@@ -1402,6 +1436,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b4 = Block::new::<Sha256Hash>(
@@ -1422,6 +1457,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b5 = Block::new::<Sha256Hash>(
@@ -1462,6 +1498,7 @@ mod test {
                         round: Round(0),
                         parent_id: BlockId(Hash([0x00_u8; 32])),
                         parent_round: Round(0),
+                        seq_num: 0,
                     },
                     ledger_commit: LedgerCommitInfo::default(),
                 },
@@ -1474,6 +1511,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b1 = Block::new::<Sha256Hash>(
@@ -1494,6 +1532,7 @@ mod test {
             round: Round(1),
             parent_id: g.get_id(),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let b2 = Block::new::<Sha256Hash>(

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -701,6 +701,7 @@ mod test {
             round: expected_qc_high_round,
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: expected_qc_high_round - Round(1),
+            seq_num: 0,
         };
         let v = Vote {
             vote_info: vi,

--- a/monad-consensus-types/src/convert/voting.rs
+++ b/monad-consensus-types/src/convert/voting.rs
@@ -10,6 +10,7 @@ impl From<&VoteInfo> for ProtoVoteInfo {
             round: vi.round.0,
             parent_id: Some((&vi.parent_id).into()),
             parent_round: vi.parent_round.0,
+            seq_num: vi.seq_num,
         }
     }
 }
@@ -29,6 +30,7 @@ impl TryFrom<ProtoVoteInfo> for VoteInfo {
                 ))?
                 .try_into()?,
             parent_round: Round(proto_vi.parent_round),
+            seq_num: proto_vi.seq_num,
         })
     }
 }

--- a/monad-consensus-types/src/quorum_certificate.rs
+++ b/monad-consensus-types/src/quorum_certificate.rs
@@ -72,6 +72,7 @@ pub fn genesis_vote_info(genesis_block_id: BlockId) -> VoteInfo {
         round: Round(0),
         parent_id: BlockId(GENESIS_PRIME_QC_HASH),
         parent_round: Round(0),
+        seq_num: 0,
     }
 }
 
@@ -92,6 +93,7 @@ impl<SCT: SignatureCollection> QuorumCertificate<SCT> {
             round: Round(0),
             parent_id: BlockId(GENESIS_PRIME_QC_HASH),
             parent_round: Round(0),
+            seq_num: 0,
         };
         let lci = LedgerCommitInfo::new::<H>(None, &vote_info);
 

--- a/monad-consensus-types/src/validation.rs
+++ b/monad-consensus-types/src/validation.rs
@@ -15,6 +15,8 @@ pub enum Error {
     InvalidTcRound,
     /// The SignatureCollection doesn't have supermajority of the stake signed
     InsufficientStake,
+    /// Seq num in block proposal must be 1 higher than in the QC
+    InvalidSeqNum,
 }
 
 pub trait Hashable {

--- a/monad-consensus-types/src/voting.rs
+++ b/monad-consensus-types/src/voting.rs
@@ -57,6 +57,7 @@ pub struct VoteInfo {
     pub round: Round,
     pub parent_id: BlockId,
     pub parent_round: Round,
+    pub seq_num: u64,
 }
 
 impl std::fmt::Debug for VoteInfo {
@@ -66,6 +67,7 @@ impl std::fmt::Debug for VoteInfo {
             .field("r", &self.round)
             .field("pid", &self.parent_id)
             .field("pr", &self.parent_round)
+            .field("sn", &self.seq_num)
             .finish()
     }
 }
@@ -76,6 +78,7 @@ impl Hashable for VoteInfo {
         state.update(self.round.as_bytes());
         state.update(self.parent_id.0.as_bytes());
         state.update(self.parent_round.as_bytes());
+        state.update(self.seq_num.as_bytes());
     }
 }
 
@@ -84,6 +87,7 @@ mod test {
     use monad_types::{BlockId, Hash, Round};
     use sha2::Digest;
     use test_case::test_case;
+    use zerocopy::AsBytes;
 
     use super::VoteInfo;
     use crate::{
@@ -99,6 +103,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let mut hasher = sha2::Sha256::new();
@@ -106,6 +111,7 @@ mod test {
         hasher.update(vi.round);
         hasher.update(vi.parent_id.0);
         hasher.update(vi.parent_round);
+        hasher.update(vi.seq_num.as_bytes());
 
         let h1 = Hash(hasher.finalize_reset().into());
         let h2 = Sha256Hash::hash_object(&vi);
@@ -121,6 +127,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let vi_hash = Sha256Hash::hash_object(&vi);

--- a/monad-consensus/src/validation/safety.rs
+++ b/monad-consensus/src/validation/safety.rs
@@ -99,6 +99,7 @@ impl Safety {
                 round: block.round,
                 parent_id: block.qc.info.vote.id,
                 parent_round: block.qc.info.vote.round,
+                seq_num: block.get_seq_num(),
             };
 
             let commit_hash = if commit_condition(block.round, block.qc.info) {

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, ops::Deref};
 
 use monad_consensus_types::{
+    block::BlockType,
     convert::signing::message_signature_to_proto,
     message_signature::MessageSignature,
     quorum_certificate::QuorumCertificate,
@@ -217,11 +218,19 @@ where
     }
 
     fn well_formed_proposal(&self) -> Result<(), Error> {
+        self.valid_seq_num()?;
         well_formed(
             self.obj.block.round,
             self.obj.block.qc.info.vote.round,
             &self.obj.last_round_tc,
         )
+    }
+
+    fn valid_seq_num(&self) -> Result<(), Error> {
+        if self.obj.block.get_seq_num() != self.obj.block.qc.info.vote.seq_num + 1 {
+            return Err(Error::InvalidSeqNum);
+        }
+        Ok(())
     }
 }
 
@@ -568,6 +577,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let lci = LedgerCommitInfo::new::<Sha256Hash>(Some(Hash([0xad_u8; 32])), &vi);
@@ -592,6 +602,7 @@ mod test {
             round: Round(1),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let qc = QuorumCertificate::new::<Sha256Hash>(
@@ -614,6 +625,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let lci = LedgerCommitInfo::new::<Sha256Hash>(Some(Hash([0xad_u8; 32])), &vi);

--- a/monad-consensus/src/vote_state.rs
+++ b/monad-consensus/src/vote_state.rs
@@ -125,6 +125,7 @@ mod test {
             round: vote_round,
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let lci = LedgerCommitInfo::new::<Sha256Hash>(Some(Default::default()), &vi);
@@ -217,6 +218,7 @@ mod test {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let v = Vote {
@@ -241,6 +243,7 @@ mod test {
             round: Round(5),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(4),
+            seq_num: 0,
         };
 
         let vi2 = VoteInfo {
@@ -248,6 +251,7 @@ mod test {
             round: Round(1),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         };
 
         let invalid_vote = Vote {

--- a/monad-consensus/tests/block.rs
+++ b/monad-consensus/tests/block.rs
@@ -21,6 +21,7 @@ fn block_hash_id() {
                 parent_id: BlockId(Hash([0x00_u8; 32])),
                 round: Round(0),
                 parent_round: Round(0),
+                seq_num: 0,
             },
             ledger_commit: LedgerCommitInfo::default(),
         },

--- a/monad-consensus/tests/message.rs
+++ b/monad-consensus/tests/message.rs
@@ -30,6 +30,7 @@ fn timeout_msg_hash() {
                     round: Round(0),
                     parent_id: BlockId(Hash([0x00_u8; 32])),
                     parent_round: Round(0),
+                    seq_num: 0,
                 },
                 ledger_commit: Default::default(),
             },
@@ -69,6 +70,7 @@ fn proposal_msg_hash() {
                 round: Round(0),
                 parent_id: BlockId(Hash([0x00_u8; 32])),
                 parent_round: Round(0),
+                seq_num: 0,
             },
             ledger_commit: LedgerCommitInfo::default(),
         },
@@ -136,6 +138,7 @@ fn test_vote_message() {
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
+            seq_num: 0,
         },
         ledger_commit_info: lci,
     };
@@ -171,6 +174,7 @@ fn vote_msg_hash(cs: Option<Hash>) {
         round: Round(0),
         parent_id: BlockId(Hash([0x00_u8; 32])),
         parent_round: Round(0),
+        seq_num: 0,
     };
     let vi_hash = Sha256Hash::hash_object(&vi);
 

--- a/monad-consensus/tests/proposal.rs
+++ b/monad-consensus/tests/proposal.rs
@@ -29,6 +29,7 @@ fn setup_block(
         round: qc_round,
         parent_id: BlockId(Hash([0x00_u8; 32])),
         parent_round: Round(0),
+        seq_num: 0,
     };
     let qc = QuorumCertificate::<MockSignatures>::new::<Sha256Hash>(
         QcInfo {
@@ -44,7 +45,7 @@ fn setup_block(
         &Payload {
             txns,
             header: ExecutionArtifacts::zero(),
-            seq_num: 0,
+            seq_num: 1,
         },
         &qc,
     )

--- a/monad-consensus/tests/protobuf.rs
+++ b/monad-consensus/tests/protobuf.rs
@@ -93,6 +93,7 @@ test_all_combination!(test_vote_message, |num_keys| {
         round: Round(1),
         parent_id: BlockId(Hash([43_u8; 32])),
         parent_round: Round(2),
+        seq_num: 0,
     };
     let lci = LedgerCommitInfo {
         commit_state_hash: None,
@@ -132,6 +133,7 @@ test_all_combination!(test_timeout_message, |num_keys| {
         round: Round(1),
         parent_id: BlockId(Hash([43_u8; 32])),
         parent_round: Round(2),
+        seq_num: 0,
     };
     let lci = LedgerCommitInfo::new::<Sha256Hash>(None, &vi);
 

--- a/monad-consensus/tests/qc.rs
+++ b/monad-consensus/tests/qc.rs
@@ -18,6 +18,7 @@ fn comparison() {
         round: Round(2),
         parent_id: BlockId(Hash([0x00_u8; 32])),
         parent_round: Round(0),
+        seq_num: 0,
     };
 
     let vi_2 = VoteInfo {
@@ -25,6 +26,7 @@ fn comparison() {
         round: Round(3),
         parent_id: BlockId(Hash([0x00_u8; 32])),
         parent_round: Round(0),
+        seq_num: 0,
     };
 
     let qc_1 = QuorumCertificate::<MockSignatures>::new::<Sha256Hash>(

--- a/monad-consensus/tests/vote_state.rs
+++ b/monad-consensus/tests/vote_state.rs
@@ -29,6 +29,7 @@ fn create_signed_vote_message(
         round: vote_round,
         parent_id: BlockId(Hash([0x00_u8; 32])),
         parent_round: Round(0),
+        seq_num: 0,
     };
 
     let lci = LedgerCommitInfo::new::<Sha256Hash>(Some(Default::default()), &vi);

--- a/monad-proto/proto/voting.proto
+++ b/monad-proto/proto/voting.proto
@@ -10,6 +10,7 @@ message ProtoVoteInfo {
   uint64 round = 2;
   monad_proto.basic.ProtoBlockId parent_id = 3;
   uint64 parent_round = 4;
+  uint64 seq_num = 5;
 }
 
 message ProtoVote {

--- a/monad-state/tests/protobuf.rs
+++ b/monad-state/tests/protobuf.rs
@@ -49,6 +49,7 @@ fn test_consensus_message_event_vote_multisig() {
         round: Round(1),
         parent_id: BlockId(Hash([43_u8; 32])),
         parent_round: Round(2),
+        seq_num: 0,
     };
     let lci: LedgerCommitInfo = LedgerCommitInfo {
         commit_state_hash: None,

--- a/monad-testutil/src/block.rs
+++ b/monad-testutil/src/block.rs
@@ -58,6 +58,7 @@ pub fn setup_block<SCT: SignatureCollection>(
         round: qc_round,
         parent_id: BlockId(Hash([43_u8; 32])),
         parent_round: Round(0),
+        seq_num: 0,
     };
     let lci = LedgerCommitInfo::new::<Sha256Hash>(None, &vi);
 
@@ -88,7 +89,7 @@ pub fn setup_block<SCT: SignatureCollection>(
         &Payload {
             txns,
             header: execution_header,
-            seq_num: 0,
+            seq_num: 1,
         },
         &qc,
     )

--- a/monad-testutil/src/proposal.rs
+++ b/monad-testutil/src/proposal.rs
@@ -77,6 +77,7 @@ where
         );
 
         self.high_qc = self.qc.clone();
+        self.seq_num += 1;
         self.qc = self.get_next_qc(certkeys, &block, validator_mapping);
 
         let proposal = ProposalMessage {
@@ -84,7 +85,6 @@ where
             last_round_tc: self.last_tc.clone(),
         };
         self.last_tc = None;
-        self.seq_num += 1;
 
         Verified::new::<Sha256Hash>(proposal, leader_key)
     }
@@ -153,6 +153,7 @@ where
             round: block.round,
             parent_id: block.qc.info.vote.id,
             parent_round: block.qc.info.vote.round,
+            seq_num: self.seq_num,
         };
         let commit = Some(block.get_id().0); // FIXME: is this hash correct?
         let lci = LedgerCommitInfo::new::<Sha256Hash>(commit, &vi);

--- a/monad-wal/benches/event_bench.rs
+++ b/monad-wal/benches/event_bench.rs
@@ -111,6 +111,7 @@ fn bench_vote(c: &mut Criterion) {
         round: Round(1),
         parent_id: BlockId(Hash([43_u8; 32])),
         parent_round: Round(2),
+        seq_num: 0,
     };
     let lci = LedgerCommitInfo {
         commit_state_hash: None,
@@ -155,6 +156,7 @@ fn bench_timeout(c: &mut Criterion) {
         round: Round(1),
         parent_id: BlockId(Hash([43_u8; 32])),
         parent_round: Round(2),
+        seq_num: 0,
     };
     let lci = LedgerCommitInfo::new::<Sha256Hash>(None, &vi);
 


### PR DESCRIPTION
Proposals from higher rounds are expected to bring a node up to that round from whatever lower round it was at. We can trust the round because it is certified in the QC. seq_num also needs to be trusted in that same case so its not sufficient to just have it in the block, it also needs to be voted on and certified in the QC.