### PR TITLE
Enforce more mandatory trait

### DIFF
--- a/monad-consensus-types/src/block.rs
+++ b/monad-consensus-types/src/block.rs
@@ -9,7 +9,7 @@ use crate::{
     validation::{Hashable, Hasher},
 };
 
-pub trait BlockType: Clone + PartialEq + Eq {
+pub trait BlockType: Clone + PartialEq + Eq + Unpin {
     fn get_id(&self) -> BlockId;
     fn get_round(&self) -> Round;
     fn get_author(&self) -> NodeId;

--- a/monad-consensus-types/src/certificate_signature.rs
+++ b/monad-consensus-types/src/certificate_signature.rs
@@ -15,7 +15,7 @@ pub trait CertificateKeyPair: Send + Sized + Sync + 'static {
 }
 
 pub trait CertificateSignature:
-    Copy + Clone + Eq + Hashable + Send + Sync + std::fmt::Debug + std::hash::Hash + 'static
+    Copy + Clone + Eq + Hashable + Send + Sync + std::fmt::Debug + std::hash::Hash + Unpin + 'static
 {
     type KeyPairType: CertificateKeyPair;
     type Error: std::error::Error + Send + Sync;

--- a/monad-consensus-types/src/message_signature.rs
+++ b/monad-consensus-types/src/message_signature.rs
@@ -6,7 +6,7 @@ use monad_crypto::{
 };
 
 pub trait MessageSignature:
-    Copy + Clone + Eq + std::hash::Hash + Send + Sync + std::fmt::Debug + 'static
+    Copy + Clone + Eq + std::hash::Hash + Send + Sync + std::fmt::Debug + Unpin + 'static
 {
     fn sign(msg: &[u8], keypair: &SecpKeyPair) -> Self;
 

--- a/monad-consensus-types/src/signature_collection.rs
+++ b/monad-consensus-types/src/signature_collection.rs
@@ -51,7 +51,7 @@ impl<S: CertificateSignature> std::fmt::Display for SignatureCollectionError<S> 
 impl<S: CertificateSignature> std::error::Error for SignatureCollectionError<S> {}
 
 pub trait SignatureCollection:
-    Clone + Hashable + Eq + Send + Sync + std::fmt::Debug + 'static
+    Clone + Hashable + Eq + Send + Sync + std::fmt::Debug + Unpin + 'static
 {
     type SignatureType: CertificateSignature;
 

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -41,8 +41,8 @@ pub enum RouterEvent<M, Serialized> {
 pub trait RouterScheduler {
     type Config;
     /// transport-level message type - usually will be bytes
-    type M;
-    type Serialized;
+    type M: Clone + Eq + PartialEq + Send;
+    type Serialized: Clone + Eq + PartialEq + Send;
 
     fn new(config: Self::Config) -> Self;
 
@@ -65,7 +65,7 @@ pub struct NoSerRouterConfig {
 
 impl<M> RouterScheduler for NoSerRouterScheduler<M>
 where
-    M: Clone,
+    M: Clone + Eq + PartialEq + Send,
 {
     type Config = NoSerRouterConfig;
     type M = M;
@@ -344,13 +344,12 @@ pub enum MockExecutorEvent<E, Ser> {
 impl<S, RS, ME, ST, SCT> MockExecutor<S, RS, ME, ST, SCT>
 where
     S: State<Event = MonadEvent<ST, SCT>, SignatureCollection = SCT>,
-    ST: MessageSignature + Unpin,
-    SCT: SignatureCollection + Unpin,
+    ST: MessageSignature,
+    SCT: SignatureCollection,
     RS: RouterScheduler,
     ME: MockableExecutor<SignatureCollection = S::SignatureCollection, Event = S::Event>,
 
     S::Message: Deserializable<RS::M>,
-    S::Block: Unpin,
     Self: Unpin,
 {
     pub fn step_until(
@@ -590,8 +589,8 @@ impl Default for MockMempoolConfig {
 
 impl<ST, SCT> MockableExecutor for MockMempool<ST, SCT>
 where
-    ST: MessageSignature + Unpin,
-    SCT: SignatureCollection + Unpin,
+    ST: MessageSignature,
+    SCT: SignatureCollection,
 {
     type Event = MonadEvent<ST, SCT>;
     type SignatureCollection = SCT;
@@ -641,8 +640,8 @@ pub struct MockMempoolRandFailConfig {
 
 impl<ST, SCT> MockableExecutor for MockMempoolRandFail<ST, SCT>
 where
-    ST: MessageSignature + Unpin,
-    SCT: SignatureCollection + Unpin,
+    ST: MessageSignature,
+    SCT: SignatureCollection,
 {
     type Event = MonadEvent<ST, SCT>;
     type SignatureCollection = SCT;

--- a/monad-mock-swarm/src/mock_swarm.rs
+++ b/monad-mock-swarm/src/mock_swarm.rs
@@ -44,21 +44,18 @@ where
 impl<S, RS, P, LGR, ME, ST, SCT> Node<S, RS, P, LGR, ME, ST, SCT>
 where
     S: State<Event = MonadEvent<ST, SCT>, SignatureCollection = SCT>,
-    ST: MessageSignature + Unpin,
-    SCT: SignatureCollection + Unpin,
+    ST: MessageSignature,
+    SCT: SignatureCollection,
 
     RS: RouterScheduler,
     S::Message: Deserializable<RS::M>,
     S::OutboundMessage: Serializable<RS::M>,
-    RS::Serialized: Eq,
 
     P: Pipeline<RS::Serialized>,
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
 
     ME: MockableExecutor<Event = S::Event, SignatureCollection = SCT>,
-
     MockExecutor<S, RS, ME, ST, SCT>: Unpin,
-    S::Block: Unpin,
 {
     fn peek_event(&self) -> Option<(Duration, SwarmEventType)> {
         // avoid modification of the original rng
@@ -179,13 +176,12 @@ enum SwarmEventType {
 impl<S, RS, P, LGR, ME, ST, SCT> Nodes<S, RS, P, LGR, ME, ST, SCT>
 where
     S: State<Event = MonadEvent<ST, SCT>, SignatureCollection = SCT>,
-    ST: MessageSignature + Unpin,
-    SCT: SignatureCollection + Unpin,
+    ST: MessageSignature,
+    SCT: SignatureCollection,
 
     RS: RouterScheduler,
     S::Message: Deserializable<RS::M>,
     S::OutboundMessage: Serializable<RS::M>,
-    RS::Serialized: Eq,
 
     P: Pipeline<RS::Serialized>,
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
@@ -193,9 +189,7 @@ where
     ME: MockableExecutor<Event = S::Event, SignatureCollection = SCT>,
 
     MockExecutor<S, RS, ME, ST, SCT>: Unpin,
-    S::Block: Unpin,
     Node<S, RS, P, LGR, ME, ST, SCT>: Send,
-    RS::Serialized: Send,
 {
     pub fn new(
         peers: Vec<(

--- a/monad-mock-swarm/tests/replay_test.rs
+++ b/monad-mock-swarm/tests/replay_test.rs
@@ -53,13 +53,12 @@ fn run_nodes_until<S, RS, P, LGR, ME, ST, SCT>(
 ) -> Duration
 where
     S: State<Event = MonadEvent<ST, SCT>, SignatureCollection = SCT>,
-    ST: MessageSignature + Unpin,
-    SCT: SignatureCollection + Unpin,
+    ST: MessageSignature,
+    SCT: SignatureCollection,
 
     RS: RouterScheduler,
     S::Message: Deserializable<RS::M>,
     S::OutboundMessage: Serializable<RS::M>,
-    RS::Serialized: Eq,
 
     P: Pipeline<RS::Serialized>,
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
@@ -67,9 +66,7 @@ where
     ME: MockableExecutor<Event = S::Event, SignatureCollection = SCT>,
 
     MockExecutor<S, RS, ME, ST, SCT>: Unpin,
-    S::Block: Unpin,
     Node<S, RS, P, LGR, ME, ST, SCT>: Send,
-    RS::Serialized: Send,
 {
     let mut max_tick = start_tick;
 
@@ -87,13 +84,12 @@ fn liveness<S, RS, P, LGR, ME, ST, SCT>(
 ) -> bool
 where
     S: State<Event = MonadEvent<ST, SCT>, SignatureCollection = SCT>,
-    ST: MessageSignature + Unpin,
-    SCT: SignatureCollection + Unpin,
+    ST: MessageSignature,
+    SCT: SignatureCollection,
 
     RS: RouterScheduler,
     S::Message: Deserializable<RS::M>,
     S::OutboundMessage: Serializable<RS::M>,
-    RS::Serialized: Eq,
 
     P: Pipeline<RS::Serialized>,
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
@@ -101,9 +97,7 @@ where
     ME: MockableExecutor<Event = S::Event, SignatureCollection = SCT>,
 
     MockExecutor<S, RS, ME, ST, SCT>: Unpin,
-    S::Block: Unpin,
     Node<S, RS, P, LGR, ME, ST, SCT>: Send,
-    RS::Serialized: Send,
 {
     let max_ledger_len = nodes
         .states()

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -118,22 +118,20 @@ where
         Event = MonadEvent<ST, SCT>,
         SignatureCollection = SCT,
     >,
-    ST: MessageSignature + Unpin,
-    SCT: SignatureCollection + Unpin,
+    ST: MessageSignature,
+    SCT: SignatureCollection,
 
     RS: RouterScheduler,
     S::Message: Deserializable<RS::M>,
     S::OutboundMessage: Serializable<RS::M>,
-    RS::Serialized: Eq,
 
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
     P: Pipeline<RS::Serialized> + Clone,
     ME: MockableExecutor<Event = S::Event, SignatureCollection = SCT>,
 
     MockExecutor<S, RS, ME, ST, SCT>: Unpin,
-    S::Block: PartialEq + Unpin,
+
     Node<S, RS, P, LGR, ME, ST, SCT>: Send,
-    RS::Serialized: Send,
 
     RSC: Fn(Vec<PeerId>, PeerId) -> RS::Config,
 
@@ -181,22 +179,19 @@ where
         Event = MonadEvent<ST, SCT>,
         SignatureCollection = SCT,
     >,
-    ST: MessageSignature + Unpin,
-    SCT: SignatureCollection + Unpin,
+    ST: MessageSignature,
+    SCT: SignatureCollection,
 
     RS: RouterScheduler,
     S::Message: Deserializable<RS::M>,
     S::OutboundMessage: Serializable<RS::M>,
-    RS::Serialized: Eq,
 
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
     P: Pipeline<RS::Serialized> + Clone,
     ME: MockableExecutor<Event = S::Event, SignatureCollection = SCT>,
-
     MockExecutor<S, RS, ME, ST, SCT>: Unpin,
-    S::Block: PartialEq + Unpin,
+
     Node<S, RS, P, LGR, ME, ST, SCT>: Send,
-    RS::Serialized: Send,
 
     RSC: Fn(Vec<PeerId>, PeerId) -> RS::Config,
 

--- a/monad-viz/src/graph.rs
+++ b/monad-viz/src/graph.rs
@@ -100,8 +100,8 @@ where
 impl<S, RS, P, LGR, C, ME, ST, SCT> NodesSimulation<S, RS, P, LGR, C, ME, ST, SCT>
 where
     S: monad_executor::State<Event = MonadEvent<ST, SCT>, SignatureCollection = SCT>,
-    ST: MessageSignature + Unpin,
-    SCT: SignatureCollection + Unpin,
+    ST: MessageSignature,
+    SCT: SignatureCollection,
     RS: RouterScheduler,
     P: Pipeline<RS::Serialized> + Clone,
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
@@ -110,12 +110,9 @@ where
 
     S::Message: Deserializable<RS::M>,
     S::OutboundMessage: Serializable<RS::M>,
-    RS::Serialized: Eq,
-
     MockExecutor<S, RS, ME, ST, SCT>: Unpin,
-    S::Block: Unpin,
+
     Node<S, RS, P, LGR, ME, ST, SCT>: Send,
-    RS::Serialized: Send,
 {
     pub fn new(config: C) -> Self {
         Self {
@@ -146,8 +143,8 @@ where
 impl<S, RS, P, LGR, C, ME, ST, SCT> Graph for NodesSimulation<S, RS, P, LGR, C, ME, ST, SCT>
 where
     S: monad_executor::State<Event = MonadEvent<ST, SCT>, SignatureCollection = SCT>,
-    ST: MessageSignature + Unpin,
-    SCT: SignatureCollection + Unpin,
+    ST: MessageSignature,
+    SCT: SignatureCollection,
     RS: RouterScheduler,
     P: Pipeline<RS::Serialized> + Clone,
     LGR: PersistenceLogger<Event = TimedEvent<S::Event>>,
@@ -156,12 +153,9 @@ where
 
     S::Message: Deserializable<RS::M>,
     S::OutboundMessage: Serializable<RS::M>,
-    RS::Serialized: Eq,
-
     MockExecutor<S, RS, ME, ST, SCT>: Unpin,
-    S::Block: Unpin,
+
     Node<S, RS, P, LGR, ME, ST, SCT>: Send,
-    RS::Serialized: Send,
 {
     type State = S;
     type Message = RS::Serialized;


### PR DESCRIPTION
For certain trait like BlockType, MessageSignature, SignatureCollection, it might make more sense for trait to naturally impl Unpin / Send because they will always be used as part of the information send across threads by messages.

This commit enforce these trait and remove redundant where clauses that forces them to be unpin / send