### PR TITLE
Remove user from flexnet containers

### DIFF
--- a/docker/flexnet/nets/net0/compose.yaml
+++ b/docker/flexnet/nets/net0/compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   build_monad_bft:
     build:
@@ -27,9 +25,6 @@ services:
 
   node0_us:
     image: image0:latest
-    environment:
-      - HOST_UID=${HOST_UID}
-      - HOST_GID=${HOST_GID}
     volumes:
       - ./node0:/monad
     cap_add:
@@ -38,9 +33,6 @@ services:
 
   rpc0:
     image: rpc:latest
-    environment:
-      - HOST_UID=${HOST_UID}
-      - HOST_GID=${HOST_GID}
     volumes:
       - ./node0:/monad
     expose:
@@ -49,9 +41,6 @@ services:
 
   rpc_blaster:
     image: monad-python:latest
-    environment:
-      - HOST_UID=${HOST_UID}
-      - HOST_GID=${HOST_GID}
     volumes:
       - ./rpc_blaster:/monad
       - ./data:/data
@@ -59,9 +48,6 @@ services:
 
   node1_us:
     image: image0:latest
-    environment:
-      - HOST_UID=${HOST_UID}
-      - HOST_GID=${HOST_GID}
     volumes:
       - ./node1:/monad
     cap_add:
@@ -70,9 +56,6 @@ services:
 
   node2_eu:
     image: image0:latest
-    environment:
-      - HOST_UID=${HOST_UID}
-      - HOST_GID=${HOST_GID}
     volumes:
       - ./node2:/monad
     cap_add:
@@ -81,9 +64,6 @@ services:
 
   node3_eu:
     image: image0:latest
-    environment:
-      - HOST_UID=${HOST_UID}
-      - HOST_GID=${HOST_GID}
     volumes:
       - ./node3:/monad
     cap_add:

--- a/docker/flexnet/nets/net0/node0/scripts/rpc.sh
+++ b/docker/flexnet/nets/net0/node0/scripts/rpc.sh
@@ -1,17 +1,10 @@
 #!/bin/bash
 
-groupadd -g $HOST_GID user
-useradd -u $HOST_UID -g user -N user
-# usermod -aG sudo user
-# echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-
-su -c "mkdir /monad/logs" -m user 
-
 # wait for node service to create IPC socket
 while [[ ! -S "/monad/mempool.sock" ]]; do
     sleep 1
 done
 
-su -c "monad-rpc \
-        --ipc-path /monad/mempool.sock > /monad/logs/rpc.log 2>&1" -m user
+monad-rpc \
+    --ipc-path /monad/mempool.sock > /monad/logs/rpc.log 2>&1
         

--- a/docker/flexnet/nets/net0/node0/scripts/run.sh
+++ b/docker/flexnet/nets/net0/node0/scripts/run.sh
@@ -2,18 +2,14 @@
 
 bash /monad/scripts/tc.sh
 
-groupadd -g $HOST_GID user
-useradd -u $HOST_UID -g user -N user
-# usermod -aG sudo user
-# echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+mkdir /monad/logs
 
-su -c "mkdir /monad/logs" -m user 
-
-su -c "monad-node \
+monad-node \
     --secp-identity /monad/config/id-secp \
     --bls-identity /monad/config/id-bls \
     --node-config /monad/config/node.toml \
     --genesis-config /monad/config/genesis.toml \
     --wal-path /monad/wal \
+    --blockdb-path /monad/blockdb \
     --mempool-ipc-path /monad/mempool.sock \
-    --execution-ledger-path /monad/ledger > /monad/logs/client.log 2>&1" -m user
+    --execution-ledger-path /monad/ledger > /monad/logs/client.log 2>&1

--- a/docker/flexnet/nets/net0/node1/scripts/run.sh
+++ b/docker/flexnet/nets/net0/node1/scripts/run.sh
@@ -2,18 +2,14 @@
 
 bash /monad/scripts/tc.sh
 
