### PR TITLE
Add Raptor broadcast algorithm implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2913,6 +2913,7 @@ dependencies = [
  "monad-virtual-bench",
  "rand",
  "rand_chacha",
+ "raptorq",
  "serde",
  "test-case",
  "tracing",
@@ -3045,6 +3046,7 @@ name = "monad-node"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.5",
+ "bytes",
  "clap 4.4.10",
  "env_logger",
  "futures-util",
@@ -4344,6 +4346,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raptorq"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c9cf9270cc5903afdef387f06ef1cd89fb77f45c357c2a425bae78b839fd866"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "rayon"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5455,9 +5466,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.34.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ opt-level = 1
 
 [profile.release]
 debug = true
+panic = "abort"
 
 [workspace.dependencies]
 reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "685d1c5", default-features = false }
@@ -108,6 +109,7 @@ quinn-proto = { git = "https://github.com/quinn-rs/quinn.git", rev = "dd34d57a" 
 
 rand = "0.8"
 rand_chacha = "0.3"
+raptorq = "1.8"
 rayon = "1.7"
 rcgen = "0.11"
 ring = "0.17"
@@ -123,7 +125,7 @@ tempfile = "3.5"
 test-case = "3.0"
 thiserror = "1.0"
 tiny-keccak = "2"
-tokio = "1.28"
+tokio = "1.36"
 tokio-util = "0.7"
 toml = "0.7"
 tracing = "0.1"

--- a/docker/gossip-testground/topology-gen.py
+++ b/docker/gossip-testground/topology-gen.py
@@ -1,13 +1,23 @@
 topology = [
     {
         "name": "us",
-        "latencies_ms": [100],
+        "latencies_ms": [10, 100],
         "nodes": [
             {
                 "up_Mbps": 1000,
                 "down_Mbps": 1000,
             },
-        ] * 100,
+        ] * 50,
+    },
+    {
+        "name": "eu",
+        "latencies_ms": [100, 10],
+        "nodes": [
+            {
+                "up_Mbps": 1000,
+                "down_Mbps": 1000,
+            },
+        ] * 50,
     },
 ]
 

