### PR TITLE
Debug control panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,6 +1802,22 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
@@ -2045,6 +2061,12 @@ dependencies = [
  "quote",
  "syn 2.0.39",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "ecdsa"
@@ -2383,6 +2405,24 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -2820,6 +2860,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "inquire"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
+dependencies = [
+ "bitflags 2.4.1",
+ "crossterm 0.25.0",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "fxhash",
+ "newline-converter",
+ "once_cell",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3367,6 +3424,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-control-panel"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "bincode",
+ "futures",
+ "inquire",
+ "monad-bls",
+ "monad-consensus-types",
+ "monad-crypto",
+ "monad-executor",
+ "monad-executor-glue",
+ "monad-secp",
+ "monad-types",
+ "serde",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "monad-crypto"
 version = "0.1.0"
 dependencies = [
@@ -3541,6 +3619,7 @@ dependencies = [
  "monad-types",
  "prost",
  "reth-primitives",
+ "serde",
 ]
 
 [[package]]
@@ -3718,6 +3797,7 @@ dependencies = [
  "monad-bls",
  "monad-consensus-state",
  "monad-consensus-types",
+ "monad-control-panel",
  "monad-crypto",
  "monad-eth-block-policy",
  "monad-eth-block-validator",
@@ -3951,6 +4031,7 @@ dependencies = [
  "monad-blocktree",
  "monad-consensus-state",
  "monad-consensus-types",
+ "monad-control-panel",
  "monad-crypto",
  "monad-eth-types",
  "monad-executor",
@@ -4181,7 +4262,7 @@ dependencies = [
  "chrono",
  "clap 4.4.10",
  "criterion",
- "crossterm",
+ "crossterm 0.27.0",
  "itertools 0.10.5",
  "monad-bls",
  "monad-consensus",
@@ -4260,6 +4341,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "newline-converter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -5234,7 +5324,7 @@ dependencies = [
  "bitflags 2.4.1",
  "cassowary",
  "compact_str",
- "crossterm",
+ "crossterm 0.27.0",
  "indoc 2.0.4",
  "itertools 0.12.0",
  "lru",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "monad-blockdb-utils",
     "monad-blocktree",
     "monad-bls",
+    "monad-control-panel",
     "monad-compress",
     "monad-consensus",
     "monad-consensus-state",
@@ -108,6 +109,7 @@ heed = "0.11.0"
 hex = "0.4"
 hex-literal = "0.4"
 inventory = "0.3"
+inquire = "0.7"
 itertools = "0.10"
 async-graphql = "7.0"
 libc = "0.2.153"

--- a/docker/devnet/Dockerfile
+++ b/docker/devnet/Dockerfile
@@ -98,6 +98,7 @@ CMD monad-node \
     --forkpoint-config /monad/config/forkpoint.toml \
     --wal-path /monad/wal \
     --mempool-ipc-path /monad/mempool.sock \
+    --control-panel-ipc-path /monad/controlpanel.sock \
     --execution-ledger-path /monad/ledger \
     --blockdb-path /monad/blockdb \
     --triedb-path /monad/triedb

--- a/docker/flexnet/common/run-gen.py
+++ b/docker/flexnet/common/run-gen.py
@@ -20,6 +20,7 @@ monad-node \\
     --wal-path /monad/wal \\
     --blockdb-path /monad/blockdb \\
     --mempool-ipc-path /monad/mempool.sock \\
+    --control-panel-ipc-path /monad/controlpanel.sock \
     --execution-ledger-path /monad/ledger > /monad/logs/client.log 2>&1
 """
 

--- a/docker/flexnet/nets/full-nodes/node0/scripts/run.sh
+++ b/docker/flexnet/nets/full-nodes/node0/scripts/run.sh
@@ -9,6 +9,7 @@ monad-node \
     --forkpoint-config /monad/config/forkpoint.toml \
     --wal-path /monad/wal \
     --mempool-ipc-path /monad/mempool.sock \
+    --control-panel-ipc-path /monad/controlpanel.sock \
     --execution-ledger-path /monad/ledger \
     --blockdb-path /monad/blockdb \
     --triedb-path /monad/triedb \

--- a/docker/flexnet/nets/full-nodes/node1/scripts/run.sh
+++ b/docker/flexnet/nets/full-nodes/node1/scripts/run.sh
@@ -9,6 +9,7 @@ monad-node \
     --forkpoint-config /monad/config/forkpoint.toml \
     --wal-path /monad/wal \
     --mempool-ipc-path /monad/mempool.sock \
+    --control-panel-ipc-path /monad/controlpanel.sock \
     --execution-ledger-path /monad/ledger \
     --blockdb-path /monad/blockdb \
     --triedb-path /monad/triedb \

--- a/docker/flexnet/nets/full-nodes/node2/scripts/run.sh
+++ b/docker/flexnet/nets/full-nodes/node2/scripts/run.sh
@@ -9,6 +9,7 @@ monad-node \
     --forkpoint-config /monad/config/forkpoint.toml \
     --wal-path /monad/wal \
     --mempool-ipc-path /monad/mempool.sock \
+    --control-panel-ipc-path /monad/controlpanel.sock \
     --execution-ledger-path /monad/ledger \
     --blockdb-path /monad/blockdb \
     --triedb-path /monad/triedb \

--- a/docker/flexnet/nets/full-nodes/node3/scripts/run.sh
+++ b/docker/flexnet/nets/full-nodes/node3/scripts/run.sh
@@ -9,6 +9,7 @@ monad-node \
     --forkpoint-config /monad/config/forkpoint.toml \
     --wal-path /monad/wal \
     --mempool-ipc-path /monad/mempool.sock \
+    --control-panel-ipc-path /monad/controlpanel.sock \
     --execution-ledger-path /monad/ledger \
     --blockdb-path /monad/blockdb \
     --triedb-path /monad/triedb \

--- a/docker/flexnet/nets/net1/node0/scripts/run.sh
+++ b/docker/flexnet/nets/net1/node0/scripts/run.sh
@@ -12,5 +12,6 @@ monad-node \
     --wal-path /monad/wal \
     --blockdb-path /monad/blockdb \
     --mempool-ipc-path /monad/mempool.sock \
+    --control-panel-ipc-path /monad/controlpanel.sock \
     --execution-ledger-path /monad/ledger \
     test-mode > /monad/logs/client.log 2>&1

--- a/docker/flexnet/nets/net1/node1/scripts/run.sh
+++ b/docker/flexnet/nets/net1/node1/scripts/run.sh
@@ -12,5 +12,6 @@ monad-node \
     --wal-path /monad/wal \
     --blockdb-path /monad/blockdb \
     --mempool-ipc-path /monad/mempool.sock \
+    --control-panel-ipc-path /monad/controlpanel.sock \
     --execution-ledger-path /monad/ledger \
     test-mode --byzantine-execution > /monad/logs/client.log 2>&1

--- a/docker/flexnet/nets/net1/node2/scripts/run.sh
+++ b/docker/flexnet/nets/net1/node2/scripts/run.sh
@@ -12,5 +12,6 @@ monad-node \
     --wal-path /monad/wal \
     --blockdb-path /monad/blockdb \
     --mempool-ipc-path /monad/mempool.sock \
+    --control-panel-ipc-path /monad/controlpanel.sock \
     --execution-ledger-path /monad/ledger \
     test-mode > /monad/logs/client.log 2>&1

--- a/docker/flexnet/nets/net1/node3/scripts/run.sh
+++ b/docker/flexnet/nets/net1/node3/scripts/run.sh
@@ -12,5 +12,6 @@ monad-node \
     --wal-path /monad/wal \
     --blockdb-path /monad/blockdb \
     --mempool-ipc-path /monad/mempool.sock \
+    --control-panel-ipc-path /monad/controlpanel.sock \
     --execution-ledger-path /monad/ledger \
     test-mode > /monad/logs/client.log 2>&1

--- a/monad-consensus-types/src/metrics.rs
+++ b/monad-consensus-types/src/metrics.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Default, Clone, Copy)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
 pub struct ValidationErrors {
     pub invalid_author: u64,
     pub not_well_formed_sig: u64,
@@ -13,7 +15,7 @@ pub struct ValidationErrors {
     pub invalid_epoch: u64,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
 pub struct ConsensusEvents {
     pub local_timeout: u64,
     pub handle_proposal: u64,
@@ -47,14 +49,14 @@ pub struct ConsensusEvents {
     pub trigger_state_sync: u64,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
 pub struct BlocktreeEvents {
     pub prune_success: u64,
     pub add_success: u64,
     pub add_dup: u64,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
 pub struct BlocksyncEvents {
     pub blocksync_response_successful: u64,
     pub blocksync_response_failed: u64,
@@ -62,7 +64,7 @@ pub struct BlocksyncEvents {
     pub blocksync_request: u64,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
 pub struct Metrics {
     pub validation_errors: ValidationErrors,
     pub consensus_events: ConsensusEvents,

--- a/monad-control-panel/Cargo.toml
+++ b/monad-control-panel/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "monad-control-panel"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+# this is necessary for criterion bench options
+# https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false
+
+[[bin]]
+name = "control-panel"
+path = "src/bin/control_panel.rs"
+bench = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+alloy-primitives = { workspace = true }
+bincode = { workspace = true }
+futures = { workspace = true }
+inquire = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = [
+    "io-util",
+    "macros",
+    "net",
+    "rt-multi-thread",
+    "time",
+] }
+tokio-util = { workspace = true, features = ["codec"] }
+tracing = { workspace = true }
+
+monad-bls = { path = "../monad-bls" }
+monad-consensus-types = { path = "../monad-consensus-types" }
+monad-crypto = { path = "../monad-crypto" }
+monad-executor = { path = "../monad-executor" }
+monad-executor-glue = { path = "../monad-executor-glue" }
+monad-types = { path = "../monad-types" }
+monad-secp = { path = "../monad-secp" }

--- a/monad-control-panel/src/bin/control_panel.rs
+++ b/monad-control-panel/src/bin/control_panel.rs
@@ -1,0 +1,126 @@
+use std::io::Error;
+
+use futures::{sink::SinkExt, StreamExt};
+use inquire::{Confirm, InquireError, Select};
+use monad_bls::BlsSignatureCollection;
+use monad_crypto::certificate_signature::CertificateSignaturePubKey;
+use monad_executor_glue::{
+    ClearMetrics, ControlPanelCommand, GetValidatorSet, ReadCommand, WriteCommand,
+};
+use monad_secp::SecpSignature;
+use tokio::net::UnixStream;
+use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
+
+const COMMANDS: [&str; 3] = ["validators", "update-validators", "clear-metrics"];
+
+type SignatureType = SecpSignature;
+type SignatureCollectionType = BlsSignatureCollection<CertificateSignaturePubKey<SignatureType>>;
+type Command = ControlPanelCommand<SignatureCollectionType>;
+
+fn main() -> Result<(), i32> {
+    let mut args = std::env::args();
+    if args.len() != 2 {
+        eprintln!("ERROR: pass in the path to the node control panel IPC socket");
+        return Err(-1);
+    }
+    let socket_path = args.nth(1).unwrap();
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let (mut read, mut write) = rt
+        .block_on(async move {
+            let client_stream = UnixStream::connect(socket_path.as_str()).await?;
+
+            let (read, write) = client_stream.into_split();
+
+            let read = FramedRead::new(read, LengthDelimitedCodec::default());
+            let write = FramedWrite::new(write, LengthDelimitedCodec::default());
+
+            Ok::<_, Error>((read, write))
+        })
+        .map_err(|e| {
+            eprintln!("failed to initialize socket {:?}", e);
+            -1
+        })?;
+
+    loop {
+        let available_commands: Vec<&'static str> = Vec::from(COMMANDS);
+        let command = rt.block_on(async {
+            Select::new("monad-consensus-cli $", available_commands)
+                .with_help_message("↑-↓ or j-k to move, enter to select, type to filter]")
+                .with_vim_mode(true)
+                .prompt()
+        });
+
+        match command {
+            Ok(command) => match command {
+                "validators" => {
+                    let request =
+                        Command::Read(ReadCommand::GetValidatorSet(GetValidatorSet::Request));
+                    let bytes = bincode::serialize(&request).unwrap();
+                    if let Err(e) = rt.block_on(write.send(bytes.into())) {
+                        println!("Failed to send command {:?} to server: {:?}", &request, e);
+                        continue;
+                    };
+
+                    let Some(Ok(response)) = rt.block_on(read.next()) else {
+                        println!("Did not receive response from server");
+                        continue;
+                    };
+
+                    let response = bincode::deserialize::<
+                        ControlPanelCommand<SignatureCollectionType>,
+                    >(&response)
+                    .unwrap();
+
+                    dbg!(response);
+                }
+                "clear-metrics" => {
+                    let Ok(confirmation) = rt.block_on(async {
+                        Confirm::new("Are you sure you want to reset metrics?")
+                            .with_default(false)
+                            .with_help_message("This will set all metrics/counters/stats to zero.")
+                            .prompt()
+                    }) else {
+                        eprintln!("Error getting confirmation. Try again.");
+                        continue;
+                    };
+
+                    if !confirmation {
+                        println!("Interrupted reset metrics.");
+                        continue;
+                    }
+
+                    let request = Command::Write(WriteCommand::ClearMetrics(ClearMetrics::Request));
+                    let bytes = bincode::serialize(&request).unwrap();
+                    if let Err(e) = rt.block_on(write.send(bytes.into())) {
+                        println!("Failed to send command {:?} to server: {:?}", &request, e);
+                        continue;
+                    };
+
+                    let Some(Ok(response)) = rt.block_on(read.next()) else {
+                        println!("Did not receive response from server");
+                        continue;
+                    };
+
+                    let response = bincode::deserialize::<
+                        ControlPanelCommand<SignatureCollectionType>,
+                    >(&response)
+                    .unwrap();
+
+                    dbg!(response);
+                    println!("🔥 metrics reset 🔥");
+                }
+                _ => println!("Unknown command `{command}`"),
+            },
+            Err(e) => match e {
+                InquireError::OperationInterrupted => {
+                    println!();
+                    break;
+                }
+                _ => panic!("unhandled error {:?}", e),
+            },
+        }
+    }
+
+    Ok(())
+}

--- a/monad-control-panel/src/ipc.rs
+++ b/monad-control-panel/src/ipc.rs
@@ -1,0 +1,176 @@
+use std::{
+    path::PathBuf,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{SinkExt, Stream, StreamExt};
+use monad_consensus_types::signature_collection::SignatureCollection;
+use monad_crypto::certificate_signature::{
+    CertificateSignaturePubKey, CertificateSignatureRecoverable,
+};
+use monad_executor::Executor;
+use monad_executor_glue::{
+    ClearMetrics, ControlPanelCommand, ControlPanelEvent, GetValidatorSet, MonadEvent, ReadCommand,
+    WriteCommand,
+};
+use tokio::{
+    net::{unix::OwnedReadHalf, UnixListener},
+    sync::{broadcast, mpsc},
+};
+use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
+use tracing::{debug, error, warn};
+
+pub struct ControlPanelIpcReceiver<ST, SCT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+{
+    receiver: mpsc::Receiver<MonadEvent<ST, SCT>>,
+    client_sender: broadcast::Sender<ControlPanelCommand<SCT>>,
+}
+
+impl<ST, SCT> Stream for ControlPanelIpcReceiver<ST, SCT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+{
+    type Item = MonadEvent<ST, SCT>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.receiver.poll_recv(cx)
+    }
+}
+
+impl<ST, SCT> ControlPanelIpcReceiver<ST, SCT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+{
+    pub fn new(bind_path: PathBuf, buf_size: usize) -> Result<Self, std::io::Error> {
+        let (sender, receiver) = mpsc::channel(buf_size);
+        let (client_sender, _client_receiver) =
+            broadcast::channel::<ControlPanelCommand<SCT>>(buf_size);
+        let client_sender_clone = client_sender.clone();
+
+        let r = Self {
+            receiver,
+            client_sender,
+        };
+
+        let listener = UnixListener::bind(bind_path)?;
+        tokio::spawn(async move {
+            loop {
+                match listener.accept().await {
+                    Ok((stream, sockaddr)) => {
+                        debug!("new ipc connection sockaddr={:?}", sockaddr);
+
+                        let (read, write) = stream.into_split();
+
+                        let read = FramedRead::new(read, LengthDelimitedCodec::default());
+                        let mut write = FramedWrite::new(write, LengthDelimitedCodec::default());
+
+                        let mut client_receiver = client_sender_clone.subscribe();
+                        tokio::spawn(async move {
+                            while let Ok(command) = client_receiver.recv().await {
+                                let Ok(encoded) = bincode::serialize(&command) else {
+                                    error!("failed to serialize {:?} message to client", &command);
+                                    continue;
+                                };
+
+                                if let Err(e) = write.send(encoded.into()).await {
+                                    error!("failed to send {:?} to client, they likely disconnected, exiting loop: {:?}", &command, e);
+                                    break;
+                                }
+                            }
+                        });
+
+                        ControlPanelIpcReceiver::new_connection(read, sender.clone()).await;
+                    }
+                    Err(err) => {
+                        warn!("listener poll accept error={:?}", err);
+                        // TODO-2: handle error
+                        todo!("ipc listener error");
+                    }
+                }
+            }
+        });
+
+        Ok(r)
+    }
+
+    async fn new_connection(
+        mut read: FramedRead<OwnedReadHalf, LengthDelimitedCodec>,
+        event_channel: mpsc::Sender<MonadEvent<ST, SCT>>,
+    ) {
+        while let Some(Ok(bytes)) = read.next().await {
+            debug!("control panel ipc server bytes: {:?}", &bytes);
+
+            let Ok(request) = bincode::deserialize::<ControlPanelCommand<SCT>>(&bytes) else {
+                error!(
+                    "failed to deserialize bytes from client {:?}, closing connection",
+                    &bytes
+                );
+                break;
+            };
+
+            debug!("control panel ipc request: {:?}", request);
+
+            match request {
+                ControlPanelCommand::Read(r) => match r {
+                    ReadCommand::GetValidatorSet(v) => match v {
+                        GetValidatorSet::Request => {
+                            let event =
+                                MonadEvent::ControlPanelEvent(ControlPanelEvent::GetValidatorSet);
+                            let Ok(_) = event_channel.send(event.clone()).await else {
+                                error!("failed to forward request {:?} to executor, closing connection", &event);
+                                break;
+                            };
+                        }
+                        m => error!("unhandled message {:?}", m),
+                    },
+                },
+                ControlPanelCommand::Write(w) => match w {
+                    WriteCommand::ClearMetrics(clear_metrics) => match clear_metrics {
+                        ClearMetrics::Request => {
+                            let event =
+                                MonadEvent::ControlPanelEvent(ControlPanelEvent::ClearMetricsEvent);
+                            let Ok(_) = event_channel.send(event.clone()).await else {
+                                error!("failed to forward request {:?} to executor, closing connection", &event);
+                                break;
+                            };
+                        }
+                        m => error!("unhandled message {:?}", m),
+                    },
+                    m => error!("unhandled message {:?}", m),
+                },
+            }
+        }
+    }
+}
+
+impl<ST, SCT> Executor for ControlPanelIpcReceiver<ST, SCT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+{
+    type Command = ControlPanelCommand<SCT>;
+
+    fn replay(&mut self, mut commands: Vec<Self::Command>) {
+        commands.retain(|command| match command {
+            ControlPanelCommand::Read(_) => false,
+            // commands that write/change state should be replayed
+            ControlPanelCommand::Write(_) => true,
+        });
+        self.exec(commands);
+    }
+
+    fn exec(&mut self, commands: Vec<Self::Command>) {
+        for command in commands {
+            debug!(num_clients = %self.client_sender.receiver_count(), "broadcasting {:?} to clients", &command);
+            self.client_sender
+                .send(command)
+                .expect("failed to broadcast command to clients");
+        }
+    }
+}

--- a/monad-control-panel/src/lib.rs
+++ b/monad-control-panel/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod ipc;
+
+#[cfg(test)]
+mod tests {}

--- a/monad-debugger/src/graphql.rs
+++ b/monad-debugger/src/graphql.rs
@@ -4,8 +4,8 @@ use async_graphql::{Context, NewType, Object, Union};
 use monad_consensus_types::{metrics::Metrics, state_root_hash::StateRootHashInfo};
 use monad_crypto::certificate_signature::{CertificateSignaturePubKey, PubKey};
 use monad_executor_glue::{
-    AsyncStateVerifyEvent, BlockSyncEvent, ConsensusEvent, MempoolEvent, MetricsEvent, MonadEvent,
-    ValidatorEvent,
+    AsyncStateVerifyEvent, BlockSyncEvent, ConsensusEvent, ControlPanelEvent, MempoolEvent,
+    MetricsEvent, MonadEvent, ValidatorEvent,
 };
 use monad_mock_swarm::{
     node::Node,
@@ -220,6 +220,7 @@ enum GraphQLMonadEvent<'s> {
     StateRootEvent(GraphQLStateRootEvent<'s>),
     AsyncStateVerifyEvent(GraphQLAsyncStateVerifyEvent<'s>),
     MetricsEvent(GraphQLMetricsEvent<'s>),
+    ControlPanelEvent(GraphQLControlPanelEvent<'s>),
 }
 
 impl<'s> From<&'s MonadEventType> for GraphQLMonadEvent<'s> {
@@ -234,6 +235,9 @@ impl<'s> From<&'s MonadEventType> for GraphQLMonadEvent<'s> {
                 Self::AsyncStateVerifyEvent(GraphQLAsyncStateVerifyEvent(event))
             }
             MonadEventType::MetricsEvent(event) => Self::MetricsEvent(GraphQLMetricsEvent(event)),
+            MonadEventType::ControlPanelEvent(event) => {
+                Self::ControlPanelEvent(GraphQLControlPanelEvent(event))
+            }
         }
     }
 }
@@ -290,6 +294,15 @@ struct GraphQLMetricsEvent<'s>(&'s MetricsEvent);
 
 #[Object]
 impl<'s> GraphQLMetricsEvent<'s> {
+    async fn debug(&self) -> String {
+        format!("{:?}", self.0)
+    }
+}
+
+struct GraphQLControlPanelEvent<'s>(&'s ControlPanelEvent);
+
+#[Object]
+impl<'s> GraphQLControlPanelEvent<'s> {
     async fn debug(&self) -> String {
         format!("{:?}", self.0)
     }

--- a/monad-executor-glue/Cargo.toml
+++ b/monad-executor-glue/Cargo.toml
@@ -23,6 +23,7 @@ bincode = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 prost = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 monad-multi-sig = { path = "../monad-multi-sig" }

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -179,6 +179,7 @@ impl<S: SwarmRelation> Executor for MockExecutor<S> {
             state_root_hash_cmds,
             loopback_cmds,
             metrics_cmds,
+            control_panel_cmds,
         ) = Self::Command::split_commands(commands);
 
         for command in timer_cmds {
@@ -229,6 +230,7 @@ impl<S: SwarmRelation> Executor for MockExecutor<S> {
             state_root_hash_cmds,
             loopback_cmds,
             metrics_cmds,
+            control_panel_cmds,
         ) = Self::Command::split_commands(commands);
 
         for command in timer_cmds {

--- a/monad-node/Cargo.toml
+++ b/monad-node/Cargo.toml
@@ -18,6 +18,7 @@ name = "genesis_config_upgrade"
 
 [dependencies]
 monad-async-state-verify = { path = "../monad-async-state-verify" }
+monad-control-panel = { path = "../monad-control-panel" }
 monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-blockdb = { path = "../monad-blockdb" }

--- a/monad-node/README.md
+++ b/monad-node/README.md
@@ -5,5 +5,5 @@ Starting a Monad consensus node generates a blockdb directory, a ledger director
 Run the following in the repo root directory:
 1. `export RUST_LOG=info`
     - The logging level can be adjusted as needed.
-2. `cargo run --bin monad-node -- --secp-identity docker/devnet/monad/config/id-secp --bls-identity docker/devnet/monad/config/id-bls --node-config docker/devnet/monad/config/node.toml --forkpoint-config docker/devnet/monad/config/forkpoint.toml --wal-path docker/devnet/monad/wal --mempool-ipc-path docker/devnet/monad/mempool.sock --execution-ledger-path docker/devnet/monad/ledger --blockdb-path docker/devnet/monad/blockdb`
+2. `cargo run --bin monad-node -- --secp-identity docker/devnet/monad/config/id-secp --bls-identity docker/devnet/monad/config/id-bls --node-config docker/devnet/monad/config/node.toml --forkpoint-config docker/devnet/monad/config/forkpoint.toml --wal-path docker/devnet/monad/wal --mempool-ipc-path docker/devnet/monad/mempool.sock --control-panel-ipc-path docker/devnet/monad/controlpanel.sock --execution-ledger-path docker/devnet/monad/ledger --blockdb-path docker/devnet/monad/blockdb`
     - The generated files and directories path (`--wal-path`, `--mempool-ipc-path`, `--execution-ledger-path`, `--blockdb-path`) can be changed.

--- a/monad-node/src/cli.rs
+++ b/monad-node/src/cli.rs
@@ -43,6 +43,10 @@ pub struct Cli {
     #[arg(long)]
     pub triedb_path: PathBuf,
 
+    /// Set a custom monad control panel ipc path
+    #[arg(long)]
+    pub control_panel_ipc_path: PathBuf,
+
     /// Set the opentelemetry OTLP exporter endpoint
     #[arg(long)]
     pub otel_endpoint: Option<String>,

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -17,6 +17,7 @@ use monad_consensus_types::{
     payload::{NopStateRoot, StateRoot, StateRootValidator},
     state_root_hash::StateRootHash,
 };
+use monad_control_panel::ipc::ControlPanelIpcReceiver;
 use monad_crypto::{
     certificate_signature::{CertificateSignature, CertificateSignaturePubKey},
     hasher::Hash,
@@ -231,6 +232,8 @@ async fn run(
             val_set_update_interval,
         ),
         ipc: IpcReceiver::new(node_state.mempool_ipc_path, 1000).expect("uds bind failed"),
+        control_panel: ControlPanelIpcReceiver::new(node_state.control_panel_ipc_path, 1000)
+            .expect("uds bind failed"),
         loopback: LoopbackExecutor::default(),
         metrics: metrics_executor,
     };

--- a/monad-node/src/state.rs
+++ b/monad-node/src/state.rs
@@ -28,6 +28,7 @@ pub struct NodeState {
     pub wal_path: PathBuf,
     pub execution_ledger_path: PathBuf,
     pub mempool_ipc_path: PathBuf,
+    pub control_panel_ipc_path: PathBuf,
     pub blockdb_path: PathBuf,
     pub triedb_path: PathBuf,
     pub otel_endpoint: Option<String>,
@@ -81,6 +82,7 @@ impl NodeState {
             blockdb_path: cli.blockdb_path,
             triedb_path: cli.triedb_path,
             mempool_ipc_path: cli.mempool_ipc_path,
+            control_panel_ipc_path: cli.control_panel_ipc_path,
             otel_endpoint: cli.otel_endpoint,
             record_metrics_interval: cli
                 .record_metrics_interval_seconds

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -119,6 +119,16 @@ message ProtoMetricsEvent {
   }
 }
 
+message ProtoGetValidatorSetEvent {}
+message ProtoClearMetricsEvent {}
+
+message ProtoControlPanelEvent {
+  oneof event {
+    ProtoGetValidatorSetEvent get_validator_set_event = 1;
+    ProtoClearMetricsEvent clear_metrics_event = 2;
+  }
+}
+
 message ProtoMonadEvent{
   oneof event {
     ProtoConsensusEvent consensus_event = 1;
@@ -128,5 +138,6 @@ message ProtoMonadEvent{
     ProtoStateUpdateEvent state_root_event = 5;
     ProtoAsyncStateVerifyEvent async_state_verify_event = 6;
     ProtoMetricsEvent metrics_event = 7;
+    ProtoControlPanelEvent control_panel_event = 8;
   }
 }

--- a/monad-testground/Cargo.toml
+++ b/monad-testground/Cargo.toml
@@ -9,6 +9,7 @@ bench = false
 
 [dependencies]
 monad-blocktree = { path = "../monad-blocktree" }
+monad-control-panel = { path = "../monad-control-panel" }
 monad-consensus-state = { path = "../monad-consensus-state" }
 monad-consensus-types = { path = "../monad-consensus-types" }
 monad-crypto = { path = "../monad-crypto" }

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -10,6 +10,7 @@ use monad_consensus_types::{
     txpool::MockTxPool,
     validator_data::ValidatorSetData,
 };
+use monad_control_panel::ipc::ControlPanelIpcReceiver;
 use monad_crypto::certificate_signature::{
     CertificateSignature, CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
@@ -101,6 +102,7 @@ pub fn make_monad_executor<ST, SCT>(
     MockCheckpoint<Checkpoint<SCT>>,
     BoxUpdater<'static, StateRootHashCommand<Block<SCT>>, MonadEvent<ST, SCT>>,
     IpcReceiver<ST, SCT>,
+    ControlPanelIpcReceiver<ST, SCT>,
     LoopbackExecutor<MonadEvent<ST, SCT>>,
     NopMetricsExecutor<MonadEvent<ST, SCT>>,
 >
@@ -144,6 +146,8 @@ where
             )),
         },
         ipc: IpcReceiver::new(generate_uds_path().into(), 100).expect("uds bind failed"),
+        control_panel: ControlPanelIpcReceiver::new(generate_uds_path().into(), 1000)
+            .expect("usd bind failed"),
         loopback: LoopbackExecutor::default(),
         metrics: NopMetricsExecutor::default(),
     }

--- a/monad-wal/examples/wal-tool.rs
+++ b/monad-wal/examples/wal-tool.rs
@@ -443,6 +443,7 @@ impl Widget for &EventListWidget {
                 MonadEvent::StateRootEvent(_) => "STATEROOT".to_string(),
                 MonadEvent::AsyncStateVerifyEvent(_) => "ASYNCSTATEVERIFY".to_string(),
                 MonadEvent::MetricsEvent(_) => "METRICS".to_string(),
+                MonadEvent::ControlPanelEvent(_) => "CONTROLPANEL".to_string(),
             };
 
             let s = Span::styled(format!("{header_str:<20}"), Style::default().blue());
@@ -561,6 +562,7 @@ fn counter(events: &Vec<WalEvent>) -> HashMap<String, u64> {
             MonadEvent::StateRootEvent(_) => "staterootevent",
             MonadEvent::AsyncStateVerifyEvent(_) => "asyncstateverifyevent",
             MonadEvent::MetricsEvent(_) => "metricsevent",
+            WalEvent::ControlPanelEvent(_) => "controlpanelevent",
         };
 
         buckets


### PR DESCRIPTION
https://github.com/monad-crypto/monad-internal/issues/121

Implements support for a command-line based interactive node control
panel by adding a separate binary client that connects to the node
via unix domain socket, giving the client an interactive session for
sending commands to the node. Inside the node, we add an executor
for listening to client connections and issuing and responding to
debug events/commands

### Note

This adds a new required CLI flag to the monad node `--control-panel-ipc-path` that specifies where to place the socket file for listening.

Demo
![output](https://github.com/monad-crypto/monad-bft/assets/22534842/43bd577b-8b2c-45d8-ae19-69e5f3c53364)


Supported in this PR
- [x] Getting current validator set
- [ ] https://github.com/monad-crypto/monad-bft/pull/849
- [x] Clearing metrics/stats/counters
