### PR TITLE
Add StateRootCommand::CancelBelow

### DIFF
--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -21,7 +21,7 @@ use monad_consensus_types::{
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
 };
-use monad_types::{BlockId, Epoch, NodeId, Round, RouterTarget, Stake, TimeoutVariant};
+use monad_types::{BlockId, Epoch, NodeId, Round, RouterTarget, SeqNum, Stake, TimeoutVariant};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone)]
@@ -78,6 +78,7 @@ pub enum CheckpointCommand<C> {
 
 pub enum StateRootHashCommand<B> {
     LedgerCommit(B),
+    CancelBelow(SeqNum),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/monad-updaters/Cargo.toml
+++ b/monad-updaters/Cargo.toml
@@ -26,7 +26,7 @@ rand_chacha = { workspace = true }
 rayon = { workspace = true }
 alloy-rlp = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros", "time", "sync"], optional = true }
+tokio = { workspace = true, features = ["macros", "rt", "time", "sync"], optional = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/monad-updaters/src/state_root_hash.rs
+++ b/monad-updaters/src/state_root_hash.rs
@@ -156,6 +156,7 @@ where
     fn replay(&mut self, mut commands: Vec<Self::Command>) {
         commands.retain(|cmd| match cmd {
             // we match on all commands to be explicit
+            StateRootHashCommand::CancelBelow(..) => true,
             StateRootHashCommand::LedgerCommit(..) => true,
         });
         self.exec(commands)
@@ -166,6 +167,15 @@ where
 
         for command in commands {
             match command {
+                StateRootHashCommand::CancelBelow(cancel_below) => {
+                    while self
+                        .state_root_update
+                        .front()
+                        .is_some_and(|state_root| state_root.seq_num < cancel_below)
+                    {
+                        self.state_root_update.pop_front().unwrap();
+                    }
+                }
                 StateRootHashCommand::LedgerCommit(block) => {
                     debug!("commit block {:?}", block.payload.seq_num);
                     self.state_root_update
@@ -349,6 +359,7 @@ where
     fn replay(&mut self, mut commands: Vec<Self::Command>) {
         commands.retain(|cmd| match cmd {
             // we match on all commands to be explicit
+            StateRootHashCommand::CancelBelow(..) => true,
             StateRootHashCommand::LedgerCommit(..) => true,
         });
         self.exec(commands)
@@ -359,6 +370,15 @@ where
 
         for command in commands {
             match command {
+                StateRootHashCommand::CancelBelow(cancel_below) => {
+                    while self
+                        .state_root_update
+                        .front()
+                        .is_some_and(|state_root| state_root.seq_num < cancel_below)
+                    {
+                        self.state_root_update.pop_front().unwrap();
+                    }
+                }
                 StateRootHashCommand::LedgerCommit(block) => {
                     self.state_root_update
                         .push_back(self.compute_state_root_hash(&block));


### PR DESCRIPTION
After block N is committed, we should cancel all queued state roots less than N-delay+1. This is because we should only have `delay` state roots requested at any given time, specifically (N-delay, N].