### PR TITLE
Enforce stricter consensus process type in state

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest-32
-
+    strategy:
+      matrix: 
+          TARGET: [--all-targets, -p monad-mock-swarm --features monad_test]
     steps:
       - uses: actions/checkout@v3
       - run: rustup toolchain install nightly --profile minimal --component rustfmt
@@ -20,7 +22,7 @@ jobs:
         run: cargo +nightly fmt --all --check --verbose
       - uses: Swatinem/rust-cache@v2
       - name: Lint
-        run: cargo clippy --all-targets --all-features --
+        run: cargo clippy ${{ matrix.TARGET }} --
           -D clippy::suspicious
           -D clippy::style
           -D clippy::clone_on_copy
@@ -39,10 +41,10 @@ jobs:
           -A clippy::type_complexity
           -A clippy::int_plus_one
           -A clippy::uninlined-format-args
-          -A clippy::enum-variant-names
+          -A clippy::enum-variant-names 
       - name: Lint unused deps
         run: cargo clippy --all-features -- -D unused_crate_dependencies
       - name: Check
-        run: cargo check --all-targets --all-features --verbose
+        run: cargo check ${{ matrix.TARGET }} --verbose 
       - name: Run tests
-        run: cargo test --release --all-targets --all-features --verbose
+        run: cargo test --release ${{ matrix.TARGET }} --verbose 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4461,6 +4461,7 @@ dependencies = [
 name = "monad-executor"
 version = "0.1.0"
 dependencies = [
+ "monad-consensus-state",
  "monad-consensus-types",
  "monad-crypto",
  "monad-executor-glue",
@@ -4722,7 +4723,6 @@ dependencies = [
  "monad-mock-swarm",
  "monad-proto",
  "monad-quic",
- "monad-state",
  "monad-testutil",
  "monad-tracing-counter",
  "monad-types",
@@ -4889,7 +4889,6 @@ dependencies = [
  "monad-state",
  "monad-testutil",
  "monad-types",
- "monad-wal",
  "tempfile",
 ]
 

--- a/monad-consensus-state/Cargo.toml
+++ b/monad-consensus-state/Cargo.toml
@@ -27,8 +27,8 @@ log = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-monad-blocktree = { path = "../monad-blocktree", features = ["monad_test"] }
-monad-consensus = { path = "../monad-consensus", features = ["monad_test"] }
+monad-blocktree = { path = "../monad-blocktree"}
+monad-consensus = { path = "../monad-consensus"}
 monad-testutil = { path = "../monad-testutil" }
 
 env_logger = { workspace = true }

--- a/monad-executor/Cargo.toml
+++ b/monad-executor/Cargo.toml
@@ -16,6 +16,7 @@ monad-crypto = { path = "../monad-crypto" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-executor-glue = { path = "../monad-executor-glue" }
 monad-types = { path = "../monad-types" }
+monad-consensus-state = { path = "../monad-consensus-state" }
 
 [dev-dependencies]
 monad-testutil = { path = "../monad-testutil" }

--- a/monad-executor/src/lib.rs
+++ b/monad-executor/src/lib.rs
@@ -1,7 +1,8 @@
 pub mod replay_nodes;
 pub mod timed_event;
-
-use monad_consensus_types::block::BlockType;
+#[cfg(feature = "monad_test")]
+use monad_consensus_state::ConsensusProcess;
+use monad_consensus_types::{block::BlockType, signature_collection::SignatureCollection};
 use monad_executor_glue::{Command, Message};
 
 pub trait Executor {
@@ -16,9 +17,9 @@ pub trait State: Sized {
     type Message: Message<Event = Self::Event>;
     type Block: BlockType;
     type Checkpoint;
-    type SignatureCollection;
+    type SignatureCollection: SignatureCollection;
     #[cfg(feature = "monad_test")]
-    type ConsensusState: PartialEq + Eq;
+    type ConsensusState: ConsensusProcess<Self::SignatureCollection> + PartialEq + Eq;
 
     fn init(
         config: Self::Config,

--- a/monad-mock-swarm/Cargo.toml
+++ b/monad-mock-swarm/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2021"
 [lib]
 bench = false
 
+[features]
+monad_test = ["monad-state/monad_test", "monad-executor/monad_test", "monad-consensus-state/monad_test"]
+
 [dependencies]
 monad-crypto = { path = "../monad-crypto" }
 monad-consensus-types = { path = "../monad-consensus-types" }
@@ -30,13 +33,10 @@ itertools = { workspace = true }
 [dev-dependencies]
 monad-block-sync = { path = "../monad-block-sync" }
 monad-consensus = { path = "../monad-consensus" }
-monad-consensus-state = { path = "../monad-consensus-state", features = [
-    "monad_test",
-] }
-monad-executor = { path = "../monad-executor", features = ["monad_test"] }
+monad-consensus-state = { path = "../monad-consensus-state" }
 monad-gossip = { path = "../monad-gossip" }
 monad-quic = { path = "../monad-quic" }
-monad-state = { path = "../monad-state", features = ["monad_test"] }
+monad-state = { path = "../monad-state" }
 monad-testutil = { path = "../monad-testutil" }
 monad-tracing-counter = { path = "../monad-tracing-counter" }
 monad-validator = { path = "../monad-validator" }

--- a/monad-mock-swarm/tests/replay_test.rs
+++ b/monad-mock-swarm/tests/replay_test.rs
@@ -1,301 +1,316 @@
-use std::time::Duration;
+#[cfg(all(test, feature = "monad_test"))]
+mod test {
+    use std::time::Duration;
 
-use monad_block_sync::BlockSyncState;
-use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{
-    message_signature::MessageSignature, multi_sig::MultiSig, payload::StateRoot,
-    signature_collection::SignatureCollection, transaction_validator::MockValidator,
-};
-use monad_crypto::NopSignature;
-use monad_executor::{timed_event::TimedEvent, State};
-use monad_executor_glue::{MonadEvent, PeerId};
-use monad_mock_swarm::{
-    mock::{
-        MockExecutor, MockMempool, MockMempoolConfig, MockableExecutor, NoSerRouterConfig,
-        NoSerRouterScheduler, RouterScheduler,
-    },
-    mock_swarm::{Node, Nodes},
-    transformer::{GenericTransformer, LatencyTransformer, Pipeline},
-};
-use monad_state::{MonadMessage, MonadState};
-use monad_testutil::swarm::{get_configs, node_ledger_verification};
-use monad_types::{Deserializable, Serializable};
-use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
-use monad_wal::{
-    mock::{MockMemLogger, MockMemLoggerConfig},
-    PersistenceLogger,
-};
-use tracing_test::traced_test;
+    use monad_block_sync::BlockSyncState;
+    use monad_consensus_state::ConsensusState;
+    use monad_consensus_types::{
+        message_signature::MessageSignature, multi_sig::MultiSig, payload::StateRoot,
+        signature_collection::SignatureCollection, transaction_validator::MockValidator,
+    };
+    use monad_crypto::NopSignature;
+    use monad_executor::{timed_event::TimedEvent, State};
+    use monad_executor_glue::{MonadEvent, PeerId};
+    use monad_mock_swarm::{
+        mock::{
+            MockExecutor, MockMempool, MockMempoolConfig, MockableExecutor, NoSerRouterConfig,
+            NoSerRouterScheduler, RouterScheduler,
+        },
+        mock_swarm::{Node, Nodes},
+        transformer::{GenericTransformer, LatencyTransformer, Pipeline},
+    };
+    use monad_state::{MonadMessage, MonadState};
+    use monad_testutil::swarm::{get_configs, node_ledger_verification};
+    use monad_types::{Deserializable, Serializable};
+    use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
+    use monad_wal::{
+        mock::{MockMemLogger, MockMemLoggerConfig},
+        PersistenceLogger,
+    };
+    use tracing_test::traced_test;
 
-const CONSENSUS_DELTA: Duration = Duration::from_millis(10);
+    const CONSENSUS_DELTA: Duration = Duration::from_millis(10);
 
-type ST = NopSignature;
-type SignatureCollectionType = MultiSig<NopSignature>;
-type TxValType = MockValidator;
-type StateRootValType = StateRoot;
-type RS = NoSerRouterScheduler<MonadMessage<ST, SignatureCollectionType>>;
-type S = MonadState<
-    ConsensusState<SignatureCollectionType, TxValType, StateRootValType>,
-    ST,
-    SignatureCollectionType,
-    ValidatorSet,
-    SimpleRoundRobin,
-    BlockSyncState,
->;
-type LoggerType = MockMemLogger<TimedEvent<MonadEvent<ST, SignatureCollectionType>>>;
-type ME = MockMempool<ST, SignatureCollectionType>;
+    type ST = NopSignature;
+    type SignatureCollectionType = MultiSig<NopSignature>;
+    type TxValType = MockValidator;
+    type StateRootValType = StateRoot;
+    type RS = NoSerRouterScheduler<MonadMessage<ST, SignatureCollectionType>>;
+    type S = MonadState<
+        ConsensusState<SignatureCollectionType, TxValType, StateRootValType>,
+        ST,
+        SignatureCollectionType,
+        ValidatorSet,
+        SimpleRoundRobin,
+        BlockSyncState,
+    >;
+    type LoggerType = MockMemLogger<TimedEvent<MonadEvent<ST, SignatureCollectionType>>>;
+    type ME = MockMempool<ST, SignatureCollectionType>;
 
-fn run_nodes_until<S, RS, P, LGR, ME, ST, SCT>(
-    nodes: &mut Nodes<S, RS, P, LGR, ME, ST, SCT>,
-    start_tick: Duration,
-    until_tick: Duration,
-    until_block: usize,
-) -> Duration
-where
-    S: State<Event = MonadEvent<ST, SCT>, SignatureCollection = SCT>,
-    ST: MessageSignature + Unpin,
-    SCT: SignatureCollection + Unpin,
+    fn run_nodes_until<S, RS, P, LGR, ME, ST, SCT>(
+        nodes: &mut Nodes<S, RS, P, LGR, ME, ST, SCT>,
+        start_tick: Duration,
+        until_tick: Duration,
+        until_block: usize,
+    ) -> Duration
+    where
+        S: State<Event = MonadEvent<ST, SCT>, SignatureCollection = SCT>,
+        ST: MessageSignature + Unpin,
+        SCT: SignatureCollection + Unpin,
 
-    RS: RouterScheduler,
-    S::Message: Deserializable<RS::M>,
-    S::OutboundMessage: Serializable<RS::M>,
-    RS::Serialized: Eq,
+        RS: RouterScheduler,
+        S::Message: Deserializable<RS::M>,
+        S::OutboundMessage: Serializable<RS::M>,
+        RS::Serialized: Eq,
 
-    P: Pipeline<RS::Serialized>,
-    LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
+        P: Pipeline<RS::Serialized>,
+        LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
 
-    ME: MockableExecutor<Event = S::Event, SignatureCollection = SCT>,
+        ME: MockableExecutor<Event = S::Event, SignatureCollection = SCT>,
 
-    MockExecutor<S, RS, ME, ST, SCT>: Unpin,
-    S::Block: Unpin,
-    Node<S, RS, P, LGR, ME, ST, SCT>: Send,
-    RS::Serialized: Send,
-{
-    let mut max_tick = start_tick;
+        MockExecutor<S, RS, ME, ST, SCT>: Unpin,
+        S::Block: Unpin,
+        Node<S, RS, P, LGR, ME, ST, SCT>: Send,
+        RS::Serialized: Send,
+    {
+        let mut max_tick = start_tick;
 
-    while let Some((tick, _, _)) = nodes.step_until(until_tick, until_block) {
-        assert!(tick >= max_tick);
-        max_tick = tick;
+        while let Some((tick, _, _)) = nodes.step_until(until_tick, until_block) {
+            assert!(tick >= max_tick);
+            max_tick = tick;
+        }
+
+        max_tick
     }
 
-    max_tick
-}
+    fn liveness<S, RS, P, LGR, ME, ST, SCT>(
+        nodes: &Nodes<S, RS, P, LGR, ME, ST, SCT>,
+        last_ledger_len: usize,
+    ) -> bool
+    where
+        S: State<Event = MonadEvent<ST, SCT>, SignatureCollection = SCT>,
+        ST: MessageSignature + Unpin,
+        SCT: SignatureCollection + Unpin,
 
-fn liveness<S, RS, P, LGR, ME, ST, SCT>(
-    nodes: &Nodes<S, RS, P, LGR, ME, ST, SCT>,
-    last_ledger_len: usize,
-) -> bool
-where
-    S: State<Event = MonadEvent<ST, SCT>, SignatureCollection = SCT>,
-    ST: MessageSignature + Unpin,
-    SCT: SignatureCollection + Unpin,
+        RS: RouterScheduler,
+        S::Message: Deserializable<RS::M>,
+        S::OutboundMessage: Serializable<RS::M>,
+        RS::Serialized: Eq,
 
-    RS: RouterScheduler,
-    S::Message: Deserializable<RS::M>,
-    S::OutboundMessage: Serializable<RS::M>,
-    RS::Serialized: Eq,
+        P: Pipeline<RS::Serialized>,
+        LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
 
-    P: Pipeline<RS::Serialized>,
-    LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
+        ME: MockableExecutor<Event = S::Event, SignatureCollection = SCT>,
 
-    ME: MockableExecutor<Event = S::Event, SignatureCollection = SCT>,
-
-    MockExecutor<S, RS, ME, ST, SCT>: Unpin,
-    S::Block: Unpin,
-    Node<S, RS, P, LGR, ME, ST, SCT>: Send,
-    RS::Serialized: Send,
-{
-    let max_ledger_len = nodes
-        .states()
-        .values()
-        .map(|node| node.executor.ledger().get_blocks().len())
-        .max()
-        .unwrap();
-    max_ledger_len > last_ledger_len + 2
-}
-
-#[traced_test]
-#[test_case::test_case(&[0,1]; "fail 0 1")]
-#[test_case::test_case(&[0,2]; "fail 0 2")]
-#[test_case::test_case(&[0,3]; "fail 0 3")]
-#[test_case::test_case(&[1,2]; "fail 1 2")]
-#[test_case::test_case(&[1,3]; "fail 1 3")]
-#[test_case::test_case(&[2,3]; "fail 2 3")]
-fn replay_one_honest(failure_idx: &[usize]) {
-    let default_seed = 1;
-    // setup 4 nodes
-    let (peers, state_configs) =
-        get_configs::<ST, SignatureCollectionType, TxValType>(MockValidator, 4, CONSENSUS_DELTA, 4);
-    let (_, mut state_configs_duplicate) =
-        get_configs::<ST, SignatureCollectionType, TxValType>(MockValidator, 4, CONSENSUS_DELTA, 4);
-
-    let pubkeys = peers;
-    let router_scheduler_config = |all_peers: Vec<PeerId>, _: PeerId| NoSerRouterConfig {
-        all_peers: all_peers.into_iter().collect(),
-    };
-    let logger_config = MockMemLoggerConfig::default();
-    let pipeline = vec![GenericTransformer::<
-        MonadMessage<ST, SignatureCollectionType>,
-    >::Latency(LatencyTransformer(Duration::from_millis(1)))];
-    let phase_one_until = Duration::from_secs(4);
-    let phase_one_until_block = 1024;
-
-    let mut nodes = Nodes::<S, RS, _, LoggerType, ME, ST, SignatureCollectionType>::new(
-        pubkeys
-            .iter()
-            .copied()
-            .zip(state_configs)
-            .map(|(pubkey, state_config)| {
-                (
-                    pubkey,
-                    state_config,
-                    logger_config.clone(),
-                    router_scheduler_config(
-                        pubkeys.iter().copied().map(PeerId).collect(),
-                        PeerId(pubkey),
-                    ),
-                    MockMempoolConfig::default(),
-                    pipeline.clone(),
-                    default_seed,
-                )
-            })
-            .collect(),
-    );
-
-    let f0 = failure_idx[0];
-    let f1 = failure_idx[1];
-
-    println!("f0 {:?}", pubkeys[f0]);
-    println!("f1 {:?}", pubkeys[f1]);
-
-    assert!(f0 < 4);
-    assert!(f0 < f1);
-    assert!(f1 < 4);
-
-    // play nodes till some step
-    let max_tick = Duration::from_nanos(0);
-    let max_tick = run_nodes_until(&mut nodes, max_tick, phase_one_until, phase_one_until_block);
-
-    // it should've reached some `until` condition, rather than losing liveness
-    assert!(liveness::<S, RS, _, LoggerType, ME, _, _>(&nodes, 0));
-
-    let phase_one_length = nodes
-        .states()
-        .values()
-        .map(|node| node.executor.ledger().get_blocks().len())
-        .max()
-        .unwrap();
-
-    // bring down 2 nodes
-    let node0 = nodes
-        .remove_state(&PeerId(pubkeys[f0]))
-        .expect("peer0 exists");
-    let node1 = nodes
-        .remove_state(&PeerId(pubkeys[f1]))
-        .expect("peer1 exists");
-
-    let phase_two_until = max_tick + Duration::from_secs(4);
-    let phase_two_until_block = 2048;
-
-    // run the remaining 2 nodes for some steps, they can't make progress because less than f+1
-    let max_tick = run_nodes_until(&mut nodes, max_tick, phase_two_until, phase_two_until_block);
-
-    // nodes lost liveness because only 2/4 are online
-    assert!(!liveness::<S, RS, _, LoggerType, ME, _, _>(
-        &nodes,
-        phase_one_length
-    ));
-
-    let phase_two_length = nodes
-        .states()
-        .values()
-        .map(|node| node.executor.ledger().get_blocks().len())
-        .max()
-        .unwrap();
-
-    // bring up failed nodes with the replay logs
-    let node0_logger_config = MockMemLoggerConfig::new(node0.logger.log);
-    let node1_logger_config = MockMemLoggerConfig::new(node1.logger.log);
-
-    nodes.add_state((
-        pubkeys[f0],
-        state_configs_duplicate.remove(f0),
-        node0_logger_config,
-        router_scheduler_config(
-            pubkeys.iter().copied().map(PeerId).collect(),
-            PeerId(pubkeys[f0]),
-        ),
-        MockMempoolConfig::default(),
-        pipeline.clone(),
-        default_seed,
-    ));
-
-    nodes.add_state((
-        pubkeys[f1],
-        state_configs_duplicate.remove(f1 - 1),
-        node1_logger_config,
-        router_scheduler_config(
-            pubkeys.iter().copied().map(PeerId).collect(),
-            PeerId(pubkeys[f1]),
-        ),
-        MockMempoolConfig::default(),
-        pipeline,
-        default_seed,
-    ));
-
-    // assert consensus state is the same after replay
-    let node0_consensus = node0.state.consensus();
-    let node0_consensus_recovered = nodes
-        .states()
-        .get(&PeerId(pubkeys[f0]))
-        .unwrap()
-        .state
-        .consensus();
-    assert_eq!(node0_consensus, node0_consensus_recovered);
-
-    let node1_consensus = node1.state.consensus();
-    let node1_consensus_recovered = nodes
-        .states()
-        .get(&PeerId(pubkeys[f1]))
-        .unwrap()
-        .state
-        .consensus();
-    assert_eq!(node1_consensus, node1_consensus_recovered);
-
-    // the nodes should resume progress
-    let phase_three_until = max_tick + Duration::from_secs(4);
-    let phase_three_until_block = 3072;
-
-    run_nodes_until(
-        &mut nodes,
-        max_tick,
-        phase_three_until,
-        phase_three_until_block,
-    );
-    assert!(liveness::<S, RS, _, LoggerType, ME, _, _>(
-        &nodes,
-        phase_two_length
-    ));
-
-    node_ledger_verification(
-        &nodes
+        MockExecutor<S, RS, ME, ST, SCT>: Unpin,
+        S::Block: Unpin,
+        Node<S, RS, P, LGR, ME, ST, SCT>: Send,
+        RS::Serialized: Send,
+    {
+        let max_ledger_len = nodes
             .states()
             .values()
-            .map(|node| node.executor.ledger().get_blocks().clone())
-            .collect(),
-        phase_one_length + 1,
-    );
+            .map(|node| node.executor.ledger().get_blocks().len())
+            .max()
+            .unwrap();
+        max_ledger_len > last_ledger_len + 2
+    }
 
-    // assert that block sync isn't triggered
-    logs_assert(|lines: &[&str]| {
-        assert!(!lines.is_empty());
-        match lines
-            .iter()
-            .filter(|line| line.contains("monotonic_counter.block_sync_request"))
-            .count()
-        {
-            0 => Ok(()),
-            n => Err(format!("Block sync triggered {} times", n)),
-        }
-    })
+    #[traced_test]
+    #[test_case::test_case(&[0,1]; "fail 0 1")]
+    #[test_case::test_case(&[0,2]; "fail 0 2")]
+    #[test_case::test_case(&[0,3]; "fail 0 3")]
+    #[test_case::test_case(&[1,2]; "fail 1 2")]
+    #[test_case::test_case(&[1,3]; "fail 1 3")]
+    #[test_case::test_case(&[2,3]; "fail 2 3")]
+    fn replay_one_honest(failure_idx: &[usize]) {
+        let default_seed = 1;
+        // setup 4 nodes
+        let (peers, state_configs) = get_configs::<ST, SignatureCollectionType, TxValType>(
+            MockValidator,
+            4,
+            CONSENSUS_DELTA,
+            4,
+        );
+        let (_, mut state_configs_duplicate) = get_configs::<ST, SignatureCollectionType, TxValType>(
+            MockValidator,
+            4,
+            CONSENSUS_DELTA,
+            4,
+        );
+
+        let pubkeys = peers;
+        let router_scheduler_config = |all_peers: Vec<PeerId>, _: PeerId| NoSerRouterConfig {
+            all_peers: all_peers.into_iter().collect(),
+        };
+        let logger_config = MockMemLoggerConfig::default();
+        let pipeline = vec![GenericTransformer::<
+            MonadMessage<ST, SignatureCollectionType>,
+        >::Latency(LatencyTransformer(
+            Duration::from_millis(1),
+        ))];
+        let phase_one_until = Duration::from_secs(4);
+        let phase_one_until_block = 1024;
+
+        let mut nodes = Nodes::<S, RS, _, LoggerType, ME, ST, SignatureCollectionType>::new(
+            pubkeys
+                .iter()
+                .copied()
+                .zip(state_configs)
+                .map(|(pubkey, state_config)| {
+                    (
+                        pubkey,
+                        state_config,
+                        logger_config.clone(),
+                        router_scheduler_config(
+                            pubkeys.iter().copied().map(PeerId).collect(),
+                            PeerId(pubkey),
+                        ),
+                        MockMempoolConfig::default(),
+                        pipeline.clone(),
+                        default_seed,
+                    )
+                })
+                .collect(),
+        );
+
+        let f0 = failure_idx[0];
+        let f1 = failure_idx[1];
+
+        println!("f0 {:?}", pubkeys[f0]);
+        println!("f1 {:?}", pubkeys[f1]);
+
+        assert!(f0 < 4);
+        assert!(f0 < f1);
+        assert!(f1 < 4);
+
+        // play nodes till some step
+        let max_tick = Duration::from_nanos(0);
+        let max_tick =
+            run_nodes_until(&mut nodes, max_tick, phase_one_until, phase_one_until_block);
+
+        // it should've reached some `until` condition, rather than losing liveness
+        assert!(liveness::<S, RS, _, LoggerType, ME, _, _>(&nodes, 0));
+
+        let phase_one_length = nodes
+            .states()
+            .values()
+            .map(|node| node.executor.ledger().get_blocks().len())
+            .max()
+            .unwrap();
+
+        // bring down 2 nodes
+        let node0 = nodes
+            .remove_state(&PeerId(pubkeys[f0]))
+            .expect("peer0 exists");
+        let node1 = nodes
+            .remove_state(&PeerId(pubkeys[f1]))
+            .expect("peer1 exists");
+
+        let phase_two_until = max_tick + Duration::from_secs(4);
+        let phase_two_until_block = 2048;
+
+        // run the remaining 2 nodes for some steps, they can't make progress because less than f+1
+        let max_tick =
+            run_nodes_until(&mut nodes, max_tick, phase_two_until, phase_two_until_block);
+
+        // nodes lost liveness because only 2/4 are online
+        assert!(!liveness::<S, RS, _, LoggerType, ME, _, _>(
+            &nodes,
+            phase_one_length
+        ));
+
+        let phase_two_length = nodes
+            .states()
+            .values()
+            .map(|node| node.executor.ledger().get_blocks().len())
+            .max()
+            .unwrap();
+
+        // bring up failed nodes with the replay logs
+        let node0_logger_config = MockMemLoggerConfig::new(node0.logger.log);
+        let node1_logger_config = MockMemLoggerConfig::new(node1.logger.log);
+
+        nodes.add_state((
+            pubkeys[f0],
+            state_configs_duplicate.remove(f0),
+            node0_logger_config,
+            router_scheduler_config(
+                pubkeys.iter().copied().map(PeerId).collect(),
+                PeerId(pubkeys[f0]),
+            ),
+            MockMempoolConfig::default(),
+            pipeline.clone(),
+            default_seed,
+        ));
+
+        nodes.add_state((
+            pubkeys[f1],
+            state_configs_duplicate.remove(f1 - 1),
+            node1_logger_config,
+            router_scheduler_config(
+                pubkeys.iter().copied().map(PeerId).collect(),
+                PeerId(pubkeys[f1]),
+            ),
+            MockMempoolConfig::default(),
+            pipeline,
+            default_seed,
+        ));
+
+        // assert consensus state is the same after replay
+        let node0_consensus = node0.state.consensus();
+        let node0_consensus_recovered = nodes
+            .states()
+            .get(&PeerId(pubkeys[f0]))
+            .unwrap()
+            .state
+            .consensus();
+        assert_eq!(node0_consensus, node0_consensus_recovered);
+
+        let node1_consensus = node1.state.consensus();
+        let node1_consensus_recovered = nodes
+            .states()
+            .get(&PeerId(pubkeys[f1]))
+            .unwrap()
+            .state
+            .consensus();
+        assert_eq!(node1_consensus, node1_consensus_recovered);
+
+        // the nodes should resume progress
+        let phase_three_until = max_tick + Duration::from_secs(4);
+        let phase_three_until_block = 3072;
+
+        run_nodes_until(
+            &mut nodes,
+            max_tick,
+            phase_three_until,
+            phase_three_until_block,
+        );
+        assert!(liveness::<S, RS, _, LoggerType, ME, _, _>(
+            &nodes,
+            phase_two_length
+        ));
+
+        node_ledger_verification(
+            &nodes
+                .states()
+                .values()
+                .map(|node| node.executor.ledger().get_blocks().clone())
+                .collect(),
+            phase_one_length + 1,
+        );
+
+        // assert that block sync isn't triggered
+        logs_assert(|lines: &[&str]| {
+            assert!(!lines.is_empty());
+            match lines
+                .iter()
+                .filter(|line| line.contains("monotonic_counter.block_sync_request"))
+                .count()
+            {
+                0 => Ok(()),
+                n => Err(format!("Block sync triggered {} times", n)),
+            }
+        })
+    }
 }

--- a/monad-state/Cargo.toml
+++ b/monad-state/Cargo.toml
@@ -28,11 +28,6 @@ monad-validator = { path = "../monad-validator" }
 ref-cast = { workspace = true }
 
 [dev-dependencies]
-monad-consensus-state = { path = "../monad-consensus-state", features = [
-    "monad_test",
-] }
-monad-executor = { path = "../monad-executor", features = ["monad_test"] }
-monad-state = { path = ".", features = ["monad_test"] }
 monad-quic = { path = "../monad-quic" }
 monad-mock-swarm = { path = "../monad-mock-swarm" }
 monad-testutil = { path = "../monad-testutil" }

--- a/monad-wal/Cargo.toml
+++ b/monad-wal/Cargo.toml
@@ -8,8 +8,6 @@ edition = "2021"
 [lib]
 bench = false
 
-[features]
-monad_test = []
 
 [dependencies]
 monad-types = { path = "../monad-types" }
@@ -18,12 +16,13 @@ monad-types = { path = "../monad-types" }
 monad-consensus = { path = "../monad-consensus" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
-monad-executor = { path = "../monad-executor", features = ["monad_test"] }
+monad-executor = { path = "../monad-executor"}
 monad-executor-glue = { path = "../monad-executor-glue" }
 monad-state = { path = "../monad-state" }
 monad-testutil = { path = "../monad-testutil" }
 monad-types = { path = "../monad-types" }
-monad-wal = { path = ".", features = ["monad_test"] }
+
+
 
 criterion = { workspace = true }
 tempfile = { workspace = true }

--- a/monad-wal/tests/replay.rs
+++ b/monad-wal/tests/replay.rs
@@ -2,6 +2,8 @@
 mod test {
     use std::{array::TryFromSliceError, fs::OpenOptions};
 
+    use monad_consensus_types::multi_sig::MultiSig;
+    use monad_crypto::NopSignature;
     use monad_executor::State;
     use monad_executor_glue::{Identifiable, Message};
     use monad_testutil::block::MockBlock;
@@ -80,9 +82,7 @@ mod test {
         type Message = MockMessage;
         type Block = MockBlock;
         type Checkpoint = ();
-        type SignatureCollection = ();
-        #[cfg(feature = "monad_test")]
-        type ConsensusState = ();
+        type SignatureCollection = MultiSig<NopSignature>;
 
         fn init(
             _config: Self::Config,
@@ -116,10 +116,6 @@ mod test {
         > {
             self.events.push(event);
             Vec::new()
-        }
-        #[cfg(feature = "monad_test")]
-        fn consensus(&self) -> &Self::ConsensusState {
-            unimplemented!()
         }
     }
 


### PR DESCRIPTION
previously, state doesn't enforce consensus type to be consensus process even under test feature "monad_test". With introduction of Twins, its quiet useful to allow mockswarm to terminate based on consensus related condition (such as round number) as suppose just ledger or tick.

This change enforce the SignatureCollection type and Consensus type, and is fine for majority of test case due to how State is used in practice. However, monad-wal had some problem because its the only module that tests only component unrelated to consensus thus leaving consensus as ()

Some form of mass refactor would be able to avoid this issue by either impl ConsensusProcess for () or convert state => monad-state in Nodes. However, both approach drastically increase the complexity of the module in unnecessary way, making it difficult to read & manage in the future.

The alternative solution, is we compile twice, tests that relies on debug tagged function with "monad_test" would have to export those test as a specialized test with test features and add itself to the CI tool after -p, so they get compiled and tested in a different run from rest of the test that doesn't care about the "monad_test" feature flag

Change is possibly not idiomatic, so looking for suggestion&alternatives