### PR TITLE
Extract monad_test related features

### DIFF
--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -33,8 +33,8 @@ impl std::error::Error for BlockTreeError {
     }
 }
 
-#[derive(Debug, Clone)]
 #[cfg_attr(feature = "monad_test", derive(PartialEq, Eq))]
+#[derive(Debug, Clone)]
 pub struct BlockTreeBlock<T> {
     block: FullBlock<T>,
     parent: Option<BlockId>,

--- a/monad-consensus-state/src/blocksync.rs
+++ b/monad-consensus-state/src/blocksync.rs
@@ -17,8 +17,8 @@ use crate::command::ConsensusCommand;
 
 const DEFAULT_PEER_INDEX: usize = 0;
 
-#[derive(Debug, Clone)]
 #[cfg_attr(feature = "monad_test", derive(PartialEq, Eq))]
+#[derive(Debug, Clone)]
 pub struct InFlightBlockSync<SCT> {
     pub req_target: NodeId,
     pub retry_cnt: usize,
@@ -68,9 +68,8 @@ impl<SCT: SignatureCollection> InFlightBlockSync<SCT> {
         }
     }
 }
-
-#[derive(Debug, Clone)]
 #[cfg_attr(feature = "monad_test", derive(PartialEq, Eq))]
+#[derive(Debug, Clone)]
 pub struct BlockSyncManager<SCT> {
     requests: HashMap<BlockId, InFlightBlockSync<SCT>>,
     id: NodeId,

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -62,45 +62,6 @@ pub struct ConsensusState<SCT: SignatureCollection, TV, SVT> {
     beneficiary: EthAddress,
 }
 
-#[cfg(feature = "monad_test")]
-impl<SCT, TVT, SVT> PartialEq for ConsensusState<SCT, TVT, SVT>
-where
-    SCT: SignatureCollection,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.pending_block_tree.eq(&other.pending_block_tree)
-            && self.vote_state.eq(&other.vote_state)
-            && self.high_qc.eq(&other.high_qc)
-            && self.pacemaker.eq(&other.pacemaker)
-            && self.safety.eq(&other.safety)
-            && self.nodeid.eq(&other.nodeid)
-            && self.config.eq(&other.config)
-            && self.block_sync_manager.eq(&other.block_sync_manager)
-    }
-}
-
-#[cfg(feature = "monad_test")]
-impl<SCT, TVT, SVT> std::fmt::Debug for ConsensusState<SCT, TVT, SVT>
-where
-    SCT: SignatureCollection,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ConsensusState")
-            .field("pending_block_tree", &self.pending_block_tree)
-            .field("vote_state", &self.vote_state)
-            .field("high_qc", &self.high_qc)
-            .field("pacemaker", &self.pacemaker)
-            .field("safety", &self.safety)
-            .field("nodeid", &self.nodeid)
-            .field("config", &self.config)
-            .field("block_sync_manager", &self.block_sync_manager)
-            .finish()
-    }
-}
-
-#[cfg(feature = "monad_test")]
-impl<SCT, TVT, SVT> Eq for ConsensusState<SCT, TVT, SVT> where SCT: SignatureCollection {}
-
 #[cfg_attr(feature = "monad_test", derive(PartialEq, Eq))]
 #[derive(Debug)]
 pub struct ConsensusConfig {
@@ -783,6 +744,47 @@ pub enum ConsensusAction {
     Propose(Hash, Vec<TransactionList>),
     ProposeEmpty,
     Abstain,
+}
+#[cfg(feature = "monad_test")]
+mod monad_test {
+    use monad_consensus_types::signature_collection::SignatureCollection;
+
+    use crate::ConsensusState;
+
+    impl<SCT, TVT, SVT> PartialEq for ConsensusState<SCT, TVT, SVT>
+    where
+        SCT: SignatureCollection,
+    {
+        fn eq(&self, other: &Self) -> bool {
+            self.pending_block_tree.eq(&other.pending_block_tree)
+                && self.vote_state.eq(&other.vote_state)
+                && self.high_qc.eq(&other.high_qc)
+                && self.pacemaker.eq(&other.pacemaker)
+                && self.safety.eq(&other.safety)
+                && self.nodeid.eq(&other.nodeid)
+                && self.config.eq(&other.config)
+                && self.block_sync_manager.eq(&other.block_sync_manager)
+        }
+    }
+    impl<SCT, TVT, SVT> std::fmt::Debug for ConsensusState<SCT, TVT, SVT>
+    where
+        SCT: SignatureCollection,
+    {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("ConsensusState")
+                .field("pending_block_tree", &self.pending_block_tree)
+                .field("vote_state", &self.vote_state)
+                .field("high_qc", &self.high_qc)
+                .field("pacemaker", &self.pacemaker)
+                .field("safety", &self.safety)
+                .field("nodeid", &self.nodeid)
+                .field("config", &self.config)
+                .field("block_sync_manager", &self.block_sync_manager)
+                .finish()
+        }
+    }
+
+    impl<SCT, TVT, SVT> Eq for ConsensusState<SCT, TVT, SVT> where SCT: SignatureCollection {}
 }
 
 #[cfg(test)]

