### PR TITLE
Allow ethtx tool to send over JSON-RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,6 +2031,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,6 +2442,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2553,6 +2581,12 @@ name = "inventory"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0508c56cfe9bfd5dfeb0c22ab9a6abfda2f27bdca422132e494266351ed8d83c"
+
+[[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
@@ -3149,6 +3183,8 @@ dependencies = [
  "bytes",
  "clap 4.4.10",
  "futures",
+ "hex",
+ "itertools 0.10.5",
  "monad-bls",
  "monad-consensus-types",
  "monad-crypto",
@@ -3156,7 +3192,9 @@ dependencies = [
  "monad-executor-glue",
  "monad-secp",
  "rand",
+ "reqwest",
  "reth-primitives",
+ "serde_json",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3734,6 +3772,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3957,10 +4013,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -4726,6 +4820,46 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.5",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.11",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
 
 [[package]]
 name = "reth-codecs"
@@ -5637,6 +5771,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5843,6 +5998,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.39",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -6211,6 +6376,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6273,6 +6444,18 @@ dependencies = [
  "quote",
  "syn 2.0.39",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -6505,6 +6688,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ rand_chacha = "0.3"
 raptorq = "1.8"
 rayon = "1.7"
 rcgen = "0.11"
+reqwest = { version = "0.11", features = ["json"] }
 ring = "0.17"
 rustls = "0.21"
 scrypt = { version = "0.11", default-features = false }

--- a/monad-ipc/Cargo.toml
+++ b/monad-ipc/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { workspace = true, features = [
     "net",
     "rt",
     "time",
-]}
+] }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }
 
@@ -30,7 +30,12 @@ monad-bls = { path = "../monad-bls" }
 monad-secp = { path = "../monad-secp" }
 
 clap = { workspace = true, features = ["derive"] }
+hex = { workspace = true }
+itertools = { workspace = true }
 reth-primitives = { workspace = true }
+reqwest = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "time"] }
 tracing-subscriber = { workspace = true }
 
 [[example]]

--- a/monad-ipc/examples/ethtx.rs
+++ b/monad-ipc/examples/ethtx.rs
@@ -4,12 +4,14 @@ use std::{
     task::Poll,
 };
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use futures::{Sink, SinkExt};
+use itertools::Itertools;
 use rand::RngCore;
 use reth_primitives::{
     sign_message, Address, Transaction, TransactionKind, TransactionSigned, TxLegacy, B256,
 };
+use serde_json::json;
 use tokio::{net::UnixStream, time};
 use tokio_util::codec::{FramedWrite, LengthDelimitedCodec};
 
@@ -65,43 +67,137 @@ impl Sink<TransactionSigned> for MempoolTxIpcSender {
     }
 }
 
+#[derive(Subcommand, Debug)]
+pub enum Transport {
+    Ipc {
+        #[arg(long)]
+        ipc_path: PathBuf,
+
+        #[arg(long, default_value_t = u32::MAX)]
+        tps: u32,
+    },
+    Rpc {
+        #[arg(long, default_value_t = String::from("0.0.0.0"))]
+        rpc_addr: String,
+
+        #[arg(long, default_value_t = 8080)]
+        rpc_port: u16,
+
+        /// If set, will divide `num_tx` in `Args` into chunks of size `batch_size` to submit over a JSON-RPC batch.
+        #[arg(long, default_value_t = 1)]
+        batch_size: usize,
+
+        /// If set will issue the JSON-RPC HTTP requests concurrently
+        #[arg(long, default_value_t = false)]
+        concurrent: bool,
+    },
+}
+
 /// Tool to create and send Ethereum Txs to monad-bft directly through IPC
 #[derive(Parser, Debug)]
 struct Args {
     #[arg(long, default_value_t = 250)]
-    input_len: u32,
+    input_len: usize,
 
     #[arg(short, long, default_value_t = 1000)]
-    num_tx: u32,
+    num_tx: usize,
 
-    #[arg(long)]
-    ipc_path: PathBuf,
+    #[command(subcommand)]
+    transport: Transport,
+}
 
