### PR TITLE
Disable ptree default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,15 +215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,7 +274,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
- "num-traits 0.2.16",
+ "num-traits",
 ]
 
 [[package]]
@@ -304,7 +295,7 @@ dependencies = [
  "ark-std 0.3.0",
  "derivative",
  "num-bigint",
- "num-traits 0.2.16",
+ "num-traits",
  "paste",
  "rustc_version 0.3.3",
  "zeroize",
@@ -324,7 +315,7 @@ dependencies = [
  "digest 0.10.7",
  "itertools",
  "num-bigint",
- "num-traits 0.2.16",
+ "num-traits",
  "paste",
  "rustc_version 0.4.0",
  "zeroize",
@@ -357,7 +348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
  "num-bigint",
- "num-traits 0.2.16",
+ "num-traits",
  "quote",
  "syn 1.0.109",
 ]
@@ -369,7 +360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint",
- "num-traits 0.2.16",
+ "num-traits",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -402,7 +393,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
- "num-traits 0.2.16",
+ "num-traits",
  "rand 0.8.5",
 ]
 
@@ -412,7 +403,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
- "num-traits 0.2.16",
+ "num-traits",
  "rand 0.8.5",
 ]
 
@@ -452,8 +443,8 @@ dependencies = [
  "asn1-rs-derive 0.1.0",
  "asn1-rs-impl",
  "displaydoc",
- "nom 7.1.3",
- "num-traits 0.2.16",
+ "nom",
+ "num-traits",
  "rusticata-macros",
  "thiserror",
  "time",
@@ -468,8 +459,8 @@ dependencies = [
  "asn1-rs-derive 0.4.0",
  "asn1-rs-impl",
  "displaydoc",
- "nom 7.1.3",
- "num-traits 0.2.16",
+ "nom",
+ "num-traits",
  "rusticata-macros",
  "thiserror",
  "time",
@@ -656,7 +647,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite 0.2.13",
  "rustversion",
- "serde 1.0.188",
+ "serde",
  "sync_wrapper",
  "tower",
  "tower-layer",
@@ -737,7 +728,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -749,7 +740,7 @@ dependencies = [
  "bitflags 2.4.0",
  "cexpr",
  "clang-sys",
- "lazy_static 1.4.0",
+ "lazy_static",
  "lazycell",
  "log",
  "peeking_take_while",
@@ -790,7 +781,7 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 dependencies = [
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -801,7 +792,7 @@ checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
- "serde 1.0.188",
+ "serde",
  "tap",
  "wyz",
 ]
@@ -952,7 +943,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 dependencies = [
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -966,7 +957,7 @@ dependencies = [
  "glob",
  "hex",
  "libc",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -1029,7 +1020,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -1071,8 +1062,8 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "num-traits 0.2.16",
- "serde 1.0.188",
+ "num-traits",
+ "serde",
  "windows-targets 0.48.5",
 ]
 
@@ -1084,7 +1075,7 @@ checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -1292,7 +1283,7 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "serde 1.0.188",
+ "serde",
  "syn 2.0.37",
 ]
 
@@ -1328,22 +1319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "config"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
-dependencies = [
- "lazy_static 1.4.0",
- "nom 5.1.3",
- "rust-ini",
- "serde 1.0.188",
- "serde-hjson",
- "serde_json",
- "toml 0.5.11",
- "yaml-rust",
-]
-
-[[package]]
 name = "const-hex"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,7 +1327,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "hex",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -1495,13 +1470,13 @@ dependencies = [
  "clap 3.2.25",
  "criterion-plot",
  "itertools",
- "lazy_static 1.4.0",
- "num-traits 0.2.16",
+ "lazy_static",
+ "num-traits",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
- "serde 1.0.188",
+ "serde",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -1893,9 +1868,9 @@ checksum = "fe398ac75057914d7d07307bf67dc7f3f574a26783b4fc7805a20ffa9f506e82"
 dependencies = [
  "asn1-rs 0.3.1",
  "displaydoc",
- "nom 7.1.3",
+ "nom",
  "num-bigint",
- "num-traits 0.2.16",
+ "num-traits",
  "rusticata-macros",
 ]
 
@@ -1907,9 +1882,9 @@ checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
 dependencies = [
  "asn1-rs 0.5.2",
  "displaydoc",
- "nom 7.1.3",
+ "nom",
  "num-bigint",
- "num-traits 0.2.16",
+ "num-traits",
  "rusticata-macros",
 ]
 
@@ -1919,7 +1894,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
 dependencies = [
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -1999,26 +1974,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2062,9 +2017,9 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
- "serde 1.0.188",
+ "serde",
  "serde_derive",
  "winapi",
  "wio",
@@ -2114,7 +2069,7 @@ dependencies = [
  "curve25519-dalek 3.2.0",
  "ed25519",
  "rand 0.7.3",
- "serde 1.0.188",
+ "serde",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -2281,7 +2236,7 @@ dependencies = [
  "hex",
  "once_cell",
  "regex",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "sha3",
  "thiserror",
@@ -2337,7 +2292,7 @@ dependencies = [
  "open-fastrlp",
  "rand 0.8.5",
  "rlp",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "strum",
  "tempfile",
@@ -2352,7 +2307,7 @@ version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f253bc5c813ca05792837a0ff4b3a580336b224512d48f7eda1d7dd9210787"
 dependencies = [
- "num-traits 0.2.16",
+ "num-traits",
 ]
 
 [[package]]
@@ -2476,7 +2431,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fc612c5837986b7104a87a0df74a5460931f1c5274be12f8d0f40aa2f30d632"
 dependencies = [
- "num-traits 0.2.16",
+ "num-traits",
 ]
 
 [[package]]
@@ -2796,7 +2751,7 @@ checksum = "a3676f482c536a985fca36ce320a5e5b8fafd7b260806742af1963b71c5dc38c"
 dependencies = [
  "glyph_brush_draw_cache",
  "glyph_brush_layout",
- "ordered-float 4.1.0",
+ "ordered-float",
  "rustc-hash",
  "twox-hash",
 ]
@@ -2964,7 +2919,7 @@ checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 dependencies = [
  "ahash",
  "allocator-api2",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -3009,7 +2964,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -3272,7 +3227,7 @@ dependencies = [
  "iced_core",
  "iced_futures",
  "iced_style",
- "num-traits 0.2.16",
+ "num-traits",
  "thiserror",
  "twox-hash",
  "unicode-segmentation",
@@ -3407,7 +3362,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
 dependencies = [
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -3429,7 +3384,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -3440,7 +3395,7 @@ checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.1",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -3603,12 +3558,6 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-
-[[package]]
-name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -3618,19 +3567,6 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec 0.5.2",
- "bitflags 1.3.2",
- "cfg-if",
- "ryu",
- "static_assertions",
-]
 
 [[package]]
 name = "libc"
@@ -4039,7 +3975,7 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.5",
  "rcgen 0.9.3",
- "serde 1.0.188",
+ "serde",
  "sha2 0.10.8",
  "stun",
  "thiserror",
@@ -4094,7 +4030,7 @@ dependencies = [
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
- "serde 1.0.188",
+ "serde",
  "sha2 0.9.9",
  "typenum",
 ]
@@ -4208,7 +4144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00a0349cd8f0270781bb93a824b63df6178e3b4a27794e7be3ce3763f5a44d6e"
 dependencies = [
  "lyon_path",
- "num-traits 0.2.16",
+ "num-traits",
 ]
 
 [[package]]
@@ -4219,7 +4155,7 @@ checksum = "74df1ff0a0147282eb10699537a03baa7d31972b58984a1d44ce0624043fe8ad"
 dependencies = [
  "arrayvec 0.7.4",
  "euclid",
- "num-traits 0.2.16",
+ "num-traits",
 ]
 
 [[package]]
@@ -4229,7 +4165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca507745ba7ccbc76e5c44e7b63b1a29d2b0d6126f375806a5bbaf657c7d6c45"
 dependencies = [
  "lyon_geom",
- "num-traits 0.2.16",
+ "num-traits",
 ]
 
 [[package]]
@@ -4693,7 +4629,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_api",
  "rustls-pemfile",
- "serde 1.0.188",
+ "serde",
  "thiserror",
  "tokio",
  "toml 0.7.8",
@@ -4950,7 +4886,7 @@ dependencies = [
  "multibase",
  "multihash",
  "percent-encoding",
- "serde 1.0.188",
+ "serde",
  "static_assertions",
  "unsigned-varint",
  "url",
@@ -5029,7 +4965,7 @@ dependencies = [
  "hexf-parse",
  "indexmap 1.9.3",
  "log",
- "num-traits 0.2.16",
+ "num-traits",
  "rustc-hash",
  "spirv",
  "termcolor",
@@ -5207,17 +5143,6 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
-version = "5.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
-]
-
-[[package]]
-name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
@@ -5244,7 +5169,7 @@ checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.16",
+ "num-traits",
 ]
 
 [[package]]
@@ -5254,16 +5179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
- "num-traits 0.2.16",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-dependencies = [
- "num-traits 0.2.16",
+ "num-traits",
 ]
 
 [[package]]
@@ -5527,20 +5443,11 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
-dependencies = [
- "num-traits 0.2.16",
-]
-
-[[package]]
-name = "ordered-float"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a540f3e3b3d7929c884e46d093d344e4e5bdeed54d08bf007df50c93cc85d5"
 dependencies = [
- "num-traits 0.2.16",
+ "num-traits",
 ]
 
 [[package]]
@@ -5617,7 +5524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f9cd68f7112581033f157e56c77ac4a5538ec5836a2e39284e65bd7d7275e49"
 dependencies = [
  "approx",
- "num-traits 0.2.16",
+ "num-traits",
  "palette_derive",
  "phf",
 ]
@@ -5646,7 +5553,7 @@ dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -5743,7 +5650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3163d2912b7c3b52d651a055f2c7eec9ba5cd22d26ef75b8dd3a59980b185923"
 dependencies = [
  "base64 0.21.4",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -5909,7 +5816,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
 dependencies = [
- "num-traits 0.2.16",
+ "num-traits",
  "plotters-backend",
  "plotters-svg",
  "wasm-bindgen",
@@ -6114,8 +6021,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
 dependencies = [
  "bitflags 2.4.0",
- "lazy_static 1.4.0",
- "num-traits 0.2.16",
+ "lazy_static",
+ "num-traits",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
@@ -6142,7 +6049,7 @@ dependencies = [
  "bytes",
  "heck",
  "itertools",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "multimap",
  "petgraph",
@@ -6192,14 +6099,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0de80796b316aec75344095a6d2ef68ec9b8f573b9e7adc821149ba3598e270"
 dependencies = [
- "ansi_term",
- "atty",
- "config",
- "directories",
- "petgraph",
- "serde 1.0.188",
- "serde-value",
- "tint",
+ "serde",
 ]
 
 [[package]]
@@ -6476,17 +6376,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom 0.2.10",
- "redox_syscall 0.2.16",
- "thiserror",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6603,7 +6492,7 @@ dependencies = [
  "revm-primitives",
  "ruint",
  "secp256k1 0.27.0",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "serde_with",
  "sha2 0.10.8",
@@ -6664,7 +6553,7 @@ dependencies = [
  "primitive-types",
  "rlp",
  "ruint",
- "serde 1.0.188",
+ "serde",
  "sha3",
 ]
 
@@ -6761,7 +6650,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "rand 0.8.5",
- "serde 1.0.188",
+ "serde",
  "thiserror",
  "webrtc-util",
 ]
@@ -6784,7 +6673,7 @@ dependencies = [
  "rand 0.8.5",
  "rlp",
  "ruint-macro",
- "serde 1.0.188",
+ "serde",
  "valuable",
  "zeroize",
 ]
@@ -6794,12 +6683,6 @@ name = "ruint-macro"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
-
-[[package]]
-name = "rust-ini"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rustc-demangle"
@@ -6843,7 +6726,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -7141,39 +7024,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
-
-[[package]]
-name = "serde"
 version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-hjson"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
-dependencies = [
- "lazy_static 1.4.0",
- "num-traits 0.1.43",
- "regex",
- "serde 0.8.23",
-]
-
-[[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float 2.10.0",
- "serde 1.0.188",
 ]
 
 [[package]]
@@ -7183,7 +7038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -7205,7 +7060,7 @@ checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -7214,7 +7069,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -7228,7 +7083,7 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.0.2",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -7331,7 +7186,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b21f559e07218024e7e9f90f96f601825397de0e25420135f7f952453fed0b"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -7423,7 +7278,7 @@ dependencies = [
  "bitflags 1.3.2",
  "calloop",
  "dlib",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "memmap2",
  "nix 0.24.3",
@@ -7449,7 +7304,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
 dependencies = [
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -7518,7 +7373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
 dependencies = [
  "bitflags 1.3.2",
- "num-traits 0.2.16",
+ "num-traits",
 ]
 
 [[package]]
@@ -7595,7 +7450,7 @@ checksum = "a7e94b1ec00bad60e6410e058b52f1c66de3dc5fe4d62d09b3e52bb7d3b73e25"
 dependencies = [
  "base64 0.13.1",
  "crc",
- "lazy_static 1.4.0",
+ "lazy_static",
  "md-5",
  "rand 0.8.5",
  "ring",
@@ -7813,7 +7668,7 @@ checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
 dependencies = [
  "deranged",
  "itoa",
- "serde 1.0.188",
+ "serde",
  "time-core",
  "time-macros",
 ]
@@ -7831,15 +7686,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
-]
-
-[[package]]
-name = "tint"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af24570664a3074673dbbf69a65bdae0ae0b72f2949b1adfbacb736ee4d6896"
-dependencies = [
- "lazy_static 0.2.11",
 ]
 
 [[package]]
@@ -7882,7 +7728,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde 1.0.188",
+ "serde",
  "serde_json",
 ]
 
@@ -7973,7 +7819,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -7982,7 +7828,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
- "serde 1.0.188",
+ "serde",
  "serde_spanned",
  "toml_datetime",
  "toml_edit",
@@ -7994,7 +7840,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
- "serde 1.0.188",
+ "serde",
 ]
 
 [[package]]
@@ -8004,7 +7850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.0.2",
- "serde 1.0.188",
+ "serde",
  "serde_spanned",
  "toml_datetime",
  "winnow",
@@ -8124,7 +7970,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "tracing-core",
 ]
@@ -8167,7 +8013,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a2c0ff408fe918a94c428a3f2ad04e4afd5c95bbc08fcf868eff750c15728a4"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "tracing-core",
  "tracing-subscriber",
  "tracing-test-macro",
@@ -8179,7 +8025,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "quote",
  "syn 1.0.109",
 ]
@@ -8209,7 +8055,7 @@ dependencies = [
  "futures-util",
  "idna 0.2.3",
  "ipnet",
- "lazy_static 1.4.0",
+ "lazy_static",
  "rand 0.8.5",
  "smallvec",
  "socket2 0.4.9",
@@ -8229,7 +8075,7 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "ipconfig",
- "lazy_static 1.4.0",
+ "lazy_static",
  "lru-cache",
  "parking_lot 0.12.1",
  "resolv-conf",
@@ -8645,7 +8491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4"
 dependencies = [
  "dlib",
- "lazy_static 1.4.0",
+ "lazy_static",
  "pkg-config",
 ]
 
@@ -8699,7 +8545,7 @@ dependencies = [
  "bytes",
  "hex",
  "interceptor",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "rand 0.8.5",
  "rcgen 0.9.3",
@@ -8709,7 +8555,7 @@ dependencies = [
  "rtp",
  "rustls 0.19.1",
  "sdp",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "sha2 0.10.8",
  "stun",
@@ -8771,7 +8617,7 @@ dependencies = [
  "ring",
  "rustls 0.19.1",
  "sec1 0.3.0",
- "serde 1.0.188",
+ "serde",
  "sha1",
  "sha2 0.10.8",
  "signature 1.6.4",
@@ -8795,7 +8641,7 @@ dependencies = [
  "crc",
  "log",
  "rand 0.8.5",
- "serde 1.0.188",
+ "serde",
  "serde_json",
  "stun",
  "thiserror",
@@ -8886,7 +8732,7 @@ dependencies = [
  "bytes",
  "cc",
  "ipnet",
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "log",
  "nix 0.24.3",
@@ -9425,7 +9271,7 @@ checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
 dependencies = [
  "curve25519-dalek 4.1.1",
  "rand_core 0.6.4",
- "serde 1.0.188",
+ "serde",
  "zeroize",
 ]
 
@@ -9439,8 +9285,8 @@ dependencies = [
  "base64 0.13.1",
  "data-encoding",
  "der-parser 7.0.0",
- "lazy_static 1.4.0",
- "nom 7.1.3",
+ "lazy_static",
+ "nom",
  "oid-registry 0.4.0",
  "ring",
  "rusticata-macros",
@@ -9457,8 +9303,8 @@ dependencies = [
  "asn1-rs 0.5.2",
  "data-encoding",
  "der-parser 8.2.0",
- "lazy_static 1.4.0",
- "nom 7.1.3",
+ "lazy_static",
+ "nom",
  "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror",
@@ -9471,7 +9317,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "463705a63313cd4301184381c5e8042f0a7e9b4bb63653f216311d4ae74690b7"
 dependencies = [
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -9485,15 +9331,6 @@ name = "xml-rs"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "yamux"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ prost = "0.11.9"
 prost-build = "0.11.9"
 prost-types = "0.11.8"
 protobuf-src = "1.1.0"
-ptree = "0.4.0"
+ptree = { version = "0.4.0", default-features = false }
 
 # the important commit: "307d80b9398d4e1e305c0131f2c3989090ec9432"
 # we can use latest release once it includes that


### PR DESCRIPTION
ptree has many unused features enabled by default which depend on old versions of common crates like serde, nom, etc. Disabling default features cuts back workspace deps from 780 to 756.