### PR TITLE
Add debug node binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3557,8 +3557,10 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "bincode",
+ "clap 4.4.10",
  "futures",
  "inquire",
+ "itertools 0.10.5",
  "monad-bls",
  "monad-consensus-types",
  "monad-crypto",
@@ -3567,8 +3569,10 @@ dependencies = [
  "monad-secp",
  "monad-types",
  "serde",
+ "serde_json",
  "tokio",
  "tokio-util",
+ "toml 0.7.8",
  "tracing",
 ]
 

--- a/monad-control-panel/Cargo.toml
+++ b/monad-control-panel/Cargo.toml
@@ -13,14 +13,21 @@ name = "control-panel"
 path = "src/bin/control_panel.rs"
 bench = false
 
+[[bin]]
+name = "debug-node"
+path = "src/bin/debug_node.rs"
+bench = false
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 alloy-primitives = { workspace = true }
 bincode = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
 futures = { workspace = true }
 inquire = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = [
     "io-util",
     "macros",
@@ -29,6 +36,7 @@ tokio = { workspace = true, features = [
     "time",
 ] }
 tokio-util = { workspace = true, features = ["codec"] }
+toml = { workspace = true }
 tracing = { workspace = true }
 
 monad-bls = { path = "../monad-bls" }

--- a/monad-control-panel/src/bin/debug_node.rs
+++ b/monad-control-panel/src/bin/debug_node.rs
@@ -1,0 +1,153 @@
+use std::{io::Error, path::PathBuf};
+
+use clap::{ArgGroup, Args, Parser, Subcommand};
+use futures::{SinkExt, StreamExt};
+use monad_bls::BlsSignatureCollection;
+use monad_consensus_types::signature_collection::SignatureCollection;
+use monad_crypto::certificate_signature::CertificateSignaturePubKey;
+use monad_executor_glue::{
+    ClearMetrics, ControlPanelCommand, GetValidatorSet, ReadCommand, WriteCommand,
+};
+use monad_secp::SecpSignature;
+use tokio::net::{
+    unix::{OwnedReadHalf, OwnedWriteHalf},
+    UnixStream,
+};
+use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
+
+type SignatureType = SecpSignature;
+type SignatureCollectionType = BlsSignatureCollection<CertificateSignaturePubKey<SignatureType>>;
+type Command = ControlPanelCommand<SignatureCollectionType>;
+
+/// CLI program to manage validators and metrics.
+#[derive(Parser, Debug)]
+#[command(name = "Validator Manager")]
+#[command(about = "CLI program to manage validators and metrics", long_about = None)]
+struct Cli {
+    #[arg(short, long)]
+    control_panel_ipc_path: PathBuf,
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, Args)]
+#[clap(group(ArgGroup::new("method").required(true).args(&["filter", "file"])))]
+struct UpdateLogFilter {
+    #[arg(long, value_name = "FILTER")]
+    filter: Option<String>,
+    #[arg(long, value_name = "FILE")]
+    file: Option<PathBuf>,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Displays the list of validators of the current epoch
+    Validators,
+    /// Updates the validators using the provided TOML file
+    UpdateValidators {
+        /// Path to the TOML file
+        #[arg(short, long, value_name = "FILE")]
+        path: PathBuf,
+    },
+    /// Clears the metrics
+    ClearMetrics,
+    /// Update the logging filter
+    UpdateLogFilter(UpdateLogFilter),
+}
+
+struct Read {
+    read: FramedRead<OwnedReadHalf, LengthDelimitedCodec>,
+}
+
+impl Read {
+    pub async fn next<SCT: SignatureCollection>(
+        &mut self,
+    ) -> Result<ControlPanelCommand<SCT>, Error> {
+        let bytes = self
+            .read
+            .next()
+            .await
+            .ok_or(Error::other("client stream ended"))??;
+        bincode::deserialize(&bytes).map_err(Error::other)
+    }
+}
+
+struct Write {
+    write: FramedWrite<OwnedWriteHalf, LengthDelimitedCodec>,
+}
+
+impl Write {
+    pub async fn send<SCT: SignatureCollection>(
+        &mut self,
+        request: ControlPanelCommand<SCT>,
+    ) -> Result<(), Error> {
+        let bytes = bincode::serialize(&request).map_err(Error::other)?;
+        self.write.send(bytes.into()).await
+    }
+}
+
+fn main() -> Result<(), Error> {
+    let cli = Cli::parse();
+    let socket_path = cli.control_panel_ipc_path;
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let (read, write) = rt.block_on(async move {
+        let client_stream = UnixStream::connect(socket_path.as_path()).await?;
+
+        let (read, write) = client_stream.into_split();
+
+        let read = FramedRead::new(read, LengthDelimitedCodec::default());
+        let write = FramedWrite::new(write, LengthDelimitedCodec::default());
+
+        Ok::<_, Error>((read, write))
+    })?;
+
+    let mut read = Read { read };
+    let mut write = Write { write };
+
+    match cli.command {
+        Commands::Validators => {
+            rt.block_on(write.send(Command::Read(ReadCommand::GetValidatorSet(
+                GetValidatorSet::Request,
+            ))))?;
+
+            let response = rt.block_on(read.next::<SignatureCollectionType>())?;
+
+            let parsed_validator_set = match response {
+                ControlPanelCommand::Read(read) => match read {
+                    ReadCommand::GetValidatorSet(v) => match v {
+                        GetValidatorSet::Response(s) => s,
+                        r => {
+                            return Err(Error::other(format!(
+                                "expected validator set response, got {:?}",
+                                r
+                            )));
+                        }
+                    },
+                },
+                r => {
+                    return Err(Error::other(format!(
+                        "expected validator set response, got {:?}",
+                        r
+                    )));
+                }
+            };
+            println!("{}", toml::to_string(&parsed_validator_set).unwrap());
+        }
+        Commands::UpdateValidators { path } => {
+            todo!("UpdateValidators not implemented");
+        }
+        Commands::ClearMetrics => {
+            rt.block_on(write.send(Command::Write(WriteCommand::ClearMetrics(
+                ClearMetrics::Request,
+            ))))?;
+
+            let response = rt.block_on(read.next::<SignatureCollectionType>())?;
+            println!("{}", serde_json::to_string(&response).unwrap());
+        }
+
+        Commands::UpdateLogFilter(_) => todo!("UpdateValidators not implemented"),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Adds a client-side binary for the `monad-control-panel` crate for sending debug commands.

No breaking changes.

Needed by #918 