### PR TITLE
Initial websocket support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb72882332b6d6282f428b77ba0358cb2687e61a6f6df6a6d3871e8a177c2d4f"
+dependencies = [
+ "actix-macros",
+ "actix-rt",
+ "actix_derive",
+ "bitflags 2.4.1",
+ "bytes",
+ "crossbeam-channel",
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "actix-codec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +94,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-http-test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061d27c2a6fea968fdaca0961ff429d23a4ec878c4f68f5d08626663ade69c80"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-tls",
+ "actix-utils",
+ "awc",
+ "bytes",
+ "futures-core",
+ "http 0.2.11",
+ "log",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "slab",
+ "socket2 0.5.5",
+ "tokio",
+]
+
+[[package]]
 name = "actix-macros"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +147,7 @@ version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28f32d40287d3f402ae0028a9d54bef51af15c8769492826a69d28f81893151d"
 dependencies = [
+ "actix-macros",
  "futures-core",
  "tokio",
 ]
@@ -127,6 +178,48 @@ dependencies = [
  "futures-core",
  "paste",
  "pin-project-lite",
+]
+
+[[package]]
+name = "actix-test"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c0bc744219177d18f6244d035e1a0b4e36defb6707be2388348ba7e3f071772"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-http-test",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "awc",
+ "futures-core",
+ "futures-util",
+ "log",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+]
+
+[[package]]
+name = "actix-tls"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4cce60a2f2b477bc72e5cde0af1812a6e82d8fd85b5570a5dcf2a5bf2c5be5f"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "http 0.2.11",
+ "http 1.0.0",
+ "impl-more",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -180,12 +273,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-actors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420b001bb709d8510c3e2659dae046e54509ff9528018d09c78381e765a1f9fa"
+dependencies = [
+ "actix",
+ "actix-codec",
+ "actix-http",
+ "actix-web",
+ "bytes",
+ "bytestring",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "actix-web-codegen"
 version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb1f50ebbb30eca122b188319a4398b3f7bb4a8cdf50ecfb73bfc6a3c3ce54f5"
 dependencies = [
  "actix-router",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "actix_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.39",
@@ -779,6 +901,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8da1805e028a172334c3b680f93e71126f2327622faef2ec3d893c0a4ad77"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "awc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c09cc97310b926f01621faee652f3d1b0962545a3cec6c9ac07def9ea36c2c"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-rt",
+ "actix-service",
+ "actix-tls",
+ "actix-utils",
+ "base64 0.21.5",
+ "bytes",
+ "cfg-if",
+ "cookie",
+ "derive_more",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.11",
+ "itoa",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
 ]
 
 [[package]]
@@ -2320,6 +2475,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-more"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206ca75c9c03ba3d4ace2460e57b189f39f43de612c2f85836e65c929701bb2d"
+
+[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,8 +3389,13 @@ dependencies = [
 name = "monad-rpc"
 version = "0.1.0"
 dependencies = [
+ "actix",
+ "actix-codec",
  "actix-http",
+ "actix-http-test",
+ "actix-test",
  "actix-web",
+ "actix-web-actors",
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
@@ -3237,6 +3403,7 @@ dependencies = [
  "env_logger",
  "flume",
  "futures",
+ "futures-util",
  "heed",
  "log",
  "monad-blockdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,13 @@ reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "685d
 alloy-primitives = "0.6"
 alloy-rlp = "0.3"
 
+actix = "0.13"
+actix-codec = "0.5"
 actix-http = "3.6.0"
 actix-web = "4.5.1"
+actix-web-actors = "4.3.0"
+actix-http-test = "3.2"
+actix-test = "0.1"
 aes = "0.8.3"
 as-any = "0.3.1"
 async-trait = "0.1"

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -14,8 +14,13 @@ bench = false
 monad-blockdb = { path = "../monad-blockdb" }
 monad-triedb = { path = "../monad-triedb" }
 
+actix = { workspace = true }
+actix-codec = { workspace = true }
 actix-http = { workspace = true }
+actix-http-test = { workspace = true }
+actix-test = { worspace = true }
 actix-web = { workspace = true }
+actix-web-actors = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }
 bytes = { workspace = true }
@@ -23,6 +28,7 @@ clap = { workspace = true, features = ["derive"] }
 env_logger = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
+futures-util = { workspace = true }
 heed = { workspace = true }
 log = { workspace = true }
 rayon = { workspace = true }

--- a/monad-rpc/src/websocket.rs
+++ b/monad-rpc/src/websocket.rs
@@ -1,0 +1,134 @@
+use std::time::{Duration, Instant};
+
+use actix::prelude::*;
+use actix_http::ws::{Message as WebsocketMessage, ProtocolError};
+use actix_web::{web, HttpRequest, HttpResponse};
+use actix_web_actors::ws;
+use log::debug;
+
+use crate::MonadRpcResources;
+
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+const CLIENT_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct Disconnect {}
+
+pub async fn handler(
+    req: HttpRequest,
+    stream: web::Payload,
+    app_state: web::Data<Addr<MonadRpcResources>>,
+) -> Result<HttpResponse, actix_web::Error> {
+    debug!("ws_handler {:?}", &req);
+    ws::start(
+        WebsocketSession {
+            heartbeat: Instant::now(),
+            server: app_state.get_ref().clone(),
+        },
+        &req,
+        stream,
+    )
+}
+
+pub struct WebsocketSession {
+    pub heartbeat: Instant,
+    pub server: Addr<MonadRpcResources>,
+}
+
+impl WebsocketSession {
+    fn heartbeat(&self, ctx: &mut ws::WebsocketContext<Self>) {
+        ctx.run_interval(HEARTBEAT_INTERVAL, |actor, ctx| {
+            debug!("heartbeat");
+            if Instant::now().duration_since(actor.heartbeat) > CLIENT_TIMEOUT {
+                debug!("client failed heartbeat, disconnecting");
+
+                actor.server.do_send(Disconnect {});
+
+                ctx.stop();
+                return;
+            }
+
+            ctx.ping(b"");
+        });
+    }
+}
+
+impl Actor for WebsocketSession {
+    type Context = ws::WebsocketContext<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        self.heartbeat(ctx);
+    }
+
+    fn stopping(&mut self, ctx: &mut Self::Context) -> Running {
+        self.server.do_send(Disconnect {});
+        Running::Stop
+    }
+}
+
+impl StreamHandler<Result<WebsocketMessage, ProtocolError>> for WebsocketSession {
+    fn handle(&mut self, item: Result<WebsocketMessage, ProtocolError>, ctx: &mut Self::Context) {
+        match item {
+            Ok(message) => {
+                debug!("StreamHandler::handle {:?}", message);
+                match message {
+                    WebsocketMessage::Text(text) => {}
+                    WebsocketMessage::Binary(binary) => {}
+                    WebsocketMessage::Continuation(continuation) => {}
+                    WebsocketMessage::Ping(_) => {
+                        debug!("received ping frame from client {:?}", ctx.address());
+                    }
+                    WebsocketMessage::Pong(_) => {
+                        debug!("received pong frame from client {:?}", ctx.address());
+                    }
+                    WebsocketMessage::Close(close) => {}
+                    WebsocketMessage::Nop => {}
+                }
+            }
+            Err(e) => {
+                debug!("StreamHandler::handle error {:?}", e);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use actix::Actor;
+    use actix_http::{ws, ws::Frame};
+    use bytes::Bytes;
+    use futures_util::{SinkExt as _, StreamExt as _};
+    use reth_primitives::TransactionSigned;
+
+    use crate::{create_app, tests::MonadRpcResourcesState, MonadRpcResources};
+
+    fn create_test_server() -> (MonadRpcResourcesState, actix_test::TestServer) {
+        let (ipc_sender, ipc_receiver) = flume::unbounded::<TransactionSigned>();
+        let resources = MonadRpcResources {
+            mempool_sender: ipc_sender,
+            blockdb_reader: None,
+            triedb_reader: None,
+        }
+        .start();
+        (
+            MonadRpcResourcesState { ipc_receiver },
+            actix_test::start(move || create_app(resources.clone())),
+        )
+    }
+
+    #[actix::test]
+    async fn websocket_wait_for_ping() {
+        env_logger::try_init().expect("failed to initialize logger");
+
+        let (_, mut server) = create_test_server();
+
+        let mut framed = server.ws_at("/ws/").await.unwrap();
+        let frame = framed.next().await.unwrap().unwrap();
+        assert_eq!(frame, Frame::Ping(Bytes::from_static(b"")));
+        framed
+            .send(ws::Message::Pong(Bytes::from_static(b"")))
+            .await
+            .unwrap();
+    }
+}


### PR DESCRIPTION
This PR adds initial websocket support needed for #619 and #620. Further functionality needed for those RPCs will be added later, but currently this PR only ensures that
- a client can perform the websocket upgrade
- client will stay connected provided they respond to WS ping frames