### PR TITLE
consensus exposure draft

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,4 +45,6 @@ jobs:
       - name: Check
         run: cargo check --all-targets --all-features --verbose
       - name: Run tests
-        run: cargo test --release --all-targets --all-features --verbose
+        run: |
+          cargo test --release --all-targets --all-features --verbose && \
+          cd monad-wal && cargo test --release --all-targets --verbose && cd ..

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4461,6 +4461,7 @@ dependencies = [
 name = "monad-executor"
 version = "0.1.0"
 dependencies = [
+ "monad-consensus-state",
  "monad-consensus-types",
  "monad-crypto",
  "monad-executor-glue",
@@ -4889,7 +4890,6 @@ dependencies = [
  "monad-state",
  "monad-testutil",
  "monad-types",
- "monad-wal",
  "tempfile",
 ]
 

--- a/monad-executor/Cargo.toml
+++ b/monad-executor/Cargo.toml
@@ -16,6 +16,7 @@ monad-crypto = { path = "../monad-crypto" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-executor-glue = { path = "../monad-executor-glue" }
 monad-types = { path = "../monad-types" }
+monad-consensus-state = { path = "../monad-consensus-state" }
 
 [dev-dependencies]
 monad-testutil = { path = "../monad-testutil" }

--- a/monad-executor/src/lib.rs
+++ b/monad-executor/src/lib.rs
@@ -1,7 +1,8 @@
 pub mod replay_nodes;
 pub mod timed_event;
 
-use monad_consensus_types::block::BlockType;
+use monad_consensus_state::ConsensusProcess;
+use monad_consensus_types::{block::BlockType, signature_collection::SignatureCollection};
 use monad_executor_glue::{Command, Message};
 
 pub trait Executor {
@@ -16,9 +17,9 @@ pub trait State: Sized {
     type Message: Message<Event = Self::Event>;
     type Block: BlockType;
     type Checkpoint;
-    type SignatureCollection;
+    type SignatureCollection: SignatureCollection;
     #[cfg(feature = "monad_test")]
-    type ConsensusState: PartialEq + Eq;
+    type ConsensusState: ConsensusProcess<Self::SignatureCollection> + PartialEq + Eq;
 
     fn init(
         config: Self::Config,

--- a/monad-wal/Cargo.toml
+++ b/monad-wal/Cargo.toml
@@ -18,12 +18,13 @@ monad-types = { path = "../monad-types" }
 monad-consensus = { path = "../monad-consensus" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
-monad-executor = { path = "../monad-executor", features = ["monad_test"] }
+monad-executor = { path = "../monad-executor"}
 monad-executor-glue = { path = "../monad-executor-glue" }
 monad-state = { path = "../monad-state" }
 monad-testutil = { path = "../monad-testutil" }
 monad-types = { path = "../monad-types" }
-monad-wal = { path = ".", features = ["monad_test"] }
+
+
 
 criterion = { workspace = true }
 tempfile = { workspace = true }

--- a/monad-wal/tests/replay.rs
+++ b/monad-wal/tests/replay.rs
@@ -1,7 +1,9 @@
-#[cfg(test)]
+#[cfg(all(test, not(feature = "monad_test")))]
 mod test {
     use std::{array::TryFromSliceError, fs::OpenOptions};
 
+    use monad_consensus_types::multi_sig::MultiSig;
+    use monad_crypto::NopSignature;
     use monad_executor::State;
     use monad_executor_glue::{Identifiable, Message};
     use monad_testutil::block::MockBlock;
@@ -80,9 +82,7 @@ mod test {
         type Message = MockMessage;
         type Block = MockBlock;
         type Checkpoint = ();
-        type SignatureCollection = ();
-        #[cfg(feature = "monad_test")]
-        type ConsensusState = ();
+        type SignatureCollection = MultiSig<NopSignature>;
 
         fn init(
             _config: Self::Config,
@@ -116,10 +116,6 @@ mod test {
         > {
             self.events.push(event);
             Vec::new()
-        }
-        #[cfg(feature = "monad_test")]
-        fn consensus(&self) -> &Self::ConsensusState {
-            unimplemented!()
         }
     }
 


### PR DESCRIPTION
This is just a draft for review purpose, 

right now, I want to be able to inspect into the state during mock swarm. There are 2 ways to deal with it.

The first way is describe in this PR, we add ConsensusProcess as a trait onto the type of State, making it possible to extra internal consensus machine while running twin bft related tests.

The **Cons** of such approach is that monad-wal has a test that doesn't really care about the consensus process but it still ran with the "monad_test" feature when cargo test is called, this forces us to have an some form of mock consensus process implemented, which is quiet ugly.

I was trying to see if I can disable the feature "monad_test" when running monad_wal, but no matter how I influence cargo.toml it seems like cargo-test always have monad_test enabled as feature. if anyone knows how to get around it please let me know.

Alternatively, I have to put up a big refactor pr like the following screen shot that makes the concrete impl of MonadState as suppose to state, and I like it even less.

<img width="1834" alt="Screenshot 2023-10-13 at 4 53 16 PM" src="https://github.com/monad-crypto/monad-bft/assets/35275103/682d37c0-c9a4-4034-b378-e55ba579c179">

I think the right plan here is find out a way for cargo to run that test with monad_test feature flag disabled, but if there is any other way around it please let me know!
