### PR TITLE
Update reth dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy 0.7.26",
@@ -88,14 +89,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
+name = "alloy-chains"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a5f61137c31916542bb63cd70d0e0dd7a76f76b7f962f4337bc438612d45b2"
+dependencies = [
+ "alloy-rlp",
+ "num_enum 0.7.1",
+ "serde",
+ "strum",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3729132072f369bc4e8e6e070f9cf4deb3490fc9b9eea6f71f75ec19406df811"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "getrandom",
+ "hex-literal",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "proptest",
+ "rand",
+ "ruint",
+ "serde",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "alloy-rlp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc0fac0fc16baf1f63f78b47c3d24718f3619b0714076f6a02957d808d52cbef"
 dependencies = [
+ "alloy-rlp-derive",
  "arrayvec 0.7.4",
  "bytes",
  "smol_str",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a047897373be4bbb0224c1afdabca92648dc57a9c9ef6e7b0be3aff7a859c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "alloy-rpc-trace-types"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#1443559ca53fc156cda1012e383af988b2e962b3"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#1443559ca53fc156cda1012e383af988b2e962b3"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "itertools 0.12.0",
+ "jsonrpsee-types",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677fd3c62d77b0550288d63723d331dbd88adcf3578e1f58daa123f0b599e383"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "tracing",
 ]
 
 [[package]]
@@ -183,6 +271,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,7 +306,7 @@ dependencies = [
  "ark-std 0.4.0",
  "derivative",
  "digest 0.10.7",
- "itertools",
+ "itertools 0.10.5",
  "num-bigint",
  "num-traits",
  "paste",
@@ -417,6 +511,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aurora-engine-modexp"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfacad86e9e138fca0670949eb8ed4ffdf73a55bded8887efe0863cd1a3a6f70"
+dependencies = [
+ "hex",
+ "num",
+]
+
+[[package]]
 name = "auto_impl"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,6 +630,15 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bincode"
@@ -722,8 +835,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "0.1.0"
-source = "git+https://github.com/ethereum/c-kzg-4844?rev=f5f6f863d475847876a2bd5ee252058d37c3a15d#f5f6f863d475847876a2bd5ee252058d37c3a15d"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32700dc7904064bb64e857d38a1766607372928e2466ee5f02a869829b3297d7"
 dependencies = [
  "bindgen",
  "blst",
@@ -732,19 +846,6 @@ dependencies = [
  "hex",
  "libc",
  "serde",
-]
-
-[[package]]
-name = "c-kzg"
-version = "0.1.0"
-source = "git+https://github.com/ethereum/c-kzg-4844#712ccb629d64552561e2eeb1a1bf094f65c7f3ea"
-dependencies = [
- "bindgen",
- "blst",
- "cc",
- "glob",
- "hex",
- "libc",
 ]
 
 [[package]]
@@ -1002,8 +1103,8 @@ dependencies = [
 
 [[package]]
 name = "codecs-derive"
-version = "0.1.0-alpha.9"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=b701cbc#b701cbc9a3eda39578ad19fb453c2c151aa72aab"
+version = "0.1.0-alpha.14"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=685d1c5#685d1c51e4cff23e410bd43a18242c6a1b1a724c"
 dependencies = [
  "convert_case 0.6.0",
  "parity-scale-codec",
@@ -1191,7 +1292,7 @@ dependencies = [
  "ciborium",
  "clap 3.2.25",
  "criterion-plot",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -1212,7 +1313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1659,81 +1760,6 @@ checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
 dependencies = [
  "libc",
  "str-buf",
-]
-
-[[package]]
-name = "ethabi"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
-dependencies = [
- "ethereum-types",
- "hex",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sha3",
- "thiserror",
- "uint",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
-dependencies = [
- "crunchy",
- "fixed-hash",
- "impl-codec",
- "impl-rlp",
- "impl-serde",
- "scale-info",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
-dependencies = [
- "ethbloom",
- "fixed-hash",
- "impl-codec",
- "impl-rlp",
- "impl-serde",
- "primitive-types",
- "scale-info",
- "uint",
-]
-
-[[package]]
-name = "ethers-core"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f03e0bdc216eeb9e355b90cf610ef6c5bb8aca631f97b5ae9980ce34ea7878d"
-dependencies = [
- "arrayvec 0.7.4",
- "bytes",
- "chrono",
- "const-hex",
- "elliptic-curve",
- "ethabi",
- "generic-array",
- "k256",
- "num_enum 0.7.1",
- "open-fastrlp",
- "rand",
- "rlp",
- "serde",
- "serde_json",
- "strum",
- "tempfile",
- "thiserror",
- "tiny-keccak",
- "unicode-xid",
 ]
 
 [[package]]
@@ -2217,12 +2243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
-name = "hash-db"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,24 +2588,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-rlp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
-dependencies = [
- "rlp",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,6 +2659,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2687,6 +2707,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-types"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be0be325642e850ed0bdff426674d2e66b2b7117c9be23a7caef68a2902b7d9"
+dependencies = [
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2697,15 +2731,17 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "sha2",
+ "signature",
 ]
 
 [[package]]
-name = "keccak"
-version = "0.1.4"
+name = "keccak-asm"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+checksum = "bb8515fff80ed850aea4a1595f2e519c003e2a00a82fe168ebf5269196caf444"
 dependencies = [
- "cpufeatures",
+ "digest 0.10.7",
+ "sha3-asm",
 ]
 
 [[package]]
@@ -2724,6 +2760,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "lazycell"
@@ -3045,7 +3084,7 @@ dependencies = [
 name = "monad-consensus-state"
 version = "0.1.0"
 dependencies = [
- "itertools",
+ "itertools 0.10.5",
  "monad-blocktree",
  "monad-consensus",
  "monad-consensus-types",
@@ -3076,7 +3115,6 @@ dependencies = [
  "prost",
  "rand",
  "rand_chacha",
- "reth-primitives",
  "serde_cbor",
  "test-case",
  "tracing",
@@ -3107,9 +3145,10 @@ dependencies = [
 name = "monad-eth-types"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
  "bytes",
  "reth-primitives",
- "reth-rlp",
  "serde",
 ]
 
@@ -3122,7 +3161,6 @@ dependencies = [
  "monad-crypto",
  "monad-executor-glue",
  "monad-types",
- "tokio",
 ]
 
 [[package]]
@@ -3162,12 +3200,13 @@ dependencies = [
 name = "monad-ledger"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
  "monad-consensus-types",
  "monad-crypto",
  "monad-eth-types",
  "monad-types",
  "reth-primitives",
- "reth-rlp",
 ]
 
 [[package]]
@@ -3177,7 +3216,7 @@ dependencies = [
  "bytes",
  "criterion",
  "futures",
- "itertools",
+ "itertools 0.10.5",
  "monad-consensus",
  "monad-consensus-state",
  "monad-consensus-types",
@@ -3432,7 +3471,7 @@ dependencies = [
 name = "monad-twins-utils"
 version = "0.1.0"
 dependencies = [
- "itertools",
+ "itertools 0.10.5",
  "monad-consensus-types",
  "monad-crypto",
  "monad-mock-swarm",
@@ -3732,6 +3771,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3743,12 +3796,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3812,6 +3897,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.39",
+]
+
+[[package]]
+name = "nybbles"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836816c354fb2c09622b54545a6f98416147346b13cc7eba5f92fab6b3042c93"
+dependencies = [
+ "alloy-rlp",
+ "const-hex",
+ "proptest",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -3882,31 +3980,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "open-fastrlp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
-dependencies = [
- "arrayvec 0.7.4",
- "auto_impl",
- "bytes",
- "ethereum-types",
- "open-fastrlp-derive",
-]
-
-[[package]]
-name = "open-fastrlp-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
-dependencies = [
- "bytes",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "openssl-probe"
@@ -4301,15 +4374,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
-name = "plain_hasher"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e19e6491bdde87c2c43d70f4c194bc8a758f2eb732df00f61e43f7362e3b4cc"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "plotters"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4390,9 +4454,6 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "impl-rlp",
- "impl-serde",
- "scale-info",
  "uint",
 ]
 
@@ -4470,6 +4531,8 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
+ "bit-set",
+ "bit-vec",
  "bitflags 2.4.1",
  "lazy_static",
  "num-traits",
@@ -4477,6 +4540,8 @@ dependencies = [
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax 0.8.2",
+ "rusty-fork",
+ "tempfile",
  "unarray",
 ]
 
@@ -4498,7 +4563,7 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
@@ -4519,7 +4584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4542,6 +4607,12 @@ checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
 dependencies = [
  "autotools",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -4775,104 +4846,133 @@ checksum = "f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157"
 
 [[package]]
 name = "reth-codecs"
-version = "0.1.0-alpha.9"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=b701cbc#b701cbc9a3eda39578ad19fb453c2c151aa72aab"
+version = "0.1.0-alpha.14"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=685d1c5#685d1c51e4cff23e410bd43a18242c6a1b1a724c"
 dependencies = [
+ "alloy-primitives",
  "bytes",
  "codecs-derive",
- "revm-primitives",
+]
+
+[[package]]
+name = "reth-ethereum-forks"
+version = "0.1.0-alpha.14"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=685d1c5#685d1c51e4cff23e410bd43a18242c6a1b1a724c"
+dependencies = [
+ "alloy-chains",
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
 name = "reth-primitives"
-version = "0.1.0-alpha.9"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=b701cbc#b701cbc9a3eda39578ad19fb453c2c151aa72aab"
+version = "0.1.0-alpha.14"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=685d1c5#685d1c51e4cff23e410bd43a18242c6a1b1a724c"
 dependencies = [
+ "ahash",
+ "alloy-chains",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie",
+ "byteorder",
  "bytes",
- "c-kzg 0.1.0 (git+https://github.com/ethereum/c-kzg-4844?rev=f5f6f863d475847876a2bd5ee252058d37c3a15d)",
- "crc",
- "crunchy",
  "derive_more",
- "ethers-core",
- "fixed-hash",
- "hash-db",
- "hex",
- "hex-literal",
- "impl-serde",
+ "itertools 0.11.0",
  "modular-bitfield",
+ "num_enum 0.7.1",
+ "nybbles",
  "once_cell",
- "paste",
- "plain_hasher",
  "rayon",
  "reth-codecs",
- "reth-rlp",
- "reth-rlp-derive",
+ "reth-ethereum-forks",
+ "reth-rpc-types",
+ "revm",
  "revm-primitives",
- "ruint",
  "secp256k1 0.27.0",
  "serde",
  "serde_json",
- "serde_with",
  "sha2",
+ "smallvec",
  "strum",
  "sucds",
  "tempfile",
  "thiserror",
- "tiny-keccak",
- "tokio",
- "tokio-stream",
  "tracing",
- "triehash",
- "url",
  "zstd",
 ]
 
 [[package]]
-name = "reth-rlp"
-version = "0.1.0-alpha.9"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=b701cbc#b701cbc9a3eda39578ad19fb453c2c151aa72aab"
+name = "reth-rpc-types"
+version = "0.1.0-alpha.14"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=685d1c5#685d1c51e4cff23e410bd43a18242c6a1b1a724c"
 dependencies = [
- "arrayvec 0.7.4",
- "auto_impl",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-trace-types",
+ "alloy-rpc-types",
  "bytes",
- "c-kzg 0.1.0 (git+https://github.com/ethereum/c-kzg-4844?rev=f5f6f863d475847876a2bd5ee252058d37c3a15d)",
- "ethereum-types",
- "reth-rlp-derive",
+ "itertools 0.12.0",
+ "jsonrpsee-types",
+ "secp256k1 0.27.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "revm"
+version = "3.5.0"
+source = "git+https://github.com/bluealloy/revm?branch=reth_freeze#5ea9d7948bd5cd34bc5fe00e33ae9fcba5340448"
+dependencies = [
+ "auto_impl",
+ "revm-interpreter",
+ "revm-precompile",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "1.3.0"
+source = "git+https://github.com/bluealloy/revm?branch=reth_freeze#5ea9d7948bd5cd34bc5fe00e33ae9fcba5340448"
+dependencies = [
  "revm-primitives",
 ]
 
 [[package]]
-name = "reth-rlp-derive"
-version = "0.1.0-alpha.9"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=b701cbc#b701cbc9a3eda39578ad19fb453c2c151aa72aab"
+name = "revm-precompile"
+version = "2.2.0"
+source = "git+https://github.com/bluealloy/revm?branch=reth_freeze#5ea9d7948bd5cd34bc5fe00e33ae9fcba5340448"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.39",
+ "aurora-engine-modexp",
+ "c-kzg",
+ "k256",
+ "once_cell",
+ "revm-primitives",
+ "ripemd",
+ "secp256k1 0.28.1",
+ "sha2",
+ "substrate-bn",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "1.1.2"
-source = "git+https://github.com/bluealloy/revm?rev=516f62cc#516f62ccc1c5f2a62e5fc58115213fe04c7f7a8c"
+version = "1.3.0"
+source = "git+https://github.com/bluealloy/revm?branch=reth_freeze#5ea9d7948bd5cd34bc5fe00e33ae9fcba5340448"
 dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
  "auto_impl",
  "bitflags 2.4.1",
  "bitvec",
- "bytes",
- "c-kzg 0.1.0 (git+https://github.com/ethereum/c-kzg-4844)",
- "derive_more",
+ "c-kzg",
  "enumn",
- "fixed-hash",
  "hashbrown 0.14.3",
  "hex",
- "hex-literal",
- "once_cell",
- "primitive-types",
- "rlp",
- "ruint",
  "serde",
- "sha3",
 ]
 
 [[package]]
@@ -4915,25 +5015,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
- "rlp-derive",
  "rustc-hex",
-]
-
-[[package]]
-name = "rlp-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -5074,6 +5171,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5095,30 +5204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "scale-info"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7d66a1128282b7ef025a8ead62a4a9fcf017382ec53b8ffbf4d7bf77bd3c60"
-dependencies = [
- "cfg-if",
- "derive_more",
- "parity-scale-codec",
- "scale-info-derive",
-]
-
-[[package]]
-name = "scale-info-derive"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf2c68b89cafb3b8d918dd07b42be0da66ff202cf1155c5739a4e0c1ea0dc19"
-dependencies = [
- "proc-macro-crate 1.1.3",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -5184,7 +5269,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
 dependencies = [
- "secp256k1-sys",
+ "secp256k1-sys 0.8.1",
 ]
 
 [[package]]
@@ -5194,7 +5279,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "rand",
- "secp256k1-sys",
+ "secp256k1-sys 0.8.1",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f622567e3b4b38154fb8190bcf6b160d7a4301d70595a49195b48c116007a27"
+dependencies = [
+ "secp256k1-sys 0.9.2",
 ]
 
 [[package]]
@@ -5202,6 +5296,15 @@ name = "secp256k1-sys"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
 dependencies = [
  "cc",
 ]
@@ -5366,13 +5469,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.10.8"
+name = "sha3-asm"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "bac61da6b35ad76b195eb4771210f947734321a8d81d7738e1580d953bc7a15e"
 dependencies = [
- "digest 0.10.7",
- "keccak",
+ "cc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -5453,6 +5556,10 @@ name = "smallvec"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+dependencies = [
+ "arbitrary",
+ "serde",
+]
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -5588,6 +5695,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.39",
+]
+
+[[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -6148,16 +6268,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "triehash"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1631b201eb031b563d2e85ca18ec8092508e262a3196ce9bd10a67ec87b9f5c"
-dependencies = [
- "hash-db",
- "rlp",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6301,6 +6411,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,9 @@ opt-level = 1
 debug = true
 
 [workspace.dependencies]
-reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "b701cbc" }
-reth-rlp = { git = "https://github.com/paradigmxyz/reth.git", rev = "b701cbc" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "685d1c5", default-features = false }
+alloy-primitives = "0.6"
+alloy-rlp = "0.3"
 
 async-trait = "0.1"
 base64 = "0.21"

--- a/monad-consensus-types/Cargo.toml
+++ b/monad-consensus-types/Cargo.toml
@@ -19,7 +19,6 @@ monad-types = { path = "../monad-types" }
 bitvec = { workspace = true, features = ["serde"] }
 bytes = { workspace = true }
 prost = { workspace = true }
-reth-primitives = { workspace = true }
 serde_cbor = { workspace = true }
 tracing = { workspace = true }
 zerocopy = { workspace = true }

--- a/monad-eth-types/Cargo.toml
+++ b/monad-eth-types/Cargo.toml
@@ -9,9 +9,10 @@ edition = "2021"
 bench = false
 
 [dependencies]
+alloy-primitives = { workspace = true }
+alloy-rlp = { workspace = true }
 bytes = { workspace = true }
 reth-primitives = { workspace = true }
-reth-rlp = { workspace = true }
 serde = { workspace = true, optional = true }
 
 [features]

--- a/monad-eth-types/src/lib.rs
+++ b/monad-eth-types/src/lib.rs
@@ -1,6 +1,7 @@
+use alloy_primitives::{Address, FixedBytes, TxHash};
+use alloy_rlp::{Decodable, Encodable};
 use bytes::{Bytes, BytesMut};
-use reth_primitives::{Address, TransactionSignedEcRecovered, TxHash, H160};
-use reth_rlp::{Decodable, Encodable};
+use reth_primitives::TransactionSignedEcRecovered;
 
 #[cfg(feature = "serde")]
 pub mod serde;
@@ -24,7 +25,7 @@ impl EthTransactionList {
         buf.into()
     }
 
-    pub fn rlp_decode(rlp_data: Bytes) -> Result<Self, reth_rlp::DecodeError> {
+    pub fn rlp_decode(rlp_data: Bytes) -> Result<Self, alloy_rlp::Error> {
         Vec::<EthTxHash>::decode(&mut rlp_data.as_ref()).map(Self)
     }
 }
@@ -43,7 +44,7 @@ impl EthFullTransactionList {
         buf.into()
     }
 
-    pub fn rlp_decode(rlp_data: Bytes) -> Result<Self, reth_rlp::DecodeError> {
+    pub fn rlp_decode(rlp_data: Bytes) -> Result<Self, alloy_rlp::Error> {
         Vec::<EthTransaction>::decode(&mut rlp_data.as_ref()).map(Self)
     }
 
@@ -59,12 +60,12 @@ pub struct EthAddress(pub Address);
 
 impl EthAddress {
     pub fn from_bytes(bytes: [u8; 20]) -> Self {
-        Self(H160(bytes))
+        Self(Address(FixedBytes(bytes)))
     }
 }
 
 impl AsRef<[u8]> for EthAddress {
     fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
+        self.0.as_slice()
     }
 }

--- a/monad-eth-types/src/serde/mod.rs
+++ b/monad-eth-types/src/serde/mod.rs
@@ -1,6 +1,6 @@
 use std::{fmt, str::FromStr};
 
-use reth_primitives::H160;
+use alloy_primitives::{Address, FixedBytes, U160};
 use serde::{de::Visitor, Deserializer};
 
 use crate::EthAddress;
@@ -23,7 +23,7 @@ where
         where
             E: serde::de::Error,
         {
-            Ok(EthAddress(H160::from_str(value).unwrap()))
+            Ok(EthAddress(Address(U160::from_str(value).unwrap().into())))
         }
 
         fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>
@@ -44,7 +44,7 @@ where
                 ));
             }
 
-            Ok(EthAddress(H160(bytes)))
+            Ok(EthAddress(Address(FixedBytes(bytes))))
         }
     }
 

--- a/monad-executor/Cargo.toml
+++ b/monad-executor/Cargo.toml
@@ -15,6 +15,3 @@ monad-executor-glue = { path = "../monad-executor-glue" }
 monad-types = { path = "../monad-types" }
 
 bytes = { workspace = true }
-
-[dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }

--- a/monad-ledger/Cargo.toml
+++ b/monad-ledger/Cargo.toml
@@ -13,8 +13,9 @@ monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
 monad-eth-types = { path = "../monad-eth-types" }
 
+alloy-primitives = { workspace = true }
+alloy-rlp = { workspace = true }
 reth-primitives = { workspace = true }
-reth-rlp = { workspace = true }
 
 [dev-dependencies]
 monad-types = { path = "../monad-types" }

--- a/monad-ledger/src/lib.rs
+++ b/monad-ledger/src/lib.rs
@@ -1,3 +1,5 @@
+use alloy_primitives::{keccak256, Bloom, Bytes, FixedBytes, U256};
+use alloy_rlp::Encodable;
 use monad_consensus_types::{
     block::Block as MonadBlock,
     payload::{ExecutionArtifacts, FullTransactionList},
@@ -5,8 +7,7 @@ use monad_consensus_types::{
 };
 use monad_crypto::hasher::{Hasher, HasherType};
 use monad_eth_types::EthFullTransactionList;
-use reth_primitives::{keccak256, BlockBody, Bloom, Bytes, Header, H256, U256};
-use reth_rlp::Encodable;
+use reth_primitives::{BlockBody, Header};
 
 /// Create an RLP encoded Ethereum block from a Monad consensus block
 pub fn encode_full_block<SCT: SignatureCollection>(block: MonadBlock<SCT>) -> Vec<u8> {
@@ -68,14 +69,14 @@ fn generate_header<SCT: SignatureCollection>(
     randao_reveal_hasher.update(monad_block.payload.randao_reveal.0);
 
     Header {
-        parent_hash: H256(parent_hash.0),
+        parent_hash: FixedBytes(parent_hash.0),
         ommers_hash: block_body.calculate_ommers_root(),
         beneficiary: monad_block.payload.beneficiary.0,
-        state_root: H256(state_root.0),
-        transactions_root: H256(transactions_root.0),
-        receipts_root: H256(receipts_root.0),
+        state_root: FixedBytes(state_root.0),
+        transactions_root: FixedBytes(transactions_root.0),
+        receipts_root: FixedBytes(receipts_root.0),
         withdrawals_root: block_body.calculate_withdrawals_root(),
-        logs_bloom: Bloom(logs_bloom.0),
+        logs_bloom: Bloom(FixedBytes(logs_bloom.0)),
         difficulty: U256::ZERO,
         number: monad_block.payload.seq_num.0,
         // TODO-1: need to get the actual sum gas limit from the list of transactions being used


### PR DESCRIPTION
This updated reth version allows us to disable pulling in extraneous crypto libraries.