### PR TITLE
Split out QC creation from Proposal Generation

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-32
 
     permissions:
       contents: read

--- a/monad-consensus/src/pacemaker.rs
+++ b/monad-consensus/src/pacemaker.rs
@@ -96,6 +96,10 @@ impl<SCT: SignatureCollection> Pacemaker<SCT> {
         self.current_round
     }
 
+    pub fn get_last_round_tc(&self) -> &Option<TimeoutCertificate<SCT>> {
+        &self.last_round_tc
+    }
+
     fn get_round_timer(&self) -> Duration {
         self.delta * 4
     }

--- a/monad-consensus/src/vote_state.rs
+++ b/monad-consensus/src/vote_state.rs
@@ -27,8 +27,6 @@ pub struct VoteState<SCT: SignatureCollection> {
     /// The earliest round that we'll accept votes for
     /// We use this to not build the same QC twice, and to know which votes are stale
     earliest_round: Round,
-    /// Store a created QC that we do not want to process immediately
-    pub pending_qc: Option<QuorumCertificate<SCT>>,
 }
 
 impl<SCT: SignatureCollection> Default for VoteState<SCT> {
@@ -36,7 +34,6 @@ impl<SCT: SignatureCollection> Default for VoteState<SCT> {
         VoteState {
             pending_votes: BTreeMap::new(),
             earliest_round: Round(0),
-            pending_qc: None,
         }
     }
 }
@@ -72,7 +69,6 @@ where
     #[must_use]
     pub fn process_vote<VT>(
         &mut self,
-        current_round: Round,
         author: &NodeId<SCT::NodeIdPubKey>,
         vote_msg: &VoteMessage<SCT>,
         validators: &VT,
@@ -127,15 +123,6 @@ where
                     // we update self.earliest round so that we no longer will build a QC for
                     // current round
                     self.earliest_round = round + Round(1);
-
-                    // if the votes we have collected are for the Round one higher than our current
-                    // round, we store it as the pending_qc to allow time for the previous
-                    // proposal/qc to arrive.
-                    if current_round + Round(1) == round {
-                        self.pending_qc = Some(qc);
-                        return (None, ret_commands);
-                    }
-
                     return (Some(qc), ret_commands);
                 }
                 Err(SignatureCollectionError::InvalidSignaturesCreate(invalid_sigs)) => {
@@ -174,15 +161,6 @@ where
     pub fn start_new_round(&mut self, new_round: Round) {
         self.earliest_round = new_round;
         self.pending_votes.retain(|k, _| *k >= new_round);
-        if let Some(qc) = &self.pending_qc {
-            if new_round > qc.get_round() {
-                self.pending_qc = None;
-            }
-        }
-    }
-
-    pub fn get_pending_qc_round(&self) -> Option<Round> {
-        self.pending_qc.as_ref().map(|qc| qc.get_round())
     }
 }
 
