### PR TITLE
Bls SignatureCollection bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4390,6 +4390,7 @@ name = "monad-consensus-types"
 version = "0.1.0"
 dependencies = [
  "bitvec",
+ "criterion",
  "log",
  "monad-crypto",
  "monad-eth-types",

--- a/monad-consensus-types/Cargo.toml
+++ b/monad-consensus-types/Cargo.toml
@@ -29,6 +29,11 @@ zerocopy = { workspace = true }
 [dev-dependencies]
 monad-testutil = { path = "../monad-testutil" }
 
+criterion = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 test-case = { workspace = true }
+
+[[bench]]
+name = "bls"
+harness = false

--- a/monad-consensus-types/benches/bls.rs
+++ b/monad-consensus-types/benches/bls.rs
@@ -1,0 +1,51 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use monad_consensus_types::{
+    bls::BlsSignatureCollection, signature_collection::SignatureCollection,
+};
+use monad_crypto::hasher::{Hasher, HasherType};
+use monad_testutil::validators::create_keys_w_validators;
+use monad_types::NodeId;
+
+const N: u32 = 1000;
+
+type SignatureCollectionType = BlsSignatureCollection;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let (keys, certkeys, _, validator_mapping) =
+        create_keys_w_validators::<SignatureCollectionType>(N);
+    let mut hasher = HasherType::new();
+    hasher.update(b"hello world");
+    let data = hasher.hash();
+
+    // sign
+    c.bench_function("bls_sign", |b| b.iter(|| certkeys[0].sign(data.as_ref())));
+
+    let mut sigs = Vec::new();
+    for (node_id, certkey) in keys.iter().map(|k| NodeId(k.pubkey())).zip(certkeys.iter()) {
+        sigs.push((node_id, certkey.sign(data.as_ref())));
+    }
+
+    // aggregate N signatures
+    c.bench_function("bls_aggregate_1000", |b| {
+        b.iter_batched(
+            || sigs.clone(),
+            |sigs| SignatureCollectionType::new(sigs, &validator_mapping, data.as_ref()).unwrap(),
+            criterion::BatchSize::SmallInput,
+        )
+    });
+
+    // verify
+    c.bench_function("bls_verify", |b| {
+        b.iter_batched(
+            || {
+                SignatureCollectionType::new(sigs.clone(), &validator_mapping, data.as_ref())
+                    .unwrap()
+            },
+            |sig_col| sig_col.verify(&validator_mapping, data.as_ref()).unwrap(),
+            criterion::BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
On peach6
```
bls_sign                time:   [424.46 µs 428.60 µs 432.21 µs]
                        change: [-3.2291% -2.2365% -1.2809%] (p = 0.00 < 0.05)
                        Performance has improved.

bls_aggregate_1000      time:   [7.9453 ms 7.9799 ms 8.0146 ms]

bls_verify              time:   [2.6496 ms 2.6580 ms 2.6657 ms]
                        change: [-0.6918% -0.0114% +0.8417%] (p = 0.98 > 0.05)
```