### PR TITLE
Allow Consensus to track in flight block sync

### DIFF
--- a/monad-block-sync/src/lib.rs
+++ b/monad-block-sync/src/lib.rs
@@ -1,19 +1,27 @@
+use std::collections::{hash_map::Entry, HashMap};
+
 use monad_consensus::messages::{
-    consensus_message::ConsensusMessage, message::RequestBlockSyncMessage,
+    consensus_message::ConsensusMessage,
+    message::{BlockSyncMessage, RequestBlockSyncMessage},
 };
 use monad_consensus_state::command::{ConsensusCommand, FetchedBlock};
 use monad_consensus_types::{
-    message_signature::MessageSignature, signature_collection::SignatureCollection,
+    block::Block, message_signature::MessageSignature, signature_collection::SignatureCollection,
 };
-use monad_executor::{PeerId, RouterTarget};
+use monad_executor::PeerId;
 use monad_types::{BlockId, NodeId};
 use monad_validator::validator_set::ValidatorSetType;
-
+const DEFAULT_AUTHOR_INDEX: usize = 0;
+const DEFAULT_RETRY_INIT: usize = 0;
 #[derive(Debug)]
 pub struct BlockSyncState {
-    round_robin_validator_selector: usize,
+    request_mapping: HashMap<(PeerId, BlockId), usize>,
 }
-
+pub enum BlockRetrievalResult<ST, SC: SignatureCollection> {
+    Success(Block<SC>),                         // retrieved
+    Failed((PeerId, ConsensusMessage<ST, SC>)), // unable to retrieve
+    IllegalResponse(PeerId),                    // never requested from this peer (slash)
+}
 pub trait BlockSyncProcess<ST, SC, VT>
 where
     ST: MessageSignature,
@@ -24,15 +32,22 @@ where
 
     fn request_block_sync(
         &mut self,
-        blockid: BlockId,
+        bid: BlockId,
         validators: &VT,
-    ) -> (RouterTarget, ConsensusMessage<ST, SC>);
+    ) -> Option<(PeerId, ConsensusMessage<ST, SC>)>;
 
     fn handle_request_block_sync_message(
         &mut self,
         author: NodeId,
         s: RequestBlockSyncMessage,
     ) -> Vec<ConsensusCommand<ST, SC>>;
+
+    fn handle_block_sync_message(
+        &mut self,
+        author: NodeId,
+        s: BlockSyncMessage<SC>,
+        validators: &VT,
+    ) -> BlockRetrievalResult<ST, SC>;
 }
 
 impl<ST, SC, VT> BlockSyncProcess<ST, SC, VT> for BlockSyncState
@@ -43,22 +58,25 @@ where
 {
     fn new() -> Self {
         BlockSyncState {
-            round_robin_validator_selector: 0,
+            request_mapping: HashMap::new(),
         }
     }
 
     fn request_block_sync(
         &mut self,
-        blockid: BlockId,
+        bid: BlockId,
         validators: &VT,
-    ) -> (RouterTarget, ConsensusMessage<ST, SC>) {
-        let target = RouterTarget::PointToPoint(PeerId(
-            validators.get_list()[self.round_robin_validator_selector % validators.len()].0,
-        ));
-        self.round_robin_validator_selector += 1;
-        let message =
-            ConsensusMessage::RequestBlockSync(RequestBlockSyncMessage { block_id: blockid });
-        (target, message)
+    ) -> Option<(PeerId, ConsensusMessage<ST, SC>)> {
+        assert!(validators.len() > 0);
+        let peer = PeerId(validators.get_list()[DEFAULT_AUTHOR_INDEX].0);
+        let message = ConsensusMessage::RequestBlockSync(RequestBlockSyncMessage { block_id: bid });
+        match self.request_mapping.entry((peer, bid)) {
+            Entry::Occupied(_entry) => None,
+            Entry::Vacant(entry) => {
+                entry.insert(DEFAULT_RETRY_INIT);
+                Some((peer, message))
+            }
+        }
     }
 
     fn handle_request_block_sync_message(
@@ -70,9 +88,47 @@ where
             s.block_id,
             Box::new(move |block| FetchedBlock {
                 requester: author,
+                block_id: s.block_id,
                 block,
             }),
         )]
