### PR TITLE
add perf util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3473,6 +3473,7 @@ dependencies = [
  "monad-crypto",
  "monad-eth-tx",
  "monad-multi-sig",
+ "monad-perf-util",
  "monad-types",
  "rand",
  "rand_chacha",
@@ -3741,6 +3742,10 @@ dependencies = [
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "monad-perf-util"
+version = "0.1.0"
 
 [[package]]
 name = "monad-proto"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "monad-multi-sig",
     "monad-node",
     "monad-opentelemetry-executor",
+    "monad-perf-util",
     "monad-proto",
     "monad-quic",
     "monad-randomized-tests",

--- a/monad-eth-txpool/Cargo.toml
+++ b/monad-eth-txpool/Cargo.toml
@@ -26,9 +26,10 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 tracing-test = { workspace = true }
 
-monad-multi-sig = { path = "../monad-multi-sig" }
-monad-types = { path = "../monad-types" }
 monad-crypto = { path = "../monad-crypto" }
+monad-multi-sig = { path = "../monad-multi-sig" }
+monad-perf-util = { path = "../monad-perf-util" }
+monad-types = { path = "../monad-types" }
 
 [[bench]]
 name = "proposal_bench"

--- a/monad-perf-util/Cargo.toml
+++ b/monad-perf-util/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "monad-perf-util"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+bench = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/monad-perf-util/src/lib.rs
+++ b/monad-perf-util/src/lib.rs
@@ -1,0 +1,44 @@
+use std::{
+    env::VarError,
+    fs::File,
+    io::{Read, Write},
+    os::fd::FromRawFd,
+    str::FromStr,
+};
+
+pub struct PerfController {
+    control: File,
+    control_ack: File,
+}
+
+impl PerfController {
+    pub fn from_env() -> Result<Self, VarError> {
+        let ctl_fd = std::env::var("PERF_CTL_FD")?;
+        let ctl_fd_ack = std::env::var("PERF_CTL_FD_ACK")?;
+
+        let control = unsafe { File::from_raw_fd(std::ffi::c_int::from_str(&ctl_fd).unwrap()) };
+        let control_ack =
+            unsafe { File::from_raw_fd(std::ffi::c_int::from_str(&ctl_fd_ack).unwrap()) };
+
+        Ok(Self {
+            control,
+            control_ack,
+        })
+    }
+
+    /// Enables sampling by writing to the control file descriptor and blocks waiting for ack.
+    pub fn enable(&mut self) {
+        self.control.write_all(b"enable\n").unwrap();
+        let mut buf = [0; 5];
+        self.control_ack.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, &['a' as u8, 'c' as u8, 'k' as u8, '\n' as u8, 0u8]);
+    }
+
+    /// Disables sampling by writing to the control file descriptor and blocks waiting for ack.
+    pub fn disable(&mut self) {
+        self.control.write_all(b"disable\n").unwrap();
+        let mut buf = [0; 5];
+        self.control_ack.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, &['a' as u8, 'c' as u8, 'k' as u8, '\n' as u8, 0u8]);
+    }
+}

--- a/monad-scripts/bench/perf.sh
+++ b/monad-scripts/bench/perf.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 set +x
+
+if [ -f "ctl_fd.fifo" ]; then
+  rm "ctl_fd.fifo"
+fi
+
+if [ -f "ctl_fd_ack.fifo" ]; then
+  rm "ctl_fd_ack.fifo"
+fi
+
 mkfifo ctl_fd.fifo
 exec {ctl_fd}<>ctl_fd.fifo
 mkfifo ctl_fd_ack.fifo


### PR DESCRIPTION
Inspired from this stack overflow answer 

https://stackoverflow.com/questions/74340680/perf-record-after-my-code-reaches-a-certain-point/74350866#74350866

Very niche use case. But if you want to sample the stack traces of a criterion benchmark where the setup/tear-down of the benchmark uses up a ton of compute (this was the case when testing `create_proposal`, inserting into the mempool and destroying it was taking up much more overhead than `create_proposal`) you can use this perf utility to enable/disable sampling programmatically like so


```rust
use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
use monad_perf_util::PerfController;

struct State {/* ... */}

fn some_heavy_initialization_function() -> State {
    State {
        /* ... */
    }
}

fn function_you_want_to_measure(state: &State) {
    /* ... */
}

fn criterion_benchmark(c: &mut Criterion) {
    let mut group = c.benchmark_group("bench");

    let mut perf = PerfController::from_env().unwrap();
    group.bench_function("bench", |b| {
        b.iter_batched_ref(
            some_heavy_initialization_function,
            |state| {
                perf.enable();
                function_you_want_to_measure(&state);
                perf.disable();
            },
            BatchSize::SmallInput,
        )
    });
}

criterion_group!(benches, criterion_benchmark);
criterion_main!(benches);

```

A convenience script is in https://github.com/monad-crypto/monad-bft/blob/db66c4c4c162d53cc93c97eede8009b517aeebe6/monad-scripts/bench/perf.sh