### PR TITLE
Retry blockdb intialization if consensus node not fully started

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -189,6 +189,9 @@ jobs:
       - run: cat /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages
       - run: cat /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages
 
+      - name: Get Execution Commit Hash
+        run: echo "GIT_COMMIT_HASH=$(git -C ${{ env.MONAD_EXECUTION_ROOT }} rev-parse HEAD)" >> $GITHUB_ENV
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5.3.0
         with:
@@ -198,6 +201,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            GIT_COMMIT_HASH=$(git -C ${{ env.MONAD_EXECUTION_ROOT }} rev-parse HEAD)
+            GIT_COMMIT_HASH=${{ env.GIT_COMMIT_HASH }}
           builder: ${{ steps.setup-buildx.outputs.name }}
           allow: security.insecure

--- a/docker/rpc/Dockerfile
+++ b/docker/rpc/Dockerfile
@@ -38,7 +38,7 @@ RUN apt install -y \
   liburing-dev \
   libzstd-dev
 
-FROM base as builder
+FROM base AS builder
 
 ######## BEGIN CMAKE
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
@@ -82,7 +82,7 @@ RUN --mount=type=cache,target=${CARGO_ROOT}/registry    \
     cp `ls -lt $(find target/release | grep lib${TRIEDB_TARGET}.so) | head -1 | awk '{print $9}'` .
 
 # Runner
-FROM base as runner
+FROM base AS runner
 WORKDIR /usr/src/monad-bft
 
 ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"

--- a/monad-blockdb-utils/src/lib.rs
+++ b/monad-blockdb-utils/src/lib.rs
@@ -25,7 +25,7 @@ pub struct BlockDbEnv {
 }
 
 impl BlockDbEnv {
-    pub fn new(blockdb_path: &Path) -> Option<Self> {
+    pub fn new(blockdb_path: &Path) -> Result<Self, std::io::Error> {
         // unsafe because of the flag function for lmdb options
         unsafe {
             let blockdb_env = EnvOpenOptions::new()
@@ -54,7 +54,7 @@ impl BlockDbEnv {
                         .expect("block_tag_dbi should exist")
                         .unwrap();
 
-                    Some(Self {
+                    Ok(Self {
                         blockdb_env: env,
                         block_dbi,
                         block_num_dbi,
@@ -62,7 +62,10 @@ impl BlockDbEnv {
                         block_tag_dbi,
                     })
                 }
-                Err(_) => None,
+                Err(_) => Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "cannot initialize blockdb env",
+                )),
             }
         }
     }


### PR DESCRIPTION
In relation to this commit: https://github.com/monad-crypto/monad-bft/pull/785 we also need to make sure that the blockdb is ready when starting the RPC node, otherwise we wouldn't be able to read from blockdb