### PR TITLE
Unix socket IPC executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3167,13 +3167,16 @@ dependencies = [
 name = "monad-executor-glue"
 version = "0.1.0"
 dependencies = [
+ "alloy-rlp",
  "bytes",
  "monad-consensus",
  "monad-consensus-types",
  "monad-crypto",
+ "monad-eth-types",
  "monad-proto",
  "monad-types",
  "prost",
+ "reth-primitives",
 ]
 
 [[package]]
@@ -3499,6 +3502,8 @@ dependencies = [
 name = "monad-updaters"
 version = "0.1.0"
 dependencies = [
+ "alloy-rlp",
+ "clap 4.4.10",
  "futures",
  "monad-consensus-types",
  "monad-crypto",
@@ -3511,11 +3516,14 @@ dependencies = [
  "ntest",
  "rand",
  "rand_chacha",
+ "reth-primitives",
  "tempfile",
  "test-case",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/monad-executor-glue/Cargo.toml
+++ b/monad-executor-glue/Cargo.toml
@@ -14,8 +14,13 @@ bench = false
 monad-consensus = { path = "../monad-consensus" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
+monad-eth-types = { path = "../monad-eth-types" }
 monad-proto = { path = "../monad-proto" }
 monad-types = { path = "../monad-types" }
 
+alloy-rlp = { workspace = true }
 bytes = { workspace = true }
 prost = { workspace = true }
+
+[dev-dependencies]
+reth-primitives = { workspace = true }

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -19,6 +19,7 @@ use monad_crypto::{
     certificate_signature::{CertificateSignatureRecoverable, PubKey},
     hasher::Hash as ConsensusHash,
 };
+use monad_eth_types::EthTransaction;
 use monad_types::{BlockId, Epoch, NodeId, RouterTarget, SeqNum, TimeoutVariant};
 
 #[derive(Clone)]
@@ -213,6 +214,11 @@ pub enum ValidatorEvent<SCT: SignatureCollection> {
     UpdateValidators((ValidatorData<SCT>, Epoch)),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MempoolEvent {
+    UserTx(EthTransaction),
+}
+
 /// MonadEvent are inputs to MonadState
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MonadEvent<ST, SCT>
@@ -226,6 +232,8 @@ where
     BlockSyncEvent(BlockSyncEvent<SCT>),
     /// Events to update validator set
     ValidatorEvent(ValidatorEvent<SCT>),
+    /// Events to mempool
+    MempoolEvent(MempoolEvent),
 }
 
 impl monad_types::Deserializable<[u8]>

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -25,6 +25,7 @@ use monad_types::{NodeId, Round, SeqNum, Stake};
 use monad_updaters::{
     checkpoint::MockCheckpoint,
     execution_ledger::MonadFileLedger,
+    ipc::MockIpcReceiver,
     ledger::MockLedger,
     parent::ParentExecutor,
     state_root_hash::{MockStateRootHashNop, MockableStateRootHash},
@@ -122,6 +123,7 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
             ValidatorData::new(validators.clone()),
             val_set_update_interval,
         ),
+        ipc: MockIpcReceiver::default(),
     };
 
     let Ok((mut wal, wal_events)) = WALogger::new(WALoggerConfig {

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -50,8 +50,7 @@ message ProtoStateUpdateEvent {
 
 message ProtoBlockSyncRequestWithSender {
   monad_proto.basic.ProtoPubkey sender = 1;
-  monad_proto.message.ProtoRequestBlockSyncMessage request = 2;
-
+  monad_proto.message.ProtoRequestBlockSyncMessage request = 2;  
 }
 
 message ProtoBlockSyncResponseWithSender {
@@ -81,10 +80,21 @@ message ProtoValidatorEvent {
   }
 }
 
+message ProtoUserTx {
+  bytes tx = 1;
+}
+
+message ProtoMempoolEvent {
+  oneof event {
+    ProtoUserTx usertx = 1;
+  }
+}
+
 message ProtoMonadEvent{
   oneof event {
     ProtoConsensusEvent consensus_event = 1;
     ProtoBlockSyncEvent block_sync_event = 2;
     ProtoValidatorEvent validator_event = 3;
+    ProtoMempoolEvent mempool_event = 4;
   }
 }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -28,7 +28,7 @@ use monad_crypto::certificate_signature::{
 use monad_eth_types::EthAddress;
 use monad_executor::State;
 use monad_executor_glue::{
-    BlockSyncEvent, Command, ConsensusEvent, Message, MonadEvent, ValidatorEvent,
+    BlockSyncEvent, Command, ConsensusEvent, MempoolEvent, Message, MonadEvent, ValidatorEvent,
 };
 use monad_tracing_counter::inc_count;
 use monad_types::{Epoch, NodeId, Round, SeqNum, Stake, TimeoutVariant};
@@ -391,6 +391,12 @@ where
                     .flat_map(Into::<Vec<Command<_, _, _, _, _>>>::into)
                     .collect::<Vec<_>>()
             }
+
+            MonadEvent::MempoolEvent(mempool_event) => match mempool_event {
+                MempoolEvent::UserTx(_tx) => {
+                    todo!()
+                }
+            },
         }
     }
 }

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -19,6 +19,7 @@ use monad_types::{Round, SeqNum, Stake};
 use monad_updaters::{
     checkpoint::MockCheckpoint,
     execution_ledger::MonadFileLedger,
+    ipc::MockIpcReceiver,
     ledger::MockLedger,
     local_router::LocalPeerRouter,
     parent::ParentExecutor,
@@ -86,6 +87,7 @@ pub async fn make_monad_executor<ST, SCT>(
     BoxExecutor<'static, ExecutionLedgerCommand<SCT>>,
     MockCheckpoint<Checkpoint<SCT>>,
     BoxUpdater<'static, StateRootHashCommand<Block<SCT>>, MonadEvent<ST, SCT>>,
+    MockIpcReceiver<ST, SCT>,
 >
 where
     ST: CertificateSignatureRecoverable + Unpin,
@@ -124,6 +126,7 @@ where
                 val_set_update_interval,
             )),
         },
+        ipc: MockIpcReceiver::default(),
     }
 }
 

--- a/monad-updaters/Cargo.toml
+++ b/monad-updaters/Cargo.toml
@@ -22,13 +22,27 @@ monad-types = { path = "../monad-types" }
 futures = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
+reth-primitives = { workspace = true }
+alloy-rlp = { workspace = true }
 thiserror = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt", "time"], optional = true }
+tokio = { workspace = true, features = [
+    "macros",
+    "net",
+    "rt",
+    "time",
+], optional = true }
+tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
 monad-testutil = { path = "../monad-testutil" }
 
+clap = { workspace = true, features = ["derive"] }
 ntest = { workspace = true }
 test-case = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+
+[[example]]
+name = "ipc_receiver"

--- a/monad-updaters/examples/ipc_receiver.rs
+++ b/monad-updaters/examples/ipc_receiver.rs
@@ -1,0 +1,147 @@
+use std::{
+    error::Error,
+    path::{Path, PathBuf},
+    str::FromStr,
+    task::Poll,
+    thread::sleep,
+    time::Duration,
+};
+
+use alloy_rlp::Decodable;
+use clap::Parser;
+use futures::{Sink, SinkExt, StreamExt};
+use monad_consensus_types::bls::BlsSignatureCollection;
+use monad_crypto::{certificate_signature::CertificateSignaturePubKey, secp256k1::SecpSignature};
+use monad_eth_types::EthTransaction;
+use monad_executor_glue::{MempoolEvent, MonadEvent};
+use monad_updaters::ipc::IpcReceiver;
+use reth_primitives::{hex_literal::hex, Address};
+use tokio::net::UnixStream;
+use tokio_util::codec::{FramedWrite, LengthDelimitedCodec};
+use tracing::debug;
+
+type MessageSignatureType = SecpSignature;
+type SignatureCollectionType =
+    BlsSignatureCollection<CertificateSignaturePubKey<MessageSignatureType>>;
+
+const MSG_PER_SENDER: u64 = 10;
+const SENDERS: u64 = 4;
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(long)]
+    ipc_path: PathBuf,
+}
+
+struct IpcSender {
+    writer: FramedWrite<UnixStream, LengthDelimitedCodec>,
+}
+
+impl IpcSender {
+    async fn new(ipc_path: impl AsRef<Path>) -> Result<Self, std::io::Error> {
+        Ok(Self {
+            writer: FramedWrite::new(
+                UnixStream::connect(ipc_path).await?,
+                LengthDelimitedCodec::default(),
+            ),
+        })
+    }
+}
+
+impl Sink<EthTransaction> for IpcSender {
+    type Error = std::io::Error;
+
+    fn poll_ready(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.writer.poll_ready_unpin(cx)
+    }
+
+    fn start_send(
+        mut self: std::pin::Pin<&mut Self>,
+        tx: EthTransaction,
+    ) -> Result<(), Self::Error> {
+        let buf = tx.envelope_encoded();
+
+        self.writer.start_send_unpin(buf.into())
+    }
+
+    fn poll_flush(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.writer.poll_flush_unpin(cx)
+    }
+
+    fn poll_close(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.writer.poll_close_unpin(cx)
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    tracing_subscriber::fmt::init();
+    let args = Args::parse();
+
+    let ipc_path = args.ipc_path;
+
+    if ipc_path.exists() {
+        std::fs::remove_file(ipc_path.clone()).unwrap();
+    }
+
+    let mut receiver =
+        IpcReceiver::<MessageSignatureType, SignatureCollectionType>::new(ipc_path.clone())?;
+
+    // https://etherscan.io/tx/0xc97438c9ac71f94040abec76967bcaf16445ff747bcdeb383e5b94033cbed201
+    let raw_tx = hex!("02f871018302877a8085070adf56b2825208948880bb98e7747f73b52a9cfa34dab9a4a06afa3887eecbb1ada2fad280c080a0d5e6f03b507cc86b59bed88c201f98c9ca6514dc5825f41aa923769cf0402839a0563f21850c0c212ce6f402f140acdcebbb541c9bb6a051070851efec99e4dd8d");
+    let author_address = Address::from_str("0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97").unwrap();
+
+    let eth_tx = EthTransaction::decode(&mut &raw_tx[..]).unwrap();
+
+    // spawn three sender connections, 100ms from each other
+    let spawn_sender = |eth_tx: EthTransaction, ipc_path: PathBuf, start_time: Duration| {
+        std::thread::spawn(move || {
+            for i in 0..SENDERS {
+                sleep(start_time);
+                debug!("spawning sender {:?}", i);
+                let rt = tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                rt.block_on(async {
+                    let mut sender = IpcSender::new(ipc_path.clone())
+                        .await
+                        .expect("creating sender to succeed");
+                    for _ in 0..MSG_PER_SENDER {
+                        sender.feed(eth_tx.clone()).await.expect("feed to succeed");
+                    }
+                    sender.close().await.expect("close sender to succeed");
+                });
+            }
+        })
+    };
+
+    let handler = spawn_sender(eth_tx.clone(), ipc_path.clone(), Duration::from_millis(100));
+
+    for _ in 0..MSG_PER_SENDER * SENDERS {
+        let monad_event = receiver.next().await.expect("never terminates");
+        match monad_event {
+            MonadEvent::MempoolEvent(event) => match event {
+                MempoolEvent::UserTx(tx) => {
+                    let signer = tx.signer();
+                    assert_eq!(signer, author_address);
+                    assert_eq!(tx.transaction, eth_tx.transaction);
+                    debug!("received tx");
+                }
+            },
+
+            _ => Err("Wrong MonadEvent variant")?,
+        }
+    }
+    handler.join().unwrap();
+    Ok(())
+}

--- a/monad-updaters/src/ipc.rs
+++ b/monad-updaters/src/ipc.rs
@@ -1,0 +1,120 @@
+use std::{marker::PhantomData, path::Path, task::Poll};
+
+use alloy_rlp::Decodable;
+use futures::{stream::SelectAll, Stream, StreamExt};
+use monad_consensus_types::signature_collection::SignatureCollection;
+use monad_crypto::certificate_signature::{
+    CertificateSignaturePubKey, CertificateSignatureRecoverable,
+};
+use monad_eth_types::EthTransaction;
+use monad_executor_glue::{MempoolEvent, MonadEvent};
+use tokio::net::{UnixListener, UnixStream};
+use tokio_util::codec::{FramedRead, LengthDelimitedCodec};
+use tracing::{debug, info, warn};
+
+pub struct IpcReceiver<ST, SCT> {
+    /// Listener for incoming connections on the socket
+    listener: UnixListener,
+    /// A reader is created per stream on the Unix socket
+    readers: SelectAll<FramedRead<UnixStream, LengthDelimitedCodec>>,
+
+    _phantom: PhantomData<(ST, SCT)>,
+}
+
+impl<ST, SCT> IpcReceiver<ST, SCT> {
+    pub fn new(bind_path: impl AsRef<Path>) -> Result<Self, std::io::Error> {
+        Ok(Self {
+            listener: UnixListener::bind(bind_path)?,
+            readers: SelectAll::default(),
+            _phantom: PhantomData,
+        })
+    }
+}
+
+impl<ST, SCT> Stream for IpcReceiver<ST, SCT>
+where
+    Self: Unpin,
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+{
+    type Item = MonadEvent<ST, SCT>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        if let Poll::Ready(result) = self.listener.poll_accept(cx) {
+            match result {
+                Ok((stream, sockaddr)) => {
+                    debug!("new ipc connection sockaddr={:?}", sockaddr);
+                    self.readers
+                        .push(FramedRead::new(stream, LengthDelimitedCodec::default()));
+                }
+                Err(err) => {
+                    warn!("listener poll accept error={:?}", err);
+                    // TODO-2: handle error
+                    todo!("ipc listener error");
+                }
+            }
+        }
+
+        while !self.readers.is_empty() {
+            let bytes = match self.readers.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(bytes))) => bytes,
+                Poll::Ready(Some(Err(err))) => {
+                    warn!("framed reader error err={:?}", err);
+                    continue;
+                }
+                Poll::Ready(None) => {
+                    // SelectAll is empty: all streams have terminated
+                    debug!("all streams terminated");
+                    break;
+                }
+                Poll::Pending => break,
+            };
+
+            let user_tx = match EthTransaction::decode(&mut bytes.freeze().as_ref()) {
+                Ok(eth_tx) => eth_tx,
+                Err(err) => {
+                    info!("tx decoder error error={:?}", err);
+                    continue;
+                }
+            };
+
+            return Poll::Ready(Some(MonadEvent::MempoolEvent(MempoolEvent::UserTx(
+                user_tx,
+            ))));
+        }
+
+        Poll::Pending
+    }
+}
+
+pub struct MockIpcReceiver<ST, SCT> {
+    _phantom: PhantomData<(ST, SCT)>,
+}
+
+impl<ST, SCT> Default for MockIpcReceiver<ST, SCT> {
+    fn default() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<ST, SCT> Stream for MockIpcReceiver<ST, SCT>
+where
+    Self: Unpin,
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection,
+{
+    type Item = MonadEvent<ST, SCT>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        // TODO: generate user tx
+        Poll::Ready(None)
+    }
+}

--- a/monad-updaters/src/lib.rs
+++ b/monad-updaters/src/lib.rs
@@ -5,6 +5,7 @@ use monad_executor::Executor;
 
 pub mod checkpoint;
 pub mod execution_ledger;
+pub mod ipc;
 pub mod ledger;
 pub mod parent;
 pub mod state_root_hash;


### PR DESCRIPTION
Real IPC is ported from mempool-ipc. Added a placeholder mock ipc executor that doesn't nothing right now. We can use it to generate user transactions for testing.