### PR TITLE
PeerStateRootVerify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,9 +2272,12 @@ version = "0.1.0"
 dependencies = [
  "monad-consensus-types",
  "monad-crypto",
+ "monad-multi-sig",
  "monad-proto",
+ "monad-testutil",
  "monad-types",
  "monad-validator",
+ "tracing",
  "zerocopy 0.6.5",
 ]
 

--- a/monad-async-state-verify/Cargo.toml
+++ b/monad-async-state-verify/Cargo.toml
@@ -9,10 +9,15 @@ edition = "2021"
 bench = false
 
 [dependencies]
-monad-consensus-types = { version = "0.1.0", path = "../monad-consensus-types" }
+monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }
 monad-proto = { path = "../monad-proto" }
 monad-types = { path = "../monad-types" }
-monad-validator = { version = "0.1.0", path = "../monad-validator" }
+monad-validator = { path = "../monad-validator" }
 
+tracing = { workspace = true }
 zerocopy = { workspace = true }
+
+[dev-dependencies]
+monad-multi-sig = { path = "../monad-multi-sig" }
+monad-testutil = { path = "../monad-testutil" }

--- a/monad-async-state-verify/src/lib.rs
+++ b/monad-async-state-verify/src/lib.rs
@@ -9,8 +9,10 @@ use monad_types::NodeId;
 use monad_validator::validator_set::ValidatorSetType;
 
 pub mod local;
+pub mod peer;
 
 pub use local::LocalAsyncStateVerify;
