### PR TITLE
Support configurable validator stakes

### DIFF
--- a/docker/flexnet/common/config-gen.py
+++ b/docker/flexnet/common/config-gen.py
@@ -63,6 +63,7 @@ class Peer:
     service: str = None
     secp_pubkey: str = None
     bls_pubkey: str = None
+    stake: int = None
 
 
 # volume name -> Peer
@@ -189,6 +190,7 @@ if __name__ == "__main__":
             volume = node.name
             service_name = node.name
             peers[volume].service = service_name
+            peers[volume].stake = node.stake
 
     volume_list = [Path(vol) for vol in peers.keys()]
     if node_count != len(volume_list):
@@ -287,7 +289,7 @@ if __name__ == "__main__":
             {
                 "node_id": peers[volume].secp_pubkey,
                 "cert_pubkey": peers[volume].bls_pubkey,
-                "stake": 1,
+                "stake": peers[volume].stake,
             }
         )
 

--- a/docker/flexnet/testing-library/monad_flexnet/topology/node.py
+++ b/docker/flexnet/testing-library/monad_flexnet/topology/node.py
@@ -57,7 +57,7 @@ class Node:
             '> /monad/logs/client.log 2>&1'
         ]
 
-    def __init__(self, name: str, has_execution: bool = False, has_rpc: bool = False, upload_speed: int = 100, download_speed: int = 100):
+    def __init__(self, name: str, has_execution: bool = False, has_rpc: bool = False, upload_speed: int = 100, download_speed: int = 100, stake: int = 1):
         self.name = name
         self.has_execution = has_execution
         self.has_rpc = has_rpc
@@ -70,6 +70,7 @@ class Node:
         self.is_byzantine = False
         self.node_root = None
         self.test_mode = False
+        self.stake = stake
 
     def set_byzantine(self, is_byzantine: bool = True):
         self.test_mode = True

--- a/docker/flexnet/testing-library/monad_flexnet/topology/topology.py
+++ b/docker/flexnet/testing-library/monad_flexnet/topology/topology.py
@@ -23,6 +23,7 @@ class Topology:
             for node_dict in region_dict['nodes']:
                 region.create_node(
                     node_dict['name'],
+                    stake=node_dict.get('stake', 1),
                     has_execution=node_dict['execution'],
                     has_rpc=node_dict['rpc'],
                     upload_speed=node_dict['up_Mbps'],


### PR DESCRIPTION
Right now, all validators are configured with stake of 1. To test weighted leader election, it is necessary to make this configurable.