### PR TITLE
Add count getter to CounterLayer

### DIFF
--- a/monad-mock-swarm/tests/many_nodes_metrics.rs
+++ b/monad-mock-swarm/tests/many_nodes_metrics.rs
@@ -18,7 +18,7 @@ use tracing_subscriber::{filter::Targets, prelude::*, Registry};
 #[test]
 fn many_nodes_metrics() {
     let fmt_layer = tracing_subscriber::fmt::layer();
-    let counter_layer = CounterLayer::new();
+    let counter_layer = CounterLayer::default();
 
     let subscriber = Registry::default()
         .with(

--- a/monad-mock-swarm/tests/replay_test.rs
+++ b/monad-mock-swarm/tests/replay_test.rs
@@ -24,6 +24,7 @@ use monad_wal::{
     PersistenceLogger,
 };
 use tracing_test::traced_test;
+
 const CONSENSUS_DELTA: Duration = Duration::from_millis(10);
 
 struct ReplaySwarm;

--- a/monad-mock-swarm/tests/single_node_metrics.rs
+++ b/monad-mock-swarm/tests/single_node_metrics.rs
@@ -16,9 +16,9 @@ use tracing_core::LevelFilter;
 use tracing_subscriber::{filter::Targets, prelude::*, Registry};
 
 #[test]
-fn two_nodes() {
+fn two_nodes_metrics() {
     let fmt_layer = tracing_subscriber::fmt::layer();
-    let counter_layer = CounterLayer::new();
+    let counter_layer = CounterLayer::default();
 
     let subscriber = Registry::default()
         .with(


### PR DESCRIPTION
Our tests used `traced_test` with `logs_assert` on counter logs to detect if certain events occured. When the test fails, it emits a massive log, taking forever to print and we can't filter it by log level because counter logs are on the trace log level.

This PR allows us to access the counter directly, making writing assertions like these easier. They run faster than logs_assert as well.

Tracing subscriber cannot be unset once set, so we can't have multiple tests in the same file all use this functionality. This can be fixed if we create a top-level scope/span for each test case, and make counter aware of that. That's deferred for now.