### PR TITLE
Generate non-empty txn lists at MockMempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4588,6 +4588,7 @@ dependencies = [
  "monad-consensus-state",
  "monad-consensus-types",
  "monad-crypto",
+ "monad-eth-types",
  "monad-executor",
  "monad-executor-glue",
  "monad-quic",

--- a/monad-consensus-types/src/payload.rs
+++ b/monad-consensus-types/src/payload.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use monad_eth_types::EthAddress;
+use monad_eth_types::{EthAddress, EMPTY_RLP_TX_LIST};
 use monad_types::{Hash, Round};
 use zerocopy::AsBytes;
 
@@ -70,9 +70,15 @@ impl Hashable for ExecutionArtifacts {
     }
 }
 
-#[derive(Clone, Default, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 // TODO rename to TransactionHashList or something
 pub struct TransactionList(pub Vec<u8>);
+
+impl Default for TransactionList {
+    fn default() -> Self {
+        Self(vec![EMPTY_RLP_TX_LIST])
+    }
+}
 
 impl std::fmt::Debug for TransactionList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/monad-eth-types/src/lib.rs
+++ b/monad-eth-types/src/lib.rs
@@ -4,6 +4,8 @@ use reth_rlp::{Decodable, Encodable};
 #[cfg(feature = "serde")]
 pub mod serde;
 
+pub const EMPTY_RLP_TX_LIST: u8 = 0xc0;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EthTransactionList(pub Vec<TxHash>);
 

--- a/monad-mock-swarm/Cargo.toml
+++ b/monad-mock-swarm/Cargo.toml
@@ -13,6 +13,7 @@ bench = false
 [dependencies]
 monad-crypto = { path = "../monad-crypto" }
 monad-consensus-types = { path = "../monad-consensus-types" }
+monad-eth-types = { path = "../monad-eth-types" }
 monad-executor = { path = "../monad-executor" }
 monad-executor-glue = { path = "../monad-executor-glue" }
 monad-types = { path = "../monad-types" }

--- a/monad-mock-swarm/benches/two_node_benchmark.rs
+++ b/monad-mock-swarm/benches/two_node_benchmark.rs
@@ -58,6 +58,7 @@ fn two_nodes() {
             until: Duration::from_secs(10),
             until_block: usize::MAX,
             expected_block: 1024,
+            state_root_delay: 4,
             seed: 1,
         },
     );

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -57,6 +57,7 @@ fn many_nodes() {
             until: Duration::from_secs(4),
             until_block: usize::MAX,
             expected_block: 1024,
+            state_root_delay: 4,
             seed: 1,
         },
     );
@@ -104,6 +105,7 @@ fn many_nodes_quic() {
             until: Duration::from_secs(4),
             until_block: usize::MAX,
             expected_block: 10,
+            state_root_delay: 4,
             seed: 1,
         },
     );

--- a/monad-mock-swarm/tests/many_nodes_metrics.rs
+++ b/monad-mock-swarm/tests/many_nodes_metrics.rs
@@ -72,6 +72,7 @@ fn many_nodes_metrics() {
             until: Duration::from_secs(4),
             until_block: usize::MAX,
             expected_block: 1024,
+            state_root_delay: 4,
             seed: 1,
         },
     );

--- a/monad-mock-swarm/tests/msg_delays.rs
+++ b/monad-mock-swarm/tests/msg_delays.rs
@@ -53,6 +53,7 @@ fn two_nodes() {
             until: Duration::from_secs(60),
             until_block: usize::MAX,
             expected_block: 40,
+            state_root_delay: 4,
             seed: 1,
         },
     );

--- a/monad-mock-swarm/tests/order.rs
+++ b/monad-mock-swarm/tests/order.rs
@@ -53,7 +53,9 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
     let num_nodes = 4;
     let delta = Duration::from_millis(2);
     let (pubkeys, state_configs) =
