### PR TITLE
Allow MockMempool to initialize with a seed

### DIFF
--- a/monad-mock-swarm/benches/two_node_benchmark.rs
+++ b/monad-mock-swarm/benches/two_node_benchmark.rs
@@ -47,7 +47,7 @@ fn two_nodes() {
             all_peers: all_peers.into_iter().collect(),
         },
         MockWALoggerConfig,
-        MockMempoolConfig,
+        MockMempoolConfig::default(),
         vec![GenericTransformer::Latency(LatencyTransformer(
             Duration::from_millis(1),
         ))],

--- a/monad-mock-swarm/tests/block_sync.rs
+++ b/monad-mock-swarm/tests/block_sync.rs
@@ -69,7 +69,7 @@ mod test {
                 all_peers: all_peers.into_iter().collect(),
             },
             MockWALoggerConfig,
-            MockMempoolConfig,
+            MockMempoolConfig::default(),
             vec![
                 GenericTransformer::Latency(LatencyTransformer(Duration::from_millis(1))), // everyone get delayed no matter what
                 GenericTransformer::Partition(PartitionTransformer(filter_peers)), // partition the victim node
@@ -147,7 +147,7 @@ mod test {
                 all_peers: all_peers.into_iter().collect(),
             },
             MockWALoggerConfig,
-            MockMempoolConfig,
+            MockMempoolConfig::default(),
             vec![
                 GenericTransformer::Latency(LatencyTransformer(Duration::from_millis(1))), // everyone get delayed no matter what
                 GenericTransformer::Partition(PartitionTransformer(filter_peers)), // partition the victim node

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -44,7 +44,7 @@ fn many_nodes() {
             all_peers: all_peers.into_iter().collect(),
         },
         MockWALoggerConfig,
-        MockMempoolConfig,
+        MockMempoolConfig::default(),
         vec![GenericTransformer::Latency(LatencyTransformer(
             Duration::from_millis(1),
         ))],
@@ -92,7 +92,7 @@ fn many_nodes_quic() {
             gossip_config: MockGossipConfig { all_peers },
         },
         MockWALoggerConfig,
-        MockMempoolConfig,
+        MockMempoolConfig::default(),
         vec![GenericTransformer::Latency::<Vec<u8>>(LatencyTransformer(
             Duration::from_millis(1),
         ))],

--- a/monad-mock-swarm/tests/many_nodes_metrics.rs
+++ b/monad-mock-swarm/tests/many_nodes_metrics.rs
@@ -59,7 +59,7 @@ fn many_nodes_metrics() {
             all_peers: all_peers.into_iter().collect(),
         },
         MockWALoggerConfig,
-        MockMempoolConfig,
+        MockMempoolConfig::default(),
         vec![GenericTransformer::<
             MonadMessage<NopSignature, MultiSig<NopSignature>>,
         >::Latency(LatencyTransformer(

--- a/monad-mock-swarm/tests/msg_delays.rs
+++ b/monad-mock-swarm/tests/msg_delays.rs
@@ -42,7 +42,7 @@ fn two_nodes() {
             all_peers: all_peers.into_iter().collect(),
         },
         MockWALoggerConfig,
-        MockMempoolConfig,
+        MockMempoolConfig::default(),
         vec![GenericTransformer::XorLatency(XorLatencyTransformer(
             Duration::from_millis(u8::MAX as u64),
         ))],

--- a/monad-mock-swarm/tests/order.rs
+++ b/monad-mock-swarm/tests/order.rs
@@ -90,7 +90,7 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
             all_peers: all_peers.into_iter().collect(),
         },
         MockWALoggerConfig,
-        MockMempoolConfig,
+        MockMempoolConfig::default(),
         vec![
             GenericTransformer::Latency(LatencyTransformer(Duration::from_millis(1))),
             GenericTransformer::Partition(PartitionTransformer(filter_peers)),

--- a/monad-mock-swarm/tests/rand_lat.rs
+++ b/monad-mock-swarm/tests/rand_lat.rs
@@ -80,7 +80,7 @@ fn nodes_with_random_latency(seed: u64) {
             all_peers: all_peers.into_iter().collect(),
         },
         MockWALoggerConfig,
-        MockMempoolConfig,
+        MockMempoolConfig::default(),
         vec![GenericTransformer::<
             MonadMessage<NopSignature, MultiSig<NopSignature>>,
         >::RandLatency(RandLatencyTransformer::new(

--- a/monad-mock-swarm/tests/replay.rs
+++ b/monad-mock-swarm/tests/replay.rs
@@ -67,7 +67,7 @@ pub fn recover_nodes_msg_delays(
                 NoSerRouterConfig {
                     all_peers: pubkeys.iter().map(|pubkey| PeerId(*pubkey)).collect(),
                 },
-                MockMempoolConfig,
+                MockMempoolConfig::default(),
                 vec![GenericTransformer::XorLatency(XorLatencyTransformer(
                     Duration::from_millis(u8::MAX as u64),
                 ))],
@@ -154,7 +154,7 @@ pub fn recover_nodes_msg_delays(
                 NoSerRouterConfig {
                     all_peers: pubkeys.iter().map(|pubkey| PeerId(*pubkey)).collect(),
                 },
-                MockMempoolConfig,
+                MockMempoolConfig::default(),
                 vec![GenericTransformer::Latency(LatencyTransformer(
                     Duration::from_millis(1),
                 ))],

--- a/monad-mock-swarm/tests/replay_test.rs
+++ b/monad-mock-swarm/tests/replay_test.rs
@@ -154,7 +154,7 @@ fn replay_one_honest(failure_idx: &[usize]) {
                         pubkeys.iter().copied().map(PeerId).collect(),
                         PeerId(pubkey),
                     ),
-                    MockMempoolConfig,
+                    MockMempoolConfig::default(),
                     pipeline.clone(),
                     default_seed,
                 )
@@ -225,7 +225,7 @@ fn replay_one_honest(failure_idx: &[usize]) {
             pubkeys.iter().copied().map(PeerId).collect(),
             PeerId(pubkeys[f0]),
         ),
-        MockMempoolConfig,
+        MockMempoolConfig::default(),
         pipeline.clone(),
         default_seed,
     ));
@@ -238,7 +238,7 @@ fn replay_one_honest(failure_idx: &[usize]) {
             pubkeys.iter().copied().map(PeerId).collect(),
             PeerId(pubkeys[f1]),
         ),
-        MockMempoolConfig,
+        MockMempoolConfig::default(),
         pipeline,
         default_seed,
     ));

--- a/monad-mock-swarm/tests/single_node.rs
+++ b/monad-mock-swarm/tests/single_node.rs
@@ -44,7 +44,7 @@ fn two_nodes() {
             all_peers: all_peers.into_iter().collect(),
         },
         MockWALoggerConfig,
-        MockMempoolConfig,
+        MockMempoolConfig::default(),
         vec![GenericTransformer::Latency::<
             MonadMessage<NopSignature, MultiSig<NopSignature>>,
         >(LatencyTransformer(Duration::from_millis(1)))],
@@ -92,7 +92,7 @@ fn two_nodes_quic() {
             gossip_config: MockGossipConfig { all_peers },
         },
         MockWALoggerConfig,
-        MockMempoolConfig,
+        MockMempoolConfig::default(),
         vec![GenericTransformer::Latency::<Vec<u8>>(LatencyTransformer(
             Duration::from_millis(1),
         ))],

--- a/monad-mock-swarm/tests/single_node_metrics.rs
+++ b/monad-mock-swarm/tests/single_node_metrics.rs
@@ -59,7 +59,7 @@ fn two_nodes() {
             all_peers: all_peers.into_iter().collect(),
         },
         MockWALoggerConfig,
-        MockMempoolConfig,
+        MockMempoolConfig::default(),
         vec![GenericTransformer::Latency(LatencyTransformer(
             Duration::from_millis(1),
         ))],

--- a/monad-mock-swarm/tests/two_nodes_bls.rs
+++ b/monad-mock-swarm/tests/two_nodes_bls.rs
@@ -45,7 +45,7 @@ fn two_nodes_bls() {
             all_peers: all_peers.into_iter().collect(),
         },
         MockWALoggerConfig,
-        MockMempoolConfig,
+        MockMempoolConfig::default(),
         vec![GenericTransformer::Latency::<
             MonadMessage<SignatureType, SignatureCollectionType>,
         >(LatencyTransformer(Duration::from_millis(1)))],

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -45,7 +45,7 @@ fn random_latency_test(seed: u64) {
             all_peers: all_peers.into_iter().collect(),
         },
         MockWALoggerConfig,
-        MockMempoolConfig,
+        MockMempoolConfig::default(),
         vec![GenericTransformer::RandLatency(
             RandLatencyTransformer::new(seed, 330),
         )],
@@ -101,7 +101,7 @@ fn delayed_message_test(seed: u64) {
             all_peers: all_peers.into_iter().collect(),
         },
         MockWALoggerConfig,
-        MockMempoolConfig,
+        MockMempoolConfig::default(),
         vec![
             GenericTransformer::Latency(LatencyTransformer(Duration::from_millis(1))),
             GenericTransformer::Partition(PartitionTransformer(filter_peers)),

--- a/monad-testutil/examples/logs_gen.rs
+++ b/monad-testutil/examples/logs_gen.rs
@@ -65,7 +65,7 @@ pub fn generate_log<P: Pipeline<MM>>(
                 NoSerRouterConfig {
                     all_peers: pubkeys.iter().map(|pubkey| PeerId(*pubkey)).collect(),
                 },
-                MockMempoolConfig,
+                MockMempoolConfig::default(),
                 pipeline.clone(),
                 1,
             )

--- a/monad-virtual-bench/benches/two_node_bench.rs
+++ b/monad-virtual-bench/benches/two_node_bench.rs
@@ -39,7 +39,7 @@ fn two_nodes() -> u128 {
             all_peers: all_peers.into_iter().collect(),
         },
         MockWALoggerConfig,
-        MockMempoolConfig,
+        MockMempoolConfig::default(),
         vec![GenericTransformer::Latency(LatencyTransformer(
             Duration::from_millis(1),
         ))],

--- a/monad-viz/src/config.rs
+++ b/monad-viz/src/config.rs
@@ -131,7 +131,7 @@ impl
                     Rsc {
                         all_peers: pubkeys.iter().map(|pubkey| PeerId(*pubkey)).collect(),
                     },
-                    MockMempoolConfig,
+                    MockMempoolConfig::default(),
                     self.pipeline.clone(),
                     1,
                 )


### PR DESCRIPTION
MockMempool currently return the same bytes as long as the original fetch_txs requested non-empty transactions.

For TwinBFT's testing, is very useful to have mock_mempool to return different txs (or in this setting, simply bytes) given the same round condition thus generating a proposal that is similar but not identical.

Thus, a seed is added to the initialization process of MockMempool, the default value when using MockMempoolConfig::default() is set to 1