### PR TITLE
bench artifact

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,7 +2,7 @@ name: Benchmark Regression Check
 
 on:
   pull_request:
-    branches: [master]
+    branches: [ master ]
 
 jobs:
   benchmark:
@@ -27,12 +27,16 @@ jobs:
       # Run benchmark on master
       - name: Run benchmark on master
         shell: bash
-        run: cd master && cargo bench -- --output-format bencher | tee bench.txt
+        run: cd master && cargo bench -- --output-format bencher --save-baseline master | tee bench.txt
+
+      # Copy baseline results to the PR directory so that criterion can properly recognize it as a baseline
+      - name: Copy baseline results
+        run: mkdir -p pr/target/criterion && cp -r master/target/criterion/* pr/target/criterion
 
       # Run benchmark on PR
       - name: Run benchmark on PR
         shell: bash
-        run: cd pr && cargo bench -- --output-format bencher | tee bench.txt
+        run: cd pr && cargo bench -- --output-format bencher --baseline master | tee bench.txt
 
       - name: Compare benchmarks
         uses: openpgpjs/github-action-pull-request-benchmark@v1
@@ -44,3 +48,9 @@ jobs:
           comment-always: true
           fail-on-alert: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Archive criterion benchmark plots
+        uses: actions/upload-artifact@v4
+        with:
+          name: criterion benchmark plot
+          path: |
+            pr/target/criterion


### PR DESCRIPTION
This PR enhances the benchmark CI workflow

- archives and uploads Criterion benchmark plots as a github artifact which is easy to download
- previously, the plots for both master and the PR were being generated in separate directories which made it a hassle to compare results. Now, changes are easier to visualize like so
![image](https://github.com/monad-crypto/monad-bft/assets/22534842/07273a3d-42ea-4042-9a1a-adc6035310ec)