-        get_configs::<NopSignature, MultiSig<NopSignature>, _>(MockValidator, num_nodes, delta);
+        // due to the burst behavior of replay-transformer, its okay to have delay as 1
+        // TODO?: Make Replay Transformer's stored message not burst within the same Duration
+        get_configs::<NopSignature, MultiSig<NopSignature>, _>(MockValidator, num_nodes, delta, 1);
 
     assert!(num_nodes >= 2, "test requires 2 or more nodes");
 

--- a/monad-mock-swarm/tests/rand_lat.rs
+++ b/monad-mock-swarm/tests/rand_lat.rs
@@ -92,6 +92,9 @@ fn nodes_with_random_latency(seed: u64) {
             until: Duration::from_secs(60 * 60),
             until_block: usize::MAX,
             expected_block: 2048,
+            // avoid state_root trigger in rand latency setting
+            // TODO, cover cases with low state_root_delay once state_sync is done
+            state_root_delay: 1000,
             seed: 1,
         },
     );

--- a/monad-mock-swarm/tests/random_mempool.rs
+++ b/monad-mock-swarm/tests/random_mempool.rs
@@ -56,6 +56,7 @@ fn random_mempool_failures() {
             until: Duration::from_secs(7),
             until_block: usize::MAX,
             expected_block: 1024,
+            state_root_delay: 4,
             seed: 1,
         },
     );

--- a/monad-mock-swarm/tests/replay.rs
+++ b/monad-mock-swarm/tests/replay.rs
@@ -27,14 +27,20 @@ type StateRootValidatorType = NopStateRoot;
 
 #[test]
 fn test_replay() {
-    recover_nodes_msg_delays(4, 10, 5);
+    recover_nodes_msg_delays(4, 10, 5, 4);
 }
 
-pub fn recover_nodes_msg_delays(num_nodes: u16, num_blocks_before: usize, num_block_after: usize) {
+pub fn recover_nodes_msg_delays(
+    num_nodes: u16,
+    num_blocks_before: usize,
+    num_block_after: usize,
+    state_root_delay: u64,
+) {
     let (pubkeys, state_configs) = get_configs::<SignatureType, SignatureCollectionType, _>(
         TransactionValidatorType {},
         num_nodes,
         Duration::from_millis(101),
+        state_root_delay,
     );
 
     // create the log file path
@@ -132,6 +138,7 @@ pub fn recover_nodes_msg_delays(num_nodes: u16, num_blocks_before: usize, num_bl
             TransactionValidatorType {},
             num_nodes,
             Duration::from_millis(2),
+            4,
         );
 
     let peers_clone = pubkeys_clone

--- a/monad-mock-swarm/tests/replay_test.rs
+++ b/monad-mock-swarm/tests/replay_test.rs
@@ -125,9 +125,9 @@ fn replay_one_honest(failure_idx: &[usize]) {
     let default_seed = 1;
     // setup 4 nodes
     let (peers, state_configs) =
-        get_configs::<ST, SignatureCollectionType, TxValType>(MockValidator, 4, CONSENSUS_DELTA);
+        get_configs::<ST, SignatureCollectionType, TxValType>(MockValidator, 4, CONSENSUS_DELTA, 4);
     let (_, mut state_configs_duplicate) =
-        get_configs::<ST, SignatureCollectionType, TxValType>(MockValidator, 4, CONSENSUS_DELTA);
+        get_configs::<ST, SignatureCollectionType, TxValType>(MockValidator, 4, CONSENSUS_DELTA, 4);
 
     let pubkeys = peers;
     let router_scheduler_config = |all_peers: Vec<PeerId>, _: PeerId| NoSerRouterConfig {

--- a/monad-mock-swarm/tests/single_node.rs
+++ b/monad-mock-swarm/tests/single_node.rs
@@ -57,6 +57,7 @@ fn two_nodes() {
             until: Duration::from_secs(10),
             until_block: usize::MAX,
             expected_block: 1024,
+            state_root_delay: 4,
             seed: 1,
         },
     );
@@ -104,6 +105,7 @@ fn two_nodes_quic() {
             until: Duration::from_secs(10),
             until_block: usize::MAX,
             expected_block: 256,
+            state_root_delay: 4,
             seed: 1,
         },
     );

--- a/monad-mock-swarm/tests/single_node_metrics.rs
+++ b/monad-mock-swarm/tests/single_node_metrics.rs
@@ -70,6 +70,7 @@ fn two_nodes() {
             until: Duration::from_secs(10),
             until_block: usize::MAX,
             expected_block: 1024,
+            state_root_delay: 4,
             seed: 1,
         },
     );

--- a/monad-mock-swarm/tests/two_nodes_bls.rs
+++ b/monad-mock-swarm/tests/two_nodes_bls.rs
@@ -56,6 +56,7 @@ fn two_nodes_bls() {
             until: Duration::from_secs(10),
             until_block: usize::MAX,
             expected_block: 128,
+            state_root_delay: 4,
             seed: 1,
         },
     );

