### PR TITLE
Start replacing tracing counters with in-mem counters

### DIFF
--- a/monad-consensus-types/src/lib.rs
+++ b/monad-consensus-types/src/lib.rs
@@ -2,6 +2,7 @@ pub mod block;
 pub mod block_validator;
 pub mod convert;
 pub mod ledger;
+pub mod metrics;
 pub mod payload;
 pub mod quorum_certificate;
 pub mod signature_collection;

--- a/monad-consensus-types/src/metrics.rs
+++ b/monad-consensus-types/src/metrics.rs
@@ -1,0 +1,63 @@
+#[derive(Debug, Default)]
+pub struct ValidationErrors {
+    pub invalid_author: u64,
+    pub not_well_formed_sig: u64,
+    pub invalid_signature: u64,
+    pub author_not_sender: u64,
+    pub invalid_tc_round: u64,
+    pub insufficient_stake: u64,
+    pub invalid_seq_num: u64,
+    pub val_data_unavailable: u64,
+    pub invalid_vote_message: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct ConsensusEvents {
+    pub local_timeout: u64,
+    pub handle_proposal: u64,
+    pub failed_txn_validation: u64,
+    pub invalid_proposal_round_leader: u64,
+    pub out_of_order_proposals: u64,
+    pub created_vote: u64,
+    pub old_vote_received: u64,
+    pub vote_received: u64,
+    pub created_qc: u64,
+    pub old_remote_timeout: u64,
+    pub remote_timeout_msg: u64,
+    pub remote_timeout_msg_with_tc: u64,
+    pub created_tc: u64,
+    pub process_old_qc: u64,
+    pub process_qc: u64,
+    pub creating_proposal: u64,
+    pub abstain_proposal: u64,
+    pub creating_empty_block_proposal: u64,
+    pub rx_empty_block: u64,
+    pub rx_execution_lagging: u64,
+    pub rx_bad_state_root: u64,
+    pub rx_proposal: u64,
+    pub proposal_with_tc: u64,
+    pub failed_verify_randao_reveal_sig: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct BlocktreeEvents {
+    pub prune_success: u64,
+    pub add_success: u64,
+    pub add_dup: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct BlocksyncEvents {
+    pub blocksync_response_successful: u64,
+    pub blocksync_response_failed: u64,
+    pub blocksync_response_unexpected: u64,
+    pub blocksync_request: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct Metrics {
+    pub validation_errors: ValidationErrors,
+    pub consensus_events: ConsensusEvents,
+    pub blocktree_events: BlocktreeEvents,
+    pub blocksync_events: BlocksyncEvents,
+}

--- a/monad-mock-swarm/tests/replay_test.rs
+++ b/monad-mock-swarm/tests/replay_test.rs
@@ -295,15 +295,7 @@ fn replay_one_honest(failure_idx: &[usize]) {
     swarm_ledger_verification(&swarm, phase_one_length + 1);
 
     // assert that block sync isn't triggered
-    logs_assert(|lines: &[&str]| {
-        assert!(!lines.is_empty());
-        match lines
-            .iter()
-            .filter(|line| line.contains("monotonic_counter.block_sync_request"))
-            .count()
-        {
-            0 => Ok(()),
-            n => Err(format!("Block sync triggered {} times", n)),
-        }
-    })
+    for s in swarm.states().values() {
+        assert_eq!(0, s.state.metrics().blocksync_events.blocksync_request);
+    }
 }


### PR DESCRIPTION
Another PR can add an executor that polls monad-state via event for latest counters and then manually does the opentel export. But this will be useful for now to see counts in debugger