### PR TITLE
Consolidate SeqNum to Epoch conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3898,6 +3898,7 @@ dependencies = [
  "monad-crypto",
  "monad-proto",
  "serde",
+ "test-case",
  "zerocopy 0.6.5",
 ]
 

--- a/monad-types/Cargo.toml
+++ b/monad-types/Cargo.toml
@@ -14,3 +14,6 @@ monad-proto = { path = "../monad-proto" }
 
 serde = { workspace = true, features = ["derive"] }
 zerocopy = { workspace = true }
+
+[dev-dependencies]
+test-case = { workspace = true }

--- a/monad-updaters/src/state_root_hash.rs
+++ b/monad-updaters/src/state_root_hash.rs
@@ -144,9 +144,16 @@ where
                         round,
                     });
 
-                    if block.get_seq_num() % self.val_set_update_interval == SeqNum(0) {
+                    if block
+                        .get_seq_num()
+                        .is_epoch_end(self.val_set_update_interval)
+                    {
+                        let next_epoch = block
+                            .get_seq_num()
+                            .get_next_block_epoch(self.val_set_update_interval);
+                        assert_eq!(next_epoch, self.epoch + Epoch(1));
+                        self.epoch = next_epoch;
                         self.next_val_data = Some(self.genesis_validator_data.clone());
-                        self.epoch = self.epoch + Epoch(1);
                     }
 
                     wake = true;
@@ -298,13 +305,20 @@ where
                         round,
                     });
 
-                    if block.get_seq_num() % self.val_set_update_interval == SeqNum(0) {
+                    if block
+                        .get_seq_num()
+                        .is_epoch_end(self.val_set_update_interval)
+                    {
                         self.next_val_data = if self.epoch.0 % 2 == 0 {
                             Some(self.val_data_1.clone())
                         } else {
                             Some(self.val_data_2.clone())
                         };
-                        self.epoch = self.epoch + Epoch(1);
+
+                        let next_epoch =
+                            block.get_seq_num().to_epoch(self.val_set_update_interval) + Epoch(1);
+                        assert_eq!(next_epoch, self.epoch + Epoch(1));
+                        self.epoch = next_epoch;
                     }
 
                     wake = true;

--- a/monad-validator/src/epoch_manager.rs
+++ b/monad-validator/src/epoch_manager.rs
@@ -42,10 +42,10 @@ impl EpochManager {
 
     /// Schedule next epoch start if the committed block is the last one in the current epoch
     pub fn schedule_epoch_start(&mut self, block_num: SeqNum, block_round: Round) {
-        if block_num % self.val_set_update_interval == SeqNum(0) {
-            let epoch = Epoch((block_num / self.val_set_update_interval).0 + 1);
+        if block_num.is_epoch_end(self.val_set_update_interval) {
+            let next_epoch = block_num.to_epoch(self.val_set_update_interval) + Epoch(1);
             let epoch_start_round = block_round + self.epoch_start_delay;
-            self.insert_epoch_start(epoch, epoch_start_round);
+            self.insert_epoch_start(next_epoch, epoch_start_round);
         }
     }
 


### PR DESCRIPTION
Both the state root hash updater and epoch_manager check the epoch boundary conditions. The checkpoint code will do the same check. This PR consolidates SeqNum to Epoch conversion and lifts it to monad-types. It's easier to maintain and reason about.