### PR TITLE
human readable node_name CLI argument for observability

### DIFF
--- a/docker/devnet/clean.sh
+++ b/docker/devnet/clean.sh
@@ -3,6 +3,7 @@
 blockdb="./monad/blockdb"
 ledger="./monad/ledger"
 mempool_sock="./monad/mempool.sock"
+controlpanel_sock="./monad/controlpanel.sock"
 triedb="./monad/triedb"
 wal="./monad/wal"
 
@@ -21,6 +22,10 @@ fi
 
 if [ -S "$mempool_sock" ]; then
     rm "$mempool_sock"
+fi
+
+if [ -S "$controlpanel_sock" ]; then
+    rm "$controlpanel_sock"
 fi
 
 if [ -f "$wal" ]; then

--- a/monad-node/README.md
+++ b/monad-node/README.md
@@ -5,5 +5,5 @@ Starting a Monad consensus node generates a blockdb directory, a ledger director
 Run the following in the repo root directory:
 1. `export RUST_LOG=info`
     - The logging level can be adjusted as needed.
-2. `cargo run --bin monad-node -- --secp-identity docker/devnet/monad/config/id-secp --bls-identity docker/devnet/monad/config/id-bls --node-config docker/devnet/monad/config/node.toml --forkpoint-config docker/devnet/monad/config/forkpoint.toml --wal-path docker/devnet/monad/wal --mempool-ipc-path docker/devnet/monad/mempool.sock --control-panel-ipc-path docker/devnet/monad/controlpanel.sock --execution-ledger-path docker/devnet/monad/ledger --blockdb-path docker/devnet/monad/blockdb`
-    - The generated files and directories path (`--wal-path`, `--mempool-ipc-path`, `--execution-ledger-path`, `--blockdb-path`) can be changed.
+2. `cargo run --bin monad-node -- --secp-identity docker/devnet/monad/config/id-secp --bls-identity docker/devnet/monad/config/id-bls --node-config docker/devnet/monad/config/node.toml --forkpoint-config docker/devnet/monad/config/forkpoint.toml --wal-path docker/devnet/monad/wal --mempool-ipc-path docker/devnet/monad/mempool.sock --control-panel-ipc-path docker/devnet/monad/controlpanel.sock --execution-ledger-path docker/devnet/monad/ledger --blockdb-path docker/devnet/monad/blockdb --triedb-path <path_to_triedb>`
+    - The generated files and directories path (`--wal-path`, `--mempool-ipc-path`, `--control-panel-ipc-path`, `--execution-ledger-path`, `--blockdb-path`) can be changed.

--- a/monad-node/src/cli.rs
+++ b/monad-node/src/cli.rs
@@ -61,6 +61,7 @@ pub struct Cli {
     #[command(subcommand)]
     pub run_mode: Option<RunModeCommand>,
 
+    /// Set the time interval for metrics collection
     #[arg(long, requires = "otel_endpoint")]
     pub record_metrics_interval_seconds: Option<u64>,
 }

--- a/monad-node/src/config/mod.rs
+++ b/monad-node/src/config/mod.rs
@@ -25,6 +25,7 @@ pub type SignatureCollectionType =
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct NodeConfig {
+    pub name: Option<String>,
     #[serde(deserialize_with = "deserialize_eth_address_from_str")]
     pub beneficiary: EthAddress,
 

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -97,11 +97,8 @@ async fn wrapped_run(mut cmd: clap::Command) -> Result<(), ()> {
 
     // if provider is dropped, then traces stop getting sent silently...
     let maybe_provider = node_state.otel_endpoint.as_ref().map(|endpoint| {
-        build_otel_provider(
-            endpoint,
-            format!("monad-node-{:?}", &node_state.secp256k1_identity.pubkey()),
-        )
-        .expect("failed to build otel monad-node")
+        build_otel_provider(endpoint, node_state.node_name.clone())
+            .expect("failed to build otel monad-node")
     });
 
     let maybe_telemetry = if let Some(provider) = &maybe_provider {
@@ -205,7 +202,7 @@ async fn run(
             node_state.otel_endpoint.expect(
                 "cannot specify record metrics interval without specifying OpenTelemetry endpoint",
             ),
-            format!("monad-node-{:?}", &node_state.secp256k1_identity.pubkey()),
+            node_state.node_name.clone(),
             record_metrics_interval,
             /*enable_grpc_gzip=*/ false,
         ))


### PR DESCRIPTION
We can pass in a name when starting the node - this should allow easier mapping on the Grafana dashboard https://github.com/monad-crypto/monad-internal/issues/124