### PR TITLE
Separate triedb utilities from monad-rpc into crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3778,6 +3778,7 @@ dependencies = [
  "monad-blockdb",
  "monad-cxx",
  "monad-triedb",
+ "monad-triedb-utils",
  "rayon",
  "reth-primitives",
  "reth-rpc-types",
@@ -3922,6 +3923,19 @@ dependencies = [
  "bindgen 0.69.4",
  "cmake",
  "log",
+]
+
+[[package]]
+name = "monad-triedb-utils"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "log",
+ "monad-blockdb",
+ "monad-triedb",
+ "rayon",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
     "monad-validator",
     "monad-virtual-bench",
     "monad-wal",
+    "monad-triedb-utils",
 ]
 resolver = "2"
 

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -14,6 +14,7 @@ bench = false
 monad-blockdb = { path = "../monad-blockdb" }
 monad-cxx = { path = "../monad-cxx" }
 monad-triedb = { path = "../monad-triedb" }
+monad-triedb-utils = { path = "../monad-triedb-utils" }
 
 actix = { workspace = true }
 actix-codec = { workspace = true }

--- a/monad-rpc/src/block_handlers.rs
+++ b/monad-rpc/src/block_handlers.rs
@@ -1,6 +1,7 @@
 use alloy_primitives::aliases::{U256, U64};
 use log::{debug, trace};
 use monad_blockdb::{BlockTableKey, BlockValue};
+use monad_triedb_utils::{TriedbEnv, TriedbResult};
 use reth_primitives::BlockHash;
 use reth_rpc_types::{Block, BlockTransactions, Header, TransactionReceipt, Withdrawal};
 use serde::Deserialize;
@@ -13,7 +14,7 @@ use crate::{
     },
     eth_txn_handlers::{parse_tx_content, parse_tx_receipt},
     jsonrpc::JsonRpcError,
