### PR TITLE
Prefix enum hashing with a discriminant

### DIFF
--- a/monad-consensus/src/messages/consensus_message.rs
+++ b/monad-consensus/src/messages/consensus_message.rs
@@ -7,6 +7,7 @@ use monad_crypto::{
     hasher::{Hashable, Hasher},
     secp256k1::KeyPair,
 };
+use monad_types::EnumDiscriminant;
 
 use crate::{
     messages::message::{ProposalMessage, TimeoutMessage, VoteMessage},
@@ -42,15 +43,25 @@ where
     SCT: SignatureCollection,
 {
     fn hash(&self, state: &mut impl Hasher) {
+        state.update(std::any::type_name::<Self>().as_bytes());
         match self {
-            ConsensusMessage::Proposal(m) => m.hash(state),
+            ConsensusMessage::Proposal(m) => {
+                EnumDiscriminant(1).hash(state);
+                m.hash(state);
+            }
             // FIXME-2:
             // it can be confusing as we are hashing only part of the message
             // in the signature refactoring, we might want a clean split between:
             //      integrity sig: sign over the entire serialized struct
             //      protocol sig: signatures outlined in the protocol
-            ConsensusMessage::Vote(m) => m.hash(state),
-            ConsensusMessage::Timeout(m) => m.hash(state),
+            ConsensusMessage::Vote(m) => {
+                EnumDiscriminant(2).hash(state);
+                m.hash(state);
+            }
+            ConsensusMessage::Timeout(m) => {
+                EnumDiscriminant(3).hash(state);
+                m.hash(state);
+            }
         }
     }
 }

--- a/monad-consensus/src/messages/message.rs
+++ b/monad-consensus/src/messages/message.rs
@@ -6,7 +6,7 @@ use monad_consensus_types::{
     voting::Vote,
 };
 use monad_crypto::hasher::{Hashable, Hasher, HasherType};
-use monad_types::BlockId;
+use monad_types::{BlockId, EnumDiscriminant};
 
 /// Consensus protocol vote message
 ///
@@ -121,15 +121,18 @@ impl<T: SignatureCollection> BlockSyncResponseMessage<T> {
     }
 }
 
