### PR TITLE
Make `proposal_size` configurable

### DIFF
--- a/monad-mock-swarm/benches/two_node_benchmark.rs
+++ b/monad-mock-swarm/benches/two_node_benchmark.rs
@@ -15,7 +15,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("two_nodes", |b| b.iter(two_nodes));
 }
 
-criterion_group!(benches, criterion_benchmark);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = criterion_benchmark
+}
 criterion_main!(benches);
 
 fn two_nodes() {
@@ -37,6 +41,7 @@ fn two_nodes() {
             expected_block: 1024,
             state_root_delay: 4,
             seed: 1,
+            proposal_size: 5_000,
         },
     );
 }

--- a/monad-mock-swarm/tests/block_sync.rs
+++ b/monad-mock-swarm/tests/block_sync.rs
@@ -33,6 +33,7 @@ mod test {
             num_nodes,
             delta,
             u64::MAX,
+            0,
         );
 
         let first_node = ID::new(PeerId(*pubkeys.first().unwrap()));
@@ -82,6 +83,7 @@ mod test {
             num_nodes,
             delta,
             u64::MAX,
+            0,
         );
 
         assert!(num_nodes >= 2, "test requires 2 or more nodes");
@@ -141,6 +143,7 @@ mod test {
             num_nodes,
             delta,
             u64::MAX,
+            0,
         );
 
         assert!(num_nodes >= 2, "test requires 2 or more nodes");

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -33,6 +33,7 @@ fn many_nodes_noser() {
             expected_block: 1024,
             state_root_delay: 4,
             seed: 1,
+            proposal_size: 0,
         },
     );
 }
@@ -66,6 +67,7 @@ fn many_nodes_quic() {
             expected_block: 10,
             state_root_delay: 4,
             seed: 1,
+            proposal_size: 150,
         },
     );
 }
@@ -81,6 +83,7 @@ fn many_nodes_quic_bw() {
         expected_block: 10,
         state_root_delay: u64::MAX,
         seed: 1,
+        proposal_size: 150,
     };
 
     let xfmrs = vec![

--- a/monad-mock-swarm/tests/many_nodes_metrics.rs
+++ b/monad-mock-swarm/tests/many_nodes_metrics.rs
@@ -54,6 +54,7 @@ fn many_nodes_metrics() {
             expected_block: 1024,
             state_root_delay: 4,
             seed: 1,
+            proposal_size: 0,
         },
     );
 

--- a/monad-mock-swarm/tests/msg_delays.rs
+++ b/monad-mock-swarm/tests/msg_delays.rs
@@ -33,6 +33,7 @@ fn two_nodes() {
             expected_block: 40,
             state_root_delay: 4,
             seed: 1,
+            proposal_size: 0,
         },
     );
 }

--- a/monad-mock-swarm/tests/order.rs
+++ b/monad-mock-swarm/tests/order.rs
@@ -52,7 +52,7 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
     let (pubkeys, state_configs) =
         // due to the burst behavior of replay-transformer, its okay to have delay as 1
         // TODO?: Make Replay Transformer's stored message not burst within the same Duration
-        get_configs::<NopSignature, MultiSig<NopSignature>, _>(MockValidator, num_nodes, delta, 1);
+        get_configs::<NopSignature, MultiSig<NopSignature>, _>(MockValidator, num_nodes, delta, 1, 0);
 
     assert!(num_nodes >= 2, "test requires 2 or more nodes");
 

--- a/monad-mock-swarm/tests/rand_lat.rs
+++ b/monad-mock-swarm/tests/rand_lat.rs
@@ -77,6 +77,7 @@ fn nodes_with_random_latency(seed: u64) {
             // TODO, cover cases with low state_root_delay once state_sync is done
             state_root_delay: u64::MAX,
             seed: 1,
+            proposal_size: 0,
         },
     );
 }

--- a/monad-mock-swarm/tests/random_mempool.rs
+++ b/monad-mock-swarm/tests/random_mempool.rs
@@ -74,6 +74,7 @@ fn random_mempool_failures() {
             expected_block: 1024,
             state_root_delay: 4,
             seed: 1,
+            proposal_size: 0,
         },
     );
 }

