### PR TITLE
Split signature verification and protocol validation

### DIFF
--- a/monad-consensus/src/messages/consensus_message.rs
+++ b/monad-consensus/src/messages/consensus_message.rs
@@ -13,7 +13,7 @@ use crate::{
         BlockSyncResponseMessage, ProposalMessage, RequestBlockSyncMessage, TimeoutMessage,
         VoteMessage,
     },
-    validation::signing::Verified,
+    validation::signing::{Validated, Verified},
 };
 
 /// Consensus protocol messages
@@ -75,7 +75,7 @@ where
     pub fn sign<ST: MessageSignature>(
         self,
         keypair: &KeyPair,
-    ) -> Verified<ST, ConsensusMessage<SCT>> {
-        Verified::new(self, keypair)
+    ) -> Verified<ST, Validated<ConsensusMessage<SCT>>> {
+        Verified::new(Validated::new(self), keypair)
     }
 }

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -4,7 +4,8 @@ use std::{fmt::Debug, hash::Hash};
 
 use bytes::Bytes;
 use monad_consensus::{
-    messages::consensus_message::ConsensusMessage, validation::signing::Unverified,
+    messages::consensus_message::ConsensusMessage,
+    validation::signing::{Unvalidated, Unverified},
 };
 use monad_consensus_types::{
     block::FullBlock,
@@ -144,7 +145,7 @@ impl<E, OM, B, C, SCT> Command<E, OM, B, C, SCT> {
 pub enum ConsensusEvent<ST, SCT: SignatureCollection> {
     Message {
         sender: PubKey,
-        unverified_message: Unverified<ST, ConsensusMessage<SCT>>,
+        unverified_message: Unverified<ST, Unvalidated<ConsensusMessage<SCT>>>,
     },
     Timeout(TimeoutVariant),
     FetchedTxs(FetchTxParams<SCT>, TransactionHashList),

--- a/monad-executor/src/lib.rs
+++ b/monad-executor/src/lib.rs
@@ -51,7 +51,7 @@ pub trait State: Sized {
     type Message: Message<Event = Self::Event>;
 
     type Event: Clone;
-    type OutboundMessage: Clone + Into<Self::Message> + AsRef<Self::Message>;
+    type OutboundMessage: Clone + Into<Self::Message>;
     type Block: BlockType;
     type Checkpoint;
     type SignatureCollection;

--- a/monad-mock-swarm/tests/protobuf.rs
+++ b/monad-mock-swarm/tests/protobuf.rs
@@ -1,6 +1,6 @@
 use monad_consensus::{
     messages::{consensus_message::ConsensusMessage, message::VoteMessage},
-    validation::signing::Unverified,
+    validation::signing::{Unvalidated, Unverified},
 };
 use monad_consensus_types::{
     bls::BlsSignatureCollection,
@@ -66,7 +66,7 @@ fn test_consensus_message_event_vote_multisig() {
     let votemsg_hash = HasherType::hash_object(&votemsg);
     let sig = keypair.sign(votemsg_hash.as_ref());
 
-    let unverified_votemsg = Unverified::new(votemsg, sig);
+    let unverified_votemsg = Unverified::new(Unvalidated::new(votemsg), sig);
 
     let event = MonadEvent::ConsensusEvent(ConsensusEvent::Message {
         sender: keypair.pubkey(),
@@ -104,7 +104,10 @@ fn test_consensus_message_event_proposal_bls() {
 
     let event = MonadEvent::ConsensusEvent(ConsensusEvent::Message {
         sender: proposal.author().0,
-        unverified_message: Unverified::new(consensus_proposal_msg, *proposal.author_signature()),
+        unverified_message: Unverified::new(
+            Unvalidated::new(consensus_proposal_msg),
+            *proposal.author_signature(),
+        ),
     });
 
     let buf = serialize_event(&event);

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -16,6 +16,7 @@ use monad_executor_glue::Message;
 use monad_gossip::mock::{MockGossip, MockGossipConfig};
 use monad_mempool_controller::ControllerConfig;
 use monad_quic::service::{SafeQuinnConfig, ServiceConfig};
+use monad_state::{MonadMessage, VerifiedMonadMessage};
 use monad_types::{NodeId, SeqNum};
 use monad_updaters::{
     checkpoint::MockCheckpoint, execution_ledger::MonadFileLedger, ledger::MockLedger,
@@ -75,7 +76,10 @@ fn main() {
 }
 
 async fn run(node_state: NodeState) -> Result<(), ()> {
-    let router = build_router(
+    let router = build_router::<
+        MonadMessage<SignatureType, SignatureCollectionType>,
+        VerifiedMonadMessage<SignatureType, SignatureCollectionType>,
+    >(
         node_state.config.network,
         &node_state.secp256k1_identity,
         &node_state.config.bootstrap.peers,

--- a/monad-quic/src/service.rs
+++ b/monad-quic/src/service.rs
@@ -119,7 +119,7 @@ where
     <M as Deserializable<Bytes>>::ReadError: 'static,
     OM: Serializable<Bytes> + Send + Sync + 'static,
 
-    OM: Into<M> + AsRef<M> + Clone,
+    OM: Into<M> + Clone,
 {
     type Command = RouterCommand<OM>;
 
@@ -154,7 +154,7 @@ where
     <M as Deserializable<Bytes>>::ReadError: 'static,
     OM: Serializable<Bytes> + Send + Sync + 'static,
 
-    OM: Into<M> + AsRef<M> + Clone,
+    OM: Into<M> + Clone,
 
     Self: Unpin,
 {

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -101,7 +101,12 @@ where
             RouterConfig::MonadP2P {
                 config,
                 gossip_config,
-            } => Updater::boxed(monad_quic::service::Service::new(
+            } => Updater::boxed(monad_quic::service::Service::<
+                _,
+                _,
+                MonadMessage<MessageSignatureType, SignatureCollectionType>,
+                VerifiedMonadMessage<MessageSignatureType, SignatureCollectionType>,
+            >::new(
                 config,
                 match gossip_config {
                     MonadP2PGossipConfig::Simple(mock_config) => Gossip::boxed(mock_config.build()),

--- a/monad-testutil/src/signing.rs
+++ b/monad-testutil/src/signing.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, marker::PhantomData};
 
-use monad_consensus::validation::signing::Unverified;
+use monad_consensus::validation::signing::{Unvalidated, Unverified};
 use monad_consensus_types::{
     block::Block,
     certificate_signature::CertificateKeyPair,
@@ -153,11 +153,14 @@ pub struct TestSigner<S> {
 }
 
 impl TestSigner<SecpSignature> {
-    pub fn sign_object<T: Hashable>(o: T, key: &KeyPair) -> Unverified<SecpSignature, T> {
+    pub fn sign_object<T: Hashable>(
+        o: T,
+        key: &KeyPair,
+    ) -> Unverified<SecpSignature, Unvalidated<T>> {
         let msg = HasherType::hash_object(&o);
         let sig = key.sign(msg.as_ref());
 
-        Unverified::new(o, sig)
+        Unverified::new(Unvalidated::new(o), sig)
     }
 }
 

--- a/monad-updaters/src/local_router.rs
+++ b/monad-updaters/src/local_router.rs
@@ -98,7 +98,7 @@ impl<M, OM> LocalPeerRouter<M, OM> {
 impl<M, OM> Executor for LocalPeerRouter<M, OM>
 where
     M: Clone,
-    OM: Into<M> + AsRef<M>,
+    OM: Into<M>,
 {
     type Command = RouterCommand<OM>;
 

--- a/monad-wal/benches/event_bench.rs
+++ b/monad-wal/benches/event_bench.rs
@@ -7,7 +7,7 @@ use monad_consensus::{
         consensus_message::ConsensusMessage,
         message::{ProposalMessage, TimeoutMessage, VoteMessage},
     },
-    validation::signing::Unverified,
+    validation::signing::{Unvalidated, Unverified},
 };
 use monad_consensus_types::{
     certificate_signature::CertificateSignature,
@@ -93,7 +93,10 @@ fn bench_proposal(c: &mut Criterion) {
         last_round_tc: None,
     });
     let proposal_hash = HasherType::hash_object(&proposal);
-    let unverified_message = Unverified::new(proposal, author_keypair.sign(proposal_hash.as_ref()));
+    let unverified_message = Unverified::new(
+        Unvalidated::new(proposal),
+        author_keypair.sign(proposal_hash.as_ref()),
+    );
 
     let event = MonadEvent::ConsensusEvent(ConsensusEvent::Message {
         sender: author_keypair.pubkey(),
@@ -130,7 +133,7 @@ fn bench_vote(c: &mut Criterion) {
     let vote = ConsensusMessage::Vote(vm);
 
     let vote_hash = HasherType::hash_object(&vote);
-    let unverified_message = Unverified::new(vote, <<SignatureCollectionType as SignatureCollection>::SignatureType as CertificateSignature>::sign(vote_hash.as_ref(), &keypair));
+    let unverified_message = Unverified::new(Unvalidated::new(vote), <<SignatureCollectionType as SignatureCollection>::SignatureType as CertificateSignature>::sign(vote_hash.as_ref(), &keypair));
 
     let event = MonadEvent::ConsensusEvent(ConsensusEvent::Message {
         sender: keypair.pubkey(),
@@ -221,7 +224,10 @@ fn bench_timeout(c: &mut Criterion) {
     let tmo = ConsensusMessage::Timeout(TimeoutMessage::new(timeout, author_certkey));
 
     let tmo_hash = HasherType::hash_object(&tmo);
-    let unverified_message = Unverified::new(tmo, author_keypair.sign(tmo_hash.as_ref()));
+    let unverified_message = Unverified::new(
+        Unvalidated::new(tmo),
+        author_keypair.sign(tmo_hash.as_ref()),
+    );
 
     let event = MonadEvent::ConsensusEvent(ConsensusEvent::Message {
         sender: author_keypair.pubkey(),


### PR DESCRIPTION
`Unverified::verified` was overloaded to do both consensus message signature verification and protocol validation (QC, well-form, etc.) Message types under MonadMessage won't fit in because they don't have a consensus message signature. Splitting the two so we always remember to verify.