### PR TITLE
Delete monad-test feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4406,7 +4406,6 @@ dependencies = [
  "monad-executor",
  "monad-executor-glue",
  "monad-gossip",
- "monad-mock-swarm",
  "monad-quic",
  "monad-state",
  "monad-testutil",
@@ -4526,7 +4525,6 @@ dependencies = [
  "monad-mock-swarm",
  "monad-proto",
  "monad-quic",
- "monad-state",
  "monad-testutil",
  "monad-tracing-counter",
  "monad-types",
@@ -4632,6 +4630,7 @@ version = "0.1.0"
 dependencies = [
  "itertools",
  "monad-consensus-types",
+ "monad-crypto",
  "monad-mock-swarm",
  "monad-state",
  "monad-testutil",
@@ -4744,7 +4743,6 @@ dependencies = [
  "monad-state",
  "monad-testutil",
  "monad-types",
- "monad-wal",
  "tempfile",
 ]
 

--- a/monad-blocktree/Cargo.toml
+++ b/monad-blocktree/Cargo.toml
@@ -8,9 +8,6 @@ edition = "2021"
 [lib]
 bench = false
 
-[features]
-monad_test = []
-
 [dependencies]
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-tracing-counter = { path = "../monad-tracing-counter" }

--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -33,8 +33,7 @@ impl std::error::Error for BlockTreeError {
     }
 }
 
-#[cfg_attr(feature = "monad_test", derive(PartialEq, Eq))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockTreeBlock<T> {
     block: FullBlock<T>,
     parent: Option<BlockId>,
@@ -106,7 +105,7 @@ pub enum RootKind {
     Unrooted(Round),
 }
 
-#[cfg_attr(feature = "monad_test", derive(PartialEq, Eq))]
+#[derive(PartialEq, Eq)]
 pub struct BlockTree<T> {
     pub root: RootKind,
     tree: HashMap<BlockId, BlockTreeBlock<T>>,

--- a/monad-consensus-state/Cargo.toml
+++ b/monad-consensus-state/Cargo.toml
@@ -8,10 +8,6 @@ edition = "2021"
 [lib]
 bench = false
 
-
-[features]
-monad_test = ["monad-blocktree/monad_test", "monad-consensus/monad_test"]
-
 [dependencies]
 monad-blocktree = { path = "../monad-blocktree" }
 monad-consensus = { path = "../monad-consensus" }
@@ -27,8 +23,6 @@ log = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-monad-blocktree = { path = "../monad-blocktree", features = ["monad_test"] }
-monad-consensus = { path = "../monad-consensus", features = ["monad_test"] }
 monad-testutil = { path = "../monad-testutil" }
 
 env_logger = { workspace = true }

--- a/monad-consensus-state/src/blocksync.rs
+++ b/monad-consensus-state/src/blocksync.rs
@@ -20,8 +20,7 @@ use crate::command::ConsensusCommand;
 
 const DEFAULT_PEER_INDEX: usize = 0;
 
-#[cfg_attr(feature = "monad_test", derive(PartialEq, Eq))]
-#[derive(Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InFlightBlockSync<SCT> {
     pub req_target: NodeId,
     pub retry_cnt: usize,
@@ -71,8 +70,7 @@ impl<SCT: SignatureCollection> InFlightBlockSync<SCT> {
         }
     }
 }
-#[cfg_attr(feature = "monad_test", derive(PartialEq, Eq))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockSyncManager<SCT> {
     requests: HashMap<BlockId, InFlightBlockSync<SCT>>,
     id: NodeId,

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -62,8 +62,42 @@ pub struct ConsensusState<SCT: SignatureCollection, TV, SVT> {
     beneficiary: EthAddress,
 }
 
-#[cfg_attr(feature = "monad_test", derive(PartialEq, Eq, Clone))]
-#[derive(Debug)]
+impl<SCT, TVT, SVT> PartialEq for ConsensusState<SCT, TVT, SVT>
+where
+    SCT: SignatureCollection,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.pending_block_tree.eq(&other.pending_block_tree)
+            && self.vote_state.eq(&other.vote_state)
+            && self.high_qc.eq(&other.high_qc)
+            && self.pacemaker.eq(&other.pacemaker)
+            && self.safety.eq(&other.safety)
+            && self.nodeid.eq(&other.nodeid)
+            && self.config.eq(&other.config)
+            && self.block_sync_manager.eq(&other.block_sync_manager)
+    }
+}
+impl<SCT, TVT, SVT> std::fmt::Debug for ConsensusState<SCT, TVT, SVT>
+where
+    SCT: SignatureCollection,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConsensusState")
+            .field("pending_block_tree", &self.pending_block_tree)
+            .field("vote_state", &self.vote_state)
+            .field("high_qc", &self.high_qc)
+            .field("pacemaker", &self.pacemaker)
+            .field("safety", &self.safety)
+            .field("nodeid", &self.nodeid)
+            .field("config", &self.config)
+            .field("block_sync_manager", &self.block_sync_manager)
+            .finish()
+    }
+}
+
+impl<SCT, TVT, SVT> Eq for ConsensusState<SCT, TVT, SVT> where SCT: SignatureCollection {}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ConsensusConfig {
     pub proposal_size: usize,
     pub state_root_delay: u64,
@@ -758,47 +792,6 @@ pub enum ConsensusAction {
     Propose(Hash, Vec<TransactionHashList>),
     ProposeEmpty,
     Abstain,
-}
-#[cfg(feature = "monad_test")]
-mod monad_test {
-    use monad_consensus_types::signature_collection::SignatureCollection;
-
-    use crate::ConsensusState;
-
-    impl<SCT, TVT, SVT> PartialEq for ConsensusState<SCT, TVT, SVT>
-    where
-        SCT: SignatureCollection,
-    {
-        fn eq(&self, other: &Self) -> bool {
-            self.pending_block_tree.eq(&other.pending_block_tree)
-                && self.vote_state.eq(&other.vote_state)
-                && self.high_qc.eq(&other.high_qc)
-                && self.pacemaker.eq(&other.pacemaker)
-                && self.safety.eq(&other.safety)
-                && self.nodeid.eq(&other.nodeid)
-                && self.config.eq(&other.config)
-                && self.block_sync_manager.eq(&other.block_sync_manager)
-        }
-    }
-    impl<SCT, TVT, SVT> std::fmt::Debug for ConsensusState<SCT, TVT, SVT>
-    where
-        SCT: SignatureCollection,
-    {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.debug_struct("ConsensusState")
-                .field("pending_block_tree", &self.pending_block_tree)
-                .field("vote_state", &self.vote_state)
-                .field("high_qc", &self.high_qc)
-                .field("pacemaker", &self.pacemaker)
-                .field("safety", &self.safety)
-                .field("nodeid", &self.nodeid)
-                .field("config", &self.config)
-                .field("block_sync_manager", &self.block_sync_manager)
-                .finish()
-        }
-    }
-
-    impl<SCT, TVT, SVT> Eq for ConsensusState<SCT, TVT, SVT> where SCT: SignatureCollection {}
 }
 
 #[cfg(test)]

