### PR TITLE
Add wal-tool and debug-node to flexnet

### DIFF
--- a/docker/flexnet/images/control-panel/Dockerfile
+++ b/docker/flexnet/images/control-panel/Dockerfile
@@ -1,0 +1,13 @@
+# control-panel: a tool to send debug commands to a running node over UNIX sockets
+
+FROM ubuntu:24.04
+WORKDIR /usr/src/monad-bft
+
+RUN apt update && apt install -y openssl
+
+ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
+
+COPY --from=monad-bft-builder /output/bin/debug-node /usr/local/bin/debug-node
+COPY --from=monad-bft-builder /output/lib/*.so /usr/local/lib
+
+ENV RUST_LOG=info

--- a/docker/flexnet/images/monad-bft-builder/Dockerfile
+++ b/docker/flexnet/images/monad-bft-builder/Dockerfile
@@ -76,7 +76,7 @@ RUN --mount=type=cache,target=${CARGO_ROOT}/registry     \
     --mount=type=cache,target=${CARGO_ROOT}/git          \
     --mount=type=cache,target=/usr/src/monad-bft/target     \
     ASMFLAGS="-march=haswell" CFLAGS="-march=haswell" CXXFLAGS="-march=haswell" \
-    CC=gcc-13 CXX=g++-13 cargo build --release --bin monad-node --bin monad-rpc --example ethtx
+    CC=gcc-13 CXX=g++-13 cargo build --release --bin monad-node --bin monad-rpc --example ethtx --bin debug-node --example wal-tool
     
 RUN --mount=type=cache,target=/usr/src/monad-bft/target     \
     find target/release/ -maxdepth 1 -perm /a+x -type f -exec cp {} /output/bin \; && \

--- a/docker/flexnet/images/wal/Dockerfile
+++ b/docker/flexnet/images/wal/Dockerfile
@@ -1,0 +1,13 @@
+# wal: a tool to parse and perform transformations to the binary write ahead log written by a node
+
+FROM ubuntu:24.04
+WORKDIR /usr/src/monad-bft
+
+RUN apt update && apt install -y openssl
+
+ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
+
+COPY --from=monad-bft-builder /output/bin/wal-tool /usr/local/bin/wal-tool
+COPY --from=monad-bft-builder /output/lib/*.so /usr/local/lib
+
+ENV RUST_LOG=info

--- a/docker/flexnet/testing-library/monad_flexnet/flexnet.py
+++ b/docker/flexnet/testing-library/monad_flexnet/flexnet.py
@@ -94,6 +94,16 @@ class Flexnet:
                 "ETH_CALL_TARGET": ethcall_driver,
             },
         )
+        docker.build(
+            './images/control-panel',
+            file='./images/control-panel/Dockerfile',
+            tags='control-panel:latest'
+        )
+        docker.build(
+            './images/wal',
+            file='./images/wal/Dockerfile',
+            tags='wal:latest'
+        )
 
         try:
             insecure_builder = docker.buildx.inspect("insecure")


### PR DESCRIPTION
The [`wal-tool`](https://github.com/monad-crypto/monad-bft/blob/master/monad-wal/examples/wal-tool.rs) is a binary that can parse the write-ahead log written by a monad node and compute useful statistics for asserting in tests.

The [`debug-node`](https://github.com/monad-crypto/monad-bft/blob/master/monad-control-panel/src/bin/debug_node.rs) is a binary that sends useful debug commands to a running node.

This PR builds both binaries and wraps them in docker images so that they can be invoked in flexnet.