+    }
+
+    fn handle_block_sync_message(
+        &mut self,
+        author: NodeId,
+        s: BlockSyncMessage<SC>,
+        validators: &VT,
+    ) -> BlockRetrievalResult<ST, SC> {
+        assert!(validators.len() > 0);
+
+        let peer = PeerId(author.0);
+        let bid = s.block_id;
+
+        match self.request_mapping.entry((peer, bid)) {
+            Entry::Occupied(entry) => {
+                match s.block {
+                    Some(block) => {
+                        // block retrieve successful
+                        entry.remove_entry();
+                        BlockRetrievalResult::Success(block)
+                    }
+                    None => {
+                        // block retrieve failed, re-request
+                        let (_, mut retry) = entry.remove_entry();
+                        retry += 1;
+
+                        let peer = PeerId(validators.get_list()[retry % validators.len()].0);
+                        let message = ConsensusMessage::RequestBlockSync(RequestBlockSyncMessage {
+                            block_id: bid,
+                        });
+                        self.request_mapping.insert((peer, bid), retry);
+                        BlockRetrievalResult::Failed((peer, message))
+                    }
+                }
+            }
+            _ => BlockRetrievalResult::IllegalResponse(peer),
+        }
     }
 }
 
@@ -84,7 +140,7 @@ mod test {
     use monad_consensus_state::command::ConsensusCommand;
     use monad_consensus_types::multi_sig::MultiSig;
     use monad_crypto::{secp256k1::PubKey, NopSignature};
-    use monad_executor::RouterTarget;
+    use monad_executor::PeerId;
     use monad_testutil::{signing::get_key, validators::create_keys_w_validators};
     use monad_types::{BlockId, Hash, NodeId};
     use monad_validator::validator_set::{ValidatorSet, ValidatorSetType};
@@ -95,7 +151,7 @@ mod test {
     type VT = ValidatorSet;
 
     fn verify_target_and_message(
-        target: &RouterTarget,
+        target: &PeerId,
         message: &ConsensusMessage<ST, SC>,
         desired_pubkey: PubKey,
         desired_block_id: BlockId,
@@ -109,8 +165,8 @@ mod test {
         }
 
         match target {
-            RouterTarget::PointToPoint(node) => {
-                assert_eq!(node.0, desired_pubkey);
+            PeerId(pubkey) => {
+                assert_eq!(*pubkey, desired_pubkey);
             }
             _ => panic!("request_block_sync didn't produce a valid routing target"),
         }
@@ -121,32 +177,46 @@ mod test {
         let mut process: BlockSyncState = BlockSyncProcess::<ST, SC, VT>::new();
         let (_, _, valset, _) = create_keys_w_validators::<SC>(4);
 
-        let (target, message): (RouterTarget, ConsensusMessage<ST, SC>) =
-            process.request_block_sync(BlockId(Hash([0x00_u8; 32])), &valset);
-
-        verify_target_and_message(
-            &target,
-            &message,
-            valset.get_list()[0].0,
-            BlockId(Hash([0x00_u8; 32])),
-        );
-    }
-
-    #[test]
-    fn test_request_block_sync_round_robin() {
-        let mut process: BlockSyncState = BlockSyncProcess::<ST, SC, VT>::new();
-        let (_, _, valset, _) = create_keys_w_validators::<SC>(4);
-
-        let (mut target, mut message): (RouterTarget, ConsensusMessage<ST, SC>) =
-            process.request_block_sync(BlockId(Hash([0x00_u8; 32])), &valset);
-        for i in 0..15 {
+        if let Some((target, message)) =
+            process.request_block_sync(BlockId(Hash([0x00_u8; 32])), &valset)
+        {
             verify_target_and_message(
                 &target,
                 &message,
-                valset.get_list()[i % 4].0,
+                valset.get_list()[0].0,
                 BlockId(Hash([0x00_u8; 32])),
             );
-            (target, message) = process.request_block_sync(BlockId(Hash([0x00_u8; 32])), &valset);
+        } else {
+            panic!("request_block_sync no return")
+        }
+    }
+
+    #[test]
+    fn test_request_block_sync_no_duplicate() {
+        let mut process: BlockSyncState = BlockSyncProcess::<ST, SC, VT>::new();
+        let (_, _, valset, _) = create_keys_w_validators::<SC>(4);
+
+        if let Some((target, message)) =
+            process.request_block_sync(BlockId(Hash([0x00_u8; 32])), &valset)
+        {
+            verify_target_and_message(
+                &target,
+                &message,
+                valset.get_list()[0].0,
+                BlockId(Hash([0x00_u8; 32])),
+            );
+            for _ in 0..15 {
+                assert!(
+                    <BlockSyncState as BlockSyncProcess<ST, SC, ValidatorSet>>::request_block_sync(
+                        &mut process,
+                        BlockId(Hash([0x00_u8; 32])),
+                        &valset
+                    )
+                    .is_none()
+                );
+            }
+        } else {
+            panic!("request_block_sync no return")
         }
     }
 

--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, fmt, result::Result as StdResult};
 
 use monad_consensus_types::{
     block::{Block, BlockType},
+    quorum_certificate::QuorumCertificate,
     signature_collection::SignatureCollection,
 };
 use monad_tracing_counter::inc_count;
@@ -258,11 +259,25 @@ impl<T: SignatureCollection> BlockTree<T> {
         }
     }
 
-    pub fn get_missing_ancestor(&self, b: &BlockId) -> Option<BlockId> {
-        let mut bid = b;
+    pub fn get_missing_ancestor(&self, qc: &QuorumCertificate<T>) -> Option<QuorumCertificate<T>> {
+        match self.root {
+            RootKind::Rooted(b) => {
+                if self.tree.get(&b).unwrap().get_block().round >= qc.info.vote.round {
+                    return None;
+                }
+            }
+            RootKind::Unrooted(r) => {
+                if r >= qc.info.vote.round {
+                    return None;
+                }
+            }
+        };
+
+        let mut bid = &qc.info.vote.id;
+        let mut current_qc = qc;
         loop {
             let Some(i) = self.tree.get(bid) else {
-                return Some(*bid);
+                return Some(current_qc.clone());
             };
             if self.root_match(i) {
                 return None;
@@ -271,6 +286,7 @@ impl<T: SignatureCollection> BlockTree<T> {
                 return None;
             };
             bid = parent_id;
+            current_qc = &i.block.qc;
         }
     }
 
@@ -1482,6 +1498,13 @@ mod test {
 
     #[test]
     fn test_get_missing_ancestor() {
+        // Initial blocktree
+        //        g
+        //        |
+        //        b1
+        //  |  -  |  -  |
+        //  b2    b3    b4
+
         let payload = Payload {
             txns: TransactionList(vec![]),
             header: ExecutionArtifacts::zero(),
@@ -1575,30 +1598,30 @@ mod test {
         );
 
         let mut blocktree = BlockTree::<MockSignatures>::new(g.clone());
-        assert!(blocktree.get_missing_ancestor(&g.get_id()).is_none()); // root naturally don't have missing ancestor
-        assert!(blocktree.get_missing_ancestor(&b1.get_id()).unwrap() == b1.get_id());
+        assert!(blocktree.get_missing_ancestor(&g.qc).is_none()); // root naturally don't have missing ancestor
 
         assert!(blocktree.add(b2.clone()).is_ok());
-        assert!(blocktree.get_missing_ancestor(&b2.get_id()).unwrap() == b1.get_id());
+        assert!(blocktree.get_missing_ancestor(&b2.qc).unwrap() == b2.qc);
 
         assert!(blocktree.add(b3.clone()).is_ok());
-        assert!(blocktree.get_missing_ancestor(&b3.get_id()).unwrap() == b1.get_id());
+        assert!(blocktree.get_missing_ancestor(&b3.qc).unwrap() == b2.qc);
 
         assert!(blocktree.add(b4.clone()).is_ok());
-        assert!(blocktree.get_missing_ancestor(&b4.get_id()).unwrap() == b1.get_id());
+        assert!(blocktree.get_missing_ancestor(&b4.qc).unwrap() == b2.qc);
 
         assert!(blocktree.add(b1.clone()).is_ok());
-        assert!(blocktree.get_missing_ancestor(&b1.get_id()).is_none());
-        assert!(blocktree.get_missing_ancestor(&b2.get_id()).is_none());
-        assert!(blocktree.get_missing_ancestor(&b3.get_id()).is_none());
-        assert!(blocktree.get_missing_ancestor(&b4.get_id()).is_none());
+        assert!(blocktree.get_missing_ancestor(&b1.qc).is_none());
+        assert!(blocktree.get_missing_ancestor(&b2.qc).is_none());
+        assert!(blocktree.get_missing_ancestor(&b3.qc).is_none());
+        assert!(blocktree.get_missing_ancestor(&b4.qc).is_none());
 
         blocktree.prune(&b1.get_id()).unwrap();
-        assert!(blocktree.get_missing_ancestor(&g.get_id()).unwrap() == g.get_id());
+        assert!(blocktree.get_missing_ancestor(&g.qc).is_none());
+        assert!(blocktree.get_missing_ancestor(&b1.qc).is_none());
+        assert!(blocktree.get_missing_ancestor(&b2.qc).is_none());
+        assert!(blocktree.get_missing_ancestor(&b3.qc).is_none());
+        assert!(blocktree.get_missing_ancestor(&b4.qc).is_none());
 
-        assert!(blocktree.get_missing_ancestor(&b1.get_id()).is_none());
-        assert!(blocktree.get_missing_ancestor(&b2.get_id()).is_none());
-        assert!(blocktree.get_missing_ancestor(&b3.get_id()).is_none());
-        assert!(blocktree.get_missing_ancestor(&b4.get_id()).is_none());
+        assert!(blocktree.size() == 4);
     }
 }

--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -15,6 +15,8 @@ use monad_consensus_types::{
 use monad_executor::RouterTarget;
 use monad_types::{BlockId, Epoch, Hash, NodeId, Round};
 
+use crate::manager::InFlightBlockSync;
+
 pub enum ConsensusCommand<ST, SCT: SignatureCollection> {
     Publish {
         target: RouterTarget,
@@ -73,6 +75,16 @@ impl<S: MessageSignature, SC: SignatureCollection> From<PacemakerCommand<S, SC>>
     }
 }
 
+impl<S: MessageSignature, SCT: SignatureCollection> From<&InFlightBlockSync<SCT>>
+    for ConsensusCommand<S, SCT>
+{
+    fn from(cmd: &InFlightBlockSync<SCT>) -> Self {
+        ConsensusCommand::RequestSync {
+            blockid: cmd.qc.info.vote.id,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Checkpoint<SCT> {
     block: Block<SCT>,
@@ -103,5 +115,6 @@ pub struct FetchedFullTxs<ST, SCT> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FetchedBlock<SCT> {
     pub requester: NodeId,
+    pub block_id: BlockId,
     pub block: Option<Block<SCT>>,
 }

--- a/monad-consensus-state/src/manager.rs
+++ b/monad-consensus-state/src/manager.rs
@@ -1,0 +1,55 @@
+use std::collections::{hash_map::Entry, HashMap};
+
+use monad_consensus_types::{
+    quorum_certificate::QuorumCertificate, signature_collection::SignatureCollection,
+};
+use monad_types::{BlockId, Round};
+
+#[derive(Debug, Clone)]
+pub struct InFlightBlockSync<SCT> {
+    pub qc: QuorumCertificate<SCT>, // qc responsible for this event
+}
+
+impl<SCT: SignatureCollection> InFlightBlockSync<SCT> {
+    pub fn new(qc: QuorumCertificate<SCT>) -> Self {
+        Self { qc }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BlockSyncManager<SCT> {
+    requests: HashMap<BlockId, InFlightBlockSync<SCT>>,
+}
+
+impl<SCT: SignatureCollection> Default for BlockSyncManager<SCT> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<SCT: SignatureCollection> BlockSyncManager<SCT> {
+    pub fn new() -> Self {
+        Self {
+            requests: HashMap::new(),
+        }
+    }
+
+    pub fn request(&mut self, qc: &QuorumCertificate<SCT>) -> Option<&InFlightBlockSync<SCT>> {
+        let id = &qc.info.vote.id;
+        match self.requests.entry(*id) {
+            Entry::Occupied(_) => None,
+            Entry::Vacant(entry) => Some(entry.insert(InFlightBlockSync::new(qc.clone()))),
+        }
+    }
+
+    pub fn prune(&mut self, round: Round) {
+        self.requests.retain(|_, v| v.qc.info.vote.round <= round)
+    }
+
+    pub fn handle_request(&mut self, bid: &BlockId) -> Option<QuorumCertificate<SCT>> {
+        match self.requests.remove(bid) {
+            Some(req) => Some(req.qc),
+            _ => None,
+        }
+    }
+}

--- a/monad-consensus-types/src/validation.rs
+++ b/monad-consensus-types/src/validation.rs
@@ -17,6 +17,8 @@ pub enum Error {
     InsufficientStake,
     /// Seq num in block proposal must be 1 higher than in the QC
     InvalidSeqNum,
+    /// Block retrieved doesn't match with the block_id requested (block sync)
+    InvalidBlock,
 }
 
 pub trait Hashable {

--- a/monad-consensus/src/convert/message.rs
+++ b/monad-consensus/src/convert/message.rs
@@ -134,7 +134,8 @@ impl TryFrom<ProtoRequestBlockSyncMessage> for RequestBlockSyncMessage {
 impl<SCT: SignatureCollection> From<&BlockSyncMessage<SCT>> for ProtoBlockSyncMessage {
     fn from(value: &BlockSyncMessage<SCT>) -> Self {
         ProtoBlockSyncMessage {
-            block: Some((&value.block).into()),
+            block_id: Some((&value.block_id).into()),
+            block: value.block.as_ref().map(|b| b.into()),
         }
     }
 }
@@ -144,12 +145,13 @@ impl<SCT: SignatureCollection> TryFrom<ProtoBlockSyncMessage> for BlockSyncMessa
 
     fn try_from(value: ProtoBlockSyncMessage) -> Result<Self, Self::Error> {
         Ok(Self {
-            block: value
-                .block
+            block_id: value
+                .block_id
                 .ok_or(Self::Error::MissingRequiredField(
-                    "BlockSyncMessage.block_id".to_owned(),
+                    "RequestBlockSyncMessage.block_id".to_owned(),
                 ))?
                 .try_into()?,
+            block: value.block.map(|b| b.try_into()).transpose()?,
         })
     }
 }

--- a/monad-consensus/src/messages/message.rs
+++ b/monad-consensus/src/messages/message.rs
@@ -88,11 +88,15 @@ impl Hashable for RequestBlockSyncMessage {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BlockSyncMessage<T> {
-    pub block: Block<T>,
+    pub block_id: BlockId,
+    pub block: Option<Block<T>>,
 }
 
 impl<T: SignatureCollection> Hashable for BlockSyncMessage<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.block.hash(state);
+        state.update(self.block_id.0.as_bytes());
+        if let Some(b) = &self.block {
+            b.hash(state);
+        }
     }
 }

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -336,12 +336,12 @@ where
             &self.author_signature,
         )?;
 
-        verify_certificates::<S, H, _, _>(
-            validators,
-            validator_mapping,
-            &(None),
-            &self.obj.block.qc,
-        )?;
+        if let Some(b) = &self.obj.block {
+            if self.obj.block_id != b.get_id() {
+                return Err(Error::InvalidBlock);
+            }
+            verify_certificates::<S, H, _, _>(validators, validator_mapping, &(None), &b.qc)?;
+        }
 
         let result = Verified {
             author: NodeId(author),

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -42,7 +42,8 @@ message ProtoFetchedFullTxs {
 
 message ProtoFetchedBlock {
   monad_proto.basic.ProtoNodeId requester = 1;
-  monad_proto.block.ProtoBlock block = 2;
+  monad_proto.basic.ProtoBlockId block_id = 2;
+  monad_proto.block.ProtoBlock block = 3;
 }
 
 message ProtoAdvanceEpochEvent {

--- a/monad-proto/proto/message.proto
+++ b/monad-proto/proto/message.proto
@@ -20,7 +20,8 @@ message ProtoRequestBlockSyncMessage {
 }
 
 message ProtoBlockSyncMessage {
-  monad_proto.block.ProtoBlock block = 1;
+  monad_proto.basic.ProtoBlockId block_id = 1;
+  optional monad_proto.block.ProtoBlock block = 2;
 }
 
 message ProtoTimeoutMessage {

--- a/monad-state/src/convert/event.rs
+++ b/monad-state/src/convert/event.rs
@@ -53,6 +53,7 @@ impl<S: MessageSignature, SCT: SignatureCollection> From<&ConsensusEvent<S, SCT>
             ConsensusEvent::FetchedBlock(fetched_block) => {
                 proto_consensus_event::Event::FetchedBlock(ProtoFetchedBlock {
                     requester: Some((&fetched_block.requester).into()),
+                    block_id: Some((&fetched_block.block_id).into()),
                     block: fetched_block.block.as_ref().map(|b| b.into()),
                 })
             }
@@ -158,6 +159,12 @@ impl<S: MessageSignature, SCT: SignatureCollection> TryFrom<ProtoConsensusEvent>
                 ConsensusEvent::FetchedBlock(FetchedBlock {
                     requester: fetched_block
                         .requester
+                        .ok_or(ProtoError::MissingRequiredField(
+                            "ConsensusEvent::fetched_block.requester".to_owned(),
+                        ))?
+                        .try_into()?,
+                    block_id: fetched_block
+                        .block_id
                         .ok_or(ProtoError::MissingRequiredField(
                             "ConsensusEvent::fetched_block.requester".to_owned(),
                         ))?


### PR DESCRIPTION
When request block sync is triggered, it lacks
ability to keep track of blocks that are already
in flight and which validator is currently
processing corresponding block sync request.

such system can cause broadcast storm if given
frequent trigger condition (such as observing qc),
In order to avoid such case, now

1. BlockSyncProcess keeps track of in flight
requests for block sync, (both who are we
asking and block id that we are asking)

2. Nodes are capable to answer block sync
request in 2 different ways: I have block,
or block currently not available

3. requested_bock is being changed to a proper
class for potential future expansion

4. outdated request are also pruned 

5. block sync also relies on qc instead of blockId 
(5 probably belong in the next pr, but they are plan
to be merged right after each other)

More test cases supporting new feature added
to this pr will be added in anther pr

This PR partially complete https://github.com/monad-crypto/monad-bft/pull/254 
This PR is followed up by https://github.com/monad-crypto/monad-bft/pull/260 for styling and testing
