### PR TITLE
Add sampling rate parameter to BwTransformer

### DIFF
--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -78,7 +78,7 @@ fn many_nodes_quic_bw() {
 
     let swarm_config = SwarmTestConfig {
         num_nodes: 40,
-        consensus_delta: Duration::from_millis(100),
+        consensus_delta: Duration::from_millis(300),
         parallelize: true,
         expected_block: 95,
         state_root_delay: u64::MAX,
@@ -88,7 +88,7 @@ fn many_nodes_quic_bw() {
 
     let xfmrs = vec![
         BytesTransformer::Latency(LatencyTransformer(Duration::from_millis(100))),
-        BytesTransformer::Bw(BwTransformer::new(100)),
+        BytesTransformer::Bw(BwTransformer::new(1000, Duration::from_millis(5))),
     ];
 
     create_and_run_nodes::<QuicSwarm, _, _>(
@@ -106,7 +106,7 @@ fn many_nodes_quic_bw() {
         MockWALoggerConfig,
         MockMempoolConfig::default(),
         xfmrs,
-        UntilTerminator::new().until_tick(Duration::from_secs(20)),
+        UntilTerminator::new().until_tick(Duration::from_secs(100)),
         swarm_config,
     );
 }

--- a/monad-mock-swarm/tests/single_node.rs
+++ b/monad-mock-swarm/tests/single_node.rs
@@ -95,7 +95,7 @@ fn two_nodes_quic_bw() {
         MockMempoolConfig::default(),
         vec![
             BytesTransformer::Latency(LatencyTransformer(Duration::from_millis(1))),
-            BytesTransformer::Bw(BwTransformer::new(4)),
+            BytesTransformer::Bw(BwTransformer::new(4, Duration::from_secs(1))),
         ],
         UntilTerminator::new().until_tick(Duration::from_secs(5)),
         SwarmTestConfig {

--- a/monad-quic/src/router_scheduler.rs
+++ b/monad-quic/src/router_scheduler.rs
@@ -11,8 +11,8 @@ use monad_gossip::{Gossip, GossipEvent};
 use monad_router_scheduler::{RouterEvent, RouterScheduler};
 use monad_types::{Deserializable, NodeId, RouterTarget, Serializable};
 use quinn_proto::{
-    congestion, ClientConfig, Connection, ConnectionHandle, DatagramEvent, Dir, EndpointConfig,
-    StreamId, TransportConfig, WriteError,
+    ClientConfig, Connection, ConnectionHandle, DatagramEvent, Dir, EndpointConfig, StreamId,
+    TransportConfig, WriteError,
 };
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 
@@ -70,11 +70,6 @@ where
             let mut config = TransportConfig::default();
             config.max_idle_timeout(None);
             // TODO-1 reasonable initial window sizes
-            config.congestion_controller_factory(Arc::new(
-                congestion::CubicConfig::default()
-                    .initial_window(u64::MAX)
-                    .to_owned(),
-            ));
             Arc::new(config)
         };
         let mut seed = [0; 32];

--- a/monad-virtual-bench/benches/many_nodes_bench.rs
+++ b/monad-virtual-bench/benches/many_nodes_bench.rs
@@ -34,6 +34,7 @@ fn setup() -> (
     let zero_instant = Instant::now();
     let stc = SwarmTestConfig {
         num_nodes: 20,
+        // intentially smaller than latency so nodes keep timing out
         consensus_delta: Duration::from_millis(30),
         parallelize: false,
         expected_block: 0,
@@ -51,7 +52,7 @@ fn setup() -> (
     };
     let xfmrs = vec![
         BytesTransformer::Latency(LatencyTransformer(Duration::from_millis(100))),
-        BytesTransformer::Bw(BwTransformer::new(4)),
+        BytesTransformer::Bw(BwTransformer::new(4, Duration::from_secs(1))),
     ];
     let terminator = UntilTerminator::new().until_round(Round(10));
 


### PR DESCRIPTION
BwTransformer used to allow an unrealistic instant burst of 100mb for a 100mbps link. It now takes in a sampling frequency parameter to limit the burst size.