--- a/monad-mock-swarm/tests/replay.rs
+++ b/monad-mock-swarm/tests/replay.rs
@@ -57,7 +57,7 @@ impl SwarmRelation for ReplaySwarm {
 
 #[test]
 fn test_replay() {
-    recover_nodes_msg_delays(4, 10, 5, 4);
+    recover_nodes_msg_delays(4, 10, 5, 4, 0);
 }
 
 pub fn recover_nodes_msg_delays(
@@ -65,6 +65,7 @@ pub fn recover_nodes_msg_delays(
     num_blocks_before: usize,
     num_block_after: usize,
     state_root_delay: u64,
+    proposal_size: usize,
 ) {
     let (pubkeys, state_configs) = get_configs::<
         <ReplaySwarm as SwarmRelation>::SignatureType,
@@ -75,6 +76,7 @@ pub fn recover_nodes_msg_delays(
         num_nodes,
         Duration::from_millis(101),
         state_root_delay,
+        proposal_size,
     );
 
     // create the log file path
@@ -134,12 +136,17 @@ pub fn recover_nodes_msg_delays(
     // drop the nodes -> close the files
     drop(nodes);
 
-    let (pubkeys_clone, state_configs_clone) =
-        get_configs::<
-            <ReplaySwarm as SwarmRelation>::SignatureType,
-            <ReplaySwarm as SwarmRelation>::SignatureCollectionType,
-            _,
-        >(MockValidator {}, num_nodes, Duration::from_millis(2), 4);
+    let (pubkeys_clone, state_configs_clone) = get_configs::<
+        <ReplaySwarm as SwarmRelation>::SignatureType,
+        <ReplaySwarm as SwarmRelation>::SignatureCollectionType,
+        _,
+    >(
+        MockValidator {},
+        num_nodes,
+        Duration::from_millis(2),
+        4,
+        proposal_size,
+    );
 
     let peers_clone = pubkeys_clone
         .iter()

--- a/monad-mock-swarm/tests/replay_test.rs
+++ b/monad-mock-swarm/tests/replay_test.rs
@@ -121,12 +121,12 @@ fn replay_one_honest(failure_idx: &[usize]) {
         <ReplaySwarm as SwarmRelation>::SignatureType,
         <ReplaySwarm as SwarmRelation>::SignatureCollectionType,
         _,
-    >(MockValidator, 4, CONSENSUS_DELTA, 4);
+    >(MockValidator, 4, CONSENSUS_DELTA, 4, 0);
     let (_, mut state_configs_duplicate) = get_configs::<
         <ReplaySwarm as SwarmRelation>::SignatureType,
         <ReplaySwarm as SwarmRelation>::SignatureCollectionType,
         _,
-    >(MockValidator, 4, CONSENSUS_DELTA, 4);
+    >(MockValidator, 4, CONSENSUS_DELTA, 4, 0);
 
     let pubkeys = peers;
     let router_scheduler_config = |all_peers: Vec<PeerId>, _: PeerId| NoSerRouterConfig {

--- a/monad-mock-swarm/tests/single_node.rs
+++ b/monad-mock-swarm/tests/single_node.rs
@@ -37,6 +37,7 @@ fn two_nodes() {
             expected_block: 1024,
             state_root_delay: 4,
             seed: 1,
+            proposal_size: 0,
         },
     );
 }
@@ -70,6 +71,7 @@ fn two_nodes_quic() {
             expected_block: 256,
             state_root_delay: 4,
             seed: 1,
+            proposal_size: 150,
         },
     );
 }
@@ -95,7 +97,7 @@ fn two_nodes_quic_bw() {
         MockMempoolConfig::default(),
         vec![
             BytesTransformer::Latency(LatencyTransformer(Duration::from_millis(1))),
-            BytesTransformer::Bw(BwTransformer::new(3)),
+            BytesTransformer::Bw(BwTransformer::new(4)),
         ],
         UntilTerminator::new().until_tick(Duration::from_secs(5)),
         SwarmTestConfig {
@@ -105,6 +107,7 @@ fn two_nodes_quic_bw() {
             expected_block: 100,
             state_root_delay: 4,
             seed: 1,
+            proposal_size: 100,
         },
     );
 

--- a/monad-mock-swarm/tests/single_node_metrics.rs
+++ b/monad-mock-swarm/tests/single_node_metrics.rs
@@ -50,6 +50,7 @@ fn two_nodes() {
             expected_block: 1024,
             state_root_delay: 4,
             seed: 1,
+            proposal_size: 0,
         },
     );
     counter_status!();

--- a/monad-mock-swarm/tests/two_nodes_bls.rs
+++ b/monad-mock-swarm/tests/two_nodes_bls.rs
@@ -74,6 +74,7 @@ fn two_nodes_bls() {
             expected_block: 128,
             state_root_delay: 4,
             seed: 1,
+            proposal_size: 0,
         },
     );
 }

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -36,6 +36,7 @@ fn random_latency_test(seed: u64) {
             expected_block: 2048,
             state_root_delay: 4,
             seed: 1,
+            proposal_size: 0,
         },
     );
 }
