### PR TITLE
Move message serde to RouterScheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4928,6 +4928,7 @@ dependencies = [
  "iced",
  "iced_lazy",
  "iced_native",
+ "monad-block-sync",
  "monad-consensus-state",
  "monad-consensus-types",
  "monad-crypto",
@@ -4938,6 +4939,7 @@ dependencies = [
  "monad-state",
  "monad-testutil",
  "monad-types",
+ "monad-validator",
  "monad-wal",
 ]
 

--- a/monad-executor/src/lib.rs
+++ b/monad-executor/src/lib.rs
@@ -35,9 +35,10 @@ pub type BoxExecutor<C> = Pin<Box<dyn Executor<Command = C> + Send + Unpin>>;
 
 pub trait State: Sized {
     type Config;
+    type Message: Message<Event = Self::Event>;
+
     type Event: Clone;
     type OutboundMessage: Into<Self::Message> + AsRef<Self::Message>;
-    type Message: Message<Event = Self::Event>;
     type Block: BlockType;
     type Checkpoint;
     type SignatureCollection;

--- a/monad-mock-swarm/tests/common/mod.rs
+++ b/monad-mock-swarm/tests/common/mod.rs
@@ -1,4 +1,8 @@
-use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
+use monad_block_sync::BlockSyncState;
+use monad_consensus_state::ConsensusState;
+use monad_consensus_types::{
+    multi_sig::MultiSig, payload::StateRoot, transaction_validator::MockValidator,
+};
 use monad_crypto::NopSignature;
 use monad_executor::timed_event::TimedEvent;
 use monad_executor_glue::MonadEvent;
@@ -6,29 +10,45 @@ use monad_gossip::mock::{MockGossip, MockGossipConfig};
 pub use monad_mock_swarm::swarm_relation::NoSerSwarm;
 use monad_mock_swarm::{
     mock::{MockMempool, MockMempoolConfig},
-    swarm_relation::{SwarmRelation, SwarmStateType},
+    swarm_relation::SwarmRelation,
     transformer::BytesTransformerPipeline,
 };
 use monad_quic::{QuicRouterScheduler, QuicRouterSchedulerConfig};
-use monad_state::{MonadMessage, VerifiedMonadMessage};
+use monad_state::{MonadMessage, MonadState, VerifiedMonadMessage};
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
 use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
 
 pub struct QuicSwarm;
+
 impl SwarmRelation for QuicSwarm {
-    type State = SwarmStateType<Self>;
     type SignatureType = NopSignature;
     type SignatureCollectionType = MultiSig<Self::SignatureType>;
-    type RouterScheduler = QuicRouterScheduler<MockGossip>;
+
+    type InboundMessage = MonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
+    type OutboundMessage = VerifiedMonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
+    type TransportMessage = Vec<u8>;
+
+    type TransactionValidator = MockValidator;
+
+    type State = MonadState<
+        ConsensusState<Self::SignatureCollectionType, Self::TransactionValidator, StateRoot>,
+        Self::SignatureType,
+        Self::SignatureCollectionType,
+        ValidatorSet,
+        SimpleRoundRobin,
+        BlockSyncState,
+    >;
+
+    type RouterSchedulerConfig = QuicRouterSchedulerConfig<MockGossipConfig>;
+    type RouterScheduler =
+        QuicRouterScheduler<MockGossip, Self::InboundMessage, Self::OutboundMessage>;
+
     type Pipeline = BytesTransformerPipeline;
+
+    type LoggerConfig = MockWALoggerConfig;
     type Logger =
         MockWALogger<TimedEvent<MonadEvent<Self::SignatureType, Self::SignatureCollectionType>>>;
-    type MempoolExecutor = MockMempool<Self::SignatureType, Self::SignatureCollectionType>;
-    type TransactionValidator = MockValidator;
-    type LoggerConfig = MockWALoggerConfig;
-    type RouterSchedulerConfig = QuicRouterSchedulerConfig<MockGossipConfig>;
+
     type MempoolConfig = MockMempoolConfig;
-    type Message = Vec<u8>;
-    type StateMessage = MonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
-    type OutboundStateMessage =
-        VerifiedMonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
+    type MempoolExecutor = MockMempool<Self::SignatureType, Self::SignatureCollectionType>;
 }

--- a/monad-mock-swarm/tests/two_nodes_bls.rs
+++ b/monad-mock-swarm/tests/two_nodes_bls.rs
@@ -21,6 +21,15 @@ use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
 
 struct BLSSwarm;
 impl SwarmRelation for BLSSwarm {
+    type SignatureType = SecpSignature;
+    type SignatureCollectionType = BlsSignatureCollection;
+
+    type InboundMessage = MonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
+    type OutboundMessage = VerifiedMonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
+    type TransportMessage = Self::InboundMessage;
+
+    type TransactionValidator = MockValidator;
+
     type State = MonadState<
         ConsensusState<Self::SignatureCollectionType, MockValidator, StateRoot>,
         Self::SignatureType,
@@ -29,24 +38,18 @@ impl SwarmRelation for BLSSwarm {
         SimpleRoundRobin,
         BlockSyncState,
     >;
-    type SignatureType = SecpSignature;
-    type SignatureCollectionType = BlsSignatureCollection;
-    type RouterScheduler =
-        NoSerRouterScheduler<MonadMessage<Self::SignatureType, Self::SignatureCollectionType>>;
-    type Pipeline = GenericTransformerPipeline<
-        MonadMessage<Self::SignatureType, Self::SignatureCollectionType>,
-    >;
+
+    type RouterSchedulerConfig = NoSerRouterConfig;
+    type RouterScheduler = NoSerRouterScheduler<Self::InboundMessage, Self::OutboundMessage>;
+
+    type Pipeline = GenericTransformerPipeline<Self::TransportMessage>;
+
+    type LoggerConfig = MockWALoggerConfig;
     type Logger =
         MockWALogger<TimedEvent<MonadEvent<Self::SignatureType, Self::SignatureCollectionType>>>;
-    type MempoolExecutor = MockMempool<Self::SignatureType, Self::SignatureCollectionType>;
-    type TransactionValidator = MockValidator;
-    type LoggerConfig = MockWALoggerConfig;
-    type RouterSchedulerConfig = NoSerRouterConfig;
+
     type MempoolConfig = MockMempoolConfig;
-    type StateMessage = MonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
-    type OutboundStateMessage =
-        VerifiedMonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
-    type Message = MonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
+    type MempoolExecutor = MockMempool<Self::SignatureType, Self::SignatureCollectionType>;
 }
 
 type SignatureType = SecpSignature;

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -16,13 +16,13 @@ use monad_crypto::{
 use monad_eth_types::EthAddress;
 use monad_executor_glue::PeerId;
 use monad_mock_swarm::{
-    mock::{MockExecutor, RouterScheduler},
+    mock::MockExecutor,
     mock_swarm::{Node, Nodes, NodesTerminator},
     swarm_relation::SwarmRelation,
     transformer::ID,
 };
-use monad_state::{MonadConfig, MonadMessage, VerifiedMonadMessage};
-use monad_types::{Deserializable, NodeId, Serializable};
+use monad_state::MonadConfig;
+use monad_types::NodeId;
 
 use crate::{signing::get_genesis_config, validators::create_keys_w_validators};
 
@@ -151,10 +151,6 @@ pub fn create_and_run_nodes<S, R, T>(
 where
     S: SwarmRelation,
 
-    MonadMessage<S::SignatureType, S::SignatureCollectionType>: Deserializable<S::Message>,
-    VerifiedMonadMessage<S::SignatureType, S::SignatureCollectionType>:
-        Serializable<<S::RouterScheduler as RouterScheduler>::M>,
-
     MockExecutor<S>: Unpin,
     Node<S>: Send,
     R: Fn(Vec<PeerId>, PeerId) -> S::RouterSchedulerConfig,
@@ -197,10 +193,6 @@ pub fn run_nodes_until<S, R, T>(
 ) -> Duration
 where
     S: SwarmRelation,
-
-    MonadMessage<S::SignatureType, S::SignatureCollectionType>: Deserializable<S::Message>,
-    VerifiedMonadMessage<S::SignatureType, S::SignatureCollectionType>:
-        Serializable<<S::RouterScheduler as RouterScheduler>::M>,
 
     MockExecutor<S>: Unpin,
     Node<S>: Send,

--- a/monad-twins/utils/src/lib.rs
+++ b/monad-twins/utils/src/lib.rs
@@ -3,7 +3,7 @@ pub mod twin_reader;
 use std::collections::BTreeMap;
 
 use monad_mock_swarm::{
-    mock::{MockExecutor, RouterScheduler},
+    mock::MockExecutor,
     mock_swarm::{Node, Nodes},
     swarm_relation::SwarmRelation,
     transformer::{
@@ -11,8 +11,6 @@ use monad_mock_swarm::{
         RandLatencyTransformer, ID,
     },
 };
-use monad_state::{MonadMessage, VerifiedMonadMessage};
-use monad_types::{Deserializable, Serializable};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 
@@ -27,9 +25,6 @@ pub fn run_twins_test<S, L, R, M>(
 ) where
     S: SwarmRelation<Pipeline = MonadMessageTransformerPipeline>,
     MockExecutor<S>: Unpin,
-    MonadMessage<S::SignatureType, S::SignatureCollectionType>: Deserializable<S::Message>,
-    VerifiedMonadMessage<S::SignatureType, S::SignatureCollectionType>:
-        Serializable<<S::RouterScheduler as RouterScheduler>::M>,
     Node<S>: Send,
     L: Fn(&ID, &Vec<ID>) -> S::LoggerConfig,
     R: Fn(&ID, &Vec<ID>) -> S::RouterSchedulerConfig,

--- a/monad-viz/Cargo.toml
+++ b/monad-viz/Cargo.toml
@@ -8,6 +8,7 @@ name = "monad-viz"
 bench = false
 
 [dependencies]
+monad-block-sync = { path = "../monad-block-sync" }
 monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
@@ -18,6 +19,7 @@ monad-mock-swarm = { path = "../monad-mock-swarm" }
 monad-state = { path = "../monad-state" }
 monad-testutil = { path = "../monad-testutil" }
 monad-types = { path = "../monad-types" }
+monad-validator = { path = "../monad-validator" }
 monad-wal = { path = "../monad-wal" }
 
 clap = { workspace = true, features = ["derive"] }

--- a/monad-viz/src/config.rs
+++ b/monad-viz/src/config.rs
@@ -15,10 +15,7 @@ use monad_executor::State;
 use monad_executor_glue::PeerId;
 use monad_mock_swarm::{
     swarm_relation::SwarmRelation,
-    transformer::{
-        GenericTransformer, GenericTransformerPipeline, LatencyTransformer, XorLatencyTransformer,
-        ID,
-    },
+    transformer::{GenericTransformer, LatencyTransformer, XorLatencyTransformer, ID},
 };
 use monad_state::MonadConfig;
 use monad_testutil::{signing::get_genesis_config, validators::create_keys_w_validators};
@@ -26,19 +23,18 @@ use monad_types::NodeId;
 
 use crate::{graph::SimulationConfig, VizSwarm};
 
-type MM = <VizSwarm as SwarmRelation>::Message;
-type MC = <<VizSwarm as SwarmRelation>::State as State>::Config;
+type MonadStateConfig = <<VizSwarm as SwarmRelation>::State as State>::Config;
 type LoggerConfig = <VizSwarm as SwarmRelation>::LoggerConfig;
 type RouterSchedulerConfig = <VizSwarm as SwarmRelation>::RouterSchedulerConfig;
 type MempoolConfig = <VizSwarm as SwarmRelation>::MempoolConfig;
-type Pipe = <VizSwarm as SwarmRelation>::Pipeline;
+type Pipeline = <VizSwarm as SwarmRelation>::Pipeline;
 
 #[derive(Debug, Clone)]
 pub struct SimConfig {
     pub num_nodes: u32,
     pub delta: Duration,
     pub max_tick: Duration,
-    pub pipeline: GenericTransformerPipeline<MM>,
+    pub pipeline: Pipeline,
 }
 
 impl SimConfig {
@@ -63,11 +59,11 @@ impl SimulationConfig<VizSwarm> for SimConfig {
         &self,
     ) -> Vec<(
         ID,
-        MC,
+        MonadStateConfig,
         LoggerConfig,
         RouterSchedulerConfig,
         MempoolConfig,
-        Pipe,
+        Pipeline,
         u64,
     )> {
         let (keys, cert_keys, _validators, validator_mapping) = create_keys_w_validators::<


### PR DESCRIPTION
Added easy to read Inbound, Outbound, and Transport Messages to RouterScheduler and propagated type names throughout SwarmRelations.