### PR TITLE
Fix response format for eth_chainId

### DIFF
--- a/monad-rpc/src/blockdb_handlers.rs
+++ b/monad-rpc/src/blockdb_handlers.rs
@@ -32,17 +32,10 @@ pub async fn monad_eth_blockNumber(blockdb_env: &BlockDbEnv) -> Result<Value, Js
     })
 }
 
-#[derive(Serialize, Debug)]
-struct MonadEthChainIdReturn {
-    number: String,
-}
-
 // TODO: does chainId come from a config file?
 #[allow(non_snake_case)]
 pub async fn monad_eth_chainId(blockdb_env: &BlockDbEnv) -> Result<Value, JsonRpcError> {
     trace!("monad_eth_chainId");
 
-    serialize_result(MonadEthChainIdReturn {
-        number: format!("0x{:x}", 1337),
-    })
+    serialize_result(format!("0x{:x}", 1337))
 }


### PR DESCRIPTION
Fix response format as specified in https://ethereum.github.io/execution-apis/api-documentation/ - needed in order to get Metamask to work. 