### PR TITLE
Stream blocks using file watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4024,6 +4024,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-stream"
+version = "0.1.0"
+dependencies = [
+ "clap 4.4.10",
+ "env_logger 0.10.1",
+ "futures",
+ "log",
+ "monad-blockdb",
+ "monad-blockdb-utils",
+ "notify",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "monad-testground"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "monad-rpc",
     "monad-secp",
     "monad-state",
+    "monad-stream",
     "monad-testground",
     "monad-testutil",
     "monad-tracing-counter",
@@ -51,7 +52,7 @@ members = [
     "monad-updaters",
     "monad-validator",
     "monad-virtual-bench",
-    "monad-wal",
+    "monad-wal"
 ]
 resolver = "2"
 

--- a/monad-blockdb-utils/Cargo.toml
+++ b/monad-blockdb-utils/Cargo.toml
@@ -11,4 +11,4 @@ monad-blockdb = { path = "../monad-blockdb" }
 
 heed = { workspace = true }
 rayon = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }

--- a/monad-stream/Cargo.toml
+++ b/monad-stream/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "monad-stream"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+bench = false
+
+[dependencies]
+monad-blockdb = { path = "../monad-blockdb" }
+monad-blockdb-utils = {path = "../monad-blockdb-utils" }
+
+futures = { workspace = true }
+pin-project = "1.1.5"
+tokio = { workspace = true, features = ["net", "macros"] }
+notify = "6.1.1"
+
+[dev-dependencies]
+clap = { workspace = true, features = ["derive"] }
+env_logger = { workspace = true }
+log = { workspace = true }
+
+[[example]]
+name = "blocks"
+

--- a/monad-stream/README.md
+++ b/monad-stream/README.md
@@ -1,0 +1,5 @@
+# monad-rpc
+
+```sh
+RUST_LOG=info TRIEDB_TARGET=triedb_driver cargo run --example blocks -- --triedb-path=<TRIEDB_PATH>  --blockdb-path=<BLOCKDB_PATH>
+```

--- a/monad-stream/examples/blocks.rs
+++ b/monad-stream/examples/blocks.rs
@@ -1,0 +1,38 @@
+use std::time;
+
+use clap::Parser;
+use futures::StreamExt;
+use log::info;
+
+#[derive(clap::Parser)]
+pub struct Args {
+    #[arg(long)]
+    pub triedb_path: std::path::PathBuf,
+    #[arg(long)]
+    pub blockdb_path: std::path::PathBuf,
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+    env_logger::try_init().expect("failed to initialize logger");
+
+    let deps = monad_stream::Deps::new(&args.blockdb_path).expect("database path is incorrect");
+    let mut stream = monad_stream::BlockStream::new(deps, &args.triedb_path);
+
+    let start = time::Instant::now();
+    let mut num_blocks = 0;
+    loop {
+        tokio::select! {
+            Some(block) = stream.next() => {
+                info!("block {} has {} txns", block.block.number, block.block.body.len());
+                num_blocks += 1;
+            },
+            _ = tokio::signal::ctrl_c() => {
+                info!("ctrl-c received, shutting down");
+                info!("processed {} blocks in {:?}", num_blocks, start.elapsed());
+                break;
+            }
+        };
+    }
+}

