### PR TITLE
Abstract swarm relationship into SwarmRelation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4703,15 +4703,11 @@ name = "monad-randomized-tests"
 version = "0.1.0"
 dependencies = [
  "inventory",
- "monad-block-sync",
- "monad-consensus-state",
  "monad-consensus-types",
  "monad-crypto",
  "monad-executor-glue",
  "monad-mock-swarm",
- "monad-state",
  "monad-testutil",
- "monad-validator",
  "monad-wal",
  "simple-xml-builder",
 ]

--- a/monad-mock-swarm/Cargo.toml
+++ b/monad-mock-swarm/Cargo.toml
@@ -11,13 +11,18 @@ edition = "2021"
 bench = false
 
 [dependencies]
+monad-block-sync = { path = "../monad-block-sync" }
+monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }
+monad-crypto = { path = "../monad-crypto" }
 monad-eth-types = { path = "../monad-eth-types" }
 monad-executor = { path = "../monad-executor" }
 monad-executor-glue = { path = "../monad-executor-glue" }
+monad-state = { path = "../monad-state" }
 monad-tracing-counter = { path = "../monad-tracing-counter" }
 monad-types = { path = "../monad-types" }
 monad-updaters = { path = "../monad-updaters" }
+monad-validator = { path = "../monad-validator" }
 monad-wal = { path = "../monad-wal" }
 
 futures = { workspace = true }
@@ -28,8 +33,6 @@ tracing = { workspace = true }
 itertools = { workspace = true }
 
 [dev-dependencies]
