### PR TITLE
Store full_txs in BlockTree

### DIFF
--- a/monad-block-sync/src/lib.rs
+++ b/monad-block-sync/src/lib.rs
@@ -37,10 +37,10 @@ where
         vec![ConsensusCommand::LedgerFetch(
             author,
             s.block_id,
-            Box::new(move |block| FetchedBlock {
+            Box::new(move |unverified_full_block| FetchedBlock {
                 requester: author,
                 block_id: s.block_id,
-                block,
+                unverified_full_block,
             }),
         )]
     }

--- a/monad-consensus-types/src/block.rs
+++ b/monad-consensus-types/src/block.rs
@@ -2,15 +2,21 @@ use monad_types::{BlockId, Hash as HashType, NodeId, Round};
 use zerocopy::AsBytes;
 
 use crate::{
-    payload::Payload,
+    payload::{FullTransactionList, Payload},
     quorum_certificate::QuorumCertificate,
     signature_collection::SignatureCollection,
+    transaction_validator::TransactionValidator,
     validation::{Hashable, Hasher},
 };
 
 pub trait BlockType: Clone + PartialEq + Eq {
     fn get_id(&self) -> BlockId;
+    fn get_round(&self) -> Round;
+    fn get_author(&self) -> NodeId;
+
     fn get_parent_id(&self) -> BlockId;
+    fn get_parent_round(&self) -> Round;
+
     fn get_seq_num(&self) -> u64;
 }
 
@@ -76,11 +82,119 @@ impl<T: SignatureCollection> BlockType for Block<T> {
         self.id
     }
 
+    fn get_round(&self) -> Round {
+        self.round
+    }
+
+    fn get_author(&self) -> NodeId {
+        self.author
+    }
+
     fn get_parent_id(&self) -> BlockId {
         self.qc.info.vote.id
     }
 
+    fn get_parent_round(&self) -> Round {
+        self.qc.info.vote.round
+    }
+
     fn get_seq_num(&self) -> u64 {
         self.payload.seq_num
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnverifiedFullBlock<T> {
+    pub block: Block<T>,
+    pub full_txs: FullTransactionList,
+}
+
+impl<T> UnverifiedFullBlock<T> {
+    pub fn new(block: Block<T>, full_txs: FullTransactionList) -> Self {
+        Self { block, full_txs }
+    }
+}
+
+impl<T> From<FullBlock<T>> for UnverifiedFullBlock<T> {
+    fn from(value: FullBlock<T>) -> Self {
+        Self {
+            block: value.block,
+            full_txs: value.full_txs,
+        }
+    }
+}
+
+impl<T: SignatureCollection> Hashable for UnverifiedFullBlock<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.block.hash(state);
+        state.update(self.full_txs.0.as_bytes());
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FullBlock<T> {
+    block: Block<T>,
+    full_txs: FullTransactionList,
+}
+
+impl<T> FullBlock<T> {
+    pub fn from_block(
+        block: Block<T>,
+        full_txs: FullTransactionList,
+        validator: &impl TransactionValidator,
+    ) -> Option<Self> {
+        validator
+            .validate(&block.payload.txns, &full_txs)
+            .then_some(Self { block, full_txs })
+    }
+
+    pub fn try_from_unverified(
+        unverified: UnverifiedFullBlock<T>,
+        validator: &impl TransactionValidator,
+    ) -> Option<Self> {
+        validator
+            .validate(&unverified.block.payload.txns, &unverified.full_txs)
+            .then_some(Self {
+                block: unverified.block,
+                full_txs: unverified.full_txs,
+            })
+    }
+
+    pub fn get_block(&self) -> &Block<T> {
+        &self.block
+    }
+
+    pub fn get_full_txs(&self) -> &FullTransactionList {
+        &self.full_txs
+    }
+
+    pub fn split(self) -> (Block<T>, FullTransactionList) {
+        (self.block, self.full_txs)
+    }
+}
+
+impl<T: SignatureCollection> BlockType for FullBlock<T> {
+    fn get_id(&self) -> BlockId {
+        self.block.get_id()
+    }
+
+    fn get_round(&self) -> Round {
+        self.block.get_round()
+    }
+
+    fn get_author(&self) -> NodeId {
+        self.block.get_author()
+    }
+
+    fn get_parent_id(&self) -> BlockId {
+        self.block.get_parent_id()
+    }
+
+    fn get_parent_round(&self) -> Round {
+        self.block.get_parent_round()
+    }
+
+    fn get_seq_num(&self) -> u64 {
+        self.block.get_seq_num()
     }
 }

--- a/monad-consensus-types/src/transaction_validator.rs
+++ b/monad-consensus-types/src/transaction_validator.rs
@@ -1,16 +1,16 @@
 use core::fmt::Debug;
 
-use crate::payload::FullTransactionList;
+use crate::payload::{FullTransactionList, TransactionList};
 
-pub trait TransactionValidator {
-    fn validate(&self, txs: &FullTransactionList) -> bool;
+pub trait TransactionValidator: Clone + Default {
+    fn validate(&self, txs: &TransactionList, full_txs: &FullTransactionList) -> bool;
 }
 
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
 pub struct MockValidator;
 
 impl TransactionValidator for MockValidator {
-    fn validate(&self, _txs: &FullTransactionList) -> bool {
+    fn validate(&self, _txs: &TransactionList, _full_txs: &FullTransactionList) -> bool {
         true
     }
 }
@@ -19,7 +19,7 @@ impl TransactionValidator for MockValidator {
 pub struct EthereumValidator;
 
 impl TransactionValidator for EthereumValidator {
-    fn validate(&self, _txs: &FullTransactionList) -> bool {
+    fn validate(&self, _txs: &TransactionList, _full_txs: &FullTransactionList) -> bool {
         unimplemented!()
     }
 }

--- a/monad-consensus/src/convert/message.rs
+++ b/monad-consensus/src/convert/message.rs
@@ -126,7 +126,7 @@ impl TryFrom<ProtoRequestBlockSyncMessage> for RequestBlockSyncMessage {
 
 impl<SCT: SignatureCollection> From<&BlockSyncMessage<SCT>> for ProtoBlockSyncMessage {
     fn from(value: &BlockSyncMessage<SCT>) -> Self {
-        return Self {
+        Self {
             oneof_message: Some(match value.deref() {
                 BlockSyncMessage::BlockFound(b) => {
                     proto_block_sync_message::OneofMessage::BlockFound(b.into())
@@ -135,7 +135,7 @@ impl<SCT: SignatureCollection> From<&BlockSyncMessage<SCT>> for ProtoBlockSyncMe
                     proto_block_sync_message::OneofMessage::NotAvailable(bid.into())
                 }
             }),
-        };
+        }
     }
 }
 

--- a/monad-consensus/src/messages/message.rs
+++ b/monad-consensus/src/messages/message.rs
@@ -1,5 +1,5 @@
 use monad_consensus_types::{
-    block::Block,
+    block::{Block, UnverifiedFullBlock},
     certificate_signature::CertificateSignature,
     signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
     timeout::{Timeout, TimeoutCertificate},
@@ -99,14 +99,16 @@ impl Hashable for RequestBlockSyncMessage {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BlockSyncMessage<T> {
-    BlockFound(Block<T>),
+    BlockFound(UnverifiedFullBlock<T>),
     NotAvailable(BlockId),
 }
 
 impl<T: SignatureCollection> Hashable for BlockSyncMessage<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {
-            BlockSyncMessage::BlockFound(b) => b.hash(state),
+            BlockSyncMessage::BlockFound(unverified_full_block) => {
+                unverified_full_block.hash(state)
+            }
             BlockSyncMessage::NotAvailable(bid) => state.update(bid.0.as_bytes()),
         }
     }

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -337,7 +337,7 @@ where
         )?;
 
         if let BlockSyncMessage::BlockFound(b) = &self.obj {
-            verify_certificates::<H, _, _>(validators, validator_mapping, &(None), &b.qc)?;
+            verify_certificates::<H, _, _>(validators, validator_mapping, &(None), &b.block.qc)?;
         }
 
         let result = Verified {

--- a/monad-driver/src/lib.rs
+++ b/monad-driver/src/lib.rs
@@ -110,10 +110,14 @@ mod tests {
             .map(|(key, certkey, _, _)| (key.pubkey(), certkey.pubkey()))
             .collect::<Vec<_>>();
 
-        let (genesis_block, genesis_sigs) = get_genesis_config::<Sha256Hash, SignatureCollectionType>(
-            voting_keys.iter(),
-            &validator_mapping,
-        );
+        let transaction_validator = TransactionValidatorType::default();
+
+        let (genesis_block, genesis_sigs) =
+            get_genesis_config::<Sha256Hash, SignatureCollectionType, TransactionValidatorType>(
+                voting_keys.iter(),
+                &validator_mapping,
+                &transaction_validator,
+            );
 
         let state_configs = node_configs
             .into_iter()
@@ -122,7 +126,7 @@ mod tests {
                 (
                     exec,
                     MonadConfig {
-                        transaction_validator: TransactionValidatorType {},
+                        transaction_validator,
                         key,
                         certkey,
                         validators: config_validators.clone(),

--- a/monad-proto/proto/block.proto
+++ b/monad-proto/proto/block.proto
@@ -30,3 +30,8 @@ message ProtoBlock {
   ProtoPayload payload = 3;
   monad_proto.quorum_certificate.ProtoQuorumCertificate qc = 4;
 }
+
+message ProtoUnverifiedFullBlock {
+  ProtoBlock block = 1;
+  bytes full_txs = 2;
+}

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -43,7 +43,7 @@ message ProtoFetchedFullTxs {
 message ProtoFetchedBlock {
   monad_proto.basic.ProtoNodeId requester = 1;
   monad_proto.basic.ProtoBlockId block_id = 2;
-  optional monad_proto.block.ProtoBlock block = 3;
+  optional monad_proto.block.ProtoUnverifiedFullBlock unverified_full_block = 3;
 }
 
 message ProtoAdvanceEpochEvent {

--- a/monad-proto/proto/message.proto
+++ b/monad-proto/proto/message.proto
@@ -21,7 +21,7 @@ message ProtoRequestBlockSyncMessage {
 
 message ProtoBlockSyncMessage {
   oneof OneofMessage {
-    monad_proto.block.ProtoBlock block_found = 1;
+    monad_proto.block.ProtoUnverifiedFullBlock block_found = 1;
     monad_proto.basic.ProtoBlockId not_available = 2;
   }
 }

--- a/monad-state/src/convert/event.rs
+++ b/monad-state/src/convert/event.rs
@@ -54,7 +54,10 @@ impl<S: MessageSignature, SCT: SignatureCollection> From<&ConsensusEvent<S, SCT>
                 proto_consensus_event::Event::FetchedBlock(ProtoFetchedBlock {
                     requester: Some((&fetched_block.requester).into()),
                     block_id: Some((&fetched_block.block_id).into()),
-                    block: fetched_block.block.as_ref().map(|b| b.into()),
+                    unverified_full_block: fetched_block
+                        .unverified_full_block
+                        .as_ref()
+                        .map(|b| b.into()),
                 })
             }
             ConsensusEvent::LoadEpoch(epoch, valset, upcoming_valset) => {
@@ -169,11 +172,11 @@ impl<S: MessageSignature, SCT: SignatureCollection> TryFrom<ProtoConsensusEvent>
                             "ConsensusEvent::fetched_block.requester".to_owned(),
                         ))?
                         .try_into()?,
-                    block: Some(
+                    unverified_full_block: Some(
                         fetched_block
-                            .block
+                            .unverified_full_block
                             .ok_or(ProtoError::MissingRequiredField(
-                                "ConsensusEvent::fetched_block.block".to_owned(),
+                                "ConsensusEvent::fetched_block.unverified_full_block".to_owned(),
                             ))?
                             .try_into()?,
                     ),

--- a/monad-state/tests/protobuf.rs
+++ b/monad-state/tests/protobuf.rs
@@ -10,6 +10,7 @@ use monad_consensus_types::{
     multi_sig::MultiSig,
     payload::ExecutionArtifacts,
     quorum_certificate::{genesis_vote_info, QuorumCertificate},
+    transaction_validator::MockValidator,
     validation::{Hasher, Sha256Hash},
     voting::{Vote, VoteInfo},
 };
@@ -87,7 +88,11 @@ fn test_consensus_message_event_proposal_bls() {
         .zip(cert_keys.iter())
         .collect::<Vec<_>>();
     let (genesis_block, genesis_sigs) =
-        get_genesis_config::<Sha256Hash, BlsSignatureCollection>(voting_keys.iter(), &valmap);
+        get_genesis_config::<Sha256Hash, BlsSignatureCollection, MockValidator>(
+            voting_keys.iter(),
+            &valmap,
+            &MockValidator::default(),
+        );
     let genesis_qc = QuorumCertificate::genesis_qc::<Sha256Hash>(
         genesis_vote_info(genesis_block.get_id()),
         genesis_sigs,

--- a/monad-testutil/src/block.rs
+++ b/monad-testutil/src/block.rs
@@ -20,19 +20,30 @@ pub struct MockBlock {
 impl Default for MockBlock {
     fn default() -> Self {
         MockBlock {
-            block_id: monad_types::BlockId(monad_types::Hash([0x00_u8; 32])),
-            parent_block_id: monad_types::BlockId(monad_types::Hash([0x01_u8; 32])),
+            block_id: BlockId(Hash([0x00_u8; 32])),
+            parent_block_id: BlockId(Hash([0x01_u8; 32])),
         }
     }
 }
 
 impl BlockType for MockBlock {
-    fn get_id(&self) -> monad_types::BlockId {
+    fn get_id(&self) -> BlockId {
         self.block_id
     }
-    fn get_parent_id(&self) -> monad_types::BlockId {
+    fn get_round(&self) -> Round {
+        Round(1)
+    }
+    fn get_author(&self) -> NodeId {
+        unimplemented!()
+    }
+
+    fn get_parent_id(&self) -> BlockId {
         self.parent_block_id
     }
+    fn get_parent_round(&self) -> Round {
+        Round(0)
+    }
+
     fn get_seq_num(&self) -> u64 {
         0
     }

--- a/monad-viz/src/config.rs
+++ b/monad-viz/src/config.rs
@@ -23,7 +23,10 @@ use monad_testutil::{signing::get_genesis_config, validators::create_keys_w_vali
 use monad_types::NodeId;
 use monad_wal::{mock::MockWALoggerConfig, PersistenceLogger};
 
-use crate::{graph::SimulationConfig, PersistenceLoggerType, Rsc, SignatureCollectionType, MM, MS};
+use crate::{
+    graph::SimulationConfig, PersistenceLoggerType, Rsc, SignatureCollectionType,
+    TransactionValidatorType, MM, MS,
+};
 
 #[derive(Debug, Clone)]
 pub struct SimConfig {
@@ -76,10 +79,12 @@ impl
             .map(|k| NodeId(k.pubkey()))
             .zip(cert_keys.iter())
             .collect::<Vec<_>>();
-        let (genesis_block, genesis_sigs) = get_genesis_config::<Sha256Hash, SignatureCollectionType>(
-            voting_keys.iter(),
-            &validator_mapping,
-        );
+        let (genesis_block, genesis_sigs) =
+            get_genesis_config::<Sha256Hash, SignatureCollectionType, TransactionValidatorType>(
+                voting_keys.iter(),
+                &validator_mapping,
+                &TransactionValidatorType::default(),
+            );
 
         let state_configs = keys
             .into_iter()

--- a/monad-viz/src/main.rs
+++ b/monad-viz/src/main.rs
@@ -24,7 +24,7 @@ use iced::{
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
-    block::{Block, BlockType},
+    block::{BlockType, FullBlock},
     multi_sig::MultiSig,
     payload::NopStateRoot,
     transaction_validator::MockValidator,
@@ -298,7 +298,7 @@ impl Application for Viz {
 
 fn draw_ledger(
     frame: &mut Frame,
-    ledger: &Vec<Block<MultiSig<NopSignature>>>,
+    ledger: &Vec<FullBlock<MultiSig<NopSignature>>>,
     idx: usize,
     x: &f32,
     y: &f32,

--- a/monad-viz/src/replay_graph.rs
+++ b/monad-viz/src/replay_graph.rs
@@ -15,7 +15,7 @@ use monad_types::{Deserializable, NodeId, Serializable};
 
 use crate::{
     graph::{Graph, NodeEvent, NodeState, ReplayConfig},
-    SignatureCollectionType, MS,
+    SignatureCollectionType, TransactionValidatorType, MS,
 };
 
 #[derive(Debug, Clone)]
@@ -36,10 +36,12 @@ impl ReplayConfig<MS> for RepConfig {
             .map(|k| NodeId(k.pubkey()))
             .zip(cert_keys.iter())
             .collect::<Vec<_>>();
-        let (genesis_block, genesis_sigs) = get_genesis_config::<Sha256Hash, SignatureCollectionType>(
-            voting_keys.iter(),
-            &validator_mapping,
-        );
+        let (genesis_block, genesis_sigs) =
+            get_genesis_config::<Sha256Hash, SignatureCollectionType, TransactionValidatorType>(
+                voting_keys.iter(),
+                &validator_mapping,
+                &TransactionValidatorType::default(),
+            );
 
         let state_configs = keys
             .into_iter()


### PR DESCRIPTION
Create FullBlock type which contains Block and FullTransactionList so that on LedgerCommit we don't need to re-fetch full_txs from mempool.