### PR TITLE
Forkpoint boilerplate

### DIFF
--- a/monad-consensus/src/validation/safety.rs
+++ b/monad-consensus/src/validation/safety.rs
@@ -26,6 +26,13 @@ impl Default for Safety {
 }
 
 impl Safety {
+    pub fn new(highest_vote_round: Round, highest_qc_round: Round) -> Self {
+        Safety {
+            highest_vote_round,
+            highest_qc_round,
+        }
+    }
+
     fn update_highest_vote_round(&mut self, r: Round) {
         self.highest_vote_round = cmp::max(r, self.highest_vote_round);
     }

--- a/monad-consensus/src/vote_state.rs
+++ b/monad-consensus/src/vote_state.rs
@@ -66,6 +66,13 @@ impl<SCT> VoteState<SCT>
 where
     SCT: SignatureCollection,
 {
+    pub fn new(round: Round) -> Self {
+        VoteState {
+            earliest_round: round,
+            ..Default::default()
+        }
+    }
+
     #[must_use]
     pub fn process_vote<VT>(
         &mut self,

--- a/monad-debugger/src/lib.rs
+++ b/monad-debugger/src/lib.rs
@@ -57,7 +57,7 @@ pub fn simulation_make() -> *mut Simulation {
                 .into_iter()
                 .enumerate()
                 .map(|(seed, state_builder)| {
-                    let validators = state_builder.validators.clone();
+                    let validators = state_builder.forkpoint.validator_set.clone();
                     NodeBuilder::<BytesSwarm>::new(
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,

--- a/monad-mock-swarm/benches/two_node_benchmark.rs
+++ b/monad-mock-swarm/benches/two_node_benchmark.rs
@@ -59,7 +59,7 @@ fn two_nodes() {
             .into_iter()
             .enumerate()
             .map(|(seed, state_builder)| {
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::<NoSerSwarm>::new(
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,

--- a/monad-mock-swarm/src/node.rs
+++ b/monad-mock-swarm/src/node.rs
@@ -101,12 +101,12 @@ impl<S: SwarmRelation> NodeBuilder<S> {
                 async_state_verify: BoxedAsyncStateVerifyProcess::new(
                     self.state_builder.async_state_verify,
                 ),
-                validators: self.state_builder.validators,
                 key: self.state_builder.key,
                 certkey: self.state_builder.certkey,
                 val_set_update_interval: self.state_builder.val_set_update_interval,
                 epoch_start_delay: self.state_builder.epoch_start_delay,
                 beneficiary: self.state_builder.beneficiary,
+                forkpoint: self.state_builder.forkpoint,
                 consensus_config: self.state_builder.consensus_config,
             },
             logger: Box::new(self.logger),

--- a/monad-mock-swarm/tests/block_sync.rs
+++ b/monad-mock-swarm/tests/block_sync.rs
@@ -82,7 +82,7 @@ mod test {
                 .into_iter()
                 .enumerate()
                 .map(|(seed, state_builder)| {
-                    let validators = state_builder.validators.clone();
+                    let validators = state_builder.forkpoint.validator_set.clone();
                     NodeBuilder::<MonadMessageNoSerSwarm>::new(
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
@@ -193,7 +193,7 @@ mod test {
                 .into_iter()
                 .enumerate()
                 .map(|(seed, state_builder)| {
-                    let validators = state_builder.validators.clone();
+                    let validators = state_builder.forkpoint.validator_set.clone();
                     NodeBuilder::<NoSerSwarm>::new(
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
@@ -272,7 +272,7 @@ mod test {
                 .into_iter()
                 .enumerate()
                 .map(|(seed, state_builder)| {
-                    let validators = state_builder.validators.clone();
+                    let validators = state_builder.forkpoint.validator_set.clone();
                     NodeBuilder::<NoSerSwarm>::new(
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
@@ -403,7 +403,7 @@ mod test {
                 .into_iter()
                 .enumerate()
                 .map(|(seed, state_builder)| {
-                    let validators = state_builder.validators.clone();
+                    let validators = state_builder.forkpoint.validator_set.clone();
                     NodeBuilder::<NoSerSwarm>::new(
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,

--- a/monad-mock-swarm/tests/epoch.rs
+++ b/monad-mock-swarm/tests/epoch.rs
@@ -166,7 +166,7 @@ mod test {
                 .into_iter()
                 .enumerate()
                 .map(|(seed, state_builder)| {
-                    let validators = state_builder.validators.clone();
+                    let validators = state_builder.forkpoint.validator_set.clone();
                     NodeBuilder::<NoSerSwarm>::new(
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
@@ -257,7 +257,7 @@ mod test {
                 .into_iter()
                 .enumerate()
                 .map(|(seed, state_builder)| {
-                    let validators = state_builder.validators.clone();
+                    let validators = state_builder.forkpoint.validator_set.clone();
                     NodeBuilder::<NoSerSwarm>::new(
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
@@ -403,7 +403,8 @@ mod test {
         );
 
         let genesis_validators: Vec<NodeId<NopPubKey>> = state_configs[0]
-            .validators
+            .forkpoint
+            .validator_set
             .0
             .clone()
             .iter()
@@ -428,7 +429,7 @@ mod test {
                 .into_iter()
                 .enumerate()
                 .map(|(seed, state_builder)| {
-                    let validators = state_builder.validators.clone();
+                    let validators = state_builder.forkpoint.validator_set.clone();
                     NodeBuilder::<ValidatorSwapSwarm>::new(
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
@@ -570,7 +571,7 @@ mod test {
                 .into_iter()
                 .enumerate()
                 .map(|(seed, state_builder)| {
-                    let validators = state_builder.validators.clone();
+                    let validators = state_builder.forkpoint.validator_set.clone();
                     NodeBuilder::<ValidatorSwapSwarm>::new(
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -63,7 +63,7 @@ fn many_nodes_noser() {
             .into_iter()
             .enumerate()
             .map(|(seed, state_builder)| {
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::<NoSerSwarm>::new(
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
@@ -124,7 +124,7 @@ fn many_nodes_quic_latency() {
             .enumerate()
             .map(|(seed, state_builder)| {
                 let me = NodeId::new(state_builder.key.pubkey());
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::<QuicSwarm>::new(
                     ID::new(me),
                     state_builder,
@@ -221,7 +221,7 @@ fn many_nodes_quic_bw() {
             .enumerate()
             .map(|(seed, state_builder)| {
                 let me = NodeId::new(state_builder.key.pubkey());
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::new(
                     ID::new(me),
                     state_builder,

--- a/monad-mock-swarm/tests/many_nodes_metrics.rs
+++ b/monad-mock-swarm/tests/many_nodes_metrics.rs
@@ -70,7 +70,7 @@ fn many_nodes_metrics() {
             .into_iter()
             .enumerate()
             .map(|(seed, state_builder)| {
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::<NoSerSwarm>::new(
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,

--- a/monad-mock-swarm/tests/msg_delays.rs
+++ b/monad-mock-swarm/tests/msg_delays.rs
@@ -56,7 +56,7 @@ fn two_nodes() {
             .into_iter()
             .enumerate()
             .map(|(seed, state_builder)| {
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::<NoSerSwarm>::new(
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,

--- a/monad-mock-swarm/tests/order.rs
+++ b/monad-mock-swarm/tests/order.rs
@@ -103,7 +103,7 @@ fn all_messages_delayed(direction: TransformerReplayOrder) {
             .into_iter()
             .enumerate()
             .map(|(seed, state_builder)| {
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::<NoSerSwarm>::new(
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,

--- a/monad-mock-swarm/tests/rand_lat.rs
+++ b/monad-mock-swarm/tests/rand_lat.rs
@@ -100,7 +100,7 @@ fn nodes_with_random_latency(latency_seed: u64) {
             .into_iter()
             .enumerate()
             .map(|(seed, state_builder)| {
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::<NoSerSwarm>::new(
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,

--- a/monad-mock-swarm/tests/replay.rs
+++ b/monad-mock-swarm/tests/replay.rs
@@ -129,7 +129,7 @@ pub fn recover_nodes_msg_delays(
             .zip(logger_configs.clone())
             .enumerate()
             .map(|(seed, (state_builder, logger_config))| {
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::<ReplaySwarm>::new(
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
@@ -199,7 +199,7 @@ pub fn recover_nodes_msg_delays(
             .zip(logger_configs)
             .enumerate()
             .map(|(seed, (state_builder, logger_config))| {
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::<ReplaySwarm>::new(
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,

--- a/monad-mock-swarm/tests/replay_test.rs
+++ b/monad-mock-swarm/tests/replay_test.rs
@@ -176,7 +176,7 @@ fn replay_one_honest(failure_idx: &[usize]) {
             .into_iter()
             .map(|state_builder| {
                 let me = NodeId::new(state_builder.key.pubkey());
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::new(
                     ID::new(me),
                     state_builder,
@@ -286,7 +286,7 @@ fn replay_one_honest(failure_idx: &[usize]) {
 
     {
         let state_builder = state_configs_duplicates.remove(f0);
-        let validators = state_builder.validators.clone();
+        let validators = state_builder.forkpoint.validator_set.clone();
         swarm.add_state(NodeBuilder::new(
             ID::new(node_ids[f0]),
             state_builder,
@@ -303,7 +303,7 @@ fn replay_one_honest(failure_idx: &[usize]) {
 
     {
         let state_builder = state_configs_duplicates.remove(f1 - 1);
-        let validators = state_builder.validators.clone();
+        let validators = state_builder.forkpoint.validator_set.clone();
         swarm.add_state(NodeBuilder::new(
             ID::new(node_ids[f1]),
             state_builder,

--- a/monad-mock-swarm/tests/two_nodes.rs
+++ b/monad-mock-swarm/tests/two_nodes.rs
@@ -68,7 +68,7 @@ fn two_nodes_noser() {
             .into_iter()
             .enumerate()
             .map(|(seed, state_builder)| {
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::<NoSerSwarm>::new(
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
@@ -136,7 +136,7 @@ fn two_nodes_quic_latency() {
             .enumerate()
             .map(|(seed, state_builder)| {
                 let me = NodeId::new(state_builder.key.pubkey());
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::<QuicSwarm>::new(
                     ID::new(me),
                     state_builder,
@@ -255,7 +255,7 @@ fn two_nodes_quic_bw() {
             .enumerate()
             .map(|(seed, state_builder)| {
                 let me = NodeId::new(state_builder.key.pubkey());
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::new(
                     ID::new(me),
                     state_builder,

--- a/monad-mock-swarm/tests/two_nodes_bls.rs
+++ b/monad-mock-swarm/tests/two_nodes_bls.rs
@@ -103,7 +103,7 @@ fn two_nodes_bls() {
             .into_iter()
             .enumerate()
             .map(|(seed, state_builder)| {
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::<BLSSwarm>::new(
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,

--- a/monad-mock-swarm/tests/two_nodes_metrics.rs
+++ b/monad-mock-swarm/tests/two_nodes_metrics.rs
@@ -69,7 +69,7 @@ fn two_nodes_metrics() {
             .into_iter()
             .enumerate()
             .map(|(seed, state_builder)| {
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::<NoSerSwarm>::new(
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -33,7 +33,7 @@ use monad_ipc::IpcReceiver;
 use monad_ledger::MonadBlockFileLedger;
 use monad_quic::{SafeQuinnConfig, Service, ServiceConfig};
 use monad_secp::SecpSignature;
-use monad_state::{MonadMessage, MonadStateBuilder, MonadVersion, VerifiedMonadMessage};
+use monad_state::{Forkpoint, MonadMessage, MonadStateBuilder, MonadVersion, VerifiedMonadMessage};
 use monad_types::{Deserializable, NodeId, Round, SeqNum, Serializable};
 use monad_updaters::{
     checkpoint::MockCheckpoint, ledger::BoundedLedger, loopback::LoopbackExecutor,
@@ -238,12 +238,12 @@ async fn run(
         block_validator: MockValidator,
         state_root_validator: Box::new(NopStateRoot {}) as Box<dyn StateRootValidator>,
         async_state_verify: PeerAsyncStateVerify::default(),
-        validators,
         key: node_state.secp256k1_identity,
         certkey: node_state.bls12_381_identity,
         val_set_update_interval,
         epoch_start_delay: Round(50),
         beneficiary: node_state.node_config.beneficiary,
+        forkpoint: Forkpoint::genesis(validators),
         consensus_config: ConsensusConfig {
             proposal_txn_limit: 1000,
             proposal_gas_limit: 800_000_000,

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -55,7 +55,7 @@ fn random_latency_test(latency_seed: u64) {
             .into_iter()
             .enumerate()
             .map(|(seed, state_builder)| {
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::<NoSerSwarm>::new(
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
@@ -115,7 +115,7 @@ fn delayed_message_test(latency_seed: u64) {
             .into_iter()
             .enumerate()
             .map(|(seed, state_builder)| {
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::<NoSerSwarm>::new(
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -23,7 +23,7 @@ use monad_ledger::MonadFileLedger;
 use monad_mock_swarm::mock::MockExecutionLedger;
 use monad_quic::{SafeQuinnConfig, Service, ServiceConfig};
 use monad_state::{
-    MonadMessage, MonadState, MonadStateBuilder, MonadVersion, VerifiedMonadMessage,
+    Forkpoint, MonadMessage, MonadState, MonadStateBuilder, MonadVersion, VerifiedMonadMessage,
 };
 use monad_types::{NodeId, Round, SeqNum};
 use monad_updaters::{
@@ -200,12 +200,12 @@ where
         block_validator: MockValidator {},
         state_root_validator: NopStateRoot::default(),
         async_state_verify: PeerAsyncStateVerify::default(),
-        validators: config.validators,
         key: config.key,
         certkey: config.cert_key,
         val_set_update_interval: config.val_set_update_interval,
         epoch_start_delay: config.epoch_start_delay,
         beneficiary: EthAddress::default(),
+        forkpoint: Forkpoint::genesis(config.validators),
         consensus_config: config.consensus_config,
     }
     .build()

--- a/monad-testutil/examples/logs_gen.rs
+++ b/monad-testutil/examples/logs_gen.rs
@@ -105,7 +105,7 @@ pub fn generate_log(
             .enumerate()
             .map(|(seed, state_builder)| {
                 let pubkey = state_builder.key.pubkey();
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 NodeBuilder::<LogSwarm>::new(
                     ID::new(NodeId::new(pubkey)),
                     state_builder,

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -4,7 +4,7 @@ use monad_consensus_state::ConsensusConfig;
 use monad_consensus_types::{block::BlockType, validator_data::ValidatorData};
 use monad_eth_types::EthAddress;
 use monad_mock_swarm::{mock_swarm::Nodes, swarm_relation::SwarmRelation};
-use monad_state::{MonadStateBuilder, MonadVersion};
+use monad_state::{Forkpoint, MonadStateBuilder, MonadVersion};
 use monad_types::{Round, SeqNum, Stake};
 use monad_validator::validator_set::ValidatorSetType;
 
@@ -69,7 +69,7 @@ pub fn make_state_configs<S: SwarmRelation>(
             block_validator: block_validator(),
             state_root_validator: state_root_validator(),
             async_state_verify: async_state_verify(state_root_quorum_threshold),
-            validators: validator_data.clone(),
+            forkpoint: Forkpoint::genesis(validator_data.clone()),
 
             key,
             certkey,

--- a/monad-twins/utils/src/lib.rs
+++ b/monad-twins/utils/src/lib.rs
@@ -61,7 +61,7 @@ where
 
     for TwinsNodeConfig {
         id,
-        state_config,
+        state_config: state_builder,
         default_partition,
         partition,
     } in nodes.into_values()
@@ -81,10 +81,10 @@ where
                 Duration::from_millis(delta),
             )),
         ];
-        let validators = state_config.validators.clone();
+        let validators = state_builder.forkpoint.validator_set.clone();
         swarm.add_state(NodeBuilder::<S>::new(
             id,
-            state_config,
+            state_builder,
             MockWALoggerConfig::default(),
             NoSerRouterConfig::new(
                 ids.iter()

--- a/monad-twins/utils/src/twin_reader.rs
+++ b/monad-twins/utils/src/twin_reader.rs
@@ -25,7 +25,7 @@ use monad_crypto::{
 };
 use monad_eth_types::EthAddress;
 use monad_mock_swarm::{swarm_relation::SwarmRelation, terminator::ProgressTerminator};
-use monad_state::{MonadStateBuilder, MonadVersion};
+use monad_state::{Forkpoint, MonadStateBuilder, MonadVersion};
 use monad_testutil::validators::complete_keys_w_validators;
 use monad_transformer::ID;
 use monad_types::{NodeId, Round, SeqNum};
@@ -122,7 +122,7 @@ where
                 state_root_validator: self.state_config.state_root_validator.clone(),
                 async_state_verify: self.state_config.async_state_verify.clone(),
 
-                validators: self.state_config.validators.clone(),
+                forkpoint: self.state_config.forkpoint.clone(),
                 key: CertificateKeyPair::from_bytes(&mut self.key_secret.clone()).unwrap(),
                 certkey: SignatureCollectionKeyPairType::<SCT>::from_bytes(
                     &mut self.certkey_secret.clone(),
@@ -337,7 +337,7 @@ where
             block_validator: S::BlockValidator::default(),
             state_root_validator: StateRoot::new(monad_types::SeqNum(TWINS_STATE_ROOT_DELAY)),
             async_state_verify: S::AsyncStateRootVerify::default(),
-            validators: validator_data.clone(),
+            forkpoint: Forkpoint::genesis(validator_data.clone()),
 
             key,
             certkey,

--- a/monad-virtual-bench/benches/many_nodes_bench.rs
+++ b/monad-virtual-bench/benches/many_nodes_bench.rs
@@ -141,7 +141,7 @@ fn many_nodes_nop_timeout() -> u128 {
             .into_iter()
             .enumerate()
             .map(|(seed, state_builder)| {
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 let me = NodeId::new(state_builder.key.pubkey());
                 NodeBuilder::<NopSwarm>::new(
                     ID::new(me),
@@ -216,7 +216,7 @@ fn many_nodes_bls_timeout() -> u128 {
             .into_iter()
             .enumerate()
             .map(|(seed, state_builder)| {
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 let me = NodeId::new(state_builder.key.pubkey());
                 NodeBuilder::<BlsSwarm>::new(
                     ID::new(me),

--- a/monad-virtual-bench/benches/two_node_bench.rs
+++ b/monad-virtual-bench/benches/two_node_bench.rs
@@ -47,7 +47,7 @@ fn two_nodes_virtual() -> u128 {
             .into_iter()
             .enumerate()
             .map(|(seed, state_builder)| {
-                let validators = state_builder.validators.clone();
+                let validators = state_builder.forkpoint.validator_set.clone();
                 let me = NodeId::new(state_builder.key.pubkey());
                 NodeBuilder::new(
                     ID::new(me),


### PR DESCRIPTION
Struct definition and handler code for forkpoints. Genesis config is a special case of a forkpoint, so it seamlessly integrates.

Next steps are
- Define a forkpoint toml format and replace config.toml in monad-node
- Test manual catch up with forkpoint + blocksync