### PR TITLE
Allow Lazy evaluation of Hash on get_participants

### DIFF
--- a/monad-consensus-types/src/bls.rs
+++ b/monad-consensus-types/src/bls.rs
@@ -226,10 +226,10 @@ impl SignatureCollection for BlsSignatureCollection {
         Ok(signers)
     }
 
-    fn get_participants(
+    fn get_participants<F: Fn() -> Hash>(
         &self,
         validator_mapping: &ValidatorMapping<SignatureCollectionKeyPairType<Self>>,
-        _msg: &[u8],
+        _: F,
     ) -> HashSet<NodeId> {
         assert_eq!(self.signers.len(), validator_mapping.map.len());
 

--- a/monad-consensus-types/src/multi_sig.rs
+++ b/monad-consensus-types/src/multi_sig.rs
@@ -155,16 +155,17 @@ impl<S: CertificateSignatureRecoverable> SignatureCollection for MultiSig<S> {
         Ok(node_ids)
     }
 
-    fn get_participants(
+    fn get_participants<F: Fn() -> Hash>(
         &self,
         validator_mapping: &ValidatorMapping<SignatureCollectionKeyPairType<Self>>,
-        msg: &[u8],
+        get_msg: F,
     ) -> HashSet<NodeId> {
         let mut node_ids = HashSet::new();
         let mut pub_keys = HashSet::new();
+        let msg = get_msg();
 
         for sig in self.sigs.iter() {
-            if let Ok(pubkey) = sig.recover_pubkey(msg) {
+            if let Ok(pubkey) = sig.recover_pubkey(msg.as_ref()) {
                 pub_keys.insert(pubkey);
             }
         }

--- a/monad-consensus-types/src/quorum_certificate.rs
+++ b/monad-consensus-types/src/quorum_certificate.rs
@@ -140,7 +140,9 @@ impl<SCT: SignatureCollection> QuorumCertificate<SCT> {
     ) -> HashSet<NodeId> {
         // TODO, consider caching this qc_msg hash in qc for performance in future
         let qc_msg = H::hash_object(&self.info.ledger_commit);
-        self.signatures
-            .get_participants(validator_mapping, qc_msg.as_ref())
+
+        self.signatures.get_participants(validator_mapping, || {
+            H::hash_object(&self.info.ledger_commit)
+        })
     }
 }

--- a/monad-consensus-types/src/signature_collection.rs
+++ b/monad-consensus-types/src/signature_collection.rs
@@ -74,10 +74,10 @@ pub trait SignatureCollection:
      * Get participants doesn't verify the validity of the certificate,
      * but retrieve any valid nodeId participated given a validator mapping.
      */
-    fn get_participants(
+    fn get_participants<F: Fn() -> Hash>(
         &self,
         validator_mapping: &ValidatorMapping<SignatureCollectionKeyPairType<Self>>,
-        msg: &[u8],
+        get_msg: F,
     ) -> HashSet<NodeId>;
     // TODO: deprecate this function: only used by tests
     fn num_signatures(&self) -> usize;
@@ -259,7 +259,7 @@ mod test {
         let sigs = get_sigs::<T>(msg_hash.as_ref(), voting_keys.iter());
         let sigcol = T::new(sigs, &valmap, msg_hash.as_ref()).unwrap();
 
-        let signers = sigcol.get_participants(&valmap, msg_hash.as_ref());
+        let signers = sigcol.get_participants(&valmap, || msg_hash);
 
         let expected_set = valmap.map.into_keys().collect::<HashSet<_>>();
         assert_eq!(signers, expected_set);

--- a/monad-testutil/src/signing.rs
+++ b/monad-testutil/src/signing.rs
@@ -69,10 +69,10 @@ impl SignatureCollection for MockSignatures {
         Ok(self.pubkey.iter().map(|pubkey| NodeId(*pubkey)).collect())
     }
 
-    fn get_participants(
+    fn get_participants<F: Fn() -> Hash>(
         &self,
-        _validator_mapping: &ValidatorMapping<SignatureCollectionKeyPairType<Self>>,
-        _msg: &[u8],
+        _: &ValidatorMapping<SignatureCollectionKeyPairType<Self>>,
+        _: F,
     ) -> HashSet<NodeId> {
         HashSet::from_iter(self.pubkey.iter().map(|pubkey| NodeId(*pubkey)))
     }


### PR DESCRIPTION
BLS signature doesn't rely on having the original
msg, thus, instead of passing in the Hash, a
closure that can be used to evaluate to
hash is passed.

We might need more bench mark to see if the hash
is actually lazily evaluated or not, and if this
approach is actually an improvement