### PR TITLE
Add `Updater` trait for dynamic dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4767,6 +4767,7 @@ dependencies = [
  "monad-crypto",
  "monad-eth-types",
  "monad-executor",
+ "monad-executor-glue",
  "monad-p2p",
  "monad-state",
  "monad-types",

--- a/monad-testground/Cargo.toml
+++ b/monad-testground/Cargo.toml
@@ -14,6 +14,7 @@ monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto", features = ["libp2p-identity"] }
 monad-eth-types = { path = "../monad-eth-types" }
 monad-executor = { path = "../monad-executor" }
+monad-executor-glue = { path = "../monad-executor-glue" }
 monad-p2p = { path = "../monad-p2p", features = ["tokio"] }
 monad-state = { path = "../monad-state" }
 monad-types = { path = "../monad-types" }

--- a/monad-updaters/src/lib.rs
+++ b/monad-updaters/src/lib.rs
@@ -1,3 +1,8 @@
+use std::pin::Pin;
+
+use futures::Stream;
+use monad_executor::Executor;
+
 pub mod checkpoint;
 pub mod epoch;
 pub mod execution_ledger;
@@ -13,3 +18,8 @@ pub mod timer;
 
 #[cfg(feature = "tokio")]
 pub mod local_router;
+
+pub trait Updater<C, E>: Executor<Command = C> + Stream<Item = E> {}
+impl<U, C, E> Updater<C, E> for U where U: Executor<Command = C> + Stream<Item = E> {}
+
+pub type BoxUpdater<C, E> = Pin<Box<dyn Updater<C, E> + Send + Unpin>>;


### PR DESCRIPTION
Adds an `Updater` trait - which is implemented for all types that implement both `Executor` and `Stream`. `Updater` can be used to dynamically dispatch over multiple different types in `ParentExecutor`.

The motivation of this is to allow selecting the set of executors/updaters that monad-testground uses at runtime (eg CLI args).