--- a/monad-consensus-types/Cargo.toml
+++ b/monad-consensus-types/Cargo.toml
@@ -8,9 +8,6 @@ edition = "2021"
 [lib]
 bench = false
 
-[features]
-monad_test = []
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/monad-consensus/Cargo.toml
+++ b/monad-consensus/Cargo.toml
@@ -8,9 +8,6 @@ edition = "2021"
 [lib]
 bench = false
 
-[features]
-monad_test = []
-
 [dependencies]
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }

--- a/monad-consensus/src/pacemaker.rs
+++ b/monad-consensus/src/pacemaker.rs
@@ -17,8 +17,7 @@ use crate::{
     validation::{message::well_formed, safety::Safety},
 };
 
-#[cfg_attr(feature = "monad_test", derive(PartialEq, Eq))]
-#[derive(Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct Pacemaker<SCT: SignatureCollection> {
     delta: Duration,
 

--- a/monad-consensus/src/validation/safety.rs
+++ b/monad-consensus/src/validation/safety.rs
@@ -11,8 +11,7 @@ use monad_consensus_types::{
 use monad_crypto::hasher::Hasher;
 use monad_types::*;
 
-#[cfg_attr(feature = "monad_test", derive(PartialEq, Eq))]
-#[derive(Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct Safety {
     highest_vote_round: Round,
     highest_qc_round: Round,

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -503,26 +503,6 @@ impl ValidatorPubKey for PubKey {
     }
 }
 
