### PR TITLE
Replace PeerId within LinkMessage to ID

### DIFF
--- a/monad-mock-swarm/Cargo.toml
+++ b/monad-mock-swarm/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2021"
 bench = false
 
 [dependencies]
-monad-crypto = { path = "../monad-crypto" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-eth-types = { path = "../monad-eth-types" }
 monad-executor = { path = "../monad-executor" }
@@ -28,6 +27,7 @@ tracing = { workspace = true }
 itertools = { workspace = true }
 
 [dev-dependencies]
+monad-crypto = { path = "../monad-crypto" }
 monad-block-sync = { path = "../monad-block-sync" }
 monad-consensus = { path = "../monad-consensus" }
 monad-consensus-state = { path = "../monad-consensus-state", features = [

--- a/monad-mock-swarm/tests/block_sync.rs
+++ b/monad-mock-swarm/tests/block_sync.rs
@@ -12,7 +12,7 @@ mod test {
         mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
         transformer::{
             DropTransformer, GenericTransformer, LatencyTransformer, PartitionTransformer,
-            PeriodicTransformer,
+            PeriodicTransformer, ID,
         },
     };
     use monad_state::{MonadMessage, MonadState};
@@ -38,9 +38,9 @@ mod test {
 
         assert!(num_nodes >= 2, "test requires 2 or more nodes");
 
-        let first_node = PeerId(*pubkeys.first().unwrap());
+        let first_node = ID::new(PeerId(*pubkeys.first().unwrap()));
 
-        let mut filter_peers: HashSet<PeerId> = HashSet::new();
+        let mut filter_peers = HashSet::new();
         filter_peers.insert(first_node);
 
         println!("blackout node ID: {:?}", first_node);
@@ -116,10 +116,14 @@ mod test {
 
         assert!(num_nodes >= 2, "test requires 2 or more nodes");
 
-        let first_node = PeerId(*pubkeys.first().unwrap());
+        let first_node = ID::new(PeerId(*pubkeys.first().unwrap()));
 
-        let filter_peers: HashSet<PeerId> =
-            HashSet::from_iter(pubkeys.iter().take(black_out_cnt).map(|k| PeerId(*k)));
+        let filter_peers = HashSet::from_iter(
+            pubkeys
+                .iter()
+                .take(black_out_cnt)
+                .map(|k| ID::new(PeerId(*k))),
+        );
 
         println!("delayed node ID: {:?}", first_node);
 

--- a/monad-mock-swarm/tests/order.rs
+++ b/monad-mock-swarm/tests/order.rs
@@ -11,7 +11,7 @@ use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
     transformer::{
         GenericTransformer, LatencyTransformer, PartitionTransformer, ReplayTransformer,
-        TransformerReplayOrder,
+        TransformerReplayOrder, ID,
     },
 };
 use monad_state::{MonadMessage, MonadState};
@@ -59,7 +59,7 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
 
     assert!(num_nodes >= 2, "test requires 2 or more nodes");
 
-    let first_node = PeerId(*pubkeys.first().unwrap());
+    let first_node = ID::new(PeerId(*pubkeys.first().unwrap()));
 
     let mut filter_peers = HashSet::new();
     filter_peers.insert(first_node);

--- a/monad-mock-swarm/tests/replay.rs
+++ b/monad-mock-swarm/tests/replay.rs
@@ -12,7 +12,7 @@ use monad_executor_glue::{MonadEvent, PeerId};
 use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
     mock_swarm::Nodes,
-    transformer::{GenericTransformer, LatencyTransformer, XorLatencyTransformer},
+    transformer::{GenericTransformer, LatencyTransformer, XorLatencyTransformer, ID},
 };
 use monad_state::{MonadMessage, MonadState};
 use monad_testutil::swarm::{get_configs, node_ledger_verification};
@@ -61,7 +61,7 @@ pub fn recover_nodes_msg_delays(
         .zip(logger_configs.clone())
         .map(|((a, b), c)| {
             (
-                a,
+                ID::new(PeerId(a)),
                 b,
                 c,
                 NoSerRouterConfig {
@@ -148,7 +148,7 @@ pub fn recover_nodes_msg_delays(
         .zip(logger_configs)
         .map(|((a, b), c)| {
             (
-                a,
+                ID::new(PeerId(a)),
                 b,
                 c,
                 NoSerRouterConfig {

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -11,7 +11,7 @@ use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
     transformer::{
         GenericTransformer, LatencyTransformer, PartitionTransformer, RandLatencyTransformer,
-        ReplayTransformer, TransformerReplayOrder,
+        ReplayTransformer, TransformerReplayOrder, ID,
     },
 };
 use monad_state::{MonadMessage, MonadState};
@@ -73,7 +73,7 @@ fn delayed_message_test(seed: u64) {
     let first_node = PeerId(*pubkeys.first().unwrap());
 
     let mut filter_peers = HashSet::new();
-    filter_peers.insert(first_node);
+    filter_peers.insert(ID::new(first_node));
 
     println!("delayed node ID: {:?}", first_node);
 

--- a/monad-testutil/examples/logs_gen.rs
+++ b/monad-testutil/examples/logs_gen.rs
@@ -11,7 +11,7 @@ use monad_executor_glue::{MonadEvent, PeerId};
 use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
     mock_swarm::Nodes,
-    transformer::{GenericTransformer, Pipeline},
+    transformer::{GenericTransformer, Pipeline, ID},
 };
 use monad_state::MonadState;
 use monad_testutil::swarm::get_configs;
@@ -59,7 +59,7 @@ pub fn generate_log<P: Pipeline<MM>>(
         .zip(file_path_vec)
         .map(|((a, b), c)| {
             (
-                a,
+                ID::new(PeerId(a)),
                 b,
                 c,
                 NoSerRouterConfig {

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -13,7 +13,7 @@ use monad_executor_glue::{MonadEvent, PeerId};
 use monad_mock_swarm::{
     mock::{MockExecutor, MockableExecutor, RouterScheduler},
     mock_swarm::{Node, Nodes},
-    transformer::Pipeline,
+    transformer::{Pipeline, ID},
 };
 use monad_state::MonadConfig;
 use monad_types::{Deserializable, NodeId, Serializable};
@@ -210,7 +210,7 @@ where
             .zip(state_configs)
             .map(|(pubkey, state_config)| {
                 (
-                    pubkey,
+                    ID::new(PeerId(pubkey)),
                     state_config,
                     logger_config.clone(),
                     router_scheduler_config(

--- a/monad-viz/src/config.rs
+++ b/monad-viz/src/config.rs
@@ -10,7 +10,7 @@ use monad_consensus_types::{
     block::BlockType, quorum_certificate::genesis_vote_info, transaction_validator::MockValidator,
     validation::Sha256Hash,
 };
-use monad_crypto::secp256k1::{KeyPair, PubKey};
+use monad_crypto::secp256k1::KeyPair;
 use monad_eth_types::EthAddress;
 use monad_executor::State;
 use monad_executor_glue::PeerId;
@@ -18,6 +18,7 @@ use monad_mock_swarm::{
     mock::{MockMempoolConfig, MockableExecutor, NoSerRouterScheduler},
     transformer::{
         GenericTransformer, GenericTransformerPipeline, LatencyTransformer, XorLatencyTransformer,
+        ID,
     },
 };
 use monad_state::MonadConfig;
@@ -69,7 +70,7 @@ impl
     fn nodes(
         &self,
     ) -> Vec<(
-        PubKey,
+        ID,
         <MS as State>::Config,
         <PersistenceLoggerType as PersistenceLogger>::Config,
         Rsc,
@@ -125,7 +126,7 @@ impl
             .zip(state_configs)
             .map(|(a, b)| {
                 (
-                    a,
+                    ID::new(PeerId(a)),
                     b,
                     MockWALoggerConfig {},
                     Rsc {

--- a/monad-viz/src/main.rs
+++ b/monad-viz/src/main.rs
@@ -36,6 +36,7 @@ use monad_mock_swarm::{
     mock::{MockMempool, NoSerRouterScheduler, RouterScheduler},
     transformer::{
         GenericTransformer, GenericTransformerPipeline, LatencyTransformer, XorLatencyTransformer,
+        ID,
     },
 };
 use monad_state::{MonadMessage, MonadState};
@@ -435,7 +436,7 @@ impl Program<Message> for &Sim {
             let ledger = self
                 .nodes
                 .states()
-                .get(node.id)
+                .get(&ID::new(*node.id))
                 .unwrap()
                 .executor
                 .ledger()


### PR DESCRIPTION
This change is the alternative suggested by Aashish and works quiet nice with limiting the amount of changes, essentially we don't touch router scheduler, and try to control twin-testing's filter mechanism from the transformer level.

With this change, there is no longer a need to refactor router scheduler and changes made to swarm/linkmessage/pipeline is minimized.