### PR TITLE
Switch `TimeoutCertificate` to `SignatureCollection`

### DIFF
--- a/monad-consensus-state/src/wrapper.rs
+++ b/monad-consensus-state/src/wrapper.rs
@@ -1,24 +1,18 @@
-use monad_consensus_types::{
-    message_signature::MessageSignature, signature_collection::SignatureCollection,
-};
+use monad_consensus_types::signature_collection::SignatureCollection;
 
 use crate::ConsensusState;
 
-struct ConsensusStateWrapper<S: MessageSignature, SC: SignatureCollection, TV, SV> {
-    consensus_state: ConsensusState<S, SC, TV, SV>,
+struct ConsensusStateWrapper<SCT: SignatureCollection, TV, SV> {
+    consensus_state: ConsensusState<SCT, TV, SV>,
 }
 
-impl<S: MessageSignature, SC: SignatureCollection, TV, SV> Drop
-    for ConsensusStateWrapper<S, SC, TV, SV>
-{
+impl<SCT: SignatureCollection, TV, SV> Drop for ConsensusStateWrapper<SCT, TV, SV> {
     fn drop(&mut self) {
         eprintln!("{:?}", self);
     }
 }
 
-impl<S: MessageSignature, SC: SignatureCollection, TV, SV> std::fmt::Debug
-    for ConsensusStateWrapper<S, SC, TV, SV>
-{
+impl<SC: SignatureCollection, TV, SV> std::fmt::Debug for ConsensusStateWrapper<SC, TV, SV> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ConsensusState")
             .field(

--- a/monad-consensus-types/src/timeout.rs
+++ b/monad-consensus-types/src/timeout.rs
@@ -1,16 +1,54 @@
+use std::collections::HashMap;
+
 use monad_types::*;
 use zerocopy::AsBytes;
 
 use super::quorum_certificate::QuorumCertificate;
-use crate::validation::{Hashable, Hasher};
+use crate::{
+    signature_collection::{
+        SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
+    },
+    validation::{Hashable, Hasher},
+    voting::ValidatorMapping,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TimeoutInfo<T> {
-    pub round: Round,
-    pub high_qc: QuorumCertificate<T>,
+pub struct Timeout<SCT: SignatureCollection> {
+    pub tminfo: TimeoutInfo<SCT>,
+    pub last_round_tc: Option<TimeoutCertificate<SCT>>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+impl<SCT: SignatureCollection> Hashable for Timeout<SCT> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // similar to ProposalMessage, not hashing over last_round_tc
+        self.tminfo.hash(state);
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TimeoutInfo<SCT> {
+    pub round: Round,
+    pub high_qc: QuorumCertificate<SCT>,
+}
+
+impl<SCT: SignatureCollection> Hashable for TimeoutInfo<SCT> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.update(self.round);
+        state.update(self.high_qc.info.vote.id.0.as_bytes());
+        state.update(self.high_qc.get_hash());
+    }
+}
+
+impl<SCT: SignatureCollection> TimeoutInfo<SCT> {
+    pub fn timeout_digest<H: Hasher>(&self) -> Hash {
+        let mut hasher = H::new();
+        hasher.update(self.round.as_bytes());
+        hasher.update(self.high_qc.info.vote.round.as_bytes());
+        hasher.hash()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct HighQcRound {
     pub qc_round: Round,
 }
@@ -22,18 +60,52 @@ impl Hashable for HighQcRound {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct HighQcRoundSigTuple<S> {
+pub struct HighQcRoundSigColTuple<SCT> {
     pub high_qc_round: HighQcRound,
-    pub author_signature: S,
+    pub sigs: SCT,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TimeoutCertificate<S> {
+pub struct TimeoutCertificate<SCT> {
     pub round: Round,
-    pub high_qc_rounds: Vec<HighQcRoundSigTuple<S>>,
+    pub high_qc_rounds: Vec<HighQcRoundSigColTuple<SCT>>,
 }
 
-impl<S> TimeoutCertificate<S> {
+impl<SCT: SignatureCollection> TimeoutCertificate<SCT> {
+    pub fn new<H: Hasher>(
+        round: Round,
+        high_qc_round_sig_tuple: &[(NodeId, TimeoutInfo<SCT>, SCT::SignatureType)],
+        validator_mapping: &ValidatorMapping<SignatureCollectionKeyPairType<SCT>>,
+    ) -> Result<Self, SignatureCollectionError<SCT::SignatureType>> {
+        let mut sigs = HashMap::new();
+        for (node_id, tmo_info, sig) in high_qc_round_sig_tuple {
+            let high_qc_round = HighQcRound {
+                qc_round: tmo_info.high_qc.info.vote.round,
+            };
+            let tminfo_digest = tmo_info.timeout_digest::<H>();
+            let entry = sigs
+                .entry(high_qc_round)
+                .or_insert((tminfo_digest, Vec::new()));
+            assert_eq!(entry.0, tminfo_digest);
+            entry.1.push((*node_id, *sig));
+        }
+        let mut high_qc_rounds = Vec::new();
+
+        for (high_qc_round, (tminfo_digest, sigs)) in sigs.into_iter() {
+            let sct = SCT::new(sigs, validator_mapping, tminfo_digest.as_ref())?;
+            high_qc_rounds.push(HighQcRoundSigColTuple::<SCT> {
+                high_qc_round,
+                sigs: sct,
+            });
+        }
+        Ok(Self {
+            round,
+            high_qc_rounds,
+        })
+    }
+}
+
+impl<SCT> TimeoutCertificate<SCT> {
     pub fn max_round(&self) -> Round {
         self.high_qc_rounds
             .iter()

--- a/monad-consensus/src/messages/consensus_message.rs
+++ b/monad-consensus/src/messages/consensus_message.rs
@@ -15,15 +15,15 @@ use crate::{
 };
 
 #[derive(Clone, PartialEq, Eq)]
-pub enum ConsensusMessage<ST, SCT: SignatureCollection> {
-    Proposal(ProposalMessage<ST, SCT>),
+pub enum ConsensusMessage<SCT: SignatureCollection> {
+    Proposal(ProposalMessage<SCT>),
     Vote(VoteMessage<SCT>),
-    Timeout(TimeoutMessage<ST, SCT>),
+    Timeout(TimeoutMessage<SCT>),
     RequestBlockSync(RequestBlockSyncMessage),
     BlockSync(BlockSyncMessage<SCT>),
 }
 
-impl<ST: Debug, SCT: Debug + SignatureCollection> Debug for ConsensusMessage<ST, SCT> {
+impl<SCT: Debug + SignatureCollection> Debug for ConsensusMessage<SCT> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ConsensusMessage::Proposal(p) => f.debug_tuple("").field(&p).finish(),
@@ -35,9 +35,8 @@ impl<ST: Debug, SCT: Debug + SignatureCollection> Debug for ConsensusMessage<ST,
     }
 }
 
-impl<ST, SCT> Hashable for ConsensusMessage<ST, SCT>
+impl<SCT> Hashable for ConsensusMessage<SCT>
 where
-    ST: MessageSignature,
     SCT: SignatureCollection,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -57,12 +56,14 @@ where
     }
 }
 
-impl<ST, SCT> ConsensusMessage<ST, SCT>
+impl<SCT> ConsensusMessage<SCT>
 where
-    ST: MessageSignature,
     SCT: SignatureCollection,
 {
-    pub fn sign<H: Hasher>(self, keypair: &KeyPair) -> Verified<ST, ConsensusMessage<ST, SCT>> {
+    pub fn sign<H: Hasher, ST: MessageSignature>(
+        self,
+        keypair: &KeyPair,
+    ) -> Verified<ST, ConsensusMessage<SCT>> {
         Verified::new::<H>(self, keypair)
     }
 }

--- a/monad-consensus/src/validation/message.rs
+++ b/monad-consensus/src/validation/message.rs
@@ -3,10 +3,10 @@ use monad_types::*;
 
 // (DiemBFT v4, p.12)
 // https://developers.diem.com/papers/diem-consensus-state-machine-replication-in-the-diem-blockchain/2021-08-17.pdf
-pub fn well_formed<S>(
+pub fn well_formed<SCT>(
     round: Round,
     qc_round: Round,
-    tc: &Option<TimeoutCertificate<S>>,
+    tc: &Option<TimeoutCertificate<SCT>>,
 ) -> Result<(), Error> {
     let prev_round = round - Round(1);
     let valid_qc_round = qc_round == prev_round;

--- a/monad-consensus/tests/proposal.rs
+++ b/monad-consensus/tests/proposal.rs
@@ -7,7 +7,7 @@ use monad_consensus_types::{
     validation::{Error, Sha256Hash},
     voting::{ValidatorMapping, VoteInfo},
 };
-use monad_crypto::secp256k1::{PubKey, SecpSignature};
+use monad_crypto::secp256k1::PubKey;
 use monad_testutil::{
     signing::{get_key, MockSignatures, TestSigner},
     validators::create_keys_w_validators,
@@ -56,7 +56,7 @@ fn test_proposal_hash() {
     let (keypairs, _certkeys, vset, vmap) = create_keys_w_validators::<SignatureCollectionType>(1);
     let author = NodeId(keypairs[0].pubkey());
 
-    let proposal: ProposalMessage<SecpSignature, MockSignatures> = ProposalMessage {
+    let proposal: ProposalMessage<MockSignatures> = ProposalMessage {
         block: setup_block(
             author,
             Round(234),

--- a/monad-driver/src/lib.rs
+++ b/monad-driver/src/lib.rs
@@ -31,12 +31,7 @@ mod tests {
     type TransactionValidatorType = MockValidator;
     type StateRootValidatorType = NopStateRoot;
     type S = MonadState<
-        ConsensusState<
-            SignatureType,
-            SignatureCollectionType,
-            TransactionValidatorType,
-            StateRootValidatorType,
-        >,
+        ConsensusState<SignatureCollectionType, TransactionValidatorType, StateRootValidatorType>,
         SignatureType,
         SignatureCollectionType,
         ValidatorSet,

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -47,12 +47,7 @@ type SignatureCollectionType = MultiSig<SignatureType>;
 type TransactionValidatorType = MockValidator;
 type StateRootValidatorType = NopStateRoot;
 type MonadState = monad_state::MonadState<
-    ConsensusState<
-        SignatureType,
-        SignatureCollectionType,
-        TransactionValidatorType,
-        StateRootValidatorType,
-    >,
+    ConsensusState<SignatureCollectionType, TransactionValidatorType, StateRootValidatorType>,
     SignatureType,
     SignatureCollectionType,
     ValidatorSet,

--- a/monad-proto/proto/message.proto
+++ b/monad-proto/proto/message.proto
@@ -24,8 +24,8 @@ message ProtoBlockSyncMessage {
 }
 
 message ProtoTimeoutMessage {
-  monad_proto.timeout.ProtoTimeoutInfo tminfo = 1;
-  optional monad_proto.timeout.ProtoTimeoutCertificate last_round_tc = 2;
+  monad_proto.timeout.ProtoTimeout timeout = 1;
+  monad_proto.signing.ProtoSignature sig = 2;
 }
 
 message ProtoProposalMessage {

--- a/monad-proto/proto/timeout.proto
+++ b/monad-proto/proto/timeout.proto
@@ -11,17 +11,22 @@ message ProtoHighQcRound {
   monad_proto.basic.ProtoRound qc_round = 1;
 }
 
-message ProtoHighQcRoundSigTuple {
+message ProtoHighQcRoundSigColTuple {
   ProtoHighQcRound high_qc_round = 1;
-  monad_proto.signing.ProtoSignature author_signature = 2;
+  monad_proto.signing.ProtoSignatureCollection sigs = 2;
 }
 
 message ProtoTimeoutCertificate {
   monad_proto.basic.ProtoRound round = 1;
-  repeated ProtoHighQcRoundSigTuple high_qc_rounds = 2;
+  repeated ProtoHighQcRoundSigColTuple high_qc_rounds = 2;
 }
 
 message ProtoTimeoutInfo {
   monad_proto.basic.ProtoRound round = 1;
   monad_proto.quorum_certificate.ProtoQuorumCertificate high_qc = 2;
+}
+
+message ProtoTimeout {
+  ProtoTimeoutInfo tminfo = 1;
+  optional ProtoTimeoutCertificate last_round_tc = 2;
 }

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -24,7 +24,7 @@ use crate::RandomizedTest;
 fn random_latency_test(seed: u64) {
     create_and_run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, NopStateRoot>,
+            ConsensusState<MultiSig<NopSignature>, MockValidator, NopStateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,
@@ -73,7 +73,7 @@ fn delayed_message_test(seed: u64) {
 
     run_nodes_until::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, NopStateRoot>,
+            ConsensusState<MultiSig<NopSignature>, MockValidator, NopStateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/benches/two_node_benchmark.rs
+++ b/monad-state/benches/two_node_benchmark.rs
@@ -27,7 +27,7 @@ criterion_main!(benches);
 fn two_nodes() {
     create_and_run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
+            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/block_sync.rs
+++ b/monad-state/tests/block_sync.rs
@@ -41,7 +41,7 @@ fn black_out() {
 
     run_nodes_until::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
+            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,
@@ -98,7 +98,7 @@ fn extreme_delay() {
 
     run_nodes_until::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
+            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/many_nodes.rs
+++ b/monad-state/tests/many_nodes.rs
@@ -26,7 +26,7 @@ fn many_nodes() {
 
     create_and_run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
+            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,
@@ -64,7 +64,7 @@ fn many_nodes_quic() {
 
     create_and_run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
+            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/many_nodes_metrics.rs
+++ b/monad-state/tests/many_nodes_metrics.rs
@@ -39,7 +39,7 @@ fn many_nodes_metrics() {
 
     create_and_run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
+            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/msg_delays.rs
+++ b/monad-state/tests/msg_delays.rs
@@ -22,7 +22,7 @@ fn two_nodes() {
 
     create_and_run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
+            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/order.rs
+++ b/monad-state/tests/order.rs
@@ -66,7 +66,7 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
 
     run_nodes_until::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
+            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/protobuf.rs
+++ b/monad-state/tests/protobuf.rs
@@ -60,7 +60,7 @@ fn test_consensus_message_event_vote_multisig() {
         ledger_commit_info: lci,
     };
 
-    let votemsg: ConsensusMessage<SecpSignature, SignatureCollectionType> =
+    let votemsg: ConsensusMessage<SignatureCollectionType> =
         ConsensusMessage::Vote(VoteMessage::new::<Sha256Hash>(vote, &certkeypair));
     let votemsg_hash = Sha256Hash::hash_object(&votemsg);
     let sig = keypair.sign(votemsg_hash.as_ref());
@@ -98,7 +98,7 @@ fn test_consensus_message_event_proposal_bls() {
 
     let proposal = propgen.next_proposal(
         &keys,
-        &cert_keys,
+        cert_keys.as_slice(),
         &valset,
         &election,
         &valmap,

--- a/monad-state/tests/rand_lat.rs
+++ b/monad-state/tests/rand_lat.rs
@@ -59,7 +59,7 @@ fn nodes_with_random_latency(seed: u64) {
 
     create_and_run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
+            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/replay.rs
+++ b/monad-state/tests/replay.rs
@@ -71,7 +71,6 @@ pub fn recover_nodes_msg_delays(num_nodes: u16, num_blocks_before: usize, num_bl
     let mut nodes = Nodes::<
         MonadState<
             ConsensusState<
-                SignatureType,
                 SignatureCollectionType,
                 TransactionValidatorType,
                 StateRootValidatorType,
@@ -154,7 +153,6 @@ pub fn recover_nodes_msg_delays(num_nodes: u16, num_blocks_before: usize, num_bl
     let mut nodes_recovered = Nodes::<
         MonadState<
             ConsensusState<
-                SignatureType,
                 SignatureCollectionType,
                 TransactionValidatorType,
                 StateRootValidatorType,

--- a/monad-state/tests/single_node.rs
+++ b/monad-state/tests/single_node.rs
@@ -26,7 +26,7 @@ fn two_nodes() {
 
     create_and_run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
+            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,
@@ -64,7 +64,7 @@ fn two_nodes_quic() {
 
     create_and_run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
+            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/single_node_metrics.rs
+++ b/monad-state/tests/single_node_metrics.rs
@@ -39,7 +39,7 @@ fn two_nodes() {
 
     create_and_run_nodes::<
         MonadState<
-            ConsensusState<NopSignature, MultiSig<NopSignature>, MockValidator, StateRoot>,
+            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
             NopSignature,
             MultiSig<NopSignature>,
             ValidatorSet,

--- a/monad-state/tests/two_nodes_bls.rs
+++ b/monad-state/tests/two_nodes_bls.rs
@@ -25,7 +25,7 @@ fn two_nodes_bls() {
 
     create_and_run_nodes::<
         MonadState<
-            ConsensusState<SignatureType, SignatureCollectionType, MockValidator, StateRoot>,
+            ConsensusState<SignatureCollectionType, MockValidator, StateRoot>,
             SignatureType,
             SignatureCollectionType,
             ValidatorSet,

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -40,12 +40,7 @@ type SignatureCollectionType = MultiSig<SignatureType>;
 type TransactionValidatorType = MockValidator;
 type StateRootValidatorType = NopStateRoot;
 type MonadState = monad_state::MonadState<
-    ConsensusState<
-        SignatureType,
-        SignatureCollectionType,
-        TransactionValidatorType,
-        StateRootValidatorType,
-    >,
+    ConsensusState<SignatureCollectionType, TransactionValidatorType, StateRootValidatorType>,
     SignatureType,
     SignatureCollectionType,
     ValidatorSet,

--- a/monad-testutil/examples/logs_gen.rs
+++ b/monad-testutil/examples/logs_gen.rs
@@ -21,7 +21,7 @@ use monad_wal::wal::{WALogger, WALoggerConfig};
 type SignatureType = NopSignature;
 type SignatureCollectionType = MultiSig<SignatureType>;
 type MS = MonadState<
-    ConsensusState<SignatureType, SignatureCollectionType, MockValidator, NopStateRoot>,
+    ConsensusState<SignatureCollectionType, MockValidator, NopStateRoot>,
     SignatureType,
     SignatureCollectionType,
     ValidatorSet,

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -27,7 +27,7 @@ impl AsRef<[u8]> for Hash {
 }
 
 #[repr(transparent)]
-#[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd, AsBytes)]
+#[derive(Copy, Clone, Eq, Hash, Ord, PartialEq, PartialOrd, AsBytes)]
 pub struct Round(pub u64);
 
 impl AsRef<[u8]> for Round {

--- a/monad-viz/src/main.rs
+++ b/monad-viz/src/main.rs
@@ -57,12 +57,7 @@ type NS<'a> = NodeState<
     MonadEvent<SignatureType, SignatureCollectionType>,
 >;
 type MS = MonadState<
-    ConsensusState<
-        SignatureType,
-        SignatureCollectionType,
-        TransactionValidatorType,
-        StateRootValidatorType,
-    >,
+    ConsensusState<SignatureCollectionType, TransactionValidatorType, StateRootValidatorType>,
     SignatureType,
     SignatureCollectionType,
     ValidatorSet,
@@ -152,7 +147,6 @@ impl Application for Viz {
                 ReplayNodesSimulation::<
                     MonadState<
                         ConsensusState<
-                            SignatureType,
                             SignatureCollectionType,
                             TransactionValidatorType,
                             StateRootValidatorType,
@@ -187,7 +181,6 @@ impl Application for Viz {
                 NodesSimulation::<
                     MonadState<
                         ConsensusState<
-                            SignatureType,
                             SignatureCollectionType,
                             TransactionValidatorType,
                             StateRootValidatorType,


### PR DESCRIPTION
`TimeoutCertificate` was created with a vector of signatures over the current round and the high qc round. The size of the certificate is thus proportional to the number of signers on it.

We note that nodes are likely to be locked on a small number of high qcs, so we can leverage aggregate signatures to make TC more compact and potentially faster to verify.

`TimeoutMessage` now carries a signature created with the certificate keypair. We bucket the timeout signatures by `high_qc_round` and aggregate signatures in the same bucket when constructing the TC.

Closes #253 