--- a/monad-crypto/src/hasher.rs
+++ b/monad-crypto/src/hasher.rs
@@ -4,7 +4,7 @@ use sha2::Digest;
 use zerocopy::AsBytes;
 
 /// A 32-byte/256-bit hash
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Hash(pub [u8; 32]);
 
 impl Debug for Hash {

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -34,9 +34,9 @@ pub enum RouterCommand<PT: PubKey, OM> {
     // TODO-2 add a RouterCommand for setting peer set for broadcast
 }
 
-pub trait Message: Clone {
+pub trait Message: Clone + Send + Sync {
     type NodeIdPubKey: PubKey;
-    type Event;
+    type Event: Send + Sync;
 
     // TODO-3 NodeId -> &NodeId
     fn event(self, from: NodeId<Self::NodeIdPubKey>) -> Self::Event;

--- a/monad-gossip/Cargo.toml
+++ b/monad-gossip/Cargo.toml
@@ -20,6 +20,7 @@ bytes = { workspace = true }
 bytes-utils = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
+raptorq = { workspace = true, features = ["serde_support"] }
 serde = { workspace = true, features = ["derive"] }
 tracing = { workspace = true }
 

--- a/monad-gossip/src/lib.rs
+++ b/monad-gossip/src/lib.rs
@@ -10,6 +10,7 @@ mod connection_manager;
 pub use connection_manager::{ConnectionManager, ConnectionManagerEvent};
 pub mod gossipsub;
 pub mod mock;
+pub mod seeder;
 pub mod testutil;
 
 type GossipMessage = Bytes;
@@ -27,6 +28,8 @@ pub enum GossipEvent<PT: PubKey> {
     /// Send gossip_message to peer
     /// Delivery is not guaranteed (connection may sever at any point)
     /// Framing of each individual message is guaranteed
+    ///
+    /// There are NO ordering guarantees between multiple Sends
     Send(NodeId<PT>, FragmentedGossipMessage),
 
     /// Emit app_message to executor (NOTE: not gossip_message)

--- a/monad-gossip/src/seeder/chunker.rs
+++ b/monad-gossip/src/seeder/chunker.rs
@@ -1,0 +1,84 @@
+use std::{error::Error, fmt::Debug, time::Duration};
+
+use bytes::Bytes;
+use monad_crypto::certificate_signature::{
+    CertificateSignature, CertificateSignaturePubKey, CertificateSignatureRecoverable,
+};
+use monad_types::NodeId;
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::AppMessage;
+
+/// Chunker is responsible for constructing a chunking scheme
+/// Examples of different schemes:
+/// 1) Splitting payload into N chunks
+/// 2) RS encoding, splitting into N chunks
+/// 3) Fountain encoding, splitting into N chunks
+///
+/// One other implicit responsiblity it has is validating `Meta` and `Chunk`.
+///
+/// Flow:
+/// 1) Payload is constructed from AppMessage, sender, time, etc.
+/// 2) Chunks are generated from payload
+pub trait Chunker<'k>: Sized {
+    type SignatureType: CertificateSignatureRecoverable;
+    // payload includes AppMessage + created_at TS as entropy
+    type PayloadId: Clone + Ord + Debug;
+    type Meta: Meta<PayloadId = Self::PayloadId>;
+    type Chunk: Chunk<PayloadId = Self::PayloadId>;
+
+    /// This must generate a Chunker with a UNIQUE PayloadId
+    /// This is to ensure that two separate chunkers are generated for two separate broadcasts,
+    /// even if they are the same AppMessage
+    fn new_from_message(
+        time: Duration,
+        all_peers: &[NodeId<CertificateSignaturePubKey<Self::SignatureType>>],
+        key: &'k <Self::SignatureType as CertificateSignature>::KeyPairType,
+        message: AppMessage,
+    ) -> Self;
+    fn try_new_from_meta(
+        time: Duration,
+        all_peers: &[NodeId<CertificateSignaturePubKey<Self::SignatureType>>],
+        key: &'k <Self::SignatureType as CertificateSignature>::KeyPairType,
+        meta: Self::Meta,
+    ) -> Result<Self, Box<dyn Error>>;
+
+    fn meta(&self) -> &Self::Meta;
+    /// populated from meta
+    fn creator(&self) -> NodeId<CertificateSignaturePubKey<Self::SignatureType>>;
+    /// populated from meta
+    fn created_at(&self) -> Duration;
+
+    // Payload has been reconstructed - process_chunk should not be called if this returns true
+    fn is_seeder(&self) -> bool;
+
+    /// Some(x) indicates that the chunker doesn't need to receive any more chunks, because it has
+    /// successfully reconstructed payload. Chunker::is_complete MUST return true after this.
+    fn process_chunk(
+        &mut self,
+        from: NodeId<CertificateSignaturePubKey<Self::SignatureType>>,
+        chunk: Self::Chunk,
+        data: Bytes,
+    ) -> Result<Option<AppMessage>, Box<dyn Error>>;
+
+    fn generate_chunk(
+        &mut self,
+    ) -> Option<(
+        NodeId<CertificateSignaturePubKey<Self::SignatureType>>,
+        Self::Chunk,
+        Bytes,
+    )>;
+
+    /// Peer is now seeding - so we can stop sending them chunks
+    fn set_peer_seeder(&mut self, peer: NodeId<CertificateSignaturePubKey<Self::SignatureType>>);
+}
+
+pub trait Meta: Clone + Debug + Serialize + DeserializeOwned {
+    type PayloadId;
+    fn id(&self) -> Self::PayloadId;
+}
+
+pub trait Chunk: Clone + Debug + Serialize + DeserializeOwned {
+    type PayloadId;
+    fn id(&self) -> Self::PayloadId;
+}

--- a/monad-gossip/src/seeder/mod.rs
+++ b/monad-gossip/src/seeder/mod.rs
@@ -1,0 +1,582 @@
+use std::{
+    collections::{hash_map::Entry, BTreeMap, HashMap, VecDeque},
+    time::Duration,
+};
+
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use monad_crypto::certificate_signature::{
+    CertificateKeyPair, CertificateSignature, CertificateSignaturePubKey,
+};
+use monad_types::{NodeId, RouterTarget};
+use serde::{Deserialize, Serialize};
+
+use super::{Gossip, GossipEvent};
+use crate::{AppMessage, FragmentedGossipMessage, GossipMessage};
+
+mod chunker;
+use chunker::{Chunk, Chunker, Meta};
+mod raptor;
+pub use raptor::Raptor;
+mod tree;
+pub use tree::Tree;
+
+pub struct SeederConfig<'k, C: Chunker<'k>> {
+    pub all_peers: Vec<NodeId<CertificateSignaturePubKey<C::SignatureType>>>,
+    pub key: &'k <C::SignatureType as CertificateSignature>::KeyPairType,
+
+    pub timeout: Duration,
+    pub up_bandwidth_Mbps: u16,
+    pub chunker_poll_interval: Duration,
+}
+
+impl<'k, C: Chunker<'k>> SeederConfig<'k, C> {
+    pub fn build(self) -> Seeder<'k, C> {
+        Seeder {
+            me: NodeId::new(self.key.pubkey()),
+            config: self,
+
+            chunkers: Default::default(),
+            chunker_timeouts: Default::default(),
+
+            events: VecDeque::default(),
+            current_tick: Duration::ZERO,
+            next_chunker_poll: None,
+        }
+    }
+}
+
+pub struct Seeder<'k, C: Chunker<'k>> {
+    /// convenience derived from config.key.pubkey()
+    me: NodeId<CertificateSignaturePubKey<C::SignatureType>>,
+    config: SeederConfig<'k, C>,
+
+    chunkers: BTreeMap<C::PayloadId, ChunkerStatus<'k, C>>,
+    /// Chunker is scheduled to be deleted `timeout` after C::Meta::created_at
+    chunker_timeouts: BTreeMap<Duration, Vec<C::PayloadId>>,
+
+    events: VecDeque<GossipEvent<CertificateSignaturePubKey<C::SignatureType>>>,
+    current_tick: Duration,
+    next_chunker_poll: Option<Duration>,
+}
+
+struct ChunkerStatus<'k, C: Chunker<'k>> {
+    chunker: C,
+    sent_metas: HashMap<NodeId<CertificateSignaturePubKey<C::SignatureType>>, MetaInfo<C::Meta>>,
+}
+
+impl<'k, C: Chunker<'k>> ChunkerStatus<'k, C> {
+    fn new(chunker: C) -> Self {
+        Self {
+            chunker,
+            sent_metas: Default::default(),
+        }
+    }
+
+    fn sent_seeding(&self, peer: &NodeId<CertificateSignaturePubKey<C::SignatureType>>) -> bool {
+        self.sent_metas
+            .get(peer)
+            .map(|meta| meta.seeding)
+            .unwrap_or(false)
+    }
+}
+
+impl<'k, C: Chunker<'k>> Seeder<'k, C> {
+    fn prepare_message(
+        message_type: MessageType<C::Meta, C::Chunk>,
+        data: Bytes,
+    ) -> FragmentedGossipMessage {
+        let mut inner_header_buf = BytesMut::new().writer();
+        bincode::serialize_into(
+            &mut inner_header_buf,
+            &Header::<C::Meta, C::Chunk> {
+                data_len: data.len().try_into().unwrap(),
+                message_type,
+            },
+        )
+        .expect("serializing gossip header should succeed");
+        let inner_header_buf: Bytes = inner_header_buf.into_inner().into();
+
+        let outer_header = OuterHeader(inner_header_buf.len() as u32);
+        let mut outer_header_buf = BytesMut::new().writer();
+        bincode::serialize_into(&mut outer_header_buf, &outer_header)
+            .expect("serializing outer header should succeed");
+        let outer_header_buf: Bytes = outer_header_buf.into_inner().into();
+
+        std::iter::once(outer_header_buf)
+            .chain(std::iter::once(inner_header_buf))
+            .chain(std::iter::once(data))
+            .collect()
+    }
+
+    fn handle_protocol_message(
+        &mut self,
+        from: NodeId<CertificateSignaturePubKey<C::SignatureType>>,
+        header: ProtocolHeader<C::Meta, C::Chunk>,
+        data: Bytes,
+    ) {
+        match header {
+            ProtocolHeader::Meta(MetaInfo { meta, seeding }) => {
+                let id = meta.id();
+                if !self.chunkers.contains_key(&id) {
+                    match C::try_new_from_meta(
+                        self.current_tick,
+                        &self.config.all_peers,
+                        self.config.key,
+                        meta,
+                    ) {
+                        Ok(chunker) => {
+                            tracing::info!("initialized chunker for id: {:?}", id);
+                            self.insert_chunker(chunker);
+                        }
+                        Err(e) => {
+                            tracing::warn!("failed to create chunker from meta: {:?}", e);
+                        }
+                    }
+                } else {
+                    tracing::trace!("received duplicate meta for id: {:?}", id);
+                }
+
+                if seeding {
+                    self.chunkers
+                        .get_mut(&id)
+                        .expect("invariant broken")
+                        .chunker
+                        .set_peer_seeder(from);
+                }
+            }
+
+            ProtocolHeader::Chunk(chunk) => {
+                let id = chunk.id();
+                if let Some(status) = self.chunkers.get_mut(&id) {
+                    if !status.chunker.is_seeder() {
+                        let result = status.chunker.process_chunk(from, chunk, data);
+                        match result {
+                            Ok(None) => {}
+                            Ok(Some(app_message)) => {
+                                tracing::debug!("emitting app_message, len={}", app_message.len());
+                                self.events.push_back(GossipEvent::Emit(
+                                    status.chunker.creator(),
+                                    app_message,
+                                ));
+                                assert!(status.chunker.is_seeder());
+                            }
+                            Err(e) => {
+                                tracing::warn!("failed to process chunk: {:?}", e);
+                            }
+                        }
+                    }
+                    // chunker may be complete if event was emitted
+                    if status.chunker.is_seeder() && !status.sent_seeding(&from) {
+                        let meta_info = MetaInfo {
+                            meta: status.chunker.meta().clone(),
+                            seeding: true,
+                        };
+                        let msg =
+                            MessageType::BroadcastProtocol(ProtocolHeader::Meta(meta_info.clone()));
+                        self.events.push_back(GossipEvent::Send(
+                            from,
+                            Self::prepare_message(msg, Bytes::default()),
+                        ));
+
+                        // this shouldn't usually be dropped, because there must already be an
+                        // outstanding connection
+                        status.sent_metas.insert(from, meta_info);
+                    }
+                } else {
+                    tracing::trace!("no chunker initialized for id: {:?}", id);
+                }
+            }
+        }
+    }
+
+    fn insert_chunker(&mut self, chunker: C) {
+        let created_at = chunker.created_at();
+        self.chunker_timeouts
+            .entry(created_at + self.config.timeout)
+            .or_default()
+            .push(chunker.meta().id());
+
+        let removed = self
+            .chunkers
+            .insert(chunker.meta().id(), ChunkerStatus::new(chunker));
+        assert!(removed.is_none());
+    }
+
+    fn update_tick(&mut self, time: Duration) {
+        assert!(time >= self.current_tick);
+        self.current_tick = time;
+    }
+}
+
+impl<'k, C: Chunker<'k>> Gossip for Seeder<'k, C> {
+    type NodeIdPubKey = CertificateSignaturePubKey<C::SignatureType>;
+
+    fn send(&mut self, time: Duration, to: RouterTarget<Self::NodeIdPubKey>, message: AppMessage) {
+        self.update_tick(time);
+        match to {
+            RouterTarget::Broadcast => {
+                if self.next_chunker_poll.is_none() {
+                    self.next_chunker_poll = Some(self.current_tick);
+                }
+                self.events
+                    .push_back(GossipEvent::Emit(self.me, message.clone()));
+
+                let chunker =
+                    C::new_from_message(time, &self.config.all_peers, self.config.key, message);
+                tracing::info!(
+                    "initialized chunker on broadcast attempt: {:?}",
+                    chunker.meta()
+                );
+                // this is safe because chunkers are guaranteed to be unique, even for
+                // same AppMessage.
+                self.insert_chunker(chunker);
+            }
+            RouterTarget::PointToPoint(to) => {
+                if to == self.me {
+                    self.events.push_back(GossipEvent::Emit(self.me, message))
+                } else {
+                    self.events.push_back(GossipEvent::Send(
+                        to,
+                        Self::prepare_message(MessageType::Direct, message),
+                    ))
+                }
+            }
+        }
+    }
+
+    fn handle_gossip_message(
+        &mut self,
+        time: Duration,
+        from: NodeId<Self::NodeIdPubKey>,
+        mut gossip_message: GossipMessage,
+    ) {
+        self.update_tick(time);
+
+        // FIXME we don't do ANY input sanitization right now
+        // It's trivial for any node to crash any other node by sending malformed input
+
+        let outer_header: OuterHeader =
+            bincode::deserialize(&gossip_message.copy_to_bytes(OUTER_HEADER_SIZE)).unwrap();
+        let header: Header<C::Meta, C::Chunk> =
+            bincode::deserialize(&gossip_message.copy_to_bytes(outer_header.0 as usize)).unwrap();
+        let data = gossip_message.copy_to_bytes(header.data_len as usize);
+        assert!(
+            gossip_message.is_empty(),
+            "header data_len should match data section size"
+        );
+
+        match header.message_type {
+            MessageType::Direct => self.events.push_back(GossipEvent::Emit(from, data)),
+            MessageType::BroadcastProtocol(header) => {
+                if self.next_chunker_poll.is_none() {
+                    self.next_chunker_poll = Some(self.current_tick);
+                }
+                self.handle_protocol_message(from, header, data)
+            }
+        }
+    }
+
+    fn peek_tick(&self) -> Option<Duration> {
+        if !self.events.is_empty() {
+            Some(self.current_tick)
+        } else {
+            let next_chunker_poll = self.next_chunker_poll?.max(self.current_tick);
+            Some(next_chunker_poll)
+        }
+    }
+
+    fn poll(&mut self, time: Duration) -> Option<GossipEvent<Self::NodeIdPubKey>> {
+        self.update_tick(time);
+
+        if self
+            .next_chunker_poll
+            .map(|next_poll| time >= next_poll)
+            .unwrap_or(false)
+        {
+            while time
+                >= self
+                    .chunker_timeouts
+                    .keys()
+                    .next()
+                    .copied()
+                    .unwrap_or(Duration::MAX)
+            {
+                let gc_ids = self.chunker_timeouts.pop_first().expect("must exist").1;
+                for gc_id in gc_ids {
+                    let removed = self.chunkers.remove(&gc_id);
+                    if removed.is_some() {
+                        tracing::debug!("garbage collected chunk with id: {:?}", gc_id);
+                    }
+                }
+            }
+
+            // TODO we can do more intelligent selection of chunkers here - eg time-weighted decay?
+            //      stake-weighted selection?
+            // TODO can we eliminate disconnected peers from selection here? or is that too jank?
+            let mut chunkers: Vec<_> = self.chunkers.values_mut().collect();
+            // TODO shuffle chunkers with deterministic RNG
+
+            let mut chunk_bytes_generated: u64 = 0; // TODO should we include outbound meta bytes?
+            let mut chunker_idx = 0;
+            while {
+                let up_bandwidth_Bps = self.config.up_bandwidth_Mbps as u64 * 125_000;
+                let up_bandwidth_Bpms = up_bandwidth_Bps / 1_000;
+                let exceeded_limit =
+                    Duration::from_millis(chunk_bytes_generated / up_bandwidth_Bpms)
+                        >= self.config.chunker_poll_interval;
+                !chunkers.is_empty() && !exceeded_limit
+            } {
+                let status = &mut chunkers[chunker_idx];
+                if let Some((to, chunk, data)) = status.chunker.generate_chunk() {
+                    if let Entry::Vacant(e) = status.sent_metas.entry(to) {
+                        let meta_info = MetaInfo {
+                            meta: status.chunker.meta().clone(),
+                            seeding: status.chunker.is_seeder(),
+                        };
+                        e.insert(meta_info.clone());
+                        let meta_message = Self::prepare_message(
+                            MessageType::BroadcastProtocol(ProtocolHeader::Meta(meta_info)),
+                            Bytes::default(),
+                        );
+                        // Note that as currently constructed, this will always be dropped by the
+                        // ConnectionManager if there isn't already an established connection. This
+                        // should be fine for now - adding an extra timeout/retry mechanism seems
+                        // unnecessary given latencies.
+                        self.events.push_back(GossipEvent::Send(to, meta_message));
+                    }
+
+                    let chunk_message = Self::prepare_message(
+                        MessageType::BroadcastProtocol(ProtocolHeader::Chunk(chunk)),
+                        data,
+                    );
+                    chunk_bytes_generated += chunk_message.remaining() as u64;
+                    self.events.push_back(GossipEvent::Send(to, chunk_message));
+                    chunker_idx = (chunker_idx + 1) % chunkers.len();
+                } else {
+                    chunkers.swap_remove(chunker_idx);
+                    if chunkers.is_empty() {
+                        break;
+                    }
+                    chunker_idx %= chunkers.len();
+                }
+            }
+
+            self.next_chunker_poll = if chunk_bytes_generated == 0 {
+                None
+            } else {
+                let up_bandwidth_Bps = self.config.up_bandwidth_Mbps as u64 * 125_000;
+                let up_bandwidth_Bpms = up_bandwidth_Bps / 1_000;
+                Some(time + Duration::from_millis(chunk_bytes_generated / up_bandwidth_Bpms))
+            };
+        }
+
+        self.events.pop_front()
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct OuterHeader(u32);
+const OUTER_HEADER_SIZE: usize = std::mem::size_of::<OuterHeader>();
+
+#[derive(Clone, Deserialize, Serialize)]
+struct Header<M, C> {
+    data_len: u32,
+    message_type: MessageType<M, C>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+enum MessageType<M, C> {
+    Direct,
+    BroadcastProtocol(ProtocolHeader<M, C>),
+}
+
+#[derive(Clone, Deserialize, Serialize, Debug)]
+enum ProtocolHeader<M, C> {
+    Meta(MetaInfo<M>),
+    Chunk(C),
+}
+
+#[derive(Clone, Deserialize, Serialize, Debug)]
+struct MetaInfo<M> {
+    meta: M,
+    seeding: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use monad_crypto::{
+        certificate_signature::{CertificateKeyPair, CertificateSignature},
+        hasher::{Hasher, HasherType},
+        NopSignature,
+    };
+    use monad_transformer::{BytesTransformer, LatencyTransformer, PacerTransformer};
+    use monad_types::NodeId;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    use super::{raptor::Raptor, tree::Tree, SeederConfig};
+    use crate::testutil::{test_broadcast, test_direct, Swarm};
+
+    const NUM_NODES: u16 = 20;
+    const PAYLOAD_SIZE_BYTES: usize = 1024;
+
+    type SignatureType = NopSignature;
+
+    #[test]
+    fn test_framed_messages() {
+        let keys: Vec<_> = (1_u32..)
+            .take(NUM_NODES.into())
+            .map(|idx| {
+                let mut secret = {
+                    let mut hasher = HasherType::new();
+                    hasher.update(idx.to_le_bytes());
+                    hasher.hash().0
+                };
+                <SignatureType as CertificateSignature>::KeyPairType::from_bytes(&mut secret)
+                    .unwrap()
+            })
+            .collect();
+        let mut swarm = {
+            Swarm::new(keys.iter().map(|key| {
+                (
+                    NodeId::new(key.pubkey()),
+                    SeederConfig::<Tree<SignatureType>> {
+                        all_peers: keys.iter().map(|key| NodeId::new(key.pubkey())).collect(),
+                        key,
+
+                        timeout: Duration::from_millis(700),
+                        up_bandwidth_Mbps: 1_000,
+                        chunker_poll_interval: Duration::from_millis(10),
+                    }
+                    .build(),
+                    vec![BytesTransformer::Latency(LatencyTransformer::new(
+                        Duration::from_millis(100),
+                    ))],
+                )
+            }))
+        };
+
+        let mut rng = ChaCha8Rng::from_seed([0; 32]);
+        test_broadcast(
+            &mut rng,
+            &mut swarm,
+            Duration::from_secs(1),
+            PAYLOAD_SIZE_BYTES,
+            usize::MAX,
+            1.0,
+        );
+        test_direct(
+            &mut rng,
+            &mut swarm,
+            Duration::from_secs(1),
+            PAYLOAD_SIZE_BYTES,
+        );
+    }
+
+    #[test]
+    fn test_framed_messages_raptor() {
+        let keys: Vec<_> = (1_u32..)
+            .take(NUM_NODES.into())
+            .map(|idx| {
+                let mut secret = {
+                    let mut hasher = HasherType::new();
+                    hasher.update(idx.to_le_bytes());
+                    hasher.hash().0
+                };
+                <SignatureType as CertificateSignature>::KeyPairType::from_bytes(&mut secret)
+                    .unwrap()
+            })
+            .collect();
+        let mut swarm = {
+            Swarm::new(keys.iter().map(|key| {
+                (
+                    NodeId::new(key.pubkey()),
+                    SeederConfig::<Raptor<SignatureType>> {
+                        all_peers: keys.iter().map(|key| NodeId::new(key.pubkey())).collect(),
+                        key,
+
+                        timeout: Duration::from_millis(700),
+                        up_bandwidth_Mbps: 1_000,
+                        chunker_poll_interval: Duration::from_millis(10),
+                    }
+                    .build(),
+                    vec![BytesTransformer::Latency(LatencyTransformer::new(
+                        Duration::from_millis(100),
+                    ))],
+                )
+            }))
+        };
+
+        let mut rng = ChaCha8Rng::from_seed([0; 32]);
+        test_broadcast(
+            &mut rng,
+            &mut swarm,
+            Duration::from_secs(1),
+            PAYLOAD_SIZE_BYTES,
+            usize::MAX,
+            1.0,
+        );
+        test_direct(
+            &mut rng,
+            &mut swarm,
+            Duration::from_secs(1),
+            PAYLOAD_SIZE_BYTES,
+        );
+    }
+
+    #[test]
+    fn test_framed_messages_raptor_large() {
+        const UP_BANDWIDTH_MBIT: u16 = 100;
+        let keys: Vec<_> = (1_u32..)
+            .take(100)
+            .map(|idx| {
+                let mut secret = {
+                    let mut hasher = HasherType::new();
+                    hasher.update(idx.to_le_bytes());
+                    hasher.hash().0
+                };
+                <SignatureType as CertificateSignature>::KeyPairType::from_bytes(&mut secret)
+                    .unwrap()
+            })
+            .collect();
+        let mut swarm = {
+            Swarm::new(keys.iter().map(|key| {
+                (
+                    NodeId::new(key.pubkey()),
+                    SeederConfig::<Raptor<SignatureType>> {
+                        all_peers: keys.iter().map(|key| NodeId::new(key.pubkey())).collect(),
+                        key,
+
+                        timeout: Duration::from_millis(700),
+                        up_bandwidth_Mbps: UP_BANDWIDTH_MBIT,
+                        chunker_poll_interval: Duration::from_millis(10),
+                    }
+                    .build(),
+                    vec![
+                        BytesTransformer::Latency(LatencyTransformer::new(Duration::from_millis(
+                            100,
+                        ))),
+                        BytesTransformer::Pacer(PacerTransformer::new(
+                            UP_BANDWIDTH_MBIT.into(),
+                            8 * 1450,
+                        )),
+                    ],
+                )
+            }))
+        };
+
+        let mut rng = ChaCha8Rng::from_seed([0; 32]);
+        let elapsed = test_broadcast(
+            &mut rng,
+            &mut swarm,
+            Duration::from_secs(1),
+            1_000 * 400, // payload_size
+            1,           // num_messages
+            1.0,
+        );
+        eprintln!("took {:?} to broadcast", elapsed);
+        assert!(elapsed < Duration::from_millis(500));
+    }
+}

--- a/monad-gossip/src/seeder/raptor.rs
+++ b/monad-gossip/src/seeder/raptor.rs
@@ -1,0 +1,414 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    error::Error,
+    time::Duration,
+};
+
+use bytes::Bytes;
+use monad_crypto::{
+    certificate_signature::{
+        CertificateKeyPair, CertificateSignature, CertificateSignaturePubKey,
+        CertificateSignatureRecoverable, PubKey,
+    },
+    hasher::{Hash, Hasher, HasherType},
+};
+use monad_types::NodeId;
+use rand::{seq::SliceRandom, Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use raptorq::{Decoder, Encoder, EncodingPacket, ObjectTransmissionInformation};
+use serde::{Deserialize, Serialize};
+
+use super::chunker::{Chunk, Chunker, Meta};
+use crate::{connection_manager::MAX_DATAGRAM_SIZE, AppMessage};
+
+pub struct Raptor<'k, ST: CertificateSignatureRecoverable> {
+    me: NodeId<CertificateSignaturePubKey<ST>>,
+    rng: ChaCha8Rng,
+
+    meta: RaptorMeta<ST>,
+    /// computed from meta signature
+    creator: NodeId<CertificateSignaturePubKey<ST>>,
+
+    role: Role<'k, ST>,
+
+    non_seeders: BTreeSet<NodeId<CertificateSignaturePubKey<ST>>>,
+}
+
+enum Role<'k, ST: CertificateSignatureRecoverable> {
+    Encoder {
+        key: &'k ST::KeyPairType,
+        encoder: Encoder,
+        source_packets: Vec<EncodingPacket>,
+        repair_idx: Vec<u32>, // index of last generated symbol id, for given chunk idx
+    },
+    Decoder {
+        seeder: bool,
+        decoder: Decoder,
+        chunks: BTreeMap<raptorq::PayloadId, ChunkData<ST>>,
+    },
+}
+
+struct ChunkData<ST: CertificateSignatureRecoverable> {
+    chunk: RaptorChunk<ST>,
+    data: Bytes,
+    to_forward: BTreeSet<NodeId<CertificateSignaturePubKey<ST>>>,
+}
+
+impl<'k, ST: CertificateSignatureRecoverable> Chunker<'k> for Raptor<'k, ST> {
+    type SignatureType = ST;
+    type PayloadId = RaptorPayloadId;
+    type Meta = RaptorMeta<ST>;
+    type Chunk = RaptorChunk<ST>;
+
+    fn new_from_message(
+        time: Duration,
+        all_peers: &[NodeId<CertificateSignaturePubKey<Self::SignatureType>>],
+        key: &'k <Self::SignatureType as CertificateSignature>::KeyPairType,
+        message: AppMessage,
+    ) -> Self {
+        let me = NodeId::new(key.pubkey());
+        // FIXME set this RNG non-jankly
+        let rng = ChaCha8Rng::from_seed(me.pubkey().bytes()[..32].try_into().unwrap());
+
+        // TODO size this properly
+        let raptor_symbol_size = MAX_DATAGRAM_SIZE - 100;
+
+        let encoder = Encoder::with_defaults(&message, raptor_symbol_size.try_into().unwrap());
+        let meta = RaptorMeta::create(key, &message, time, encoder.get_config());
+
+        let mut source_packets = Vec::new();
+        let mut repair_idx = Vec::new();
+        for encoder in encoder.get_block_encoders() {
+            source_packets.extend(encoder.source_packets());
+            repair_idx.push(0);
+        }
+        // reverse so that we can pop these off in order
+        source_packets.reverse();
+
+        Self {
+            me,
+            rng,
+            meta,
+            creator: me,
+
+            role: Role::Encoder {
+                key,
+                encoder,
+                source_packets,
+                repair_idx,
+            },
+            non_seeders: all_peers.iter().copied().filter(|id| id != &me).collect(),
+        }
+    }
+
+    /// Can be called in untrusted context
+    fn try_new_from_meta(
+        _time: Duration,
+        all_peers: &[NodeId<CertificateSignaturePubKey<Self::SignatureType>>],
+        key: &'k <Self::SignatureType as CertificateSignature>::KeyPairType,
+        meta: Self::Meta,
+    ) -> Result<Self, Box<dyn Error>> {
+        let me = NodeId::new(key.pubkey());
+        // FIXME set this RNG non-jankly
+        let rng = ChaCha8Rng::from_seed(me.pubkey().bytes()[..32].try_into().unwrap());
+
+        // TODO validate that fields in `meta` are valid
+        let creator = NodeId::new(
+            meta.signature
+                .recover_pubkey(meta.id().0.as_slice())
+                .map_err(|_| "failed to recover pubkey")?,
+        );
+        // TODO verify that creator is current leader
+        // otherwise any non-leader validator can broadcast anything
+
+        let decoder = Decoder::new(meta.raptor_meta);
+        let chunker = Self {
+            me,
+            rng,
+            meta,
+            creator,
+            role: Role::Decoder {
+                seeder: false,
+                decoder,
+                chunks: Default::default(),
+            },
+            non_seeders: all_peers
+                .iter()
+                .copied()
+                .filter(|id| id != &creator && id != &me)
+                .collect(),
+        };
+
+        Ok(chunker)
+    }
+
+    fn meta(&self) -> &Self::Meta {
+        &self.meta
+    }
+
+    fn creator(&self) -> NodeId<CertificateSignaturePubKey<Self::SignatureType>> {
+        self.creator
+    }
+
+    fn created_at(&self) -> Duration {
+        Duration::from_micros(self.meta.created_at_us)
+    }
+
+    fn is_seeder(&self) -> bool {
+        match &self.role {
+            Role::Encoder { .. } => true,
+            Role::Decoder { seeder, .. } => *seeder,
+        }
+    }
+
+    /// Can be called in untrusted context
+    fn process_chunk(
+        &mut self,
+        from: NodeId<CertificateSignaturePubKey<Self::SignatureType>>,
+        chunk: Self::Chunk,
+        data: Bytes,
+    ) -> Result<Option<AppMessage>, Box<dyn Error>> {
+        assert!(!self.is_seeder());
+        // TODO validate that fields in `chunk` are valid
+        let chunk_hash = Self::Chunk::compute_hash(&self.meta.id(), &data);
+        let signer = chunk
+            .signature
+            .recover_pubkey(chunk_hash.as_slice())
+            .map_err(|_| "failed to recover pubkey")?;
+        if self.creator.pubkey() != signer {
+            return Err("chunk wasn't signed by publisher!".into());
+        }
+
+        let Role::Decoder {
+            ref mut decoder,
+            ref mut seeder,
+            ref mut chunks,
+        } = self.role
+        else {
+            unreachable!("invariant broken, not seeder");
+        };
+
+        let encoding_packet = EncodingPacket::deserialize(data.as_ref());
+
+        if from == self.creator {
+            // TODO this branch will never get hit once we become a Decoder { seeder }, this is
+            // suboptimal
+            chunks
+                .entry(encoding_packet.payload_id().clone())
+                .or_insert_with(|| ChunkData {
+                    chunk,
+                    data,
+                    to_forward: self.non_seeders.clone(),
+                });
+        } else {
+            // not responsible for forwarding
+        }
+
+        if let Some(app_mesage) = decoder.decode(encoding_packet) {
+            *seeder = true;
+            return Ok(Some(app_mesage.into()));
+        }
+        Ok(None)
+    }
+
+    fn generate_chunk(
+        &mut self,
+    ) -> Option<(
+        NodeId<CertificateSignaturePubKey<Self::SignatureType>>,
+        Self::Chunk,
+        Bytes,
+    )> {
+        match &mut self.role {
+            Role::Encoder {
+                key,
+                source_packets,
+                encoder,
+                repair_idx,
+            } => {
+                let to_node = **self
+                    .non_seeders
+                    .iter()
+                    .collect::<Vec<_>>()
+                    .choose(&mut self.rng)?;
+                let packet = source_packets.pop().unwrap_or_else(|| {
+                    let idx = self.rng.gen_range(0..encoder.get_block_encoders().len());
+                    let encoder = &encoder.get_block_encoders()[idx];
+                    let repair_idx = &mut repair_idx[idx];
+                    let mut repair_packet = encoder.repair_packets(*repair_idx, 1);
+                    *repair_idx += 1;
+                    repair_packet
+                        .pop()
+                        .expect("failed to generate repair packet")
+                });
+                let data: Bytes = packet.serialize().into();
+                let chunk = RaptorChunk::create(*key, self.meta.id(), &data);
+                Some((to_node, chunk, data))
+            }
+            Role::Decoder { chunks, .. } => loop {
+                let mut chunks_vec = chunks.iter_mut().collect::<Vec<_>>();
+                let (payload_id, chunk_data) = chunks_vec.choose_mut(&mut self.rng)?;
+                let Some(to_node) = chunk_data
+                    .to_forward
+                    .iter()
+                    .collect::<Vec<_>>()
+                    .choose(&mut self.rng)
+                    .map(|id| **id)
+                else {
+                    // noone left to forward the chunk to, so remove it and try a different chunk
+                    let payload_id: raptorq::PayloadId = (*payload_id).clone();
+                    chunks.remove(&payload_id);
+                    continue;
+                };
+                chunk_data.to_forward.remove(&to_node);
+                if !self.non_seeders.contains(&to_node) {
+                    // to_node is seeder now, so remove it and try a different node
+                    continue;
+                }
+                return Some((to_node, chunk_data.chunk.clone(), chunk_data.data.clone()));
+            },
+        }
+    }
+
+    fn set_peer_seeder(&mut self, peer: NodeId<CertificateSignaturePubKey<Self::SignatureType>>) {
+        self.non_seeders.remove(&peer);
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RaptorMeta<ST: CertificateSignatureRecoverable> {
+    #[serde(with = "HashDef")]
+    message_hash: Hash,
+    created_at_us: u64,
+    raptor_meta: ObjectTransmissionInformation,
+
+    #[serde(with = "signature_serde")]
+    #[serde(bound = "")]
+    signature: ST,
+}
+
+impl<ST: CertificateSignatureRecoverable> Meta for RaptorMeta<ST> {
+    type PayloadId = RaptorPayloadId;
+
+    fn id(&self) -> Self::PayloadId {
+        RaptorPayloadId(Self::compute_id(
+            &self.message_hash,
+            self.created_at_us,
+            self.raptor_meta,
+        ))
+    }
+}
+
+impl<ST: CertificateSignatureRecoverable> RaptorMeta<ST> {
+    fn compute_id(
+        message_hash: &Hash,
+        created_at_us: u64,
+        raptor_meta: ObjectTransmissionInformation,
+    ) -> Hash {
+        let mut hasher = HasherType::new();
+        hasher.update(message_hash);
+        hasher.update(created_at_us.to_le_bytes());
+        hasher.update(raptor_meta.serialize());
+        hasher.hash()
+    }
+    /// this function must only be called in trusted contexts!
+    pub fn create(
+        key: &ST::KeyPairType,
+        message: &AppMessage,
+        created_at: Duration,
+        raptor_meta: ObjectTransmissionInformation,
+    ) -> Self {
+        let message_hash = {
+            let mut hasher = HasherType::new();
+            hasher.update(message);
+            hasher.hash()
+        };
+        let created_at_us = created_at.as_micros().try_into().unwrap();
+        let signature = ST::sign(
+            Self::compute_id(&message_hash, created_at_us, raptor_meta).as_slice(),
+            key,
+        );
+        Self {
+            message_hash,
+            created_at_us,
+            raptor_meta,
+
+            signature,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RaptorChunk<ST: CertificateSignatureRecoverable> {
+    payload_id: RaptorPayloadId,
+
+    #[serde(with = "signature_serde")]
+    #[serde(bound = "")]
+    signature: ST,
+}
+
+impl<ST: CertificateSignatureRecoverable> RaptorChunk<ST> {
+    fn compute_hash(payload_id: &RaptorPayloadId, chunk: &Bytes) -> Hash {
+        let mut hasher = HasherType::new();
+        hasher.update(payload_id.0);
+        hasher.update(chunk);
+        hasher.hash()
+    }
+
+    pub fn create(key: &ST::KeyPairType, payload_id: RaptorPayloadId, chunk: &Bytes) -> Self {
+        let hash = Self::compute_hash(&payload_id, chunk);
+        let signature = ST::sign(hash.as_slice(), key);
+        Self {
+            payload_id,
+            signature,
+        }
+    }
+}
+
+impl<ST: CertificateSignatureRecoverable> Chunk for RaptorChunk<ST> {
+    type PayloadId = RaptorPayloadId;
+
+    fn id(&self) -> Self::PayloadId {
+        self.payload_id
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
+pub struct RaptorPayloadId(#[serde(with = "HashDef")] Hash);
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
+#[serde(remote = "Hash")]
+pub struct HashDef(pub [u8; 32]);
+
+mod signature_serde {
+    use monad_crypto::certificate_signature::CertificateSignature;
+    use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn deserialize<'de, D, ST>(deserializer: D) -> Result<ST, D::Error>
+    where
+        D: Deserializer<'de>,
+        ST: CertificateSignature,
+    {
+        let bytes = Vec::deserialize(deserializer)?;
+        ST::deserialize(&bytes).map_err(|e| D::Error::custom(format!("{:?}", e)))
+    }
+
+    pub fn serialize<S, ST>(signature: &ST, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        ST: CertificateSignature,
+    {
+        signature.serialize().serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use raptorq::Encoder;
+
+    #[test]
+    fn test_encoder() {
+        const RAPTOR_SYMBOL_SIZE: u16 = 1024;
+        let message = vec![0; 10_000 * 400];
+        let _encoder = Encoder::with_defaults(&message, RAPTOR_SYMBOL_SIZE);
+    }
+}

--- a/monad-gossip/src/seeder/tree.rs
+++ b/monad-gossip/src/seeder/tree.rs
@@ -1,0 +1,386 @@
+use std::{collections::BTreeMap, error::Error, time::Duration};
+
+use bytes::{Buf, Bytes, BytesMut};
+use monad_crypto::{
+    certificate_signature::{
+        CertificateKeyPair, CertificateSignature, CertificateSignaturePubKey,
+        CertificateSignatureRecoverable,
+    },
+    hasher::{Hash, Hasher, HasherType},
+};
+use monad_types::NodeId;
+use rand::{seq::SliceRandom, SeedableRng};
+use rand_chacha::ChaChaRng;
+use serde::{Deserialize, Serialize};
+
+use super::chunker::{Chunk, Chunker, Meta};
+use crate::AppMessage;
+
+const TREE_ARITY: usize = 6;
+
+pub struct Tree<ST: CertificateSignatureRecoverable> {
+    /// tree_peers should not include broadcaster!
+    tree_peers: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
+    me: NodeId<CertificateSignaturePubKey<ST>>,
+
+    meta: TreeMeta<ST>,
+    /// computed from meta signature
+    creator: NodeId<CertificateSignaturePubKey<ST>>,
+
+    chunks: BTreeMap<u16, ChunkStatus<ST>>,
+}
+
+struct ChunkStatus<ST: CertificateSignatureRecoverable> {
+    chunk: TreeChunk<ST>,
+    data: Bytes,
+
+    children: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
+}
+
+impl<ST: CertificateSignatureRecoverable> ChunkStatus<ST> {
+    /// tree_peers should not include broadcaster! it should also be sorted
+    pub fn new(
+        mut tree_peers: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
+        me: NodeId<CertificateSignaturePubKey<ST>>,
+        tree_arity: usize,
+        chunk: TreeChunk<ST>,
+        chunk_hash: Hash,
+        data: Bytes,
+    ) -> Self {
+        let children = {
+            let mut rng = ChaChaRng::from_seed(chunk_hash.0);
+            tree_peers.shuffle(&mut rng);
+
+            let maybe_my_idx = tree_peers.iter().position(|&x| x == me);
+
+            match maybe_my_idx {
+                None => tree_peers.into_iter().take(1).collect(),
+                Some(my_idx) => {
+                    // children of a node at index i are at indices (i*k)+1 through (i*k)+k
+                    let start_idx = my_idx * tree_arity + 1;
+                    tree_peers
+                        .into_iter()
+                        .skip(start_idx)
+                        .take(tree_arity)
+                        .collect()
+                }
+            }
+        };
+
+        Self {
+            chunk,
+            data,
+            children,
+        }
+    }
+}
+
+impl<'k, ST: CertificateSignatureRecoverable> Chunker<'k> for Tree<ST> {
+    type SignatureType = ST;
+    type PayloadId = TreePayloadId;
+    type Meta = TreeMeta<ST>;
+    type Chunk = TreeChunk<ST>;
+
+    fn new_from_message(
+        time: Duration,
+        all_peers: &[NodeId<CertificateSignaturePubKey<Self::SignatureType>>],
+        key: &'k <Self::SignatureType as CertificateSignature>::KeyPairType,
+        mut message: AppMessage,
+    ) -> Self {
+        let me = NodeId::new(key.pubkey());
+        let mut tree_peers: Vec<_> = all_peers
+            .iter()
+            .copied()
+            .filter(|peer| peer != &me)
+            .collect();
+        tree_peers.sort();
+
+        const CHUNK_SIZE_BYTES: usize = 8192;
+        let meta = TreeMeta::create(key, &message, time, CHUNK_SIZE_BYTES);
+        let mut chunks = BTreeMap::default();
+        let mut chunk_idx = 0;
+        while message.has_remaining() {
+            let chunk_data = message.copy_to_bytes(CHUNK_SIZE_BYTES.min(message.remaining()));
+            let (chunk, chunk_hash) = TreeChunk::create(key, meta.id(), chunk_idx, &chunk_data);
+            chunks.insert(
+                chunk_idx,
+                ChunkStatus::new(
+                    tree_peers.clone(),
+                    me,
+                    TREE_ARITY,
+                    chunk,
+                    chunk_hash,
+                    chunk_data,
+                ),
+            );
+            chunk_idx += 1;
+        }
+
+        Self {
+            tree_peers,
+            me,
+            meta,
+            creator: me,
+            chunks,
+        }
+    }
+
+    /// Can be called in untrusted context
+    fn try_new_from_meta(
+        _time: Duration,
+        all_peers: &[NodeId<CertificateSignaturePubKey<Self::SignatureType>>],
+        key: &'k <Self::SignatureType as CertificateSignature>::KeyPairType,
+        meta: Self::Meta,
+    ) -> Result<Self, Box<dyn Error>> {
+        // TODO validate that fields in `meta` are valid
+        let creator = NodeId::new(
+            meta.signature
+                .recover_pubkey(meta.id().0.as_slice())
+                .map_err(|_| "failed to recover pubkey")?,
+        );
+        // TODO verify that creator is current leader
+        // otherwise any non-leader validator can broadcast anything
+
+        let mut tree_peers: Vec<_> = all_peers
+            .iter()
+            .copied()
+            .filter(|peer| peer != &creator)
+            .collect();
+        tree_peers.sort();
+
+        let chunker = Self {
+            tree_peers,
+            me: NodeId::new(key.pubkey()),
+            meta,
+            creator,
+            chunks: Default::default(),
+        };
+
+        Ok(chunker)
+    }
+
+    fn meta(&self) -> &Self::Meta {
+        &self.meta
+    }
+
+    fn creator(&self) -> NodeId<CertificateSignaturePubKey<Self::SignatureType>> {
+        self.creator
+    }
+
+    fn created_at(&self) -> Duration {
+        Duration::from_micros(self.meta.created_at_us)
+    }
+
+    fn is_seeder(&self) -> bool {
+        self.chunks.len() == self.meta.num_chunks.into()
+    }
+
+    /// Can be called in untrusted context
+    fn process_chunk(
+        &mut self,
+        _from: NodeId<CertificateSignaturePubKey<Self::SignatureType>>,
+        chunk: Self::Chunk,
+        data: Bytes,
+    ) -> Result<Option<AppMessage>, Box<dyn Error>> {
+        assert!(!self.is_seeder());
+        // TODO validate that fields in `chunk` are valid
+        let chunk_hash = Self::Chunk::compute_hash(&self.meta.id(), &chunk.chunk_idx, &data);
+        let signer = chunk
+            .signature
+            .recover_pubkey(chunk_hash.as_slice())
+            .map_err(|_| "failed to recover pubkey")?;
+        if self.creator.pubkey() != signer {
+            return Err("chunk wasn't signed by publisher!".into());
+        }
+        self.chunks.insert(
+            chunk.chunk_idx,
+            ChunkStatus::new(
+                self.tree_peers.clone(),
+                self.me,
+                TREE_ARITY,
+                chunk,
+                chunk_hash,
+                data,
+            ),
+        );
+
+        Ok(if self.chunks.len() == self.meta.num_chunks.into() {
+            let message_size = self.chunks.values().map(|status| status.data.len()).sum();
+            let message = self
+                .chunks
+                .values()
+                .fold(BytesMut::with_capacity(message_size), |mut b, status| {
+                    b.extend_from_slice(&status.data);
+                    b
+                })
+                .freeze();
+            Some(message)
+        } else {
+            None
+        })
+    }
+
+    fn generate_chunk(
+        &mut self,
+    ) -> Option<(
+        NodeId<CertificateSignaturePubKey<Self::SignatureType>>,
+        Self::Chunk,
+        Bytes,
+    )> {
+        let statuses: Vec<_> = self.chunks.values_mut().collect();
+        // TODO shuffle chunkers with deterministic RNG
+        for status in statuses {
+            if let Some(to) = status.children.pop() {
+                return Some((to, status.chunk.clone(), status.data.clone()));
+            }
+        }
+        None
+    }
+
+    fn set_peer_seeder(&mut self, _peer: NodeId<CertificateSignaturePubKey<Self::SignatureType>>) {
+        // There's no special encoding done on blocks, so there's no need to track seeders
+        // Every node should receive each chunk only once with broadcast trees
+        // Also, each node MUST receive every chunk in order to become a seeder, which implies that
+        // we've already sent them the chunk they need, or they've received it through some
+        // side-channel mechanism. Either way, tracking seeders is not required
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TreeMeta<ST: CertificateSignatureRecoverable> {
+    #[serde(with = "HashDef")]
+    message_hash: Hash,
+    created_at_us: u64,
+    num_chunks: u16,
+
+    #[serde(with = "signature_serde")]
+    #[serde(bound = "")]
+    signature: ST,
+}
+
+impl<ST: CertificateSignatureRecoverable> Meta for TreeMeta<ST> {
+    type PayloadId = TreePayloadId;
+
+    fn id(&self) -> Self::PayloadId {
+        TreePayloadId(Self::compute_id(
+            &self.message_hash,
+            self.created_at_us,
+            self.num_chunks,
+        ))
+    }
+}
+
+impl<ST: CertificateSignatureRecoverable> TreeMeta<ST> {
+    fn compute_id(message_hash: &Hash, created_at_us: u64, num_chunks: u16) -> Hash {
+        let mut hasher = HasherType::new();
+        hasher.update(message_hash);
+        hasher.update(created_at_us.to_le_bytes());
+        hasher.update(num_chunks.to_le_bytes());
+        hasher.hash()
+    }
+    /// this function must only be called in trusted contexts!
+    pub fn create(
+        key: &ST::KeyPairType,
+        message: &AppMessage,
+        created_at: Duration,
+        chunk_size_bytes: usize,
+    ) -> Self {
+        let message_hash = {
+            let mut hasher = HasherType::new();
+            hasher.update(message);
+            hasher.hash()
+        };
+        let num_chunks = message
+            .len()
+            .div_ceil(chunk_size_bytes)
+            .try_into()
+            .expect("can't generate more than u16 chunks");
+        let created_at_us = created_at.as_micros().try_into().unwrap();
+        let signature = ST::sign(
+            Self::compute_id(&message_hash, created_at_us, num_chunks).as_slice(),
+            key,
+        );
+        Self {
+            message_hash,
+            created_at_us,
+            num_chunks,
+
+            signature,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TreeChunk<ST: CertificateSignatureRecoverable> {
+    payload_id: TreePayloadId,
+    chunk_idx: u16,
+
+    #[serde(with = "signature_serde")]
+    #[serde(bound = "")]
+    signature: ST,
+}
+
+impl<ST: CertificateSignatureRecoverable> TreeChunk<ST> {
+    fn compute_hash(payload_id: &TreePayloadId, chunk_idx: &u16, chunk: &Bytes) -> Hash {
+        let mut hasher = HasherType::new();
+        hasher.update(payload_id.0);
+        hasher.update(chunk_idx.to_le_bytes());
+        hasher.update(chunk);
+        hasher.hash()
+    }
+
+    pub fn create(
+        key: &ST::KeyPairType,
+        payload_id: TreePayloadId,
+        chunk_idx: u16,
+        chunk: &Bytes,
+    ) -> (Self, Hash) {
+        let hash = Self::compute_hash(&payload_id, &chunk_idx, chunk);
+        let signature = ST::sign(hash.as_slice(), key);
+        (
+            Self {
+                payload_id,
+                chunk_idx,
+                signature,
+            },
+            hash,
+        )
+    }
+}
+
+impl<ST: CertificateSignatureRecoverable> Chunk for TreeChunk<ST> {
+    type PayloadId = TreePayloadId;
+
+    fn id(&self) -> Self::PayloadId {
+        self.payload_id
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
+pub struct TreePayloadId(#[serde(with = "HashDef")] Hash);
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
+#[serde(remote = "Hash")]
+pub struct HashDef(pub [u8; 32]);
+
+mod signature_serde {
+    use monad_crypto::certificate_signature::CertificateSignature;
+    use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn deserialize<'de, D, ST>(deserializer: D) -> Result<ST, D::Error>
+    where
+        D: Deserializer<'de>,
+        ST: CertificateSignature,
+    {
+        let bytes = Vec::deserialize(deserializer)?;
+        ST::deserialize(&bytes).map_err(|e| D::Error::custom(format!("{:?}", e)))
+    }
+
+    pub fn serialize<S, ST>(signature: &ST, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        ST: CertificateSignature,
+    {
+        signature.serialize().serialize(serializer)
+    }
+}

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -255,11 +255,11 @@ fn many_nodes_quic_bw() {
         .unwrap();
 
     let max_block_sync_requests = 10;
-    let min_ledger_len = 100;
+    let min_ledger_len = 99;
     swarm_ledger_verification(&swarm, min_ledger_len);
 
     let mut verifier =
-        MockSwarmVerifier::default().tick_range(Duration::from_secs(122), Duration::from_secs(1));
+        MockSwarmVerifier::default().tick_range(Duration::from_secs(105), Duration::from_secs(1));
 
     let node_ids = swarm.states().keys().copied().collect_vec();
     verifier

--- a/monad-mock-swarm/tests/two_nodes.rs
+++ b/monad-mock-swarm/tests/two_nodes.rs
@@ -294,7 +294,7 @@ fn two_nodes_quic_bw() {
     // this is empirical, don't want to spend too much time figuring out a
     // degenerative case
     let mut verifier =
-        MockSwarmVerifier::default().tick_range(Duration::from_secs(5), Duration::from_secs(1));
+        MockSwarmVerifier::default().tick_range(Duration::from_secs(6), Duration::from_secs(1));
     assert!(verifier.verify(&swarm));
 
     let node_ids = swarm.states().keys().copied().collect_vec();

--- a/monad-node/Cargo.toml
+++ b/monad-node/Cargo.toml
@@ -32,6 +32,7 @@ monad-validator = { path = "../monad-validator" }
 monad-wal = { path = "../monad-wal" }
 
 base64 = { workspace = true }
+bytes = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 env_logger = { workspace = true }
 futures-util = { workspace = true }

--- a/monad-quic/src/endpoint.rs
+++ b/monad-quic/src/endpoint.rs
@@ -1,0 +1,454 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    marker::PhantomData,
+    net::SocketAddr,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::{Context, Poll, Waker},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use bytes::Bytes;
+use futures::{
+    future::BoxFuture,
+    stream::{SelectAll, StreamExt},
+    FutureExt, Stream,
+};
+use monad_crypto::certificate_signature::PubKey;
+use monad_executor_glue::{Message, RouterCommand};
+use monad_gossip::{ConnectionManager, ConnectionManagerEvent, Gossip};
+use monad_types::{Deserializable, NodeId, Serializable};
+use quinn::Connecting;
+use quinn_proto::ClientConfig;
+
+use crate::{
+    connection::{Connection, ConnectionEvent, ConnectionId, ConnectionWriter},
+    QuinnConfig, ServiceConfig,
+};
+
+const ZERO_INSTANT: SystemTime = UNIX_EPOCH;
+
+pub(crate) struct SyncEndpoint<QC, G, M, OM>(Arc<Mutex<Endpoint<QC, G, M, OM>>>)
+where
+    G: Gossip,
+    M: Message<NodeIdPubKey = G::NodeIdPubKey>,
+    QC: QuinnConfig<NodeIdPubKey = G::NodeIdPubKey>;
+
+impl<G, QC, M, OM> Clone for SyncEndpoint<QC, G, M, OM>
+where
+    G: Gossip,
+    M: Message<NodeIdPubKey = G::NodeIdPubKey>,
+    QC: QuinnConfig<NodeIdPubKey = G::NodeIdPubKey>,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<QC, G, M, OM> SyncEndpoint<QC, G, M, OM>
+where
+    G: Gossip,
+    M: Message<NodeIdPubKey = G::NodeIdPubKey>,
+    QC: QuinnConfig<NodeIdPubKey = G::NodeIdPubKey>,
+{
+    pub fn new(config: ServiceConfig<QC>, gossip: G) -> Self {
+        Self(Arc::new(Mutex::new(Endpoint::new(config, gossip))))
+    }
+}
+
+impl<QC, G, M, OM> SyncEndpoint<QC, G, M, OM>
+where
+    G: Gossip,
+    M: Message<NodeIdPubKey = G::NodeIdPubKey> + Deserializable<Bytes> + Send + Sync + 'static,
+    QC: QuinnConfig<NodeIdPubKey = G::NodeIdPubKey>,
+    <M as Deserializable<Bytes>>::ReadError: 'static,
+    OM: Serializable<Bytes> + Send + Sync + 'static,
+{
+    pub fn exec(&mut self, commands: Vec<RouterCommand<G::NodeIdPubKey, OM>>) {
+        self.0.lock().unwrap().exec(commands)
+    }
+}
+
+pub(crate) struct Endpoint<QC, G, M, OM>
+where
+    G: Gossip,
+    M: Message<NodeIdPubKey = G::NodeIdPubKey>,
+    QC: QuinnConfig<NodeIdPubKey = G::NodeIdPubKey>,
+{
+    /// Time since ZERO_INSTANT (duration since epoch start)
+    current_time: Duration,
+
+    /// The NodeId of self
+    me: NodeId<G::NodeIdPubKey>,
+    /// known_addresses is used for knowing what address to dial to connect to a given PeerId.
+    ///
+    /// The dialed peer's certificate MUST be validated to ensure that it matches the expected
+    /// PeerId.
+    ///
+    /// This might be replaced in the future once we support peer discovery
+    known_addresses: HashMap<NodeId<G::NodeIdPubKey>, SocketAddr>,
+
+    /// The gossip implementation
+    gossip: ConnectionManager<G>,
+
+    /// The main entrypoint into Quinn's API
+    endpoint: quinn::Endpoint,
+    /// Configuration generator used for Quinn initialization and connections
+    quinn_config: QC,
+
+    /// Future that yields on the next inbound connection attempt
+    accept: BoxFuture<'static, Connecting>,
+
+    /// Future that yields whenever the gossip implementation wants to be woken up
+    gossip_timeout: Pin<Box<tokio::time::Sleep>>,
+    waker: Option<Waker>,
+
+    connections: SelectAll<Connection<G::NodeIdPubKey>>,
+
+    /// Each currently open canonical connection
+    canonical_connections: HashMap<ConnectionId, CanonicalConnection<G::NodeIdPubKey>>,
+    /// Latest tie-broken connection for any given NodeId
+    ///
+    /// If the value is None, then the canonical connection is not yet ready
+    /// This can happen if there's a pending outbound connection
+    node_connections: HashMap<NodeId<G::NodeIdPubKey>, Option<ConnectionId>>,
+
+    _pd: PhantomData<(M, OM)>,
+}
+
+struct CanonicalConnection<PT: PubKey> {
+    node_id: NodeId<PT>,
+    writer: ConnectionWriter,
+}
+
+impl<QC, G, M, OM> Endpoint<QC, G, M, OM>
+where
+    G: Gossip,
+    M: Message<NodeIdPubKey = G::NodeIdPubKey>,
+    QC: QuinnConfig<NodeIdPubKey = G::NodeIdPubKey>,
+{
+    pub fn new(config: ServiceConfig<QC>, gossip: G) -> Self {
+        let mut server_config = quinn::ServerConfig::with_crypto(config.quinn_config.server());
+        server_config.transport_config(config.quinn_config.transport());
+        let endpoint = quinn::Endpoint::server(server_config, config.server_address)
+            .unwrap_or_else(|_| {
+                panic!(
+                    "Endpoint initialization shouldn't fail: {:?}",
+                    config.server_address
+                )
+            });
+
+        let accept = {
+            let endpoint = endpoint.clone();
+            #[allow(clippy::async_yields_async)]
+            async move { endpoint.accept().await.expect("endpoint is never closed") }.boxed()
+        };
+
+        Self {
+            current_time: ZERO_INSTANT.elapsed().unwrap(),
+
+            me: config.me,
+            known_addresses: config.known_addresses,
+
+            gossip: ConnectionManager::new(gossip),
+
+            endpoint,
+            quinn_config: config.quinn_config,
+
+            accept,
+
+            gossip_timeout: Box::pin(tokio::time::sleep(Duration::ZERO)),
+            waker: None,
+
+            connections: SelectAll::new(),
+            canonical_connections: Default::default(),
+            node_connections: Default::default(),
+
+            _pd: PhantomData,
+        }
+    }
+
+    fn update_current_time(&mut self) {
+        // enforce monotonicity of SystemTime
+        self.current_time = self.current_time.max(ZERO_INSTANT.elapsed().unwrap());
+    }
+}
+
+impl<QC, G, M, OM> Endpoint<QC, G, M, OM>
+where
+    G: Gossip,
+    M: Message<NodeIdPubKey = G::NodeIdPubKey> + Deserializable<Bytes> + Send + Sync + 'static,
+    QC: QuinnConfig<NodeIdPubKey = G::NodeIdPubKey>,
+    <M as Deserializable<Bytes>>::ReadError: 'static,
+    OM: Serializable<Bytes> + Send + Sync + 'static,
+{
+    fn exec(&mut self, commands: Vec<RouterCommand<G::NodeIdPubKey, OM>>) {
+        self.update_current_time();
+
+        for command in commands {
+            match command {
+                RouterCommand::Publish { target, message } => {
+                    let message = {
+                        let mut _ser_span = tracing::info_span!("serialize_span").entered();
+                        message.serialize()
+                    };
+                    let mut _publish_span =
+                        tracing::info_span!("publish_span", message_len = message.len()).entered();
+                    self.gossip.send(self.current_time, target, message);
+
+                    if let Some(waker) = self.waker.take() {
+                        waker.wake();
+                    }
+                }
+            }
+        }
+    }
+
+    fn connecting(&mut self, connection: Connection<G::NodeIdPubKey>) {
+        self.connections.push(connection);
+    }
+
+    /// Populates self.outbound_messages for a new established connection
+    fn connected(&mut self, node_id: NodeId<G::NodeIdPubKey>, writer: ConnectionWriter) {
+        let connection_id = writer.connection_id();
+
+        if let Some(old_connection_id) = self.node_connections.get(&node_id).copied().flatten() {
+            if self.me < node_id {
+                // disconnect new connection
+                self.disconnected(&connection_id);
+                return;
+            } else {
+                // disconnect old connection
+                self.disconnected(&old_connection_id)
+            }
+        }
+
+        self.gossip.connected(self.current_time, node_id);
+        self.canonical_connections
+            .insert(connection_id, CanonicalConnection { node_id, writer });
+        self.node_connections.insert(node_id, Some(connection_id));
+    }
+
+    /// Cleans up self.outbound_messages for a connection that's shutting down
+    /// Will cause quinn::Connection::close() to be called if it still exists
+    fn disconnected(&mut self, connection_id: &ConnectionId) {
+        if let Some(connection) = self.canonical_connections.remove(connection_id) {
+            self.gossip
+                .disconnected(self.current_time, connection.node_id);
+            self.node_connections.remove(&connection.node_id);
+        }
+    }
+
+    fn handle_gossip_event(
+        &mut self,
+        gossip_event: ConnectionManagerEvent<G::NodeIdPubKey>,
+    ) -> Option<M::Event> {
+        match gossip_event {
+            ConnectionManagerEvent::RequestConnect(to) => {
+                if let Entry::Vacant(e) = self.node_connections.entry(to) {
+                    let known_address = match self.known_addresses.get(&to) {
+                        Some(address) => *address,
+                        None => todo!("Peer discovery unsupported, address unknown for: {:?}", to),
+                    };
+                    let client_config = {
+                        let mut c = ClientConfig::new(self.quinn_config.client());
+                        c.transport_config(self.quinn_config.transport());
+                        c
+                    };
+                    let connection = match self.endpoint.connect_with(
+                        client_config,
+                        known_address,
+                        "MONAD", // server_name doesn't matter because we're verifying the peer_id that signed the certificate
+                    ) {
+                        Ok(connecting) => Connection::outbound::<QC>(connecting, to),
+                        Err(err) => {
+                            todo!("Unexpected connection error: {:?}", err)
+                        }
+                    };
+                    e.insert(None);
+                    self.connecting(connection);
+                } else {
+                    // (connection|connection_attempt) already exists
+                }
+                None
+            }
+            ConnectionManagerEvent::Send(to, gossip_message) => {
+                let connection_id = self
+                    .node_connections
+                    .get(&to)
+                    .copied()
+                    .flatten()
+                    .expect("must only emit Send once connected");
+                let connection = self.canonical_connections.get_mut(&connection_id).expect(
+                    "invariant broken: node_connections connection_id not in canonical_connections",
+                );
+                let mut gossip_message: Vec<_> = gossip_message.into_inner().into_iter().collect();
+                let result = connection
+                    .writer
+                    .write_chunks(&mut gossip_message)
+                    .now_or_never()?;
+                match result {
+                    Ok(num_chunks) if num_chunks == gossip_message.len() => {}
+                    Ok(_) => {
+                        todo!("wrote partial chunks, replace with try_write_chunks");
+                    }
+                    Err(failure) => {
+                        tracing::warn!("disconnecting, connection failure: {:?}", failure);
+                        // this implies that the connection died
+                        self.disconnected(&connection_id)
+                    }
+                }
+                None
+            }
+            ConnectionManagerEvent::SendDatagram(to, gossip_message) => {
+                let connection_id = self
+                    .node_connections
+                    .get(&to)
+                    .copied()
+                    .flatten()
+                    .expect("must only emit Send once connected");
+                let connection = self.canonical_connections.get_mut(&connection_id).expect(
+                    "invariant broken: node_connections connection_id not in canonical_connections",
+                );
+                let result = connection.writer.write_datagram(gossip_message);
+                if let Err(failure) = result {
+                    tracing::warn!("disconnecting, connection failure: {:?}", failure);
+                    // this implies that the connection died
+                    // or MTU wasn't big enough?
+                    self.disconnected(&connection_id)
+                }
+                None
+            }
+            ConnectionManagerEvent::Emit(from, app_message) => {
+                let message = {
+                    let mut _deser_span =
+                        tracing::info_span!("deserialize_span", message_len = app_message.len())
+                            .entered();
+                    match M::deserialize(&app_message) {
+                        Ok(m) => m,
+                        Err(e) => todo!("err deserializing message: {:?}", e),
+                    }
+                };
+                let event = {
+                    let mut _message_to_event_span = tracing::info_span!(
+                        "message_to_event_span",
+                        message_len = app_message.len()
+                    )
+                    .entered();
+                    message.event(from)
+                };
+                Some(event)
+            }
+        }
+    }
+}
+
+impl<QC, G, M, OM> Stream for SyncEndpoint<QC, G, M, OM>
+where
+    G: Gossip,
+    M: Message<NodeIdPubKey = G::NodeIdPubKey> + Deserializable<Bytes> + Send + Sync + 'static,
+    QC: QuinnConfig<NodeIdPubKey = G::NodeIdPubKey>,
+    <M as Deserializable<Bytes>>::ReadError: 'static,
+    OM: Serializable<Bytes> + Send + Sync + 'static,
+
+    Self: Unpin,
+{
+    type Item = M::Event;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.0.lock().unwrap();
+        let mut _router_poll_span = tracing::info_span!("router_poll_span").entered();
+
+        if this.waker.is_none() {
+            this.waker = Some(cx.waker().clone());
+        }
+        this.update_current_time();
+        let current_time = this.current_time;
+
+        loop {
+            if let Poll::Ready(connecting) = this.accept.poll_unpin(cx) {
+                let endpoint = this.endpoint.clone();
+                this.accept = {
+                    #[allow(clippy::async_yields_async)]
+                    async move { endpoint.accept().await.expect("endpoint is never closed") }
+                        .boxed()
+                };
+
+                this.connecting(Connection::inbound::<QC>(connecting));
+                continue;
+            }
+
+            if let Some(timeout) = this.gossip.peek_tick() {
+                // unit of timeout is duration since unix epoch
+                let duration_until_timeout =
+                    timeout.checked_sub(current_time).unwrap_or(Duration::ZERO);
+                let current_instant = Instant::now();
+
+                let deadline = current_instant + duration_until_timeout;
+                if deadline > this.gossip_timeout.deadline().into_std() + Duration::from_millis(1) {
+                    tokio::time::Sleep::reset(this.gossip_timeout.as_mut(), deadline.into());
+                }
+                if this.gossip_timeout.poll_unpin(cx).is_ready()
+                    || duration_until_timeout == Duration::ZERO
+                {
+                    if let Some(gossip_event) = this.gossip.poll(current_time) {
+                        if let Some(event) = this.handle_gossip_event(gossip_event) {
+                            return Poll::Ready(Some(event));
+                        }
+                    }
+                    // loop if don't return value, because need to re-poll timeout
+                    continue;
+                }
+            }
+
+            if let Poll::Ready(Some(connection_event)) = this.connections.poll_next_unpin(cx) {
+                match connection_event {
+                    ConnectionEvent::ConnectionFailure(maybe_expected_peer, failure) => {
+                        tracing::warn!("connection failure, failure={:?}", failure);
+                        if let Some(expected_peer) = maybe_expected_peer {
+                            if let Some(None) = this.node_connections.get(&expected_peer) {
+                                this.node_connections.remove(&expected_peer);
+                            } else {
+                                // don't need to do anything, because established conn is still
+                                // alive
+                            }
+                        }
+                    }
+                    ConnectionEvent::Connected(connection_id, node_id, writer) => {
+                        assert_eq!(connection_id, writer.connection_id());
+                        this.connected(node_id, writer);
+                    }
+                    ConnectionEvent::InboundMessage(from, gossip_messages) => {
+                        if let Some(connection) = this.canonical_connections.get(&from) {
+                            let node_id = connection.node_id;
+                            for gossip_message in gossip_messages {
+                                this.gossip.handle_unframed_gossip_message(
+                                    current_time,
+                                    node_id,
+                                    gossip_message,
+                                );
+                            }
+                        }
+                    }
+                    ConnectionEvent::InboundDatagram(from, datagram) => {
+                        if let Some(connection) = this.canonical_connections.get(&from) {
+                            let node_id = connection.node_id;
+                            this.gossip.handle_datagram(current_time, node_id, datagram);
+                        }
+                    }
+                    ConnectionEvent::Disconnected(connection_id, failure) => {
+                        tracing::warn!(
+                            "connection disconnected, id={:?}, failure={:?}",
+                            connection_id,
+                            failure
+                        );
+                        this.disconnected(&connection_id);
+                    }
+                }
+                continue;
+            }
+
+            return Poll::Pending;
+        }
+    }
+}

--- a/monad-quic/src/lib.rs
+++ b/monad-quic/src/lib.rs
@@ -4,8 +4,9 @@ pub use router_scheduler::*;
 mod timeout_queue;
 
 // FIXME-4 split the following into monad-quic-service crate
+mod connection;
+mod endpoint;
 mod quinn_config;
 pub use quinn_config::*;
 mod service;
 pub use service::*;
-mod connection;

--- a/monad-quic/src/service.rs
+++ b/monad-quic/src/service.rs
@@ -1,28 +1,19 @@
 use std::{
-    collections::{hash_map::Entry, HashMap},
-    marker::PhantomData,
+    collections::HashMap,
     net::SocketAddr,
     ops::DerefMut,
-    pin::Pin,
     task::{Poll, Waker},
-    time::{Duration, Instant},
 };
 
 use bytes::Bytes;
-use futures::{future::BoxFuture, FutureExt, Stream, StreamExt};
-use monad_crypto::certificate_signature::PubKey;
+use futures::{Stream, StreamExt};
 use monad_executor::Executor;
 use monad_executor_glue::{Message, RouterCommand};
-use monad_gossip::{ConnectionManager, ConnectionManagerEvent, Gossip, GossipEvent};
+use monad_gossip::Gossip;
 use monad_types::{Deserializable, NodeId, Serializable};
-use quinn::Connecting;
-use quinn_proto::ClientConfig;
 use tokio::sync::mpsc::error::TrySendError;
 
-use crate::{
-    connection::{Connection, ConnectionEvent, ConnectionId, ConnectionWriter},
-    quinn_config::QuinnConfig,
-};
+use crate::{endpoint::SyncEndpoint, quinn_config::QuinnConfig};
 
 /// Service is an implementation of a RouterCommand updater that's backed by Quic
 /// It can be parameterized by a Gossip algorithm
@@ -32,63 +23,14 @@ where
     M: Message<NodeIdPubKey = G::NodeIdPubKey>,
     QC: QuinnConfig<NodeIdPubKey = G::NodeIdPubKey>,
 {
-    /// An arbitrary starting time - used for computing internally consistent relative times,
-    /// which are in std::time::Duration, for the Gossip trait
-    zero_instant: Instant,
-    /// The NodeId of self
     me: NodeId<G::NodeIdPubKey>,
-    /// known_addresses is used for knowing what address to dial to connect to a given PeerId.
-    ///
-    /// The dialed peer's certificate MUST be validated to ensure that it matches the expected
-    /// PeerId.
-    ///
-    /// This might be replaced in the future once we support peer discovery
-    known_addresses: HashMap<NodeId<G::NodeIdPubKey>, SocketAddr>,
-
-    /// The gossip implementation
-    gossip: ConnectionManager<G>,
-
-    /// The main entrypoint into Quinn's API
-    endpoint: quinn::Endpoint,
-    /// Configuration generator used for Quinn initialization and connections
-    quinn_config: QC,
-
-    /// Future that yields on the next inbound connection attempt
-    accept: BoxFuture<'static, Connecting>,
-
-    /// Receiver channel for all connection events
-    connection_events: tokio::sync::mpsc::Receiver<ConnectionEvent<G::NodeIdPubKey>>,
-    // Sender channel for connection events (cloned for each new connection)
-    connection_events_sender: tokio::sync::mpsc::Sender<ConnectionEvent<G::NodeIdPubKey>>,
-
-    /// Each currently open canonical connection
-    canonical_connections: HashMap<ConnectionId, CanonicalConnection<G::NodeIdPubKey>>,
-
-    /// Latest tie-broken connection for any given NodeId
-    ///
-    /// If the value is None, then the canonical connection is not yet ready
-    /// This can happen if there's a pending outbound connection
-    node_connections: HashMap<NodeId<G::NodeIdPubKey>, Option<ConnectionId>>,
-
-    /// Future that yields whenever the gossip implementation wants to be woken up
-    gossip_timeout: Pin<Box<tokio::time::Sleep>>,
-    waker: Option<Waker>,
 
     poll_budget: u64,
+    waker: Option<Waker>,
 
-    _pd: PhantomData<(M, OM)>,
+    endpoint: SyncEndpoint<QC, G, M, OM>,
+    rx: tokio::sync::mpsc::Receiver<M::Event>,
 }
-
-struct CanonicalConnection<PT: PubKey> {
-    node_id: NodeId<PT>,
-    /// Channel that can be used for writing bytes on the connection
-    writer: tokio::sync::mpsc::Sender<Bytes>,
-}
-
-/// Inbound event buffer size for ALL connections
-const CONNECTION_EVENTS_BUFFER_SIZE: usize = 1_000;
-/// Outbound message buffer size for EACH connection
-const CONNECTION_OUTBOUND_MESSAGE_BUFFER_SIZE: usize = 100;
 
 /// Configuration for Service
 pub struct ServiceConfig<QC: QuinnConfig> {
@@ -109,53 +51,47 @@ pub struct ServiceConfig<QC: QuinnConfig> {
 
 impl<QC, G, M, OM> Service<QC, G, M, OM>
 where
-    G: Gossip,
-    M: Message<NodeIdPubKey = G::NodeIdPubKey>,
-    QC: QuinnConfig<NodeIdPubKey = G::NodeIdPubKey>,
+    G: Gossip + Send + 'static,
+    M: Message<NodeIdPubKey = G::NodeIdPubKey> + Deserializable<Bytes> + Send + Sync + 'static,
+    QC: QuinnConfig<NodeIdPubKey = G::NodeIdPubKey> + Send + 'static,
+    <M as Deserializable<Bytes>>::ReadError: 'static,
+    OM: Serializable<Bytes> + Send + Sync + 'static,
 {
     pub fn new(config: ServiceConfig<QC>, gossip: G) -> Self {
-        let mut server_config = quinn::ServerConfig::with_crypto(config.quinn_config.server());
-        server_config.transport_config(config.quinn_config.transport());
-        let endpoint = quinn::Endpoint::server(server_config, config.server_address)
-            .unwrap_or_else(|_| {
-                panic!(
-                    "Endpoint initialization shouldn't fail: {:?}",
-                    config.server_address
-                )
-            });
+        let me = config.me;
+        let endpoint = SyncEndpoint::new(config, gossip);
 
-        let accept = {
-            let endpoint = endpoint.clone();
-            #[allow(clippy::async_yields_async)]
-            async move { endpoint.accept().await.expect("endpoint is never closed") }.boxed()
-        };
+        // TODO size this appropriately?
+        const EVENT_BUFFER_SIZE: usize = 1_000;
+        let (tx, rx) = tokio::sync::mpsc::channel(EVENT_BUFFER_SIZE);
+        tokio::task::spawn({
+            let mut endpoint = endpoint.clone();
 
-        let (connection_events_sender, connection_events) =
-            tokio::sync::mpsc::channel(CONNECTION_EVENTS_BUFFER_SIZE);
-
+            async move {
+                while let Some(event) = endpoint.next().await {
+                    let result = tx.try_send(event);
+                    match result {
+                        Ok(()) => {}
+                        Err(TrySendError::Full(_)) => todo!(
+                            "consensus event loop not consuming fast enough, buf_size={}",
+                            EVENT_BUFFER_SIZE
+                        ),
+                        Err(TrySendError::Closed(_)) => break,
+                    }
+                }
+            }
+        });
         Self {
-            zero_instant: Instant::now(),
-            me: config.me,
-            known_addresses: config.known_addresses,
-
-            gossip: ConnectionManager::new(gossip),
-
-            endpoint,
-            quinn_config: config.quinn_config,
-
-            accept,
-            connection_events,
-            connection_events_sender,
-            canonical_connections: HashMap::new(),
-            node_connections: HashMap::new(),
-
-            gossip_timeout: Box::pin(tokio::time::sleep(Duration::ZERO)),
+            me,
+            poll_budget: 0,
             waker: None,
 
-            poll_budget: 0,
-
-            _pd: PhantomData,
+            endpoint,
+            rx,
         }
+    }
+    pub fn me(&self) -> NodeId<QC::NodeIdPubKey> {
+        self.me
     }
 }
 
@@ -180,25 +116,7 @@ where
     }
 
     fn exec(&mut self, commands: Vec<Self::Command>) {
-        let time = self.zero_instant.elapsed();
-
-        for command in commands {
-            match command {
-                RouterCommand::Publish { target, message } => {
-                    let message = {
-                        let mut _ser_span = tracing::info_span!("serialize_span").entered();
-                        message.serialize()
-                    };
-                    let mut _publish_span =
-                        tracing::info_span!("publish_span", message_len = message.len()).entered();
-                    self.gossip.send(time, target, message);
-
-                    if let Some(waker) = self.waker.take() {
-                        waker.wake();
-                    }
-                }
-            }
-        }
+        self.endpoint.exec(commands);
     }
 }
 
@@ -226,7 +144,6 @@ where
         if this.waker.is_none() {
             this.waker = Some(cx.waker().clone());
         }
-        let time = this.zero_instant.elapsed();
 
         this.poll_budget += 1;
         if this.poll_budget >= 16 {
@@ -236,236 +153,7 @@ where
             }
             return Poll::Pending;
         }
-        loop {
-            if let Poll::Ready(connecting) = this.accept.poll_unpin(cx) {
-                let endpoint = this.endpoint.clone();
-                this.accept = {
-                    #[allow(clippy::async_yields_async)]
-                    async move { endpoint.accept().await.expect("endpoint is never closed") }
-                        .boxed()
-                };
 
-                this.connecting(Connection::inbound::<QC>(connecting));
-                continue;
-            }
-
-            if let Poll::Ready(connection_event) = this.connection_events.poll_recv(cx) {
-                let connection_event =
-                    connection_event.expect("connection_event stream should never be exhausted");
-                match connection_event {
-                    ConnectionEvent::ConnectionFailure(maybe_expected_peer, failure) => {
-                        tracing::warn!("connection failure, failure={:?}", failure);
-                        if let Some(expected_peer) = maybe_expected_peer {
-                            let removed = this.node_connections.remove(&expected_peer);
-                            assert_eq!(removed, Some(None));
-                        }
-                    }
-                    ConnectionEvent::Connected(connection_id, node_id, writer) => {
-                        assert_eq!(connection_id, writer.connection_id());
-                        this.connected(time, node_id, writer);
-                    }
-                    ConnectionEvent::InboundMessage(from, gossip_messages) => {
-                        if let Some(connection) = this.canonical_connections.get(&from) {
-                            for gossip_message in gossip_messages {
-                                this.gossip.handle_unframed_gossip_message(
-                                    time,
-                                    connection.node_id,
-                                    gossip_message,
-                                );
-                            }
-                        }
-                    }
-                    ConnectionEvent::Disconnected(connection_id, failure) => {
-                        tracing::warn!(
-                            "connection disconnected, id={:?}, failure={:?}",
-                            connection_id,
-                            failure
-                        );
-                        this.disconnected(time, &connection_id);
-                    }
-                }
-                continue;
-            }
-
-            if let Some(timeout) = this.gossip.peek_tick() {
-                let deadline = this.zero_instant + timeout;
-                if deadline > this.gossip_timeout.deadline().into_std() {
-                    tokio::time::Sleep::reset(this.gossip_timeout.as_mut(), deadline.into());
-                }
-                if this.gossip_timeout.poll_unpin(cx).is_ready() || timeout <= time {
-                    if let Some(gossip_event) = this.gossip.poll(time) {
-                        if let Some(event) = this.handle_gossip_event(time, gossip_event) {
-                            return Poll::Ready(Some(event));
-                        }
-                    }
-                    // loop if don't return value, because need to re-poll timeout
-                    continue;
-                }
-            }
-
-            return Poll::Pending;
-        }
-    }
-}
-
-impl<QC, G, M, OM> Service<QC, G, M, OM>
-where
-    G: Gossip,
-    M: Message<NodeIdPubKey = G::NodeIdPubKey> + Deserializable<Bytes> + Send + Sync + 'static,
-    QC: QuinnConfig<NodeIdPubKey = G::NodeIdPubKey>,
-    <M as Deserializable<Bytes>>::ReadError: 'static,
-    OM: Serializable<Bytes> + Send + Sync + 'static,
-
-    OM: Into<M> + Clone,
-{
-    pub fn me(&self) -> NodeId<G::NodeIdPubKey> {
-        self.me
-    }
-
-    /// Wires events from a new pending connection to self.connection_events
-    fn connecting(&mut self, mut connection: Connection<G::NodeIdPubKey>) {
-        let connection_events_sender = self.connection_events_sender.clone();
-        tokio::spawn(async move {
-            while let Some(event) = connection.next().await {
-                match connection_events_sender.try_send(event) {
-                    Ok(()) => {}
-                    Err(TrySendError::Full(_)) => todo!("Inbound_events channel full! Consider raising CONNECTION_EVENTS_BUFFER_SIZE={}?", CONNECTION_EVENTS_BUFFER_SIZE),
-                    Err(TrySendError::Closed(_)) => break,
-                }
-            }
-        });
-    }
-
-    /// Populates self.outbound_messages for a new established connection
-    fn connected(
-        &mut self,
-        time: Duration,
-        node_id: NodeId<G::NodeIdPubKey>,
-        mut connection_writer: ConnectionWriter,
-    ) {
-        let connection_id = connection_writer.connection_id();
-        let (connection_sender, mut connection_reader) =
-            tokio::sync::mpsc::channel(CONNECTION_OUTBOUND_MESSAGE_BUFFER_SIZE);
-
-        if let Some(old_connection_id) = self.node_connections.get(&node_id).copied().flatten() {
-            if self.me < node_id {
-                // disconnect new connection
-                self.disconnected(time, &connection_id);
-                return;
-            } else {
-                // disconnect old connection
-                self.disconnected(time, &old_connection_id)
-            }
-        }
-
-        self.gossip.connected(time, node_id);
-        self.canonical_connections.insert(
-            connection_id,
-            CanonicalConnection {
-                node_id,
-                writer: connection_sender,
-            },
-        );
-        self.node_connections.insert(node_id, Some(connection_id));
-        tokio::spawn(async move {
-            while let Some(chunk) = connection_reader.recv().await {
-                if let Err(failure) = connection_writer.write_chunk(chunk).await {
-                    tracing::warn!("connection write failure, failure={:?}", failure);
-                    break;
-                }
-            }
-            // connection_writer gets dropped here, so quinn::Connection::close() will be called
-        });
-    }
-
-    /// Cleans up self.outbound_messages for a connection that's shutting down
-    /// Will cause quinn::Connection::close() to be called if it still exists
-    fn disconnected(&mut self, time: Duration, connection_id: &ConnectionId) {
-        if let Some(connection) = self.canonical_connections.remove(connection_id) {
-            self.gossip.disconnected(time, connection.node_id);
-            self.node_connections.remove(&connection.node_id);
-        }
-    }
-
-    fn handle_gossip_event(
-        &mut self,
-        time: Duration,
-        gossip_event: ConnectionManagerEvent<G::NodeIdPubKey>,
-    ) -> Option<M::Event> {
-        match gossip_event {
-            ConnectionManagerEvent::RequestConnect(to) => {
-                if let Entry::Vacant(e) = self.node_connections.entry(to) {
-                    let known_address = match self.known_addresses.get(&to) {
-                        Some(address) => *address,
-                        None => todo!("Peer discovery unsupported, address unknown for: {:?}", to),
-                    };
-                    let client_config = {
-                        let mut c = ClientConfig::new(self.quinn_config.client());
-                        c.transport_config(self.quinn_config.transport());
-                        c
-                    };
-                    let connection = match self.endpoint.connect_with(
-                        client_config,
-                        known_address,
-                        "MONAD", // server_name doesn't matter because we're verifying the peer_id that signed the certificate
-                    ) {
-                        Ok(connecting) => Connection::outbound::<QC>(connecting, to),
-                        Err(err) => {
-                            todo!("Unexpected connection error: {:?}", err)
-                        }
-                    };
-                    e.insert(None);
-                    self.connecting(connection);
-                } else {
-                    // (connection|connection_attempt) already exists
-                }
-                None
-            }
-            ConnectionManagerEvent::GossipEvent(GossipEvent::Send(to, gossip_message)) => {
-                let connection_id = self
-                    .node_connections
-                    .get(&to)
-                    .copied()
-                    .flatten()
-                    .expect("must only emit Send once connected");
-                let connection = self.canonical_connections.get(&connection_id).expect(
-                    "invariant broken: node_connections connection_id not in canonical_connections",
-                );
-                for gossip_message in gossip_message.into_inner() {
-                    match connection.writer.try_send(gossip_message) {
-                        Ok(()) => continue,
-                        Err(TrySendError::Full(_)) => {
-                            todo!("outbound message channel full! Consider raising CONNNECTION_OUTBOUND_MESSAGE_BUFFER_SIZE={}?", CONNECTION_OUTBOUND_MESSAGE_BUFFER_SIZE);
-                        }
-                        Err(TrySendError::Closed(_)) => {
-                            // this implies that the connection died
-                            self.disconnected(time, &connection_id)
-                        }
-                    }
-                    break;
-                }
-                None
-            }
-            ConnectionManagerEvent::GossipEvent(GossipEvent::Emit(from, app_message)) => {
-                let message = {
-                    let mut _deser_span =
-                        tracing::info_span!("deserialize_span", message_len = app_message.len())
-                            .entered();
-                    match M::deserialize(&app_message) {
-                        Ok(m) => m,
-                        Err(e) => todo!("err deserializing message: {:?}", e),
-                    }
-                };
-                let event = {
-                    let mut _message_to_event_span = tracing::info_span!(
-                        "message_to_event_span",
-                        message_len = app_message.len()
-                    )
-                    .entered();
-                    message.event(from)
-                };
-                Some(event)
-            }
-        }
+        this.rx.poll_recv(cx)
     }
 }


### PR DESCRIPTION
This adds support for the Raptor-based broadcast implementation. It's built on top of a generic Seeder abstraction. Further details are in comments in the respective files.

This required adding support for QUIC datagrams, hence the changes inside monad-quic.

The monad-gossip/src/seeder changes are still quite rough and subject to change, but it's functional and performs well.