### PR TITLE
eth_getBlockByNumber

### DIFF
--- a/monad-rpc/src/blockdb_handlers.rs
+++ b/monad-rpc/src/blockdb_handlers.rs
@@ -1,6 +1,5 @@
 use log::trace;
 use monad_blockdb::BlockTagKey;
-use serde::Serialize;
 use serde_json::Value;
 
 use crate::{

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -20,9 +20,7 @@ use triedb::TriedbEnv;
 use crate::{
     blockdb::BlockDbEnv,
     eth_txn_handlers::{
-        monad_eth_getBlockByHash,
-        monad_eth_getBlockByNumber,
-        monad_eth_sendRawTransaction
+        monad_eth_getBlockByHash, monad_eth_getBlockByNumber, monad_eth_sendRawTransaction,
     },
     jsonrpc::{JsonRpcError, Request, RequestWrapper, Response, ResponseWrapper},
     mempool_tx::MempoolTxIpcSender,


### PR DESCRIPTION
Fix response format for `eth_blockNumber` and implemented an endpoint `eth_getBlockByNumber` which is part of the Ethereum RPC specs and needed by Metamask to connect.