### PR TITLE
Fix benchmarks CI.

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,10 +26,12 @@ jobs:
 
       # Run benchmark on master
       - name: Run benchmark on master
+        shell: bash
         run: cd master && cargo bench -- --output-format bencher | tee bench.txt
 
       # Run benchmark on PR
       - name: Run benchmark on PR
+        shell: bash
         run: cd pr && cargo bench -- --output-format bencher | tee bench.txt
 
       - name: Compare benchmarks


### PR DESCRIPTION
builds on #542 

Piping the output of `cargo bench` to `tee` was inadvertently swallowing the error status of the `cargo bench` command. Setting the shell explicitly to `bash` in Github Actions fixes this to fail fast by setting `-o pipefail` .

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference