### PR TITLE
Lock n+2 validator set in epoch n

### DIFF
--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -437,7 +437,10 @@ where
 
         let mut init_cmds = Vec::new();
         init_cmds.extend(monad_state.update(MonadEvent::ValidatorEvent(
-            ValidatorEvent::UpdateValidators((self.validators, Epoch(1))),
+            ValidatorEvent::UpdateValidators((self.validators.clone(), Epoch(1))),
+        )));
+        init_cmds.extend(monad_state.update(MonadEvent::ValidatorEvent(
+            ValidatorEvent::UpdateValidators((self.validators, Epoch(2))),
         )));
 
         init_cmds.extend(


### PR DESCRIPTION
Our previous implementation locks n+1 validator set in epoch n, giving validators a small window to compute and validate that they all agree on the same set. This PR changes it to n+2. Validators have at least an entire epoch to prepare for their validating duties, e.g. syncing etc.

Eth adopts the same [policy](https://eth2book.info/capella/part2/building_blocks/randomness/#lookahead)