### PR TITLE
Allow fair&random selection of event in mock_swarm

### DIFF
--- a/monad-mock-swarm/Cargo.toml
+++ b/monad-mock-swarm/Cargo.toml
@@ -24,6 +24,7 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
 tracing = { workspace = true }
+itertools = { workspace = true }
 
 [dev-dependencies]
 monad-block-sync = { path = "../monad-block-sync" }
@@ -39,7 +40,6 @@ monad-tracing-counter = { path = "../monad-tracing-counter" }
 monad-validator = { path = "../monad-validator" }
 
 criterion = { workspace = true }
-itertools = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 tempfile = { workspace = true }

--- a/monad-mock-swarm/benches/two_node_benchmark.rs
+++ b/monad-mock-swarm/benches/two_node_benchmark.rs
@@ -57,6 +57,7 @@ fn two_nodes() {
             until: Duration::from_secs(10),
             until_block: usize::MAX,
             expected_block: 1024,
+            seed: 1,
         },
     );
 }

--- a/monad-mock-swarm/tests/block_sync.rs
+++ b/monad-mock-swarm/tests/block_sync.rs
@@ -77,6 +77,7 @@ mod test {
             Duration::from_secs(4),
             usize::MAX,
             20,
+            1,
         );
     }
 
@@ -145,6 +146,7 @@ mod test {
             until,
             usize::MAX,
             20,
+            1,
         );
     }
 }

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -56,6 +56,7 @@ fn many_nodes() {
             until: Duration::from_secs(4),
             until_block: usize::MAX,
             expected_block: 1024,
+            seed: 1,
         },
     );
 }
@@ -101,6 +102,7 @@ fn many_nodes_quic() {
             until: Duration::from_secs(4),
             until_block: usize::MAX,
             expected_block: 10,
+            seed: 1,
         },
     );
 }

--- a/monad-mock-swarm/tests/many_nodes_metrics.rs
+++ b/monad-mock-swarm/tests/many_nodes_metrics.rs
@@ -71,6 +71,7 @@ fn many_nodes_metrics() {
             until: Duration::from_secs(4),
             until_block: usize::MAX,
             expected_block: 1024,
+            seed: 1,
         },
     );
 

--- a/monad-mock-swarm/tests/msg_delays.rs
+++ b/monad-mock-swarm/tests/msg_delays.rs
@@ -52,6 +52,7 @@ fn two_nodes() {
             until: Duration::from_secs(60),
             until_block: usize::MAX,
             expected_block: 40,
+            seed: 1,
         },
     );
 }

--- a/monad-mock-swarm/tests/order.rs
+++ b/monad-mock-swarm/tests/order.rs
@@ -100,5 +100,6 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
         Duration::from_secs(1),
         usize::MAX,
         20,
+        1,
     );
 }

--- a/monad-mock-swarm/tests/rand_lat.rs
+++ b/monad-mock-swarm/tests/rand_lat.rs
@@ -91,6 +91,7 @@ fn nodes_with_random_latency(seed: u64) {
             until: Duration::from_secs(60 * 60),
             until_block: usize::MAX,
             expected_block: 2048,
+            seed: 1,
         },
     );
 }

--- a/monad-mock-swarm/tests/replay.rs
+++ b/monad-mock-swarm/tests/replay.rs
@@ -64,6 +64,7 @@ pub fn recover_nodes_msg_delays(num_nodes: u16, num_blocks_before: usize, num_bl
                 vec![GenericTransformer::XorLatency(XorLatencyTransformer(
                     Duration::from_millis(u8::MAX as u64),
                 ))],
+                1,
             )
         })
         .collect::<Vec<_>>();
@@ -148,6 +149,7 @@ pub fn recover_nodes_msg_delays(num_nodes: u16, num_blocks_before: usize, num_bl
                 vec![GenericTransformer::Latency(LatencyTransformer(
                     Duration::from_millis(1),
                 ))],
+                1,
             )
         })
         .collect::<Vec<_>>();

--- a/monad-mock-swarm/tests/replay_test.rs
+++ b/monad-mock-swarm/tests/replay_test.rs
@@ -127,6 +127,7 @@ where
 #[test_case::test_case(&[1,3]; "fail 1 3")]
 // #[test_case::test_case(&[2,3]; "fail 2 3")]
 fn replay_one_honest(failure_idx: &[usize]) {
+    let default_seed = 1;
     // setup 4 nodes
     let (peers, state_configs) =
         get_configs::<ST, SignatureCollectionType, TxValType>(MockValidator, 4, CONSENSUS_DELTA);
@@ -159,6 +160,7 @@ fn replay_one_honest(failure_idx: &[usize]) {
                         PeerId(pubkey),
                     ),
                     pipeline.clone(),
+                    default_seed,
                 )
             })
             .collect(),
@@ -226,6 +228,7 @@ fn replay_one_honest(failure_idx: &[usize]) {
             PeerId(pubkeys[f0]),
         ),
         pipeline.clone(),
+        default_seed,
     ));
 
     nodes.add_state((
@@ -237,6 +240,7 @@ fn replay_one_honest(failure_idx: &[usize]) {
             PeerId(pubkeys[f1]),
         ),
         pipeline,
+        default_seed,
     ));
 
     // assert consensus state is the same after replay

