### PR TITLE
Remove extraneous gossip flush messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2823,7 +2823,6 @@ name = "monad-transformer"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "bytes-utils",
  "monad-crypto",
  "monad-tracing-counter",
  "monad-types",

--- a/monad-gossip/src/broadcasttree.rs
+++ b/monad-gossip/src/broadcasttree.rs
@@ -337,7 +337,7 @@ mod tests {
         hasher::{Hasher, HasherType},
         NopKeyPair, NopSignature,
     };
-    use monad_transformer::{BytesSplitterTransformer, BytesTransformer, LatencyTransformer};
+    use monad_transformer::{BytesTransformer, LatencyTransformer};
     use monad_types::{NodeId, RouterTarget};
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
@@ -655,45 +655,6 @@ mod tests {
                 vec![BytesTransformer::Latency(LatencyTransformer::new(
                     Duration::from_millis(5),
                 ))]
-            },
-        );
-
-        let mut rng = ChaCha8Rng::from_seed([0; 32]);
-        test_broadcast(
-            &mut rng,
-            &mut swarm,
-            Duration::from_secs(1),
-            1024,
-            usize::MAX,
-            1.0,
-        );
-        test_direct(&mut rng, &mut swarm, Duration::from_secs(1), 1024);
-    }
-
-    // TODO: This test relies on the BytesSplitterTransformer to split messages. The transformer
-    // needs to be flushed to make sure that all split parts arrive. The mechanism for doing
-    // this right now is broadcasting random messages, but the broadcast tree algorithm is using
-    // a different tree/route for every message, so this isn't a reliable flush.
-    // Test happens to pass with small number of nodes for now. Better change would be to add
-    // ability to flush the transformer explicitly.
-    #[test]
-    fn test_split_messages() {
-        let mut swarm = make_swarm::<NopSignature, _>(
-            3,
-            |all_peers, me| {
-                BroadcastTreeConfig {
-                    all_peers: all_peers.to_vec(),
-                    my_id: *me,
-                    tree_arity: 2,
-                    num_routes: 2,
-                }
-                .build()
-            },
-            |_all_peers, _me| {
-                vec![
-                    BytesTransformer::Latency(LatencyTransformer::new(Duration::from_millis(5))),
-                    BytesTransformer::BytesSplitter(BytesSplitterTransformer::new()),
-                ]
             },
         );
 

--- a/monad-gossip/src/connection_manager.rs
+++ b/monad-gossip/src/connection_manager.rs
@@ -172,7 +172,7 @@ impl<G: Gossip> ConnectionManager<G> {
 mod tests {
     use std::time::Duration;
 
-    use bytes::Bytes;
+    use bytes::{Buf, Bytes};
     use monad_crypto::{
         certificate_signature::{
             CertificateKeyPair, CertificateSignature, CertificateSignaturePubKey,
@@ -189,15 +189,14 @@ mod tests {
 
     type SignatureType = NopSignature;
 
-    struct Swarm {
+    struct Node {
         connection_manager:
             ConnectionManager<MockGossip<CertificateSignaturePubKey<SignatureType>>>,
         me: NodeId<CertificateSignaturePubKey<SignatureType>>,
-        other: NodeId<CertificateSignaturePubKey<SignatureType>>,
     }
 
-    impl Swarm {
-        fn create() -> Self {
+    impl Node {
+        fn create_swarm() -> Vec<Self> {
             const NUM_NODES: usize = 2;
             let all_peers: Vec<_> = (1_u32..)
                 .take(NUM_NODES)
@@ -214,85 +213,182 @@ mod tests {
                     NodeId::new(keypair.pubkey())
                 })
                 .collect();
-            let me = all_peers[0];
-            let other = all_peers[1];
-            let gossip = MockGossipConfig { all_peers, me }.build();
-            let connection_manager = ConnectionManager::new(gossip);
 
-            Self {
-                connection_manager,
-                me,
-                other,
-            }
+            all_peers
+                .iter()
+                .copied()
+                .map(|me| {
+                    let gossip = MockGossipConfig {
+                        all_peers: all_peers.clone(),
+                        me,
+                    }
+                    .build();
+                    let connection_manager = ConnectionManager::new(gossip);
+
+                    Self {
+                        connection_manager,
+                        me,
+                    }
+                })
+                .collect()
         }
     }
 
     #[test]
     fn test_send_disconnected() {
-        let mut swarm = Swarm::create();
-        swarm.connection_manager.send(
+        let mut swarm = Node::create_swarm();
+        let mut node_1 = swarm.pop().unwrap();
+        let node_2 = swarm.pop().unwrap();
+        node_1.connection_manager.send(
             Duration::ZERO,
-            monad_types::RouterTarget::PointToPoint(swarm.other),
+            monad_types::RouterTarget::PointToPoint(node_2.me),
             Bytes::new(),
         );
 
         assert!(
-            matches!(swarm.connection_manager.poll(Duration::ZERO), Some(ConnectionManagerEvent::RequestConnect(other)) if other == swarm.other)
+            matches!(node_1.connection_manager.poll(Duration::ZERO), Some(ConnectionManagerEvent::RequestConnect(other)) if other == node_2.me)
         );
         // is not connected, so nothing else should happen (no sends)
-        assert!(swarm.connection_manager.poll(Duration::ZERO).is_none());
+        assert!(node_1.connection_manager.poll(Duration::ZERO).is_none());
 
         // now we connect
-        swarm
+        node_1
             .connection_manager
-            .connected(Duration::ZERO, swarm.other);
+            .connected(Duration::ZERO, node_2.me);
         // retry same send
-        swarm.connection_manager.send(
+        node_1.connection_manager.send(
             Duration::ZERO,
-            monad_types::RouterTarget::PointToPoint(swarm.other),
+            monad_types::RouterTarget::PointToPoint(node_2.me),
             Bytes::new(),
         );
         // should emit a Send event
         assert!(
-            matches!(swarm.connection_manager.poll(Duration::ZERO), Some(ConnectionManagerEvent::GossipEvent(GossipEvent::Send(other, _))) if other == swarm.other)
+            matches!(node_1.connection_manager.poll(Duration::ZERO), Some(ConnectionManagerEvent::GossipEvent(GossipEvent::Send(other, _))) if other == node_2.me)
         );
         // no RequestConnect event
-        assert!(swarm.connection_manager.poll(Duration::ZERO).is_none());
+        assert!(node_1.connection_manager.poll(Duration::ZERO).is_none());
     }
 
     #[test]
     fn test_disconnected_clears_sends() {
-        let mut swarm = Swarm::create();
+        let mut swarm = Node::create_swarm();
+        let mut node_1 = swarm.pop().unwrap();
+        let node_2 = swarm.pop().unwrap();
 
-        swarm
+        node_1
             .connection_manager
-            .connected(Duration::ZERO, swarm.other);
-        swarm.connection_manager.send(
+            .connected(Duration::ZERO, node_2.me);
+        node_1.connection_manager.send(
             Duration::ZERO,
-            monad_types::RouterTarget::PointToPoint(swarm.other),
+            monad_types::RouterTarget::PointToPoint(node_2.me),
             Bytes::new(),
         );
         // we disconnect before we poll the Send event
-        swarm
+        node_1
             .connection_manager
-            .disconnected(Duration::ZERO, swarm.other);
+            .disconnected(Duration::ZERO, node_2.me);
 
         // Send event got replaced with RequestConnect
         assert!(
-            matches!(swarm.connection_manager.poll(Duration::ZERO), Some(ConnectionManagerEvent::RequestConnect(other)) if other == swarm.other)
+            matches!(node_1.connection_manager.poll(Duration::ZERO), Some(ConnectionManagerEvent::RequestConnect(other)) if other == node_2.me)
         );
-        assert!(swarm.connection_manager.poll(Duration::ZERO).is_none());
+        assert!(node_1.connection_manager.poll(Duration::ZERO).is_none());
     }
 
     #[test]
     #[should_panic]
     fn test_receive_disconnected() {
-        let mut swarm = Swarm::create();
+        let mut swarm = Node::create_swarm();
+        let mut node_1 = swarm.pop().unwrap();
+        let node_2 = swarm.pop().unwrap();
         // we didn't call handle_unframed_gossip_message first
-        swarm.connection_manager.handle_unframed_gossip_message(
+        node_1.connection_manager.handle_unframed_gossip_message(
             Duration::ZERO,
-            swarm.other,
+            node_2.me,
             Bytes::new(),
         )
+    }
+
+    #[test]
+    fn test_split_message() {
+        let mut swarm = Node::create_swarm();
+        let mut node_1 = swarm.pop().unwrap();
+        let mut node_2 = swarm.pop().unwrap();
+
+        let app_message_1_bytes: Bytes = [1, 2, 3].as_ref().into();
+        let app_message_2_bytes: Bytes = [3, 4, 5].as_ref().into();
+
+        // tx side
+        node_1
+            .connection_manager
+            .connected(Duration::ZERO, node_2.me);
+        node_1.connection_manager.send(
+            Duration::ZERO,
+            monad_types::RouterTarget::PointToPoint(node_2.me),
+            app_message_1_bytes.clone(),
+        );
+        node_1.connection_manager.send(
+            Duration::ZERO,
+            monad_types::RouterTarget::PointToPoint(node_2.me),
+            app_message_2_bytes.clone(),
+        );
+        let Some(ConnectionManagerEvent::GossipEvent(GossipEvent::Send(
+            message_1_to,
+            mut message_1,
+        ))) = node_1.connection_manager.poll(Duration::ZERO)
+        else {
+            unreachable!("unexpected event");
+        };
+        assert_eq!(message_1_to, node_2.me);
+        let Some(ConnectionManagerEvent::GossipEvent(GossipEvent::Send(message_2_to, message_2))) =
+            node_1.connection_manager.poll(Duration::ZERO)
+        else {
+            unreachable!("unexpected event");
+        };
+        assert_eq!(message_2_to, node_2.me);
+        assert!(node_1.connection_manager.poll(Duration::ZERO).is_none());
+
+        // rx side
+        node_2
+            .connection_manager
+            .connected(Duration::ZERO, node_1.me);
+        node_2.connection_manager.handle_unframed_gossip_message(
+            Duration::ZERO,
+            node_1.me,
+            // send half of first message
+            message_1.copy_to_bytes(message_1.remaining() / 2),
+        );
+        // doesn't emit on incomplete message
+        assert!(node_2.connection_manager.poll(Duration::ZERO).is_none());
+
+        message_1.extend(message_2.into_inner());
+
+        node_2.connection_manager.handle_unframed_gossip_message(
+            Duration::ZERO,
+            node_1.me,
+            // send second half of first message + second message
+            message_1.copy_to_bytes(message_1.remaining()),
+        );
+
+        let Some(ConnectionManagerEvent::GossipEvent(GossipEvent::Emit(
+            message_1_from,
+            app_message_1,
+        ))) = node_2.connection_manager.poll(Duration::ZERO)
+        else {
+            unreachable!("unexpected event");
+        };
+        assert_eq!(message_1_from, node_1.me);
+        let Some(ConnectionManagerEvent::GossipEvent(GossipEvent::Emit(
+            message_2_from,
+            app_message_2,
+        ))) = node_2.connection_manager.poll(Duration::ZERO)
+        else {
+            unreachable!("unexpected event");
+        };
+        assert_eq!(message_2_from, node_1.me);
+        assert!(node_2.connection_manager.poll(Duration::ZERO).is_none());
+
+        assert_eq!(app_message_1, app_message_1_bytes);
+        assert_eq!(app_message_2, app_message_2_bytes);
     }
 }

--- a/monad-gossip/src/gossipsub.rs
+++ b/monad-gossip/src/gossipsub.rs
@@ -188,7 +188,7 @@ mod tests {
         hasher::{Hasher, HasherType},
         NopSignature,
     };
-    use monad_transformer::{BytesSplitterTransformer, BytesTransformer, LatencyTransformer};
+    use monad_transformer::{BytesTransformer, LatencyTransformer};
     use monad_types::NodeId;
     use rand::SeedableRng;
     use rand_chacha::ChaCha20Rng;
@@ -221,48 +221,6 @@ mod tests {
                 vec![BytesTransformer::Latency(LatencyTransformer::new(
                     Duration::from_millis(5),
                 ))]
-            },
-        );
-
-        let mut rng = ChaCha20Rng::from_seed([0; 32]);
-        test_broadcast(
-            &mut rng,
-            &mut swarm,
-            Duration::from_secs(1),
-            PAYLOAD_SIZE_BYTES,
-            usize::MAX,
-            0.95,
-        );
-        test_direct(
-            &mut rng,
-            &mut swarm,
-            Duration::from_secs(1),
-            PAYLOAD_SIZE_BYTES,
-        );
-    }
-
-    #[test]
-    fn test_split_messages() {
-        let mut swarm = make_swarm::<NopSignature, _>(
-            NUM_NODES,
-            |all_peers, me: &NodeId<CertificateSignaturePubKey<NopSignature>>| {
-                UnsafeGossipsubConfig {
-                    seed: {
-                        let mut hasher = HasherType::new();
-                        hasher.update(&me.pubkey().bytes());
-                        hasher.hash().0
-                    },
-                    me: *me,
-                    all_peers: all_peers.to_vec(),
-                    fanout: FANOUT,
-                }
-                .build()
-            },
-            |_all_peers, _me| {
-                vec![
-                    BytesTransformer::Latency(LatencyTransformer::new(Duration::from_millis(5))),
-                    BytesTransformer::BytesSplitter(BytesSplitterTransformer::new()),
-                ]
             },
         );
 

--- a/monad-gossip/src/mock.rs
+++ b/monad-gossip/src/mock.rs
@@ -90,7 +90,7 @@ mod tests {
     use std::time::Duration;
 
     use monad_crypto::NopSignature;
-    use monad_transformer::{BytesSplitterTransformer, BytesTransformer, LatencyTransformer};
+    use monad_transformer::{BytesTransformer, LatencyTransformer};
     use rand::SeedableRng;
     use rand_chacha::ChaCha20Rng;
 
@@ -115,42 +115,6 @@ mod tests {
                 vec![BytesTransformer::Latency(LatencyTransformer::new(
                     Duration::from_millis(5),
                 ))]
-            },
-        );
-
-        let mut rng = ChaCha20Rng::from_seed([0; 32]);
-        test_broadcast(
-            &mut rng,
-            &mut swarm,
-            Duration::from_secs(1),
-            PAYLOAD_SIZE_BYTES,
-            usize::MAX,
-            1.0,
-        );
-        test_direct(
-            &mut rng,
-            &mut swarm,
-            Duration::from_secs(1),
-            PAYLOAD_SIZE_BYTES,
-        );
-    }
-
-    #[test]
-    fn test_split_messages() {
-        let mut swarm = make_swarm::<NopSignature, _>(
-            NUM_NODES,
-            |all_peers, me| {
-                MockGossipConfig {
-                    all_peers: all_peers.to_vec(),
-                    me: *me,
-                }
-                .build()
-            },
-            |_all_peers, _me| {
-                vec![
-                    BytesTransformer::Latency(LatencyTransformer::new(Duration::from_millis(5))),
-                    BytesTransformer::BytesSplitter(BytesSplitterTransformer::new()),
-                ]
             },
         );
 

--- a/monad-gossip/src/testutil.rs
+++ b/monad-gossip/src/testutil.rs
@@ -246,15 +246,6 @@ pub fn test_broadcast<G: Gossip>(
         swarm.send(tx_peer, target, message);
     }
 
-    // some random extra messages to flush pipeline transformers
-    for _ in 0..10 {
-        for tx_peer in &peer_ids {
-            let message: AppMessage = (0..10).map(|_| rng.gen()).collect();
-            let target = RouterTarget::Broadcast;
-            swarm.send(tx_peer, target, message);
-        }
-    }
-
     let num_expected = pending_messages.len();
     while let Some((tick, rx_peer, (tx_peer, message))) = swarm.step_until(max_tick) {
         pending_messages.remove(&(rx_peer, (tx_peer, message)));
@@ -286,17 +277,6 @@ pub fn test_direct<G: Gossip>(
             swarm.send(tx_peer, target, message.clone());
 
             pending_messages.insert((*rx_peer, (*tx_peer, message)));
-        }
-    }
-
-    // some random extra messages to flush pipeline transformers
-    for _ in 0..10 {
-        for tx_peer in &peer_ids {
-            let message: AppMessage = (0..10).map(|_| rng.gen()).collect();
-            for rx_peer in &peer_ids {
-                let target = RouterTarget::PointToPoint(*rx_peer);
-                swarm.send(tx_peer, target, message.clone());
-            }
         }
     }
 

--- a/monad-transformer/Cargo.toml
+++ b/monad-transformer/Cargo.toml
@@ -16,7 +16,6 @@ monad-tracing-counter = { path = "../monad-tracing-counter" }
 monad-types = { path = "../monad-types" }
 
 bytes = { workspace = true }
-bytes-utils = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
In our gossip swarm tests, we currently send extra messages in test_broadcast and test_direct. These extra messages were used to flush any buffered messages within the pipeline transformers. Now that we've moved from the BwTransformer to the PacerTransformer, these extra messages are no longer necessary. Removing these extra messages opens up the option of adding metering for the total amount of bytes transmitted.