### PR TITLE
Refactor SwarmRelation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,6 +2107,7 @@ dependencies = [
  "monad-proto",
  "monad-testutil",
  "monad-types",
+ "monad-validator",
  "prost",
  "rand",
  "serde_cbor",
@@ -2374,6 +2375,7 @@ dependencies = [
  "monad-proto",
  "monad-testutil",
  "monad-types",
+ "monad-validator",
  "prost",
  "rand",
  "rand_chacha",
@@ -2466,6 +2468,8 @@ dependencies = [
  "monad-testutil",
  "monad-transformer",
  "monad-types",
+ "monad-updaters",
+ "monad-validator",
  "monad-wal",
  "simple-xml-builder",
 ]
@@ -2630,13 +2634,20 @@ name = "monad-twins-utils"
 version = "0.1.0"
 dependencies = [
  "itertools 0.10.5",
+ "monad-consensus-state",
  "monad-consensus-types",
  "monad-crypto",
+ "monad-eth-types",
+ "monad-executor-glue",
  "monad-mock-swarm",
+ "monad-router-scheduler",
  "monad-state",
  "monad-testutil",
  "monad-transformer",
  "monad-types",
+ "monad-updaters",
+ "monad-validator",
+ "monad-wal",
  "rand",
  "rand_chacha",
  "serde",
@@ -2728,6 +2739,7 @@ dependencies = [
  "monad-state",
  "monad-testutil",
  "monad-types",
+ "monad-validator",
  "tempfile",
 ]
 

--- a/monad-bls/Cargo.toml
+++ b/monad-bls/Cargo.toml
@@ -13,6 +13,7 @@ monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
 monad-proto = { path = "../monad-proto" }
 monad-types = { path = "../monad-types" }
+monad-validator = { path = "../monad-validator" }
 
 bitvec = { workspace = true, features = ["serde"] }
 blst = { workspace = true }

--- a/monad-bls/benches/bls.rs
+++ b/monad-bls/benches/bls.rs
@@ -8,6 +8,7 @@ use monad_crypto::{
 };
 use monad_testutil::validators::create_keys_w_validators;
 use monad_types::NodeId;
+use monad_validator::validator_set::ValidatorSetFactory;
 
 const N: u32 = 1000;
 
@@ -15,8 +16,11 @@ type SignatureType = NopSignature;
 type SignatureCollectionType = BlsSignatureCollection<CertificateSignaturePubKey<SignatureType>>;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let (keys, certkeys, _, validator_mapping) =
-        create_keys_w_validators::<SignatureType, SignatureCollectionType>(N);
+    let (keys, certkeys, _, validator_mapping) = create_keys_w_validators::<
+        SignatureType,
+        SignatureCollectionType,
+        _,
+    >(N, ValidatorSetFactory::default());
     let mut hasher = HasherType::new();
     hasher.update(b"hello world");
     let data = hasher.hash();

--- a/monad-bls/src/aggregation_tree.rs
+++ b/monad-bls/src/aggregation_tree.rs
@@ -294,6 +294,7 @@ mod test {
         validators::create_keys_w_validators,
     };
     use monad_types::NodeId;
+    use monad_validator::validator_set::ValidatorSetFactory;
     use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
     use test_case::test_case;
 
@@ -329,8 +330,11 @@ mod test {
     #[test_case(5; "5 sigs")]
     #[test_case(100; "100 sigs")]
     fn test_creation(num_keys: u32) {
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_keys);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_keys, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -354,8 +358,11 @@ mod test {
             // skip test because we can't "steal" others signature
             return;
         }
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_keys);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_keys, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -396,8 +403,11 @@ mod test {
     #[test_case(5; "5 sigs")]
     #[test_case(100; "100 sigs")]
     fn test_num_signatures(num_keys: u32) {
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_keys);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_keys, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -417,8 +427,11 @@ mod test {
     #[test_case(100; "100 sigs")]
     fn test_node_id_not_in_validator_mapping(num_keys: u32) {
         use monad_crypto::certificate_signature::CertificateKeyPair;
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_keys);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_keys, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -455,8 +468,11 @@ mod test {
     #[test_case(5; "5 sigs")]
     #[test_case(100; "100 sigs")]
     fn test_duplicate_sig(num_keys: u32) {
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_keys);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_keys, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -481,8 +497,11 @@ mod test {
     #[test_case(5; "5 sigs")]
     #[test_case(100; "100 sigs")]
     fn test_verify(num_keys: u32) {
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_keys);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_keys, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -506,8 +525,11 @@ mod test {
     #[test_case(5; "5 sigs")]
     #[test_case(100; "100 sigs")]
     fn test_get_participants(num_keys: u32) {
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_keys);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_keys, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -530,8 +552,11 @@ mod test {
     #[test_case(5; "5 sigs")]
     #[test_case(100; "100 sigs")]
     fn test_serialization_roundtrip(num_keys: u32) {
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_keys);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_keys, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -573,8 +598,11 @@ mod test {
         //     /  \          /   \         /   \
         //  (1)    (2)    (3)    (4)    (5)    (6)
 
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(7);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(7, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -637,8 +665,11 @@ mod test {
     #[test_case(5,2; "5 signatures, 2-3 split")]
     fn test_merge_node(num_sigs: u32, first: usize) {
         assert!(num_sigs as usize >= first);
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_sigs);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_sigs, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -674,8 +705,11 @@ mod test {
 
     fn test_creation_multiple_invalid(seed: u64, num_sigs: u32, num_invalid: u32) {
         assert!(num_invalid <= num_sigs);
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_sigs);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_sigs, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -714,8 +748,11 @@ mod test {
 
     #[test]
     fn test_conflict_signatures() {
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(5);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(5, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)

--- a/monad-consensus-types/src/block_validator.rs
+++ b/monad-consensus-types/src/block_validator.rs
@@ -2,8 +2,14 @@ use core::fmt::Debug;
 
 use crate::payload::FullTransactionList;
 
-pub trait BlockValidator: Clone + Default {
+pub trait BlockValidator {
     fn validate(&self, full_txs: &FullTransactionList) -> bool;
+}
+
+impl<T: BlockValidator + ?Sized> BlockValidator for Box<T> {
+    fn validate(&self, full_txs: &FullTransactionList) -> bool {
+        (**self).validate(full_txs)
+    }
 }
 
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]

--- a/monad-consensus-types/src/signature_collection.rs
+++ b/monad-consensus-types/src/signature_collection.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, fmt::Debug};
 
 use monad_crypto::{
     certificate_signature::{CertificateKeyPair, CertificateSignature, PubKey},
@@ -51,7 +51,7 @@ impl<PT: PubKey, S: CertificateSignature> std::fmt::Display for SignatureCollect
 impl<PT: PubKey, S: CertificateSignature> std::error::Error for SignatureCollectionError<PT, S> {}
 
 pub trait SignatureCollection:
-    Clone + Hashable + Eq + Send + Sync + std::fmt::Debug + 'static
+    Clone + Hashable + Eq + Debug + Send + Sync + Unpin + 'static
 {
     type NodeIdPubKey: PubKey;
     type SignatureType: CertificateSignature + Unpin;

--- a/monad-consensus/src/pacemaker.rs
+++ b/monad-consensus/src/pacemaker.rs
@@ -300,7 +300,7 @@ mod test {
         validators::create_keys_w_validators,
     };
     use monad_types::{BlockId, SeqNum, Stake};
-    use monad_validator::validator_set::ValidatorSet;
+    use monad_validator::validator_set::{ValidatorSetFactory, ValidatorSetTypeFactory};
     use zerocopy::AsBytes;
 
     use super::*;
@@ -372,8 +372,11 @@ mod test {
             Pacemaker::<SignatureCollectionType>::new(Duration::from_secs(1), Round(1), None);
         let mut safety = Safety::default();
 
-        let (keys, certkeys, valset, vmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(4);
+        let (keys, certkeys, valset, vmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(4, ValidatorSetFactory::default());
         let timeout_round = Round(1);
         let high_qc = get_high_qc(
             Round(0),
@@ -449,8 +452,11 @@ mod test {
             Pacemaker::<SignatureCollectionType>::new(Duration::from_secs(1), Round(1), None);
         let mut safety = Safety::default();
 
-        let (keys, certkeys, valset, vmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(4);
+        let (keys, certkeys, valset, vmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(4, ValidatorSetFactory::default());
         let timeout_round = Round(1);
         let high_qc = get_high_qc(
             Round(0),
@@ -528,7 +534,9 @@ mod test {
             .zip(certkeys.iter().map(|k| k.pubkey()))
             .collect::<Vec<_>>();
 
-        let valset = ValidatorSet::new(staking_list).expect("create validator set");
+        let valset = ValidatorSetFactory::default()
+            .create(staking_list)
+            .expect("create validator set");
         let vmap = ValidatorMapping::new(voting_identity);
 
         let timeout_round = Round(1);

--- a/monad-consensus/tests/vote_state.rs
+++ b/monad-consensus/tests/vote_state.rs
@@ -13,7 +13,7 @@ use monad_crypto::{
 use monad_multi_sig::MultiSig;
 use monad_testutil::validators::create_keys_w_validators;
 use monad_types::{BlockId, NodeId, Round, SeqNum};
-use monad_validator::validator_set::ValidatorSet;
+use monad_validator::validator_set::{ValidatorSet, ValidatorSetFactory};
 use test_case::test_case;
 
 type SignatureType = NopSignature;
@@ -52,8 +52,11 @@ fn setup_ctx(
     ValidatorMapping<PubKeyType, SignatureCollectionKeyPairType<SignatureCollectionType>>,
     Vec<(NodeId<PubKeyType>, VoteMessage<SignatureCollectionType>)>,
 ) {
-    let (keys, cert_keys, valset, vmap) =
-        create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_nodes);
+    let (keys, cert_keys, valset, vmap) = create_keys_w_validators::<
+        SignatureType,
+        SignatureCollectionType,
+        _,
+    >(num_nodes, ValidatorSetFactory::default());
 
     let mut votes = Vec::new();
     for j in 0..num_rounds {

--- a/monad-crypto/src/certificate_signature.rs
+++ b/monad-crypto/src/certificate_signature.rs
@@ -26,7 +26,7 @@ pub type CertificateSignaturePubKey<T> =
     <<T as CertificateSignature>::KeyPairType as CertificateKeyPair>::PubKeyType;
 
 pub trait CertificateSignature:
-    Copy + Clone + Eq + Hashable + Send + Sync + Unpin + std::fmt::Debug + std::hash::Hash + 'static
+    Copy + Clone + Eq + Hashable + Debug + Hash + Send + Sync + Unpin + 'static
 {
     type KeyPairType: CertificateKeyPair;
     type Error: Display + Debug + Send + Sync;

--- a/monad-eth-txpool/src/lib.rs
+++ b/monad-eth-txpool/src/lib.rs
@@ -5,13 +5,10 @@ use bytes::Bytes;
 use monad_consensus_types::{payload::FullTransactionList, txpool::TxPool};
 use monad_eth_tx::{EthFullTransactionList, EthTransaction, EthTxHash};
 
+#[derive(Default)]
 pub struct EthTxPool(BTreeMap<EthTxHash, EthTransaction>);
 
 impl TxPool for EthTxPool {
-    fn new() -> Self {
-        Self(BTreeMap::new())
-    }
-
     fn insert_tx(&mut self, tx: Bytes) {
         // TODO: unwrap can be removed when this is made generic over the actual
         // tx type rather than Bytes and decoding won't be necessary

--- a/monad-mock-swarm/benches/two_node_benchmark.rs
+++ b/monad-mock-swarm/benches/two_node_benchmark.rs
@@ -1,12 +1,20 @@
-use std::time::Duration;
+use std::{collections::BTreeSet, time::Duration};
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use monad_consensus_types::block_validator::MockValidator;
-use monad_mock_swarm::{mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm};
-use monad_router_scheduler::NoSerRouterConfig;
-use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
-use monad_transformer::{GenericTransformer, LatencyTransformer};
-use monad_types::{Round, SeqNum};
+use monad_consensus_types::{
+    block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
+};
+use monad_crypto::certificate_signature::CertificateKeyPair;
+use monad_mock_swarm::{
+    mock_swarm::SwarmBuilder, node::NodeBuilder, swarm_relation::NoSerSwarm,
+    terminator::UntilTerminator,
+};
+use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+use monad_testutil::swarm::{make_state_configs, swarm_ledger_verification};
+use monad_transformer::{GenericTransformer, LatencyTransformer, ID};
+use monad_types::{NodeId, Round, SeqNum};
+use monad_updaters::state_root_hash::MockStateRootHashNop;
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 use monad_wal::mock::MockWALoggerConfig;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
@@ -21,26 +29,51 @@ criterion_group! {
 criterion_main!(benches);
 
 fn two_nodes() {
-    create_and_run_nodes::<NoSerSwarm, _, _>(
-        MockValidator,
-        |all_peers, _| NoSerRouterConfig {
-            all_peers: all_peers.into_iter().collect(),
+    let state_configs = make_state_configs::<NoSerSwarm>(
+        2, // num_nodes
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        MockTxPool::default,
+        || MockValidator,
+        || {
+            StateRoot::new(
+                SeqNum(4), // state_root_delay
+            )
         },
-        MockWALoggerConfig,
-        vec![GenericTransformer::Latency(LatencyTransformer::new(
-            Duration::from_millis(1),
-        ))],
-        UntilTerminator::new().until_tick(Duration::from_secs(10)),
-        SwarmTestConfig {
-            num_nodes: 2,
-            consensus_delta: Duration::from_millis(2),
-            parallelize: false,
-            expected_block: 1024,
-            state_root_delay: 4,
-            seed: 1,
-            proposal_size: 5_000,
-            val_set_update_interval: SeqNum(2000),
-            epoch_start_delay: Round(50),
-        },
+        Duration::from_millis(2), // delta
+        5_000,                    // proposal_tx_limit
+        SeqNum(2000),             // val_set_update_interval
+        Round(50),                // epoch_start_delay
     );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|state_config| NodeId::new(state_config.key.pubkey()))
+        .collect();
+    let swarm_config = SwarmBuilder::<NoSerSwarm>(
+        state_configs
+            .into_iter()
+            .enumerate()
+            .map(|(seed, state_builder)| {
+                let validators = state_builder.validators.clone();
+                NodeBuilder::<NoSerSwarm>::new(
+                    ID::new(NodeId::new(state_builder.key.pubkey())),
+                    state_builder,
+                    MockWALoggerConfig::default(),
+                    NoSerRouterConfig::new(all_peers.clone()).build(),
+                    MockStateRootHashNop::new(validators, SeqNum(2000)),
+                    vec![GenericTransformer::Latency(LatencyTransformer::new(
+                        Duration::from_millis(1),
+                    ))],
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
+    );
+
+    let mut swarm = swarm_config.build();
+    while swarm
+        .step_until(&UntilTerminator::new().until_tick(Duration::from_secs(10)))
+        .is_some()
+    {}
+    swarm_ledger_verification(&swarm, 1024);
 }

--- a/monad-mock-swarm/src/lib.rs
+++ b/monad-mock-swarm/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod mock;
 pub mod mock_swarm;
+pub mod node;
 pub mod swarm_relation;
+pub mod terminator;
 pub mod transformer;
 mod utils;

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -10,9 +10,7 @@ use std::{
 
 use futures::{Stream, StreamExt};
 use monad_consensus_state::command::Checkpoint;
-use monad_consensus_types::{
-    block::Block, signature_collection::SignatureCollection, validator_data::ValidatorData,
-};
+use monad_consensus_types::{block::Block, signature_collection::SignatureCollection};
 use monad_crypto::certificate_signature::{CertificateSignaturePubKey, PubKey};
 use monad_executor::Executor;
 use monad_executor_glue::{
@@ -20,7 +18,7 @@ use monad_executor_glue::{
 };
 use monad_router_scheduler::{RouterEvent, RouterScheduler};
 use monad_state::VerifiedMonadMessage;
-use monad_types::{NodeId, SeqNum, TimeoutVariant};
+use monad_types::{NodeId, TimeoutVariant};
 use monad_updaters::{
     checkpoint::MockCheckpoint, ledger::MockLedger, loopback::LoopbackExecutor,
     state_root_hash::MockableStateRootHash,
@@ -29,10 +27,7 @@ use priority_queue::PriorityQueue;
 
 use crate::swarm_relation::SwarmRelation;
 
-pub struct MockExecutor<S>
-where
-    S: SwarmRelation,
-{
+pub struct MockExecutor<S: SwarmRelation> {
     ledger: MockLedger<
         CertificateSignaturePubKey<S::SignatureType>,
         Block<S::SignatureCollectionType>,
@@ -94,25 +89,19 @@ enum ExecutorEventType {
     Loopback,
 }
 
-impl<S> MockExecutor<S>
-where
-    S: SwarmRelation,
-{
+impl<S: SwarmRelation> MockExecutor<S> {
     pub fn new(
         router: S::RouterScheduler,
-        genesis_validator_data: ValidatorData<S::SignatureCollectionType>,
-        val_set_update_interval: SeqNum,
+        state_root_hash: S::StateRootHashExecutor,
         tick: Duration,
     ) -> Self {
         Self {
             checkpoint: Default::default(),
             ledger: Default::default(),
             execution_ledger: Default::default(),
-            state_root_hash: <S::StateRootHashExecutor as MockableStateRootHash>::new(
-                genesis_validator_data,
-                val_set_update_interval,
-            ),
+            state_root_hash,
             loopback: Default::default(),
+
             tick,
 
             timer: PriorityQueue::new(),
@@ -170,10 +159,7 @@ where
     }
 }
 
-impl<S> Executor for MockExecutor<S>
-where
-    S: SwarmRelation,
-{
+impl<S: SwarmRelation> Executor for MockExecutor<S> {
     type Command = Command<
         MonadEvent<S::SignatureType, S::SignatureCollectionType>,
         VerifiedMonadMessage<S::SignatureType, S::SignatureCollectionType>,
@@ -275,10 +261,7 @@ pub enum MockExecutorEvent<E, PT: PubKey, TransportMessage> {
     Send(NodeId<PT>, TransportMessage),
 }
 
-impl<S> MockExecutor<S>
-where
-    S: SwarmRelation,
-{
+impl<S: SwarmRelation> MockExecutor<S> {
     pub fn step_until(
         &mut self,
         until: Duration,
@@ -332,10 +315,7 @@ where
     }
 }
 
-impl<S> MockExecutor<S>
-where
-    S: SwarmRelation,
-{
+impl<S: SwarmRelation> MockExecutor<S> {
     pub fn ledger(
         &self,
     ) -> &MockLedger<

--- a/monad-mock-swarm/src/node.rs
+++ b/monad-mock-swarm/src/node.rs
@@ -1,0 +1,267 @@
+use std::{
+    collections::{BTreeMap, VecDeque},
+    time::Duration,
+    usize,
+};
+
+use itertools::Itertools;
+use monad_crypto::certificate_signature::CertificateSignaturePubKey;
+use monad_executor::Executor;
+use monad_executor_glue::MonadEvent;
+use monad_state::MonadStateBuilder;
+use monad_transformer::{LinkMessage, Pipeline, ID};
+use monad_validator::validator_set::BoxedValidatorSetTypeFactory;
+use monad_wal::{PersistenceLogger, PersistenceLoggerBuilder};
+use rand::{Rng, SeedableRng};
+use rand_chacha::{ChaCha20Rng, ChaChaRng};
+use tracing::info_span;
+
+use crate::{
+    mock::{MockExecutor, MockExecutorEvent},
+    mock_swarm::SwarmEventType,
+    swarm_relation::{DebugSwarmRelation, SwarmRelation, SwarmRelationStateType},
+};
+
+pub struct NodeBuilder<S: SwarmRelation> {
+    pub id: ID<CertificateSignaturePubKey<S::SignatureType>>,
+    pub state_builder: MonadStateBuilder<
+        S::SignatureType,
+        S::SignatureCollectionType,
+        S::ValidatorSetTypeFactory,
+        S::LeaderElection,
+        S::TxPool,
+        S::BlockValidator,
+        S::StateRootValidator,
+    >,
+    pub logger: S::Logger,
+    pub replay_events: Vec<MonadEvent<S::SignatureType, S::SignatureCollectionType>>,
+    pub router_scheduler: S::RouterScheduler,
+    pub state_root_executor: S::StateRootHashExecutor,
+    pub pipeline: S::Pipeline,
+    pub seed: u64,
+}
+impl<S: SwarmRelation> NodeBuilder<S> {
+    pub fn new(
+        id: ID<CertificateSignaturePubKey<S::SignatureType>>,
+        state_builder: MonadStateBuilder<
+            S::SignatureType,
+            S::SignatureCollectionType,
+            S::ValidatorSetTypeFactory,
+            S::LeaderElection,
+            S::TxPool,
+            S::BlockValidator,
+            S::StateRootValidator,
+        >,
+        logger_builder: impl PersistenceLoggerBuilder<PersistenceLogger = S::Logger>,
+        router_scheduler: S::RouterScheduler,
+        state_root_executor: S::StateRootHashExecutor,
+        pipeline: S::Pipeline,
+        seed: u64,
+    ) -> Self {
+        let (logger, replay_events) = logger_builder.build().unwrap();
+        Self {
+            id,
+            state_builder,
+            logger,
+            replay_events,
+            router_scheduler,
+            state_root_executor,
+            pipeline,
+            seed,
+        }
+    }
+
+    pub fn debug(self) -> NodeBuilder<DebugSwarmRelation>
+    where
+        S: SwarmRelation<
+            SignatureType = <DebugSwarmRelation as SwarmRelation>::SignatureType,
+            SignatureCollectionType = <DebugSwarmRelation as SwarmRelation>::SignatureCollectionType,
+                TransportMessage = <DebugSwarmRelation as SwarmRelation>::TransportMessage,
+        >,
+
+    // FIXME can this be deleted?
+        S::RouterScheduler: Sync,
+    {
+        NodeBuilder {
+            id: self.id,
+            state_builder: MonadStateBuilder {
+                validator_set_factory: BoxedValidatorSetTypeFactory::new(
+                    self.state_builder.validator_set_factory,
+                ),
+                leader_election: Box::new(self.state_builder.leader_election),
+                transaction_pool: Box::new(self.state_builder.transaction_pool),
+                block_validator: Box::new(self.state_builder.block_validator),
+                state_root_validator: Box::new(self.state_builder.state_root_validator),
+                validators: self.state_builder.validators,
+                key: self.state_builder.key,
+                certkey: self.state_builder.certkey,
+                val_set_update_interval: self.state_builder.val_set_update_interval,
+                epoch_start_delay: self.state_builder.epoch_start_delay,
+                beneficiary: self.state_builder.beneficiary,
+                consensus_config: self.state_builder.consensus_config,
+            },
+            logger: Box::new(self.logger),
+            replay_events: self.replay_events,
+            router_scheduler: Box::new(self.router_scheduler),
+            state_root_executor: Box::new(self.state_root_executor),
+            pipeline: Box::new(self.pipeline),
+            seed: self.seed,
+        }
+    }
+    pub fn build(self, tick: Duration) -> Node<S> {
+        let mut executor: MockExecutor<S> =
+            MockExecutor::new(self.router_scheduler, self.state_root_executor, tick);
+        let (mut state, init_commands) = self.state_builder.build();
+
+        executor.exec(init_commands);
+
+        for event in self.replay_events {
+            executor.replay(state.update(event));
+        }
+
+        let mut rng = ChaChaRng::seed_from_u64(self.seed);
+
+        Node {
+            id: self.id,
+            executor,
+            state,
+            logger: self.logger,
+            pipeline: self.pipeline,
+            pending_inbound_messages: Default::default(),
+            rng: ChaCha20Rng::seed_from_u64(rng.gen()),
+            current_seed: rng.gen(),
+        }
+    }
+}
+
+pub struct Node<S>
+where
+    S: SwarmRelation,
+{
+    pub id: ID<CertificateSignaturePubKey<S::SignatureType>>,
+    pub executor: MockExecutor<S>,
+    pub state: SwarmRelationStateType<S>,
+    pub logger: S::Logger,
+    pub pipeline: S::Pipeline,
+    pub pending_inbound_messages: BTreeMap<
+        Duration,
+        VecDeque<LinkMessage<CertificateSignaturePubKey<S::SignatureType>, S::TransportMessage>>,
+    >,
+    rng: ChaCha20Rng,
+    current_seed: usize,
+}
+
+impl<S: SwarmRelation> Node<S> {
+    fn update_rng(&mut self) {
+        self.current_seed = self.rng.gen();
+    }
+
+    pub fn peek_event(&self) -> Option<(Duration, SwarmEventType)> {
+        // avoid modification of the original rng
+        let events = std::iter::empty()
+            .chain(
+                self.executor
+                    .peek_tick()
+                    .iter()
+                    .map(|tick| (*tick, SwarmEventType::ExecutorEvent)),
+            )
+            .chain(self.pending_inbound_messages.first_key_value().map(
+                |(min_scheduled_tick, _)| (*min_scheduled_tick, SwarmEventType::ScheduledMessage),
+            ))
+            .min_set();
+        if !events.is_empty() {
+            Some(events[self.current_seed % events.len()])
+        } else {
+            None
+        }
+    }
+
+    pub fn step_until(
+        &mut self,
+        until: Duration,
+        emitted_messages: &mut Vec<(
+            Duration,
+            LinkMessage<CertificateSignaturePubKey<S::SignatureType>, S::TransportMessage>,
+        )>,
+    ) -> Option<(
+        Duration,
+        MonadEvent<S::SignatureType, S::SignatureCollectionType>,
+    )> {
+        while let Some((tick, event_type)) = self.peek_event() {
+            if tick > until {
+                break;
+            }
+            // polling event, thus update the rng
+            self.update_rng();
+            let event = match event_type {
+                SwarmEventType::ExecutorEvent => {
+                    let executor_event = self.executor.step_until(tick);
+                    match executor_event {
+                        None => continue,
+                        Some(MockExecutorEvent::Event(event)) => {
+                            self.logger.push(&event).unwrap(); // FIXME-4: propagate the error
+                            let node_span = info_span!("node", id = ?self.id);
+                            let _guard = node_span.enter();
+                            let commands = self.state.update(event.clone());
+
+                            self.executor.exec(commands);
+
+                            (tick, event)
+                        }
+                        Some(MockExecutorEvent::Send(to, serialized)) => {
+                            let lm = LinkMessage {
+                                from: self.id,
+                                to: ID::new(to),
+                                message: serialized,
+
+                                from_tick: tick,
+                            };
+                            let transformed = self.pipeline.process(lm);
+                            for (delay, msg) in transformed {
+                                let sched_tick = tick + delay;
+
+                                // FIXME-3: do we need to transform msg to self?
+                                if msg.to == self.id {
+                                    self.pending_inbound_messages
+                                        .entry(sched_tick)
+                                        .or_default()
+                                        .push_back(msg)
+                                } else {
+                                    emitted_messages.push((sched_tick, msg))
+                                }
+                            }
+                            continue;
+                        }
+                    }
+                }
+                SwarmEventType::ScheduledMessage => {
+                    let mut entry = self
+                        .pending_inbound_messages
+                        .first_entry()
+                        .expect("logic error, should be nonempty");
+
+                    let scheduled_tick = *entry.key();
+                    let msgs = entry.get_mut();
+
+                    assert_eq!(tick, scheduled_tick);
+
+                    let message = msgs.pop_front().expect("logic error, should be nonempty");
+
+                    if msgs.is_empty() {
+                        entry.remove_entry();
+                    }
+
+                    self.executor.send_message(
+                        scheduled_tick,
+                        *message.from.get_peer_id(),
+                        message.message,
+                    );
+
+                    continue;
+                }
+            };
+            return Some(event);
+        }
+        None
+    }
+}

--- a/monad-mock-swarm/src/terminator.rs
+++ b/monad-mock-swarm/src/terminator.rs
@@ -1,0 +1,154 @@
+use std::{collections::BTreeMap, time::Duration, usize};
+
+use monad_consensus_state::ConsensusProcess;
+use monad_crypto::certificate_signature::{CertificateSignaturePubKey, PubKey};
+use monad_transformer::ID;
+use monad_types::Round;
+
+use crate::{mock_swarm::Nodes, swarm_relation::SwarmRelation};
+
+pub trait NodesTerminator<S>
+where
+    S: SwarmRelation,
+{
+    fn should_terminate(&self, nodes: &Nodes<S>) -> bool;
+}
+
+#[derive(Clone, Copy)]
+pub struct UntilTerminator {
+    until_tick: Duration,
+    until_block: usize,
+    until_round: Round,
+}
+
+impl Default for UntilTerminator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UntilTerminator {
+    pub fn new() -> Self {
+        UntilTerminator {
+            until_tick: Duration::MAX,
+            until_block: usize::MAX,
+            until_round: Round(u64::MAX),
+        }
+    }
+
+    pub fn until_tick(mut self, tick: Duration) -> Self {
+        self.until_tick = tick;
+        self
+    }
+
+    pub fn until_block(mut self, b_cnt: usize) -> Self {
+        self.until_block = b_cnt;
+        self
+    }
+
+    pub fn until_round(mut self, round: Round) -> Self {
+        self.until_round = round;
+        self
+    }
+}
+
+impl<S> NodesTerminator<S> for UntilTerminator
+where
+    S: SwarmRelation,
+{
+    fn should_terminate(&self, nodes: &Nodes<S>) -> bool {
+        nodes.tick > self.until_tick
+            || nodes
+                .states
+                .values()
+                .any(|node| node.executor.ledger().get_blocks().len() > self.until_block)
+            || nodes
+                .states
+                .values()
+                .any(|node| node.state.consensus().get_current_round() > self.until_round)
+    }
+}
+
+// observe and monitor progress of certain nodes until commit progress is achieved for all
+pub struct ProgressTerminator<PT: PubKey> {
+    // NodeId -> Ledger len
+    nodes_monitor: BTreeMap<ID<PT>, usize>,
+    timeout: Duration,
+}
+
+impl<PT: PubKey> ProgressTerminator<PT> {
+    pub fn new(nodes_monitor: BTreeMap<ID<PT>, usize>, timeout: Duration) -> Self {
+        ProgressTerminator {
+            nodes_monitor,
+            timeout,
+        }
+    }
+
+    pub fn extend_all(&mut self, progress: usize) {
+        // extend the required termination progress of all monitor
+        for original_progress in self.nodes_monitor.values_mut() {
+            *original_progress += progress;
+        }
+    }
+}
+
+impl<S> NodesTerminator<S> for ProgressTerminator<CertificateSignaturePubKey<S::SignatureType>>
+where
+    S: SwarmRelation,
+{
+    fn should_terminate(&self, nodes: &Nodes<S>) -> bool {
+        if nodes.tick > self.timeout {
+            panic!(
+                "ProgressTerminator timed-out, expecting nodes 
+                to reach following progress before timeout: {:?},
+                but the actual progress is: {:?}",
+                self.nodes_monitor,
+                nodes
+                    .states
+                    .iter()
+                    .map(|(id, nodes)| (id, nodes.executor.ledger().get_blocks().len()))
+                    .collect::<BTreeMap<_, _>>()
+            );
+        }
+
+        let mut block_ref = None;
+        for (peer_id, expected_len) in &self.nodes_monitor {
+            let blocks = nodes
+                .states
+                .get(peer_id)
+                .expect("node must exists")
+                .executor
+                .ledger()
+                .get_blocks();
+            if blocks.len() < *expected_len {
+                return false;
+            }
+            match block_ref {
+                None => block_ref = Some(blocks),
+                Some(reference) => {
+                    if reference.len() < blocks.len() {
+                        block_ref = Some(blocks);
+                    }
+                }
+            }
+        }
+
+        // reference to the longest ledger
+        let block_ref = block_ref.expect("must have at least 1 entry");
+        // once termination condition is met, all the ledger should also have identical blocks
+        for (peer_id, expected_len) in &self.nodes_monitor {
+            let blocks = nodes
+                .states
+                .get(peer_id)
+                .expect("node must exists")
+                .executor
+                .ledger()
+                .get_blocks();
+            for i in 0..(*expected_len) {
+                assert!(block_ref[i] == blocks[i]);
+            }
+        }
+
+        true
+    }
+}

--- a/monad-mock-swarm/tests/common/mod.rs
+++ b/monad-mock-swarm/tests/common/mod.rs
@@ -3,17 +3,16 @@ use monad_consensus_types::{
     block::Block, block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
 };
 use monad_crypto::{certificate_signature::CertificateSignaturePubKey, NopSignature};
-use monad_executor::timed_event::TimedEvent;
 use monad_executor_glue::MonadEvent;
 use monad_gossip::mock::MockGossip;
 use monad_mock_swarm::swarm_relation::SwarmRelation;
 use monad_multi_sig::MultiSig;
-use monad_quic::{QuicRouterScheduler, QuicRouterSchedulerConfig};
+use monad_quic::QuicRouterScheduler;
 use monad_state::{MonadMessage, VerifiedMonadMessage};
 use monad_transformer::BytesTransformerPipeline;
 use monad_updaters::state_root_hash::MockStateRootHashNop;
-use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
-use monad_wal::mock::{MockWALogger, MockWALoggerConfig};
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
+use monad_wal::mock::MockWALogger;
 
 pub struct QuicSwarm;
 
@@ -25,12 +24,11 @@ impl SwarmRelation for QuicSwarm {
 
     type BlockValidator = MockValidator;
     type StateRootValidator = StateRoot;
-    type ValidatorSet = ValidatorSet<CertificateSignaturePubKey<Self::SignatureType>>;
-    type LeaderElection = SimpleRoundRobin;
+    type ValidatorSetTypeFactory =
+        ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
+    type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
     type TxPool = MockTxPool;
 
-    type RouterSchedulerConfig =
-        QuicRouterSchedulerConfig<MockGossip<CertificateSignaturePubKey<Self::SignatureType>>>;
     type RouterScheduler = QuicRouterScheduler<
         MockGossip<CertificateSignaturePubKey<Self::SignatureType>>,
         MonadMessage<Self::SignatureType, Self::SignatureCollectionType>,
@@ -39,9 +37,7 @@ impl SwarmRelation for QuicSwarm {
 
     type Pipeline = BytesTransformerPipeline<CertificateSignaturePubKey<Self::SignatureType>>;
 
-    type LoggerConfig = MockWALoggerConfig;
-    type Logger =
-        MockWALogger<TimedEvent<MonadEvent<Self::SignatureType, Self::SignatureCollectionType>>>;
+    type Logger = MockWALogger<MonadEvent<Self::SignatureType, Self::SignatureCollectionType>>;
 
     type StateRootHashExecutor = MockStateRootHashNop<
         Block<Self::SignatureCollectionType>,

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -1,112 +1,202 @@
 mod common;
-use std::time::{Duration, Instant};
+use std::{
+    collections::BTreeSet,
+    time::{Duration, Instant},
+};
 
 use common::QuicSwarm;
-use monad_consensus_types::block_validator::MockValidator;
+use monad_consensus_types::{
+    block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
+};
+use monad_crypto::certificate_signature::CertificateKeyPair;
 use monad_gossip::mock::MockGossipConfig;
-use monad_mock_swarm::{mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm};
+use monad_mock_swarm::{
+    mock_swarm::SwarmBuilder, node::NodeBuilder, swarm_relation::NoSerSwarm,
+    terminator::UntilTerminator,
+};
 use monad_quic::QuicRouterSchedulerConfig;
-use monad_router_scheduler::NoSerRouterConfig;
-use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
-use monad_transformer::{BwTransformer, BytesTransformer, GenericTransformer, LatencyTransformer};
-use monad_types::{Round, SeqNum};
+use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+use monad_testutil::swarm::{make_state_configs, swarm_ledger_verification};
+use monad_transformer::{
+    BwTransformer, BytesTransformer, GenericTransformer, LatencyTransformer, ID,
+};
+use monad_types::{NodeId, Round, SeqNum};
+use monad_updaters::state_root_hash::MockStateRootHashNop;
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 use monad_wal::mock::MockWALoggerConfig;
 
 #[test]
 fn many_nodes_noser() {
-    create_and_run_nodes::<NoSerSwarm, _, _>(
-        MockValidator,
-        |all_peers, _| NoSerRouterConfig {
-            all_peers: all_peers.into_iter().collect(),
+    let state_configs = make_state_configs::<NoSerSwarm>(
+        100, // num_nodes
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        MockTxPool::default,
+        || MockValidator,
+        || {
+            StateRoot::new(
+                SeqNum(4), // state_root_delay
+            )
         },
-        MockWALoggerConfig,
-        vec![GenericTransformer::Latency(LatencyTransformer::new(
-            Duration::from_millis(1),
-        ))],
-        UntilTerminator::new().until_tick(Duration::from_secs(4)),
-        SwarmTestConfig {
-            num_nodes: 100,
-            consensus_delta: Duration::from_millis(2),
-            parallelize: true,
-            expected_block: 1024,
-            state_root_delay: 4,
-            seed: 1,
-            proposal_size: 0,
-            val_set_update_interval: SeqNum(2000),
-            epoch_start_delay: Round(50),
-        },
+        Duration::from_millis(2), // delta
+        0,                        // proposal_tx_limit
+        SeqNum(2000),             // val_set_update_interval
+        Round(50),                // epoch_start_delay
     );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|state_config| NodeId::new(state_config.key.pubkey()))
+        .collect();
+    let swarm_config = SwarmBuilder::<NoSerSwarm>(
+        state_configs
+            .into_iter()
+            .enumerate()
+            .map(|(seed, state_builder)| {
+                let validators = state_builder.validators.clone();
+                NodeBuilder::<NoSerSwarm>::new(
+                    ID::new(NodeId::new(state_builder.key.pubkey())),
+                    state_builder,
+                    MockWALoggerConfig::default(),
+                    NoSerRouterConfig::new(all_peers.clone()).build(),
+                    MockStateRootHashNop::new(validators, SeqNum(2000)),
+                    vec![GenericTransformer::Latency(LatencyTransformer::new(
+                        Duration::from_millis(1),
+                    ))],
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
+    );
+
+    let mut swarm = swarm_config.build();
+    swarm.batch_step_until(&UntilTerminator::new().until_tick(Duration::from_secs(4)));
+    swarm_ledger_verification(&swarm, 1024);
 }
 
 #[test]
 fn many_nodes_quic() {
     let zero_instant = Instant::now();
 
-    create_and_run_nodes::<QuicSwarm, _, _>(
-        MockValidator,
-        |all_peers, me| QuicRouterSchedulerConfig {
-            zero_instant,
-            all_peers: all_peers.iter().cloned().collect(),
-            me,
-
-            master_seed: 7,
-
-            gossip: MockGossipConfig { all_peers, me }.build(),
+    let state_configs = make_state_configs::<QuicSwarm>(
+        40, // num_nodes
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        MockTxPool::default,
+        || MockValidator,
+        || {
+            StateRoot::new(
+                SeqNum(4), // state_root_delay
+            )
         },
-        MockWALoggerConfig,
-        vec![BytesTransformer::Latency(LatencyTransformer::new(
-            Duration::from_millis(1),
-        ))],
-        UntilTerminator::new().until_tick(Duration::from_secs(4)),
-        SwarmTestConfig {
-            num_nodes: 40,
-            consensus_delta: Duration::from_millis(10),
-            parallelize: true,
-            expected_block: 10,
-            state_root_delay: 4,
-            seed: 1,
-            proposal_size: 150,
-            val_set_update_interval: SeqNum(2000),
-            epoch_start_delay: Round(50),
-        },
+        Duration::from_millis(10), // delta
+        150,                       // proposal_tx_limit
+        SeqNum(2000),              // val_set_update_interval
+        Round(50),                 // epoch_start_delay
     );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|state_config| NodeId::new(state_config.key.pubkey()))
+        .collect();
+    let swarm_config = SwarmBuilder::<QuicSwarm>(
+        state_configs
+            .into_iter()
+            .enumerate()
+            .map(|(seed, state_builder)| {
+                let me = NodeId::new(state_builder.key.pubkey());
+                let validators = state_builder.validators.clone();
+                NodeBuilder::<QuicSwarm>::new(
+                    ID::new(me),
+                    state_builder,
+                    MockWALoggerConfig::default(),
+                    QuicRouterSchedulerConfig::new(
+                        zero_instant,
+                        all_peers.clone(),
+                        me,
+                        seed.try_into().unwrap(),
+                        MockGossipConfig {
+                            all_peers: all_peers.iter().copied().collect(),
+                            me,
+                        }
+                        .build(),
+                    )
+                    .build(),
+                    MockStateRootHashNop::new(validators, SeqNum(2000)),
+                    vec![BytesTransformer::Latency(LatencyTransformer::new(
+                        Duration::from_millis(1),
+                    ))],
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
+    );
+
+    let mut swarm = swarm_config.build();
+    swarm.batch_step_until(&UntilTerminator::new().until_tick(Duration::from_secs(4)));
+    swarm_ledger_verification(&swarm, 10);
 }
 
 #[test]
 fn many_nodes_quic_bw() {
     let zero_instant = Instant::now();
 
-    let swarm_config = SwarmTestConfig {
-        num_nodes: 40,
-        consensus_delta: Duration::from_millis(300),
-        parallelize: true,
-        expected_block: 95,
-        state_root_delay: u64::MAX,
-        seed: 1,
-        proposal_size: 5000,
-        val_set_update_interval: SeqNum(2000),
-        epoch_start_delay: Round(50),
-    };
-
-    let xfmrs = vec![
-        BytesTransformer::Latency(LatencyTransformer::new(Duration::from_millis(100))),
-        BytesTransformer::Bw(BwTransformer::new(1000, Duration::from_millis(10))),
-    ];
-
-    create_and_run_nodes::<QuicSwarm, _, _>(
-        MockValidator,
-        |all_peers, me| QuicRouterSchedulerConfig {
-            zero_instant,
-            all_peers: all_peers.iter().cloned().collect(),
-            me,
-
-            master_seed: 7,
-
-            gossip: MockGossipConfig { all_peers, me }.build(),
+    let state_configs = make_state_configs::<QuicSwarm>(
+        40, // num_nodes
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        MockTxPool::default,
+        || MockValidator,
+        || {
+            StateRoot::new(
+                SeqNum(u64::MAX), // state_root_delay
+            )
         },
-        MockWALoggerConfig,
-        xfmrs,
-        UntilTerminator::new().until_tick(Duration::from_secs(100)),
-        swarm_config,
+        Duration::from_millis(300), // delta
+        5000,                       // proposal_tx_limit
+        SeqNum(2000),               // val_set_update_interval
+        Round(50),                  // epoch_start_delay
     );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|state_config| NodeId::new(state_config.key.pubkey()))
+        .collect();
+    let swarm_config = SwarmBuilder::<QuicSwarm>(
+        state_configs
+            .into_iter()
+            .enumerate()
+            .map(|(seed, state_builder)| {
+                let me = NodeId::new(state_builder.key.pubkey());
+                let validators = state_builder.validators.clone();
+                NodeBuilder::new(
+                    ID::new(me),
+                    state_builder,
+                    MockWALoggerConfig::default(),
+                    QuicRouterSchedulerConfig::new(
+                        zero_instant,
+                        all_peers.clone(),
+                        me,
+                        seed.try_into().unwrap(),
+                        MockGossipConfig {
+                            all_peers: all_peers.iter().copied().collect(),
+                            me,
+                        }
+                        .build(),
+                    )
+                    .build(),
+                    MockStateRootHashNop::new(validators, SeqNum(2000)),
+                    vec![
+                        BytesTransformer::Latency(LatencyTransformer::new(Duration::from_millis(
+                            100,
+                        ))),
+                        BytesTransformer::Bw(BwTransformer::new(1000, Duration::from_millis(10))),
+                    ],
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
+    );
+
+    let mut swarm = swarm_config.build();
+    swarm.batch_step_until(&UntilTerminator::new().until_tick(Duration::from_secs(100)));
+
+    swarm_ledger_verification(&swarm, 95);
 }

--- a/monad-mock-swarm/tests/msg_delays.rs
+++ b/monad-mock-swarm/tests/msg_delays.rs
@@ -1,38 +1,71 @@
 mod common;
-use std::time::Duration;
+use std::{collections::BTreeSet, time::Duration};
 
-use monad_consensus_types::block_validator::MockValidator;
-use monad_mock_swarm::{mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm};
-use monad_router_scheduler::NoSerRouterConfig;
-use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
-use monad_transformer::{GenericTransformer, XorLatencyTransformer};
-use monad_types::{Round, SeqNum};
+use monad_consensus_types::{
+    block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
+};
+use monad_crypto::certificate_signature::CertificateKeyPair;
+use monad_mock_swarm::{
+    mock_swarm::SwarmBuilder, node::NodeBuilder, swarm_relation::NoSerSwarm,
+    terminator::UntilTerminator,
+};
+use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+use monad_testutil::swarm::{make_state_configs, swarm_ledger_verification};
+use monad_transformer::{GenericTransformer, XorLatencyTransformer, ID};
+use monad_types::{NodeId, Round, SeqNum};
+use monad_updaters::state_root_hash::MockStateRootHashNop;
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 use monad_wal::mock::MockWALoggerConfig;
 
 #[test]
 fn two_nodes() {
     tracing_subscriber::fmt::init();
 
-    create_and_run_nodes::<NoSerSwarm, _, _>(
-        MockValidator,
-        |all_peers, _| NoSerRouterConfig {
-            all_peers: all_peers.into_iter().collect(),
+    let state_configs = make_state_configs::<NoSerSwarm>(
+        4, // num_nodes
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        MockTxPool::default,
+        || MockValidator,
+        || {
+            StateRoot::new(
+                SeqNum(4), // state_root_delay
+            )
         },
-        MockWALoggerConfig,
-        vec![GenericTransformer::XorLatency(XorLatencyTransformer::new(
-            Duration::from_millis(u8::MAX as u64),
-        ))],
-        UntilTerminator::new().until_tick(Duration::from_secs(60)),
-        SwarmTestConfig {
-            num_nodes: 4,
-            consensus_delta: Duration::from_millis(101),
-            parallelize: false,
-            expected_block: 40,
-            state_root_delay: 4,
-            seed: 1,
-            proposal_size: 0,
-            val_set_update_interval: SeqNum(2000),
-            epoch_start_delay: Round(50),
-        },
+        Duration::from_millis(101), // delta
+        0,                          // proposal_tx_limit
+        SeqNum(2000),               // val_set_update_interval
+        Round(50),                  // epoch_start_delay
     );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|state_config| NodeId::new(state_config.key.pubkey()))
+        .collect();
+    let swarm_config = SwarmBuilder::<NoSerSwarm>(
+        state_configs
+            .into_iter()
+            .enumerate()
+            .map(|(seed, state_builder)| {
+                let validators = state_builder.validators.clone();
+                NodeBuilder::<NoSerSwarm>::new(
+                    ID::new(NodeId::new(state_builder.key.pubkey())),
+                    state_builder,
+                    MockWALoggerConfig::default(),
+                    NoSerRouterConfig::new(all_peers.clone()).build(),
+                    MockStateRootHashNop::new(validators, SeqNum(2000)),
+                    vec![GenericTransformer::XorLatency(XorLatencyTransformer::new(
+                        Duration::from_millis(u8::MAX as u64),
+                    ))],
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
+    );
+
+    let mut swarm = swarm_config.build();
+    while swarm
+        .step_until(&UntilTerminator::new().until_tick(Duration::from_secs(60)))
+        .is_some()
+    {}
+    swarm_ledger_verification(&swarm, 40);
 }

--- a/monad-mock-swarm/tests/order.rs
+++ b/monad-mock-swarm/tests/order.rs
@@ -1,17 +1,27 @@
 mod common;
-use std::{collections::HashSet, env, time::Duration};
+use std::{
+    collections::{BTreeSet, HashSet},
+    env,
+    time::Duration,
+};
 
-use monad_consensus_types::block_validator::MockValidator;
-use monad_crypto::NopSignature;
-use monad_mock_swarm::{mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm};
-use monad_multi_sig::MultiSig;
-use monad_router_scheduler::NoSerRouterConfig;
-use monad_testutil::swarm::{get_configs, run_nodes_until};
+use monad_consensus_types::{
+    block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
+};
+use monad_crypto::certificate_signature::CertificateKeyPair;
+use monad_mock_swarm::{
+    mock_swarm::SwarmBuilder, node::NodeBuilder, swarm_relation::NoSerSwarm,
+    terminator::UntilTerminator,
+};
+use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+use monad_testutil::swarm::{make_state_configs, swarm_ledger_verification};
 use monad_transformer::{
     GenericTransformer, LatencyTransformer, PartitionTransformer, ReplayTransformer,
     TransformerReplayOrder, ID,
 };
 use monad_types::{NodeId, Round, SeqNum};
+use monad_updaters::state_root_hash::MockStateRootHashNop;
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 use monad_wal::mock::MockWALoggerConfig;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use test_case::test_case;
@@ -45,40 +55,68 @@ fn all_messages_delayed_cron() {
 #[test_case(TransformerReplayOrder::Random(4); "random seed 4")]
 #[test_case(TransformerReplayOrder::Random(5); "random seed 5")]
 fn all_messages_delayed(direction: TransformerReplayOrder) {
-    let num_nodes = 4;
-    let delta = Duration::from_millis(2);
-    let (pubkeys, state_configs) =
-        // due to the burst behavior of replay-transformer, its okay to have delay as 1
-        // TODO-4?: Make Replay Transformer's stored message not burst within the same Duration
-        get_configs::<NopSignature, MultiSig<NopSignature>, _>(MockValidator, num_nodes, delta, 1, 0, SeqNum(2000), Round(50));
+    let state_configs = make_state_configs::<NoSerSwarm>(
+        4, // num_nodes
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        MockTxPool::default,
+        || MockValidator,
+        || {
+            StateRoot::new(
+                // due to the burst behavior of replay-transformer, its okay to have delay as 1
+                // TODO-4?: Make Replay Transformer's stored message not burst within the same Duration
+                SeqNum(1), // state_root_delay
+            )
+        },
+        Duration::from_millis(2), // delta
+        0,                        // proposal_tx_limit
+        SeqNum(2000),             // val_set_update_interval
+        Round(50),                // epoch_start_delay
+    );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|state_config| NodeId::new(state_config.key.pubkey()))
+        .collect();
 
-    assert!(num_nodes >= 2, "test requires 2 or more nodes");
-
-    let first_node = ID::new(NodeId::new(*pubkeys.first().unwrap()));
+    let first_node = ID::new(*all_peers.first().unwrap());
 
     let mut filter_peers = HashSet::new();
     filter_peers.insert(first_node);
 
     println!("delayed node ID: {:?}", first_node);
 
-    run_nodes_until::<NoSerSwarm, _, _>(
-        pubkeys,
-        state_configs,
-        |all_peers: Vec<_>, _| NoSerRouterConfig {
-            all_peers: all_peers.into_iter().collect(),
-        },
-        MockWALoggerConfig,
-        vec![
-            GenericTransformer::Latency(LatencyTransformer::new(Duration::from_millis(1))),
-            GenericTransformer::Partition(PartitionTransformer(filter_peers)),
-            GenericTransformer::Replay(ReplayTransformer::new(
-                Duration::from_millis(500),
-                direction,
-            )),
-        ],
-        false,
-        UntilTerminator::new().until_tick(Duration::from_secs(1)),
-        20,
-        1,
+    let swarm_config = SwarmBuilder::<NoSerSwarm>(
+        state_configs
+            .into_iter()
+            .enumerate()
+            .map(|(seed, state_builder)| {
+                let validators = state_builder.validators.clone();
+                NodeBuilder::<NoSerSwarm>::new(
+                    ID::new(NodeId::new(state_builder.key.pubkey())),
+                    state_builder,
+                    MockWALoggerConfig::default(),
+                    NoSerRouterConfig::new(all_peers.clone()).build(),
+                    MockStateRootHashNop::new(validators, SeqNum(2000)),
+                    vec![
+                        GenericTransformer::Latency(LatencyTransformer::new(
+                            Duration::from_millis(1),
+                        )),
+                        GenericTransformer::Partition(PartitionTransformer(filter_peers.clone())),
+                        GenericTransformer::Replay(ReplayTransformer::new(
+                            Duration::from_millis(500),
+                            direction.clone(),
+                        )),
+                    ],
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
     );
+
+    let mut swarm = swarm_config.build();
+    while swarm
+        .step_until(&UntilTerminator::new().until_tick(Duration::from_secs(1)))
+        .is_some()
+    {}
+    swarm_ledger_verification(&swarm, 20);
 }

--- a/monad-mock-swarm/tests/protobuf.rs
+++ b/monad-mock-swarm/tests/protobuf.rs
@@ -26,9 +26,8 @@ use monad_testutil::{
 use monad_types::{BlockId, Epoch, Round, SeqNum};
 use monad_validator::{
     epoch_manager::EpochManager,
-    leader_election::LeaderElection,
     simple_round_robin::SimpleRoundRobin,
-    validator_set::{ValidatorSet, ValidatorSetType},
+    validator_set::{ValidatorSetFactory, ValidatorSetType},
     validators_epoch_mapping::ValidatorsEpochMapping,
 };
 
@@ -85,19 +84,20 @@ fn test_consensus_message_event_vote_multisig() {
 
 #[test]
 fn test_consensus_message_event_proposal_bls() {
+    let validator_set_factory = ValidatorSetFactory::default();
     let (keys, cert_keys, valset, valmap) = create_keys_w_validators::<
         SignatureType,
         BlsSignatureCollection<CertificateSignaturePubKey<SignatureType>>,
-    >(10);
-    let mut val_epoch_map = ValidatorsEpochMapping::default();
+        _,
+    >(10, validator_set_factory);
+    let mut val_epoch_map = ValidatorsEpochMapping::new(validator_set_factory);
     val_epoch_map.insert(
         Epoch(1),
-        ValidatorSet::new(Vec::from_iter(valset.get_members().clone()))
-            .expect("ValidatorData should not have duplicates or invalid entries"),
+        Vec::from_iter(valset.get_members().clone()),
         ValidatorMapping::new(valmap),
     );
     let epoch_manager = EpochManager::new(SeqNum(2000), Round(50));
-    let election = SimpleRoundRobin::new();
+    let election = SimpleRoundRobin::default();
     let mut propgen: ProposalGen<
         SignatureType,
         BlsSignatureCollection<CertificateSignaturePubKey<SignatureType>>,

--- a/monad-mock-swarm/tests/replay.rs
+++ b/monad-mock-swarm/tests/replay.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, fs::create_dir_all, time::Duration};
+use std::{
+    collections::{BTreeSet, HashMap},
+    fs::create_dir_all,
+    time::Duration,
+};
 
 use monad_consensus_types::{
     block::{Block, BlockType},
@@ -6,23 +10,25 @@ use monad_consensus_types::{
     payload::NopStateRoot,
     txpool::MockTxPool,
 };
-use monad_crypto::{certificate_signature::CertificateSignaturePubKey, NopSignature};
-use monad_executor::timed_event::TimedEvent;
+use monad_crypto::{
+    certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey},
+    NopSignature,
+};
 use monad_executor_glue::MonadEvent;
 use monad_mock_swarm::{
-    mock_swarm::{Nodes, UntilTerminator},
-    swarm_relation::SwarmRelation,
+    mock_swarm::SwarmBuilder, node::NodeBuilder, swarm_relation::SwarmRelation,
+    terminator::UntilTerminator,
 };
 use monad_multi_sig::MultiSig;
-use monad_router_scheduler::{NoSerRouterConfig, NoSerRouterScheduler};
+use monad_router_scheduler::{NoSerRouterConfig, NoSerRouterScheduler, RouterSchedulerBuilder};
 use monad_state::{MonadMessage, VerifiedMonadMessage};
-use monad_testutil::swarm::{get_configs, node_ledger_verification};
+use monad_testutil::swarm::{make_state_configs, swarm_ledger_verification};
 use monad_transformer::{
     GenericTransformer, GenericTransformerPipeline, LatencyTransformer, XorLatencyTransformer, ID,
 };
 use monad_types::{NodeId, Round, SeqNum};
 use monad_updaters::state_root_hash::MockStateRootHashNop;
-use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 use monad_wal::wal::{WALogger, WALoggerConfig};
 use tempfile::tempdir;
 
@@ -37,11 +43,11 @@ impl SwarmRelation for ReplaySwarm {
 
     type BlockValidator = MockValidator;
     type StateRootValidator = NopStateRoot;
-    type ValidatorSet = ValidatorSet<CertificateSignaturePubKey<Self::SignatureType>>;
-    type LeaderElection = SimpleRoundRobin;
+    type ValidatorSetTypeFactory =
+        ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
+    type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
     type TxPool = MockTxPool;
 
-    type RouterSchedulerConfig = NoSerRouterConfig<CertificateSignaturePubKey<Self::SignatureType>>;
     type RouterScheduler = NoSerRouterScheduler<
         CertificateSignaturePubKey<Self::SignatureType>,
         MonadMessage<Self::SignatureType, Self::SignatureCollectionType>,
@@ -53,9 +59,7 @@ impl SwarmRelation for ReplaySwarm {
         Self::TransportMessage,
     >;
 
-    type LoggerConfig = WALoggerConfig;
-    type Logger =
-        WALogger<TimedEvent<MonadEvent<Self::SignatureType, Self::SignatureCollectionType>>>;
+    type Logger = WALogger<MonadEvent<Self::SignatureType, Self::SignatureCollectionType>>;
 
     type StateRootHashExecutor = MockStateRootHashNop<
         Block<Self::SignatureCollectionType>,
@@ -66,30 +70,28 @@ impl SwarmRelation for ReplaySwarm {
 
 #[test]
 fn test_replay() {
-    recover_nodes_msg_delays(4, 10, 5, 4, 0, SeqNum(2000), Round(50));
+    recover_nodes_msg_delays(4, 10, 5, 0, SeqNum(2000), Round(50));
 }
 
 pub fn recover_nodes_msg_delays(
     num_nodes: u16,
     num_blocks_before: usize,
     num_block_after: usize,
-    state_root_delay: u64,
     proposal_size: usize,
     val_set_update_interval: SeqNum,
     epoch_start_delay: Round,
 ) {
-    let (pubkeys, state_configs) = get_configs::<
-        <ReplaySwarm as SwarmRelation>::SignatureType,
-        <ReplaySwarm as SwarmRelation>::SignatureCollectionType,
-        _,
-    >(
-        MockValidator {},
-        num_nodes,
-        Duration::from_millis(101),
-        state_root_delay,
-        proposal_size,
-        val_set_update_interval,
-        epoch_start_delay,
+    let state_configs = make_state_configs::<ReplaySwarm>(
+        num_nodes, // num_nodes
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        MockTxPool::default,
+        || MockValidator,
+        || NopStateRoot,
+        Duration::from_millis(101), // delta
+        proposal_size,              // proposal_tx_limit
+        val_set_update_interval,    // val_set_update_interval
+        epoch_start_delay,          // epoch_start_delay
     );
 
     // create the log file path
@@ -97,34 +99,39 @@ pub fn recover_nodes_msg_delays(
     let tmpdir = tempdir().unwrap();
     create_dir_all(tmpdir.path()).unwrap();
     for i in 0..num_nodes {
-        logger_configs.push(WALoggerConfig {
-            file_path: tmpdir.path().join(format!("wal{}", i)),
-            sync: false,
-        });
+        logger_configs.push(WALoggerConfig::new(
+            tmpdir.path().join(format!("wal{}", i)),
+            false, // sync
+        ));
     }
 
-    let peers = pubkeys
+    let all_peers: BTreeSet<_> = state_configs
         .iter()
-        .copied()
-        .zip(state_configs)
-        .zip(logger_configs.clone())
-        .map(|((a, b), c)| {
-            (
-                ID::new(NodeId::new(a)),
-                b,
-                c,
-                NoSerRouterConfig {
-                    all_peers: pubkeys.iter().map(|pubkey| NodeId::new(*pubkey)).collect(),
-                },
-                vec![GenericTransformer::XorLatency(XorLatencyTransformer::new(
-                    Duration::from_millis(u8::MAX as u64),
-                ))],
-                1,
-            )
-        })
-        .collect::<Vec<_>>();
+        .map(|state_config| NodeId::new(state_config.key.pubkey()))
+        .collect();
+    let swarm_config = SwarmBuilder::<ReplaySwarm>(
+        state_configs
+            .into_iter()
+            .zip(logger_configs.clone())
+            .enumerate()
+            .map(|(seed, (state_builder, logger_config))| {
+                let validators = state_builder.validators.clone();
+                NodeBuilder::<ReplaySwarm>::new(
+                    ID::new(NodeId::new(state_builder.key.pubkey())),
+                    state_builder,
+                    logger_config,
+                    NoSerRouterConfig::new(all_peers.clone()).build(),
+                    MockStateRootHashNop::new(validators, val_set_update_interval),
+                    vec![GenericTransformer::XorLatency(XorLatencyTransformer::new(
+                        Duration::from_millis(u8::MAX as u64),
+                    ))],
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
+    );
 
-    let mut nodes = Nodes::<ReplaySwarm>::new(peers);
+    let mut nodes = swarm_config.build();
     let term = UntilTerminator::new().until_block(num_blocks_before);
     while nodes.step_until(&term).is_some() {}
 
@@ -148,42 +155,42 @@ pub fn recover_nodes_msg_delays(
     // drop the nodes -> close the files
     drop(nodes);
 
-    let (pubkeys_clone, state_configs_clone) = get_configs::<
-        <ReplaySwarm as SwarmRelation>::SignatureType,
-        <ReplaySwarm as SwarmRelation>::SignatureCollectionType,
-        _,
-    >(
-        MockValidator {},
-        num_nodes,
-        Duration::from_millis(2),
-        4,
-        proposal_size,
-        val_set_update_interval,
-        epoch_start_delay,
+    let state_configs_clone = make_state_configs::<ReplaySwarm>(
+        num_nodes, // num_nodes
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        MockTxPool::default,
+        || MockValidator,
+        || NopStateRoot,
+        Duration::from_millis(2), // delta
+        proposal_size,            // proposal_tx_limit
+        val_set_update_interval,  // val_set_update_interval
+        epoch_start_delay,        // epoch_start_delay
     );
 
-    let peers_clone = pubkeys_clone
-        .iter()
-        .copied()
-        .zip(state_configs_clone)
-        .zip(logger_configs)
-        .map(|((a, b), c)| {
-            (
-                ID::new(NodeId::new(a)),
-                b,
-                c,
-                NoSerRouterConfig {
-                    all_peers: pubkeys.iter().map(|pubkey| NodeId::new(*pubkey)).collect(),
-                },
-                vec![GenericTransformer::Latency(LatencyTransformer::new(
-                    Duration::from_millis(1),
-                ))],
-                1,
-            )
-        })
-        .collect::<Vec<_>>();
+    let swarm_config_clone = SwarmBuilder::<ReplaySwarm>(
+        state_configs_clone
+            .into_iter()
+            .zip(logger_configs)
+            .enumerate()
+            .map(|(seed, (state_builder, logger_config))| {
+                let validators = state_builder.validators.clone();
+                NodeBuilder::<ReplaySwarm>::new(
+                    ID::new(NodeId::new(state_builder.key.pubkey())),
+                    state_builder,
+                    logger_config,
+                    NoSerRouterConfig::new(all_peers.clone()).build(),
+                    MockStateRootHashNop::new(validators, val_set_update_interval),
+                    vec![GenericTransformer::Latency(LatencyTransformer::new(
+                        Duration::from_millis(1),
+                    ))],
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
+    );
 
-    let mut nodes_recovered = Nodes::<ReplaySwarm>::new(peers_clone);
+    let mut nodes_recovered = swarm_config_clone.build();
 
     let node_ledger_recovered = nodes_recovered
         .states()
@@ -205,12 +212,5 @@ pub fn recover_nodes_msg_delays(
     let term = UntilTerminator::new().until_block(num_blocks_before + num_block_after);
     while nodes_recovered.step_until(&term).is_some() {}
 
-    node_ledger_verification(
-        &nodes_recovered
-            .states()
-            .values()
-            .map(|node| node.executor.ledger().get_blocks().clone())
-            .collect(),
-        1,
-    );
+    swarm_ledger_verification(&nodes_recovered, 1);
 }

--- a/monad-mock-swarm/tests/replay_test.rs
+++ b/monad-mock-swarm/tests/replay_test.rs
@@ -1,28 +1,29 @@
-use std::time::Duration;
+use std::{collections::BTreeSet, time::Duration};
 
 use monad_consensus_types::{
     block::Block, block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
 };
-use monad_crypto::{certificate_signature::CertificateSignaturePubKey, NopSignature};
-use monad_executor::timed_event::TimedEvent;
+use monad_crypto::{
+    certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey},
+    NopSignature,
+};
 use monad_executor_glue::MonadEvent;
 use monad_mock_swarm::{
     mock::MockExecutor,
-    mock_swarm::{Node, Nodes, UntilTerminator},
+    mock_swarm::{Nodes, SwarmBuilder},
+    node::{Node, NodeBuilder},
     swarm_relation::SwarmRelation,
+    terminator::UntilTerminator,
 };
 use monad_multi_sig::MultiSig;
-use monad_router_scheduler::{NoSerRouterConfig, NoSerRouterScheduler};
+use monad_router_scheduler::{NoSerRouterConfig, NoSerRouterScheduler, RouterSchedulerBuilder};
 use monad_state::{MonadMessage, VerifiedMonadMessage};
-use monad_testutil::swarm::{get_configs, node_ledger_verification};
+use monad_testutil::swarm::{make_state_configs, swarm_ledger_verification};
 use monad_transformer::{GenericTransformer, GenericTransformerPipeline, LatencyTransformer, ID};
 use monad_types::{NodeId, Round, SeqNum};
 use monad_updaters::state_root_hash::MockStateRootHashNop;
-use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSet};
-use monad_wal::{
-    mock::{MockMemLogger, MockMemLoggerConfig},
-    PersistenceLogger,
-};
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
+use monad_wal::mock::{MockMemLogger, MockMemLoggerConfig};
 use tracing_test::traced_test;
 
 const CONSENSUS_DELTA: Duration = Duration::from_millis(10);
@@ -37,11 +38,11 @@ impl SwarmRelation for ReplaySwarm {
 
     type BlockValidator = MockValidator;
     type StateRootValidator = StateRoot;
-    type ValidatorSet = ValidatorSet<CertificateSignaturePubKey<Self::SignatureType>>;
-    type LeaderElection = SimpleRoundRobin;
+    type ValidatorSetTypeFactory =
+        ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
+    type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
     type TxPool = MockTxPool;
 
-    type RouterSchedulerConfig = NoSerRouterConfig<CertificateSignaturePubKey<Self::SignatureType>>;
     type RouterScheduler = NoSerRouterScheduler<
         CertificateSignaturePubKey<Self::SignatureType>,
         MonadMessage<Self::SignatureType, Self::SignatureCollectionType>,
@@ -53,9 +54,7 @@ impl SwarmRelation for ReplaySwarm {
         Self::TransportMessage,
     >;
 
-    type LoggerConfig = <Self::Logger as PersistenceLogger>::Config;
-    type Logger =
-        MockMemLogger<TimedEvent<MonadEvent<Self::SignatureType, Self::SignatureCollectionType>>>;
+    type Logger = MockMemLogger<MonadEvent<Self::SignatureType, Self::SignatureCollectionType>>;
 
     type StateRootHashExecutor = MockStateRootHashNop<
         Block<Self::SignatureCollectionType>,
@@ -114,71 +113,75 @@ where
 fn replay_one_honest(failure_idx: &[usize]) {
     let default_seed = 1;
     // setup 4 nodes
-    let (peers, state_configs) = get_configs::<
-        <ReplaySwarm as SwarmRelation>::SignatureType,
-        <ReplaySwarm as SwarmRelation>::SignatureCollectionType,
-        _,
-    >(
-        MockValidator,
-        4,
-        CONSENSUS_DELTA,
-        4,
-        0,
-        SeqNum(2000),
-        Round(50),
+    let state_configs = make_state_configs::<ReplaySwarm>(
+        4, // num_nodes
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        MockTxPool::default,
+        || MockValidator,
+        || {
+            StateRoot::new(
+                SeqNum(4), // state_root_delay
+            )
+        },
+        CONSENSUS_DELTA, // delta
+        0,               // proposal_tx_limit
+        SeqNum(2000),    // val_set_update_interval
+        Round(50),       // epoch_start_delay
     );
-    let (_, mut state_configs_duplicate) = get_configs::<
-        <ReplaySwarm as SwarmRelation>::SignatureType,
-        <ReplaySwarm as SwarmRelation>::SignatureCollectionType,
-        _,
-    >(
-        MockValidator,
-        4,
-        CONSENSUS_DELTA,
-        4,
-        0,
-        SeqNum(2000),
-        Round(50),
+    let node_ids: Vec<_> = state_configs
+        .iter()
+        .map(|state_builder| NodeId::new(state_builder.key.pubkey()))
+        .collect();
+    let all_peers: BTreeSet<_> = node_ids.iter().copied().collect();
+    let mut state_configs_duplicates = make_state_configs::<ReplaySwarm>(
+        4, // num_nodes
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        MockTxPool::default,
+        || MockValidator,
+        || {
+            StateRoot::new(
+                SeqNum(4), // state_root_delay
+            )
+        },
+        CONSENSUS_DELTA, // delta
+        0,               // proposal_tx_limit
+        SeqNum(2000),    // val_set_update_interval
+        Round(50),       // epoch_start_delay
     );
 
-    let pubkeys = peers;
-    let router_scheduler_config = |all_peers: Vec<NodeId<_>>, _: NodeId<_>| NoSerRouterConfig {
-        all_peers: all_peers.into_iter().collect(),
-    };
-    let logger_config = MockMemLoggerConfig::default();
-    let pipeline = vec![GenericTransformer::Latency(LatencyTransformer::new(
-        Duration::from_millis(1),
-    ))];
-    let phase_one_until = Duration::from_secs(4);
-    let phase_one_until_block = 1024;
-
-    let mut nodes = Nodes::<ReplaySwarm>::new(
-        pubkeys
-            .iter()
-            .copied()
-            .zip(state_configs)
-            .map(|(pubkey, state_config)| {
-                (
-                    ID::new(NodeId::new(pubkey)),
-                    state_config,
-                    logger_config.clone(),
-                    router_scheduler_config(
-                        pubkeys.iter().copied().map(NodeId::new).collect(),
-                        NodeId::new(pubkey),
-                    ),
-                    pipeline.clone(),
+    let swarm_config = SwarmBuilder::<ReplaySwarm>(
+        state_configs
+            .into_iter()
+            .map(|state_builder| {
+                let me = NodeId::new(state_builder.key.pubkey());
+                let validators = state_builder.validators.clone();
+                NodeBuilder::new(
+                    ID::new(me),
+                    state_builder,
+                    MockMemLoggerConfig::default(),
+                    NoSerRouterConfig::new(all_peers.clone()).build(),
+                    MockStateRootHashNop::new(validators, SeqNum(2000)),
+                    vec![GenericTransformer::Latency(LatencyTransformer::new(
+                        Duration::from_millis(1),
+                    ))],
                     default_seed,
                 )
             })
             .collect(),
-    )
-    .can_fail_deliver();
+    );
+
+    let mut swarm = swarm_config.build().can_fail_deliver();
+
+    let phase_one_until = Duration::from_secs(4);
+    let phase_one_until_block = 1024;
 
     let f0 = failure_idx[0];
     let f1 = failure_idx[1];
 
-    println!("f0 {:?}", pubkeys[f0]);
-    println!("f1 {:?}", pubkeys[f1]);
+    println!("f0 {:?}", node_ids[f0]);
+    println!("f1 {:?}", node_ids[f1]);
 
     assert!(f0 < 4);
     assert!(f0 < f1);
@@ -186,12 +189,12 @@ fn replay_one_honest(failure_idx: &[usize]) {
 
     // play nodes till some step
     let max_tick = Duration::from_nanos(0);
-    let max_tick = run_nodes_until(&mut nodes, max_tick, phase_one_until, phase_one_until_block);
+    let max_tick = run_nodes_until(&mut swarm, max_tick, phase_one_until, phase_one_until_block);
 
     // it should've reached some `until` condition, rather than losing liveness
-    assert!(liveness::<ReplaySwarm>(&nodes, 0));
+    assert!(liveness::<ReplaySwarm>(&swarm, 0));
 
-    let phase_one_length = nodes
+    let phase_one_length = swarm
         .states()
         .values()
         .map(|node| node.executor.ledger().get_blocks().len())
@@ -199,23 +202,23 @@ fn replay_one_honest(failure_idx: &[usize]) {
         .unwrap();
 
     // bring down 2 nodes
-    let node0 = nodes
-        .remove_state(&ID::new(NodeId::new(pubkeys[f0])))
+    let node0 = swarm
+        .remove_state(&ID::new(node_ids[f0]))
         .expect("peer0 exists");
-    let node1 = nodes
-        .remove_state(&ID::new(NodeId::new(pubkeys[f1])))
+    let node1 = swarm
+        .remove_state(&ID::new(node_ids[f1]))
         .expect("peer1 exists");
 
     let phase_two_until = max_tick + Duration::from_secs(4);
     let phase_two_until_block = 2048;
 
     // run the remaining 2 nodes for some steps, they can't make progress because less than f+1
-    let max_tick = run_nodes_until(&mut nodes, max_tick, phase_two_until, phase_two_until_block);
+    let max_tick = run_nodes_until(&mut swarm, max_tick, phase_two_until, phase_two_until_block);
 
     // nodes lost liveness because only 2/4 are online
-    assert!(!liveness::<ReplaySwarm>(&nodes, phase_one_length));
+    assert!(!liveness::<ReplaySwarm>(&swarm, phase_one_length));
 
-    let phase_two_length = nodes
+    let phase_two_length = swarm
         .states()
         .values()
         .map(|node| node.executor.ledger().get_blocks().len())
@@ -226,44 +229,52 @@ fn replay_one_honest(failure_idx: &[usize]) {
     let node0_logger_config = MockMemLoggerConfig::new(node0.logger.log);
     let node1_logger_config = MockMemLoggerConfig::new(node1.logger.log);
 
-    nodes.add_state((
-        ID::new(NodeId::new(pubkeys[f0])),
-        state_configs_duplicate.remove(f0),
-        node0_logger_config,
-        router_scheduler_config(
-            pubkeys.iter().copied().map(NodeId::new).collect(),
-            NodeId::new(pubkeys[f0]),
-        ),
-        pipeline.clone(),
-        default_seed,
-    ));
+    {
+        let state_builder = state_configs_duplicates.remove(f0);
+        let validators = state_builder.validators.clone();
+        swarm.add_state(NodeBuilder::new(
+            ID::new(node_ids[f0]),
+            state_builder,
+            node0_logger_config,
+            NoSerRouterConfig::new(all_peers.clone()).build(),
+            MockStateRootHashNop::new(validators, SeqNum(2000)),
+            vec![GenericTransformer::Latency(LatencyTransformer::new(
+                Duration::from_millis(1),
+            ))],
+            default_seed,
+        ));
+    }
 
-    nodes.add_state((
-        ID::new(NodeId::new(pubkeys[f1])),
-        state_configs_duplicate.remove(f1 - 1),
-        node1_logger_config,
-        router_scheduler_config(
-            pubkeys.iter().copied().map(NodeId::new).collect(),
-            NodeId::new(pubkeys[f1]),
-        ),
-        pipeline,
-        default_seed,
-    ));
+    {
+        let state_builder = state_configs_duplicates.remove(f1 - 1);
+        let validators = state_builder.validators.clone();
+        swarm.add_state(NodeBuilder::new(
+            ID::new(node_ids[f1]),
+            state_builder,
+            node1_logger_config,
+            NoSerRouterConfig::new(all_peers).build(),
+            MockStateRootHashNop::new(validators, SeqNum(2000)),
+            vec![GenericTransformer::Latency(LatencyTransformer::new(
+                Duration::from_millis(1),
+            ))],
+            default_seed,
+        ));
+    }
 
     // assert consensus state is the same after replay
     let node0_consensus = node0.state.consensus();
-    let node0_consensus_recovered = nodes
+    let node0_consensus_recovered = swarm
         .states()
-        .get(&ID::new(NodeId::new(pubkeys[f0])))
+        .get(&ID::new(node_ids[f0]))
         .unwrap()
         .state
         .consensus();
     assert_eq!(node0_consensus, node0_consensus_recovered);
 
     let node1_consensus = node1.state.consensus();
-    let node1_consensus_recovered = nodes
+    let node1_consensus_recovered = swarm
         .states()
-        .get(&ID::new(NodeId::new(pubkeys[f1])))
+        .get(&ID::new(node_ids[f1]))
         .unwrap()
         .state
         .consensus();
@@ -274,21 +285,14 @@ fn replay_one_honest(failure_idx: &[usize]) {
     let phase_three_until_block = 3072;
 
     run_nodes_until(
-        &mut nodes,
+        &mut swarm,
         max_tick,
         phase_three_until,
         phase_three_until_block,
     );
-    assert!(liveness::<ReplaySwarm>(&nodes, phase_two_length));
+    assert!(liveness::<ReplaySwarm>(&swarm, phase_two_length));
 
-    node_ledger_verification(
-        &nodes
-            .states()
-            .values()
-            .map(|node| node.executor.ledger().get_blocks().clone())
-            .collect(),
-        phase_one_length + 1,
-    );
+    swarm_ledger_verification(&swarm, phase_one_length + 1);
 
     // assert that block sync isn't triggered
     logs_assert(|lines: &[&str]| {

--- a/monad-mock-swarm/tests/single_node.rs
+++ b/monad-mock-swarm/tests/single_node.rs
@@ -1,83 +1,149 @@
 mod common;
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeSet, HashMap},
     sync::{Arc, RwLock},
     time::{Duration, Instant},
 };
 
 use common::QuicSwarm;
-use monad_consensus_types::block_validator::MockValidator;
+use monad_consensus_types::{
+    block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
+};
+use monad_crypto::certificate_signature::CertificateKeyPair;
 use monad_gossip::mock::MockGossipConfig;
-use monad_mock_swarm::{mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm};
+use monad_mock_swarm::{
+    mock_swarm::SwarmBuilder, node::NodeBuilder, swarm_relation::NoSerSwarm,
+    terminator::UntilTerminator,
+};
 use monad_quic::QuicRouterSchedulerConfig;
-use monad_router_scheduler::NoSerRouterConfig;
-use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
+use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+use monad_testutil::swarm::{make_state_configs, swarm_ledger_verification};
 use monad_tracing_counter::counter::{counter_get, CounterLayer, MetricFilter};
-use monad_transformer::{BwTransformer, BytesTransformer, GenericTransformer, LatencyTransformer};
-use monad_types::{Round, SeqNum};
+use monad_transformer::{
+    BwTransformer, BytesTransformer, GenericTransformer, LatencyTransformer, ID,
+};
+use monad_types::{NodeId, Round, SeqNum};
+use monad_updaters::state_root_hash::MockStateRootHashNop;
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 use monad_wal::mock::MockWALoggerConfig;
 use tracing_core::LevelFilter;
 use tracing_subscriber::{filter::Targets, prelude::*, Layer, Registry};
 
 #[test]
 fn two_nodes() {
-    create_and_run_nodes::<NoSerSwarm, _, _>(
-        MockValidator,
-        |all_peers, _| NoSerRouterConfig {
-            all_peers: all_peers.into_iter().collect(),
+    let state_configs = make_state_configs::<NoSerSwarm>(
+        2, // num_nodes
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        MockTxPool::default,
+        || MockValidator,
+        || {
+            StateRoot::new(
+                SeqNum(4), // state_root_delay
+            )
         },
-        MockWALoggerConfig,
-        vec![GenericTransformer::Latency(LatencyTransformer::new(
-            Duration::from_millis(1),
-        ))],
-        UntilTerminator::new().until_tick(Duration::from_secs(10)),
-        SwarmTestConfig {
-            num_nodes: 2,
-            consensus_delta: Duration::from_millis(2),
-            parallelize: false,
-            expected_block: 1024,
-            state_root_delay: 4,
-            seed: 1,
-            proposal_size: 0,
-            val_set_update_interval: SeqNum(2000),
-            epoch_start_delay: Round(50),
-        },
+        Duration::from_millis(2), // delta
+        0,                        // proposal_tx_limit
+        SeqNum(2000),             // val_set_update_interval
+        Round(50),                // epoch_start_delay
     );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|state_config| NodeId::new(state_config.key.pubkey()))
+        .collect();
+    let swarm_config = SwarmBuilder::<NoSerSwarm>(
+        state_configs
+            .into_iter()
+            .enumerate()
+            .map(|(seed, state_builder)| {
+                let validators = state_builder.validators.clone();
+                NodeBuilder::<NoSerSwarm>::new(
+                    ID::new(NodeId::new(state_builder.key.pubkey())),
+                    state_builder,
+                    MockWALoggerConfig::default(),
+                    NoSerRouterConfig::new(all_peers.clone()).build(),
+                    MockStateRootHashNop::new(validators, SeqNum(2000)),
+                    vec![GenericTransformer::Latency(LatencyTransformer::new(
+                        Duration::from_millis(1),
+                    ))],
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
+    );
+
+    let mut swarm = swarm_config.build();
+    while swarm
+        .step_until(&UntilTerminator::new().until_tick(Duration::from_secs(10)))
+        .is_some()
+    {}
+    swarm_ledger_verification(&swarm, 1024);
 }
 
 #[test]
 fn two_nodes_quic() {
     let zero_instant = Instant::now();
 
-    create_and_run_nodes::<QuicSwarm, _, _>(
-        MockValidator,
-        |all_peers, me| QuicRouterSchedulerConfig {
-            zero_instant,
-            all_peers: all_peers.iter().cloned().collect(),
-            me,
-
-            master_seed: 7,
-
-            gossip: MockGossipConfig { all_peers, me }.build(),
+    let state_configs = make_state_configs::<QuicSwarm>(
+        2, // num_nodes
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        MockTxPool::default,
+        || MockValidator,
+        || {
+            StateRoot::new(
+                SeqNum(4), // state_root_delay
+            )
         },
-        MockWALoggerConfig,
-        vec![BytesTransformer::Latency(LatencyTransformer::new(
-            Duration::from_millis(1),
-        ))],
-        UntilTerminator::new().until_tick(Duration::from_secs(10)),
-        SwarmTestConfig {
-            num_nodes: 2,
-            consensus_delta: Duration::from_millis(10),
-            parallelize: false,
-            expected_block: 256,
-            state_root_delay: 4,
-            seed: 1,
-            proposal_size: 150,
-            val_set_update_interval: SeqNum(2000),
-            epoch_start_delay: Round(50),
-        },
+        Duration::from_millis(10), // delta
+        150,                       // proposal_tx_limit
+        SeqNum(2000),              // val_set_update_interval
+        Round(50),                 // epoch_start_delay
     );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|state_config| NodeId::new(state_config.key.pubkey()))
+        .collect();
+    let swarm_config = SwarmBuilder::<QuicSwarm>(
+        state_configs
+            .into_iter()
+            .enumerate()
+            .map(|(seed, state_builder)| {
+                let me = NodeId::new(state_builder.key.pubkey());
+                let validators = state_builder.validators.clone();
+                NodeBuilder::<QuicSwarm>::new(
+                    ID::new(me),
+                    state_builder,
+                    MockWALoggerConfig::default(),
+                    QuicRouterSchedulerConfig::new(
+                        zero_instant,
+                        all_peers.clone(),
+                        me,
+                        seed.try_into().unwrap(),
+                        MockGossipConfig {
+                            all_peers: all_peers.iter().copied().collect(),
+                            me,
+                        }
+                        .build(),
+                    )
+                    .build(),
+                    MockStateRootHashNop::new(validators, SeqNum(2000)),
+                    vec![BytesTransformer::Latency(LatencyTransformer::new(
+                        Duration::from_millis(1),
+                    ))],
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
+    );
+
+    let mut swarm = swarm_config.build();
+    while swarm
+        .step_until(&UntilTerminator::new().until_tick(Duration::from_secs(10)))
+        .is_some()
+    {}
+    swarm_ledger_verification(&swarm, 256);
 }
 
 #[test]
@@ -97,35 +163,68 @@ fn two_nodes_quic_bw() {
 
     let zero_instant = Instant::now();
 
-    create_and_run_nodes::<QuicSwarm, _, _>(
-        MockValidator,
-        |all_peers, me| QuicRouterSchedulerConfig {
-            zero_instant,
-            all_peers: all_peers.iter().cloned().collect(),
-            me,
-
-            master_seed: 7,
-
-            gossip: MockGossipConfig { all_peers, me }.build(),
+    let state_configs = make_state_configs::<QuicSwarm>(
+        2, // num_nodes
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        MockTxPool::default,
+        || MockValidator,
+        || {
+            StateRoot::new(
+                SeqNum(4), // state_root_delay
+            )
         },
-        MockWALoggerConfig,
-        vec![
-            BytesTransformer::Latency(LatencyTransformer::new(Duration::from_millis(1))),
-            BytesTransformer::Bw(BwTransformer::new(8, Duration::from_secs(1))),
-        ],
-        UntilTerminator::new().until_tick(Duration::from_secs(10)),
-        SwarmTestConfig {
-            num_nodes: 2,
-            consensus_delta: Duration::from_millis(1000),
-            parallelize: false,
-            expected_block: 100,
-            state_root_delay: 4,
-            seed: 1,
-            proposal_size: 100,
-            val_set_update_interval: SeqNum(2000),
-            epoch_start_delay: Round(50),
-        },
+        Duration::from_millis(1000), // delta
+        100,                         // proposal_tx_limit
+        SeqNum(2000),                // val_set_update_interval
+        Round(50),                   // epoch_start_delay
     );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|state_config| NodeId::new(state_config.key.pubkey()))
+        .collect();
+    let swarm_config = SwarmBuilder::<QuicSwarm>(
+        state_configs
+            .into_iter()
+            .enumerate()
+            .map(|(seed, state_builder)| {
+                let me = NodeId::new(state_builder.key.pubkey());
+                let validators = state_builder.validators.clone();
+                NodeBuilder::new(
+                    ID::new(me),
+                    state_builder,
+                    MockWALoggerConfig::default(),
+                    QuicRouterSchedulerConfig::new(
+                        zero_instant,
+                        all_peers.clone(),
+                        me,
+                        seed.try_into().unwrap(),
+                        MockGossipConfig {
+                            all_peers: all_peers.iter().copied().collect(),
+                            me,
+                        }
+                        .build(),
+                    )
+                    .build(),
+                    MockStateRootHashNop::new(validators, SeqNum(2000)),
+                    vec![
+                        BytesTransformer::Latency(LatencyTransformer::new(Duration::from_millis(
+                            1,
+                        ))),
+                        BytesTransformer::Bw(BwTransformer::new(8, Duration::from_secs(1))),
+                    ],
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
+    );
+
+    let mut swarm = swarm_config.build();
+    while swarm
+        .step_until(&UntilTerminator::new().until_tick(Duration::from_secs(10)))
+        .is_some()
+    {}
+    swarm_ledger_verification(&swarm, 100);
 
     let dropped_msg = counter_get(counter, None, "bwtransformer_dropped_msg");
     assert!(dropped_msg.is_some());

--- a/monad-mock-swarm/tests/single_node_metrics.rs
+++ b/monad-mock-swarm/tests/single_node_metrics.rs
@@ -1,16 +1,24 @@
 mod common;
-use std::time::Duration;
+use std::{collections::BTreeSet, time::Duration};
 
-use monad_consensus_types::block_validator::MockValidator;
-use monad_mock_swarm::{mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm};
-use monad_router_scheduler::NoSerRouterConfig;
-use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
+use monad_consensus_types::{
+    block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
+};
+use monad_crypto::certificate_signature::CertificateKeyPair;
+use monad_mock_swarm::{
+    mock_swarm::SwarmBuilder, node::NodeBuilder, swarm_relation::NoSerSwarm,
+    terminator::UntilTerminator,
+};
+use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+use monad_testutil::swarm::{make_state_configs, swarm_ledger_verification};
 use monad_tracing_counter::{
     counter::{CounterLayer, MetricFilter},
     counter_status,
 };
-use monad_transformer::{GenericTransformer, LatencyTransformer};
-use monad_types::{Round, SeqNum};
+use monad_transformer::{GenericTransformer, LatencyTransformer, ID};
+use monad_types::{NodeId, Round, SeqNum};
+use monad_updaters::state_root_hash::MockStateRootHashNop;
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 use monad_wal::mock::MockWALoggerConfig;
 use tracing_core::LevelFilter;
 use tracing_subscriber::{filter::Targets, prelude::*, Registry};
@@ -30,27 +38,53 @@ fn two_nodes_metrics() {
 
     tracing::subscriber::set_global_default(subscriber).expect("unable to set global subscriber");
 
-    create_and_run_nodes::<NoSerSwarm, _, _>(
-        MockValidator,
-        |all_peers, _| NoSerRouterConfig {
-            all_peers: all_peers.into_iter().collect(),
+    let state_configs = make_state_configs::<NoSerSwarm>(
+        2, // num_nodes
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        MockTxPool::default,
+        || MockValidator,
+        || {
+            StateRoot::new(
+                SeqNum(4), // state_root_delay
+            )
         },
-        MockWALoggerConfig,
-        vec![GenericTransformer::Latency(LatencyTransformer::new(
-            Duration::from_millis(1),
-        ))],
-        UntilTerminator::new().until_tick(Duration::from_secs(10)),
-        SwarmTestConfig {
-            num_nodes: 2,
-            consensus_delta: Duration::from_millis(2),
-            parallelize: false,
-            expected_block: 1024,
-            state_root_delay: 4,
-            seed: 1,
-            proposal_size: 0,
-            val_set_update_interval: SeqNum(2000),
-            epoch_start_delay: Round(50),
-        },
+        Duration::from_millis(2), // delta
+        0,                        // proposal_tx_limit
+        SeqNum(2000),             // val_set_update_interval
+        Round(50),                // epoch_start_delay
     );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|state_config| NodeId::new(state_config.key.pubkey()))
+        .collect();
+    let swarm_config = SwarmBuilder::<NoSerSwarm>(
+        state_configs
+            .into_iter()
+            .enumerate()
+            .map(|(seed, state_builder)| {
+                let validators = state_builder.validators.clone();
+                NodeBuilder::<NoSerSwarm>::new(
+                    ID::new(NodeId::new(state_builder.key.pubkey())),
+                    state_builder,
+                    MockWALoggerConfig::default(),
+                    NoSerRouterConfig::new(all_peers.clone()).build(),
+                    MockStateRootHashNop::new(validators, SeqNum(2000)),
+                    vec![GenericTransformer::Latency(LatencyTransformer::new(
+                        Duration::from_millis(1),
+                    ))],
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
+    );
+
+    let mut swarm = swarm_config.build();
+    while swarm
+        .step_until(&UntilTerminator::new().until_tick(Duration::from_secs(10)))
+        .is_some()
+    {}
+    swarm_ledger_verification(&swarm, 1024);
+
     counter_status!();
 }

--- a/monad-multi-sig/Cargo.toml
+++ b/monad-multi-sig/Cargo.toml
@@ -21,6 +21,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 monad-testutil = { path = "../monad-testutil" }
+monad-validator = { path = "../monad-validator" }
 
 rand = { workspace = true }
 rand_chacha = { workspace = true }

--- a/monad-multi-sig/src/lib.rs
+++ b/monad-multi-sig/src/lib.rs
@@ -228,6 +228,7 @@ mod test {
         validators::create_keys_w_validators,
     };
     use monad_types::NodeId;
+    use monad_validator::validator_set::ValidatorSetFactory;
     use rand::{seq::SliceRandom, SeedableRng};
     use rand_chacha::ChaChaRng;
     use test_case::test_case;
@@ -265,8 +266,11 @@ mod test {
     #[test_case(5; "5 sigs")]
     #[test_case(100; "100 sigs")]
     fn test_creation(num_keys: u32) {
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_keys);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_keys, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -290,8 +294,11 @@ mod test {
             // skip test because we can't "steal" others signature
             return;
         }
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_keys);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_keys, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -332,8 +339,11 @@ mod test {
     #[test_case(5; "5 sigs")]
     #[test_case(100; "100 sigs")]
     fn test_num_signatures(num_keys: u32) {
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_keys);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_keys, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -353,8 +363,11 @@ mod test {
     #[test_case(100; "100 sigs")]
     fn test_node_id_not_in_validator_mapping(num_keys: u32) {
         use monad_crypto::certificate_signature::CertificateKeyPair;
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_keys);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_keys, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -391,8 +404,11 @@ mod test {
     #[test_case(5; "5 sigs")]
     #[test_case(100; "100 sigs")]
     fn test_duplicate_sig(num_keys: u32) {
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_keys);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_keys, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -417,8 +433,11 @@ mod test {
     #[test_case(5; "5 sigs")]
     #[test_case(100; "100 sigs")]
     fn test_verify(num_keys: u32) {
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_keys);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_keys, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -442,8 +461,11 @@ mod test {
     #[test_case(5; "5 sigs")]
     #[test_case(100; "100 sigs")]
     fn test_get_participants(num_keys: u32) {
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_keys);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_keys, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -466,8 +488,11 @@ mod test {
     #[test_case(5; "5 sigs")]
     #[test_case(100; "100 sigs")]
     fn test_serialization_roundtrip(num_keys: u32) {
-        let (keys, voting_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_keys);
+        let (keys, voting_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_keys, ValidatorSetFactory::default());
         let voting_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -507,8 +532,11 @@ mod test {
     #[test_case(8, 32, 32; "seed 8, 32/32 invalid")]
     fn test_creation_invalid_signature(seed: u64, num_keys: u32, num_invalid: u32) {
         assert!(num_invalid <= num_keys);
-        let (keys, cert_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(num_keys);
+        let (keys, cert_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(num_keys, ValidatorSetFactory::default());
         let cert_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -553,8 +581,11 @@ mod test {
 
     #[test]
     fn test_verify_invalid_signature() {
-        let (keys, cert_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(5);
+        let (keys, cert_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(5, ValidatorSetFactory::default());
         let cert_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)
@@ -581,8 +612,11 @@ mod test {
 
     #[test]
     fn test_verify_non_validator_signer() {
-        let (keys, cert_keys, _, valmap) =
-            create_keys_w_validators::<SignatureType, SignatureCollectionType>(5);
+        let (keys, cert_keys, _, valmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(5, ValidatorSetFactory::default());
         let cert_keys: Vec<_> = keys
             .iter()
             .map(CertificateKeyPair::pubkey)

--- a/monad-randomized-tests/Cargo.toml
+++ b/monad-randomized-tests/Cargo.toml
@@ -12,8 +12,10 @@ monad-mock-swarm = { path = "../monad-mock-swarm" }
 monad-multi-sig = { path = "../monad-multi-sig" }
 monad-router-scheduler = { path = "../monad-router-scheduler" }
 monad-testutil = { path = "../monad-testutil" }
+monad-updaters = { path = "../monad-updaters" }
 monad-transformer = { path = "../monad-transformer" }
 monad-types = { path = "../monad-types" }
+monad-validator = { path = "../monad-validator" }
 monad-wal = { path = "../monad-wal" }
 
 inventory = { workspace = true }

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -1,87 +1,139 @@
-use std::{collections::HashSet, time::Duration};
+use std::{
+    collections::{BTreeSet, HashSet},
+    time::Duration,
+};
 
-use monad_consensus_types::block_validator::MockValidator;
-use monad_crypto::NopSignature;
-use monad_mock_swarm::{mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm};
-use monad_multi_sig::MultiSig;
-use monad_router_scheduler::NoSerRouterConfig;
-use monad_testutil::swarm::{create_and_run_nodes, get_configs, run_nodes_until, SwarmTestConfig};
+use monad_consensus_types::{
+    block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
+};
+use monad_crypto::certificate_signature::CertificateKeyPair;
+use monad_mock_swarm::{
+    mock_swarm::SwarmBuilder, node::NodeBuilder, swarm_relation::NoSerSwarm,
+    terminator::UntilTerminator,
+};
+use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+use monad_testutil::swarm::{make_state_configs, swarm_ledger_verification};
 use monad_transformer::{
     GenericTransformer, LatencyTransformer, PartitionTransformer, RandLatencyTransformer,
     ReplayTransformer, TransformerReplayOrder, ID,
 };
 use monad_types::{NodeId, Round, SeqNum};
+use monad_updaters::state_root_hash::MockStateRootHashNop;
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 use monad_wal::mock::MockWALoggerConfig;
 
 use crate::RandomizedTest;
 
 fn random_latency_test(seed: u64) {
-    create_and_run_nodes::<NoSerSwarm, _, _>(
-        MockValidator,
-        |all_peers, _| NoSerRouterConfig {
-            all_peers: all_peers.into_iter().collect(),
+    let state_configs = make_state_configs::<NoSerSwarm>(
+        4, // num_nodes
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        MockTxPool::default,
+        || MockValidator,
+        || {
+            StateRoot::new(
+                SeqNum(4), // state_root_delay
+            )
         },
-        MockWALoggerConfig,
-        vec![GenericTransformer::RandLatency(
-            RandLatencyTransformer::new(seed, 330),
-        )],
-        UntilTerminator::new().until_tick(Duration::from_secs(10)),
-        SwarmTestConfig {
-            num_nodes: 4,
-            consensus_delta: Duration::from_millis(250),
-            parallelize: false,
-            expected_block: 2048,
-            state_root_delay: 4,
-            seed: 1,
-            proposal_size: 0,
-            val_set_update_interval: SeqNum(2000),
-            epoch_start_delay: Round(50),
-        },
+        Duration::from_millis(250), // delta
+        0,                          // proposal_tx_limit
+        SeqNum(2000),               // val_set_update_interval
+        Round(50),                  // epoch_start_delay
     );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|state_config| NodeId::new(state_config.key.pubkey()))
+        .collect();
+    let swarm_config = SwarmBuilder::<NoSerSwarm>(
+        state_configs
+            .into_iter()
+            .enumerate()
+            .map(|(seed, state_builder)| {
+                let validators = state_builder.validators.clone();
+                NodeBuilder::<NoSerSwarm>::new(
+                    ID::new(NodeId::new(state_builder.key.pubkey())),
+                    state_builder,
+                    MockWALoggerConfig::default(),
+                    NoSerRouterConfig::new(all_peers.clone()).build(),
+                    MockStateRootHashNop::new(validators, SeqNum(2000)),
+                    vec![GenericTransformer::RandLatency(
+                        RandLatencyTransformer::new(seed.try_into().unwrap(), 330),
+                    )],
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
+    );
+
+    let mut swarm = swarm_config.build();
+    while swarm
+        .step_until(&UntilTerminator::new().until_tick(Duration::from_secs(10)))
+        .is_some()
+    {}
+    swarm_ledger_verification(&swarm, 2048);
 }
 
 fn delayed_message_test(seed: u64) {
-    let num_nodes = 4;
-    let delta = Duration::from_millis(2);
-    let (pubkeys, state_configs) = get_configs::<NopSignature, MultiSig<NopSignature>, _>(
-        MockValidator,
-        num_nodes,
-        delta,
-        4,
-        0,
-        SeqNum(2000),
-        Round(50),
+    let state_configs = make_state_configs::<NoSerSwarm>(
+        4, // num_nodes
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        MockTxPool::default,
+        || MockValidator,
+        || {
+            StateRoot::new(
+                SeqNum(4), // state_root_delay
+            )
+        },
+        Duration::from_millis(2), // delta
+        0,                        // proposal_tx_limit
+        SeqNum(2000),             // val_set_update_interval
+        Round(50),                // epoch_start_delay
     );
-
-    assert!(num_nodes >= 2, "test requires 2 or more nodes");
-
-    let first_node = NodeId::new(*pubkeys.first().unwrap());
-
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|state_config| NodeId::new(state_config.key.pubkey()))
+        .collect();
+    let first_node = *all_peers.first().unwrap();
     let mut filter_peers = HashSet::new();
     filter_peers.insert(ID::new(first_node));
-
     println!("delayed node ID: {:?}", first_node);
 
-    run_nodes_until::<NoSerSwarm, _, _>(
-        pubkeys,
-        state_configs,
-        |all_peers: Vec<_>, _| NoSerRouterConfig {
-            all_peers: all_peers.into_iter().collect(),
-        },
-        MockWALoggerConfig,
-        vec![
-            GenericTransformer::Latency(LatencyTransformer::new(Duration::from_millis(1))),
-            GenericTransformer::Partition(PartitionTransformer(filter_peers)),
-            GenericTransformer::Replay(ReplayTransformer::new(
-                Duration::from_secs(1),
-                TransformerReplayOrder::Random(seed),
-            )),
-        ],
-        false,
-        UntilTerminator::new().until_tick(Duration::from_secs(2)),
-        20,
-        1,
+    let swarm_config = SwarmBuilder::<NoSerSwarm>(
+        state_configs
+            .into_iter()
+            .enumerate()
+            .map(|(seed, state_builder)| {
+                let validators = state_builder.validators.clone();
+                NodeBuilder::<NoSerSwarm>::new(
+                    ID::new(NodeId::new(state_builder.key.pubkey())),
+                    state_builder,
+                    MockWALoggerConfig::default(),
+                    NoSerRouterConfig::new(all_peers.clone()).build(),
+                    MockStateRootHashNop::new(validators, SeqNum(2000)),
+                    vec![
+                        GenericTransformer::Latency(LatencyTransformer::new(
+                            Duration::from_millis(1),
+                        )),
+                        GenericTransformer::Partition(PartitionTransformer(filter_peers.clone())),
+                        GenericTransformer::Replay(ReplayTransformer::new(
+                            Duration::from_secs(1),
+                            TransformerReplayOrder::Random(seed.try_into().unwrap()),
+                        )),
+                    ],
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
     );
+
+    let mut swarm = swarm_config.build();
+    while swarm
+        .step_until(&UntilTerminator::new().until_tick(Duration::from_secs(2)))
+        .is_some()
+    {}
+    swarm_ledger_verification(&swarm, 20);
 }
 
 inventory::submit!(RandomizedTest {

--- a/monad-state/src/blocksync.rs
+++ b/monad-state/src/blocksync.rs
@@ -13,7 +13,7 @@ use monad_executor_glue::{
     BlockSyncEvent, Command, FetchedBlock, LedgerCommand, MonadEvent, RouterCommand,
 };
 use monad_types::{BlockId, NodeId, RouterTarget};
-use monad_validator::validator_set::ValidatorSetType;
+use monad_validator::validator_set::ValidatorSetTypeFactory;
 
 use crate::{handle_validation_error, MonadState, VerifiedMonadMessage};
 
@@ -62,11 +62,11 @@ impl BlockSyncResponder {
     }
 }
 
-pub(super) struct BlockSyncChildState<'a, CP, ST, SCT, VT, LT, TT>
+pub(super) struct BlockSyncChildState<'a, CP, ST, SCT, VTF, LT, TT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    VT: ValidatorSetType,
+    VTF: ValidatorSetTypeFactory<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
 {
     block_sync_responder: &'a BlockSyncResponder,
 
@@ -74,17 +74,17 @@ where
     /// BlockSyncRequest
     consensus: &'a CP,
 
-    _phantom: PhantomData<(ST, SCT, VT, LT, TT)>,
+    _phantom: PhantomData<(ST, SCT, VTF, LT, TT)>,
 }
 
-impl<'a, CP, ST, SCT, VT, LT, TT> BlockSyncChildState<'a, CP, ST, SCT, VT, LT, TT>
+impl<'a, CP, ST, SCT, VTF, LT, TT> BlockSyncChildState<'a, CP, ST, SCT, VTF, LT, TT>
 where
     CP: ConsensusProcess<ST, SCT>,
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    VT: ValidatorSetType<NodeIdPubKey = SCT::NodeIdPubKey>,
+    VTF: ValidatorSetTypeFactory<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
 {
-    pub(super) fn new(monad_state: &'a mut MonadState<CP, ST, SCT, VT, LT, TT>) -> Self {
+    pub(super) fn new(monad_state: &'a mut MonadState<CP, ST, SCT, VTF, LT, TT>) -> Self {
         Self {
             block_sync_responder: &monad_state.block_sync_responder,
             consensus: &monad_state.consensus,

--- a/monad-state/src/consensus.rs
+++ b/monad-state/src/consensus.rs
@@ -20,39 +20,39 @@ use monad_executor_glue::{
 };
 use monad_types::{NodeId, RouterTarget, TimeoutVariant};
 use monad_validator::{
-    epoch_manager::EpochManager, leader_election::LeaderElection, validator_set::ValidatorSetType,
-    validators_epoch_mapping::ValidatorsEpochMapping,
+    epoch_manager::EpochManager, leader_election::LeaderElection,
+    validator_set::ValidatorSetTypeFactory, validators_epoch_mapping::ValidatorsEpochMapping,
 };
 
 use crate::{handle_validation_error, MonadState, VerifiedMonadMessage};
 
-pub(super) struct ConsensusChildState<'a, CP, ST, SCT, VT, LT, TT>
+pub(super) struct ConsensusChildState<'a, CP, ST, SCT, VTF, LT, TT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    VT: ValidatorSetType,
+    VTF: ValidatorSetTypeFactory<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
 {
     consensus: &'a mut CP,
 
     /// Consensus needs these states to process messages
     epoch_manager: &'a mut EpochManager,
-    val_epoch_map: &'a ValidatorsEpochMapping<VT, SCT>,
+    val_epoch_map: &'a ValidatorsEpochMapping<VTF, SCT>,
     leader_election: &'a LT,
     txpool: &'a mut TT,
 
     _phantom: PhantomData<ST>,
 }
 
-impl<'a, CP, ST, SCT, VT, LT, TT> ConsensusChildState<'a, CP, ST, SCT, VT, LT, TT>
+impl<'a, CP, ST, SCT, VTF, LT, TT> ConsensusChildState<'a, CP, ST, SCT, VTF, LT, TT>
 where
     CP: ConsensusProcess<ST, SCT>,
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    LT: LeaderElection,
-    VT: ValidatorSetType<NodeIdPubKey = SCT::NodeIdPubKey>,
+    LT: LeaderElection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    VTF: ValidatorSetTypeFactory<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     TT: TxPool,
 {
-    pub(super) fn new(monad_state: &'a mut MonadState<CP, ST, SCT, VT, LT, TT>) -> Self {
+    pub(super) fn new(monad_state: &'a mut MonadState<CP, ST, SCT, VTF, LT, TT>) -> Self {
         Self {
             consensus: &mut monad_state.consensus,
             epoch_manager: &mut monad_state.epoch_manager,

--- a/monad-state/src/epoch.rs
+++ b/monad-state/src/epoch.rs
@@ -9,31 +9,31 @@ use monad_crypto::certificate_signature::{
 };
 use monad_executor_glue::{Command, MonadEvent, ValidatorEvent};
 use monad_validator::{
-    validator_set::ValidatorSetType, validators_epoch_mapping::ValidatorsEpochMapping,
+    validator_set::ValidatorSetTypeFactory, validators_epoch_mapping::ValidatorsEpochMapping,
 };
 
 use crate::{MonadState, VerifiedMonadMessage};
 
-pub(super) struct EpochChildState<'a, CP, ST, SCT, VT, LT, TT>
+pub(super) struct EpochChildState<'a, CP, ST, SCT, VTF, LT, TT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    VT: ValidatorSetType<NodeIdPubKey = SCT::NodeIdPubKey>,
+    VTF: ValidatorSetTypeFactory<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
 {
-    val_epoch_map: &'a mut ValidatorsEpochMapping<VT, SCT>,
+    val_epoch_map: &'a mut ValidatorsEpochMapping<VTF, SCT>,
 
     _phantom: PhantomData<(CP, ST, LT, TT)>,
 }
 
 pub(super) struct EpochCommand {}
 
-impl<'a, CP, ST, SCT, VT, LT, TT> EpochChildState<'a, CP, ST, SCT, VT, LT, TT>
+impl<'a, CP, ST, SCT, VTF, LT, TT> EpochChildState<'a, CP, ST, SCT, VTF, LT, TT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    VT: ValidatorSetType<NodeIdPubKey = SCT::NodeIdPubKey>,
+    VTF: ValidatorSetTypeFactory<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
 {
-    pub(super) fn new(monad_state: &'a mut MonadState<CP, ST, SCT, VT, LT, TT>) -> Self {
+    pub(super) fn new(monad_state: &'a mut MonadState<CP, ST, SCT, VTF, LT, TT>) -> Self {
         Self {
             val_epoch_map: &mut monad_state.val_epoch_map,
             _phantom: PhantomData,
@@ -45,8 +45,7 @@ where
             ValidatorEvent::UpdateValidators((validator_data, epoch)) => {
                 self.val_epoch_map.insert(
                     epoch,
-                    VT::new(validator_data.get_stakes())
-                        .expect("ValidatorData should not have duplicates or invalid entries"),
+                    validator_data.get_stakes(),
                     ValidatorMapping::new(validator_data.get_cert_pubkeys()),
                 );
                 vec![]

--- a/monad-state/src/mempool.rs
+++ b/monad-state/src/mempool.rs
@@ -8,7 +8,7 @@ use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_executor_glue::{Command, MempoolEvent, MonadEvent};
-use monad_validator::validator_set::ValidatorSetType;
+use monad_validator::validator_set::ValidatorSetTypeFactory;
 
 use crate::{MonadState, VerifiedMonadMessage};
 
@@ -24,7 +24,7 @@ impl<'a, CP, ST, SCT, VT, LT, TT> MempoolChildState<'a, CP, ST, SCT, VT, LT, TT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    VT: ValidatorSetType<NodeIdPubKey = SCT::NodeIdPubKey>,
+    VT: ValidatorSetTypeFactory<NodeIdPubKey = SCT::NodeIdPubKey>,
     TT: TxPool,
 {
     pub(super) fn new(monad_state: &'a mut MonadState<CP, ST, SCT, VT, LT, TT>) -> Self {

--- a/monad-state/tests/protobuf.rs
+++ b/monad-state/tests/protobuf.rs
@@ -33,7 +33,9 @@ use monad_state::{
 use monad_testutil::{block::setup_block, validators::create_keys_w_validators};
 use monad_types::{BlockId, Epoch, NodeId, Round, SeqNum};
 use monad_validator::{
-    epoch_manager::EpochManager, validators_epoch_mapping::ValidatorsEpochMapping,
+    epoch_manager::EpochManager,
+    validator_set::{ValidatorSetFactory, ValidatorSetType},
+    validators_epoch_mapping::ValidatorsEpochMapping,
 };
 
 fn make_tc<
@@ -131,10 +133,18 @@ macro_rules! test_all_combination {
 // TODO-4: revisit to cleanup
 test_all_combination!(test_vote_message, |num_keys| {
     let (keypairs, certkeys, validators, validator_mapping) =
-        create_keys_w_validators::<ST, SCT>(num_keys);
+        create_keys_w_validators::<ST, SCT, _>(num_keys, ValidatorSetFactory::default());
     let epoch_manager = EpochManager::new(SeqNum(2000), Round(50));
-    let mut val_epoch_map = ValidatorsEpochMapping::default();
-    val_epoch_map.insert(Epoch(1), validators, validator_mapping);
+    let mut val_epoch_map = ValidatorsEpochMapping::new(ValidatorSetFactory::default());
+    val_epoch_map.insert(
+        Epoch(1),
+        validators
+            .get_members()
+            .iter()
+            .map(|(a, b)| (*a, *b))
+            .collect(),
+        validator_mapping,
+    );
 
     let vi = VoteInfo {
         id: BlockId(Hash([42_u8; 32])),
@@ -181,10 +191,18 @@ test_all_combination!(test_vote_message, |num_keys| {
 
 test_all_combination!(test_timeout_message, |num_keys| {
     let (keypairs, cert_keys, validators, validator_mapping) =
-        create_keys_w_validators::<ST, SCT>(num_keys);
+        create_keys_w_validators::<ST, SCT, _>(num_keys, ValidatorSetFactory::default());
     let epoch_manager = EpochManager::new(SeqNum(2000), Round(50));
-    let mut val_epoch_map = ValidatorsEpochMapping::default();
-    val_epoch_map.insert(Epoch(1), validators, validator_mapping);
+    let mut val_epoch_map = ValidatorsEpochMapping::new(ValidatorSetFactory::default());
+    val_epoch_map.insert(
+        Epoch(1),
+        validators
+            .get_members()
+            .iter()
+            .map(|(a, b)| (*a, *b))
+            .collect(),
+        validator_mapping,
+    );
     let validator_mapping = val_epoch_map.get_cert_pubkeys(&Epoch(1)).unwrap();
 
     let author_keypair = &keypairs[0];
@@ -271,10 +289,18 @@ test_all_combination!(test_timeout_message, |num_keys| {
 
 test_all_combination!(test_proposal_qc, |num_keys| {
     let (keypairs, cert_keys, validators, validator_mapping) =
-        create_keys_w_validators::<ST, SCT>(num_keys);
+        create_keys_w_validators::<ST, SCT, _>(num_keys, ValidatorSetFactory::default());
     let epoch_manager = EpochManager::new(SeqNum(2000), Round(50));
-    let mut val_epoch_map = ValidatorsEpochMapping::default();
-    val_epoch_map.insert(Epoch(1), validators, validator_mapping);
+    let mut val_epoch_map = ValidatorsEpochMapping::new(ValidatorSetFactory::default());
+    val_epoch_map.insert(
+        Epoch(1),
+        validators
+            .get_members()
+            .iter()
+            .map(|(a, b)| (*a, *b))
+            .collect(),
+        validator_mapping,
+    );
     let validator_mapping = val_epoch_map.get_cert_pubkeys(&Epoch(1)).unwrap();
 
     let author_keypair = &keypairs[0];
@@ -318,10 +344,18 @@ test_all_combination!(test_proposal_qc, |num_keys| {
 
 test_all_combination!(test_proposal_tc, |num_keys| {
     let (keypairs, cert_keys, validators, validator_mapping) =
-        create_keys_w_validators::<ST, SCT>(num_keys);
+        create_keys_w_validators::<ST, SCT, _>(num_keys, ValidatorSetFactory::default());
     let epoch_manager = EpochManager::new(SeqNum(2000), Round(50));
-    let mut val_epoch_map = ValidatorsEpochMapping::default();
-    val_epoch_map.insert(Epoch(1), validators, validator_mapping);
+    let mut val_epoch_map = ValidatorsEpochMapping::new(ValidatorSetFactory::default());
+    val_epoch_map.insert(
+        Epoch(1),
+        validators
+            .get_members()
+            .iter()
+            .map(|(a, b)| (*a, *b))
+            .collect(),
+        validator_mapping,
+    );
     let validator_mapping = val_epoch_map.get_cert_pubkeys(&Epoch(1)).unwrap();
 
     let author_keypair = &keypairs[0];
@@ -401,10 +435,18 @@ test_all_combination!(test_block_sync_request, |_| {
 
 test_all_combination!(test_block_sync_response_not_available, |num_keys| {
     let (_keypairs, _cert_keys, validators, validator_mapping) =
-        create_keys_w_validators::<ST, SCT>(num_keys);
+        create_keys_w_validators::<ST, SCT, _>(num_keys, ValidatorSetFactory::default());
     let epoch_manager = EpochManager::new(SeqNum(2000), Round(50));
-    let mut val_epoch_map = ValidatorsEpochMapping::default();
-    val_epoch_map.insert(Epoch(1), validators, validator_mapping);
+    let mut val_epoch_map = ValidatorsEpochMapping::new(ValidatorSetFactory::default());
+    val_epoch_map.insert(
+        Epoch(1),
+        validators
+            .get_members()
+            .iter()
+            .map(|(a, b)| (*a, *b))
+            .collect(),
+        validator_mapping,
+    );
 
     let bid = BlockId(Hash([0x01_u8; 32]));
     let block_sync_msg = BlockSyncResponseMessage::NotAvailable(bid);
@@ -433,10 +475,18 @@ test_all_combination!(test_block_sync_response_not_available, |num_keys| {
 
 test_all_combination!(test_block_sync_response_found, |num_keys| {
     let (keypairs, cert_keys, validators, validator_mapping) =
-        create_keys_w_validators::<ST, SCT>(num_keys);
+        create_keys_w_validators::<ST, SCT, _>(num_keys, ValidatorSetFactory::default());
     let epoch_manager = EpochManager::new(SeqNum(2000), Round(50));
-    let mut val_epoch_map = ValidatorsEpochMapping::default();
-    val_epoch_map.insert(Epoch(1), validators, validator_mapping);
+    let mut val_epoch_map = ValidatorsEpochMapping::new(ValidatorSetFactory::default());
+    val_epoch_map.insert(
+        Epoch(1),
+        validators
+            .get_members()
+            .iter()
+            .map(|(a, b)| (*a, *b))
+            .collect(),
+        validator_mapping,
+    );
     let validator_mapping = val_epoch_map.get_cert_pubkeys(&Epoch(1)).unwrap();
 
     let author_keypair = &keypairs[0];

--- a/monad-testutil/Cargo.toml
+++ b/monad-testutil/Cargo.toml
@@ -16,10 +16,12 @@ monad-crypto = { path = "../monad-crypto" }
 monad-eth-types = { path = "../monad-eth-types" }
 monad-state = { path = "../monad-state" }
 monad-mock-swarm = { path = "../monad-mock-swarm" }
+monad-router-scheduler = { path = "../monad-router-scheduler" }
 monad-transformer = { path = "../monad-transformer" }
 monad-types = { path = "../monad-types" }
 monad-updaters = { path = "../monad-updaters" }
 monad-validator = { path = "../monad-validator" }
+monad-wal = { path = "../monad-wal" }
 
 zerocopy = { workspace = true }
 
@@ -27,5 +29,3 @@ zerocopy = { workspace = true }
 monad-executor = { path = "../monad-executor" }
 monad-executor-glue = { path = "../monad-executor-glue" }
 monad-multi-sig = { path = "../monad-multi-sig" }
-monad-router-scheduler = { path = "../monad-router-scheduler" }
-monad-wal = { path = "../monad-wal" }

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -1,131 +1,96 @@
 use std::time::Duration;
 
 use monad_consensus_state::ConsensusConfig;
-use monad_consensus_types::{
-    block::BlockType,
-    block_validator::BlockValidator,
-    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
-    voting::ValidatorMapping,
-};
-use monad_crypto::certificate_signature::{
-    CertificateKeyPair, CertificateSignaturePubKey, CertificateSignatureRecoverable,
-};
+use monad_consensus_types::{block::BlockType, validator_data::ValidatorData};
 use monad_eth_types::EthAddress;
-use monad_mock_swarm::{
-    mock::MockExecutor,
-    mock_swarm::{Node, Nodes, NodesTerminator},
-    swarm_relation::SwarmRelation,
-};
-use monad_state::MonadConfig;
-use monad_transformer::ID;
-use monad_types::{NodeId, Round, SeqNum, Stake};
+use monad_mock_swarm::{mock_swarm::Nodes, swarm_relation::SwarmRelation};
+use monad_state::MonadStateBuilder;
+use monad_types::{Round, SeqNum};
+use monad_validator::validator_set::ValidatorSetType;
 
 use crate::validators::create_keys_w_validators;
 
-#[derive(Debug, Clone, Copy)]
-pub struct SwarmTestConfig {
-    pub num_nodes: u16,
-    pub consensus_delta: Duration,
-
-    pub parallelize: bool,
-    pub expected_block: usize,
-    pub state_root_delay: u64,
-    pub seed: u64,
-    pub proposal_size: usize,
-    pub val_set_update_interval: SeqNum,
-    pub epoch_start_delay: Round,
-}
-
-pub fn get_configs<
-    ST: CertificateSignatureRecoverable,
-    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    BVT: BlockValidator,
->(
-    bvt: BVT,
+pub fn make_state_configs<S: SwarmRelation>(
     num_nodes: u16,
-    delta: Duration,
-    state_root_delay: u64,
-    proposal_size: usize,
-    val_set_update_interval: SeqNum,
-    epoch_start_delay: Round,
-) -> (
-    Vec<CertificateSignaturePubKey<ST>>,
-    Vec<MonadConfig<ST, SCT, BVT>>,
-) {
-    let (keys, cert_keys, _validators, validator_mapping) =
-        create_keys_w_validators::<ST, SCT>(num_nodes as u32);
-    complete_config::<ST, SCT, BVT>(
-        bvt,
-        keys,
-        cert_keys,
-        validator_mapping,
-        delta,
-        state_root_delay,
-        proposal_size,
-        val_set_update_interval,
-        epoch_start_delay,
-    )
-}
 
-pub fn complete_config<ST, SCT, BVT>(
-    bvt: BVT,
-    keys: Vec<ST::KeyPairType>,
-    cert_keys: Vec<SignatureCollectionKeyPairType<SCT>>,
-    validator_mapping: ValidatorMapping<
-        CertificateSignaturePubKey<ST>,
-        SignatureCollectionKeyPairType<SCT>,
-    >,
+    validator_set_factory: impl Fn() -> S::ValidatorSetTypeFactory,
+    leader_election: impl Fn() -> S::LeaderElection,
+    transaction_pool: impl Fn() -> S::TxPool,
+    block_validator: impl Fn() -> S::BlockValidator,
+    state_root_validator: impl Fn() -> S::StateRootValidator,
+
     delta: Duration,
-    state_root_delay: u64,
     proposal_txn_limit: usize,
     val_set_update_interval: SeqNum,
     epoch_start_delay: Round,
-) -> (
-    Vec<CertificateSignaturePubKey<ST>>,
-    Vec<MonadConfig<ST, SCT, BVT>>,
-)
-where
-    ST: CertificateSignatureRecoverable,
-    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    BVT: BlockValidator,
-{
-    let pubkeys = keys
-        .iter()
-        .map(CertificateKeyPair::pubkey)
-        .collect::<Vec<_>>();
+) -> Vec<
+    MonadStateBuilder<
+        S::SignatureType,
+        S::SignatureCollectionType,
+        S::ValidatorSetTypeFactory,
+        S::LeaderElection,
+        S::TxPool,
+        S::BlockValidator,
+        S::StateRootValidator,
+    >,
+> {
+    let (keys, cert_keys, validators, validator_mapping) =
+        create_keys_w_validators::<S::SignatureType, S::SignatureCollectionType, _>(
+            num_nodes as u32,
+            validator_set_factory(),
+        );
 
-    let state_configs = keys
-        .into_iter()
+    let validator_data = ValidatorData::new(
+        validator_mapping
+            .map
+            .iter()
+            .map(|(node_id, sctpubkey)| {
+                (
+                    node_id.pubkey(),
+                    *validators.get_members().get(node_id).unwrap(),
+                    *sctpubkey,
+                )
+            })
+            .collect(),
+    );
+
+    keys.into_iter()
         .zip(cert_keys)
-        .map(|(key, certkey)| MonadConfig {
-            block_validator: bvt.clone(),
+        .map(|(key, certkey)| MonadStateBuilder {
+            validator_set_factory: validator_set_factory(),
+            leader_election: leader_election(),
+            transaction_pool: transaction_pool(),
+            block_validator: block_validator(),
+            state_root_validator: state_root_validator(),
+            validators: validator_data.clone(),
+
             key,
             certkey,
+
             val_set_update_interval,
             epoch_start_delay,
             beneficiary: EthAddress::default(),
-            validators: validator_mapping
-                .map
-                .iter()
-                .map(|(node_id, sctpubkey)| (node_id.pubkey(), Stake(1), *sctpubkey))
-                .collect::<Vec<_>>(),
+
             consensus_config: ConsensusConfig {
                 proposal_txn_limit,
                 proposal_gas_limit: 30_000_000,
-                state_root_delay: SeqNum(state_root_delay),
                 propose_with_missing_blocks: false,
                 delta,
             },
         })
-        .collect::<Vec<_>>();
-
-    (pubkeys, state_configs)
+        .collect()
 }
 
-pub fn node_ledger_verification<O: BlockType + PartialEq>(
-    ledgers: &Vec<Vec<O>>,
-    min_ledger_len: usize,
-) {
+pub fn swarm_ledger_verification<S: SwarmRelation>(swarm: &Nodes<S>, min_ledger_len: usize) {
+    let ledgers: Vec<Vec<_>> = swarm
+        .states()
+        .values()
+        .map(|node| node.executor.ledger().get_blocks().clone())
+        .collect();
+    ledger_verification(&ledgers, min_ledger_len)
+}
+
+pub fn ledger_verification<O: BlockType + PartialEq>(ledgers: &Vec<Vec<O>>, min_ledger_len: usize) {
     let (max_ledger_idx, max_b) = ledgers
         .iter()
         .map(Vec::len)
@@ -148,118 +113,11 @@ pub fn node_ledger_verification<O: BlockType + PartialEq>(
                     .take(ledger_len)
                     .collect::<Vec<_>>()
         );
-        assert!(max_b - ledger.len() <= 5); // this 5 block bound is arbitrary... is there a better way to do this?
-    }
-}
-
-pub fn create_and_run_nodes<S, R, T>(
-    bvt: S::BlockValidator,
-    router_scheduler_config: R,
-    logger_config: S::LoggerConfig,
-    pipeline: S::Pipeline,
-    terminator: T,
-    swarm_config: SwarmTestConfig,
-) -> Duration
-where
-    S: SwarmRelation,
-
-    MockExecutor<S>: Unpin,
-    Node<S>: Send,
-    R: Fn(
-        Vec<NodeId<CertificateSignaturePubKey<S::SignatureType>>>,
-        NodeId<CertificateSignaturePubKey<S::SignatureType>>,
-    ) -> S::RouterSchedulerConfig,
-    T: NodesTerminator<S>,
-{
-    let (peers, state_configs) =
-        get_configs::<S::SignatureType, S::SignatureCollectionType, S::BlockValidator>(
-            bvt,
-            swarm_config.num_nodes,
-            swarm_config.consensus_delta,
-            swarm_config.state_root_delay,
-            swarm_config.proposal_size,
-            swarm_config.val_set_update_interval,
-            swarm_config.epoch_start_delay,
+        assert!(
+            max_b - ledger.len() <= 5, // this 5 block bound is arbitrary... is there a better way to do this?
+            "max_b={}, ledger.len()={}",
+            max_b,
+            ledger.len()
         );
-    run_nodes_until::<S, _, _>(
-        peers,
-        state_configs,
-        router_scheduler_config,
-        logger_config,
-        pipeline,
-        swarm_config.parallelize,
-        terminator,
-        swarm_config.expected_block,
-        swarm_config.seed,
-    )
-}
-
-pub fn run_nodes_until<S, R, T>(
-    pubkeys: Vec<CertificateSignaturePubKey<S::SignatureType>>,
-    state_configs: Vec<
-        MonadConfig<S::SignatureType, S::SignatureCollectionType, S::BlockValidator>,
-    >,
-    router_scheduler_config: R,
-    logger_config: S::LoggerConfig,
-    pipeline: S::Pipeline,
-    parallelize: bool,
-
-    terminator: T,
-    min_ledger_len: usize,
-    seed: u64,
-) -> Duration
-where
-    S: SwarmRelation,
-
-    MockExecutor<S>: Unpin,
-    Node<S>: Send,
-    R: Fn(
-        Vec<NodeId<CertificateSignaturePubKey<S::SignatureType>>>,
-        NodeId<CertificateSignaturePubKey<S::SignatureType>>,
-    ) -> S::RouterSchedulerConfig,
-    T: NodesTerminator<S>,
-{
-    let mut nodes = Nodes::<S>::new(
-        pubkeys
-            .iter()
-            .copied()
-            .zip(state_configs)
-            .map(|(pubkey, state_config)| {
-                (
-                    ID::new(NodeId::new(pubkey)),
-                    state_config,
-                    logger_config.clone(),
-                    router_scheduler_config(
-                        pubkeys.iter().copied().map(NodeId::new).collect(),
-                        NodeId::new(pubkey),
-                    ),
-                    pipeline.clone(),
-                    seed,
-                )
-            })
-            .collect(),
-    );
-
-    let mut max_tick = Duration::from_nanos(0);
-    if parallelize {
-        if let Some(tick) = nodes.batch_step_until(&terminator) {
-            max_tick = tick;
-        }
-    } else {
-        while let Some(tick) = nodes.step_until(&terminator) {
-            assert!(tick >= max_tick);
-            max_tick = tick;
-        }
     }
-
-    node_ledger_verification(
-        &nodes
-            .states()
-            .values()
-            .map(|node| node.executor.ledger().get_blocks().clone())
-            .collect(),
-        min_ledger_len,
-    );
-
-    max_tick
 }

--- a/monad-testutil/src/validators.rs
+++ b/monad-testutil/src/validators.rs
@@ -6,39 +6,43 @@ use monad_crypto::certificate_signature::{
     CertificateKeyPair, CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_types::{NodeId, Stake};
-use monad_validator::validator_set::{ValidatorSet, ValidatorSetType};
+use monad_validator::validator_set::ValidatorSetTypeFactory;
 
 use crate::signing::{create_certificate_keys, create_keys};
 
-pub fn create_keys_w_validators<ST, SCT>(
+pub fn create_keys_w_validators<ST, SCT, VTF>(
     num_nodes: u32,
+    validator_set_factory: VTF,
 ) -> (
     Vec<ST::KeyPairType>,
     Vec<SignatureCollectionKeyPairType<SCT>>,
-    ValidatorSet<CertificateSignaturePubKey<ST>>,
+    VTF::ValidatorSetType,
     ValidatorMapping<CertificateSignaturePubKey<ST>, SignatureCollectionKeyPairType<SCT>>,
 )
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    VTF: ValidatorSetTypeFactory<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
 {
     let keys = create_keys::<ST>(num_nodes);
     let certificate_keys = create_certificate_keys::<SCT>(num_nodes);
     let (validators, validator_mapping) =
-        complete_keys_w_validators::<ST, SCT>(&keys, &certificate_keys);
+        complete_keys_w_validators::<ST, SCT, VTF>(&keys, &certificate_keys, validator_set_factory);
     (keys, certificate_keys, validators, validator_mapping)
 }
 
-pub fn complete_keys_w_validators<ST, SCT>(
+pub fn complete_keys_w_validators<ST, SCT, VTF>(
     keys: &[ST::KeyPairType],
     certificate_keys: &[SignatureCollectionKeyPairType<SCT>],
+    validator_set_factory: VTF,
 ) -> (
-    ValidatorSet<CertificateSignaturePubKey<ST>>,
+    VTF::ValidatorSetType,
     ValidatorMapping<CertificateSignaturePubKey<ST>, SignatureCollectionKeyPairType<SCT>>,
 )
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    VTF: ValidatorSetTypeFactory<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
 {
     let staking_list = keys
         .iter()
@@ -52,7 +56,9 @@ where
         .zip(certificate_keys.iter().map(|k| k.pubkey()))
         .collect::<Vec<_>>();
 
-    let validators = ValidatorSet::new(staking_list).expect("create validator set");
+    let validators = validator_set_factory
+        .create(staking_list)
+        .expect("create validator set");
     let validator_mapping = ValidatorMapping::new(voting_identity);
 
     (validators, validator_mapping)

--- a/monad-transformer/src/lib.rs
+++ b/monad-transformer/src/lib.rs
@@ -709,6 +709,29 @@ pub trait Pipeline<M> {
     fn min_external_delay(&self) -> Duration;
 }
 
+impl<T: Pipeline<M> + ?Sized, M> Pipeline<M> for Box<T> {
+    type NodeIdPubKey = T::NodeIdPubKey;
+
+    fn process(
+        &mut self,
+        message: LinkMessage<Self::NodeIdPubKey, M>,
+    ) -> Vec<(Duration, LinkMessage<Self::NodeIdPubKey, M>)> {
+        (**self).process(message)
+    }
+
+    fn len(&self) -> usize {
+        (**self).len()
+    }
+
+    fn is_empty(&self) -> bool {
+        (**self).is_empty()
+    }
+
+    fn min_external_delay(&self) -> Duration {
+        (**self).min_external_delay()
+    }
+}
+
 // unlike regular transformer, pipeline's job is simply organizing various form of transformer and feed them through
 impl<T, M> Pipeline<M> for Vec<T>
 where

--- a/monad-twins/tests/twin_testing.rs
+++ b/monad-twins/tests/twin_testing.rs
@@ -1,13 +1,7 @@
 #[cfg(test)]
 mod test {
-    use std::collections::BTreeSet;
-
-    use monad_consensus_types::block_validator::MockValidator;
     use monad_mock_swarm::swarm_relation::MonadMessageNoSerSwarm;
-    use monad_router_scheduler::NoSerRouterConfig;
-    use monad_transformer::ID;
     use monad_twins_utils::{run_twins_test, twin_reader::read_twins_test};
-    use monad_wal::mock::MockWALoggerConfig;
     use test_case::test_case;
 
     const TWIN_DEFAULT_SEED: u64 = 1;
@@ -18,27 +12,14 @@ mod test {
     #[test_case("./tests/make_progress.json"; "make_progress")]
 
     fn twins_testing(path: &str) {
-        let test_case = read_twins_test::<MonadMessageNoSerSwarm>(MockValidator, path);
+        let test_case = read_twins_test::<MonadMessageNoSerSwarm>(path);
 
         println!(
             "running twins_testing, description: {:?}",
             test_case.description,
         );
 
-        let get_lgr_cfg = |_: &ID<_>, _: &Vec<ID<_>>| MockWALoggerConfig;
-        let get_router_cfg = |_: &ID<_>, ids: &Vec<ID<_>>| NoSerRouterConfig {
-            all_peers: ids
-                .iter()
-                .map(|id| *id.get_peer_id())
-                .collect::<BTreeSet<_>>(),
-        };
-
-        run_twins_test::<_, MonadMessageNoSerSwarm, _, _>(
-            get_lgr_cfg,
-            get_router_cfg,
-            TWIN_DEFAULT_SEED,
-            test_case,
-        )
+        run_twins_test::<_, _, MonadMessageNoSerSwarm>(TWIN_DEFAULT_SEED, test_case)
     }
 
     #[should_panic]
@@ -47,24 +28,12 @@ mod test {
     #[test_case("./tests/mal_formed.json"; "mal_formed json")]
 
     fn twins_should_fail_testing(path: &str) {
-        let test_case = read_twins_test::<MonadMessageNoSerSwarm>(MockValidator, path);
+        let test_case = read_twins_test::<MonadMessageNoSerSwarm>(path);
         println!(
             "running expected fail twins_testing, description: {:?}",
             test_case.description
         );
-        let get_lgr_cfg = |_: &ID<_>, _: &Vec<ID<_>>| MockWALoggerConfig;
-        let get_router_cfg = |_: &ID<_>, ids: &Vec<ID<_>>| NoSerRouterConfig {
-            all_peers: ids
-                .iter()
-                .map(|id| *id.get_peer_id())
-                .collect::<BTreeSet<_>>(),
-        };
 
-        run_twins_test::<_, MonadMessageNoSerSwarm, _, _>(
-            get_lgr_cfg,
-            get_router_cfg,
-            TWIN_DEFAULT_SEED,
-            test_case,
-        )
+        run_twins_test::<_, _, MonadMessageNoSerSwarm>(TWIN_DEFAULT_SEED, test_case)
     }
 }

--- a/monad-twins/utils/Cargo.toml
+++ b/monad-twins/utils/Cargo.toml
@@ -10,14 +10,20 @@ bench = false
 
 
 [dependencies]
+monad-consensus-state = { path = "../../monad-consensus-state" }
 monad-consensus-types = { path = "../../monad-consensus-types" }
 monad-crypto = { path = "../../monad-crypto" }
+monad-eth-types = { path = "../../monad-eth-types" }
+monad-executor-glue = { path = "../../monad-executor-glue" }
 monad-mock-swarm = { path = "../../monad-mock-swarm" }
+monad-router-scheduler = { path = "../../monad-router-scheduler" }
 monad-state = { path = "../../monad-state" }
 monad-testutil = { path = "../../monad-testutil" }
 monad-transformer = { path = "../../monad-transformer" }
 monad-types = { path = "../../monad-types" }
-
+monad-updaters = { path = "../../monad-updaters" }
+monad-validator = { path = "../../monad-validator" }
+monad-wal = { path = "../../monad-wal" }
 
 itertools = { workspace = true }
 rand = { workspace = true }

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -238,7 +238,7 @@ impl<S: Clone> Serializable<S> for S {
 
 /// Deserialize from S, usually bytes
 pub trait Deserializable<S: ?Sized>: Sized {
-    type ReadError: Error + Send + Sync;
+    type ReadError: Error + Send + Sync + 'static;
 
     fn deserialize(message: &S) -> Result<Self, Self::ReadError>;
 }

--- a/monad-virtual-bench/benches/two_node_bench.rs
+++ b/monad-virtual-bench/benches/two_node_bench.rs
@@ -1,37 +1,73 @@
-use std::time::Duration;
+use std::{collections::BTreeSet, time::Duration};
 
-use monad_consensus_types::block_validator::MockValidator;
-use monad_mock_swarm::{mock_swarm::UntilTerminator, swarm_relation::NoSerSwarm};
-use monad_router_scheduler::NoSerRouterConfig;
-use monad_testutil::swarm::{create_and_run_nodes, SwarmTestConfig};
-use monad_transformer::{GenericTransformer, LatencyTransformer};
-use monad_types::{Round, SeqNum};
+use monad_consensus_types::{
+    block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
+};
+use monad_crypto::certificate_signature::CertificateKeyPair;
+use monad_mock_swarm::{
+    mock_swarm::SwarmBuilder, node::NodeBuilder, swarm_relation::NoSerSwarm,
+    terminator::UntilTerminator,
+};
+use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+use monad_testutil::swarm::{make_state_configs, swarm_ledger_verification};
+use monad_transformer::{GenericTransformer, LatencyTransformer, ID};
+use monad_types::{NodeId, Round, SeqNum};
+use monad_updaters::state_root_hash::MockStateRootHashNop;
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 use monad_wal::mock::MockWALoggerConfig;
 
 fn two_nodes_virtual() -> u128 {
-    create_and_run_nodes::<NoSerSwarm, _, _>(
-        MockValidator,
-        |all_peers, _| NoSerRouterConfig {
-            all_peers: all_peers.into_iter().collect(),
+    let state_configs = make_state_configs::<NoSerSwarm>(
+        2, // num_nodes
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        MockTxPool::default,
+        || MockValidator,
+        || {
+            StateRoot::new(
+                SeqNum(4), // state_root_delay
+            )
         },
-        MockWALoggerConfig,
-        vec![GenericTransformer::Latency(LatencyTransformer::new(
-            Duration::from_millis(1),
-        ))],
-        UntilTerminator::new().until_tick(Duration::from_secs(10)),
-        SwarmTestConfig {
-            num_nodes: 2,
-            consensus_delta: Duration::from_millis(2),
-            parallelize: false,
-            expected_block: 1024,
-            state_root_delay: 4,
-            seed: 1,
-            proposal_size: 0,
-            val_set_update_interval: SeqNum(2000),
-            epoch_start_delay: Round(50),
-        },
-    )
-    .as_millis()
+        Duration::from_millis(2), // delta
+        0,                        // proposal_tx_limit
+        SeqNum(2000),             // val_set_update_interval
+        Round(50),                // epoch_start_delay
+    );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|state_config| NodeId::new(state_config.key.pubkey()))
+        .collect();
+    let swarm_config = SwarmBuilder::<NoSerSwarm>(
+        state_configs
+            .into_iter()
+            .enumerate()
+            .map(|(seed, state_builder)| {
+                let validators = state_builder.validators.clone();
+                let me = NodeId::new(state_builder.key.pubkey());
+                NodeBuilder::new(
+                    ID::new(me),
+                    state_builder,
+                    MockWALoggerConfig::default(),
+                    NoSerRouterConfig::new(all_peers.clone()).build(),
+                    MockStateRootHashNop::new(validators, SeqNum(2000)),
+                    vec![GenericTransformer::Latency(LatencyTransformer::new(
+                        Duration::from_millis(1),
+                    ))],
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
+    );
+
+    let mut swarm = swarm_config.build();
+    let mut max_duration = Duration::ZERO;
+    while let Some(duration) =
+        swarm.step_until(&UntilTerminator::new().until_tick(Duration::from_secs(10)))
+    {
+        max_duration = duration;
+    }
+    swarm_ledger_verification(&swarm, 1024);
+    max_duration.as_millis()
 }
 
 monad_virtual_bench::virtual_bench_main! {two_nodes_virtual}

--- a/monad-wal/Cargo.toml
+++ b/monad-wal/Cargo.toml
@@ -25,6 +25,7 @@ monad-secp = { path = "../monad-secp" }
 monad-state = { path = "../monad-state" }
 monad-testutil = { path = "../monad-testutil" }
 monad-types = { path = "../monad-types" }
+monad-validator = { path = "../monad-validator" }
 
 criterion = { workspace = true }
 tempfile = { workspace = true }

--- a/monad-wal/benches/raw_bench.rs
+++ b/monad-wal/benches/raw_bench.rs
@@ -3,7 +3,7 @@ use std::{error::Error, fmt::Debug, fs::create_dir_all};
 use bytes::Bytes;
 use criterion::{criterion_group, Criterion};
 use monad_types::{Deserializable, Serializable};
-use monad_wal::{wal::*, PersistenceLogger};
+use monad_wal::{wal::*, PersistenceLoggerBuilder};
 use tempfile::{tempdir, TempDir};
 
 const VOTE_SIZE: usize = 400;
@@ -61,13 +61,12 @@ impl Bencher {
         let tmpdir = tempdir().unwrap();
         create_dir_all(tmpdir.path()).unwrap();
         let file_path = tmpdir.path().join("wal");
-        let config = WALoggerConfig {
-            file_path,
-            sync: false,
-        };
+        let config = WALoggerConfig::new(
+            file_path, false, // sync
+        );
         Bencher {
             data: Datablob::new(byte_len),
-            logger: WALogger::<Datablob>::new(config).unwrap().0,
+            logger: config.build().unwrap().0,
             _tmpdir: tmpdir,
         }
     }

--- a/monad-wal/src/lib.rs
+++ b/monad-wal/src/lib.rs
@@ -2,7 +2,23 @@ pub mod aof;
 pub mod mock;
 pub mod wal;
 
-use std::error::Error;
+use std::{error::Error, fmt::Debug, io};
+
+pub trait PersistenceLoggerBuilder {
+    type PersistenceLogger: PersistenceLogger;
+
+    /// Create new file for logging if none exists or load an existing to continue appending
+    /// and return the Events it contained for replay
+    fn build(
+        self,
+    ) -> Result<
+        (
+            Self::PersistenceLogger,
+            Vec<<Self::PersistenceLogger as PersistenceLogger>::Event>,
+        ),
+        WALError,
+    >;
+}
 
 /// PersistenceLogger is used to log all events input to MonadState and have them
 /// available for replay in case of nodes crashing
@@ -13,18 +29,38 @@ use std::error::Error;
 ///
 /// the persistence layer only accepts one type of message
 /// we can refactor M to Verified/Unverified type if we write to WAL after verifying the message
-pub trait PersistenceLogger: Sized {
-    /// Config for the file implementation
-    type Config;
-
+pub trait PersistenceLogger {
     /// The Event type to be logged
     type Event;
-    type Error: Error;
-
-    /// Create new file for logging if none exists or load an existing to continue appending
-    /// and return the Events it contained for replay
-    fn new(config: Self::Config) -> Result<(Self, Vec<Self::Event>), Self::Error>;
 
     /// Add an event to the log
-    fn push(&mut self, message: &Self::Event) -> Result<(), Self::Error>;
+    fn push(&mut self, message: &Self::Event) -> Result<(), WALError>;
 }
+
+impl<T: PersistenceLogger + ?Sized> PersistenceLogger for Box<T> {
+    type Event = T::Event;
+
+    fn push(&mut self, message: &Self::Event) -> Result<(), WALError> {
+        (**self).push(message)
+    }
+}
+
+#[derive(Debug)]
+pub enum WALError {
+    IOError(io::Error),
+    DeserError(Box<dyn Error>),
+}
+
+impl From<io::Error> for WALError {
+    fn from(value: io::Error) -> Self {
+        Self::IOError(value)
+    }
+}
+
+impl std::fmt::Display for WALError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <Self as Debug>::fmt(self, f)
+    }
+}
+
+impl std::error::Error for WALError {}

--- a/monad-wal/tests/replay.rs
+++ b/monad-wal/tests/replay.rs
@@ -6,7 +6,7 @@ mod test {
     use monad_types::{Deserializable, Serializable};
     use monad_wal::{
         wal::{WALogger, WALoggerConfig},
-        PersistenceLogger,
+        PersistenceLoggerBuilder,
     };
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -65,13 +65,12 @@ mod test {
         let tmpdir = tempdir().unwrap();
         create_dir_all(tmpdir.path()).unwrap();
         let log1_path = tmpdir.path().join("wal1");
-        let logger1_config = WALoggerConfig {
-            file_path: log1_path.clone(),
-            sync: false,
-        };
+        let logger1_config = WALoggerConfig::new(
+            log1_path.clone(),
+            false, // sync
+        );
 
-        let (mut logger1, events1): (WALogger<TestEvent>, _) =
-            WALogger::new(logger1_config).unwrap();
+        let (mut logger1, events1): (WALogger<TestEvent>, _) = logger1_config.build().unwrap();
         assert!(events1.is_empty());
         let mut state1 = VecState::default();
         for event in events1 {
@@ -113,12 +112,12 @@ mod test {
         let log2_path = tmpdir.path().join("wal2");
         let copied = fs::copy(&log1_path, &log2_path).unwrap();
         assert_eq!(log1_len, copied);
-        let logger2_config = WALoggerConfig {
-            file_path: log2_path.clone(),
-            sync: false,
-        };
+        let logger2_config = WALoggerConfig::new(
+            log2_path.clone(),
+            false, // sync
+        );
 
-        let (mut logger2, events2) = WALogger::new(logger2_config).unwrap();
+        let (mut logger2, events2) = logger2_config.build().unwrap();
         assert!(!events2.is_empty());
         let mut state2 = VecState::default();
         for event in events2 {
@@ -137,12 +136,11 @@ mod test {
         let log3_path = tmpdir.path().join("wal3");
         let copied = fs::copy(&log2_path, &log3_path).unwrap();
         assert_eq!(log2_len, copied);
-        let logger3_config = WALoggerConfig {
-            file_path: log3_path,
-            sync: false,
-        };
+        let logger3_config = WALoggerConfig::new(
+            log3_path, false, // sync
+        );
 
-        let (_, events3) = WALogger::new(logger3_config).unwrap();
+        let (_, events3) = logger3_config.build().unwrap();
         assert!(!events3.is_empty());
         let mut state3 = VecState::default();
         for event in events3 {


### PR DESCRIPTION
This allows SwarmRelation to be dynamically dispatched over. This touches everything because most of our traits utilize T::new(), which is incompatible with dynamic dispatch.