### PR TITLE
Make `MonadState` generic over `Hasher`

### DIFF
--- a/monad-driver/src/lib.rs
+++ b/monad-driver/src/lib.rs
@@ -42,6 +42,7 @@ mod tests {
         ValidatorSet,
         SimpleRoundRobin,
         BlockSyncState,
+        Sha256Hash,
     >;
     type PersistenceLoggerType = MockWALogger<<S as State>::Event>;
 

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -58,6 +58,7 @@ type MonadState = monad_state::MonadState<
     ValidatorSet,
     SimpleRoundRobin,
     BlockSyncState,
+    HasherType,
 >;
 type MonadConfig = <MonadState as State>::Config;
 

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -4,6 +4,7 @@ use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
     multi_sig::MultiSig, payload::NopStateRoot, transaction_validator::MockValidator,
+    validation::Sha256Hash,
 };
 use monad_crypto::NopSignature;
 use monad_executor::{
@@ -30,6 +31,7 @@ fn random_latency_test(seed: u64) {
             ValidatorSet,
             SimpleRoundRobin,
             BlockSyncState,
+            Sha256Hash,
         >,
         NopSignature,
         MultiSig<NopSignature>,
@@ -79,6 +81,7 @@ fn delayed_message_test(seed: u64) {
             ValidatorSet,
             SimpleRoundRobin,
             BlockSyncState,
+            Sha256Hash,
         >,
         NopSignature,
         MultiSig<NopSignature>,

--- a/monad-state/benches/two_node_benchmark.rs
+++ b/monad-state/benches/two_node_benchmark.rs
@@ -5,6 +5,7 @@ use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
     multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+    validation::Sha256Hash,
 };
 use monad_crypto::NopSignature;
 use monad_executor::{
@@ -33,6 +34,7 @@ fn two_nodes() {
             ValidatorSet,
             SimpleRoundRobin,
             BlockSyncState,
+            Sha256Hash,
         >,
         NopSignature,
         MultiSig<NopSignature>,

--- a/monad-state/tests/block_sync.rs
+++ b/monad-state/tests/block_sync.rs
@@ -4,6 +4,7 @@ use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
     multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+    validation::Sha256Hash,
 };
 use monad_crypto::NopSignature;
 use monad_executor::{
@@ -47,6 +48,7 @@ fn black_out() {
             ValidatorSet,
             SimpleRoundRobin,
             BlockSyncState,
+            Sha256Hash,
         >,
         NopSignature,
         MultiSig<NopSignature>,
@@ -104,6 +106,7 @@ fn extreme_delay() {
             ValidatorSet,
             SimpleRoundRobin,
             BlockSyncState,
+            Sha256Hash,
         >,
         NopSignature,
         MultiSig<NopSignature>,

--- a/monad-state/tests/many_nodes.rs
+++ b/monad-state/tests/many_nodes.rs
@@ -4,6 +4,7 @@ use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
     multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+    validation::Sha256Hash,
 };
 use monad_crypto::NopSignature;
 use monad_executor::{
@@ -32,6 +33,7 @@ fn many_nodes() {
             ValidatorSet,
             SimpleRoundRobin,
             BlockSyncState,
+            Sha256Hash,
         >,
         NopSignature,
         MultiSig<NopSignature>,
@@ -70,6 +72,7 @@ fn many_nodes_quic() {
             ValidatorSet,
             SimpleRoundRobin,
             BlockSyncState,
+            Sha256Hash,
         >,
         NopSignature,
         MultiSig<NopSignature>,

--- a/monad-state/tests/many_nodes_metrics.rs
+++ b/monad-state/tests/many_nodes_metrics.rs
@@ -4,6 +4,7 @@ use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
     multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+    validation::Sha256Hash,
 };
 use monad_crypto::NopSignature;
 use monad_executor::{
@@ -45,6 +46,7 @@ fn many_nodes_metrics() {
             ValidatorSet,
             SimpleRoundRobin,
             BlockSyncState,
+            Sha256Hash,
         >,
         NopSignature,
         MultiSig<NopSignature>,

--- a/monad-state/tests/msg_delays.rs
+++ b/monad-state/tests/msg_delays.rs
@@ -4,6 +4,7 @@ use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
     multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+    validation::Sha256Hash,
 };
 use monad_crypto::NopSignature;
 use monad_executor::{
@@ -28,6 +29,7 @@ fn two_nodes() {
             ValidatorSet,
             SimpleRoundRobin,
             BlockSyncState,
+            Sha256Hash,
         >,
         NopSignature,
         MultiSig<NopSignature>,

--- a/monad-state/tests/order.rs
+++ b/monad-state/tests/order.rs
@@ -4,6 +4,7 @@ use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
     multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+    validation::Sha256Hash,
 };
 use monad_crypto::NopSignature;
 use monad_executor::{
@@ -72,6 +73,7 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
             ValidatorSet,
             SimpleRoundRobin,
             BlockSyncState,
+            Sha256Hash,
         >,
         NopSignature,
         MultiSig<NopSignature>,

--- a/monad-state/tests/rand_lat.rs
+++ b/monad-state/tests/rand_lat.rs
@@ -4,6 +4,7 @@ use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
     multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+    validation::Sha256Hash,
 };
 use monad_crypto::NopSignature;
 use monad_executor::{
@@ -65,6 +66,7 @@ fn nodes_with_random_latency(seed: u64) {
             ValidatorSet,
             SimpleRoundRobin,
             BlockSyncState,
+            Sha256Hash,
         >,
         NopSignature,
         MultiSig<NopSignature>,

--- a/monad-state/tests/replay.rs
+++ b/monad-state/tests/replay.rs
@@ -4,7 +4,7 @@ use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
     block::BlockType, multi_sig::MultiSig, payload::NopStateRoot,
-    transaction_validator::MockValidator,
+    transaction_validator::MockValidator, validation::Sha256Hash,
 };
 use monad_crypto::secp256k1::SecpSignature;
 use monad_executor::{
@@ -20,6 +20,7 @@ use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::Valid
 use monad_wal::wal::{WALogger, WALoggerConfig};
 use tempfile::tempdir;
 
+type HasherType = Sha256Hash;
 type SignatureType = SecpSignature;
 type SignatureCollectionType = MultiSig<SignatureType>;
 type TransactionValidatorType = MockValidator;
@@ -81,6 +82,7 @@ pub fn recover_nodes_msg_delays(num_nodes: u16, num_blocks_before: usize, num_bl
             ValidatorSet,
             SimpleRoundRobin,
             BlockSyncState,
+            HasherType,
         >,
         NoSerRouterScheduler<MonadMessage<SignatureType, SignatureCollectionType>>,
         _,
@@ -164,6 +166,7 @@ pub fn recover_nodes_msg_delays(num_nodes: u16, num_blocks_before: usize, num_bl
             ValidatorSet,
             SimpleRoundRobin,
             BlockSyncState,
+            HasherType,
         >,
         NoSerRouterScheduler<MonadMessage<SignatureType, SignatureCollectionType>>,
         _,

--- a/monad-state/tests/single_node.rs
+++ b/monad-state/tests/single_node.rs
@@ -4,6 +4,7 @@ use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
     multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+    validation::Sha256Hash,
 };
 use monad_crypto::NopSignature;
 use monad_executor::{
@@ -32,6 +33,7 @@ fn two_nodes() {
             ValidatorSet,
             SimpleRoundRobin,
             BlockSyncState,
+            Sha256Hash,
         >,
         NopSignature,
         MultiSig<NopSignature>,
@@ -70,6 +72,7 @@ fn two_nodes_quic() {
             ValidatorSet,
             SimpleRoundRobin,
             BlockSyncState,
+            Sha256Hash,
         >,
         NopSignature,
         MultiSig<NopSignature>,

--- a/monad-state/tests/single_node_metrics.rs
+++ b/monad-state/tests/single_node_metrics.rs
@@ -4,6 +4,7 @@ use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
     multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+    validation::Sha256Hash,
 };
 use monad_crypto::NopSignature;
 use monad_executor::{
@@ -45,6 +46,7 @@ fn two_nodes() {
             ValidatorSet,
             SimpleRoundRobin,
             BlockSyncState,
+            Sha256Hash,
         >,
         NopSignature,
         MultiSig<NopSignature>,

--- a/monad-state/tests/two_nodes_bls.rs
+++ b/monad-state/tests/two_nodes_bls.rs
@@ -4,6 +4,7 @@ use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
     bls::BlsSignatureCollection, payload::StateRoot, transaction_validator::MockValidator,
+    validation::Sha256Hash,
 };
 use monad_crypto::secp256k1::SecpSignature;
 use monad_executor::{
@@ -31,6 +32,7 @@ fn two_nodes_bls() {
             ValidatorSet,
             SimpleRoundRobin,
             BlockSyncState,
+            Sha256Hash,
         >,
         SignatureType,
         SignatureCollectionType,

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -51,6 +51,7 @@ type MonadState = monad_state::MonadState<
     ValidatorSet,
     SimpleRoundRobin,
     BlockSyncState,
+    HasherType,
 >;
 type MonadConfig = <MonadState as State>::Config;
 

--- a/monad-testutil/examples/logs_gen.rs
+++ b/monad-testutil/examples/logs_gen.rs
@@ -4,6 +4,7 @@ use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
     multi_sig::MultiSig, payload::NopStateRoot, transaction_validator::MockValidator,
+    validation::Sha256Hash,
 };
 use monad_crypto::NopSignature;
 use monad_executor::{
@@ -27,6 +28,7 @@ type MS = MonadState<
     ValidatorSet,
     SimpleRoundRobin,
     BlockSyncState,
+    Sha256Hash,
 >;
 type MM = <MS as State>::Message;
 type ME = <MS as State>::Event;

--- a/monad-viz/src/main.rs
+++ b/monad-viz/src/main.rs
@@ -28,6 +28,7 @@ use monad_consensus_types::{
     multi_sig::MultiSig,
     payload::NopStateRoot,
     transaction_validator::MockValidator,
+    validation::Sha256Hash,
 };
 use monad_crypto::NopSignature;
 use monad_executor::{
@@ -45,6 +46,7 @@ use monad_wal::{
 };
 use replay_graph::{RepConfig, ReplayNodesSimulation};
 
+type HasherType = Sha256Hash;
 type SignatureType = NopSignature;
 type SignatureCollectionType = MultiSig<SignatureType>;
 type TransactionValidatorType = MockValidator;
@@ -68,6 +70,7 @@ type MS = MonadState<
     ValidatorSet,
     SimpleRoundRobin,
     BlockSyncState,
+    HasherType,
 >;
 type MM = <MS as State>::Message;
 type ME = <MS as State>::Event;
@@ -162,6 +165,7 @@ impl Application for Viz {
                         ValidatorSet,
                         SimpleRoundRobin,
                         BlockSyncState,
+                        HasherType,
                     >,
                     _,
                 >::new(config, replay_events)
@@ -197,6 +201,7 @@ impl Application for Viz {
                         ValidatorSet,
                         SimpleRoundRobin,
                         BlockSyncState,
+                        HasherType,
                     >,
                     NoSerRouterScheduler<MonadMessage<SignatureType, SignatureCollectionType>>,
                     _,


### PR DESCRIPTION
`HasherType` determines the hashing algorithm when calculating `Block.Id`, `Qc.sigs` hash, etc. The top-level binary creates genesis config and pass it to `MonadState`. `MonadState` must use the same hashing algorithm as the top-level to verify the config.

Previously, `MonadState` is hardcoding the `HasherType` to `Sha256Hash`. So it's possible to use a different hasher for the top-level (`MonadNode`, `testground`), though unlikely because we only have a single Hasher implementation.

This PR address the issue by making `MonadState` generic over `Hasher`. The top-level can configure the hashing algo so it's always consistent with what's used to create the genesis config.

Closes #252 