### PR TITLE
Add BytesTransformerPipeline Specialization

### DIFF
--- a/monad-executor/src/mock_swarm.rs
+++ b/monad-executor/src/mock_swarm.rs
@@ -16,7 +16,7 @@ use crate::{
     transformer::Pipeline,
     Executor, PeerId, State,
 };
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinkMessage<M> {
     pub from: PeerId,
     pub to: PeerId,


### PR DESCRIPTION
Our current GenericTransformerPipeline contains transformers that are properly generic over any message type. BytesTransformerPipeline is a specialization for message bytes that has additional functionality, eg splitting/merging messages together.