### PR TITLE
Advance pacemaker epoch on block commit

### DIFF
--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -17,7 +17,6 @@ use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_types::{BlockId, Epoch, NodeId, Round, RouterTarget, TimeoutVariant};
-use monad_validator::epoch_manager::EpochManager;
 
 /// Command type that the consensus state-machine outputs
 /// This is converted to a monad-executor-glue::Command at the top-level monad-state
@@ -70,12 +69,11 @@ where
         keypair: &ST::KeyPairType,
         cert_keypair: &SignatureCollectionKeyPairType<SCT>,
         version: &str,
-        epoch_manager: &EpochManager,
         cmd: PacemakerCommand<SCT>,
     ) -> Self {
         match cmd {
-            PacemakerCommand::EnterRound(round) => {
-                ConsensusCommand::EnterRound(epoch_manager.get_epoch(round), round)
+            PacemakerCommand::EnterRound((epoch, round)) => {
+                ConsensusCommand::EnterRound(epoch, round)
             }
             PacemakerCommand::PrepareTimeout(tmo) => ConsensusCommand::Publish {
                 target: RouterTarget::Broadcast(tmo.tminfo.epoch, tmo.tminfo.round),

--- a/monad-state/src/consensus.rs
+++ b/monad-state/src/consensus.rs
@@ -129,14 +129,13 @@ where
             ConsensusEvent::Timeout(tmo_event) => match tmo_event {
                 TimeoutVariant::Pacemaker => self
                     .consensus
-                    .handle_timeout_expiry(self.node_state.epoch_manager, self.node_state.metrics)
+                    .handle_timeout_expiry(self.node_state.metrics)
                     .into_iter()
                     .map(|cmd| {
                         ConsensusCommand::from_pacemaker_command(
                             self.consensus.get_keypair(),
                             self.consensus.get_cert_keypair(),
                             self.node_state.version,
-                            self.node_state.epoch_manager,
                             cmd,
                         )
                     })


### PR DESCRIPTION
Committing boundary block might update the epoch manager records and bumps the current epoch. Pacemaker now tracks the current epoch number and sync with latest epoch manager records on every block commit