-groupadd -g $HOST_GID user
-useradd -u $HOST_UID -g user -N user
-# usermod -aG sudo user
-# echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+mkdir /monad/logs
 
-su -c "mkdir /monad/logs" -m user 
-
-su -c "monad-node \
+monad-node \
     --secp-identity /monad/config/id-secp \
     --bls-identity /monad/config/id-bls \
     --node-config /monad/config/node.toml \
     --genesis-config /monad/config/genesis.toml \
     --wal-path /monad/wal \
+    --blockdb-path /monad/blockdb \
     --mempool-ipc-path /monad/mempool.sock \
-    --execution-ledger-path /monad/ledger > /monad/logs/client.log 2>&1" -m user
+    --execution-ledger-path /monad/ledger > /monad/logs/client.log 2>&1

--- a/docker/flexnet/nets/net0/node2/scripts/run.sh
+++ b/docker/flexnet/nets/net0/node2/scripts/run.sh
@@ -2,18 +2,14 @@
 
 bash /monad/scripts/tc.sh
 
-groupadd -g $HOST_GID user
-useradd -u $HOST_UID -g user -N user
-# usermod -aG sudo user
-# echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+mkdir /monad/logs
 
-su -c "mkdir /monad/logs" -m user 
-
-su -c "monad-node \
+monad-node \
     --secp-identity /monad/config/id-secp \
     --bls-identity /monad/config/id-bls \
     --node-config /monad/config/node.toml \
     --genesis-config /monad/config/genesis.toml \
     --wal-path /monad/wal \
+    --blockdb-path /monad/blockdb \
     --mempool-ipc-path /monad/mempool.sock \
-    --execution-ledger-path /monad/ledger > /monad/logs/client.log 2>&1" -m user
+    --execution-ledger-path /monad/ledger > /monad/logs/client.log 2>&1

--- a/docker/flexnet/nets/net0/node3/scripts/run.sh
+++ b/docker/flexnet/nets/net0/node3/scripts/run.sh
@@ -2,18 +2,14 @@
 
 bash /monad/scripts/tc.sh
 
-groupadd -g $HOST_GID user
-useradd -u $HOST_UID -g user -N user
-# usermod -aG sudo user
-# echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+mkdir /monad/logs
 
-su -c "mkdir /monad/logs" -m user 
-
-su -c "monad-node \
+monad-node \
     --secp-identity /monad/config/id-secp \
     --bls-identity /monad/config/id-bls \
     --node-config /monad/config/node.toml \
     --genesis-config /monad/config/genesis.toml \
     --wal-path /monad/wal \
+    --blockdb-path /monad/blockdb \
     --mempool-ipc-path /monad/mempool.sock \
-    --execution-ledger-path /monad/ledger > /monad/logs/client.log 2>&1" -m user
+    --execution-ledger-path /monad/ledger > /monad/logs/client.log 2>&1

--- a/docker/flexnet/nets/net0/rpc_blaster/scripts/run.sh
+++ b/docker/flexnet/nets/net0/rpc_blaster/scripts/run.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-groupadd -g $HOST_GID user
-useradd -u $HOST_UID -g user -N user
+mkdir /monad/logs
 
-su -c "mkdir /monad/logs" -m user 
-
-su -c "python3 /monad/scripts/blaster.py --rpc http://rpc0:8080 --data /data/txns.json > /monad/logs/rpc-blaster.log 2>&1" -m user
+python3 /monad/scripts/blaster.py --rpc http://rpc0:8080 --data /data/txns.json > /monad/logs/rpc-blaster.log 2>&1

--- a/docker/flexnet/nets/net1/compose.yaml
+++ b/docker/flexnet/nets/net1/compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   build_monad_bft:
     build:
@@ -33,9 +31,6 @@ services:
 
   node0:
     image: image0:latest
