### PR TITLE
Record metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,19 +1543,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.3",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3064,6 +3051,7 @@ dependencies = [
  "monad-gossip",
  "monad-ipc",
  "monad-ledger",
+ "monad-opentelemetry-executor",
  "monad-quic",
  "monad-secp",
  "monad-state",
@@ -3082,6 +3070,23 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "zeroize",
+]
+
+[[package]]
+name = "monad-opentelemetry-executor"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "monad-consensus-types",
+ "monad-crypto",
+ "monad-executor",
+ "monad-executor-glue",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3707,9 +3712,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4b8347cc26099d3aeee044065ecc3ae11469796b4d65d065a23a584ed92a6f"
+checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -3717,16 +3722,17 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af72d59a4484654ea8eb183fea5ae4eb6a41d7ac3e3bae5f4d2a282a3a7d3ca"
+checksum = "7e5e5a5c4135864099f3faafbe939eb4d7f9b80ebf68a8448da961b32a7c1275"
 dependencies = [
  "async-trait",
- "futures",
- "futures-util",
+ "futures-core",
  "http 0.2.11",
- "opentelemetry",
  "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
  "prost",
  "thiserror",
  "tokio",
@@ -3735,36 +3741,35 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045f8eea8c0fa19f7d48e7bc3128a39c2e5c533d5c61298c548dfefc1064474c"
+checksum = "b1e3f814aa9f8c905d0ee4bde026afd3b2577a97c10e1699912e3e44f0c4cbeb"
 dependencies = [
- "futures",
- "futures-util",
- "opentelemetry",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
  "prost",
  "tonic",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e33428e6bf08c6f7fcea4ddb8e358fab0fe48ab877a87c70c6ebe20f673ce5"
+checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
 dependencies = [
  "opentelemetry",
 ]
 
 [[package]]
 name = "opentelemetry_api"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed41783a5bf567688eb38372f2b7a8530f5a607a4b49d38dd7573236c23ca7e2"
+checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
 dependencies = [
- "fnv",
  "futures-channel",
  "futures-util",
  "indexmap 1.9.3",
+ "js-sys",
  "once_cell",
  "pin-project-lite",
  "thiserror",
@@ -3773,24 +3778,34 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3a2a91fdbfdd4d212c0dcc2ab540de2c2bcbbd90be17de7a7daf8822d010c1"
+checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
- "dashmap",
- "fnv",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "once_cell",
  "opentelemetry_api",
+ "ordered-float",
  "percent-encoding",
  "rand",
+ "regex",
+ "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "ordered-float"
+version = "3.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -5586,14 +5601,13 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64 0.21.5",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5605,15 +5619,12 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "prost-derive",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -5682,16 +5693,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5715,9 +5716,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a39dcf9bfc1742fa4d6215253b33a6e474be78275884c216fc2a06267b3600"
+checksum = "fc09e402904a5261e42cf27aea09ccb7d5318c6717a9eec3d8e2e65c56b18f19"
 dependencies = [
  "once_cell",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "monad-triedb",
     "monad-multi-sig",
     "monad-node",
+    "monad-opentelemetry-executor",
     "monad-proto",
     "monad-quic",
     "monad-randomized-tests",
@@ -90,10 +91,11 @@ log = "0.4"
 lz4 = "1.24"
 multihash = "0.17"
 ntest = "0.9"
-opentelemetry = "0.19"
-opentelemetry_api = "0.19"
-opentelemetry-otlp = "0.12"
-opentelemetry-semantic-conventions = "0.11"
+opentelemetry = "0.20"
+opentelemetry_api = "0.20"
+opentelemetry-otlp = "0.13"
+opentelemetry-semantic-conventions = "0.12"
+opentelemetry_sdk = "0.20"
 pbkdf2 = "0.12"
 peak_alloc = "0.2"
 priority-queue = "1.3"
@@ -130,7 +132,7 @@ tokio-util = "0.7"
 toml = "0.7"
 tracing = "0.1"
 tracing-core = "0.1"
-tracing-opentelemetry = "0.19"
+tracing-opentelemetry = "0.20"
 tracing-subscriber = "0.3"
 tracing-test = "0.2"
 wasm-bindgen = "0.2"

--- a/monad-consensus-types/src/metrics.rs
+++ b/monad-consensus-types/src/metrics.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct ValidationErrors {
     pub invalid_author: u64,
     pub not_well_formed_sig: u64,
@@ -12,7 +12,7 @@ pub struct ValidationErrors {
     pub invalid_version: u64,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct ConsensusEvents {
     pub local_timeout: u64,
     pub handle_proposal: u64,
@@ -45,14 +45,14 @@ pub struct ConsensusEvents {
     pub enter_new_round_tc: u64,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct BlocktreeEvents {
     pub prune_success: u64,
     pub add_success: u64,
     pub add_dup: u64,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct BlocksyncEvents {
     pub blocksync_response_successful: u64,
     pub blocksync_response_failed: u64,
@@ -60,7 +60,7 @@ pub struct BlocksyncEvents {
     pub blocksync_request: u64,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct Metrics {
     pub validation_errors: ValidationErrors,
     pub consensus_events: ConsensusEvents,

--- a/monad-debugger/src/graphql.rs
+++ b/monad-debugger/src/graphql.rs
@@ -3,7 +3,8 @@ use std::{ops::Deref, time::Duration};
 use async_graphql::{Context, NewType, Object, Union};
 use monad_crypto::certificate_signature::{CertificateSignaturePubKey, PubKey};
 use monad_executor_glue::{
-    AsyncStateVerifyEvent, BlockSyncEvent, ConsensusEvent, MempoolEvent, MonadEvent, ValidatorEvent,
+    AsyncStateVerifyEvent, BlockSyncEvent, ConsensusEvent, MempoolEvent, MetricsEvent, MonadEvent,
+    ValidatorEvent,
 };
 use monad_mock_swarm::{
     node::Node,
@@ -178,6 +179,7 @@ enum GraphQLMonadEvent<'s> {
     ValidatorEvent(GraphQLValidatorEvent<'s>),
     MempoolEvent(GraphQLMempoolEvent<'s>),
     AsyncStateVerifyEvent(GraphQLAsyncStateVerifyEvent<'s>),
+    MetricsEvent(GraphQLMetricsEvent<'s>),
 }
 
 impl<'s> From<&'s MonadEventType> for GraphQLMonadEvent<'s> {
@@ -190,6 +192,7 @@ impl<'s> From<&'s MonadEventType> for GraphQLMonadEvent<'s> {
             MonadEvent::AsyncStateVerifyEvent(event) => {
                 Self::AsyncStateVerifyEvent(GraphQLAsyncStateVerifyEvent(event))
             }
+            MonadEventType::MetricsEvent(event) => Self::MetricsEvent(GraphQLMetricsEvent(event)),
         }
     }
 }
@@ -229,6 +232,15 @@ impl<'s> GraphQLMempoolEvent<'s> {
 struct GraphQLAsyncStateVerifyEvent<'s>(&'s AsyncStateVerifyEvent<SignatureCollectionType>);
 #[Object]
 impl<'s> GraphQLAsyncStateVerifyEvent<'s> {
+    async fn debug(&self) -> String {
+        format!("{:?}", self.0)
+    }
+}
+
+struct GraphQLMetricsEvent<'s>(&'s MetricsEvent);
+
+#[Object]
+impl<'s> GraphQLMetricsEvent<'s> {
     async fn debug(&self) -> String {
         format!("{:?}", self.0)
     }

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -177,6 +177,7 @@ impl<S: SwarmRelation> Executor for MockExecutor<S> {
             checkpoint_cmds,
             state_root_hash_cmds,
             loopback_cmds,
+            metrics_cmds,
         ) = Self::Command::split_commands(commands);
 
         for command in timer_cmds {
@@ -220,6 +221,7 @@ impl<S: SwarmRelation> Executor for MockExecutor<S> {
             checkpoint_cmds,
             state_root_hash_cmds,
             loopback_cmds,
+            metrics_cmds,
         ) = Self::Command::split_commands(commands);
 
         for command in timer_cmds {
@@ -435,7 +437,7 @@ mod tests {
     use monad_crypto::hasher::Hash;
     use monad_executor::Executor;
     use monad_executor_glue::TimerCommand;
-    use monad_types::BlockId;
+    use monad_types::{BlockId, TimeoutVariant};
 
     use super::*;
 

--- a/monad-node/Cargo.toml
+++ b/monad-node/Cargo.toml
@@ -30,6 +30,7 @@ monad-types = { path = "../monad-types" }
 monad-updaters = { path = "../monad-updaters", features = ["tokio"] }
 monad-validator = { path = "../monad-validator" }
 monad-wal = { path = "../monad-wal" }
+monad-opentelemetry-executor = { path = "../monad-opentelemetry-executor" }
 
 base64 = { workspace = true }
 bytes = { workspace = true }
@@ -40,7 +41,7 @@ hex = { workspace = true }
 log = { workspace = true }
 opentelemetry = { workspace = true, features = ["rt-tokio"] }
 opentelemetry_api = { workspace = true }
-opentelemetry-otlp = { workspace = true }
+opentelemetry-otlp = { workspace = true, features = ["metrics"] }
 opentelemetry-semantic-conventions = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/monad-node/src/cli.rs
+++ b/monad-node/src/cli.rs
@@ -36,4 +36,7 @@ pub struct Cli {
     /// Set the opentelemetry OTLP exporter endpoint
     #[arg(long)]
     pub otel_endpoint: Option<String>,
+
+    #[arg(long, requires = "otel_endpoint")]
+    pub record_metrics_interval_seconds: Option<u64>,
 }

--- a/monad-node/src/error.rs
+++ b/monad-node/src/error.rs
@@ -39,6 +39,9 @@ pub enum NodeSetupError {
 
     #[error(transparent)]
     TraceError(#[from] opentelemetry_api::trace::TraceError),
+
+    #[error(transparent)]
+    MetricsError(#[from] opentelemetry_api::metrics::MetricsError),
 }
 
 impl NodeSetupError {
@@ -54,6 +57,7 @@ impl NodeSetupError {
             NodeSetupError::SignatureCollectionError(_) => ErrorKind::ValueValidation,
             NodeSetupError::TomlDeError(_) => ErrorKind::ValueValidation,
             NodeSetupError::TraceError(_) => ErrorKind::ValueValidation,
+            NodeSetupError::MetricsError(_) => ErrorKind::ValueValidation,
         }
     }
 }

--- a/monad-opentelemetry-executor/Cargo.toml
+++ b/monad-opentelemetry-executor/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "monad-opentelemetry-executor"
+version = "0.1.0"
+edition = "2021"
+
+# this is necessary for criterion bench options
+# https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+[lib]
+bench = false
+
+[dependencies]
+futures = { workspace = true }
+monad-consensus-types = { path = "../monad-consensus-types" }
+monad-crypto = { path = "../monad-crypto" }
+monad-executor = { path = "../monad-executor" }
+monad-executor-glue = { path = "../monad-executor-glue" }
+
+opentelemetry_api = { workspace = true }
+opentelemetry-otlp = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-semantic-conventions = { workspace = true }
+
+tokio = { workspace = true }
+tracing = { workspace = true, features = ["log"] }

--- a/monad-opentelemetry-executor/src/lib.rs
+++ b/monad-opentelemetry-executor/src/lib.rs
@@ -1,0 +1,3 @@
+mod opentelemetry;
+
+pub use opentelemetry::OpenTelemetryExecutor;

--- a/monad-opentelemetry-executor/src/opentelemetry.rs
+++ b/monad-opentelemetry-executor/src/opentelemetry.rs
@@ -1,0 +1,481 @@
+use std::{
+    collections::HashMap,
+    marker::PhantomData,
+    ops::DerefMut,
+    pin::Pin,
+    sync::{Arc, RwLock},
+    task::{Context, Poll, Waker},
+    time::Duration,
+};
+
+use futures::Stream;
+use monad_consensus_types::{metrics::Metrics, signature_collection::SignatureCollection};
+use monad_crypto::certificate_signature::CertificateSignatureRecoverable;
+use monad_executor::Executor;
+use monad_executor_glue::{MetricsCommand, MetricsEvent, MonadEvent};
+use opentelemetry_api::{
+    metrics::{Counter, Meter, MeterProvider as _, Observer},
+    KeyValue,
+};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::{
+    metrics::{data::Temporality, Aggregation, InstrumentKind, MeterProvider},
+    Resource,
+};
+use tokio::task::{AbortHandle, JoinSet};
+use tracing::warn;
+
+type SharedMetrics = Arc<RwLock<Metrics>>;
+
+/// A OpenTelemetry executor for recording metrics
+pub struct OpenTelemetryExecutor<ST, SCT> {
+    interval: Duration,
+    meter_provider: MeterProvider,
+    meter: Meter,
+    // TODO(rene): refactor to use a Gauge type instead of `Counter<u64>`. right now, the metrics
+    // will be summed together by the open telemetry backend leading to nonsensical metrics readings
+    counters: HashMap<&'static str, Counter<u64>>,
+    cached_metrics: Metrics,
+    timers: JoinSet<Option<MetricsEvent>>,
+    handle: Option<AbortHandle>,
+    waker: Option<Waker>,
+    phantom: PhantomData<(ST, SCT)>,
+}
+
+const COUNTERS: [&str; 46] = [
+    "invalid_author",
+    "not_well_formed_sig",
+    "invalid_signature",
+    "author_not_sender",
+    "invalid_tc_round",
+    "insufficient_stake",
+    "invalid_seq_num",
+    "val_data_unavailable",
+    "invalid_vote_message",
+    "invalid_version",
+    "local_timeout",
+    "handle_proposal",
+    "failed_txn_validation",
+    "invalid_proposal_round_leader",
+    "out_of_order_proposals",
+    "created_vote",
+    "old_vote_received",
+    "vote_received",
+    "created_qc",
+    "old_remote_timeout",
+    "remote_timeout_msg",
+    "remote_timeout_msg_with_tc",
+    "created_tc",
+    "process_old_qc",
+    "process_qc",
+    "creating_proposal",
+    "abstain_proposal",
+    "creating_empty_block_proposal",
+    "rx_empty_block",
+    "rx_execution_lagging",
+    "rx_bad_state_root",
+    "rx_missing_state_root",
+    "rx_proposal",
+    "proposal_with_tc",
+    "failed_verify_randao_reveal_sig",
+    "commit_empty_block",
+    "state_root_update",
+    "enter_new_round_qc",
+    "enter_new_round_tc",
+    "prune_success",
+    "add_success",
+    "add_dup",
+    "blocksync_response_successful",
+    "blocksync_response_failed",
+    "blocksync_response_unexpected",
+    "blocksync_request",
+];
+
+/// The following struct along with the `impl TemporalitySelector` are only to prevent a cumulative sum of counters
+/// that is done behind the scenes, because the default temporality selector is `Temporality::Cumulative` which leads
+/// to metric graphs that are difficult to interpret.
+struct LatestValueTemporalitySelector;
+
+impl opentelemetry_sdk::metrics::reader::TemporalitySelector for LatestValueTemporalitySelector {
+    fn temporality(&self, _kind: InstrumentKind) -> Temporality {
+        // A measurement interval that resets each cycle.
+        // Measurements from one cycle are recorded independently, measurements from
+        // other cycles do not affect them.
+        Temporality::Delta
+    }
+}
+
+struct AggregationSelector;
+
+impl opentelemetry_sdk::metrics::reader::AggregationSelector for AggregationSelector {
+    fn aggregation(&self, _kind: InstrumentKind) -> Aggregation {
+        // An aggregation that summarizes a set of measurements as the last one made.
+        Aggregation::LastValue
+    }
+}
+
+fn observe_metric(observer: &dyn Observer, counter_name: &'static str, metrics: &Metrics) {}
+
+impl<ST, SCT> OpenTelemetryExecutor<ST, SCT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection,
+{
+    pub fn new<T: Into<String>>(endpoint: T, interval: Duration, enable_grpc_gzip: bool) -> Self {
+        let mut exporter = opentelemetry_otlp::new_exporter()
+            .tonic()
+            .with_endpoint(endpoint.into());
+
+        if enable_grpc_gzip {
+            exporter = exporter.with_compression(opentelemetry_otlp::Compression::Gzip);
+        }
+
+        let meter_provider = opentelemetry_otlp::new_pipeline()
+            .metrics(opentelemetry_sdk::runtime::Tokio)
+            .with_period(interval)
+            .with_exporter(exporter)
+            // can uncomment these when using `ObservableGauge` instead of `Counter`
+            // .with_temporality_selector(LatestValueTemporalitySelector {})
+            // .with_aggregation_selector(AggregationSelector {})
+            .with_resource(Resource::new(vec![KeyValue::new(
+                opentelemetry_semantic_conventions::resource::SERVICE_NAME,
+                "monad_node",
+            )]))
+            .build()
+            .expect("failed to initialize opentelemetry_otlp metrics pipeline");
+
+        let meter = meter_provider.meter("node");
+        let counters = COUNTERS
+            .into_iter()
+            .map(|counter_name| (counter_name, meter.u64_counter(counter_name).init()))
+            .collect();
+
+        Self {
+            interval,
+            meter_provider,
+            meter,
+            counters,
+            cached_metrics: Default::default(),
+            timers: Default::default(),
+            handle: None,
+            waker: None,
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn record(&mut self, name: &'static str, value: u64) {
+        self.counters.get(name).unwrap().add(value, &[]);
+    }
+
+    fn record_metrics(&mut self, metrics: &Metrics) {
+        // TODO(rene): must be a nice way to not rewrite all these fields.
+        // we are recording the diff between `metrics` and `self.cached_metrics` to work around
+        // the lack of a synchronous gauge counter
+        let cached_metrics = self.cached_metrics;
+        self.record(
+            "invalid_author",
+            metrics.validation_errors.invalid_author
+                - cached_metrics.validation_errors.invalid_author,
+        );
+        self.record(
+            "not_well_formed_sig",
+            metrics.validation_errors.not_well_formed_sig
+                - cached_metrics.validation_errors.not_well_formed_sig,
+        );
+        self.record(
+            "invalid_signature",
+            metrics.validation_errors.invalid_signature
+                - cached_metrics.validation_errors.invalid_signature,
+        );
+        self.record(
+            "author_not_sender",
+            metrics.validation_errors.author_not_sender
+                - cached_metrics.validation_errors.author_not_sender,
+        );
+        self.record(
+            "invalid_tc_round",
+            metrics.validation_errors.invalid_tc_round
+                - cached_metrics.validation_errors.invalid_tc_round,
+        );
+        self.record(
+            "insufficient_stake",
+            metrics.validation_errors.insufficient_stake
+                - cached_metrics.validation_errors.insufficient_stake,
+        );
+        self.record(
+            "invalid_seq_num",
+            metrics.validation_errors.invalid_seq_num
+                - cached_metrics.validation_errors.invalid_seq_num,
+        );
+        self.record(
+            "val_data_unavailable",
+            metrics.validation_errors.val_data_unavailable
+                - cached_metrics.validation_errors.val_data_unavailable,
+        );
+        self.record(
+            "invalid_vote_message",
+            metrics.validation_errors.invalid_vote_message
+                - cached_metrics.validation_errors.invalid_vote_message,
+        );
+        self.record(
+            "invalid_version",
+            metrics.validation_errors.invalid_version
+                - cached_metrics.validation_errors.invalid_version,
+        );
+        self.record(
+            "local_timeout",
+            metrics.consensus_events.local_timeout - cached_metrics.consensus_events.local_timeout,
+        );
+        self.record(
+            "handle_proposal",
+            metrics.consensus_events.handle_proposal
+                - cached_metrics.consensus_events.handle_proposal,
+        );
+        self.record(
+            "failed_txn_validation",
+            metrics.consensus_events.failed_txn_validation
+                - cached_metrics.consensus_events.failed_txn_validation,
+        );
+        self.record(
+            "invalid_proposal_round_leader",
+            metrics.consensus_events.invalid_proposal_round_leader
+                - cached_metrics
+                    .consensus_events
+                    .invalid_proposal_round_leader,
+        );
+        self.record(
+            "out_of_order_proposals",
+            metrics.consensus_events.out_of_order_proposals
+                - cached_metrics.consensus_events.out_of_order_proposals,
+        );
+        self.record(
+            "created_vote",
+            metrics.consensus_events.created_vote - cached_metrics.consensus_events.created_vote,
+        );
+        self.record(
+            "old_vote_received",
+            metrics.consensus_events.old_vote_received
+                - cached_metrics.consensus_events.old_vote_received,
+        );
+        self.record(
+            "vote_received",
+            metrics.consensus_events.vote_received - cached_metrics.consensus_events.vote_received,
+        );
+        self.record(
+            "created_qc",
+            metrics.consensus_events.created_qc - cached_metrics.consensus_events.created_qc,
+        );
+        self.record(
+            "old_remote_timeout",
+            metrics.consensus_events.old_remote_timeout
+                - cached_metrics.consensus_events.old_remote_timeout,
+        );
+        self.record(
+            "remote_timeout_msg",
+            metrics.consensus_events.remote_timeout_msg
+                - cached_metrics.consensus_events.remote_timeout_msg,
+        );
+        self.record(
+            "remote_timeout_msg_with_tc",
+            metrics.consensus_events.remote_timeout_msg_with_tc
+                - cached_metrics.consensus_events.remote_timeout_msg_with_tc,
+        );
+        self.record(
+            "created_tc",
+            metrics.consensus_events.created_tc - cached_metrics.consensus_events.created_tc,
+        );
+        self.record(
+            "process_old_qc",
+            metrics.consensus_events.process_old_qc
+                - cached_metrics.consensus_events.process_old_qc,
+        );
+        self.record(
+            "process_qc",
+            metrics.consensus_events.process_qc - cached_metrics.consensus_events.process_qc,
+        );
+        self.record(
+            "creating_proposal",
+            metrics.consensus_events.creating_proposal
+                - cached_metrics.consensus_events.creating_proposal,
+        );
+        self.record(
+            "abstain_proposal",
+            metrics.consensus_events.abstain_proposal
+                - cached_metrics.consensus_events.abstain_proposal,
+        );
+        self.record(
+            "creating_empty_block_proposal",
+            metrics.consensus_events.creating_empty_block_proposal
+                - cached_metrics
+                    .consensus_events
+                    .creating_empty_block_proposal,
+        );
+        self.record(
+            "rx_empty_block",
+            metrics.consensus_events.rx_empty_block
+                - cached_metrics.consensus_events.rx_empty_block,
+        );
+        self.record(
+            "rx_execution_lagging",
+            metrics.consensus_events.rx_execution_lagging
+                - cached_metrics.consensus_events.rx_execution_lagging,
+        );
+        self.record(
+            "rx_bad_state_root",
+            metrics.consensus_events.rx_bad_state_root
+                - cached_metrics.consensus_events.rx_bad_state_root,
+        );
+        self.record(
+            "rx_missing_state_root",
+            metrics.consensus_events.rx_missing_state_root
+                - cached_metrics.consensus_events.rx_missing_state_root,
+        );
+        self.record(
+            "rx_proposal",
+            metrics.consensus_events.rx_proposal - cached_metrics.consensus_events.rx_proposal,
+        );
+        self.record(
+            "proposal_with_tc",
+            metrics.consensus_events.proposal_with_tc
+                - cached_metrics.consensus_events.proposal_with_tc,
+        );
+        self.record(
+            "failed_verify_randao_reveal_sig",
+            metrics.consensus_events.failed_verify_randao_reveal_sig
+                - cached_metrics
+                    .consensus_events
+                    .failed_verify_randao_reveal_sig,
+        );
+        self.record(
+            "commit_empty_block",
+            metrics.consensus_events.commit_empty_block
+                - cached_metrics.consensus_events.commit_empty_block,
+        );
+        self.record(
+            "state_root_update",
+            metrics.consensus_events.state_root_update
+                - cached_metrics.consensus_events.state_root_update,
+        );
+        self.record(
+            "enter_new_round_qc",
+            metrics.consensus_events.enter_new_round_qc
+                - cached_metrics.consensus_events.enter_new_round_qc,
+        );
+        self.record(
+            "enter_new_round_tc",
+            metrics.consensus_events.enter_new_round_tc
+                - cached_metrics.consensus_events.enter_new_round_tc,
+        );
+        self.record(
+            "prune_success",
+            metrics.blocktree_events.prune_success - cached_metrics.blocktree_events.prune_success,
+        );
+        self.record(
+            "add_success",
+            metrics.blocktree_events.add_success - cached_metrics.blocktree_events.add_success,
+        );
+        self.record(
+            "add_dup",
+            metrics.blocktree_events.add_dup - cached_metrics.blocktree_events.add_dup,
+        );
+        self.record(
+            "blocksync_response_successful",
+            metrics.blocksync_events.blocksync_response_successful
+                - cached_metrics
+                    .blocksync_events
+                    .blocksync_response_successful,
+        );
+        self.record(
+            "blocksync_response_failed",
+            metrics.blocksync_events.blocksync_response_failed
+                - cached_metrics.blocksync_events.blocksync_response_failed,
+        );
+        self.record(
+            "blocksync_response_unexpected",
+            metrics.blocksync_events.blocksync_response_unexpected
+                - cached_metrics
+                    .blocksync_events
+                    .blocksync_response_unexpected,
+        );
+        self.record(
+            "blocksync_request",
+            metrics.blocksync_events.blocksync_request
+                - cached_metrics.blocksync_events.blocksync_request,
+        );
+        self.cached_metrics = *metrics;
+    }
+}
+
+impl<ST, SCT> Drop for OpenTelemetryExecutor<ST, SCT> {
+    fn drop(&mut self) {
+        if self.meter_provider.shutdown().is_err() {
+            warn!("opentelemetry meter provider already shut down");
+        }
+    }
+}
+
+impl<ST, SCT> Executor for OpenTelemetryExecutor<ST, SCT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection,
+{
+    type Command = MetricsCommand;
+
+    fn replay(&mut self, mut _commands: Vec<Self::Command>) {}
+
+    fn exec(&mut self, commands: Vec<Self::Command>) {
+        let mut wake = false;
+        for command in commands {
+            match command {
+                MetricsCommand::RecordMetrics(metrics) => {
+                    wake = true;
+                    let interval = self.interval;
+                    self.record_metrics(&metrics);
+                    let future = async move {
+                        tokio::time::sleep(interval).await;
+                        Some(MetricsEvent::Timeout)
+                    };
+                    let handle = self.timers.spawn(future);
+                    if let Some(old_handle) = self.handle.replace(handle) {
+                        old_handle.abort();
+                    }
+                }
+            }
+        }
+        if wake {
+            if let Some(waker) = self.waker.take() {
+                waker.wake();
+            }
+        }
+    }
+}
+
+impl<ST, SCT> Stream for OpenTelemetryExecutor<ST, SCT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection,
+{
+    type Item = MonadEvent<ST, SCT>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut _timer_poll_span = tracing::info_span!("timer_poll_span").entered();
+
+        let this = self.deref_mut();
+
+        // its possible to get Poll::Ready(None) because the join_set might be empty
+        while let Poll::Ready(Some(poll_result)) = this.timers.poll_join_next(cx) {
+            match poll_result {
+                Ok(e) => {
+                    return Poll::Ready(e.and_then(|e| Some(MonadEvent::MetricsEvent(e))));
+                }
+                Err(join_error) => {
+                    // only case where this happen is when task is aborted
+                    assert!(join_error.is_cancelled());
+                }
+            };
+        }
+
+        self.waker = Some(cx.waker().clone());
+        Poll::Pending
+    }
+}

--- a/monad-proto/Cargo.toml
+++ b/monad-proto/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 prost = { workspace = true }
 
 [build-dependencies]
-prost-build = { workspace = true}
+prost-build = { workspace = true }
 protobuf-src = { workspace = true }

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -50,7 +50,7 @@ message ProtoStateUpdateEvent {
 
 message ProtoBlockSyncRequestWithSender {
   monad_proto.basic.ProtoNodeId sender = 1;
-  monad_proto.message.ProtoRequestBlockSyncMessage request = 2;  
+  monad_proto.message.ProtoRequestBlockSyncMessage request = 2;
 }
 
 message ProtoBlockSyncResponseWithSender {
@@ -98,7 +98,7 @@ message ProtoMempoolEvent {
 
 message ProtoPeerStateUpdateWithSender {
   monad_proto.basic.ProtoNodeId sender = 1;
-  monad_proto.message.ProtoPeerStateRootMessage message = 2;  
+  monad_proto.message.ProtoPeerStateRootMessage message = 2;
 }
 
 
@@ -109,12 +109,21 @@ message ProtoAsyncStateVerifyEvent {
   }
 }
 
+message ProtoMetricsTimeout {}
+
+message ProtoMetricsEvent {
+  oneof event {
+    ProtoMetricsTimeout timeout = 1;
+  }
+}
+
 message ProtoMonadEvent{
   oneof event {
     ProtoConsensusEvent consensus_event = 1;
     ProtoBlockSyncEvent block_sync_event = 2;
     ProtoValidatorEvent validator_event = 3;
     ProtoMempoolEvent mempool_event = 4;
-    ProtoAsyncStateVerifyEvent async_state_verify_event = 5 ;
+    ProtoAsyncStateVerifyEvent async_state_verify_event = 5;
+    ProtoMetricsEvent metrics_event = 6;
   }
 }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -35,7 +35,7 @@ use monad_crypto::certificate_signature::{
 use monad_eth_types::EthAddress;
 use monad_executor_glue::{
     AsyncStateVerifyEvent, BlockSyncEvent, Command, ConsensusEvent, MempoolEvent, Message,
-    MonadEvent, ValidatorEvent,
+    MetricsCommand, MetricsEvent, MonadEvent, ValidatorEvent,
 };
 use monad_types::{Epoch, NodeId, Round, SeqNum, TimeoutVariant};
 use monad_validator::{
@@ -427,6 +427,8 @@ where
             ))),
         );
 
+        init_cmds.extend(monad_state.update(MonadEvent::MetricsEvent(MetricsEvent::Timeout)));
+
         (monad_state, init_cmds)
     }
 }
@@ -505,6 +507,13 @@ where
                     .flat_map(Into::<Vec<Command<_, _, _, _, _>>>::into)
                     .collect::<Vec<_>>()
             }
+            MonadEvent::MetricsEvent(metrics_event) => match metrics_event {
+                MetricsEvent::Timeout => {
+                    vec![Command::MetricsCommand(MetricsCommand::RecordMetrics(
+                        self.metrics,
+                    ))]
+                }
+            },
         }
     }
 }

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -24,8 +24,8 @@ use monad_state::{
 use monad_types::{NodeId, Round, SeqNum};
 use monad_updaters::{
     checkpoint::MockCheckpoint, ledger::MockLedger, local_router::LocalPeerRouter,
-    loopback::LoopbackExecutor, parent::ParentExecutor, state_root_hash::MockStateRootHashNop,
-    timer::TokioTimer, BoxUpdater, Updater,
+    loopback::LoopbackExecutor, nop_metrics::NopMetricsExecutor, parent::ParentExecutor,
+    state_root_hash::MockStateRootHashNop, timer::TokioTimer, BoxUpdater, Updater,
 };
 use monad_validator::{
     simple_round_robin::SimpleRoundRobin,
@@ -93,6 +93,7 @@ pub async fn make_monad_executor<ST, SCT>(
     BoxUpdater<'static, StateRootHashCommand<Block<SCT>>, MonadEvent<ST, SCT>>,
     IpcReceiver<ST, SCT>,
     LoopbackExecutor<MonadEvent<ST, SCT>>,
+    NopMetricsExecutor<MonadEvent<ST, SCT>>,
 >
 where
     ST: CertificateSignatureRecoverable + Unpin,
@@ -135,6 +136,7 @@ where
         },
         ipc: IpcReceiver::new(generate_uds_path().into(), 100).expect("uds bind failed"),
         loopback: LoopbackExecutor::default(),
+        metrics: NopMetricsExecutor::default(),
     }
 }
 

--- a/monad-updaters/src/lib.rs
+++ b/monad-updaters/src/lib.rs
@@ -7,6 +7,7 @@ pub mod checkpoint;
 pub mod ipc;
 pub mod ledger;
 pub mod loopback;
+pub mod nop_metrics;
 pub mod parent;
 pub mod state_root_hash;
 pub mod validator_set;

--- a/monad-updaters/src/nop_metrics.rs
+++ b/monad-updaters/src/nop_metrics.rs
@@ -1,0 +1,38 @@
+use std::{
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::Stream;
+use monad_executor::Executor;
+use monad_executor_glue::MetricsCommand;
+
+/// A no-op executor for executing metrics commands.
+pub struct NopMetricsExecutor<E> {
+    _phantom: PhantomData<E>,
+}
+
+impl<E> Default for NopMetricsExecutor<E> {
+    fn default() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<E> Executor for NopMetricsExecutor<E> {
+    type Command = MetricsCommand;
+
+    fn replay(&mut self, mut _commands: Vec<Self::Command>) {}
+
+    fn exec(&mut self, _commands: Vec<Self::Command>) {}
+}
+
+impl<E> Stream for NopMetricsExecutor<E> {
+    type Item = E;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Pending
+    }
+}


### PR DESCRIPTION
We want to have a metrics executor that is responsible for recording [metrics](https://github.com/monad-crypto/monad-bft/blob/master/monad-consensus-types/src/metrics.rs#L64-L64). This PR lays the groundwork for that by
- adding a new event type for a metrics timeout event that fires when it is time to record metrics
- adding a new command type for recording metrics
- adding a no-op metrics executor owned by [`ParentExecutor`](https://github.com/monad-crypto/monad-bft/blob/master/monad-updaters/src/parent.rs#L18-L18) for testing
- adding an OpenTelemetry executor that is responsible for exporting metrics to a back-end
- adds a `--record-metrics-interval-seconds` CLI arg to the `monad-node` binary which allows controlling the interval in which metrics are sent to the OpenTelemetry back-end. 


### TODOs before merging
- [x] fix wasm build
wasm build is broken because the 2nd commit in this PR added a dependency that made `monad-debugger` depend on `mio` which can't be compiled on wasm
```
monad-debugger v0.1.0 (/home/rgarc/monad-bft/monad-debugger)
└── monad-mock-swarm v0.1.0 (/home/rgarc/monad-bft/monad-mock-swarm)
    └── monad-updaters v0.1.0 (/home/rgarc/monad-bft/monad-updaters)
        └── opentelemetry v0.20.0
            └── opentelemetry_sdk v0.20.0
                └── tokio v1.34.0
                    └── mio v0.8.9
```
- [ ] refactor the OpenTelemetry executor to use some sort of Gauge type instead of `Counter<u64>`. The latter causes metrics to be summed together in the OpenTelemetry back-end which leads to nonsensical metrics graphs.