### PR TITLE
QC/TC creation error handling

### DIFF
--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -6,6 +6,7 @@ use monad_consensus::{
         message::{BlockSyncMessage, ProposalMessage},
     },
     pacemaker::{PacemakerCommand, PacemakerTimerExpire},
+    vote_state::VoteStateCommand,
 };
 use monad_consensus_types::{
     block::{Block, FullBlock, UnverifiedFullBlock},
@@ -84,6 +85,12 @@ impl<SCT: SignatureCollection> From<&InFlightBlockSync<SCT>> for ConsensusComman
             peer: sync.req_target,
             block_id: sync.qc.info.vote.id,
         }
+    }
+}
+
+impl<SCT: SignatureCollection> From<VoteStateCommand> for ConsensusCommand<SCT> {
+    fn from(value: VoteStateCommand) -> Self {
+        todo!()
     }
 }
 

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -349,11 +349,12 @@ where
         }
         inc_count!(vote_received);
 
-        let qc: Option<QuorumCertificate<SCT>> =
+        let mut cmds = Vec::new();
+        let (qc, vote_state_cmds) =
             self.vote_state
                 .process_vote::<H, _>(&author, &vote_msg, validators, validator_mapping);
+        cmds.extend(vote_state_cmds.into_iter().map(Into::into));
 