--- a/monad-node/src/genesis/mod.rs
+++ b/monad-node/src/genesis/mod.rs
@@ -11,7 +11,7 @@ use monad_consensus_types::{
     voting::{ValidatorMapping, VoteInfo},
 };
 use monad_crypto::secp256k1::{KeyPair, PubKey};
-use monad_eth_types::EthAddress;
+use monad_eth_types::{EthAddress, EMPTY_RLP_TX_LIST};
 use monad_types::{NodeId, Round};
 
 use crate::{error::NodeSetupError, HasherType, SignatureCollectionType, TransactionValidatorType};
@@ -53,8 +53,10 @@ fn build_genesis_block(
     author: PubKey,
 ) -> Result<FullBlock<SignatureCollectionType>, NodeSetupError> {
     // TODO: Deserialize transactions from GenesisConfig
-    let (genesis_txs, genesis_full_txs) =
-        (TransactionList(vec![0xc0]), FullTransactionList(vec![0xc0]));
+    let (genesis_txs, genesis_full_txs) = (
+        TransactionList(vec![EMPTY_RLP_TX_LIST]),
+        FullTransactionList(vec![EMPTY_RLP_TX_LIST]),
+    );
 
     let genesis_prime_qc = QuorumCertificate::genesis_prime_qc::<HasherType>();
     let genesis_execution_header = ExecutionArtifacts::zero();

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -56,6 +56,7 @@ fn random_latency_test(seed: u64) {
             until: Duration::from_secs(10),
             until_block: usize::MAX,
             expected_block: 2048,
+            state_root_delay: 4,
             seed: 1,
         },
     );