@@ -43,8 +44,13 @@ fn random_latency_test(seed: u64) {
 fn delayed_message_test(seed: u64) {
     let num_nodes = 4;
     let delta = Duration::from_millis(2);
-    let (pubkeys, state_configs) =
-        get_configs::<NopSignature, MultiSig<NopSignature>, _>(MockValidator, num_nodes, delta, 4);
+    let (pubkeys, state_configs) = get_configs::<NopSignature, MultiSig<NopSignature>, _>(
+        MockValidator,
+        num_nodes,
+        delta,
+        4,
+        0,
+    );
 
     assert!(num_nodes >= 2, "test requires 2 or more nodes");
 

--- a/monad-testutil/examples/logs_gen.rs
+++ b/monad-testutil/examples/logs_gen.rs
@@ -38,12 +38,24 @@ impl SwarmRelation for LogSwarm {
     type Message = MonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
 }
 
-pub fn generate_log(num_nodes: u16, num_blocks: usize, delta: Duration, state_root_delay: u64) {
+pub fn generate_log(
+    num_nodes: u16,
+    num_blocks: usize,
+    delta: Duration,
+    state_root_delay: u64,
+    proposal_size: usize,
+) {
     let (pubkeys, state_configs) = get_configs::<
         <LogSwarm as SwarmRelation>::SignatureType,
         <LogSwarm as SwarmRelation>::SignatureCollectionType,
         _,
-    >(MockValidator, num_nodes, delta, state_root_delay);
+    >(
+        MockValidator,
+        num_nodes,
+        delta,
+        state_root_delay,
+        proposal_size,
+    );
     let file_path_vec = pubkeys.iter().map(|pubkey| WALoggerConfig {
         file_path: PathBuf::from(format!("{:?}.log", pubkey)),
         sync: false,
@@ -78,6 +90,6 @@ pub fn generate_log(num_nodes: u16, num_blocks: usize, delta: Duration, state_ro
 }
 
 fn main() {
-    generate_log(4, 10, Duration::from_millis(101), 4);
+    generate_log(4, 10, Duration::from_millis(101), 4, 0);
     println!("Logs Generated!");
 }

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -35,6 +35,7 @@ pub struct SwarmTestConfig {
     pub expected_block: usize,
     pub state_root_delay: u64,
     pub seed: u64,
+    pub proposal_size: usize,
 }
 
 pub fn get_configs<ST: MessageSignature, SCT: SignatureCollection, TVT: TransactionValidator>(
@@ -42,6 +43,7 @@ pub fn get_configs<ST: MessageSignature, SCT: SignatureCollection, TVT: Transact
     num_nodes: u16,
     delta: Duration,
     state_root_delay: u64,
+    proposal_size: usize,
 ) -> (Vec<PubKey>, Vec<MonadConfig<SCT, TVT>>) {
     let (keys, cert_keys, _validators, validator_mapping) =
         create_keys_w_validators::<SCT>(num_nodes as u32);
@@ -52,6 +54,7 @@ pub fn get_configs<ST: MessageSignature, SCT: SignatureCollection, TVT: Transact
         validator_mapping,
         delta,
         state_root_delay,
+        proposal_size,
     )
 }
 
@@ -66,6 +69,7 @@ pub fn complete_config<
     validator_mapping: ValidatorMapping<SignatureCollectionKeyPairType<SCT>>,
     delta: Duration,
     state_root_delay: u64,
+    proposal_size: usize,
 ) -> (Vec<PubKey>, Vec<MonadConfig<SCT, TVT>>) {
     let pubkeys = keys.iter().map(KeyPair::pubkey).collect::<Vec<_>>();
     let voting_keys = keys
@@ -92,7 +96,7 @@ pub fn complete_config<
                 .collect::<Vec<_>>(),
             delta,
             consensus_config: ConsensusConfig {
-                proposal_size: 5000,
+                proposal_size,
                 state_root_delay,
                 propose_with_missing_blocks: false,
             },
@@ -162,6 +166,7 @@ where
             swarm_config.num_nodes,
             swarm_config.consensus_delta,
             swarm_config.state_root_delay,
+            swarm_config.proposal_size,
         );
     run_nodes_until::<S, _, _>(
         peers,

--- a/monad-twins/utils/src/twin_reader.rs
+++ b/monad-twins/utils/src/twin_reader.rs
@@ -203,6 +203,7 @@ where
         validator_mapping,
         Duration::from_millis(delta_ms),
         TWINS_STATE_ROOT_DELAY,
+        10,
     );
 
     let mut nodes = BTreeMap::new();

--- a/monad-virtual-bench/benches/many_nodes_bench.rs
+++ b/monad-virtual-bench/benches/many_nodes_bench.rs
@@ -33,6 +33,7 @@ fn setup() -> (
         expected_block: 0,
         state_root_delay: u64::MAX,
         seed: 1,
+        proposal_size: 0,
     };
     let rsc = move |all_peers: Vec<PeerId>, me: PeerId| QuicRouterSchedulerConfig {
         zero_instant,

--- a/monad-virtual-bench/benches/two_node_bench.rs
+++ b/monad-virtual-bench/benches/two_node_bench.rs
@@ -29,6 +29,7 @@ fn two_nodes_virtual() -> u128 {
             expected_block: 1024,
             state_root_delay: 4,
             seed: 1,
+            proposal_size: 0,
         },
     )
     .as_millis()


### PR DESCRIPTION
Only a small subset of all the tests needs (random) payload data, namely twins testing and tests involving `QuicRouterScheduler`. Empty payloads works fine for `NoSerRouterScheduler` test as the RS is moving the entire block atomically. Computing a random payload of 5k * 32 every test is wasteful.

This PR makes `proposal_size` configurable. It also fixes `get_fetched_txs_list`:
1. the total payload size `num_fetch_txs -> num_fetch_txs * 32`
2. use `fill_bytes` instead of calling `rng.gen` many times. This method is 4x faster from my benchmarks