### PR TITLE
Name images in docker compose

### DIFF
--- a/docker/flexnet/nets/devnet-integration/compose.yaml
+++ b/docker/flexnet/nets/devnet-integration/compose.yaml
@@ -27,6 +27,7 @@ services:
     build:
       context: ${MONAD_BFT_ROOT}
       dockerfile: ${DEVNET_DIR}/Dockerfile
+    image: monad-node:latest
     depends_on:
       - monad_execution
     environment:
@@ -38,6 +39,7 @@ services:
     build:
       context: ${MONAD_BFT_ROOT}
       dockerfile: ${RPC_DIR}/Dockerfile
+    image: monad-rpc:latest
     depends_on:
       - monad_node
     volumes:

--- a/docker/flexnet/nets/net0/compose.yaml
+++ b/docker/flexnet/nets/net0/compose.yaml
@@ -15,7 +15,7 @@ services:
     build:
       context: ${MONAD_BFT_ROOT}
       dockerfile: ${FLEXNET_IMAGE_ROOT}/rpc/Dockerfile
-    image: rpc:latest
+    image: flexnet-rpc:latest
 
   runner_python:
     build:
@@ -32,7 +32,7 @@ services:
     entrypoint: ["bash", "/monad/scripts/run.sh"]
 
   rpc0:
-    image: rpc:latest
+    image: flexnet-rpc:latest
     volumes:
       - ./node0:/monad
     expose:


### PR DESCRIPTION
devnet-integration was building new images every run. Naming them to make re-runs faster. Renaming flexnet images to `flexnet-rpc` to avoid confusion