### PR TITLE
Modify block sync Logs to be more precise

### DIFF
--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -515,8 +515,6 @@ where
             &self.transaction_validator,
         ) {
             BlockSyncResult::Success(full_block) => {
-                debug!("Block sync response: bid={:?}", full_block.get_id());
-                inc_count!(block_sync_response);
                 if self.pending_block_tree.is_valid(&full_block) {
                     // check if this block will extend into root
                     if let Some(qc) = self


### PR DESCRIPTION
block sync request report (bid, qc)

block sync response always report regardless of result, the report format is (bid, result), also each unique type of result is recorded by a different type of counter