### PR TITLE
Dynamic log level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3592,6 +3592,7 @@ dependencies = [
  "clap 4.4.10",
  "futures",
  "inquire",
+ "itertools 0.10.5",
  "monad-bls",
  "monad-consensus-types",
  "monad-crypto",
@@ -3605,6 +3606,7 @@ dependencies = [
  "tokio-util",
  "toml 0.7.8",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/monad-control-panel/Cargo.toml
+++ b/monad-control-panel/Cargo.toml
@@ -26,6 +26,7 @@ bincode = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 futures = { workspace = true }
 inquire = { workspace = true }
+itertools = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = [
@@ -38,6 +39,7 @@ tokio = { workspace = true, features = [
 tokio-util = { workspace = true, features = ["codec"] }
 toml = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 monad-bls = { path = "../monad-bls" }
 monad-consensus-types = { path = "../monad-consensus-types" }

--- a/monad-executor-glue/src/convert/event.rs
+++ b/monad-executor-glue/src/convert/event.rs
@@ -416,6 +416,13 @@ where
                     )),
                 }
             }
+            ControlPanelEvent::UpdateLogFilter(filter) => ProtoControlPanelEvent {
+                event: Some(proto_control_panel_event::Event::UpdateLogFilter(
+                    ProtoUpdateLogFilter {
+                        filter: filter.clone(),
+                    },
+                )),
+            },
         }
     }
 }
@@ -451,6 +458,9 @@ where
                             ))?
                             .try_into()?,
                     ))
+                }
+                proto_control_panel_event::Event::UpdateLogFilter(update_log_filter) => {
+                    ControlPanelEvent::UpdateLogFilter(update_log_filter.filter)
                 }
             }
         })
@@ -748,8 +758,8 @@ mod test {
         let mempool_event_bytes: Bytes = mempool_event.serialize();
         assert_eq!(
             mempool_event_bytes,
-            <MonadEvent::<MessageSignatureType, SignatureCollectionType> as Serializable<Bytes>>::serialize(&MonadEvent::<MessageSignatureType,SignatureCollectionType>::deserialize(mempool_event_bytes.as_ref()).expect("deserialization to succeed")
-        )
+            <MonadEvent::<MessageSignatureType, SignatureCollectionType> as Serializable<Bytes>>::serialize(&MonadEvent::<MessageSignatureType, SignatureCollectionType>::deserialize(mempool_event_bytes.as_ref()).expect("deserialization to succeed")
+            )
         )
     }
 }

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -130,6 +130,7 @@ pub enum WriteCommand<SCT: SignatureCollection> {
     ))]
     UpdateValidatorSet(UpdateValidatorSet<SCT>),
     ClearMetrics(ClearMetrics),
+    UpdateLogFilter(String),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -450,6 +451,7 @@ where
     GetValidatorSet,
     ClearMetricsEvent,
     UpdateValidators((ValidatorSetData<SCT>, Epoch)),
+    UpdateLogFilter(String),
 }
 
 /// MonadEvent are inputs to MonadState

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -132,12 +132,16 @@ message ProtoMetricsTimeout {}
 
 message ProtoGetValidatorSetEvent {}
 message ProtoClearMetricsEvent {}
+message ProtoUpdateLogFilter {
+  string filter = 1;
+}
 
 message ProtoControlPanelEvent {
   oneof event {
     ProtoGetValidatorSetEvent get_validator_set_event = 1;
     ProtoClearMetricsEvent clear_metrics_event = 2;
     ProtoUpdateValidatorsEvent update_validators_event = 3;
+    ProtoUpdateLogFilter update_log_filter = 4;
   }
 }
 

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1034,7 +1034,7 @@ where
                         root_parent_chain.push(block);
                         let delay = self.state_root_validator.get_delay();
                         if block_parent_id != GENESIS_BLOCK_ID
-                            && (block_is_empty ||// if block is empty, keep requesting until we hit non-empty
+                            && (block_is_empty || // if block is empty, keep requesting until we hit non-empty
                             block_seq_num
                                 > root_seq_num.max(delay + NUM_BLOCK_HASH) - delay - NUM_BLOCK_HASH)
                         {
@@ -1096,6 +1096,11 @@ where
                     vec![Command::StateRootHashCommand(
                         StateRootHashCommand::UpdateValidators((validators, epoch)),
                     )]
+                }
+                ControlPanelEvent::UpdateLogFilter(filter) => {
+                    vec![Command::ControlPanelCommand(ControlPanelCommand::Write(
+                        WriteCommand::UpdateLogFilter(filter),
+                    ))]
                 }
             },
             MonadEvent::TimestampUpdateEvent(t) => {


### PR DESCRIPTION

https://github.com/monad-crypto/monad-internal/issues/386

Adds new events/commands to support changing the logging directive at runtime via a [reload](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/reload/index.html) layer.

Adds a `debug-node` binary to make it easier to send debug commands
```
CLI program to manage validators and metrics

Usage: debug-node --control-panel-ipc-path <CONTROL_PANEL_IPC_PATH> <COMMAND>

Commands:
  validators         Displays the list of validators of the current epoch
  update-validators  Updates the validators using the provided TOML file
  clear-metrics      Clears the metrics
  update-log-filter  Update the logging directive
  help               Print this message or the help of the given subcommand(s)
```

```
Update the logging filter

Usage: debug-node --control-panel-ipc-path <CONTROL_PANEL_IPC_PATH> update-log-filter <--filter <FILTER>|--file <FILE>>

Options:
      --filter <FILTER>  
      --file <FILE>      
  -h, --help      
```

### String Example
This will set the logging directive for all crates to `trace`
```
debug-node  --control-panel-ipc-path controlpanel.sock update-log-filter --filter "trace"
```
But this also supports the same syntax as the env filter so you can set specific crates like so
```
debug-node  --control-panel-ipc-path controlpanel.sock update-log-filter --filter "monad_consensus_state=trace,monad_updaters=info"
```
Setting the directive to an empty string will disable logging entirely
```
debug-node  --control-panel-ipc-path controlpanel.sock update-log-filter --filter ""
```

### File example
You can also specify a complicated directive via a file. For example assume the file `filter.txt` contains the following.
```
monad_triedb_utils=info
monad_proto=info
monad_eth_tx=trace
monad_quic=trace
monad_secp=info
monad_router_scheduler=debug
monad_eth_types=info
monad_async_state_verify=trace
```
Then doing
```
debug-node  --control-panel-ipc-path controlpanel.sock update-log-filter --file filter.txt
```
is equivalent to doing
```
debug-node  --control-panel-ipc-path controlpanel.sock update-log-filter \
    --filter "monad_triedb_utils=info,monad_proto=info,monad_eth_tx=trace,monad_quic=trace,monad_secp=info,monad_router_scheduler=debug,monad_eth_types=info,monad_async_state_verify=trace"
```