-    environment:
-      - HOST_UID=${HOST_UID}
-      - HOST_GID=${HOST_GID}
     volumes:
       - ./node0:/monad
     cap_add:
@@ -44,9 +39,6 @@ services:
 
   rpc0:
     image: rpc:latest
-    environment:
-      - HOST_UID=${HOST_UID}
-      - HOST_GID=${HOST_GID}
     volumes:
       - ./node0:/monad
     expose:
@@ -55,9 +47,6 @@ services:
 
   rpc_blaster:
     image: monad-python:latest
-    environment:
-      - HOST_UID=${HOST_UID}
-      - HOST_GID=${HOST_GID}
     volumes:
       - ./rpc_blaster:/monad
       - ./data:/data
@@ -65,9 +54,6 @@ services:
 
   node1:
     image: image0:latest
-    environment:
-      - HOST_UID=${HOST_UID}
-      - HOST_GID=${HOST_GID}
     volumes:
       - ./node1:/monad
     cap_add:
@@ -76,18 +62,12 @@ services:
 
   ethtx1:
     image: ethtx:latest
-    environment:
-      - HOST_UID=${HOST_UID}
-      - HOST_GID=${HOST_GID}
     volumes:
       - ./node1:/monad
     entrypoint: ["bash", "/monad/scripts/ethtx.sh"]
   
   node2:
     image: image0:latest
-    environment:
-      - HOST_UID=${HOST_UID}
-      - HOST_GID=${HOST_GID}
     volumes:
       - ./node2:/monad
     cap_add:
@@ -96,9 +76,6 @@ services:
 
   node3:
     image: image0:latest
-    environment:
-      - HOST_UID=${HOST_UID}
-      - HOST_GID=${HOST_GID}
     volumes:
       - ./node3:/monad
     cap_add:

--- a/docker/flexnet/nets/net1/node0/scripts/rpc.sh
+++ b/docker/flexnet/nets/net1/node0/scripts/rpc.sh
@@ -1,17 +1,12 @@
 #!/bin/bash
 
-groupadd -g $HOST_GID user
-useradd -u $HOST_UID -g user -N user
-# usermod -aG sudo user
-# echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-
-su -c "mkdir /monad/logs" -m user 
+mkdir /monad/logs
 
 # wait for node service to create IPC socket
 while [[ ! -S "/monad/mempool.sock" ]]; do
     sleep 1
 done
 
-su -c "monad-rpc \
-        --ipc-path /monad/mempool.sock > /monad/logs/rpc.log 2>&1" -m user
+monad-rpc \
+    --ipc-path /monad/mempool.sock > /monad/logs/rpc.log 2>&1
         

--- a/docker/flexnet/nets/net1/node0/scripts/run.sh
+++ b/docker/flexnet/nets/net1/node0/scripts/run.sh
@@ -2,19 +2,15 @@
 
 bash /monad/scripts/tc.sh
 
-groupadd -g $HOST_GID user
-useradd -u $HOST_UID -g user -N user
-# usermod -aG sudo user
-# echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+mkdir /monad/logs
 
-su -c "mkdir /monad/logs" -m user 
-
-su -c "monad-node \
+monad-node \
     --secp-identity /monad/config/id-secp \
     --bls-identity /monad/config/id-bls \
     --node-config /monad/config/node.toml \
     --genesis-config /monad/config/genesis.toml \
     --wal-path /monad/wal \
+    --blockdb-path /monad/blockdb \
     --mempool-ipc-path /monad/mempool.sock \
     --execution-ledger-path /monad/ledger \
-    test-mode > /monad/logs/client.log 2>&1" -m user
+    test-mode > /monad/logs/client.log 2>&1

--- a/docker/flexnet/nets/net1/node1/scripts/run.sh
+++ b/docker/flexnet/nets/net1/node1/scripts/run.sh
@@ -2,19 +2,15 @@
 
 bash /monad/scripts/tc.sh
 
