### PR TITLE
Virtual Mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3909,6 +3909,7 @@ name = "monad-state"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "itertools 0.10.5",
  "monad-async-state-verify",
  "monad-blocktree",
  "monad-bls",

--- a/monad-debugger/src/graphql.rs
+++ b/monad-debugger/src/graphql.rs
@@ -260,7 +260,7 @@ impl<'s> GraphQLValidatorEvent<'s> {
     }
 }
 
-struct GraphQLMempoolEvent<'s>(&'s MempoolEvent);
+struct GraphQLMempoolEvent<'s>(&'s MempoolEvent<CertificateSignaturePubKey<SignatureType>>);
 #[Object]
 impl<'s> GraphQLMempoolEvent<'s> {
     async fn debug(&self) -> String {

--- a/monad-ipc/examples/ipc_receiver.rs
+++ b/monad-ipc/examples/ipc_receiver.rs
@@ -143,7 +143,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         debug!("received tx");
                     }
                 }
-                MempoolEvent::Clear => {}
+                MempoolEvent::ForwardedTxns { .. } | MempoolEvent::Clear => {}
             },
 
             _ => Err("Wrong MonadEvent variant")?,

--- a/monad-mock-swarm/src/transformer.rs
+++ b/monad-mock-swarm/src/transformer.rs
@@ -60,6 +60,7 @@ where
             VerifiedMonadMessage::BlockSyncRequest(_)
             | VerifiedMonadMessage::BlockSyncResponse(_) => self.drop_block_sync,
             VerifiedMonadMessage::PeerStateRootMessage(_) => self.drop_state_root,
+            VerifiedMonadMessage::ForwardedTx(_) => false,
         };
 
         if should_drop {
@@ -152,6 +153,10 @@ where
                 } else {
                     TwinsCapture::Spread(pid)
                 }
+            }
+            VerifiedMonadMessage::ForwardedTx(_) => {
+                // is this correct?
+                TwinsCapture::Drop
             }
         };
 

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -86,10 +86,16 @@ message ProtoUserTx {
 
 message ProtoClearMempool {}
 
+message ProtoForwardedTxs {
+  monad_proto.basic.ProtoNodeId sender = 1;
+  monad_proto.message.ProtoForwardedTx forwarded_tx = 2;
+}
+
 message ProtoMempoolEvent {
   oneof event {
     ProtoUserTx usertx = 1;
-    ProtoClearMempool clear = 2;
+    ProtoForwardedTxs forwarded_txs = 2;
+    ProtoClearMempool clear = 3;
   }
 }
 

--- a/monad-proto/proto/message.proto
+++ b/monad-proto/proto/message.proto
@@ -52,11 +52,16 @@ message ProtoPeerStateRootMessage {
   monad_proto.signing.ProtoSignature sig = 3;
 }
 
+message ProtoForwardedTx {
+  repeated bytes tx = 1;
+}
+
 message ProtoMonadMessage {
   oneof OneofMessage {
     ProtoUnverifiedConsensusMessage consensus = 1;
     ProtoRequestBlockSyncMessage block_sync_request = 2;
     ProtoBlockSyncMessage block_sync_response = 3;
     ProtoPeerStateRootMessage peer_state_root = 4;
+    ProtoForwardedTx forwarded_tx = 5;
   }
 }

--- a/monad-state/Cargo.toml
+++ b/monad-state/Cargo.toml
@@ -23,8 +23,9 @@ monad-types = { path = "../monad-types" }
 monad-validator = { path = "../monad-validator" }
 
 bytes = { workspace = true }
-tracing = { workspace = true }
+itertools = { workspace = true }
 prost = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 monad-bls = { path = "../monad-bls" }

--- a/monad-state/src/convert/message.rs
+++ b/monad-state/src/convert/message.rs
@@ -26,6 +26,11 @@ where
                 VerifiedMonadMessage::PeerStateRootMessage(msg) => {
                     proto_monad_message::OneofMessage::PeerStateRoot(msg.into())
                 }
+                VerifiedMonadMessage::ForwardedTx(msg) => {
+                    proto_monad_message::OneofMessage::ForwardedTx(ProtoForwardedTx {
+                        tx: (*msg).clone(),
+                    })
+                }
             }),
         }
     }
@@ -51,6 +56,9 @@ where
             }
             Some(proto_monad_message::OneofMessage::PeerStateRoot(msg)) => {
                 MonadMessage::PeerStateRoot(msg.try_into()?)
+            }
+            Some(proto_monad_message::OneofMessage::ForwardedTx(msg)) => {
+                MonadMessage::ForwardedTx(msg.tx)
             }
             None => Err(ProtoError::MissingRequiredField(
                 "MonadMessage.oneofmessage".to_owned(),


### PR DESCRIPTION
This contains an implementation of the virtual mempool. Transactions from RPC are forwarded to the next K leaders.

Ideally we can test this in mock-swarm, but need to add some infrastructure in mock-swarm for that. Might be easier to test this in flexnet in the interim.