### PR TITLE
Remove empty blocks from Eth ledger

### DIFF
--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -506,7 +506,7 @@ mod test {
     use monad_consensus_types::{
         block::{Block as ConsensusBlock, BlockType, PassthruBlockPolicy},
         ledger::CommitResult,
-        payload::{FullTransactionList, Payload},
+        payload::{FullTransactionList, Payload, TransactionPayload},
         quorum_certificate::{QcInfo, QuorumCertificate},
         voting::{Vote, VoteInfo},
     };
@@ -861,7 +861,7 @@ mod test {
             Epoch(1),
             Round(2),
             &Payload {
-                txns: FullTransactionList::new(vec![1].into()),
+                txns: TransactionPayload::List(FullTransactionList::new(vec![1].into())),
                 ..DontCare::dont_care()
             },
             &mock_qc(v1),
@@ -873,7 +873,7 @@ mod test {
             Epoch(1),
             Round(2),
             &Payload {
-                txns: FullTransactionList::new(vec![2].into()),
+                txns: TransactionPayload::List(FullTransactionList::new(vec![2].into())),
                 ..DontCare::dont_care()
             },
             &mock_qc(v1),
@@ -893,7 +893,7 @@ mod test {
             Epoch(1),
             Round(3),
             &Payload {
-                txns: FullTransactionList::new(vec![3].into()),
+                txns: TransactionPayload::List(FullTransactionList::new(vec![3].into())),
                 ..DontCare::dont_care()
             },
             &mock_qc(v2),
@@ -968,7 +968,7 @@ mod test {
             Epoch(1),
             Round(2),
             &Payload {
-                txns: FullTransactionList::new(vec![1].into()),
+                txns: TransactionPayload::List(FullTransactionList::new(vec![1].into())),
                 ..DontCare::dont_care()
             },
             &mock_qc(v1),

--- a/monad-compress/examples/proposal.rs
+++ b/monad-compress/examples/proposal.rs
@@ -3,7 +3,7 @@ use monad_bls::BlsSignatureCollection;
 use monad_compress::{brotli::BrotliCompression, CompressionAlgo};
 use monad_consensus::messages::consensus_message::{ConsensusMessage, ProtocolMessage};
 use monad_consensus_types::{
-    payload::{ExecutionArtifacts, FullTransactionList},
+    payload::{ExecutionArtifacts, FullTransactionList, TransactionPayload},
     voting::ValidatorMapping,
 };
 use monad_secp::SecpSignature;
@@ -52,7 +52,7 @@ fn main() {
             &epoch_manager,
             &val_epoch_map,
             &election,
-            FullTransactionList::new(transactions.to_vec().into()),
+            TransactionPayload::List(FullTransactionList::new(transactions.to_vec().into())),
             ExecutionArtifacts::zero(),
         )
         .destructure()

--- a/monad-consensus-state/benches/state_machine.rs
+++ b/monad-consensus-state/benches/state_machine.rs
@@ -13,7 +13,10 @@ use monad_consensus_state::{
 use monad_consensus_types::{
     checkpoint::RootInfo,
     metrics::Metrics,
-    payload::{Bloom, ExecutionArtifacts, FullTransactionList, NopStateRoot, StateRootValidator},
+    payload::{
+        Bloom, ExecutionArtifacts, FullTransactionList, NopStateRoot, StateRootValidator,
+        TransactionPayload,
+    },
     signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
     state_root_hash::StateRootHash,
     txpool::TxPool,
@@ -101,7 +104,7 @@ where
             &self.epoch_manager,
             &self.val_epoch_map,
             &self.election,
-            FullTransactionList::empty(),
+            TransactionPayload::Empty,
             ExecutionArtifacts::zero(),
         )
     }
@@ -117,7 +120,7 @@ where
             &self.epoch_manager,
             &self.val_epoch_map,
             &self.election,
-            txn_list,
+            TransactionPayload::List(txn_list),
             execution_hdr,
         )
     }
@@ -130,7 +133,7 @@ where
             &self.epoch_manager,
             &self.val_epoch_map,
             &self.election,
-            FullTransactionList::new(vec![5].into()),
+            TransactionPayload::List(FullTransactionList::new(vec![5].into())),
             ExecutionArtifacts::zero(),
         )
     }
@@ -147,7 +150,7 @@ where
             &self.epoch_manager,
             &self.val_epoch_map,
             &self.election,
-            txn_list,
+            TransactionPayload::List(txn_list),
             execution_hdr,
         )
     }
