### PR TITLE
Remove propose_with_missing_blocks config

### DIFF
--- a/monad-consensus-types/src/metrics.rs
+++ b/monad-consensus-types/src/metrics.rs
@@ -30,7 +30,6 @@ pub struct ConsensusEvents {
     pub process_old_qc: u64,
     pub process_qc: u64,
     pub creating_proposal: u64,
-    pub abstain_proposal: u64,
     pub creating_empty_block_proposal: u64,
     pub rx_empty_block: u64,
     pub rx_execution_lagging: u64,

--- a/monad-mock-swarm/src/verifier.rs
+++ b/monad-mock-swarm/src/verifier.rs
@@ -160,12 +160,6 @@ impl<S: SwarmRelation> MockSwarmVerifier<S> {
             )
             // initial TC. If the node is in the happy path, it should never create a TC otherwise
             .metric_exact(node_ids, fetch_metric!(consensus_events.created_tc), 1)
-            // should always create a proposal
-            .metric_exact(
-                node_ids,
-                fetch_metric!(consensus_events.abstain_proposal),
-                0,
-            )
             .metric_exact(
                 node_ids,
                 fetch_metric!(consensus_events.creating_empty_block_proposal),

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -266,7 +266,6 @@ async fn run(
         consensus_config: ConsensusConfig {
             proposal_txn_limit: 1000,
             proposal_gas_limit: 800_000_000,
-            propose_with_missing_blocks: false,
             delta: Duration::from_millis(node_state.node_config.network.max_rtt_ms),
             max_blocksync_retries: 5,
             state_sync_threshold: SeqNum(state_sync_bound as u64),

--- a/monad-opentelemetry-executor/src/opentelemetry.rs
+++ b/monad-opentelemetry-executor/src/opentelemetry.rs
@@ -42,7 +42,7 @@ pub struct OpenTelemetryExecutor<ST, SCT> {
     phantom: PhantomData<(ST, SCT)>,
 }
 
-const COUNTERS: [&str; 48] = [
+const COUNTERS: [&str; 47] = [
     "invalid_author",
     "not_well_formed_sig",
     "invalid_signature",
@@ -69,7 +69,6 @@ const COUNTERS: [&str; 48] = [
     "process_old_qc",
     "process_qc",
     "creating_proposal",
-    "abstain_proposal",
     "creating_empty_block_proposal",
     "rx_empty_block",
     "rx_execution_lagging",
@@ -304,11 +303,6 @@ where
             "creating_proposal",
             metrics.consensus_events.creating_proposal
                 - cached_metrics.consensus_events.creating_proposal,
-        );
-        self.record(
-            "abstain_proposal",
-            metrics.consensus_events.abstain_proposal
-                - cached_metrics.consensus_events.abstain_proposal,
         );
         self.record(
             "creating_empty_block_proposal",

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -358,7 +358,6 @@ where
                     consensus_config: ConsensusConfig {
                         proposal_txn_limit: args.proposal_size,
                         proposal_gas_limit: 800_000_000,
-                        propose_with_missing_blocks: false,
                         delta: Duration::from_millis(args.delta_ms),
                         max_blocksync_retries: 5,
                         state_sync_threshold: SeqNum(100),

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -81,7 +81,6 @@ pub fn make_state_configs<S: SwarmRelation>(
             consensus_config: ConsensusConfig {
                 proposal_txn_limit,
                 proposal_gas_limit: 30_000_000,
-                propose_with_missing_blocks: false,
                 delta,
                 max_blocksync_retries,
                 state_sync_threshold,

--- a/monad-twins/utils/src/twin_reader.rs
+++ b/monad-twins/utils/src/twin_reader.rs
@@ -350,7 +350,6 @@ where
             consensus_config: ConsensusConfig {
                 proposal_txn_limit: 10,
                 proposal_gas_limit: 30_000_000,
-                propose_with_missing_blocks: false,
                 delta: Duration::from_millis(delta_ms),
                 max_blocksync_retries: 5,
                 state_sync_threshold: SeqNum(100),


### PR DESCRIPTION
Path to BlockTree root is checked in `try_propose` before reaching here. `config.propose_with_missing_blocks` is redundant and code never reaches `ConsensusAction::Abstain`