### PR TITLE
Add epoch number to consensus messages

### DIFF
--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -275,7 +275,7 @@ mod test {
     };
     use monad_eth_types::EthAddress;
     use monad_testutil::signing::MockSignatures;
-    use monad_types::{BlockId, NodeId, Round, SeqNum};
+    use monad_types::{BlockId, Epoch, NodeId, Round, SeqNum};
 
     use super::BlockTree;
 
@@ -304,10 +304,11 @@ mod test {
             beneficiary: EthAddress::default(),
             randao_reveal: RandaoReveal::default(),
         };
-        let g = Block::new(node_id(), Round(1), &payload, &QC::genesis_qc());
+        let g = Block::new(node_id(), Epoch(1), Round(1), &payload, &QC::genesis_qc());
 
         let v1 = VoteInfo {
             id: g.get_id(),
+            epoch: Epoch(1),
             round: Round(1),
             parent_id: g.get_parent_id(),
             parent_round: Round(0),
@@ -316,6 +317,7 @@ mod test {
 
         let b1 = Block::new(
             node_id(),
+            Epoch(1),
             Round(2),
             &payload,
             &QC::new(
@@ -331,6 +333,7 @@ mod test {
 
         let v2 = VoteInfo {
             id: b1.get_id(),
+            epoch: Epoch(1),
             round: Round(2),
             parent_id: b1.get_parent_id(),
             parent_round: Round(1),
@@ -339,6 +342,7 @@ mod test {
 
         let b2 = Block::new(
             node_id(),
+            Epoch(1),
             Round(2),
             &payload,
             &QC::new(
@@ -354,6 +358,7 @@ mod test {
 
         let v3 = VoteInfo {
             id: g.get_id(),
+            epoch: Epoch(1),
             round: Round(1),
             parent_id: g.get_parent_id(),
             parent_round: Round(0),
@@ -362,6 +367,7 @@ mod test {
 
         let b3 = Block::new(
             node_id(),
+            Epoch(1),
             Round(2),
             &payload,
             &QC::new(
@@ -377,6 +383,7 @@ mod test {
 
         let v4 = VoteInfo {
             id: g.get_id(),
+            epoch: Epoch(1),
             round: Round(1),
             parent_id: g.get_parent_id(),
             parent_round: Round(0),
@@ -385,6 +392,7 @@ mod test {
 
         let b4 = Block::new(
             node_id(),
+            Epoch(1),
             Round(2),
             &payload,
             &QC::new(
@@ -400,6 +408,7 @@ mod test {
 
         let v5 = VoteInfo {
             id: b3.get_id(),
+            epoch: Epoch(1),
             round: Round(2),
             parent_id: g.get_id(),
             parent_round: Round(1),
@@ -408,6 +417,7 @@ mod test {
 
         let b5 = Block::new(
             node_id(),
+            Epoch(1),
             Round(3),
             &payload,
             &QC::new(
@@ -423,6 +433,7 @@ mod test {
 
         let v6 = VoteInfo {
             id: b5.get_id(),
+            epoch: Epoch(1),
             round: Round(3),
             parent_id: b5.get_parent_id(),
             parent_round: Round(2),
@@ -431,6 +442,7 @@ mod test {
 
         let b6 = Block::new(
             node_id(),
+            Epoch(1),
             Round(4),
             &payload,
             &QC::new(
@@ -446,6 +458,7 @@ mod test {
 
         let v7 = VoteInfo {
             id: b6.get_id(),
+            epoch: Epoch(1),
             round: Round(6),
             parent_id: b5.get_id(),
             parent_round: Round(5),
@@ -454,6 +467,7 @@ mod test {
 
         let b7 = Block::new(
             node_id(),
+            Epoch(1),
             Round(7),
             &payload,
             &QC::new(
@@ -528,6 +542,7 @@ mod test {
 
         let v8 = VoteInfo {
             id: b5.get_id(),
+            epoch: Epoch(1),
             round: Round(5),
             parent_id: b3.get_id(),
             parent_round: Round(3),
@@ -536,6 +551,7 @@ mod test {
 
         let b8 = Block::new(
             node_id(),
+            Epoch(1),
             Round(8),
             &payload,
             &QC::new(
@@ -562,10 +578,11 @@ mod test {
             beneficiary: EthAddress::default(),
             randao_reveal: RandaoReveal::default(),
         };
-        let g = Block::new(node_id(), Round(1), &payload, &QC::genesis_qc());
+        let g = Block::new(node_id(), Epoch(1), Round(1), &payload, &QC::genesis_qc());
 
         let v1 = VoteInfo {
             id: g.get_id(),
+            epoch: Epoch(1),
             round: Round(1),
             parent_id: g.get_parent_id(),
             parent_round: Round(0),
@@ -574,6 +591,7 @@ mod test {
 
         let b1 = Block::new(
             node_id(),
+            Epoch(1),
             Round(2),
             &payload,
             &QC::new(
@@ -589,6 +607,7 @@ mod test {
 
         let v2 = VoteInfo {
             id: b1.get_id(),
+            epoch: Epoch(1),
             round: Round(2),
             parent_id: g.get_parent_id(),
             parent_round: Round(1),
@@ -597,6 +616,7 @@ mod test {
 
         let b2 = Block::new(
             node_id(),
+            Epoch(1),
             Round(3),
             &payload,
             &QC::new(
@@ -638,6 +658,7 @@ mod test {
     fn equal_level_branching() {
         let g = Block::new(
             node_id(),
+            Epoch(1),
             Round(1),
             &Payload {
                 txns: FullTransactionList::empty(),
@@ -651,6 +672,7 @@ mod test {
 
         let v1 = VoteInfo {
             id: g.get_id(),
+            epoch: Epoch(1),
             round: Round(1),
             parent_id: g.get_parent_id(),
             parent_round: Round(0),
@@ -659,6 +681,7 @@ mod test {
 
         let b1 = Block::new(
             node_id(),
+            Epoch(1),
             Round(2),
             &Payload {
                 txns: FullTransactionList::new(vec![1].into()),
@@ -680,6 +703,7 @@ mod test {
 
         let b2 = Block::new(
             node_id(),
+            Epoch(1),
             Round(2),
             &Payload {
                 txns: FullTransactionList::new(vec![2].into()),
@@ -701,6 +725,7 @@ mod test {
 
         let v2 = VoteInfo {
             id: b1.get_id(),
+            epoch: Epoch(1),
             round: Round(2),
             parent_id: g.get_id(),
             parent_round: Round(1),
@@ -709,6 +734,7 @@ mod test {
 
         let b3 = Block::new(
             node_id(),
+            Epoch(1),
             Round(3),
             &Payload {
                 txns: FullTransactionList::new(vec![3].into()),
@@ -762,6 +788,7 @@ mod test {
     fn duplicate_blocks() {
         let g = Block::new(
             node_id(),
+            Epoch(1),
             Round(1),
             &Payload {
                 txns: FullTransactionList::empty(),
@@ -775,6 +802,7 @@ mod test {
 
         let v1 = VoteInfo {
             id: g.get_id(),
+            epoch: Epoch(1),
             round: Round(1),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
@@ -783,6 +811,7 @@ mod test {
 
         let b1 = Block::new(
             node_id(),
+            Epoch(1),
             Round(2),
             &Payload {
                 txns: FullTransactionList::new(vec![1].into()),
@@ -821,10 +850,11 @@ mod test {
             beneficiary: EthAddress::default(),
             randao_reveal: RandaoReveal::default(),
         };
-        let g = Block::new(node_id(), Round(1), &payload, &QC::genesis_qc());
+        let g = Block::new(node_id(), Epoch(1), Round(1), &payload, &QC::genesis_qc());
 
         let v1 = VoteInfo {
             id: g.get_id(),
+            epoch: Epoch(1),
             round: Round(1),
             parent_id: g.get_parent_id(),
             parent_round: Round(0),
@@ -833,6 +863,7 @@ mod test {
 
         let b1 = Block::new(
             node_id(),
+            Epoch(1),
             Round(2),
             &payload,
             &QC::new(
@@ -848,6 +879,7 @@ mod test {
 
         let v2 = VoteInfo {
             id: b1.get_id(),
+            epoch: Epoch(1),
             round: Round(2),
             parent_id: b1.get_parent_id(),
             parent_round: Round(1),
@@ -856,6 +888,7 @@ mod test {
 
         let b2 = Block::new(
             node_id(),
+            Epoch(1),
             Round(3),
             &payload,
             &QC::new(
@@ -871,6 +904,7 @@ mod test {
 
         let b3 = Block::new(
             node_id(),
+            Epoch(1),
             Round(4),
             &payload,
             &QC::new(
@@ -886,6 +920,7 @@ mod test {
 
         let b4 = Block::new(
             node_id(),
+            Epoch(1),
             Round(5),
             &payload,
             &QC::new(
@@ -944,10 +979,11 @@ mod test {
             beneficiary: EthAddress::default(),
             randao_reveal: RandaoReveal::default(),
         };
-        let g = Block::new(node_id(), Round(1), &payload, &QC::genesis_qc());
+        let g = Block::new(node_id(), Epoch(1), Round(1), &payload, &QC::genesis_qc());
 
         let v1 = VoteInfo {
             id: g.get_id(),
+            epoch: Epoch(1),
             round: Round(1),
             parent_id: g.get_parent_id(),
             parent_round: Round(0),
@@ -956,6 +992,7 @@ mod test {
 
         let b1 = Block::new(
             node_id(),
+            Epoch(1),
             Round(2),
             &payload,
             &QC::new(
@@ -971,6 +1008,7 @@ mod test {
 
         let v2 = VoteInfo {
             id: b1.get_id(),
+            epoch: Epoch(1),
             round: Round(2),
             parent_id: b1.get_parent_id(),
             parent_round: Round(1),
@@ -979,6 +1017,7 @@ mod test {
 
         let b2 = Block::new(
             node_id(),
+            Epoch(1),
             Round(3),
             &payload,
             &QC::new(
@@ -994,6 +1033,7 @@ mod test {
 
         let b3 = Block::new(
             node_id(),
+            Epoch(1),
             Round(4),
             &payload,
             &QC::new(
@@ -1009,6 +1049,7 @@ mod test {
 
         let b4 = Block::new(
             node_id(),
+            Epoch(1),
             Round(5),
             &payload,
             &QC::new(

--- a/monad-consensus-state/benches/state_machine.rs
+++ b/monad-consensus-state/benches/state_machine.rs
@@ -150,8 +150,13 @@ where
     fn next_tc(&mut self, epoch: Epoch) -> Vec<Verified<ST, TimeoutMessage<SCT>>> {
         let valset = self.val_epoch_map.get_val_set(&epoch).unwrap();
         let val_cert_pubkeys = self.val_epoch_map.get_cert_pubkeys(&epoch).unwrap();
-        self.proposal_gen
-            .next_tc(&self.keys, &self.cert_keys, valset, val_cert_pubkeys)
+        self.proposal_gen.next_tc(
+            &self.keys,
+            &self.cert_keys,
+            valset,
+            &self.epoch_manager,
+            val_cert_pubkeys,
+        )
     }
 }
 
@@ -496,6 +501,7 @@ fn make_block<SCT: SignatureCollection<NodeIdPubKey = NopPubKey>>() -> Block<SCT
 
     Block::new(
         NodeId::new(NopPubKey::from_bytes(&[0u8; 32]).unwrap()),
+        Epoch(1),
         Round(1),
         &Payload {
             txns,
@@ -681,6 +687,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                             Vote {
                                 vote_info: VoteInfo {
                                     id: proposal_message.block.get_id(),
+                                    epoch: proposal_message.block.epoch,
                                     round: proposal_message.block.round,
                                     parent_id: BlockId(Hash([0u8; 32])),
                                     parent_round: Round(0),

--- a/monad-consensus-state/src/blocksync.rs
+++ b/monad-consensus-state/src/blocksync.rs
@@ -377,7 +377,7 @@ mod test {
         signing::{get_key, MockSignatures},
         validators::create_keys_w_validators,
     };
-    use monad_types::{BlockId, NodeId, Round, SeqNum, TimeoutVariant};
+    use monad_types::{BlockId, Epoch, NodeId, Round, SeqNum, TimeoutVariant};
     use monad_validator::validator_set::{ValidatorSet, ValidatorSetFactory, ValidatorSetType};
 
     use super::BlockSyncRequester;
@@ -420,6 +420,7 @@ mod test {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: BlockId(Hash([0x01_u8; 32])),
+                        epoch: Epoch(1),
                         round: Round(0),
                         parent_id: BlockId(Hash([0x02_u8; 32])),
                         parent_round: Round(0),
@@ -453,6 +454,7 @@ mod test {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: BlockId(Hash([0x02_u8; 32])),
+                        epoch: Epoch(1),
                         round: Round(0),
                         parent_id: BlockId(Hash([0x02_u8; 32])),
                         parent_round: Round(0),
@@ -499,6 +501,7 @@ mod test {
 
         let block_1 = Block::new(
             NodeId::new(keypair.pubkey()),
+            Epoch(1),
             Round(0),
             &payload,
             &QC::new(
@@ -506,6 +509,7 @@ mod test {
                     vote: Vote {
                         vote_info: VoteInfo {
                             id: BlockId(Hash([0x01_u8; 32])),
+                            epoch: Epoch(1),
                             round: Round(0),
                             parent_id: BlockId(Hash([0x02_u8; 32])),
                             parent_round: Round(0),
@@ -520,6 +524,7 @@ mod test {
 
         let block_2 = Block::new(
             NodeId::new(keypair.pubkey()),
+            Epoch(1),
             Round(1),
             &payload,
             &QC::new(
@@ -527,6 +532,7 @@ mod test {
                     vote: Vote {
                         vote_info: VoteInfo {
                             id: BlockId(Hash([0x01_u8; 32])),
+                            epoch: Epoch(1),
                             round: Round(0),
                             parent_id: BlockId(Hash([0x02_u8; 32])),
                             parent_round: Round(0),
@@ -541,6 +547,7 @@ mod test {
 
         let block_3 = Block::new(
             NodeId::new(keypair.pubkey()),
+            Epoch(1),
             Round(2),
             &payload,
             &QC::new(
@@ -548,6 +555,7 @@ mod test {
                     vote: Vote {
                         vote_info: VoteInfo {
                             id: BlockId(Hash([0x01_u8; 32])),
+                            epoch: Epoch(1),
                             round: Round(0),
                             parent_id: BlockId(Hash([0x02_u8; 32])),
                             parent_round: Round(0),
@@ -566,6 +574,7 @@ mod test {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: block_1.get_id(),
+                        epoch: Epoch(1),
                         round: Round(0),
                         parent_id: BlockId(Hash([0x02_u8; 32])),
                         parent_round: Round(0),
@@ -594,6 +603,7 @@ mod test {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: block_2.get_id(),
+                        epoch: Epoch(1),
                         round: Round(0),
                         parent_id: BlockId(Hash([0x02_u8; 32])),
                         parent_round: Round(0),
@@ -622,6 +632,7 @@ mod test {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: block_3.get_id(),
+                        epoch: Epoch(1),
                         round: Round(0),
                         parent_id: BlockId(Hash([0x02_u8; 32])),
                         parent_round: Round(0),
@@ -785,6 +796,7 @@ mod test {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: BlockId(Hash([0x01_u8; 32])),
+                        epoch: Epoch(1),
                         round: Round(0),
                         parent_id: BlockId(Hash([0x02_u8; 32])),
                         parent_round: Round(0),
@@ -866,6 +878,7 @@ mod test {
                     vote: Vote {
                         vote_info: VoteInfo {
                             id: BlockId(Hash([0x01_u8; 32])),
+                            epoch: Epoch(1),
                             round: Round(0),
                             parent_id: BlockId(Hash([0x02_u8; 32])),
                             parent_round: Round(0),
@@ -879,6 +892,7 @@ mod test {
 
             Block::new(
                 *valset.get_members().iter().next().unwrap().0,
+                Epoch(1),
                 Round(0),
                 &payload,
                 qc,
@@ -890,6 +904,7 @@ mod test {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: block.get_id(),
+                        epoch: Epoch(1),
                         round: Round(0),
                         parent_id: BlockId(Hash([0x02_u8; 32])),
                         parent_round: Round(0),
@@ -1040,6 +1055,7 @@ mod test {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: BlockId(Hash([0x01_u8; 32])),
+                        epoch: Epoch(1),
                         round: Round(1),
                         parent_id: BlockId(Hash([0x02_u8; 32])),
                         parent_round: Round(0),
@@ -1068,6 +1084,7 @@ mod test {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: BlockId(Hash([0x02_u8; 32])),
+                        epoch: Epoch(1),
                         round: Round(2),
                         parent_id: BlockId(Hash([0x02_u8; 32])),
                         parent_round: Round(0),
@@ -1095,6 +1112,7 @@ mod test {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: BlockId(Hash([0x03_u8; 32])),
+                        epoch: Epoch(1),
                         round: Round(3),
                         parent_id: BlockId(Hash([0x03_u8; 32])),
                         parent_round: Round(0),

--- a/monad-consensus-types/src/convert/block.rs
+++ b/monad-consensus-types/src/convert/block.rs
@@ -35,6 +35,7 @@ impl<SCT: SignatureCollection> From<&Block<SCT>> for ProtoBlock {
     fn from(value: &Block<SCT>) -> Self {
         Self {
             author: Some((&value.author).into()),
+            epoch: Some((&value.epoch).into()),
             round: Some((&value.round).into()),
             payload: Some((&value.payload).into()),
             qc: Some((&value.qc).into()),
@@ -51,6 +52,12 @@ impl<SCT: SignatureCollection> TryFrom<ProtoBlock> for Block<SCT> {
                 .author
                 .ok_or(Self::Error::MissingRequiredField(
                     "Block<AggregateSignatures>.author".to_owned(),
+                ))?
+                .try_into()?,
+            value
+                .epoch
+                .ok_or(Self::Error::MissingRequiredField(
+                    "Block<AggregateSignatures>.epoch".to_owned(),
                 ))?
                 .try_into()?,
             value

--- a/monad-consensus-types/src/convert/timeout.rs
+++ b/monad-consensus-types/src/convert/timeout.rs
@@ -58,6 +58,7 @@ impl<SCT: SignatureCollection> TryFrom<ProtoHighQcRoundSigColTuple>
 impl<SCT: SignatureCollection> From<&TimeoutCertificate<SCT>> for ProtoTimeoutCertificate {
     fn from(value: &TimeoutCertificate<SCT>) -> Self {
         Self {
+            epoch: Some((&value.epoch).into()),
             round: Some((&value.round).into()),
             high_qc_rounds: value
                 .high_qc_rounds
@@ -73,6 +74,12 @@ impl<SCT: SignatureCollection> TryFrom<ProtoTimeoutCertificate> for TimeoutCerti
 
     fn try_from(value: ProtoTimeoutCertificate) -> Result<Self, Self::Error> {
         Ok(Self {
+            epoch: value
+                .epoch
+                .ok_or(Self::Error::MissingRequiredField(
+                    "TimeoutCertificate.epoch".to_owned(),
+                ))?
+                .try_into()?,
             round: value
                 .round
                 .ok_or(Self::Error::MissingRequiredField(
@@ -91,6 +98,7 @@ impl<SCT: SignatureCollection> TryFrom<ProtoTimeoutCertificate> for TimeoutCerti
 impl<SCT: SignatureCollection> From<&TimeoutInfo<SCT>> for ProtoTimeoutInfo {
     fn from(value: &TimeoutInfo<SCT>) -> Self {
         Self {
+            epoch: Some((&value.epoch).into()),
             round: Some((&value.round).into()),
             high_qc: Some((&value.high_qc).into()),
         }
@@ -102,6 +110,12 @@ impl<SCT: SignatureCollection> TryFrom<ProtoTimeoutInfo> for TimeoutInfo<SCT> {
 
     fn try_from(value: ProtoTimeoutInfo) -> Result<Self, Self::Error> {
         Ok(Self {
+            epoch: value
+                .epoch
+                .ok_or(Self::Error::MissingRequiredField(
+                    "TimeoutInfo<AggregateSignatures>.epoch".to_owned(),
+                ))?
+                .try_into()?,
             round: value
                 .round
                 .ok_or(Self::Error::MissingRequiredField(

--- a/monad-consensus-types/src/convert/voting.rs
+++ b/monad-consensus-types/src/convert/voting.rs
@@ -15,6 +15,7 @@ impl From<&VoteInfo> for ProtoVoteInfo {
     fn from(vi: &VoteInfo) -> Self {
         ProtoVoteInfo {
             id: Some((&vi.id).into()),
+            epoch: Some((&vi.epoch).into()),
             round: Some((&vi.round).into()),
             parent_id: Some((&vi.parent_id).into()),
             parent_round: Some((&vi.parent_round).into()),
@@ -29,6 +30,12 @@ impl TryFrom<ProtoVoteInfo> for VoteInfo {
             id: proto_vi
                 .id
                 .ok_or(Self::Error::MissingRequiredField("VoteInfo.id".to_owned()))?
+                .try_into()?,
+            epoch: proto_vi
+                .epoch
+                .ok_or(Self::Error::MissingRequiredField(
+                    "VoteInfo.epoch".to_owned(),
+                ))?
                 .try_into()?,
             round: proto_vi
                 .round

--- a/monad-consensus-types/src/metrics.rs
+++ b/monad-consensus-types/src/metrics.rs
@@ -10,6 +10,7 @@ pub struct ValidationErrors {
     pub val_data_unavailable: u64,
     pub invalid_vote_message: u64,
     pub invalid_version: u64,
+    pub invalid_epoch: u64,
 }
 
 #[derive(Debug, Default, Clone, Copy)]

--- a/monad-consensus-types/src/quorum_certificate.rs
+++ b/monad-consensus-types/src/quorum_certificate.rs
@@ -38,6 +38,10 @@ impl QcInfo {
     pub fn get_round(&self) -> Round {
         self.vote.vote_info.round
     }
+
+    pub fn get_epoch(&self) -> Epoch {
+        self.vote.vote_info.epoch
+    }
 }
 
 impl std::fmt::Debug for QcInfo {
@@ -83,6 +87,7 @@ impl<SCT: SignatureCollection> QuorumCertificate<SCT> {
     pub fn genesis_qc() -> Self {
         let vote_info = VoteInfo {
             id: BlockId(GENESIS_QC_HASH),
+            epoch: Epoch(1),
             round: Round(0),
             parent_id: BlockId(GENESIS_QC_HASH),
             parent_round: Round(0),
@@ -124,6 +129,10 @@ impl<SCT: SignatureCollection> QuorumCertificate<SCT> {
 
     pub fn get_round(&self) -> Round {
         self.info.get_round()
+    }
+
+    pub fn get_epoch(&self) -> Epoch {
+        self.info.get_epoch()
     }
 
     pub fn get_block_id(&self) -> BlockId {

--- a/monad-consensus-types/src/validation.rs
+++ b/monad-consensus-types/src/validation.rs
@@ -20,4 +20,6 @@ pub enum Error {
     InvalidVoteMessage,
     /// Consensus Message version must match
     InvalidVersion,
+    /// Epoch number in message doesn't match local records
+    InvalidEpoch,
 }

--- a/monad-consensus-types/src/voting.rs
+++ b/monad-consensus-types/src/voting.rs
@@ -60,6 +60,8 @@ impl Hashable for Vote {
 pub struct VoteInfo {
     /// id of the proposed block
     pub id: BlockId,
+    /// epoch of the proposed block
+    pub epoch: Epoch,
     /// round of the proposed block
     pub round: Round,
     /// parent block id of the proposed block
@@ -74,6 +76,7 @@ impl std::fmt::Debug for VoteInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("VoteInfo")
             .field("id", &self.id)
+            .field("epoch", &self.epoch)
             .field("r", &self.round)
             .field("pid", &self.parent_id)
             .field("pr", &self.parent_round)
@@ -85,6 +88,7 @@ impl std::fmt::Debug for VoteInfo {
 impl Hashable for VoteInfo {
     fn hash(&self, state: &mut impl Hasher) {
         self.id.hash(state);
+        state.update(self.epoch.as_bytes());
         state.update(self.round.as_bytes());
         self.parent_id.hash(state);
         state.update(self.parent_round.as_bytes());
@@ -95,7 +99,7 @@ impl Hashable for VoteInfo {
 #[cfg(test)]
 mod test {
     use monad_crypto::hasher::{Hash, Hashable, Hasher, HasherType};
-    use monad_types::{BlockId, Round, SeqNum};
+    use monad_types::{BlockId, Epoch, Round, SeqNum};
     use test_case::test_case;
     use zerocopy::AsBytes;
 
@@ -106,6 +110,7 @@ mod test {
     fn voteinfo_hash() {
         let vi = VoteInfo {
             id: BlockId(Hash([0x00_u8; 32])),
+            epoch: Epoch(1),
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
@@ -114,6 +119,7 @@ mod test {
 
         let mut hasher = HasherType::new();
         hasher.update(vi.id.0);
+        hasher.update(vi.epoch);
         hasher.update(vi.round);
         hasher.update(vi.parent_id.0);
         hasher.update(vi.parent_round);
@@ -130,6 +136,7 @@ mod test {
     fn vote_hash(cr: CommitResult) {
         let vi = VoteInfo {
             id: BlockId(Hash([0x00_u8; 32])),
+            epoch: Epoch(1),
             round: Round(0),
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),

--- a/monad-consensus/src/validation/safety.rs
+++ b/monad-consensus/src/validation/safety.rs
@@ -77,6 +77,7 @@ impl Safety {
     /// Make a TimeoutInfo if it's safe to timeout the current round
     pub fn make_timeout<SCT: SignatureCollection>(
         &mut self,
+        epoch: Epoch,
         round: Round,
         high_qc: QuorumCertificate<SCT>,
         last_tc: &Option<TimeoutCertificate<SCT>>,
@@ -84,7 +85,11 @@ impl Safety {
         let qc_round = high_qc.get_round();
         if self.safe_to_timeout(round, qc_round, last_tc) {
             self.update_highest_vote_round(round);
-            Some(TimeoutInfo { round, high_qc })
+            Some(TimeoutInfo {
+                epoch,
+                round,
+                high_qc,
+            })
         } else {
             None
         }
@@ -105,6 +110,7 @@ impl Safety {
 
             let vote_info = VoteInfo {
                 id: block.get_id(),
+                epoch: block.get_epoch(),
                 round: block.get_round(),
                 parent_id: block.get_parent_id(),
                 parent_round: block.get_parent_round(),

--- a/monad-consensus/src/vote_state.rs
+++ b/monad-consensus/src/vote_state.rs
@@ -180,7 +180,7 @@ mod test {
     };
     use monad_multi_sig::MultiSig;
     use monad_testutil::{signing::*, validators::create_keys_w_validators};
-    use monad_types::{BlockId, NodeId, Round, SeqNum, Stake};
+    use monad_types::{BlockId, Epoch, NodeId, Round, SeqNum, Stake};
     use monad_validator::validator_set::{ValidatorSetFactory, ValidatorSetTypeFactory};
 
     use super::VoteState;
@@ -196,6 +196,7 @@ mod test {
     ) -> VoteMessage<SCT> {
         let vi = VoteInfo {
             id: BlockId(Hash([0x00_u8; 32])),
+            epoch: Epoch(1),
             round: vote_round,
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),

--- a/monad-consensus/tests/block.rs
+++ b/monad-consensus/tests/block.rs
@@ -10,7 +10,7 @@ use monad_crypto::{
     NopSignature,
 };
 use monad_eth_types::EthAddress;
-use monad_testutil::signing::{hash, node_id, MockSignatures};
+use monad_testutil::signing::{block_hash, node_id, MockSignatures};
 use monad_types::*;
 
 type SignatureType = NopSignature;
@@ -19,6 +19,7 @@ type SignatureType = NopSignature;
 fn block_hash_id() {
     let txns = FullTransactionList::new(vec![1, 2, 3, 4].into());
     let author = node_id::<SignatureType>();
+    let epoch = Epoch(1);
     let round = Round(234);
     let qc = QuorumCertificate::<MockSignatures<SignatureType>>::new(
         QcInfo {
@@ -26,6 +27,7 @@ fn block_hash_id() {
                 vote_info: VoteInfo {
                     id: BlockId(Hash([0x00_u8; 32])),
                     parent_id: BlockId(Hash([0x00_u8; 32])),
+                    epoch: Epoch(1),
                     round: Round(0),
                     parent_round: Round(0),
                     seq_num: SeqNum(0),
@@ -38,6 +40,7 @@ fn block_hash_id() {
 
     let block = Block::<MockSignatures<SignatureType>>::new(
         author,
+        epoch,
         round,
         &Payload {
             txns,
@@ -50,7 +53,7 @@ fn block_hash_id() {
     );
 
     let h1 = HasherType::hash_object(&block);
-    let h2: Hash = hash(&block);
+    let h2: Hash = block_hash(&block);
 
     assert_eq!(h1, h2);
 }

--- a/monad-consensus/tests/message.rs
+++ b/monad-consensus/tests/message.rs
@@ -26,12 +26,14 @@ type SignatureCollectionType = MultiSig<NopSignature>;
 #[test]
 fn timeout_digest() {
     let ti = TimeoutInfo {
+        epoch: Epoch(1),
         round: Round(10),
         high_qc: QuorumCertificate::<MockSignatures<SignatureType>>::new(
             QcInfo {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: BlockId(Hash([0x00_u8; 32])),
+                        epoch: Epoch(1),
                         round: Round(0),
                         parent_id: BlockId(Hash([0x00_u8; 32])),
                         parent_round: Round(0),
@@ -45,6 +47,7 @@ fn timeout_digest() {
     };
 
     let mut hasher = HasherType::new();
+    hasher.update(ti.epoch);
     hasher.update(ti.round);
     hasher.update(ti.high_qc.get_round());
     let h1 = hasher.hash();
@@ -57,12 +60,14 @@ fn timeout_digest() {
 #[test]
 fn timeout_info_hash() {
     let ti = TimeoutInfo {
+        epoch: Epoch(1),
         round: Round(10),
         high_qc: QuorumCertificate::<MockSignatures<SignatureType>>::new(
             QcInfo {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: BlockId(Hash([0x00_u8; 32])),
+                        epoch: Epoch(1),
                         round: Round(0),
                         parent_id: BlockId(Hash([0x00_u8; 32])),
                         parent_round: Round(0),
@@ -76,6 +81,7 @@ fn timeout_info_hash() {
     };
 
     let mut hasher = HasherType::new();
+    hasher.update(ti.epoch);
     hasher.update(ti.round.0.as_bytes());
     hasher.update(ti.high_qc.get_block_id().0.as_bytes());
     hasher.update(ti.high_qc.get_hash());
@@ -89,12 +95,14 @@ fn timeout_info_hash() {
 #[test]
 fn timeout_hash() {
     let ti = TimeoutInfo {
+        epoch: Epoch(1),
         round: Round(10),
         high_qc: QuorumCertificate::<MockSignatures<SignatureType>>::new(
             QcInfo {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: BlockId(Hash([0x00_u8; 32])),
+                        epoch: Epoch(1),
                         round: Round(0),
                         parent_id: BlockId(Hash([0x00_u8; 32])),
                         parent_round: Round(0),
@@ -113,6 +121,7 @@ fn timeout_hash() {
     };
 
     let mut hasher = HasherType::new();
+    hasher.update(tmo.tminfo.epoch.0.as_bytes());
     hasher.update(tmo.tminfo.round.0.as_bytes());
     hasher.update(tmo.tminfo.high_qc.get_block_id().0.as_bytes());
     hasher.update(tmo.tminfo.high_qc.get_hash());
@@ -126,12 +135,14 @@ fn timeout_hash() {
 #[test]
 fn timeout_msg_hash() {
     let ti = TimeoutInfo {
+        epoch: Epoch(1),
         round: Round(10),
         high_qc: QuorumCertificate::<MockSignatures<SignatureType>>::new(
             QcInfo {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: BlockId(Hash([0x00_u8; 32])),
+                        epoch: Epoch(1),
                         round: Round(0),
                         parent_id: BlockId(Hash([0x00_u8; 32])),
                         parent_round: Round(0),
@@ -154,6 +165,7 @@ fn timeout_msg_hash() {
     let tmo_msg = TimeoutMessage::new(tmo, &cert_key);
 
     let mut hasher = HasherType::new();
+    hasher.update(tmo_msg.timeout.tminfo.epoch.0.as_bytes());
     hasher.update(tmo_msg.timeout.tminfo.round.0.as_bytes());
     hasher.update(
         tmo_msg
@@ -187,18 +199,20 @@ fn timeout_msg_hash() {
 
 #[test]
 fn proposal_msg_hash() {
-    use monad_testutil::signing::hash;
+    use monad_testutil::signing::block_hash;
 
     let txns = FullTransactionList::new(vec![1, 2, 3, 4].into());
 
     let mut privkey: [u8; 32] = [127; 32];
     let keypair = <NopKeyPair as CertificateKeyPair>::from_bytes(&mut privkey).unwrap();
     let author = NodeId::new(keypair.pubkey());
+    let epoch = Epoch(1);
     let round = Round(234);
     let qc = QuorumCertificate::<MockSignatures<SignatureType>>::new(
         QcInfo {
             vote: Vote {
                 vote_info: VoteInfo {
+                    epoch: Epoch(1),
                     id: BlockId(Hash([0x00_u8; 32])),
                     round: Round(0),
                     parent_id: BlockId(Hash([0x00_u8; 32])),
@@ -213,6 +227,7 @@ fn proposal_msg_hash() {
 
     let block = Block::<MockSignatures<SignatureType>>::new(
         author,
+        epoch,
         round,
         &Payload {
             txns,
@@ -230,7 +245,7 @@ fn proposal_msg_hash() {
     };
 
     let h1 = HasherType::hash_object(&proposal);
-    let h2 = hash(&block);
+    let h2 = block_hash(&block);
 
     assert_eq!(h1, h2);
 }
@@ -254,6 +269,7 @@ fn max_high_qc() {
     .collect();
 
     let tc = TimeoutCertificate {
+        epoch: Epoch(1),
         round: Round(2),
         high_qc_rounds,
     };
@@ -266,6 +282,7 @@ fn max_high_qc() {
 fn vote_msg_hash(cs: CommitResult) {
     let vi = VoteInfo {
         id: BlockId(Hash([0x00_u8; 32])),
+        epoch: Epoch(1),
         round: Round(0),
         parent_id: BlockId(Hash([0x00_u8; 32])),
         parent_round: Round(0),

--- a/monad-consensus/tests/qc.rs
+++ b/monad-consensus/tests/qc.rs
@@ -15,6 +15,7 @@ fn comparison() {
 
     let vi_1 = VoteInfo {
         id: BlockId(Hash([0x00_u8; 32])),
+        epoch: Epoch(1),
         round: Round(2),
         parent_id: BlockId(Hash([0x00_u8; 32])),
         parent_round: Round(0),
@@ -23,6 +24,7 @@ fn comparison() {
 
     let vi_2 = VoteInfo {
         id: BlockId(Hash([0x00_u8; 32])),
+        epoch: Epoch(1),
         round: Round(3),
         parent_id: BlockId(Hash([0x00_u8; 32])),
         parent_round: Round(0),

--- a/monad-consensus/tests/vote_state.rs
+++ b/monad-consensus/tests/vote_state.rs
@@ -12,7 +12,7 @@ use monad_crypto::{
 };
 use monad_multi_sig::MultiSig;
 use monad_testutil::validators::create_keys_w_validators;
-use monad_types::{BlockId, NodeId, Round, SeqNum};
+use monad_types::{BlockId, Epoch, NodeId, Round, SeqNum};
 use monad_validator::validator_set::{ValidatorSet, ValidatorSetFactory};
 use test_case::test_case;
 
@@ -23,10 +23,12 @@ type SignatureCollectionType = MultiSig<SignatureType>;
 fn create_vote_message(
     key: &NopKeyPair,
     certkey: &SignatureCollectionKeyPairType<SignatureCollectionType>,
+    vote_epoch: Epoch,
     vote_round: Round,
 ) -> (NodeId<PubKeyType>, VoteMessage<SignatureCollectionType>) {
     let vi = VoteInfo {
         id: BlockId(Hash([0x00_u8; 32])),
+        epoch: vote_epoch,
         round: vote_round,
         parent_id: BlockId(Hash([0x00_u8; 32])),
         parent_round: Round(0),
@@ -61,8 +63,12 @@ fn setup_ctx(
     let mut votes = Vec::new();
     for j in 0..num_rounds {
         for i in 0..num_nodes {
-            let svm_with_author =
-                create_vote_message(&keys[i as usize], &cert_keys[i as usize], Round(j));
+            let svm_with_author = create_vote_message(
+                &keys[i as usize],
+                &cert_keys[i as usize],
+                Epoch(1),
+                Round(j),
+            );
 
             votes.push(svm_with_author);
         }

--- a/monad-eth-txpool/src/lib.rs
+++ b/monad-eth-txpool/src/lib.rs
@@ -11,7 +11,7 @@ use monad_consensus_types::{
 };
 use monad_crypto::hasher::{Hashable, Hasher};
 use monad_eth_tx::{EthFullTransactionList, EthSignedTransaction, EthTransaction, EthTxHash};
-use monad_types::{BlockId, NodeId, Round, SeqNum};
+use monad_types::{BlockId, Epoch, NodeId, Round, SeqNum};
 
 #[derive(Default)]
 pub struct EthTxPool(BTreeMap<EthTxHash, EthTransaction>);
@@ -117,6 +117,10 @@ impl<SCT: SignatureCollection> BlockType<SCT> for EthValidatedBlock<SCT> {
 
     fn get_round(&self) -> Round {
         self.block.round
+    }
+
+    fn get_epoch(&self) -> Epoch {
+        self.block.epoch
     }
 
     fn get_author(&self) -> NodeId<Self::NodeIdPubKey> {

--- a/monad-mock-swarm/src/utils.rs
+++ b/monad-mock-swarm/src/utils.rs
@@ -33,7 +33,7 @@ pub mod test_tool {
     use monad_state::VerifiedMonadMessage;
     use monad_testutil::signing::create_keys;
     use monad_transformer::{LinkMessage, ID};
-    use monad_types::{BlockId, NodeId, Round, SeqNum};
+    use monad_types::{BlockId, Epoch, NodeId, Round, SeqNum};
 
     type ST = NopSignature;
     type KeyPairType = <ST as CertificateSignature>::KeyPairType;
@@ -64,6 +64,7 @@ pub mod test_tool {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: BlockId(Hash([0x00_u8; 32])),
+                        epoch: Epoch(1),
                         round: Round(0),
                         parent_id: BlockId(Hash([0x00_u8; 32])),
                         parent_round: Round(0),
@@ -85,7 +86,7 @@ pub mod test_tool {
             randao_reveal: RandaoReveal::default(),
         };
 
-        Block::new(fake_node_id(), round, &payload, &fake_qc())
+        Block::new(fake_node_id(), Epoch(1), round, &payload, &fake_qc())
     }
 
     pub fn fake_proposal_message(kp: &KeyPairType, round: Round) -> VerifiedMonadMessage<ST, SC> {
@@ -104,6 +105,7 @@ pub mod test_tool {
     pub fn fake_vote_message(kp: &KeyPairType, round: Round) -> VerifiedMonadMessage<ST, SC> {
         let vote_info = VoteInfo {
             id: BlockId(Hash([0x00_u8; 32])),
+            epoch: Epoch(1),
             round,
             parent_id: BlockId(Hash([0x00_u8; 32])),
             parent_round: Round(0),
@@ -126,6 +128,7 @@ pub mod test_tool {
 
     pub fn fake_timeout_message(kp: &KeyPairType) -> VerifiedMonadMessage<ST, SC> {
         let timeout_info = TimeoutInfo {
+            epoch: Epoch(1),
             round: Round(0),
             high_qc: fake_qc(),
         };

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -267,7 +267,7 @@ fn many_nodes_quic_bw() {
     swarm_ledger_verification(&swarm, min_ledger_len);
 
     let mut verifier =
-        MockSwarmVerifier::default().tick_range(Duration::from_secs(106), Duration::from_secs(1));
+        MockSwarmVerifier::default().tick_range(Duration::from_secs(107), Duration::from_secs(1));
 
     let node_ids = swarm.states().keys().copied().collect_vec();
     verifier

--- a/monad-mock-swarm/tests/protobuf.rs
+++ b/monad-mock-swarm/tests/protobuf.rs
@@ -57,6 +57,7 @@ fn test_consensus_message_event_vote_multisig() {
     let certkeypair = get_certificate_key::<SignatureCollectionType>(7);
     let vi = VoteInfo {
         id: BlockId(Hash([42_u8; 32])),
+        epoch: Epoch(1),
         round: Round(1),
         parent_id: BlockId(Hash([43_u8; 32])),
         parent_round: Round(2),

--- a/monad-proto/proto/block.proto
+++ b/monad-proto/proto/block.proto
@@ -29,7 +29,8 @@ message ProtoPayload {
 
 message ProtoBlock {
   monad_proto.basic.ProtoNodeId author = 1;
-  monad_proto.basic.ProtoRound round = 2;
-  ProtoPayload payload = 3;
-  monad_proto.quorum_certificate.ProtoQuorumCertificate qc = 4;
+  monad_proto.basic.ProtoEpoch epoch = 2;
+  monad_proto.basic.ProtoRound round = 3;
+  ProtoPayload payload = 4;
+  monad_proto.quorum_certificate.ProtoQuorumCertificate qc = 5;
 }

--- a/monad-proto/proto/timeout.proto
+++ b/monad-proto/proto/timeout.proto
@@ -17,13 +17,15 @@ message ProtoHighQcRoundSigColTuple {
 }
 
 message ProtoTimeoutCertificate {
-  monad_proto.basic.ProtoRound round = 1;
-  repeated ProtoHighQcRoundSigColTuple high_qc_rounds = 2;
+  monad_proto.basic.ProtoEpoch epoch = 1;
+  monad_proto.basic.ProtoRound round = 2;
+  repeated ProtoHighQcRoundSigColTuple high_qc_rounds = 3;
 }
 
 message ProtoTimeoutInfo {
-  monad_proto.basic.ProtoRound round = 1;
-  monad_proto.quorum_certificate.ProtoQuorumCertificate high_qc = 2;
+  monad_proto.basic.ProtoEpoch epoch = 1;
+  monad_proto.basic.ProtoRound round = 2;
+  monad_proto.quorum_certificate.ProtoQuorumCertificate high_qc = 3;
 }
 
 message ProtoTimeout {

--- a/monad-proto/proto/voting.proto
+++ b/monad-proto/proto/voting.proto
@@ -7,10 +7,11 @@ import "ledger.proto";
 
 message ProtoVoteInfo {
   monad_proto.basic.ProtoBlockId id = 1;
-  monad_proto.basic.ProtoRound round = 2;
-  monad_proto.basic.ProtoBlockId parent_id = 3;
-  monad_proto.basic.ProtoRound parent_round = 4;
-  monad_proto.basic.ProtoSeqNum seq_num = 5;
+  monad_proto.basic.ProtoEpoch epoch = 2;
+  monad_proto.basic.ProtoRound round = 3;
+  monad_proto.basic.ProtoBlockId parent_id = 4;
+  monad_proto.basic.ProtoRound parent_round = 5;
+  monad_proto.basic.ProtoSeqNum seq_num = 6;
 }
 
 message ProtoVote {

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -79,8 +79,9 @@ pub(crate) fn handle_validation_error(e: validation::Error, metrics: &mut Metric
             metrics.validation_errors.invalid_seq_num += 1;
         }
         validation::Error::ValidatorDataUnavailable => {
-            // This error occurs when the node knows when the next epoch starts, but
-            // didn't get enough execution deltas to build the next validator set.
+            // This error occurs when the node knows when the next epoch starts,
+            // but didn't get enough execution deltas to build the next
+            // validator set.
             // TODO: This should trigger statesync
             metrics.validation_errors.val_data_unavailable += 1;
         }
@@ -89,6 +90,13 @@ pub(crate) fn handle_validation_error(e: validation::Error, metrics: &mut Metric
         }
         validation::Error::InvalidVersion => {
             metrics.validation_errors.invalid_version += 1;
+        }
+        validation::Error::InvalidEpoch => {
+            // TODO: If the node is not actively participating, getting this
+            // error can indicate that the node is behind by more than an epoch
+            // and needs state sync. Else if actively participating, this is
+            // spam
+            metrics.validation_errors.invalid_epoch += 1;
         }
     };
 }

--- a/monad-testutil/src/block.rs
+++ b/monad-testutil/src/block.rs
@@ -16,7 +16,7 @@ use monad_crypto::{
     hasher::{Hash, Hasher, HasherType},
 };
 use monad_eth_types::EthAddress;
-use monad_types::{BlockId, NodeId, Round, SeqNum};
+use monad_types::{BlockId, Epoch, NodeId, Round, SeqNum};
 
 // test utility if you only wish for simple block
 #[derive(Clone, PartialEq, Eq)]
@@ -56,9 +56,15 @@ impl<SCT: SignatureCollection, PT: PubKey> BlockType<SCT> for MockBlock<PT> {
     fn get_id(&self) -> BlockId {
         self.block_id
     }
+
     fn get_round(&self) -> Round {
         Round(1)
     }
+
+    fn get_epoch(&self) -> Epoch {
+        Epoch(1)
+    }
+
     fn get_author(&self) -> NodeId<Self::NodeIdPubKey> {
         unimplemented!()
     }
@@ -123,6 +129,7 @@ where
 {
     let vi = VoteInfo {
         id: BlockId(Hash([42_u8; 32])),
+        epoch: Epoch(1),
         round: qc_round,
         parent_id: BlockId(Hash([43_u8; 32])),
         parent_round: Round(0),
@@ -153,6 +160,7 @@ where
 
     Block::<SCT>::new(
         author,
+        Epoch(1),
         block_round,
         &Payload {
             txns,

--- a/monad-testutil/src/signing.rs
+++ b/monad-testutil/src/signing.rs
@@ -108,10 +108,11 @@ impl<ST: CertificateSignatureRecoverable> SignatureCollection for MockSignatures
     }
 }
 
-pub fn hash<T: SignatureCollection>(b: &Block<T>) -> Hash {
+pub fn block_hash<T: SignatureCollection>(b: &Block<T>) -> Hash {
     let block_id = {
         let mut hasher = HasherType::new();
         hasher.update(b.author.pubkey().bytes());
+        hasher.update(b.epoch);
         hasher.update(b.round);
         hasher.update(b.payload.txns.bytes());
         hasher.update(b.payload.header.parent_hash);

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -59,8 +59,14 @@ impl std::fmt::Debug for Round {
 /// During an epoch, the validator set remain stable: no validator is allowed to
 /// stake or unstake until the next epoch
 #[repr(transparent)]
-#[derive(Copy, Clone, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Hash, Eq, PartialEq, PartialOrd, Ord, AsBytes)]
 pub struct Epoch(pub u64);
+
+impl AsRef<[u8]> for Epoch {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
 
 impl Add for Epoch {
     type Output = Self;

--- a/monad-wal/benches/event_bench.rs
+++ b/monad-wal/benches/event_bench.rs
@@ -29,7 +29,7 @@ use monad_testutil::{
     signing::{get_certificate_key, get_key},
     validators::create_keys_w_validators,
 };
-use monad_types::{BlockId, NodeId, Round, SeqNum, Serializable, TimeoutVariant};
+use monad_types::{BlockId, Epoch, NodeId, Round, SeqNum, Serializable, TimeoutVariant};
 use monad_validator::validator_set::ValidatorSetFactory;
 use monad_wal::{
     wal::{WALogger, WALoggerConfig},
@@ -119,6 +119,7 @@ fn bench_vote(c: &mut Criterion) {
     let certkey = get_certificate_key::<SignatureCollectionType>(2);
     let vi = VoteInfo {
         id: BlockId(Hash([42_u8; 32])),
+        epoch: Epoch(1),
         round: Round(1),
         parent_id: BlockId(Hash([43_u8; 32])),
         parent_round: Round(2),
@@ -169,6 +170,7 @@ fn bench_timeout(c: &mut Criterion) {
 
     let vi = VoteInfo {
         id: BlockId(Hash([42_u8; 32])),
+        epoch: Epoch(1),
         round: Round(1),
         parent_id: BlockId(Hash([43_u8; 32])),
         parent_round: Round(2),
@@ -196,11 +198,13 @@ fn bench_timeout(c: &mut Criterion) {
     let qc = QuorumCertificate::new(qcinfo, aggsig);
 
     let tmo_info = TimeoutInfo {
+        epoch: Epoch(1),
         round: Round(3),
         high_qc: qc,
     };
 
     let high_qc_round = HighQcRound { qc_round: Round(1) };
+    let tc_epoch = Epoch(1);
     let tc_round = Round(2);
     let mut hasher = HasherType::new();
     hasher.update(tc_round);
@@ -223,6 +227,7 @@ fn bench_timeout(c: &mut Criterion) {
     }];
 
     let tc = TimeoutCertificate {
+        epoch: tc_epoch,
         round: tc_round,
         high_qc_rounds,
     };


### PR DESCRIPTION
Our epochs only have a starting round, but no ending round. Epoch numbers help newly joined/recovered validators find out if they are behind, and if so, they need to request the new set.

The epoch number is added to all the messages hashes, including the `(timeout round, high qc round)` pair in timeout certificate. Now it's signing over the triplet `(timeout epoch, timeout round, high qc round)`