--- a/monad-stream/src/lib.rs
+++ b/monad-stream/src/lib.rs
@@ -1,0 +1,145 @@
+use std::{io::ErrorKind, path::Path, task::Poll};
+
+use futures::{executor::block_on, FutureExt, Stream};
+use monad_blockdb::BlockValue;
+use monad_blockdb_utils::BlockDbEnv;
+use notify::{Event, EventKind, RecursiveMode, Watcher};
+use pin_project::pin_project;
+
+#[derive(Clone)]
+pub struct Deps {
+    blockdb: BlockDbEnv,
+}
+
+impl Deps {
+    pub fn new(blockdb_path: &Path) -> std::io::Result<Self> {
+        Ok(Self {
+            blockdb: BlockDbEnv::new(blockdb_path)?,
+        })
+    }
+
+    pub async fn get_latest_block(&self) -> Option<BlockValue> {
+        self.blockdb
+            .get_block_by_tag(monad_blockdb_utils::BlockTags::Default(
+                monad_blockdb::BlockTagKey::Latest,
+            ))
+            .await
+    }
+}
+
+pub struct DbFileWatcher {
+    watcher: notify::INotifyWatcher,
+    rx: tokio::sync::mpsc::UnboundedReceiver<notify::Result<notify::Event>>,
+}
+
+impl DbFileWatcher {
+    pub fn try_new(path: &Path) -> std::io::Result<Self> {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<notify::Result<notify::Event>>();
+
+        let mut watcher = notify::INotifyWatcher::new(
+            move |res| {
+                block_on(async {
+                    tx.send(res).expect("inotify channel");
+                })
+            },
+            notify::Config::default(),
+        )
+        .map_err(|e| std::io::Error::new(ErrorKind::Other, e))?;
+
+        watcher
+            .watch(path, RecursiveMode::NonRecursive)
+            .map_err(|e| std::io::Error::new(ErrorKind::Other, e))?;
+
+        Ok(Self { watcher, rx })
+    }
+}
+
+impl Stream for DbFileWatcher {
+    type Item = bool;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        match self.rx.poll_recv(cx) {
+            Poll::Ready(Some(Ok(Event {
+                kind: EventKind::Modify(_),
+                ..
+            }))) => Poll::Ready(Some(true)),
+            Poll::Ready(_) => {
+                // TODO: waker
+                Poll::Pending
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[pin_project(project = StateProj)]
+enum State {
+    WaitingForBlock,
+    FetchBlock {
+        task: std::pin::Pin<Box<dyn futures::Future<Output = std::option::Option<BlockValue>>>>,
+    },
+}
+
+#[pin_project]
+pub struct BlockStream {
+    #[pin]
+    watcher: DbFileWatcher,
+    deps: Deps,
+    #[pin]
+    state: State,
+}
+
+impl BlockStream {
+    pub fn new(deps: Deps, path: &Path) -> Self {
+        Self {
+            watcher: DbFileWatcher::try_new(path).expect("failed to create blockdb watcher"),
+            deps,
+            state: State::WaitingForBlock,
+        }
+    }
+}
+
+impl Stream for BlockStream {
+    type Item = BlockValue;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let mut this = self.as_mut().project();
+        let mut state = this.state.as_mut();
+
+        match state.as_mut().project() {
+            StateProj::WaitingForBlock => match this.watcher.poll_next(cx) {
+                Poll::Ready(Some(true)) => {
+                    let deps = this.deps.clone();
+                    let task = async move { deps.get_latest_block().await };
+                    let task = Box::pin(task);
+                    state.set(State::FetchBlock { task });
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+                Poll::Ready(_) => {
+                    this.state.set(State::WaitingForBlock);
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+                Poll::Pending => Poll::Pending,
+            },
+            StateProj::FetchBlock { task } => match task.as_mut().poll_unpin(cx) {
+                Poll::Ready(Some(block)) => {
+                    this.state.set(State::WaitingForBlock);
+                    Poll::Ready(Some(block))
+                }
+                Poll::Ready(None) => {
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+                Poll::Pending => Poll::Pending,
+            },
+        }
+    }
+}


### PR DESCRIPTION
Adds an initial `monad-stream` implementation that watches database files and returns a stream of blocks. This will be useful for us when we want to expose a stream-oriented API and is a good building block for a gas oracle in RPC. Eventually, the file watcher can be a secondary backend with preference to a stream from execution.

```sh
# Example `blocks` stream
[2024-07-02T16:04:11Z INFO  blocks] block 1431 has 5 txns
[2024-07-02T16:04:12Z INFO  blocks] block 1432 has 6 txns
[2024-07-02T16:04:12Z INFO  blocks] block 1433 has 6 txns
[2024-07-02T16:04:12Z INFO  blocks] block 1434 has 5 txns
[2024-07-02T16:04:13Z INFO  blocks] block 1435 has 6 txns
[2024-07-02T16:04:13Z INFO  blocks] block 1436 has 6 txns
[2024-07-02T16:04:13Z INFO  blocks] ctrl-c received, shutting down
[2024-07-02T16:04:13Z INFO  blocks] processed 13 blocks in 4.25343985s
```