### PR TITLE
Reorganize MonadEvent

### DIFF
--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -32,7 +32,7 @@ use tracing::{debug, trace, warn};
 
 use crate::{
     blocksync::{BlockSyncRequester, BlockSyncResult},
-    command::{ConsensusCommand, PublishMessage},
+    command::ConsensusCommand,
 };
 
 pub mod blocksync;
@@ -457,7 +457,7 @@ where
             let next_leader = election.get_leader(round + Round(1), validators.get_list());
             let send_cmd = ConsensusCommand::Publish {
                 target: RouterTarget::PointToPoint(NodeId(next_leader.0)),
-                message: PublishMessage::ConsensusMessage(ConsensusMessage::Vote(vote_msg)),
+                message: ConsensusMessage::Vote(vote_msg),
             };
             debug!("Created Vote: vote={:?} next_leader={:?}", v, next_leader);
             inc_count!(created_vote);
@@ -900,8 +900,7 @@ mod test {
     use tracing_test::traced_test;
 
     use crate::{
-        command::PublishMessage, ConsensusCommand, ConsensusConfig, ConsensusMessage,
-        ConsensusProcess, ConsensusState,
+        ConsensusCommand, ConsensusConfig, ConsensusMessage, ConsensusProcess, ConsensusState,
     };
 
     type SignatureType = NopSignature;
@@ -1045,7 +1044,7 @@ mod test {
                 c,
                 ConsensusCommand::Publish {
                     target: RouterTarget::PointToPoint(_),
-                    message: PublishMessage::ConsensusMessage(ConsensusMessage::Vote(_)),
+                    message: ConsensusMessage::Vote(_),
                 }
             )
         });
@@ -1084,7 +1083,7 @@ mod test {
                 c,
                 ConsensusCommand::Publish {
                     target: RouterTarget::PointToPoint(_),
-                    message: PublishMessage::ConsensusMessage(ConsensusMessage::Vote(_)),
+                    message: ConsensusMessage::Vote(_),
                 }
             )
         });
@@ -1115,7 +1114,7 @@ mod test {
                 c,
                 ConsensusCommand::Publish {
                     target: RouterTarget::PointToPoint(_),
-                    message: PublishMessage::ConsensusMessage(ConsensusMessage::Vote(_)),
+                    message: ConsensusMessage::Vote(_),
                 }
             )
         });
@@ -1187,7 +1186,7 @@ mod test {
                 c,
                 ConsensusCommand::Publish {
                     target: RouterTarget::PointToPoint(_),
-                    message: PublishMessage::ConsensusMessage(ConsensusMessage::Vote(_)),
+                    message: ConsensusMessage::Vote(_),
                 }
             )
         });
@@ -1246,7 +1245,7 @@ mod test {
                 c,
                 ConsensusCommand::Publish {
                     target: RouterTarget::PointToPoint(_),
-                    message: PublishMessage::ConsensusMessage(ConsensusMessage::Vote(_)),
+                    message: ConsensusMessage::Vote(_),
                 }
             )
         });
@@ -1278,7 +1277,7 @@ mod test {
                 c,
                 ConsensusCommand::Publish {
                     target: RouterTarget::PointToPoint(_),
-                    message: PublishMessage::ConsensusMessage(ConsensusMessage::Vote(_)),
+                    message: ConsensusMessage::Vote(_),
                 }
             )
         });
@@ -1347,9 +1346,7 @@ mod test {
                         m,
                         ConsensusCommand::Publish {
                             target: RouterTarget::PointToPoint(_),
-                            message: PublishMessage::ConsensusMessage(ConsensusMessage::Proposal(
-                                _
-                            )),
+                            message: ConsensusMessage::Proposal(_),
                         }
                     )
                 })
