### PR TITLE
Add timeout bench with MultiSig<Nop> and Bls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4906,9 +4906,13 @@ dependencies = [
  "monad-consensus-types",
  "monad-crypto",
  "monad-executor",
+ "monad-executor-glue",
+ "monad-gossip",
  "monad-mock-swarm",
+ "monad-quic",
  "monad-state",
  "monad-testutil",
+ "monad-types",
  "monad-validator",
  "monad-wal",
 ]

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -15,7 +15,6 @@ use monad_consensus_state::{
 };
 use monad_consensus_types::{
     block::{Block, FullBlock},
-    certificate_signature::CertificateSignatureRecoverable,
     message_signature::MessageSignature,
     payload::{ExecutionArtifacts, Payload, RandaoReveal},
     quorum_certificate::QuorumCertificate,
@@ -141,8 +140,8 @@ impl<MS: MessageSignature, SCT: SignatureCollection> monad_types::Deserializable
     }
 }
 
-impl<MS: MessageSignature, CS: CertificateSignatureRecoverable> monad_types::Deserializable<Vec<u8>>
-    for MonadMessage<MS, monad_consensus_types::multi_sig::MultiSig<CS>>
+impl<MS: MessageSignature, SCT: SignatureCollection> monad_types::Deserializable<Vec<u8>>
+    for MonadMessage<MS, SCT>
 {
     type ReadError = monad_proto::error::ProtoError;
 

--- a/monad-virtual-bench/Cargo.toml
+++ b/monad-virtual-bench/Cargo.toml
@@ -16,13 +16,21 @@ monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
 monad-executor = { path = "../monad-executor" }
+monad-executor-glue = { path = "../monad-executor-glue" }
+monad-gossip = { path = "../monad-gossip" }
 monad-mock-swarm = { path = "../monad-mock-swarm" }
+monad-quic = { path = "../monad-quic" }
 monad-state = { path = "../monad-state" }
 monad-testutil = { path = "../monad-testutil" }
+monad-types = { path = "../monad-types" }
 monad-validator = { path = "../monad-validator" }
 monad-wal = { path = "../monad-wal" }
 
 
 [[bench]]
 name = "two_node_bench"
+harness = false
+
+[[bench]]
+name = "many_nodes_bench"
 harness = false

--- a/monad-virtual-bench/benches/many_nodes_bench.rs
+++ b/monad-virtual-bench/benches/many_nodes_bench.rs
@@ -1,0 +1,128 @@
+use std::time::{Duration, Instant};
+
+use monad_consensus_types::{
+    bls::BlsSignatureCollection, multi_sig::MultiSig, transaction_validator::MockValidator,
+};
+use monad_crypto::NopSignature;
+use monad_executor::timed_event::TimedEvent;
+use monad_executor_glue::{MonadEvent, PeerId};
+use monad_gossip::mock::{MockGossip, MockGossipConfig};
+use monad_mock_swarm::{
+    mock::{MockMempool, MockMempoolConfig},
+    mock_swarm::UntilTerminator,
+    swarm_relation::{SwarmRelation, SwarmStateType},
+    transformer::{BwTransformer, BytesTransformer, BytesTransformerPipeline, LatencyTransformer},
+};
+use monad_quic::{QuicRouterScheduler, QuicRouterSchedulerConfig};
+use monad_state::{MonadMessage, VerifiedMonadMessage};
+use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
+use monad_types::Round;
+use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
+
+fn setup() -> (
+    SwarmTestConfig,
+    impl Fn(Vec<PeerId>, PeerId) -> QuicRouterSchedulerConfig<MockGossipConfig>,
+    Vec<BytesTransformer>,
+    UntilTerminator,
+) {
+    let zero_instant = Instant::now();
+    let stc = SwarmTestConfig {
+        num_nodes: 20,
+        consensus_delta: Duration::from_millis(30),
+        parallelize: false,
+        expected_block: 0,
+        state_root_delay: u64::MAX,
+        seed: 1,
+    };
+    let rsc = move |all_peers: Vec<PeerId>, me: PeerId| QuicRouterSchedulerConfig {
+        zero_instant,
+        all_peers: all_peers.iter().cloned().collect(),
+        me,
+        tls_key_der: Vec::new(),
+        master_seed: 7,
+        gossip_config: MockGossipConfig { all_peers },
+    };
+    let xfmrs = vec![
+        BytesTransformer::Latency(LatencyTransformer(Duration::from_millis(100))),
+        BytesTransformer::Bw(BwTransformer::new(4)),
+    ];
+    let terminator = UntilTerminator::new().until_round(Round(10));
+
+    (stc, rsc, xfmrs, terminator)
+}
+
+struct NopSwarm;
+
+impl SwarmRelation for NopSwarm {
+    type State = SwarmStateType<Self>;
+    type SignatureType = NopSignature;
+    type SignatureCollectionType = MultiSig<NopSignature>;
+    type RouterScheduler = QuicRouterScheduler<MockGossip>;
+    type Pipeline = BytesTransformerPipeline;
+    type Logger =
+        MockWALogger<TimedEvent<MonadEvent<Self::SignatureType, Self::SignatureCollectionType>>>;
+    type MempoolExecutor = MockMempool<Self::SignatureType, Self::SignatureCollectionType>;
+    type TransactionValidator = MockValidator;
+    type LoggerConfig = MockWALoggerConfig;
+    type RouterSchedulerConfig = QuicRouterSchedulerConfig<MockGossipConfig>;
+    type MempoolConfig = MockMempoolConfig;
+    type Message = Vec<u8>;
+    type StateMessage = MonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
+    type OutboundStateMessage =
+        VerifiedMonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
+}
+
+struct BlsSwarm;
+
+impl SwarmRelation for BlsSwarm {
+    type State = SwarmStateType<Self>;
+    type SignatureType = NopSignature;
+    type SignatureCollectionType = BlsSignatureCollection;
+    type RouterScheduler = QuicRouterScheduler<MockGossip>;
+    type Pipeline = BytesTransformerPipeline;
+    type Logger =
+        MockWALogger<TimedEvent<MonadEvent<Self::SignatureType, Self::SignatureCollectionType>>>;
+    type MempoolExecutor = MockMempool<Self::SignatureType, Self::SignatureCollectionType>;
+    type TransactionValidator = MockValidator;
+    type LoggerConfig = MockWALoggerConfig;
+    type RouterSchedulerConfig = QuicRouterSchedulerConfig<MockGossipConfig>;
+    type MempoolConfig = MockMempoolConfig;
+    type Message = Vec<u8>;
+    type StateMessage = MonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
+    type OutboundStateMessage =
+        VerifiedMonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
+}
+
+fn many_nodes_nop_timeout() -> u128 {
+    let (stc, rsc, xfmrs, terminator) = setup();
+
+    let duration = create_and_run_nodes::<NopSwarm, _, _>(
+        MockValidator,
+        rsc,
+        MockWALoggerConfig,
+        MockMempoolConfig::default(),
+        xfmrs,
+        terminator,
+        stc,
+    );
+
+    duration.as_millis()
+}
+
+fn many_nodes_bls_timeout() -> u128 {
+    let (stc, rsc, xfmrs, terminator) = setup();
+
+    let duration = create_and_run_nodes::<BlsSwarm, _, _>(
+        MockValidator,
+        rsc,
+        MockWALoggerConfig,
+        MockMempoolConfig::default(),
+        xfmrs,
+        terminator,
+        stc,
+    );
+
+    duration.as_millis()
+}
+
+monad_virtual_bench::virtual_bench_main! {many_nodes_nop_timeout, many_nodes_bls_timeout}


### PR DESCRIPTION
Virtual bench results from the additional two benchmarks:
```
test many_nodes_nop_timeout ... bench: 4390 ns/iter (+/- 0)
test many_nodes_bls_timeout ... bench: 3395 ns/iter (+/- 0)
```