### PR TITLE
Added test feature to check round of State

### DIFF
--- a/monad-executor/src/lib.rs
+++ b/monad-executor/src/lib.rs
@@ -3,7 +3,8 @@ pub mod timed_event;
 
 use monad_consensus_types::block::BlockType;
 use monad_executor_glue::{Command, Message};
-
+#[cfg(feature = "monad_test")]
+use monad_types::Round;
 pub trait Executor {
     type Command;
     fn exec(&mut self, commands: Vec<Self::Command>);
@@ -48,4 +49,6 @@ pub trait State: Sized {
     >;
     #[cfg(feature = "monad_test")]
     fn consensus(&self) -> &Self::ConsensusState;
+    #[cfg(feature = "monad_test")]
+    fn round(&self) -> Round;
 }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -34,6 +34,8 @@ use monad_executor_glue::{
     LedgerCommand, MempoolCommand, Message, MonadEvent, PeerId, RouterCommand, RouterTarget,
     StateRootHashCommand, TimerCommand,
 };
+#[cfg(feature = "monad_test")]
+use monad_types::Round;
 use monad_types::{Epoch, NodeId, Stake, ValidatorData};
 use monad_validator::{leader_election::LeaderElection, validator_set::ValidatorSetType};
 use ref_cast::RefCast;
@@ -574,5 +576,10 @@ where
     #[cfg(feature = "monad_test")]
     fn consensus(&self) -> &Self::ConsensusState {
         &self.consensus
+    }
+
+    #[cfg(feature = "monad_test")]
+    fn round(&self) -> Round {
+        self.consensus.get_current_round()
     }
 }

--- a/monad-wal/tests/replay.rs
+++ b/monad-wal/tests/replay.rs
@@ -5,12 +5,13 @@ mod test {
     use monad_executor::State;
     use monad_executor_glue::{Identifiable, Message};
     use monad_testutil::block::MockBlock;
+    #[cfg(feature = "monad_test")]
+    use monad_types::Round;
     use monad_types::{Deserializable, Serializable};
     use monad_wal::{
         wal::{WALogger, WALoggerConfig},
         PersistenceLogger,
     };
-
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct TestEvent {
         data: i32,
@@ -120,6 +121,11 @@ mod test {
         #[cfg(feature = "monad_test")]
         fn consensus(&self) -> &Self::ConsensusState {
             unimplemented!()
+        }
+
+        #[cfg(feature = "monad_test")]
+        fn round(&self) -> Round {
+            Round(0)
         }
     }
 


### PR DESCRIPTION
Allow twins testing to inspect the internal of consensus's current round without mass refactoring