-        let mut cmds = Vec::new();
         if let Some(qc) = qc {
             debug!("Created QC {:?}", qc);
             inc_count!(created_qc);

--- a/monad-consensus-types/src/timeout.rs
+++ b/monad-consensus-types/src/timeout.rs
@@ -90,7 +90,6 @@ impl<SCT: SignatureCollection> TimeoutCertificate<SCT> {
             entry.1.push((*node_id, *sig));
         }
         let mut high_qc_rounds = Vec::new();
-
         for (high_qc_round, (tminfo_digest, sigs)) in sigs.into_iter() {
             let sct = SCT::new(sigs, validator_mapping, tminfo_digest.as_ref())?;
             high_qc_rounds.push(HighQcRoundSigColTuple::<SCT> {

--- a/monad-consensus/src/pacemaker.rs
+++ b/monad-consensus/src/pacemaker.rs
@@ -2,7 +2,9 @@ use std::{collections::HashMap, time::Duration};
 
 use monad_consensus_types::{
     quorum_certificate::QuorumCertificate,
-    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
+    signature_collection::{
+        SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
+    },
     timeout::{Timeout, TimeoutCertificate},
     validation::Hasher,
     voting::ValidatorMapping,
@@ -147,35 +149,58 @@ impl<SCT: SignatureCollection> Pacemaker<SCT> {
         // it's fine to overwrite if already exists
         self.pending_timeouts.insert(author, tmo.clone());
 
-        let timeouts: Vec<NodeId> = self.pending_timeouts.keys().copied().collect();
+        let mut timeouts: Vec<NodeId> = self.pending_timeouts.keys().copied().collect();
 
         if self.phase == PhaseHonest::Zero && validators.has_honest_vote(&timeouts) {
             // self.local_timeout_round emits PacemakerCommand::ScheduleReset
             ret_commands.extend(self.local_timeout_round(safety, high_qc));
             self.phase = PhaseHonest::One;
         }
-        let mut ret_tc: Option<TimeoutCertificate<SCT>> = None;
-        if self.phase == PhaseHonest::One && validators.has_super_majority_votes(&timeouts) {
-            // FIXME: error handling when creating certificate
-            ret_tc = Some(
-                TimeoutCertificate::new::<H>(
-                    tm_info.round,
-                    self.pending_timeouts
-                        .iter()
-                        .map(|(node_id, tmo_msg)| {
-                            (*node_id, tmo_msg.timeout.tminfo.clone(), tmo_msg.sig)
-                        })
-                        .collect::<Vec<_>>()
-                        .as_slice(),
-                    validator_mapping,
-                )
-                .expect("TimeoutCertificate creation"),
-            );
 
-            self.phase = PhaseHonest::Supermajority;
+        let mut ret_tc: Option<TimeoutCertificate<SCT>> = None;
+        while self.phase == PhaseHonest::One && validators.has_super_majority_votes(&timeouts) {
+            match TimeoutCertificate::new::<H>(
+                tm_info.round,
+                self.pending_timeouts
+                    .iter()
+                    .map(|(node_id, tmo_msg)| {
+                        (*node_id, tmo_msg.timeout.tminfo.clone(), tmo_msg.sig)
+                    })
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+                validator_mapping,
+            ) {
+                Ok(tc) => {
+                    self.phase = PhaseHonest::Supermajority;
+                    ret_tc = Some(tc);
+                }
+                Err(err) => match err {
+                    SignatureCollectionError::InvalidSignaturesCreate(invalid_sigs) => {
+                        ret_commands.extend(self.handle_invalid_timeout(invalid_sigs));
+                        timeouts = self.pending_timeouts.keys().copied().collect();
+                    }
+                    _ => {
+                        unreachable!("unexpected error {}", err)
+                    }
+                },
+            };
         }
 
         (ret_tc, ret_commands)
+    }
+
+    #[must_use]
+    fn handle_invalid_timeout(
+        &mut self,
+        invalid_timeouts: Vec<(NodeId, SCT::SignatureType)>,
+    ) -> Vec<PacemakerCommand<SCT>> {
+        for (node_id, sig) in invalid_timeouts {
+            let removed = self.pending_timeouts.remove(&node_id);
+            // TODO: debug assert
+            assert_eq!(removed.expect("Timeout removed").sig, sig);
+        }
+        // TODO: evidence collection
+        vec![]
     }
 
     #[must_use]
@@ -201,5 +226,307 @@ impl<SCT: SignatureCollection> Pacemaker<SCT> {
         }
         self.last_round_tc = None;
         Some(self.start_timer(qc.info.vote.round + Round(1)))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashSet;
+
+    use monad_consensus_types::{
+        certificate_signature::CertificateSignature,
+        ledger::LedgerCommitInfo,
+        multi_sig::MultiSig,
+        quorum_certificate::QcInfo,
+        timeout::TimeoutInfo,
+        validation::Sha256Hash,
+        voting::{Vote, VoteInfo},
+    };
+    use monad_crypto::secp256k1::{KeyPair, SecpSignature};
+    use monad_testutil::{
+        signing::{create_certificate_keys, create_keys},
+        validators::create_keys_w_validators,
+    };
+    use monad_types::{BlockId, Hash, Stake};
+    use monad_validator::validator_set::ValidatorSet;
+    use zerocopy::AsBytes;
+
+    use super::*;
+
+    type SignatureCollectionType = MultiSig<SecpSignature>;
+
+    fn get_high_qc<SCT: SignatureCollection>(
+        qc_round: Round,
+        keys: &[KeyPair],
+        certkeys: &[SignatureCollectionKeyPairType<SCT>],
+        valmap: &ValidatorMapping<SignatureCollectionKeyPairType<SCT>>,
+    ) -> QuorumCertificate<SCT> {
+        let vote_info = VoteInfo {
+            id: BlockId(Hash([0x00_u8; 32])),
+            round: qc_round,
+            parent_id: BlockId(Hash([0x00_u8; 32])),
+            parent_round: Round(0),
+            seq_num: 0,
+        };
+
+        let ledger_commit_info = LedgerCommitInfo::new::<Sha256Hash>(None, &vote_info);
+
+        let qc_info = QcInfo {
+            vote: vote_info,
+            ledger_commit: ledger_commit_info,
+        };
+
+        let vote = Vote {
+            vote_info,
+            ledger_commit_info,
+        };
+
+        let vote_hash = Sha256Hash::hash_object(&vote);
+
+        let mut sigs = Vec::new();
+
+        for (key, certkey) in keys.iter().zip(certkeys.iter()) {
+            let node_id = NodeId(key.pubkey());
+            let sig =
+                <SCT::SignatureType as CertificateSignature>::sign(vote_hash.as_ref(), certkey);
+            sigs.push((node_id, sig));
+        }
+
+        let sigcol = SCT::new(sigs, valmap, vote_hash.as_ref()).expect("success");
+
+        QuorumCertificate::<SCT>::new::<Sha256Hash>(qc_info, sigcol)
+    }
+
+    fn create_timeout_message<SCT: SignatureCollection>(
+        certkeypair: &SignatureCollectionKeyPairType<SCT>,
+        timeout_round: Round,
+        high_qc: QuorumCertificate<SCT>,
+        valid: bool,
+    ) -> TimeoutMessage<SCT> {
+        let timeout = Timeout {
+            tminfo: TimeoutInfo {
+                round: timeout_round,
+                high_qc,
+            },
+            last_round_tc: None,
+        };
+
+        let invalid_msg = b"invalid";
+
+        let mut tmo_msg = TimeoutMessage::<SCT>::new::<Sha256Hash>(timeout, certkeypair);
+        if !valid {
+            tmo_msg.sig =
+                <SCT::SignatureType as CertificateSignature>::sign(invalid_msg, certkeypair);
+        }
+        tmo_msg
+    }
+
+    #[test]
+    fn all_honest() {
+        let mut pacemaker =
+            Pacemaker::<SignatureCollectionType>::new(Duration::from_secs(1), Round(1), None);
+        let mut safety = Safety::default();
+
+        let (keys, certkeys, valset, vmap) = create_keys_w_validators::<SignatureCollectionType>(4);
+        let timeout_round = Round(1);
+        let high_qc = get_high_qc(Round(0), keys.as_slice(), certkeys.as_slice(), &vmap);
+
+        let tm0 = create_timeout_message(&certkeys[0], timeout_round, high_qc.clone(), true);
+        let tm1 = create_timeout_message(&certkeys[1], timeout_round, high_qc.clone(), true);
+        let tm2 = create_timeout_message(&certkeys[2], timeout_round, high_qc.clone(), true);
+        let tm3 = create_timeout_message(&certkeys[3], timeout_round, high_qc.clone(), true);
+
+        let (tc, cmds) = pacemaker.process_remote_timeout::<Sha256Hash, _>(
+            &valset,
+            &vmap,
+            &mut safety,
+            &high_qc,
+            NodeId(keys[0].pubkey()),
+            tm0,
+        );
+        assert!(tc.is_none());
+        assert!(cmds.is_empty());
+
+        // enter PhaseHonest::One, timeout itself
+        let (tc, cmds) = pacemaker.process_remote_timeout::<Sha256Hash, _>(
+            &valset,
+            &vmap,
+            &mut safety,
+            &high_qc,
+            NodeId(keys[1].pubkey()),
+            tm1,
+        );
+        assert_eq!(pacemaker.phase, PhaseHonest::One);
+        assert!(tc.is_none());
+        assert_eq!(cmds.len(), 2);
+        assert!(matches!(cmds[0], PacemakerCommand::ScheduleReset));
+        assert!(matches!(cmds[1], PacemakerCommand::PrepareTimeout(_)));
+
+        // enter PhaseHonest::SuperMajority, qc is created
+        let (tc, cmds) = pacemaker.process_remote_timeout::<Sha256Hash, _>(
+            &valset,
+            &vmap,
+            &mut safety,
+            &high_qc,
+            NodeId(keys[2].pubkey()),
+            tm2,
+        );
+        assert_eq!(pacemaker.phase, PhaseHonest::Supermajority);
+        assert!(tc.is_some());
+        assert!(cmds.is_empty());
+
+        // in PhaseHonest::SuperMajority, pacemaker doesn't create TC with new timeouts
+        let (tc, cmds) = pacemaker.process_remote_timeout::<Sha256Hash, _>(
+            &valset,
+            &vmap,
+            &mut safety,
+            &high_qc,
+            NodeId(keys[3].pubkey()),
+            tm3,
+        );
+        assert!(tc.is_none());
+        assert!(cmds.is_empty());
+    }
+
+    #[test]
+    fn phase_supermajority_invalid_no_progress() {
+        let mut pacemaker =
+            Pacemaker::<SignatureCollectionType>::new(Duration::from_secs(1), Round(1), None);
+        let mut safety = Safety::default();
+
+        let (keys, certkeys, valset, vmap) = create_keys_w_validators::<SignatureCollectionType>(4);
+        let timeout_round = Round(1);
+        let high_qc = get_high_qc(Round(0), keys.as_slice(), certkeys.as_slice(), &vmap);
+
+        let tm0_valid = create_timeout_message(&certkeys[0], timeout_round, high_qc.clone(), true);
+        let tm1_valid = create_timeout_message(&certkeys[1], timeout_round, high_qc.clone(), true);
+        let tm2_invalid =
+            create_timeout_message(&certkeys[2], timeout_round, high_qc.clone(), false);
+
+        let _ = pacemaker.process_remote_timeout::<Sha256Hash, _>(
+            &valset,
+            &vmap,
+            &mut safety,
+            &high_qc,
+            NodeId(keys[0].pubkey()),
+            tm0_valid,
+        );
+
+        let _ = pacemaker.process_remote_timeout::<Sha256Hash, _>(
+            &valset,
+            &vmap,
+            &mut safety,
+            &high_qc,
+            NodeId(keys[1].pubkey()),
+            tm1_valid,
+        );
+
+        let (tc, cmds) = pacemaker.process_remote_timeout::<Sha256Hash, _>(
+            &valset,
+            &vmap,
+            &mut safety,
+            &high_qc,
+            NodeId(keys[2].pubkey()),
+            tm2_invalid,
+        );
+        assert!(tc.is_none());
+        assert!(cmds.is_empty());
+        assert_eq!(pacemaker.phase, PhaseHonest::One);
+        assert_eq!(pacemaker.pending_timeouts.len(), 2);
+    }
+
+    #[test]
+    fn phase_supermajority_invalid_progress() {
+        let mut pacemaker =
+            Pacemaker::<SignatureCollectionType>::new(Duration::from_secs(1), Round(1), None);
+        let mut safety = Safety::default();
+
+        let keys = create_keys(4);
+        let certkeys = create_certificate_keys::<SignatureCollectionType>(4);
+
+        let mut staking_list = keys
+            .iter()
+            .map(|k| NodeId(k.pubkey()))
+            .zip(std::iter::repeat(Stake(1)))
+            .collect::<Vec<_>>();
+
+        // total stake = 7, f = 2
+        // node1 holds f+1 stake
+        // node1 + node2 has 2f+1 stake
+        staking_list[0].1 = Stake(1);
+        staking_list[1].1 = Stake(3);
+        staking_list[2].1 = Stake(2);
+        staking_list[3].1 = Stake(1);
+
+        let voting_identity = keys
+            .iter()
+            .map(|k| NodeId(k.pubkey()))
+            .zip(certkeys.iter().map(|k| k.pubkey()))
+            .collect::<Vec<_>>();
+
+        let valset = ValidatorSet::new(staking_list).expect("create validator set");
+        let vmap = ValidatorMapping::new(voting_identity);
+
+        let timeout_round = Round(1);
+        let high_qc = get_high_qc(Round(0), keys.as_slice(), certkeys.as_slice(), &vmap);
+
+        let tm0_invalid =
+            create_timeout_message(&certkeys[0], timeout_round, high_qc.clone(), false);
+        let tm1_valid = create_timeout_message(&certkeys[1], timeout_round, high_qc.clone(), true);
+        let tm2_valid = create_timeout_message(&certkeys[2], timeout_round, high_qc.clone(), true);
+
+        let _ = pacemaker.process_remote_timeout::<Sha256Hash, _>(
+            &valset,
+            &vmap,
+            &mut safety,
+            &high_qc,
+            NodeId(keys[1].pubkey()),
+            tm1_valid,
+        );
+
+        let (tc, _cmds) = pacemaker.process_remote_timeout::<Sha256Hash, _>(
+            &valset,
+            &vmap,
+            &mut safety,
+            &high_qc,
+            NodeId(keys[0].pubkey()),
+            tm0_invalid,
+        );
+        assert!(tc.is_none());
+        assert_eq!(pacemaker.pending_timeouts.len(), 2);
+
+        // invalid timeout is removed
+        // the remaining two timeouts has 5/7 stake, so TC is created
+        let (tc, cmds) = pacemaker.process_remote_timeout::<Sha256Hash, _>(
+            &valset,
+            &vmap,
+            &mut safety,
+            &high_qc,
+            NodeId(keys[2].pubkey()),
+            tm2_valid,
+        );
+        assert_eq!(pacemaker.phase, PhaseHonest::Supermajority);
+        assert!(tc.is_some());
+
+        // assert the TC is created over the two valid timeouts
+        let mut hasher = Sha256Hash::new();
+        hasher.update(Round(1).as_bytes());
+        hasher.update(Round(0).as_bytes());
+        let timeout_hash = hasher.hash();
+        let tc = tc.unwrap();
+        assert_eq!(tc.high_qc_rounds.len(), 1);
+        let sc = tc.high_qc_rounds.first().unwrap().sigs.clone();
+        assert_eq!(
+            sc.verify(&vmap, timeout_hash.as_ref())
+                .unwrap()
+                .into_iter()
+                .collect::<HashSet<_>>(),
+            vec![NodeId(keys[1].pubkey()), NodeId(keys[2].pubkey())]
+                .into_iter()
+                .collect::<HashSet<_>>()
+        );
+
+        assert!(cmds.is_empty());
+        assert_eq!(pacemaker.pending_timeouts.len(), 2);
     }
 }

--- a/monad-consensus/tests/vote_state.rs
+++ b/monad-consensus/tests/vote_state.rs
@@ -96,7 +96,8 @@ fn test_votes(num_nodes: u32) {
     let mut qcs = Vec::new();
     for i in 0..num_nodes {
         let v = &votes[i as usize];
-        let qc = voteset.process_vote::<Sha256Hash, _>(v.author(), v, &valset, &vmap);
+        let (qc, cmds) = voteset.process_vote::<Sha256Hash, _>(v.author(), v, &valset, &vmap);
+        assert!(cmds.is_empty());
         qcs.push(qc);
     }
     let valid_qc: Vec<&Option<QuorumCertificate<SignatureCollectionType>>> =
@@ -121,7 +122,8 @@ fn test_reset(num_nodes: u32, num_rounds: u32) {
     for k in 0..num_rounds {
         for i in 0..num_nodes {
             let v = &votes[i as usize];
-            let qc = voteset.process_vote::<Sha256Hash, _>(v.author(), v, &valset, &vmap);
+            let (qc, cmds) = voteset.process_vote::<Sha256Hash, _>(v.author(), v, &valset, &vmap);
+            assert!(cmds.is_empty());
             qcs.push(qc);
         }
 
@@ -148,7 +150,8 @@ fn test_minority(num_nodes: u32) {
 
     for i in 0..majority - 1 {
         let v = &votes[i as usize];
-        let qc = voteset.process_vote::<Sha256Hash, _>(v.author(), v, &valset, &vmap);
+        let (qc, cmds) = voteset.process_vote::<Sha256Hash, _>(v.author(), v, &valset, &vmap);
+        assert!(cmds.is_empty());
         qcs.push(qc);
     }
 


### PR DESCRIPTION
`SignatureCollection` creation returns the signers' NodeId on success, and reports the invalid signatures and their respective signers on error. QC/TC creation currently expect `SignatureCollection to awlays returns success.

This PR handles error from `SignatureCollection` creation. When it reports the `InvalidSignatureCreate` error, the node removes the invalid votes/timeouts from the pending list. It retries until the total stake falls under supermajority.

We can later emit evidence collection commands for these invalid signatures.