### PR TITLE
Fix `many_nodes_quic_bw` test

### DIFF
--- a/monad-mock-swarm/src/mock_swarm.rs
+++ b/monad-mock-swarm/src/mock_swarm.rs
@@ -1,6 +1,5 @@
 use std::{
-    cmp::Reverse,
-    collections::{BTreeMap, BinaryHeap},
+    collections::{BTreeMap, VecDeque},
     time::Duration,
     usize,
 };
@@ -37,7 +36,7 @@ where
     pub state: S::State,
     pub logger: S::Logger,
     pub pipeline: S::Pipeline,
-    pub pending_inbound_messages: BinaryHeap<Reverse<(Duration, LinkMessage<S::TransportMessage>)>>,
+    pub pending_inbound_messages: BTreeMap<Duration, VecDeque<LinkMessage<S::TransportMessage>>>,
     pub rng: ChaCha20Rng,
     pub current_seed: usize,
 }
@@ -61,10 +60,8 @@ where
                     .iter()
                     .map(|tick| (*tick, SwarmEventType::ExecutorEvent)),
             )
-            .chain(self.pending_inbound_messages.peek().iter().map(
-                |Reverse((min_scheduled_tick, _))| {
-                    (*min_scheduled_tick, SwarmEventType::ScheduledMessage)
-                },
+            .chain(self.pending_inbound_messages.first_key_value().map(
+                |(min_scheduled_tick, _)| (*min_scheduled_tick, SwarmEventType::ScheduledMessage),
             ))
             .min_set();
         if !events.is_empty() {
@@ -119,7 +116,9 @@ where
                                 // FIXME: do we need to transform msg to self?
                                 if msg.to == self.id {
                                     self.pending_inbound_messages
-                                        .push(Reverse((sched_tick, msg)))
+                                        .entry(sched_tick)
+                                        .or_default()
+                                        .push_back(msg)
                                 } else {
                                     emitted_messages.push((sched_tick, msg))
                                 }
@@ -129,12 +128,21 @@ where
                     }
                 }
                 SwarmEventType::ScheduledMessage => {
-                    let Reverse((scheduled_tick, message)) = self
+                    let mut entry = self
                         .pending_inbound_messages
-                        .pop()
+                        .first_entry()
                         .expect("logic error, should be nonempty");
 
+                    let scheduled_tick = *entry.key();
+                    let msgs = entry.get_mut();
+
                     assert_eq!(tick, scheduled_tick);
+
+                    let message = msgs.pop_front().expect("logic error, should be nonempty");
+
+                    if msgs.is_empty() {
+                        entry.remove_entry();
+                    }
 
                     self.executor.send_message(
                         scheduled_tick,
@@ -400,7 +408,9 @@ where
                 assert!(!self.must_deliver || node.is_some());
                 if let Some(node) = node {
                     node.pending_inbound_messages
-                        .push(Reverse((sched_tick, message)))
+                        .entry(sched_tick)
+                        .or_default()
+                        .push_back(message);
                 };
             }
             if let Some((tick, _)) = emitted_event {
@@ -448,7 +458,9 @@ where
 
                 if let Some(node) = node {
                     node.pending_inbound_messages
-                        .push(Reverse((sched_tick, message)))
+                        .entry(sched_tick)
+                        .or_default()
+                        .push_back(message);
                 };
             }
         }

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -78,17 +78,17 @@ fn many_nodes_quic_bw() {
 
     let swarm_config = SwarmTestConfig {
         num_nodes: 40,
-        consensus_delta: Duration::from_millis(1000),
+        consensus_delta: Duration::from_millis(100),
         parallelize: true,
-        expected_block: 10,
+        expected_block: 95,
         state_root_delay: u64::MAX,
         seed: 1,
-        proposal_size: 150,
+        proposal_size: 5000,
     };
 
     let xfmrs = vec![
-        BytesTransformer::Latency(LatencyTransformer(Duration::from_millis(1))),
-        BytesTransformer::Bw(BwTransformer::new(5)),
+        BytesTransformer::Latency(LatencyTransformer(Duration::from_millis(100))),
+        BytesTransformer::Bw(BwTransformer::new(100)),
     ];
 
     create_and_run_nodes::<QuicSwarm, _, _>(
@@ -106,7 +106,7 @@ fn many_nodes_quic_bw() {
         MockWALoggerConfig,
         MockMempoolConfig::default(),
         xfmrs,
-        UntilTerminator::new().until_tick(Duration::from_secs(100)),
+        UntilTerminator::new().until_tick(Duration::from_secs(20)),
         swarm_config,
     );
 }

--- a/monad-viz/src/graph.rs
+++ b/monad-viz/src/graph.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Reverse, time::Duration};
+use std::time::Duration;
 
 use monad_block_sync::BlockSyncProcess;
 use monad_consensus_state::ConsensusProcess;
@@ -168,11 +168,13 @@ where
                 pending_events: node
                     .pending_inbound_messages
                     .iter()
-                    .map(|Reverse((rx_time, message))| NodeEvent::Message {
-                        tx_time: message.from_tick,
-                        rx_time: *rx_time,
-                        tx_peer: message.from.get_peer_id(),
-                        message: &message.message,
+                    .flat_map(|(rx_time, messages)| {
+                        messages.iter().map(|message| NodeEvent::Message {
+                            tx_time: message.from_tick,
+                            rx_time: *rx_time,
+                            tx_peer: message.from.get_peer_id(),
+                            message: &message.message,
+                        })
                     })
                     .collect(),
             })


### PR DESCRIPTION
The test was taking unusually long (in virtual time) to complete because of several reasons

1. `Node.pending_inbound_messages` is a binary heap. It reorders inbound messages. Quinn-proto drops short packets during handshake [[1](https://github.com/quinn-rs/quinn/blob/main/quinn-proto/src/connection/mod.rs#L2103-L2106)]. This causes unnecessary retransmission during the intial period of time

2. `QuicRouterScheduler` should re-poll transmit after moving calling `send_stream.write` on pending outbound messages.

This PR fixes the above. No packets get dropped by the `BwTransformer` in this test. The proposal size is 162935 bytes (without gossip & quic header). Broadcasting to 40 nodes takes about 52 Mbps, well under 100 Mbps limit.

The swarm produces 97 blocks in 20 seconds, thus setting `expected_block` to be 95.