+pub use peer::PeerAsyncStateVerify;
 
 pub enum AsyncStateVerifyCommand<SCT: SignatureCollection> {
     /// Broadcast local execution result to other validators

--- a/monad-async-state-verify/src/peer.rs
+++ b/monad-async-state-verify/src/peer.rs
@@ -1,0 +1,483 @@
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    marker::PhantomData,
+};
+
+use monad_consensus_types::{
+    signature_collection::{
+        SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
+    },
+    state_root_hash::StateRootHashInfo,
+    voting::ValidatorMapping,
+};
+use monad_crypto::{
+    certificate_signature::CertificateSignature,
+    hasher::{Hash, Hasher, HasherType},
+};
+use monad_types::{NodeId, SeqNum};
+use monad_validator::validator_set::ValidatorSetType;
+use tracing::{info, warn};
+
+use crate::{AsyncStateVerifyCommand, AsyncStateVerifyProcess, StateRootCertificate};
+
+#[derive(Debug, Clone)]
+struct BlockStateRootState<SCT: SignatureCollection> {
+    local_root: Option<StateRootHashInfo>,
+    pending_roots: HashMap<Hash, BTreeMap<NodeId<SCT::NodeIdPubKey>, SCT::SignatureType>>,
+    node_roots: HashMap<NodeId<SCT::NodeIdPubKey>, HashSet<SCT::SignatureType>>,
+    quorum: Option<StateRootCertificate<SCT>>,
+}
+
+impl<SCT: SignatureCollection> Default for BlockStateRootState<SCT> {
+    fn default() -> Self {
+        Self {
+            local_root: Option::None,
+            pending_roots: HashMap::new(),
+            node_roots: HashMap::new(),
+            quorum: None,
+        }
+    }
+}
+
+// TODO: garbage clean old state roots
+#[derive(Debug, Clone)]
+pub struct PeerAsyncStateVerify<SCT, VT>
+where
+    SCT: SignatureCollection,
+    VT: ValidatorSetType<NodeIdPubKey = SCT::NodeIdPubKey>,
+{
+    /// Collection of StateRoots after executing each block
+    state_roots: BTreeMap<SeqNum, BlockStateRootState<SCT>>,
+    /// The highest sequence number where a quorum of validators agree on the
+    /// execution state root
+    latest_certified: SeqNum,
+
+    _phantom: PhantomData<(SCT, VT)>,
+}
+
+impl<SCT, VT> Default for PeerAsyncStateVerify<SCT, VT>
+where
+    SCT: SignatureCollection,
+    VT: ValidatorSetType<NodeIdPubKey = SCT::NodeIdPubKey>,
+{
+    fn default() -> Self {
+        Self {
+            state_roots: Default::default(),
+            latest_certified: SeqNum(0),
+            _phantom: Default::default(),
+        }
+    }
+}
+
+impl<SCT, VT> AsyncStateVerifyProcess for PeerAsyncStateVerify<SCT, VT>
+where
+    SCT: SignatureCollection,
+    VT: ValidatorSetType<NodeIdPubKey = SCT::NodeIdPubKey>,
+{
+    type SignatureCollectionType = SCT;
+    type ValidatorSetType = VT;
+
+    fn handle_local_state_root(
+        &mut self,
+        self_id: NodeId<<Self::SignatureCollectionType as SignatureCollection>::NodeIdPubKey>,
+        cert_keypair: &SignatureCollectionKeyPairType<Self::SignatureCollectionType>,
+        info: StateRootHashInfo,
+    ) -> Vec<AsyncStateVerifyCommand<Self::SignatureCollectionType>> {
+        let entry = self.state_roots.entry(info.seq_num).or_default();
+
+        // note the local execution result
+        if let Some(local_root) = &entry.local_root {
+            if local_root != &info {
+                warn!("conflicting local state root");
+            } else {
+                info!("duplicate local state root");
+            }
+        }
+        entry.local_root = Some(info);
+
+        if let Some(cert) = &entry.quorum {
+            // TODO-2: handle the state root mismatch error
+            if cert.info != info {
+                warn!(
+                    "local execution result differ from quorum seq_num={:?}",
+                    info.seq_num
+                );
+            }
+        }
+
+        // we don't insert to pending roots because consensus broadcast sends to
+        // self
+
+        let msg = HasherType::hash_object(&info);
+        let sig = <SCT::SignatureType as CertificateSignature>::sign(msg.as_ref(), cert_keypair);
+        vec![AsyncStateVerifyCommand::BroadcastStateRoot {
+            peer: self_id,
+            info,
+            sig,
+        }]
+    }
+
+    fn handle_peer_state_root(
+        &mut self,
+        peer: NodeId<<Self::SignatureCollectionType as SignatureCollection>::NodeIdPubKey>,
+        info: StateRootHashInfo,
+        sig: <Self::SignatureCollectionType as SignatureCollection>::SignatureType,
+        validators: &Self::ValidatorSetType,
+        validator_mapping: &ValidatorMapping<
+            <Self::SignatureCollectionType as SignatureCollection>::NodeIdPubKey,
+            SignatureCollectionKeyPairType<Self::SignatureCollectionType>,
+        >,
+    ) -> Vec<AsyncStateVerifyCommand<Self::SignatureCollectionType>> {
+        // TODO: anti-spam: don't accept state root hash much higher than
+        // current consensus value
+        let mut cmds = Vec::new();
+        if info.seq_num <= self.latest_certified {
+            return cmds;
+        }
+
+        // check double voting
+        let block_state = self.state_roots.entry(info.seq_num).or_default();
+        let node_votes = block_state.node_roots.entry(peer).or_default();
+        node_votes.insert(sig);
+        if node_votes.len() > 1 {
+            // TODO: double voting evidence collection, might be acceptable if
+            // it's correcting state root based on msgs received. Can bump the
+            // threshold slightly higher
+        }
+
+        // add to pending votes
+        let info_hash = HasherType::hash_object(&info);
+        let pending_roots = block_state.pending_roots.entry(info_hash).or_default();
+        pending_roots.insert(peer, sig);
+
+        while validators.has_majority_votes(&pending_roots.keys().copied().collect::<Vec<_>>()) {
+            assert!(info.seq_num > self.latest_certified);
+            assert!(block_state.quorum.is_none());
+            match SCT::new(
+                pending_roots.iter().map(|(node, sig)| (*node, *sig)),
+                validator_mapping,
+                info_hash.as_ref(),
+            ) {
+                Ok(sigcol) => {
+                    // forward certified state root to consensus
+                    self.latest_certified = info.seq_num;
+                    if let Some(local_root) = block_state.local_root {
+                        if local_root != info {
+                            warn!("conflicting local state root");
+                        }
+                    } else {
+                        info!("local execution delayed");
+                    }
+                    block_state.quorum = Some(StateRootCertificate { info, sigs: sigcol });
+                    // TODO: log the quorum to a database
+                    // forward quorum to consensus?
+                    cmds.push(AsyncStateVerifyCommand::StateRootUpdate(info));
+                    return cmds;
+                }
+
+                Err(SignatureCollectionError::InvalidSignaturesCreate(invalid_sigs)) => {
+                    // remove the invalid signatures from pending votes
+                    let invalid_nodes = invalid_sigs
+                        .into_iter()
+                        .map(|(node_id, _)| node_id)
+                        .collect::<HashSet<_>>();
+
+                    pending_roots.retain(|node_id, _| !invalid_nodes.contains(node_id));
+                    // TODO: evidence
+                }
+
+                Err(
+                    SignatureCollectionError::NodeIdNotInMapping(_)
+                    | SignatureCollectionError::ConflictingSignatures(_)
+                    | SignatureCollectionError::InvalidSignaturesVerify
+                    | SignatureCollectionError::DeserializeError(_),
+                ) => {
+                    unreachable!("InvalidSignaturesCreate is only expected error from creating SC");
+                }
+            }
+        }
+
+        cmds
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use monad_consensus_types::{
+        signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
+        state_root_hash::StateRootHash,
+        voting::ValidatorMapping,
+    };
+    use monad_crypto::{
+        certificate_signature::{
+            CertificateKeyPair, CertificateSignature, CertificateSignaturePubKey,
+        },
+        hasher::{Hash, Hasher, HasherType},
+        NopSignature,
+    };
+    use monad_multi_sig::MultiSig;
+    use monad_testutil::{signing::*, validators::create_keys_w_validators};
+    use monad_types::{NodeId, Round, SeqNum, Stake};
+    use monad_validator::validator_set::{
+        ValidatorSet, ValidatorSetFactory, ValidatorSetTypeFactory,
+    };
+
+    use super::*;
+    use crate::PeerAsyncStateVerify;
+
+    type SignatureType = NopSignature;
+    type SignatureCollectionType = MultiSig<NopSignature>;
+
+    fn sign_state_root_info(
+        cert_key: &SignatureCollectionKeyPairType<SignatureCollectionType>,
+        info: StateRootHashInfo,
+    ) -> <SignatureCollectionType as SignatureCollection>::SignatureType {
+        let msg = HasherType::hash_object(&info);
+        <<SignatureCollectionType as SignatureCollection>::SignatureType as CertificateSignature>::sign(
+            msg.as_ref(),
+            cert_key,
+        )
+    }
+
+    #[test]
+    fn nominal() {
+        let (keys, certkeys, valset, vmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(4, ValidatorSetFactory::default());
+
+        let node0 = NodeId::new(keys[0].pubkey());
+        let mut asv = PeerAsyncStateVerify::<
+            SignatureCollectionType,
+            ValidatorSet<CertificateSignaturePubKey<SignatureType>>,
+        >::default();
+
+        let true_info = StateRootHashInfo {
+            state_root_hash: StateRootHash(Hash([0xab_u8; 32])),
+            seq_num: SeqNum(1),
+            round: Round(1),
+        };
+
+        let false_info = StateRootHashInfo {
+            state_root_hash: StateRootHash(Hash([0xff_u8; 32])),
+            seq_num: SeqNum(1),
+            round: Round(1),
+        };
+
+        let cmds = asv.handle_local_state_root(node0, &certkeys[0], true_info);
+        assert_eq!(cmds.len(), 1);
+
+        if let AsyncStateVerifyCommand::BroadcastStateRoot { peer, info, sig } = cmds[0] {
+            assert_eq!(peer, node0);
+            assert_eq!(info, true_info);
+            assert_eq!(sig, sign_state_root_info(&certkeys[0], true_info));
+        } else {
+            panic!("Command type mismatch");
+        }
+        assert_eq!(
+            asv.state_roots.get(&SeqNum(1)).unwrap().local_root,
+            Some(true_info)
+        );
+
+        let cmds = asv.handle_peer_state_root(
+            node0,
+            true_info,
+            sign_state_root_info(&certkeys[0], true_info),
+            &valset,
+            &vmap,
+        );
+        assert!(cmds.is_empty());
+
+        let cmds = asv.handle_peer_state_root(
+            NodeId::new(keys[1].pubkey()),
+            true_info,
+            sign_state_root_info(&certkeys[1], true_info),
+            &valset,
+            &vmap,
+        );
+        assert!(cmds.is_empty());
+
+        // node2 submits a different state root, no quorum is formed
+        let cmds = asv.handle_peer_state_root(
+            NodeId::new(keys[2].pubkey()),
+            false_info,
+            sign_state_root_info(&certkeys[2], false_info),
+            &valset,
+            &vmap,
+        );
+        assert!(cmds.is_empty());
+
+        let cmds = asv.handle_peer_state_root(
+            NodeId::new(keys[3].pubkey()),
+            true_info,
+            sign_state_root_info(&certkeys[3], true_info),
+            &valset,
+            &vmap,
+        );
+        assert_eq!(cmds.len(), 1);
+
+        if let AsyncStateVerifyCommand::StateRootUpdate(info) = cmds[0] {
+            assert_eq!(info, true_info);
+        } else {
+            panic!("Command type mismatch");
+        }
+
+        assert_eq!(asv.latest_certified, SeqNum(1));
+        let block_state = asv.state_roots.get(&SeqNum(1)).unwrap();
+        assert_eq!(block_state.local_root, Some(true_info));
+        assert_eq!(block_state.pending_roots.len(), 2);
+        assert_eq!(block_state.node_roots.len(), 4);
+        assert!(block_state.quorum.is_some());
+    }
+
+    #[test]
+    fn invalid_sigs_quorum() {
+        let keys = create_keys::<SignatureType>(4);
+        let certkeys = create_certificate_keys::<SignatureCollectionType>(4);
+
+        let mut staking_list = keys
+            .iter()
+            .map(|k| NodeId::new(k.pubkey()))
+            .zip(std::iter::repeat(Stake(1)))
+            .collect::<Vec<_>>();
+
+        // node1 has majority stake by itself
+        staking_list[1].1 = Stake(10);
+
+        let voting_identity = keys
+            .iter()
+            .map(|k| NodeId::new(k.pubkey()))
+            .zip(certkeys.iter().map(|k| k.pubkey()))
+            .collect::<Vec<_>>();
+
+        let valset = ValidatorSetFactory::default()
+            .create(staking_list)
+            .expect("create validator set");
+        let vmap = ValidatorMapping::new(voting_identity);
+
+        let node0 = NodeId::new(keys[0].pubkey());
+        let mut asv = PeerAsyncStateVerify::<
+            SignatureCollectionType,
+            ValidatorSet<CertificateSignaturePubKey<SignatureType>>,
+        >::default();
+
+        let true_info = StateRootHashInfo {
+            state_root_hash: StateRootHash(Hash([0xab_u8; 32])),
+            seq_num: SeqNum(1),
+            round: Round(1),
+        };
+
+        let false_info = StateRootHashInfo {
+            state_root_hash: StateRootHash(Hash([0xff_u8; 32])),
+            seq_num: SeqNum(1),
+            round: Round(1),
+        };
+
+        // malformed sig
+        let cmds = asv.handle_peer_state_root(
+            node0,
+            true_info,
+            sign_state_root_info(&certkeys[0], false_info),
+            &valset,
+            &vmap,
+        );
+        assert!(cmds.is_empty());
+
+        // majority-staked validator sends the state root
+        let cmds = asv.handle_peer_state_root(
+            NodeId::new(keys[1].pubkey()),
+            true_info,
+            sign_state_root_info(&certkeys[1], true_info),
+            &valset,
+            &vmap,
+        );
+        assert_eq!(cmds.len(), 1);
+        assert!(matches!(
+            cmds[0],
+            AsyncStateVerifyCommand::StateRootUpdate(_)
+        ));
+
+        let info_hash = HasherType::hash_object(&true_info);
+        let block_state = asv.state_roots.get(&SeqNum(1)).unwrap();
+        let root_state = block_state.pending_roots.get(&info_hash).unwrap();
+        // the invalid signature is removed from the map
+        assert_eq!(root_state.len(), 1);
+    }
+
+    #[test]
+    fn invalid_sigs_no_quorum() {
+        let (keys, certkeys, valset, vmap) = create_keys_w_validators::<
+            SignatureType,
+            SignatureCollectionType,
+            _,
+        >(4, ValidatorSetFactory::default());
+
+        let node0 = NodeId::new(keys[0].pubkey());
+        let mut asv = PeerAsyncStateVerify::<
+            SignatureCollectionType,
+            ValidatorSet<CertificateSignaturePubKey<SignatureType>>,
+        >::default();
+
+        let true_info = StateRootHashInfo {
+            state_root_hash: StateRootHash(Hash([0xab_u8; 32])),
+            seq_num: SeqNum(1),
+            round: Round(1),
+        };
+
+        let false_info = StateRootHashInfo {
+            state_root_hash: StateRootHash(Hash([0xff_u8; 32])),
+            seq_num: SeqNum(1),
+            round: Round(1),
+        };
+
+        let cmds = asv.handle_local_state_root(node0, &certkeys[0], true_info);
+        assert_eq!(cmds.len(), 1);
+
+        if let AsyncStateVerifyCommand::BroadcastStateRoot { peer, info, sig } = cmds[0] {
+            assert_eq!(peer, node0);
+            assert_eq!(info, true_info);
+            assert_eq!(sig, sign_state_root_info(&certkeys[0], true_info));
+        } else {
+            panic!("Command type mismatch");
+        }
+        assert_eq!(
+            asv.state_roots.get(&SeqNum(1)).unwrap().local_root,
+            Some(true_info)
+        );
+
+        let cmds = asv.handle_peer_state_root(
+            node0,
+            true_info,
+            sign_state_root_info(&certkeys[0], true_info),
+            &valset,
+            &vmap,
+        );
+        assert!(cmds.is_empty());
+
+        let cmds = asv.handle_peer_state_root(
+            NodeId::new(keys[1].pubkey()),
+            true_info,
+            sign_state_root_info(&certkeys[1], true_info),
+            &valset,
+            &vmap,
+        );
+        assert!(cmds.is_empty());
+
+        // node2 submits the same state root with an invalid signature, no
+        // quorum is formed
+        let cmds = asv.handle_peer_state_root(
+            NodeId::new(keys[2].pubkey()),
+            true_info,
+            sign_state_root_info(&certkeys[2], false_info),
+            &valset,
+            &vmap,
+        );
+        assert!(cmds.is_empty());
+        let info_hash = HasherType::hash_object(&true_info);
+        let block_state = asv.state_roots.get(&SeqNum(1)).unwrap();
+        let root_state = block_state.pending_roots.get(&info_hash).unwrap();
+        // the invalid signature is removed from the map
+        assert_eq!(root_state.len(), 2);
+    }
+}

--- a/monad-consensus-types/src/state_root_hash.rs
+++ b/monad-consensus-types/src/state_root_hash.rs
@@ -24,7 +24,7 @@ impl AsRef<[u8]> for StateRootHash {
 
 /// Votes on the state root hash after executing block `seq_num`. `round` is the
 /// consensus round where the block is proposed
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct StateRootHashInfo {
     pub state_root_hash: StateRootHash,
     pub seq_num: SeqNum,

--- a/monad-crypto/src/hasher.rs
+++ b/monad-crypto/src/hasher.rs
@@ -1,11 +1,21 @@
-use std::ops::Deref;
+use std::{fmt::Debug, ops::Deref};
 
 use sha2::Digest;
 use zerocopy::AsBytes;
 
 /// A 32-byte/256-bit hash
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct Hash(pub [u8; 32]);
+
+impl Debug for Hash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:>02x}{:>02x}..{:>02x}{:>02x}",
+            self.0[0], self.0[1], self.0[30], self.0[31]
+        )
+    }
+}
 
 impl Deref for Hash {
     type Target = [u8; 32];

--- a/monad-crypto/src/lib.rs
+++ b/monad-crypto/src/lib.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use hasher::{Hashable, Hasher};
 
 #[cfg(feature = "rustls")]
@@ -12,8 +14,18 @@ pub struct NopKeyPair {
     pubkey: NopPubKey,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct NopPubKey([u8; 32]);
+
+impl Debug for NopPubKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:>02x}{:>02x}..{:>02x}{:>02x}",
+            self.0[0], self.0[1], self.0[30], self.0[31]
+        )
+    }
+}
 
 /// NopSignature is an implementation of CertificateSignature that's not cryptographically secure
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/monad-debugger/src/lib.rs
+++ b/monad-debugger/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeSet, time::Duration};
 
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_consensus_types::{
     block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
 };