-groupadd -g $HOST_GID user
-useradd -u $HOST_UID -g user -N user
-# usermod -aG sudo user
-# echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+mkdir /monad/logs
 
-su -c "mkdir /monad/logs" -m user 
-
-su -c "monad-node \
+monad-node \
     --secp-identity /monad/config/id-secp \
     --bls-identity /monad/config/id-bls \
     --node-config /monad/config/node.toml \
     --genesis-config /monad/config/genesis.toml \
     --wal-path /monad/wal \
+    --blockdb-path /monad/blockdb \
     --mempool-ipc-path /monad/mempool.sock \
     --execution-ledger-path /monad/ledger \
-    test-mode --byzantine-execution > /monad/logs/client.log 2>&1" -m user
+    test-mode --byzantine-execution > /monad/logs/client.log 2>&1

--- a/docker/flexnet/nets/net1/node2/scripts/run.sh
+++ b/docker/flexnet/nets/net1/node2/scripts/run.sh
@@ -2,19 +2,15 @@
 
 bash /monad/scripts/tc.sh
 
-groupadd -g $HOST_GID user
-useradd -u $HOST_UID -g user -N user
-# usermod -aG sudo user
-# echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+mkdir /monad/logs 
 
-su -c "mkdir /monad/logs" -m user 
-
-su -c "monad-node \
+monad-node \
     --secp-identity /monad/config/id-secp \
     --bls-identity /monad/config/id-bls \
     --node-config /monad/config/node.toml \
     --genesis-config /monad/config/genesis.toml \
     --wal-path /monad/wal \
+    --blockdb-path /monad/blockdb \
     --mempool-ipc-path /monad/mempool.sock \
     --execution-ledger-path /monad/ledger \
-    test-mode > /monad/logs/client.log 2>&1" -m user
+    test-mode > /monad/logs/client.log 2>&1

--- a/docker/flexnet/nets/net1/node3/scripts/run.sh
+++ b/docker/flexnet/nets/net1/node3/scripts/run.sh
@@ -2,19 +2,15 @@
 
 bash /monad/scripts/tc.sh
 
-groupadd -g $HOST_GID user
-useradd -u $HOST_UID -g user -N user
-# usermod -aG sudo user
-# echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+mkdir /monad/logs
 
-su -c "mkdir /monad/logs" -m user 
-
-su -c "monad-node \
+monad-node \
     --secp-identity /monad/config/id-secp \
     --bls-identity /monad/config/id-bls \
     --node-config /monad/config/node.toml \
     --genesis-config /monad/config/genesis.toml \
     --wal-path /monad/wal \
+    --blockdb-path /monad/blockdb \
     --mempool-ipc-path /monad/mempool.sock \
     --execution-ledger-path /monad/ledger \
-    test-mode > /monad/logs/client.log 2>&1" -m user
+    test-mode > /monad/logs/client.log 2>&1

--- a/docker/flexnet/nets/net1/rpc_blaster/scripts/run.sh
+++ b/docker/flexnet/nets/net1/rpc_blaster/scripts/run.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-groupadd -g $HOST_GID user
-useradd -u $HOST_UID -g user -N user
+mkdir /monad/logs
 
-su -c "mkdir /monad/logs" -m user 
+sleep 1
 
-su -c "python3 /monad/scripts/blaster.py --rpc http://rpc0:8080 --data /data/txns.json > /monad/logs/rpc-blaster.log 2>&1" -m user
+python3 /monad/scripts/blaster.py --rpc http://rpc0:8080 --data /data/txns.json > /monad/logs/rpc-blaster.log 2>&1


### PR DESCRIPTION
With the old setup, we had to create a user with same user and group id as the host user running the container so the logs has the right permissions.

The rootless docker changes the volume mounting behavior. Root user in container is mapped to host user running the container. We no longer need this workaround.