### PR TITLE
Version check the consensus protocol messages

### DIFF
--- a/monad-compress/examples/proposal.rs
+++ b/monad-compress/examples/proposal.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use monad_bls::BlsSignatureCollection;
 use monad_compress::{brotli::BrotliCompression, CompressionAlgo};
-use monad_consensus::messages::consensus_message::ConsensusMessage;
+use monad_consensus::messages::consensus_message::{ConsensusMessage, ProtocolMessage};
 use monad_consensus_types::{
     payload::{ExecutionArtifacts, FullTransactionList},
     voting::ValidatorMapping,
@@ -69,9 +69,12 @@ fn main() {
         .find(|k| k.pubkey() == proposer_leader.pubkey())
         .expect("key in valset");
 
-    let proposal: VerifiedMonadMessage<_, _> = ConsensusMessage::Proposal(proposal)
-        .sign::<SecpSignature>(leader_key)
-        .into();
+    let proposal: VerifiedMonadMessage<_, _> = ConsensusMessage {
+        version: "Example".into(),
+        message: ProtocolMessage::Proposal(proposal),
+    }
+    .sign::<SecpSignature>(leader_key)
+    .into();
 
     let proposal_bytes: Bytes = proposal.serialize();
 

--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -2,7 +2,10 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use monad_consensus::{
-    messages::{consensus_message::ConsensusMessage, message::TimeoutMessage},
+    messages::{
+        consensus_message::{ConsensusMessage, ProtocolMessage},
+        message::TimeoutMessage,
+    },
     pacemaker::PacemakerCommand,
     validation::signing::{Validated, Verified},
     vote_state::VoteStateCommand,
@@ -69,13 +72,17 @@ where
     pub fn from_pacemaker_command(
         keypair: &ST::KeyPairType,
         cert_keypair: &SignatureCollectionKeyPairType<SCT>,
+        version: &str,
         cmd: PacemakerCommand<SCT>,
     ) -> Self {
         match cmd {
             PacemakerCommand::PrepareTimeout(tmo) => ConsensusCommand::Publish {
                 target: RouterTarget::Broadcast,
-                message: ConsensusMessage::Timeout(TimeoutMessage::new(tmo, cert_keypair))
-                    .sign(keypair),
+                message: ConsensusMessage {
+                    version: version.into(),
+                    message: ProtocolMessage::Timeout(TimeoutMessage::new(tmo, cert_keypair)),
+                }
+                .sign(keypair),
             },
             PacemakerCommand::Schedule { duration } => ConsensusCommand::Schedule {
                 duration,

--- a/monad-consensus-types/src/metrics.rs
+++ b/monad-consensus-types/src/metrics.rs
@@ -9,6 +9,7 @@ pub struct ValidationErrors {
     pub invalid_seq_num: u64,
     pub val_data_unavailable: u64,
     pub invalid_vote_message: u64,
+    pub invalid_version: u64,
 }
 
 #[derive(Debug, Default)]

--- a/monad-consensus-types/src/validation.rs
+++ b/monad-consensus-types/src/validation.rs
@@ -18,4 +18,6 @@ pub enum Error {
     ValidatorDataUnavailable,
     /// VoteMessage does not contain a valid commit condition
     InvalidVoteMessage,
+    /// Consensus Message version must match
+    InvalidVersion,
 }

--- a/monad-consensus/tests/proposal.rs
+++ b/monad-consensus/tests/proposal.rs
@@ -1,5 +1,8 @@
 use monad_consensus::{
-    messages::{consensus_message::ConsensusMessage, message::ProposalMessage},
+    messages::{
+        consensus_message::{ConsensusMessage, ProtocolMessage},
+        message::ProposalMessage,
+    },
     validation::signing::Unvalidated,
 };
 use monad_consensus_types::{
@@ -87,7 +90,7 @@ fn test_proposal_hash() {
     );
     let author = NodeId::new(keypairs[0].pubkey());
 
-    let proposal = ConsensusMessage::Proposal(ProposalMessage {
+    let proposal = ProtocolMessage::Proposal(ProposalMessage {
         block: setup_block(
             author,
             Round(234),
@@ -100,8 +103,11 @@ fn test_proposal_hash() {
         ),
         last_round_tc: None,
     });
-
-    let sp = TestSigner::<SignatureType>::sign_object(proposal, &keypairs[0]);
+    let conmsg = ConsensusMessage {
+        version: "TEST".into(),
+        message: proposal,
+    };
+    let sp = TestSigner::<SignatureType>::sign_object(conmsg, &keypairs[0]);
 
     assert!(sp
         .verify(&epoch_manager, &val_epoch_map, &keypairs[0].pubkey())
@@ -164,7 +170,7 @@ fn test_proposal_author_not_sender() {
     let sender_keypair = &keypairs[1];
     let author = NodeId::new(author_keypair.pubkey());
 
-    let proposal = ConsensusMessage::Proposal(ProposalMessage {
+    let proposal = ProtocolMessage::Proposal(ProposalMessage {
         block: setup_block(
             author,
             Round(234),
@@ -177,8 +183,11 @@ fn test_proposal_author_not_sender() {
         ),
         last_round_tc: None,
     });
-
-    let sp = TestSigner::<SignatureType>::sign_object(proposal, author_keypair);
+    let conmsg = ConsensusMessage {
+        version: "TEST".into(),
+        message: proposal,
+    };
+    let sp = TestSigner::<SignatureType>::sign_object(conmsg, author_keypair);
     assert_eq!(
         sp.verify(&epoch_manager, &val_epoch_map, &sender_keypair.pubkey())
             .unwrap_err(),
@@ -195,7 +204,7 @@ fn test_proposal_invalid_author() {
     vlist.push((NodeId::new(author_keypair.pubkey()), Stake(0)));
 
     let author = NodeId::new(author_keypair.pubkey());
-    let proposal = ConsensusMessage::Proposal(ProposalMessage {
+    let proposal = ProtocolMessage::Proposal(ProposalMessage {
         block: setup_block(
             author,
             Round(234),
@@ -204,8 +213,11 @@ fn test_proposal_invalid_author() {
         ),
         last_round_tc: None,
     });
-
-    let sp = TestSigner::<SignatureType>::sign_object(proposal, &non_valdiator_keypair);
+    let conmsg = ConsensusMessage {
+        version: "TEST".into(),
+        message: proposal,
+    };
+    let sp = TestSigner::<SignatureType>::sign_object(conmsg, &non_valdiator_keypair);
 
     let vset = ValidatorSetFactory::default().create(vlist).unwrap();
     let vmap: ValidatorMapping<PubKeyType, _> = ValidatorMapping::new(vec![(

--- a/monad-mock-swarm/src/node.rs
+++ b/monad-mock-swarm/src/node.rs
@@ -9,7 +9,7 @@ use monad_async_state_verify::BoxedAsyncStateVerifyProcess;
 use monad_crypto::certificate_signature::CertificateSignaturePubKey;
 use monad_executor::Executor;
 use monad_executor_glue::MonadEvent;
-use monad_state::MonadStateBuilder;
+use monad_state::{MonadStateBuilder, MonadVersion};
 use monad_transformer::{LinkMessage, Pipeline, ID};
 use monad_validator::validator_set::BoxedValidatorSetTypeFactory;
 use monad_wal::{PersistenceLogger, PersistenceLoggerBuilder};
@@ -88,6 +88,7 @@ impl<S: SwarmRelation> NodeBuilder<S> {
         NodeBuilder {
             id: self.id,
             state_builder: MonadStateBuilder {
+                version: MonadVersion::new("MOCK_SWARM"),
                 validator_set_factory: BoxedValidatorSetTypeFactory::new(
                     self.state_builder.validator_set_factory,
                 ),

--- a/monad-mock-swarm/src/utils.rs
+++ b/monad-mock-swarm/src/utils.rs
@@ -5,7 +5,7 @@ pub mod test_tool {
 
     use monad_consensus::{
         messages::{
-            consensus_message::ConsensusMessage,
+            consensus_message::{ConsensusMessage, ProtocolMessage},
             message::{
                 BlockSyncResponseMessage, ProposalMessage, RequestBlockSyncMessage, TimeoutMessage,
                 VoteMessage,
@@ -93,7 +93,12 @@ pub mod test_tool {
             block: UnverifiedBlock(fake_block(round)),
             last_round_tc: None,
         };
-        ConsensusMessage::Proposal(internal_msg).sign(kp).into()
+        ConsensusMessage {
+            version: "TEST".into(),
+            message: ProtocolMessage::Proposal(internal_msg),
+        }
+        .sign(kp)
+        .into()
     }
 
     pub fn fake_vote_message(kp: &KeyPairType, round: Round) -> VerifiedMonadMessage<ST, SC> {
@@ -111,7 +116,12 @@ pub mod test_tool {
             },
             sig: NopSignature::sign(&[0x00_u8, 32], kp),
         };
-        ConsensusMessage::Vote(internal_msg).sign(kp).into()
+        ConsensusMessage {
+            version: "TEST".into(),
+            message: ProtocolMessage::Vote(internal_msg),
+        }
+        .sign(kp)
+        .into()
     }
 
     pub fn fake_timeout_message(kp: &KeyPairType) -> VerifiedMonadMessage<ST, SC> {
@@ -126,7 +136,12 @@ pub mod test_tool {
             },
             sig: NopSignature::sign(&[0x00_u8, 32], kp),
         };
-        ConsensusMessage::Timeout(internal_msg).sign(kp).into()
+        ConsensusMessage {
+            version: "TEST".into(),
+            message: ProtocolMessage::Timeout(internal_msg),
+        }
+        .sign(kp)
+        .into()
     }
 
     pub fn fake_request_block_sync() -> VerifiedMonadMessage<ST, SC> {

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -21,7 +21,7 @@ use monad_ipc::IpcReceiver;
 use monad_ledger::MonadFileLedger;
 use monad_quic::{SafeQuinnConfig, Service, ServiceConfig};
 use monad_secp::{KeyPair, SecpSignature};
-use monad_state::{MonadMessage, MonadStateBuilder, VerifiedMonadMessage};
+use monad_state::{MonadMessage, MonadStateBuilder, MonadVersion, VerifiedMonadMessage};
 use monad_types::{NodeId, Round, SeqNum};
 use monad_updaters::{
     checkpoint::MockCheckpoint, ledger::MockLedger, loopback::LoopbackExecutor,
@@ -129,6 +129,7 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
     };
 
     let builder = MonadStateBuilder {
+        version: MonadVersion::new("ALPHA"),
         validator_set_factory: ValidatorSetFactory::default(),
         leader_election: SimpleRoundRobin::default(),
         transaction_pool: EthTxPool::default(),

--- a/monad-proto/proto/message.proto
+++ b/monad-proto/proto/message.proto
@@ -46,6 +46,7 @@ message ProtoUnverifiedConsensusMessage {
     ProtoTimeoutMessage timeout = 2;
     ProtoVoteMessage vote = 3;
   }
+  string version = 4;
   monad_proto.signing.ProtoSignature author_signature = 6;
 }
 

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -18,7 +18,9 @@ use monad_ipc::{generate_uds_path, IpcReceiver};
 use monad_ledger::MonadFileLedger;
 use monad_mock_swarm::mock::MockExecutionLedger;
 use monad_quic::{SafeQuinnConfig, Service, ServiceConfig};
-use monad_state::{MonadMessage, MonadState, MonadStateBuilder, VerifiedMonadMessage};
+use monad_state::{
+    MonadMessage, MonadState, MonadStateBuilder, MonadVersion, VerifiedMonadMessage,
+};
 use monad_types::{NodeId, Round, SeqNum};
 use monad_updaters::{
     checkpoint::MockCheckpoint, ledger::MockLedger, local_router::LocalPeerRouter,
@@ -181,6 +183,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
 {
     MonadStateBuilder {
+        version: MonadVersion::new("TESTGROUND"),
         validator_set_factory: ValidatorSetFactory::default(),
         leader_election: SimpleRoundRobin::default(),
         transaction_pool: EthTxPool::default(),

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -4,7 +4,7 @@ use monad_consensus_state::ConsensusConfig;
 use monad_consensus_types::{block::BlockType, validator_data::ValidatorData};
 use monad_eth_types::EthAddress;
 use monad_mock_swarm::{mock_swarm::Nodes, swarm_relation::SwarmRelation};
-use monad_state::MonadStateBuilder;
+use monad_state::{MonadStateBuilder, MonadVersion};
 use monad_types::{Round, SeqNum, Stake};
 use monad_validator::validator_set::ValidatorSetType;
 
@@ -60,6 +60,7 @@ pub fn make_state_configs<S: SwarmRelation>(
     keys.into_iter()
         .zip(cert_keys)
         .map(|(key, certkey)| MonadStateBuilder {
+            version: MonadVersion::new("MOCK_SWARM"),
             validator_set_factory: validator_set_factory(),
             leader_election: leader_election(),
             transaction_pool: transaction_pool(),

--- a/monad-twins/utils/src/twin_reader.rs
+++ b/monad-twins/utils/src/twin_reader.rs
@@ -25,7 +25,7 @@ use monad_crypto::{
 };
 use monad_eth_types::EthAddress;
 use monad_mock_swarm::{swarm_relation::SwarmRelation, terminator::ProgressTerminator};
-use monad_state::MonadStateBuilder;
+use monad_state::{MonadStateBuilder, MonadVersion};
 use monad_testutil::validators::complete_keys_w_validators;
 use monad_transformer::ID;
 use monad_types::{NodeId, Round, SeqNum};
@@ -114,6 +114,7 @@ where
         Self {
             id: self.id,
             state_config: MonadStateBuilder {
+                version: MonadVersion::new("TWINS_TEST"),
                 validator_set_factory: self.state_config.validator_set_factory.clone(),
                 leader_election: self.state_config.leader_election.clone(),
                 transaction_pool: TT::default(),
@@ -329,6 +330,7 @@ where
             S::StateRootValidator,
             S::AsyncStateRootVerify,
         > {
+            version: MonadVersion::new("TWINS_TEST"),
             validator_set_factory: S::ValidatorSetTypeFactory::default(),
             leader_election: S::LeaderElection::default(),
             transaction_pool: S::TxPool::default(),


### PR DESCRIPTION
The consensus protocol and algorithm could change without any of the protocol messages acutally changing their structure so we should have a way of checking for versions. This aids in upgradability of the consensus algorithm.

The consensus protocol is neither backwards nor forwards compatible so we just use an exact string match to determine if a message should be validated.

This patch also includes the structure for a client major-minor version number but it is not checked yet.