### PR TITLE
Modify NopStateRoot output hash

### DIFF
--- a/monad-consensus-types/src/payload.rs
+++ b/monad-consensus-types/src/payload.rs
@@ -334,7 +334,7 @@ impl StateRootValidator for NopStateRoot {
     fn add_state_root(&mut self, _seq_num: SeqNum, _root_hash: Hash) {}
 
     fn get_next_state_root(&self, _seq_num: SeqNum) -> Option<Hash> {
-        Some(Hash([0; 32]))
+        Some(Hash([0xdb; 32]))
     }
 
     fn validate(&self, _seq_num: SeqNum, _block_state_root_hash: Hash) -> StateRootResult {


### PR DESCRIPTION
NopStateRoot is intended to skip state root hash checks in testing but the original state root hash value that it returned for proposal_policy was the special empty block hash which would cause all proposals to be ProposeEmpty.