### PR TITLE
Allow router sends that are best-effort

### DIFF
--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -21,6 +21,10 @@ pub enum ConsensusCommand<SCT: SignatureCollection> {
         target: RouterTarget,
         message: ConsensusMessage<SCT>,
     },
+    Send {
+        target: RouterTarget,
+        message: ConsensusMessage<SCT>,
+    },
     Schedule {
         duration: Duration,
         on_timeout: PacemakerTimerExpire,

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -41,8 +41,22 @@ where
     M: Message,
 {
     // TODO add a RouterCommand for setting peer set for broadcast
-    Publish { target: RouterTarget, message: OM },
-    Unpublish { target: RouterTarget, id: M::Id },
+    /// Message is published for delivery to target and will continue to attempt
+    /// delivery until unpublished
+    Publish {
+        target: RouterTarget,
+        message: OM,
+    },
+    Unpublish {
+        target: RouterTarget,
+        id: M::Id,
+    },
+
+    /// Best-effort send to target
+    Send {
+        target: RouterTarget,
+        message: OM,
+    },
 }
 
 pub trait Message: Identifiable + Clone {

--- a/monad-executor/src/replay_nodes.rs
+++ b/monad-executor/src/replay_nodes.rs
@@ -124,6 +124,9 @@ where
                     RouterCommand::Unpublish { target, id } => {
                         to_unpublish.insert((target, id));
                     }
+                    RouterCommand::Send { target, message } => {
+                        to_publish.push((target, message));
+                    }
                 },
                 _ => {}
             }

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -281,6 +281,7 @@ where
     fn exec(&mut self, commands: Vec<Self::Command>) {
         let mut to_publish = Vec::new();
         let mut to_unpublish = HashSet::new();
+        let mut to_send = Vec::new();
 
         let (
             router_cmds,
@@ -297,6 +298,9 @@ where
                 }
                 RouterCommand::Unpublish { target, id } => {
                     to_unpublish.insert((target, id));
+                }
+                RouterCommand::Send { target, message } => {
+                    to_send.push((target, message));
                 }
             }
         }
@@ -326,6 +330,10 @@ where
             if to_unpublish.contains(&(target, id)) {
                 continue;
             }
+            self.router.outbound(self.tick, target, message.serialize());
+        }
+
+        for (target, message) in to_send {
             self.router.outbound(self.tick, target, message.serialize());
         }
     }


### PR DESCRIPTION
Existing RouterCommand::Publish expects that a published message will be resent until unpublished. Unpublishing can be called manually or after an ack is received. The Publish/Unpublish guarantee is required for consensus protocol messages but other types of messages don't need this behaviour.

A Send router command is added to allow for nodes to send a single message without retries.