### PR TITLE
Remove UnverifiedBlock struct

### DIFF
--- a/monad-compress/examples/proposal.rs
+++ b/monad-compress/examples/proposal.rs
@@ -58,9 +58,9 @@ fn main() {
         .destructure()
         .2;
 
-    let epoch = epoch_manager.get_epoch(proposal.block.0.round);
+    let epoch = epoch_manager.get_epoch(proposal.block.round);
     let proposer_leader = election.get_leader(
-        proposal.block.0.round,
+        proposal.block.round,
         epoch,
         val_epoch_map.get_val_set(&epoch).unwrap().get_members(),
     );

--- a/monad-consensus-types/src/block.rs
+++ b/monad-consensus-types/src/block.rs
@@ -1,5 +1,3 @@
-use std::fmt::Debug;
-
 use monad_crypto::{
     certificate_signature::PubKey,
     hasher::{Hashable, Hasher, HasherType},
@@ -8,7 +6,7 @@ use monad_types::{BlockId, NodeId, Round, SeqNum};
 use zerocopy::AsBytes;
 
 use crate::{
-    block_validator::BlockValidator, payload::Payload, quorum_certificate::QuorumCertificate,
+    payload::Payload, quorum_certificate::QuorumCertificate,
     signature_collection::SignatureCollection,
 };
 
@@ -110,17 +108,6 @@ impl<SCT: SignatureCollection> Block<SCT> {
             },
         }
     }
