### PR TITLE
Fix tracing counter doc test and add --doc to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,3 +47,5 @@ jobs:
         run: cargo check --all-targets --all-features --verbose
       - name: Run tests
         run: cargo test --release --all-targets --all-features --verbose
+      - name: Run doc tests
+        run: cargo test --release --doc --all-features --verbose

--- a/monad-tracing-counter/src/counter.rs
+++ b/monad-tracing-counter/src/counter.rs
@@ -37,7 +37,9 @@ macro_rules! inc_count {
 /// (printing) the counter messages
 ///
 /// ```
+/// use tracing_core::LevelFilter;
 /// use tracing_subscriber::{filter::Targets, prelude::*, Registry};
+/// use monad_tracing_counter::{counter::{CounterLayer, MetricFilter}, inc_count};
 ///
 /// let fmt_layer = tracing_subscriber::fmt::layer();
 /// let counter_layer = CounterLayer::new();


### PR DESCRIPTION
> --doc
>     Test only the library’s documentation. This cannot be mixed with other target options.