--- a/monad-mock-swarm/tests/single_node.rs
+++ b/monad-mock-swarm/tests/single_node.rs
@@ -56,6 +56,7 @@ fn two_nodes() {
             until: Duration::from_secs(10),
             until_block: usize::MAX,
             expected_block: 1024,
+            seed: 1,
         },
     );
 }
@@ -101,6 +102,7 @@ fn two_nodes_quic() {
             until: Duration::from_secs(10),
             until_block: usize::MAX,
             expected_block: 256,
+            seed: 1,
         },
     );
 }

--- a/monad-mock-swarm/tests/single_node_metrics.rs
+++ b/monad-mock-swarm/tests/single_node_metrics.rs
@@ -69,6 +69,7 @@ fn two_nodes() {
             until: Duration::from_secs(10),
             until_block: usize::MAX,
             expected_block: 1024,
+            seed: 1,
         },
     );
     counter_status!();

--- a/monad-mock-swarm/tests/two_nodes_bls.rs
+++ b/monad-mock-swarm/tests/two_nodes_bls.rs
@@ -55,6 +55,7 @@ fn two_nodes_bls() {
             until: Duration::from_secs(10),
             until_block: usize::MAX,
             expected_block: 128,
+            seed: 1,
         },
     );
 }

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -55,6 +55,7 @@ fn random_latency_test(seed: u64) {
             until: Duration::from_secs(10),
             until_block: usize::MAX,
             expected_block: 2048,
+            seed: 1,
         },
     );
 }
@@ -110,6 +111,7 @@ fn delayed_message_test(seed: u64) {
         Duration::from_secs(2),
         usize::MAX,
         20,
+        1,
     );
 }
 

--- a/monad-testutil/examples/logs_gen.rs
+++ b/monad-testutil/examples/logs_gen.rs
@@ -61,6 +61,7 @@ pub fn generate_log<P: Pipeline<MM>>(
                     all_peers: pubkeys.iter().map(|pubkey| PeerId(*pubkey)).collect(),
                 },
                 pipeline.clone(),
+                1,
             )
         })
         .collect::<Vec<_>>();

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -28,6 +28,7 @@ pub struct SwarmTestConfig {
     pub until: Duration,
     pub until_block: usize,
     pub expected_block: usize,
+    pub seed: u64,
 }
 
 pub fn get_configs<ST: MessageSignature, SCT: SignatureCollection, TVT: TransactionValidator>(
@@ -146,6 +147,7 @@ where
         swarm_config.until,
         swarm_config.until_block,
         swarm_config.expected_block,
+        swarm_config.seed,
     )
 }
 
@@ -160,6 +162,7 @@ pub fn run_nodes_until<S, ST, SCT, RS, RSC, LGR, P, TVT, ME>(
     until: Duration,
     until_block: usize,
     min_ledger_len: usize,
+    seed: u64,
 ) -> Duration
 where
     S: State<
@@ -204,6 +207,7 @@ where
                         PeerId(pubkey),
                     ),
                     pipeline.clone(),
+                    seed,
                 )
             })
             .collect(),

--- a/monad-virtual-bench/benches/two_node_bench.rs
+++ b/monad-virtual-bench/benches/two_node_bench.rs
@@ -49,6 +49,7 @@ fn two_nodes() -> u128 {
             until: Duration::from_secs(10),
             until_block: 1024,
             expected_block: 1024,
+            seed: 1,
         },
     )
     .as_millis()

--- a/monad-viz/src/config.rs
+++ b/monad-viz/src/config.rs
@@ -72,6 +72,7 @@ impl
         <PersistenceLoggerType as PersistenceLogger>::Config,
         Rsc,
         GenericTransformerPipeline<MM>,
+        u64,
     )> {
         let (keys, cert_keys, _validators, validator_mapping) =
             create_keys_w_validators::<SignatureCollectionType>(self.num_nodes);
@@ -127,6 +128,7 @@ impl
                         all_peers: pubkeys.iter().map(|pubkey| PeerId(*pubkey)).collect(),
                     },
                     self.pipeline.clone(),
+                    1,
                 )
             })
             .collect()

--- a/monad-viz/src/graph.rs
+++ b/monad-viz/src/graph.rs
@@ -65,7 +65,7 @@ where
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
 {
     fn max_tick(&self) -> Duration;
-    fn nodes(&self) -> Vec<(PubKey, S::Config, LGR::Config, RS::Config, P)>;
+    fn nodes(&self) -> Vec<(PubKey, S::Config, LGR::Config, RS::Config, P, u64)>;
 }
 
 pub struct NodesSimulation<S, RS, P, LGR, C, ME, ST, SCT>


### PR DESCRIPTION
This PR for "mock_swarm" improves event selection by eliminating a fixed
preference for executor events or external messages when they occur
simultaneously at the same tick. Instead, it enables fair and random
selection between these two event types. This change may uncover hidden
issues, even though some were resolved by "blocksync." The selection
randomness is based on the first 32 bytes of the peerid's pubkey for
each node.