### PR TITLE
feat(rpc): basic eth_estimateGas support

### DIFF
--- a/monad-cxx/include/eth_call.hpp
+++ b/monad-cxx/include/eth_call.hpp
@@ -10,10 +10,12 @@ struct monad_evmc_result
     int status_code;
     std::vector<uint8_t> output_data;
     std::string message;
+    int64_t gas_used;
 
     int get_status_code() const;
     std::vector<uint8_t> get_output_data() const;
     std::string get_message() const;
+    int64_t get_gas_used() const;
 };
 
 monad_evmc_result eth_call(

--- a/monad-cxx/src/eth_call.cpp
+++ b/monad-cxx/src/eth_call.cpp
@@ -89,6 +89,11 @@ std::string monad_evmc_result::get_message() const
     return message;
 }
 
+int64_t monad_evmc_result::get_gas_used() const
+{
+    return gas_used;
+}
+
 monad_evmc_result eth_call(
     std::vector<uint8_t> const &rlp_txn, std::vector<uint8_t> const &rlp_header,
     std::vector<uint8_t> const &rlp_sender, uint64_t const block_number,
@@ -150,11 +155,13 @@ monad_evmc_result eth_call(
         ret.message = result.error().message().c_str();
     }
     else {
+        int64_t const gas_used = txn.gas_limit - result.assume_value().gas_left;
         ret.status_code = result.assume_value().status_code;
         ret.output_data = {
             result.assume_value().output_data,
             result.assume_value().output_data +
                 result.assume_value().output_size};
+        ret.gas_used = gas_used;
     }
     return ret;
 }

--- a/monad-cxx/src/mock_eth_call.cpp
+++ b/monad-cxx/src/mock_eth_call.cpp
@@ -19,6 +19,11 @@ std::string monad_evmc_result::get_message() const
     return message;
 }
 
+int64_t monad_evmc_result::get_gas_used() const
+{
+    return gas_used;
+}
+
 monad_evmc_result eth_call(
     std::vector<uint8_t> const &rlp_encoded_transaction,
     std::vector<uint8_t> const &rlp_encoded_block_header,
@@ -33,5 +38,6 @@ monad_evmc_result eth_call(
     return monad_evmc_result{
         .status_code = 0,
         .output_data = std::vector<uint8_t>{data.begin(), data.end()},
-        .message = "test message"};
+        .message = "test message",
+        .gas_used = 21000};
 }

--- a/monad-rpc/src/gas_handlers.rs
+++ b/monad-rpc/src/gas_handlers.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use log::{debug, trace};
 use monad_blockdb::BlockTagKey;
 use reth_rpc_types::FeeHistory;
@@ -11,6 +13,7 @@ use crate::{
         deserialize_block_tags, deserialize_quantity, serialize_result, BlockTags, Quantity,
     },
     jsonrpc::JsonRpcError,
+    triedb::{TriedbEnv, TriedbResult},
 };
 
 #[derive(Deserialize, Debug)]
@@ -21,10 +24,15 @@ struct MonadEthEstimateGasParams {
 }
 
 #[allow(non_snake_case)]
-pub async fn monad_eth_estimateGas(params: Value) -> Result<Value, JsonRpcError> {
+pub async fn monad_eth_estimateGas(
+    blockdb_env: &BlockDbEnv,
+    triedb_path: &Path,
+    execution_ledger_path: &Path,
+    params: Value,
+) -> Result<Value, JsonRpcError> {
     trace!("monad_eth_estimateGas: {params:?}");
 
-    let p: MonadEthEstimateGasParams = match serde_json::from_value(params) {
+    let params: MonadEthEstimateGasParams = match serde_json::from_value(params) {
         Ok(s) => s,
         Err(e) => {
             debug!("invalid params {e}");
@@ -32,9 +40,41 @@ pub async fn monad_eth_estimateGas(params: Value) -> Result<Value, JsonRpcError>
         }
     };
 
-    // TODO: send transaction to execution client for required gas calculation
-    // Hardcoded as 200,000 gas for now
-    serialize_result(format!("0x{:x}", 2000000))
+    // TODO: use the provided block from user
+    let TriedbResult::BlockNum(block_number) = TriedbEnv::new(triedb_path).get_latest_block().await
+    else {
+        debug!("triedb did not have latest block header");
+        return Err(JsonRpcError::internal_error());
+    };
+
+    let Some(block_header) = blockdb_env
+        .get_block_by_tag(BlockTags::Number(Quantity(block_number)))
+        .await
+    else {
+        debug!("blockdb did not have latest block header");
+        return Err(JsonRpcError::internal_error());
+    };
+
+    let sender = params.tx.from.unwrap_or_default();
+    let txn: reth_primitives::transaction::Transaction = params.tx.try_into()?;
+
+    // TODO: return an optimized gas estimate instead of a single call result.
+    // Also, skip the call step if it's a typed transaction we already know.
+    match monad_cxx::eth_call(
+        txn,
+        block_header.block.header,
+        sender,
+        block_number,
+        triedb_path,
+        execution_ledger_path,
+    ) {
+        monad_cxx::CallResult::Success(monad_cxx::SuccessCallResult { gas_used, .. }) => {
+            serialize_result(format!("0x{:x}", gas_used))
+        }
+        monad_cxx::CallResult::Failure(error_message) => {
+            Err(JsonRpcError::eth_call_error(error_message))
+        }
+    }
 }
 
 pub async fn suggested_priority_fee(blockdb_env: &BlockDbEnv) -> Result<u64, JsonRpcError> {


### PR DESCRIPTION
Notes for reviewer:
- change `eth_call` from Result to enum since pattern matching different exec results will be useful later 
- simple conversion from `CallRequest` to a typed ethereum transaction based on available fields
- basic functionality for gas estimation, lots of todos to actually improve reliability and skip eth_calls for transfer transactions

Qs:
- ~~Is there an easy way to seed triedb with populated accounts so I can test behavior?~~
