### PR TITLE
Remove ConsensusProcess

### DIFF
--- a/monad-mock-swarm/src/swarm_relation.rs
+++ b/monad-mock-swarm/src/swarm_relation.rs
@@ -1,5 +1,4 @@
 use bytes::Bytes;
-use monad_consensus_state::ConsensusState;
 use monad_consensus_types::{
     block::Block,
     block_validator::{BlockValidator, MockValidator},
@@ -27,17 +26,13 @@ use monad_wal::{mock::MockWALogger, PersistenceLogger};
 use crate::{mock::MockExecutor, node::Node, transformer::MonadMessageTransformerPipeline};
 
 pub type SwarmRelationStateType<S> = MonadState<
-    ConsensusState<
-        <S as SwarmRelation>::SignatureType,
-        <S as SwarmRelation>::SignatureCollectionType,
-        <S as SwarmRelation>::BlockValidator,
-        <S as SwarmRelation>::StateRootValidator,
-    >,
     <S as SwarmRelation>::SignatureType,
     <S as SwarmRelation>::SignatureCollectionType,
     <S as SwarmRelation>::ValidatorSetTypeFactory,
     <S as SwarmRelation>::LeaderElection,
     <S as SwarmRelation>::TxPool,
+    <S as SwarmRelation>::BlockValidator,
+    <S as SwarmRelation>::StateRootValidator,
 >;
 pub trait SwarmRelation
 where

--- a/monad-mock-swarm/src/terminator.rs
+++ b/monad-mock-swarm/src/terminator.rs
@@ -1,6 +1,5 @@
 use std::{collections::BTreeMap, time::Duration, usize};
 
-use monad_consensus_state::ConsensusProcess;
 use monad_crypto::certificate_signature::{CertificateSignaturePubKey, PubKey};
 use monad_transformer::ID;
 use monad_types::Round;

--- a/monad-mock-swarm/tests/epoch.rs
+++ b/monad-mock-swarm/tests/epoch.rs
@@ -7,7 +7,6 @@ mod test {
     };
 
     use itertools::Itertools;
-    use monad_consensus_state::ConsensusProcess;
     use monad_consensus_types::{
         block::Block, block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
     };

--- a/monad-state/src/epoch.rs
+++ b/monad-state/src/epoch.rs
@@ -14,7 +14,7 @@ use monad_validator::{
 
 use crate::{MonadState, VerifiedMonadMessage};
 
-pub(super) struct EpochChildState<'a, CP, ST, SCT, VTF, LT, TT>
+pub(super) struct EpochChildState<'a, ST, SCT, VTF, LT, TT, BVT, SVT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
@@ -22,18 +22,18 @@ where
 {
     val_epoch_map: &'a mut ValidatorsEpochMapping<VTF, SCT>,
 
-    _phantom: PhantomData<(CP, ST, LT, TT)>,
+    _phantom: PhantomData<(ST, LT, TT, BVT, SVT)>,
 }
 
 pub(super) struct EpochCommand {}
 
-impl<'a, CP, ST, SCT, VTF, LT, TT> EpochChildState<'a, CP, ST, SCT, VTF, LT, TT>
+impl<'a, ST, SCT, VTF, LT, TT, BVT, SVT> EpochChildState<'a, ST, SCT, VTF, LT, TT, BVT, SVT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     VTF: ValidatorSetTypeFactory<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
 {
-    pub(super) fn new(monad_state: &'a mut MonadState<CP, ST, SCT, VTF, LT, TT>) -> Self {
+    pub(super) fn new(monad_state: &'a mut MonadState<ST, SCT, VTF, LT, TT, BVT, SVT>) -> Self {
         Self {
             val_epoch_map: &mut monad_state.val_epoch_map,
             _phantom: PhantomData,

--- a/monad-state/src/mempool.rs
+++ b/monad-state/src/mempool.rs
@@ -12,22 +12,22 @@ use monad_validator::validator_set::ValidatorSetTypeFactory;
 
 use crate::{MonadState, VerifiedMonadMessage};
 
-pub(super) struct MempoolChildState<'a, CP, ST, SCT, VT, LT, TT> {
+pub(super) struct MempoolChildState<'a, ST, SCT, VT, LT, TT, BVT, SVT> {
     txpool: &'a mut TT,
 
-    _phantom: PhantomData<(CP, ST, SCT, VT, LT)>,
+    _phantom: PhantomData<(ST, SCT, VT, LT, BVT, SVT)>,
 }
 
 pub(super) struct MempoolCommand {}
 
-impl<'a, CP, ST, SCT, VT, LT, TT> MempoolChildState<'a, CP, ST, SCT, VT, LT, TT>
+impl<'a, ST, SCT, VT, LT, TT, BVT, SVT> MempoolChildState<'a, ST, SCT, VT, LT, TT, BVT, SVT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     VT: ValidatorSetTypeFactory<NodeIdPubKey = SCT::NodeIdPubKey>,
     TT: TxPool,
 {
-    pub(super) fn new(monad_state: &'a mut MonadState<CP, ST, SCT, VT, LT, TT>) -> Self {
+    pub(super) fn new(monad_state: &'a mut MonadState<ST, SCT, VT, LT, TT, BVT, SVT>) -> Self {
         Self {
             txpool: &mut monad_state.txpool,
             _phantom: PhantomData,

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -1,4 +1,4 @@
-use monad_consensus_state::{command::Checkpoint, ConsensusConfig, ConsensusState};
+use monad_consensus_state::{command::Checkpoint, ConsensusConfig};
 use monad_consensus_types::{
     block::Block, block_validator::MockValidator, payload::NopStateRoot,
     signature_collection::SignatureCollection, validator_data::ValidatorData,
@@ -130,12 +130,13 @@ where
 }
 
 type MonadStateType<ST, SCT> = MonadState<
-    ConsensusState<ST, SCT, MockValidator, NopStateRoot>,
     ST,
     SCT,
     ValidatorSetFactory<CertificateSignaturePubKey<ST>>,
     SimpleRoundRobin<CertificateSignaturePubKey<ST>>,
     EthTxPool,
+    MockValidator,
+    NopStateRoot,
 >;
 
 pub struct StateConfig<ST, SCT>


### PR DESCRIPTION
MonadState won't have any functionality of its own and should just send events to sub-states and sub-states can communicate if needed via loopback executor so there's no need to mock out consensus state so we can just use the concrete type