-/// FIXME-2, possible hash malleability for variants, similar for
-/// [crate::messages::consensus_message::ConsensusMessage]
 impl<T: SignatureCollection> Hashable for BlockSyncResponseMessage<T> {
     fn hash(&self, state: &mut impl Hasher) {
+        state.update(std::any::type_name::<Self>().as_bytes());
         match self {
             BlockSyncResponseMessage::BlockFound(unverified_full_block) => {
-                unverified_full_block.hash(state)
+                EnumDiscriminant(1).hash(state);
+                unverified_full_block.hash(state);
             }
-            BlockSyncResponseMessage::NotAvailable(bid) => bid.hash(state),
+            BlockSyncResponseMessage::NotAvailable(bid) => {
+                EnumDiscriminant(2).hash(state);
+                bid.hash(state)
+            }
         }
     }
 }

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -226,6 +226,8 @@ impl<SCT: SignatureCollection> Unvalidated<ConsensusMessage<SCT>> {
 }
 
 impl<SCT: SignatureCollection> Unvalidated<ProposalMessage<SCT>> {
+    // A verified proposal is one which is well-formed and has valid
+    // signatures for the present TC or QC
     pub fn validate<VT: ValidatorSetType>(
         self,
         validators: &VT,

--- a/monad-consensus/tests/proposal.rs
+++ b/monad-consensus/tests/proposal.rs
@@ -1,4 +1,7 @@
-use monad_consensus::{messages::message::ProposalMessage, validation::signing::Unvalidated};
+use monad_consensus::{
+    messages::{consensus_message::ConsensusMessage, message::ProposalMessage},
+    validation::signing::Unvalidated,
+};
 use monad_consensus_types::{
     block::Block,
     ledger::LedgerCommitInfo,
@@ -59,7 +62,7 @@ fn test_proposal_hash() {
     let (keypairs, _certkeys, vset, _vmap) = create_keys_w_validators::<SignatureCollectionType>(1);
     let author = NodeId(keypairs[0].pubkey());
 
-    let proposal = ProposalMessage {
+    let proposal = ConsensusMessage::Proposal(ProposalMessage {
         block: setup_block(
             author,
             Round(234),
@@ -71,7 +74,7 @@ fn test_proposal_hash() {
                 .as_slice(),
         ),
         last_round_tc: None,
-    };
+    });
 
     let sp = TestSigner::sign_object(proposal, &keypairs[0]);
 
@@ -111,7 +114,7 @@ fn test_proposal_author_not_sender() {
     let sender_keypair = &keypairs[1];
     let author = NodeId(author_keypair.pubkey());
 
-    let proposal = ProposalMessage {
+    let proposal = ConsensusMessage::Proposal(ProposalMessage {
         block: setup_block(
             author,
             Round(234),
@@ -123,7 +126,7 @@ fn test_proposal_author_not_sender() {
                 .as_ref(),
         ),
         last_round_tc: None,
-    };
+    });
 
     let sp = TestSigner::sign_object(proposal, author_keypair);
     assert_eq!(
@@ -141,7 +144,7 @@ fn test_proposal_invalid_author() {
     vlist.push((NodeId(author_keypair.pubkey()), Stake(0)));
 
     let author = NodeId(author_keypair.pubkey());
-    let proposal = ProposalMessage {
+    let proposal = ConsensusMessage::Proposal(ProposalMessage {
         block: setup_block(
             author,
             Round(234),
@@ -149,7 +152,7 @@ fn test_proposal_invalid_author() {
             &[author_keypair.pubkey(), non_valdiator_keypair.pubkey()],
         ),
         last_round_tc: None,
-    };
+    });
 
     let sp = TestSigner::sign_object(proposal, &non_valdiator_keypair);
 

--- a/monad-mock-swarm/src/transformer.rs
+++ b/monad-mock-swarm/src/transformer.rs
@@ -609,12 +609,11 @@ mod test {
         }
 
         // throwing it block sync message should get rejected
-
         for msg in vec![
-            fake_request_block_sync(&keys[1]),
-            fake_block_sync(&keys[1]),
-            fake_request_block_sync(&keys[0]),
-            fake_block_sync(&keys[0]),
+            fake_request_block_sync(),
+            fake_block_sync(),
+            fake_request_block_sync(),
+            fake_block_sync(),
         ] {
             let TransformerStream::Complete(c) = t.transform(LinkMessage {
                 from: default_id,
@@ -630,10 +629,10 @@ mod test {
         // however if we enable block_sync then it should be broadcasted
         t = TwinsTransformer::new(pid_to_dups, filter, vec![], false);
         for msg in vec![
-            fake_request_block_sync(&keys[1]),
-            fake_block_sync(&keys[1]),
-            fake_request_block_sync(&keys[0]),
-            fake_block_sync(&keys[0]),
+            fake_request_block_sync(),
+            fake_block_sync(),
+            fake_request_block_sync(),
+            fake_block_sync(),
         ] {
             let TransformerStream::Continue(c) = t.transform(LinkMessage {
                 from: default_id,

--- a/monad-mock-swarm/src/utils.rs
+++ b/monad-mock-swarm/src/utils.rs
@@ -120,14 +120,14 @@ pub mod test_tool {
         ConsensusMessage::Timeout(internal_msg).sign(kp).into()
     }
 
-    pub fn fake_request_block_sync(kp: &KeyPair) -> VerifiedMonadMessage<ST, SC> {
+    pub fn fake_request_block_sync() -> VerifiedMonadMessage<ST, SC> {
         let internal_msg = RequestBlockSyncMessage {
             block_id: BlockId(Hash([0x00_u8; 32])),
         };
         VerifiedMonadMessage::BlockSyncRequest(Validated::new(internal_msg))
     }
 
-    pub fn fake_block_sync(kp: &KeyPair) -> VerifiedMonadMessage<ST, SC> {
+    pub fn fake_block_sync() -> VerifiedMonadMessage<ST, SC> {
         let internal_msg = BlockSyncResponseMessage::NotAvailable(BlockId(Hash([0x00_u8; 32])));
         VerifiedMonadMessage::BlockSyncResponse(Validated::new(internal_msg))
     }

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -236,3 +236,12 @@ pub enum TimeoutVariant {
     Pacemaker,
     BlockSync(BlockId),
 }
+
+#[repr(transparent)]
+pub struct EnumDiscriminant(pub i32);
+
+impl Hashable for EnumDiscriminant {
+    fn hash(&self, state: &mut impl Hasher) {
+        state.update(self.0.to_le_bytes());
+    }
+}


### PR DESCRIPTION
Add a discriminant prefix when hashing ConsensusMessage and BlockSyncResponse to avoid malleable hash/signatures.