### PR TITLE
Add TestMode to monad-node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3136,6 +3136,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
+ "rand_chacha",
  "serde",
  "thiserror",
  "tokio",

--- a/monad-node/Cargo.toml
+++ b/monad-node/Cargo.toml
@@ -42,6 +42,7 @@ log = { workspace = true }
 opentelemetry = { workspace = true, features = ["rt-tokio"] }
 opentelemetry-otlp = { workspace = true, features = ["metrics"] }
 opentelemetry-semantic-conventions = { workspace = true }
+rand_chacha = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }

--- a/monad-node/src/cli.rs
+++ b/monad-node/src/cli.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 
 use clap::Parser;
 
+use crate::mode::RunModeCommand;
+
 #[derive(Debug, Parser)]
 #[command(name = "monad-node", about, long_about = None)]
 pub struct Cli {
@@ -36,6 +38,11 @@ pub struct Cli {
     /// Set the opentelemetry OTLP exporter endpoint
     #[arg(long)]
     pub otel_endpoint: Option<String>,
+
+    /// Default to run in prod mode
+    /// Passing "testmode" enables test only arguments
+    #[command(subcommand)]
+    pub run_mode: Option<RunModeCommand>,
 
     #[arg(long, requires = "otel_endpoint")]
     pub record_metrics_interval_seconds: Option<u64>,

--- a/monad-node/src/mode/mod.rs
+++ b/monad-node/src/mode/mod.rs
@@ -1,0 +1,16 @@
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum RunModeCommand {
+    ProdMode,
+    TestMode {
+        #[arg(long, default_value_t = false)]
+        byzantine_execution: bool,
+    },
+}
+
+impl Default for RunModeCommand {
+    fn default() -> Self {
+        RunModeCommand::ProdMode
+    }
+}

--- a/monad-node/src/state.rs
+++ b/monad-node/src/state.rs
@@ -12,6 +12,7 @@ use crate::{
     cli::Cli,
     config::{GenesisConfig, NodeConfig},
     error::NodeSetupError,
+    mode::RunModeCommand,
 };
 
 pub struct NodeState {
@@ -26,6 +27,8 @@ pub struct NodeState {
     pub mempool_ipc_path: PathBuf,
     pub otel_endpoint: Option<String>,
     pub record_metrics_interval: Option<Duration>,
+
+    pub run_mode: RunModeCommand,
 }
 
 impl NodeState {
@@ -49,6 +52,8 @@ impl NodeState {
         let genesis_config: GenesisConfig =
             toml::from_str(&std::fs::read_to_string(cli.genesis_config)?)?;
 
+        let run_mode = cli.run_mode.unwrap_or_default();
+
         Ok(Self {
             node_config,
             genesis_config,
@@ -63,6 +68,8 @@ impl NodeState {
             record_metrics_interval: cli
                 .record_metrics_interval_seconds
                 .and_then(|s| Some(Duration::from_secs(s))),
+
+            run_mode,
         })
     }
 }


### PR DESCRIPTION
monad-node by default runs in production mode. The test mode adds commands to inject different behaviors/updaters, at the cost of some updaters getting dynamically dispatched.

I switched to this approach cause it's too hard to keep two binaries in sync for the most part, but different in subtle ways. That might be easier to do after we have fewer commits to the binary.