### PR TITLE
Add NodesTerminator

### DIFF
--- a/monad-mock-swarm/benches/two_node_benchmark.rs
+++ b/monad-mock-swarm/benches/two_node_benchmark.rs
@@ -9,6 +9,7 @@ use monad_consensus_types::{
 use monad_crypto::NopSignature;
 use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock_swarm::UntilTerminator,
     transformer::{GenericTransformer, LatencyTransformer},
 };
 use monad_state::{MonadMessage, MonadState};
@@ -41,6 +42,7 @@ fn two_nodes() {
         _,
         MockValidator,
         MockMempool<_, _>,
+        _,
     >(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
@@ -51,12 +53,11 @@ fn two_nodes() {
         vec![GenericTransformer::Latency(LatencyTransformer(
             Duration::from_millis(1),
         ))],
+        UntilTerminator::new().until_tick(Duration::from_secs(10)),
         SwarmTestConfig {
             num_nodes: 2,
             consensus_delta: Duration::from_millis(2),
             parallelize: false,
-            until: Duration::from_secs(10),
-            until_block: usize::MAX,
             expected_block: 1024,
             state_root_delay: 4,
             seed: 1,

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -9,6 +9,7 @@ use monad_crypto::NopSignature;
 use monad_gossip::mock::{MockGossip, MockGossipConfig};
 use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock_swarm::UntilTerminator,
     transformer::{GenericTransformer, LatencyTransformer},
 };
 use monad_quic::{QuicRouterScheduler, QuicRouterSchedulerConfig};
@@ -38,6 +39,7 @@ fn many_nodes() {
         _,
         MockValidator,
         MockMempool<_, _>,
+        _,
     >(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
@@ -48,12 +50,11 @@ fn many_nodes() {
         vec![GenericTransformer::Latency(LatencyTransformer(
             Duration::from_millis(1),
         ))],
+        UntilTerminator::new().until_tick(Duration::from_secs(4)),
         SwarmTestConfig {
             num_nodes: 100,
             consensus_delta: Duration::from_millis(2),
             parallelize: true,
-            until: Duration::from_secs(4),
-            until_block: usize::MAX,
             expected_block: 1024,
             state_root_delay: 4,
             seed: 1,
@@ -82,6 +83,7 @@ fn many_nodes_quic() {
         _,
         MockValidator,
         MockMempool<_, _>,
+        _,
     >(
         MockValidator,
         |all_peers, me| QuicRouterSchedulerConfig {
@@ -96,12 +98,11 @@ fn many_nodes_quic() {
         vec![GenericTransformer::Latency::<Vec<u8>>(LatencyTransformer(
             Duration::from_millis(1),
         ))],
+        UntilTerminator::new().until_tick(Duration::from_secs(4)),
         SwarmTestConfig {
             num_nodes: 40,
             consensus_delta: Duration::from_millis(10),
             parallelize: true,
-            until: Duration::from_secs(4),
-            until_block: usize::MAX,
             expected_block: 10,
             state_root_delay: 4,
             seed: 1,

--- a/monad-mock-swarm/tests/many_nodes_metrics.rs
+++ b/monad-mock-swarm/tests/many_nodes_metrics.rs
@@ -8,6 +8,7 @@ use monad_consensus_types::{
 use monad_crypto::NopSignature;
 use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock_swarm::UntilTerminator,
     transformer::{GenericTransformer, LatencyTransformer},
 };
 use monad_state::{MonadMessage, MonadState};
@@ -53,6 +54,7 @@ fn many_nodes_metrics() {
         _,
         MockValidator,
         MockMempool<_, _>,
+        _,
     >(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
@@ -65,12 +67,11 @@ fn many_nodes_metrics() {
         >::Latency(LatencyTransformer(
             Duration::from_millis(1),
         ))],
+        UntilTerminator::new().until_tick(Duration::from_secs(4)),
         SwarmTestConfig {
             num_nodes: 100,
             consensus_delta: Duration::from_millis(2),
             parallelize: false,
-            until: Duration::from_secs(4),
-            until_block: usize::MAX,
             expected_block: 1024,
             state_root_delay: 4,
             seed: 1,

--- a/monad-mock-swarm/tests/msg_delays.rs
+++ b/monad-mock-swarm/tests/msg_delays.rs
@@ -8,6 +8,7 @@ use monad_consensus_types::{
 use monad_crypto::NopSignature;
 use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock_swarm::UntilTerminator,
     transformer::{GenericTransformer, XorLatencyTransformer},
 };
 use monad_state::{MonadMessage, MonadState};
@@ -36,6 +37,7 @@ fn two_nodes() {
         _,
         MockValidator,
         MockMempool<_, _>,
+        _,
     >(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
@@ -46,12 +48,11 @@ fn two_nodes() {
         vec![GenericTransformer::XorLatency(XorLatencyTransformer(
             Duration::from_millis(u8::MAX as u64),
         ))],
+        UntilTerminator::new().until_tick(Duration::from_secs(60)),
         SwarmTestConfig {
             num_nodes: 4,
             consensus_delta: Duration::from_millis(101),
             parallelize: false,
-            until: Duration::from_secs(60),
-            until_block: usize::MAX,
             expected_block: 40,
             state_root_delay: 4,
             seed: 1,

--- a/monad-mock-swarm/tests/order.rs
+++ b/monad-mock-swarm/tests/order.rs
@@ -9,6 +9,7 @@ use monad_crypto::NopSignature;
 use monad_executor_glue::PeerId;
 use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock_swarm::UntilTerminator,
     transformer::{
         GenericTransformer, LatencyTransformer, PartitionTransformer, ReplayTransformer,
         TransformerReplayOrder, ID,
@@ -83,6 +84,7 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
         _,
         MockValidator,
         MockMempool<_, _>,
+        _,
     >(
         pubkeys,
         state_configs,
@@ -100,8 +102,7 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
             )),
         ],
         false,
-        Duration::from_secs(1),
-        usize::MAX,
+        UntilTerminator::new().until_tick(Duration::from_secs(1)),
         20,
         1,
     );

--- a/monad-mock-swarm/tests/rand_lat.rs
+++ b/monad-mock-swarm/tests/rand_lat.rs
@@ -8,6 +8,7 @@ use monad_consensus_types::{
 use monad_crypto::NopSignature;
 use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock_swarm::UntilTerminator,
     transformer::GenericTransformer,
 };
 use monad_state::{MonadMessage, MonadState};
@@ -74,6 +75,7 @@ fn nodes_with_random_latency(seed: u64) {
         _,
         MockValidator,
         MockMempool<_, _>,
+        _,
     >(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
@@ -86,12 +88,11 @@ fn nodes_with_random_latency(seed: u64) {
         >::RandLatency(RandLatencyTransformer::new(
             seed, 330,
         ))],
+        UntilTerminator::new().until_tick(Duration::from_secs(60 * 60)),
         SwarmTestConfig {
             num_nodes: 4,
             consensus_delta: Duration::from_millis(250),
             parallelize: false,
-            until: Duration::from_secs(60 * 60),
-            until_block: usize::MAX,
             expected_block: 2048,
             // avoid state_root trigger in rand latency setting
             // TODO, cover cases with low state_root_delay once state_sync is done

--- a/monad-mock-swarm/tests/random_mempool.rs
+++ b/monad-mock-swarm/tests/random_mempool.rs
@@ -10,6 +10,7 @@ use monad_mock_swarm::{
     mock::{
         MockMempoolRandFail, MockMempoolRandFailConfig, NoSerRouterConfig, NoSerRouterScheduler,
     },
+    mock_swarm::UntilTerminator,
     transformer::{GenericTransformer, LatencyTransformer},
 };
 use monad_state::{MonadMessage, MonadState};
@@ -36,6 +37,7 @@ fn random_mempool_failures() {
         _,
         MockValidator,
         MockMempoolRandFail<_, _>,
+        _,
     >(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
@@ -49,12 +51,11 @@ fn random_mempool_failures() {
         vec![GenericTransformer::Latency(LatencyTransformer(
             Duration::from_millis(1),
         ))],
+        UntilTerminator::new().until_tick(Duration::from_secs(7)),
         SwarmTestConfig {
             num_nodes: 4,
             consensus_delta: Duration::from_millis(2),
             parallelize: false,
-            until: Duration::from_secs(7),
-            until_block: usize::MAX,
             expected_block: 1024,
             state_root_delay: 4,
             seed: 1,

--- a/monad-mock-swarm/tests/replay_test.rs
+++ b/monad-mock-swarm/tests/replay_test.rs
@@ -14,7 +14,7 @@ use monad_mock_swarm::{
         MockExecutor, MockMempool, MockMempoolConfig, MockableExecutor, NoSerRouterConfig,
         NoSerRouterScheduler, RouterScheduler,
     },
-    mock_swarm::{Node, Nodes},
+    mock_swarm::{Node, Nodes, UntilTerminator},
     transformer::{GenericTransformer, LatencyTransformer, Pipeline, ID},
 };
 use monad_state::{MonadMessage, MonadState};
@@ -72,8 +72,11 @@ where
     RS::Serialized: Send,
 {
     let mut max_tick = start_tick;
+    let terminator = UntilTerminator::new()
+        .until_tick(until_tick)
+        .until_block(until_block);
 
-    while let Some((tick, _, _)) = nodes.step_until(until_tick, until_block) {
+    while let Some(tick) = nodes.step_until(&terminator) {
         assert!(tick >= max_tick);
         max_tick = tick;
     }

--- a/monad-mock-swarm/tests/single_node.rs
+++ b/monad-mock-swarm/tests/single_node.rs
@@ -9,6 +9,7 @@ use monad_crypto::NopSignature;
 use monad_gossip::mock::{MockGossip, MockGossipConfig};
 use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock_swarm::UntilTerminator,
     transformer::{GenericTransformer, LatencyTransformer},
 };
 use monad_quic::{QuicRouterScheduler, QuicRouterSchedulerConfig};
@@ -38,6 +39,7 @@ fn two_nodes() {
         _,
         MockValidator,
         MockMempool<_, _>,
+        _,
     >(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
@@ -48,12 +50,11 @@ fn two_nodes() {
         vec![GenericTransformer::Latency::<
             MonadMessage<NopSignature, MultiSig<NopSignature>>,
         >(LatencyTransformer(Duration::from_millis(1)))],
+        UntilTerminator::new().until_tick(Duration::from_secs(10)),
         SwarmTestConfig {
             num_nodes: 2,
             consensus_delta: Duration::from_millis(2),
             parallelize: false,
-            until: Duration::from_secs(10),
-            until_block: usize::MAX,
             expected_block: 1024,
             state_root_delay: 4,
             seed: 1,
@@ -82,6 +83,7 @@ fn two_nodes_quic() {
         _,
         MockValidator,
         MockMempool<_, _>,
+        _,
     >(
         MockValidator,
         |all_peers, me| QuicRouterSchedulerConfig {
@@ -96,12 +98,11 @@ fn two_nodes_quic() {
         vec![GenericTransformer::Latency::<Vec<u8>>(LatencyTransformer(
             Duration::from_millis(1),
         ))],
+        UntilTerminator::new().until_tick(Duration::from_secs(10)),
         SwarmTestConfig {
             num_nodes: 2,
             consensus_delta: Duration::from_millis(10),
             parallelize: false,
-            until: Duration::from_secs(10),
-            until_block: usize::MAX,
             expected_block: 256,
             state_root_delay: 4,
             seed: 1,

--- a/monad-mock-swarm/tests/single_node_metrics.rs
+++ b/monad-mock-swarm/tests/single_node_metrics.rs
@@ -8,6 +8,7 @@ use monad_consensus_types::{
 use monad_crypto::NopSignature;
 use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock_swarm::UntilTerminator,
     transformer::{GenericTransformer, LatencyTransformer},
 };
 use monad_state::{MonadMessage, MonadState};
@@ -53,6 +54,7 @@ fn two_nodes() {
         _,
         MockValidator,
         MockMempool<_, _>,
+        _,
     >(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
@@ -63,12 +65,11 @@ fn two_nodes() {
         vec![GenericTransformer::Latency(LatencyTransformer(
             Duration::from_millis(1),
         ))],
+        UntilTerminator::new().until_tick(Duration::from_secs(10)),
         SwarmTestConfig {
             num_nodes: 2,
             consensus_delta: Duration::from_millis(2),
             parallelize: false,
-            until: Duration::from_secs(10),
-            until_block: usize::MAX,
             expected_block: 1024,
             state_root_delay: 4,
             seed: 1,

--- a/monad-mock-swarm/tests/two_nodes_bls.rs
+++ b/monad-mock-swarm/tests/two_nodes_bls.rs
@@ -8,6 +8,7 @@ use monad_consensus_types::{
 use monad_crypto::secp256k1::SecpSignature;
 use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock_swarm::UntilTerminator,
     transformer::{GenericTransformer, LatencyTransformer},
 };
 use monad_state::{MonadMessage, MonadState};
@@ -39,6 +40,7 @@ fn two_nodes_bls() {
         _,
         MockValidator,
         MockMempool<_, _>,
+        _,
     >(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
@@ -49,12 +51,11 @@ fn two_nodes_bls() {
         vec![GenericTransformer::Latency::<
             MonadMessage<SignatureType, SignatureCollectionType>,
         >(LatencyTransformer(Duration::from_millis(1)))],
+        UntilTerminator::new().until_tick(Duration::from_secs(10)),
         SwarmTestConfig {
             num_nodes: 2,
             consensus_delta: Duration::from_millis(2),
             parallelize: false,
-            until: Duration::from_secs(10),
-            until_block: usize::MAX,
             expected_block: 128,
             state_root_delay: 4,
             seed: 1,

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -9,6 +9,7 @@ use monad_crypto::NopSignature;
 use monad_executor_glue::PeerId;
 use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock_swarm::UntilTerminator,
     transformer::{
         GenericTransformer, LatencyTransformer, PartitionTransformer, RandLatencyTransformer,
         ReplayTransformer, TransformerReplayOrder, ID,
@@ -39,6 +40,7 @@ fn random_latency_test(seed: u64) {
         _,
         MockValidator,
         MockMempool<_, _>,
+        _,
     >(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
@@ -49,12 +51,11 @@ fn random_latency_test(seed: u64) {
         vec![GenericTransformer::RandLatency(
             RandLatencyTransformer::new(seed, 330),
         )],
+        UntilTerminator::new().until_tick(Duration::from_secs(10)),
         SwarmTestConfig {
             num_nodes: 4,
             consensus_delta: Duration::from_millis(250),
             parallelize: false,
-            until: Duration::from_secs(10),
-            until_block: usize::MAX,
             expected_block: 2048,
             state_root_delay: 4,
             seed: 1,
@@ -94,6 +95,7 @@ fn delayed_message_test(seed: u64) {
         _,
         MockValidator,
         MockMempool<_, _>,
+        _,
     >(
         pubkeys,
         state_configs,
@@ -111,8 +113,7 @@ fn delayed_message_test(seed: u64) {
             )),
         ],
         false,
-        Duration::from_secs(2),
-        usize::MAX,
+        UntilTerminator::new().until_tick(Duration::from_secs(2)),
         20,
         1,
     );

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -12,7 +12,7 @@ use monad_executor::{timed_event::TimedEvent, State};
 use monad_executor_glue::{MonadEvent, PeerId};
 use monad_mock_swarm::{
     mock::{MockExecutor, MockableExecutor, RouterScheduler},
-    mock_swarm::{Node, Nodes},
+    mock_swarm::{Node, Nodes, NodesTerminator},
     transformer::{Pipeline, ID},
 };
 use monad_state::MonadConfig;
@@ -26,8 +26,6 @@ pub struct SwarmTestConfig {
     pub consensus_delta: Duration,
 
     pub parallelize: bool,
-    pub until: Duration,
-    pub until_block: usize,
     pub expected_block: usize,
     pub state_root_delay: u64,
     pub seed: u64,
@@ -104,12 +102,13 @@ pub fn node_ledger_verification<O: BlockType + PartialEq>(
     }
 }
 
-pub fn create_and_run_nodes<S, ST, SCT, RS, RSC, LGR, P, TVT, ME>(
+pub fn create_and_run_nodes<S, ST, SCT, RS, RSC, LGR, P, TVT, ME, TERM>(
     tvt: TVT,
     router_scheduler_config: RSC,
     logger_config: LGR::Config,
     mock_mempool_config: ME::Config,
     pipeline: P,
+    terminator: TERM,
     swarm_config: SwarmTestConfig,
 ) -> Duration
 where
@@ -139,6 +138,7 @@ where
 
     LGR::Config: Clone,
     TVT: TransactionValidator,
+    TERM: NodesTerminator<S, RS, P, LGR, ME, ST, SCT>,
 {
     let (peers, state_configs) = get_configs::<ST, SCT, TVT>(
         tvt,
@@ -146,7 +146,7 @@ where
         swarm_config.consensus_delta,
         swarm_config.state_root_delay,
     );
-    run_nodes_until::<S, ST, SCT, RS, RSC, LGR, P, TVT, ME>(
+    run_nodes_until::<_, _, _, _, _, _, _, _, _, _>(
         peers,
         state_configs,
         router_scheduler_config,
@@ -154,14 +154,13 @@ where
         mock_mempool_config,
         pipeline,
         swarm_config.parallelize,
-        swarm_config.until,
-        swarm_config.until_block,
+        terminator,
         swarm_config.expected_block,
         swarm_config.seed,
     )
 }
 
-pub fn run_nodes_until<S, ST, SCT, RS, RSC, LGR, P, TVT, ME>(
+pub fn run_nodes_until<S, ST, SCT, RS, RSC, LGR, P, TVT, ME, TERM>(
     pubkeys: Vec<PubKey>,
     state_configs: Vec<MonadConfig<SCT, TVT>>,
     router_scheduler_config: RSC,
@@ -170,8 +169,7 @@ pub fn run_nodes_until<S, ST, SCT, RS, RSC, LGR, P, TVT, ME>(
     pipeline: P,
     parallelize: bool,
 
-    until: Duration,
-    until_block: usize,
+    terminator: TERM,
     min_ledger_len: usize,
     seed: u64,
 ) -> Duration
@@ -202,6 +200,7 @@ where
 
     LGR::Config: Clone,
     TVT: Clone,
+    TERM: NodesTerminator<S, RS, P, LGR, ME, ST, SCT>,
 {
     let mut nodes = Nodes::<S, RS, P, LGR, ME, ST, SCT>::new(
         pubkeys
@@ -227,9 +226,11 @@ where
 
     let mut max_tick = Duration::from_nanos(0);
     if parallelize {
-        max_tick = nodes.batch_step_until(until, until_block);
+        if let Some(tick) = nodes.batch_step_until(&terminator) {
+            max_tick = tick;
+        }
     } else {
-        while let Some((tick, _, _)) = nodes.step_until(until, until_block) {
+        while let Some(tick) = nodes.step_until(&terminator) {
             assert!(tick >= max_tick);
             max_tick = tick;
         }

--- a/monad-virtual-bench/benches/two_node_bench.rs
+++ b/monad-virtual-bench/benches/two_node_bench.rs
@@ -8,6 +8,7 @@ use monad_consensus_types::{
 use monad_crypto::NopSignature;
 use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock_swarm::UntilTerminator,
     transformer::{GenericTransformer, LatencyTransformer},
 };
 use monad_state::{MonadMessage, MonadState};
@@ -33,6 +34,7 @@ fn two_nodes_virtual() -> u128 {
         _,
         MockValidator,
         MockMempool<_, _>,
+        _,
     >(
         MockValidator,
         |all_peers, _| NoSerRouterConfig {
@@ -43,12 +45,11 @@ fn two_nodes_virtual() -> u128 {
         vec![GenericTransformer::Latency(LatencyTransformer(
             Duration::from_millis(1),
         ))],
+        UntilTerminator::new().until_tick(Duration::from_secs(10)),
         SwarmTestConfig {
             num_nodes: 2,
             consensus_delta: Duration::from_millis(2),
             parallelize: false,
-            until: Duration::from_secs(10),
-            until_block: 1024,
             expected_block: 1024,
             state_root_delay: 4,
             seed: 1,

--- a/monad-viz/src/graph.rs
+++ b/monad-viz/src/graph.rs
@@ -8,7 +8,7 @@ use monad_executor::timed_event::TimedEvent;
 use monad_executor_glue::{Identifiable, MonadEvent, PeerId};
 use monad_mock_swarm::{
     mock::{MockExecutor, MockableExecutor, RouterScheduler},
-    mock_swarm::{Node, Nodes},
+    mock_swarm::{Node, Nodes, UntilTerminator},
     transformer::{Pipeline, ID},
 };
 use monad_types::{Deserializable, Serializable};
@@ -200,7 +200,9 @@ where
             self.reset();
         }
         assert!(tick >= self.current_tick);
-        while self.nodes.step_until(tick, usize::MAX).is_some() {}
+        let term = UntilTerminator::new().until_tick(tick);
+
+        while self.nodes.step_until(&term).is_some() {}
         self.current_tick = tick;
     }
 }


### PR DESCRIPTION
Nodes used to terminate on simple condition such until (tick) and until_block (which terminates when any block reaches long enough ledger)

NodesTerminator provides a way for caller of Nodes to terminate on more complex condition, as well as combining assertion and checks within the same terminator as needed.

This change helps Twins to terminate on more precise state.

There are also some minor change to block_sync integration tests to avoid trigger state sync