### PR TITLE
Abstract the node identifier in mock_swarm

### DIFF
--- a/monad-gossip/src/testutil.rs
+++ b/monad-gossip/src/testutil.rs
@@ -14,8 +14,9 @@ type BytesType = Vec<u8>;
 
 pub(crate) struct Swarm<G> {
     current_tick: Duration,
-    nodes: BTreeMap<PeerId, (G, BytesTransformerPipeline)>,
-    pending_inbound_messages: BinaryHeap<Reverse<(Duration, usize, LinkMessage<BytesType>)>>,
+    nodes: BTreeMap<PeerId, (G, BytesTransformerPipeline<PeerId>)>,
+    pending_inbound_messages:
+        BinaryHeap<Reverse<(Duration, usize, LinkMessage<PeerId, BytesType>)>>,
     seq_no: usize,
 }
 
@@ -27,7 +28,7 @@ pub enum SwarmEventType {
 
 impl<G: Gossip> Swarm<G> {
     pub fn new(
-        configs: impl Iterator<Item = (PeerId, G::Config, BytesTransformerPipeline)>,
+        configs: impl Iterator<Item = (PeerId, G::Config, BytesTransformerPipeline<PeerId>)>,
     ) -> Self {
         let nodes = configs
             .map(|(peer_id, config, pipeline)| (peer_id, (G::new(config), pipeline)))

--- a/monad-mock-swarm/Cargo.toml
+++ b/monad-mock-swarm/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2021"
 bench = false
 
 [dependencies]
-monad-crypto = { path = "../monad-crypto" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-eth-types = { path = "../monad-eth-types" }
 monad-executor = { path = "../monad-executor" }
@@ -28,6 +27,7 @@ tracing = { workspace = true }
 itertools = { workspace = true }
 
 [dev-dependencies]
+monad-crypto = { path = "../monad-crypto" }
 monad-block-sync = { path = "../monad-block-sync" }
 monad-consensus = { path = "../monad-consensus" }
 monad-consensus-state = { path = "../monad-consensus-state", features = [

--- a/monad-mock-swarm/tests/block_sync.rs
+++ b/monad-mock-swarm/tests/block_sync.rs
@@ -54,6 +54,7 @@ mod test {
                 SimpleRoundRobin,
                 BlockSyncState,
             >,
+            PeerId,
             NopSignature,
             MultiSig<NopSignature>,
             NoSerRouterScheduler<MonadMessage<_, _>>,
@@ -63,7 +64,7 @@ mod test {
             MockValidator,
             MockMempool<_, _>,
         >(
-            pubkeys,
+            pubkeys.into_iter().map(PeerId).collect(),
             state_configs,
             |all_peers: Vec<_>, _| NoSerRouterConfig {
                 all_peers: all_peers.into_iter().collect(),
@@ -132,6 +133,7 @@ mod test {
                 SimpleRoundRobin,
                 BlockSyncState,
             >,
+            PeerId,
             NopSignature,
             MultiSig<NopSignature>,
             NoSerRouterScheduler<MonadMessage<_, _>>,
@@ -141,7 +143,7 @@ mod test {
             MockValidator,
             MockMempool<_, _>,
         >(
-            pubkeys,
+            pubkeys.into_iter().map(PeerId).collect(),
             state_configs,
             |all_peers: Vec<_>, _| NoSerRouterConfig {
                 all_peers: all_peers.into_iter().collect(),

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -93,7 +93,7 @@ fn many_nodes_quic() {
         },
         MockWALoggerConfig,
         MockMempoolConfig::default(),
-        vec![GenericTransformer::Latency::<Vec<u8>>(LatencyTransformer(
+        vec![GenericTransformer::Latency::<_, _>(LatencyTransformer(
             Duration::from_millis(1),
         ))],
         SwarmTestConfig {

--- a/monad-mock-swarm/tests/many_nodes_metrics.rs
+++ b/monad-mock-swarm/tests/many_nodes_metrics.rs
@@ -60,9 +60,7 @@ fn many_nodes_metrics() {
         },
         MockWALoggerConfig,
         MockMempoolConfig::default(),
-        vec![GenericTransformer::<
-            MonadMessage<NopSignature, MultiSig<NopSignature>>,
-        >::Latency(LatencyTransformer(
+        vec![GenericTransformer::<_, _>::Latency(LatencyTransformer(
             Duration::from_millis(1),
         ))],
         SwarmTestConfig {

--- a/monad-mock-swarm/tests/order.rs
+++ b/monad-mock-swarm/tests/order.rs
@@ -75,6 +75,7 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
             SimpleRoundRobin,
             BlockSyncState,
         >,
+        PeerId,
         NopSignature,
         MultiSig<NopSignature>,
         NoSerRouterScheduler<MonadMessage<_, _>>,
@@ -84,7 +85,7 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
         MockValidator,
         MockMempool<_, _>,
     >(
-        pubkeys,
+        pubkeys.into_iter().map(PeerId).collect(),
         state_configs,
         |all_peers: Vec<_>, _| NoSerRouterConfig {
             all_peers: all_peers.into_iter().collect(),

--- a/monad-mock-swarm/tests/rand_lat.rs
+++ b/monad-mock-swarm/tests/rand_lat.rs
@@ -81,11 +81,9 @@ fn nodes_with_random_latency(seed: u64) {
         },
         MockWALoggerConfig,
         MockMempoolConfig::default(),
-        vec![GenericTransformer::<
-            MonadMessage<NopSignature, MultiSig<NopSignature>>,
-        >::RandLatency(RandLatencyTransformer::new(
-            seed, 330,
-        ))],
+        vec![GenericTransformer::<_, _>::RandLatency(
+            RandLatencyTransformer::new(seed, 330),
+        )],
         SwarmTestConfig {
             num_nodes: 4,
             consensus_delta: Duration::from_millis(250),

--- a/monad-mock-swarm/tests/replay.rs
+++ b/monad-mock-swarm/tests/replay.rs
@@ -24,6 +24,7 @@ type SignatureType = SecpSignature;
 type SignatureCollectionType = MultiSig<SignatureType>;
 type TransactionValidatorType = MockValidator;
 type StateRootValidatorType = NopStateRoot;
+type ID = PeerId;
 
 #[test]
 fn test_replay() {
@@ -61,7 +62,7 @@ pub fn recover_nodes_msg_delays(
         .zip(logger_configs.clone())
         .map(|((a, b), c)| {
             (
-                a,
+                PeerId(a),
                 b,
                 c,
                 NoSerRouterConfig {
@@ -95,6 +96,7 @@ pub fn recover_nodes_msg_delays(
         MockMempool<_, _>,
         SignatureType,
         SignatureCollectionType,
+        ID,
     >::new(peers);
 
     while let Some((_, _, _)) = nodes.step() {
@@ -148,7 +150,7 @@ pub fn recover_nodes_msg_delays(
         .zip(logger_configs)
         .map(|((a, b), c)| {
             (
-                a,
+                PeerId(a),
                 b,
                 c,
                 NoSerRouterConfig {
@@ -182,6 +184,7 @@ pub fn recover_nodes_msg_delays(
         MockMempool<_, _>,
         SignatureType,
         SignatureCollectionType,
+        ID,
     >::new(peers_clone);
 
     let node_ledger_recovered = nodes_recovered

--- a/monad-mock-swarm/tests/single_node.rs
+++ b/monad-mock-swarm/tests/single_node.rs
@@ -45,9 +45,9 @@ fn two_nodes() {
         },
         MockWALoggerConfig,
         MockMempoolConfig::default(),
-        vec![GenericTransformer::Latency::<
-            MonadMessage<NopSignature, MultiSig<NopSignature>>,
-        >(LatencyTransformer(Duration::from_millis(1)))],
+        vec![GenericTransformer::Latency::<_, _>(LatencyTransformer(
+            Duration::from_millis(1),
+        ))],
         SwarmTestConfig {
             num_nodes: 2,
             consensus_delta: Duration::from_millis(2),
@@ -93,7 +93,7 @@ fn two_nodes_quic() {
         },
         MockWALoggerConfig,
         MockMempoolConfig::default(),
-        vec![GenericTransformer::Latency::<Vec<u8>>(LatencyTransformer(
+        vec![GenericTransformer::Latency::<_, _>(LatencyTransformer(
             Duration::from_millis(1),
         ))],
         SwarmTestConfig {

--- a/monad-mock-swarm/tests/two_nodes_bls.rs
+++ b/monad-mock-swarm/tests/two_nodes_bls.rs
@@ -46,9 +46,9 @@ fn two_nodes_bls() {
         },
         MockWALoggerConfig,
         MockMempoolConfig::default(),
-        vec![GenericTransformer::Latency::<
-            MonadMessage<SignatureType, SignatureCollectionType>,
-        >(LatencyTransformer(Duration::from_millis(1)))],
+        vec![GenericTransformer::Latency::<_, _>(LatencyTransformer(
+            Duration::from_millis(1),
+        ))],
         SwarmTestConfig {
             num_nodes: 2,
             consensus_delta: Duration::from_millis(2),

--- a/monad-quic/src/router_scheduler.rs
+++ b/monad-quic/src/router_scheduler.rs
@@ -40,13 +40,14 @@ pub struct QuicRouterScheduler<G: Gossip> {
 
     timeouts: TimeoutQueue,
 
-    pending_events: BTreeMap<Duration, Vec<RouterEvent<Vec<u8>, Vec<u8>>>>,
+    pending_events: BTreeMap<Duration, Vec<RouterEvent<PeerId, Vec<u8>, Vec<u8>>>>,
     pending_outbound_messages: HashMap<PeerId, VecDeque<Vec<u8>>>,
 }
 
 const SERVER_NAME: &str = "MONAD";
 
 impl<G: Gossip> RouterScheduler for QuicRouterScheduler<G> {
+    type ID = PeerId;
     type Config = QuicRouterSchedulerConfig<G::Config>;
     type M = Vec<u8>;
     type Serialized = Vec<u8>;
@@ -199,7 +200,10 @@ impl<G: Gossip> RouterScheduler for QuicRouterScheduler<G> {
         self.peek_event().map(|(tick, _)| tick)
     }
 
-    fn step_until(&mut self, until: Duration) -> Option<RouterEvent<Self::M, Self::Serialized>> {
+    fn step_until(
+        &mut self,
+        until: Duration,
+    ) -> Option<RouterEvent<Self::ID, Self::M, Self::Serialized>> {
         while let Some((min_tick, event_type)) = self.peek_event() {
             if min_tick > until {
                 break;

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -86,6 +86,7 @@ fn delayed_message_test(seed: u64) {
             SimpleRoundRobin,
             BlockSyncState,
         >,
+        PeerId,
         NopSignature,
         MultiSig<NopSignature>,
         NoSerRouterScheduler<MonadMessage<_, _>>,
@@ -95,7 +96,7 @@ fn delayed_message_test(seed: u64) {
         MockValidator,
         MockMempool<_, _>,
     >(
-        pubkeys,
+        pubkeys.into_iter().map(PeerId).collect(),
         state_configs,
         |all_peers: Vec<_>, _| NoSerRouterConfig {
             all_peers: all_peers.into_iter().collect(),

--- a/monad-testutil/examples/logs_gen.rs
+++ b/monad-testutil/examples/logs_gen.rs
@@ -28,10 +28,12 @@ type MS = MonadState<
     SimpleRoundRobin,
     BlockSyncState,
 >;
+
+type ID = PeerId;
 type MM = <MS as State>::Message;
 type ME = MonadEvent<SignatureType, SignatureCollectionType>;
 
-pub fn generate_log<P: Pipeline<MM>>(
+pub fn generate_log<P: Pipeline<ID, MM>>(
     num_nodes: u16,
     num_blocks: usize,
     delta: Duration,
@@ -59,7 +61,7 @@ pub fn generate_log<P: Pipeline<MM>>(
         .zip(file_path_vec)
         .map(|((a, b), c)| {
             (
-                a,
+                PeerId(a),
                 b,
                 c,
                 NoSerRouterConfig {
@@ -79,6 +81,7 @@ pub fn generate_log<P: Pipeline<MM>>(
         MockMempool<SignatureType, SignatureCollectionType>,
         SignatureType,
         SignatureCollectionType,
+        ID,
     >::new(peers);
 
     while let Some((duration, id, event)) = nodes.step() {

--- a/monad-viz/src/config.rs
+++ b/monad-viz/src/config.rs
@@ -10,7 +10,7 @@ use monad_consensus_types::{
     block::BlockType, quorum_certificate::genesis_vote_info, transaction_validator::MockValidator,
     validation::Sha256Hash,
 };
-use monad_crypto::secp256k1::{KeyPair, PubKey};
+use monad_crypto::secp256k1::KeyPair;
 use monad_eth_types::EthAddress;
 use monad_executor::State;
 use monad_executor_glue::PeerId;
@@ -27,7 +27,7 @@ use monad_wal::{mock::MockWALoggerConfig, PersistenceLogger};
 
 use crate::{
     graph::SimulationConfig, MockableMempoolType, PersistenceLoggerType, Rsc,
-    SignatureCollectionType, SignatureType, TransactionValidatorType, MM, MS,
+    SignatureCollectionType, SignatureType, TransactionValidatorType, ID, MM, MS,
 };
 
 #[derive(Debug, Clone)]
@@ -35,7 +35,7 @@ pub struct SimConfig {
     pub num_nodes: u32,
     pub delta: Duration,
     pub max_tick: Duration,
-    pub pipeline: GenericTransformerPipeline<MM>,
+    pub pipeline: GenericTransformerPipeline<ID, MM>,
 }
 
 impl SimConfig {
@@ -59,22 +59,23 @@ impl
     SimulationConfig<
         MS,
         NoSerRouterScheduler<MM>,
-        GenericTransformerPipeline<MM>,
+        GenericTransformerPipeline<ID, MM>,
         PersistenceLoggerType,
         MockableMempoolType,
         SignatureType,
         SignatureCollectionType,
+        ID,
     > for SimConfig
 {
     fn nodes(
         &self,
     ) -> Vec<(
-        PubKey,
+        ID,
         <MS as State>::Config,
         <PersistenceLoggerType as PersistenceLogger>::Config,
         Rsc,
         <MockableMempoolType as MockableExecutor>::Config,
-        GenericTransformerPipeline<MM>,
+        GenericTransformerPipeline<ID, MM>,
         u64,
     )> {
         let (keys, cert_keys, _validators, validator_mapping) =
@@ -125,7 +126,7 @@ impl
             .zip(state_configs)
             .map(|(a, b)| {
                 (
-                    a,
+                    PeerId(a),
                     b,
                     MockWALoggerConfig {},
                     Rsc {

--- a/monad-viz/src/main.rs
+++ b/monad-viz/src/main.rs
@@ -67,20 +67,21 @@ type MS = MonadState<
     BlockSyncState,
 >;
 type MM = <MS as State>::Message;
-type ME = MonadEvent<SignatureType, SignatureCollectionType>;
 type PersistenceLoggerType =
     MockWALogger<TimedEvent<MonadEvent<SignatureType, SignatureCollectionType>>>;
 type MockableMempoolType = MockMempool<SignatureType, SignatureCollectionType>;
 type Rsc = <NoSerRouterScheduler<MM> as RouterScheduler>::Config;
+type ID = PeerId;
 type Sim = NodesSimulation<
     MS,
     NoSerRouterScheduler<MM>,
-    GenericTransformerPipeline<MM>,
+    GenericTransformerPipeline<ID, MM>,
     PersistenceLoggerType,
     SimConfig,
     MockMempool<SignatureType, SignatureCollectionType>,
     SignatureType,
     SignatureCollectionType,
+    ID,
 >;
 type ReplaySim = ReplayNodesSimulation<MS, RepConfig, SignatureType, SignatureCollectionType>;
 
@@ -207,6 +208,7 @@ impl Application for Viz {
                     _,
                     SignatureType,
                     SignatureCollectionType,
+                    PeerId,
                 >::new(config)
             };
 


### PR DESCRIPTION
Nodes in mock_swarm relies on PeerId for identification, but with TwinBFT, its possible to get duplicate PeerIds within the same swarm.

This PR generalized the identification of nodes to a trait, and added an assert! within the add_state function to ensure each insert is unique.

The generalization applies until the stage where Nodes class is created within test-utils.