### PR TITLE
Allow pruning of in-flight blocks

### DIFF
--- a/monad-consensus-state/src/blocksync.rs
+++ b/monad-consensus-state/src/blocksync.rs
@@ -225,6 +225,10 @@ where
         }
         cmds
     }
+
+    pub fn remove(&mut self, bid: BlockId) {
+        self.requests.remove(&bid);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
if a proposal successfully added a missing block to the pending block tree, then block sync no longer cares about if such block is retrieved. retry and timeout will longer be happening