### PR TITLE
Optimize cargo build cache in docker

### DIFF
--- a/docker/flexnet/images/image0/Dockerfile
+++ b/docker/flexnet/images/image0/Dockerfile
@@ -1,24 +1,11 @@
 # Default monad node
 
-# builder stage
-FROM rust:1-buster AS builder
-WORKDIR /usr/src/monad-bft
-RUN apt update
-RUN apt install -y clang
-
-# devnet image
-COPY . .
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/src/monad-bft/target \
-    cargo build --release --bin monad-node && \
-    mv target/release/monad-node monad-node-bin
-
 # runner stage
 FROM debian:buster-slim
 WORKDIR /usr/src/monad-bft
 
-COPY --from=builder /usr/src/monad-bft/monad-node-bin /usr/local/bin/monad-node
-
 RUN apt update && apt install -y net-tools iputils-ping iproute2
+
+COPY --from=monad-bft-builder /output/release/monad-node /usr/local/bin/monad-node
 
 ENV RUST_LOG=info

--- a/docker/flexnet/images/monad-bft-builder/Dockerfile
+++ b/docker/flexnet/images/monad-bft-builder/Dockerfile
@@ -1,0 +1,20 @@
+FROM rust:1-buster AS builder
+WORKDIR /usr/src/cmake
+RUN apt update
+RUN apt install -y clang
+
+RUN wget https://cmake.org/files/v3.20/cmake-3.20.0-linux-x86_64.sh 
+RUN bash cmake-3.20.0-linux-x86_64.sh --skip-license
+ENV PATH="/usr/src/cmake/bin:$PATH" 
+
+RUN mkdir /output
+
+WORKDIR /usr/src/monad-bft
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry     \
+    --mount=type=cache,target=/usr/local/cargo/git          \
+    --mount=type=cache,target=/usr/src/monad-bft/target     \
+    cargo build --release --bin monad-node --bin monad-rpc --example ethtx && \
+    cp -r target/release /output
+    
+RUN mkdir /output/release/lib && cp `find /output/release | grep libtriedb` /output/release/lib

--- a/docker/flexnet/images/rpc/Dockerfile
+++ b/docker/flexnet/images/rpc/Dockerfile
@@ -1,20 +1,10 @@
-FROM rust:1-buster AS builder
-
-# builder stage
-WORKDIR /usr/src/monad-bft
-RUN apt update
-RUN apt install -y clang
-
-COPY . .
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/src/monad-bft/target \
-    cargo build --release --bin monad-rpc && \
-    mv target/release/monad-rpc monad-rpc-bin
-
-# runner stage
+# RPC server
 FROM debian:buster-slim
 WORKDIR /usr/src/monad-bft
 
-COPY --from=builder /usr/src/monad-bft/monad-rpc-bin /usr/local/bin/monad-rpc
+ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
+
+COPY --from=monad-bft-builder /output/release/monad-rpc /usr/local/bin/monad-rpc
+COPY --from=monad-bft-builder /output/release/lib/*.so /usr/local/lib
 
 ENV RUST_LOG=info

--- a/docker/flexnet/nets/net0/compose.yaml
+++ b/docker/flexnet/nets/net0/compose.yaml
@@ -1,19 +1,25 @@
 version: '3.8'
 
 services:
-  build_image0:
+  build_monad_bft:
+    build:
+      context: ${MONAD_BFT_ROOT}
+      dockerfile: ${FLEXNET_IMAGE_ROOT}/monad-bft-builder/Dockerfile
+    image: monad-bft-builder:latest
+
+  runner_image0:
     build: 
       context: ${MONAD_BFT_ROOT}
       dockerfile: ${FLEXNET_IMAGE_ROOT}/image0/Dockerfile
     image: image0:latest
 
-  build_rpc:
+  runner_rpc:
     build:
       context: ${MONAD_BFT_ROOT}
       dockerfile: ${FLEXNET_IMAGE_ROOT}/rpc/Dockerfile
     image: rpc:latest
 
-  build_python:
+  runner_python:
     build:
       context: ${FLEXNET_IMAGE_ROOT}/python
       dockerfile: ${FLEXNET_IMAGE_ROOT}/python/Dockerfile

--- a/docker/flexnet/nets/net0/scripts/net-run.sh
+++ b/docker/flexnet/nets/net0/scripts/net-run.sh
@@ -97,7 +97,9 @@ export HOST_UID=$(id -u)
 pushd $vol_root
 
 build_services=$(docker compose config --services | grep build)
-node_services=$(docker compose config --services | grep -v build)
+runner_services=$(docker compose config --services | grep runner)
+node_services=$(docker compose config --services | grep -v -E "(build|runner)")
+
 docker compose build $build_services &&
 docker compose up --detach $node_services
 sleep 30


### PR DESCRIPTION
Previously, each docker image has a builder stage and a runner stage. All of the builder stages are building from root directory of monad-bft, and are sharing cache. It creates problems if we want to cache the dependencies checked out from git. Building multiple of these images in parallel creates conflicts on the git checkouts. If we don't cache the git checkouts, every image build re-pulls github, which is quite slow.

This PR combines all binary builds into a single image `monad-bft-builder`, so there's no sharing on the git checkout cache. The runner images, e.g. `image0`, `rpc` directly copies from the builder images to the runner.