-#[cfg(feature = "monad_test")]
-mod monad_test {
-    use monad_consensus_types::{
-        message_signature::MessageSignature, signature_collection::SignatureCollection,
-    };
-
-    use super::Unverified;
-    use crate::messages::consensus_message::ConsensusMessage;
-
-    impl<S, SCT> Unverified<S, ConsensusMessage<SCT>>
-    where
-        S: MessageSignature,
-        SCT: SignatureCollection,
-    {
-        pub fn spy_internal(&self) -> &ConsensusMessage<SCT> {
-            &self.obj
-        }
-    }
-}
-
 #[cfg(test)]
 mod test {
     use monad_consensus_types::{

--- a/monad-consensus/src/vote_state.rs
+++ b/monad-consensus/src/vote_state.rs
@@ -16,8 +16,7 @@ use crate::messages::message::VoteMessage;
 // accumulate votes and create a QC if enough votes are received
 // only one QC should be created in a round using the first supermajority of votes received
 // At the end of a round, older rounds can be cleaned up
-#[cfg_attr(feature = "monad_test", derive(PartialEq, Eq))]
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct VoteState<SCT: SignatureCollection> {
     pending_votes:
         BTreeMap<Round, HashMap<Hash, (Vec<(NodeId, SCT::SignatureType)>, HashSet<NodeId>)>>,

--- a/monad-crypto/Cargo.toml
+++ b/monad-crypto/Cargo.toml
@@ -28,7 +28,6 @@ hex = { workspace = true }
 tiny-keccak = { workspace = true, features = ["keccak"] }
 
 [features]
-monad_test = []
 rustls = ["dep:rcgen", "dep:rustls"]
 
 [[bench]]

--- a/monad-crypto/src/secp256k1.rs
+++ b/monad-crypto/src/secp256k1.rs
@@ -6,7 +6,6 @@ use crate::hasher::{Hashable, Hasher, HasherType};
 
 #[derive(Copy, Clone)]
 pub struct PubKey(secp256k1::PublicKey);
-#[cfg_attr(feature = "monad_test", derive(Clone))]
 pub struct KeyPair(secp256k1::KeyPair);
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SecpSignature(secp256k1::ecdsa::RecoverableSignature);

--- a/monad-executor-glue/Cargo.toml
+++ b/monad-executor-glue/Cargo.toml
@@ -10,9 +10,6 @@ edition = "2021"
 [lib]
 bench = false
 
-[features]
-monad_test = []
-
 [dependencies]
 monad-consensus = { path = "../monad-consensus" }
 monad-consensus-types = { path = "../monad-consensus-types" }

--- a/monad-executor/Cargo.toml
+++ b/monad-executor/Cargo.toml
@@ -8,9 +8,6 @@ edition = "2021"
 [lib]
 bench = false
 
-[features]
-monad_test = []
-
 [dependencies]
 monad-crypto = { path = "../monad-crypto" }
 monad-consensus-types = { path = "../monad-consensus-types" }

--- a/monad-executor/src/lib.rs
+++ b/monad-executor/src/lib.rs
@@ -45,7 +45,7 @@ pub trait State: Sized {
     type Message: Message<Event = Self::Event>;
 
     type Event: Clone;
-    type OutboundMessage: Into<Self::Message> + AsRef<Self::Message>;
+    type OutboundMessage: Clone + Into<Self::Message> + AsRef<Self::Message>;
     type Block: BlockType;
     type Checkpoint;
     type SignatureCollection;

--- a/monad-executor/src/replay_nodes.rs
+++ b/monad-executor/src/replay_nodes.rs
@@ -13,7 +13,7 @@ where
     pub send_id: NodeId,
     pub send_tick: Duration,
     pub event: S::Event,
-    pub message: <S as State>::Message,
+    pub message: <S as State>::OutboundMessage,
 }
 
 pub struct NodesInfo<S>
@@ -113,8 +113,6 @@ where
                 }
                 Command::RouterCommand(cmd) => match cmd {
                     RouterCommand::Publish { target, message } => {
-                        let message = message.into();
-
                         let tos = match target {
                             RouterTarget::PointToPoint(to) => vec![to],
                             RouterTarget::Broadcast => {
@@ -132,7 +130,7 @@ where
                             msg_queue.push(PendingMsg {
                                 send_id: *node_id,
                                 send_tick: tick,
-                                event: message.clone().event(*node_id),
+                                event: message.clone().into().event(*node_id),
                                 message: message.clone(),
                             });
                         }

--- a/monad-mock-swarm/Cargo.toml
+++ b/monad-mock-swarm/Cargo.toml
@@ -10,13 +10,6 @@ edition = "2021"
 [lib]
 bench = false
 
-[features]
-monad_test = [
-    "monad-consensus/monad_test",
-    "monad-executor-glue/monad_test",
-    "monad-state/monad_test",
-]
-
 [dependencies]
 monad-block-sync = { path = "../monad-block-sync" }
 monad-consensus = { path = "../monad-consensus" }
@@ -26,7 +19,7 @@ monad-crypto = { path = "../monad-crypto" }
 monad-eth-types = { path = "../monad-eth-types" }
 monad-executor = { path = "../monad-executor" }
 monad-executor-glue = { path = "../monad-executor-glue" }
-monad-state = { path = "../monad-state", features = ["monad_test"] }
+monad-state = { path = "../monad-state" }
 monad-tracing-counter = { path = "../monad-tracing-counter" }
 monad-types = { path = "../monad-types" }
 monad-updaters = { path = "../monad-updaters" }
@@ -43,13 +36,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 monad-block-sync = { path = "../monad-block-sync" }
-monad-consensus = { path = "../monad-consensus", features = ["monad_test"] }
-monad-consensus-state = { path = "../monad-consensus-state", features = [
-    "monad_test",
-] }
-monad-executor = { path = "../monad-executor", features = ["monad_test"] }
 monad-gossip = { path = "../monad-gossip" }
-monad-mock-swarm = { path = ".", features = ["monad_test"] }
 monad-quic = { path = "../monad-quic" }
 monad-testutil = { path = "../monad-testutil" }
 

--- a/monad-mock-swarm/src/utils.rs
+++ b/monad-mock-swarm/src/utils.rs
@@ -3,15 +3,11 @@
 pub mod test_tool {
     use std::time::Duration;
 
-    use monad_consensus::{
-        messages::{
-            consensus_message::ConsensusMessage,
-            message::{
-                BlockSyncMessage, ProposalMessage, RequestBlockSyncMessage, TimeoutMessage,
-                VoteMessage,
-            },
+    use monad_consensus::messages::{
+        consensus_message::ConsensusMessage,
+        message::{
+            BlockSyncMessage, ProposalMessage, RequestBlockSyncMessage, TimeoutMessage, VoteMessage,
         },
-        validation::signing::Unverified,
     };
     use monad_consensus_types::{
         block::Block,
@@ -24,12 +20,12 @@ pub mod test_tool {
         voting::{Vote, VoteInfo},
     };
     use monad_crypto::{
-        hasher::{Hash, Sha256Hash},
+        hasher::{Hash, HasherType, Sha256Hash},
         secp256k1::KeyPair,
         NopSignature,
     };
     use monad_eth_types::EthAddress;
-    use monad_state::MonadMessage;
+    use monad_state::VerifiedMonadMessage;
     use monad_testutil::signing::create_keys;
     use monad_types::{BlockId, NodeId, Round};
 
@@ -85,19 +81,17 @@ pub mod test_tool {
         Block::new::<H>(fake_node_id(), round, &payload, &fake_qc())
     }
 
-    pub fn fake_proposal_message(kp: &KeyPair, round: Round) -> MonadMessage<ST, SC> {
+    pub fn fake_proposal_message(kp: &KeyPair, round: Round) -> VerifiedMonadMessage<ST, SC> {
         let internal_msg = ProposalMessage {
             block: fake_block(round),
             last_round_tc: None,
         };
-        let msg = Unverified::new(
-            ConsensusMessage::Proposal(internal_msg),
-            NopSignature::sign(&[0x00_u8, 32], kp),
-        );
-        MonadMessage::<ST, SC>::new(msg)
+        ConsensusMessage::Proposal(internal_msg)
+            .sign::<HasherType, NopSignature>(kp)
+            .into()
     }
 
-    pub fn fake_vote_message(kp: &KeyPair, round: Round) -> MonadMessage<ST, SC> {
+    pub fn fake_vote_message(kp: &KeyPair, round: Round) -> VerifiedMonadMessage<ST, SC> {
         let vote_info = VoteInfo {
             id: BlockId(Hash([0x00_u8; 32])),
             round,
@@ -112,14 +106,12 @@ pub mod test_tool {
             },
             sig: NopSignature::sign(&[0x00_u8, 32], kp),
         };
-        let msg = Unverified::new(
-            ConsensusMessage::Vote(internal_msg),
-            NopSignature::sign(&[0x00_u8, 32], kp),
-        );
-        MonadMessage::<ST, SC>::new(msg)
+        ConsensusMessage::Vote(internal_msg)
+            .sign::<HasherType, NopSignature>(kp)
+            .into()
     }
 
-    pub fn fake_timeout_message(kp: &KeyPair) -> MonadMessage<ST, SC> {
+    pub fn fake_timeout_message(kp: &KeyPair) -> VerifiedMonadMessage<ST, SC> {
         let timeout_info = TimeoutInfo {
             round: Round(0),
             high_qc: fake_qc(),
@@ -131,30 +123,24 @@ pub mod test_tool {
             },
             sig: NopSignature::sign(&[0x00_u8, 32], kp),
         };
-        let msg = Unverified::new(
-            ConsensusMessage::Timeout(internal_msg),
-            NopSignature::sign(&[0x00_u8, 32], kp),
-        );
-        MonadMessage::<ST, SC>::new(msg)
+        ConsensusMessage::Timeout(internal_msg)
+            .sign::<HasherType, NopSignature>(kp)
+            .into()
     }
 
-    pub fn fake_request_block_sync(kp: &KeyPair) -> MonadMessage<ST, SC> {
+    pub fn fake_request_block_sync(kp: &KeyPair) -> VerifiedMonadMessage<ST, SC> {
         let internal_msg = RequestBlockSyncMessage {
             block_id: BlockId(Hash([0x00_u8; 32])),
         };
-        let msg = Unverified::new(
-            ConsensusMessage::RequestBlockSync(internal_msg),
-            NopSignature::sign(&[0x00_u8, 32], kp),
-        );
-        MonadMessage::<ST, SC>::new(msg)
+        ConsensusMessage::RequestBlockSync(internal_msg)
+            .sign::<HasherType, NopSignature>(kp)
+            .into()
     }
 
-    pub fn fake_block_sync(kp: &KeyPair) -> MonadMessage<ST, SC> {
+    pub fn fake_block_sync(kp: &KeyPair) -> VerifiedMonadMessage<ST, SC> {
         let internal_msg = BlockSyncMessage::NotAvailable(BlockId(Hash([0x00_u8; 32])));
-        let msg = Unverified::new(
-            ConsensusMessage::BlockSync(internal_msg),
-            NopSignature::sign(&[0x00_u8, 32], kp),
-        );
-        MonadMessage::<ST, SC>::new(msg)
+        ConsensusMessage::BlockSync(internal_msg)
+            .sign::<HasherType, NopSignature>(kp)
+            .into()
     }
 }

--- a/monad-mock-swarm/tests/block_sync.rs
+++ b/monad-mock-swarm/tests/block_sync.rs
@@ -11,19 +11,16 @@ mod test {
     use monad_mock_swarm::{
         mock::{MockMempoolConfig, NoSerRouterConfig},
         mock_swarm::{Nodes, ProgressTerminator, UntilTerminator},
-        swarm_relation::{monad_test::MonadMessageNoSerSwarm, SwarmRelation},
+        swarm_relation::{MonadMessageNoSerSwarm, NoSerSwarm, SwarmRelation},
         transformer::{
-            monad_test::{FilterTransformer, MonadMessageTransformer},
-            DropTransformer, GenericTransformer, LatencyTransformer, PartitionTransformer,
-            PeriodicTransformer, ID,
+            DropTransformer, FilterTransformer, GenericTransformer, LatencyTransformer,
+            MonadMessageTransformer, PartitionTransformer, PeriodicTransformer, ID,
         },
     };
     use monad_testutil::swarm::{get_configs, node_ledger_verification, run_nodes_until};
     use monad_types::NodeId;
     use monad_wal::mock::MockWALoggerConfig;
     use test_case::test_case;
-
-    use super::common::NoSerSwarm;
 
     #[test]
     fn bsync_timeout_recovery() {

--- a/monad-mock-swarm/tests/many_nodes_metrics.rs
+++ b/monad-mock-swarm/tests/many_nodes_metrics.rs
@@ -2,14 +2,12 @@ mod common;
 use std::time::Duration;
 
 use common::NoSerSwarm;
-use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
-use monad_crypto::NopSignature;
+use monad_consensus_types::transaction_validator::MockValidator;
 use monad_mock_swarm::{
     mock::{MockMempoolConfig, NoSerRouterConfig},
     mock_swarm::UntilTerminator,
     transformer::{GenericTransformer, LatencyTransformer},
 };
-use monad_state::MonadMessage;
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
 use monad_tracing_counter::{
     counter::{CounterLayer, MetricFilter},
@@ -41,9 +39,7 @@ fn many_nodes_metrics() {
         },
         MockWALoggerConfig,
         MockMempoolConfig::default(),
-        vec![GenericTransformer::<
-            MonadMessage<NopSignature, MultiSig<NopSignature>>,
-        >::Latency(LatencyTransformer(
+        vec![GenericTransformer::Latency(LatencyTransformer(
             Duration::from_millis(1),
         ))],
         UntilTerminator::new().until_tick(Duration::from_secs(4)),

--- a/monad-mock-swarm/tests/rand_lat.rs
+++ b/monad-mock-swarm/tests/rand_lat.rs
@@ -2,14 +2,12 @@ mod common;
 use std::env;
 
 use common::NoSerSwarm;
-use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
-use monad_crypto::NopSignature;
+use monad_consensus_types::transaction_validator::MockValidator;
 use monad_mock_swarm::{
     mock::{MockMempoolConfig, NoSerRouterConfig},
     mock_swarm::UntilTerminator,
     transformer::GenericTransformer,
 };
-use monad_state::MonadMessage;
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
 use monad_wal::mock::MockWALoggerConfig;
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -62,11 +60,9 @@ fn nodes_with_random_latency(seed: u64) {
         },
         MockWALoggerConfig,
         MockMempoolConfig::default(),
-        vec![GenericTransformer::<
-            MonadMessage<NopSignature, MultiSig<NopSignature>>,
-        >::RandLatency(RandLatencyTransformer::new(
-            seed, 330,
-        ))],
+        vec![GenericTransformer::RandLatency(
+            RandLatencyTransformer::new(seed, 330),
+        )],
         UntilTerminator::new().until_tick(Duration::from_secs(60 * 60)),
         SwarmTestConfig {
             num_nodes: 4,

--- a/monad-mock-swarm/tests/random_mempool.rs
+++ b/monad-mock-swarm/tests/random_mempool.rs
@@ -28,7 +28,7 @@ impl SwarmRelation for RandFailSwarm {
 
     type InboundMessage = MonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
     type OutboundMessage = VerifiedMonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
-    type TransportMessage = Self::InboundMessage;
+    type TransportMessage = Self::OutboundMessage;
 
     type TransactionValidator = MockValidator;
 

--- a/monad-mock-swarm/tests/replay.rs
+++ b/monad-mock-swarm/tests/replay.rs
@@ -33,7 +33,7 @@ impl SwarmRelation for ReplaySwarm {
 
     type InboundMessage = MonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
     type OutboundMessage = VerifiedMonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
-    type TransportMessage = Self::InboundMessage;
+    type TransportMessage = Self::OutboundMessage;
 
     type TransactionValidator = MockValidator;
 

--- a/monad-mock-swarm/tests/replay_test.rs
+++ b/monad-mock-swarm/tests/replay_test.rs
@@ -37,7 +37,7 @@ impl SwarmRelation for ReplaySwarm {
 
     type InboundMessage = MonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
     type OutboundMessage = VerifiedMonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
-    type TransportMessage = Self::InboundMessage;
+    type TransportMessage = Self::OutboundMessage;
 
     type TransactionValidator = MockValidator;
 

--- a/monad-mock-swarm/tests/single_node.rs
+++ b/monad-mock-swarm/tests/single_node.rs
@@ -3,8 +3,7 @@ mod common;
 use std::time::{Duration, Instant};
 
 use common::{NoSerSwarm, QuicSwarm};
-use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
-use monad_crypto::NopSignature;
+use monad_consensus_types::transaction_validator::MockValidator;
 use monad_gossip::mock::MockGossipConfig;
 use monad_mock_swarm::{
     mock::{MockMempoolConfig, NoSerRouterConfig},
@@ -12,7 +11,6 @@ use monad_mock_swarm::{
     transformer::{BwTransformer, BytesTransformer, GenericTransformer, LatencyTransformer},
 };
 use monad_quic::QuicRouterSchedulerConfig;
-use monad_state::MonadMessage;
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
 use monad_wal::mock::MockWALoggerConfig;
 use tracing_test::traced_test;
@@ -26,9 +24,9 @@ fn two_nodes() {
         },
         MockWALoggerConfig,
         MockMempoolConfig::default(),
-        vec![GenericTransformer::Latency::<
-            MonadMessage<NopSignature, MultiSig<NopSignature>>,
-        >(LatencyTransformer(Duration::from_millis(1)))],
+        vec![GenericTransformer::Latency(LatencyTransformer(
+            Duration::from_millis(1),
+        ))],
         UntilTerminator::new().until_tick(Duration::from_secs(10)),
         SwarmTestConfig {
             num_nodes: 2,

--- a/monad-mock-swarm/tests/two_nodes_bls.rs
+++ b/monad-mock-swarm/tests/two_nodes_bls.rs
@@ -26,7 +26,7 @@ impl SwarmRelation for BLSSwarm {
 
     type InboundMessage = MonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
     type OutboundMessage = VerifiedMonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
-    type TransportMessage = Self::InboundMessage;
+    type TransportMessage = Self::OutboundMessage;
 
     type TransactionValidator = MockValidator;
 
@@ -52,9 +52,6 @@ impl SwarmRelation for BLSSwarm {
     type MempoolExecutor = MockMempool<Self::SignatureType, Self::SignatureCollectionType>;
 }
 
-type SignatureType = SecpSignature;
-type SignatureCollectionType = BlsSignatureCollection;
-
 #[test]
 fn two_nodes_bls() {
     tracing_subscriber::fmt::init();
@@ -66,9 +63,9 @@ fn two_nodes_bls() {
         },
         MockWALoggerConfig,
         MockMempoolConfig::default(),
-        vec![GenericTransformer::Latency::<
-            MonadMessage<SignatureType, SignatureCollectionType>,
-        >(LatencyTransformer(Duration::from_millis(1)))],
+        vec![GenericTransformer::Latency(LatencyTransformer(
+            Duration::from_millis(1),
+        ))],
         UntilTerminator::new().until_tick(Duration::from_secs(10)),
         SwarmTestConfig {
             num_nodes: 2,

--- a/monad-state/Cargo.toml
+++ b/monad-state/Cargo.toml
@@ -8,9 +8,6 @@ edition = "2021"
 [lib]
 bench = false
 
-[features]
-monad_test = ["monad-consensus-state/monad_test", "monad-consensus-types/monad_test", "monad-crypto/monad_test"]
-
 [dependencies]
 monad-blocktree = { path = "../monad-blocktree" }
 monad-block-sync = { path = "../monad-block-sync" }
@@ -28,11 +25,6 @@ monad-validator = { path = "../monad-validator" }
 ref-cast = { workspace = true }
 
 [dev-dependencies]
-monad-consensus-state = { path = "../monad-consensus-state", features = [
-    "monad_test",
-] }
-monad-executor = { path = "../monad-executor", features = ["monad_test"] }
-monad-state = { path = ".", features = ["monad_test"] }
 monad-quic = { path = "../monad-quic" }
 monad-mock-swarm = { path = "../monad-mock-swarm" }
 monad-testutil = { path = "../monad-testutil" }

--- a/monad-testutil/examples/logs_gen.rs
+++ b/monad-testutil/examples/logs_gen.rs
@@ -28,7 +28,7 @@ impl SwarmRelation for LogSwarm {
 
     type InboundMessage = MonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
     type OutboundMessage = VerifiedMonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
-    type TransportMessage = Self::InboundMessage;
+    type TransportMessage = Self::OutboundMessage;
 
     type TransactionValidator = MockValidator;
 

--- a/monad-testutil/src/signing.rs
+++ b/monad-testutil/src/signing.rs
@@ -233,9 +233,3 @@ pub fn get_certificate_key<SCT: SignatureCollection>(
     let mut hash = hasher.hash();
     <SignatureCollectionKeyPairType<SCT> as CertificateKeyPair>::from_bytes(&mut hash.0).unwrap()
 }
-
-pub fn get_certificate_key_secret(seed: u64) -> [u8; 32] {
-    let mut hasher = HasherType::new();
-    hasher.update(seed.to_le_bytes());
-    hasher.hash().0
-}

--- a/monad-twins/Cargo.toml
+++ b/monad-twins/Cargo.toml
@@ -10,14 +10,14 @@ bench = false
 
 [dev-dependencies]
 monad-block-sync = { path = "../monad-block-sync" }
-monad-consensus = { path = "../monad-consensus", features = ["monad_test"] }
-monad-consensus-state = { path = "../monad-consensus-state", features = ["monad_test"] }
+monad-consensus = { path = "../monad-consensus" }
+monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
-monad-executor = { path = "../monad-executor", features = ["monad_test"] }
-monad-executor-glue = { path = "../monad-executor-glue", features = ["monad_test"] }
+monad-executor = { path = "../monad-executor" }
+monad-executor-glue = { path = "../monad-executor-glue" }
 monad-mock-swarm = { path = "../monad-mock-swarm" }
-monad-state = { path = "../monad-state", features = ["monad_test"]}
+monad-state = { path = "../monad-state" }
 monad-testutil = { path = "../monad-testutil" }
 monad-twins-utils = { path = "utils" }
 monad-types = { path = "../monad-types" }

--- a/monad-twins/tests/twin_testing.rs
+++ b/monad-twins/tests/twin_testing.rs
@@ -5,7 +5,7 @@ mod test {
     use monad_consensus_types::transaction_validator::MockValidator;
     use monad_mock_swarm::{
         mock::{MockMempoolConfig, NoSerRouterConfig},
-        swarm_relation::monad_test::MonadMessageNoSerSwarm,
+        swarm_relation::MonadMessageNoSerSwarm,
         transformer::ID,
     };
     use monad_twins_utils::{run_twins_test, twin_reader::read_twins_test};

--- a/monad-twins/utils/Cargo.toml
+++ b/monad-twins/utils/Cargo.toml
@@ -10,9 +10,10 @@ bench = false
 
 
 [dependencies]
-monad-consensus-types = { path = "../../monad-consensus-types",  features = ["monad_test"]}
-monad-mock-swarm = { path = "../../monad-mock-swarm", features = ["monad_test"] }
-monad-state = { path = "../../monad-state", features = ["monad_test"]}
+monad-consensus-types = { path = "../../monad-consensus-types" }
+monad-crypto = { path = "../../monad-crypto" }
+monad-mock-swarm = { path = "../../monad-mock-swarm" }
+monad-state = { path = "../../monad-state" }
 monad-testutil = { path = "../../monad-testutil" }
 monad-types = { path = "../../monad-types" }
 
@@ -20,5 +21,5 @@ monad-types = { path = "../../monad-types" }
 itertools = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-serde = {version = "1.0.130", features= ["derive"] }
+serde = {version = "1.0.130", features = ["derive"] }
 serde_json = {version = "1.0.68", features= ["preserve_order"] }

--- a/monad-twins/utils/src/lib.rs
+++ b/monad-twins/utils/src/lib.rs
@@ -7,8 +7,8 @@ use monad_mock_swarm::{
     mock_swarm::{Node, Nodes},
     swarm_relation::SwarmRelation,
     transformer::{
-        monad_test::{MonadMessageTransformer, MonadMessageTransformerPipeline, TwinsTransformer},
-        RandLatencyTransformer, ID,
+        MonadMessageTransformer, MonadMessageTransformerPipeline, RandLatencyTransformer,
+        TwinsTransformer, ID,
     },
 };
 use rand::{Rng, SeedableRng};

--- a/monad-twins/utils/src/twin_reader.rs
+++ b/monad-twins/utils/src/twin_reader.rs
@@ -6,20 +6,21 @@ use std::{
     time::Duration,
 };
 
-use itertools::izip;
+use itertools::{izip, Itertools};
 use monad_consensus_types::{
-    certificate_signature::CertificateKeyPair, signature_collection::SignatureCollection,
+    certificate_signature::CertificateKeyPair,
+    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
     transaction_validator::TransactionValidator,
+};
+use monad_crypto::{
+    hasher::{Hasher, HasherType},
+    secp256k1::KeyPair,
 };
 use monad_mock_swarm::{
     mock_swarm::ProgressTerminator, swarm_relation::SwarmRelation, transformer::ID,
 };
 use monad_state::MonadConfig;
-use monad_testutil::{
-    signing::{create_keys, create_seed_for_certificate_keys, get_certificate_key_secret},
-    swarm::complete_config,
-    validators::complete_keys_w_validators,
-};
+use monad_testutil::{swarm::complete_config, validators::complete_keys_w_validators};
 use monad_types::{NodeId, Round};
 use serde::Deserialize;
 
@@ -67,7 +68,8 @@ where
     default_partition: Vec<ID>,
 
     // some redundant info in case its useful for future
-    secret: [u8; 32],
+    key_secret: [u8; 32],
+    certkey_secret: [u8; 32],
     name: String,
     expected_block: usize,
     is_honest: bool,
@@ -81,13 +83,27 @@ where
     fn clone(&self) -> Self {
         Self {
             id: self.id,
-            secret: self.secret,
-            state_config: self.state_config.dup(self.secret),
+            state_config: MonadConfig {
+                transaction_validator: self.state_config.transaction_validator.clone(),
+                validators: self.state_config.validators.clone(),
+                key: KeyPair::from_bytes(self.key_secret).unwrap(),
+                certkey: SignatureCollectionKeyPairType::<SCT>::from_bytes(self.certkey_secret)
+                    .unwrap(),
+                beneficiary: self.state_config.beneficiary,
+                delta: self.state_config.delta,
+                consensus_config: self.state_config.consensus_config.clone(),
+                genesis_block: self.state_config.genesis_block.clone(),
+                genesis_vote_info: self.state_config.genesis_vote_info,
+                genesis_signatures: self.state_config.genesis_signatures.clone(),
+            },
             partition: self.partition.clone(),
             default_partition: self.default_partition.clone(),
+
+            key_secret: self.key_secret,
+            certkey_secret: self.certkey_secret,
+            name: self.name.clone(),
             expected_block: self.expected_block,
             is_honest: self.is_honest,
-            name: self.name.clone(),
         }
     }
 }
@@ -127,12 +143,7 @@ where
             state_config,
             default_partition,
             partition,
-
-            //extra info
-            is_honest: _,
-            expected_block: _,
-            name: _,
-            secret: _,
+            ..
         } = value;
 
         Self {
@@ -178,27 +189,33 @@ where
     } = serde_json::from_str(&raw_str).expect("twins test case JSON is not formatted correctly");
 
     let expected_block = expected_block.unwrap_or(BTreeMap::new());
-    let keys = create_keys(names.len() as u32);
-    let cert_key_secrete: Vec<_> =
-        create_seed_for_certificate_keys::<S::SignatureCollectionType>(names.len() as u32)
-            .into_iter()
-            .map(get_certificate_key_secret)
-            .collect();
+    let mut seeds = (0_u32..).map(|i| {
+        let mut h = HasherType::new();
+        h.update(i.to_le_bytes());
+        h.hash().0
+    });
+    let key_secrets = seeds.by_ref().take(names.len()).collect_vec();
+    let certkey_secrets = seeds.by_ref().take(names.len()).collect_vec();
 
-    let cert_keys: Vec<_> = cert_key_secrete
+    let keys = key_secrets
         .iter()
-        .map(|secret| {
-            CertificateKeyPair::from_bytes(*secret)
-                .expect("secret is invalid when convert to cert-key")
-        })
-        .collect();
+        .copied()
+        .map(KeyPair::from_bytes)
+        .collect::<Result<Vec<_>, _>>()
+        .expect("secp secret invalid");
+    let certkeys: Vec<_> = certkey_secrets
+        .iter()
+        .copied()
+        .map(CertificateKeyPair::from_bytes)
+        .collect::<Result<Vec<_>, _>>()
+        .expect("secret is invalid when convert to cert-key");
 
     let (_, validator_mapping) =
-        complete_keys_w_validators::<S::SignatureCollectionType>(&keys, &cert_keys);
+        complete_keys_w_validators::<S::SignatureCollectionType>(&keys, &certkeys);
     let (pubkeys, state_configs) = complete_config::<S::SignatureType, S::SignatureCollectionType, _>(
         tvt,
         keys,
-        cert_keys,
+        certkeys,
         validator_mapping,
         Duration::from_millis(delta_ms),
         TWINS_STATE_ROOT_DELAY,
@@ -208,9 +225,13 @@ where
     let mut nodes = BTreeMap::new();
     let mut duplicates = BTreeMap::new();
 
-    for (name, pubkey, secret, state_config) in
-        izip!(names.iter(), pubkeys, cert_key_secrete, state_configs)
-    {
+    for (name, pubkey, key_secret, certkey_secret, state_config) in izip!(
+        names.iter(),
+        pubkeys,
+        key_secrets,
+        certkey_secrets,
+        state_configs
+    ) {
         let pid = NodeId(pubkey);
         let id = ID::new(pid).as_non_unique(TWINS_DEFAULT_IDENTIFIER);
         let expected_block = *expected_block.get(name).unwrap_or(&expected_block_default);
@@ -220,7 +241,8 @@ where
                 id,
                 name: name.clone(),
                 state_config,
-                secret,
+                key_secret,
+                certkey_secret,
                 partition: BTreeMap::new(),
                 default_partition: vec![],
                 is_honest: true,

--- a/monad-viz/src/graph.rs
+++ b/monad-viz/src/graph.rs
@@ -94,7 +94,7 @@ impl<S, C, CT, ST, SCT, VT, LT, BST> NodesSimulation<S, C>
 where
     S: SwarmRelation<
         State = MonadState<CT, ST, SCT, VT, LT, BST>,
-        TransportMessage = <S as SwarmRelation>::InboundMessage,
+        TransportMessage = <S as SwarmRelation>::OutboundMessage,
     >,
     C: SimulationConfig<S>,
 
@@ -138,7 +138,7 @@ impl<S, C, CT, ST, SCT, VT, LT, BST> Graph for NodesSimulation<S, C>
 where
     S: SwarmRelation<
         State = MonadState<CT, ST, SCT, VT, LT, BST>,
-        TransportMessage = <S as SwarmRelation>::InboundMessage,
+        TransportMessage = <S as SwarmRelation>::OutboundMessage,
     >,
     C: SimulationConfig<S>,
 
@@ -153,7 +153,7 @@ where
     Node<S>: Send,
 {
     type State = S::State;
-    type InboundMessage = S::InboundMessage;
+    type InboundMessage = S::TransportMessage;
     type NodeId = NodeId;
     type Swarm = S;
 

--- a/monad-viz/src/main.rs
+++ b/monad-viz/src/main.rs
@@ -58,7 +58,7 @@ impl SwarmRelation for VizSwarm {
 
     type InboundMessage = MonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
     type OutboundMessage = VerifiedMonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
-    type TransportMessage = Self::InboundMessage;
+    type TransportMessage = Self::OutboundMessage;
 
     type TransactionValidator = MockValidator;
 
@@ -74,9 +74,7 @@ impl SwarmRelation for VizSwarm {
     type RouterSchedulerConfig = NoSerRouterConfig;
     type RouterScheduler = NoSerRouterScheduler<Self::InboundMessage, Self::OutboundMessage>;
 
-    type Pipeline = GenericTransformerPipeline<
-        MonadMessage<Self::SignatureType, Self::SignatureCollectionType>,
-    >;
+    type Pipeline = GenericTransformerPipeline<Self::OutboundMessage>;
 
     type LoggerConfig = MockWALoggerConfig;
     type Logger =
@@ -87,7 +85,7 @@ impl SwarmRelation for VizSwarm {
 }
 
 type NS<'a> =
-    NodeState<'a, NodeId, VizSwarm, <<VizSwarm as SwarmRelation>::State as State>::Message>;
+    NodeState<'a, NodeId, VizSwarm, <<VizSwarm as SwarmRelation>::State as State>::OutboundMessage>;
 
 type Sim = NodesSimulation<VizSwarm, SimConfig>;
 type ReplaySim = ReplayNodesSimulation<VizSwarm, RepConfig>;

--- a/monad-viz/src/replay_graph.rs
+++ b/monad-viz/src/replay_graph.rs
@@ -123,7 +123,8 @@ where
     fn get_pending_events(
         &self,
         node_id: &NodeId,
-    ) -> Vec<NodeEvent<NodeId, <S::State as State>::Message, <S::State as State>::Event>> {
+    ) -> Vec<NodeEvent<NodeId, <S::State as State>::OutboundMessage, <S::State as State>::Event>>
+    {
         let mut nes = vec![];
         for pmsg in self
             .nodes
@@ -157,7 +158,7 @@ where
     C: ReplayConfig<S::State>,
 {
     type State = S::State;
-    type InboundMessage = S::InboundMessage;
+    type InboundMessage = S::OutboundMessage;
     type NodeId = NodeId;
     type Swarm = S;
 

--- a/monad-wal/Cargo.toml
+++ b/monad-wal/Cargo.toml
@@ -8,9 +8,6 @@ edition = "2021"
 [lib]
 bench = false
 
-[features]
-monad_test = []
-
 [dependencies]
 monad-types = { path = "../monad-types" }
 
@@ -19,12 +16,11 @@ monad-consensus = { path = "../monad-consensus" }
 monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
-monad-executor = { path = "../monad-executor", features = ["monad_test"] }
+monad-executor = { path = "../monad-executor" }
 monad-executor-glue = { path = "../monad-executor-glue" }
 monad-state = { path = "../monad-state" }
 monad-testutil = { path = "../monad-testutil" }
 monad-types = { path = "../monad-types" }
-monad-wal = { path = ".", features = ["monad_test"] }
 
 criterion = { workspace = true }
 tempfile = { workspace = true }


### PR DESCRIPTION
The monad-test feature was being used for two things:
1. Clone implementation of a Secp KeyPair
2. Internal interospection of Unverified<_> messages

The observation made is that neither of these are actually necessary - we just change the NoSer RouterScheduler to use OutboundMessage instead of InboundMessage for its TransportMessage.