### PR TITLE
Simplify some tests with dont_care impls

### DIFF
--- a/monad-consensus-state/src/blocksync.rs
+++ b/monad-consensus-state/src/blocksync.rs
@@ -387,7 +387,7 @@ mod test {
         signing::{get_key, MockSignatures},
         validators::create_keys_w_validators,
     };
-    use monad_types::{BlockId, Epoch, NodeId, Round, SeqNum, TimeoutVariant};
+    use monad_types::{BlockId, DontCare, Epoch, NodeId, Round, SeqNum, TimeoutVariant};
     use monad_validator::validator_set::{ValidatorSet, ValidatorSetFactory, ValidatorSetType};
 
     use super::BlockSyncRequester;
@@ -428,11 +428,8 @@ mod test {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: BlockId(Hash([0x01_u8; 32])),
-                        epoch: Epoch(1),
-                        round: Round(0),
                         parent_id: BlockId(Hash([0x02_u8; 32])),
-                        parent_round: Round(0),
-                        seq_num: SeqNum(0),
+                        ..DontCare::dont_care()
                     },
                     ledger_commit_info: CommitResult::NoCommit,
                 },
@@ -462,11 +459,8 @@ mod test {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: BlockId(Hash([0x02_u8; 32])),
-                        epoch: Epoch(1),
-                        round: Round(0),
                         parent_id: BlockId(Hash([0x02_u8; 32])),
-                        parent_round: Round(0),
-                        seq_num: SeqNum(0),
+                        ..DontCare::dont_care()
                     },
                     ledger_commit_info: CommitResult::NoCommit,
                 },
@@ -514,11 +508,8 @@ mod test {
                     vote: Vote {
                         vote_info: VoteInfo {
                             id: BlockId(Hash([0x01_u8; 32])),
-                            epoch: Epoch(1),
-                            round: Round(0),
                             parent_id: BlockId(Hash([0x02_u8; 32])),
-                            parent_round: Round(0),
-                            seq_num: SeqNum(0),
+                            ..DontCare::dont_care()
                         },
                         ledger_commit_info: CommitResult::NoCommit,
                     },
@@ -537,11 +528,8 @@ mod test {
                     vote: Vote {
                         vote_info: VoteInfo {
                             id: BlockId(Hash([0x01_u8; 32])),
-                            epoch: Epoch(1),
-                            round: Round(0),
                             parent_id: BlockId(Hash([0x02_u8; 32])),
-                            parent_round: Round(0),
-                            seq_num: SeqNum(0),
+                            ..DontCare::dont_care()
                         },
                         ledger_commit_info: CommitResult::NoCommit,
                     },
@@ -560,11 +548,8 @@ mod test {
                     vote: Vote {
                         vote_info: VoteInfo {
                             id: BlockId(Hash([0x01_u8; 32])),
-                            epoch: Epoch(1),
-                            round: Round(0),
                             parent_id: BlockId(Hash([0x02_u8; 32])),
-                            parent_round: Round(0),
-                            seq_num: SeqNum(0),
+                            ..DontCare::dont_care()
                         },
                         ledger_commit_info: CommitResult::NoCommit,
                     },
@@ -579,11 +564,8 @@ mod test {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: block_1.get_id(),
-                        epoch: Epoch(1),
-                        round: Round(0),
                         parent_id: BlockId(Hash([0x02_u8; 32])),
-                        parent_round: Round(0),
-                        seq_num: SeqNum(0),
+                        ..DontCare::dont_care()
                     },
                     ledger_commit_info: CommitResult::NoCommit,
                 },
@@ -608,11 +590,8 @@ mod test {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: block_2.get_id(),
-                        epoch: Epoch(1),
-                        round: Round(0),
                         parent_id: BlockId(Hash([0x02_u8; 32])),
-                        parent_round: Round(0),
-                        seq_num: SeqNum(0),
+                        ..DontCare::dont_care()
                     },
                     ledger_commit_info: CommitResult::NoCommit,
                 },
@@ -637,11 +616,8 @@ mod test {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: block_3.get_id(),
-                        epoch: Epoch(1),
-                        round: Round(0),
                         parent_id: BlockId(Hash([0x02_u8; 32])),
-                        parent_round: Round(0),
-                        seq_num: SeqNum(0),
+                        ..DontCare::dont_care()
                     },
                     ledger_commit_info: CommitResult::NoCommit,
                 },
