### PR TITLE
Fix benchmark regression CI

### DIFF
--- a/monad-mempool-txpool/benches/pool.rs
+++ b/monad-mempool-txpool/benches/pool.rs
@@ -14,7 +14,7 @@ const WARMUP_TXS: u16 = 10000;
 const TX_PER_THREAD: u16 = 10000;
 
 pub fn benchmark_pool(c: &mut Criterion) {
-    c.bench_function("create single proposal with concurrent write/read", |b| {
+    c.bench_function("create_single_proposal_with_concurrent_write_read", |b| {
         let txs_for_threads: Vec<Vec<TransactionSignedEcRecovered>> = (0..THREAD_COUNT)
             .map(|i| create_signed_eth_txs(i.into(), TX_PER_THREAD))
             .collect();
@@ -47,7 +47,7 @@ pub fn benchmark_pool(c: &mut Criterion) {
         )
     });
 
-    c.bench_function("create multi proposal with concurrent write/read", |b| {
+    c.bench_function("create_multi_proposal_with_concurrent_write_read", |b| {
         let txs_for_threads: Vec<Vec<TransactionSignedEcRecovered>> = (0..THREAD_COUNT)
             .map(|i| create_signed_eth_txs(i.into(), TX_PER_THREAD))
             .collect();

--- a/monad-virtual-bench/benches/two_node_bench.rs
+++ b/monad-virtual-bench/benches/two_node_bench.rs
@@ -15,7 +15,7 @@ use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
 use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
 use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
 
-fn two_nodes() -> u128 {
+fn two_nodes_virtual() -> u128 {
     create_and_run_nodes::<
         MonadState<
             ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
@@ -57,4 +57,4 @@ fn two_nodes() -> u128 {
     .as_millis()
 }
 
-monad_virtual_bench::virtual_bench_main! {two_nodes}
+monad_virtual_bench::virtual_bench_main! {two_nodes_virtual}

--- a/monad-virtual-bench/src/lib.rs
+++ b/monad-virtual-bench/src/lib.rs
@@ -7,6 +7,6 @@ pub fn runner(benches: &[&(&'static str, fn() -> u128)]) {
         // expected output format:
         //   test bench_fib_20 ... bench:      37,174 ns/iter (+/- 7,527)
 
-        println!("test {} bench: {} ms/iter ", name, result);
+        println!("test {} ... bench: {} ns/iter (+/- 0)", name, result);
     }
 }


### PR DESCRIPTION
Fix the output format from virtual bench so the output is captured by the benchmark compare tool.

Change the mempool benchmark names so it's all word character.

The benchmark compare tool is quite strict about the output formatting. The above changes make the [regex](https://github.com/openpgpjs/github-action-pull-request-benchmark/blob/master/src/extract.ts#L194) happy.