### PR TITLE
Publish RPC and execution docker image in github actions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,14 +2,16 @@ name: Create and publish a Docker image
 
 on:
   push:
-    branches: ['master']
+    branches:
+      - 'release*'
+      - 'staging*'
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  publish-monad-bft-node:
+  publish-monad-bft:
     runs-on: ubuntu-24.04-32
 
     permissions:
@@ -43,6 +45,54 @@ jobs:
           context: .
           push: true
           file: docker/devnet/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  publish-monad-rpc:
+    runs-on: ubuntu-24.04-32
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.REPO_READONLY_GITHUB_APP_ID }}
+          private-key: ${{ secrets.REPO_READONLY_GITHUB_APP_KEY }}
+          repositories: "monad,monad-bft,evmone,thread-safe-lru"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Log in to the Peach10 Container registry
+        uses: docker/login-action@v3.1.0
+        with:
+          registry: peach10.monad.spacetime.org
+          username: ${{ secrets.PRIVATE_REGISTRY_USERNAME }}
+          password: ${{ secrets.PRIVATE_REGISTRY_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: |
+            peach10.monad.spacetime.org/monad-crypto/monad-rpc
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: .
+          push: true
+          file: docker/rpc/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -82,3 +132,72 @@ jobs:
           file: docker/blockwatch/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  publish-monad-execution:
+    runs-on: ubuntu-24.04-32
+
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      MONAD_EXECUTION_ROOT: ${{ github.workspace }}/monad-cxx/monad-execution
+
+    steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.REPO_READONLY_GITHUB_APP_ID }}
+          private-key: ${{ secrets.REPO_READONLY_GITHUB_APP_KEY }}
+          repositories: "monad,monad-bft,evmone,thread-safe-lru"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Log in to the Peach10 Container registry
+        uses: docker/login-action@v3.1.0
+        with:
+          registry: peach10.monad.spacetime.org
+          username: ${{ secrets.PRIVATE_REGISTRY_USERNAME }}
+          password: ${{ secrets.PRIVATE_REGISTRY_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: |
+            peach10.monad.spacetime.org/monad-crypto/monad-execution
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=
+
+      - name: Setup Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: |
+            --allow-insecure-entitlement security.insecure
+      
+      - run: cat /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages
+      - run: cat /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages
+      - run: sudo bash -c "echo 1024 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages"
+      - run: sudo bash -c "echo 16 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages"
+      - run: cat /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages
+      - run: cat /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: ${{ env.MONAD_EXECUTION_ROOT }}
+          push: true
+          file: ${{ env.MONAD_EXECUTION_ROOT }}/docker/release.Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_COMMIT_HASH=$(git -C ${{ env.MONAD_EXECUTION_ROOT }} rev-parse HEAD)
+          builder: ${{ steps.setup-buildx.outputs.name }}
+          allow: security.insecure


### PR DESCRIPTION
As part of the effort in https://github.com/monad-crypto/monad-internal/issues/228

Updates to the branch with names starting with *release* or *staging* will now push consensus + execution + rpc to the docker registry. I think we can staging for internal testing and release for larger updates.