-    #[arg(long, default_value_t = u32::MAX)]
-    tps: u32,
+async fn send_requests<'a, C: Iterator<Item = &'a TransactionSigned>>(
+    transaction_chunk: C,
+    rpc_addr: &String,
+    rpc_port: u16,
+) -> String {
+    let client = reqwest::Client::new();
+    let url = reqwest::Url::parse(&format!("http://{}:{}", rpc_addr, rpc_port)).unwrap();
+    let payload = transaction_chunk
+        .into_iter()
+        .map(|tx| {
+            let encoded_tx = format!("0x{}", hex::encode(tx.envelope_encoded()));
+            json!({
+                "jsonrpc": "2.0",
+                "method": "eth_sendRawTransaction",
+                "params": [
+                    encoded_tx
+                ],
+                "id": 1
+            })
+        })
+        .collect::<Vec<serde_json::Value>>();
+    client
+        .post(url)
+        .header(
+            reqwest::header::CONTENT_TYPE,
+            reqwest::header::HeaderValue::from_static("application/json"),
+        )
+        .body(serde_json::to_string(&payload).unwrap())
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap()
+        .to_string()
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
-    let mut sender = MempoolTxIpcSender::new(args.ipc_path).await?;
-
     let txs: Vec<_> = (0..args.num_tx).map(|_| make_tx(args.input_len)).collect();
-    let interval = time::Duration::from_secs(1) / args.tps;
-    for tx in txs {
-        let start_time = time::Instant::now();
-        sender.send(tx).await?;
+    match args.transport {
+        Transport::Ipc { ipc_path, tps } => {
+            let mut sender = MempoolTxIpcSender::new(ipc_path).await?;
 
-        if let Some(sleep_duration) = interval.checked_sub(start_time.elapsed()) {
-            time::sleep(sleep_duration).await;
+            let interval = time::Duration::from_secs(1) / tps;
+            for tx in txs {
+                let start_time = time::Instant::now();
+                sender.send(tx).await?;
+
+                if let Some(sleep_duration) = interval.checked_sub(start_time.elapsed()) {
+                    time::sleep(sleep_duration).await;
+                }
+            }
+
+            Ok(())
+        }
+        Transport::Rpc {
+            rpc_addr,
+            rpc_port,
+            batch_size,
+            concurrent,
+        } => {
+            if concurrent {
+                let responses =
+                    futures::future::join_all(txs.iter().chunks(batch_size).into_iter().map(
+                        |txs_batch| async { send_requests(txs_batch, &rpc_addr, rpc_port).await },
+                    ))
+                    .await
+                    .into_iter()
+                    .collect::<Vec<String>>();
+
+                for response in responses {
+                    println!("{}", response);
+                }
+            } else {
+                let mut responses = Vec::new();
+                for txs_batch in &txs.iter().chunks(batch_size) {
+                    responses.push(send_requests(txs_batch, &rpc_addr, rpc_port).await);
+                }
+                for response in responses {
+                    println!("{}", response);
+                }
+            }
+
+            Ok(())
         }
     }
-
-    Ok(())
 }
 
-fn make_tx(input_len: u32) -> TransactionSigned {
-    let mut input = vec![0; input_len as usize];
+fn make_tx(input_len: usize) -> TransactionSigned {
+    let mut input = vec![0; input_len];
     rand::thread_rng().fill_bytes(&mut input);
     let transaction = Transaction::Legacy(TxLegacy {
         chain_id: Some(1337),


### PR DESCRIPTION
This PR adds a new feature to the ethtx tool, enabling the sending of transactions over HTTP/JSON-RPC with customizable behavior. Two new options are introduced: `batch_size`, which divides the number of transactions into chunks for submission over JSON-RPC batch, and `concurrent`, which is a flag that allows issuing JSON-RPC HTTP requests concurrently.