### PR TITLE
Add smart contract revert message in rpc response

### DIFF
--- a/monad-rpc/src/gas_handlers.rs
+++ b/monad-rpc/src/gas_handlers.rs
@@ -119,8 +119,8 @@ pub async fn monad_eth_estimateGas(
             gas_refund,
             ..
         }) => (gas_used, gas_refund),
-        monad_cxx::CallResult::Failure(error_message) => {
-            return Err(JsonRpcError::eth_call_error(error_message))
+        monad_cxx::CallResult::Failure(error) => {
+            return Err(JsonRpcError::eth_call_error(error.message, error.data))
         }
     };
 

--- a/monad-rpc/src/jsonrpc.rs
+++ b/monad-rpc/src/jsonrpc.rs
@@ -154,11 +154,11 @@ impl JsonRpcError {
         }
     }
 
-    pub fn eth_call_error(message: String) -> Self {
+    pub fn eth_call_error(message: String, data: Option<String>) -> Self {
         Self {
             code: -32000,
             message,
-            data: None,
+            data: data.map(Value::String),
         }
     }
 


### PR DESCRIPTION
If a smart contract transaction revert, we want to be able to pass the revert message in `eth_call` and `eth_estimateGas`. Tested and made sure it returns with the same format as geth. 

Closes https://github.com/monad-crypto/monad-internal/issues/337