--- a/monad-consensus/src/pacemaker.rs
+++ b/monad-consensus/src/pacemaker.rs
@@ -17,8 +17,8 @@ use crate::{
     validation::{message::well_formed, safety::Safety},
 };
 
-#[derive(Debug)]
 #[cfg_attr(feature = "monad_test", derive(PartialEq, Eq))]
+#[derive(Debug)]
 pub struct Pacemaker<SCT: SignatureCollection> {
     delta: Duration,
 

--- a/monad-consensus/src/validation/safety.rs
+++ b/monad-consensus/src/validation/safety.rs
@@ -11,8 +11,8 @@ use monad_consensus_types::{
 use monad_crypto::hasher::Hasher;
 use monad_types::*;
 
-#[derive(Debug)]
 #[cfg_attr(feature = "monad_test", derive(PartialEq, Eq))]
+#[derive(Debug)]
 pub struct Safety {
     highest_vote_round: Round,
     highest_qc_round: Round,

--- a/monad-consensus/src/vote_state.rs
+++ b/monad-consensus/src/vote_state.rs
@@ -16,8 +16,8 @@ use crate::messages::message::VoteMessage;
 // accumulate votes and create a QC if enough votes are received
 // only one QC should be created in a round using the first supermajority of votes received
 // At the end of a round, older rounds can be cleaned up
-#[derive(Debug)]
 #[cfg_attr(feature = "monad_test", derive(PartialEq, Eq))]
+#[derive(Debug)]
 pub struct VoteState<SCT: SignatureCollection> {
     pending_votes:
         BTreeMap<Round, HashMap<Hash, (Vec<(NodeId, SCT::SignatureType)>, HashSet<NodeId>)>>,

--- a/monad-executor/src/lib.rs
+++ b/monad-executor/src/lib.rs
@@ -17,8 +17,6 @@ pub trait State: Sized {
     type Block: BlockType;
     type Checkpoint;
     type SignatureCollection;
-    #[cfg(feature = "monad_test")]
-    type ConsensusState: PartialEq + Eq;
 
     fn init(
         config: Self::Config,
@@ -46,6 +44,4 @@ pub trait State: Sized {
             Self::SignatureCollection,
         >,
     >;
-    #[cfg(feature = "monad_test")]
-    fn consensus(&self) -> &Self::ConsensusState;
 }

--- a/monad-wal/tests/replay.rs
+++ b/monad-wal/tests/replay.rs
@@ -81,8 +81,6 @@ mod test {
         type Block = MockBlock;
         type Checkpoint = ();
         type SignatureCollection = ();
-        #[cfg(feature = "monad_test")]
-        type ConsensusState = ();
 
         fn init(
             _config: Self::Config,
@@ -116,10 +114,6 @@ mod test {
         > {
             self.events.push(event);
             Vec::new()
-        }
-        #[cfg(feature = "monad_test")]
-        fn consensus(&self) -> &Self::ConsensusState {
-            unimplemented!()
         }
     }
 


### PR DESCRIPTION
Allow monad_test to be abstracted to a mod and add impl as needed, thus making the code base more readable.

Also ordered the derive vs test_derive to be the same across