@@ -258,7 +236,6 @@ mod test {
                 true,
             );
             let (_qc, cmds) = votestate.process_vote(
-                svm.vote.vote_info.round,
                 &NodeId::new(cert_keys[0].pubkey()),
                 &svm,
                 &valset,
@@ -274,13 +251,8 @@ mod test {
         // removed
         for certkey in cert_keys.iter().take(4) {
             let svm = create_vote_message::<SignatureCollectionType>(certkey, Round(4), true);
-            let _qc = votestate.process_vote(
-                Round(4),
-                &NodeId::new(certkey.pubkey()),
-                &svm,
-                &valset,
-                &val_map,
-            );
+            let _qc =
+                votestate.process_vote(&NodeId::new(certkey.pubkey()), &svm, &valset, &val_map);
         }
         votestate.start_new_round(Round(5));
 
@@ -289,7 +261,6 @@ mod test {
         // apply old votes again
         for svm in votes {
             let (_qc, cmds) = votestate.process_vote(
-                svm.vote.vote_info.round,
                 &NodeId::new(cert_keys[0].pubkey()),
                 &svm,
                 &valset,
@@ -313,24 +284,14 @@ mod test {
         // add one vote for rounds 0-3 and 5-8
         for i in 0..4 {
             let svm = create_vote_message(&cert_keys[0], Round(i.try_into().unwrap()), true);
-            let _qc = votestate.process_vote(
-                svm.vote.vote_info.round,
-                &NodeId::new(cert_keys[0].pubkey()),
-                &svm,
-                &valset,
-                &vmap,
-            );
+            let _qc =
+                votestate.process_vote(&NodeId::new(cert_keys[0].pubkey()), &svm, &valset, &vmap);
         }
 
         for i in 5..9 {
             let svm = create_vote_message(&cert_keys[0], Round(i.try_into().unwrap()), true);
-            let _qc = votestate.process_vote(
-                svm.vote.vote_info.round,
-                &NodeId::new(cert_keys[0].pubkey()),
-                &svm,
-                &valset,
-                &vmap,
-            );
+            let _qc =
+                votestate.process_vote(&NodeId::new(cert_keys[0].pubkey()), &svm, &valset, &vmap);
         }
 
         assert_eq!(votestate.pending_votes.len(), 8);
@@ -339,13 +300,7 @@ mod test {
         // removed
         for certkey in cert_keys.iter().take(4) {
             let svm = create_vote_message::<SignatureCollectionType>(certkey, Round(4), true);
-            let _qc = votestate.process_vote(
-                Round(4),
-                &NodeId::new(certkey.pubkey()),
-                &svm,
-                &valset,
-                &vmap,
-            );
+            let _qc = votestate.process_vote(&NodeId::new(certkey.pubkey()), &svm, &valset, &vmap);
         }
         votestate.start_new_round(Round(5));
 
@@ -367,7 +322,7 @@ mod test {
         let author = NodeId::new(certkeys[0].pubkey());
 
         for _ in 0..4 {
-            let (qc, cmds) = votestate.process_vote(Round(0), &author, &svm, &valset, &vmap);
+            let (qc, cmds) = votestate.process_vote(&author, &svm, &valset, &vmap);
             assert!(cmds.is_empty());
             assert!(qc.is_none());
         }
@@ -389,13 +344,8 @@ mod test {
 
         let vote_idx = HasherType::hash_object(&v0_valid.vote);
 
-        let (qc, _) = votestate.process_vote(
-            vote_round,
-            &NodeId::new(keys[0].pubkey()),
-            &v0_valid,
-            &valset,
-            &vmap,
-        );
+        let (qc, _) =
+            votestate.process_vote(&NodeId::new(keys[0].pubkey()), &v0_valid, &valset, &vmap);
         assert!(qc.is_none());
         assert!(
             votestate
@@ -409,13 +359,8 @@ mod test {
                 == 1
         );
 
-        let (qc, _) = votestate.process_vote(
-            vote_round,
-            &NodeId::new(keys[1].pubkey()),
-            &v1_valid,
-            &valset,
-            &vmap,
-        );
+        let (qc, _) =
+            votestate.process_vote(&NodeId::new(keys[1].pubkey()), &v1_valid, &valset, &vmap);
         assert!(qc.is_none());
         assert!(
             votestate
@@ -431,13 +376,8 @@ mod test {
 
         // VoteState attempts to create a QC, but failed because one of the sigs is invalid
         // doesn't have supermajority after removing the invalid
-        let (qc, _) = votestate.process_vote(
-            vote_round,
-            &NodeId::new(keys[2].pubkey()),
-            &v2_invalid,
-            &valset,
-            &vmap,
-        );
+        let (qc, _) =
+            votestate.process_vote(&NodeId::new(keys[2].pubkey()), &v2_invalid, &valset, &vmap);
         assert!(qc.is_none());
         assert!(
             votestate
@@ -487,13 +427,8 @@ mod test {
 
         let vote_idx = HasherType::hash_object(&v0_valid.vote);
 
-        let (qc, _) = votestate.process_vote(
-            vote_round,
-            &NodeId::new(keys[0].pubkey()),
-            &v0_valid,
-            &valset,
-            &vmap,
-        );
+        let (qc, _) =
+            votestate.process_vote(&NodeId::new(keys[0].pubkey()), &v0_valid, &valset, &vmap);
         assert!(qc.is_none());
         assert!(
             votestate
@@ -509,13 +444,8 @@ mod test {
 
         // VoteState accepts the invalid signature because the stake is not enough
         // to trigger verification
-        let (qc, _) = votestate.process_vote(
-            vote_round,
-            &NodeId::new(keys[1].pubkey()),
-            &v1_invalid,
-            &valset,
-            &vmap,
-        );
+        let (qc, _) =
+            votestate.process_vote(&NodeId::new(keys[1].pubkey()), &v1_invalid, &valset, &vmap);
         assert!(qc.is_none());
         assert!(
             votestate
@@ -532,13 +462,8 @@ mod test {
         // VoteState attempts to create a QC
         // the first attempt fails: v1.sig is invalid
         // the second iteration succeeds: still have enough stake after removing v1
-        let (qc, _) = votestate.process_vote(
-            vote_round,
-            &NodeId::new(keys[2].pubkey()),
-            &v2_valid,
-            &valset,
-            &vmap,
-        );
+        let (qc, _) =
+            votestate.process_vote(&NodeId::new(keys[2].pubkey()), &v2_valid, &valset, &vmap);
         assert!(qc.is_some());
         assert_eq!(
             qc.unwrap()

--- a/monad-consensus/tests/vote_state.rs
+++ b/monad-consensus/tests/vote_state.rs
@@ -99,7 +99,7 @@ fn test_votes(num_nodes: u32) {
     let mut qcs = Vec::new();
     for i in 0..num_nodes {
         let (author, v) = &votes[i as usize];
-        let (qc, cmds) = voteset.process_vote(v.vote.vote_info.round, author, v, &valset, &vmap);
+        let (qc, cmds) = voteset.process_vote(author, v, &valset, &vmap);
         assert!(cmds.is_empty());
         qcs.push(qc);
     }
@@ -125,8 +125,7 @@ fn test_reset(num_nodes: u32, num_rounds: u32) {
     for k in 0..num_rounds {
         for i in 0..num_nodes {
             let (author, v) = &votes[(k * num_nodes + i) as usize];
-            let (qc, cmds) =
-                voteset.process_vote(v.vote.vote_info.round, author, v, &valset, &vmap);
+            let (qc, cmds) = voteset.process_vote(author, v, &valset, &vmap);
             assert!(cmds.is_empty());
             qcs.push(qc);
         }
@@ -154,7 +153,7 @@ fn test_minority(num_nodes: u32) {
 
     for i in 0..majority - 1 {
         let (author, v) = &votes[i as usize];
-        let (qc, cmds) = voteset.process_vote(v.vote.vote_info.round, author, v, &valset, &vmap);
+        let (qc, cmds) = voteset.process_vote(author, v, &valset, &vmap);
         assert!(cmds.is_empty());
         qcs.push(qc);
     }

--- a/monad-state/src/consensus.rs
+++ b/monad-state/src/consensus.rs
@@ -197,15 +197,16 @@ where
                         }
                     }
                     .into_inner();
-                let current_epoch = self
-                    .epoch_manager
-                    .get_epoch(self.consensus.get_current_round());
-                let val_set = self
-                    .val_epoch_map
-                    .get_val_set(&current_epoch)
-                    .expect("current validator set should be in the map");
-                self.consensus
-                    .handle_block_sync(sender, validated_response, val_set, self.metrics)
+                self.consensus.handle_block_sync(
+                    sender,
+                    validated_response,
+                    self.txpool,
+                    self.epoch_manager,
+                    self.val_epoch_map,
+                    self.leader_election,
+                    self.metrics,
+                    self.version.protocol_version,
+                )
             }
         };
         let consensus_cmds = vec;


### PR DESCRIPTION
Previously, we would try and construct a proposal the moment we created a valid QC. Now, the proposal creation is disjoint from QC creation. This allows us to only construct a proposal once we have a valid path_to_root, which avoids us needing to Abstain/ProposeEmpty. We make sure to not double propose with an extra monotonically increasing ConsensusState::last_proposed_round that gets updated on every proposal generation.