-
-    /// Try to create a Block from an UnverifiedBlock, verifying
-    /// with the TransactionValidator
-    pub fn try_from_unverified(
-        unverified: UnverifiedBlock<SCT>,
-        validator: &impl BlockValidator,
-    ) -> Option<Self> {
-        validator
-            .validate(&unverified.0.payload.txns)
-            .then_some(unverified.0)
-    }
 }
 
 impl<SCT: SignatureCollection> BlockType for Block<SCT> {
@@ -148,28 +135,5 @@ impl<SCT: SignatureCollection> BlockType for Block<SCT> {
 
     fn get_seq_num(&self) -> SeqNum {
         self.payload.seq_num
-    }
-}
-
-/// A block alongside the list of RLP encoded full transactions
-/// The transactions have not been verified
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UnverifiedBlock<SCT: SignatureCollection>(pub Block<SCT>);
-
-impl<SCT: SignatureCollection> UnverifiedBlock<SCT> {
-    pub fn new(block: Block<SCT>) -> Self {
-        Self(block)
-    }
-}
-
-impl<SCT: SignatureCollection> From<Block<SCT>> for UnverifiedBlock<SCT> {
-    fn from(value: Block<SCT>) -> Self {
-        Self(value)
-    }
-}
-
-impl<SCT: SignatureCollection> Hashable for UnverifiedBlock<SCT> {
-    fn hash(&self, state: &mut impl Hasher) {
-        self.0.hash(state);
     }
 }

--- a/monad-consensus-types/src/convert/block.rs
+++ b/monad-consensus-types/src/convert/block.rs
@@ -8,7 +8,7 @@ use monad_proto::{
 };
 
 use crate::{
-    block::{Block, UnverifiedBlock},
+    block::Block,
     payload::{
         Bloom, ExecutionArtifacts, FullTransactionList, Gas, Payload, RandaoReveal,
         TransactionHashList,
@@ -69,29 +69,6 @@ impl<SCT: SignatureCollection> TryFrom<ProtoBlock> for Block<SCT> {
                 .qc
                 .ok_or(Self::Error::MissingRequiredField(
                     "Block<AggregateSignatures>.qc".to_owned(),
-                ))?
-                .try_into()?,
-        ))
-    }
-}
-
-impl<SCT: SignatureCollection> From<&UnverifiedBlock<SCT>> for ProtoUnverifiedBlock {
-    fn from(value: &UnverifiedBlock<SCT>) -> Self {
-        Self {
-            block: Some((&value.0).into()),
-        }
-    }
-}
-
-impl<SCT: SignatureCollection> TryFrom<ProtoUnverifiedBlock> for UnverifiedBlock<SCT> {
-    type Error = ProtoError;
-
-    fn try_from(value: ProtoUnverifiedBlock) -> Result<Self, Self::Error> {
-        Ok(Self(
-            value
-                .block
-                .ok_or(Self::Error::MissingRequiredField(
-                    "UnverifiedBlock<AggregateSignatures>.block".to_owned(),
                 ))?
                 .try_into()?,
         ))

--- a/monad-consensus/src/messages/consensus_message.rs
+++ b/monad-consensus/src/messages/consensus_message.rs
@@ -97,7 +97,7 @@ where
 
     pub fn get_round(&self) -> Round {
         match &self.message {
-            ProtocolMessage::Proposal(p) => p.block.0.round,
+            ProtocolMessage::Proposal(p) => p.block.round,
             ProtocolMessage::Vote(v) => v.vote.vote_info.round,
             ProtocolMessage::Timeout(t) => t.timeout.tminfo.round,
         }

--- a/monad-consensus/src/messages/message.rs
+++ b/monad-consensus/src/messages/message.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use bytes::Bytes;
 use monad_consensus_types::{
-    block::{BlockType, UnverifiedBlock},
+    block::{Block, BlockType},
     signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
     state_root_hash::StateRootHashInfo,
     timeout::{Timeout, TimeoutCertificate},
@@ -85,7 +85,7 @@ impl<SCT: SignatureCollection> Hashable for TimeoutMessage<SCT> {
 /// Consensus protocol proposal message
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProposalMessage<SCT: SignatureCollection> {
-    pub block: UnverifiedBlock<SCT>,
+    pub block: Block<SCT>,
     pub last_round_tc: Option<TimeoutCertificate<SCT>>,
 }
 
@@ -114,14 +114,14 @@ impl Hashable for RequestBlockSyncMessage {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BlockSyncResponseMessage<SCT: SignatureCollection> {
-    BlockFound(UnverifiedBlock<SCT>),
+    BlockFound(Block<SCT>),
     NotAvailable(BlockId),
 }
 
 impl<T: SignatureCollection> BlockSyncResponseMessage<T> {
     pub fn get_block_id(&self) -> BlockId {
         match self {
-            BlockSyncResponseMessage::BlockFound(b) => b.0.get_id(),
+            BlockSyncResponseMessage::BlockFound(b) => b.get_id(),
             BlockSyncResponseMessage::NotAvailable(bid) => *bid,
         }
     }

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -308,7 +308,7 @@ impl<SCT: SignatureCollection> Unvalidated<ProposalMessage<SCT>> {
             epoch_manager,
             val_epoch_map,
             &self.obj.last_round_tc,
-            &self.obj.block.0.qc,
+            &self.obj.block.qc,
         )?;
 
         Ok(Validated { message: self })
@@ -321,14 +321,14 @@ impl<SCT: SignatureCollection> Unvalidated<ProposalMessage<SCT>> {
     fn well_formed_proposal(&self) -> Result<(), Error> {
         self.valid_seq_num()?;
         well_formed(
-            self.obj.block.0.round,
-            self.obj.block.0.qc.get_round(),
+            self.obj.block.round,
+            self.obj.block.qc.get_round(),
             &self.obj.last_round_tc,
         )
     }
 
     fn valid_seq_num(&self) -> Result<(), Error> {
-        if self.obj.block.0.get_seq_num() != self.obj.block.0.qc.get_seq_num() + SeqNum(1) {
+        if self.obj.block.get_seq_num() != self.obj.block.qc.get_seq_num() + SeqNum(1) {
             return Err(Error::InvalidSeqNum);
         }
         Ok(())
@@ -408,7 +408,7 @@ impl<SCT: SignatureCollection> Unvalidated<BlockSyncResponseMessage<SCT>> {
         VT: ValidatorSetType<NodeIdPubKey = SCT::NodeIdPubKey>,
     {
         if let BlockSyncResponseMessage::BlockFound(b) = &self.obj {
-            verify_certificates(epoch_manager, val_epoch_map, &(None), &b.0.qc)?;
+            verify_certificates(epoch_manager, val_epoch_map, &(None), &b.qc)?;
         }
 
         Ok(Validated { message: self })

--- a/monad-consensus/tests/message.rs
+++ b/monad-consensus/tests/message.rs
@@ -1,6 +1,6 @@
 use monad_consensus::messages::message::{ProposalMessage, TimeoutMessage, VoteMessage};
 use monad_consensus_types::{
-    block::{Block, UnverifiedBlock},
+    block::Block,
     ledger::CommitResult,
     payload::{ExecutionArtifacts, FullTransactionList, Payload, RandaoReveal},
     quorum_certificate::{QcInfo, QuorumCertificate},
@@ -225,7 +225,7 @@ fn proposal_msg_hash() {
     );
 
     let proposal: ProposalMessage<MockSignatures<SignatureType>> = ProposalMessage {
-        block: UnverifiedBlock(block.clone()),
+        block: block.clone(),
         last_round_tc: None,
     };
 

--- a/monad-consensus/tests/proposal.rs
+++ b/monad-consensus/tests/proposal.rs
@@ -6,7 +6,7 @@ use monad_consensus::{
     validation::signing::Unvalidated,
 };
 use monad_consensus_types::{
-    block::{Block, UnverifiedBlock},
+    block::Block,
     ledger::CommitResult,
     payload::{ExecutionArtifacts, FullTransactionList, Payload, RandaoReveal},
     quorum_certificate::{QcInfo, QuorumCertificate},
@@ -39,7 +39,7 @@ fn setup_block(
     block_round: Round,
     qc_round: Round,
     signers: &[PubKeyType],
-) -> UnverifiedBlock<MockSignatures<SignatureType>> {
+) -> Block<MockSignatures<SignatureType>> {
     let txns = FullTransactionList::new(vec![1, 2, 3, 4].into());
     let vi = VoteInfo {
         id: BlockId(Hash([0x00_u8; 32])),
@@ -58,7 +58,7 @@ fn setup_block(
         MockSignatures::with_pubkeys(signers),
     );
 
-    let b = Block::<MockSignatures<SignatureType>>::new(
+    Block::<MockSignatures<SignatureType>>::new(
         author,
         block_round,
         &Payload {
@@ -69,8 +69,7 @@ fn setup_block(
             randao_reveal: RandaoReveal::default(),
         },
         &qc,
-    );
-    UnverifiedBlock(b)
+    )
 }
 
 #[test]

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -15,11 +15,8 @@ use monad_consensus::{
     validation::signing::{Unvalidated, Unverified},
 };
 use monad_consensus_types::{
-    block::{Block, UnverifiedBlock},
-    metrics::Metrics,
-    signature_collection::SignatureCollection,
-    state_root_hash::StateRootHashInfo,
-    validator_data::ValidatorData,
+    block::Block, metrics::Metrics, signature_collection::SignatureCollection,
+    state_root_hash::StateRootHashInfo, validator_data::ValidatorData,
 };
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
@@ -197,7 +194,7 @@ pub struct FetchedBlock<SCT: SignatureCollection> {
     /// FetchedBlock results should only be used to send block data to nodes
     /// over the network so we should unverify it before sending to consensus
     /// to prevent it from being used for anything else
-    pub unverified_block: Option<UnverifiedBlock<SCT>>,
+    pub unverified_block: Option<Block<SCT>>,
 }
 
 /// BlockSync related events

--- a/monad-mock-swarm/src/transformer.rs
+++ b/monad-mock-swarm/src/transformer.rs
@@ -133,7 +133,7 @@ where
         let capture = match &message {
             VerifiedMonadMessage::Consensus(consensus_msg) => {
                 match &consensus_msg.deref().deref().message {
-                    ProtocolMessage::Proposal(p) => TwinsCapture::Process(pid, p.block.0.round),
+                    ProtocolMessage::Proposal(p) => TwinsCapture::Process(pid, p.block.round),
                     ProtocolMessage::Vote(v) => TwinsCapture::Process(pid, v.vote.vote_info.round),
                     // timeout naturally spread because liveness
                     ProtocolMessage::Timeout(_) => TwinsCapture::Spread(pid),

--- a/monad-mock-swarm/src/utils.rs
+++ b/monad-mock-swarm/src/utils.rs
@@ -14,7 +14,7 @@ pub mod test_tool {
         validation::signing::Validated,
     };
     use monad_consensus_types::{
-        block::{Block, UnverifiedBlock},
+        block::Block,
         ledger::CommitResult,
         payload::{ExecutionArtifacts, FullTransactionList, Payload, RandaoReveal},
         quorum_certificate::{QcInfo, QuorumCertificate},
@@ -90,7 +90,7 @@ pub mod test_tool {
 
     pub fn fake_proposal_message(kp: &KeyPairType, round: Round) -> VerifiedMonadMessage<ST, SC> {
         let internal_msg = ProposalMessage {
-            block: UnverifiedBlock(fake_block(round)),
+            block: fake_block(round),
             last_round_tc: None,
         };
         ConsensusMessage {

--- a/monad-proto/proto/block.proto
+++ b/monad-proto/proto/block.proto
@@ -33,7 +33,3 @@ message ProtoBlock {
   ProtoPayload payload = 3;
   monad_proto.quorum_certificate.ProtoQuorumCertificate qc = 4;
 }
-
-message ProtoUnverifiedBlock {
-  ProtoBlock block = 1;
-}

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -36,7 +36,7 @@ message ProtoScheduleTimeout {
 message ProtoFetchedBlock {
   monad_proto.basic.ProtoNodeId requester = 1;
   monad_proto.basic.ProtoBlockId block_id = 2;
-  optional monad_proto.block.ProtoUnverifiedBlock unverified_block = 3;
+  optional monad_proto.block.ProtoBlock unverified_block = 3;
 }
 
 message ProtoUpdateValidatorsEvent {

--- a/monad-proto/proto/message.proto
+++ b/monad-proto/proto/message.proto
@@ -21,7 +21,7 @@ message ProtoRequestBlockSyncMessage {
 
 message ProtoBlockSyncMessage {
   oneof OneofMessage {
-    monad_proto.block.ProtoUnverifiedBlock block_found = 1;
+    monad_proto.block.ProtoBlock block_found = 1;
     monad_proto.basic.ProtoBlockId not_available = 2;
   }
 }
@@ -32,7 +32,7 @@ message ProtoTimeoutMessage {
 }
 
 message ProtoProposalMessage {
-  monad_proto.block.ProtoUnverifiedBlock block = 1;
+  monad_proto.block.ProtoBlock block = 1;
   optional monad_proto.timeout.ProtoTimeoutCertificate last_round_tc = 2;
 }
 

--- a/monad-state/src/blocksync.rs
+++ b/monad-state/src/blocksync.rs
@@ -51,9 +51,7 @@ impl BlockSyncResponder {
             vec![BlockSyncCommand::BlockSyncResponse {
                 requester,
                 block_id: s.block_id,
-                response: Validated::new(BlockSyncResponseMessage::BlockFound(
-                    block.clone().into(),
-                )),
+                response: Validated::new(BlockSyncResponseMessage::BlockFound(block.clone())),
             }]
         } else {
             // else ask ledger
@@ -176,7 +174,7 @@ where
                     MonadEvent::BlockSyncEvent(BlockSyncEvent::FetchedBlock(FetchedBlock {
                         requester,
                         block_id,
-                        unverified_block: block.map(|b| b.into()),
+                        unverified_block: block,
                     }))
                 }),
             ))],

--- a/monad-state/tests/protobuf.rs
+++ b/monad-state/tests/protobuf.rs
@@ -10,7 +10,6 @@ use monad_consensus::{
     validation::signing::{Validated, Verified},
 };
 use monad_consensus_types::{
-    block::UnverifiedBlock,
     ledger::CommitResult,
     payload::{ExecutionArtifacts, FullTransactionList},
     quorum_certificate::{QcInfo, QuorumCertificate},
@@ -324,7 +323,7 @@ test_all_combination!(test_proposal_qc, |num_keys| {
         validator_mapping,
     );
     let proposal = ProtocolMessage::Proposal(ProposalMessage {
-        block: UnverifiedBlock(blk),
+        block: blk,
         last_round_tc: None,
     });
     let conmsg = ConsensusMessage {
@@ -398,7 +397,7 @@ test_all_combination!(test_proposal_tc, |num_keys| {
     );
 
     let proposal_msg = ProtocolMessage::Proposal(ProposalMessage {
-        block: UnverifiedBlock(blk),
+        block: blk,
         last_round_tc: Some(tc),
     });
     let con_msg = ConsensusMessage {
@@ -519,7 +518,7 @@ test_all_combination!(test_block_sync_response_found, |num_keys| {
         validator_mapping,
     );
 
-    let full_blk = UnverifiedBlock::new(blk);
+    let full_blk = blk;
 
     let block_sync_msg = BlockSyncResponseMessage::BlockFound(full_blk);
 

--- a/monad-testutil/src/proposal.rs
+++ b/monad-testutil/src/proposal.rs
@@ -5,7 +5,7 @@ use monad_consensus::{
     validation::signing::Verified,
 };
 use monad_consensus_types::{
-    block::{Block, BlockType, UnverifiedBlock},
+    block::{Block, BlockType},
     ledger::CommitResult,
     payload::{ExecutionArtifacts, FullTransactionList, Payload, RandaoReveal},
     quorum_certificate::{QcInfo, QuorumCertificate},
@@ -122,7 +122,7 @@ where
         self.qc = self.get_next_qc(certkeys, &block, validator_cert_pubkeys);
 
         let proposal = ProposalMessage {
-            block: UnverifiedBlock(block),
+            block,
             last_round_tc: self.last_tc.clone(),
         };
         self.last_tc = None;

--- a/monad-wal/benches/event_bench.rs
+++ b/monad-wal/benches/event_bench.rs
@@ -10,7 +10,6 @@ use monad_consensus::{
     validation::signing::{Unvalidated, Unverified},
 };
 use monad_consensus_types::{
-    block::UnverifiedBlock,
     ledger::CommitResult,
     payload::{ExecutionArtifacts, FullTransactionList},
     quorum_certificate::{QcInfo, QuorumCertificate},
@@ -92,7 +91,7 @@ fn bench_proposal(c: &mut Criterion) {
     );
 
     let proposal = ProtocolMessage::Proposal(ProposalMessage {
-        block: UnverifiedBlock(blk),
+        block: blk,
         last_round_tc: None,
     });
     let conmsg = ConsensusMessage {

--- a/monad-wal/examples/wal-tool.rs
+++ b/monad-wal/examples/wal-tool.rs
@@ -506,7 +506,7 @@ impl StatExtractor {
                     let msg = unverified_message.get_obj_unsafe();
                     match &msg.message {
                         ProtocolMessage::Proposal(p) => {
-                            let r = p.block.0.get_round();
+                            let r = p.block.get_round();
                             stat.block_time.insert(r.0, event.timestamp);
                         }
                         _ => continue,


### PR DESCRIPTION
The UnverifiedBlock struct doesn't actually protect anything - the internal block is extractable without any verification. Verification will anyway need to change with the new blocksync implementation, so this commit removes UnverifiedBlock in preparation for that.