### PR TITLE
Disable CI tests that need mock backend

### DIFF
--- a/monad-scripts/jenkins/flexnet-ci.sh
+++ b/monad-scripts/jenkins/flexnet-ci.sh
@@ -31,12 +31,16 @@ pip install -r testing-library/requirements.txt
 pip install ./testing-library
 
 rm -rf logs && mkdir -p logs
-python nets/net0/scripts/net-run.py
+# TODO use mock backend
+# python nets/net0/scripts/net-run.py
+# TODO use mock backend
+# nets/net1/scripts/net-run.sh --output-dir logs --net-dir nets/net1/ --flexnet-root . --monad-bft-root ../.. 
 nets/devnet-integration/scripts/net-run.sh test --output-dir logs --net-dir nets/devnet-integration/ --image-root images --monad-bft-root ../..
 python nets/net1/scripts/net-run.py
 python nets/devnet-integration/scripts/net-run.py devnet test
 python nets/full-nodes/scripts/net-run.py
-nets/consensus-nodes-nonce-test-1/scripts/net-run.sh --output-dir logs --net-dir nets/consensus-nodes-nonce-test-1/ --flexnet-root . --monad-bft-root ../..
+# TODO use mock backend
+# nets/consensus-nodes-nonce-test-1/scripts/net-run.sh --output-dir logs --net-dir nets/consensus-nodes-nonce-test-1/ --flexnet-root . --monad-bft-root ../..
 nets/full-nodes-nonce-test-1/scripts/net-run.sh --output-dir logs --net-dir nets/full-nodes-nonce-test-1/ --flexnet-root . --monad-bft-root ../..
 nets/full-nodes-nonce-test-2/scripts/net-run.sh --output-dir logs --net-dir nets/full-nodes-nonce-test-2/ --flexnet-root . --monad-bft-root ../..
 nets/full-nodes-nonce-test-3/scripts/net-run.sh --output-dir logs --net-dir nets/full-nodes-nonce-test-3/ --flexnet-root . --monad-bft-root ../..


### PR DESCRIPTION
The commented out tests do not need a backend to run. Once mock backend is added the tests should be re-enabled.