@@ -1365,7 +1362,7 @@ mod test {
             match c {
                 ConsensusCommand::Publish {
                     target: RouterTarget::PointToPoint(_self_id),
-                    message: PublishMessage::ConsensusMessage(ConsensusMessage::Proposal(m)),
+                    message: ConsensusMessage::Proposal(m),
                 } => {
                     proposals.extend(state.handle_proposal_message_full(
                         m.block.author,
@@ -1445,7 +1442,7 @@ mod test {
             .filter_map(|c| match c {
                 ConsensusCommand::Publish {
                     target: RouterTarget::PointToPoint(_),
-                    message: PublishMessage::ConsensusMessage(ConsensusMessage::Vote(vote)),
+                    message: ConsensusMessage::Vote(vote),
                 } => Some(vote),
                 _ => None,
             })
@@ -1484,7 +1481,7 @@ mod test {
             .filter_map(|c| match c {
                 ConsensusCommand::Publish {
                     target: RouterTarget::PointToPoint(_),
-                    message: PublishMessage::ConsensusMessage(ConsensusMessage::Vote(vote)),
+                    message: ConsensusMessage::Vote(vote),
                 } => Some(vote),
                 _ => None,
             })
@@ -1572,7 +1569,7 @@ mod test {
             .filter_map(|c| match c {
                 ConsensusCommand::Publish {
                     target: RouterTarget::PointToPoint(_),
-                    message: PublishMessage::ConsensusMessage(ConsensusMessage::Vote(vote)),
+                    message: ConsensusMessage::Vote(vote),
                 } => Some(vote),
                 _ => None,
             })
@@ -1627,7 +1624,7 @@ mod test {
             .filter_map(|c| match c {
                 ConsensusCommand::Publish {
                     target: RouterTarget::PointToPoint(_),
-                    message: PublishMessage::ConsensusMessage(ConsensusMessage::Vote(vote)),
+                    message: ConsensusMessage::Vote(vote),
                 } => Some(vote),
                 _ => None,
             })
@@ -1694,7 +1691,7 @@ mod test {
             .filter_map(|c| match c {
                 ConsensusCommand::Publish {
                     target: RouterTarget::PointToPoint(_),
-                    message: PublishMessage::ConsensusMessage(ConsensusMessage::Vote(vote)),
+                    message: ConsensusMessage::Vote(vote),
                 } => Some(vote),
                 _ => None,
             })
@@ -1713,7 +1710,7 @@ mod test {
             .filter_map(|c| match c {
                 ConsensusCommand::Publish {
                     target: RouterTarget::PointToPoint(_),
-                    message: PublishMessage::ConsensusMessage(ConsensusMessage::Vote(vote)),
+                    message: ConsensusMessage::Vote(vote),
                 } => Some(vote),
                 _ => None,
             })
@@ -1732,7 +1729,7 @@ mod test {
             .filter_map(|c| match c {
                 ConsensusCommand::Publish {
                     target: RouterTarget::PointToPoint(_),
-                    message: PublishMessage::ConsensusMessage(ConsensusMessage::Vote(vote)),
+                    message: ConsensusMessage::Vote(vote),
                 } => Some(vote),
                 _ => None,
             })
@@ -1752,7 +1749,7 @@ mod test {
             .filter_map(|c| match c {
                 ConsensusCommand::Publish {
                     target: RouterTarget::PointToPoint(_),
-                    message: PublishMessage::ConsensusMessage(ConsensusMessage::Vote(vote)),
+                    message: ConsensusMessage::Vote(vote),
                 } => Some(vote),
                 _ => None,
             })
@@ -2518,7 +2515,7 @@ mod test {
                     .filter_map(|c| match c {
                         ConsensusCommand::Publish {
                             target: RouterTarget::PointToPoint(peer),
-                            message: PublishMessage::ConsensusMessage(ConsensusMessage::Vote(vote)),
+                            message: ConsensusMessage::Vote(vote),
                         } => {
                             if peer == next_leader {
                                 Some(vote)

--- a/monad-consensus-types/src/command.rs
+++ b/monad-consensus-types/src/command.rs
@@ -1,10 +1,8 @@
 use monad_crypto::hasher::Hash;
-use monad_types::{BlockId, NodeId, Round, SeqNum};
+use monad_types::{NodeId, Round, SeqNum};
 
 use crate::{
-    block::{Block, UnverifiedFullBlock},
-    payload::TransactionHashList,
-    quorum_certificate::QuorumCertificate,
+    block::Block, payload::TransactionHashList, quorum_certificate::QuorumCertificate,
     timeout::TimeoutCertificate,
 };
 
@@ -42,20 +40,4 @@ pub struct FetchFullTxParams<SCT> {
     pub author: NodeId,
     pub p_block: Block<SCT>,
     pub p_last_round_tc: Option<TimeoutCertificate<SCT>>,
-}
-
-/// FetchedBlock is used to respond to BlockSync requests from other
-/// nodes.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FetchedBlock<SCT> {
-    /// The node that requested this block
-    pub requester: NodeId,
-
-    /// id of the requested block
-    pub block_id: BlockId,
-
-    /// FetchedBlock results should only be used to send block data to nodes
-    /// over the network so we should unverify it before sending to consensus
-    /// to prevent it from being used for anything else
-    pub unverified_full_block: Option<UnverifiedFullBlock<SCT>>,
 }

--- a/monad-executor-glue/src/convert/event.rs
+++ b/monad-executor-glue/src/convert/event.rs
@@ -7,7 +7,46 @@ use monad_proto::{
     proto::{basic::ProtoPubkey, event::*},
 };
 
-use crate::MonadEvent;
+use crate::{BlockSyncEvent, FetchedBlock, MonadEvent};
+
+impl<SCT: SignatureCollection> From<&FetchedBlock<SCT>> for ProtoFetchedBlock {
+    fn from(value: &FetchedBlock<SCT>) -> Self {
+        ProtoFetchedBlock {
+            requester: Some((&value.requester).into()),
+            block_id: Some((&value.block_id).into()),
+            unverified_full_block: value.unverified_full_block.as_ref().map(|b| b.into()),
+        }
+    }
+}
+
+impl<SCT: SignatureCollection> TryFrom<ProtoFetchedBlock> for FetchedBlock<SCT> {
+    type Error = ProtoError;
+
+    fn try_from(value: ProtoFetchedBlock) -> Result<Self, Self::Error> {
+        Ok(FetchedBlock {
+            requester: value
+                .requester
+                .ok_or(ProtoError::MissingRequiredField(
+                    "FetchedBlock.requester".to_owned(),
+                ))?
+                .try_into()?,
+            block_id: value
+                .block_id
+                .ok_or(ProtoError::MissingRequiredField(
+                    "FetchedBlock.requester".to_owned(),
+                ))?
+                .try_into()?,
+            unverified_full_block: Some(
+                value
+                    .unverified_full_block
+                    .ok_or(ProtoError::MissingRequiredField(
+                        "FetchedBlock.unverified_full_block".to_owned(),
+                    ))?
+                    .try_into()?,
+            ),
+        })
+    }
+}
 
 impl<S: MessageSignature, SCT: SignatureCollection> From<&MonadEvent<S, SCT>> for ProtoMonadEvent
 where
@@ -16,6 +55,7 @@ where
     fn from(value: &MonadEvent<S, SCT>) -> Self {
         let event = match value {
             MonadEvent::ConsensusEvent(msg) => proto_monad_event::Event::ConsensusEvent(msg.into()),
+            MonadEvent::BlockSyncEvent(msg) => proto_monad_event::Event::BlockSyncEvent(msg.into()),
         };
         Self { event: Some(event) }
     }
@@ -31,10 +71,68 @@ where
             Some(proto_monad_event::Event::ConsensusEvent(event)) => {
                 MonadEvent::ConsensusEvent(event.try_into()?)
             }
+            Some(proto_monad_event::Event::BlockSyncEvent(event)) => {
+                MonadEvent::BlockSyncEvent(event.try_into()?)
+            }
             None => Err(ProtoError::MissingRequiredField(
                 "MonadEvent.event".to_owned(),
             ))?,
         };
+        Ok(event)
+    }
+}
+
+impl<SCT: SignatureCollection> From<&BlockSyncEvent<SCT>> for ProtoBlockSyncEvent {
+    fn from(value: &BlockSyncEvent<SCT>) -> Self {
+        let event = match value {
+            BlockSyncEvent::BlockSyncRequest {
+                sender,
+                unvalidated_request,
+            } => proto_block_sync_event::Event::BlockSyncReq(ProtoBlockSyncRequestWithSender {
+                sender: Some(sender.into()),
+                request: Some(unvalidated_request.into()),
+            }),
+            BlockSyncEvent::FetchedBlock(fetched_block) => {
+                proto_block_sync_event::Event::FetchedBlock(fetched_block.into())
+            }
+        };
+        Self { event: Some(event) }
+    }
+}
+
+impl<SCT: SignatureCollection> TryFrom<ProtoBlockSyncEvent> for BlockSyncEvent<SCT> {
+    type Error = ProtoError;
+
+    fn try_from(value: ProtoBlockSyncEvent) -> Result<Self, Self::Error> {
+        let event = match value.event {
+            Some(event) => match event {
+                proto_block_sync_event::Event::BlockSyncReq(event) => {
+                    let sender = event
+                        .sender
+                        .ok_or(ProtoError::MissingRequiredField(
+                            "BlockSyncEvent.block_sync_req.sender".to_owned(),
+                        ))?
+                        .try_into()?;
+                    let unvalidated_request = event
+                        .request
+                        .ok_or(ProtoError::MissingRequiredField(
+                            "BlockSyncEvent.block_sync_req.req".to_owned(),
+                        ))?
+                        .try_into()?;
+                    BlockSyncEvent::BlockSyncRequest {
+                        sender,
+                        unvalidated_request,
+                    }
+                }
+                proto_block_sync_event::Event::FetchedBlock(event) => {
+                    BlockSyncEvent::FetchedBlock(event.try_into()?)
+                }
+            },
+            None => Err(ProtoError::MissingRequiredField(
+                "BlockSyncEvent.event".to_owned(),
+            ))?,
+        };
+
         Ok(event)
     }
 }

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -91,15 +91,21 @@ message ProtoConsensusEvent {
     ProtoFetchedFullTxs fetched_full_txs = 4;
     ProtoAdvanceEpochEvent advance_epoch = 5;
     ProtoLoadEpochEvent load_epoch = 6;
-    ProtoFetchedBlock fetched_block = 7;
-    ProtoStateUpdateEvent state_update = 8;
-    ProtoBlockSyncRequestWithSender block_sync_req = 9;
-    ProtoBlockSyncResponseWithSender block_sync_resp = 10;
+    ProtoStateUpdateEvent state_update = 7;
+    ProtoBlockSyncResponseWithSender block_sync_resp = 8;
+  }
+}
+
+message ProtoBlockSyncEvent {
+  oneof event {
+    ProtoBlockSyncRequestWithSender block_sync_req = 1;
+    ProtoFetchedBlock fetched_block = 2;
   }
 }
 
 message ProtoMonadEvent{
   oneof event {
-    ProtoConsensusEvent consensus_event = 2;
+    ProtoConsensusEvent consensus_event = 1;
+    ProtoBlockSyncEvent block_sync_event = 2;
   }
 }


### PR DESCRIPTION
Move FetchedBlock and BlockSyncRequest out of ConsensusEvent, into BlockSyncEvent. It untangles the messages so we can delete the `PublishMessage` enum.

It's also easier now to fit sub-states (e.g. consensus, block sync) under MonadState.