### PR TITLE
Process QC/TC in `process_proposal_message`

### DIFF
--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -434,9 +434,15 @@ where
                         };
                         let (author, _, verified_message) = verified_message.destructure();
                         match verified_message {
-                            ConsensusMessage::Proposal(msg) => self
-                                .consensus
-                                .handle_proposal_message::<HasherType>(author, msg),
+                            ConsensusMessage::Proposal(msg) => {
+                                self.consensus.handle_proposal_message::<HasherType, _, _>(
+                                    author,
+                                    msg,
+                                    &self.validator_set,
+                                    &self.validator_mapping,
+                                    &self.leader_election,
+                                )
+                            }
                             ConsensusMessage::Vote(msg) => {
                                 self.consensus.handle_vote_message::<HasherType, _, _>(
                                     author,


### PR DESCRIPTION
In the previous implementation, a faulty mempool can cause the consensus to stuck on a round because it never processes the certificates in the proposal.

Consensus should process the certificates before fetching the transactions from the mempool. This PR moves certificate handling earlier so mempool issues won't stall consensus.