@@ -39,7 +39,7 @@ pub fn simulation_make() -> *mut Simulation {
                     SeqNum(4), // state_root_delay
                 )
             },
-            LocalAsyncStateVerify::default,
+            PeerAsyncStateVerify::default,
             Duration::from_millis(20), // delta
             100,                       // proposal_tx_limit
             SeqNum(2000),              // val_set_update_interval

--- a/monad-mock-swarm/benches/two_node_benchmark.rs
+++ b/monad-mock-swarm/benches/two_node_benchmark.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeSet, time::Duration};
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_consensus_types::{
     block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
 };
@@ -41,7 +41,7 @@ fn two_nodes() {
                 SeqNum(4), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(2), // delta
         5_000,                    // proposal_tx_limit
         SeqNum(2000),             // val_set_update_interval

--- a/monad-mock-swarm/src/swarm_relation.rs
+++ b/monad-mock-swarm/src/swarm_relation.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use monad_async_state_verify::{
-    AsyncStateVerifyProcess, BoxedAsyncStateVerifyProcess, LocalAsyncStateVerify,
+    AsyncStateVerifyProcess, BoxedAsyncStateVerifyProcess, PeerAsyncStateVerify,
 };
 use monad_consensus_types::{
     block::Block,
@@ -175,7 +175,7 @@ impl SwarmRelation for NoSerSwarm {
         ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
     type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
     type TxPool = MockTxPool;
-    type AsyncStateRootVerify = LocalAsyncStateVerify<
+    type AsyncStateRootVerify = PeerAsyncStateVerify<
         Self::SignatureCollectionType,
         <Self::ValidatorSetTypeFactory as ValidatorSetTypeFactory>::ValidatorSetType,
     >;
@@ -213,7 +213,7 @@ impl SwarmRelation for BytesSwarm {
         ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
     type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
     type TxPool = MockTxPool;
-    type AsyncStateRootVerify = LocalAsyncStateVerify<
+    type AsyncStateRootVerify = PeerAsyncStateVerify<
         Self::SignatureCollectionType,
         <Self::ValidatorSetTypeFactory as ValidatorSetTypeFactory>::ValidatorSetType,
     >;
@@ -252,7 +252,7 @@ impl SwarmRelation for MonadMessageNoSerSwarm {
         ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
     type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
     type TxPool = MockTxPool;
-    type AsyncStateRootVerify = LocalAsyncStateVerify<
+    type AsyncStateRootVerify = PeerAsyncStateVerify<
         Self::SignatureCollectionType,
         <Self::ValidatorSetTypeFactory as ValidatorSetTypeFactory>::ValidatorSetType,
     >;

--- a/monad-mock-swarm/tests/block_sync.rs
+++ b/monad-mock-swarm/tests/block_sync.rs
@@ -6,7 +6,7 @@ mod test {
         time::Duration,
     };
 
-    use monad_async_state_verify::LocalAsyncStateVerify;
+    use monad_async_state_verify::PeerAsyncStateVerify;
     use monad_consensus_types::{
         block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
     };
@@ -48,7 +48,7 @@ mod test {
                     SeqNum(u64::MAX), // state_root_delay
                 )
             },
-            LocalAsyncStateVerify::default,
+            PeerAsyncStateVerify::default,
             delta,        // delta
             0,            // proposal_tx_limit
             SeqNum(2000), // val_set_update_interval
@@ -157,7 +157,7 @@ mod test {
                     SeqNum(u64::MAX), // state_root_delay
                 )
             },
-            LocalAsyncStateVerify::default,
+            PeerAsyncStateVerify::default,
             Duration::from_millis(2), // delta
             0,                        // proposal_tx_limit
             SeqNum(2000),             // val_set_update_interval
@@ -231,7 +231,7 @@ mod test {
                     SeqNum(u64::MAX), // state_root_delay
                 )
             },
-            LocalAsyncStateVerify::default,
+            PeerAsyncStateVerify::default,
             Duration::from_millis(2), // delta
             0,                        // proposal_tx_limit
             SeqNum(2000),             // val_set_update_interval
@@ -322,7 +322,7 @@ mod test {
                     SeqNum(u64::MAX), // state_root_delay
                 )
             },
-            LocalAsyncStateVerify::default,
+            PeerAsyncStateVerify::default,
             Duration::from_millis(2), // delta
             0,                        // proposal_tx_limit
             SeqNum(2000),             // val_set_update_interval

--- a/monad-mock-swarm/tests/common/mod.rs
+++ b/monad-mock-swarm/tests/common/mod.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_consensus_types::{
     block::Block, block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
 };
@@ -40,7 +40,7 @@ impl SwarmRelation for QuicSwarm {
         ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
     type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
     type TxPool = MockTxPool;
-    type AsyncStateRootVerify = LocalAsyncStateVerify<
+    type AsyncStateRootVerify = PeerAsyncStateVerify<
         Self::SignatureCollectionType,
         <Self::ValidatorSetTypeFactory as ValidatorSetTypeFactory>::ValidatorSetType,
     >;

--- a/monad-mock-swarm/tests/epoch.rs
+++ b/monad-mock-swarm/tests/epoch.rs
@@ -7,7 +7,7 @@ mod test {
     };
 
     use itertools::Itertools;
-    use monad_async_state_verify::LocalAsyncStateVerify;
+    use monad_async_state_verify::PeerAsyncStateVerify;
     use monad_consensus_types::{
         block::Block, block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
     };
@@ -53,7 +53,7 @@ mod test {
             ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
         type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
         type TxPool = MockTxPool;
-        type AsyncStateRootVerify = LocalAsyncStateVerify<
+        type AsyncStateRootVerify = PeerAsyncStateVerify<
             Self::SignatureCollectionType,
             <Self::ValidatorSetTypeFactory as ValidatorSetTypeFactory>::ValidatorSetType,
         >;
@@ -144,7 +144,7 @@ mod test {
                     SeqNum(u64::MAX), // state_root_delay
                 )
             },
-            LocalAsyncStateVerify::default,
+            PeerAsyncStateVerify::default,
             Duration::from_millis(2), // delta
             0,                        // proposal_tx_limit
             val_set_update_interval,  // val_set_update_interval
@@ -219,7 +219,7 @@ mod test {
                     SeqNum(u64::MAX), // state_root_delay
                 )
             },
-            LocalAsyncStateVerify::default,
+            PeerAsyncStateVerify::default,
             Duration::from_millis(2), // delta
             0,                        // proposal_tx_limit
             val_set_update_interval,  // val_set_update_interval
@@ -327,7 +327,7 @@ mod test {
                     SeqNum(4), // state_root_delay
                 )
             },
