### PR TITLE
Flexnet lib fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 /docker/devnet/monad/ledger
 /docker/devnet/monad/wal
 /docker/devnet/monad/triedb
+/docker/flexnet/.venv
 
 test-keys

--- a/docker/flexnet/testing-library/.gitignore
+++ b/docker/flexnet/testing-library/.gitignore
@@ -1,2 +1,3 @@
 *.egg-info/
 __pycache__/
+build

--- a/docker/flexnet/testing-library/requirements.txt
+++ b/docker/flexnet/testing-library/requirements.txt
@@ -1,0 +1,1 @@
+setuptools

--- a/monad-scripts/jenkins/flexnet-ci.sh
+++ b/monad-scripts/jenkins/flexnet-ci.sh
@@ -27,6 +27,7 @@ if [ ! -d "./.venv" ]; then
 fi
 source ./.venv/bin/activate
 
+pip install -r testing-library/requirements.txt
 pip install ./testing-library
 
 rm -rf logs && mkdir -p logs


### PR DESCRIPTION
Ignore venv and build files in git. Add setuptools to lib requirements or it complains about
```
ModuleNotFoundError: No module named 'pkg_resources'
```
when running the net-run.py script