### PR TITLE
Change sender in MonadEvent to NodeId

### DIFF
--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -134,13 +134,13 @@ impl<E, OM, B, C, SCT: SignatureCollection> Command<E, OM, B, C, SCT> {
 #[derive(Clone, PartialEq, Eq)]
 pub enum ConsensusEvent<ST, SCT: SignatureCollection> {
     Message {
-        sender: SCT::NodeIdPubKey,
+        sender: NodeId<SCT::NodeIdPubKey>,
         unverified_message: Unverified<ST, Unvalidated<ConsensusMessage<SCT>>>,
     },
     Timeout(TimeoutVariant),
     StateUpdate((SeqNum, ConsensusHash)),
     BlockSyncResponse {
-        sender: SCT::NodeIdPubKey,
+        sender: NodeId<SCT::NodeIdPubKey>,
         unvalidated_response: Unvalidated<BlockSyncResponseMessage<SCT>>,
     },
 }
@@ -191,7 +191,7 @@ pub struct FetchedBlock<SCT: SignatureCollection> {
 pub enum BlockSyncEvent<SCT: SignatureCollection> {
     /// A peer requesting for a missing block
     BlockSyncRequest {
-        sender: SCT::NodeIdPubKey,
+        sender: NodeId<SCT::NodeIdPubKey>,
         unvalidated_request: Unvalidated<RequestBlockSyncMessage>,
     },
     /// Fetched full block from the consensus ledger
@@ -226,7 +226,7 @@ pub enum ValidatorEvent<SCT: SignatureCollection> {
 pub enum MempoolEvent<SCT: SignatureCollection> {
     /// Txns that are incoming from other Nodes
     CascadeTxns {
-        sender: SCT::NodeIdPubKey,
+        sender: NodeId<SCT::NodeIdPubKey>,
         txns: Unvalidated<CascadeTxMessage>,
     },
     /// Txns that are incoming via RPC (users)

--- a/monad-mock-swarm/tests/protobuf.rs
+++ b/monad-mock-swarm/tests/protobuf.rs
@@ -23,7 +23,7 @@ use monad_testutil::{
     signing::{get_certificate_key, get_key},
     validators::create_keys_w_validators,
 };
-use monad_types::{BlockId, Epoch, Round, SeqNum};
+use monad_types::{BlockId, Epoch, NodeId, Round, SeqNum};
 use monad_validator::{
     epoch_manager::EpochManager,
     simple_round_robin::SimpleRoundRobin,
@@ -72,7 +72,7 @@ fn test_consensus_message_event_vote_multisig() {
     let unverified_votemsg = Unverified::new(Unvalidated::new(votemsg), sig);
 
     let event = MonadEvent::ConsensusEvent(ConsensusEvent::Message {
-        sender: keypair.pubkey(),
+        sender: NodeId::new(keypair.pubkey()),
         unverified_message: unverified_votemsg,
     });
 
@@ -116,7 +116,7 @@ fn test_consensus_message_event_proposal_bls() {
     let consensus_proposal_msg = ConsensusMessage::Proposal((*proposal).clone());
 
     let event = MonadEvent::ConsensusEvent(ConsensusEvent::Message {
-        sender: proposal.author().pubkey(),
+        sender: NodeId::new(proposal.author().pubkey()),
         unverified_message: Unverified::new(
             Unvalidated::new(consensus_proposal_msg),
             *proposal.author_signature(),

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -13,7 +13,7 @@ import "validator_data.proto";
 // this type doesn't have a pair rust type
 // conversion is done in ProtoConsensusEvent
 message ProtoMessageWithSender {
-  monad_proto.basic.ProtoPubkey sender = 1;
+  monad_proto.basic.ProtoNodeId sender = 1;
   monad_proto.message.ProtoUnverifiedConsensusMessage unverified_message = 2;
 }
 
@@ -49,12 +49,12 @@ message ProtoStateUpdateEvent {
 }
 
 message ProtoBlockSyncRequestWithSender {
-  monad_proto.basic.ProtoPubkey sender = 1;
+  monad_proto.basic.ProtoNodeId sender = 1;
   monad_proto.message.ProtoRequestBlockSyncMessage request = 2;  
 }
 
 message ProtoBlockSyncResponseWithSender {
-  monad_proto.basic.ProtoPubkey sender = 1;
+  monad_proto.basic.ProtoNodeId sender = 1;
   monad_proto.message.ProtoBlockSyncMessage response = 2;
 }
 
@@ -85,7 +85,7 @@ message ProtoUserTx {
 }
 
 message ProtoCascadeTxnsWithSender {
-  monad_proto.basic.ProtoPubkey sender = 1;
+  monad_proto.basic.ProtoNodeId sender = 1;
   monad_proto.message.ProtoCascadeTxMessage cascade = 2;
 }
 

--- a/monad-state/src/blocksync.rs
+++ b/monad-state/src/blocksync.rs
@@ -117,7 +117,7 @@ where
                 .into_inner();
                 let block_id = validated_request.block_id;
                 self.block_sync_responder.handle_request_block_sync_message(
-                    NodeId::new(sender),
+                    sender,
                     validated_request,
                     self.consensus.fetch_uncommitted_block(&block_id),
                 )

--- a/monad-state/src/consensus.rs
+++ b/monad-state/src/consensus.rs
@@ -22,7 +22,7 @@ use monad_executor_glue::{
     CheckpointCommand, Command, ConsensusEvent, ExecutionLedgerCommand, LedgerCommand, MonadEvent,
     RouterCommand, StateRootHashCommand, TimerCommand,
 };
-use monad_types::{NodeId, RouterTarget, TimeoutVariant};
+use monad_types::{RouterTarget, TimeoutVariant};
 use monad_validator::{
     epoch_manager::EpochManager, leader_election::LeaderElection,
     validator_set::ValidatorSetTypeFactory, validators_epoch_mapping::ValidatorsEpochMapping,
@@ -82,7 +82,7 @@ where
                 let verified_message = match unverified_message.verify(
                     self.epoch_manager,
                     self.val_epoch_map,
-                    &sender,
+                    &sender.pubkey(),
                 ) {
                     Ok(m) => m,
                     Err(e) => {
@@ -188,12 +188,8 @@ where
                     .val_epoch_map
                     .get_val_set(&current_epoch)
                     .expect("current validator set should be in the map");
-                self.consensus.handle_block_sync(
-                    NodeId::new(sender),
-                    validated_response,
-                    val_set,
-                    self.metrics,
-                )
+                self.consensus
+                    .handle_block_sync(sender, validated_response, val_set, self.metrics)
             }
         };
         consensus_cmds

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -248,24 +248,24 @@ where
         // malformed stuff (that gets added to event log) can be slashed? TODO
         match self {
             MonadMessage::Consensus(msg) => MonadEvent::ConsensusEvent(ConsensusEvent::Message {
-                sender: from.pubkey(),
+                sender: from,
                 unverified_message: msg,
             }),
 
             MonadMessage::BlockSyncRequest(msg) => {
                 MonadEvent::BlockSyncEvent(BlockSyncEvent::BlockSyncRequest {
-                    sender: from.pubkey(),
+                    sender: from,
                     unvalidated_request: msg,
                 })
             }
             MonadMessage::BlockSyncResponse(msg) => {
                 MonadEvent::ConsensusEvent(ConsensusEvent::BlockSyncResponse {
-                    sender: from.pubkey(),
+                    sender: from,
                     unvalidated_response: msg,
                 })
             }
             MonadMessage::CascadeTxns(msg) => MonadEvent::MempoolEvent(MempoolEvent::CascadeTxns {
-                sender: from.pubkey(),
+                sender: from,
                 txns: msg,
             }),
         }

--- a/monad-wal/benches/event_bench.rs
+++ b/monad-wal/benches/event_bench.rs
@@ -102,7 +102,7 @@ fn bench_proposal(c: &mut Criterion) {
     );
 
     let event = MonadEvent::ConsensusEvent(ConsensusEvent::Message {
-        sender: author_keypair.pubkey(),
+        sender: NodeId::new(author_keypair.pubkey()),
         unverified_message,
     });
 
@@ -135,7 +135,7 @@ fn bench_vote(c: &mut Criterion) {
     let unverified_message = Unverified::new(Unvalidated::new(vote), <<SignatureCollectionType as SignatureCollection>::SignatureType as CertificateSignature>::sign(vote_hash.as_ref(), &keypair));
 
     let event = MonadEvent::ConsensusEvent(ConsensusEvent::Message {
-        sender: keypair.pubkey(),
+        sender: NodeId::new(keypair.pubkey()),
         unverified_message,
     });
 
@@ -234,7 +234,7 @@ fn bench_timeout(c: &mut Criterion) {
     );
 
     let event = MonadEvent::ConsensusEvent(ConsensusEvent::Message {
-        sender: author_keypair.pubkey(),
+        sender: NodeId::new(author_keypair.pubkey()),
         unverified_message,
     });
 


### PR DESCRIPTION
MonadState uses NodeId to identify its peers/sender of the message. We are unwrap then immediately wrap the pubkeys with NodeId. The change removes that step.