### PR TITLE
Force rebuild in devnet-integration

### DIFF
--- a/docker/flexnet/nets/devnet-integration/scripts/net-run.sh
+++ b/docker/flexnet/nets/devnet-integration/scripts/net-run.sh
@@ -152,7 +152,7 @@ elif [ "$mode" == "test" ]; then
     sed -i 's/ports:/expose:/g' compose.yaml
 
     docker compose build $build_services &&
-    docker compose up --detach $node_services
+    docker compose up --detach --build $node_services
     sleep 10
     docker compose down $node_services
 


### PR DESCRIPTION
We have both `build` and `image` set in monad_node and monad_rpc services. @mikety found that it pulls the existing image even if local files have changed. Adding `--build` to force rebuild