-            LocalAsyncStateVerify::default,
+            PeerAsyncStateVerify::default,
             Duration::from_millis(2), // delta
             0,                        // proposal_tx_limit
             val_set_update_interval,  // val_set_update_interval

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use common::QuicSwarm;
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_consensus_types::{
     block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
 };
@@ -29,7 +29,7 @@ use monad_wal::mock::MockWALoggerConfig;
 #[test]
 fn many_nodes_noser() {
     let state_configs = make_state_configs::<NoSerSwarm>(
-        100, // num_nodes
+        40, // num_nodes
         ValidatorSetFactory::default,
         SimpleRoundRobin::default,
         MockTxPool::default,
@@ -39,7 +39,7 @@ fn many_nodes_noser() {
                 SeqNum(4), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(2), // delta
         0,                        // proposal_tx_limit
         SeqNum(2000),             // val_set_update_interval
@@ -90,7 +90,7 @@ fn many_nodes_quic() {
                 SeqNum(4), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(10), // delta
         150,                       // proposal_tx_limit
         SeqNum(2000),              // val_set_update_interval
@@ -153,7 +153,7 @@ fn many_nodes_quic_bw() {
                 SeqNum(u64::MAX), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(300), // delta
         5000,                       // proposal_tx_limit
         SeqNum(2000),               // val_set_update_interval

--- a/monad-mock-swarm/tests/many_nodes_metrics.rs
+++ b/monad-mock-swarm/tests/many_nodes_metrics.rs
@@ -1,7 +1,7 @@
 mod common;
 use std::{collections::BTreeSet, time::Duration};
 
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_consensus_types::{
     block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
 };
@@ -40,7 +40,7 @@ fn many_nodes_metrics() {
     tracing::subscriber::set_global_default(subscriber).expect("unable to set global subscriber");
 
     let state_configs = make_state_configs::<NoSerSwarm>(
-        100, // num_nodes
+        40, // num_nodes
         ValidatorSetFactory::default,
         SimpleRoundRobin::default,
         MockTxPool::default,
@@ -50,7 +50,7 @@ fn many_nodes_metrics() {
                 SeqNum(4), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(2), // delta
         0,                        // proposal_tx_limit
         SeqNum(2000),             // val_set_update_interval

--- a/monad-mock-swarm/tests/msg_delays.rs
+++ b/monad-mock-swarm/tests/msg_delays.rs
@@ -1,7 +1,7 @@
 mod common;
 use std::{collections::BTreeSet, time::Duration};
 
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_consensus_types::{
     block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
 };
@@ -33,7 +33,7 @@ fn two_nodes() {
                 SeqNum(4), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(101), // delta
         0,                          // proposal_tx_limit
         SeqNum(2000),               // val_set_update_interval

--- a/monad-mock-swarm/tests/order.rs
+++ b/monad-mock-swarm/tests/order.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_consensus_types::{
     block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
 };
@@ -69,7 +69,7 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
                 SeqNum(1), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(2), // delta
         0,                        // proposal_tx_limit
         SeqNum(2000),             // val_set_update_interval

--- a/monad-mock-swarm/tests/rand_lat.rs
+++ b/monad-mock-swarm/tests/rand_lat.rs
@@ -1,7 +1,7 @@
 mod common;
 use std::{collections::BTreeSet, env};
 
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_consensus_types::{
     block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
 };
@@ -73,7 +73,7 @@ fn nodes_with_random_latency(seed: u64) {
                 SeqNum(u64::MAX), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(250), // delta
         0,                          // proposal_tx_limit
         SeqNum(2000),               // val_set_update_interval

--- a/monad-mock-swarm/tests/replay.rs
+++ b/monad-mock-swarm/tests/replay.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_consensus_types::{
     block::{Block, BlockType},
     block_validator::MockValidator,
@@ -51,7 +51,7 @@ impl SwarmRelation for ReplaySwarm {
         ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
     type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
     type TxPool = MockTxPool;
-    type AsyncStateRootVerify = LocalAsyncStateVerify<
+    type AsyncStateRootVerify = PeerAsyncStateVerify<
         Self::SignatureCollectionType,
         <Self::ValidatorSetTypeFactory as ValidatorSetTypeFactory>::ValidatorSetType,
     >;
@@ -96,7 +96,7 @@ pub fn recover_nodes_msg_delays(
         MockTxPool::default,
         || MockValidator,
         || NopStateRoot,
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(101), // delta
         proposal_size,              // proposal_tx_limit
         val_set_update_interval,    // val_set_update_interval
@@ -171,7 +171,7 @@ pub fn recover_nodes_msg_delays(
         MockTxPool::default,
         || MockValidator,
         || NopStateRoot,
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(2), // delta
         proposal_size,            // proposal_tx_limit
         val_set_update_interval,  // val_set_update_interval

--- a/monad-mock-swarm/tests/single_node_metrics.rs
+++ b/monad-mock-swarm/tests/single_node_metrics.rs
@@ -1,7 +1,7 @@
 mod common;
 use std::{collections::BTreeSet, time::Duration};
 
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_consensus_types::{
     block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
 };
@@ -50,7 +50,7 @@ fn two_nodes_metrics() {
                 SeqNum(4), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(2), // delta
         0,                        // proposal_tx_limit
         SeqNum(2000),             // val_set_update_interval

--- a/monad-mock-swarm/tests/two_nodes_bls.rs
+++ b/monad-mock-swarm/tests/two_nodes_bls.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeSet, time::Duration};
 
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_bls::BlsSignatureCollection;
 use monad_consensus_types::{
     block::Block, block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
@@ -39,7 +39,7 @@ impl SwarmRelation for BLSSwarm {
         ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
     type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
     type TxPool = MockTxPool;
-    type AsyncStateRootVerify = LocalAsyncStateVerify<
+    type AsyncStateRootVerify = PeerAsyncStateVerify<
         Self::SignatureCollectionType,
         <Self::ValidatorSetTypeFactory as ValidatorSetTypeFactory>::ValidatorSetType,
     >;
@@ -79,7 +79,7 @@ fn two_nodes_bls() {
                 SeqNum(4), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(2), // delta
         0,                        // proposal_tx_limit
         SeqNum(2000),             // val_set_update_interval

--- a/monad-mock-swarm/tests/two_nodes_quic.rs
+++ b/monad-mock-swarm/tests/two_nodes_quic.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use common::QuicSwarm;
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_consensus_types::{
     block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
 };
@@ -40,7 +40,7 @@ fn two_nodes_quic() {
                 SeqNum(4), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(10), // delta
         150,                       // proposal_tx_limit
         SeqNum(2000),              // val_set_update_interval
@@ -108,7 +108,7 @@ fn two_nodes_quic_bw() {
                 SeqNum(4), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(1000), // delta
         100,                         // proposal_tx_limit
         SeqNum(2000),                // val_set_update_interval

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -6,7 +6,7 @@ use std::{
 use clap::CommandFactory;
 use config::{NodeBootstrapPeerConfig, NodeNetworkConfig};
 use futures_util::{FutureExt, StreamExt};
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_bls::BlsSignatureCollection;
 use monad_consensus_state::ConsensusConfig;
 use monad_consensus_types::{
@@ -134,7 +134,7 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         transaction_pool: EthTxPool::default(),
         block_validator: MockValidator,
         state_root_validator: NopStateRoot {},
-        async_state_verify: LocalAsyncStateVerify::default(),
+        async_state_verify: PeerAsyncStateVerify::default(),
         validators,
         key: node_state.secp256k1_identity,
         certkey: node_state.bls12_381_identity,

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -3,7 +3,7 @@ use std::{
     time::Duration,
 };
 
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_consensus_types::{
     block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
 };
@@ -37,7 +37,7 @@ fn random_latency_test(seed: u64) {
                 SeqNum(4), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(250), // delta
         0,                          // proposal_tx_limit
         SeqNum(2000),               // val_set_update_interval
@@ -88,7 +88,7 @@ fn delayed_message_test(seed: u64) {
                 SeqNum(4), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(2), // delta
         0,                        // proposal_tx_limit
         SeqNum(2000),             // val_set_update_interval

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -1,4 +1,4 @@
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_consensus_state::{command::Checkpoint, ConsensusConfig};
 use monad_consensus_types::{
     block::Block, block_validator::MockValidator, payload::NopStateRoot,
@@ -144,8 +144,7 @@ type MonadStateType<ST, SCT> = MonadState<
     EthTxPool,
     MockValidator,
     NopStateRoot,
-    LocalAsyncStateVerify<SCT, <ValidatorSetFactory<CertificateSignaturePubKey<ST>> as ValidatorSetTypeFactory>::ValidatorSetType>
-    >;
+    PeerAsyncStateVerify<SCT, <ValidatorSetFactory<CertificateSignaturePubKey<ST>> as ValidatorSetTypeFactory>::ValidatorSetType>>;
 
 pub struct StateConfig<ST, SCT>
 where
@@ -187,7 +186,7 @@ where
         transaction_pool: EthTxPool::default(),
         block_validator: MockValidator {},
         state_root_validator: NopStateRoot::default(),
-        async_state_verify: LocalAsyncStateVerify::default(),
+        async_state_verify: PeerAsyncStateVerify::default(),
         validators: config.validators,
         key: config.key,
         certkey: config.cert_key,

--- a/monad-testutil/examples/logs_gen.rs
+++ b/monad-testutil/examples/logs_gen.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeSet, path::PathBuf, time::Duration};
 
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_consensus_types::{
     block::Block, block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
 };
@@ -41,7 +41,7 @@ impl SwarmRelation for LogSwarm {
         ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
     type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
     type TxPool = MockTxPool;
-    type AsyncStateRootVerify = LocalAsyncStateVerify<
+    type AsyncStateRootVerify = PeerAsyncStateVerify<
         Self::SignatureCollectionType,
         <Self::ValidatorSetTypeFactory as ValidatorSetTypeFactory>::ValidatorSetType,
     >;
@@ -86,7 +86,7 @@ pub fn generate_log(
                 SeqNum(state_root_delay), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         delta,                   // delta
         proposal_size,           // proposal_tx_limit
         val_set_update_interval, // val_set_update_interval

--- a/monad-virtual-bench/benches/many_nodes_bench.rs
+++ b/monad-virtual-bench/benches/many_nodes_bench.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_bls::BlsSignatureCollection;
 use monad_consensus_types::{
     block::Block, block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
@@ -52,7 +52,7 @@ impl SwarmRelation for NopSwarm {
         ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
     type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
     type TxPool = MockTxPool;
-    type AsyncStateRootVerify = LocalAsyncStateVerify<
+    type AsyncStateRootVerify = PeerAsyncStateVerify<
         Self::SignatureCollectionType,
         <Self::ValidatorSetTypeFactory as ValidatorSetTypeFactory>::ValidatorSetType,
     >;
@@ -88,7 +88,7 @@ impl SwarmRelation for BlsSwarm {
         ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
     type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
     type TxPool = MockTxPool;
-    type AsyncStateRootVerify = LocalAsyncStateVerify<
+    type AsyncStateRootVerify = PeerAsyncStateVerify<
         Self::SignatureCollectionType,
         <Self::ValidatorSetTypeFactory as ValidatorSetTypeFactory>::ValidatorSetType,
     >;
@@ -123,7 +123,7 @@ fn many_nodes_nop_timeout() -> u128 {
                 SeqNum(u64::MAX), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(20), // delta
         0,                         // proposal_tx_limit
         SeqNum(2000),              // val_set_update_interval
@@ -192,7 +192,7 @@ fn many_nodes_bls_timeout() -> u128 {
                 SeqNum(u64::MAX), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(20), // delta
         0,                         // proposal_tx_limit
         SeqNum(2000),              // val_set_update_interval

--- a/monad-virtual-bench/benches/two_node_bench.rs
+++ b/monad-virtual-bench/benches/two_node_bench.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeSet, time::Duration};
 
-use monad_async_state_verify::LocalAsyncStateVerify;
+use monad_async_state_verify::PeerAsyncStateVerify;
 use monad_consensus_types::{
     block_validator::MockValidator, payload::StateRoot, txpool::MockTxPool,
 };
@@ -29,7 +29,7 @@ fn two_nodes_virtual() -> u128 {
                 SeqNum(4), // state_root_delay
             )
         },
-        LocalAsyncStateVerify::default,
+        PeerAsyncStateVerify::default,
         Duration::from_millis(2), // delta
         0,                        // proposal_tx_limit
         SeqNum(2000),             // val_set_update_interval


### PR DESCRIPTION
An AsyncStateRootVerify implementation that does the actual broadcast and forms certificate after collection majority votes on the same state root hash.