### PR TITLE
Raptorcast Implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3722,6 +3722,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-raptorcast"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "clap 4.4.10",
+ "criterion",
+ "futures",
+ "futures-util",
+ "itertools 0.10.5",
+ "monad-crypto",
+ "monad-dataplane",
+ "monad-executor",
+ "monad-executor-glue",
+ "monad-merkle",
+ "monad-secp",
+ "monad-types",
+ "raptor-code",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "monad-router-scheduler"
 version = "0.1.0"
 dependencies = [
@@ -4771,6 +4794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "primes"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a61082d8bceecd71a3870e9162002bb75f7ba9c7aa8b76227e887782fef9c8"
+
+[[package]]
 name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5029,6 +5058,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "raptor-code"
+version = "1.0.6"
+source = "git+https://github.com/omegablitz/raptor?rev=8cdd8fcc#8cdd8fcc44f135aebe0d6b6e7782c6840ac6d3c5"
+dependencies = [
+ "bytes",
+ "log",
+ "primes",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "monad-proto",
     "monad-quic",
     "monad-randomized-tests",
+    "monad-raptorcast",
     "monad-router-scheduler",
     "monad-rpc",
     "monad-secp",
@@ -129,6 +130,7 @@ quinn-proto = { git = "https://github.com/omegablitz/quinn.git", rev = "0780497b
 
 rand = "0.8"
 rand_chacha = "0.3"
+raptor-code = { git = "https://github.com/omegablitz/raptor", rev = "8cdd8fcc" }
 raptorq = "1.8"
 rayon = "1.7"
 rcgen = "0.11"

--- a/monad-crypto/benches/hasher_bench.rs
+++ b/monad-crypto/benches/hasher_bench.rs
@@ -1,15 +1,42 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use monad_crypto::hasher::{Blake3Hash, Hasher, Sha256Hash};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("sha256 (5_000 * 32 bytes)", |b| {
-        let bytes = vec![0xff; 5_000 * 32];
-        b.iter(|| hash::<Sha256Hash>(&bytes));
+    let mut group = c.benchmark_group("hasher");
+    let total_bytes = 10_000 * 400;
+    group.throughput(Throughput::Bytes(total_bytes as u64));
+    group.bench_function("sha256 10KB batch", |b| {
+        let batch = vec![vec![0xff; 10_000]; 400];
+        b.iter(|| {
+            for bytes in &batch {
+                hash::<Sha256Hash>(bytes)
+            }
+        });
+    });
+    group.bench_function("sha256 1KB batch", |b| {
+        let batch = vec![vec![0xff; 1_000]; 4_000];
+        b.iter(|| {
+            for bytes in &batch {
+                hash::<Sha256Hash>(bytes)
+            }
+        });
     });
 
-    c.bench_function("blake3 (5_000 * 32 bytes)", |b| {
-        let bytes = vec![0xff; 5_000 * 32];
-        b.iter(|| hash::<Blake3Hash>(&bytes));
+    group.bench_function("blake3 10KB batch", |b| {
+        let batch = vec![vec![0xff; 10_000]; 400];
+        b.iter(|| {
+            for bytes in &batch {
+                hash::<Blake3Hash>(bytes)
+            }
+        });
+    });
+    group.bench_function("blake3 1KB batch", |b| {
+        let batch = vec![vec![0xff; 1_000]; 4_000];
+        b.iter(|| {
+            for bytes in &batch {
+                hash::<Blake3Hash>(bytes)
+            }
+        });
     });
 }
 

--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "monad-raptorcast"
+version = "0.1.0"
+edition = "2021"
+
+# this is necessary for criterion bench options
+# https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+[lib]
+bench = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+monad-crypto = { path = "../monad-crypto" }
+monad-dataplane = { path = "../monad-dataplane" }
+monad-executor = { path = "../monad-executor" }
+monad-executor-glue = { path = "../monad-executor-glue" }
+monad-merkle = { path = "../monad-merkle" }
+monad-secp = { path = "../monad-secp" }
+monad-types = { path = "../monad-types" }
+
+bytes = { workspace = true }
+futures = { workspace = true }
+itertools = { workspace = true }
+raptor-code = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+clap = { workspace = true, features = ["derive"] }
+criterion = { workspace = true }
+futures-util = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+[[bench]]
+name = "raptor_bench"
+harness = false
+
+[[example]]
+name = "service"

--- a/monad-raptorcast/benches/raptor_bench.rs
+++ b/monad-raptorcast/benches/raptor_bench.rs
@@ -1,0 +1,143 @@
+use std::{
+    collections::HashMap,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+};
+
+use bytes::Bytes;
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+use itertools::Itertools;
+use monad_crypto::hasher::{Hasher, HasherType};
+use monad_dataplane::network::MONAD_GSO_SIZE;
+use monad_raptorcast::{build_messages, parse_message, Validator};
+use monad_secp::{KeyPair, SecpSignature};
+use monad_types::{NodeId, RouterTarget, Stake};
+use raptor_code::SourceBlockDecoder;
+
+#[allow(clippy::useless_vec)]
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let message_size = 10_000 * 400;
+    let message: Bytes = vec![123_u8; message_size].into();
+
+    let mut group = c.benchmark_group("encoder/decoder");
+    group.throughput(Throughput::Bytes(message_size as u64));
+    group.bench_function("Encoding", |b| {
+        let keys = (0_u8..100_u8)
+            .map(|n| {
+                let mut hasher = HasherType::new();
+                hasher.update(n.to_le_bytes());
+                let mut hash = hasher.hash();
+                KeyPair::from_bytes(&mut hash.0).unwrap()
+            })
+            .collect_vec();
+
+        let round_validators = keys[1..]
+            .iter()
+            .map(|key| (NodeId::new(key.pubkey()), Validator { stake: Stake(1) }))
+            .collect();
+
+        let known_addresses = keys
+            .iter()
+            .map(|key| {
+                (
+                    NodeId::new(key.pubkey()),
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                )
+            })
+            .collect();
+
+        b.iter(|| {
+            let _ = build_messages::<SecpSignature>(
+                &keys[0],
+                MONAD_GSO_SIZE.try_into().unwrap(), // gso_size
+                message.clone(),
+                2, // redundancy,
+                0, // round_no
+                RouterTarget::Broadcast,
+                &round_validators,
+                &known_addresses,
+            );
+        });
+    });
+
+    group.bench_function("Decoding", |b| {
+        let keys = (0_u8..100_u8)
+            .map(|n| {
+                let mut hasher = HasherType::new();
+                hasher.update(n.to_le_bytes());
+                let mut hash = hasher.hash();
+                KeyPair::from_bytes(&mut hash.0).unwrap()
+            })
+            .collect_vec();
+
+        let round_validators = keys[1..]
+            .iter()
+            .map(|key| (NodeId::new(key.pubkey()), Validator { stake: Stake(1) }))
+            .collect();
+
+        let known_addresses = keys
+            .iter()
+            .map(|key| {
+                (
+                    NodeId::new(key.pubkey()),
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                )
+            })
+            .collect();
+
+        let messages = build_messages::<SecpSignature>(
+            &keys[0],
+            MONAD_GSO_SIZE.try_into().unwrap(), // gso_size
+            message.clone(),
+            2, // redundancy,
+            0, // round_no
+            RouterTarget::Broadcast,
+            &round_validators,
+            &known_addresses,
+        )
+        .into_iter()
+        .map(|(_to, message)| message)
+        .collect_vec();
+
+        let example_chunk = parse_message::<SecpSignature>(
+            &mut Default::default(),
+            messages[0].clone().split_to(MONAD_GSO_SIZE),
+        )
+        .expect("valid chunk");
+
+        b.iter_batched(
+            || messages.clone(),
+            |messages| {
+                let mut signature_cache = HashMap::new();
+                let mut decoder = {
+                    // data_size is always greater than zero, so this division is safe
+                    let num_source_symbols = message_size.div_ceil(example_chunk.chunk.len());
+                    SourceBlockDecoder::new(num_source_symbols)
+                };
+                let mut decode_success = false;
+                for mut message in messages {
+                    while !message.is_empty() {
+                        let parsed_message = parse_message::<SecpSignature>(
+                            &mut signature_cache,
+                            message.split_to(MONAD_GSO_SIZE),
+                        )
+                        .expect("valid message");
+                        decoder.push_encoding_symbol(
+                            parsed_message.chunk,
+                            parsed_message.chunk_id.into(),
+                        );
+                        if let Some(decoded) = decoder.decode(message_size) {
+                            decode_success = true;
+                            break;
+                        }
+                    }
+                }
+                assert!(decode_success);
+            },
+            BatchSize::LargeInput,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/monad-raptorcast/examples/service.rs
+++ b/monad-raptorcast/examples/service.rs
@@ -1,0 +1,237 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    net::SocketAddr,
+    num::ParseIntError,
+    time::{Duration, Instant},
+};
+
+use bytes::{Bytes, BytesMut};
+use clap::Parser;
+use futures_util::StreamExt;
+use monad_crypto::certificate_signature::{
+    CertificateKeyPair, CertificateSignature, CertificateSignaturePubKey,
+};
+use monad_executor::Executor;
+use monad_executor_glue::{Message, RouterCommand};
+use monad_raptorcast::{EpochValidators, RaptorCast, RaptorCastConfig, Validator};
+use monad_secp::SecpSignature;
+use monad_types::{Deserializable, NodeId, Round, RouterTarget, Serializable, Stake};
+use tracing_subscriber::fmt::format::FmtSpan;
+
+#[derive(Parser, Debug)]
+struct Args {
+    /// addresses
+    #[arg(short, long, required=true, num_args=1..)]
+    addresses: Vec<String>,
+}
+
+pub fn main() {
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_span_events(FmtSpan::CLOSE)
+        .init();
+    let args = Args::parse();
+
+    let payload_size = 10_000 * 400;
+
+    let num_rt = 2;
+    let threads_per_rt = 2;
+
+    service(num_rt, threads_per_rt, args.addresses, 1, payload_size);
+}
+
+type SignatureType = SecpSignature;
+type PubKeyType = CertificateSignaturePubKey<SignatureType>;
+
+fn service(
+    num_rt: usize,
+    threads_per_rt: usize,
+    addresses: Vec<String>,
+    num_broadcast: u32,
+    message_len: usize,
+) {
+    assert!(message_len >= 4);
+    let num_peers = addresses.len() as u32;
+    let keys: Vec<_> = (0..num_peers)
+        .map(|idx| {
+            let mut privkey: [u8; 32] = [1; 32];
+            let idx_bytes = idx.to_le_bytes();
+            privkey[0] = idx_bytes[0];
+            privkey[1] = idx_bytes[1];
+            privkey[2] = idx_bytes[2];
+            privkey[3] = idx_bytes[3];
+            <<SignatureType as CertificateSignature>::KeyPairType as CertificateKeyPair>::from_bytes(&mut privkey).unwrap()
+        })
+        .collect();
+
+    let peers: Vec<NodeId<PubKeyType>> = keys
+        .iter()
+        .map(|keypair| NodeId::new(keypair.pubkey()))
+        .collect();
+
+    let known_addresses: HashMap<NodeId<PubKeyType>, SocketAddr> = peers
+        .iter()
+        .copied()
+        .zip(addresses)
+        .map(|(peer, address)| (peer, address.parse().unwrap()))
+        .collect();
+
+    let epoch_validators: BTreeMap<Round, EpochValidators<SignatureType>> = vec![(
+        Round(u64::MAX),
+        EpochValidators {
+            start_round: Round(0),
+            end_round: Round(u64::MAX),
+            validators: peers
+                .iter()
+                .copied()
+                .map(|peer| (peer, Validator { stake: Stake(1) }))
+                .collect(),
+        },
+    )]
+    .into_iter()
+    .collect();
+
+    let (tx_writer, tx_reader): (BTreeMap<_, _>, Vec<_>) = peers
+        .iter()
+        .copied()
+        .map(|peer| {
+            let (sender, receiver) =
+                tokio::sync::mpsc::unbounded_channel::<RouterCommand<PubKeyType, MockMessage>>();
+            ((peer, sender), receiver)
+        })
+        .unzip();
+    let (rx_writer, rx_reader) =
+        std::sync::mpsc::channel::<(NodeId<PubKeyType>, <MockMessage as Message>::Event)>();
+
+    let rts: Vec<_> = std::iter::repeat_with(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(threads_per_rt)
+            .build()
+            .unwrap()
+    })
+    .take(num_rt)
+    .collect();
+
+    rts.iter()
+        .cycle()
+        .zip(keys.into_iter().zip(tx_reader))
+        .for_each(|(rt, (key, mut tx_reader))| {
+            let rx_writer = rx_writer.clone();
+            let me = NodeId::new(key.pubkey());
+            let all_peers = peers.clone();
+            let server_address = *known_addresses.get(&me).unwrap();
+            let known_addresses = known_addresses.clone();
+            let epoch_validators = epoch_validators.clone();
+
+            rt.spawn(async move {
+                let service_config = RaptorCastConfig {
+                    key,
+                    known_addresses,
+                    epoch_validators,
+                    redundancy: 2,
+                    local_addr: server_address.to_string(),
+                };
+
+                let mut service =
+                    RaptorCast::<SignatureType, MockMessage, MockMessage>::new(service_config);
+                loop {
+                    tokio::select! {
+                        maybe_message = service.next() => {
+                            let message = maybe_message.expect("never terminates");
+                            rx_writer
+                                .send((me, message))
+                                .expect("rx_reader should never be dropped");
+                        }
+                        maybe_tx = tx_reader.recv() => {
+                            let tx = maybe_tx.expect("tx_writer should never be dropped");
+                            // TODO batch these?
+                            service.exec(vec![tx]);
+                        }
+                    };
+                }
+            });
+        });
+
+    let (tx_peer, tx_router) = tx_writer.first_key_value().expect("at least 1 tx");
+
+    std::thread::sleep(Duration::from_secs(1));
+
+    let start = Instant::now();
+    let mut expected_message_ids = HashMap::new();
+    for broadcast_id in 0..num_broadcast {
+        let message = MockMessage::new(broadcast_id, message_len);
+        tx_router
+            .send(RouterCommand::Publish {
+                target: RouterTarget::Broadcast,
+                message,
+            })
+            .expect("reader should never be dropped");
+        expected_message_ids.insert(message.id, num_peers);
+    }
+    while let Ok((_, (tx, msg_id))) = rx_reader.recv_timeout(Duration::from_secs(1)) {
+        if &tx == tx_peer {
+            let num_left = expected_message_ids
+                .get_mut(&msg_id)
+                .expect("msg_id must exist");
+            *num_left -= 1;
+            if num_left == &0 {
+                expected_message_ids.remove(&msg_id);
+            }
+            if expected_message_ids.is_empty() {
+                tracing::info!(
+                    "took {:?} to broadcast/receive {} messages!",
+                    start.elapsed(),
+                    num_broadcast
+                );
+                std::thread::sleep(Duration::from_secs(3));
+                std::process::exit(0);
+            }
+        }
+    }
+    unreachable!("timed out!");
+}
+
+#[derive(Clone, Copy)]
+struct MockMessage {
+    id: u32,
+    message_len: usize,
+}
+
+impl MockMessage {
+    fn new(id: u32, message_len: usize) -> Self {
+        Self { id, message_len }
+    }
+}
+
+impl Message for MockMessage {
+    type NodeIdPubKey = PubKeyType;
+    type Event = (NodeId<Self::NodeIdPubKey>, u32);
+
+    fn event(self, from: NodeId<Self::NodeIdPubKey>) -> Self::Event {
+        (from, self.id)
+    }
+}
+
+impl Serializable<Bytes> for MockMessage {
+    fn serialize(&self) -> Bytes {
+        let mut message = BytesMut::zeroed(self.message_len);
+        let id_bytes = self.id.to_le_bytes();
+        message[0] = id_bytes[0];
+        message[1] = id_bytes[1];
+        message[2] = id_bytes[2];
+        message[3] = id_bytes[3];
+        message.into()
+    }
+}
+
+impl Deserializable<Bytes> for MockMessage {
+    type ReadError = ParseIntError;
+
+    fn deserialize(message: &Bytes) -> Result<Self, Self::ReadError> {
+        Ok(Self::new(
+            u32::from_le_bytes(message[..4].try_into().unwrap()),
+            message.len(),
+        ))
+    }
+}


### PR DESCRIPTION
Raptorcast is a replacement for monad_quic::Service, built on top of monad_dataplane.