### PR TITLE
Adds rpc call to list storage keys by contract account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4389,6 +4389,7 @@ dependencies = [
 name = "monad-triedb"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "bindgen 0.69.4",
  "cmake",
  "futures",
@@ -6012,9 +6013,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608a5726529f2f0ef81b8fde9873c4bb829d6b5b5ca6be4d97345ddf0749c825"
+checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -6036,9 +6037,9 @@ dependencies = [
 
 [[package]]
 name = "ruint-macro"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-demangle"

--- a/monad-rpc/src/eth_json_types.rs
+++ b/monad-rpc/src/eth_json_types.rs
@@ -354,7 +354,7 @@ impl<'de, const N: usize> Deserialize<'de> for FixedData<N> {
     }
 }
 
-impl Serialize for EthHash {
+impl<const N: usize> Serialize for FixedData<N> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -158,6 +158,11 @@ async fn rpc_select(
     params: Value,
 ) -> Result<Value, JsonRpcError> {
     match method {
+        "monad_listStorageKeys" => {
+            let reader = &app_state.triedb_reader.as_ref().method_not_supported()?;
+            let params = serde_json::from_value(params).invalid_params()?;
+            account_handlers::monad_listStorageKeys(reader, params).await
+        }
         "debug_getRawBlock" => {
             let reader = app_state.blockdb_reader.as_ref().method_not_supported()?;
             let params = serde_json::from_value(params).invalid_params()?;

--- a/monad-triedb-utils/src/lib.rs
+++ b/monad-triedb-utils/src/lib.rs
@@ -117,6 +117,15 @@ impl TriedbReader {
         rlp_decode_storage_slot(storage_rlp)
     }
 
+    pub fn get_storage_keys(
+        &self,
+        eth_address: &[u8; 20],
+        block_id: u64,
+    ) -> Option<Vec<([u8; 32], [u8; 32])>> {
+        let (triedb_key, key_len_nibbles) = create_addr_key(eth_address);
+        self.handle.traverse(&triedb_key, key_len_nibbles, block_id)
+    }
+
     pub fn get_code(&self, code_hash: &[u8; 32], block_id: u64) -> Option<Vec<u8>> {
         let (triedb_key, key_len_nibbles) = create_code_key(code_hash);
 

--- a/monad-triedb/Cargo.toml
+++ b/monad-triedb/Cargo.toml
@@ -9,6 +9,7 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+alloy-primitives = { workspace = true, features = ["rlp"] }
 futures = { workspace = true }
 tracing = { workspace = true }
 

--- a/monad-triedb/triedb-driver/include/triedb.h
+++ b/monad-triedb/triedb-driver/include/triedb.h
@@ -25,8 +25,8 @@ int triedb_read_data(
 // found. If >=0, returns length of
 // value. Call triedb_finalize when
 // done with the value.
-typedef void (*state_callback)(bytes, size_t, bytes, size_t);
-void triedb_traverse_state(triedb *, bytes key, uint8_t key_len_nibbles, uint64_t block_id, state_callback callback);
+typedef void (*state_callback)(void*, bytes, size_t);
+void triedb_traverse_state(triedb *, bytes key, uint8_t key_len_nibbles, uint64_t block_id, void* context, state_callback callback);
 void triedb_async_read(
     triedb *, bytes key, uint8_t key_len_nibbles, uint64_t block_id,
     void (*completed)(bytes value, int length, void *user), void *user);

--- a/monad-triedb/triedb-driver/src/triedb_mock.cpp
+++ b/monad-triedb/triedb-driver/src/triedb_mock.cpp
@@ -50,6 +50,10 @@ int triedb_read_data(triedb *db, bytes key, uint8_t key_len_nibbles, bytes *valu
     return 0;
 }
 
+void triedb_traverse_state(triedb *db, bytes key, uint8_t key_len_nibbles, uint64_t block_id, void* context, state_callback callback) {
+    return;
+}
+
 int triedb_finalize(bytes value)
 {
     delete value;


### PR DESCRIPTION
Reponse for Example contract:

```solidity
contract Example {
            address private addr;
            uint256 num;

            constructor() {
                addr = msg.sender;
                num = 1776;
            }
}
```

```json
{
  "jsonrpc": "2.0",
  "result": [
    {
      "key": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "value": "0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266"
    },
    {
      "key": "0x0000000000000000000000000000000000000000000000000000000000000001",
      "value": "0x00000000000000000000000000000000000000000000000000000000000006f0"
    }
  ],
  "id": 1
}
```