### PR TITLE
Remove monad-tracing-counter metrics test

### DIFF
--- a/monad-mock-swarm/tests/many_nodes_metrics.rs
+++ b/monad-mock-swarm/tests/many_nodes_metrics.rs
@@ -25,6 +25,7 @@ use tracing_core::LevelFilter;
 use tracing_subscriber::{filter::Targets, prelude::*, Registry};
 
 #[test]
+#[ignore = "monad-tracing-counter to deprecate soon"]
 fn many_nodes_metrics() {
     let fmt_layer = tracing_subscriber::fmt::layer();
     let counter_layer = CounterLayer::default();

--- a/monad-mock-swarm/tests/two_nodes_metrics.rs
+++ b/monad-mock-swarm/tests/two_nodes_metrics.rs
@@ -25,6 +25,7 @@ use tracing_core::LevelFilter;
 use tracing_subscriber::{filter::Targets, prelude::*, Registry};
 
 #[test]
+#[ignore = "monad-tracing-counter to deprecate soon"]
 fn two_nodes_metrics() {
     let fmt_layer = tracing_subscriber::fmt::layer();
     let counter_layer = CounterLayer::default();


### PR DESCRIPTION
The counter metrics were migrated to an in-memory version. The test was a demonstration on printing the metrics. It's no longer needed. Ignoring the test for now. We can remove it when we deprecate that crate.