### PR TITLE
MockSwarmVerifier

### DIFF
--- a/monad-mock-swarm/src/lib.rs
+++ b/monad-mock-swarm/src/lib.rs
@@ -5,3 +5,4 @@ pub mod swarm_relation;
 pub mod terminator;
 pub mod transformer;
 mod utils;
+pub mod verifier;

--- a/monad-mock-swarm/src/verifier.rs
+++ b/monad-mock-swarm/src/verifier.rs
@@ -1,0 +1,76 @@
+use std::time::Duration;
+
+use crate::{mock_swarm::Nodes, swarm_relation::SwarmRelation};
+
+#[derive(Debug, PartialEq, Eq)]
+enum ExpectedTick {
+    /// Exact tick timestamp
+    Exact(Duration),
+    /// Range(tick, delta)
+    /// Expects swarm tick in the range [tick - delta, tick + delta]
+    Range(Duration, Duration),
+    /// No expected
+    None,
+}
+
+#[derive(Debug)]
+pub struct MockSwarmVerifier {
+    tick: ExpectedTick,
+}
+
+impl Default for MockSwarmVerifier {
+    fn default() -> Self {
+        Self {
+            tick: ExpectedTick::None,
+        }
+    }
+}
+
+impl MockSwarmVerifier {
+    pub fn tick_exact(mut self, tick: Duration) -> Self {
+        if self.tick != ExpectedTick::None {
+            panic!("Tick verify already set");
+        }
+        self.tick = ExpectedTick::Exact(tick);
+        self
+    }
+
+    pub fn tick_range(mut self, mean_tick: Duration, delta: Duration) -> Self {
+        if self.tick != ExpectedTick::None {
+            panic!("Tick verify already set");
+        }
+        self.tick = ExpectedTick::Range(mean_tick, delta);
+        self
+    }
+}
+
+impl MockSwarmVerifier {
+    pub fn verify<S: SwarmRelation>(&self, swarm: &Nodes<S>) -> bool {
+        let actual_tick = swarm.tick;
+        match self.tick {
+            ExpectedTick::Exact(tick) => {
+                if actual_tick != tick {
+                    eprintln!(
+                        "Tick verify error expected={:?} actual={:?}",
+                        tick, swarm.tick
+                    );
+                    return false;
+                }
+            }
+            ExpectedTick::Range(mean, delta) => {
+                let lower = mean.saturating_sub(delta);
+                let upper = mean.saturating_add(delta);
+                if actual_tick < lower || actual_tick > upper {
+                    eprintln!(
+                        "Tick verify error expected=[{:?},{:?}] actual={:?}",
+                        lower, upper, actual_tick
+                    );
+                    return false;
+                }
+            }
+            ExpectedTick::None => {}
+        }
+
+        true
+    }
+}

--- a/monad-mock-swarm/tests/single_node.rs
+++ b/monad-mock-swarm/tests/single_node.rs
@@ -14,7 +14,7 @@ use monad_crypto::certificate_signature::CertificateKeyPair;
 use monad_gossip::mock::MockGossipConfig;
 use monad_mock_swarm::{
     mock_swarm::SwarmBuilder, node::NodeBuilder, swarm_relation::NoSerSwarm,
-    terminator::UntilTerminator,
+    terminator::UntilTerminator, verifier::MockSwarmVerifier,
 };
 use monad_quic::QuicRouterSchedulerConfig;
 use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
@@ -78,6 +78,10 @@ fn two_nodes() {
         .step_until(&mut UntilTerminator::new().until_tick(Duration::from_secs(10)))
         .is_some()
     {}
+
+    let verifier = MockSwarmVerifier::default().tick_exact(Duration::from_secs(10));
+    assert!(verifier.verify(&swarm));
+
     swarm_ledger_verification(&swarm, 1024);
 }
 


### PR DESCRIPTION
MockSwarmVerifier verifies the Nodes state after running the mock swarm test. It supports tick verification. Adds an example to two_nodes test