-    triedb::{decode_receipt, ReceiptDetails, TriedbEnv, TriedbResult},
+    receipt::{decode_receipt, ReceiptDetails},
 };
 
 fn parse_block_content(value: &BlockValue, return_full_txns: bool) -> Option<Block> {

--- a/monad-rpc/src/eth_json_types.rs
+++ b/monad-rpc/src/eth_json_types.rs
@@ -95,6 +95,15 @@ pub enum BlockTags {
     Default(BlockTagKey),
 }
 
+impl From<BlockTags> for monad_triedb_utils::BlockTags {
+    fn from(t: BlockTags) -> Self {
+        match t {
+            BlockTags::Number(q) => monad_triedb_utils::BlockTags::Number(q.0),
+            BlockTags::Default(k) => monad_triedb_utils::BlockTags::Default(k),
+        }
+    }
+}
+
 impl Default for BlockTags {
     fn default() -> Self {
         BlockTags::Default(BlockTagKey::Latest)

--- a/monad-rpc/src/eth_txn_handlers.rs
+++ b/monad-rpc/src/eth_txn_handlers.rs
@@ -3,6 +3,7 @@ use std::cmp::min;
 use alloy_primitives::aliases::{B256, U128, U256, U64};
 use log::{debug, trace};
 use monad_blockdb::{BlockTableKey, BlockValue, EthTxKey};
+use monad_triedb_utils::{TriedbEnv, TriedbResult};
 use reth_primitives::{transaction::TransactionKind, BlockHash, TransactionSigned};
 use reth_rpc_types::{AccessListItem, Log, Parity, Signature, Transaction, TransactionReceipt};
 use serde::Deserialize;
@@ -16,7 +17,7 @@ use crate::{
         UnformattedData,
     },
     jsonrpc::JsonRpcError,
-    triedb::{decode_receipt, ReceiptDetails, TriedbEnv, TriedbResult},
+    receipt::{decode_receipt, ReceiptDetails},
 };
 
 pub fn parse_tx_content(

--- a/monad-rpc/src/gas_handlers.rs
+++ b/monad-rpc/src/gas_handlers.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use log::{debug, trace};
 use monad_blockdb::BlockTagKey;
+use monad_triedb_utils::{TriedbEnv, TriedbResult};
 use reth_rpc_types::FeeHistory;
 use serde::Deserialize;
 use serde_json::Value;
@@ -13,7 +14,6 @@ use crate::{
         deserialize_block_tags, deserialize_quantity, serialize_result, BlockTags, Quantity,
     },
     jsonrpc::JsonRpcError,
-    triedb::{TriedbEnv, TriedbResult},
 };
 
 #[derive(Deserialize, Debug)]

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -23,9 +23,9 @@ use eth_txn_handlers::{
 };
 use futures::SinkExt;
 use log::{debug, info};
+use monad_triedb_utils::TriedbEnv;
 use reth_primitives::TransactionSigned;
 use serde_json::Value;
-use triedb::TriedbEnv;
 
 use crate::{
     blockdb::BlockDbEnv,
@@ -51,7 +51,7 @@ mod gas_handlers;
 mod hex;
 mod jsonrpc;
 mod mempool_tx;
-mod triedb;
+mod receipt;
 mod websocket;
 
 async fn rpc_handler(body: bytes::Bytes, app_state: web::Data<MonadRpcResources>) -> HttpResponse {

--- a/monad-rpc/src/receipt.rs
+++ b/monad-rpc/src/receipt.rs
@@ -1,0 +1,62 @@
+use alloy_primitives::{Address, Bloom, Bytes};
+use alloy_rlp::{Decodable, RlpDecodable, RlpEncodable};
+use reth_primitives::{B256, U64, U8};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, RlpEncodable, RlpDecodable, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReceiptDetails {
+    #[rlp(skip)]
+    #[rlp(default)]
+    pub tx_type: U8,
+    pub status: U64,
+    pub cumulative_gas_used: U64,
+    pub logs_bloom: Bloom,
+    pub logs: Vec<ReceiptLog>,
+}
+
+#[derive(Debug, Clone, RlpDecodable, RlpEncodable, Serialize, Deserialize)]
+pub struct ReceiptLog {
+    pub address: Address,
+    pub topics: Vec<B256>,
+    pub data: Bytes,
+}
+
+pub fn decode_receipt(rlp_buf: &mut &[u8]) -> alloy_rlp::Result<ReceiptDetails> {
+    let tx_type = decode_tx_type(rlp_buf)?;
+    let receipt = ReceiptDetails::decode(rlp_buf)?;
+    Ok(ReceiptDetails { tx_type, ..receipt })
+}
+
+pub fn decode_tx_type(rlp_buf: &mut &[u8]) -> Result<U8, alloy_rlp::Error> {
+    match rlp_buf.first() {
+        None => Err(alloy_rlp::Error::InputTooShort),
+        Some(&x) if x < 0xc0 => {
+            // first byte represents transaction type
+            let tx_type = match x {
+                1 => 1, // EIP2930
+                2 => 2, // EIP1559
+                // TODO: add support for EIP4844
+                _ => return Err(alloy_rlp::Error::Custom("InvalidTxnType")),
+            };
+            *rlp_buf = &rlp_buf[1..]; // advance the buffer
+            Ok(U8::from(tx_type))
+        }
+        Some(_) => Ok(U8::from(0)), // legacy transactions do not have first byte as transaction type
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use reth_primitives::U8;
+
+    use crate::hex;
+
+    #[test]
+    fn decode_receipt() {
+        let rlp = hex::decode("0x02f90109018301ab80b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0").unwrap();
+        let mut rlp_buf = rlp.as_slice();
+        let receipt = super::decode_receipt(&mut rlp_buf).unwrap();
+        assert_eq!(receipt.tx_type, U8::from(2));
+    }
+}

--- a/monad-triedb-utils/Cargo.toml
+++ b/monad-triedb-utils/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "monad-triedb-utils"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+bench = false
+
+[dependencies]
+monad-blockdb = { path = "../monad-blockdb" }
+monad-triedb = { path = "../monad-triedb" }
+
+alloy-primitives = { workspace = true }
+alloy-rlp = { workspace = true }
+log = { workspace = true }
+rayon = { workspace = true }
+tokio.workspace = true
+

--- a/monad-triedb-utils/src/lib.rs
+++ b/monad-triedb-utils/src/lib.rs
@@ -3,15 +3,19 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use alloy_primitives::{keccak256, Address, Bloom, Bytes};
-use alloy_rlp::{Decodable, Encodable, RlpDecodable, RlpEncodable};
+use alloy_primitives::keccak256;
+use alloy_rlp::{Decodable, Encodable};
 use log::debug;
 use monad_blockdb::BlockTagKey;
 use monad_triedb::Handle;
-use reth_primitives::{B256, U64, U8};
-use serde::{Deserialize, Serialize};
 
-use crate::eth_json_types::{BlockTags, EthAddress, EthStorageKey};
+pub enum BlockTags {
+    Number(u64),
+    Default(BlockTagKey),
+}
+
+pub type EthAddress = [u8; 20];
+pub type EthStorageKey = [u8; 32];
 
 #[derive(Clone)]
 pub struct TriedbEnv {
@@ -28,49 +32,6 @@ pub enum TriedbResult {
     Code(Vec<u8>),
     Receipt(Vec<u8>),
     BlockNum(u64),
-}
-
-#[derive(Debug, Clone, RlpEncodable, RlpDecodable, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ReceiptDetails {
-    #[rlp(skip)]
-    #[rlp(default)]
-    pub tx_type: U8,
-    pub status: U64,
-    pub cumulative_gas_used: U64,
-    pub logs_bloom: Bloom,
-    pub logs: Vec<ReceiptLog>,
-}
-
-#[derive(Debug, Clone, RlpDecodable, RlpEncodable, Serialize, Deserialize)]
-pub struct ReceiptLog {
-    pub address: Address,
-    pub topics: Vec<B256>,
-    pub data: Bytes,
-}
-
-pub fn decode_receipt(rlp_buf: &mut &[u8]) -> alloy_rlp::Result<ReceiptDetails> {
-    let tx_type = decode_tx_type(rlp_buf)?;
-    let receipt = ReceiptDetails::decode(rlp_buf)?;
-    Ok(ReceiptDetails { tx_type, ..receipt })
-}
-
-pub fn decode_tx_type(rlp_buf: &mut &[u8]) -> Result<U8, alloy_rlp::Error> {
-    match rlp_buf.first() {
-        None => Err(alloy_rlp::Error::InputTooShort),
-        Some(&x) if x < 0xc0 => {
-            // first byte represents transaction type
-            let tx_type = match x {
-                1 => 1, // EIP2930
-                2 => 2, // EIP1559
-                // TODO: add support for EIP4844
-                _ => return Err(alloy_rlp::Error::Custom("InvalidTxnType")),
-            };
-            *rlp_buf = &rlp_buf[1..]; // advance the buffer
-            Ok(U8::from(tx_type))
-        }
-        Some(_) => Ok(U8::from(0)), // legacy transactions do not have first byte as transaction type
-    }
 }
 
 impl TriedbEnv {
@@ -112,7 +73,7 @@ impl TriedbEnv {
 
                 // parse block tag
                 let block_num = match block_tag {
-                    BlockTags::Number(q) => q.0,
+                    BlockTags::Number(q) => q,
                     BlockTags::Default(t) => match t {
                         BlockTagKey::Latest => TriedbEnv::latest_block(db),
                         BlockTagKey::Finalized => TriedbEnv::latest_block(db),
@@ -185,7 +146,7 @@ impl TriedbEnv {
 
                 // parse block tag
                 let block_num = match block_tag {
-                    BlockTags::Number(q) => q.0,
+                    BlockTags::Number(q) => q,
                     BlockTags::Default(t) => match t {
                         BlockTagKey::Latest => TriedbEnv::latest_block(db),
                         BlockTagKey::Finalized => TriedbEnv::latest_block(db),
@@ -226,7 +187,7 @@ impl TriedbEnv {
 
                 // parse block tag
                 let block_num = match block_tag {
-                    BlockTags::Number(q) => q.0,
+                    BlockTags::Number(q) => q,
                     BlockTags::Default(t) => match t {
                         BlockTagKey::Latest => TriedbEnv::latest_block(db),
                         BlockTagKey::Finalized => TriedbEnv::latest_block(db),
@@ -286,7 +247,7 @@ impl TriedbEnv {
 
         key_nibbles.push(state_nibble);
 
-        let hashed_addr = keccak256(addr.0);
+        let hashed_addr = keccak256(addr);
         for byte in &hashed_addr {
             key_nibbles.push(*byte >> 4);
             key_nibbles.push(*byte & 0xF);
@@ -310,13 +271,13 @@ impl TriedbEnv {
         let state_nibble = 0_u8;
         key_nibbles.push(state_nibble);
 
-        let hashed_addr = keccak256(addr.0);
+        let hashed_addr = keccak256(addr);
         for byte in &hashed_addr {
             key_nibbles.push(*byte >> 4);
             key_nibbles.push(*byte & 0xF);
         }
 
-        let hashed_at = keccak256(at.0);
+        let hashed_at = keccak256(at);
         for byte in &hashed_at {
             key_nibbles.push(*byte >> 4);
             key_nibbles.push(*byte & 0xF);
@@ -385,20 +346,5 @@ impl TriedbEnv {
             .collect();
 
         (key, num_nibbles)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use reth_primitives::U8;
-
-    use crate::hex;
-
-    #[test]
-    fn decode_receipt() {
-        let rlp = hex::decode("0x02f90109018301ab80b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0").unwrap();
-        let mut rlp_buf = rlp.as_slice();
-        let receipt = super::decode_receipt(&mut rlp_buf).unwrap();
-        assert_eq!(receipt.tx_type, U8::from(2));
     }
 }


### PR DESCRIPTION
Move triedb utilities from `monad-rpc` into a separate crate. Blocks `monad-indexer` project. These utilities do not go into `monad-triedb` in order to avoid unnecessary dependencies. 