### PR TITLE
Deduplicate transactions in pending blocktree

### DIFF
--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -28,6 +28,7 @@ pub enum ConsensusCommand<SCT: SignatureCollection> {
     ScheduleReset,
     FetchTxs(
         usize,
+        Vec<TransactionList>,
         Box<dyn (FnOnce(TransactionList) -> FetchedTxs<SCT>) + Send + Sync>,
     ),
     FetchTxsReset,

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -74,7 +74,11 @@ pub enum MempoolCommand<E> {
     /// FetchReset should ALMOST ALWAYS be emitted by the state machine after handling E
     /// This is to prevent E from firing twice on replay
     // TODO create test to demonstrate faulty behavior if written improperly
-    FetchTxs(usize, Box<dyn (FnOnce(TransactionList) -> E) + Send + Sync>),
+    FetchTxs(
+        usize,
+        Vec<TransactionList>,
+        Box<dyn (FnOnce(TransactionList) -> E) + Send + Sync>,
+    ),
     FetchReset,
     FetchFullTxs(
         TransactionList,

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -490,7 +490,7 @@ impl<E> Executor for MockMempool<E> {
 
         for command in commands {
             match command {
-                MempoolCommand::FetchTxs(_, cb) => {
+                MempoolCommand::FetchTxs(_, _, cb) => {
                     self.fetch_txs_state = Some(cb);
                     wake = true;
                 }
@@ -675,7 +675,7 @@ mod tests {
     #[test]
     fn test_fetch() {
         let mut mempool = MockMempool::<()>::default();
-        mempool.exec(vec![MempoolCommand::FetchTxs(0, Box::new(|_| {}))]);
+        mempool.exec(vec![MempoolCommand::FetchTxs(0, vec![], Box::new(|_| {}))]);
         assert!(futures::executor::block_on(mempool.next()).is_some());
         assert!(!mempool.ready());
     }
@@ -683,8 +683,8 @@ mod tests {
     #[test]
     fn test_double_fetch() {
         let mut mempool = MockMempool::<()>::default();
-        mempool.exec(vec![MempoolCommand::FetchTxs(0, Box::new(|_| {}))]);
-        mempool.exec(vec![MempoolCommand::FetchTxs(0, Box::new(|_| {}))]);
+        mempool.exec(vec![MempoolCommand::FetchTxs(0, vec![], Box::new(|_| {}))]);
+        mempool.exec(vec![MempoolCommand::FetchTxs(0, vec![], Box::new(|_| {}))]);
         assert!(futures::executor::block_on(mempool.next()).is_some());
         assert!(!mempool.ready());
     }
@@ -692,7 +692,7 @@ mod tests {
     #[test]
     fn test_reset() {
         let mut mempool = MockMempool::<()>::default();
-        mempool.exec(vec![MempoolCommand::FetchTxs(0, Box::new(|_| {}))]);
+        mempool.exec(vec![MempoolCommand::FetchTxs(0, vec![], Box::new(|_| {}))]);
         mempool.exec(vec![MempoolCommand::FetchReset]);
         assert!(!mempool.ready());
     }
@@ -701,8 +701,8 @@ mod tests {
     fn test_inline_double_fetch() {
         let mut mempool = MockMempool::<()>::default();
         mempool.exec(vec![
-            MempoolCommand::FetchTxs(0, Box::new(|_| {})),
-            MempoolCommand::FetchTxs(0, Box::new(|_| {})),
+            MempoolCommand::FetchTxs(0, vec![], Box::new(|_| {})),
+            MempoolCommand::FetchTxs(0, vec![], Box::new(|_| {})),
         ]);
         assert!(futures::executor::block_on(mempool.next()).is_some());
         assert!(!mempool.ready());
@@ -712,7 +712,7 @@ mod tests {
     fn test_inline_reset() {
         let mut mempool = MockMempool::<()>::default();
         mempool.exec(vec![
-            MempoolCommand::FetchTxs(0, Box::new(|_| {})),
+            MempoolCommand::FetchTxs(0, vec![], Box::new(|_| {})),
             MempoolCommand::FetchReset,
         ]);
         assert!(!mempool.ready());
@@ -723,7 +723,7 @@ mod tests {
         let mut mempool = MockMempool::<()>::default();
         mempool.exec(vec![
             MempoolCommand::FetchReset,
-            MempoolCommand::FetchTxs(0, Box::new(|_| {})),
+            MempoolCommand::FetchTxs(0, vec![], Box::new(|_| {})),
         ]);
         assert!(futures::executor::block_on(mempool.next()).is_some());
         assert!(!mempool.ready());
@@ -732,7 +732,7 @@ mod tests {
     #[test]
     fn test_noop_exec() {
         let mut mempool = MockMempool::<()>::default();
-        mempool.exec(vec![MempoolCommand::FetchTxs(0, Box::new(|_| {}))]);
+        mempool.exec(vec![MempoolCommand::FetchTxs(0, vec![], Box::new(|_| {}))]);
         mempool.exec(Vec::new());
         assert!(futures::executor::block_on(mempool.next()).is_some());
         assert!(!mempool.ready());

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -332,7 +332,7 @@ where
                             cmds.push(ConsensusCommand::Publish {
                                 target: RouterTarget::Broadcast,
                                 message: ConsensusMessage::Proposal(p),
-                            })
+                            });
                         }
 
                         cmds
@@ -478,9 +478,10 @@ where
                         ConsensusCommand::ScheduleReset => {
                             cmds.push(Command::TimerCommand(TimerCommand::ScheduleReset))
                         }
-                        ConsensusCommand::FetchTxs(max_txns, cb) => {
+                        ConsensusCommand::FetchTxs(max_txns, pending_txs, cb) => {
                             cmds.push(Command::MempoolCommand(MempoolCommand::FetchTxs(
                                 max_txns,
+                                pending_txs,
                                 Box::new(|txs| {
                                     MonadEvent::ConsensusEvent(ConsensusEvent::FetchedTxs(cb(txs)))
                                 }),


### PR DESCRIPTION
Provide TransactionList of each pending block in the extending branch to the mempool on FetchTxs so that it can avoid these transactions and return unused transactions.