### PR TITLE
Document consensus message, add Hashable to BlockId

### DIFF
--- a/monad-consensus-types/src/block.rs
+++ b/monad-consensus-types/src/block.rs
@@ -74,7 +74,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Block<T> {
 
 impl<T: SignatureCollection> Hashable for Block<T> {
     fn hash(&self, state: &mut impl Hasher) {
-        state.update(self.id.0);
+        self.id.hash(state);
     }
 }
 
@@ -95,7 +95,7 @@ impl<T: SignatureCollection> Block<T> {
                 state.update(author.0.bytes());
                 state.update(round.as_bytes());
                 payload.hash(&mut state);
-                state.update(qc.info.vote.id.0.as_bytes());
+                qc.info.vote.id.hash(&mut state);
                 state.update(qc.get_hash().as_bytes());
 
                 BlockId(state.hash())

--- a/monad-consensus-types/src/timeout.rs
+++ b/monad-consensus-types/src/timeout.rs
@@ -34,7 +34,7 @@ pub struct TimeoutInfo<SCT> {
 impl<SCT: SignatureCollection> Hashable for TimeoutInfo<SCT> {
     fn hash(&self, state: &mut impl Hasher) {
         state.update(self.round);
-        state.update(self.high_qc.info.vote.id.0.as_bytes());
+        self.high_qc.info.vote.id.hash(state);
         state.update(self.high_qc.get_hash());
     }
 }

--- a/monad-consensus-types/src/voting.rs
+++ b/monad-consensus-types/src/voting.rs
@@ -71,9 +71,9 @@ impl std::fmt::Debug for VoteInfo {
 
 impl Hashable for VoteInfo {
     fn hash(&self, state: &mut impl Hasher) {
-        state.update(self.id.0.as_bytes());
+        self.id.hash(state);
         state.update(self.round.as_bytes());
-        state.update(self.parent_id.0.as_bytes());
+        self.parent_id.hash(state);
         state.update(self.parent_round.as_bytes());
         state.update(self.seq_num.as_bytes());
     }

--- a/monad-consensus/src/messages/consensus_message.rs
+++ b/monad-consensus/src/messages/consensus_message.rs
@@ -16,12 +16,22 @@ use crate::{
     validation::signing::Verified,
 };
 
+/// Consensus protocol messages
 #[derive(Clone, PartialEq, Eq)]
 pub enum ConsensusMessage<SCT: SignatureCollection> {
+    /// Consensus protocol proposal message
     Proposal(ProposalMessage<SCT>),
+
+    /// Consensus protocol vote message
     Vote(VoteMessage<SCT>),
+
+    /// Consensus protocol timeout message
     Timeout(TimeoutMessage<SCT>),
+
+    /// Request a missing block given BlockId
     RequestBlockSync(RequestBlockSyncMessage),
+
+    /// Block sync response
     BlockSync(BlockSyncResponseMessage<SCT>),
 }
 
@@ -37,6 +47,7 @@ impl<SCT: Debug + SignatureCollection> Debug for ConsensusMessage<SCT> {
     }
 }
 
+/// Integrity hash
 impl<SCT> Hashable for ConsensusMessage<SCT>
 where
     SCT: SignatureCollection,
@@ -49,7 +60,6 @@ where
             // in the signature refactoring, we might want a clean split between:
             //      integrity sig: sign over the entire serialized struct
             //      protocol sig: signatures outlined in the protocol
-            // TimeoutMsg doesn't have a protocol sig
             ConsensusMessage::Vote(m) => m.hash(state),
             ConsensusMessage::Timeout(m) => m.hash(state),
             ConsensusMessage::RequestBlockSync(m) => m.hash(state),

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -6,7 +6,10 @@ use std::{
     ops::{Add, AddAssign, Sub, SubAssign},
 };
 
-use monad_crypto::{hasher::Hash, secp256k1::PubKey};
+use monad_crypto::{
+    hasher::{Hash, Hashable, Hasher},
+    secp256k1::PubKey,
+};
 use zerocopy::AsBytes;
 
 #[repr(transparent)]
@@ -129,6 +132,12 @@ impl std::fmt::Debug for BlockId {
             "{:>02x}{:>02x}..{:>02x}{:>02x}",
             self.0[0], self.0[1], self.0[30], self.0[31]
         )
+    }
+}
+
+impl Hashable for BlockId {
+    fn hash(&self, state: &mut impl Hasher) {
+        state.update(self.0);
     }
 }
 


### PR DESCRIPTION
Multiple places call `state.update(bid.0.as_bytes())` when hashing `BlockId`. The `Hashable` implementation consolidates those calls.