### PR TITLE
Allow uncommitted block to be synced

### DIFF
--- a/monad-state/tests/block_sync.rs
+++ b/monad-state/tests/block_sync.rs
@@ -38,7 +38,7 @@ mod test {
         let mut filter_peers: HashSet<PeerId> = HashSet::new();
         filter_peers.insert(first_node);
 
-        println!("delayed node ID: {:?}", first_node);
+        println!("blackout node ID: {:?}", first_node);
 
         run_nodes_until::<
             MonadState<


### PR DESCRIPTION
Now that QC backed block sync is in placed,
we can ensure that even uncommitted blocks
cannot be abused to cause fake commit