### PR TITLE
Unit Test Coverage for Verify and Validate

### DIFF
--- a/monad-consensus/tests/proposal.rs
+++ b/monad-consensus/tests/proposal.rs
@@ -10,36 +10,48 @@ use monad_consensus_types::{
     ledger::CommitResult,
     payload::{ExecutionProtocol, FullTransactionList, Payload, RandaoReveal, TransactionPayload},
     quorum_certificate::{QcInfo, QuorumCertificate},
+    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
+    timeout::{HighQcRound, HighQcRoundSigColTuple, TimeoutCertificate, TimeoutInfo},
     validation::Error,
-    voting::{ValidatorMapping, Vote, VoteInfo},
+    voting::{Vote, VoteInfo},
 };
 use monad_crypto::{
-    certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey},
+    certificate_signature::{CertificateKeyPair, CertificateSignature, CertificateSignaturePubKey},
     hasher::Hash,
-    NopSignature,
+    NopKeyPair, NopPubKey, NopSignature,
 };
 use monad_eth_types::EthAddress;
+use monad_multi_sig::MultiSig;
 use monad_testutil::{
-    signing::{get_key, MockSignatures, TestSigner},
+    signing::{MockSignatures, TestSigner},
     validators::create_keys_w_validators,
 };
-use monad_types::{BlockId, Epoch, NodeId, Round, SeqNum, Stake};
+use monad_types::{BlockId, Epoch, NodeId, Round, SeqNum};
 use monad_validator::{
     epoch_manager::EpochManager,
-    validator_set::{ValidatorSetFactory, ValidatorSetType, ValidatorSetTypeFactory},
+    validator_set::{ValidatorSetFactory, ValidatorSetType},
     validators_epoch_mapping::ValidatorsEpochMapping,
 };
+use test_case::test_case;
 
 type SignatureType = NopSignature;
 type PubKeyType = CertificateSignaturePubKey<SignatureType>;
-type SignatureCollectionType = MockSignatures<SignatureType>;
+type MockSignatureCollectionType = MockSignatures<SignatureType>;
+type SignatureCollectionType = MultiSig<NopSignature>;
 
