### PR TITLE
Add config param for proposal behaviour when missing blocks

### DIFF
--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -101,7 +101,7 @@ pub enum RootKind {
 }
 
 pub struct BlockTree<T> {
-    root: RootKind,
+    pub root: RootKind,
     tree: HashMap<BlockId, BlockTreeBlock<T>>,
     high_round: Round,
 }

--- a/monad-driver/src/lib.rs
+++ b/monad-driver/src/lib.rs
@@ -4,7 +4,7 @@ mod tests {
 
     use futures::StreamExt;
     use monad_block_sync::BlockSyncState;
-    use monad_consensus_state::ConsensusState;
+    use monad_consensus_state::{ConsensusConfig, ConsensusState};
     use monad_consensus_types::{
         block::BlockType, certificate_signature::CertificateKeyPair, multi_sig::MultiSig,
         payload::NopStateRoot, quorum_certificate::genesis_vote_info,
@@ -132,7 +132,11 @@ mod tests {
                         certkey,
                         validators: config_validators.clone(),
                         delta: Duration::from_millis(2),
-                        state_root_delay: 0,
+                        consensus_config: ConsensusConfig {
+                            proposal_size: 5000,
+                            state_root_delay: 0,
+                            propose_with_missing_blocks: false,
+                        },
                         genesis_block: genesis_block.clone(),
                         genesis_vote_info: genesis_vote_info(genesis_block.get_id()),
                         genesis_signatures: genesis_sigs.clone(),

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -7,7 +7,7 @@ use clap::CommandFactory;
 use config::{NodeBootstrapPeerConfig, NodeNetworkConfig};
 use futures_util::{FutureExt, StreamExt};
 use monad_block_sync::BlockSyncState;
-use monad_consensus_state::ConsensusState;
+use monad_consensus_state::{ConsensusConfig, ConsensusState};
 use monad_consensus_types::{
     multi_sig::MultiSig, payload::NopStateRoot, transaction_validator::MockValidator,
     validation::Sha256Hash,
@@ -122,7 +122,11 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         key: node_state.identity,
         certkey: node_state.certkey,
         delta: Duration::from_secs(1),
-        state_root_delay: 0,
+        consensus_config: ConsensusConfig {
+            proposal_size: 5000,
+            state_root_delay: 0,
+            propose_with_missing_blocks: false,
+        },
         genesis_block: node_state.genesis.genesis_block,
         genesis_vote_info: node_state.genesis.genesis_vote_info,
         genesis_signatures: node_state.genesis.genesis_signatures,

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -13,7 +13,7 @@ use monad_consensus::{
 };
 use monad_consensus_state::{
     command::{Checkpoint, ConsensusCommand, FetchedBlock, FetchedFullTxs, FetchedTxs},
-    ConsensusProcess,
+    ConsensusConfig, ConsensusProcess,
 };
 use monad_consensus_types::{
     block::Block,
@@ -285,7 +285,7 @@ pub struct MonadConfig<SCT: SignatureCollection, TV> {
     pub certkey: SignatureCollectionKeyPairType<SCT>,
 
     pub delta: Duration,
-    pub state_root_delay: u64,
+    pub consensus_config: ConsensusConfig,
     pub genesis_block: Block<SCT>,
     pub genesis_vote_info: VoteInfo,
     pub genesis_signatures: SCT,
@@ -355,7 +355,7 @@ where
                 config.genesis_block,
                 genesis_qc,
                 config.delta,
-                config.state_root_delay,
+                config.consensus_config,
                 config.key,
                 config.certkey,
             ),

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use clap::Parser;
 use futures_util::{FutureExt, StreamExt};
 use monad_block_sync::BlockSyncState;
-use monad_consensus_state::ConsensusState;
+use monad_consensus_state::{ConsensusConfig, ConsensusState};
 use monad_consensus_types::{
     block::{Block, BlockType},
     certificate_signature::{CertificateKeyPair, CertificateSignature},
@@ -70,7 +70,7 @@ pub struct Config {
         SignatureCollectionPubKeyType<SignatureCollectionType>,
     )>,
     pub delta: Duration,
-    pub state_root_delay: u64,
+    pub consensus_config: ConsensusConfig,
     pub genesis_block: Block<SignatureCollectionType>,
     pub genesis_vote_info: VoteInfo,
     pub genesis_signatures: SignatureCollectionType,
@@ -283,7 +283,11 @@ fn testnet(
             libp2p_keepalive: keepalive,
             genesis_peers: peers.clone(),
             delta,
-            state_root_delay,
+            consensus_config: ConsensusConfig {
+                proposal_size: 5000,
+                state_root_delay,
+                propose_with_missing_blocks: false,
+            },
             genesis_block: genesis_block.clone(),
             genesis_vote_info: genesis_vote_info(genesis_block.get_id()),
             genesis_signatures: genesis_signatures.clone(),
@@ -337,7 +341,7 @@ async fn run(
         key: keypair,
         certkey: certkeypair,
         delta: config.delta,
-        state_root_delay: config.state_root_delay,
+        consensus_config: config.consensus_config,
         genesis_block: config.genesis_block,
         genesis_vote_info: config.genesis_vote_info,
         genesis_signatures: config.genesis_signatures,

--- a/monad-testutil/Cargo.toml
+++ b/monad-testutil/Cargo.toml
@@ -10,6 +10,7 @@ bench = false
 
 [dependencies]
 monad-consensus = { path = "../monad-consensus" }
+monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
 monad-executor = { path = "../monad-executor" }
@@ -23,4 +24,3 @@ zerocopy = { workspace = true }
 
 [dev-dependencies]
 monad-block-sync = { path = "../monad-block-sync" }
-monad-consensus-state = { path = "../monad-consensus-state" }

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use monad_consensus_state::ConsensusConfig;
 use monad_consensus_types::{
     block::BlockType, message_signature::MessageSignature, quorum_certificate::genesis_vote_info,
     signature_collection::SignatureCollection, validation::Sha256Hash,
@@ -48,7 +49,11 @@ pub fn get_configs<ST: MessageSignature, SCT: SignatureCollection, TVT: Clone>(
                 .map(|(node_id, sctpubkey)| (node_id.0, *sctpubkey))
                 .collect::<Vec<_>>(),
             delta,
-            state_root_delay: 4,
+            consensus_config: ConsensusConfig {
+                proposal_size: 5000,
+                state_root_delay: 4,
+                propose_with_missing_blocks: false,
+            },
             genesis_block: genesis_block.clone(),
             genesis_vote_info: genesis_vote_info(genesis_block.get_id()),
             genesis_signatures: genesis_sigs.clone(),

--- a/monad-viz/src/config.rs
+++ b/monad-viz/src/config.rs
@@ -5,6 +5,7 @@ use iced::{
     Element,
 };
 use iced_lazy::Component;
+use monad_consensus_state::ConsensusConfig;
 use monad_consensus_types::{
     block::BlockType, quorum_certificate::genesis_vote_info, transaction_validator::MockValidator,
     validation::Sha256Hash,
@@ -89,7 +90,11 @@ impl SimulationConfig<MS, NoSerRouterScheduler<MM>, TransformerPipeline<MM>, Per
                     .collect::<Vec<_>>(),
 
                 delta: self.delta,
-                state_root_delay: 0,
+                consensus_config: ConsensusConfig {
+                    proposal_size: 5000,
+                    state_root_delay: 0,
+                    propose_with_missing_blocks: false,
+                },
                 genesis_block: genesis_block.clone(),
                 genesis_vote_info: genesis_vote_info(genesis_block.get_id()),
                 genesis_signatures: genesis_sigs.clone(),

--- a/monad-viz/src/replay_graph.rs
+++ b/monad-viz/src/replay_graph.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, fmt::Debug, time::Duration, vec};
 
+use monad_consensus_state::ConsensusConfig;
 use monad_consensus_types::{
     block::BlockType, quorum_certificate::genesis_vote_info, transaction_validator::MockValidator,
     validation::Sha256Hash,
@@ -51,7 +52,11 @@ impl ReplayConfig<MS> for RepConfig {
                     .map(|(node_id, sctpubkey)| (node_id.0, *sctpubkey))
                     .collect::<Vec<_>>(),
                 delta: self.delta,
-                state_root_delay: 0,
+                consensus_config: ConsensusConfig {
+                    proposal_size: 5000,
+                    state_root_delay: 0,
+                    propose_with_missing_blocks: false,
+                },
                 genesis_block: genesis_block.clone(),
                 genesis_vote_info: genesis_vote_info(genesis_block.get_id()),
                 genesis_signatures: genesis_sigs.clone(),


### PR DESCRIPTION
In certain situations where we are missing blocks in the pending blocktree (don't have a chain of blocks back to the root), we still might have enough information to try and propose a block. The block may have a higher chance to fail, but proposing in that situation gives the validator a chance to try and push a block through.