### PR TITLE
enable carriage cost

### DIFF
--- a/docker/devnet/monad/config/node.toml
+++ b/docker/devnet/monad/config/node.toml
@@ -18,7 +18,7 @@ peers = []
 [consensus]
 block_txn_limit = 10_000
 block_gas_limit = 1_000_000_000
-max_reserve_balance = 100_000_000
+max_reserve_balance = 9_223_372_036_854_775_807
 execution_delay = 10
 reserve_balance_check_mode = 0
 

--- a/docker/flexnet/common/config-gen.py
+++ b/docker/flexnet/common/config-gen.py
@@ -236,7 +236,7 @@ if __name__ == "__main__":
         toml["consensus"] = {
             "block_txn_limit": 1000,
             "block_gas_limit": 800_000_000,
-            "max_reserve_balance": 100_000_000,
+            "max_reserve_balance": 9_223_372_036_854_775_807,
             "execution_delay": 10,
             "reserve_balance_check_mode": 0,
         }

--- a/monad-eth-reserve-balance/src/lib.rs
+++ b/monad-eth-reserve-balance/src/lib.rs
@@ -40,6 +40,6 @@ impl ReserveBalanceCacheTrait for PassthruReserveBalanceCache {
         _address: &EthAddress,
     ) -> ReserveBalanceCacheResult {
         debug!("passthru cache get_reserve_balance");
-        ReserveBalanceCacheResult::Val(GENESIS_SEQ_NUM, 1000000)
+        ReserveBalanceCacheResult::Val(GENESIS_SEQ_NUM, u64::MAX.into())
     }
 }

--- a/monad-mock-swarm/tests/nonces.rs
+++ b/monad-mock-swarm/tests/nonces.rs
@@ -93,7 +93,7 @@ mod test {
                 account_nonces: BTreeMap::new(),
                 last_commit: GENESIS_SEQ_NUM,
                 execution_delay: 0,
-                max_reserve_balance: 0,
+                max_reserve_balance: u64::MAX.into(),
                 txn_cache: SortedVectorMap::new(),
                 reserve_balance_check_mode: 0,
             },

--- a/monad-triedb-cache/src/lib.rs
+++ b/monad-triedb-cache/src/lib.rs
@@ -89,7 +89,8 @@ impl ReserveBalanceCache {
         }
 
         if divider.is_some() {
-            self.cache.split_off(&divider.unwrap());
+            // TODO: revisit once perf implications are understood
+            self.cache = self.cache.split_off(&divider.unwrap());
         }
     }
 


### PR DESCRIPTION
Enable carriage cost validation,  for testing purposes  max_reserve_balance is set to u64::max so triedb account balances will be used as a reserve balance on full nodes.