### PR TITLE
Only include root_qc_N-delay root in forkpoint

### DIFF
--- a/docker/devnet/monad/config/forkpoint.toml
+++ b/docker/devnet/monad/config/forkpoint.toml
@@ -1,4 +1,4 @@
-[[state_roots]]
+[state_root]
 state_root_hash = "0x3aeacb8c741724594aa4d8853e431eb8378cf490cf27fc2f176ce02e93a61eb4"
 seq_num = "0"
 

--- a/docker/flexnet/common/config-gen.py
+++ b/docker/flexnet/common/config-gen.py
@@ -294,7 +294,7 @@ if __name__ == "__main__":
     state_root = {"state_root_hash": "0x3aeacb8c741724594aa4d8853e431eb8378cf490cf27fc2f176ce02e93a61eb4", "seq_num": "0"}
 
     genesis_toml = {
-        "state_roots": [state_root],
+        "state_root": state_root,
         "root_qc": root_qc,
         "validator_sets": [epoch1_validators, epoch2_validators],
     }

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -179,15 +179,10 @@ impl SeqNum {
     /// Compute the epoch that the sequence number belong to. It does NOT mean
     /// that the block is proposed in the epoch
     ///
-    /// The genesis qc represents a committed genesis block. This function
-    /// should never be called on GENESIS_SEQ_NUM
-    ///
-    /// GENESIS_SEQ_NUM -> undefined
     /// [0, val_set_update_interval] -> Epoch 1
     /// [val_set_update_interval + 1, 2 * val_set_update_interval] -> Epoch 2
     /// ... The first epoch is one block longer than all other ones
     pub fn to_epoch(&self, val_set_update_interval: SeqNum) -> Epoch {
-        assert_ne!(self, &GENESIS_SEQ_NUM);
         Epoch((self.0.saturating_sub(1) / val_set_update_interval.0) + 1)
     }
 
@@ -397,6 +392,7 @@ mod test {
 
     use super::*;
 
+    #[test_case(SeqNum(0), Epoch(1), SeqNum(100); "sn_0_epoch_1")]
     #[test_case(SeqNum(1), Epoch(1), SeqNum(100); "sn_1_epoch_1")]
     #[test_case(SeqNum(100), Epoch(1), SeqNum(100); "sn_100_epoch_1")]
     #[test_case(SeqNum(101), Epoch(2), SeqNum(100); "sn_101_epoch_2")]
@@ -407,11 +403,5 @@ mod test {
         val_set_update_interval: SeqNum,
     ) {
         assert_eq!(seq_num.to_epoch(val_set_update_interval), expected_epoch);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_epoch_conversion_genesis() {
-        GENESIS_SEQ_NUM.to_epoch(SeqNum(100));
     }
 }


### PR DESCRIPTION
The ledger is required to have blocks (N - delay, N], so those roots are all fetchable. The root_qc_N-delay root is only necessary for statesyncing and validating the initial execution state.