### PR TITLE
Separate blockdb utilities from monad-rpc into crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3217,6 +3217,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-blockdb-utils"
+version = "0.1.0"
+dependencies = [
+ "heed",
+ "monad-blockdb",
+ "rayon",
+ "tokio",
+]
+
+[[package]]
 name = "monad-blocktree"
 version = "0.1.0"
 dependencies = [
@@ -3820,9 +3830,9 @@ dependencies = [
  "flume",
  "futures",
  "futures-util",
- "heed",
  "log",
  "monad-blockdb",
+ "monad-blockdb-utils",
  "monad-cxx",
  "monad-triedb",
  "monad-triedb-utils",
@@ -3980,6 +3990,7 @@ dependencies = [
  "alloy-rlp",
  "log",
  "monad-blockdb",
+ "monad-blockdb-utils",
  "monad-triedb",
  "rayon",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "monad-async-state-verify",
     "monad-blockdb",
+    "monad-blockdb-utils",
     "monad-blocktree",
     "monad-bls",
     "monad-compress",
@@ -41,13 +42,13 @@ members = [
     "monad-testutil",
     "monad-tracing-counter",
     "monad-transformer",
+    "monad-triedb-utils",
     "monad-twins",
     "monad-types",
     "monad-updaters",
     "monad-validator",
     "monad-virtual-bench",
     "monad-wal",
-    "monad-triedb-utils",
 ]
 resolver = "2"
 

--- a/monad-blockdb-utils/Cargo.toml
+++ b/monad-blockdb-utils/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "monad-blockdb-utils"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+bench = false
+
+[dependencies]
+monad-blockdb = { path = "../monad-blockdb" }
+
+heed = { workspace = true }
+rayon = { workspace = true }
+tokio = { workspace = true }

--- a/monad-blockdb-utils/src/lib.rs
+++ b/monad-blockdb-utils/src/lib.rs
@@ -2,13 +2,16 @@ use std::path::Path;
 
 use heed::{flags::Flags, Env, EnvOpenOptions};
 use monad_blockdb::{
-    BlockNumTableKey, BlockNumTableType, BlockTableKey, BlockTableType, BlockTagTableType,
-    BlockTagValue, BlockValue, EthTxKey, EthTxValue, TxnHashTableType, BLOCK_DB_MAP_SIZE,
-    BLOCK_DB_NUM_DBS, BLOCK_NUM_TABLE_NAME, BLOCK_TABLE_NAME, BLOCK_TAG_TABLE_NAME,
-    TXN_HASH_TABLE_NAME,
+    BlockNumTableKey, BlockNumTableType, BlockTableKey, BlockTableType, BlockTagKey,
+    BlockTagTableType, BlockTagValue, BlockValue, EthTxKey, EthTxValue, TxnHashTableType,
+    BLOCK_DB_MAP_SIZE, BLOCK_DB_NUM_DBS, BLOCK_NUM_TABLE_NAME, BLOCK_TABLE_NAME,
+    BLOCK_TAG_TABLE_NAME, TXN_HASH_TABLE_NAME,
 };
 
-use crate::eth_json_types::BlockTags;
+pub enum BlockTags {
+    Number(u64),
+    Default(BlockTagKey),
+}
 
 // FIXME: make a blockdb trait
 
@@ -110,7 +113,7 @@ impl BlockDbEnv {
                 BlockTags::Number(q) => {
                     let db_txn = env.read_txn().expect("read txn failed");
                     let result: Option<BlockTableKey> = block_num_dbi
-                        .get(&db_txn, &BlockNumTableKey(q.0))
+                        .get(&db_txn, &BlockNumTableKey(q))
                         .expect("get operation should not fail");
                     result
                 }

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -12,6 +12,7 @@ bench = false
 
 [dependencies]
 monad-blockdb = { path = "../monad-blockdb" }
+monad-blockdb-utils = { path = "../monad-blockdb-utils" }
 monad-cxx = { path = "../monad-cxx" }
 monad-triedb = { path = "../monad-triedb" }
 monad-triedb-utils = { path = "../monad-triedb-utils" }
@@ -31,7 +32,6 @@ env_logger = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
-heed = { workspace = true }
 log = { workspace = true }
 rayon = { workspace = true }
 reth-primitives = { workspace = true }

--- a/monad-rpc/src/block_handlers.rs
+++ b/monad-rpc/src/block_handlers.rs
@@ -1,6 +1,7 @@
 use alloy_primitives::aliases::{U256, U64};
 use log::{debug, trace};
 use monad_blockdb::{BlockTableKey, BlockValue};
+use monad_blockdb_utils::BlockDbEnv;
 use monad_triedb_utils::{TriedbEnv, TriedbResult};
 use reth_primitives::BlockHash;
 use reth_rpc_types::{Block, BlockTransactions, Header, TransactionReceipt, Withdrawal};
@@ -8,7 +9,6 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::{
-    blockdb::BlockDbEnv,
     eth_json_types::{
         deserialize_block_tags, deserialize_fixed_data, serialize_result, BlockTags, EthHash,
     },
@@ -163,7 +163,7 @@ pub async fn monad_eth_getBlockByNumber(
         }
     };
 
-    let Some(value) = blockdb_env.get_block_by_tag(p.block_number).await else {
+    let Some(value) = blockdb_env.get_block_by_tag(p.block_number.into()).await else {
         return serialize_result(None::<Block>);
     };
 
@@ -222,7 +222,7 @@ pub async fn monad_eth_getBlockTransactionCountByNumber(
         }
     };
 
-    let Some(value) = blockdb_env.get_block_by_tag(p.block_tag).await else {
+    let Some(value) = blockdb_env.get_block_by_tag(p.block_tag.into()).await else {
         return serialize_result(format!("0x{:x}", 0));
     };
 
@@ -252,7 +252,7 @@ pub async fn monad_eth_getBlockReceipts(
         }
     };
 
-    let Some(block) = blockdb_env.get_block_by_tag(p.block_tag).await else {
+    let Some(block) = blockdb_env.get_block_by_tag(p.block_tag.into()).await else {
         return serialize_result(None::<Vec<TransactionReceipt>>);
     };
     let block_num = block.block.number;

--- a/monad-rpc/src/call.rs
+++ b/monad-rpc/src/call.rs
@@ -2,13 +2,13 @@ use std::path::Path;
 
 use alloy_primitives::{Address, Uint, U256, U64, U8};
 use log::debug;
+use monad_blockdb_utils::BlockDbEnv;
 use monad_triedb_utils::{TriedbEnv, TriedbResult};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::{
-    blockdb::BlockDbEnv,
-    eth_json_types::{deserialize_block_tags, BlockTags, Quantity},
+    eth_json_types::{deserialize_block_tags, BlockTags},
     hex,
     jsonrpc::JsonRpcError,
 };
@@ -162,7 +162,7 @@ pub async fn sender_gas_allowance(
         let TriedbResult::Account(_, balance, _) = triedb_env
             .get_account(
                 from.into(),
-                monad_triedb_utils::BlockTags::Number(block_number),
+                monad_blockdb_utils::BlockTags::Number(block_number),
             )
             .await
         else {
@@ -229,7 +229,7 @@ pub async fn monad_eth_call(
     };
 
     let Some(block_header) = blockdb_env
-        .get_block_by_tag(BlockTags::Number(Quantity(block_number)))
+        .get_block_by_tag(monad_blockdb_utils::BlockTags::Number(block_number))
         .await
     else {
         debug!("blockdb did not have latest block header");

--- a/monad-rpc/src/eth_json_types.rs
+++ b/monad-rpc/src/eth_json_types.rs
@@ -101,11 +101,11 @@ pub enum BlockTags {
     Default(BlockTagKey),
 }
 
-impl From<BlockTags> for monad_triedb_utils::BlockTags {
+impl From<BlockTags> for monad_blockdb_utils::BlockTags {
     fn from(t: BlockTags) -> Self {
         match t {
-            BlockTags::Number(q) => monad_triedb_utils::BlockTags::Number(q.0),
-            BlockTags::Default(k) => monad_triedb_utils::BlockTags::Default(k),
+            BlockTags::Number(q) => monad_blockdb_utils::BlockTags::Number(q.0),
+            BlockTags::Default(k) => monad_blockdb_utils::BlockTags::Default(k),
         }
     }
 }

--- a/monad-rpc/src/eth_txn_handlers.rs
+++ b/monad-rpc/src/eth_txn_handlers.rs
@@ -3,6 +3,7 @@ use std::cmp::min;
 use alloy_primitives::aliases::{B256, U128, U256, U64};
 use log::{debug, trace};
 use monad_blockdb::{BlockTableKey, BlockValue, EthTxKey};
+use monad_blockdb_utils::BlockDbEnv;
 use monad_triedb_utils::{TriedbEnv, TriedbResult};
 use reth_primitives::{transaction::TransactionKind, BlockHash, TransactionSigned};
 use reth_rpc_types::{AccessListItem, Log, Parity, Signature, Transaction, TransactionReceipt};
@@ -10,7 +11,6 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::{
-    blockdb::BlockDbEnv,
     eth_json_types::{
         deserialize_block_tags, deserialize_fixed_data, deserialize_quantity,
         deserialize_unformatted_data, serialize_result, BlockTags, EthHash, Quantity,
@@ -369,7 +369,7 @@ pub async fn monad_eth_getTransactionByBlockNumberAndIndex(
         }
     };
 
-    let Some(block) = blockdb_env.get_block_by_tag(p.block_tag).await else {
+    let Some(block) = blockdb_env.get_block_by_tag(p.block_tag.into()).await else {
         return serialize_result(None::<Transaction>);
     };
 

--- a/monad-rpc/src/gas_handlers.rs
+++ b/monad-rpc/src/gas_handlers.rs
@@ -2,13 +2,13 @@ use std::path::Path;
 
 use log::{debug, trace};
 use monad_blockdb::BlockTagKey;
+use monad_blockdb_utils::BlockDbEnv;
 use monad_triedb_utils::{TriedbEnv, TriedbResult};
 use reth_rpc_types::FeeHistory;
 use serde::Deserialize;
 use serde_json::Value;
 
 use crate::{
-    blockdb::BlockDbEnv,
     call::{sender_gas_allowance, CallRequest},
     eth_json_types::{
         deserialize_block_tags, deserialize_quantity, serialize_result, BlockTags, Quantity,
@@ -54,7 +54,7 @@ pub async fn monad_eth_estimateGas(
     };
 
     let Some(block_header) = blockdb_env
-        .get_block_by_tag(BlockTags::Number(Quantity(block_number)))
+        .get_block_by_tag(monad_blockdb_utils::BlockTags::Number(block_number))
         .await
     else {
         debug!("blockdb did not have latest block header");
@@ -104,7 +104,7 @@ pub async fn monad_eth_gasPrice(blockdb_env: &BlockDbEnv) -> Result<Value, JsonR
     trace!("monad_eth_gasPrice");
 
     let block = match blockdb_env
-        .get_block_by_tag(BlockTags::Default(BlockTagKey::Latest))
+        .get_block_by_tag(monad_blockdb_utils::BlockTags::Default(BlockTagKey::Latest))
         .await
     {
         Some(block) => block,

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -23,12 +23,12 @@ use eth_txn_handlers::{
 };
 use futures::SinkExt;
 use log::{debug, info};
+use monad_blockdb_utils::BlockDbEnv;
 use monad_triedb_utils::TriedbEnv;
 use reth_primitives::TransactionSigned;
 use serde_json::Value;
 
 use crate::{
-    blockdb::BlockDbEnv,
     call::monad_eth_call,
     eth_txn_handlers::monad_eth_sendRawTransaction,
     gas_handlers::{
@@ -42,7 +42,6 @@ use crate::{
 
 mod account_handlers;
 mod block_handlers;
-mod blockdb;
 mod call;
 mod cli;
 mod eth_json_types;

--- a/monad-triedb-utils/Cargo.toml
+++ b/monad-triedb-utils/Cargo.toml
@@ -8,6 +8,7 @@ bench = false
 
 [dependencies]
 monad-blockdb = { path = "../monad-blockdb" }
+monad-blockdb-utils = { path = "../monad-blockdb-utils" }
 monad-triedb = { path = "../monad-triedb" }
 
 alloy-primitives = { workspace = true }

--- a/monad-triedb-utils/src/lib.rs
+++ b/monad-triedb-utils/src/lib.rs
@@ -7,12 +7,8 @@ use alloy_primitives::keccak256;
 use alloy_rlp::{Decodable, Encodable};
 use log::debug;
 use monad_blockdb::BlockTagKey;
+use monad_blockdb_utils::BlockTags;
 use monad_triedb::Handle;
-
-pub enum BlockTags {
-    Number(u64),
-    Default(BlockTagKey),
-}
 
 pub type EthAddress = [u8; 20];
 pub type EthStorageKey = [u8; 32];


### PR DESCRIPTION
Moves blockdb utilities from monad-rpc into a separate crate. Last reorganization for `monad-indexer`