### PR TITLE
Add LocalRouter executor

### DIFF
--- a/monad-updaters/src/lib.rs
+++ b/monad-updaters/src/lib.rs
@@ -10,3 +10,6 @@ pub mod mempool;
 
 #[cfg(feature = "tokio")]
 pub mod timer;
+
+#[cfg(feature = "tokio")]
+pub mod local_router;

--- a/monad-updaters/src/local_router.rs
+++ b/monad-updaters/src/local_router.rs
@@ -1,0 +1,143 @@
+use std::{
+    collections::HashMap,
+    marker::PhantomData,
+    ops::DerefMut,
+    task::Poll,
+    time::{Duration, Instant},
+};
+
+use futures::Stream;
+use monad_executor::Executor;
+use monad_executor_glue::{Message, PeerId, RouterCommand, RouterTarget};
+
+pub struct LocalRouterConfig {
+    pub all_peers: Vec<PeerId>,
+    pub external_latency: Duration,
+}
+
+impl LocalRouterConfig {
+    pub fn build<M, OM>(self) -> HashMap<PeerId, LocalPeerRouter<M, OM>>
+    where
+        M: Send + 'static,
+    {
+        let mut txs = HashMap::new();
+        let mut rxs = HashMap::new();
+        for peer in &self.all_peers {
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+            rxs.insert(*peer, rx);
+            txs.insert(*peer, tx);
+        }
+
+        let mut peer_txs = HashMap::new(); // for each peer, represents tx map
+        for from_peer in &self.all_peers {
+            let mut to_peer_txs = HashMap::new();
+            for to_peer in &self.all_peers {
+                let (delayed_tx, mut delayed_rx) =
+                    tokio::sync::mpsc::unbounded_channel::<(Instant, _, _)>();
+                let to_tx = txs.get(to_peer).unwrap().clone();
+                let delay = if from_peer == to_peer {
+                    Duration::ZERO
+                } else {
+                    self.external_latency
+                };
+                tokio::spawn(async move {
+                    while let Some((instant, from, message)) = delayed_rx.recv().await {
+                        let now = Instant::now();
+                        // we wake up 2ms early because tokio's timer granularity is 1ms
+                        // (1ms is inherited from epoll_wait)
+                        let delayed = instant + delay - Duration::from_millis(2);
+                        if delayed > now {
+                            tokio::time::sleep_until(delayed.into()).await;
+                        }
+                        // spin until ready
+                        while Instant::now() <= delayed {}
+                        to_tx.send((from, message)).unwrap();
+                    }
+                });
+                to_peer_txs.insert(*to_peer, delayed_tx);
+            }
+            peer_txs.insert(*from_peer, to_peer_txs);
+        }
+
+        rxs.into_iter()
+            .map(|(me, rx)| {
+                let router = LocalPeerRouter::new(me, peer_txs.remove(&me).unwrap(), rx);
+
+                (me, router)
+            })
+            .collect()
+    }
+}
+
+pub struct LocalPeerRouter<M, OM> {
+    me: PeerId,
+    txs: HashMap<PeerId, tokio::sync::mpsc::UnboundedSender<(Instant, PeerId, M)>>,
+    rx: tokio::sync::mpsc::UnboundedReceiver<(PeerId, M)>,
+
+    _pd: PhantomData<OM>,
+}
+
+impl<M, OM> LocalPeerRouter<M, OM> {
+    fn new(
+        me: PeerId,
+        txs: HashMap<PeerId, tokio::sync::mpsc::UnboundedSender<(Instant, PeerId, M)>>,
+        rx: tokio::sync::mpsc::UnboundedReceiver<(PeerId, M)>,
+    ) -> Self {
+        Self {
+            me,
+            rx,
+            txs,
+            _pd: PhantomData,
+        }
+    }
+}
+
+impl<M, OM> Executor for LocalPeerRouter<M, OM>
+where
+    M: Clone,
+    OM: Into<M> + AsRef<M>,
+{
+    type Command = RouterCommand<OM>;
+
+    fn exec(&mut self, commands: Vec<Self::Command>) {
+        for command in commands {
+            let now = Instant::now();
+            match command {
+                RouterCommand::Publish { target, message } => match target {
+                    RouterTarget::Broadcast => {
+                        let message = message.into();
+                        for tx in self.txs.values() {
+                            tx.send((now, self.me, message.clone())).unwrap();
+                        }
+                    }
+                    RouterTarget::PointToPoint(peer) => {
+                        self.txs
+                            .get(&peer)
+                            .unwrap()
+                            .send((now, self.me, message.into()))
+                            .unwrap();
+                    }
+                },
+            }
+        }
+    }
+}
+
+impl<M, OM> Stream for LocalPeerRouter<M, OM>
+where
+    M: Message,
+    Self: Unpin,
+{
+    type Item = M::Event;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let this = self.deref_mut();
+
+        this.rx
+            .poll_recv(cx)
+            .map(|maybe_message| maybe_message.map(|(from, message)| message.event(from)))
+    }
+}


### PR DESCRIPTION
LocalRouter is a router implementation that can be used for wiring together multiple state machines in the same binary. Given a list of `n` peers, it outputs `n` executors - one for each peer.