### PR TITLE
Factor out tc-gen script

### DIFF
--- a/docker/testground/Dockerfile
+++ b/docker/testground/Dockerfile
@@ -10,10 +10,12 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/src/monad-bft/target \
     cargo build --release --bin monad-testground && \
     mv target/release/monad-testground testground
-RUN python3 docker/testground/tc-gen.py > tc.sh
+RUN python3 docker/testground/topology-gen.py topo.json
+RUN python3 monad-scripts/tc/tc-gen.py topo.json tc.sh addresses
 
 # Runner
 FROM debian:buster-slim
+SHELL ["/bin/bash", "-c"]
 WORKDIR /usr/src/monad-bft
 
 RUN apt update
@@ -21,6 +23,7 @@ RUN apt install -y iproute2
 RUN apt clean
 COPY --from=builder /usr/src/monad-bft/testground /usr/local/bin/monad-testground
 COPY --from=builder /usr/src/monad-bft/tc.sh .
+COPY --from=builder /usr/src/monad-bft/addresses .
 
 ENV RUST_LOG=monad_testground=DEBUG
-CMD ["bash", "tc.sh"]
+CMD source tc.sh && MONAD_MEMPOOL_RNDUDS=true monad-testground -o http://jaeger:4317 --addresses $(<addresses)

--- a/docker/testground/topology-gen.py
+++ b/docker/testground/topology-gen.py
@@ -1,0 +1,41 @@
+topology = [
+    {
+        "name": "us",
+        "latencies_ms": [10, 50, 100],
+        "nodes": [
+            {
+                "up_Mbps": 100,
+                "down_Mbps": 100,
+            },
+        ] * 5,
+    },
+    {
+        "name": "europe",
+        "latencies_ms": [50, 10, 50],
+        "nodes": [
+            {
+                "up_Mbps": 100,
+                "down_Mbps": 100,
+            },
+        ] * 5,
+    },
+    {
+        "name": "asia",
+        "latencies_ms": [100, 50, 10],
+        "nodes": [
+            {
+                "up_Mbps": 100,
+                "down_Mbps": 100,
+            },
+        ] * 5,
+    },
+]
+
+import argparse
+parser = argparse.ArgumentParser()
+parser.add_argument("topology_output_file")
+args = parser.parse_args()
+
+with open(args.topology_output_file, 'w') as f:
+    import json
+    json.dump(topology, f)

--- a/monad-scripts/tc/tc-gen.py
+++ b/monad-scripts/tc/tc-gen.py
@@ -1,38 +1,17 @@
 #!/usr/bin/python3
 
+import argparse
+parser = argparse.ArgumentParser()
+parser.add_argument("topology_input_file")
+parser.add_argument("tc_output_file")
+parser.add_argument("addresses_output_file")
+args = parser.parse_args()
+
+with open(args.topology_input_file) as topofile:
+    import json
+    regions = json.load(topofile)
+
 device = "lo"
-regions = [
-    {
-        "name": "us",
-        "latencies_ms": [10, 50, 100],
-        "nodes": [
-            {
-                "up_Mbps": 100,
-                "down_Mbps": 100,
-            },
-        ] * 20,
-    },
-    {
-        "name": "europe",
-        "latencies_ms": [50, 10, 50],
-        "nodes": [
-            {
-                "up_Mbps": 100,
-                "down_Mbps": 100,
-            },
-        ] * 20,
-    },
-    {
-        "name": "asia",
-        "latencies_ms": [100, 50, 10],
-        "nodes": [
-            {
-                "up_Mbps": 100,
-                "down_Mbps": 100,
-            },
-        ] * 20,
-    },
-]
 
 commands = []
 node_ips = []
@@ -156,10 +135,9 @@ for region_idx, region in enumerate(regions):
         node_ips.append(node_ip + ":5000")
         node_idx += 1
 
+with open(args.tc_output_file, 'w') as tcfile:
+    for command in commands:
+        tcfile.write(f"{command}\n")
 
-commands.append("")
-commands.append("")
-commands.append("MONAD_MEMPOOL_RNDUDS=true monad-testground -o http://jaeger:4317 --addresses {}".format(" ".join(node_ips)))
-
-for command in commands:
-    print(command)
+with open(args.addresses_output_file, 'w') as addressesfile:
+    addressesfile.write(" ".join(node_ips))


### PR DESCRIPTION
Factor out the tc-gen script into tc-gen.py and topology-gen.py This allows tc-gen to be reused across multiple containers

This is in preparation for a gossip-only test using the tc environment.