### PR TITLE
Track in-flight block-sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4644,7 +4644,6 @@ dependencies = [
  "monad-consensus-state",
  "monad-consensus-types",
  "monad-crypto",
- "monad-executor",
  "monad-testutil",
  "monad-types",
  "monad-validator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+    "monad-block-sync",
     "monad-blocktree",
     "monad-consensus",
     "monad-consensus-state",

--- a/monad-block-sync/Cargo.toml
+++ b/monad-block-sync/Cargo.toml
@@ -14,7 +14,6 @@ bench = false
 monad-consensus = { path = "../monad-consensus" }
 monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }
-monad-executor = { path = "../monad-executor" }
 monad-types = { path = "../monad-types" }
 monad-validator = { path = "../monad-validator" }
 

--- a/monad-block-sync/src/lib.rs
+++ b/monad-block-sync/src/lib.rs
@@ -1,16 +1,10 @@
-use monad_consensus::messages::{
-    consensus_message::ConsensusMessage, message::RequestBlockSyncMessage,
-};
+use monad_consensus::messages::message::RequestBlockSyncMessage;
 use monad_consensus_state::command::{ConsensusCommand, FetchedBlock};
 use monad_consensus_types::signature_collection::SignatureCollection;
-use monad_executor::{PeerId, RouterTarget};
-use monad_types::{BlockId, NodeId};
+use monad_types::NodeId;
 use monad_validator::validator_set::ValidatorSetType;
-
 #[derive(Debug)]
-pub struct BlockSyncState {
-    round_robin_validator_selector: usize,
-}
+pub struct BlockSyncState {}
 
 pub trait BlockSyncProcess<SCT, VT>
 where
