### PR TITLE
Augment state_root_hash_validation return value

### DIFF
--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -18,6 +18,7 @@ use monad_types::{BlockId, Epoch, NodeId, RouterTarget, TimeoutVariant};
 
 /// Command type that the consensus state-machine outputs
 /// This is converted to a monad-executor-glue::Command at the top-level monad-state
+#[derive(Debug)]
 pub enum ConsensusCommand<ST, SCT>
 where
     ST: CertificateSignatureRecoverable,

--- a/monad-consensus-types/src/metrics.rs
+++ b/monad-consensus-types/src/metrics.rs
@@ -34,6 +34,7 @@ pub struct ConsensusEvents {
     pub rx_empty_block: u64,
     pub rx_execution_lagging: u64,
     pub rx_bad_state_root: u64,
+    pub rx_missing_state_root: u64,
     pub rx_proposal: u64,
     pub proposal_with_tc: u64,
     pub failed_verify_randao_reveal_sig: u64,


### PR DESCRIPTION
Switch the return value from a boolean to an enum StateRootAction. It targets the cases where local execution/state root verification is lagging/missing msgs.

The node doesn't have enough information to decide whether the state root is valid, so it can't vote on the block. However, it's safe to process other components in the block (X) - certificates, etc, and insert it to the block tree, instead of discarding it. If the next proposal (X+1) carrying the QC(X) arrives, it's proof that 2f+1 block have the state root and we can proceed without requesting block sync.