### PR TITLE
Refactor MockableExecutor for generality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7193,9 +7193,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+checksum = "c1b21f559e07218024e7e9f90f96f601825397de0e25420135f7f952453fed0b"
 dependencies = [
  "lazy_static",
 ]

--- a/monad-consensus-types/src/block.rs
+++ b/monad-consensus-types/src/block.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use monad_types::{BlockId, Hash as HashType, NodeId, Round};
 use zerocopy::AsBytes;
 
@@ -9,7 +11,7 @@ use crate::{
     validation::{Hashable, Hasher},
 };
 
-pub trait BlockType: Clone + PartialEq + Eq {
+pub trait BlockType: Clone + PartialEq + Eq + Debug {
     fn get_id(&self) -> BlockId;
     fn get_round(&self) -> Round;
     fn get_author(&self) -> NodeId;

--- a/monad-mock-swarm/src/mock_swarm.rs
+++ b/monad-mock-swarm/src/mock_swarm.rs
@@ -10,7 +10,7 @@ use monad_consensus_types::{
 };
 use monad_crypto::secp256k1::PubKey;
 use monad_executor::{timed_event::TimedEvent, Executor, State};
-use monad_executor_glue::{MonadEvent, PeerId};
+use monad_executor_glue::{MempoolCommand, MonadEvent, PeerId};
 use monad_types::{Deserializable, Serializable};
 use monad_wal::PersistenceLogger;
 use rand::{Rng, SeedableRng};
@@ -27,7 +27,7 @@ pub struct Node<S, RS, P, LGR, ME, ST, SCT>
 where
     S: State,
     RS: RouterScheduler,
-    ME: MockableExecutor<SignatureCollection = SCT>,
+    ME: MockableExecutor<Command = MempoolCommand<SCT>, SignatureCollection = SCT>,
     ST: MessageSignature,
     SCT: SignatureCollection,
 {
@@ -55,7 +55,11 @@ where
     P: Pipeline<RS::Serialized>,
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
 
-    ME: MockableExecutor<Event = S::Event, SignatureCollection = SCT>,
+    ME: MockableExecutor<
+        Command = MempoolCommand<SCT>,
+        Event = S::Event,
+        SignatureCollection = SCT,
+    >,
 
     MockExecutor<S, RS, ME, ST, SCT>: Unpin,
     S::Block: Unpin,
@@ -164,7 +168,7 @@ where
     RS: RouterScheduler,
     P: Pipeline<RS::Serialized>,
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
-    ME: MockableExecutor<SignatureCollection = SCT>,
+    ME: MockableExecutor<Command = MempoolCommand<SCT>, SignatureCollection = SCT>,
 {
     states: BTreeMap<PeerId, Node<S, RS, P, LGR, ME, ST, SCT>>,
     tick: Duration,
@@ -190,7 +194,11 @@ where
     P: Pipeline<RS::Serialized>,
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
 
-    ME: MockableExecutor<Event = S::Event, SignatureCollection = SCT>,
+    ME: MockableExecutor<
+        Command = MempoolCommand<SCT>,
+        Event = S::Event,
+        SignatureCollection = SCT,
+    >,
 
     MockExecutor<S, RS, ME, ST, SCT>: Unpin,
     S::Block: Unpin,

--- a/monad-mock-swarm/tests/replay_test.rs
+++ b/monad-mock-swarm/tests/replay_test.rs
@@ -8,7 +8,7 @@ use monad_consensus_types::{
 };
 use monad_crypto::NopSignature;
 use monad_executor::{timed_event::TimedEvent, State};
-use monad_executor_glue::{MonadEvent, PeerId};
+use monad_executor_glue::{MempoolCommand, MonadEvent, PeerId};
 use monad_mock_swarm::{
     mock::{
         MockExecutor, MockMempool, MockMempoolConfig, MockableExecutor, NoSerRouterConfig,
@@ -64,7 +64,11 @@ where
     P: Pipeline<RS::Serialized>,
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
 
-    ME: MockableExecutor<Event = S::Event, SignatureCollection = SCT>,
+    ME: MockableExecutor<
+        Command = MempoolCommand<SCT>,
+        Event = S::Event,
+        SignatureCollection = SCT,
+    >,
 
     MockExecutor<S, RS, ME, ST, SCT>: Unpin,
     S::Block: Unpin,
@@ -98,7 +102,11 @@ where
     P: Pipeline<RS::Serialized>,
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
 
-    ME: MockableExecutor<Event = S::Event, SignatureCollection = SCT>,
+    ME: MockableExecutor<
+        Command = MempoolCommand<SCT>,
+        Event = S::Event,
+        SignatureCollection = SCT,
+    >,
 
     MockExecutor<S, RS, ME, ST, SCT>: Unpin,
     S::Block: Unpin,

--- a/monad-viz/src/graph.rs
+++ b/monad-viz/src/graph.rs
@@ -5,7 +5,7 @@ use monad_consensus_types::{
 };
 use monad_crypto::secp256k1::PubKey;
 use monad_executor::timed_event::TimedEvent;
-use monad_executor_glue::{Identifiable, MonadEvent, PeerId};
+use monad_executor_glue::{Identifiable, MempoolCommand, MonadEvent, PeerId};
 use monad_mock_swarm::{
     mock::{MockExecutor, MockableExecutor, RouterScheduler},
     mock_swarm::{Node, Nodes},
@@ -88,7 +88,7 @@ where
     P: Pipeline<RS::Serialized>,
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
     C: SimulationConfig<S, RS, P, LGR, ME, ST, SCT>,
-    ME: MockableExecutor<SignatureCollection = SCT>,
+    ME: MockableExecutor<Command = MempoolCommand<SCT>, SignatureCollection = SCT>,
 {
     config: C,
 
@@ -106,7 +106,11 @@ where
     P: Pipeline<RS::Serialized> + Clone,
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
     C: SimulationConfig<S, RS, P, LGR, ME, ST, SCT>,
-    ME: MockableExecutor<Event = S::Event, SignatureCollection = SCT>,
+    ME: MockableExecutor<
+        Command = MempoolCommand<SCT>,
+        Event = S::Event,
+        SignatureCollection = SCT,
+    >,
 
     S::Message: Deserializable<RS::M>,
     S::OutboundMessage: Serializable<RS::M>,
@@ -152,7 +156,11 @@ where
     P: Pipeline<RS::Serialized> + Clone,
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
     C: SimulationConfig<S, RS, P, LGR, ME, ST, SCT>,
-    ME: MockableExecutor<Event = S::Event, SignatureCollection = SCT>,
+    ME: MockableExecutor<
+        Command = MempoolCommand<SCT>,
+        Event = S::Event,
+        SignatureCollection = SCT,
+    >,
 
     S::Message: Deserializable<RS::M>,
     S::OutboundMessage: Serializable<RS::M>,


### PR DESCRIPTION
This change aims to make the MockableExecutor applicable to any
executor, as well as enabling block comparison for debugging purposes.

These adjustments are part of ongoing refactoring for twin BFT. Due to
some failing tests related to non-empty mempool retrieval, changes
related to it would be added in another pr