### PR TITLE
Remove epoch number from pacemaker

### DIFF
--- a/monad-state/src/consensus.rs
+++ b/monad-state/src/consensus.rs
@@ -132,7 +132,7 @@ where
             ConsensusEvent::Timeout(tmo_event) => match tmo_event {
                 TimeoutVariant::Pacemaker => self
                     .consensus
-                    .handle_timeout_expiry(self.node_state.metrics)
+                    .handle_timeout_expiry(self.node_state.epoch_manager, self.node_state.metrics)
                     .into_iter()
                     .map(|cmd| {
                         ConsensusCommand::from_pacemaker_command(


### PR DESCRIPTION
Pacemaker needs epoch number when creating timeout messages. Epoch manager provides the ground truth for that. Removing epoch number from pacemaker struct reduces the state it's keeping and make it less error prone.