### PR TITLE
Avoid state root update overwrite in mock executor

### DIFF
--- a/monad-mock-swarm/tests/two_nodes.rs
+++ b/monad-mock-swarm/tests/two_nodes.rs
@@ -306,7 +306,7 @@ fn two_nodes_quic_bw() {
     // this is empirical, don't want to spend too much time figuring out a
     // degenerative case
     let mut verifier =
-        MockSwarmVerifier::default().tick_range(Duration::from_secs(6), Duration::from_secs(1));
+        MockSwarmVerifier::default().tick_range(Duration::from_secs(7), Duration::from_secs(1));
     assert!(verifier.verify(&swarm));
 
     let node_ids = swarm.states().keys().copied().collect_vec();


### PR DESCRIPTION
We previously overwrite the state root update when multiple blocks are committed at the same time