### PR TITLE
Add connection retry support

### DIFF
--- a/monad-mock-swarm/tests/single_node.rs
+++ b/monad-mock-swarm/tests/single_node.rs
@@ -95,7 +95,7 @@ fn two_nodes_quic_bw() {
             BytesTransformer::Latency(LatencyTransformer(Duration::from_millis(1))),
             BytesTransformer::Bw(BwTransformer::new(8, Duration::from_secs(1))),
         ],
-        UntilTerminator::new().until_tick(Duration::from_secs(5)),
+        UntilTerminator::new().until_tick(Duration::from_secs(10)),
         SwarmTestConfig {
             num_nodes: 2,
             consensus_delta: Duration::from_millis(1000),

--- a/monad-quic/src/connection.rs
+++ b/monad-quic/src/connection.rs
@@ -1,0 +1,222 @@
+use std::{
+    ops::DerefMut,
+    pin::Pin,
+    task::{ready, Poll},
+};
+
+use bytes::Bytes;
+use futures::{future::BoxFuture, FutureExt, Stream, TryFutureExt};
+use monad_types::NodeId;
+use quinn::{Connecting, ReadError, RecvStream, SendStream, WriteError};
+use quinn_proto::ConnectionError;
+
+use crate::QuinnConfig;
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub struct ConnectionId(u64);
+
+pub(crate) enum Connection {
+    Pending(
+        BoxFuture<
+            'static,
+            Result<
+                (quinn::Connection, NodeId, SendStream, RecvStream),
+                (Option<NodeId>, ConnectionFailure),
+            >,
+        >,
+    ),
+    Active(
+        quinn::Connection,
+        BoxFuture<'static, Result<(RecvStream, Vec<Bytes>), ConnectionFailure>>,
+    ),
+    Closed,
+}
+pub(crate) struct ConnectionWriter {
+    connection: quinn::Connection,
+    send_stream: SendStream,
+}
+
+impl ConnectionWriter {
+    fn new(connection: quinn::Connection, send_stream: SendStream) -> Self {
+        Self {
+            connection,
+            send_stream,
+        }
+    }
+
+    pub fn connection_id(&self) -> ConnectionId {
+        ConnectionId(self.connection.stable_id() as u64)
+    }
+
+    pub async fn write_chunk(&mut self, chunk: Bytes) -> Result<(), ConnectionFailure> {
+        self.send_stream
+            .write_chunk(chunk)
+            .await
+            .map_err(ConnectionFailure::WriteError)
+    }
+}
+
+impl Drop for ConnectionWriter {
+    fn drop(&mut self) {
+        self.connection.close(
+            quinn_proto::VarInt::from_u32(1),
+            b"outbound connection err, disconnecting",
+        );
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ConnectionFailure {
+    /// Dialed peer did not have expected node_id
+    UnexpectedPeerId,
+
+    ConnectionError(ConnectionError),
+    WriteError(WriteError),
+    ReadError(ReadError),
+
+    /// The remote closed their outbound stream
+    RemoteStreamClosed,
+}
+
+pub(crate) enum ConnectionEvent {
+    /// Contains a NodeId if it was an outbound connection failure
+    ConnectionFailure(Option<NodeId>, ConnectionFailure),
+
+    Connected(ConnectionId, NodeId, ConnectionWriter),
+    InboundMessage(ConnectionId, Vec<Bytes>),
+    Disconnected(ConnectionId, ConnectionFailure),
+}
+
+impl Connection {
+    pub fn outbound<QC: QuinnConfig>(connecting: Connecting, expected_peer_id: NodeId) -> Self {
+        let fut = async move {
+            tracing::info!("attempting to connect to={:?}", connecting.remote_address());
+            let connection = connecting
+                .await
+                .map_err(ConnectionFailure::ConnectionError)?;
+            tracing::info!(
+                "connected to={:?}, connection_id={:?}, opening stream",
+                connection.remote_address(),
+                connection.stable_id(),
+            );
+            let peer_id = QC::remote_peer_id(&connection);
+            if peer_id != expected_peer_id {
+                return Err(ConnectionFailure::UnexpectedPeerId);
+            }
+
+            let (send_stream, recv_stream) = connection
+                .open_bi()
+                .await
+                .map_err(ConnectionFailure::ConnectionError)?;
+            tracing::info!(
+                "connected to={:?}, connection_id={:?}, stream ready",
+                connection.remote_address(),
+                connection.stable_id(),
+            );
+            Ok((connection, peer_id, send_stream, recv_stream))
+        }
+        .map_err(move |err| (Some(expected_peer_id), err))
+        .boxed();
+        Self::Pending(fut)
+    }
+    pub fn inbound<QC: QuinnConfig>(connecting: Connecting) -> Self {
+        let fut = async move {
+            tracing::info!(
+                "inbound connection attempt from={:?}",
+                connecting.remote_address()
+            );
+            let connection = connecting
+                .await
+                .map_err(ConnectionFailure::ConnectionError)?;
+            let peer_id = QC::remote_peer_id(&connection);
+
+            tracing::info!(
+                "connected to={:?}, connection_id={:?}, waiting for stream open",
+                connection.remote_address(),
+                connection.stable_id(),
+            );
+
+            let (send_stream, recv_stream) = connection
+                .accept_bi()
+                .await
+                .map_err(ConnectionFailure::ConnectionError)?;
+
+            tracing::info!(
+                "connected to={:?}, connection_id={:?}, stream ready",
+                connection.remote_address(),
+                connection.stable_id(),
+            );
+            Ok((connection, peer_id, send_stream, recv_stream))
+        }
+        .map_err(|err| (None, err))
+        .boxed();
+        Self::Pending(fut)
+    }
+
+    fn active(connection: quinn::Connection, mut recv_stream: RecvStream) -> Self {
+        let fut = async move {
+            let mut bufs = vec![Bytes::new(); 32];
+            let num_chunks = recv_stream
+                .read_chunks(&mut bufs)
+                .await
+                .map_err(ConnectionFailure::ReadError)?
+                .ok_or(ConnectionFailure::RemoteStreamClosed)?;
+            bufs.truncate(num_chunks);
+            Ok((recv_stream, bufs))
+        };
+        Self::Active(connection, fut.boxed())
+    }
+}
+
+impl Stream for Connection
+where
+    Self: Unpin,
+{
+    type Item = ConnectionEvent;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let this = self.deref_mut();
+        match this {
+            Connection::Pending(pending) => match ready!(pending.poll_unpin(cx)) {
+                Ok((connection, node_id, send_stream, recv_stream)) => {
+                    let connection_id = ConnectionId(connection.stable_id() as u64);
+                    *this = Connection::active(connection.clone(), recv_stream);
+                    Poll::Ready(Some(ConnectionEvent::Connected(
+                        connection_id,
+                        node_id,
+                        ConnectionWriter::new(connection, send_stream),
+                    )))
+                }
+                Err((maybe_expected_peer, err)) => {
+                    *this = Connection::Closed;
+                    Poll::Ready(Some(ConnectionEvent::ConnectionFailure(
+                        maybe_expected_peer,
+                        err,
+                    )))
+                }
+            },
+            Connection::Active(connection, active) => {
+                let connection_id = ConnectionId(connection.stable_id() as u64);
+                match ready!(active.poll_unpin(cx)) {
+                    Ok((recv_stream, chunks)) => {
+                        assert!(!chunks.is_empty());
+                        *this = Connection::active(connection.clone(), recv_stream);
+                        Poll::Ready(Some(ConnectionEvent::InboundMessage(connection_id, chunks)))
+                    }
+                    Err(err) => {
+                        connection.close(
+                            quinn_proto::VarInt::from_u32(1),
+                            b"inbound connection err, disconnecting",
+                        );
+                        *this = Connection::Closed;
+                        Poll::Ready(Some(ConnectionEvent::Disconnected(connection_id, err)))
+                    }
+                }
+            }
+            Connection::Closed => Poll::Ready(None),
+        }
+    }
+}

--- a/monad-quic/src/lib.rs
+++ b/monad-quic/src/lib.rs
@@ -8,3 +8,4 @@ mod quinn_config;
 pub use quinn_config::*;
 mod service;
 pub use service::*;
+mod connection;

--- a/monad-quic/src/service.rs
+++ b/monad-quic/src/service.rs
@@ -1,6 +1,5 @@
 use std::{
-    collections::HashMap,
-    error::Error,
+    collections::{hash_map::Entry, HashMap},
     marker::PhantomData,
     net::SocketAddr,
     ops::DerefMut,
@@ -10,16 +9,19 @@ use std::{
 };
 
 use bytes::Bytes;
-use futures::{future::BoxFuture, stream::SelectAll, FutureExt, Stream, StreamExt};
+use futures::{future::BoxFuture, FutureExt, Stream, StreamExt};
 use monad_executor::Executor;
 use monad_executor_glue::{Message, RouterCommand};
 use monad_gossip::{Gossip, GossipEvent};
 use monad_types::{Deserializable, NodeId, Serializable};
-use quinn::{Connecting, RecvStream};
+use quinn::Connecting;
 use quinn_proto::ClientConfig;
 use tokio::sync::mpsc::error::TrySendError;
 
-use crate::quinn_config::QuinnConfig;
+use crate::{
+    connection::{Connection, ConnectionEvent, ConnectionId, ConnectionWriter},
+    quinn_config::QuinnConfig,
+};
 
 /// Service is an implementation of a RouterCommand updater that's backed by Quic
 /// It can be parameterized by a Gossip algorithm
@@ -51,12 +53,20 @@ where
 
     /// Future that yields on the next inbound connection attempt
     accept: BoxFuture<'static, Connecting>,
-    /// SelectAll over InboundConnection streams
-    /// Each InboundConnection corresponds to a single inbound connection
-    /// Polling from inbound_connections yields the next ready inbound connection event
-    inbound_connections: SelectAll<InboundConnection>,
-    /// Sender channels for each currently open outbound connection
-    outbound_messages: HashMap<NodeId, tokio::sync::mpsc::Sender<Bytes>>,
+
+    /// Receiver channel for all connection events
+    connection_events: tokio::sync::mpsc::Receiver<ConnectionEvent>,
+    // Sender channel for connection events (cloned for each new connection)
+    connection_events_sender: tokio::sync::mpsc::Sender<ConnectionEvent>,
+
+    /// Each currently open canonical connection
+    canonical_connections: HashMap<ConnectionId, CanonicalConnection>,
+
+    /// Latest tie-broken connection for any given NodeId
+    ///
+    /// If the value is None, then the canonical connection is not yet ready
+    /// This can happen if there's a pending outbound connection
+    node_connections: HashMap<NodeId, Option<ConnectionId>>,
 
     /// Future that yields whenever the gossip implementation wants to be woken up
     gossip_timeout: Pin<Box<tokio::time::Sleep>>,
@@ -64,6 +74,17 @@ where
 
     _pd: PhantomData<(M, OM)>,
 }
+
+struct CanonicalConnection {
+    node_id: NodeId,
+    /// Channel that can be used for writing bytes on the connection
+    writer: tokio::sync::mpsc::Sender<Bytes>,
+}
+
+/// Inbound event buffer size for ALL connections
+const CONNECTION_EVENTS_BUFFER_SIZE: usize = 1_000;
+/// Outbound message buffer size for EACH connection
+const CONNECTION_OUTBOUND_MESSAGE_BUFFER_SIZE: usize = 100;
 
 /// Configuration for Service
 pub struct ServiceConfig<QC> {
@@ -105,6 +126,9 @@ where
             async move { endpoint.accept().await.expect("endpoint is never closed") }.boxed()
         };
 
+        let (connection_events_sender, connection_events) =
+            tokio::sync::mpsc::channel(CONNECTION_EVENTS_BUFFER_SIZE);
+
         Self {
             zero_instant: Instant::now(),
             me: config.me,
@@ -116,8 +140,10 @@ where
             quinn_config: config.quinn_config,
 
             accept,
-            inbound_connections: SelectAll::new(),
-            outbound_messages: HashMap::new(),
+            connection_events,
+            connection_events_sender,
+            canonical_connections: HashMap::new(),
+            node_connections: HashMap::new(),
 
             gossip_timeout: Box::pin(tokio::time::sleep(Duration::ZERO)),
             waker: None,
@@ -197,21 +223,46 @@ where
                         .boxed()
                 };
 
-                this.inbound_connections
-                    .push(InboundConnection::pending::<QC>(connecting));
+                this.connecting(Connection::inbound::<QC>(connecting));
                 continue;
             }
 
-            if !this.inbound_connections.is_empty() {
-                if let Poll::Ready(message) = this.inbound_connections.poll_next_unpin(cx) {
-                    let (from, gossip_messages) =
-                        message.expect("inbound stream should never be exhausted");
-                    for gossip_message in gossip_messages {
-                        this.gossip
-                            .handle_gossip_message(time, from, gossip_message);
+            if let Poll::Ready(connection_event) = this.connection_events.poll_recv(cx) {
+                let connection_event =
+                    connection_event.expect("connection_event stream should never be exhausted");
+                match connection_event {
+                    ConnectionEvent::ConnectionFailure(maybe_expected_peer, failure) => {
+                        tracing::warn!("connection failure, failure={:?}", failure);
+                        if let Some(expected_peer) = maybe_expected_peer {
+                            let removed = this.node_connections.remove(&expected_peer);
+                            assert_eq!(removed, Some(None));
+                        }
                     }
-                    continue;
+                    ConnectionEvent::Connected(connection_id, node_id, writer) => {
+                        assert_eq!(connection_id, writer.connection_id());
+                        this.connected(time, node_id, writer);
+                    }
+                    ConnectionEvent::InboundMessage(from, gossip_messages) => {
+                        if let Some(connection) = this.canonical_connections.get(&from) {
+                            for gossip_message in gossip_messages {
+                                this.gossip.handle_gossip_message(
+                                    time,
+                                    connection.node_id,
+                                    gossip_message,
+                                );
+                            }
+                        }
+                    }
+                    ConnectionEvent::Disconnected(connection_id, failure) => {
+                        tracing::warn!(
+                            "connection disconnected, id={:?}, failure={:?}",
+                            connection_id,
+                            failure
+                        );
+                        this.disconnected(time, &connection_id);
+                    }
                 }
+                continue;
             }
 
             if let Some(timeout) = this.gossip.peek_tick() {
@@ -245,82 +296,125 @@ where
 
     OM: Into<M> + Clone,
 {
+    /// Wires events from a new pending connection to self.connection_events
+    fn connecting(&mut self, mut connection: Connection) {
+        let connection_events_sender = self.connection_events_sender.clone();
+        tokio::spawn(async move {
+            while let Some(event) = connection.next().await {
+                match connection_events_sender.try_send(event) {
+                    Ok(()) => {}
+                    Err(TrySendError::Full(_)) => todo!("Inbound_events channel full! Consider raising CONNECTION_EVENTS_BUFFER_SIZE={}?", CONNECTION_EVENTS_BUFFER_SIZE),
+                    Err(TrySendError::Closed(_)) => break,
+                }
+            }
+        });
+    }
+
+    /// Populates self.outbound_messages for a new established connection
+    fn connected(
+        &mut self,
+        time: Duration,
+        node_id: NodeId,
+        mut connection_writer: ConnectionWriter,
+    ) {
+        let connection_id = connection_writer.connection_id();
+        let (connection_sender, mut connection_reader) =
+            tokio::sync::mpsc::channel(CONNECTION_OUTBOUND_MESSAGE_BUFFER_SIZE);
+
+        if let Some(old_connection_id) = self.node_connections.get(&node_id).copied().flatten() {
+            if self.me < node_id {
+                // disconnect new connection
+                self.disconnected(time, &connection_id);
+                return;
+            } else {
+                // disconnect old connection
+                self.disconnected(time, &old_connection_id)
+            }
+        }
+
+        self.gossip.connected(time, node_id);
+        self.canonical_connections.insert(
+            connection_id,
+            CanonicalConnection {
+                node_id,
+                writer: connection_sender,
+            },
+        );
+        self.node_connections.insert(node_id, Some(connection_id));
+        tokio::spawn(async move {
+            while let Some(chunk) = connection_reader.recv().await {
+                if let Err(failure) = connection_writer.write_chunk(chunk).await {
+                    tracing::warn!("connection write failure, failure={:?}", failure);
+                    break;
+                }
+            }
+            // connection_writer gets dropped here, so quinn::Connection::close() will be called
+        });
+    }
+
+    /// Cleans up self.outbound_messages for a connection that's shutting down
+    /// Will cause quinn::Connection::close() to be called if it still exists
+    fn disconnected(&mut self, time: Duration, connection_id: &ConnectionId) {
+        if let Some(connection) = self.canonical_connections.remove(connection_id) {
+            self.gossip.disconnected(time, connection.node_id);
+            self.node_connections.remove(&connection.node_id);
+        }
+    }
+
     fn handle_gossip_event(
         &mut self,
         time: Duration,
         gossip_event: GossipEvent,
     ) -> Option<M::Event> {
         match gossip_event {
-            GossipEvent::Send(to, gossip_message) if to == self.me => {
-                self.gossip
-                    .handle_gossip_message(time, self.me, gossip_message);
-                None
-            }
-            GossipEvent::Send(to, gossip_message) => {
-                let maybe_unsent_gossip_message = match self.outbound_messages.get_mut(&to) {
-                    Some(sender) => {
-                        let result = sender.try_send(gossip_message);
-
-                        match result {
-                            Ok(()) => None,
-                            Err(TrySendError::Full(gossip_message)) => {
-                                todo!("channel full, how should we handle this?")
-                            }
-                            Err(TrySendError::Closed(gossip_message)) => {
-                                // this implies that the connection died
-                                self.outbound_messages.remove(&to);
-                                Some(gossip_message)
-                            }
-                        }
-                    }
-                    None => Some(gossip_message),
-                };
-
-                if let Some(unsent_gossip_message) = maybe_unsent_gossip_message {
-                    const MAX_BUFFERED_MESSAGES: usize = 100;
-                    let (sender, mut receiver) = tokio::sync::mpsc::channel(MAX_BUFFERED_MESSAGES);
-                    sender
-                        .try_send(unsent_gossip_message)
-                        .expect("try_send should always succeed on new chan");
-                    self.outbound_messages.insert(to, sender);
-
+            GossipEvent::RequestConnect(to) => {
+                if let Entry::Vacant(e) = self.node_connections.entry(to) {
                     let known_address = match self.known_addresses.get(&to) {
                         Some(address) => *address,
-                        None => todo!("what do we do for peer discovery?"),
+                        None => todo!("Peer discovery unsupported, address unknown for: {:?}", to),
                     };
-
-                    let endpoint = self.endpoint.clone();
                     let client_config = {
                         let mut c = ClientConfig::new(self.quinn_config.client());
                         c.transport_config(self.quinn_config.transport());
                         c
                     };
-                    tokio::spawn(async move {
-                        let fut = async move {
-                            let connection = endpoint
-                                .connect_with(
-                                    client_config,
-                                    known_address,
-                                    "MONAD", // server_name doesn't matter because we're verifying the peer_id that signed the certificate
-                                )?
-                                .await?;
-
-                            if QC::remote_peer_id(&connection) != to {
-                                todo!("unexpected peer_id, return and retry?");
-                            }
-
-                            let mut stream = connection.open_uni().await?;
-
-                            while let Some(gossip_message) = receiver.recv().await {
-                                stream.write_all(&gossip_message).await?;
-                            }
-                            Ok::<_, OutboundConnectionError>(())
-                        };
-                        if let Err(e) = fut.await {
-                            todo!("handle outbound connection err: {:?}", e);
+                    let connection = match self.endpoint.connect_with(
+                        client_config,
+                        known_address,
+                        "MONAD", // server_name doesn't matter because we're verifying the peer_id that signed the certificate
+                    ) {
+                        Ok(connecting) => Connection::outbound::<QC>(connecting, to),
+                        Err(err) => {
+                            todo!("Unexpected connection error: {:?}", err)
                         }
-                    });
+                    };
+                    e.insert(None);
+                    self.connecting(connection);
+                } else {
+                    // (connection|connection_attempt) already exists
                 }
+                None
+            }
+            GossipEvent::Send(to, gossip_message) => {
+                let connection_id = self
+                    .node_connections
+                    .get(&to)
+                    .copied()
+                    .flatten()
+                    .expect("must only emit Send once connected");
+                let connection = self.canonical_connections.get(&connection_id).expect(
+                    "invariant broken: node_connections connection_id not in canonical_connections",
+                );
+                match connection.writer.try_send(gossip_message) {
+                    Ok(()) => {}
+                    Err(TrySendError::Full(_)) => {
+                        todo!("outbound message channel full! Consider raising CONNNECTION_OUTBOUND_MESSAGE_BUFFER_SIZE={}?", CONNECTION_OUTBOUND_MESSAGE_BUFFER_SIZE);
+                    }
+                    Err(TrySendError::Closed(_)) => {
+                        // this implies that the connection died
+                        self.disconnected(time, &connection_id)
+                    }
+                };
                 None
             }
             GossipEvent::Emit(from, app_message) => {
@@ -346,78 +440,3 @@ where
         }
     }
 }
-
-type InboundConnectionError = Box<dyn Error>;
-enum InboundConnection {
-    Pending(BoxFuture<'static, Result<(NodeId, RecvStream), InboundConnectionError>>),
-    Active(BoxFuture<'static, Result<(NodeId, RecvStream, Vec<Bytes>), InboundConnectionError>>),
-}
-
-impl InboundConnection {
-    fn pending<QC: QuinnConfig>(connecting: Connecting) -> Self {
-        let fut = async move {
-            let connection = connecting.await?;
-            let peer_id = QC::remote_peer_id(&connection);
-
-            let stream = connection.accept_uni().await?;
-            Ok((peer_id, stream))
-        }
-        .boxed();
-        Self::Pending(fut)
-    }
-    fn active(peer: NodeId, mut stream: RecvStream) -> Self {
-        let fut = async move {
-            let mut bufs = vec![Bytes::new(); 32];
-            let num_chunks = stream.read_chunks(&mut bufs).await?.unwrap_or(0);
-            bufs.truncate(num_chunks);
-            Ok((peer, stream, bufs))
-        };
-        Self::Active(fut.boxed())
-    }
-}
-
-impl Stream for InboundConnection
-where
-    Self: Unpin,
-{
-    type Item = (NodeId, Vec<Bytes>);
-
-    fn poll_next(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
-        let this = self.deref_mut();
-        loop {
-            match this {
-                InboundConnection::Pending(pending) => {
-                    if let Poll::Ready(maybe_stream) = pending.poll_unpin(cx) {
-                        match maybe_stream {
-                            Ok((peer_id, stream)) => {
-                                *this = InboundConnection::active(peer_id, stream);
-                                continue;
-                            }
-                            Err(e) => todo!("TODO error accepting connection, should we ignore and log this? err={:?}", e),
-                        }
-                    }
-                }
-                InboundConnection::Active(stream) => {
-                    if let Poll::Ready(maybe_bytes) = stream.poll_unpin(cx) {
-                        match maybe_bytes {
-                            Ok((peer, stream, chunks)) => {
-                                if chunks.is_empty() {
-                                    return Poll::Ready(None);
-                                }
-                                *this = InboundConnection::active(peer, stream);
-                                return Poll::Ready(Some((peer, chunks)));
-                            }
-                            Err(e) => todo!("connection read stream err: {:?}", e),
-                        }
-                    }
-                }
-            };
-            return Poll::Pending;
-        }
-    }
-}
-
-type OutboundConnectionError = Box<dyn Error>;

--- a/monad-quic/src/timeout_queue.rs
+++ b/monad-quic/src/timeout_queue.rs
@@ -48,4 +48,16 @@ impl TimeoutQueue {
             }
         }
     }
+
+    pub fn remove(&mut self, handle: &ConnectionHandle) {
+        let duration = self.connection_timeouts.remove(handle);
+        if let Some(duration) = duration {
+            let timeouts = self.timeouts.get_mut(&duration).expect("invariant broken");
+            let removed = timeouts.remove(handle);
+            assert!(removed);
+            if timeouts.is_empty() {
+                self.timeouts.remove(&duration).expect("invariant broken");
+            }
+        }
+    }
 }


### PR DESCRIPTION
These changes are rooted on the additions made to the Gossip trait, namely the `Gossip::connected`, `Gossip::disconnected` functions and the `GossipEvent::RequestConnect` and `GossipEvent::RequestDisconnect` emittable events.

`monad_quic::Service` and `monad_quic::RouterScheduler` needed to be modified to accomodate these changes.