@@ -18,12 +12,6 @@ where
     VT: ValidatorSetType,
 {
     fn new() -> Self;
-
-    fn request_block_sync(
-        &mut self,
-        blockid: BlockId,
-        validators: &VT,
-    ) -> (RouterTarget, ConsensusMessage<SCT>);
 
     fn handle_request_block_sync_message(
         &mut self,
@@ -38,23 +26,7 @@ where
     VT: ValidatorSetType,
 {
     fn new() -> Self {
-        BlockSyncState {
-            round_robin_validator_selector: 0,
-        }
-    }
-
-    fn request_block_sync(
-        &mut self,
-        blockid: BlockId,
-        validators: &VT,
-    ) -> (RouterTarget, ConsensusMessage<SCT>) {
-        let target = RouterTarget::PointToPoint(PeerId(
-            validators.get_list()[self.round_robin_validator_selector % validators.len()].0,
-        ));
-        self.round_robin_validator_selector += 1;
-        let message =
-            ConsensusMessage::RequestBlockSync(RequestBlockSyncMessage { block_id: blockid });
-        (target, message)
+        BlockSyncState {}
     }
 
     fn handle_request_block_sync_message(
@@ -66,6 +38,7 @@ where
             s.block_id,
             Box::new(move |block| FetchedBlock {
                 requester: author,
+                block_id: s.block_id,
                 block,
             }),
         )]
@@ -74,79 +47,18 @@ where
 
 #[cfg(test)]
 mod test {
-    use monad_consensus::messages::{
-        consensus_message::ConsensusMessage, message::RequestBlockSyncMessage,
-    };
+    use monad_consensus::messages::message::RequestBlockSyncMessage;
     use monad_consensus_state::command::ConsensusCommand;
     use monad_consensus_types::multi_sig::MultiSig;
-    use monad_crypto::{secp256k1::PubKey, NopSignature};
-    use monad_executor::RouterTarget;
-    use monad_testutil::{signing::get_key, validators::create_keys_w_validators};
+    use monad_crypto::NopSignature;
+    use monad_testutil::signing::get_key;
     use monad_types::{BlockId, Hash, NodeId};
-    use monad_validator::validator_set::{ValidatorSet, ValidatorSetType};
+    use monad_validator::validator_set::ValidatorSet;
 
     use crate::{BlockSyncProcess, BlockSyncState};
     type SignatureType = NopSignature;
     type SignatureCollectionType = MultiSig<SignatureType>;
     type ValidatorSetT = ValidatorSet;
-
-    fn verify_target_and_message(
-        target: &RouterTarget,
-        message: &ConsensusMessage<SignatureCollectionType>,
-        desired_pubkey: PubKey,
-        desired_block_id: BlockId,
-    ) {
-        match message {
-            ConsensusMessage::RequestBlockSync(rbsm) => {
-                let block_id = rbsm.block_id;
-                assert_eq!(block_id, desired_block_id);
-            }
-            _ => panic!("request_block_sync didn't produce a valid ConsensusMessage type"),
-        }
-
-        match target {
-            RouterTarget::PointToPoint(node) => {
-                assert_eq!(node.0, desired_pubkey);
-            }
-            _ => panic!("request_block_sync didn't produce a valid routing target"),
-        }
-    }
-
-    #[test]
-    fn test_request_block_sync_basic_functionality() {
-        let mut process: BlockSyncState =
-            BlockSyncProcess::<SignatureCollectionType, ValidatorSetT>::new();
-        let (_, _, valset, _) = create_keys_w_validators::<SignatureCollectionType>(4);
-
-        let (target, message): (RouterTarget, ConsensusMessage<SignatureCollectionType>) =
-            process.request_block_sync(BlockId(Hash([0x00_u8; 32])), &valset);
-
-        verify_target_and_message(
-            &target,
-            &message,
-            valset.get_list()[0].0,
-            BlockId(Hash([0x00_u8; 32])),
-        );
-    }
-
-    #[test]
-    fn test_request_block_sync_round_robin() {
-        let mut process: BlockSyncState =
-            BlockSyncProcess::<SignatureCollectionType, ValidatorSetT>::new();
-        let (_, _, valset, _) = create_keys_w_validators::<SignatureCollectionType>(4);
-
-        let (mut target, mut message): (RouterTarget, ConsensusMessage<SignatureCollectionType>) =
-            process.request_block_sync(BlockId(Hash([0x00_u8; 32])), &valset);
-        for i in 0..15 {
-            verify_target_and_message(
-                &target,
-                &message,
-                valset.get_list()[i % 4].0,
-                BlockId(Hash([0x00_u8; 32])),
-            );
-            (target, message) = process.request_block_sync(BlockId(Hash([0x00_u8; 32])), &valset);
-        }
-    }
 
     #[test]
     fn test_handle_request_block_sync_message_basic_functionality() {

--- a/monad-consensus-state/src/blocksync.rs
+++ b/monad-consensus-state/src/blocksync.rs
@@ -1,0 +1,496 @@
+use std::collections::{hash_map::Entry, HashMap};
+
+use monad_consensus::messages::message::BlockSyncMessage;
+use monad_consensus_types::{
+    block::{Block, BlockType},
+    quorum_certificate::QuorumCertificate,
+    signature_collection::SignatureCollection,
+};
+use monad_tracing_counter::inc_count;
+use monad_types::{BlockId, NodeId};
+use monad_validator::validator_set::ValidatorSetType;
+
+use crate::command::ConsensusCommand;
+
+const DEFAULT_AUTHOR_INDEX: usize = 0;
+const DEFAULT_RETRY: usize = 0;
+
+#[derive(Debug, Clone)]
+pub struct InFlightBlockSync<SCT> {
+    pub req_target: NodeId,
+    pub retry_cnt: usize,
+    pub qc: QuorumCertificate<SCT>, // qc responsible for this event
+}
+pub enum BlockSyncResult<SCT: SignatureCollection> {
+    Success(Block<SCT>),           // retrieved
+    Failed(ConsensusCommand<SCT>), // unable to retrieve
+    IllegalResponse,               // never requested from this peer or never requested
+}
+
+impl<SCT: SignatureCollection> InFlightBlockSync<SCT> {
+    pub fn new(req_target: NodeId, qc: QuorumCertificate<SCT>) -> Self {
+        Self {
+            req_target,
+            retry_cnt: DEFAULT_RETRY,
+            qc,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BlockSyncManager<SCT> {
+    requests: HashMap<BlockId, InFlightBlockSync<SCT>>,
+}
+
+impl<SCT> Default for BlockSyncManager<SCT>
+where
+    SCT: SignatureCollection,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<SCT> BlockSyncManager<SCT>
+where
+    SCT: SignatureCollection,
+{
+    pub fn new() -> Self {
+        Self {
+            requests: HashMap::new(),
+        }
+    }
+
+    pub fn request<VT: ValidatorSetType>(
+        &mut self,
+        qc: &QuorumCertificate<SCT>,
+        validator_set: &VT,
+    ) -> Vec<ConsensusCommand<SCT>> {
+        assert!(validator_set.len() > 0);
+        let id = &qc.info.vote.id;
+        match self.requests.entry(*id) {
+            Entry::Occupied(_) => vec![],
+            Entry::Vacant(entry) => {
+                inc_count!(block_sync_request);
+                // TODO: Avoid requesting to yourself
+                let peer = validator_set.get_list()[DEFAULT_AUTHOR_INDEX % validator_set.len()];
+                let req = InFlightBlockSync::new(peer, qc.clone());
+                let req_cmd = vec![(&req).into()];
+                entry.insert(req);
+                req_cmd
+            }
+        }
+    }
+
+    pub fn handle_retrieval<VT: ValidatorSetType>(
+        &mut self,
+        author: &NodeId,
+        msg: BlockSyncMessage<SCT>,
+        validator_set: &VT,
+    ) -> BlockSyncResult<SCT> {
+        let bid = match &msg {
+            BlockSyncMessage::BlockFound(b) => b.get_id(),
+            BlockSyncMessage::NotAvailable(bid) => *bid,
+        };
+        if let Entry::Occupied(mut entry) = self.requests.entry(bid) {
+            let InFlightBlockSync {
+                req_target,
+                retry_cnt,
+                qc: _,
+            } = entry.get_mut();
+
+            // TODO: remove this check and check it at router level
+            if author != req_target {
+                return BlockSyncResult::IllegalResponse;
+            }
+
+            match msg {
+                BlockSyncMessage::BlockFound(block) => {
+                    entry.remove_entry();
+                    // block retrieve successful
+                    BlockSyncResult::Success(block)
+                }
+                BlockSyncMessage::NotAvailable(_) => {
+                    // block retrieve failed, re-request
+                    *retry_cnt += 1;
+
+                    // TODO: Avoid requesting to yourself
+                    *req_target = validator_set.get_list()[(*retry_cnt) % validator_set.len()];
+                    BlockSyncResult::Failed(ConsensusCommand::RequestSync {
+                        peer: *req_target,
+                        block_id: bid,
+                    })
+                }
+            }
+        } else {
+            BlockSyncResult::IllegalResponse
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core::panic;
+
+    use monad_consensus_types::{
+        block::Block,
+        ledger::LedgerCommitInfo,
+        payload::{ExecutionArtifacts, Payload, TransactionList},
+        quorum_certificate::{QcInfo, QuorumCertificate},
+        validation::{Hasher, Sha256Hash},
+        voting::VoteInfo,
+    };
+    use monad_crypto::NopSignature;
+    use monad_testutil::{
+        signing::{get_key, MockSignatures},
+        validators::create_keys_w_validators,
+    };
+    use monad_types::{BlockId, Hash, NodeId, Round};
+    use monad_validator::validator_set::{ValidatorSet, ValidatorSetType};
+
+    use super::BlockSyncManager;
+    use crate::{command::ConsensusCommand, BlockSyncMessage, BlockSyncResult};
+    type ST = NopSignature;
+    type SC = MockSignatures;
+    type VT = ValidatorSet;
+    type QC = QuorumCertificate<SC>;
+
+    struct FakeHasher1();
+
+    impl Hasher for FakeHasher1 {
+        fn new() -> Self {
+            Self()
+        }
+        fn update(&mut self, _data: impl AsRef<[u8]>) {}
+        fn hash(self) -> Hash {
+            Hash([0x01_u8; 32])
+        }
+    }
+
+    struct FakeHasher2();
+
+    impl Hasher for FakeHasher2 {
+        fn new() -> Self {
+            Self()
+        }
+        fn update(&mut self, _data: impl AsRef<[u8]>) {}
+        fn hash(self) -> Hash {
+            Hash([0x02_u8; 32])
+        }
+    }
+
+    struct FakeHasher3();
+
+    impl Hasher for FakeHasher3 {
+        fn new() -> Self {
+            Self()
+        }
+        fn update(&mut self, _data: impl AsRef<[u8]>) {}
+        fn hash(self) -> Hash {
+            Hash([0x03_u8; 32])
+        }
+    }
+
+    #[test]
+    fn test_handle_request_block_sync_message_basic_functionality() {
+        let mut manager = BlockSyncManager::<SC>::default();
+        let (_, _, valset, _) = create_keys_w_validators::<SC>(4);
+
+        let qc = &QC::new::<Sha256Hash>(
+            QcInfo {
+                vote: VoteInfo {
+                    id: BlockId(Hash([0x01_u8; 32])),
+                    round: Round(0),
+                    parent_id: BlockId(Hash([0x02_u8; 32])),
+                    parent_round: Round(0),
+                    seq_num: 0,
+                },
+                ledger_commit: LedgerCommitInfo::default(),
+            },
+            MockSignatures::with_pubkeys(&[]),
+        );
+
+        let cmds = manager.request::<VT>(qc, &valset);
+
+        assert!(cmds.len() == 1);
+        let (peer, bid) = match cmds[0] {
+            ConsensusCommand::RequestSync { peer, block_id } => (peer, block_id),
+            _ => panic!("manager didn't request a block when no inflight block is observed"),
+        };
+
+        assert!(peer == valset.get_list()[0]);
+        assert!(bid == qc.info.vote.id);
+
+        // repeated request would yield no result
+        for _ in 0..1000 {
+            let cmds = manager.request::<VT>(qc, &valset);
+            assert!(cmds.is_empty());
+        }
+
+        let qc = &QC::new::<Sha256Hash>(
+            QcInfo {
+                vote: VoteInfo {
+                    id: BlockId(Hash([0x02_u8; 32])),
+                    round: Round(0),
+                    parent_id: BlockId(Hash([0x02_u8; 32])),
+                    parent_round: Round(0),
+                    seq_num: 0,
+                },
+                ledger_commit: LedgerCommitInfo::default(),
+            },
+            MockSignatures::with_pubkeys(&[]),
+        );
+        let cmds = manager.request::<VT>(qc, &valset);
+
+        assert!(cmds.len() == 1);
+        let (peer, bid) = match cmds[0] {
+            ConsensusCommand::RequestSync { peer, block_id } => (peer, block_id),
+            _ => panic!("manager didn't request a block when no inflight block is observed"),
+        };
+
+        assert!(peer == valset.get_list()[0]);
+        assert!(bid == qc.info.vote.id);
+    }
+
+    #[test]
+    fn test_handle_retrieval() {
+        let mut manager = BlockSyncManager::<SC>::default();
+        let (_, _, valset, _) = create_keys_w_validators::<SC>(4);
+
+        // first qc
+        let qc_1 = &QC::new::<Sha256Hash>(
+            QcInfo {
+                vote: VoteInfo {
+                    id: BlockId(Hash([0x01_u8; 32])),
+                    round: Round(0),
+                    parent_id: BlockId(Hash([0x02_u8; 32])),
+                    parent_round: Round(0),
+                    seq_num: 0,
+                },
+                ledger_commit: LedgerCommitInfo::default(),
+            },
+            MockSignatures::with_pubkeys(&[]),
+        );
+
+        let cmds = manager.request::<VT>(qc_1, &valset);
+
+        assert!(cmds.len() == 1);
+        let (peer_1, bid) = match cmds[0] {
+            ConsensusCommand::RequestSync { peer, block_id } => (peer, block_id),
+            _ => panic!("manager didn't request a block when no inflight block is observed"),
+        };
+
+        assert!(peer_1 == valset.get_list()[0]);
+        assert!(bid == qc_1.info.vote.id);
+
+        // second qc
+        let qc_2 = &QC::new::<Sha256Hash>(
+            QcInfo {
+                vote: VoteInfo {
+                    id: BlockId(Hash([0x02_u8; 32])),
+                    round: Round(0),
+                    parent_id: BlockId(Hash([0x02_u8; 32])),
+                    parent_round: Round(0),
+                    seq_num: 0,
+                },
+                ledger_commit: LedgerCommitInfo::default(),
+            },
+            MockSignatures::with_pubkeys(&[]),
+        );
+
+        let cmds = manager.request::<VT>(qc_2, &valset);
+
+        assert!(cmds.len() == 1);
+        let (peer_2, bid) = match cmds[0] {
+            ConsensusCommand::RequestSync { peer, block_id } => (peer, block_id),
+            _ => panic!("manager didn't request a block when no inflight block is observed"),
+        };
+
+        assert!(peer_2 == valset.get_list()[0]);
+        assert!(bid == qc_2.info.vote.id);
+
+        // third request
+        let qc_3 = &QC::new::<Sha256Hash>(
+            QcInfo {
+                vote: VoteInfo {
+                    id: BlockId(Hash([0x03_u8; 32])),
+                    round: Round(0),
+                    parent_id: BlockId(Hash([0x02_u8; 32])),
+                    parent_round: Round(0),
+                    seq_num: 0,
+                },
+                ledger_commit: LedgerCommitInfo::default(),
+            },
+            MockSignatures::with_pubkeys(&[]),
+        );
+
+        let cmds = manager.request::<VT>(qc_3, &valset);
+
+        assert!(cmds.len() == 1);
+        let (peer_3, bid) = match cmds[0] {
+            ConsensusCommand::RequestSync { peer, block_id } => (peer, block_id),
+            _ => panic!("manager didn't request a block when no inflight block is observed"),
+        };
+
+        assert!(peer_3 == valset.get_list()[0]);
+        assert!(bid == qc_3.info.vote.id);
+
+        let keypair = get_key(6);
+
+        let payload = Payload {
+            txns: TransactionList(vec![]),
+            header: ExecutionArtifacts::zero(),
+            seq_num: 0,
+        };
+
+        let block_1 = Block::new::<FakeHasher1>(
+            NodeId(keypair.pubkey()),
+            Round(3),
+            &payload,
+            &QC::new::<Sha256Hash>(
+                QcInfo {
+                    vote: VoteInfo {
+                        id: BlockId(Hash([0x01_u8; 32])),
+                        round: Round(0),
+                        parent_id: BlockId(Hash([0x02_u8; 32])),
+                        parent_round: Round(0),
+                        seq_num: 0,
+                    },
+                    ledger_commit: LedgerCommitInfo::default(),
+                },
+                MockSignatures::with_pubkeys(&[]),
+            ),
+        );
+
+        let block_2 = Block::new::<FakeHasher2>(
+            NodeId(keypair.pubkey()),
+            Round(3),
+            &payload,
+            &QC::new::<Sha256Hash>(
+                QcInfo {
+                    vote: VoteInfo {
+                        id: BlockId(Hash([0x01_u8; 32])),
+                        round: Round(0),
+                        parent_id: BlockId(Hash([0x02_u8; 32])),
+                        parent_round: Round(0),
+                        seq_num: 0,
+                    },
+                    ledger_commit: LedgerCommitInfo::default(),
+                },
+                MockSignatures::with_pubkeys(&[]),
+            ),
+        );
+
+        let block_3 = Block::new::<FakeHasher3>(
+            NodeId(keypair.pubkey()),
+            Round(3),
+            &payload,
+            &QC::new::<Sha256Hash>(
+                QcInfo {
+                    vote: VoteInfo {
+                        id: BlockId(Hash([0x01_u8; 32])),
+                        round: Round(0),
+                        parent_id: BlockId(Hash([0x02_u8; 32])),
+                        parent_round: Round(0),
+                        seq_num: 0,
+                    },
+                    ledger_commit: LedgerCommitInfo::default(),
+                },
+                MockSignatures::with_pubkeys(&[]),
+            ),
+        );
+
+        let msg_no_block_1 = BlockSyncMessage::<SC>::NotAvailable(BlockId(Hash([0x01_u8; 32])));
+
+        let msg_with_block_1 = BlockSyncMessage::<SC>::BlockFound(block_1.clone());
+
+        let msg_no_block_2 = BlockSyncMessage::<SC>::NotAvailable(BlockId(Hash([0x02_u8; 32])));
+
+        let msg_with_block_2 = BlockSyncMessage::<SC>::BlockFound(block_2.clone());
+
+        let msg_no_block_3 = BlockSyncMessage::<SC>::NotAvailable(BlockId(Hash([0x03_u8; 32])));
+
+        let msg_with_block_3 = BlockSyncMessage::<SC>::BlockFound(block_3.clone());
+
+        // arbitrary response should be rejected
+        let BlockSyncResult::<SC>::IllegalResponse =
+            manager.handle_retrieval(&NodeId(keypair.pubkey()), msg_no_block_1, &valset)
+        else {
+            panic!("illegal response is processed");
+        };
+
+        // valid message from invalid individual should still get dropped
+
+        let BlockSyncResult::<SC>::IllegalResponse =
+            manager.handle_retrieval(&NodeId(keypair.pubkey()), msg_with_block_2.clone(), &valset)
+        else {
+            panic!("illegal response is processed");
+        };
+
+        let BlockSyncResult::<SC>::Failed(retry_command) =
+            manager.handle_retrieval(&peer_2, msg_no_block_2.clone(), &valset)
+        else {
+            panic!("illegal response is processed");
+        };
+
+        let ConsensusCommand::RequestSync {
+            peer: peer_2,
+            block_id: _,
+        } = retry_command
+        else {
+            panic!("retry didn't create a publish command");
+        };
+
+        let BlockSyncResult::<SC>::Success(b) =
+            manager.handle_retrieval(&peer_1, msg_with_block_1, &valset)
+        else {
+            panic!("illegal response is processed");
+        };
+
+        let BlockSyncResult::<SC>::Failed(retry_command) =
+            manager.handle_retrieval(&peer_3, msg_no_block_3, &valset)
+        else {
+            panic!("illegal response is processed");
+        };
+
+        let ConsensusCommand::RequestSync {
+            peer: peer_3,
+            block_id: _,
+        } = retry_command
+        else {
+            panic!("retry didn't create a publish command");
+        };
+
+        assert!(b == block_1);
+
+        let BlockSyncResult::<SC>::Failed(retry_command) =
+            manager.handle_retrieval(&peer_2, msg_no_block_2, &valset)
+        else {
+            panic!("illegal response is processed");
+        };
+
+        let ConsensusCommand::RequestSync {
+            peer: peer_2,
+            block_id: _,
+        } = retry_command
+        else {
+            panic!("retry didn't create a publish command");
+        };
+
+        let BlockSyncResult::<SC>::Success(b) =
+            manager.handle_retrieval(&peer_3, msg_with_block_3, &valset)
+        else {
+            panic!("illegal response is processed");
+        };
+
+        assert!(b == block_3);
+
+        let BlockSyncResult::<SC>::Success(b) =
+            manager.handle_retrieval(&peer_2, msg_with_block_2, &valset)
+        else {
+            panic!("illegal response is processed");
+        };
+
+        assert!(b == block_2);
+    }
+}

--- a/monad-consensus/src/messages/message.rs
+++ b/monad-consensus/src/messages/message.rs
@@ -98,12 +98,16 @@ impl Hashable for RequestBlockSyncMessage {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct BlockSyncMessage<T> {
-    pub block: Block<T>,
+pub enum BlockSyncMessage<T> {
+    BlockFound(Block<T>),
+    NotAvailable(BlockId),
 }
 
 impl<T: SignatureCollection> Hashable for BlockSyncMessage<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.block.hash(state);
+        match self {
+            BlockSyncMessage::BlockFound(b) => b.hash(state),
+            BlockSyncMessage::NotAvailable(bid) => state.update(bid.0.as_bytes()),
+        }
     }
 }

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -336,7 +336,9 @@ where
             &self.author_signature,
         )?;
 
-        verify_certificates::<H, _, _>(validators, validator_mapping, &(None), &self.obj.block.qc)?;
+        if let BlockSyncMessage::BlockFound(b) = &self.obj {
+            verify_certificates::<H, _, _>(validators, validator_mapping, &(None), &b.qc)?;
+        }
 
         let result = Verified {
             author: NodeId(author),

--- a/monad-executor/src/state.rs
+++ b/monad-executor/src/state.rs
@@ -5,7 +5,7 @@ use monad_consensus_types::{
     payload::{FullTransactionList, TransactionList},
 };
 use monad_crypto::secp256k1::PubKey;
-use monad_types::{BlockId, Hash as ConsensusHash};
+use monad_types::{BlockId, Hash as ConsensusHash, NodeId};
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PeerId(pub PubKey);
@@ -13,6 +13,12 @@ pub struct PeerId(pub PubKey);
 impl std::fmt::Debug for PeerId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+impl From<&NodeId> for PeerId {
+    fn from(id: &NodeId) -> Self {
+        PeerId(id.0)
     }
 }
 

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -42,7 +42,8 @@ message ProtoFetchedFullTxs {
 
 message ProtoFetchedBlock {
   monad_proto.basic.ProtoNodeId requester = 1;
-  monad_proto.block.ProtoBlock block = 2;
+  monad_proto.basic.ProtoBlockId block_id = 2;
+  optional monad_proto.block.ProtoBlock block = 3;
 }
 
 message ProtoAdvanceEpochEvent {

--- a/monad-proto/proto/message.proto
+++ b/monad-proto/proto/message.proto
@@ -20,7 +20,10 @@ message ProtoRequestBlockSyncMessage {
 }
 
 message ProtoBlockSyncMessage {
-  monad_proto.block.ProtoBlock block = 1;
+  oneof OneofMessage {
+    monad_proto.block.ProtoBlock block_found = 1;
+    monad_proto.basic.ProtoBlockId not_available = 2;
+  }
 }
 
 message ProtoTimeoutMessage {
@@ -40,7 +43,6 @@ message ProtoUnverifiedConsensusMessage {
     ProtoVoteMessage vote = 3;
     ProtoRequestBlockSyncMessage request_block_sync = 4;
     ProtoBlockSyncMessage block_sync = 5;
-
   }
   monad_proto.signing.ProtoSignature author_signature = 6;
 }

--- a/monad-state/src/convert/event.rs
+++ b/monad-state/src/convert/event.rs
@@ -53,6 +53,7 @@ impl<S: MessageSignature, SCT: SignatureCollection> From<&ConsensusEvent<S, SCT>
             ConsensusEvent::FetchedBlock(fetched_block) => {
                 proto_consensus_event::Event::FetchedBlock(ProtoFetchedBlock {
                     requester: Some((&fetched_block.requester).into()),
+                    block_id: Some((&fetched_block.block_id).into()),
                     block: fetched_block.block.as_ref().map(|b| b.into()),
                 })
             }
@@ -158,6 +159,12 @@ impl<S: MessageSignature, SCT: SignatureCollection> TryFrom<ProtoConsensusEvent>
                 ConsensusEvent::FetchedBlock(FetchedBlock {
                     requester: fetched_block
                         .requester
+                        .ok_or(ProtoError::MissingRequiredField(
+                            "ConsensusEvent::fetched_block.requester".to_owned(),
+                        ))?
+                        .try_into()?,
+                    block_id: fetched_block
+                        .block_id
                         .ok_or(ProtoError::MissingRequiredField(
                             "ConsensusEvent::fetched_block.requester".to_owned(),
                         ))?


### PR DESCRIPTION
When request block sync is triggered, it lacks
ability to keep track of blocks that are already
in flight and which validator is currently
processing corresponding block sync request.

such system can cause broadcast storm if given
frequent trigger condition (such as observing qc), In order to avoid such case, now

1. BlockSyncProcess keeps track of in flight requests for block sync, (both who are we
asking and block id that we are asking)

2. Nodes are capable to answer block sync request in 2 different ways: I have block,
or block currently not available

3. requested_block is being changed to a proper class

4. block sync also relies on qc instead of blockId (4 probably belong in the next pr, but they are plan to be merged right after each other)

More test cases supporting new feature added from a follow up pr monad-crypto/monad-bft/pull/265