-monad-crypto = { path = "../monad-crypto" }
-monad-block-sync = { path = "../monad-block-sync" }
 monad-consensus = { path = "../monad-consensus" }
 monad-consensus-state = { path = "../monad-consensus-state", features = [
     "monad_test",
@@ -39,7 +42,6 @@ monad-gossip = { path = "../monad-gossip" }
 monad-quic = { path = "../monad-quic" }
 monad-state = { path = "../monad-state", features = ["monad_test"] }
 monad-testutil = { path = "../monad-testutil" }
-monad-validator = { path = "../monad-validator" }
 
 criterion = { workspace = true }
 rand = { workspace = true }

--- a/monad-mock-swarm/benches/two_node_benchmark.rs
+++ b/monad-mock-swarm/benches/two_node_benchmark.rs
@@ -1,21 +1,15 @@
 use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use monad_block_sync::BlockSyncState;
-use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{
-    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
-};
-use monad_crypto::NopSignature;
+use monad_consensus_types::transaction_validator::MockValidator;
 use monad_mock_swarm::{
-    mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock::{MockMempoolConfig, NoSerRouterConfig},
     mock_swarm::UntilTerminator,
+    swarm_relation::NoSerSwarm,
     transformer::{GenericTransformer, LatencyTransformer},
 };
-use monad_state::{MonadMessage, MonadState};
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
-use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
-use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
+use monad_wal::mock::MockWALoggerConfig;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("two_nodes", |b| b.iter(two_nodes));
@@ -25,25 +19,7 @@ criterion_group!(benches, criterion_benchmark);
 criterion_main!(benches);
 
 fn two_nodes() {
-    create_and_run_nodes::<
-        MonadState<
-            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-            NopSignature,
-            MultiSig<NopSignature>,
-            ValidatorSet,
-            SimpleRoundRobin,
-            BlockSyncState,
-        >,
-        NopSignature,
-        MultiSig<NopSignature>,
-        NoSerRouterScheduler<MonadMessage<_, _>>,
-        _,
-        MockWALogger<_>,
-        _,
-        MockValidator,
-        MockMempool<_, _>,
-        _,
-    >(
+    create_and_run_nodes::<NoSerSwarm, _, _>(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
             all_peers: all_peers.into_iter().collect(),

--- a/monad-mock-swarm/src/lib.rs
+++ b/monad-mock-swarm/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod mock;
 pub mod mock_swarm;
+pub mod swarm_relation;
 pub mod transformer;

--- a/monad-mock-swarm/src/swarm_relation.rs
+++ b/monad-mock-swarm/src/swarm_relation.rs
@@ -1,0 +1,86 @@
+use monad_block_sync::BlockSyncState;
+use monad_consensus_state::ConsensusState;
+use monad_consensus_types::{
+    block::FullBlock,
+    message_signature::MessageSignature,
+    multi_sig::MultiSig,
+    payload::StateRoot,
+    signature_collection::SignatureCollection,
+    transaction_validator::{MockValidator, TransactionValidator},
+};
+use monad_crypto::NopSignature;
+use monad_executor::{timed_event::TimedEvent, State};
+use monad_executor_glue::MonadEvent;
+use monad_state::{MonadConfig, MonadMessage, MonadState, VerifiedMonadMessage};
+use monad_types::{Deserializable, Serializable};
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
+use monad_wal::{
+    mock::{MockWALogger, MockWALoggerConfig},
+    PersistenceLogger,
+};
+
+use crate::{
+    mock::{
+        MockMempool, MockMempoolConfig, MockableExecutor, NoSerRouterConfig, NoSerRouterScheduler,
+        RouterScheduler,
+    },
+    transformer::{GenericTransformerPipeline, Pipeline},
+};
+
+pub trait SwarmRelation {
+    type STATE: State<
+        Event = MonadEvent<Self::ST, Self::SCT>,
+        SignatureCollection = Self::SCT,
+        Message = Self::StateMessage,
+        OutboundMessage = Self::OutboundStateMessage,
+        Block = FullBlock<Self::SCT>,
+        Config = MonadConfig<Self::SCT, Self::TVT>,
+    >;
+    type ST: MessageSignature + Unpin;
+    type SCT: SignatureCollection + Unpin;
+    type RS: RouterScheduler<M = Self::Message, Serialized = Self::Message, Config = Self::RSCFG>;
+    type P: Pipeline<Self::Message> + Clone;
+    type LGR: PersistenceLogger<
+        Config = Self::LGRCFG,
+        Event = TimedEvent<MonadEvent<Self::ST, Self::SCT>>,
+    >;
+    type ME: MockableExecutor<
+        Event = MonadEvent<Self::ST, Self::SCT>,
+        SignatureCollection = Self::SCT,
+        Config = Self::MPCFG,
+    >;
+
+    type TVT: TransactionValidator + Clone;
+    type StateMessage: Deserializable<Self::Message>;
+    type OutboundStateMessage: Serializable<Self::Message>;
+    type Message: Clone + PartialEq + Eq + Send;
+    type LGRCFG: Clone;
+    type RSCFG;
+    type MPCFG: Copy;
+}
+// default swarm relation impl
+pub struct NoSerSwarm;
+
+impl SwarmRelation for NoSerSwarm {
+    type STATE = MonadState<
+        ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
+        NopSignature,
+        MultiSig<NopSignature>,
+        ValidatorSet,
+        SimpleRoundRobin,
+        BlockSyncState,
+    >;
+    type ST = NopSignature;
+    type SCT = MultiSig<Self::ST>;
+    type RS = NoSerRouterScheduler<MonadMessage<Self::ST, Self::SCT>>;
+    type P = GenericTransformerPipeline<MonadMessage<Self::ST, Self::SCT>>;
+    type LGR = MockWALogger<TimedEvent<MonadEvent<Self::ST, Self::SCT>>>;
+    type ME = MockMempool<Self::ST, Self::SCT>;
+    type TVT = MockValidator;
+    type LGRCFG = MockWALoggerConfig;
+    type RSCFG = NoSerRouterConfig;
+    type MPCFG = MockMempoolConfig;
+    type StateMessage = MonadMessage<Self::ST, Self::SCT>;
+    type OutboundStateMessage = VerifiedMonadMessage<Self::ST, Self::SCT>;
+    type Message = MonadMessage<Self::ST, Self::SCT>;
+}

--- a/monad-mock-swarm/tests/block_sync.rs
+++ b/monad-mock-swarm/tests/block_sync.rs
@@ -1,31 +1,27 @@
+mod common;
+
 mod test {
     use std::{
         collections::{BTreeMap, HashSet},
         time::Duration,
     };
 
-    use monad_block_sync::BlockSyncState;
-    use monad_consensus_state::ConsensusState;
-    use monad_consensus_types::{
-        multi_sig::MultiSig,
-        payload::{NopStateRoot, StateRoot},
-        transaction_validator::MockValidator,
-    };
+    use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
     use monad_crypto::NopSignature;
     use monad_executor_glue::PeerId;
     use monad_mock_swarm::{
-        mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+        mock::{MockMempoolConfig, NoSerRouterConfig},
         mock_swarm::{ProgressTerminator, UntilTerminator},
         transformer::{
             DropTransformer, GenericTransformer, LatencyTransformer, PartitionTransformer,
             PeriodicTransformer, ID,
         },
     };
-    use monad_state::{MonadMessage, MonadState};
     use monad_testutil::swarm::{get_configs, run_nodes_until};
-    use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
-    use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
+    use monad_wal::mock::MockWALoggerConfig;
     use test_case::test_case;
+
+    use super::common::NoSerSwarm;
 
     #[test]
     #[should_panic]
@@ -54,25 +50,7 @@ mod test {
             Duration::from_secs(1),
         );
 
-        run_nodes_until::<
-            MonadState<
-                ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-                NopSignature,
-                MultiSig<NopSignature>,
-                ValidatorSet,
-                SimpleRoundRobin,
-                BlockSyncState,
-            >,
-            NopSignature,
-            MultiSig<NopSignature>,
-            NoSerRouterScheduler<MonadMessage<_, _>>,
-            _,
-            MockWALogger<_>,
-            _,
-            MockValidator,
-            MockMempool<_, _>,
-            _,
-        >(
+        run_nodes_until::<NoSerSwarm, _, _>(
             pubkeys,
             state_configs,
             |all_peers: Vec<_>, _| NoSerRouterConfig {
@@ -115,25 +93,7 @@ mod test {
 
         println!("blackout node ID: {:?}", first_node);
 
-        run_nodes_until::<
-            MonadState<
-                ConsensusState<MultiSig<NopSignature>, MockValidator, NopStateRoot>,
-                NopSignature,
-                MultiSig<NopSignature>,
-                ValidatorSet,
-                SimpleRoundRobin,
-                BlockSyncState,
-            >,
-            NopSignature,
-            MultiSig<NopSignature>,
-            NoSerRouterScheduler<MonadMessage<_, _>>,
-            _,
-            MockWALogger<_>,
-            _,
-            MockValidator,
-            MockMempool<_, _>,
-            _,
-        >(
+        run_nodes_until::<NoSerSwarm, _, _>(
             pubkeys,
             state_configs,
             |all_peers: Vec<_>, _| NoSerRouterConfig {
@@ -196,25 +156,7 @@ mod test {
 
         println!("delayed node ID: {:?}", first_node);
 
-        run_nodes_until::<
-            MonadState<
-                ConsensusState<MultiSig<NopSignature>, MockValidator, NopStateRoot>,
-                NopSignature,
-                MultiSig<NopSignature>,
-                ValidatorSet,
-                SimpleRoundRobin,
-                BlockSyncState,
-            >,
-            NopSignature,
-            MultiSig<NopSignature>,
-            NoSerRouterScheduler<MonadMessage<_, _>>,
-            _,
-            MockWALogger<_>,
-            _,
-            MockValidator,
-            MockMempool<_, _>,
-            _,
-        >(
+        run_nodes_until::<NoSerSwarm, _, _>(
             pubkeys,
             state_configs,
             |all_peers: Vec<_>, _| NoSerRouterConfig {

--- a/monad-mock-swarm/tests/common/mod.rs
+++ b/monad-mock-swarm/tests/common/mod.rs
@@ -1,0 +1,44 @@
+use monad_block_sync::BlockSyncState;
+use monad_consensus_state::ConsensusState;
+use monad_consensus_types::{
+    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+};
+use monad_crypto::NopSignature;
+use monad_executor::timed_event::TimedEvent;
+use monad_executor_glue::MonadEvent;
+use monad_gossip::mock::{MockGossip, MockGossipConfig};
+pub use monad_mock_swarm::swarm_relation::NoSerSwarm;
+use monad_mock_swarm::{
+    mock::{MockMempool, MockMempoolConfig},
+    swarm_relation::SwarmRelation,
+    transformer::BytesTransformerPipeline,
+};
+use monad_quic::{QuicRouterScheduler, QuicRouterSchedulerConfig};
+use monad_state::{MonadMessage, MonadState, VerifiedMonadMessage};
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
+use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
+
+pub struct QuicSwarm;
+impl SwarmRelation for QuicSwarm {
+    type STATE = MonadState<
+        ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
+        NopSignature,
+        MultiSig<NopSignature>,
+        ValidatorSet,
+        SimpleRoundRobin,
+        BlockSyncState,
+    >;
+    type ST = NopSignature;
+    type SCT = MultiSig<Self::ST>;
+    type RS = QuicRouterScheduler<MockGossip>;
+    type P = BytesTransformerPipeline;
+    type LGR = MockWALogger<TimedEvent<MonadEvent<Self::ST, Self::SCT>>>;
+    type ME = MockMempool<Self::ST, Self::SCT>;
+    type TVT = MockValidator;
+    type LGRCFG = MockWALoggerConfig;
+    type RSCFG = QuicRouterSchedulerConfig<MockGossipConfig>;
+    type MPCFG = MockMempoolConfig;
+    type Message = Vec<u8>;
+    type StateMessage = MonadMessage<Self::ST, Self::SCT>;
+    type OutboundStateMessage = VerifiedMonadMessage<Self::ST, Self::SCT>;
+}

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -1,50 +1,27 @@
+mod common;
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 
-use monad_block_sync::BlockSyncState;
-use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{
-    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
-};
-use monad_crypto::NopSignature;
+use common::{NoSerSwarm, QuicSwarm};
+use monad_consensus_types::transaction_validator::MockValidator;
 use monad_executor_glue::PeerId;
-use monad_gossip::mock::{MockGossip, MockGossipConfig};
+use monad_gossip::mock::MockGossipConfig;
 use monad_mock_swarm::{
-    mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock::{MockMempoolConfig, NoSerRouterConfig},
     mock_swarm::UntilTerminator,
     transformer::{BwTransformer, BytesTransformer, GenericTransformer, LatencyTransformer},
 };
-use monad_quic::{QuicRouterScheduler, QuicRouterSchedulerConfig};
-use monad_state::{MonadMessage, MonadState};
+use monad_quic::QuicRouterSchedulerConfig;
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
-use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
-use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
+use monad_wal::mock::MockWALoggerConfig;
 use tracing_test::traced_test;
 
 #[test]
 fn many_nodes_noser() {
-    create_and_run_nodes::<
-        MonadState<
-            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-            NopSignature,
-            MultiSig<NopSignature>,
-            ValidatorSet,
-            SimpleRoundRobin,
-            BlockSyncState,
-        >,
-        NopSignature,
-        MultiSig<NopSignature>,
-        NoSerRouterScheduler<MonadMessage<_, _>>,
-        _,
-        MockWALogger<_>,
-        _,
-        MockValidator,
-        MockMempool<_, _>,
-        _,
-    >(
+    create_and_run_nodes::<NoSerSwarm, _, _>(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
             all_peers: all_peers.into_iter().collect(),
@@ -70,25 +47,7 @@ fn many_nodes_noser() {
 fn many_nodes_quic() {
     let zero_instant = Instant::now();
 
-    create_and_run_nodes::<
-        MonadState<
-            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-            NopSignature,
-            MultiSig<NopSignature>,
-            ValidatorSet,
-            SimpleRoundRobin,
-            BlockSyncState,
-        >,
-        NopSignature,
-        MultiSig<NopSignature>,
-        QuicRouterScheduler<MockGossip>,
-        _,
-        MockWALogger<_>,
-        _,
-        MockValidator,
-        MockMempool<_, _>,
-        _,
-    >(
+    create_and_run_nodes::<QuicSwarm, _, _>(
         MockValidator,
         |all_peers, me| QuicRouterSchedulerConfig {
             zero_instant,
@@ -102,7 +61,7 @@ fn many_nodes_quic() {
         },
         MockWALoggerConfig,
         MockMempoolConfig::default(),
-        vec![GenericTransformer::Latency::<Vec<u8>>(LatencyTransformer(
+        vec![BytesTransformer::Latency(LatencyTransformer(
             Duration::from_millis(1),
         ))],
         UntilTerminator::new().until_tick(Duration::from_secs(4)),
@@ -136,25 +95,7 @@ fn many_nodes_quic_bw() {
         BytesTransformer::Bw(BwTransformer::new(5)),
     ];
 
-    create_and_run_nodes::<
-        MonadState<
-            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-            NopSignature,
-            MultiSig<NopSignature>,
-            ValidatorSet,
-            SimpleRoundRobin,
-            BlockSyncState,
-        >,
-        NopSignature,
-        MultiSig<NopSignature>,
-        QuicRouterScheduler<MockGossip>,
-        _,
-        MockWALogger<_>,
-        _,
-        MockValidator,
-        MockMempool<_, _>,
-        _,
-    >(
+    create_and_run_nodes::<QuicSwarm, _, _>(
         MockValidator,
         |all_peers, me| QuicRouterSchedulerConfig {
             zero_instant,
@@ -235,25 +176,7 @@ fn many_nodes_quic_deterministic() {
         }
     };
 
-    let duration1 = create_and_run_nodes::<
-        MonadState<
-            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-            NopSignature,
-            MultiSig<NopSignature>,
-            ValidatorSet,
-            SimpleRoundRobin,
-            BlockSyncState,
-        >,
-        NopSignature,
-        MultiSig<NopSignature>,
-        QuicRouterScheduler<MockGossip>,
-        _,
-        MockWALogger<_>,
-        _,
-        MockValidator,
-        MockMempool<_, _>,
-        _,
-    >(
+    let duration1 = create_and_run_nodes::<QuicSwarm, _, _>(
         MockValidator,
         router_scheduler_config,
         MockWALoggerConfig,
@@ -269,25 +192,7 @@ fn many_nodes_quic_deterministic() {
         swarm_config.num_nodes as usize
     );
 
-    let duration2 = create_and_run_nodes::<
-        MonadState<
-            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-            NopSignature,
-            MultiSig<NopSignature>,
-            ValidatorSet,
-            SimpleRoundRobin,
-            BlockSyncState,
-        >,
-        NopSignature,
-        MultiSig<NopSignature>,
-        QuicRouterScheduler<MockGossip>,
-        _,
-        MockWALogger<_>,
-        _,
-        MockValidator,
-        MockMempool<_, _>,
-        _,
-    >(
+    let duration2 = create_and_run_nodes::<QuicSwarm, _, _>(
         MockValidator,
         router_scheduler_config,
         MockWALoggerConfig,

--- a/monad-mock-swarm/tests/many_nodes_metrics.rs
+++ b/monad-mock-swarm/tests/many_nodes_metrics.rs
@@ -1,24 +1,21 @@
+mod common;
 use std::time::Duration;
 
-use monad_block_sync::BlockSyncState;
-use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{
-    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
-};
+use common::NoSerSwarm;
+use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
 use monad_crypto::NopSignature;
 use monad_mock_swarm::{
-    mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock::{MockMempoolConfig, NoSerRouterConfig},
     mock_swarm::UntilTerminator,
     transformer::{GenericTransformer, LatencyTransformer},
 };
-use monad_state::{MonadMessage, MonadState};
+use monad_state::MonadMessage;
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
 use monad_tracing_counter::{
     counter::{CounterLayer, MetricFilter},
     counter_status,
 };
-use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
-use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
+use monad_wal::mock::MockWALoggerConfig;
 use tracing_core::LevelFilter;
 use tracing_subscriber::{filter::Targets, prelude::*, Registry};
 
@@ -37,25 +34,7 @@ fn many_nodes_metrics() {
 
     tracing::subscriber::set_global_default(subscriber).expect("unable to set global subscriber");
 
-    create_and_run_nodes::<
-        MonadState<
-            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-            NopSignature,
-            MultiSig<NopSignature>,
-            ValidatorSet,
-            SimpleRoundRobin,
-            BlockSyncState,
-        >,
-        NopSignature,
-        MultiSig<NopSignature>,
-        NoSerRouterScheduler<MonadMessage<_, _>>,
-        _,
-        MockWALogger<_>,
-        _,
-        MockValidator,
-        MockMempool<_, _>,
-        _,
-    >(
+    create_and_run_nodes::<NoSerSwarm, _, _>(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
             all_peers: all_peers.into_iter().collect(),

--- a/monad-mock-swarm/tests/msg_delays.rs
+++ b/monad-mock-swarm/tests/msg_delays.rs
@@ -1,44 +1,21 @@
+mod common;
 use std::time::Duration;
 
-use monad_block_sync::BlockSyncState;
-use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{
-    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
-};
-use monad_crypto::NopSignature;
+use common::NoSerSwarm;
+use monad_consensus_types::transaction_validator::MockValidator;
 use monad_mock_swarm::{
-    mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock::{MockMempoolConfig, NoSerRouterConfig},
     mock_swarm::UntilTerminator,
     transformer::{GenericTransformer, XorLatencyTransformer},
 };
-use monad_state::{MonadMessage, MonadState};
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
-use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
-use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
+use monad_wal::mock::MockWALoggerConfig;
 
 #[test]
 fn two_nodes() {
     tracing_subscriber::fmt::init();
 
-    create_and_run_nodes::<
-        MonadState<
-            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-            NopSignature,
-            MultiSig<NopSignature>,
-            ValidatorSet,
-            SimpleRoundRobin,
-            BlockSyncState,
-        >,
-        NopSignature,
-        MultiSig<NopSignature>,
-        NoSerRouterScheduler<MonadMessage<_, _>>,
-        _,
-        MockWALogger<_>,
-        _,
-        MockValidator,
-        MockMempool<_, _>,
-        _,
-    >(
+    create_and_run_nodes::<NoSerSwarm, _, _>(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
             all_peers: all_peers.into_iter().collect(),

--- a/monad-mock-swarm/tests/order.rs
+++ b/monad-mock-swarm/tests/order.rs
@@ -1,24 +1,20 @@
+mod common;
 use std::{collections::HashSet, env, time::Duration};
 
-use monad_block_sync::BlockSyncState;
-use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{
-    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
-};
+use common::NoSerSwarm;
+use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
 use monad_crypto::NopSignature;
 use monad_executor_glue::PeerId;
 use monad_mock_swarm::{
-    mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock::{MockMempoolConfig, NoSerRouterConfig},
     mock_swarm::UntilTerminator,
     transformer::{
         GenericTransformer, LatencyTransformer, PartitionTransformer, ReplayTransformer,
         TransformerReplayOrder, ID,
     },
 };
-use monad_state::{MonadMessage, MonadState};
 use monad_testutil::swarm::{get_configs, run_nodes_until};
-use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
-use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
+use monad_wal::mock::MockWALoggerConfig;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use test_case::test_case;
 
@@ -67,25 +63,7 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
 
     println!("delayed node ID: {:?}", first_node);
 
-    run_nodes_until::<
-        MonadState<
-            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-            NopSignature,
-            MultiSig<NopSignature>,
-            ValidatorSet,
-            SimpleRoundRobin,
-            BlockSyncState,
-        >,
-        NopSignature,
-        MultiSig<NopSignature>,
-        NoSerRouterScheduler<MonadMessage<_, _>>,
-        _,
-        MockWALogger<_>,
-        _,
-        MockValidator,
-        MockMempool<_, _>,
-        _,
-    >(
+    run_nodes_until::<NoSerSwarm, _, _>(
         pubkeys,
         state_configs,
         |all_peers: Vec<_>, _| NoSerRouterConfig {

--- a/monad-mock-swarm/tests/rand_lat.rs
+++ b/monad-mock-swarm/tests/rand_lat.rs
@@ -1,20 +1,17 @@
+mod common;
 use std::env;
 
-use monad_block_sync::BlockSyncState;
-use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{
-    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
-};
+use common::NoSerSwarm;
+use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
 use monad_crypto::NopSignature;
 use monad_mock_swarm::{
-    mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock::{MockMempoolConfig, NoSerRouterConfig},
     mock_swarm::UntilTerminator,
     transformer::GenericTransformer,
 };
-use monad_state::{MonadMessage, MonadState};
+use monad_state::MonadMessage;
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
-use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
-use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
+use monad_wal::mock::MockWALoggerConfig;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use test_case::test_case;
 
@@ -58,25 +55,7 @@ fn nodes_with_random_latency(seed: u64) {
 
     use monad_mock_swarm::transformer::RandLatencyTransformer;
 
-    create_and_run_nodes::<
-        MonadState<
-            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-            NopSignature,
-            MultiSig<NopSignature>,
-            ValidatorSet,
-            SimpleRoundRobin,
-            BlockSyncState,
-        >,
-        NopSignature,
-        MultiSig<NopSignature>,
-        NoSerRouterScheduler<MonadMessage<_, _>>,
-        _,
-        MockWALogger<_>,
-        _,
-        MockValidator,
-        MockMempool<_, _>,
-        _,
-    >(
+    create_and_run_nodes::<NoSerSwarm, _, _>(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
             all_peers: all_peers.into_iter().collect(),

--- a/monad-mock-swarm/tests/random_mempool.rs
+++ b/monad-mock-swarm/tests/random_mempool.rs
@@ -6,39 +6,49 @@ use monad_consensus_types::{
     multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
 };
 use monad_crypto::NopSignature;
+use monad_executor::timed_event::TimedEvent;
+use monad_executor_glue::MonadEvent;
 use monad_mock_swarm::{
     mock::{
         MockMempoolRandFail, MockMempoolRandFailConfig, NoSerRouterConfig, NoSerRouterScheduler,
     },
     mock_swarm::UntilTerminator,
-    transformer::{GenericTransformer, LatencyTransformer},
+    swarm_relation::SwarmRelation,
+    transformer::{GenericTransformer, GenericTransformerPipeline, LatencyTransformer},
 };
-use monad_state::{MonadMessage, MonadState};
+use monad_state::{MonadMessage, MonadState, VerifiedMonadMessage};
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
 use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
 use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
 
-#[test]
-fn random_mempool_failures() {
-    create_and_run_nodes::<
-        MonadState<
-            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-            NopSignature,
-            MultiSig<NopSignature>,
-            ValidatorSet,
-            SimpleRoundRobin,
-            BlockSyncState,
-        >,
+struct RandFailSwarm;
+impl SwarmRelation for RandFailSwarm {
+    type STATE = MonadState<
+        ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
         NopSignature,
         MultiSig<NopSignature>,
-        NoSerRouterScheduler<MonadMessage<_, _>>,
-        _,
-        MockWALogger<_>,
-        _,
-        MockValidator,
-        MockMempoolRandFail<_, _>,
-        _,
-    >(
+        ValidatorSet,
+        SimpleRoundRobin,
+        BlockSyncState,
+    >;
+    type ST = NopSignature;
+    type SCT = MultiSig<Self::ST>;
+    type RS = NoSerRouterScheduler<MonadMessage<Self::ST, Self::SCT>>;
+    type P = GenericTransformerPipeline<MonadMessage<Self::ST, Self::SCT>>;
+    type LGR = MockWALogger<TimedEvent<MonadEvent<Self::ST, Self::SCT>>>;
+    type ME = MockMempoolRandFail<Self::ST, Self::SCT>;
+    type TVT = MockValidator;
+    type LGRCFG = MockWALoggerConfig;
+    type RSCFG = NoSerRouterConfig;
+    type MPCFG = MockMempoolRandFailConfig;
+    type StateMessage = MonadMessage<Self::ST, Self::SCT>;
+    type OutboundStateMessage = VerifiedMonadMessage<Self::ST, Self::SCT>;
+    type Message = MonadMessage<Self::ST, Self::SCT>;
+}
+
+#[test]
+fn random_mempool_failures() {
+    create_and_run_nodes::<RandFailSwarm, _, _>(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
             all_peers: all_peers.into_iter().collect(),

--- a/monad-mock-swarm/tests/single_node.rs
+++ b/monad-mock-swarm/tests/single_node.rs
@@ -1,46 +1,26 @@
+mod common;
+
 use std::time::{Duration, Instant};
 
-use monad_block_sync::BlockSyncState;
-use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{
-    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
-};
+use common::{NoSerSwarm, QuicSwarm};
+use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
 use monad_crypto::NopSignature;
-use monad_gossip::mock::{MockGossip, MockGossipConfig};
+use monad_gossip::mock::MockGossipConfig;
 use monad_mock_swarm::{
-    mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock::{MockMempoolConfig, NoSerRouterConfig},
     mock_swarm::UntilTerminator,
-    transformer::{GenericTransformer, LatencyTransformer},
+    transformer::{BytesTransformer, GenericTransformer, LatencyTransformer},
 };
-use monad_quic::{QuicRouterScheduler, QuicRouterSchedulerConfig};
-use monad_state::{MonadMessage, MonadState};
+use monad_quic::QuicRouterSchedulerConfig;
+use monad_state::MonadMessage;
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
-use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
-use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
+use monad_wal::mock::MockWALoggerConfig;
 
 #[test]
 fn two_nodes() {
     tracing_subscriber::fmt::init();
 
-    create_and_run_nodes::<
-        MonadState<
-            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-            NopSignature,
-            MultiSig<NopSignature>,
-            ValidatorSet,
-            SimpleRoundRobin,
-            BlockSyncState,
-        >,
-        NopSignature,
-        MultiSig<NopSignature>,
-        NoSerRouterScheduler<MonadMessage<_, _>>,
-        _,
-        MockWALogger<_>,
-        _,
-        MockValidator,
-        MockMempool<_, _>,
-        _,
-    >(
+    create_and_run_nodes::<NoSerSwarm, _, _>(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
             all_peers: all_peers.into_iter().collect(),
@@ -66,25 +46,7 @@ fn two_nodes() {
 fn two_nodes_quic() {
     let zero_instant = Instant::now();
 
-    create_and_run_nodes::<
-        MonadState<
-            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-            NopSignature,
-            MultiSig<NopSignature>,
-            ValidatorSet,
-            SimpleRoundRobin,
-            BlockSyncState,
-        >,
-        NopSignature,
-        MultiSig<NopSignature>,
-        QuicRouterScheduler<MockGossip>,
-        _,
-        MockWALogger<_>,
-        _,
-        MockValidator,
-        MockMempool<_, _>,
-        _,
-    >(
+    create_and_run_nodes::<QuicSwarm, _, _>(
         MockValidator,
         |all_peers, me| QuicRouterSchedulerConfig {
             zero_instant,
@@ -98,7 +60,7 @@ fn two_nodes_quic() {
         },
         MockWALoggerConfig,
         MockMempoolConfig::default(),
-        vec![GenericTransformer::Latency::<Vec<u8>>(LatencyTransformer(
+        vec![BytesTransformer::Latency(LatencyTransformer(
             Duration::from_millis(1),
         ))],
         UntilTerminator::new().until_tick(Duration::from_secs(10)),

--- a/monad-mock-swarm/tests/single_node_metrics.rs
+++ b/monad-mock-swarm/tests/single_node_metrics.rs
@@ -1,24 +1,19 @@
+mod common;
 use std::time::Duration;
 
-use monad_block_sync::BlockSyncState;
-use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{
-    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
-};
-use monad_crypto::NopSignature;
+use common::NoSerSwarm;
+use monad_consensus_types::transaction_validator::MockValidator;
 use monad_mock_swarm::{
-    mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock::{MockMempoolConfig, NoSerRouterConfig},
     mock_swarm::UntilTerminator,
     transformer::{GenericTransformer, LatencyTransformer},
 };
-use monad_state::{MonadMessage, MonadState};
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
 use monad_tracing_counter::{
     counter::{CounterLayer, MetricFilter},
     counter_status,
 };
-use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
-use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
+use monad_wal::mock::MockWALoggerConfig;
 use tracing_core::LevelFilter;
 use tracing_subscriber::{filter::Targets, prelude::*, Registry};
 
@@ -37,25 +32,7 @@ fn two_nodes() {
 
     tracing::subscriber::set_global_default(subscriber).expect("unable to set global subscriber");
 
-    create_and_run_nodes::<
-        MonadState<
-            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-            NopSignature,
-            MultiSig<NopSignature>,
-            ValidatorSet,
-            SimpleRoundRobin,
-            BlockSyncState,
-        >,
-        NopSignature,
-        MultiSig<NopSignature>,
-        NoSerRouterScheduler<MonadMessage<_, _>>,
-        _,
-        MockWALogger<_>,
-        _,
-        MockValidator,
-        MockMempool<_, _>,
-        _,
-    >(
+    create_and_run_nodes::<NoSerSwarm, _, _>(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
             all_peers: all_peers.into_iter().collect(),

--- a/monad-randomized-tests/Cargo.toml
+++ b/monad-randomized-tests/Cargo.toml
@@ -6,15 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-monad-block-sync = { path = "../monad-block-sync" }
-monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
 monad-executor-glue = { path = "../monad-executor-glue" }
-monad-state = { path = "../monad-state" }
 monad-mock-swarm = { path = "../monad-mock-swarm" }
 monad-testutil = { path = "../monad-testutil" }
-monad-validator = { path = "../monad-validator" }
 monad-wal = { path = "../monad-wal" }
 
 inventory = "0.3.6"

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -1,47 +1,24 @@
 use std::{collections::HashSet, time::Duration};
 
-use monad_block_sync::BlockSyncState;
-use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{
-    multi_sig::MultiSig, payload::NopStateRoot, transaction_validator::MockValidator,
-};
+use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
 use monad_crypto::NopSignature;
 use monad_executor_glue::PeerId;
 use monad_mock_swarm::{
-    mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock::{MockMempoolConfig, NoSerRouterConfig},
     mock_swarm::UntilTerminator,
+    swarm_relation::NoSerSwarm,
     transformer::{
         GenericTransformer, LatencyTransformer, PartitionTransformer, RandLatencyTransformer,
         ReplayTransformer, TransformerReplayOrder, ID,
     },
 };
-use monad_state::{MonadMessage, MonadState};
 use monad_testutil::swarm::{create_and_run_nodes, get_configs, run_nodes_until, SwarmTestConfig};
-use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
-use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
+use monad_wal::mock::MockWALoggerConfig;
 
 use crate::RandomizedTest;
 
 fn random_latency_test(seed: u64) {
-    create_and_run_nodes::<
-        MonadState<
-            ConsensusState<MultiSig<NopSignature>, MockValidator, NopStateRoot>,
-            NopSignature,
-            MultiSig<NopSignature>,
-            ValidatorSet,
-            SimpleRoundRobin,
-            BlockSyncState,
-        >,
-        NopSignature,
-        MultiSig<NopSignature>,
-        NoSerRouterScheduler<MonadMessage<_, _>>,
-        _,
-        MockWALogger<_>,
-        _,
-        MockValidator,
-        MockMempool<_, _>,
-        _,
-    >(
+    create_and_run_nodes::<NoSerSwarm, _, _>(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
             all_peers: all_peers.into_iter().collect(),
@@ -78,25 +55,7 @@ fn delayed_message_test(seed: u64) {
 
     println!("delayed node ID: {:?}", first_node);
 
-    run_nodes_until::<
-        MonadState<
-            ConsensusState<MultiSig<NopSignature>, MockValidator, NopStateRoot>,
-            NopSignature,
-            MultiSig<NopSignature>,
-            ValidatorSet,
-            SimpleRoundRobin,
-            BlockSyncState,
-        >,
-        NopSignature,
-        MultiSig<NopSignature>,
-        NoSerRouterScheduler<MonadMessage<_, _>>,
-        _,
-        MockWALogger<_>,
-        _,
-        MockValidator,
-        MockMempool<_, _>,
-        _,
-    >(
+    run_nodes_until::<NoSerSwarm, _, _>(
         pubkeys,
         state_configs,
         |all_peers: Vec<_>, _| NoSerRouterConfig {

--- a/monad-testutil/Cargo.toml
+++ b/monad-testutil/Cargo.toml
@@ -14,15 +14,15 @@ monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
 monad-eth-types = { path = "../monad-eth-types" }
-monad-executor = { path = "../monad-executor" }
 monad-executor-glue = { path = "../monad-executor-glue" }
 monad-state = { path = "../monad-state" }
 monad-mock-swarm = { path = "../monad-mock-swarm" }
 monad-types = { path = "../monad-types" }
 monad-validator = { path = "../monad-validator" }
-monad-wal = { path = "../monad-wal" }
 
 zerocopy = { workspace = true }
 
 [dev-dependencies]
 monad-block-sync = { path = "../monad-block-sync" }
+monad-executor = { path = "../monad-executor" }
+monad-wal = { path = "../monad-wal" }

--- a/monad-virtual-bench/benches/two_node_bench.rs
+++ b/monad-virtual-bench/benches/two_node_bench.rs
@@ -1,41 +1,17 @@
 use std::time::Duration;
 
-use monad_block_sync::BlockSyncState;
-use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{
-    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
-};
-use monad_crypto::NopSignature;
+use monad_consensus_types::transaction_validator::MockValidator;
 use monad_mock_swarm::{
-    mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock::{MockMempoolConfig, NoSerRouterConfig},
     mock_swarm::UntilTerminator,
+    swarm_relation::NoSerSwarm,
     transformer::{GenericTransformer, LatencyTransformer},
 };
-use monad_state::{MonadMessage, MonadState};
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
-use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
-use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
+use monad_wal::mock::MockWALoggerConfig;
 
 fn two_nodes_virtual() -> u128 {
-    create_and_run_nodes::<
-        MonadState<
-            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-            NopSignature,
-            MultiSig<NopSignature>,
-            ValidatorSet,
-            SimpleRoundRobin,
-            BlockSyncState,
-        >,
-        NopSignature,
-        MultiSig<NopSignature>,
-        NoSerRouterScheduler<MonadMessage<_, _>>,
-        _,
-        MockWALogger<_>,
-        _,
-        MockValidator,
-        MockMempool<_, _>,
-        _,
-    >(
+    create_and_run_nodes::<NoSerSwarm, _, _>(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
             all_peers: all_peers.into_iter().collect(),


### PR DESCRIPTION
This pr abstract majority of "where" clauses and Generic to a single trait, thus allow easier modification in future and readability.

With the change of converting State in Nodes to MonadState, the amount of generic and the relationship between generic is pilling up, This pr would greatly reduce the difficulty for such change and also any future changes.
