### PR TITLE
Fix getCode and getStorageAt format

### DIFF
--- a/monad-rpc/src/account_handlers.rs
+++ b/monad-rpc/src/account_handlers.rs
@@ -8,6 +8,7 @@ use crate::{
         deserialize_block_tags, deserialize_fixed_data, serialize_result, BlockTags, EthAddress,
         EthStorageKey,
     },
+    hex,
     jsonrpc::JsonRpcError,
     triedb::{TriedbEnv, TriedbResult},
 };
@@ -78,7 +79,7 @@ pub async fn monad_eth_getCode(
 
     match triedb_env.get_code(code_hash).await {
         TriedbResult::Null => Ok(serde_json::Value::Null),
-        TriedbResult::Code(code) => serialize_result(format!("0x{:x?}", code)),
+        TriedbResult::Code(code) => serialize_result(hex::encode(&code)),
         _ => Err(JsonRpcError::internal_error()),
     }
 }
@@ -112,7 +113,7 @@ pub async fn monad_eth_getStorageAt(
 
     match triedb_env.get_storage_at(p.account, p.position).await {
         TriedbResult::Null => Ok(serde_json::Value::Null),
-        TriedbResult::Storage(storage) => serialize_result(format!("0x{:x?}", storage)),
+        TriedbResult::Storage(storage) => serialize_result(hex::encode(&storage)),
         _ => Err(JsonRpcError::internal_error()),
     }
 }

--- a/monad-rpc/src/hex.rs
+++ b/monad-rpc/src/hex.rs
@@ -4,6 +4,26 @@ pub enum DecodeHexError {
     ParseErr,
 }
 
+fn nibble_to_char(nibble: u8) -> char {
+    let nibble = nibble & 0xF;
+    if nibble < 0xA {
+        (b'0' + nibble) as char
+    } else {
+        (b'a' + nibble - 0xA) as char
+    }
+}
+
+pub fn encode(bytes: &[u8]) -> String {
+    let mut chars = vec!['0', 'x'];
+
+    for byte in bytes {
+        chars.push(nibble_to_char(byte >> 4));
+        chars.push(nibble_to_char(*byte));
+    }
+
+    chars.into_iter().collect()
+}
+
 pub fn decode(s: &str) -> Result<Vec<u8>, DecodeHexError> {
     if s.len() & 1 == 1 || s.is_empty() {
         return Err(DecodeHexError::InvalidLen);
@@ -57,7 +77,7 @@ fn decode_even_suffix(s: &str) -> Result<Vec<u8>, DecodeHexError> {
 
 #[cfg(test)]
 mod test {
-    use crate::hex::{decode, decode_quantity, DecodeHexError};
+    use crate::hex::{decode, decode_quantity, encode, DecodeHexError};
 
     #[test]
     fn test_hex_invalid_len() {
@@ -80,6 +100,16 @@ mod test {
         )
         .is_ok());
         assert_eq!(Ok(vec![]), decode("0x"));
+    }
+
+    #[test]
+    fn test_hex_encode() {
+        assert_eq!(&encode(&[171_u8]), "0xab");
+
+        let hex =
+            "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675";
+        let bytes = decode(hex).unwrap();
+        assert_eq!(&encode(&bytes), hex);
     }
 
     #[test]

--- a/monad-rpc/src/triedb.rs
+++ b/monad-rpc/src/triedb.rs
@@ -82,12 +82,16 @@ impl TriedbEnv {
                 return;
             };
 
-            let Ok(storage) = <[u8; 32]>::try_from(result) else {
-                debug!("storage value is not 32 bytes");
+            if result.len() > 32 {
+                debug!("storage value is max 32 bytes");
                 let _ = send.send(TriedbResult::EncodingError);
                 return;
-            };
-            let _ = send.send(TriedbResult::Storage(storage));
+            }
+            let mut storage_value = [0_u8; 32];
+            for (byte, storage) in result.into_iter().rev().zip(storage_value.iter_mut().rev()) {
+                *storage = byte;
+            }
+            let _ = send.send(TriedbResult::Storage(storage_value));
         });
         recv.await.expect("rayon panic get_account")
     }


### PR DESCRIPTION
Tested getStorageAt with:
```bash
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getStorageAt","params":["0x6e38a457c722c6011b2dfa06d49240e797844d66", "0x0000000000000000000000000000000000000000000000000000000000000000", "latest"],"id":1}'
```

Tested getCode with:
```bash
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getCode","params":["0xa3483b08C8A0F33eB07afF3A66fbcaf5C9018CDC", "latest"],"id":1}'
```