@@ -65,7 +66,7 @@ fn delayed_message_test(seed: u64) {
     let num_nodes = 4;
     let delta = Duration::from_millis(2);
     let (pubkeys, state_configs) =
-        get_configs::<NopSignature, MultiSig<NopSignature>, _>(MockValidator, num_nodes, delta);
+        get_configs::<NopSignature, MultiSig<NopSignature>, _>(MockValidator, num_nodes, delta, 4);
 
     assert!(num_nodes >= 2, "test requires 2 or more nodes");
 

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -22,7 +22,7 @@ use monad_consensus_types::{
     voting::{ValidatorMapping, VoteInfo},
 };
 use monad_crypto::secp256k1::{KeyPair, PubKey, SecpSignature};
-use monad_eth_types::EthAddress;
+use monad_eth_types::{EthAddress, EMPTY_RLP_TX_LIST};
 use monad_executor::{Executor, State};
 use monad_p2p::Multiaddr;
 use monad_types::{NodeId, Round};
@@ -226,7 +226,7 @@ fn testnet(
         .collect::<Vec<_>>();
 
     let genesis_block = {
-        let genesis_txn = TransactionList(vec![0xc0]);
+        let genesis_txn = TransactionList(vec![EMPTY_RLP_TX_LIST]);
         let genesis_prime_qc = QuorumCertificate::genesis_prime_qc::<HasherType>();
         let genesis_execution_header = ExecutionArtifacts::zero();
         FullBlock::from_block(
@@ -243,7 +243,7 @@ fn testnet(
                 },
                 &genesis_prime_qc,
             ),
-            FullTransactionList(vec![0xc0]),
+            FullTransactionList(vec![EMPTY_RLP_TX_LIST]),
             &TransactionValidatorType::default(),
         )
         .unwrap()

--- a/monad-testutil/examples/logs_gen.rs
+++ b/monad-testutil/examples/logs_gen.rs
@@ -35,14 +35,19 @@ pub fn generate_log<P: Pipeline<MM>>(
     num_nodes: u16,
     num_blocks: usize,
     delta: Duration,
+    state_root_delay: u64,
     pipeline: P,
 ) where
     P: Clone,
     P: Send,
 {
     type WALoggerType = WALogger<TimedEvent<ME>>;
-    let (pubkeys, state_configs) =
-        get_configs::<NopSignature, MultiSig<NopSignature>, _>(MockValidator, num_nodes, delta);
+    let (pubkeys, state_configs) = get_configs::<NopSignature, MultiSig<NopSignature>, _>(
+        MockValidator,
+        num_nodes,
+        delta,
+        state_root_delay,
+    );
     let file_path_vec = pubkeys.iter().map(|pubkey| WALoggerConfig {
         file_path: PathBuf::from(format!("{:?}.log", pubkey)),
         sync: false,
@@ -99,6 +104,7 @@ fn main() {
         4,
         10,
         Duration::from_millis(101),
+        4,
         vec![GenericTransformer::Latency(LatencyTransformer(
             Duration::from_millis(100),
         ))],

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -29,6 +29,7 @@ pub struct SwarmTestConfig {
     pub until: Duration,
     pub until_block: usize,
     pub expected_block: usize,
+    pub state_root_delay: u64,
     pub seed: u64,
 }
 
@@ -36,6 +37,7 @@ pub fn get_configs<ST: MessageSignature, SCT: SignatureCollection, TVT: Transact
     tvt: TVT,
     num_nodes: u16,
     delta: Duration,
+    state_root_delay: u64,
 ) -> (Vec<PubKey>, Vec<MonadConfig<SCT, TVT>>) {
     let (keys, cert_keys, _validators, validator_mapping) =
         create_keys_w_validators::<SCT>(num_nodes as u32);
@@ -65,7 +67,7 @@ pub fn get_configs<ST: MessageSignature, SCT: SignatureCollection, TVT: Transact
             delta,
             consensus_config: ConsensusConfig {
                 proposal_size: 5000,
-                state_root_delay: 4,
+                state_root_delay,
                 propose_with_missing_blocks: false,
             },
             genesis_block: genesis_block.clone(),
@@ -138,8 +140,12 @@ where
     LGR::Config: Clone,
     TVT: TransactionValidator,
 {
-    let (peers, state_configs) =
-        get_configs::<ST, SCT, TVT>(tvt, swarm_config.num_nodes, swarm_config.consensus_delta);
+    let (peers, state_configs) = get_configs::<ST, SCT, TVT>(
+        tvt,
+        swarm_config.num_nodes,
+        swarm_config.consensus_delta,
+        swarm_config.state_root_delay,
+    );
     run_nodes_until::<S, ST, SCT, RS, RSC, LGR, P, TVT, ME>(
         peers,
         state_configs,

--- a/monad-virtual-bench/benches/two_node_bench.rs
+++ b/monad-virtual-bench/benches/two_node_bench.rs
@@ -50,6 +50,7 @@ fn two_nodes() -> u128 {
             until: Duration::from_secs(10),
             until_block: 1024,
             expected_block: 1024,
+            state_root_delay: 4,
             seed: 1,
         },
     )


### PR DESCRIPTION
By providing the ability for mempool to return non-empty transactions, Some tests such as blackout, random delay are failing due to state_sync triggered by root_hash_delay. The behaviour is correct, but we don't have state sync implemented yet, thus nodes that failed to sync due to being too behind will never make progress.

Thus, mockswarm now accept state_root_delay as a parameter as suppose to always default to 4, thus making it possible to config delay related test's state_root_delay to a higher number and avoid trigger state_sync.

Also, empty txn lists coming from mempool will be RLP encoded so check the RLP encoded empty list value for empty block checks.
