### PR TITLE
Make mempool ipc sender more robust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3876,11 +3876,14 @@ dependencies = [
  "monad-cxx",
  "monad-triedb",
  "monad-triedb-utils",
+ "notify",
+ "pin-project",
  "rayon",
  "reth-primitives",
  "reth-rpc-types",
  "serde",
  "serde_json",
+ "tempfile",
  "test-case",
  "tokio",
  "tokio-util",
@@ -4809,18 +4812,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/docker/rpc/Dockerfile
+++ b/docker/rpc/Dockerfile
@@ -91,8 +91,8 @@ COPY --from=builder /usr/src/monad-bft/rpc /usr/local/bin/monad-rpc
 COPY --from=builder /usr/src/monad-bft/*.so /usr/local/lib
 
 ENV RUST_LOG=info
-# time delay to ensure consensus node is fully started
-CMD sleep 2 && monad-rpc \
+
+CMD monad-rpc \
     --ipc-path /monad/mempool.sock \
     --blockdb-path /monad/blockdb \
     --execution-ledger-path /monad/ledger \

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -39,7 +39,10 @@ reth-rpc-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio-util = { workspace = true, features = ["codec"] }
-tokio = { workspace = true, features = ["net"] }
+tokio = { workspace = true, features = ["net", "macros"] }
+notify = "6.1.1"
+pin-project = "1.1.5"
 
 [dev-dependencies]
 test-case = { workspace = true }
+tempfile = { workspace = true }

--- a/monad-rpc/src/mempool_tx.rs
+++ b/monad-rpc/src/mempool_tx.rs
@@ -1,12 +1,34 @@
-use std::{path::Path, task::Poll};
+use std::{
+    ffi::OsStr,
+    io::ErrorKind,
+    path::{Path, PathBuf},
+    pin::Pin,
+    task::Poll,
+};
 
-use futures::{Sink, SinkExt};
+use futures::{executor::block_on, ready, Future, FutureExt, Sink, SinkExt};
+use log::debug;
+use notify::{Event, RecursiveMode, Watcher};
+use pin_project::pin_project;
 use reth_primitives::TransactionSigned;
-use tokio::net::UnixStream;
+use tokio::{net::UnixStream, pin};
 use tokio_util::codec::{FramedWrite, LengthDelimitedCodec};
 
+const MEMPOOL_TX_IPC_FILE: &str = "mempool.sock";
+
+#[pin_project(project = StateProj)]
+enum State {
+    Ready,
+    Reconnect(#[pin] WriterReconnect),
+    BrokenPipe(#[pin] SocketWatcher),
+}
+
+#[pin_project]
 pub struct MempoolTxIpcSender {
+    socket_path: PathBuf,
     writer: FramedWrite<UnixStream, LengthDelimitedCodec>,
+    #[pin]
+    state: State,
 }
 
 impl MempoolTxIpcSender {
@@ -16,10 +38,113 @@ impl MempoolTxIpcSender {
     {
         Ok(Self {
             writer: FramedWrite::new(
-                UnixStream::connect(bind_path).await?,
+                UnixStream::connect(&bind_path).await?,
                 LengthDelimitedCodec::default(),
             ),
+            socket_path: bind_path.as_ref().to_path_buf(),
+            state: State::Ready,
         })
+    }
+}
+
+struct WriterReconnect {
+    task: Pin<Box<dyn Future<Output = std::io::Result<UnixStream>> + Send>>,
+}
+
+impl WriterReconnect {
+    fn new(path: PathBuf) -> Self {
+        let task = Box::pin(UnixStream::connect(path));
+        Self { task }
+    }
+}
+
+impl Future for WriterReconnect {
+    type Output = std::io::Result<FramedWrite<UnixStream, LengthDelimitedCodec>>;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Self::Output> {
+        match self.as_mut().task.poll_unpin(cx) {
+            Poll::Ready(Ok(stream)) => Poll::Ready(Ok(FramedWrite::new(
+                stream,
+                LengthDelimitedCodec::default(),
+            ))),
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[pin_project]
+pub struct SocketWatcher {
+    socket_path: PathBuf,
+    #[pin]
+    watcher: notify::INotifyWatcher,
+    #[pin]
+    rx: tokio::sync::mpsc::UnboundedReceiver<notify::Result<notify::Event>>,
+}
+
+impl SocketWatcher {
+    pub fn try_new(socket_path: PathBuf) -> std::io::Result<Self> {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<notify::Result<notify::Event>>();
+        let mut watcher = notify::INotifyWatcher::new(
+            move |res| {
+                block_on(async {
+                    tx.send(res).expect("inotify channel");
+                })
+            },
+            notify::Config::default(),
+        )
+        .map_err(|e| std::io::Error::new(ErrorKind::Other, e))?;
+
+        let dir_path = if let Some(parent_path) = socket_path.parent() {
+            parent_path
+        } else {
+            return Err(std::io::Error::new(
+                ErrorKind::NotFound,
+                "invalid socket path",
+            ));
+        };
+
+        watcher
+            .watch(dir_path.as_ref(), RecursiveMode::NonRecursive)
+            .map_err(|e| std::io::Error::new(ErrorKind::Other, e))?;
+
+        Ok(Self {
+            socket_path,
+            watcher,
+            rx,
+        })
+    }
+}
+
+impl Future for SocketWatcher {
+    type Output = std::io::Result<()>;
+
+    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+        let event = this.rx.poll_recv(cx);
+        match event {
+            Poll::Ready(Some(Ok(Event { kind, paths, .. })))
+                if paths.first().is_some()
+                    && paths.first().unwrap().as_path().file_name()
+                        == Some(OsStr::new(MEMPOOL_TX_IPC_FILE)) =>
+            {
+                if let notify::EventKind::Create(_) = kind {
+                    debug!("new mempool socket created");
+                    Poll::Ready(Ok(()))
+                } else {
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            }
+            Poll::Ready(e) => {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            Poll::Pending => Poll::Pending,
+        }
     }
 }
 
@@ -38,7 +163,6 @@ impl Sink<TransactionSigned> for MempoolTxIpcSender {
         tx: TransactionSigned,
     ) -> Result<(), Self::Error> {
         let buf = tx.envelope_encoded();
-
         self.writer.start_send_unpin(buf.into())
     }
 
@@ -46,7 +170,43 @@ impl Sink<TransactionSigned> for MempoolTxIpcSender {
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
-        self.writer.poll_flush_unpin(cx)
+        let mut this = self.as_mut().project();
+        let mut state = this.state.as_mut();
+
+        match state.as_mut().project() {
+            StateProj::Ready => {
+                let writer: Poll<Result<(), std::io::Error>> = this.writer.poll_flush_unpin(cx);
+                match writer {
+                    Poll::Ready(Err(ref e)) if e.kind() == ErrorKind::BrokenPipe => {
+                        let sw = SocketWatcher::try_new(this.socket_path.clone())?;
+                        state.set(State::BrokenPipe(sw));
+                        cx.waker().wake_by_ref();
+                    }
+                    Poll::Ready(Err(e)) => {
+                        return Poll::Ready(Err(e));
+                    }
+                    v => return v,
+                }
+            }
+            StateProj::BrokenPipe(mut sw) => {
+                ready!(sw.as_mut().poll(cx))?;
+                let writer = WriterReconnect::new(this.socket_path.to_path_buf());
+                state.set(State::Reconnect(writer));
+                cx.waker().wake_by_ref();
+            }
+            StateProj::Reconnect(mut writer) => {
+                let res = writer.as_mut().poll(cx);
+                match res {
+                    Poll::Ready(stream) => {
+                        *this.writer = stream?;
+                        state.set(State::Ready);
+                        cx.waker().wake_by_ref();
+                    }
+                    Poll::Pending => return Poll::Pending,
+                };
+            }
+        }
+        Poll::Pending
     }
 
     fn poll_close(
@@ -54,5 +214,61 @@ impl Sink<TransactionSigned> for MempoolTxIpcSender {
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
         self.writer.poll_close_unpin(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+
+    use futures::future::join;
+    use tempfile::tempdir;
+    use tokio::{io::AsyncReadExt, net::UnixListener};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_mempool_tx_ipc_sender_broken_pipe() {
+        let listener_func = |listener: UnixListener| async move {
+            match listener.accept().await {
+                Ok((mut stream, _)) => {
+                    let mut buf = [0; 1024];
+                    let _ = stream.read(&mut buf).await;
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            }
+        };
+
+        let tmp_dir = tempdir().unwrap();
+        let socket_path: PathBuf = tmp_dir.path().join(MEMPOOL_TX_IPC_FILE);
+
+        let listener = UnixListener::bind(&socket_path).unwrap();
+        let mut sender: MempoolTxIpcSender = MempoolTxIpcSender::new(&socket_path).await.unwrap();
+
+        let listener_task = tokio::spawn(async move {
+            listener_func(listener).await.unwrap();
+        });
+
+        sender.send(TransactionSigned::default()).await.unwrap();
+
+        listener_task.await.unwrap();
+        std::fs::remove_file(&socket_path).unwrap();
+
+        let sender_task = tokio::spawn(async move {
+            sender.send(TransactionSigned::default()).await.unwrap();
+        });
+
+        let listener_task = tokio::spawn(async move {
+            File::create(tmp_dir.path().join("not-mempool-file")).unwrap();
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            File::create(tmp_dir.path().join("not-mempool-file")).unwrap();
+            let listener = UnixListener::bind(&socket_path).unwrap();
+            listener_func(listener).await.unwrap();
+        });
+
+        let (first, second) = join(listener_task, sender_task).await;
+        first.unwrap();
+        second.unwrap();
     }
 }


### PR DESCRIPTION
- Adds basic retry to initial mempool sender connection
- Handles broken pipe inside `sink` by waiting for new socket file to be created. We can't undo a`poll_ready` inside a `send` so broken pipe is handled during flush.