### PR TITLE
Cleaner rlp decoding for code hash

### DIFF
--- a/monad-rpc/src/triedb.rs
+++ b/monad-rpc/src/triedb.rs
@@ -141,11 +141,15 @@ impl TriedbEnv {
                     return;
                 };
 
-                let code_hash = match <[u8; 32]>::decode(&mut buf) {
-                    Ok(x) => x,
-                    Err(e) => {
-                        debug!("rlp code_hash decode failed: {:?}", e);
-                        [0; 32]
+                let code_hash = if buf.is_empty() {
+                    [0; 32]
+                } else {
+                    match <[u8; 32]>::decode(&mut buf) {
+                        Ok(x) => x,
+                        Err(e) => {
+                            debug!("rlp code_hash decode failed: {:?}", e);
+                            [0; 32]
+                        }
                     }
                 };
 


### PR DESCRIPTION
Currently RLP decoding for code hash is a bit misleading - it logs an error when code hash is empty in RLP. This should not be an error as an empty code hash simply means the address is not a smart contract address.