### PR TITLE
Assign protocol param to gas_limit

### DIFF
--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -31,7 +31,7 @@ use monad_gossip::{
     Gossip,
 };
 use monad_ipc::IpcReceiver;
-use monad_ledger::MonadBlockFileLedger;
+use monad_ledger::{EthHeaderParam, MonadBlockFileLedger};
 use monad_quic::{SafeQuinnConfig, Service, ServiceConfig};
 use monad_secp::SecpSignature;
 use monad_state::{MonadMessage, MonadStateBuilder, MonadVersion, VerifiedMonadMessage};
@@ -230,6 +230,9 @@ async fn run(
         execution_ledger: MonadBlockFileLedger::new(
             node_state.execution_ledger_path,
             blockdb.clone(),
+            EthHeaderParam {
+                gas_limit: node_state.node_config.consensus.block_gas_limit,
+            },
         ),
         checkpoint: MockCheckpoint::default(),
         state_root_hash: MockStateRootHashNop::new(validators.clone(), val_set_update_interval),


### PR DESCRIPTION
`gas_limit` is the maximum gas allowed in this block. Eth sets block's gas limit to the protocol parameter 30M, instead of calculating the total sum of transaction gas limits.

See [Block Size](https://ethereum.org/en/developers/docs/gas/#block-size) for current limits. [Blocks page](https://ethereum.org/en/developers/docs/blocks/) provides definitions for different fields

This is an alternative to #767 , more aligned with what Eth is doing