-fn setup_block_and_payload(
+static NUM_NODES: u32 = 4;
+static VAL_SET_UPDATE_INTERVAL: SeqNum = SeqNum(2000);
+static EPOCH_START_DELAY: Round = Round(50);
+
+fn setup_block(
     author: NodeId<PubKeyType>,
     block_epoch: Epoch,
     block_round: Round,
+    block_seq_num: SeqNum,
     qc_epoch: Epoch,
     qc_round: Round,
+    qc_parent_round: Round,
+    seq_num: SeqNum,
     signers: &[PubKeyType],
 ) -> (Block<MockSignatures<SignatureType>>, Payload) {
     let txns = TransactionPayload::List(FullTransactionList::new(vec![1, 2, 3, 4].into()));
@@ -48,17 +60,19 @@ fn setup_block_and_payload(
         epoch: qc_epoch,
         round: qc_round,
         parent_id: BlockId(Hash([0x00_u8; 32])),
-        parent_round: Round(0),
-        seq_num: SeqNum(0),
+        parent_round: qc_parent_round,
+        seq_num,
         timestamp: 0,
     };
-    let qc = QuorumCertificate::<MockSignatures<SignatureType>>::new(
-        QcInfo {
-            vote: Vote {
-                vote_info: vi,
-                ledger_commit_info: CommitResult::Commit,
-            },
+    let qcinfo = QcInfo {
+        vote: Vote {
+            vote_info: vi,
+            ledger_commit_info: CommitResult::Commit,
         },
+    };
+
+    let qc = QuorumCertificate::<MockSignatures<SignatureType>>::new(
+        qcinfo,
         MockSignatures::with_pubkeys(signers),
     );
 
@@ -72,7 +86,7 @@ fn setup_block_and_payload(
             block_round,
             &ExecutionProtocol {
                 state_root: Default::default(),
-                seq_num: SeqNum(1),
+                seq_num: block_seq_num,
                 beneficiary: EthAddress::default(),
                 randao_reveal: RandaoReveal::default(),
             },
@@ -83,36 +97,197 @@ fn setup_block_and_payload(
         payload,
     )
 }
+fn setup_val_state<SCT>(
+    known_epoch: Epoch,
+    known_round: Round,
+    val_epoch: Epoch,
+) -> (
+    Vec<<SignatureType as CertificateSignature>::KeyPairType>,
+    Vec<SignatureCollectionKeyPairType<SCT>>,
+    EpochManager,
+    ValidatorsEpochMapping<ValidatorSetFactory<CertificateSignaturePubKey<SignatureType>>, SCT>,
+)
+where
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<SignatureType>>,
+{
+    let (keypairs, certkeys, vset, vmap) = create_keys_w_validators::<SignatureType, SCT, _>(
+        NUM_NODES,
+        ValidatorSetFactory::default(),
+    );
 
-#[test]
-fn test_proposal_hash() {
-    let (keypairs, _certkeys, vset, vmap) = create_keys_w_validators::<
-        SignatureType,
-        SignatureCollectionType,
-        _,
-    >(1, ValidatorSetFactory::default());
-    let epoch_manager = EpochManager::new(SeqNum(2000), Round(50), &[(Epoch(1), Round(0))]);
-    let mut val_epoch_map: ValidatorsEpochMapping<ValidatorSetFactory<_>, SignatureCollectionType> =
+    let epoch_manager = EpochManager::new(
+        VAL_SET_UPDATE_INTERVAL,
+        EPOCH_START_DELAY,
+        &[(known_epoch, known_round)],
+    );
+    let mut val_epoch_map: ValidatorsEpochMapping<_, SCT> =
         ValidatorsEpochMapping::new(ValidatorSetFactory::default());
+
     val_epoch_map.insert(
-        Epoch(1),
+        val_epoch,
         vset.get_members().iter().map(|(a, b)| (*a, *b)).collect(),
         vmap,
     );
+
+    (keypairs, certkeys, epoch_manager, val_epoch_map)
+}
+
+fn define_proposal_with_tc(
+    known_epoch: Epoch,
+    known_round: Round,
+    val_epoch: Epoch,
+    block_epoch: Epoch,
+    block_round: Round,
+    block_seq_num: SeqNum,
+    qc_epoch: Epoch,
+    qc_round: Round,
+    qc_parent_round: Round,
+    qc_seq_num: SeqNum,
+    tc_epoch: Epoch,
+    tc_round: Round,
+) -> (
+    Vec<NopKeyPair>,
+    Vec<NopKeyPair>,
+    EpochManager,
+    ValidatorsEpochMapping<ValidatorSetFactory<NopPubKey>, MockSignatureCollectionType>,
+    ProposalMessage<MockSignatureCollectionType>,
+) {
+    let (keys, cert_keys, vset, vmap) = create_keys_w_validators::<
+        SignatureType,
+        MockSignatureCollectionType,
+        _,
+    >(NUM_NODES, ValidatorSetFactory::default());
+
+    // create valid QC
+    let vi = VoteInfo {
+        id: BlockId(Hash([0x09_u8; 32])),
+        epoch: qc_epoch,
+        round: qc_round,
+        parent_id: BlockId(Hash([0x00_u8; 32])),
+        parent_round: qc_parent_round,
+        seq_num: qc_seq_num,
+        timestamp: 0,
+    };
+
+    let qc = QuorumCertificate::<MockSignatures<SignatureType>>::new(
+        QcInfo {
+            vote: Vote {
+                vote_info: vi,
+                ledger_commit_info: CommitResult::Commit,
+            },
+        },
+        MockSignatures::with_pubkeys(
+            keys.iter()
+                .map(|kp| kp.pubkey())
+                .collect::<Vec<_>>()
+                .as_slice(),
+        ),
+    );
+
+    let high_qc_sig_tuple = HighQcRoundSigColTuple {
+        high_qc_round: HighQcRound {
+            qc_round: qc.get_round(),
+        },
+        sigs: MockSignatures::with_pubkeys(
+            keys.iter()
+                .map(|kp| kp.pubkey())
+                .collect::<Vec<_>>()
+                .as_slice(),
+        ),
+    };
+
+    let tc = TimeoutCertificate {
+        epoch: tc_epoch, // wrong epoch here
+        round: tc_round,
+        high_qc_rounds: vec![high_qc_sig_tuple],
+    };
+
+    // moved here because of valmap ownership
+    let epoch_manager = EpochManager::new(
+        VAL_SET_UPDATE_INTERVAL,
+        EPOCH_START_DELAY,
+        &[(known_epoch, known_round)],
+    );
+    let mut val_epoch_map: ValidatorsEpochMapping<
+        ValidatorSetFactory<_>,
+        MockSignatureCollectionType,
+    > = ValidatorsEpochMapping::new(ValidatorSetFactory::default());
+
+    val_epoch_map.insert(
+        val_epoch,
+        vset.get_members().iter().map(|(a, b)| (*a, *b)).collect(),
+        vmap,
+    );
+
+    let author = NodeId::new(keys[0].pubkey());
+
+    let (block, payload) = setup_block(
+        author,
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        &[keys[0].pubkey(), keys[1].pubkey(), keys[2].pubkey()],
+    );
+
+    let proposal = ProposalMessage {
+        block,
+        payload,
+        last_round_tc: Some(tc),
+    };
+
+    (keys, cert_keys, epoch_manager, val_epoch_map, proposal)
+}
+
+// test_verify tests hit all error messages in order of appearence
+// in the verify function. The error messages and their
+// related tests are the following:
+//  - test_verify_incorrect_block_epoch - Error::InvalidEpoch
+//  - test_verify_incorrect_validator_epoch - Error::ValidatorSetDataUnavailable
+//  - test_verify_invalid_author - Error::InvalidAuthor
+//  - test_verify_invalid_signature - Error::InvalidSignature
+//  - test_verify_author_not_sender - Error::AuthorNotSender
+//  - test_verify_proposal_happy - Success
+
+// epoch determined by block round does not exist in epoch manager
+#[test_case(Round(300), Round(234))]
+#[test_case(Round(9889), Round(8888))]
+fn test_verify_incorrect_block_epoch(known_round: Round, block_round: Round) {
+    let known_epoch = Epoch(2);
+    let val_epoch = Epoch(1);
+
+    let block_epoch = Epoch(1);
+    let block_seq_num = SeqNum(110);
+
+    let qc_epoch = Epoch(1);
+    let qc_round = Round(233);
+    let qc_parent_round = Round(0);
+    let qc_seq_num = SeqNum(0);
+
+    let (keypairs, _, epoch_manager, val_epoch_map) =
+        setup_val_state(known_epoch, known_round, val_epoch);
+
     let author = NodeId::new(keypairs[0].pubkey());
 
-    let (block, payload) = setup_block_and_payload(
+    let (block, payload) = setup_block(
         author,
-        epoch_manager.get_epoch(Round(234)).expect("epoch exists"),
-        Round(234),
-        epoch_manager.get_epoch(Round(233)).expect("epoch exists"),
-        Round(233),
-        keypairs
-            .iter()
-            .map(|kp| kp.pubkey())
-            .collect::<Vec<_>>()
-            .as_slice(),
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        &[
+            keypairs[0].pubkey(),
+            keypairs[1].pubkey(),
+            keypairs[2].pubkey(),
+        ],
     );
+
     let proposal = ProtocolMessage::Proposal(ProposalMessage {
         block,
         payload,
@@ -124,88 +299,57 @@ fn test_proposal_hash() {
     };
     let sp = TestSigner::<SignatureType>::sign_object(conmsg, &keypairs[0]);
 
-    assert!(sp
-        .verify(&epoch_manager, &val_epoch_map, &keypairs[0].pubkey())
-        .is_ok());
+    assert_eq!(
+        sp.verify(&epoch_manager, &val_epoch_map, &keypairs[0].pubkey()),
+        Err(Error::InvalidEpoch)
+    );
 }
 
+// sender is not equivalent to signer
 #[test]
-fn test_proposal_missing_tc() {
-    let (keypairs, _certkeys, vset, vmap) = create_keys_w_validators::<
-        SignatureType,
-        SignatureCollectionType,
-        _,
-    >(1, ValidatorSetFactory::default());
-    let epoch_manager = EpochManager::new(SeqNum(2000), Round(50), &[(Epoch(1), Round(0))]);
-    let mut val_epoch_map = ValidatorsEpochMapping::new(ValidatorSetFactory::default());
-    val_epoch_map.insert(
-        Epoch(1),
-        vset.get_members().iter().map(|(a, b)| (*a, *b)).collect(),
-        vmap,
-    );
-    let author = NodeId::new(keypairs[0].pubkey());
+fn test_verify_author_not_sender() {
+    let known_epoch = Epoch(1);
+    let known_round = Round(0);
+    let val_epoch = Epoch(1);
 
-    let (block, payload) = setup_block_and_payload(
-        author,
-        epoch_manager.get_epoch(Round(234)).expect("epoch exists"),
-        Round(234),
-        epoch_manager.get_epoch(Round(232)).expect("epoch exists"),
-        Round(232),
-        keypairs
-            .iter()
-            .map(|kp| kp.pubkey())
-            .collect::<Vec<_>>()
-            .as_slice(),
-    );
-    let proposal = Unvalidated::new(ProposalMessage {
-        block,
-        payload,
-        last_round_tc: None,
-    });
+    let block_epoch = Epoch(1);
+    let block_round = Round(234);
+    let block_seq_num = SeqNum(110);
 
-    assert!(matches!(
-        proposal.validate(&epoch_manager, &val_epoch_map),
-        Err(Error::NotWellFormed)
-    ));
-}
+    let qc_epoch = Epoch(1);
+    let qc_round = Round(233);
+    let qc_parent_round = Round(0);
+    let qc_seq_num = SeqNum(0);
 
-#[test]
-fn test_proposal_author_not_sender() {
-    let (keypairs, _certkeys, vset, vmap) = create_keys_w_validators::<
-        SignatureType,
-        SignatureCollectionType,
-        _,
-    >(2, ValidatorSetFactory::default());
-    let epoch_manager = EpochManager::new(SeqNum(2000), Round(50), &[(Epoch(1), Round(0))]);
-    let mut val_epoch_map: ValidatorsEpochMapping<_, SignatureCollectionType> =
-        ValidatorsEpochMapping::new(ValidatorSetFactory::default());
-    val_epoch_map.insert(
-        Epoch(1),
-        vset.get_members().iter().map(|(a, b)| (*a, *b)).collect(),
-        vmap,
-    );
+    let (keypairs, _, epoch_manager, val_epoch_map) =
+        setup_val_state(known_epoch, known_round, val_epoch);
 
     let author_keypair = &keypairs[0];
-    let sender_keypair = &keypairs[1];
+    let sender_keypair = &keypairs[1]; // this causes error
     let author = NodeId::new(author_keypair.pubkey());
 
-    let (block, payload) = setup_block_and_payload(
+    let (block, payload) = setup_block(
         author,
-        epoch_manager.get_epoch(Round(234)).expect("epoch exists"),
-        Round(234),
-        epoch_manager.get_epoch(Round(233)).expect("epoch exists"),
-        Round(233),
-        keypairs
-            .iter()
-            .map(|keypair| keypair.pubkey())
-            .collect::<Vec<_>>()
-            .as_ref(),
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        &[
+            keypairs[0].pubkey(),
+            keypairs[1].pubkey(),
+            keypairs[2].pubkey(),
+        ],
     );
+
     let proposal = ProtocolMessage::Proposal(ProposalMessage {
         block,
         payload,
         last_round_tc: None,
     });
+
     let conmsg = ConsensusMessage {
         version: "TEST".into(),
         message: proposal,
@@ -217,100 +361,944 @@ fn test_proposal_author_not_sender() {
         Error::AuthorNotSender
     );
 }
-
+// signed message is different than message to verify
 #[test]
-fn test_proposal_invalid_author() {
-    let mut vlist = Vec::new();
-    let author_keypair = get_key::<SignatureType>(6);
-    let non_valdiator_keypair = get_key::<SignatureType>(7);
+fn test_verify_invalid_signature() {
+    let known_epoch = Epoch(1);
+    let known_round = Round(0);
+    let val_epoch = Epoch(1);
 
-    vlist.push((NodeId::new(author_keypair.pubkey()), Stake(0)));
+    let block_epoch = Epoch(1);
+    let block_round = Round(234);
+    let block_seq_num = SeqNum(110);
 
-    let vset = ValidatorSetFactory::default().create(vlist).unwrap();
-    let vmap: ValidatorMapping<PubKeyType, _> = ValidatorMapping::new(vec![(
-        NodeId::new(author_keypair.pubkey()),
-        author_keypair.pubkey(),
-    )]);
-    let epoch_manager = EpochManager::new(SeqNum(2000), Round(50), &[(Epoch(1), Round(0))]);
-    let mut val_epoch_map: ValidatorsEpochMapping<_, SignatureCollectionType> =
-        ValidatorsEpochMapping::new(ValidatorSetFactory::default());
-    val_epoch_map.insert(
-        Epoch(1),
-        vset.get_members().iter().map(|(a, b)| (*a, *b)).collect(),
-        vmap,
-    );
+    let qc_epoch = Epoch(1);
+    let qc_round = Round(233);
+    let qc_parent_round = Round(0);
+    let qc_seq_num = SeqNum(0);
 
+    let (keypairs, _, epoch_manager, val_epoch_map) =
+        setup_val_state(known_epoch, known_round, val_epoch);
+
+    let author_keypair = &keypairs[0];
     let author = NodeId::new(author_keypair.pubkey());
-    let (block, payload) = setup_block_and_payload(
+
+    let (block, payload) = setup_block(
         author,
-        epoch_manager.get_epoch(Round(234)).expect("epoch exists"),
-        Round(234),
-        epoch_manager.get_epoch(Round(233)).expect("epoch exists"),
-        Round(233),
-        &[author_keypair.pubkey(), non_valdiator_keypair.pubkey()],
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        &[
+            keypairs[0].pubkey(),
+            keypairs[1].pubkey(),
+            keypairs[2].pubkey(),
+        ],
     );
+
     let proposal = ProtocolMessage::Proposal(ProposalMessage {
         block,
         payload,
         last_round_tc: None,
     });
+
+    let (other_block, other_payload) = setup_block(
+        author,
+        Epoch(3),
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        &[
+            keypairs[0].pubkey(),
+            keypairs[1].pubkey(),
+            keypairs[2].pubkey(),
+        ],
+    );
+
+    let other_proposal = ProtocolMessage::Proposal(ProposalMessage {
+        block: other_block,
+        payload: other_payload,
+        last_round_tc: None,
+    });
+
     let conmsg = ConsensusMessage {
         version: "TEST".into(),
         message: proposal,
     };
-    let sp = TestSigner::<SignatureType>::sign_object(conmsg, &non_valdiator_keypair);
-
+    let other_msg = ConsensusMessage {
+        version: "TEST".into(),
+        message: other_proposal,
+    };
+    // this causes error
+    let sp = TestSigner::<SignatureType>::sign_incorrect_object(other_msg, conmsg, author_keypair);
     assert_eq!(
-        sp.verify(&epoch_manager, &val_epoch_map, &author.pubkey())
+        sp.verify(&epoch_manager, &val_epoch_map, &author_keypair.pubkey())
             .unwrap_err(),
-        Error::InvalidAuthor
+        Error::InvalidSignature
     );
 }
-
+// happy path for verification (fuzz target)
 #[test]
-fn test_proposal_invalid_qc() {
-    let mut vlist = Vec::new();
-    let non_staked_keypair = get_key::<SignatureType>(6);
-    let staked_keypair = get_key::<SignatureType>(7);
+fn test_verify_proposal_happy() {
+    let known_epoch = Epoch(1);
+    let known_round = Round(0);
+    let val_epoch = known_epoch;
 
-    vlist.push((NodeId::new(non_staked_keypair.pubkey()), Stake(0)));
-    vlist.push((NodeId::new(staked_keypair.pubkey()), Stake(1)));
+    let block_epoch = Epoch(1);
+    let block_round = known_round + Round(2344);
+    let block_seq_num = SeqNum(110);
 
-    let vset = ValidatorSetFactory::default().create(vlist).unwrap();
-    let vmap = ValidatorMapping::new(vec![
-        (
-            NodeId::new(staked_keypair.pubkey()),
-            staked_keypair.pubkey(),
-        ),
-        (
-            NodeId::new(non_staked_keypair.pubkey()),
-            non_staked_keypair.pubkey(),
-        ),
-    ]);
-    let epoch_manager = EpochManager::new(SeqNum(2000), Round(50), &[(Epoch(1), Round(0))]);
-    let mut val_epoch_map = ValidatorsEpochMapping::new(ValidatorSetFactory::default());
-    val_epoch_map.insert(
-        Epoch(1),
-        vset.get_members().iter().map(|(a, b)| (*a, *b)).collect(),
-        vmap,
-    );
+    let qc_epoch = Epoch(1);
+    let qc_round = Round(233);
+    let qc_parent_round = Round(0);
+    let qc_seq_num = SeqNum(0);
 
-    let author = NodeId::new(non_staked_keypair.pubkey());
-    let (block, payload) = setup_block_and_payload(
+    let (keypairs, _, epoch_manager, val_epoch_map) =
+        setup_val_state(known_epoch, known_round, val_epoch);
+    let author = NodeId::new(keypairs[0].pubkey());
+
+    let (block, payload) = setup_block(
         author,
-        epoch_manager.get_epoch(Round(234)).expect("epoch exists"),
-        Round(234),
-        epoch_manager.get_epoch(Round(233)).expect("epoch exists"),
-        Round(233),
-        &[non_staked_keypair.pubkey()],
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        &[
+            keypairs[0].pubkey(),
+            keypairs[1].pubkey(),
+            keypairs[2].pubkey(),
+        ],
     );
+
+    let proposal = ProtocolMessage::Proposal(ProposalMessage {
+        block,
+        payload,
+        last_round_tc: None,
+    });
+
+    let conmsg = ConsensusMessage {
+        version: "TEST".into(),
+        message: proposal,
+    };
+    let sp = TestSigner::<SignatureType>::sign_object(conmsg, &keypairs[0]);
+
+    assert!(sp
+        .verify(&epoch_manager, &val_epoch_map, &keypairs[0].pubkey())
+        .is_ok());
+}
+
+// The test_validate set hits all error messages in order appearence
+// in the validate function in the case there exists no TC.
+//
+// The error messages and their related tests are the following:
+//  - test_validate_invalid_seq_num - Error::InvalidSeqNum
+//  - test_validate_missing_tc - Error::NotWellFormed
+//  - test_validate_incorrect_block_epoch - Error::InvalidEpoch
+//  - test_validate_qc_epoch - Error::InvalidEpoch
+//  - test_validate_mismatch_qc_epoch - Error::InvalidEpoch
+//  - test_proposal_invalid_qc_validator_set - Error::ValidatorSetDataUnavailable
+//  - test_validate_insufficient_qc_stake - Error::InsufficientStake
+//  - test_validate_qc_happy - happy path
+//
+// These tests do not reach Error::InvalidSignature due to mocksignature collection
+// when a proposal message contains a QC.
+
+// block seq num is not QC seq num + 1
+#[test]
+fn test_validate_invalid_seq_num() {
+    let known_epoch = Epoch(1);
+    let known_round = Round(0);
+    let val_epoch = Epoch(1);
+
+    let block_epoch = Epoch(1);
+    let block_round = Round(234);
+    let block_seq_num = SeqNum(110); // this causes error
+
+    let qc_epoch = Epoch(1);
+    let qc_round = Round(233);
+    let qc_parent_round = Round(0);
+    let qc_seq_num = block_seq_num - SeqNum(2); // this causes error
+
+    let (keypairs, _, epoch_manager, val_epoch_map) =
+        setup_val_state(known_epoch, known_round, val_epoch);
+    let author = NodeId::new(keypairs[0].pubkey());
+
+    let (block, payload) = setup_block(
+        author,
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        &[
+            keypairs[0].pubkey(),
+            keypairs[1].pubkey(),
+            keypairs[2].pubkey(),
+        ],
+    );
+
     let proposal = Unvalidated::new(ProposalMessage {
         block,
         payload,
         last_round_tc: None,
     });
 
-    let validate_result = proposal.validate(&epoch_manager, &val_epoch_map);
+    assert_eq!(
+        proposal.validate(&epoch_manager, &val_epoch_map),
+        Err(Error::InvalidSeqNum)
+    );
+}
+// block round is not either QC seq num + 1 or TC block round + 1
+#[test_case(Round(20))]
+#[test_case(Round(233))]
+fn test_validate_missing_tc(qc_round: Round) {
+    let known_epoch = Epoch(1);
+    let known_round = Round(0);
+    let val_epoch = Epoch(1);
 
-    assert!(matches!(validate_result, Err(Error::InsufficientStake)));
+    let block_epoch = Epoch(1);
+    let block_round = Round(23);
+    let block_seq_num = SeqNum(2);
+
+    let qc_epoch = Epoch(1);
+    let qc_parent_round = block_round - Round(2);
+    let qc_seq_num = block_seq_num - SeqNum(1);
+
+    let (keypairs, _, epoch_manager, val_epoch_map) =
+        setup_val_state(known_epoch, known_round, val_epoch);
+    let author = NodeId::new(keypairs[0].pubkey());
+
+    let (block, payload) = setup_block(
+        author,
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        &[
+            keypairs[0].pubkey(),
+            keypairs[1].pubkey(),
+            keypairs[2].pubkey(),
+        ],
+    );
+
+    let proposal = Unvalidated::new(ProposalMessage {
+        block,
+        payload,
+        last_round_tc: None,
+    });
+
+    assert_eq!(
+        proposal.validate(&epoch_manager, &val_epoch_map),
+        Err(Error::NotWellFormed)
+    );
+}
+
+// block epoch is not equal to epoch determined by block round
+#[test_case(Epoch(4), Epoch(1))]
+#[test_case(Epoch(11), Epoch(3))]
+fn test_validate_incorrect_block_epoch(known_epoch: Epoch, block_epoch: Epoch) {
+    let known_round = Round(0);
+    let val_epoch = Epoch(1);
+
+    let block_round = Round(23);
+    let block_seq_num = SeqNum(2);
+
+    let qc_epoch = Epoch(1);
+    let qc_round = block_round - Round(1);
+    let qc_parent_round = block_round - Round(2);
+    let qc_seq_num = block_seq_num - SeqNum(1);
+
+    let (keypairs, _, epoch_manager, val_epoch_map) =
+        setup_val_state(known_epoch, known_round, val_epoch);
+
+    let author = NodeId::new(keypairs[0].pubkey());
+
+    let (block, payload) = setup_block(
+        author,
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        &[
+            keypairs[0].pubkey(),
+            keypairs[1].pubkey(),
+            keypairs[2].pubkey(),
+        ],
+    );
+
+    let proposal = Unvalidated::new(ProposalMessage {
+        block,
+        payload,
+        last_round_tc: None,
+    });
+
+    assert_eq!(
+        proposal.validate(&epoch_manager, &val_epoch_map),
+        Err(Error::InvalidEpoch)
+    );
+}
+// epoch corresponding to qc round does not exist
+#[test]
+fn test_validate_qc_epoch() {
+    let known_epoch = Epoch(4);
+    let known_round = Round(30);
+    let val_epoch = Epoch(1);
+
+    let block_epoch = known_epoch;
+    let block_round = known_round;
+    let block_seq_num = SeqNum(2);
+
+    let qc_epoch = Epoch(4);
+    let qc_round = block_round - Round(1);
+    let qc_parent_round = block_round - Round(2);
+    let qc_seq_num = block_seq_num - SeqNum(1);
+
+    let (keypairs, _, epoch_manager, val_epoch_map) =
+        setup_val_state(known_epoch, known_round, val_epoch);
+    let author = NodeId::new(keypairs[0].pubkey());
+
+    let (block, payload) = setup_block(
+        author,
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        &[
+            keypairs[0].pubkey(),
+            keypairs[1].pubkey(),
+            keypairs[2].pubkey(),
+        ],
+    );
+
+    let proposal = Unvalidated::new(ProposalMessage {
+        block,
+        payload,
+        last_round_tc: None,
+    });
+
+    assert_eq!(
+        proposal.validate(&epoch_manager, &val_epoch_map),
+        Err(Error::InvalidEpoch)
+    );
+}
+// qc epoch is not equal to local epoch corresponding to qc round
+#[test]
+fn test_validate_mismatch_qc_epoch() {
+    let known_epoch = Epoch(1); // this causes error
+    let known_round = Round(0);
+    let val_epoch = Epoch(1);
+
+    let block_epoch = known_epoch;
+    let block_round = Round(23);
+    let block_seq_num = SeqNum(2);
+
+    let qc_epoch = Epoch(2); // this causes error
+    let qc_round = block_round - Round(1);
+    let qc_parent_round = block_round - Round(2);
+    let qc_seq_num = block_seq_num - SeqNum(1);
+
+    let (keypairs, _, epoch_manager, val_epoch_map) =
+        setup_val_state(known_epoch, known_round, val_epoch);
+    let author = NodeId::new(keypairs[0].pubkey());
+
+    let (block, payload) = setup_block(
+        author,
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        &[
+            keypairs[0].pubkey(),
+            keypairs[1].pubkey(),
+            keypairs[2].pubkey(),
+        ],
+    );
+
+    let proposal = Unvalidated::new(ProposalMessage {
+        block,
+        payload,
+        last_round_tc: None,
+    });
+
+    assert_eq!(
+        proposal.validate(&epoch_manager, &val_epoch_map),
+        Err(Error::InvalidEpoch)
+    );
+}
+// validators do not exist for correspond qc epoch
+#[test]
+fn test_proposal_invalid_qc_validator_set() {
+    let known_epoch = Epoch(1); // this causes error
+    let known_round = Round(0);
+    let val_epoch = Epoch(2); // this causes error
+
+    let block_epoch = known_epoch;
+    let block_round = Round(23);
+    let block_seq_num = SeqNum(2);
+
+    let qc_epoch = known_epoch;
+    let qc_round = block_round - Round(1);
+    let qc_parent_round = block_round - Round(2);
+    let qc_seq_num = block_seq_num - SeqNum(1);
+
+    let (keypairs, _, epoch_manager, val_epoch_map) =
+        setup_val_state(known_epoch, known_round, val_epoch);
+    let author = NodeId::new(keypairs[0].pubkey());
+
+    let (block, payload) = setup_block(
+        author,
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        &[
+            keypairs[0].pubkey(),
+            keypairs[1].pubkey(),
+            keypairs[2].pubkey(),
+        ],
+    );
+
+    let proposal = Unvalidated::new(ProposalMessage {
+        block,
+        payload,
+        last_round_tc: None,
+    });
+
+    assert_eq!(
+        proposal.validate(&epoch_manager, &val_epoch_map),
+        Err(Error::ValidatorSetDataUnavailable)
+    );
+}
+// QC has insufficient stake
+#[test]
+fn test_validate_insufficient_qc_stake() {
+    let known_epoch = Epoch(1);
+    let known_round = Round(0);
+    let val_epoch = known_epoch;
+
+    let block_epoch = known_epoch;
+    let block_round = Round(23);
+    let block_seq_num = SeqNum(2);
+
+    let qc_epoch = known_epoch;
+    let qc_round = block_round - Round(1);
+    let qc_parent_round = block_round - Round(2);
+    let qc_seq_num = block_seq_num - SeqNum(1);
+
+    let (keypairs, _, epoch_manager, val_epoch_map) =
+        setup_val_state(known_epoch, known_round, val_epoch);
+    let author = NodeId::new(keypairs[0].pubkey());
+
+    let (block, payload) = setup_block(
+        author,
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        &[keypairs[0].pubkey()],
+    );
+
+    let proposal = Unvalidated::new(ProposalMessage {
+        block,
+        payload,
+        last_round_tc: None,
+    });
+
+    assert_eq!(
+        proposal.validate(&epoch_manager, &val_epoch_map),
+        Err(Error::InsufficientStake)
+    );
+}
+// validate happy path for empty TC
+#[test]
+fn test_validate_qc_happy() {
+    let known_epoch = Epoch(1);
+    let known_round = Round(0);
+    let val_epoch = known_epoch;
+
+    let block_epoch = known_epoch;
+    let block_round = known_round + Round(3);
+    let block_seq_num = SeqNum(2);
+
+    let qc_epoch = known_epoch;
+    let qc_round = block_round - Round(1);
+    let qc_parent_round = block_round - Round(2);
+    let qc_seq_num = block_seq_num - SeqNum(1);
+
+    let (keypairs, _, epoch_manager, val_epoch_map) =
+        setup_val_state(known_epoch, known_round, val_epoch);
+
+    let author = NodeId::new(keypairs[0].pubkey());
+
+    let (block, payload) = setup_block(
+        author,
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        &[
+            keypairs[0].pubkey(),
+            keypairs[1].pubkey(),
+            keypairs[2].pubkey(),
+        ],
+    );
+
+    let proposal = Unvalidated::new(ProposalMessage {
+        block,
+        payload,
+        last_round_tc: None,
+    });
+
+    assert!(proposal.validate(&epoch_manager, &val_epoch_map).is_ok());
+}
+
+// The test_validate_tc set hits all error messages in sequential order
+// of the validate function in the case there exists a TC.
+//
+// The error messages and their related tests are the following:
+//  - test_validate_tc_qc_invalid_seq_num - Error::InvalidSeqNum
+//  - test_validate_tc_invalid_round_block - Error::NotWellFormed
+//  - test_validate_tc_invalid_epoch - Error::InvalidEpoch
+//  - test_validate_tc_incorrect_epoch - Error::InvalidEpoch
+//  - test_validate_tc_invalid_val_set - Error::ValidatorSetDataUnavailable
+//  - test_validate_tc_invalid_round - Error::InvalidTcRound
+//  - test_validate_tc_invalid_tc_signature - Error::InvalidSignature
+//  - test_validate_tc_happy - happy path
+
+// TC has invalid seq_num
+#[test]
+fn test_validate_tc_qc_invalid_seq_num() {
+    let known_epoch = Epoch(1);
+    let known_round = Round(0);
+    let val_epoch = known_epoch;
+
+    let block_epoch = known_epoch;
+    let block_round = known_round + Round(3);
+    let block_seq_num = SeqNum(2);
+
+    let qc_epoch = known_epoch;
+    let qc_round = block_round - Round(1);
+    let qc_parent_round = block_round - Round(2);
+    let qc_seq_num = block_seq_num;
+
+    let tc_epoch = Epoch(3);
+    let tc_round = Round(2);
+
+    let (_, _, epoch_manager, val_epoch_map, proposal) = define_proposal_with_tc(
+        known_epoch,
+        known_round,
+        val_epoch,
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        tc_epoch,
+        tc_round,
+    );
+
+    let proposal = Unvalidated::new(proposal);
+    assert_eq!(
+        proposal.validate(&epoch_manager, &val_epoch_map),
+        Err(Error::InvalidSeqNum)
+    );
+}
+
+// TC round is not 1 behind block round
+#[test_case(Round(3), Round(1))]
+#[test_case(Round(123), Round(321))]
+fn test_validate_tc_invalid_round_block(block_round: Round, tc_round: Round) {
+    let known_epoch = Epoch(1);
+    let known_round = Round(0);
+    let val_epoch = known_epoch;
+
+    let block_epoch = known_epoch;
+    let block_seq_num = SeqNum(2);
+
+    let qc_epoch = known_epoch;
+    let qc_round = Round(0);
+    let qc_parent_round = block_round - Round(3);
+    let qc_seq_num = block_seq_num - SeqNum(1);
+
+    let tc_epoch = Epoch(3);
+
+    let (_, _, epoch_manager, val_epoch_map, proposal) = define_proposal_with_tc(
+        known_epoch,
+        known_round,
+        val_epoch,
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        tc_epoch,
+        tc_round,
+    );
+
+    let proposal = Unvalidated::new(proposal);
+    assert_eq!(
+        proposal.validate(&epoch_manager, &val_epoch_map),
+        Err(Error::NotWellFormed)
+    );
+}
+// TC Epoch does not exist as determined by tc.round
+#[test]
+fn test_validate_tc_invalid_epoch() {
+    let known_epoch = Epoch(10);
+    let known_round = Round(10);
+    let val_epoch = known_epoch;
+
+    let block_epoch = known_epoch;
+    let block_round = known_round + Round(3);
+    let block_seq_num = SeqNum(2);
+
+    let qc_epoch = known_epoch;
+    let qc_round = block_round - Round(1);
+    let qc_parent_round = block_round - Round(2);
+    let qc_seq_num = block_seq_num - SeqNum(1);
+
+    let tc_epoch = Epoch(10);
+    let tc_round = Round(9);
+
+    let (_, _, epoch_manager, val_epoch_map, proposal) = define_proposal_with_tc(
+        known_epoch,
+        known_round,
+        val_epoch,
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        tc_epoch,
+        tc_round,
+    );
+
+    let proposal = Unvalidated::new(proposal);
+    assert_eq!(
+        proposal.validate(&epoch_manager, &val_epoch_map),
+        Err(Error::InvalidEpoch)
+    );
+}
+// TC Epoch does not match local Epoch
+#[test]
+fn test_validate_tc_incorrect_epoch() {
+    let known_epoch = Epoch(1);
+    let known_round = Round(1);
+    let val_epoch = known_epoch;
+
+    let block_epoch = known_epoch;
+    let block_round = known_round + Round(3);
+    let block_seq_num = SeqNum(2);
+
+    let qc_epoch = known_epoch;
+    let qc_round = block_round - Round(1);
+    let qc_parent_round = block_round - Round(2);
+    let qc_seq_num = block_seq_num - SeqNum(1);
+
+    let tc_epoch = Epoch(3);
+    let tc_round = Round(1);
+
+    let (_, _, epoch_manager, val_epoch_map, proposal) = define_proposal_with_tc(
+        known_epoch,
+        known_round,
+        val_epoch,
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        tc_epoch,
+        tc_round,
+    );
+
+    let proposal = Unvalidated::new(proposal);
+    assert_eq!(
+        proposal.validate(&epoch_manager, &val_epoch_map),
+        Err(Error::InvalidEpoch)
+    );
+}
+// TC Epoch does not determine a validator set
+#[test]
+fn test_validate_tc_invalid_val_set() {
+    let known_epoch = Epoch(1);
+    let known_round = Round(0);
+    let val_epoch = Epoch(0);
+
+    let block_epoch = known_epoch;
+    let block_round = known_round + Round(3);
+    let block_seq_num = SeqNum(2);
+
+    let qc_epoch = val_epoch;
+    let qc_round = block_round - Round(1);
+    let qc_parent_round = block_round - Round(2);
+    let qc_seq_num = block_seq_num - SeqNum(1);
+
+    let tc_epoch = known_epoch;
+    let tc_round = Round(0);
+
+    let (_, _, epoch_manager, val_epoch_map, proposal) = define_proposal_with_tc(
+        known_epoch,
+        known_round,
+        val_epoch,
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        tc_epoch,
+        tc_round,
+    );
+
+    let proposal = Unvalidated::new(proposal);
+    assert_eq!(
+        proposal.validate(&epoch_manager, &val_epoch_map),
+        Err(Error::ValidatorSetDataUnavailable)
+    );
+}
+// High QC round is larger than TC round
+#[test]
+fn test_validate_tc_invalid_round() {
+    let known_epoch = Epoch(1);
+    let known_round = Round(0);
+    let val_epoch = known_epoch;
+
+    let block_epoch = known_epoch;
+    let block_round = known_round + Round(3);
+    let block_seq_num = SeqNum(2);
+
+    let qc_epoch = known_epoch;
+    let qc_round = block_round - Round(1);
+    let qc_parent_round = block_round - Round(2);
+    let qc_seq_num = block_seq_num - SeqNum(1);
+
+    let tc_epoch = Epoch(1);
+    let tc_round = Round(0);
+
+    let (_, _, epoch_manager, val_epoch_map, proposal) = define_proposal_with_tc(
+        known_epoch,
+        known_round,
+        val_epoch,
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        tc_epoch,
+        tc_round,
+    );
+
+    let proposal = Unvalidated::new(proposal);
+    assert_eq!(
+        proposal.validate(&epoch_manager, &val_epoch_map),
+        Err(Error::InvalidTcRound)
+    );
+}
+// validate happy path for TC case
+#[test]
+fn test_validate_tc_happy() {
+    let known_epoch = Epoch(1);
+    let known_round = Round(0);
+    let val_epoch = known_epoch;
+
+    let block_epoch = known_epoch;
+    let block_round = known_round + Round(3);
+    let block_seq_num = SeqNum(2);
+
+    let qc_epoch = known_epoch;
+    let qc_round = block_round - Round(2);
+    let qc_parent_round = block_round - Round(3);
+    let qc_seq_num = block_seq_num - SeqNum(1);
+
+    let tc_epoch = Epoch(1);
+    let tc_round = block_round - Round(1);
+
+    let (_, _, epoch_manager, val_epoch_map, proposal) = define_proposal_with_tc(
+        known_epoch,
+        known_round,
+        val_epoch,
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        tc_epoch,
+        tc_round,
+    );
+
+    let proposal = Unvalidated::new(proposal);
+    assert!(proposal.validate(&epoch_manager, &val_epoch_map).is_ok());
+}
+
+// Mismatch between TC and tminfo
+#[test]
+fn test_validate_tc_invalid_tc_signature() {
+    let known_epoch = Epoch(1);
+    let known_round = Round(0);
+    let val_epoch = known_epoch;
+
+    let block_epoch = known_epoch;
+    let block_round = known_round + Round(1);
+    let block_seq_num = SeqNum(1);
+
+    // a malformed tmo_info
+    let tc_epoch = Epoch(1);
+    let tc_round = Round(1);
+    let tc_epoch_signed = Epoch(2);
+    let tc_round_signed = Round(2);
+
+    let tmo_info = TimeoutInfo::<SignatureCollectionType> {
+        epoch: tc_epoch_signed,
+        round: tc_round_signed,
+        high_qc: QuorumCertificate::genesis_qc(),
+    };
+
+    let tmo_digest = tmo_info.timeout_digest();
+
+    let (keys, certkeys, epoch_manager, val_epoch_map) =
+        setup_val_state(known_epoch, known_round, val_epoch);
+
+    let val_map = val_epoch_map.get_cert_pubkeys(&known_epoch).unwrap();
+
+    let mut sigs = Vec::new();
+
+    for (keypair, certkey) in keys.iter().zip(certkeys.iter()) {
+        let s = <<SignatureCollectionType as SignatureCollection>::SignatureType as CertificateSignature>::sign(
+           tmo_digest.as_ref(),
+           certkey,
+       );
+        sigs.push((NodeId::new(keypair.pubkey()), s));
+    }
+
+    let sigcol = SignatureCollectionType::new(sigs, val_map, tmo_digest.as_ref()).unwrap();
+
+    let tc = TimeoutCertificate {
+        epoch: tc_epoch,
+        round: tc_round,
+        high_qc_rounds: vec![HighQcRoundSigColTuple {
+            high_qc_round: HighQcRound {
+                qc_round: QuorumCertificate::<SignatureCollectionType>::genesis_qc().get_round(),
+            },
+            sigs: sigcol,
+        }],
+    };
+
+    let author = NodeId::new(keys[0].pubkey());
+    let txns = TransactionPayload::List(FullTransactionList::new(vec![1, 2, 3, 4].into()));
+    let qc = QuorumCertificate::genesis_qc();
+    let payload = Payload { txns };
+
+    let block = Block::<SignatureCollectionType>::new(
+        author,
+        0,
+        block_epoch,
+        block_round,
+        &ExecutionProtocol {
+            state_root: Default::default(),
+            seq_num: block_seq_num,
+            beneficiary: EthAddress::default(),
+            randao_reveal: RandaoReveal::default(),
+        },
+        payload.get_id(),
+        BlockKind::Executable,
+        &qc,
+    );
+
+    let proposal = ProposalMessage {
+        block,
+        payload,
+        last_round_tc: Some(tc),
+    };
+    let proposal = Unvalidated::new(proposal);
+
+    assert!(matches!(
+        proposal.validate(&epoch_manager, &val_epoch_map),
+        Err(Error::InvalidSignature)
+    ));
+}
+
+// This test has a proposal message whose round corresponds
+// to genesis but does not contain Genesis QC
+#[test]
+fn test_validate_genesis_sig() {
+    let known_epoch = Epoch(1);
+    let known_round = Round(0);
+    let val_epoch = known_epoch;
+
+    let block_epoch = known_epoch;
+    let block_round = known_round + Round(3);
+    let block_seq_num = SeqNum(2);
+
+    let qc_epoch = known_epoch;
+    let qc_round = Round(0);
+    let qc_parent_round = block_round - Round(3);
+    let qc_seq_num = block_seq_num - SeqNum(1);
+
+    let tc_epoch = Epoch(1);
+    let tc_round = block_round - Round(1);
+
+    let (_, _, epoch_manager, val_epoch_map, proposal) = define_proposal_with_tc(
+        known_epoch,
+        known_round,
+        val_epoch,
+        block_epoch,
+        block_round,
+        block_seq_num,
+        qc_epoch,
+        qc_round,
+        qc_parent_round,
+        qc_seq_num,
+        tc_epoch,
+        tc_round,
+    );
+    let proposal = Unvalidated::new(proposal);
+    assert_eq!(
+        proposal.validate(&epoch_manager, &val_epoch_map),
+        Err(Error::InvalidSignature)
+    );
 }

--- a/monad-testutil/src/signing.rs
+++ b/monad-testutil/src/signing.rs
@@ -177,6 +177,19 @@ impl<ST: CertificateSignatureRecoverable> TestSigner<ST> {
     }
 }
 
+impl<ST: CertificateSignatureRecoverable> TestSigner<ST> {
+    pub fn sign_incorrect_object<T: Hashable>(
+        signed_object: T,
+        unsigned_object: T,
+        key: &ST::KeyPairType,
+    ) -> Unverified<ST, Unvalidated<T>> {
+        let msg = HasherType::hash_object(&signed_object);
+        let sig = ST::sign(msg.as_ref(), key);
+
+        Unverified::new(Unvalidated::new(unsigned_object), sig)
+    }
+}
+
 pub fn get_key<ST: CertificateSignatureRecoverable>(seed: u64) -> ST::KeyPairType {
     let mut hasher = HasherType::new();
     hasher.update(seed.to_le_bytes());


### PR DESCRIPTION
**Summary:** This is a set of unit tests that hits all error messages for Proposal messages. The Monad state and state of the proposal messages are defined by the functions: setup_block; setup_val_state; define_proposal_with_tc. These functions will be the entry point for fuzzing. 

The unit tests cover verify for ConsensusMessages and Validate for Proposal messages. In particular, there are two cases for the validation of proposal messages: 
1. Proposal with a Valid QC;
2. Proposal with Valid TC and Old QC

In case 1. , it is possible for the message to contain an old TC. I discussed the implications with @MForensic and if this message was accepted then it would be possible to remove already finalized blocks. However, I am not sure if functions outside of validate would protect against such a scenario. However, this could be solved by forcing the function `well_formed` to only accept a message with a Valid QC to have an empty TC. 

Things to do on next pr: 
- Add unit tests for time out / vote validation + fuzz harnesses  (add genesis qc)
- Add fuzzing for proposal messages with relationships defined in https://github.com/monad-crypto/monad-internal/issues/328
- Update well_formed to remove degenerate case 

