### PR TITLE
Add block timestamp in block proposal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3521,6 +3521,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "chrono",
  "clap 4.4.10",
  "futures",
  "monad-blockdb",

--- a/monad-ledger/Cargo.toml
+++ b/monad-ledger/Cargo.toml
@@ -20,6 +20,7 @@ monad-types = { path = "../monad-types" }
 
 alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }
+chrono = { workspace = true }
 prost = { workspace = true }
 reth-primitives = { workspace = true }
 tokio = { workspace = true, features = [

--- a/monad-ledger/src/lib.rs
+++ b/monad-ledger/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
 
 use alloy_primitives::{Bloom, Bytes, FixedBytes, U256};
 use alloy_rlp::Encodable;
+use chrono::Utc;
 use monad_blockdb::BlockDb;
 use monad_consensus_types::{
     block::{Block as MonadBlock, BlockType},
@@ -196,11 +197,12 @@ fn generate_header<SCT: SignatureCollection>(
         number: monad_block.payload.seq_num.0,
         gas_limit: header_param.gas_limit,
         gas_used: gas_used.0,
-        // TODO-1: Add to BFT proposal
-        timestamp: 0,
+        // TODO: Validate block timestamp in consensus
+        // Timestamp is set in Unix milliseconds since blocks might be sub-seconds
+        timestamp: Utc::now().timestamp_millis() as u64,
         mix_hash: randao_reveal_hasher.hash().0.into(),
         nonce: 0,
-        // TODO: calculate base fee according to EIP1559
+        // TODO: Calculate base fee according to EIP1559
         base_fee_per_gas: Some(1000),
         blob_gas_used: None,
         excess_blob_gas: None,

--- a/monad-rpc/src/block_handlers.rs
+++ b/monad-rpc/src/block_handlers.rs
@@ -1,3 +1,5 @@
+use std::ops::Div;
+
 use alloy_primitives::aliases::{U256, U64};
 use log::{debug, trace};
 use monad_blockdb::{BlockTableKey, BlockValue};
@@ -33,7 +35,9 @@ fn parse_block_content(value: &BlockValue, return_full_txns: bool) -> Option<Blo
         gas_limit: U256::from(value.block.header.gas_limit),
         extra_data: value.block.header.clone().extra_data,
         logs_bloom: value.block.header.logs_bloom,
-        timestamp: U256::from(value.block.header.timestamp),
+        // timestamp in block header is in Unix milliseconds but we parse it
+        // to be in Unix seconds here for integration compatability
+        timestamp: U256::from(value.block.header.timestamp.div(1000)),
         difficulty: value.block.header.difficulty,
         mix_hash: Some(value.block.header.mix_hash),
         nonce: Some(value.block.header.nonce.to_be_bytes().into()),


### PR DESCRIPTION
Will need milliseconds Unix timestamp since our blocks might be subseconds but wanted to check Blockscout integration first

Edit: currently setting the block header timestamp to Unix milliseconds for validation, but on RPC side parsing back to in Unix seconds so that external integrations work as expected.