### PR TITLE
Factor RouterScheduler out of monad-mock-swarm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4405,6 +4405,7 @@ dependencies = [
  "monad-executor-glue",
  "monad-gossip",
  "monad-quic",
+ "monad-router-scheduler",
  "monad-state",
  "monad-testutil",
  "monad-tracing-counter",
@@ -4482,7 +4483,7 @@ dependencies = [
  "monad-executor",
  "monad-executor-glue",
  "monad-gossip",
- "monad-mock-swarm",
+ "monad-router-scheduler",
  "monad-types",
  "quinn",
  "quinn-proto 0.11.0",
@@ -4499,11 +4500,19 @@ dependencies = [
  "monad-consensus-types",
  "monad-crypto",
  "monad-mock-swarm",
+ "monad-router-scheduler",
  "monad-testutil",
  "monad-transformer",
  "monad-types",
  "monad-wal",
  "simple-xml-builder",
+]
+
+[[package]]
+name = "monad-router-scheduler"
+version = "0.1.0"
+dependencies = [
+ "monad-types",
 ]
 
 [[package]]
@@ -4585,6 +4594,7 @@ dependencies = [
  "monad-executor",
  "monad-executor-glue",
  "monad-mock-swarm",
+ "monad-router-scheduler",
  "monad-state",
  "monad-transformer",
  "monad-types",
@@ -4625,6 +4635,7 @@ dependencies = [
  "monad-executor",
  "monad-executor-glue",
  "monad-mock-swarm",
+ "monad-router-scheduler",
  "monad-state",
  "monad-testutil",
  "monad-transformer",
@@ -4713,6 +4724,7 @@ dependencies = [
  "monad-gossip",
  "monad-mock-swarm",
  "monad-quic",
+ "monad-router-scheduler",
  "monad-state",
  "monad-testutil",
  "monad-transformer",
@@ -4737,6 +4749,7 @@ dependencies = [
  "monad-executor",
  "monad-executor-glue",
  "monad-mock-swarm",
+ "monad-router-scheduler",
  "monad-state",
  "monad-testutil",
  "monad-transformer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "monad-proto",
     "monad-quic",
     "monad-randomized-tests",
+    "monad-router-scheduler",
     "monad-state",
     "monad-testground",
     "monad-testutil",

--- a/monad-mock-swarm/Cargo.toml
+++ b/monad-mock-swarm/Cargo.toml
@@ -20,6 +20,7 @@ monad-eth-types = { path = "../monad-eth-types" }
 monad-executor = { path = "../monad-executor" }
 monad-executor-glue = { path = "../monad-executor-glue" }
 monad-transformer = { path = "../monad-transformer" }
+monad-router-scheduler = { path = "../monad-router-scheduler" }
 monad-state = { path = "../monad-state" }
 monad-types = { path = "../monad-types" }
 monad-updaters = { path = "../monad-updaters" }

--- a/monad-mock-swarm/benches/two_node_benchmark.rs
+++ b/monad-mock-swarm/benches/two_node_benchmark.rs
@@ -3,10 +3,9 @@ use std::time::Duration;
 use criterion::{criterion_group, criterion_main, Criterion};
 use monad_consensus_types::transaction_validator::MockValidator;
 use monad_mock_swarm::{
-    mock::{MockMempoolConfig, NoSerRouterConfig},
-    mock_swarm::UntilTerminator,
-    swarm_relation::NoSerSwarm,
+    mock::MockMempoolConfig, mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm,
 };
+use monad_router_scheduler::NoSerRouterConfig;
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
 use monad_transformer::{GenericTransformer, LatencyTransformer};
 use monad_wal::mock::MockWALoggerConfig;

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -1,6 +1,5 @@
 use std::{
     cmp::{Ordering, Reverse},
-    collections::{BTreeSet, VecDeque},
     hash::{Hash, Hasher},
     marker::{PhantomData, Unpin},
     ops::DerefMut,
@@ -22,7 +21,8 @@ use monad_executor_glue::{
     Command, ExecutionLedgerCommand, MempoolCommand, Message, MonadEvent, RouterCommand,
     TimerCommand,
 };
-use monad_types::{NodeId, RouterTarget, TimeoutVariant};
+use monad_router_scheduler::{RouterEvent, RouterScheduler};
+use monad_types::{NodeId, TimeoutVariant};
 use monad_updaters::{
     checkpoint::MockCheckpoint, epoch::MockEpoch, ledger::MockLedger,
     state_root_hash::MockStateRootHash,
@@ -32,119 +32,6 @@ use rand::{Rng, RngCore};
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng, ChaChaRng};
 
 use crate::swarm_relation::SwarmRelation;
-
-const MOCK_DEFAULT_SEED: u64 = 1;
-
-#[derive(Debug)]
-pub enum RouterEvent<InboundMessage, TransportMessage> {
-    Rx(NodeId, InboundMessage),
-    Tx(NodeId, TransportMessage),
-}
-
-/// RouterScheduler describes HOW gossip messages get delivered
-pub trait RouterScheduler {
-    type Config;
-
-    // Transport level message type (usually bytes)
-    type TransportMessage;
-
-    // Application level data
-    type InboundMessage;
-    type OutboundMessage;
-
-    fn new(config: Self::Config) -> Self;
-
-    fn process_inbound(&mut self, time: Duration, from: NodeId, message: Self::TransportMessage);
-    fn send_outbound(&mut self, time: Duration, to: RouterTarget, message: Self::OutboundMessage);
-
-    fn peek_tick(&self) -> Option<Duration>;
-    fn step_until(
-        &mut self,
-        until: Duration,
-    ) -> Option<RouterEvent<Self::InboundMessage, Self::TransportMessage>>;
-}
-
-pub struct NoSerRouterScheduler<IM, OM> {
-    all_peers: BTreeSet<NodeId>,
-    events: VecDeque<(Duration, RouterEvent<IM, OM>)>,
-
-    phantom: PhantomData<OM>,
-}
-
-#[derive(Clone)]
-pub struct NoSerRouterConfig {
-    pub all_peers: BTreeSet<NodeId>,
-}
-
-impl<IM, OM> RouterScheduler for NoSerRouterScheduler<IM, OM>
-where
-    OM: Clone,
-    IM: From<OM>,
-{
-    type Config = NoSerRouterConfig;
-    type TransportMessage = OM;
-    type InboundMessage = IM;
-    type OutboundMessage = OM;
-
-    fn new(config: NoSerRouterConfig) -> Self {
-        Self {
-            all_peers: config.all_peers,
-            events: Default::default(),
-
-            phantom: PhantomData,
-        }
-    }
-
-    fn process_inbound(&mut self, time: Duration, from: NodeId, message: Self::TransportMessage) {
-        assert!(
-            time >= self
-                .events
-                .back()
-                .map(|(time, _)| *time)
-                .unwrap_or(Duration::ZERO)
-        );
-        self.events
-            .push_back((time, RouterEvent::Rx(from, message.into())))
-    }
-
-    fn send_outbound(&mut self, time: Duration, to: RouterTarget, message: Self::OutboundMessage) {
-        assert!(
-            time >= self
-                .events
-                .back()
-                .map(|(time, _)| *time)
-                .unwrap_or(Duration::ZERO)
-        );
-        match to {
-            RouterTarget::Broadcast => {
-                self.events.extend(
-                    self.all_peers
-                        .iter()
-                        .map(|to| (time, RouterEvent::Tx(*to, message.clone()))),
-                );
-            }
-            RouterTarget::PointToPoint(to) => {
-                self.events.push_back((time, RouterEvent::Tx(to, message)));
-            }
-        }
-    }
-
-    fn peek_tick(&self) -> Option<Duration> {
-        self.events.front().map(|(tick, _)| *tick)
-    }
-
-    fn step_until(
-        &mut self,
-        until: Duration,
-    ) -> Option<RouterEvent<Self::InboundMessage, Self::TransportMessage>> {
-        if self.peek_tick().unwrap_or(Duration::MAX) <= until {
-            let (_, event) = self.events.pop_front().expect("must exist");
-            Some(event)
-        } else {
-            None
-        }
-    }
-}
 
 pub trait MockableExecutor:
     Executor<Command = MempoolCommand<Self::SignatureCollection>> + Stream<Item = Self::Event> + Unpin
@@ -516,6 +403,8 @@ where
         }
     }
 }
+
+const MOCK_DEFAULT_SEED: u64 = 1;
 
 pub struct MockMempool<ST, SCT> {
     fetch_txs_state: Option<FetchTxParams<SCT>>,

--- a/monad-mock-swarm/src/mock_swarm.rs
+++ b/monad-mock-swarm/src/mock_swarm.rs
@@ -12,6 +12,7 @@ use monad_consensus_types::{
     message_signature::MessageSignature, signature_collection::SignatureCollection,
 };
 use monad_executor::{timed_event::TimedEvent, Executor, State};
+use monad_router_scheduler::RouterScheduler;
 use monad_state::MonadState;
 use monad_transformer::{LinkMessage, Pipeline, ID};
 use monad_types::Round;
@@ -23,7 +24,7 @@ use rayon::prelude::*;
 use tracing::info_span;
 
 use crate::{
-    mock::{MockExecutor, MockExecutorEvent, RouterScheduler},
+    mock::{MockExecutor, MockExecutorEvent},
     swarm_relation::SwarmRelation,
 };
 

--- a/monad-mock-swarm/src/swarm_relation.rs
+++ b/monad-mock-swarm/src/swarm_relation.rs
@@ -11,6 +11,7 @@ use monad_consensus_types::{
 use monad_crypto::NopSignature;
 use monad_executor::{timed_event::TimedEvent, State};
 use monad_executor_glue::{Message, MonadEvent};
+use monad_router_scheduler::{NoSerRouterConfig, NoSerRouterScheduler, RouterScheduler};
 use monad_state::{MonadConfig, MonadMessage, MonadState, VerifiedMonadMessage};
 use monad_transformer::{GenericTransformerPipeline, Pipeline};
 use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
@@ -20,10 +21,7 @@ use monad_wal::{
 };
 
 use crate::{
-    mock::{
-        MockMempool, MockMempoolConfig, MockableExecutor, NoSerRouterConfig, NoSerRouterScheduler,
-        RouterScheduler,
-    },
+    mock::{MockMempool, MockMempoolConfig, MockableExecutor},
     transformer::MonadMessageTransformerPipeline,
 };
 

--- a/monad-mock-swarm/tests/block_sync.rs
+++ b/monad-mock-swarm/tests/block_sync.rs
@@ -9,11 +9,12 @@ mod test {
     use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
     use monad_crypto::NopSignature;
     use monad_mock_swarm::{
-        mock::{MockMempoolConfig, NoSerRouterConfig},
+        mock::MockMempoolConfig,
         mock_swarm::{Nodes, ProgressTerminator, UntilTerminator},
         swarm_relation::{MonadMessageNoSerSwarm, NoSerSwarm, SwarmRelation},
         transformer::{FilterTransformer, MonadMessageTransformer},
     };
+    use monad_router_scheduler::NoSerRouterConfig;
     use monad_testutil::swarm::{get_configs, node_ledger_verification, run_nodes_until};
     use monad_transformer::{
         DropTransformer, GenericTransformer, LatencyTransformer, PartitionTransformer,

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -5,11 +5,10 @@ use common::QuicSwarm;
 use monad_consensus_types::transaction_validator::MockValidator;
 use monad_gossip::mock::MockGossipConfig;
 use monad_mock_swarm::{
-    mock::{MockMempoolConfig, NoSerRouterConfig},
-    mock_swarm::UntilTerminator,
-    swarm_relation::NoSerSwarm,
+    mock::MockMempoolConfig, mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm,
 };
 use monad_quic::QuicRouterSchedulerConfig;
+use monad_router_scheduler::NoSerRouterConfig;
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
 use monad_transformer::{BwTransformer, BytesTransformer, GenericTransformer, LatencyTransformer};
 use monad_wal::mock::MockWALoggerConfig;

--- a/monad-mock-swarm/tests/many_nodes_metrics.rs
+++ b/monad-mock-swarm/tests/many_nodes_metrics.rs
@@ -3,10 +3,9 @@ use std::time::Duration;
 
 use monad_consensus_types::transaction_validator::MockValidator;
 use monad_mock_swarm::{
-    mock::{MockMempoolConfig, NoSerRouterConfig},
-    mock_swarm::UntilTerminator,
-    swarm_relation::NoSerSwarm,
+    mock::MockMempoolConfig, mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm,
 };
+use monad_router_scheduler::NoSerRouterConfig;
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
 use monad_tracing_counter::{
     counter::{CounterLayer, MetricFilter},

--- a/monad-mock-swarm/tests/msg_delays.rs
+++ b/monad-mock-swarm/tests/msg_delays.rs
@@ -3,10 +3,9 @@ use std::time::Duration;
 
 use monad_consensus_types::transaction_validator::MockValidator;
 use monad_mock_swarm::{
-    mock::{MockMempoolConfig, NoSerRouterConfig},
-    mock_swarm::UntilTerminator,
-    swarm_relation::NoSerSwarm,
+    mock::MockMempoolConfig, mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm,
 };
+use monad_router_scheduler::NoSerRouterConfig;
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
 use monad_transformer::{GenericTransformer, XorLatencyTransformer};
 use monad_wal::mock::MockWALoggerConfig;

--- a/monad-mock-swarm/tests/order.rs
+++ b/monad-mock-swarm/tests/order.rs
@@ -4,10 +4,9 @@ use std::{collections::HashSet, env, time::Duration};
 use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
 use monad_crypto::NopSignature;
 use monad_mock_swarm::{
-    mock::{MockMempoolConfig, NoSerRouterConfig},
-    mock_swarm::UntilTerminator,
-    swarm_relation::NoSerSwarm,
+    mock::MockMempoolConfig, mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm,
 };
+use monad_router_scheduler::NoSerRouterConfig;
 use monad_testutil::swarm::{get_configs, run_nodes_until};
 use monad_transformer::{
     GenericTransformer, LatencyTransformer, PartitionTransformer, ReplayTransformer,

--- a/monad-mock-swarm/tests/rand_lat.rs
+++ b/monad-mock-swarm/tests/rand_lat.rs
@@ -3,10 +3,9 @@ use std::env;
 
 use monad_consensus_types::transaction_validator::MockValidator;
 use monad_mock_swarm::{
-    mock::{MockMempoolConfig, NoSerRouterConfig},
-    mock_swarm::UntilTerminator,
-    swarm_relation::NoSerSwarm,
+    mock::MockMempoolConfig, mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm,
 };
+use monad_router_scheduler::NoSerRouterConfig;
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
 use monad_transformer::GenericTransformer;
 use monad_wal::mock::MockWALoggerConfig;

--- a/monad-mock-swarm/tests/random_mempool.rs
+++ b/monad-mock-swarm/tests/random_mempool.rs
@@ -9,12 +9,11 @@ use monad_crypto::NopSignature;
 use monad_executor::timed_event::TimedEvent;
 use monad_executor_glue::MonadEvent;
 use monad_mock_swarm::{
-    mock::{
-        MockMempoolRandFail, MockMempoolRandFailConfig, NoSerRouterConfig, NoSerRouterScheduler,
-    },
+    mock::{MockMempoolRandFail, MockMempoolRandFailConfig},
     mock_swarm::UntilTerminator,
     swarm_relation::SwarmRelation,
 };
+use monad_router_scheduler::{NoSerRouterConfig, NoSerRouterScheduler};
 use monad_state::{MonadMessage, MonadState, VerifiedMonadMessage};
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
 use monad_transformer::{GenericTransformer, GenericTransformerPipeline, LatencyTransformer};

--- a/monad-mock-swarm/tests/replay.rs
+++ b/monad-mock-swarm/tests/replay.rs
@@ -10,10 +10,11 @@ use monad_crypto::secp256k1::SecpSignature;
 use monad_executor::timed_event::TimedEvent;
 use monad_executor_glue::MonadEvent;
 use monad_mock_swarm::{
-    mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock::{MockMempool, MockMempoolConfig},
     mock_swarm::{Nodes, UntilTerminator},
     swarm_relation::SwarmRelation,
 };
+use monad_router_scheduler::{NoSerRouterConfig, NoSerRouterScheduler};
 use monad_state::{MonadMessage, MonadState, VerifiedMonadMessage};
 use monad_testutil::swarm::{get_configs, node_ledger_verification};
 use monad_transformer::{

--- a/monad-mock-swarm/tests/replay_test.rs
+++ b/monad-mock-swarm/tests/replay_test.rs
@@ -10,10 +10,11 @@ use monad_crypto::NopSignature;
 use monad_executor::timed_event::TimedEvent;
 use monad_executor_glue::MonadEvent;
 use monad_mock_swarm::{
-    mock::{MockExecutor, MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock::{MockExecutor, MockMempool, MockMempoolConfig},
     mock_swarm::{Node, Nodes, UntilTerminator},
     swarm_relation::SwarmRelation,
 };
+use monad_router_scheduler::{NoSerRouterConfig, NoSerRouterScheduler};
 use monad_state::{MonadMessage, MonadState, VerifiedMonadMessage};
 use monad_testutil::swarm::{get_configs, node_ledger_verification};
 use monad_transformer::{GenericTransformer, GenericTransformerPipeline, LatencyTransformer, ID};

--- a/monad-mock-swarm/tests/single_node.rs
+++ b/monad-mock-swarm/tests/single_node.rs
@@ -6,11 +6,10 @@ use common::QuicSwarm;
 use monad_consensus_types::transaction_validator::MockValidator;
 use monad_gossip::mock::MockGossipConfig;
 use monad_mock_swarm::{
-    mock::{MockMempoolConfig, NoSerRouterConfig},
-    mock_swarm::UntilTerminator,
-    swarm_relation::NoSerSwarm,
+    mock::MockMempoolConfig, mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm,
 };
 use monad_quic::QuicRouterSchedulerConfig;
+use monad_router_scheduler::NoSerRouterConfig;
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
 use monad_transformer::{BwTransformer, BytesTransformer, GenericTransformer, LatencyTransformer};
 use monad_wal::mock::MockWALoggerConfig;

--- a/monad-mock-swarm/tests/single_node_metrics.rs
+++ b/monad-mock-swarm/tests/single_node_metrics.rs
@@ -3,10 +3,9 @@ use std::time::Duration;
 
 use monad_consensus_types::transaction_validator::MockValidator;
 use monad_mock_swarm::{
-    mock::{MockMempoolConfig, NoSerRouterConfig},
-    mock_swarm::UntilTerminator,
-    swarm_relation::NoSerSwarm,
+    mock::MockMempoolConfig, mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm,
 };
+use monad_router_scheduler::NoSerRouterConfig;
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
 use monad_tracing_counter::{
     counter::{CounterLayer, MetricFilter},

--- a/monad-mock-swarm/tests/two_nodes_bls.rs
+++ b/monad-mock-swarm/tests/two_nodes_bls.rs
@@ -9,10 +9,11 @@ use monad_crypto::secp256k1::SecpSignature;
 use monad_executor::timed_event::TimedEvent;
 use monad_executor_glue::MonadEvent;
 use monad_mock_swarm::{
-    mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock::{MockMempool, MockMempoolConfig},
     mock_swarm::UntilTerminator,
     swarm_relation::SwarmRelation,
 };
+use monad_router_scheduler::{NoSerRouterConfig, NoSerRouterScheduler};
 use monad_state::{MonadMessage, MonadState, VerifiedMonadMessage};
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
 use monad_transformer::{GenericTransformer, GenericTransformerPipeline, LatencyTransformer};

--- a/monad-quic/Cargo.toml
+++ b/monad-quic/Cargo.toml
@@ -14,8 +14,8 @@ bench = false
 monad-crypto = { path = "../monad-crypto", features = ["rustls"] }
 monad-executor-glue = { path = "../monad-executor-glue" }
 monad-gossip = { path = "../monad-gossip" }
-monad-mock-swarm = { path = "../monad-mock-swarm" }
 monad-executor = { path = "../monad-executor" }
+monad-router-scheduler = { path = "../monad-router-scheduler" }
 monad-types = { path = "../monad-types" }
 
 futures = { workspace = true }

--- a/monad-quic/src/router_scheduler.rs
+++ b/monad-quic/src/router_scheduler.rs
@@ -8,7 +8,7 @@ use std::{
 
 use monad_crypto::rustls::UnsafeTlsVerifier;
 use monad_gossip::{Gossip, GossipEvent};
-use monad_mock_swarm::mock::{RouterEvent, RouterScheduler};
+use monad_router_scheduler::{RouterEvent, RouterScheduler};
 use monad_types::{Deserializable, NodeId, RouterTarget, Serializable};
 use quinn_proto::{
     ClientConfig, Connection, ConnectionHandle, DatagramEvent, Dir, EndpointConfig, StreamId,

--- a/monad-randomized-tests/Cargo.toml
+++ b/monad-randomized-tests/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
 monad-mock-swarm = { path = "../monad-mock-swarm" }
+monad-router-scheduler = { path = "../monad-router-scheduler" }
 monad-testutil = { path = "../monad-testutil" }
 monad-transformer = { path = "../monad-transformer" }
 monad-types = { path = "../monad-types" }

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -3,10 +3,9 @@ use std::{collections::HashSet, time::Duration};
 use monad_consensus_types::{multi_sig::MultiSig, transaction_validator::MockValidator};
 use monad_crypto::NopSignature;
 use monad_mock_swarm::{
-    mock::{MockMempoolConfig, NoSerRouterConfig},
-    mock_swarm::UntilTerminator,
-    swarm_relation::NoSerSwarm,
+    mock::MockMempoolConfig, mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm,
 };
+use monad_router_scheduler::NoSerRouterConfig;
 use monad_testutil::swarm::{create_and_run_nodes, get_configs, run_nodes_until, SwarmTestConfig};
 use monad_transformer::{
     GenericTransformer, LatencyTransformer, PartitionTransformer, RandLatencyTransformer,

--- a/monad-router-scheduler/Cargo.toml
+++ b/monad-router-scheduler/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "monad-router-scheduler"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+# this is necessary for criterion bench options
+# https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+[lib]
+bench = false
+
+[dependencies]
+monad-types = { path = "../monad-types" }

--- a/monad-router-scheduler/src/lib.rs
+++ b/monad-router-scheduler/src/lib.rs
@@ -1,0 +1,113 @@
+use std::{
+    collections::{BTreeSet, VecDeque},
+    time::Duration,
+};
+
+use monad_types::{NodeId, RouterTarget};
+
+#[derive(Debug)]
+pub enum RouterEvent<InboundMessage, TransportMessage> {
+    Rx(NodeId, InboundMessage),
+    Tx(NodeId, TransportMessage),
+}
+
+/// RouterScheduler describes HOW gossip messages get delivered
+pub trait RouterScheduler {
+    type Config;
+
+    // Transport level message type (usually bytes)
+    type TransportMessage;
+
+    // Application level data
+    type InboundMessage;
+    type OutboundMessage;
+
+    fn new(config: Self::Config) -> Self;
+
+    fn process_inbound(&mut self, time: Duration, from: NodeId, message: Self::TransportMessage);
+    fn send_outbound(&mut self, time: Duration, to: RouterTarget, message: Self::OutboundMessage);
+
+    fn peek_tick(&self) -> Option<Duration>;
+    fn step_until(
+        &mut self,
+        until: Duration,
+    ) -> Option<RouterEvent<Self::InboundMessage, Self::TransportMessage>>;
+}
+
+pub struct NoSerRouterScheduler<IM, OM> {
+    all_peers: BTreeSet<NodeId>,
+    events: VecDeque<(Duration, RouterEvent<IM, OM>)>,
+}
+
+#[derive(Clone)]
+pub struct NoSerRouterConfig {
+    pub all_peers: BTreeSet<NodeId>,
+}
+
+impl<IM, OM> RouterScheduler for NoSerRouterScheduler<IM, OM>
+where
+    OM: Clone,
+    IM: From<OM>,
+{
+    type Config = NoSerRouterConfig;
+    type TransportMessage = OM;
+    type InboundMessage = IM;
+    type OutboundMessage = OM;
+
+    fn new(config: NoSerRouterConfig) -> Self {
+        Self {
+            all_peers: config.all_peers,
+            events: Default::default(),
+        }
+    }
+
+    fn process_inbound(&mut self, time: Duration, from: NodeId, message: Self::TransportMessage) {
+        assert!(
+            time >= self
+                .events
+                .back()
+                .map(|(time, _)| *time)
+                .unwrap_or(Duration::ZERO)
+        );
+        self.events
+            .push_back((time, RouterEvent::Rx(from, message.into())))
+    }
+
+    fn send_outbound(&mut self, time: Duration, to: RouterTarget, message: Self::OutboundMessage) {
+        assert!(
+            time >= self
+                .events
+                .back()
+                .map(|(time, _)| *time)
+                .unwrap_or(Duration::ZERO)
+        );
+        match to {
+            RouterTarget::Broadcast => {
+                self.events.extend(
+                    self.all_peers
+                        .iter()
+                        .map(|to| (time, RouterEvent::Tx(*to, message.clone()))),
+                );
+            }
+            RouterTarget::PointToPoint(to) => {
+                self.events.push_back((time, RouterEvent::Tx(to, message)));
+            }
+        }
+    }
+
+    fn peek_tick(&self) -> Option<Duration> {
+        self.events.front().map(|(tick, _)| *tick)
+    }
+
+    fn step_until(
+        &mut self,
+        until: Duration,
+    ) -> Option<RouterEvent<Self::InboundMessage, Self::TransportMessage>> {
+        if self.peek_tick().unwrap_or(Duration::MAX) <= until {
+            let (_, event) = self.events.pop_front().expect("must exist");
+            Some(event)
+        } else {
+            None
+        }
+    }
+}

--- a/monad-testutil/Cargo.toml
+++ b/monad-testutil/Cargo.toml
@@ -26,4 +26,5 @@ zerocopy = { workspace = true }
 monad-block-sync = { path = "../monad-block-sync" }
 monad-executor = { path = "../monad-executor" }
 monad-executor-glue = { path = "../monad-executor-glue" }
+monad-router-scheduler = { path = "../monad-router-scheduler" }
 monad-wal = { path = "../monad-wal" }

--- a/monad-testutil/examples/logs_gen.rs
+++ b/monad-testutil/examples/logs_gen.rs
@@ -9,10 +9,11 @@ use monad_crypto::NopSignature;
 use monad_executor::timed_event::TimedEvent;
 use monad_executor_glue::MonadEvent;
 use monad_mock_swarm::{
-    mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock::{MockMempool, MockMempoolConfig},
     mock_swarm::{Nodes, UntilTerminator},
     swarm_relation::SwarmRelation,
 };
+use monad_router_scheduler::{NoSerRouterConfig, NoSerRouterScheduler};
 use monad_state::{MonadMessage, MonadState, VerifiedMonadMessage};
 use monad_testutil::swarm::get_configs;
 use monad_transformer::{GenericTransformer, GenericTransformerPipeline, LatencyTransformer, ID};

--- a/monad-twins/Cargo.toml
+++ b/monad-twins/Cargo.toml
@@ -17,6 +17,7 @@ monad-crypto = { path = "../monad-crypto" }
 monad-executor = { path = "../monad-executor" }
 monad-executor-glue = { path = "../monad-executor-glue" }
 monad-mock-swarm = { path = "../monad-mock-swarm" }
+monad-router-scheduler = { path = "../monad-router-scheduler" }
 monad-state = { path = "../monad-state" }
 monad-testutil = { path = "../monad-testutil" }
 monad-twins-utils = { path = "utils" }

--- a/monad-twins/tests/twin_testing.rs
+++ b/monad-twins/tests/twin_testing.rs
@@ -3,10 +3,8 @@ mod test {
     use std::collections::BTreeSet;
 
     use monad_consensus_types::transaction_validator::MockValidator;
-    use monad_mock_swarm::{
-        mock::{MockMempoolConfig, NoSerRouterConfig},
-        swarm_relation::MonadMessageNoSerSwarm,
-    };
+    use monad_mock_swarm::{mock::MockMempoolConfig, swarm_relation::MonadMessageNoSerSwarm};
+    use monad_router_scheduler::NoSerRouterConfig;
     use monad_transformer::ID;
     use monad_twins_utils::{run_twins_test, twin_reader::read_twins_test};
     use monad_wal::mock::MockWALoggerConfig;

--- a/monad-virtual-bench/Cargo.toml
+++ b/monad-virtual-bench/Cargo.toml
@@ -20,6 +20,7 @@ monad-executor-glue = { path = "../monad-executor-glue" }
 monad-gossip = { path = "../monad-gossip" }
 monad-mock-swarm = { path = "../monad-mock-swarm" }
 monad-quic = { path = "../monad-quic" }
+monad-router-scheduler = { path = "../monad-router-scheduler" }
 monad-state = { path = "../monad-state" }
 monad-testutil = { path = "../monad-testutil" }
 monad-transformer = { path = "../monad-transformer" }

--- a/monad-virtual-bench/benches/two_node_bench.rs
+++ b/monad-virtual-bench/benches/two_node_bench.rs
@@ -2,10 +2,9 @@ use std::time::Duration;
 
 use monad_consensus_types::transaction_validator::MockValidator;
 use monad_mock_swarm::{
-    mock::{MockMempoolConfig, NoSerRouterConfig},
-    mock_swarm::UntilTerminator,
-    swarm_relation::NoSerSwarm,
+    mock::MockMempoolConfig, mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm,
 };
+use monad_router_scheduler::NoSerRouterConfig;
 use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
 use monad_transformer::{GenericTransformer, LatencyTransformer};
 use monad_wal::mock::MockWALoggerConfig;

--- a/monad-viz/Cargo.toml
+++ b/monad-viz/Cargo.toml
@@ -16,6 +16,7 @@ monad-eth-types = { path = "../monad-eth-types" }
 monad-executor = { path = "../monad-executor" }
 monad-executor-glue = { path = "../monad-executor-glue" }
 monad-mock-swarm = { path = "../monad-mock-swarm" }
+monad-router-scheduler = { path = "../monad-router-scheduler" }
 monad-state = { path = "../monad-state" }
 monad-testutil = { path = "../monad-testutil" }
 monad-transformer = { path = "../monad-transformer" }

--- a/monad-viz/src/main.rs
+++ b/monad-viz/src/main.rs
@@ -33,9 +33,10 @@ use monad_crypto::NopSignature;
 use monad_executor::{timed_event::TimedEvent, State};
 use monad_executor_glue::MonadEvent;
 use monad_mock_swarm::{
-    mock::{MockMempool, MockMempoolConfig, NoSerRouterConfig, NoSerRouterScheduler},
+    mock::{MockMempool, MockMempoolConfig},
     swarm_relation::SwarmRelation,
 };
+use monad_router_scheduler::{NoSerRouterConfig, NoSerRouterScheduler};
 use monad_state::{MonadMessage, MonadState, VerifiedMonadMessage};
 use monad_transformer::{
     GenericTransformer, GenericTransformerPipeline, LatencyTransformer, XorLatencyTransformer, ID,


### PR DESCRIPTION
This allows monad-quic to no longer depend on monad-mock-swarm.