### PR TITLE
Loopback executor

### DIFF
--- a/monad-consensus-types/src/signature_collection.rs
+++ b/monad-consensus-types/src/signature_collection.rs
@@ -54,7 +54,7 @@ pub trait SignatureCollection:
     Clone + Hashable + Eq + Send + Sync + std::fmt::Debug + 'static
 {
     type NodeIdPubKey: PubKey;
-    type SignatureType: CertificateSignature;
+    type SignatureType: CertificateSignature + Unpin;
 
     fn new(
         sigs: impl IntoIterator<Item = (NodeId<Self::NodeIdPubKey>, Self::SignatureType)>,

--- a/monad-crypto/src/certificate_signature.rs
+++ b/monad-crypto/src/certificate_signature.rs
@@ -26,7 +26,7 @@ pub type CertificateSignaturePubKey<T> =
     <<T as CertificateSignature>::KeyPairType as CertificateKeyPair>::PubKeyType;
 
 pub trait CertificateSignature:
-    Copy + Clone + Eq + Hashable + Send + Sync + std::fmt::Debug + std::hash::Hash + 'static
+    Copy + Clone + Eq + Hashable + Send + Sync + Unpin + std::fmt::Debug + std::hash::Hash + 'static
 {
     type KeyPairType: CertificateKeyPair;
     type Error: Display + Debug + Send + Sync;

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -73,6 +73,10 @@ pub enum StateRootHashCommand<B> {
     LedgerCommit(B),
 }
 
+pub enum LoopbackCommand<E> {
+    Forward(E),
+}
+
 pub enum Command<E, OM, B, C, SCT: SignatureCollection> {
     RouterCommand(RouterCommand<SCT::NodeIdPubKey, OM>),
     TimerCommand(TimerCommand<E>),
@@ -81,6 +85,7 @@ pub enum Command<E, OM, B, C, SCT: SignatureCollection> {
     ExecutionLedgerCommand(ExecutionLedgerCommand<SCT>),
     CheckpointCommand(CheckpointCommand<C>),
     StateRootHashCommand(StateRootHashCommand<B>),
+    LoopbackCommand(LoopbackCommand<E>),
 }
 
 impl<E, OM, B, C, SCT: SignatureCollection> Command<E, OM, B, C, SCT> {
@@ -93,6 +98,7 @@ impl<E, OM, B, C, SCT: SignatureCollection> Command<E, OM, B, C, SCT> {
         Vec<ExecutionLedgerCommand<SCT>>,
         Vec<CheckpointCommand<C>>,
         Vec<StateRootHashCommand<B>>,
+        Vec<LoopbackCommand<E>>,
     ) {
         let mut router_cmds = Vec::new();
         let mut timer_cmds = Vec::new();
@@ -100,6 +106,7 @@ impl<E, OM, B, C, SCT: SignatureCollection> Command<E, OM, B, C, SCT> {
         let mut execution_ledger_cmds = Vec::new();
         let mut checkpoint_cmds = Vec::new();
         let mut state_root_hash_cmds = Vec::new();
+        let mut loopback_cmds = Vec::new();
 
         for command in commands {
             match command {
@@ -109,6 +116,7 @@ impl<E, OM, B, C, SCT: SignatureCollection> Command<E, OM, B, C, SCT> {
                 Command::ExecutionLedgerCommand(cmd) => execution_ledger_cmds.push(cmd),
                 Command::CheckpointCommand(cmd) => checkpoint_cmds.push(cmd),
                 Command::StateRootHashCommand(cmd) => state_root_hash_cmds.push(cmd),
+                Command::LoopbackCommand(cmd) => loopback_cmds.push(cmd),
             }
         }
         (
@@ -118,6 +126,7 @@ impl<E, OM, B, C, SCT: SignatureCollection> Command<E, OM, B, C, SCT> {
             execution_ledger_cmds,
             checkpoint_cmds,
             state_root_hash_cmds,
+            loopback_cmds,
         )
     }
 }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -25,6 +25,7 @@ use monad_types::{NodeId, Round, SeqNum, Stake};
 use monad_updaters::{
     checkpoint::MockCheckpoint,
     ledger::MockLedger,
+    loopback::LoopbackExecutor,
     parent::ParentExecutor,
     state_root_hash::{MockStateRootHashNop, MockableStateRootHash},
     timer::TokioTimer,
@@ -132,6 +133,7 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
             val_set_update_interval,
         ),
         ipc: IpcReceiver::new(node_state.mempool_ipc_path).expect("uds bind failed"),
+        loopback: LoopbackExecutor::default(),
     };
 
     let Ok((mut wal, wal_events)) = WALogger::new(WALoggerConfig {

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -23,6 +23,7 @@ use monad_updaters::{
     checkpoint::MockCheckpoint,
     ledger::MockLedger,
     local_router::LocalPeerRouter,
+    loopback::LoopbackExecutor,
     parent::ParentExecutor,
     state_root_hash::{MockStateRootHashNop, MockableStateRootHash},
     timer::TokioTimer,
@@ -89,6 +90,7 @@ pub async fn make_monad_executor<ST, SCT>(
     MockCheckpoint<Checkpoint<SCT>>,
     BoxUpdater<'static, StateRootHashCommand<Block<SCT>>, MonadEvent<ST, SCT>>,
     IpcReceiver<ST, SCT>,
+    LoopbackExecutor<MonadEvent<ST, SCT>>,
 >
 where
     ST: CertificateSignatureRecoverable + Unpin,
@@ -128,6 +130,7 @@ where
             )),
         },
         ipc: IpcReceiver::new(generate_uds_path()).expect("uds bind failed"),
+        loopback: LoopbackExecutor::default(),
     }
 }
 

--- a/monad-updaters/src/lib.rs
+++ b/monad-updaters/src/lib.rs
@@ -6,6 +6,7 @@ use monad_executor::Executor;
 pub mod checkpoint;
 pub mod ipc;
 pub mod ledger;
+pub mod loopback;
 pub mod parent;
 pub mod state_root_hash;
 pub mod validator_set;

--- a/monad-updaters/src/loopback.rs
+++ b/monad-updaters/src/loopback.rs
@@ -1,0 +1,84 @@
+use std::{
+    collections::VecDeque,
+    ops::DerefMut,
+    task::{Poll, Waker},
+};
+
+use futures::Stream;
+use monad_executor::Executor;
+use monad_executor_glue::LoopbackCommand;
+
+/// The loopback executor routes outputs from one child state to another. The
+/// update happens asynchronously and the event/operation must be idempotent on
+/// the target state as replay can cause duplicate event to be applied.
+///
+/// e.g. StateRootUpdate for ConsensusState is idempotent because inserting the
+/// same value to a map multiple times doesn't change the final state
+pub struct LoopbackExecutor<E> {
+    /// Buffered events to send back
+    buffer: VecDeque<E>,
+    waker: Option<Waker>,
+}
+
+impl<E> Default for LoopbackExecutor<E> {
+    fn default() -> Self {
+        Self {
+            buffer: Default::default(),
+            waker: Default::default(),
+        }
+    }
+}
+
+impl<E> Executor for LoopbackExecutor<E> {
+    type Command = LoopbackCommand<E>;
+
+    /// The events replayed are idempotentent
+    fn replay(&mut self, mut commands: Vec<Self::Command>) {
+        commands.retain(|cmd| match cmd {
+            // we match on all commands to be explicit
+            LoopbackCommand::Forward(_) => true,
+        });
+        self.exec(commands)
+    }
+
+    fn exec(&mut self, commands: Vec<Self::Command>) {
+        for cmd in commands {
+            match cmd {
+                LoopbackCommand::Forward(event) => self.buffer.push_back(event),
+            }
+        }
+
+        if self.ready() {
+            if let Some(waker) = self.waker.take() {
+                waker.wake()
+            }
+        }
+    }
+}
+
+impl<E> Stream for LoopbackExecutor<E>
+where
+    Self: Unpin,
+{
+    type Item = E;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let this = self.deref_mut();
+
+        if let Some(e) = this.buffer.pop_front() {
+            Poll::Ready(Some(e))
+        } else {
+            this.waker = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+impl<E> LoopbackExecutor<E> {
+    pub fn ready(&self) -> bool {
+        !self.buffer.is_empty()
+    }
+}


### PR DESCRIPTION
The loopback executor forwards events from one childstate to another in MonadState. Asking the lo executor to forward reduces potential inter-dependencies among child states. Due to replay, the handler of the event must be idempotent.

The executor prepares for async state verification (ASV). The ASV module is only tasked to collect state roots from execution and other peers. Once it reaches agreement, it forwards a StateRootUpdate to ConsensusState. There's minimal change to ConsensusState - we change the source of state root changes from execution to async state verification via loopback. That's it.

An alternative way to approach async state verification is to move state root validator to ASV. ConsensusState handlers take in an additional parameter and calls ASV to verify the state root. I don't think it's as elegant because it's nice to keep all consensus protocol under ConsensusState. If people have different/better ideas, lmk