### PR TITLE
Make ledger commit stateless

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3279,6 +3279,8 @@ name = "monad-blockdb"
 version = "0.1.0"
 dependencies = [
  "heed",
+ "monad-consensus-types",
+ "monad-types",
  "reth-primitives",
  "serde",
 ]
@@ -3985,6 +3987,7 @@ dependencies = [
  "monad-cxx",
  "monad-triedb",
  "monad-triedb-utils",
+ "monad-types",
  "notify",
  "pin-project",
  "rayon",

--- a/monad-blockdb/Cargo.toml
+++ b/monad-blockdb/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 bench = false
 
 [dependencies]
+monad-consensus-types = { path = "../monad-consensus-types" }
+monad-types = { path = "../monad-types" }
+
 heed = { workspace = true }
 reth-primitives = { workspace = true }
 serde = { workspace = true }

--- a/monad-consensus-types/src/quorum_certificate.rs
+++ b/monad-consensus-types/src/quorum_certificate.rs
@@ -10,7 +10,7 @@ use crate::{
     voting::*,
 };
 
-pub const GENESIS_QC_HASH: Hash = Hash([0xAA; 32]);
+pub const GENESIS_BLOCK_ID: BlockId = BlockId(Hash([0xAA; 32]));
 
 #[non_exhaustive]
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -121,10 +121,10 @@ impl<SCT: SignatureCollection> QuorumCertificate<SCT> {
     // This will be the initial high qc for all nodes
     pub fn genesis_qc() -> Self {
         let vote_info = VoteInfo {
-            id: BlockId(GENESIS_QC_HASH),
+            id: GENESIS_BLOCK_ID,
             epoch: Epoch(1),
             round: Round(0),
-            parent_id: BlockId(GENESIS_QC_HASH),
+            parent_id: GENESIS_BLOCK_ID,
             parent_round: Round(0),
             seq_num: GENESIS_SEQ_NUM,
         };

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -16,6 +16,7 @@ monad-blockdb-utils = { path = "../monad-blockdb-utils" }
 monad-cxx = { path = "../monad-cxx" }
 monad-triedb = { path = "../monad-triedb" }
 monad-triedb-utils = { path = "../monad-triedb-utils" }
+monad-types = { path = "../monad-types" }
 
 actix = { workspace = true }
 actix-codec = { workspace = true }

--- a/monad-rpc/src/block_handlers.rs
+++ b/monad-rpc/src/block_handlers.rs
@@ -1,9 +1,8 @@
 use alloy_primitives::aliases::{U256, U64};
 use log::{debug, trace};
-use monad_blockdb::{BlockTableKey, BlockValue};
+use monad_blockdb::BlockValue;
 use monad_blockdb_utils::BlockDbEnv;
 use monad_triedb_utils::{TriedbEnv, TriedbResult};
-use reth_primitives::BlockHash;
 use reth_rpc_types::{Block, BlockTransactions, Header, TransactionReceipt, Withdrawal};
 use serde::Deserialize;
 use serde_json::Value;
@@ -20,7 +19,7 @@ use crate::{
 fn parse_block_content(value: &BlockValue, return_full_txns: bool) -> Option<Block> {
     // parse block header
     let header = Header {
-        hash: Some(value.block.hash_slow()),
+        hash: Some(value.block_id()),
         parent_hash: value.block.header.parent_hash,
         uncles_hash: value.block.header.ommers_hash,
         miner: value.block.header.beneficiary,
@@ -132,7 +131,7 @@ pub async fn monad_eth_getBlockByHash(
         }
     };
 
-    let key = BlockTableKey(BlockHash::new(p.block_hash.0));
+    let key = p.block_hash.into();
     let Some(value) = blockdb_env.get_block_by_hash(key).await else {
         return serialize_result(None::<Block>);
     };
@@ -192,7 +191,7 @@ pub async fn monad_eth_getBlockTransactionCountByHash(
         }
     };
 
-    let key = BlockTableKey(BlockHash::new(p.block_hash.0));
+    let key = p.block_hash.into();
     let Some(value) = blockdb_env.get_block_by_hash(key).await else {
         return serialize_result(format!("0x{:x}", 0));
     };

--- a/monad-rpc/src/eth_json_types.rs
+++ b/monad-rpc/src/eth_json_types.rs
@@ -96,7 +96,7 @@ where
 
 impl From<FixedData<32>> for monad_blockdb::BlockTableKey {
     fn from(f: FixedData<32>) -> Self {
-        monad_blockdb::BlockTableKey(f.0.into())
+        monad_blockdb::BlockTableKey(monad_types::BlockId(monad_types::Hash(f.0)))
     }
 }
 

--- a/monad-rpc/src/eth_txn_handlers.rs
+++ b/monad-rpc/src/eth_txn_handlers.rs
@@ -5,10 +5,10 @@ use alloy_primitives::{
     Address, FixedBytes,
 };
 use log::{debug, trace};
-use monad_blockdb::{BlockTableKey, BlockValue, EthTxKey};
+use monad_blockdb::{BlockValue, EthTxKey};
 use monad_blockdb_utils::BlockDbEnv;
 use monad_triedb_utils::{TriedbEnv, TriedbResult};
-use reth_primitives::{transaction::TransactionKind, BlockHash, TransactionSigned};
+use reth_primitives::{transaction::TransactionKind, TransactionSigned};
 use reth_rpc_types::{
     AccessListItem, Filter, FilteredParams, Log, Parity, Signature, Transaction, TransactionReceipt,
 };
@@ -80,7 +80,7 @@ pub fn parse_tx_content(
         chain_id: tx.chain_id().map(U64::from),
         access_list,
         transaction_type: Some(U64::from(tx.tx_type() as u8)),
-        block_hash: Some(value.block.hash_slow()),
+        block_hash: Some(value.block_id()),
         block_number: Some(U256::from(value.block.number)),
         transaction_index: Some(U256::from(tx_index)),
 
@@ -112,7 +112,7 @@ pub fn parse_tx_receipt(
             tx.max_fee_per_gas() - base_fee_per_gas,
             tx.max_priority_fee_per_gas().unwrap_or_default(),
         );
-    let block_hash = Some(block.block.hash_slow());
+    let block_hash = Some(block.block_id());
     let block_number = Some(U256::from(block_num));
     let logs = receipt
         .logs
@@ -479,7 +479,7 @@ pub async fn monad_eth_getTransactionByBlockHashAndIndex(
         }
     };
 
-    let key = BlockTableKey(BlockHash::new(p.block_hash.0));
+    let key = p.block_hash.into();
     let Some(block) = blockdb_env.get_block_by_hash(key).await else {
         return serialize_result(None::<Transaction>);
     };

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -7,9 +7,10 @@ use std::{
     str::FromStr,
 };
 
+pub use monad_crypto::hasher::Hash;
 use monad_crypto::{
     certificate_signature::PubKey,
-    hasher::{Hash, Hashable, Hasher},
+    hasher::{Hashable, Hasher},
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use zerocopy::AsBytes;


### PR DESCRIPTION
When committing blocks, the ledger maintains the block hash of the last committed block, and uses this hash to set the parent_hash of the subsequent block. This doesn't make sense - all the data that's committed should come from the block that's being committed.

For now, this parent_hash is set to the BFT parent block_id. This may change in the near future to be more consistent with Eth.