### PR TITLE
Dockerfile: copy the latest dynamic libs

### DIFF
--- a/docker/flexnet/images/monad-bft-builder/Dockerfile
+++ b/docker/flexnet/images/monad-bft-builder/Dockerfile
@@ -43,7 +43,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry     \
 RUN --mount=type=cache,target=/usr/src/monad-bft/target     \
     find target/release/ -maxdepth 1 -perm /a+x -type f -exec cp {} /output/bin \; && \
     find target/release/examples -maxdepth 1 -perm /a+x -type f -exec cp {} /output/bin \; && \
-    cp `find target/release | grep -E "(libmock_eth_call|libtriedb)"` /output/lib
+    cp `ls -lt $(find target/release | grep libmock_eth_call) | head -1 | awk '{print $9}'` /output/lib && \
+    cp `ls -lt $(find target/release | grep libtriedb) | head -1 | awk '{print $9}'` /output/lib
 
 
 FROM ubuntu:22.04 AS exporter

--- a/docker/rpc/Dockerfile
+++ b/docker/rpc/Dockerfile
@@ -37,7 +37,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/src/monad-bft/target \
     CC=gcc-13 CXX=g++-13 cargo build --release --bin monad-rpc && \
     mv target/release/monad-rpc rpc && \
-    cp `find target/release | grep -E "(libmock_eth_call|libtriedb)"` .
+    cp `ls -lt $(find target/release | grep libmock_eth_call) | head -1 | awk '{print $9}'` . && \
+    cp `ls -lt $(find target/release | grep libtriedb) | head -1 | awk '{print $9}'` .
 
 # Runner
 FROM ubuntu:22.04


### PR DESCRIPTION
The build target directory is cached so sometimes it's loaded with old build outputs. `grep` finds more than one lib.so and copying files of the same name causes an `cp` error. This change picks the latest lib.so

Fixing errors found in jenkins run: https://peach10.monad.spacetime.org/jenkins/job/monad-bft/job/ci/job/master/6/

> #<span></span>24 0.997 cp: will not overwrite just-created '/output/lib/libtriedb_driver_mock.so' with 'target/release/build/monad-triedb-c11d19df5ffa7d77/out/build/libtriedb_driver_mock.so'
> #<span></span>24 0.997 cp: will not overwrite just-created '/output/lib/libtriedb_driver_mock.so' with 'target/release/build/monad-triedb-5b44cdc3413dc2a2/out/build/libtriedb_driver_mock.so'