@@ -809,11 +785,8 @@ mod test {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: BlockId(Hash([0x01_u8; 32])),
-                        epoch: Epoch(1),
-                        round: Round(0),
                         parent_id: BlockId(Hash([0x02_u8; 32])),
-                        parent_round: Round(0),
-                        seq_num: SeqNum(0),
+                        ..DontCare::dont_care()
                     },
                     ledger_commit_info: CommitResult::NoCommit,
                 },
@@ -894,11 +867,8 @@ mod test {
                     vote: Vote {
                         vote_info: VoteInfo {
                             id: BlockId(Hash([0x01_u8; 32])),
-                            epoch: Epoch(1),
-                            round: Round(0),
                             parent_id: BlockId(Hash([0x02_u8; 32])),
-                            parent_round: Round(0),
-                            seq_num: SeqNum(0),
+                            ..DontCare::dont_care()
                         },
                         ledger_commit_info: CommitResult::NoCommit,
                     },
@@ -920,11 +890,8 @@ mod test {
                 vote: Vote {
                     vote_info: VoteInfo {
                         id: block.get_id(),
-                        epoch: Epoch(1),
-                        round: Round(0),
                         parent_id: BlockId(Hash([0x02_u8; 32])),
-                        parent_round: Round(0),
-                        seq_num: SeqNum(0),
+                        ..DontCare::dont_care()
                     },
                     ledger_commit_info: CommitResult::NoCommit,
                 },

--- a/monad-consensus-types/src/payload.rs
+++ b/monad-consensus-types/src/payload.rs
@@ -6,7 +6,7 @@ use monad_crypto::{
     hasher::{Hash, Hashable, Hasher},
 };
 use monad_eth_types::{EthAddress, EMPTY_RLP_TX_LIST};
-use monad_types::{Round, SeqNum};
+use monad_types::{DontCare, Round, SeqNum};
 use zerocopy::AsBytes;
 
 use crate::state_root_hash::StateRootHash;
@@ -153,6 +153,18 @@ impl Hashable for Payload {
         state.update(self.seq_num);
         state.update(self.beneficiary);
         state.update(&self.randao_reveal);
+    }
+}
+
+impl DontCare for Payload {
+    fn dont_care() -> Self {
+        Self {
+            txns: FullTransactionList::empty(),
+            header: ExecutionArtifacts::zero(),
+            seq_num: SeqNum(0),
+            beneficiary: EthAddress::default(),
+            randao_reveal: RandaoReveal::default(),
+        }
     }
 }
 

--- a/monad-consensus-types/src/voting.rs
+++ b/monad-consensus-types/src/voting.rs
@@ -97,6 +97,19 @@ impl Hashable for VoteInfo {
     }
 }
 
