### PR TITLE
Make quic swarm fully deterministic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4614,6 +4614,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
+ "rcgen 0.11.3",
  "tempfile",
  "test-case",
  "tracing",
@@ -4692,6 +4693,7 @@ dependencies = [
  "monad-types",
  "quinn",
  "quinn-proto 0.11.0",
+ "rand 0.8.5",
  "tokio",
  "x509-parser 0.15.1",
 ]
@@ -6183,7 +6185,7 @@ dependencies = [
 [[package]]
 name = "quinn"
 version = "0.11.0"
-source = "git+https://github.com/quinn-rs/quinn.git?rev=307d80b9#307d80b9398d4e1e305c0131f2c3989090ec9432"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=dd34d57a#dd34d57a0a184ae23707d5ae045ec62d8f0b6ecb"
 dependencies = [
  "bytes",
  "pin-project-lite 0.2.13",
@@ -6217,7 +6219,7 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.11.0"
-source = "git+https://github.com/quinn-rs/quinn.git?rev=307d80b9#307d80b9398d4e1e305c0131f2c3989090ec9432"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=dd34d57a#dd34d57a0a184ae23707d5ae045ec62d8f0b6ecb"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -6234,7 +6236,7 @@ dependencies = [
 [[package]]
 name = "quinn-udp"
 version = "0.5.0"
-source = "git+https://github.com/quinn-rs/quinn.git?rev=307d80b9#307d80b9398d4e1e305c0131f2c3989090ec9432"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=dd34d57a#dd34d57a0a184ae23707d5ae045ec62d8f0b6ecb"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,10 +75,10 @@ prost-types = "0.11.8"
 protobuf-src = "1.1.0"
 ptree = { version = "0.4.0", default-features = false }
 
-# the important commit: "307d80b9398d4e1e305c0131f2c3989090ec9432"
+# the important commit: "dd34d57a0a184ae23707d5ae045ec62d8f0b6ecb"
 # we can use latest release once it includes that
-quinn = { git = "https://github.com/quinn-rs/quinn.git", rev = "307d80b9" }
-quinn-proto = { git = "https://github.com/quinn-rs/quinn.git", rev = "307d80b9" }
+quinn = { git = "https://github.com/quinn-rs/quinn.git", rev = "dd34d57a" }
+quinn-proto = { git = "https://github.com/quinn-rs/quinn.git", rev = "dd34d57a" }
 
 rand = "0.8.5"
 rand_chacha = "0.3.1"

--- a/monad-mock-swarm/Cargo.toml
+++ b/monad-mock-swarm/Cargo.toml
@@ -39,12 +39,12 @@ monad-gossip = { path = "../monad-gossip" }
 monad-quic = { path = "../monad-quic" }
 monad-state = { path = "../monad-state", features = ["monad_test"] }
 monad-testutil = { path = "../monad-testutil" }
-monad-tracing-counter = { path = "../monad-tracing-counter" }
 monad-validator = { path = "../monad-validator" }
 
 criterion = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
+rcgen = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 tracing = { workspace = true }

--- a/monad-mock-swarm/src/mock_swarm.rs
+++ b/monad-mock-swarm/src/mock_swarm.rs
@@ -172,6 +172,7 @@ where
     fn should_terminate(&self, nodes: &Nodes<S, RS, P, LGR, ME, ST, SCT>) -> bool;
 }
 
+#[derive(Clone, Copy)]
 pub struct UntilTerminator {
     until_tick: Duration,
     until_block: usize,

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -1,4 +1,8 @@
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 
 use monad_block_sync::BlockSyncState;
 use monad_consensus_state::ConsensusState;
@@ -6,6 +10,7 @@ use monad_consensus_types::{
     multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
 };
 use monad_crypto::NopSignature;
+use monad_executor_glue::PeerId;
 use monad_gossip::mock::{MockGossip, MockGossipConfig};
 use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
@@ -90,6 +95,9 @@ fn many_nodes_quic() {
             all_peers: all_peers.iter().cloned().collect(),
             me,
 
+            tls_key_der: Vec::new(),
+            master_seed: 7,
+
             gossip_config: MockGossipConfig { all_peers },
         },
         MockWALoggerConfig,
@@ -125,7 +133,7 @@ fn many_nodes_quic_bw() {
 
     let xfmrs = vec![
         BytesTransformer::Latency(LatencyTransformer(Duration::from_millis(1))),
-        BytesTransformer::Bw(BwTransformer::new(3)),
+        BytesTransformer::Bw(BwTransformer::new(5)),
     ];
 
     create_and_run_nodes::<
@@ -153,6 +161,9 @@ fn many_nodes_quic_bw() {
             all_peers: all_peers.iter().cloned().collect(),
             me,
 
+            tls_key_der: Vec::new(),
+            master_seed: 7,
+
             gossip_config: MockGossipConfig { all_peers },
         },
         MockWALoggerConfig,
@@ -171,7 +182,133 @@ fn many_nodes_quic_bw() {
         {
             Ok(())
         } else {
-            Err(format!("Expected msg to be dropped"))
+            Err("Expected msg to be dropped".to_owned())
         }
     });
+}
+
+#[traced_test]
+#[test]
+fn many_nodes_quic_deterministic() {
+    let zero_instant = Instant::now();
+
+    let swarm_config = SwarmTestConfig {
+        num_nodes: 40,
+        consensus_delta: Duration::from_millis(1000),
+        parallelize: false,
+        expected_block: 35,
+        state_root_delay: u64::MAX,
+        seed: 1,
+    };
+
+    let terminator = UntilTerminator::new().until_block(40);
+
+    let xfmrs = vec![
+        BytesTransformer::Latency(LatencyTransformer(Duration::from_millis(1))),
+        BytesTransformer::Bw(BwTransformer::new(3)),
+    ];
+
+    let tls_keys_der = Arc::new(Mutex::new(Vec::new()));
+    let tls_keys_der_map = Arc::new(Mutex::new(HashMap::new()));
+
+    for _ in 0..swarm_config.num_nodes {
+        tls_keys_der.lock().unwrap().push(
+            rcgen::KeyPair::generate(&rcgen::PKCS_ED25519).expect("generate keypair to succeed"),
+        );
+    }
+
+    let router_scheduler_config = |all_peers: Vec<PeerId>, me: PeerId| {
+        let key_der = tls_keys_der_map
+            .lock()
+            .unwrap()
+            .entry(me.0.bytes())
+            .or_insert_with(|| tls_keys_der.lock().unwrap().remove(0).serialize_der())
+            .to_owned();
+
+        QuicRouterSchedulerConfig {
+            zero_instant,
+            all_peers: all_peers.iter().cloned().collect(),
+            me,
+            tls_key_der: key_der,
+            master_seed: 7,
+            gossip_config: MockGossipConfig { all_peers },
+        }
+    };
+
+    let duration1 = create_and_run_nodes::<
+        MonadState<
+            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
+            NopSignature,
+            MultiSig<NopSignature>,
+            ValidatorSet,
+            SimpleRoundRobin,
+            BlockSyncState,
+        >,
+        NopSignature,
+        MultiSig<NopSignature>,
+        QuicRouterScheduler<MockGossip>,
+        _,
+        MockWALogger<_>,
+        _,
+        MockValidator,
+        MockMempool<_, _>,
+        _,
+    >(
+        MockValidator,
+        router_scheduler_config,
+        MockWALoggerConfig,
+        MockMempoolConfig::default(),
+        xfmrs.clone(),
+        terminator,
+        swarm_config,
+    );
+
+    assert!(tls_keys_der.lock().unwrap().is_empty());
+    assert_eq!(
+        tls_keys_der_map.lock().unwrap().len(),
+        swarm_config.num_nodes as usize
+    );
+
+    let duration2 = create_and_run_nodes::<
+        MonadState<
+            ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
+            NopSignature,
+            MultiSig<NopSignature>,
+            ValidatorSet,
+            SimpleRoundRobin,
+            BlockSyncState,
+        >,
+        NopSignature,
+        MultiSig<NopSignature>,
+        QuicRouterScheduler<MockGossip>,
+        _,
+        MockWALogger<_>,
+        _,
+        MockValidator,
+        MockMempool<_, _>,
+        _,
+    >(
+        MockValidator,
+        router_scheduler_config,
+        MockWALoggerConfig,
+        MockMempoolConfig::default(),
+        xfmrs,
+        terminator,
+        swarm_config,
+    );
+
+    logs_assert(|lines| {
+        if lines
+            .iter()
+            .filter(|line| line.contains("monotonic_counter.bwtransfomer_dropped_msg"))
+            .count()
+            > 0
+        {
+            Ok(())
+        } else {
+            Err("Expected msg to be dropped".to_owned())
+        }
+    });
+
+    assert_eq!(duration1, duration2);
 }

--- a/monad-mock-swarm/tests/single_node.rs
+++ b/monad-mock-swarm/tests/single_node.rs
@@ -91,6 +91,9 @@ fn two_nodes_quic() {
             all_peers: all_peers.iter().cloned().collect(),
             me,
 
+            tls_key_der: Vec::new(),
+            master_seed: 7,
+
             gossip_config: MockGossipConfig { all_peers },
         },
         MockWALoggerConfig,

--- a/monad-quic/Cargo.toml
+++ b/monad-quic/Cargo.toml
@@ -25,3 +25,4 @@ quinn = { workspace = true }
 quinn-proto = { workspace = true }
 
 x509-parser = { workspace = true }
+rand = { workspace = true }

--- a/monad-quic/src/service.rs
+++ b/monad-quic/src/service.rs
@@ -447,7 +447,7 @@ impl UnsafeNoAuthQuinnConfig {
     pub fn new(me: PeerId) -> Self {
         Self {
             me,
-            client: Arc::new(UnsafeTlsVerifier::make_client_config(me.0.bytes())),
+            client: Arc::new(UnsafeTlsVerifier::make_client_config(me.0.bytes(), &[])),
             transport: Arc::new(TransportConfig::default()),
         }
     }
@@ -463,7 +463,10 @@ impl QuinnConfig for UnsafeNoAuthQuinnConfig {
     }
 
     fn server(&self) -> Arc<dyn quinn_proto::crypto::ServerConfig> {
-        Arc::new(UnsafeTlsVerifier::make_server_config(self.me.0.bytes()))
+        Arc::new(UnsafeTlsVerifier::make_server_config(
+            self.me.0.bytes(),
+            &[],
+        ))
     }
 
     fn remote_peer_id(connection: &quinn::Connection) -> Result<PeerId, Box<dyn Error>> {

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -23,6 +23,7 @@ use monad_wal::PersistenceLogger;
 
 use crate::{signing::get_genesis_config, validators::create_keys_w_validators};
 
+#[derive(Debug, Clone, Copy)]
 pub struct SwarmTestConfig {
     pub num_nodes: u16,
     pub consensus_delta: Duration,


### PR DESCRIPTION
The mock swarm tests with `QuicRouterScheduler` weren't fully deterministic because of two reasons:

1. The `quinn-proto` library calls `StdRng::from_entropy` in its implementation for connection and endpoint.

   The patching PR is pending review from quinn's people. In the meantime, the workspace dependency points to the patch commit in quinn.

2. The `make_certificate` function in `monad-crypto` generates a random key for TLS handshake. Depending on the actual value of the key, the QUIC handshake data might be off by 1 byte. The difference can cascade when mock swarm tests have a BwTransformer in place, causing different messages to be dropped across runs.

   An additional argument is added to `make_certificate` to optionally specify the tls_key bytes so the tests are fully deterministic.

In our nightly randomized tests, we should output the keys so we can debug the failures.