### PR TITLE
Add workaround parenthash for devnet and remove dead code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3488,7 +3488,6 @@ dependencies = [
  "prost",
  "reth-primitives",
  "serde",
- "tempfile",
  "tokio",
 ]
 
@@ -3769,7 +3768,6 @@ dependencies = [
  "monad-executor-glue",
  "monad-gossip",
  "monad-ipc",
- "monad-ledger",
  "monad-mock-swarm",
  "monad-multi-sig",
  "monad-quic",

--- a/monad-ledger/Cargo.toml
+++ b/monad-ledger/Cargo.toml
@@ -22,7 +22,6 @@ alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }
 prost = { workspace = true }
 reth-primitives = { workspace = true }
-tempfile = { workspace = true }
 tokio = { workspace = true, features = [
     "macros",
     "net",

--- a/monad-testground/Cargo.toml
+++ b/monad-testground/Cargo.toml
@@ -16,7 +16,6 @@ monad-executor = { path = "../monad-executor" }
 monad-executor-glue = { path = "../monad-executor-glue" }
 monad-ipc = { path = "../monad-ipc" }
 monad-gossip = { path = "../monad-gossip" }
-monad-ledger = { path = "../monad-ledger" }
 monad-mock-swarm = { path = "../monad-mock-swarm" }
 monad-multi-sig = { path = "../monad-multi-sig" }
 monad-quic = { path = "../monad-quic" }

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -19,7 +19,6 @@ use monad_gossip::{
     Gossip,
 };
 use monad_ipc::{generate_uds_path, IpcReceiver};
-use monad_ledger::MonadFileLedger;
 use monad_mock_swarm::mock::MockExecutionLedger;
 use monad_quic::{SafeQuinnConfig, Service, ServiceConfig};
 use monad_state::{
@@ -59,7 +58,6 @@ where
 
 pub enum ExecutionLedgerConfig {
     Mock,
-    File,
 }
 
 pub enum StateRootHashConfig<SCT>
@@ -128,9 +126,6 @@ where
         ledger: MockLedger::default(),
         execution_ledger: match config.execution_ledger_config {
             ExecutionLedgerConfig::Mock => Executor::boxed(MockExecutionLedger::default()),
-            ExecutionLedgerConfig::File => Executor::boxed(MonadFileLedger::new(
-                format!("{:?}-ledger", config.nodeid).into(),
-            )),
         },
         checkpoint: MockCheckpoint::default(),
         state_root_hash: match config.state_root_hash_config {

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -97,7 +97,6 @@ enum GossipArgs {
 
 pub enum ExecutionLedgerArgs {
     Mock,
-    File,
 }
 
 fn make_provider(
@@ -342,7 +341,6 @@ where
                     },
                     execution_ledger_config: match args.execution_ledger {
                         ExecutionLedgerArgs::Mock => ExecutionLedgerConfig::Mock,
-                        ExecutionLedgerArgs::File => ExecutionLedgerConfig::File,
                     },
                     state_root_hash_config: StateRootHashConfig::Mock {
                         genesis_validator_data: validators.clone(),


### PR DESCRIPTION
Parent Hash and other previous block pointing fields in the eth header are expected to be offset by the state root delay but for now to support blockscout on devnet, will just keep track of the last committed block's hash locally and populate the parent hash with that.

tested locally with a single node and blockwatch that something was going into parent hash field. 
