### PR TITLE
Add TwinsTransformer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4603,6 +4603,7 @@ dependencies = [
  "monad-executor",
  "monad-executor-glue",
  "monad-gossip",
+ "monad-mock-swarm",
  "monad-quic",
  "monad-state",
  "monad-testutil",
@@ -4668,6 +4669,7 @@ dependencies = [
  "monad-crypto",
  "monad-executor",
  "monad-executor-glue",
+ "monad-p2p",
  "monad-types",
 ]
 

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -62,7 +62,7 @@ pub struct ConsensusState<SCT: SignatureCollection, TV, SVT> {
     beneficiary: EthAddress,
 }
 
-#[cfg_attr(feature = "monad_test", derive(PartialEq, Eq))]
+#[cfg_attr(feature = "monad_test", derive(PartialEq, Eq, Clone))]
 #[derive(Debug)]
 pub struct ConsensusConfig {
     pub proposal_size: usize,

--- a/monad-consensus-types/Cargo.toml
+++ b/monad-consensus-types/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 [lib]
 bench = false
 
+[features]
+monad_test = []
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -503,6 +503,26 @@ impl ValidatorPubKey for PubKey {
     }
 }
 
+#[cfg(feature = "monad_test")]
+mod monad_test {
+    use monad_consensus_types::{
+        message_signature::MessageSignature, signature_collection::SignatureCollection,
+    };
+
+    use super::Unverified;
+    use crate::messages::consensus_message::ConsensusMessage;
+
+    impl<S, SCT> Unverified<S, ConsensusMessage<SCT>>
+    where
+        S: MessageSignature,
+        SCT: SignatureCollection,
+    {
+        pub fn spy_internal(&self) -> &ConsensusMessage<SCT> {
+            &self.obj
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use monad_consensus_types::{

--- a/monad-crypto/Cargo.toml
+++ b/monad-crypto/Cargo.toml
@@ -30,6 +30,7 @@ tiny-keccak = { workspace = true, features = ["keccak"] }
 
 [features]
 libp2p-identity = ["dep:libp2p-identity", "dep:multihash"]
+monad_test = []
 rustls = ["dep:rcgen", "dep:rustls"]
 
 [[bench]]

--- a/monad-crypto/src/secp256k1.rs
+++ b/monad-crypto/src/secp256k1.rs
@@ -5,6 +5,7 @@ use crate::hasher::{Hashable, Hasher, HasherType};
 
 #[derive(Copy, Clone)]
 pub struct PubKey(secp256k1::PublicKey);
+#[cfg_attr(feature = "monad_test", derive(Clone))]
 pub struct KeyPair(secp256k1::KeyPair);
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SecpSignature(secp256k1::ecdsa::RecoverableSignature);

--- a/monad-executor-glue/Cargo.toml
+++ b/monad-executor-glue/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2021"
 [lib]
 bench = false
 
+[features]
+monad_test = []
+
 [dependencies]
 monad-consensus = { path = "../monad-consensus" }
 monad-consensus-types = { path = "../monad-consensus-types" }

--- a/monad-mock-swarm/Cargo.toml
+++ b/monad-mock-swarm/Cargo.toml
@@ -10,9 +10,13 @@ edition = "2021"
 [lib]
 bench = false
 
+[features]
+monad_test = ["monad-consensus/monad_test", "monad-executor-glue/monad_test", "monad-state/monad_test"]
+
 [dependencies]
 monad-block-sync = { path = "../monad-block-sync" }
 monad-consensus-state = { path = "../monad-consensus-state" }
+monad-consensus = { path = "../monad-consensus"}
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
 monad-eth-types = { path = "../monad-eth-types" }
@@ -33,12 +37,17 @@ tracing = { workspace = true }
 itertools = { workspace = true }
 
 [dev-dependencies]
-monad-consensus = { path = "../monad-consensus" }
+monad-crypto = { path = "../monad-crypto" }
+monad-block-sync = { path = "../monad-block-sync" }
+monad-consensus = { path = "../monad-consensus", features = [
+    "monad_test",
+] }
 monad-consensus-state = { path = "../monad-consensus-state", features = [
     "monad_test",
 ] }
 monad-executor = { path = "../monad-executor", features = ["monad_test"] }
 monad-gossip = { path = "../monad-gossip" }
+monad-mock-swarm = { path = ".", features = ["monad_test"] }
 monad-quic = { path = "../monad-quic" }
 monad-state = { path = "../monad-state", features = ["monad_test"] }
 monad-testutil = { path = "../monad-testutil" }

--- a/monad-mock-swarm/src/lib.rs
+++ b/monad-mock-swarm/src/lib.rs
@@ -2,3 +2,4 @@ pub mod mock;
 pub mod mock_swarm;
 pub mod swarm_relation;
 pub mod transformer;
+mod utils;

--- a/monad-mock-swarm/src/mock_swarm.rs
+++ b/monad-mock-swarm/src/mock_swarm.rs
@@ -239,6 +239,7 @@ where
     states: BTreeMap<ID, Node<S>>,
     tick: Duration,
     must_deliver: bool,
+    no_duplicate_peers: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -270,6 +271,7 @@ where
             states: BTreeMap::new(),
             tick: Duration::ZERO,
             must_deliver: true,
+            no_duplicate_peers: true,
         };
 
         for peer in peers {
@@ -281,6 +283,11 @@ where
 
     pub fn can_fail_deliver(mut self) -> Self {
         self.must_deliver = false;
+        self
+    }
+
+    pub fn can_have_duplicate_peer(mut self) -> Self {
+        self.no_duplicate_peers = false;
         self
     }
 
@@ -408,6 +415,8 @@ where
 
         // No duplicate ID insertion should be allowed
         assert!(!self.states.contains_key(&id));
+        // if nodes only want to run with unique ids
+        assert!(!self.no_duplicate_peers || id.is_unique());
 
         let mut executor: MockExecutor<S::STATE, S::RS, S::ME, S::ST, S::SCT> = MockExecutor::new(
             S::RS::new(router_scheduler_config),

--- a/monad-mock-swarm/src/utils.rs
+++ b/monad-mock-swarm/src/utils.rs
@@ -1,0 +1,161 @@
+// test utils for mock swarm unit test
+#[cfg(test)]
+pub mod test_tool {
+    use std::time::Duration;
+
+    use monad_consensus::{
+        messages::{
+            consensus_message::ConsensusMessage,
+            message::{
+                BlockSyncMessage, ProposalMessage, RequestBlockSyncMessage, TimeoutMessage,
+                VoteMessage,
+            },
+        },
+        validation::signing::Unverified,
+    };
+    use monad_consensus_types::{
+        block::Block,
+        certificate_signature::CertificateSignature,
+        ledger::LedgerCommitInfo,
+        multi_sig::MultiSig,
+        payload::{ExecutionArtifacts, Payload, RandaoReveal, TransactionList},
+        quorum_certificate::{QcInfo, QuorumCertificate},
+        timeout::{Timeout, TimeoutInfo},
+        voting::{Vote, VoteInfo},
+    };
+    use monad_crypto::{
+        hasher::{Hash, Sha256Hash},
+        secp256k1::KeyPair,
+        NopSignature,
+    };
+    use monad_eth_types::EthAddress;
+    use monad_executor_glue::PeerId;
+    use monad_state::MonadMessage;
+    use monad_testutil::signing::create_keys;
+    use monad_types::{BlockId, NodeId, Round};
+
+    use crate::transformer::{LinkMessage, ID};
+
+    type ST = NopSignature;
+    type SC = MultiSig<NopSignature>;
+    type H = Sha256Hash;
+    type QC = QuorumCertificate<SC>;
+
+    /// FIXME these should take in from/to/from_tick as params, not have defaults
+    pub fn get_mock_message() -> LinkMessage<String> {
+        let keys = create_keys(2);
+        LinkMessage {
+            from: ID::new(PeerId(keys[0].pubkey())),
+            to: ID::new(PeerId(keys[1].pubkey())),
+            message: "Dummy Message".to_string(),
+            from_tick: Duration::from_millis(10),
+        }
+    }
+
+    pub fn fake_node_id() -> NodeId {
+        let mut privkey: [u8; 32] = [127; 32];
+        let keypair = KeyPair::from_bytes(&mut privkey).unwrap();
+        NodeId(keypair.pubkey())
+    }
+
+    pub fn fake_qc() -> QuorumCertificate<SC> {
+        QC::new::<H>(
+            QcInfo {
+                vote: VoteInfo {
+                    id: BlockId(Hash([0x00_u8; 32])),
+                    round: Round(0),
+                    parent_id: BlockId(Hash([0x00_u8; 32])),
+                    parent_round: Round(0),
+                    seq_num: 0,
+                },
+                ledger_commit: LedgerCommitInfo::default(),
+            },
+            MultiSig { sigs: vec![] },
+        )
+    }
+
+    pub fn fake_block(round: Round) -> Block<SC> {
+        let payload = Payload {
+            txns: TransactionList::default(),
+            header: ExecutionArtifacts::zero(),
+            seq_num: 0,
+            beneficiary: EthAddress::default(),
+            randao_reveal: RandaoReveal::default(),
+        };
+
+        Block::new::<H>(fake_node_id(), round, &payload, &fake_qc())
+    }
+
+    pub fn fake_proposal_message(kp: &KeyPair, round: Round) -> MonadMessage<ST, SC> {
+        let internal_msg = ProposalMessage {
+            block: fake_block(round),
+            last_round_tc: None,
+        };
+        let msg = Unverified::new(
+            ConsensusMessage::Proposal(internal_msg),
+            NopSignature::sign(&[0x00_u8, 32], kp),
+        );
+        MonadMessage::<ST, SC>::new(msg)
+    }
+
+    pub fn fake_vote_message(kp: &KeyPair, round: Round) -> MonadMessage<ST, SC> {
+        let vote_info = VoteInfo {
+            id: BlockId(Hash([0x00_u8; 32])),
+            round,
+            parent_id: BlockId(Hash([0x00_u8; 32])),
+            parent_round: Round(0),
+            seq_num: 0,
+        };
+        let internal_msg = VoteMessage {
+            vote: Vote {
+                vote_info,
+                ledger_commit_info: LedgerCommitInfo::new::<H>(None, &vote_info),
+            },
+            sig: NopSignature::sign(&[0x00_u8, 32], kp),
+        };
+        let msg = Unverified::new(
+            ConsensusMessage::Vote(internal_msg),
+            NopSignature::sign(&[0x00_u8, 32], kp),
+        );
+        MonadMessage::<ST, SC>::new(msg)
+    }
+
+    pub fn fake_timeout_message(kp: &KeyPair) -> MonadMessage<ST, SC> {
+        let timeout_info = TimeoutInfo {
+            round: Round(0),
+            high_qc: fake_qc(),
+        };
+        let internal_msg = TimeoutMessage {
+            timeout: Timeout {
+                tminfo: timeout_info,
+                last_round_tc: None,
+            },
+            sig: NopSignature::sign(&[0x00_u8, 32], kp),
+        };
+        let msg = Unverified::new(
+            ConsensusMessage::Timeout(internal_msg),
+            NopSignature::sign(&[0x00_u8, 32], kp),
+        );
+        MonadMessage::<ST, SC>::new(msg)
+    }
+
+    pub fn fake_request_block_sync(kp: &KeyPair) -> MonadMessage<ST, SC> {
+        let internal_msg = RequestBlockSyncMessage {
+            block_id: BlockId(Hash([0x00_u8; 32])),
+        };
+        let msg = Unverified::new(
+            ConsensusMessage::RequestBlockSync(internal_msg),
+            NopSignature::sign(&[0x00_u8, 32], kp),
+        );
+        MonadMessage::<ST, SC>::new(msg)
+    }
+
+    pub fn fake_block_sync(kp: &KeyPair) -> MonadMessage<ST, SC> {
+        let internal_msg = BlockSyncMessage::NotAvailable(BlockId(Hash([0x00_u8; 32])));
+        let msg = Unverified::new(
+            ConsensusMessage::BlockSync(internal_msg),
+            NopSignature::sign(&[0x00_u8, 32], kp),
+        );
+        MonadMessage::<ST, SC>::new(msg)
+    }
+}

--- a/monad-p2p/Cargo.toml
+++ b/monad-p2p/Cargo.toml
@@ -18,5 +18,10 @@ async-trait = { workspace = true }
 futures = { workspace = true }
 libp2p = { workspace = true, features = ["macros", "mplex", "noise", "plaintext", "identify", "request-response", "secp256k1"] }
 
+[dev-dependencies]
+monad-executor-glue = { path = "../monad-executor-glue", features = ["monad_test"] }
+monad-p2p = { path = ".", features = ["monad_test"] }
+
 [features]
+monad_test = []
 tokio = ["libp2p/quic", "libp2p/tokio"]

--- a/monad-state/Cargo.toml
+++ b/monad-state/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 bench = false
 
 [features]
-monad_test = []
+monad_test = ["monad-consensus-state/monad_test", "monad-consensus-types/monad_test", "monad-crypto/monad_test"]
 
 [dependencies]
 monad-blocktree = { path = "../monad-blocktree" }


### PR DESCRIPTION
TwinsTransformer captures messages that target default PeerId and duplicate plus broadcast to the correct target(s).

The Vote & Proposal message gets filtered by Round, Timeout always gets broadcasted to everyone to ensure liveness, and all other form of messages that doesn't touch on the core of consensus protocol get drop by default.

TwinsTransformer comes with a specialized MonadMessagePipeline, only adding relevant transformer so far.

To help with spying on message internal, several associated module are granted the ability to spy and clone under test environment