### PR TITLE
Sync latest block number in triedb and blockdb during rpc calls

### DIFF
--- a/monad-blockdb/README.md
+++ b/monad-blockdb/README.md
@@ -26,7 +26,8 @@ blockNumber => {
 Maps a block tag (*latest* or *finalized*) to its associated block hash. Since Monad BFT has single slot finality, the *latest* block is the same as the *finalized* block.
 ```
 blockTag => {
-    blockHash
+    blockHash,
+    blockNumber
 }
 ```
 

--- a/monad-rpc/src/call.rs
+++ b/monad-rpc/src/call.rs
@@ -273,11 +273,16 @@ pub async fn monad_eth_call(
 
     let block_number = match params.block {
         BlockTags::Default(_) => {
-            let TriedbResult::BlockNum(block_number) = triedb_env.get_latest_block().await else {
-                debug!("triedb did not have latest block header");
+            let TriedbResult::BlockNum(triedb_block_number) = triedb_env.get_latest_block().await
+            else {
+                debug!("triedb did not have latest block number");
                 return Err(JsonRpcError::internal_error());
             };
-            block_number
+            let Some(blockdb_block_number) = blockdb_env.get_latest_block().await else {
+                debug!("blockdb did not have latest block number");
+                return Err(JsonRpcError::internal_error());
+            };
+            std::cmp::min(triedb_block_number, blockdb_block_number.0)
         }
         BlockTags::Number(block_number) => block_number.0,
     };


### PR DESCRIPTION
It's possible for triedb to have a larger latest block number than blockdb, since blockdb is updated asynchronously by the executor, so there is no guarantee of ordering of which is finished updated first. When using the `latest` block tag, RPC should use the block number that is `min(triedb_latest_block, blockdb_latest_block)`, otherwise it wouldn't be able to retrieve from one of these dbs.