### PR TITLE
blocktree hash policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,6 +3176,9 @@ dependencies = [
 name = "monad-blocktree"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "bytes",
  "monad-consensus-types",
  "monad-crypto",
  "monad-eth-types",
@@ -3275,6 +3278,8 @@ dependencies = [
 name = "monad-consensus-types"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
  "bytes",
  "monad-crypto",
  "monad-eth-types",
@@ -3377,10 +3382,14 @@ dependencies = [
 name = "monad-eth-txpool"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "alloy-rlp",
  "bytes",
+ "criterion",
  "monad-consensus-types",
  "monad-eth-tx",
+ "rand",
+ "reth-primitives",
  "tracing",
 ]
 
@@ -3588,6 +3597,7 @@ dependencies = [
  "log",
  "monad-async-state-verify",
  "monad-blockdb",
+ "monad-blocktree",
  "monad-bls",
  "monad-consensus-state",
  "monad-consensus-types",
@@ -3784,6 +3794,7 @@ dependencies = [
  "clap 4.4.10",
  "futures-util",
  "monad-async-state-verify",
+ "monad-blocktree",
  "monad-consensus-state",
  "monad-consensus-types",
  "monad-crypto",
@@ -3816,6 +3827,7 @@ name = "monad-testutil"
 version = "0.1.0"
 dependencies = [
  "monad-async-state-verify",
+ "monad-blocktree",
  "monad-consensus",
  "monad-consensus-state",
  "monad-consensus-types",
@@ -3896,6 +3908,7 @@ version = "0.1.0"
 dependencies = [
  "itertools 0.10.5",
  "monad-async-state-verify",
+ "monad-blocktree",
  "monad-consensus-state",
  "monad-consensus-types",
  "monad-crypto",

--- a/monad-blocktree/Cargo.toml
+++ b/monad-blocktree/Cargo.toml
@@ -9,10 +9,14 @@ edition = "2021"
 bench = false
 
 [dependencies]
+alloy-rlp = { workspace = true }
+alloy-primitives = { workspace = true }
+
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-tracing-counter = { path = "../monad-tracing-counter" }
 monad-types = { path = "../monad-types" }
 
+bytes = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/monad-consensus-types/Cargo.toml
+++ b/monad-consensus-types/Cargo.toml
@@ -16,6 +16,8 @@ monad-eth-types = { path = "../monad-eth-types" }
 monad-proto = { path = "../monad-proto" }
 monad-types = { path = "../monad-types" }
 
+alloy-rlp = { workspace = true }
+alloy-primitives = { workspace = true }
 bytes = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }

--- a/monad-eth-txpool/Cargo.toml
+++ b/monad-eth-txpool/Cargo.toml
@@ -13,3 +13,13 @@ monad-eth-tx = { path = "../monad-eth-tx" }
 alloy-rlp = { workspace = true }
 bytes = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+alloy-primitives = { workspace = true }
+criterion = { workspace = true }
+reth-primitives = { workspace = true }
+rand = { workspace = true }
+
+[[bench]]
+name = "proposal_bench"
+harness = false

--- a/monad-eth-txpool/benches/proposal_bench.rs
+++ b/monad-eth-txpool/benches/proposal_bench.rs
@@ -1,0 +1,93 @@
+use alloy_rlp::Encodable;
+use bytes::Bytes;
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use monad_consensus_types::{payload::FullTransactionList, txpool::TxPool};
+use monad_eth_txpool::EthTxPool;
+use rand::{Rng, RngCore};
+use reth_primitives::{
+    sign_message, Address, Transaction, TransactionKind, TransactionSigned, TxLegacy, B256,
+};
+
+const NUM_TRANSACTIONS: usize = 10_000;
+const TRANSACTION_SIZE_BYTES: usize = 400;
+
+fn make_tx(input_len: usize) -> TransactionSigned {
+    let mut input = vec![0; input_len];
+    rand::thread_rng().fill_bytes(&mut input);
+    let transaction = Transaction::Legacy(TxLegacy {
+        chain_id: Some(1337),
+        nonce: rand::thread_rng().gen_range(10_000..50_000),
+        gas_price: 1,
+        gas_limit: 6400,
+        to: TransactionKind::Call(Address::random()),
+        value: 0.into(),
+        input: input.into(),
+    });
+
+    let hash = transaction.signature_hash();
+
+    let sender_secret_key = B256::random();
+    let signature = sign_message(sender_secret_key, hash).expect("signature should always succeed");
+
+    TransactionSigned {
+        transaction,
+        hash,
+        signature,
+    }
+}
+
+struct BenchController {
+    pub pool: EthTxPool,
+    pub transactions: FullTransactionList,
+    pub gas_limit: u64,
+}
+
+fn create_pool_and_transactions() -> BenchController {
+    let mut txpool = EthTxPool::default();
+    let txns = (0..NUM_TRANSACTIONS)
+        .map(|_| make_tx(TRANSACTION_SIZE_BYTES))
+        .collect::<Vec<_>>();
+
+    let proposal_gas_limit: u64 = txns
+        .iter()
+        .map(|txn| txn.transaction.gas_limit())
+        .sum::<u64>()
+        + 1;
+
+    let mut txns_encoded: Vec<u8> = vec![];
+    txns.encode(&mut txns_encoded);
+
+    let bytes = Bytes::copy_from_slice(&txns_encoded);
+
+    for txn in txns.iter() {
+        txpool.insert_tx(Bytes::from(txn.envelope_encoded()));
+    }
+    let txns_list = FullTransactionList::new(bytes);
+
+    BenchController {
+        pool: txpool,
+        transactions: txns_list,
+        gas_limit: proposal_gas_limit,
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let proposal_txn_limit: usize = NUM_TRANSACTIONS;
+    let mut group = c.benchmark_group("proposal");
+    group.bench_function("create_proposal", |b| {
+        b.iter_batched_ref(
+            create_pool_and_transactions,
+            |controller| {
+                controller.pool.create_proposal(
+                    proposal_txn_limit,
+                    controller.gas_limit,
+                    Default::default(),
+                );
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/monad-eth-txpool/src/lib.rs
+++ b/monad-eth-txpool/src/lib.rs
@@ -2,11 +2,24 @@ use std::collections::{BTreeMap, HashSet};
 
 use alloy_rlp::Decodable;
 use bytes::Bytes;
-use monad_consensus_types::{payload::FullTransactionList, txpool::TxPool};
+use monad_consensus_types::{
+    block::Block,
+    payload::FullTransactionList,
+    signature_collection::SignatureCollection,
+    txpool::{HashPolicyOutput, TxPool},
+};
 use monad_eth_tx::{EthFullTransactionList, EthTransaction, EthTxHash};
 
 #[derive(Default)]
 pub struct EthTxPool(BTreeMap<EthTxHash, EthTransaction>);
+
+pub fn transaction_hash_policy<SCT: SignatureCollection>(
+    block: &Block<SCT>,
+) -> Result<HashPolicyOutput, alloy_rlp::Error> {
+    Ok(HashSet::from_iter(
+        EthFullTransactionList::rlp_decode(block.payload.txns.bytes().clone())?.get_hashes(),
+    ))
+}
 
 impl TxPool for EthTxPool {
     fn insert_tx(&mut self, tx: Bytes) {
@@ -21,22 +34,8 @@ impl TxPool for EthTxPool {
         &mut self,
         tx_limit: usize,
         gas_limit: u64,
-        pending_txs: Vec<FullTransactionList>,
+        pending_blocktree_txs: HashPolicyOutput,
     ) -> (FullTransactionList, Option<FullTransactionList>) {
-        // TODO: we should enhance the pending block tree to hold tx hashses so that
-        // we don't have to calculate it here on the critical path of proposal creation
-        let mut pending_tx_hashes: Vec<EthTxHash> = Vec::new();
-        for full_tx_list in pending_txs {
-            let eth_full_tx_list = EthFullTransactionList::rlp_decode(full_tx_list.bytes().clone())
-                .expect(
-                    "transactions in blocks must have been verified and rlp decoded \
-                before being put in the pending blocktree",
-                );
-            pending_tx_hashes.extend(eth_full_tx_list.get_hashes());
-        }
-
-        let pending_blocktree_txs: HashSet<EthTxHash> = HashSet::from_iter(pending_tx_hashes);
-
         let mut txs = Vec::new();
         let mut total_gas = 0;
 

--- a/monad-mock-swarm/src/node.rs
+++ b/monad-mock-swarm/src/node.rs
@@ -108,6 +108,7 @@ impl<S: SwarmRelation> NodeBuilder<S> {
                 epoch_start_delay: self.state_builder.epoch_start_delay,
                 beneficiary: self.state_builder.beneficiary,
                 consensus_config: self.state_builder.consensus_config,
+                hash_policy: self.state_builder.hash_policy,
             },
             logger: Box::new(self.logger),
             replay_events: self.replay_events,

--- a/monad-node/Cargo.toml
+++ b/monad-node/Cargo.toml
@@ -15,6 +15,7 @@ monad-async-state-verify = { path = "../monad-async-state-verify" }
 monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-blockdb = { path = "../monad-blockdb" }
+monad-blocktree = { path = "../monad-blocktree" }
 monad-bls = { path = "../monad-bls" }
 monad-crypto = { path = "../monad-crypto" }
 monad-eth-txpool = { path = "../monad-eth-txpool" }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -271,6 +271,7 @@ async fn run(
             max_blocksync_retries: 5,
             state_sync_threshold: SeqNum(state_sync_bound as u64),
         },
+        hash_policy: monad_eth_txpool::transaction_hash_policy,
     };
 
     // parse test mode commands

--- a/monad-scripts/bench/perf.sh
+++ b/monad-scripts/bench/perf.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set +x
+mkfifo ctl_fd.fifo
+exec {ctl_fd}<>ctl_fd.fifo
+mkfifo ctl_fd_ack.fifo
+exec {ctl_fd_ack}<>ctl_fd_ack.fifo
+
+
+PERF_CTL_FD=$ctl_fd PERF_CTL_FD_ACK=$ctl_fd_ack RUSTFLAGS="-C force-frame-pointers=yes" perf record --delay=-1 -F 12000 --control fd:${ctl_fd},${ctl_fd_ack} --call-graph dwarf,16384 -- cargo bench --bench proposal_bench -- --profile-time 10
+
+unlink ctl_fd.fifo
+unlink ctl_fd_ack.fifo

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -25,7 +25,7 @@ use monad_consensus_types::{
     metrics::Metrics,
     payload::StateRootValidator,
     signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
-    txpool::TxPool,
+    txpool::{HashPolicy, TxPool},
     validation,
     validator_data::ValidatorData,
 };
@@ -362,6 +362,7 @@ where
     pub beneficiary: EthAddress,
 
     pub consensus_config: ConsensusConfig,
+    pub hash_policy: HashPolicy<SCT>,
 }
 
 impl<ST, SCT, VTF, LT, TT, BVT, SVT, ASVT> MonadStateBuilder<ST, SCT, VTF, LT, TT, BVT, SVT, ASVT>
@@ -402,6 +403,7 @@ where
             self.beneficiary,
             self.key,
             self.certkey,
+            self.hash_policy,
         );
 
         let mut monad_state = MonadState {

--- a/monad-testground/Cargo.toml
+++ b/monad-testground/Cargo.toml
@@ -8,6 +8,7 @@ name = "monad-testground"
 bench = false
 
 [dependencies]
+monad-blocktree = { path = "../monad-blocktree" }
 monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -202,6 +202,7 @@ where
         epoch_start_delay: config.epoch_start_delay,
         beneficiary: EthAddress::default(),
         consensus_config: config.consensus_config,
+        hash_policy: |_| Ok::<_, _>(Default::default()),
     }
     .build()
 }

--- a/monad-testutil/Cargo.toml
+++ b/monad-testutil/Cargo.toml
@@ -10,6 +10,7 @@ bench = false
 
 [dependencies]
 monad-async-state-verify = { path = "../monad-async-state-verify" }
+monad-blocktree = { path = "../monad-blocktree" }
 monad-consensus = { path = "../monad-consensus" }
 monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -86,6 +86,7 @@ pub fn make_state_configs<S: SwarmRelation>(
                 max_blocksync_retries,
                 state_sync_threshold,
             },
+            hash_policy: |_| Ok::<_, _>(Default::default()),
         })
         .collect()
 }

--- a/monad-twins/utils/Cargo.toml
+++ b/monad-twins/utils/Cargo.toml
@@ -11,6 +11,7 @@ bench = false
 
 [dependencies]
 monad-async-state-verify = { path = "../../monad-async-state-verify" }
+monad-blocktree = { path = "../../monad-blocktree" }
 monad-consensus-state = { path = "../../monad-consensus-state" }
 monad-consensus-types = { path = "../../monad-consensus-types" }
 monad-crypto = { path = "../../monad-crypto" }

--- a/monad-twins/utils/src/twin_reader.rs
+++ b/monad-twins/utils/src/twin_reader.rs
@@ -134,6 +134,7 @@ where
                 beneficiary: self.state_config.beneficiary,
 
                 consensus_config: self.state_config.consensus_config,
+                hash_policy: self.state_config.hash_policy,
             },
             partition: self.partition.clone(),
             default_partition: self.default_partition.clone(),
@@ -354,6 +355,7 @@ where
                 max_blocksync_retries: 5,
                 state_sync_threshold: SeqNum(100),
             },
+            hash_policy: |_| Ok::<_, _>(Default::default()),
         })
         .collect();
 


### PR DESCRIPTION
A hash policy in this context is a function
```
fn(Block) -> HashSet<TxHash>
```
that RLP decodes the transactions in the block and returns a set of their hashes. This is used to ensure we don't propose a transaction that is already pending in the block tree. 

### Problem
Currently this RLP decoding is being done on the critical path of proposal creation. Naively moving the RLP decoding to when we append to the block tree tightly couples the hash policy with the block tree which is undesirable.
### Solution
RLP decode the transactions when adding a block to the block tree. Parameterize the block tree over this hash policy to enable opting out of this behavior for tests.
