### PR TITLE
Bump docker base to ubuntu:22.04

### DIFF
--- a/docker/flexnet/images/ethtx/Dockerfile
+++ b/docker/flexnet/images/ethtx/Dockerfile
@@ -1,6 +1,6 @@
 # ethtx: a tool to send random eth transactions over UNIX sockets
 
-FROM debian:buster-slim
+FROM ubuntu:22.04
 WORKDIR /usr/src/monad-bft
 
 RUN apt update && apt install -y openssl

--- a/docker/flexnet/images/image0/Dockerfile
+++ b/docker/flexnet/images/image0/Dockerfile
@@ -1,7 +1,7 @@
 # Default monad node
 
 # runner stage
-FROM debian:buster-slim
+FROM ubuntu:22.04
 WORKDIR /usr/src/monad-bft
 
 RUN apt update && apt install -y net-tools iputils-ping iproute2

--- a/docker/flexnet/images/monad-bft-builder/Dockerfile
+++ b/docker/flexnet/images/monad-bft-builder/Dockerfile
@@ -1,11 +1,34 @@
-FROM rust:1-buster AS builder
-WORKDIR /usr/src/cmake
-RUN apt update
-RUN apt install -y clang
+FROM ubuntu:22.04 AS builder
 
-RUN wget https://cmake.org/files/v3.20/cmake-3.20.0-linux-x86_64.sh 
-RUN bash cmake-3.20.0-linux-x86_64.sh --skip-license
-ENV PATH="/usr/src/cmake/bin:$PATH" 
+RUN apt update
+RUN apt install -y ca-certificates \
+    curl \
+    gnupg \
+    software-properties-common \
+    wget \
+    pkg-config \
+    libssl-dev \
+    clang
+
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
+RUN apt install -y libstdc++-13-dev
+RUN apt install -y gcc-13 g++-13
+
+######## BEGIN CMAKE
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
+  | gpg --dearmor - \
+  | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+RUN echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' \
+  | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+RUN apt-get update
+RUN rm /usr/share/keyrings/kitware-archive-keyring.gpg
+RUN apt-get -y install kitware-archive-keyring
+RUN apt-get -y install cmake
+######## END CMAKE
+
+# install cargo
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+ENV PATH="/root/.cargo/bin:$PATH"
 
 RUN mkdir -p /output/bin
 RUN mkdir -p /output/lib
@@ -15,15 +38,15 @@ COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry     \
     --mount=type=cache,target=/usr/local/cargo/git          \
     --mount=type=cache,target=/usr/src/monad-bft/target     \
-    cargo build --release --bin monad-node --bin monad-rpc --example ethtx
+    CC=gcc-13 CXX=g++-13 cargo build --release --bin monad-node --bin monad-rpc --example ethtx
     
 RUN --mount=type=cache,target=/usr/src/monad-bft/target     \
     find target/release/ -maxdepth 1 -perm /a+x -type f -exec cp {} /output/bin \; && \
     find target/release/examples -maxdepth 1 -perm /a+x -type f -exec cp {} /output/bin \; && \
-    cp `find target/release | grep libtriedb` /output/lib
+    cp `find target/release | grep -E "(libmock_eth_call|libtriedb)"` /output/lib
 
 
-FROM debian:buster-slim AS exporter
+FROM ubuntu:22.04 AS exporter
 WORKDIR /output
 
 COPY --from=builder /output /output

--- a/docker/flexnet/images/rpc/Dockerfile
+++ b/docker/flexnet/images/rpc/Dockerfile
@@ -1,5 +1,5 @@
 # RPC server
-FROM debian:buster-slim
+FROM ubuntu:22.04
 WORKDIR /usr/src/monad-bft
 
 ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"

--- a/docker/flexnet/nets/net0/scripts/inspect-block.py
+++ b/docker/flexnet/nets/net0/scripts/inspect-block.py
@@ -29,9 +29,11 @@ if __name__ == "__main__":
     print(f"Total txns in ledger: {len(ledger_txns)}")
 
     submitted_txns = []
+    verification_success = True
     for txn in txns_json:
         if not txn["submitted"]:
             print(f"ERROR: txns {txn["hash"]} not submitted")
+            verification_success = False
             continue
         submitted_txns.append(txn["hash"])
         
@@ -40,7 +42,6 @@ if __name__ == "__main__":
     only_in_ledger = set(ledger_txns) - set(submitted_txns)
     only_in_submitted = set(submitted_txns) - set(ledger_txns)
 
-    verification_success = True
     if len(only_in_ledger) > 0:
         print("Only found in ledger: ", only_in_ledger)
         verification_success = False

--- a/docker/rpc/Dockerfile
+++ b/docker/rpc/Dockerfile
@@ -1,22 +1,46 @@
 # Builder
-FROM rust:1-buster AS builder
+FROM ubuntu:22.04 AS builder
+
+RUN apt update
+RUN apt install -y ca-certificates \
+    curl \
+    gnupg \
+    software-properties-common \
+    wget \
+    pkg-config \
+    libssl-dev \
+    clang
+
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
+RUN apt install -y libstdc++-13-dev
+RUN apt install -y gcc-13 g++-13
+
+######## BEGIN CMAKE
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
+  | gpg --dearmor - \
+  | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+RUN echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' \
+  | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+RUN apt-get update
+RUN rm /usr/share/keyrings/kitware-archive-keyring.gpg
+RUN apt-get -y install kitware-archive-keyring
+RUN apt-get -y install cmake
+######## END CMAKE
+
+# install cargo
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+ENV PATH="/root/.cargo/bin:$PATH"
 
 WORKDIR /usr/src/monad-bft
-RUN apt update
-RUN apt install -y clang
-RUN wget https://cmake.org/files/v3.20/cmake-3.20.0-linux-x86_64.sh 
-RUN bash cmake-3.20.0-linux-x86_64.sh --skip-license
-ENV PATH="/usr/src/cmake/bin:$PATH" 
-
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/src/monad-bft/target \
-    cargo build --release --bin monad-rpc && \
+    CC=gcc-13 CXX=g++-13 cargo build --release --bin monad-rpc && \
     mv target/release/monad-rpc rpc && \
-    cp `find target/release | grep libtriedb` .
+    cp `find target/release | grep -E "(libmock_eth_call|libtriedb)"` .
 
 # Runner
-FROM debian:buster-slim
+FROM ubuntu:22.04
 WORKDIR /usr/src/monad-bft
 
 ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"


### PR DESCRIPTION
`monad-cxx` fails to compile with the old image because the compiler is not equipped c++20. Bumping the base image to ubuntu:22.04 to be consistent with execution

I rebased #710 wrong when merging so one of the commits was dropped. Re-opening the PR