@@ -506,7 +509,9 @@ fn make_block<SCT: SignatureCollection<NodeIdPubKey = NopPubKey>>() -> Block<SCT
     let mut txns_encoded: Vec<u8> = vec![];
     txns.encode(&mut txns_encoded);
 
-    let txns = FullTransactionList::new(Bytes::copy_from_slice(&txns_encoded));
+    let txns = TransactionPayload::List(FullTransactionList::new(Bytes::copy_from_slice(
+        &txns_encoded,
+    )));
 
     Block::new(
         NodeId::new(NopPubKey::from_bytes(&[0u8; 32]).unwrap()),

--- a/monad-consensus/tests/block.rs
+++ b/monad-consensus/tests/block.rs
@@ -1,7 +1,7 @@
 use monad_consensus_types::{
     block::Block,
     ledger::CommitResult,
-    payload::{ExecutionArtifacts, FullTransactionList, Payload, RandaoReveal},
+    payload::{ExecutionArtifacts, FullTransactionList, Payload, RandaoReveal, TransactionPayload},
     quorum_certificate::{QcInfo, QuorumCertificate},
     voting::{Vote, VoteInfo},
 };
@@ -17,7 +17,7 @@ type SignatureType = NopSignature;
 
 #[test]
 fn block_hash_id() {
-    let txns = FullTransactionList::new(vec![1, 2, 3, 4].into());
+    let txns = TransactionPayload::List(FullTransactionList::new(vec![1, 2, 3, 4].into()));
     let author = node_id::<SignatureType>();
     let epoch = Epoch(1);
     let round = Round(234);

--- a/monad-consensus/tests/message.rs
+++ b/monad-consensus/tests/message.rs
@@ -2,7 +2,7 @@ use monad_consensus::messages::message::{ProposalMessage, TimeoutMessage, VoteMe
 use monad_consensus_types::{
     block::Block,
     ledger::CommitResult,
-    payload::{ExecutionArtifacts, FullTransactionList, Payload, RandaoReveal},
+    payload::{ExecutionArtifacts, FullTransactionList, Payload, RandaoReveal, TransactionPayload},
     quorum_certificate::{QcInfo, QuorumCertificate},
     signature_collection::SignatureCollection,
     timeout::{HighQcRound, HighQcRoundSigColTuple, Timeout, TimeoutCertificate, TimeoutInfo},
@@ -181,7 +181,7 @@ fn timeout_msg_hash() {
 fn proposal_msg_hash() {
     use monad_testutil::signing::block_hash;
 
-    let txns = FullTransactionList::new(vec![1, 2, 3, 4].into());
+    let txns = TransactionPayload::List(FullTransactionList::new(vec![1, 2, 3, 4].into()));
 
     let mut privkey: [u8; 32] = [127; 32];
     let keypair = <NopKeyPair as CertificateKeyPair>::from_bytes(&mut privkey).unwrap();

--- a/monad-consensus/tests/proposal.rs
+++ b/monad-consensus/tests/proposal.rs
@@ -8,7 +8,7 @@ use monad_consensus::{
 use monad_consensus_types::{
     block::Block,
     ledger::CommitResult,
-    payload::{ExecutionArtifacts, FullTransactionList, Payload, RandaoReveal},
+    payload::{ExecutionArtifacts, FullTransactionList, Payload, RandaoReveal, TransactionPayload},
     quorum_certificate::{QcInfo, QuorumCertificate},
     validation::Error,
     voting::{ValidatorMapping, Vote, VoteInfo},
@@ -42,7 +42,7 @@ fn setup_block(
     qc_round: Round,
     signers: &[PubKeyType],
 ) -> Block<MockSignatures<SignatureType>> {
-    let txns = FullTransactionList::new(vec![1, 2, 3, 4].into());
+    let txns = TransactionPayload::List(FullTransactionList::new(vec![1, 2, 3, 4].into()));
     let vi = VoteInfo {
         id: BlockId(Hash([0x00_u8; 32])),
         epoch: qc_epoch,

--- a/monad-eth-testutil/src/lib.rs
+++ b/monad-eth-testutil/src/lib.rs
@@ -1,6 +1,6 @@
 use monad_consensus_types::{
     block::Block,
-    payload::{ExecutionArtifacts, FullTransactionList, Payload, RandaoReveal},
+    payload::{ExecutionArtifacts, FullTransactionList, Payload, RandaoReveal, TransactionPayload},
     quorum_certificate::QuorumCertificate,
 };
 use monad_crypto::{certificate_signature::CertificateKeyPair, NopKeyPair, NopSignature};
@@ -71,7 +71,7 @@ pub fn generate_random_block_with_txns(
         Epoch(1),
         Round(1),
         &Payload {
-            txns: full_txn_list,
+            txns: TransactionPayload::List(full_txn_list),
             header: ExecutionArtifacts::zero(),
             seq_num: SeqNum(1),
             beneficiary: EthAddress::default(),

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -26,7 +26,7 @@ use monad_crypto::certificate_signature::{
 use monad_types::{BlockId, Epoch, NodeId, Round, RouterTarget, SeqNum, Stake, TimeoutVariant};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum RouterCommand<PT: PubKey, OM> {
     // Publish should not be replayed
     Publish {
@@ -48,6 +48,7 @@ pub trait Message: Clone + Send + Sync {
     fn event(self, from: NodeId<Self::NodeIdPubKey>) -> Self::Event;
 }
 
+#[derive(Debug)]
 pub enum TimerCommand<E> {
     /// ScheduleReset should ALMOST ALWAYS be emitted by the state machine after handling E
     /// This is to prevent E from firing twice on replay
@@ -63,6 +64,19 @@ pub enum TimerCommand<E> {
 pub enum LedgerCommand<SCT: SignatureCollection> {
     LedgerCommit(Vec<Block<SCT>>),
     LedgerFetch(BlockId),
+}
+
+impl<SCT: SignatureCollection> std::fmt::Debug for LedgerCommand<SCT> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LedgerCommand::LedgerCommit(blocks) => {
+                f.debug_tuple("LedgerCommit").field(blocks).finish()
+            }
+            LedgerCommand::LedgerFetch(block_id) => {
+                f.debug_tuple("LedgerFetch").field(block_id).finish()
+            }
+        }
+    }
 }
 
 pub enum CheckpointCommand<SCT: SignatureCollection> {
@@ -121,6 +135,7 @@ pub enum ControlPanelCommand<SCT: SignatureCollection> {
     Write(WriteCommand<SCT>),
 }
 
+#[derive(Debug)]
 pub enum LoopbackCommand<E> {
     Forward(E),
 }

--- a/monad-mock-swarm/src/utils.rs
+++ b/monad-mock-swarm/src/utils.rs
@@ -13,7 +13,9 @@ pub mod test_tool {
     use monad_consensus_types::{
         block::Block,
         ledger::CommitResult,
-        payload::{ExecutionArtifacts, FullTransactionList, Payload, RandaoReveal},
+        payload::{
+            ExecutionArtifacts, FullTransactionList, Payload, RandaoReveal, TransactionPayload,
+        },
         quorum_certificate::{QcInfo, QuorumCertificate},
         timeout::{Timeout, TimeoutInfo},
         voting::{Vote, VoteInfo},
@@ -71,7 +73,7 @@ pub mod test_tool {
 
     pub fn fake_block(round: Round) -> Block<SC> {
         let payload = Payload {
-            txns: FullTransactionList::empty(),
+            txns: TransactionPayload::List(FullTransactionList::empty()),
             header: ExecutionArtifacts::zero(),
             seq_num: SeqNum(0),
             beneficiary: EthAddress::default(),

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -279,7 +279,7 @@ fn many_nodes_quic_bw() {
     swarm_ledger_verification(&swarm, min_ledger_len);
 
     let mut verifier =
-        MockSwarmVerifier::default().tick_range(Duration::from_secs(72), Duration::from_secs(1));
+        MockSwarmVerifier::default().tick_range(Duration::from_secs(73), Duration::from_secs(1));
 
     let node_ids = swarm.states().keys().copied().collect_vec();
     verifier

--- a/monad-mock-swarm/tests/protobuf.rs
+++ b/monad-mock-swarm/tests/protobuf.rs
@@ -8,7 +8,7 @@ use monad_consensus::{
 };
 use monad_consensus_types::{
     ledger::CommitResult,
-    payload::{ExecutionArtifacts, FullTransactionList},
+    payload::{ExecutionArtifacts, FullTransactionList, TransactionPayload},
     voting::{ValidatorMapping, Vote, VoteInfo},
 };
 use monad_crypto::{
@@ -115,7 +115,7 @@ fn test_consensus_message_event_proposal_bls() {
         &epoch_manager,
         &val_epoch_map,
         &election,
-        FullTransactionList::empty(),
+        TransactionPayload::List(FullTransactionList::empty()),
         ExecutionArtifacts::zero(),
     );
 

--- a/monad-proto/proto/block.proto
+++ b/monad-proto/proto/block.proto
@@ -15,8 +15,19 @@ message ProtoExecutionArtifacts {
   monad_proto.basic.ProtoGas gas_used = 6;
 }
 
+
+message ProtoEmptyBlockTransactionList {}
+
+message ProtoTransactionPayload {
+  oneof txns {
+    bytes list = 1;
+    ProtoEmptyBlockTransactionList empty = 2;
+    
+  }
+}
+
 message ProtoPayload {
-  bytes txns = 1;
+  ProtoTransactionPayload txns = 1;
   ProtoExecutionArtifacts header = 2;
   monad_proto.basic.ProtoSeqNum seq_num = 3;
   bytes beneficiary = 4;

--- a/monad-state/tests/protobuf.rs
+++ b/monad-state/tests/protobuf.rs
@@ -7,7 +7,7 @@ use monad_consensus::{
 };
 use monad_consensus_types::{
     ledger::CommitResult,
-    payload::{ExecutionArtifacts, FullTransactionList},
+    payload::{ExecutionArtifacts, FullTransactionList, TransactionPayload},
     quorum_certificate::{QcInfo, QuorumCertificate},
     signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
     timeout::{HighQcRound, HighQcRoundSigColTuple, Timeout, TimeoutCertificate, TimeoutInfo},
@@ -323,7 +323,7 @@ test_all_combination!(test_proposal_qc, |num_keys| {
         Round(233),
         Round(232),
         BlockId(Hash([43_u8; 32])),
-        FullTransactionList::new(vec![1, 2, 3, 4].into()),
+        TransactionPayload::List(FullTransactionList::new(vec![1, 2, 3, 4].into())),
         ExecutionArtifacts::zero(),
         cert_keys.as_slice(),
         validator_mapping,
@@ -384,7 +384,7 @@ test_all_combination!(test_proposal_tc, |num_keys| {
         Round(233),
         Round(231),
         BlockId(Hash([43_u8; 32])),
-        FullTransactionList::new(vec![1, 2, 3, 4].into()),
+        TransactionPayload::List(FullTransactionList::new(vec![1, 2, 3, 4].into())),
         ExecutionArtifacts::zero(),
         cert_keys.as_slice(),
         validator_mapping,

--- a/monad-testutil/src/block.rs
+++ b/monad-testutil/src/block.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use monad_consensus_types::{
     block::{Block, BlockType},
     ledger::CommitResult,
-    payload::{ExecutionArtifacts, FullTransactionList, Payload, RandaoReveal},
+    payload::{ExecutionArtifacts, Payload, RandaoReveal, TransactionPayload},
     quorum_certificate::{QcInfo, QuorumCertificate},
     signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
     state_root_hash::StateRootHash,
@@ -89,7 +89,7 @@ impl<SCT: SignatureCollection, PT: PubKey> BlockType<SCT> for MockBlock<PT> {
         vec![]
     }
 
-    fn is_txn_list_empty(&self) -> bool {
+    fn is_empty_block(&self) -> bool {
         true
     }
 
@@ -125,7 +125,7 @@ pub fn setup_block<ST, SCT>(
     block_round: Round,
     qc_round: Round,
     parent_id: BlockId,
-    txns: FullTransactionList,
+    txns: TransactionPayload,
     execution_header: ExecutionArtifacts,
     certkeys: &[SignatureCollectionKeyPairType<SCT>],
     validator_mapping: &ValidatorMapping<

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -108,7 +108,7 @@ pub fn swarm_ledger_verification<S: SwarmRelation>(swarm: &Nodes<S>, min_ledger_
 }
 
 pub fn ledger_verification<SCT: SignatureCollection>(
-    ledgers: &Vec<BTreeMap<SeqNum, Block<SCT>>>,
+    ledgers: &Vec<BTreeMap<Round, Block<SCT>>>,
     min_ledger_len: usize,
 ) {
     let (max_ledger_idx, max_b) = ledgers

--- a/monad-updaters/src/state_root_hash.rs
+++ b/monad-updaters/src/state_root_hash.rs
@@ -280,6 +280,7 @@ impl<ST, SCT: SignatureCollection> MockStateRootHashSwap<ST, SCT> {
             val_data_2: ValidatorSetData(val_data_2),
             next_val_data: None,
             val_set_update_interval,
+
             waker: None,
             metrics: Default::default(),
             phantom: PhantomData,
@@ -378,7 +379,6 @@ where
                             })
                         };
                     }
-
                     wake = true;
                 }
             }

--- a/monad-wal/benches/event_bench.rs
+++ b/monad-wal/benches/event_bench.rs
@@ -11,7 +11,7 @@ use monad_consensus::{
 };
 use monad_consensus_types::{
     ledger::CommitResult,
-    payload::{ExecutionArtifacts, FullTransactionList},
+    payload::{ExecutionArtifacts, FullTransactionList, TransactionPayload},
     quorum_certificate::{QcInfo, QuorumCertificate},
     signature_collection::SignatureCollection,
     timeout::{HighQcRound, HighQcRoundSigColTuple, Timeout, TimeoutCertificate, TimeoutInfo},
@@ -74,7 +74,7 @@ impl MonadEventBencher {
 }
 
 fn bench_proposal(c: &mut Criterion) {
-    let txns = FullTransactionList::new(vec![0x23_u8; 32 * 10000].into());
+    let txns = TransactionPayload::List(FullTransactionList::new(vec![0x23_u8; 32 * 10000].into()));
     let validator_factory = ValidatorSetFactory::default();
     let (keypairs, _certkeypairs, _validators, validator_mapping) =
         create_keys_w_validators::<SignatureType, SignatureCollectionType, _>(1, validator_factory);


### PR DESCRIPTION
A node proposes an empty block if don't have the execution state root, delay blocks ago. Empty blocks now use the same sequence number and state root as their parent. They are committed to consensus ledger, but not to eth ledger. This provides a nice property that if we observe QC(N), block N-delay is guaranteed to be committed. We can then state sync to N-delay.

Some implications of the change
- Epoch is now measured in number of non-empty blocks
- We wouldn't issue reward for empty blocks, as they are not committed to execution. Otherwise nodes can always produce empty blocks, get rewards, and never move in to a new epoch

Closes https://github.com/monad-crypto/monad-internal/issues/302
