### PR TITLE
Add Twins Test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4810,6 +4810,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-twins"
+version = "0.1.0"
+dependencies = [
+ "monad-block-sync",
+ "monad-consensus",
+ "monad-consensus-state",
+ "monad-consensus-types",
+ "monad-crypto",
+ "monad-executor",
+ "monad-executor-glue",
+ "monad-mock-swarm",
+ "monad-state",
+ "monad-testutil",
+ "monad-twins-utils",
+ "monad-types",
+ "monad-validator",
+ "monad-wal",
+ "serde",
+ "serde_json",
+ "test-case",
+]
+
+[[package]]
+name = "monad-twins-utils"
+version = "0.1.0"
+dependencies = [
+ "itertools",
+ "monad-consensus-types",
+ "monad-executor-glue",
+ "monad-mock-swarm",
+ "monad-state",
+ "monad-testutil",
+ "monad-types",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "monad-types"
 version = "0.1.0"
 dependencies = [
@@ -7191,6 +7231,7 @@ version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
+ "indexmap 2.0.2",
  "itoa",
  "ryu",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "monad-testground",
     "monad-testutil",
     "monad-tracing-counter",
+    "monad-twins",
     "monad-types",
     "monad-updaters",
     "monad-validator",

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -612,7 +612,7 @@ mod monad_test {
         SCT: SignatureCollection,
         TVT: TransactionValidator,
     {
-        fn dup(&self, secret: [u8; 32]) -> Self {
+        pub fn dup(&self, secret: [u8; 32]) -> Self {
             Self {
                 transaction_validator: self.transaction_validator.clone(),
                 validators: self.validators.clone(),

--- a/monad-testutil/src/signing.rs
+++ b/monad-testutil/src/signing.rs
@@ -149,6 +149,10 @@ pub fn create_certificate_keys<SCT: SignatureCollection>(
     res
 }
 
+pub fn create_seed_for_certificate_keys<SCT: SignatureCollection>(num_keys: u32) -> Vec<u64> {
+    (0..num_keys).map(|i| i as u64 + u32::MAX as u64).collect()
+}
+
 pub fn get_genesis_config<'k, H, SCT, TVT>(
     keys: impl Iterator<Item = &'k (NodeId, &'k SignatureCollectionKeyPairType<SCT>)>,
     validator_mapping: &ValidatorMapping<SignatureCollectionKeyPairType<SCT>>,
@@ -221,4 +225,10 @@ pub fn get_certificate_key<SCT: SignatureCollection>(
     hasher.update(seed.to_le_bytes());
     let mut hash = hasher.hash();
     <SignatureCollectionKeyPairType<SCT> as CertificateKeyPair>::from_bytes(&mut hash.0).unwrap()
+}
+
+pub fn get_certificate_key_secret(seed: u64) -> [u8; 32] {
+    let mut hasher = HasherType::new();
+    hasher.update(seed.to_le_bytes());
+    hasher.hash().0
 }

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -2,8 +2,12 @@ use std::time::Duration;
 
 use monad_consensus_state::ConsensusConfig;
 use monad_consensus_types::{
-    block::BlockType, message_signature::MessageSignature, quorum_certificate::genesis_vote_info,
-    signature_collection::SignatureCollection, transaction_validator::TransactionValidator,
+    block::BlockType,
+    message_signature::MessageSignature,
+    quorum_certificate::genesis_vote_info,
+    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
+    transaction_validator::TransactionValidator,
+    voting::ValidatorMapping,
 };
 use monad_crypto::{
     hasher::HasherType,
@@ -41,6 +45,28 @@ pub fn get_configs<ST: MessageSignature, SCT: SignatureCollection, TVT: Transact
 ) -> (Vec<PubKey>, Vec<MonadConfig<SCT, TVT>>) {
     let (keys, cert_keys, _validators, validator_mapping) =
         create_keys_w_validators::<SCT>(num_nodes as u32);
+    complete_config::<ST, SCT, TVT>(
+        tvt,
+        keys,
+        cert_keys,
+        validator_mapping,
+        delta,
+        state_root_delay,
+    )
+}
+
+pub fn complete_config<
+    ST: MessageSignature,
+    SCT: SignatureCollection,
+    TVT: TransactionValidator,
+>(
+    tvt: TVT,
+    keys: Vec<KeyPair>,
+    cert_keys: Vec<SignatureCollectionKeyPairType<SCT>>,
+    validator_mapping: ValidatorMapping<SignatureCollectionKeyPairType<SCT>>,
+    delta: Duration,
+    state_root_delay: u64,
+) -> (Vec<PubKey>, Vec<MonadConfig<SCT, TVT>>) {
     let pubkeys = keys.iter().map(KeyPair::pubkey).collect::<Vec<_>>();
     let voting_keys = keys
         .iter()

--- a/monad-testutil/src/validators.rs
+++ b/monad-testutil/src/validators.rs
@@ -19,7 +19,18 @@ pub fn create_keys_w_validators<SCT: SignatureCollection>(
 ) {
     let keys = create_keys(num_nodes);
     let certificate_keys = create_certificate_keys::<SCT>(num_nodes);
+    let (validators, validator_mapping) =
+        complete_keys_w_validators::<SCT>(&keys, &certificate_keys);
+    (keys, certificate_keys, validators, validator_mapping)
+}
 
+pub fn complete_keys_w_validators<SCT: SignatureCollection>(
+    keys: &[KeyPair],
+    certificate_keys: &[SignatureCollectionKeyPairType<SCT>],
+) -> (
+    ValidatorSet,
+    ValidatorMapping<SignatureCollectionKeyPairType<SCT>>,
+) {
     let staking_list = keys
         .iter()
         .map(|k| NodeId(k.pubkey()))
@@ -35,5 +46,5 @@ pub fn create_keys_w_validators<SCT: SignatureCollection>(
     let validators = ValidatorSet::new(staking_list).expect("create validator set");
     let validator_mapping = ValidatorMapping::new(voting_identity);
 
-    (keys, certificate_keys, validators, validator_mapping)
+    (validators, validator_mapping)
 }

--- a/monad-twins/Cargo.toml
+++ b/monad-twins/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "monad-twins"
+version = "0.1.0"
+edition = "2021"
+
+# this is necessary for criterion bench options
+# https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+[lib]
+bench = false
+
+[dev-dependencies]
+monad-block-sync = { path = "../monad-block-sync" }
+monad-consensus = { path = "../monad-consensus", features = ["monad_test"] }
+monad-consensus-state = { path = "../monad-consensus-state", features = ["monad_test"] }
+monad-consensus-types = { path = "../monad-consensus-types" }
+monad-crypto = { path = "../monad-crypto" }
+monad-executor = { path = "../monad-executor", features = ["monad_test"] }
+monad-executor-glue = { path = "../monad-executor-glue", features = ["monad_test"] }
+monad-mock-swarm = { path = "../monad-mock-swarm" }
+monad-state = { path = "../monad-state", features = ["monad_test"]}
+monad-testutil = { path = "../monad-testutil" }
+monad-twins-utils = { path = "utils" }
+monad-types = { path = "../monad-types" }
+monad-validator = { path = "../monad-validator" }
+monad-wal = { path = "../monad-wal" }
+
+serde = {version = "1.0.130", features= ["derive"] }
+serde_json = {version = "1.0.68", features= ["preserve_order"] }
+test-case = { workspace = true }

--- a/monad-twins/README.md
+++ b/monad-twins/README.md
@@ -1,0 +1,6 @@
+
+# TWIN BFT
+
+## design doc
+
+<https://www.notion.so/monad-labs/Twins-BFT-Ver-0-31114885799945e68f87af6b70c48ef0?pvs=4>

--- a/monad-twins/src/lib.rs
+++ b/monad-twins/src/lib.rs
@@ -1,0 +1,1 @@
+// empty on purpose, none of the twin testing module should be used by any other module

--- a/monad-twins/tests/happy_path.json
+++ b/monad-twins/tests/happy_path.json
@@ -1,0 +1,24 @@
+{
+    "description": "happy_path, no twins just 4 nodes, all connected",
+    "nodes": ["Alice", "Bob", "Carol", "David"],    
+    "twins": [],
+    "expected_block_default": 7,
+    "round": 10,
+    "liveness": 30,
+    "timeout_ms": 1000,
+    "delta_ms": 10,
+    "allow_block_sync": false,
+    "partition": [
+        [["Alice", "Bob", "Carol", "David"]],
+        [["Alice", "Bob", "Carol", "David"]],
+        [["Alice", "Bob", "Carol", "David"]],
+        [["Alice", "Bob", "Carol", "David"]],
+        [["Alice", "Bob", "Carol", "David"]],
+        [["Alice", "Bob", "Carol", "David"]],
+        [["Alice", "Bob", "Carol", "David"]],
+        [["Alice", "Bob", "Carol", "David"]],
+        [["Alice", "Bob", "Carol", "David"]],
+        [["Alice", "Bob", "Carol", "David"]]
+    ],
+    "default_partition": [["Alice"], ["Bob"], ["Carol"], ["David"]]
+}

--- a/monad-twins/tests/make_progress.json
+++ b/monad-twins/tests/make_progress.json
@@ -1,0 +1,16 @@
+{
+    "description": "no twins, david is never connected to the rest, but rest should make progress",
+    "nodes": ["Alice", "Bob", "Carol", "David"],    
+    "twins": [],
+    "liveness": 30,
+    "expected_block_default": 10,
+    "expected_block": {
+        "David": 0
+    },
+    "round": 10,
+    "timeout_ms": 2000,
+    "delta_ms": 10,
+    "partition": [
+    ],
+    "default_partition": [["Alice", "Bob", "Carol"], ["David"]]
+}

--- a/monad-twins/tests/mal_formed.json
+++ b/monad-twins/tests/mal_formed.json
@@ -1,0 +1,15 @@
+{
+    "description": "malformed json",
+    "nodes": ["Alice", "Bob", "Carol", "David"],    
+    "twins": [],
+    "expected_block_default": 10,
+    "round": 10,
+    "timeout_ms": 1000,
+    "delta_ms": 10,
+    "partition": [
+        [["Alice", "Bob", "Carol", "David"]],
+        [["Alice", "Bob", "Carol"]],
+        [["Alice", "Bob", "Carol", "David"]]
+    ],
+    "default_partition": [["Alice"], ["Bob"], ["Carol"], ["David"]]
+}

--- a/monad-twins/tests/one_twin.json
+++ b/monad-twins/tests/one_twin.json
@@ -1,0 +1,23 @@
+{
+    "description": "a simple test, 3 honest node and 1 node with a twin",
+    "nodes": ["Alice", "Bob", "Carol", "David"],
+    "twins": ["Alice_twin"],
+    "expected_block_default": 10,
+    "round": 10,
+    "timeout_ms": 300000,
+    "delta_ms": 100,
+    "allow_block_sync": true,
+    "partition": [
+        [["Alice", "Bob", "Carol", "David", "Alice_twin"]],
+        [["Alice", "Bob", "Carol", "David", "Alice_twin"]],
+        [["Alice", "Bob", "Carol", "David", "Alice_twin"]],
+        [["Alice", "Bob", "Carol", "David", "Alice_twin"]],
+        [["Alice", "Bob", "Carol", "David", "Alice_twin"]],
+        [["Alice", "Bob", "Carol", "David", "Alice_twin"]],
+        [["Alice", "Bob", "Carol", "David", "Alice_twin"]],
+        [["Alice", "Bob", "Carol", "David", "Alice_twin"]],
+        [["Alice", "Bob", "Carol", "David", "Alice_twin"]],
+        [["Alice", "Bob", "Carol", "David", "Alice_twin"]]
+    ],
+    "default_partition": [["Alice", "Bob", "Carol", "David", "Alice_twin"]]
+}

--- a/monad-twins/tests/one_twin_partition.json
+++ b/monad-twins/tests/one_twin_partition.json
@@ -1,0 +1,37 @@
+{
+    "description": "3 honest node and 1 node with a twin + some random partition",
+    "nodes": ["Alice", "Bob", "Carol", "David"],
+    "twins": ["Alice_twin"],
+    "allow_block_sync": true,
+    "liveness": 100,
+    "expected_block_default": 100,
+    "round": 10,
+    "timeout_ms": 30000,
+    "delta_ms": 10,
+    "partition": [
+        [["Alice", "Bob", "Carol", "David", "Alice_twin"]],
+        [["Alice", "Bob", "Carol", "David", "Alice_twin"]],
+        [["Alice", "Bob", "Carol", "David", "Alice_twin"]],
+        [["Alice", "Bob", "Carol", "Alice_twin"], ["David"]],
+        [["Alice", "Bob", "David", "Alice_twin"], ["Carol"]],
+        [["Alice", "Bob", "Carol", "Alice_twin"], ["David"]],
+        [["Alice", "Bob", "David", "Alice_twin"], ["Carol"]],
+        [["Alice", "Bob", "Carol", "Alice_twin"], ["David"]],
+        [["Alice", "Bob", "David", "Alice_twin"], ["Carol"]],
+        [["Alice", "David", "Carol", "Alice_twin"], ["Bob"]],
+        [["Alice"], ["Bob", "Carol", "Alice_twin"], ["David"]],
+        [["Alice", "Bob"], ["David", "Alice_twin"], ["Carol"]],
+        [["Alice", "Bob", "Carol", "Alice_twin"], ["David"]],
+        [["Alice", "Bob", "David", "Alice_twin"], ["Carol"]],
+        [["Alice", "David", "Carol", "Alice_twin"], ["Bob"]],
+        [["Alice", "Bob", "Carol", "Alice_twin"], ["David"]],
+        [["Alice", "Bob", "David", "Alice_twin"], ["Carol"]],
+        [["Alice", "Bob", "Carol", "Alice_twin"], ["David"]],
+        [["Alice", "Bob", "David", "Alice_twin"], ["Carol"]],
+        [["Alice", "David", "Carol", "Alice_twin"], ["Bob"]],
+        [["Alice", "Bob", "Carol", "Alice_twin"], ["David"]],
+        [["Alice", "Bob", "David", "Alice_twin"], ["Carol"]]
+    ],
+    "default_partition": [["Alice", "Bob", "Carol", "David", "Alice_twin"]]
+
+}

--- a/monad-twins/tests/too_much_twin.json
+++ b/monad-twins/tests/too_much_twin.json
@@ -1,0 +1,13 @@
+{
+    "description": "2 twins and 2 honest, ledger would diverge",
+    "nodes": ["Alice", "Bob", "Carol", "David"],
+    "twins": ["Alice_twin", "Bob_twin"],
+    "expected_block_default": 50,
+    "round": 10,
+    "timeout_ms": 2000,
+    "delta_ms": 2,
+    "allow_block_sync": true,
+    "partition": [
+    ],
+    "default_partition": [["Alice", "Bob", "Carol"], [ "David", "Alice_twin", "Bob_twin"]]
+}

--- a/monad-twins/tests/too_much_twin_with_big_delay.json
+++ b/monad-twins/tests/too_much_twin_with_big_delay.json
@@ -1,0 +1,13 @@
+{
+    "description": "2 twins and 2 honest, long delay cause 1 side of partition always timing out",
+    "nodes": ["Alice", "Bob", "Carol", "David"],
+    "twins": ["Alice_twin", "Bob_twin"],
+    "expected_block_default": 30,
+    "round": 10,
+    "timeout_ms": 100000,
+    "delta_ms": 100,
+    "allow_block_sync": true,
+    "partition": [
+    ],
+    "default_partition": [["Alice", "Bob", "Carol"], [ "David", "Alice_twin", "Bob_twin"]]
+}

--- a/monad-twins/tests/twin_testing.rs
+++ b/monad-twins/tests/twin_testing.rs
@@ -1,0 +1,111 @@
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeSet;
+
+    use monad_block_sync::BlockSyncState;
+    use monad_consensus_state::ConsensusState;
+    use monad_consensus_types::{
+        multi_sig::MultiSig, payload::NopStateRoot, transaction_validator::MockValidator,
+    };
+    use monad_crypto::NopSignature;
+    use monad_executor::timed_event::TimedEvent;
+    use monad_executor_glue::MonadEvent;
+    use monad_mock_swarm::{
+        mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+        swarm_relation::SwarmRelation,
+        transformer::{monad_test::MonadMessageTransformerPipeline, ID},
+    };
+    use monad_state::{MonadMessage, MonadState, VerifiedMonadMessage};
+    use monad_twins_utils::{run_twins_test, twin_reader::read_twins_test};
+    use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
+    use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
+    use test_case::test_case;
+
+    const TWIN_DEFAULT_SEED: u64 = 1;
+
+    struct TwinsSwarm;
+
+    impl SwarmRelation for TwinsSwarm {
+        type STATE = MonadState<
+            ConsensusState<MultiSig<NopSignature>, MockValidator, NopStateRoot>,
+            NopSignature,
+            MultiSig<NopSignature>,
+            ValidatorSet,
+            SimpleRoundRobin,
+            BlockSyncState,
+        >;
+        type ST = NopSignature;
+        type SCT = MultiSig<Self::ST>;
+        type RS = NoSerRouterScheduler<MonadMessage<Self::ST, Self::SCT>>;
+        type P = MonadMessageTransformerPipeline;
+        type LGR = MockWALogger<TimedEvent<MonadEvent<Self::ST, Self::SCT>>>;
+        type ME = MockMempool<Self::ST, Self::SCT>;
+        type TVT = MockValidator;
+        type LGRCFG = MockWALoggerConfig;
+        type RSCFG = NoSerRouterConfig;
+        type MPCFG = MockMempoolConfig;
+        type StateMessage = MonadMessage<Self::ST, Self::SCT>;
+        type OutboundStateMessage = VerifiedMonadMessage<Self::ST, Self::SCT>;
+        type Message = MonadMessage<Self::ST, Self::SCT>;
+    }
+
+    #[test_case("./tests/happy_path.json"; "happy_path")]
+    #[test_case("./tests/one_twin.json"; "one_twin")]
+    #[test_case("./tests/one_twin_partition.json"; "one_twin_partition")]
+    #[test_case("./tests/make_progress.json"; "make_progress")]
+
+    fn twins_testing(path: &str) {
+        let test_case = read_twins_test::<TwinsSwarm>(MockValidator, path);
+
+        println!(
+            "running twins_testing, description: {:?}",
+            test_case.description,
+        );
+
+        let get_lgr_cfg = |_: &ID, _: &Vec<ID>| MockWALoggerConfig;
+        let get_router_cfg = |_: &ID, ids: &Vec<ID>| NoSerRouterConfig {
+            all_peers: ids
+                .iter()
+                .map(|id| *id.get_peer_id())
+                .collect::<BTreeSet<_>>(),
+        };
+        let get_mempool_cfg = |id: &ID, _: &Vec<ID>| MockMempoolConfig(*id.get_identifier() as u64);
+
+        run_twins_test::<TwinsSwarm, _, _, _>(
+            get_lgr_cfg,
+            get_router_cfg,
+            get_mempool_cfg,
+            TWIN_DEFAULT_SEED,
+            test_case,
+        )
+    }
+
+    #[should_panic]
+    #[test_case("./tests/too_much_twin.json"; "too_much_twin")]
+    #[test_case("./tests/too_much_twin_with_big_delay.json"; "too_much_twin_with_big_delay")]
+    #[test_case("./tests/mal_formed.json"; "mal_formed json")]
+
+    fn twins_should_fail_testing(path: &str) {
+        let test_case = read_twins_test::<TwinsSwarm>(MockValidator, path);
+        println!(
+            "running expected fail twins_testing, description: {:?}",
+            test_case.description
+        );
+        let get_lgr_cfg = |_: &ID, _: &Vec<ID>| MockWALoggerConfig;
+        let get_router_cfg = |_: &ID, ids: &Vec<ID>| NoSerRouterConfig {
+            all_peers: ids
+                .iter()
+                .map(|id| *id.get_peer_id())
+                .collect::<BTreeSet<_>>(),
+        };
+        let get_mempool_cfg = |id: &ID, _: &Vec<ID>| MockMempoolConfig(*id.get_identifier() as u64);
+
+        run_twins_test::<TwinsSwarm, _, _, _>(
+            get_lgr_cfg,
+            get_router_cfg,
+            get_mempool_cfg,
+            TWIN_DEFAULT_SEED,
+            test_case,
+        )
+    }
+}

--- a/monad-twins/utils/Cargo.toml
+++ b/monad-twins/utils/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "monad-twins-utils"
+version = "0.1.0"
+edition = "2021"
+
+# this is necessary for criterion bench options
+# https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+[lib]
+bench = false
+
+
+[dependencies]
+monad-consensus-types = { path = "../../monad-consensus-types",  features = ["monad_test"]}
+monad-executor-glue = { path = "../../monad-executor-glue", features = ["monad_test"] }
+monad-mock-swarm = { path = "../../monad-mock-swarm", features = ["monad_test"] }
+monad-state = { path = "../../monad-state", features = ["monad_test"]}
+monad-testutil = { path = "../../monad-testutil" }
+monad-types = { path = "../../monad-types" }
+
+
+itertools = { workspace = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }
+serde = {version = "1.0.130", features= ["derive"] }
+serde_json = {version = "1.0.68", features= ["preserve_order"] }

--- a/monad-twins/utils/src/lib.rs
+++ b/monad-twins/utils/src/lib.rs
@@ -1,0 +1,103 @@
+pub mod twin_reader;
+
+use std::collections::BTreeMap;
+
+use monad_mock_swarm::{
+    mock::{MockExecutor, RouterScheduler},
+    mock_swarm::{Node, Nodes},
+    swarm_relation::SwarmRelation,
+    transformer::{
+        monad_test::{MonadMessageTransformer, MonadMessageTransformerPipeline, TwinsTransformer},
+        RandLatencyTransformer, ID,
+    },
+};
+use monad_state::{MonadMessage, VerifiedMonadMessage};
+use monad_types::{Deserializable, Serializable};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaChaRng;
+
+use crate::twin_reader::{TwinsNodeConfig, TwinsTestCase};
+
+pub fn run_twins_test<S, LGRC, RSC, MPC>(
+    get_logger_config: LGRC,
+    get_router_cfg: RSC,
+    get_mempool_cfg: MPC,
+    seed: u64,
+    test_case: TwinsTestCase<S>,
+) where
+    S: SwarmRelation<P = MonadMessageTransformerPipeline>,
+    MockExecutor<S>: Unpin,
+    MonadMessage<S::ST, S::SCT>: Deserializable<S::Message>,
+    VerifiedMonadMessage<S::ST, S::SCT>: Serializable<<S::RS as RouterScheduler>::M>,
+    Node<S>: Send,
+    LGRC: Fn(&ID, &Vec<ID>) -> S::LGRCFG,
+    RSC: Fn(&ID, &Vec<ID>) -> S::RSCFG,
+    MPC: Fn(&ID, &Vec<ID>) -> S::MPCFG,
+{
+    let TwinsTestCase {
+        description: _,
+        allow_block_sync,
+        liveness,
+        mut terminator,
+        delta,
+        duplicates,
+        nodes,
+    } = test_case;
+
+    let ids = nodes.keys().copied().collect::<Vec<_>>();
+    let mut rng = ChaChaRng::seed_from_u64(seed);
+    let mut swarm = Nodes::<S>::new(vec![]).can_have_duplicate_peer();
+
+    for TwinsNodeConfig {
+        id,
+        state_config,
+        default_partition,
+        partition,
+    } in nodes.into_values()
+    {
+        let twins_transformer = TwinsTransformer::new(
+            duplicates.clone(),
+            partition,
+            default_partition,
+            !allow_block_sync,
+        );
+
+        let pipeline = vec![
+            MonadMessageTransformer::Twins(twins_transformer),
+            MonadMessageTransformer::RandLatency(RandLatencyTransformer::new(rng.gen(), delta)),
+        ];
+        let (lgr_cfg, router_cfg, mempool_cfg) = (
+            get_logger_config(&id, &ids),
+            get_router_cfg(&id, &ids),
+            get_mempool_cfg(&id, &ids),
+        );
+        swarm.add_state((
+            id,
+            state_config,
+            lgr_cfg,
+            router_cfg,
+            mempool_cfg,
+            pipeline,
+            seed,
+        ));
+    }
+
+    while swarm.step_until(&terminator).is_some() {}
+
+    if let Some(liveness_length) = liveness {
+        let liveness_transformer =
+            TwinsTransformer::new(duplicates, BTreeMap::new(), ids.clone(), false);
+        let pipeline = vec![
+            MonadMessageTransformer::Twins(liveness_transformer),
+            MonadMessageTransformer::RandLatency(RandLatencyTransformer::new(rng.gen(), delta)),
+        ];
+
+        for id in ids {
+            swarm.update_pipeline(&id, pipeline.clone());
+        }
+        // extend the expected termination condition
+        terminator.extend_all(liveness_length);
+        // run all nodes all connected until expected_block + liveness block check is achieved
+        while swarm.step_until(&terminator).is_some() {}
+    }
+}

--- a/monad-twins/utils/src/twin_reader.rs
+++ b/monad-twins/utils/src/twin_reader.rs
@@ -1,0 +1,339 @@
+use core::fmt;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Debug,
+    fs,
+    time::Duration,
+};
+
+use itertools::izip;
+use monad_consensus_types::{
+    certificate_signature::CertificateKeyPair, signature_collection::SignatureCollection,
+    transaction_validator::TransactionValidator,
+};
+use monad_executor_glue::PeerId;
+use monad_mock_swarm::{
+    mock_swarm::ProgressTerminator, swarm_relation::SwarmRelation, transformer::ID,
+};
+use monad_state::MonadConfig;
+use monad_testutil::{
+    signing::{create_keys, create_seed_for_certificate_keys, get_certificate_key_secret},
+    swarm::complete_config,
+    validators::complete_keys_w_validators,
+};
+use monad_types::Round;
+use serde::Deserialize;
+
+// following paramters don't matter too much for twins thus kept as constant
+const TWINS_STATE_ROOT_DELAY: u64 = u64::MAX;
+const TWINS_DEFAULT_IDENTIFIER: usize = 1;
+const TWINS_DUP_IDENTIFIER: usize = TWINS_DEFAULT_IDENTIFIER + 1;
+
+#[derive(Debug, Deserialize)]
+struct TwinsTestCaseRaw {
+    // test description
+    description: String,
+    // vector of nodes with their name (must be unique)
+    nodes: BTreeSet<String>,
+    // array representing twins, the format must start with a name of honest nodes, follow by _, and at least 1 char after ward
+    twins: BTreeSet<String>,
+    // expected amount of blocks for honest nodes if not provided by mapping
+    expected_block_default: usize,
+    // when to timeout
+    timeout_ms: u64,
+    // delta of protocol
+    delta_ms: u64,
+    // round partition setting
+    partition: Vec<Vec<Vec<String>>>,
+    // what's the behaviour of partition outside of defined
+    default_partition: Vec<Vec<String>>,
+
+    /// optional flag
+    // if the test should allow block-sync
+    allow_block_sync: Option<bool>,
+    // if liveness should be tested
+    liveness: Option<usize>,
+    // expected amount of blocks to be observed on particular honest node if diff from default
+    expected_block: Option<BTreeMap<String, usize>>,
+}
+
+pub struct FullTwinsNodeConfig<SCT, TVT>
+where
+    SCT: SignatureCollection,
+    TVT: TransactionValidator,
+{
+    id: ID,
+    state_config: MonadConfig<SCT, TVT>,
+    partition: BTreeMap<Round, Vec<ID>>,
+    default_partition: Vec<ID>,
+
+    // some redundant info in case its useful for future
+    secret: [u8; 32],
+    name: String,
+    expected_block: usize,
+    is_honest: bool,
+}
+
+impl<SCT, TVT> Clone for FullTwinsNodeConfig<SCT, TVT>
+where
+    SCT: SignatureCollection,
+    TVT: TransactionValidator,
+{
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            secret: self.secret,
+            state_config: self.state_config.dup(self.secret),
+            partition: self.partition.clone(),
+            default_partition: self.default_partition.clone(),
+            expected_block: self.expected_block,
+            is_honest: self.is_honest,
+            name: self.name.clone(),
+        }
+    }
+}
+impl<SCT, TVT> Debug for FullTwinsNodeConfig<SCT, TVT>
+where
+    SCT: SignatureCollection,
+    TVT: TransactionValidator,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{:?} \n partition: {:?}, \n default_part: {:?} \n",
+            self.name, self.partition, self.default_partition
+        )
+    }
+}
+
+pub struct TwinsNodeConfig<SCT, TVT>
+where
+    SCT: SignatureCollection,
+    TVT: TransactionValidator,
+{
+    pub id: ID,
+    pub state_config: MonadConfig<SCT, TVT>,
+    pub partition: BTreeMap<Round, Vec<ID>>,
+    pub default_partition: Vec<ID>,
+}
+
+impl<SCT, TVT> From<FullTwinsNodeConfig<SCT, TVT>> for TwinsNodeConfig<SCT, TVT>
+where
+    SCT: SignatureCollection,
+    TVT: TransactionValidator,
+{
+    fn from(value: FullTwinsNodeConfig<SCT, TVT>) -> Self {
+        let FullTwinsNodeConfig {
+            id,
+            state_config,
+            default_partition,
+            partition,
+
+            //extra info
+            is_honest: _,
+            expected_block: _,
+            name: _,
+            secret: _,
+        } = value;
+
+        Self {
+            id,
+            state_config,
+            default_partition,
+            partition,
+        }
+    }
+}
+
+pub struct TwinsTestCase<S>
+where
+    S: SwarmRelation,
+{
+    pub description: String,
+    pub terminator: ProgressTerminator,
+    pub delta: u64,
+    pub allow_block_sync: bool,
+    pub liveness: Option<usize>,
+    pub duplicates: BTreeMap<PeerId, Vec<usize>>,
+    pub nodes: BTreeMap<ID, TwinsNodeConfig<S::SCT, S::TVT>>,
+}
+
+pub fn read_twins_test<S>(tvt: S::TVT, path: &str) -> TwinsTestCase<S>
+where
+    S: SwarmRelation,
+{
+    let raw_str = fs::read_to_string(path).expect("unable to read file in twins testing");
+
+    let TwinsTestCaseRaw {
+        description,
+        nodes: mut names,
+        twins,
+        expected_block_default,
+        expected_block,
+        timeout_ms,
+        delta_ms,
+        allow_block_sync,
+        liveness,
+        partition,
+        default_partition,
+    } = serde_json::from_str(&raw_str).expect("twins test case JSON is not formatted correctly");
+
+    let expected_block = expected_block.unwrap_or(BTreeMap::new());
+    let keys = create_keys(names.len() as u32);
+    let cert_key_secrete: Vec<_> = create_seed_for_certificate_keys::<S::SCT>(names.len() as u32)
+        .into_iter()
+        .map(get_certificate_key_secret)
+        .collect();
+
+    let cert_keys: Vec<_> = cert_key_secrete
+        .iter()
+        .map(|secret| {
+            CertificateKeyPair::from_bytes(*secret)
+                .expect("secret is invalid when convert to cert-key")
+        })
+        .collect();
+
+    let (_, validator_mapping) = complete_keys_w_validators::<S::SCT>(&keys, &cert_keys);
+    let (pubkeys, state_configs) = complete_config::<S::ST, S::SCT, _>(
+        tvt,
+        keys,
+        cert_keys,
+        validator_mapping,
+        Duration::from_millis(delta_ms),
+        TWINS_STATE_ROOT_DELAY,
+    );
+
+    let mut nodes = BTreeMap::new();
+    let mut duplicates = BTreeMap::new();
+
+    for (name, pubkey, secret, state_config) in
+        izip!(names.iter(), pubkeys, cert_key_secrete, state_configs)
+    {
+        let pid = PeerId(pubkey);
+        let id = ID::new(pid).as_non_unique(TWINS_DEFAULT_IDENTIFIER);
+        let expected_block = *expected_block.get(name).unwrap_or(&expected_block_default);
+        nodes.insert(
+            name.clone(),
+            FullTwinsNodeConfig {
+                id,
+                name: name.clone(),
+                state_config,
+                secret,
+                partition: BTreeMap::new(),
+                default_partition: vec![],
+                is_honest: true,
+                expected_block,
+            },
+        );
+        duplicates.insert(pid, vec![TWINS_DEFAULT_IDENTIFIER]);
+    }
+
+    // make twins that mimic original
+    for (idx, name) in twins.iter().enumerate() {
+        let parts: Vec<&str> = name.split("_").collect::<Vec<_>>();
+        // format check
+        assert_eq!(parts.len(), 2);
+
+        let original = nodes
+            .get_mut(parts[0])
+            .expect("mimic target doesn't exists when reading test case");
+        original.is_honest = false;
+        let mut twin = original.clone();
+        let identifier = TWINS_DUP_IDENTIFIER + idx;
+        twin.id = twin.id.as_non_unique(identifier);
+        duplicates
+            .get_mut(twin.id.get_peer_id())
+            .expect("mimic target doesn't exists when reading test case")
+            .push(identifier);
+
+        nodes.insert(name.clone(), twin);
+    }
+
+    names.extend(twins);
+
+    // construct Terminator
+    let terminator = ProgressTerminator::new(
+        nodes
+            .values()
+            .filter_map(|config| {
+                if config.is_honest {
+                    Some((config.id, config.expected_block))
+                } else {
+                    None
+                }
+            })
+            .collect::<BTreeMap<_, _>>(),
+        Duration::from_millis(timeout_ms),
+    );
+
+    // used for format check
+    let mut round_nodes = BTreeSet::new();
+    // insert partitions
+    for (r, partition_round) in partition.into_iter().enumerate() {
+        let round: Round = Round((r as u64) + 1);
+
+        // in a given round, iterate through all ways of partitioning stuff.
+        for partition in partition_round {
+            let transformed_partition = partition
+                .iter()
+                .map(|name| {
+                    nodes
+                        .get(name)
+                        .expect("partition target doesn't exists when reading test case")
+                        .id
+                })
+                .collect::<Vec<_>>();
+            for node in partition {
+                nodes
+                    .get_mut(&node)
+                    .expect("partition target doesn't exists when reading test case")
+                    .partition
+                    .insert(round, transformed_partition.clone());
+                assert!(round_nodes.get(&node).is_none());
+                round_nodes.insert(node);
+            }
+        }
+        // format check
+        assert_eq!(names, round_nodes);
+        round_nodes.clear();
+    }
+
+    // insert partition_default
+    for partition in default_partition {
+        let transformed_partition = partition
+            .iter()
+            .map(|name| {
+                nodes
+                    .get(name)
+                    .expect("partition target doesn't exists when reading test case")
+                    .id
+            })
+            .collect::<Vec<_>>();
+        for node in partition {
+            nodes
+                .get_mut(&node)
+                .expect("partition target doesn't exists when reading test case")
+                .default_partition = transformed_partition.clone();
+            assert!(round_nodes.get(&node).is_none());
+            round_nodes.insert(node);
+        }
+    }
+    // format check
+    assert_eq!(names, round_nodes);
+
+    TwinsTestCase {
+        description,
+        // optional flags
+        allow_block_sync: allow_block_sync.unwrap_or(true),
+        liveness,
+        // mandatory params
+        terminator,
+        delta: delta_ms,
+        duplicates,
+        // name is not useful outside of extractor, so swap name with id in future usage
+        nodes: nodes
+            .into_values()
+            .map(|v| (v.id, v.into()))
+            .collect::<BTreeMap<_, _>>(),
+    }
+}


### PR DESCRIPTION
Twins testing provides the ability for mock_swarm to test with non-obvious byzantine behavior, such as sending 2 version of correct proposals to different parties within the system with attempts to partition the network.

More detail information is provided in the design doc (README)

This commit provides reader + execution tool and some basic test cases, the run_twin_tests can consume any swarm relation, with the only condition that the pipeline must accept and only accept MonadMessage.

Round Based termination is not yet available, but when RoundTerminator is ready it will be added

Also some minor adjustment/addition to test utilities for twins.