+impl DontCare for VoteInfo {
+    fn dont_care() -> Self {
+        Self {
+            id: BlockId(Hash([0x0_u8; 32])),
+            epoch: Epoch(1),
+            round: Round(0),
+            parent_id: BlockId(Hash([0x0_u8; 32])),
+            parent_round: Round(0),
+            seq_num: SeqNum(0),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use monad_crypto::hasher::{Hash, Hashable, Hasher, HasherType};

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -753,7 +753,7 @@ mod test {
         signing::{create_certificate_keys, create_keys, get_certificate_key, get_key},
         validators::create_keys_w_validators,
     };
-    use monad_types::{BlockId, Epoch, NodeId, Round, SeqNum, Stake, GENESIS_SEQ_NUM};
+    use monad_types::{BlockId, DontCare, Epoch, NodeId, Round, SeqNum, Stake, GENESIS_SEQ_NUM};
     use monad_validator::{
         epoch_manager::EpochManager,
         validator_set::{ValidatorSetFactory, ValidatorSetType, ValidatorSetTypeFactory},
@@ -824,12 +824,7 @@ mod test {
     #[test]
     fn qc_verification_vote_doesnt_match() {
         let vi = VoteInfo {
-            id: BlockId(Hash([0x00_u8; 32])),
-            epoch: Epoch(1),
-            round: Round(0),
-            parent_id: BlockId(Hash([0x00_u8; 32])),
-            parent_round: Round(0),
-            seq_num: SeqNum(0),
+            ..DontCare::dont_care()
         };
 
         let keypair = get_key::<SignatureType>(6);
@@ -848,12 +843,8 @@ mod test {
         let s =< <SignatureCollectionType as SignatureCollection>::SignatureType as CertificateSignature>::sign(msg.as_ref(), &cert_keypair);
 
         let vi2 = VoteInfo {
-            id: BlockId(Hash([0x00_u8; 32])),
-            epoch: Epoch(1),
             round: Round(1),
-            parent_id: BlockId(Hash([0x00_u8; 32])),
-            parent_round: Round(0),
-            seq_num: SeqNum(0),
+            ..DontCare::dont_care()
         };
         let sigs = vec![(NodeId::new(keypair.pubkey()), s)];
         let sigs = MultiSig::new(sigs, &val_mapping, msg.as_ref()).unwrap();
@@ -877,12 +868,8 @@ mod test {
     #[test]
     fn test_qc_verify_insufficient_stake() {
         let vi = VoteInfo {
-            id: BlockId(Hash([0x00_u8; 32])),
-            epoch: Epoch(1),
             round: Round(1),
-            parent_id: BlockId(Hash([0x00_u8; 32])),
-            parent_round: Round(0),
-            seq_num: SeqNum(0),
+            ..DontCare::dont_care()
         };
         let vote = Vote {
             vote_info: vi,
@@ -1032,11 +1019,10 @@ mod test {
 
         let vi = VoteInfo {
             id: BlockId(Hash([0x00_u8; 32])),
-            epoch: Epoch(1),
             round: Round(3),
             parent_id: BlockId(Hash([0x01_u8; 32])),
             parent_round: Round(2),
-            seq_num: SeqNum(0),
+            ..DontCare::dont_care()
         };
         let vote = Vote {
             vote_info: vi,
@@ -1100,12 +1086,10 @@ mod test {
 
         // create an old qc on Round(3)
         let vi = VoteInfo {
-            id: BlockId(Hash([0x00_u8; 32])),
-            epoch: Epoch(1),
             round: Round(3),
             parent_id: BlockId(Hash([0x01_u8; 32])),
             parent_round: Round(2),
-            seq_num: SeqNum(0),
+            ..DontCare::dont_care()
         };
         let vote = Vote {
             vote_info: vi,
@@ -1154,12 +1138,7 @@ mod test {
     #[test]
     fn vote_message_test() {
         let vi = VoteInfo {
-            id: BlockId(Hash([0x00_u8; 32])),
-            epoch: Epoch(1),
-            round: Round(0),
-            parent_id: BlockId(Hash([0x00_u8; 32])),
-            parent_round: Round(0),
-            seq_num: SeqNum(0),
+            ..DontCare::dont_care()
         };
         let v = Vote {
             vote_info: vi,

--- a/monad-consensus/tests/block.rs
+++ b/monad-consensus/tests/block.rs
@@ -25,12 +25,7 @@ fn block_hash_id() {
         QcInfo {
             vote: Vote {
                 vote_info: VoteInfo {
-                    id: BlockId(Hash([0x00_u8; 32])),
-                    parent_id: BlockId(Hash([0x00_u8; 32])),
-                    epoch: Epoch(1),
-                    round: Round(0),
-                    parent_round: Round(0),
-                    seq_num: SeqNum(0),
+                    ..DontCare::dont_care()
                 },
                 ledger_commit_info: CommitResult::NoCommit,
             },

--- a/monad-consensus/tests/message.rs
+++ b/monad-consensus/tests/message.rs
@@ -10,7 +10,7 @@ use monad_consensus_types::{
 };
 use monad_crypto::{
     certificate_signature::{CertificateKeyPair, CertificateSignature},
-    hasher::{Hash, Hashable, Hasher, HasherType},
+    hasher::{Hashable, Hasher, HasherType},
     NopKeyPair, NopSignature,
 };
 use monad_eth_types::EthAddress;
@@ -32,12 +32,7 @@ fn timeout_digest() {
             QcInfo {
                 vote: Vote {
                     vote_info: VoteInfo {
-                        id: BlockId(Hash([0x00_u8; 32])),
-                        epoch: Epoch(1),
-                        round: Round(0),
-                        parent_id: BlockId(Hash([0x00_u8; 32])),
-                        parent_round: Round(0),
-                        seq_num: SeqNum(0),
+                        ..DontCare::dont_care()
                     },
                     ledger_commit_info: CommitResult::NoCommit,
                 },
@@ -66,12 +61,7 @@ fn timeout_info_hash() {
             QcInfo {
                 vote: Vote {
                     vote_info: VoteInfo {
-                        id: BlockId(Hash([0x00_u8; 32])),
-                        epoch: Epoch(1),
-                        round: Round(0),
-                        parent_id: BlockId(Hash([0x00_u8; 32])),
-                        parent_round: Round(0),
-                        seq_num: SeqNum(0),
+                        ..DontCare::dont_care()
                     },
                     ledger_commit_info: CommitResult::NoCommit,
                 },
@@ -101,12 +91,7 @@ fn timeout_hash() {
             QcInfo {
                 vote: Vote {
                     vote_info: VoteInfo {
-                        id: BlockId(Hash([0x00_u8; 32])),
-                        epoch: Epoch(1),
-                        round: Round(0),
-                        parent_id: BlockId(Hash([0x00_u8; 32])),
-                        parent_round: Round(0),
-                        seq_num: SeqNum(0),
+                        ..DontCare::dont_care()
                     },
                     ledger_commit_info: CommitResult::NoCommit,
                 },
@@ -141,12 +126,7 @@ fn timeout_msg_hash() {
             QcInfo {
                 vote: Vote {
                     vote_info: VoteInfo {
-                        id: BlockId(Hash([0x00_u8; 32])),
-                        epoch: Epoch(1),
-                        round: Round(0),
-                        parent_id: BlockId(Hash([0x00_u8; 32])),
-                        parent_round: Round(0),
-                        seq_num: SeqNum(0),
+                        ..DontCare::dont_care()
                     },
                     ledger_commit_info: CommitResult::NoCommit,
                 },
@@ -212,12 +192,7 @@ fn proposal_msg_hash() {
         QcInfo {
             vote: Vote {
                 vote_info: VoteInfo {
-                    epoch: Epoch(1),
-                    id: BlockId(Hash([0x00_u8; 32])),
-                    round: Round(0),
-                    parent_id: BlockId(Hash([0x00_u8; 32])),
-                    parent_round: Round(0),
-                    seq_num: SeqNum(0),
+                    ..DontCare::dont_care()
                 },
                 ledger_commit_info: CommitResult::NoCommit,
             },
@@ -281,12 +256,7 @@ fn max_high_qc() {
 #[test_case(CommitResult::Commit ; "Some commit_state")]
 fn vote_msg_hash(cs: CommitResult) {
     let vi = VoteInfo {
-        id: BlockId(Hash([0x00_u8; 32])),
-        epoch: Epoch(1),
-        round: Round(0),
-        parent_id: BlockId(Hash([0x00_u8; 32])),
-        parent_round: Round(0),
-        seq_num: SeqNum(0),
+        ..DontCare::dont_care()
     };
 
     let v = Vote {

--- a/monad-consensus/tests/qc.rs
+++ b/monad-consensus/tests/qc.rs
@@ -3,7 +3,7 @@ use monad_consensus_types::{
     quorum_certificate::{QcInfo, QuorumCertificate, Rank},
     voting::{Vote, VoteInfo},
 };
-use monad_crypto::{hasher::Hash, NopSignature};
+use monad_crypto::NopSignature;
 use monad_testutil::signing::MockSignatures;
 use monad_types::*;
 
@@ -14,21 +14,13 @@ fn comparison() {
     let ci = CommitResult::NoCommit;
 
     let vi_1 = VoteInfo {
-        id: BlockId(Hash([0x00_u8; 32])),
-        epoch: Epoch(1),
         round: Round(2),
-        parent_id: BlockId(Hash([0x00_u8; 32])),
-        parent_round: Round(0),
-        seq_num: SeqNum(0),
+        ..DontCare::dont_care()
     };
 
     let vi_2 = VoteInfo {
-        id: BlockId(Hash([0x00_u8; 32])),
-        epoch: Epoch(1),
         round: Round(3),
-        parent_id: BlockId(Hash([0x00_u8; 32])),
-        parent_round: Round(0),
-        seq_num: SeqNum(0),
+        ..DontCare::dont_care()
     };
 
     let qc_1 = QuorumCertificate::<MockSignatures<NopSignature>>::new(

--- a/monad-consensus/tests/vote_state.rs
+++ b/monad-consensus/tests/vote_state.rs
@@ -7,12 +7,11 @@ use monad_consensus_types::{
 };
 use monad_crypto::{
     certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey},
-    hasher::Hash,
     NopKeyPair, NopSignature,
 };
 use monad_multi_sig::MultiSig;
 use monad_testutil::validators::create_keys_w_validators;
-use monad_types::{BlockId, Epoch, NodeId, Round, SeqNum};
+use monad_types::{DontCare, Epoch, NodeId, Round};
 use monad_validator::validator_set::{ValidatorSet, ValidatorSetFactory};
 use test_case::test_case;
 
@@ -27,12 +26,9 @@ fn create_vote_message(
     vote_round: Round,
 ) -> (NodeId<PubKeyType>, VoteMessage<SignatureCollectionType>) {
     let vi = VoteInfo {
-        id: BlockId(Hash([0x00_u8; 32])),
         epoch: vote_epoch,
         round: vote_round,
-        parent_id: BlockId(Hash([0x00_u8; 32])),
-        parent_round: Round(0),
-        seq_num: SeqNum(0),
+        ..DontCare::dont_care()
     };
 
     let v = Vote {

--- a/monad-mock-swarm/src/utils.rs
+++ b/monad-mock-swarm/src/utils.rs
@@ -33,7 +33,7 @@ pub mod test_tool {
     use monad_state::VerifiedMonadMessage;
     use monad_testutil::signing::create_keys;
     use monad_transformer::{LinkMessage, ID};
-    use monad_types::{BlockId, Epoch, NodeId, Round, SeqNum};
+    use monad_types::{BlockId, DontCare, Epoch, NodeId, Round, SeqNum};
 
     type ST = NopSignature;
     type KeyPairType = <ST as CertificateSignature>::KeyPairType;
@@ -63,12 +63,7 @@ pub mod test_tool {
             QcInfo {
                 vote: Vote {
                     vote_info: VoteInfo {
-                        id: BlockId(Hash([0x00_u8; 32])),
-                        epoch: Epoch(1),
-                        round: Round(0),
-                        parent_id: BlockId(Hash([0x00_u8; 32])),
-                        parent_round: Round(0),
-                        seq_num: SeqNum(0),
+                        ..DontCare::dont_care()
                     },
                     ledger_commit_info: CommitResult::NoCommit,
                 },
@@ -104,12 +99,8 @@ pub mod test_tool {
 
     pub fn fake_vote_message(kp: &KeyPairType, round: Round) -> VerifiedMonadMessage<ST, SC> {
         let vote_info = VoteInfo {
-            id: BlockId(Hash([0x00_u8; 32])),
-            epoch: Epoch(1),
             round,
-            parent_id: BlockId(Hash([0x00_u8; 32])),
-            parent_round: Round(0),
-            seq_num: SeqNum(0),
+            ..DontCare::dont_care()
         };
         let internal_msg = VoteMessage {
             vote: Vote {

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -386,6 +386,11 @@ impl Hashable for EnumDiscriminant {
     }
 }
 
+/// Trait for use in tests to populate structs where the value of the fields is not relevant
+pub trait DontCare {
+    fn dont_care() -> Self;
+}
+
 #[cfg(test)]
 mod test {
     use test_case::test_case;


### PR DESCRIPTION
Similar to constructing structs with default values but in most of these cases the structs have  no sensisble or meaningful default value. But the values of the fields may not matter for the testcases.