### PR TITLE
Make Node<S> in mock-swarm use concrete MonadState

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4877,7 +4877,6 @@ dependencies = [
  "iced",
  "iced_lazy",
  "iced_native",
- "monad-block-sync",
  "monad-consensus-state",
  "monad-consensus-types",
  "monad-crypto",
@@ -4888,7 +4887,6 @@ dependencies = [
  "monad-state",
  "monad-testutil",
  "monad-types",
- "monad-validator",
  "monad-wal",
 ]
 

--- a/monad-mock-swarm/Cargo.toml
+++ b/monad-mock-swarm/Cargo.toml
@@ -11,12 +11,16 @@ edition = "2021"
 bench = false
 
 [features]
-monad_test = ["monad-consensus/monad_test", "monad-executor-glue/monad_test", "monad-state/monad_test"]
+monad_test = [
+    "monad-consensus/monad_test",
+    "monad-executor-glue/monad_test",
+    "monad-state/monad_test",
+]
 
 [dependencies]
 monad-block-sync = { path = "../monad-block-sync" }
+monad-consensus = { path = "../monad-consensus" }
 monad-consensus-state = { path = "../monad-consensus-state" }
-monad-consensus = { path = "../monad-consensus"}
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
 monad-eth-types = { path = "../monad-eth-types" }
@@ -37,11 +41,8 @@ tracing = { workspace = true }
 itertools = { workspace = true }
 
 [dev-dependencies]
-monad-crypto = { path = "../monad-crypto" }
 monad-block-sync = { path = "../monad-block-sync" }
-monad-consensus = { path = "../monad-consensus", features = [
-    "monad_test",
-] }
+monad-consensus = { path = "../monad-consensus", features = ["monad_test"] }
 monad-consensus-state = { path = "../monad-consensus-state", features = [
     "monad_test",
 ] }

--- a/monad-mock-swarm/src/swarm_relation.rs
+++ b/monad-mock-swarm/src/swarm_relation.rs
@@ -62,14 +62,7 @@ pub trait SwarmRelation {
 pub struct NoSerSwarm;
 
 impl SwarmRelation for NoSerSwarm {
-    type STATE = MonadState<
-        ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-        NopSignature,
-        MultiSig<NopSignature>,
-        ValidatorSet,
-        SimpleRoundRobin,
-        BlockSyncState,
-    >;
+    type STATE = SwarmStateType<Self>;
     type ST = NopSignature;
     type SCT = MultiSig<Self::ST>;
     type RS = NoSerRouterScheduler<MonadMessage<Self::ST, Self::SCT>>;
@@ -84,3 +77,12 @@ impl SwarmRelation for NoSerSwarm {
     type OutboundStateMessage = VerifiedMonadMessage<Self::ST, Self::SCT>;
     type Message = MonadMessage<Self::ST, Self::SCT>;
 }
+
+pub type SwarmStateType<S> = MonadState<
+    ConsensusState<<S as SwarmRelation>::SCT, <S as SwarmRelation>::TVT, StateRoot>,
+    <S as SwarmRelation>::ST,
+    <S as SwarmRelation>::SCT,
+    ValidatorSet,
+    SimpleRoundRobin,
+    BlockSyncState,
+>;

--- a/monad-mock-swarm/tests/common/mod.rs
+++ b/monad-mock-swarm/tests/common/mod.rs
@@ -1,8 +1,4 @@
-use monad_block_sync::BlockSyncState;
-use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{
-    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
-};
+use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
 use monad_crypto::NopSignature;
 use monad_executor::timed_event::TimedEvent;
 use monad_executor_glue::MonadEvent;
@@ -10,24 +6,16 @@ use monad_gossip::mock::{MockGossip, MockGossipConfig};
 pub use monad_mock_swarm::swarm_relation::NoSerSwarm;
 use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig},
-    swarm_relation::SwarmRelation,
+    swarm_relation::{SwarmRelation, SwarmStateType},
     transformer::BytesTransformerPipeline,
 };
 use monad_quic::{QuicRouterScheduler, QuicRouterSchedulerConfig};
-use monad_state::{MonadMessage, MonadState, VerifiedMonadMessage};
-use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
+use monad_state::{MonadMessage, VerifiedMonadMessage};
 use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
 
 pub struct QuicSwarm;
 impl SwarmRelation for QuicSwarm {
-    type STATE = MonadState<
-        ConsensusState<MultiSig<NopSignature>, MockValidator, StateRoot>,
-        NopSignature,
-        MultiSig<NopSignature>,
-        ValidatorSet,
-        SimpleRoundRobin,
-        BlockSyncState,
-    >;
+    type STATE = SwarmStateType<Self>;
     type ST = NopSignature;
     type SCT = MultiSig<Self::ST>;
     type RS = QuicRouterScheduler<MockGossip>;

--- a/monad-testutil/examples/logs_gen.rs
+++ b/monad-testutil/examples/logs_gen.rs
@@ -1,35 +1,23 @@
 use std::{path::PathBuf, time::Duration};
 
-use monad_block_sync::BlockSyncState;
-use monad_consensus_state::ConsensusState;
-use monad_consensus_types::{
-    multi_sig::MultiSig, payload::NopStateRoot, transaction_validator::MockValidator,
-};
+use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
 use monad_crypto::NopSignature;
 use monad_executor::timed_event::TimedEvent;
 use monad_executor_glue::{MonadEvent, PeerId};
 use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
     mock_swarm::{Nodes, UntilTerminator},
-    swarm_relation::SwarmRelation,
+    swarm_relation::{SwarmRelation, SwarmStateType},
     transformer::{GenericTransformer, GenericTransformerPipeline, LatencyTransformer, ID},
 };
-use monad_state::{MonadMessage, MonadState, VerifiedMonadMessage};
+use monad_state::{MonadMessage, VerifiedMonadMessage};
 use monad_testutil::swarm::get_configs;
-use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
 use monad_wal::wal::{WALogger, WALoggerConfig};
 
 pub struct LogSwarm;
 
 impl SwarmRelation for LogSwarm {
-    type STATE = MonadState<
-        ConsensusState<Self::SCT, MockValidator, NopStateRoot>,
-        Self::ST,
-        Self::SCT,
-        ValidatorSet,
-        SimpleRoundRobin,
-        BlockSyncState,
-    >;
+    type STATE = SwarmStateType<Self>;
     type ST = NopSignature;
     type SCT = MultiSig<Self::ST>;
     type RS = NoSerRouterScheduler<MonadMessage<Self::ST, Self::SCT>>;

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -12,13 +12,13 @@ use monad_crypto::{
 use monad_eth_types::EthAddress;
 use monad_executor_glue::PeerId;
 use monad_mock_swarm::{
-    mock::MockExecutor,
+    mock::{MockExecutor, RouterScheduler},
     mock_swarm::{Node, Nodes, NodesTerminator},
     swarm_relation::SwarmRelation,
     transformer::ID,
 };
-use monad_state::MonadConfig;
-use monad_types::NodeId;
+use monad_state::{MonadConfig, MonadMessage, VerifiedMonadMessage};
+use monad_types::{Deserializable, NodeId, Serializable};
 
 use crate::{signing::get_genesis_config, validators::create_keys_w_validators};
 
@@ -121,7 +121,10 @@ pub fn create_and_run_nodes<S, RSC, TERM>(
 where
     S: SwarmRelation,
 
-    MockExecutor<S::STATE, S::RS, S::ME, S::ST, S::SCT>: Unpin,
+    MonadMessage<S::ST, S::SCT>: Deserializable<S::Message>,
+    VerifiedMonadMessage<S::ST, S::SCT>: Serializable<<S::RS as RouterScheduler>::M>,
+
+    MockExecutor<S>: Unpin,
     Node<S>: Send,
     RSC: Fn(Vec<PeerId>, PeerId) -> S::RSCFG,
     TERM: NodesTerminator<S>,
@@ -162,7 +165,10 @@ pub fn run_nodes_until<S, RSC, TERM>(
 where
     S: SwarmRelation,
 
-    MockExecutor<S::STATE, S::RS, S::ME, S::ST, S::SCT>: Unpin,
+    MonadMessage<S::ST, S::SCT>: Deserializable<S::Message>,
+    VerifiedMonadMessage<S::ST, S::SCT>: Serializable<<S::RS as RouterScheduler>::M>,
+
+    MockExecutor<S>: Unpin,
     Node<S>: Send,
     RSC: Fn(Vec<PeerId>, PeerId) -> S::RSCFG,
     TERM: NodesTerminator<S>,

--- a/monad-viz/Cargo.toml
+++ b/monad-viz/Cargo.toml
@@ -8,7 +8,6 @@ name = "monad-viz"
 bench = false
 
 [dependencies]
-monad-block-sync = { path = "../monad-block-sync" }
 monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
@@ -19,10 +18,9 @@ monad-mock-swarm = { path = "../monad-mock-swarm" }
 monad-state = { path = "../monad-state" }
 monad-testutil = { path = "../monad-testutil" }
 monad-types = { path = "../monad-types" }
-monad-validator = { path = "../monad-validator" }
 monad-wal = { path = "../monad-wal" }
 
-clap = { workspace = true, features= ["derive"] }
+clap = { workspace = true, features = ["derive"] }
 iced = { version = "0.9", features = ["canvas"] }
 iced_native = { version = "0.10" }
 iced_lazy = { version = "0.6" }


### PR DESCRIPTION
We used to need to add "monad_test" feature gated methods to the `State` trait to access consensus state. Writing the feature everywhere reduces the readability.

We are only using `MonadState` with mock swarm so it makes sense to use the concrete type than the generic `State` type.