### PR TITLE
Switch monad-raptorcast over to custom Raptor decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4114,7 +4114,6 @@ dependencies = [
  "monad-raptor",
  "monad-secp",
  "monad-types",
- "raptor-code",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5224,12 +5223,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "primes"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a61082d8bceecd71a3870e9162002bb75f7ba9c7aa8b76227e887782fef9c8"
-
-[[package]]
 name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5522,16 +5515,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core",
-]
-
-[[package]]
-name = "raptor-code"
-version = "1.0.6"
-source = "git+https://github.com/omegablitz/raptor?rev=8cdd8fcc#8cdd8fcc44f135aebe0d6b6e7782c6840ac6d3c5"
-dependencies = [
- "bytes",
- "log",
- "primes",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,6 @@ quinn-proto = { git = "https://github.com/omegablitz/quinn.git", rev = "0780497b
 
 rand = "0.8"
 rand_chacha = "0.3"
-raptor-code = { git = "https://github.com/omegablitz/raptor", rev = "8cdd8fcc" }
 raptorq = "1.8"
 rayon = "1.7"
 rcgen = "0.11"

--- a/monad-raptor/src/lib.rs
+++ b/monad-raptor/src/lib.rs
@@ -2,7 +2,14 @@
 
 mod binary_search;
 
+mod matrix;
+
+mod ordered_set;
+
 pub mod r10;
-pub use r10::nonsystematic::encoder::Encoder;
+pub use r10::nonsystematic::{
+    decoder::{BufferId, Decoder, ManagedDecoder},
+    encoder::Encoder,
+};
 
 pub mod xor_eq;

--- a/monad-raptor/src/matrix/dense_matrix.rs
+++ b/monad-raptor/src/matrix/dense_matrix.rs
@@ -1,0 +1,79 @@
+use std::{
+    fmt::{Display, Formatter},
+    ops::{Index, IndexMut},
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DenseMatrix {
+    data: Vec<bool>,
+    nrows: usize,
+    ncols: usize,
+}
+
+impl DenseMatrix {
+    pub fn from_element(nrows: usize, ncols: usize, elem: bool) -> DenseMatrix {
+        let data = vec![elem; nrows * ncols];
+
+        DenseMatrix { data, nrows, ncols }
+    }
+
+    pub fn from_fn(
+        nrows: usize,
+        ncols: usize,
+        mut f: impl FnMut(usize, usize) -> bool,
+    ) -> DenseMatrix {
+        let mut data = Vec::with_capacity(nrows * ncols);
+
+        for i in 0..nrows {
+            for j in 0..ncols {
+                data.push(f(i, j));
+            }
+        }
+
+        DenseMatrix { data, nrows, ncols }
+    }
+
+    pub fn nrows(&self) -> usize {
+        self.nrows
+    }
+
+    pub fn ncols(&self) -> usize {
+        self.ncols
+    }
+}
+
+impl Display for DenseMatrix {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        writeln!(f)?;
+
+        for i in 0..self.nrows {
+            write!(f, "  |")?;
+
+            for j in 0..self.ncols {
+                if self[(i, j)] {
+                    write!(f, " 1")?;
+                } else {
+                    write!(f, " 0")?;
+                }
+            }
+
+            writeln!(f, " |")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Index<(usize, usize)> for DenseMatrix {
+    type Output = bool;
+
+    fn index(&self, index: (usize, usize)) -> &bool {
+        &self.data[index.0 * self.ncols + index.1]
+    }
+}
+
+impl IndexMut<(usize, usize)> for DenseMatrix {
+    fn index_mut(&mut self, index: (usize, usize)) -> &mut bool {
+        &mut self.data[index.0 * self.ncols + index.1]
+    }
+}

--- a/monad-raptor/src/matrix/gaussian.rs
+++ b/monad-raptor/src/matrix/gaussian.rs
@@ -1,0 +1,129 @@
+use crate::matrix::{DenseMatrix, RCSwapMatrix, RowOperation};
+
+impl DenseMatrix {
+    // Compute a row-wise Gaussian elimination schedule for a.
+    fn rowwise_elimination_schedule(
+        self,
+        mut row_operation: impl FnMut(RowOperation),
+        elimination_strategy_fn: impl Fn(&RCSwapMatrix, usize) -> Option<(usize, usize)>,
+    ) -> Result<(), String> {
+        assert!(self.nrows() >= self.ncols());
+
+        let mut a = RCSwapMatrix::from_dmatrix(self);
+
+        for step in 0..a.ncols() {
+            let (row, col) = elimination_strategy_fn(&a, step)
+                .ok_or(())
+                .map_err(|_| "elimination_strategy_fn failed".to_string())?;
+
+            // Move the leading element of this row to (step, step).
+            if row != step {
+                a.swap_rows(row, step);
+            }
+
+            if col != step {
+                a.swap_columns(col, step);
+            }
+
+            // Subtract this row from every other row where necessary.
+            for i in 0..a.nrows() {
+                if i != step && a[(i, step)] {
+                    a.row_sub_assign(i, step);
+
+                    row_operation(RowOperation::SubAssign {
+                        i: a.row_permutation.index(i),
+                        j: a.row_permutation.index(step),
+                    });
+                }
+            }
+        }
+
+        for i in 0..a.nrows() {
+            for j in 0..a.ncols() {
+                debug_assert_eq!(a[(i, j)], i == j);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn rowwise_elimination_gaussian(
+        self,
+        row_operation: impl FnMut(RowOperation),
+    ) -> Result<(), String> {
+        self.rowwise_elimination_schedule(row_operation, |a, step| {
+            // In step 'step', find the first row that has column 'step' set.
+            (step..a.nrows())
+                .find(|&row| a[(row, step)])
+                .map(|row| (row, step))
+        })
+    }
+
+    pub fn rowwise_elimination_gaussian_partial_pivot(
+        self,
+        row_operation: impl FnMut(RowOperation),
+    ) -> Result<(), String> {
+        self.rowwise_elimination_schedule(row_operation, |a, step| {
+            // In step 'step', find the row that has column 'step' set that has minimal row weight.
+            let mut best = None;
+            let mut best_weight = 0;
+
+            for row in step..a.nrows() {
+                if a[(row, step)] {
+                    let mut row_weight = 0;
+
+                    for i in step..a.ncols() {
+                        if a[(row, i)] {
+                            row_weight += 1;
+                        }
+                    }
+
+                    if best.is_none() || row_weight < best_weight {
+                        best = Some(row);
+                        best_weight = row_weight;
+                    }
+                }
+            }
+
+            best.map(|row| (row, step))
+        })
+    }
+
+    pub fn rowwise_elimination_gaussian_full_pivot(
+        self,
+        row_operation: impl FnMut(RowOperation),
+    ) -> Result<(), String> {
+        self.rowwise_elimination_schedule(row_operation, |a, step| {
+            // In each step, find the row with minimal non-zero weight.
+            let mut best = None;
+
+            for row in step..a.nrows() {
+                let mut weight = 0;
+                let mut lead_column = None;
+
+                for col in 0..a.ncols() {
+                    if a[(row, col)] {
+                        weight += 1;
+
+                        if lead_column.is_none() {
+                            lead_column = Some(col);
+                        }
+                    }
+                }
+
+                if weight != 0 {
+                    let lead_column = lead_column.unwrap();
+
+                    if match best {
+                        None => true,
+                        Some((_best_row, best_weight, _best_lead_column)) => weight < best_weight,
+                    } {
+                        best = Some((row, weight, lead_column));
+                    }
+                }
+            }
+
+            best.map(|(row, _weight, lead_column)| (row, lead_column))
+        })
+    }
+}

--- a/monad-raptor/src/matrix/mod.rs
+++ b/monad-raptor/src/matrix/mod.rs
@@ -1,0 +1,9 @@
+mod dense_matrix;
+mod gaussian;
+mod rc_permutation;
+mod rc_swap_matrix;
+mod row_operation;
+
+pub use dense_matrix::DenseMatrix;
+pub use rc_swap_matrix::*;
+pub use row_operation::*;

--- a/monad-raptor/src/matrix/rc_permutation.rs
+++ b/monad-raptor/src/matrix/rc_permutation.rs
@@ -1,0 +1,125 @@
+use std::mem::swap;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RCPermutation {
+    virt_to_phys: Vec<u16>,
+    phys_to_virt: Vec<u16>,
+}
+
+impl RCPermutation {
+    pub fn new(len: usize) -> RCPermutation {
+        let len: u16 = len.try_into().unwrap();
+        let virt_to_phys: Vec<u16> = (0..len).collect();
+        let phys_to_virt: Vec<u16> = (0..len).collect();
+
+        RCPermutation {
+            virt_to_phys,
+            phys_to_virt,
+        }
+    }
+
+    pub fn index(&self, a: usize) -> usize {
+        self.virt_to_phys[a].into()
+    }
+
+    pub fn swap(&mut self, a: usize, b: usize) {
+        self.virt_to_phys.swap(a, b);
+
+        self.phys_to_virt.swap(
+            usize::from(self.virt_to_phys[a]),
+            usize::from(self.virt_to_phys[b]),
+        );
+    }
+
+    pub fn invert(&mut self) {
+        swap(&mut self.virt_to_phys, &mut self.phys_to_virt);
+    }
+
+    pub fn apply(mut self, mut swap_fn: impl FnMut(usize, usize)) {
+        let len: u16 = self.virt_to_phys.len().try_into().unwrap();
+
+        for i in 0..len {
+            let i_val = self.phys_to_virt[usize::from(i)];
+
+            if i != i_val {
+                let j = self.virt_to_phys[usize::from(i)];
+
+                self.phys_to_virt.swap(usize::from(i), usize::from(j));
+
+                self.virt_to_phys[usize::from(i)] = i;
+                self.virt_to_phys[usize::from(i_val)] = j;
+
+                swap_fn(usize::from(i), usize::from(j));
+            }
+        }
+    }
+
+    pub fn undo(mut self, swap_fn: impl FnMut(usize, usize)) {
+        self.invert();
+        self.apply(swap_fn);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use rand::{thread_rng, RngCore};
+
+    use super::RCPermutation;
+
+    #[test]
+    fn test_rc_permutation() {
+        let num = 1000;
+
+        let mut v: Vec<usize> = (0..num).collect();
+        let mut perm = RCPermutation::new(num);
+
+        let mut rng = thread_rng();
+
+        for _ in 0..num * num {
+            let a: usize = usize::try_from(rng.next_u32()).unwrap() % num;
+            let b: usize = usize::try_from(rng.next_u32()).unwrap() % num;
+
+            v.swap(a, b);
+            perm.swap(a, b);
+        }
+
+        for (i, item) in v.iter().enumerate() {
+            assert!(*item == usize::from(perm.virt_to_phys[i]));
+        }
+
+        let mut s = perm.virt_to_phys.clone();
+
+        s.sort();
+
+        for i in 0..u16::try_from(s.len()).unwrap() {
+            assert!(s[usize::from(i)] == i);
+            assert!(perm.phys_to_virt[usize::from(perm.virt_to_phys[usize::from(i)])] == i);
+        }
+    }
+
+    #[test]
+    fn test_apply_undo() {
+        let num = 32;
+
+        let mut perm = RCPermutation::new(num);
+
+        let mut rng = thread_rng();
+
+        for _ in 0..num * num {
+            let a: usize = usize::try_from(rng.next_u32()).unwrap() % num;
+            let b: usize = usize::try_from(rng.next_u32()).unwrap() % num;
+
+            perm.swap(a, b);
+        }
+
+        let mut perm2 = RCPermutation::new(num);
+
+        perm.clone().apply(|i, j| perm2.swap(i, j));
+
+        assert_eq!(perm, perm2);
+
+        perm.clone().undo(|i, j| perm2.swap(i, j));
+
+        assert_eq!(perm2, RCPermutation::new(num));
+    }
+}

--- a/monad-raptor/src/matrix/rc_swap_matrix.rs
+++ b/monad-raptor/src/matrix/rc_swap_matrix.rs
@@ -1,0 +1,112 @@
+use std::{
+    fmt::{Display, Formatter},
+    ops::{Index, IndexMut},
+};
+
+use crate::matrix::{rc_permutation::RCPermutation, DenseMatrix};
+
+#[derive(Clone, Debug)]
+pub struct RCSwapMatrix {
+    pub mat: DenseMatrix,
+    pub row_permutation: RCPermutation,
+    pub column_permutation: RCPermutation,
+}
+
+impl RCSwapMatrix {
+    pub fn from_dmatrix(mat: DenseMatrix) -> RCSwapMatrix {
+        let row_permutation = RCPermutation::new(mat.nrows());
+        let column_permutation = RCPermutation::new(mat.ncols());
+
+        RCSwapMatrix {
+            mat,
+            row_permutation,
+            column_permutation,
+        }
+    }
+
+    pub fn from_fn(
+        nrows: usize,
+        ncols: usize,
+        f: impl FnMut(usize, usize) -> bool,
+    ) -> RCSwapMatrix {
+        let mat = DenseMatrix::from_fn(nrows, ncols, f);
+        let row_permutation = RCPermutation::new(nrows);
+        let column_permutation = RCPermutation::new(ncols);
+
+        RCSwapMatrix {
+            mat,
+            row_permutation,
+            column_permutation,
+        }
+    }
+
+    pub fn nrows(&self) -> usize {
+        self.mat.nrows()
+    }
+
+    pub fn ncols(&self) -> usize {
+        self.mat.ncols()
+    }
+
+    pub fn swap_rows(&mut self, a: usize, b: usize) {
+        self.row_permutation.swap(a, b);
+    }
+
+    pub fn swap_columns(&mut self, a: usize, b: usize) {
+        self.column_permutation.swap(a, b);
+    }
+
+    // row[a] -= row[b]
+    pub fn row_sub_assign(&mut self, a: usize, b: usize) {
+        let a_phys = self.row_permutation.index(a);
+        let b_phys = self.row_permutation.index(b);
+
+        for k in 0..self.mat.ncols() {
+            self.mat[(a_phys, k)] ^= self.mat[(b_phys, k)];
+        }
+    }
+
+    pub fn to_dmatrix(&self) -> DenseMatrix {
+        DenseMatrix::from_fn(self.mat.nrows(), self.mat.ncols(), |i, j| self[(i, j)])
+    }
+
+    pub fn mult(a: &RCSwapMatrix, b: &RCSwapMatrix) -> RCSwapMatrix {
+        assert_eq!(a.ncols(), b.nrows());
+
+        RCSwapMatrix::from_fn(a.nrows(), b.ncols(), |i, j| {
+            let mut val = false;
+
+            for k in 0..a.ncols() {
+                val ^= a[(i, k)] && b[(k, j)];
+            }
+
+            val
+        })
+    }
+}
+
+impl Display for RCSwapMatrix {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "{}", self.to_dmatrix())
+    }
+}
+
+impl Index<(usize, usize)> for RCSwapMatrix {
+    type Output = bool;
+
+    fn index(&self, index: (usize, usize)) -> &Self::Output {
+        &self.mat[(
+            self.row_permutation.index(index.0),
+            self.column_permutation.index(index.1),
+        )]
+    }
+}
+
+impl IndexMut<(usize, usize)> for RCSwapMatrix {
+    fn index_mut(&mut self, index: (usize, usize)) -> &mut Self::Output {
+        &mut self.mat[(
+            self.row_permutation.index(index.0),
+            self.column_permutation.index(index.1),
+        )]
+    }
+}

--- a/monad-raptor/src/matrix/row_operation.rs
+++ b/monad-raptor/src/matrix/row_operation.rs
@@ -1,0 +1,4 @@
+#[derive(Debug)]
+pub enum RowOperation {
+    SubAssign { i: usize, j: usize },
+}

--- a/monad-raptor/src/ordered_set.rs
+++ b/monad-raptor/src/ordered_set.rs
@@ -1,0 +1,139 @@
+use std::{iter::IntoIterator, slice};
+
+use crate::binary_search::smallest_integer_satisfying;
+
+// Empirically determined threshold for binary search.
+const BINARY_SEARCH_THRESHOLD: usize = 250;
+
+#[derive(Clone, Debug)]
+pub struct OrderedSet {
+    data: Vec<u16>,
+}
+
+impl OrderedSet {
+    pub fn new() -> OrderedSet {
+        OrderedSet { data: Vec::new() }
+    }
+
+    pub fn append(&mut self, value: u16) {
+        self.data.push(value);
+    }
+
+    // Find the array index where element 'value' is located or where it would be inserted.
+    // This involves finding the lowest-numbered entry that is higher than or equal to `value`.
+    fn placement_index(&self, value: &u16) -> usize {
+        if self.data.len() < BINARY_SEARCH_THRESHOLD {
+            for i in 0..self.data.len() {
+                if self.data[i] >= *value {
+                    return i;
+                }
+            }
+
+            self.data.len()
+        } else {
+            match smallest_integer_satisfying(0, self.data.len(), |pivot| {
+                self.data[pivot] >= *value
+            }) {
+                None => self.data.len(),
+                Some(index) => index,
+            }
+        }
+    }
+
+    pub fn contains(&self, value: &u16) -> bool {
+        let index = self.placement_index(value);
+
+        index < self.data.len() && self.data[index] == *value
+    }
+
+    pub fn first(&self) -> Option<&u16> {
+        if !self.data.is_empty() {
+            Some(&self.data[0])
+        } else {
+            None
+        }
+    }
+
+    pub fn insert(&mut self, value: u16) -> bool {
+        let len = self.data.len();
+        let index = self.placement_index(&value);
+
+        if index == len || self.data[index] != value {
+            self.data.push(0);
+            self.data.copy_within(index..len, index + 1);
+            self.data[index] = value;
+
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn insert_or_remove(&mut self, value: u16) -> bool {
+        let len = self.data.len();
+        let index = self.placement_index(&value);
+
+        if index == len || self.data[index] != value {
+            self.data.push(0);
+            self.data.copy_within(index..len, index + 1);
+            self.data[index] = value;
+
+            true
+        } else {
+            self.data.copy_within(index + 1..len, index);
+            self.data.truncate(len - 1);
+
+            false
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &u16> {
+        self.data.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    pub fn remove(&mut self, value: &u16) -> bool {
+        let len = self.data.len();
+        let index = self.placement_index(value);
+
+        if index < len && self.data[index] == *value {
+            self.data.copy_within(index + 1..len, index);
+            self.data.truncate(len - 1);
+
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl Default for OrderedSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IntoIterator for OrderedSet {
+    type Item = u16;
+    type IntoIter = <Vec<u16> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a OrderedSet {
+    type Item = &'a u16;
+    type IntoIter = slice::Iter<'a, u16>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data[..].iter()
+    }
+}

--- a/monad-raptor/src/r10/nonsystematic/decoder/buffer.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/buffer.rs
@@ -1,0 +1,62 @@
+use crate::ordered_set::OrderedSet;
+
+#[derive(Debug)]
+pub struct Buffer {
+    // The IDs of all intermediate symbols that are currently XORd into this buffer.
+    pub intermediate_symbol_ids: OrderedSet,
+
+    // The number of elements of `intermediate_symbol_ids` that correspond to intermediate
+    // symbols that are in the Active or in the Used state.  (That is, the number of
+    // referenced intermediate symbols that are not in the Inactivated state.)
+    pub active_used_weight: u16,
+
+    // If this is true, intermediate_symbol_ids.len() >= 1, active_used_weight == 1, and
+    // the corresponding single active intermediate symbol is in the Used state.
+    pub used: bool,
+}
+
+impl Buffer {
+    pub fn new() -> Buffer {
+        Buffer {
+            intermediate_symbol_ids: OrderedSet::new(),
+            active_used_weight: 0,
+            used: false,
+        }
+    }
+
+    pub fn append_active_intermediate_symbol_id(&mut self, intermediate_symbol_id: usize) {
+        self.append_intermediate_symbol_id(intermediate_symbol_id, true);
+    }
+
+    pub fn append_intermediate_symbol_id(
+        &mut self,
+        intermediate_symbol_id: usize,
+        increment_active_used_weight: bool,
+    ) {
+        self.intermediate_symbol_ids
+            .append(intermediate_symbol_id.try_into().unwrap());
+
+        if increment_active_used_weight {
+            self.active_used_weight += 1;
+        }
+    }
+
+    pub fn first_intermediate_symbol_id(&self) -> u16 {
+        self.intermediate_symbol_ids.first().copied().unwrap()
+    }
+
+    // Caller is responsible for dropping `self.active_used_weight` by 1 and performing
+    // any other necessary bookkeeping associated with that.
+    pub fn xor_eq(&mut self, other: &Buffer) {
+        for intermediate_symbol_id in &other.intermediate_symbol_ids {
+            self.intermediate_symbol_ids
+                .insert_or_remove(*intermediate_symbol_id);
+        }
+    }
+}
+
+impl Default for Buffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/monad-raptor/src/r10/nonsystematic/decoder/buffer_id.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/buffer_id.rs
@@ -1,0 +1,26 @@
+use crate::r10::nonsystematic::decoder::Decoder;
+
+#[derive(Debug)]
+pub enum BufferId {
+    // One of the temporary buffers allocated by the caller for pre-code symbol recovery.
+    TempBuffer { index: usize },
+
+    // A buffer in which an encoded symbol was originally received from the encoder.
+    ReceiveBuffer { index: usize },
+}
+
+impl Decoder {
+    pub fn buffer_index_to_buffer_id(&self, index: u16) -> BufferId {
+        let index = usize::from(index);
+
+        let num_redundant_intermediate_symbols = self.num_redundant_intermediate_symbols();
+
+        if index < num_redundant_intermediate_symbols {
+            BufferId::TempBuffer { index }
+        } else {
+            BufferId::ReceiveBuffer {
+                index: index - num_redundant_intermediate_symbols,
+            }
+        }
+    }
+}

--- a/monad-raptor/src/r10/nonsystematic/decoder/buffer_state.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/buffer_state.rs
@@ -1,0 +1,59 @@
+use crate::r10::nonsystematic::decoder::Buffer;
+
+// Buffer state is not encoded explicitly; it is a function of the explicitly encoded state.
+#[derive(Debug, Eq, PartialEq)]
+pub enum BufferState {
+    // weight > 1, active_used_weight > 1
+    Active,
+
+    // weight >= 1, active_used_weight == 1, and the corresponding single active intermediate
+    // symbol is Active.
+    Usable,
+
+    // weight >= 1, active_used_weight == 1, and the corresponding single active intermediate
+    // symbol is Used.
+    //
+    // If weight == 1, the buffer is paired with its corresponding intermediate symbol.
+    Used,
+
+    // weight > 0, active_used_weight == 0
+    //
+    // Contains only inactivated intermediate symbols.  This buffer can be used in phase 2 of
+    // the inactivation decoding process, where we perform Gaussian elimination on the set of
+    // Inactivated buffers to try to reduce the weights of those buffers to 1.
+    //
+    // If weight == 1, we can reactivate the corresponding intermediate symbol and transition
+    // this buffer to Usable/Used.
+    Inactivated,
+
+    // weight == 0, active_used_weight == 0
+    //
+    // This buffer corresponds to a constrant symbol or encoded symbol that was linearly
+    // dependent on another set of constraint symbols and/or encoded symbols, and is not
+    // contributing to the decoding process.
+    Redundant,
+}
+
+impl Buffer {
+    pub fn state(&self) -> BufferState {
+        if self.active_used_weight > 1 {
+            BufferState::Active
+        } else if self.active_used_weight == 1 && !self.used {
+            BufferState::Usable
+        } else if self.active_used_weight == 1 && self.used {
+            BufferState::Used
+        } else if !self.intermediate_symbol_ids.is_empty() {
+            BufferState::Inactivated
+        } else {
+            BufferState::Redundant
+        }
+    }
+
+    pub fn is_paired(&self) -> bool {
+        self.state() == BufferState::Used && self.intermediate_symbol_ids.len() == 1
+    }
+
+    pub fn is_reactivatable(&self) -> bool {
+        self.state() == BufferState::Inactivated && self.intermediate_symbol_ids.len() == 1
+    }
+}

--- a/monad-raptor/src/r10/nonsystematic/decoder/buffer_weight_map.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/buffer_weight_map.rs
@@ -1,0 +1,272 @@
+use std::{cmp::Ordering, mem::replace, num::NonZeroU16};
+
+#[derive(Debug)]
+pub struct BufferWeightMap<const MAX_BUFFERS: usize> {
+    // weight 1..=8419
+    buffer_index_to_weight: Box<[Option<NonZeroU16>; MAX_BUFFERS]>,
+
+    num_heap_entries: usize,
+    heap_index_to_buffer_index: Box<[u16; MAX_BUFFERS]>,
+    buffer_index_to_heap_index: Box<[u16; MAX_BUFFERS]>,
+}
+
+impl<const MAX_BUFFERS: usize> BufferWeightMap<MAX_BUFFERS> {
+    pub fn new() -> BufferWeightMap<MAX_BUFFERS> {
+        BufferWeightMap {
+            buffer_index_to_weight: Box::new([None; MAX_BUFFERS]),
+            num_heap_entries: 0,
+            heap_index_to_buffer_index: Box::new([0; MAX_BUFFERS]),
+            buffer_index_to_heap_index: Box::new([0; MAX_BUFFERS]),
+        }
+    }
+
+    fn print_node(&self, heap_index: usize, indent: usize) {
+        if heap_index < self.num_heap_entries {
+            let buffer_index = self.heap_index_to_buffer_index[heap_index];
+            let weight = self.buffer_index_to_weight[usize::from(buffer_index)];
+
+            for _ in 0..indent {
+                print!("    ");
+            }
+            println!("{}: {} {:?}", heap_index, buffer_index, weight);
+
+            self.print_node(2 * heap_index + 1, indent + 1);
+            self.print_node(2 * heap_index + 2, indent + 1);
+        }
+    }
+
+    #[allow(dead_code)]
+    fn print(&self) {
+        self.print_node(0, 0);
+        println!();
+    }
+
+    pub fn check_force(&self) {
+        let mut buffer_index_to_weight = [None; MAX_BUFFERS];
+
+        for i in 0..self.num_heap_entries {
+            let buffer_index = usize::from(self.heap_index_to_buffer_index[i]);
+
+            buffer_index_to_weight[buffer_index] = self.buffer_index_to_weight[buffer_index];
+        }
+
+        assert_eq!(*self.buffer_index_to_weight, buffer_index_to_weight);
+
+        for i in 0..self.num_heap_entries {
+            let buffer_index = usize::from(self.heap_index_to_buffer_index[i]);
+
+            assert_eq!(
+                usize::from(self.buffer_index_to_heap_index[buffer_index]),
+                i
+            );
+        }
+
+        for i in 0..self.num_heap_entries {
+            let weight = self.buffer_index_to_weight
+                [usize::from(self.heap_index_to_buffer_index[i])]
+            .unwrap();
+
+            let child = 2 * i + 1;
+            if child < self.num_heap_entries {
+                let child_weight = self.buffer_index_to_weight
+                    [usize::from(self.heap_index_to_buffer_index[child])]
+                .unwrap();
+                assert!(weight <= child_weight);
+            }
+
+            let child = 2 * i + 2;
+            if child < self.num_heap_entries {
+                let child_weight = self.buffer_index_to_weight
+                    [usize::from(self.heap_index_to_buffer_index[child])]
+                .unwrap();
+                assert!(weight <= child_weight);
+            }
+        }
+    }
+
+    pub fn check(&self) {
+        if cfg!(debug_assertions) {
+            self.check_force();
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.num_heap_entries == 0
+    }
+
+    pub fn peek_min(&self) -> Option<(u16, NonZeroU16)> {
+        if self.num_heap_entries > 0 {
+            let buffer_index = self.heap_index_to_buffer_index[0];
+            let weight = self.buffer_index_to_weight[usize::from(buffer_index)].unwrap();
+
+            Some((buffer_index, weight))
+        } else {
+            None
+        }
+    }
+
+    fn heap_index_to_weight(&self, heap_index: usize) -> NonZeroU16 {
+        let buffer_index = usize::from(self.heap_index_to_buffer_index[heap_index]);
+
+        self.buffer_index_to_weight[buffer_index].unwrap()
+    }
+
+    fn swap(&mut self, heap_index_a: usize, heap_index_b: usize) {
+        let buffer_index_a = usize::from(self.heap_index_to_buffer_index[heap_index_a]);
+        let buffer_index_b = usize::from(self.heap_index_to_buffer_index[heap_index_b]);
+
+        self.heap_index_to_buffer_index
+            .swap(heap_index_a, heap_index_b);
+        self.buffer_index_to_heap_index
+            .swap(buffer_index_a, buffer_index_b);
+    }
+
+    fn pull_up(&mut self, mut heap_index: usize) {
+        while heap_index != 0 {
+            let parent_heap_index = (heap_index - 1) / 2;
+
+            if self.heap_index_to_weight(parent_heap_index) <= self.heap_index_to_weight(heap_index)
+            {
+                break;
+            }
+
+            self.swap(heap_index, parent_heap_index);
+            heap_index = parent_heap_index;
+        }
+    }
+
+    pub fn insert_buffer_weight(&mut self, buffer_index: usize, weight: NonZeroU16) {
+        assert!(replace(&mut self.buffer_index_to_weight[buffer_index], Some(weight)).is_none());
+
+        let heap_index = self.num_heap_entries;
+        self.num_heap_entries += 1;
+
+        self.heap_index_to_buffer_index[heap_index] = buffer_index.try_into().unwrap();
+        self.buffer_index_to_heap_index[buffer_index] = heap_index.try_into().unwrap();
+
+        self.pull_up(heap_index);
+
+        self.check();
+    }
+
+    fn push_down(&mut self, mut heap_index: usize) {
+        loop {
+            let mut heap_index_min = heap_index;
+
+            let child_heap_index = 2 * heap_index + 1;
+            if child_heap_index < self.num_heap_entries
+                && self.heap_index_to_weight(child_heap_index)
+                    < self.heap_index_to_weight(heap_index_min)
+            {
+                heap_index_min = child_heap_index;
+            }
+
+            let child_heap_index = 2 * heap_index + 2;
+            if child_heap_index < self.num_heap_entries
+                && self.heap_index_to_weight(child_heap_index)
+                    < self.heap_index_to_weight(heap_index_min)
+            {
+                heap_index_min = child_heap_index;
+            }
+
+            if heap_index == heap_index_min {
+                break;
+            }
+
+            self.swap(heap_index, heap_index_min);
+            heap_index = heap_index_min;
+        }
+    }
+
+    fn remove_heap_index(&mut self, heap_index: u16, buffer_index: u16) {
+        let heap_index_usize = usize::from(heap_index);
+        let buffer_index_usize = usize::from(buffer_index);
+
+        debug_assert!(self.heap_index_to_buffer_index[heap_index_usize] == buffer_index);
+        debug_assert!(self.buffer_index_to_heap_index[buffer_index_usize] == heap_index);
+
+        let last_heap_index = self.num_heap_entries - 1;
+        if heap_index_usize != last_heap_index {
+            self.swap(heap_index_usize, last_heap_index);
+        }
+
+        let prev_weight = self.buffer_index_to_weight[buffer_index_usize]
+            .take()
+            .unwrap()
+            .get();
+
+        self.num_heap_entries -= 1;
+
+        if heap_index_usize != last_heap_index {
+            match self
+                .heap_index_to_weight(heap_index_usize)
+                .get()
+                .cmp(&prev_weight)
+            {
+                Ordering::Less => self.pull_up(heap_index_usize),
+                Ordering::Greater => self.push_down(heap_index_usize),
+                Ordering::Equal => {}
+            }
+        }
+
+        self.check();
+    }
+
+    pub fn remove_min(&mut self) {
+        self.remove_heap_index(0, self.heap_index_to_buffer_index[0]);
+    }
+
+    pub fn remove_buffer_weight(&mut self, buffer_index: usize) -> Option<NonZeroU16> {
+        let weight = self.buffer_index_to_weight[buffer_index].unwrap();
+
+        self.remove_heap_index(
+            self.buffer_index_to_heap_index[buffer_index],
+            buffer_index.try_into().unwrap(),
+        );
+
+        Some(weight)
+    }
+
+    pub fn update_buffer_weight(&mut self, buffer_index: usize, weight: NonZeroU16) {
+        let prev_weight = self.buffer_index_to_weight[buffer_index].unwrap();
+
+        if prev_weight != weight {
+            self.buffer_index_to_weight[buffer_index] = Some(weight);
+
+            let heap_index = usize::from(self.buffer_index_to_heap_index[buffer_index]);
+
+            match weight.cmp(&prev_weight) {
+                Ordering::Less => self.pull_up(heap_index),
+                Ordering::Greater => self.push_down(heap_index),
+                Ordering::Equal => {}
+            }
+
+            self.check();
+        }
+    }
+
+    /*
+    pub fn update_buffer_weight_fn(
+        &mut self,
+        buffer_index: usize,
+        update_fn: impl FnMut(Option<NonZeroU16>) -> Option<NonZeroU16>,
+    ) {
+        todo!()
+    }
+    */
+
+    pub fn enumerate(&self, mut buffer_index_weight_fn: impl FnMut(u16, NonZeroU16)) {
+        for i in 0..self.num_heap_entries {
+            let buffer_index = self.heap_index_to_buffer_index[i];
+            let weight = self.buffer_index_to_weight[usize::from(buffer_index)].unwrap();
+
+            buffer_index_weight_fn(buffer_index, weight);
+        }
+    }
+}
+
+impl<const MAX_BUFFERS: usize> Default for BufferWeightMap<MAX_BUFFERS> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/monad-raptor/src/r10/nonsystematic/decoder/check.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/check.rs
@@ -1,0 +1,195 @@
+use std::collections::BTreeMap;
+
+use crate::{
+    matrix::DenseMatrix,
+    r10::nonsystematic::decoder::{BufferState, Decoder, IntermediateSymbol},
+};
+
+impl Decoder {
+    // Determine the current state of the buffer-to-intermediate-symbol mapping according to
+    // the self.buffer_state elements.
+    fn buffer_state_to_mapping(&self) -> DenseMatrix {
+        let mut m = DenseMatrix::from_element(
+            self.buffer_state.len(),
+            self.intermediate_symbol_state.len(),
+            false,
+        );
+
+        for i in 0..self.buffer_state.len() {
+            for j in &self.buffer_state[i].intermediate_symbol_ids {
+                m[(i, usize::from(*j))] = true;
+            }
+        }
+
+        m
+    }
+
+    // Determine the current state of the buffer-to-intermediate-symbol mapping according to
+    // the self.intermediate_symbol_state elements.
+    fn intermediate_symbol_state_to_mapping(&self) -> DenseMatrix {
+        let mut m = DenseMatrix::from_element(
+            self.buffer_state.len(),
+            self.intermediate_symbol_state.len(),
+            false,
+        );
+
+        for j in 0..self.intermediate_symbol_state.len() {
+            match &self.intermediate_symbol_state[j] {
+                IntermediateSymbol::Active { buffer_indices } => {
+                    for i in buffer_indices {
+                        m[(usize::from(*i), j)] = true;
+                    }
+                }
+                IntermediateSymbol::Used { buffer_index } => {
+                    m[(usize::from(*buffer_index), j)] = true;
+                }
+                IntermediateSymbol::Inactivated { buffer_indices } => {
+                    for i in buffer_indices {
+                        m[(usize::from(*i), j)] = true;
+                    }
+                }
+            }
+        }
+
+        m
+    }
+
+    fn check_elements_match(&self) {
+        let left = self.buffer_state_to_mapping();
+        let right = self.intermediate_symbol_state_to_mapping();
+
+        if left != right {
+            panic!(
+                "buffer state mapping = {}, intermediate symbol state mapping = {}",
+                left, right
+            );
+        }
+    }
+
+    fn check_used(&self) {
+        for i in 0..self.buffer_state.len() {
+            if self.buffer_state[i].used {
+                assert_eq!(self.buffer_state[i].active_used_weight, 1);
+
+                let active_used_intermediate_symbol_ids: Vec<u16> = self.buffer_state[i]
+                    .intermediate_symbol_ids
+                    .iter()
+                    .filter(|intermediate_symbol_id| {
+                        !self.intermediate_symbol_state[usize::from(**intermediate_symbol_id)]
+                            .is_inactivated()
+                    })
+                    .copied()
+                    .collect();
+
+                assert_eq!(active_used_intermediate_symbol_ids.len(), 1);
+
+                assert!(self.intermediate_symbol_state
+                    [usize::from(active_used_intermediate_symbol_ids[0])]
+                .is_used());
+            }
+        }
+
+        for j in 0..self.intermediate_symbol_state.len() {
+            if let Some(buffer_index) = self.intermediate_symbol_state[j].is_used_buffer_index() {
+                assert_eq!(
+                    self.buffer_state[usize::from(buffer_index)].state(),
+                    BufferState::Used
+                );
+            }
+        }
+    }
+
+    fn check_active_usable(&self) {
+        let mut self_buffers_active_usable: BTreeMap<u16, u16> = BTreeMap::new();
+
+        self.buffers_active_usable
+            .enumerate(|buffer_index, active_used_weight| {
+                self_buffers_active_usable.insert(buffer_index, active_used_weight.get());
+            });
+
+        let mut buffers_active_usable: BTreeMap<u16, u16> = BTreeMap::new();
+
+        for i in 0..self.buffer_state.len() {
+            let mut active_used_weight = 0;
+
+            for j in &self.buffer_state[i].intermediate_symbol_ids {
+                if !self.intermediate_symbol_state[usize::from(*j)].is_inactivated() {
+                    active_used_weight += 1;
+                }
+            }
+
+            assert_eq!(self.buffer_state[i].active_used_weight, active_used_weight);
+
+            if self.buffer_state[i].state() == BufferState::Active
+                || self.buffer_state[i].state() == BufferState::Usable
+            {
+                buffers_active_usable.insert(i.try_into().unwrap(), active_used_weight);
+            }
+        }
+
+        assert_eq!(self_buffers_active_usable, buffers_active_usable);
+    }
+
+    fn check_inactivated(&self) {
+        let mut self_buffers_inactivated: BTreeMap<u16, u16> = BTreeMap::new();
+
+        self.buffers_inactivated
+            .enumerate(|buffer_index, active_used_weight| {
+                self_buffers_inactivated.insert(buffer_index, active_used_weight.get());
+            });
+
+        let mut buffers_inactivated: BTreeMap<u16, u16> = BTreeMap::new();
+
+        for i in 0..self.buffer_state.len() {
+            let weight = self.buffer_state[i].intermediate_symbol_ids.len();
+
+            if self.buffer_state[i].state() == BufferState::Inactivated {
+                buffers_inactivated.insert(i.try_into().unwrap(), weight.try_into().unwrap());
+            }
+        }
+
+        assert_eq!(self_buffers_inactivated, buffers_inactivated);
+    }
+
+    fn check_num_redundant_buffers(&self) {
+        let mut num_redundant_buffers = 0;
+
+        for i in 0..self.buffer_state.len() {
+            if self.buffer_state[i].state() == BufferState::Redundant {
+                num_redundant_buffers += 1;
+            }
+        }
+
+        assert_eq!(self.num_redundant_buffers, num_redundant_buffers);
+    }
+
+    fn check_num_source_symbols_paired(&self) {
+        let mut num_source_symbols_paired = 0;
+
+        for i in 0..self.buffer_state.len() {
+            if self.buffer_state[i].is_paired()
+                && usize::from(self.buffer_state[i].first_intermediate_symbol_id())
+                    < self.params.num_source_symbols()
+            {
+                num_source_symbols_paired += 1;
+            }
+        }
+
+        assert_eq!(self.num_source_symbols_paired, num_source_symbols_paired);
+    }
+
+    pub fn check_force(&self) {
+        self.check_elements_match();
+        self.check_used();
+        self.check_active_usable();
+        self.check_inactivated();
+        self.check_num_redundant_buffers();
+        self.check_num_source_symbols_paired();
+    }
+
+    pub fn check(&self) {
+        if cfg!(debug_assertions) {
+            self.check_force();
+        }
+    }
+}

--- a/monad-raptor/src/r10/nonsystematic/decoder/decode.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/decode.rs
@@ -1,0 +1,138 @@
+use std::{cmp::Ordering, num::NonZeroU16};
+
+use crate::r10::nonsystematic::decoder::{BufferId, Decoder};
+
+impl Decoder {
+    // Split a borrow to be able to get two mutable references to different elements of a
+    // slice without using unsafe code.  (This essentially emulates std::slice::get_many_mut(),
+    // without using unsafe code.)
+    pub fn get_two_mut<T>(slice: &mut [T], a: usize, b: usize) -> (&mut T, &mut T) {
+        match a.cmp(&b) {
+            Ordering::Less => {
+                let (first, second) = slice.split_at_mut(b);
+
+                (&mut first[a], &mut second[0])
+            }
+            Ordering::Greater => {
+                let (first, second) = slice.split_at_mut(a);
+
+                (&mut second[0], &mut first[b])
+            }
+            Ordering::Equal => panic!(),
+        }
+    }
+
+    pub fn buffer_first_active_intermediate_symbol(&self, buffer_index: u16) -> u16 {
+        self.buffer_state[usize::from(buffer_index)]
+            .intermediate_symbol_ids
+            .iter()
+            .find(|intermediate_symbol_id| {
+                self.intermediate_symbol_state[usize::from(**intermediate_symbol_id)].is_active()
+            })
+            .copied()
+            .unwrap()
+    }
+
+    pub fn decrement_buffer_weight(&mut self, buffer_index: u16) {
+        let buffer = &mut self.buffer_state[usize::from(buffer_index)];
+
+        buffer.active_used_weight -= 1;
+
+        if buffer.active_used_weight > 0 {
+            self.buffers_active_usable.update_buffer_weight(
+                usize::from(buffer_index),
+                NonZeroU16::new(buffer.active_used_weight).unwrap(),
+            );
+        } else {
+            let weight = self
+                .buffers_active_usable
+                .remove_buffer_weight(usize::from(buffer_index))
+                .unwrap();
+            debug_assert!(weight == NonZeroU16::new(1).unwrap());
+
+            let weight = buffer.intermediate_symbol_ids.len();
+
+            if weight > 0 {
+                self.buffers_inactivated.insert_buffer_weight(
+                    buffer_index.into(),
+                    NonZeroU16::new(weight.try_into().unwrap()).unwrap(),
+                );
+            } else {
+                self.num_redundant_buffers += 1;
+            }
+        }
+    }
+
+    pub fn try_decode(
+        &mut self,
+        inactivation_symbol_threshold: usize,
+        mut xor_buffers: impl FnMut(BufferId, BufferId),
+    ) -> bool {
+        assert!(inactivation_symbol_threshold >= self.params.num_source_symbols());
+
+        #[derive(PartialEq)]
+        enum DecodingState {
+            ReactivateSymbols,
+            Peeling,
+            MaybeInactiveGaussian,
+            InactivateSymbol,
+            Done,
+        }
+
+        // If the number of (non-redundant) encoded symbols that has been received is at least
+        // a configurable multiple (>= 1.0) of the number of source symbols, we will proceed
+        // to using inactivation decoding to try to recover all source symbols.
+        //
+        // We don't want to resort to inactivation decoding too quickly, as the cost of full
+        // source symbol recovery via inactivation decoding scales inversely with the number
+        // of (non-redundant) encoded symbols that has been received.
+        let usable_buffers = self.buffer_state.len() - usize::from(self.num_redundant_buffers);
+        let try_harder = usable_buffers >= inactivation_symbol_threshold;
+
+        // Keep trying to reactivate intermediate symbols and peeling in a loop as long as that
+        // makes decoding progress.  Once those two operations stop making progress, try
+        // performing Gaussian elimination on the inactive intermediate symbols, and if that
+        // succeeds, go back to looping.  If Gaussian elimination on the inactive intermediate
+        // symbols does not succeed, try inactivating a single intermediate symbol and then
+        // re-starting from the beginning.
+        let mut operation = DecodingState::ReactivateSymbols;
+
+        while !self.decoding_done() && operation != DecodingState::Done {
+            operation = match operation {
+                DecodingState::ReactivateSymbols => {
+                    self.try_reactivate_symbols(&mut xor_buffers);
+
+                    DecodingState::Peeling
+                }
+                DecodingState::Peeling => {
+                    if self.try_peel(&mut xor_buffers) {
+                        DecodingState::ReactivateSymbols
+                    } else {
+                        DecodingState::MaybeInactiveGaussian
+                    }
+                }
+                DecodingState::MaybeInactiveGaussian => {
+                    if !try_harder {
+                        DecodingState::Done
+                    } else if self.try_inactive_gaussian(&mut xor_buffers) {
+                        DecodingState::ReactivateSymbols
+                    } else {
+                        DecodingState::InactivateSymbol
+                    }
+                }
+                DecodingState::InactivateSymbol => {
+                    if !try_harder {
+                        DecodingState::Done
+                    } else if self.try_inactivate_one_symbol() {
+                        DecodingState::ReactivateSymbols
+                    } else {
+                        DecodingState::Done
+                    }
+                }
+                DecodingState::Done => panic!(),
+            }
+        }
+
+        self.decoding_done()
+    }
+}

--- a/monad-raptor/src/r10/nonsystematic/decoder/decode_finished.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/decode_finished.rs
@@ -1,0 +1,28 @@
+use crate::r10::nonsystematic::decoder::{BufferId, Decoder};
+
+impl Decoder {
+    pub fn decoding_done(&self) -> bool {
+        self.num_source_symbols_paired == self.params.num_source_symbols()
+    }
+
+    pub fn source_symbol_to_buffer_id(&self, source_symbol_id: usize) -> Option<BufferId> {
+        if source_symbol_id < self.params.num_source_symbols() {
+            match self.intermediate_symbol_state[source_symbol_id].is_used_buffer_index() {
+                None => None,
+                Some(buffer_index) => {
+                    let buffer = &self.buffer_state[usize::from(buffer_index)];
+
+                    if buffer.intermediate_symbol_ids.len() == 1 {
+                        debug_assert!(buffer.is_paired());
+
+                        Some(self.buffer_index_to_buffer_id(buffer_index))
+                    } else {
+                        None
+                    }
+                }
+            }
+        } else {
+            None
+        }
+    }
+}

--- a/monad-raptor/src/r10/nonsystematic/decoder/decode_inactivate.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/decode_inactivate.rs
@@ -1,0 +1,32 @@
+use crate::r10::nonsystematic::decoder::Decoder;
+
+impl Decoder {
+    pub fn try_inactivate_one_symbol(&mut self) -> bool {
+        let mut made_progress = false;
+
+        if let Some((buffer_index, active_used_weight)) = self.buffers_active_usable.peek_min() {
+            if active_used_weight.get() > 1 {
+                made_progress = true;
+
+                // TODO: Make a smarter choice here.
+                let intermediate_symbol_id =
+                    self.buffer_first_active_intermediate_symbol(buffer_index);
+
+                self.intermediate_symbol_state[usize::from(intermediate_symbol_id)]
+                    .active_inactivate();
+
+                for buffer_index in self.intermediate_symbol_state
+                    [usize::from(intermediate_symbol_id)]
+                .inactivated_values()
+                .clone()
+                {
+                    self.decrement_buffer_weight(buffer_index);
+                }
+
+                self.check();
+            }
+        }
+
+        made_progress
+    }
+}

--- a/monad-raptor/src/r10/nonsystematic/decoder/decode_inactive_gaussian.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/decode_inactive_gaussian.rs
@@ -1,0 +1,126 @@
+use std::{collections::BTreeSet, num::NonZeroU16};
+
+use crate::{
+    matrix::{DenseMatrix, RowOperation},
+    r10::nonsystematic::decoder::{BufferId, BufferState, Decoder},
+};
+
+impl Decoder {
+    fn buffer_inactivated_xor_eq(&mut self, a: u16, b: u16) {
+        let (aref, bref) =
+            Self::get_two_mut(&mut self.buffer_state, usize::from(a), usize::from(b));
+
+        debug_assert!(aref.state() == BufferState::Inactivated);
+
+        debug_assert!(bref.state() == BufferState::Inactivated);
+
+        for intermediate_symbol_id in &bref.intermediate_symbol_ids {
+            let symbol = &mut self.intermediate_symbol_state[usize::from(*intermediate_symbol_id)];
+
+            if !symbol.is_inactivated() {
+                let ret = aref.intermediate_symbol_ids.remove(intermediate_symbol_id);
+                debug_assert!(ret);
+            } else if aref
+                .intermediate_symbol_ids
+                .insert_or_remove(*intermediate_symbol_id)
+            {
+                symbol.inactivated_insert(a);
+            } else {
+                symbol.inactivated_remove(a);
+            }
+        }
+    }
+
+    // Attempt Gaussian elimination on the inactivated intermediate symbols.
+    pub fn try_inactive_gaussian(
+        &mut self,
+        xor_buffers: &mut impl FnMut(BufferId, BufferId),
+    ) -> bool {
+        // TODO: Don't perform Gaussian elimination while there are Active intermediate symbols?
+
+        if self.buffers_inactivated.is_empty() {
+            // Nothing to eliminate.
+            return false;
+        }
+
+        if self.buffers_inactivated.peek_min().unwrap().1.get() == 1 {
+            // There is an inactivated intermediate symbol we can reactivate, so there is no
+            // need to perform Gaussian elimination at this point.
+            return false;
+        }
+
+        let mut inactivated_buffer_indices: Vec<u16> = Vec::new();
+
+        self.buffers_inactivated
+            .enumerate(|buffer_index, _weight| inactivated_buffer_indices.push(buffer_index));
+
+        // TODO: Consider pre-computing part of this.
+        let inactivated_intermediate_symbol_ids: BTreeSet<u16> = inactivated_buffer_indices
+            .iter()
+            .flat_map(|buffer_index| {
+                self.buffer_state[usize::from(*buffer_index)]
+                    .intermediate_symbol_ids
+                    .iter()
+                    .copied()
+            })
+            .collect();
+
+        if inactivated_buffer_indices.len() < inactivated_intermediate_symbol_ids.len() {
+            // We need at least as many buffers as intermediate symbols for Gaussian
+            // elimination to be successful.
+            return false;
+        }
+
+        let inactivated_intermediate_symbol_ids: Vec<u16> =
+            inactivated_intermediate_symbol_ids.into_iter().collect();
+
+        let mat = DenseMatrix::from_fn(
+            inactivated_buffer_indices.len(),
+            inactivated_intermediate_symbol_ids.len(),
+            |i, j| {
+                let buffer_index = inactivated_buffer_indices[i];
+                let intermediate_symbol_id = inactivated_intermediate_symbol_ids[j];
+
+                self.buffer_state[usize::from(buffer_index)]
+                    .intermediate_symbol_ids
+                    .contains(&intermediate_symbol_id)
+            },
+        );
+
+        let _ = mat.rowwise_elimination_gaussian_full_pivot(|op| match op {
+            RowOperation::SubAssign { i, j } => {
+                let reducee_buffer_index = inactivated_buffer_indices[i];
+                let reducing_buffer_index = inactivated_buffer_indices[j];
+
+                self.buffer_inactivated_xor_eq(reducee_buffer_index, reducing_buffer_index);
+
+                xor_buffers(
+                    self.buffer_index_to_buffer_id(reducee_buffer_index),
+                    self.buffer_index_to_buffer_id(reducing_buffer_index),
+                );
+            }
+        });
+
+        for buffer_index in &inactivated_buffer_indices {
+            let weight = self.buffer_state[usize::from(*buffer_index)]
+                .intermediate_symbol_ids
+                .len();
+
+            if weight > 0 {
+                self.buffers_inactivated.update_buffer_weight(
+                    usize::from(*buffer_index),
+                    NonZeroU16::new(weight.try_into().unwrap()).unwrap(),
+                );
+            } else {
+                self.buffers_inactivated
+                    .remove_buffer_weight(usize::from(*buffer_index));
+
+                self.num_redundant_buffers += 1;
+            }
+        }
+
+        self.check();
+
+        true
+    }
+}

--- a/monad-raptor/src/r10/nonsystematic/decoder/decode_peel.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/decode_peel.rs
@@ -1,0 +1,88 @@
+use crate::r10::nonsystematic::decoder::{BufferId, BufferState, Decoder};
+
+impl Decoder {
+    fn buffer_peel_xor_eq(&mut self, a: u16, b: u16) {
+        let (aref, bref) =
+            Self::get_two_mut(&mut self.buffer_state, usize::from(a), usize::from(b));
+
+        debug_assert!(aref.state() == BufferState::Active || aref.state() == BufferState::Usable);
+
+        debug_assert!(bref.state() == BufferState::Used);
+
+        for intermediate_symbol_id in &bref.intermediate_symbol_ids {
+            let symbol = &mut self.intermediate_symbol_state[usize::from(*intermediate_symbol_id)];
+
+            if !symbol.is_inactivated() {
+                let ret = aref.intermediate_symbol_ids.remove(intermediate_symbol_id);
+                debug_assert!(ret);
+            } else if aref
+                .intermediate_symbol_ids
+                .insert_or_remove(*intermediate_symbol_id)
+            {
+                symbol.inactivated_insert(a);
+            } else {
+                symbol.inactivated_remove(a);
+            }
+        }
+    }
+
+    // Check for buffers that contain exactly one non-inactivated intermediate symbol, and use
+    // such a buffer to reduce that intermediate symbol from every other buffer that contains it.
+    pub fn try_peel(&mut self, xor_buffers: &mut impl FnMut(BufferId, BufferId)) -> bool {
+        let mut made_progress = false;
+
+        while let Some((reducing_buffer_index, active_used_weight)) =
+            self.buffers_active_usable.peek_min()
+        {
+            if self.decoding_done() || active_used_weight.get() != 1 {
+                break;
+            }
+
+            // This buffer is transitioning from Usable to Used, and will therefore no longer
+            // be represented in `self.buffers_active_usable`.
+            let weight = self
+                .buffers_active_usable
+                .remove_buffer_weight(usize::from(reducing_buffer_index));
+            debug_assert!(weight == Some(active_used_weight));
+
+            let intermediate_symbol_id =
+                self.buffer_first_active_intermediate_symbol(reducing_buffer_index);
+
+            self.buffer_state[usize::from(reducing_buffer_index)].used = true;
+
+            let reducee_buffer_indices = self.intermediate_symbol_state
+                [usize::from(intermediate_symbol_id)]
+            .active_make_used(reducing_buffer_index);
+
+            for reducee_buffer_index in reducee_buffer_indices {
+                if reducee_buffer_index != reducing_buffer_index {
+                    self.buffer_peel_xor_eq(reducee_buffer_index, reducing_buffer_index);
+
+                    // Buffer `reducing_buffer_index` has active_used_weight == 1, so we
+                    // decrement the weight of buffer `reducee_buffer_index` by 1.
+                    self.decrement_buffer_weight(reducee_buffer_index);
+
+                    xor_buffers(
+                        self.buffer_index_to_buffer_id(reducee_buffer_index),
+                        self.buffer_index_to_buffer_id(reducing_buffer_index),
+                    );
+                }
+            }
+
+            if self.buffer_state[usize::from(reducing_buffer_index)]
+                .intermediate_symbol_ids
+                .len()
+                == 1
+                && usize::from(intermediate_symbol_id) < self.params.num_source_symbols()
+            {
+                self.num_source_symbols_paired += 1;
+            }
+
+            self.check();
+
+            made_progress = true;
+        }
+
+        made_progress
+    }
+}

--- a/monad-raptor/src/r10/nonsystematic/decoder/decode_reactivate.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/decode_reactivate.rs
@@ -1,0 +1,84 @@
+use std::num::NonZeroU16;
+
+use crate::r10::nonsystematic::decoder::{BufferId, Decoder};
+
+impl Decoder {
+    // Check if we have any previously inactivated intermediate symbols for which there is
+    // now a buffer that contains only that symbol -- if so, we can reactivate that symbol
+    // and use it to reduce the other buffers that contain this symbol.
+    pub fn try_reactivate_symbols(
+        &mut self,
+        xor_buffers: &mut impl FnMut(BufferId, BufferId),
+    ) -> bool {
+        let mut made_progress = false;
+
+        while let Some((reducing_buffer_index, weight)) = self.buffers_inactivated.peek_min() {
+            if self.decoding_done() || weight.get() != 1 {
+                break;
+            }
+
+            let reducing_buffer = &mut self.buffer_state[usize::from(reducing_buffer_index)];
+
+            self.buffers_inactivated
+                .remove_buffer_weight(usize::from(reducing_buffer_index));
+
+            let intermediate_symbol_id = reducing_buffer.first_intermediate_symbol_id();
+
+            reducing_buffer.active_used_weight = 1;
+            reducing_buffer.used = true;
+
+            let reducee_buffer_indices = self.intermediate_symbol_state
+                [usize::from(intermediate_symbol_id)]
+            .inactivated_make_used(reducing_buffer_index);
+
+            for reducee_buffer_index in reducee_buffer_indices {
+                if reducee_buffer_index != reducing_buffer_index {
+                    let reducee_buffer = &mut self.buffer_state[usize::from(reducee_buffer_index)];
+
+                    let ret = reducee_buffer
+                        .intermediate_symbol_ids
+                        .remove(&intermediate_symbol_id);
+                    debug_assert!(ret);
+
+                    if reducee_buffer.active_used_weight == 0 {
+                        let weight = reducee_buffer.intermediate_symbol_ids.len();
+
+                        if weight > 0 {
+                            self.buffers_inactivated.update_buffer_weight(
+                                usize::from(reducee_buffer_index),
+                                NonZeroU16::new(weight.try_into().unwrap()).unwrap(),
+                            );
+                        } else {
+                            self.buffers_inactivated
+                                .remove_buffer_weight(usize::from(reducee_buffer_index));
+
+                            self.num_redundant_buffers += 1;
+                        }
+                    }
+
+                    if reducee_buffer.is_paired()
+                        && usize::from(reducee_buffer.first_intermediate_symbol_id())
+                            < self.params.num_source_symbols()
+                    {
+                        self.num_source_symbols_paired += 1;
+                    }
+
+                    xor_buffers(
+                        self.buffer_index_to_buffer_id(reducee_buffer_index),
+                        self.buffer_index_to_buffer_id(reducing_buffer_index),
+                    );
+                }
+            }
+
+            if usize::from(intermediate_symbol_id) < self.params.num_source_symbols() {
+                self.num_source_symbols_paired += 1;
+            }
+
+            self.check();
+
+            made_progress = true;
+        }
+
+        made_progress
+    }
+}

--- a/monad-raptor/src/r10/nonsystematic/decoder/init.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/init.rs
@@ -1,0 +1,116 @@
+use std::{
+    io::{Error, ErrorKind},
+    iter,
+    num::NonZeroU16,
+};
+
+use crate::r10::{
+    lt::MAX_TRIPLES,
+    nonsystematic::decoder::{Buffer, BufferWeightMap, Decoder, IntermediateSymbol},
+    CodeParameters, SOURCE_SYMBOLS_MAX, SOURCE_SYMBOLS_MIN,
+};
+
+impl Decoder {
+    pub fn new(num_source_symbols: usize) -> Result<Decoder, Error> {
+        if !(SOURCE_SYMBOLS_MIN..=SOURCE_SYMBOLS_MAX).contains(&num_source_symbols) {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                format!(
+                    "number of source symbols {} not in range {}..={}",
+                    num_source_symbols, SOURCE_SYMBOLS_MIN, SOURCE_SYMBOLS_MAX
+                ),
+            ));
+        }
+
+        let params = CodeParameters::new(num_source_symbols).map_err(|err| {
+            Error::new(
+                ErrorKind::InvalidInput,
+                format!(
+                    "error creating CodeParameters for {} source symbols: {}",
+                    num_source_symbols, err
+                ),
+            )
+        })?;
+
+        // Initialize buffer_state and intermediate_symbol_state for the constraint
+        // symbol buffers that we start with, according to the upper part of the A
+        // matrix from RFC 5053, where the rows correspond to buffers and the columns
+        // to intermediate symbols:
+        //
+        //               K               S       H
+        //   +-----------------------+-------+-------+
+        //   |                       |       |       |
+        // S |        G_LDPC         |  I_S  | 0_SxH |
+        //   |                       |       |       |
+        //   +-----------------------+-------+-------+
+        //   |                               |       |
+        // H |        G_Half                 |  I_H  |
+        //   |                               |       |
+        //   +-------------------------------+-------+
+
+        let mut buffer_state: Vec<Buffer> = iter::repeat_with(Buffer::new)
+            .take(params.num_ldpc_symbols() + params.num_half_symbols())
+            .collect();
+
+        let mut intermediate_symbol_state: Vec<IntermediateSymbol> =
+            iter::repeat_with(IntermediateSymbol::new)
+                .take(params.num_intermediate_symbols())
+                .collect();
+
+        // G_LDPC
+        params.g_ldpc(|buffer_index, intermediate_symbol_id| {
+            buffer_state[buffer_index].append_active_intermediate_symbol_id(intermediate_symbol_id);
+            intermediate_symbol_state[intermediate_symbol_id].active_push(buffer_index);
+        });
+
+        // I_S
+        #[allow(clippy::needless_range_loop)]
+        for buffer_index in 0..params.num_ldpc_symbols() {
+            let intermediate_symbol_id = params.num_source_symbols() + buffer_index;
+
+            buffer_state[buffer_index].append_active_intermediate_symbol_id(intermediate_symbol_id);
+            intermediate_symbol_state[intermediate_symbol_id].active_push(buffer_index);
+        }
+
+        // G_Half
+        params.g_half(|i, intermediate_symbol_id| {
+            let buffer_index = params.num_ldpc_symbols() + i;
+
+            buffer_state[buffer_index].append_active_intermediate_symbol_id(intermediate_symbol_id);
+            intermediate_symbol_state[intermediate_symbol_id].active_push(buffer_index);
+        });
+
+        // I_H
+        for i in 0..params.num_half_symbols() {
+            let buffer_index = params.num_ldpc_symbols() + i;
+            let intermediate_symbol_id =
+                params.num_source_symbols() + params.num_ldpc_symbols() + i;
+
+            buffer_state[buffer_index].append_active_intermediate_symbol_id(intermediate_symbol_id);
+            intermediate_symbol_state[intermediate_symbol_id].active_push(buffer_index);
+        }
+
+        let mut buffers_active_usable = BufferWeightMap::<MAX_TRIPLES>::new();
+
+        for (i, buffer_state) in buffer_state.iter().enumerate() {
+            buffers_active_usable
+                .insert_buffer_weight(i, NonZeroU16::new(buffer_state.active_used_weight).unwrap());
+        }
+
+        let buffers_inactivated = BufferWeightMap::<MAX_TRIPLES>::new();
+
+        let decoder = Decoder {
+            params,
+            buffer_state,
+            intermediate_symbol_state,
+            buffers_active_usable,
+            buffers_inactivated,
+            num_redundant_buffers: 0,
+            num_source_symbols_paired: 0,
+        };
+
+        decoder.check();
+
+        Ok(decoder)
+    }
+}

--- a/monad-raptor/src/r10/nonsystematic/decoder/intermediate_symbol.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/intermediate_symbol.rs
@@ -1,0 +1,158 @@
+use std::mem::replace;
+
+use crate::ordered_set::OrderedSet;
+
+#[derive(Debug)]
+pub enum IntermediateSymbol {
+    // This intermediate symbol is either:
+    // - not encoded in any buffer (yet); or
+    // - XORd into a single buffer that also has other active intermediate symbols XORd into it; or
+    // - XORd into multiple buffers.
+    Active { buffer_indices: OrderedSet },
+
+    // This intermediate symbol has temporarily stopped counting toward buffer active_used_weight
+    // counts so that we can make progress with the peeling process.
+    Inactivated { buffer_indices: OrderedSet },
+
+    // This intermediate symbol is XORd into a single buffer that has no other active intermediate
+    // symbols (but maybe some inactivated intermediate symbols) XORd into it, and no other buffer
+    // has this intermediate symbol XORd into it.
+    Used { buffer_index: u16 },
+}
+
+impl IntermediateSymbol {
+    pub fn new() -> IntermediateSymbol {
+        IntermediateSymbol::Active {
+            buffer_indices: OrderedSet::new(),
+        }
+    }
+}
+
+impl Default for IntermediateSymbol {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// IntermediateSymbol::Active
+impl IntermediateSymbol {
+    pub fn is_active(&self) -> bool {
+        match self {
+            IntermediateSymbol::Active { .. } => true,
+            IntermediateSymbol::Inactivated { .. } => false,
+            IntermediateSymbol::Used { .. } => false,
+        }
+    }
+
+    // buffer_index must be larger than any element currently in the set.
+    pub fn active_push(&mut self, buffer_index: usize) {
+        match self {
+            IntermediateSymbol::Active { buffer_indices } => {
+                buffer_indices.append(buffer_index.try_into().unwrap());
+            }
+            IntermediateSymbol::Inactivated { .. } => panic!(),
+            IntermediateSymbol::Used { .. } => panic!(),
+        }
+    }
+
+    // buffer_index must be larger than any element currently in the set.
+    pub fn active_inactivated_push(&mut self, buffer_index: u16) {
+        match self {
+            IntermediateSymbol::Active { buffer_indices } => {
+                buffer_indices.append(buffer_index);
+            }
+            IntermediateSymbol::Inactivated { buffer_indices } => {
+                buffer_indices.append(buffer_index);
+            }
+            IntermediateSymbol::Used { .. } => panic!(),
+        }
+    }
+
+    pub fn active_inactivate(&mut self) {
+        // We temporarily stick this value in so that we can convert the vector of buffer
+        // indices to a `BTreeSet<>` and put it back in.
+        let buffer_indices = self.active_make_used(u16::MAX);
+
+        *self = IntermediateSymbol::Inactivated { buffer_indices };
+    }
+
+    pub fn active_make_used(&mut self, buffer_index: u16) -> OrderedSet {
+        let old = replace(self, IntermediateSymbol::Used { buffer_index });
+
+        match old {
+            IntermediateSymbol::Active { buffer_indices } => buffer_indices,
+            IntermediateSymbol::Inactivated { .. } => panic!(),
+            IntermediateSymbol::Used { .. } => panic!(),
+        }
+    }
+}
+
+// IntermediateSymbol::Inactivated
+impl IntermediateSymbol {
+    pub fn is_inactivated(&self) -> bool {
+        match self {
+            IntermediateSymbol::Active { .. } => false,
+            IntermediateSymbol::Inactivated { .. } => true,
+            IntermediateSymbol::Used { .. } => false,
+        }
+    }
+
+    pub fn inactivated_values(&self) -> &OrderedSet {
+        match self {
+            IntermediateSymbol::Active { .. } => panic!(),
+            IntermediateSymbol::Inactivated { buffer_indices } => buffer_indices,
+            IntermediateSymbol::Used { .. } => panic!(),
+        }
+    }
+
+    pub fn inactivated_insert(&mut self, buffer_index: u16) {
+        match self {
+            IntermediateSymbol::Active { .. } => panic!(),
+            IntermediateSymbol::Inactivated { buffer_indices } => {
+                let ret = buffer_indices.insert(buffer_index);
+                debug_assert!(ret);
+            }
+            IntermediateSymbol::Used { .. } => panic!(),
+        }
+    }
+
+    pub fn inactivated_remove(&mut self, buffer_index: u16) {
+        match self {
+            IntermediateSymbol::Active { .. } => panic!(),
+            IntermediateSymbol::Inactivated { buffer_indices } => {
+                let ret = buffer_indices.remove(&buffer_index);
+                debug_assert!(ret);
+            }
+            IntermediateSymbol::Used { .. } => panic!(),
+        }
+    }
+
+    pub fn inactivated_make_used(&mut self, buffer_index: u16) -> OrderedSet {
+        let old = replace(self, IntermediateSymbol::Used { buffer_index });
+
+        match old {
+            IntermediateSymbol::Active { .. } => panic!(),
+            IntermediateSymbol::Inactivated { buffer_indices } => buffer_indices,
+            IntermediateSymbol::Used { .. } => panic!(),
+        }
+    }
+}
+
+// IntermediateSymbol::Used
+impl IntermediateSymbol {
+    pub fn is_used(&self) -> bool {
+        match self {
+            IntermediateSymbol::Active { .. } => false,
+            IntermediateSymbol::Inactivated { .. } => false,
+            IntermediateSymbol::Used { .. } => true,
+        }
+    }
+
+    pub fn is_used_buffer_index(&self) -> Option<u16> {
+        match self {
+            IntermediateSymbol::Active { .. } => None,
+            IntermediateSymbol::Inactivated { .. } => None,
+            IntermediateSymbol::Used { buffer_index } => Some(*buffer_index),
+        }
+    }
+}

--- a/monad-raptor/src/r10/nonsystematic/decoder/managed_decoder.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/managed_decoder.rs
@@ -1,0 +1,137 @@
+use std::{cmp::Ordering, io::Error, iter};
+
+use crate::r10::nonsystematic::decoder::{BufferId, Decoder};
+
+// We switch from doing peeling only to performing inactivation decoding when
+// num_received_encoded_symbols >= (MULTIPLIER * num_source_symbols) >> SHIFT .
+const INACTIVATION_SYMBOL_THRESHOLD_MULTIPLIER: usize = 384;
+const INACTIVATION_SYMBOL_THRESHOLD_SHIFT: usize = 8;
+
+#[derive(Debug)]
+struct BufferSet {
+    num_temp_buffers: usize,
+    buffers: Vec<Box<[u8]>>,
+}
+
+impl BufferSet {
+    pub fn new(num_temp_buffers: usize, symbol_len: usize) -> BufferSet {
+        let buffers: Vec<Box<[u8]>> = iter::repeat(vec![0; symbol_len].into_boxed_slice())
+            .take(num_temp_buffers)
+            .collect();
+
+        BufferSet {
+            num_temp_buffers,
+            buffers,
+        }
+    }
+
+    pub fn push_buffer(&mut self, buf: Box<[u8]>) {
+        self.buffers.push(buf);
+    }
+
+    fn buffer_index(&self, buffer_id: BufferId) -> usize {
+        match buffer_id {
+            BufferId::TempBuffer { index } => index,
+            BufferId::ReceiveBuffer { index } => self.num_temp_buffers + index,
+        }
+    }
+
+    pub fn xor_buffers(&mut self, a: BufferId, b: BufferId) {
+        let a_index = self.buffer_index(a);
+        let b_index = self.buffer_index(b);
+
+        // Split the borrow to be able to get a mutable reference and an immutable
+        // reference to different elements of the slice without using unsafe code.
+        // (This essentially emulates std::slice::get_many_mut().)
+        let (dst, src) = match a_index.cmp(&b_index) {
+            Ordering::Less => {
+                let (first, second) = self.buffers.split_at_mut(b_index);
+                (&mut first[a_index], &second[0])
+            }
+            Ordering::Greater => {
+                let (first, second) = self.buffers.split_at_mut(a_index);
+                (&mut second[0], &first[b_index])
+            }
+            Ordering::Equal => panic!("xor_buffers: Was asked to XOR buffer with itself"),
+        };
+
+        let len = dst.len();
+
+        assert_eq!(len, src.len());
+
+        for i in 0..len {
+            dst[i] ^= src[i];
+        }
+    }
+
+    pub fn buffer(&self, buffer_id: BufferId) -> &[u8] {
+        &self.buffers[self.buffer_index(buffer_id)]
+    }
+}
+
+#[derive(Debug)]
+pub struct ManagedDecoder {
+    num_source_symbols: usize,
+    symbol_len: usize,
+    decoder: Decoder,
+    buffer_set: BufferSet,
+}
+
+impl ManagedDecoder {
+    pub fn new(num_source_symbols: usize, symbol_len: usize) -> Result<ManagedDecoder, Error> {
+        let decoder = Decoder::new(num_source_symbols)?;
+
+        let buffer_set = BufferSet::new(decoder.num_temp_buffers_required(), symbol_len);
+
+        Ok(ManagedDecoder {
+            num_source_symbols,
+            symbol_len,
+            decoder,
+            buffer_set,
+        })
+    }
+
+    // TODO: Explore accepting Bytes as data, making rx_buffers a vector of enums
+    // designating either an owned Box<[u8]> or an un-owned Bytes, and converting
+    // un-owned to owned buffers whenever they are targeted for XORing.
+    pub fn received_encoded_symbol(&mut self, data: &[u8], encoding_symbol_id: usize) {
+        let buf: Box<[u8]> = data.into();
+
+        self.buffer_set.push_buffer(buf);
+
+        self.decoder
+            .received_encoded_symbol(encoding_symbol_id, |a, b| self.buffer_set.xor_buffers(a, b));
+    }
+
+    pub fn try_decode(&mut self) -> bool {
+        let inactivation_symbol_threshold = (INACTIVATION_SYMBOL_THRESHOLD_MULTIPLIER
+            * self.num_source_symbols)
+            >> INACTIVATION_SYMBOL_THRESHOLD_SHIFT;
+
+        self.decoder
+            .try_decode(inactivation_symbol_threshold, |a, b| {
+                self.buffer_set.xor_buffers(a, b)
+            })
+    }
+
+    pub fn decoding_done(&self) -> bool {
+        self.decoder.decoding_done()
+    }
+
+    pub fn reconstruct_source_data(&self) -> Option<Vec<u8>> {
+        let mut data = Vec::with_capacity(self.num_source_symbols * self.symbol_len);
+
+        for i in 0..self.num_source_symbols {
+            match self.decoder.source_symbol_to_buffer_id(i) {
+                None => {
+                    return None;
+                }
+                Some(buffer_id) => {
+                    data.extend_from_slice(self.buffer_set.buffer(buffer_id));
+                }
+            }
+        }
+
+        Some(data)
+    }
+}

--- a/monad-raptor/src/r10/nonsystematic/decoder/mod.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/mod.rs
@@ -1,0 +1,67 @@
+// Decoder for non-systematic R10 code.
+
+mod buffer;
+mod buffer_id;
+mod buffer_state;
+mod buffer_weight_map;
+mod check;
+mod decode;
+mod decode_finished;
+mod decode_inactivate;
+mod decode_inactive_gaussian;
+mod decode_peel;
+mod decode_reactivate;
+mod init;
+mod intermediate_symbol;
+mod managed_decoder;
+mod receive_symbol;
+
+pub use buffer::Buffer;
+pub use buffer_id::BufferId;
+pub use buffer_state::BufferState;
+pub use buffer_weight_map::BufferWeightMap;
+pub use intermediate_symbol::IntermediateSymbol;
+pub use managed_decoder::ManagedDecoder;
+
+use crate::r10::{lt::MAX_TRIPLES, CodeParameters};
+
+#[derive(Debug)]
+pub struct Decoder {
+    params: CodeParameters,
+
+    // For each buffer, a list of intermediate symbols XORd into that buffer, plus some other
+    // bookkeeping information.
+    buffer_state: Vec<Buffer>,
+
+    // For each intermediate symbol, a list of buffers that that intermediate symbol is XORd
+    // into, plus some information about whether this intermediate symbol has been inactivated
+    // or recovered.
+    intermediate_symbol_state: Vec<IntermediateSymbol>,
+
+    // Usable and Active buffers ordered according to their Active/Used intermediate symbol weight.
+    buffers_active_usable: BufferWeightMap<MAX_TRIPLES>,
+
+    // Inactivated buffers ordered according to their total intermediate symbol weight.
+    buffers_inactivated: BufferWeightMap<MAX_TRIPLES>,
+
+    // The number of buffers we have that are in the Redundant state.
+    num_redundant_buffers: u16,
+
+    // Number of source symbols recovered.  We are done decoding if this is equal to
+    // params.num_source_symbols().
+    num_source_symbols_paired: usize,
+}
+
+impl Decoder {
+    fn num_redundant_intermediate_symbols(&self) -> usize {
+        self.params.num_ldpc_symbols() + self.params.num_half_symbols()
+    }
+
+    pub fn num_temp_buffers_required(&self) -> usize {
+        self.num_redundant_intermediate_symbols()
+    }
+
+    pub fn num_encoded_symbols_received(&self) -> usize {
+        self.buffer_state.len() - self.num_redundant_intermediate_symbols()
+    }
+}

--- a/monad-raptor/src/r10/nonsystematic/decoder/receive_symbol.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/receive_symbol.rs
@@ -1,0 +1,79 @@
+use std::num::NonZeroU16;
+
+use crate::r10::{
+    nonsystematic::decoder::{Buffer, BufferId, Decoder},
+    MAX_DEGREE,
+};
+
+impl Decoder {
+    pub fn received_encoded_symbol(
+        &mut self,
+        encoding_symbol_id: usize,
+        mut xor_buffers: impl FnMut(BufferId, BufferId),
+    ) {
+        let buffer_index: u16 = self.buffer_state.len().try_into().unwrap();
+
+        let mut buffer = Buffer::new();
+
+        let mut used_buffer_indices = Vec::with_capacity(MAX_DEGREE);
+
+        // Create initial buffer to intermediate symbol mapping.
+        self.params
+            .lt_sequence_op(encoding_symbol_id, |intermediate_symbol_id| {
+                let symbol = &self.intermediate_symbol_state[intermediate_symbol_id];
+
+                buffer.append_intermediate_symbol_id(
+                    intermediate_symbol_id,
+                    !symbol.is_inactivated(),
+                );
+
+                if let Some(used_buffer_index) = symbol.is_used_buffer_index() {
+                    used_buffer_indices.push(used_buffer_index);
+                }
+            });
+
+        // Reduce this buffer by all intermediate symbols that have already been recovered.
+        for used_buffer_index in used_buffer_indices {
+            buffer.xor_eq(&self.buffer_state[usize::from(used_buffer_index)]);
+
+            // The buffer we are reducing by has active_used_weight == 1.
+            buffer.active_used_weight -= 1;
+
+            xor_buffers(
+                self.buffer_index_to_buffer_id(buffer_index),
+                self.buffer_index_to_buffer_id(used_buffer_index),
+            );
+        }
+
+        // Fix up intermediate symbol to buffer index accounting.
+        for intermediate_symbol_id in &buffer.intermediate_symbol_ids {
+            self.intermediate_symbol_state[usize::from(*intermediate_symbol_id)]
+                .active_inactivated_push(buffer_index);
+        }
+
+        let weight = buffer.intermediate_symbol_ids.len();
+        let active_used_weight = buffer.active_used_weight;
+
+        self.buffer_state.push(buffer);
+
+        if active_used_weight > 0 {
+            self.buffers_active_usable.insert_buffer_weight(
+                usize::from(buffer_index),
+                NonZeroU16::new(active_used_weight).unwrap(),
+            );
+        } else if weight > 0 {
+            self.buffers_inactivated.insert_buffer_weight(
+                usize::from(buffer_index),
+                NonZeroU16::new(weight.try_into().unwrap()).unwrap(),
+            );
+        } else {
+            self.num_redundant_buffers += 1;
+        }
+
+        self.check();
+    }
+
+    pub fn num_redundant_encoded_symbols(&self) -> usize {
+        self.num_redundant_buffers.into()
+    }
+}

--- a/monad-raptor/src/r10/nonsystematic/mod.rs
+++ b/monad-raptor/src/r10/nonsystematic/mod.rs
@@ -1,1 +1,2 @@
+pub mod decoder;
 pub mod encoder;

--- a/monad-raptor/tests/managed_decoder.rs
+++ b/monad-raptor/tests/managed_decoder.rs
@@ -1,0 +1,61 @@
+// Tests the managed Raptor decoder.
+
+use monad_raptor::{Encoder, ManagedDecoder};
+use rand::{prelude::SliceRandom, thread_rng, Rng, RngCore};
+
+const SYMBOL_LEN: usize = 4;
+
+fn test_single_decode(src: Vec<u8>) {
+    let encoder: Encoder<SYMBOL_LEN> = Encoder::new(&src).unwrap();
+
+    let num_source_symbols = encoder.num_source_symbols();
+
+    let mut decoder = ManagedDecoder::new(num_source_symbols, SYMBOL_LEN).unwrap();
+
+    let mut esis: Vec<usize> = (0..2 * num_source_symbols).collect();
+    esis.shuffle(&mut thread_rng());
+
+    for esi in &esis {
+        let mut buf: Box<[u8]> = vec![0; SYMBOL_LEN].into_boxed_slice();
+        encoder.encode_symbol(<&mut [u8; SYMBOL_LEN]>::try_from(&mut *buf).unwrap(), *esi);
+
+        // We feed some encoded symbols back into the decoder twice to test the
+        // Redundant buffer handling paths.
+        if rand::thread_rng().gen_ratio(1, 100) {
+            decoder.received_encoded_symbol(&buf[..], *esi);
+        }
+
+        decoder.received_encoded_symbol(&buf[..], *esi);
+
+        if decoder.try_decode() {
+            break;
+        }
+    }
+
+    if !decoder.decoding_done() {
+        panic!("{:#?}", decoder);
+    }
+
+    let mut reconstructed_source_data = decoder
+        .reconstruct_source_data()
+        .expect("Error recovering source data");
+
+    reconstructed_source_data.truncate(src.len());
+
+    assert_eq!(*src, *reconstructed_source_data);
+}
+
+#[test]
+fn test_managed_decoder() {
+    let max_bytes = if cfg!(debug_assertions) { 128 } else { 2048 };
+
+    for bytes in 0..=max_bytes {
+        println!("Testing bytes = {}", bytes);
+
+        let mut src = vec![0u8; bytes];
+
+        thread_rng().fill_bytes(&mut src);
+
+        test_single_decode(src);
+    }
+}

--- a/monad-raptor/tests/verify_encode_decode.rs
+++ b/monad-raptor/tests/verify_encode_decode.rs
@@ -1,0 +1,188 @@
+// Tests the Raptor encoder and decoder against each other.
+
+use std::{cmp::Ordering, iter, slice};
+
+use monad_raptor::{
+    r10::{
+        nonsystematic::decoder::{BufferId, Decoder},
+        SOURCE_SYMBOLS_MIN,
+    },
+    xor_eq::xor_eq,
+    Encoder,
+};
+use rand::{prelude::SliceRandom, thread_rng, Rng, RngCore};
+
+const SYMBOL_LEN: usize = 4;
+
+struct BufferSet<const SYMBOL_LEN: usize> {
+    temp_buffers: Vec<[u8; SYMBOL_LEN]>,
+    rx_buffers: Vec<Box<[u8; SYMBOL_LEN]>>,
+}
+
+impl<const SYMBOL_LEN: usize> BufferSet<SYMBOL_LEN> {
+    fn new(num_temp_buffers: usize) -> BufferSet<SYMBOL_LEN> {
+        let temp_buffers: Vec<[u8; SYMBOL_LEN]> = iter::repeat([0; SYMBOL_LEN])
+            .take(num_temp_buffers)
+            .collect();
+
+        let rx_buffers: Vec<Box<[u8; SYMBOL_LEN]>> = Vec::new();
+
+        BufferSet {
+            temp_buffers,
+            rx_buffers,
+        }
+    }
+
+    fn buffer(&self, buffer_id: BufferId) -> &[u8; SYMBOL_LEN] {
+        match buffer_id {
+            BufferId::TempBuffer { index } => &self.temp_buffers[index],
+            BufferId::ReceiveBuffer { index } => &self.rx_buffers[index],
+        }
+    }
+
+    fn xor_temp_buffers(&mut self, a: usize, b: usize) {
+        // Split the borrow to be able to get a mutable reference and an immutable
+        // reference to different elements of the slice without using unsafe code.
+        // (This essentially emulates std::slice::get_many_mut(), without using
+        // unsafe code.)
+        match a.cmp(&b) {
+            Ordering::Less => {
+                let (first, second) = self.temp_buffers.split_at_mut(b);
+
+                xor_eq::<SYMBOL_LEN>(&mut first[a], slice::from_ref(&&second[0]));
+            }
+            Ordering::Greater => {
+                let (first, second) = self.temp_buffers.split_at_mut(a);
+
+                xor_eq::<SYMBOL_LEN>(&mut second[0], slice::from_ref(&&first[b]));
+            }
+            Ordering::Equal => panic!(),
+        }
+    }
+
+    fn xor_rx_buffers(&mut self, a: usize, b: usize) {
+        // Split the borrow to be able to get a mutable reference and an immutable
+        // reference to different elements of the slice without using unsafe code.
+        // (This essentially emulates std::slice::get_many_mut(), without using
+        // unsafe code.)
+        match a.cmp(&b) {
+            Ordering::Less => {
+                let (first, second) = self.rx_buffers.split_at_mut(b);
+
+                xor_eq::<SYMBOL_LEN>(&mut first[a], slice::from_ref(&&*second[0]));
+            }
+            Ordering::Greater => {
+                let (first, second) = self.rx_buffers.split_at_mut(a);
+
+                xor_eq::<SYMBOL_LEN>(&mut second[0], slice::from_ref(&&*first[b]));
+            }
+            Ordering::Equal => panic!(),
+        }
+    }
+
+    fn xor_buffers(&mut self, a: BufferId, b: BufferId) {
+        match a {
+            BufferId::TempBuffer { index: a_index } => match b {
+                BufferId::TempBuffer { index: b_index } => {
+                    self.xor_temp_buffers(a_index, b_index);
+                }
+                BufferId::ReceiveBuffer { index: b_index } => {
+                    xor_eq::<SYMBOL_LEN>(
+                        &mut self.temp_buffers[a_index],
+                        slice::from_ref(&&*self.rx_buffers[b_index]),
+                    );
+                }
+            },
+            BufferId::ReceiveBuffer { index: a_index } => match b {
+                BufferId::TempBuffer { index: b_index } => {
+                    xor_eq::<SYMBOL_LEN>(
+                        &mut self.rx_buffers[a_index],
+                        slice::from_ref(&&self.temp_buffers[b_index]),
+                    );
+                }
+                BufferId::ReceiveBuffer { index: b_index } => {
+                    self.xor_rx_buffers(a_index, b_index);
+                }
+            },
+        }
+    }
+}
+
+fn test_single_decode(mut src: Vec<u8>) {
+    let encoder: Encoder<SYMBOL_LEN> = Encoder::new(&src).unwrap();
+
+    let num_source_symbols = encoder.num_source_symbols();
+
+    let mut decoder = Decoder::new(num_source_symbols).unwrap();
+
+    let mut buffer_set = BufferSet::new(decoder.num_temp_buffers_required());
+
+    let mut esis: Vec<usize> = (0..2 * num_source_symbols).collect();
+    esis.shuffle(&mut thread_rng());
+
+    for esi in &esis {
+        let mut buf: Box<[u8; SYMBOL_LEN]> = Box::new([0; SYMBOL_LEN]);
+        encoder.encode_symbol(&mut buf, *esi);
+
+        // We feed some encoded symbols back into the decoder twice to test the
+        // Redundant buffer handling paths.
+        if rand::thread_rng().gen_ratio(1, 100) {
+            let buf = buf.clone();
+
+            buffer_set.rx_buffers.push(buf);
+            decoder.received_encoded_symbol(*esi, |a, b| buffer_set.xor_buffers(a, b));
+        }
+
+        buffer_set.rx_buffers.push(buf);
+        decoder.received_encoded_symbol(*esi, |a, b| buffer_set.xor_buffers(a, b));
+
+        if decoder.try_decode(num_source_symbols + (num_source_symbols / 4), |a, b| {
+            buffer_set.xor_buffers(a, b)
+        }) {
+            break;
+        }
+    }
+
+    if !decoder.decoding_done() {
+        panic!("{:#?}", decoder);
+    }
+
+    // Pad `src` to an integer multiple >= SOURCE_SYMBOLS_MIN of SYMBOL_LEN bytes to
+    // simplify the data consistency comparisons below.
+    {
+        let symbols = ((src.len() + SYMBOL_LEN - 1) / SYMBOL_LEN).max(SOURCE_SYMBOLS_MIN);
+
+        let len = symbols * SYMBOL_LEN;
+
+        if src.len() != len {
+            src.resize(len, 0u8);
+        }
+    }
+
+    for i in 0..num_source_symbols {
+        match decoder.source_symbol_to_buffer_id(i) {
+            None => panic!("Source symbol {} was not recovered!", i),
+            Some(buffer_id) => {
+                assert_eq!(
+                    src[i * SYMBOL_LEN..(i + 1) * SYMBOL_LEN],
+                    *buffer_set.buffer(buffer_id)
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn test_encode_decode() {
+    let max_bytes = if cfg!(debug_assertions) { 128 } else { 2048 };
+
+    for bytes in 0..=max_bytes {
+        println!("Testing bytes = {}", bytes);
+
+        let mut src = vec![0u8; bytes];
+
+        thread_rng().fill_bytes(&mut src);
+
+        test_single_decode(src);
+    }
+}

--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -23,7 +23,6 @@ monad-types = { path = "../monad-types" }
 bytes = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
-raptor-code = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This PR imports the in-house developed Raptor code decoder corresponding
to the previously merged Raptor encoder, and switches monad-raptorcast
and raptor_bench over to use this decoder.

There is some work left to be done, but the initial performance numbers
look good.  With the old decoder, raptor_bench gets these numbers on my
laptop:

```
encoder/decoder/Decoding
                        time:   [77.529 ms 78.731 ms 79.760 ms]
                        thrpt:  [47.827 MiB/s 48.453 MiB/s 49.203 MiB/s]
```

And with the new decoder:

```
encoder/decoder/Decoding
                        time:   [53.722 ms 53.814 ms 53.910 ms]
                        thrpt:  [70.760 MiB/s 70.887 MiB/s 71.008 MiB/s]
                 change:
                        time:   [-32.555% -31.648% -30.584%] (p = 0.00 < 0.05)
                        thrpt:  [+44.059% +46.302% +48.269%]
                        Performance has improved.
```

raptor_bench seems to work, but the monad-raptorcast/src/lib.rs changes
are untested -- and neither of these verify that the decoder properly
decodes the output of the encoder, but there is a separate test that
does that, and a few more tests will be submitted shortly.

Some notes about the decoder:

- The decoder implements the belief-propagation decoding and inactivation
  decoding algorithms described in the "Raptor Codes" monograph by Amin
  Shokrollahi and Michael Luby, except that where the monograph describes
  a decoding procedure that is run once, to completion, once all of the
  encoded symbols that were going to be received have been received, this
  decoder uses an incremental version of that procedure, where we try to
  perform belief-propagation decoding every time we receive an encoded
  symbol, and where we initiate inactivation decoding once we have a
  reasonable belief that we will be able to finish the decoding process
  with our current set of received encoded symbols.

  One advantage of this decoding strategy is that if the inactivation
  decoding process fails (for example, if there are linear dependencies
  between the received encoded symbols), we do not need to restart the
  decoding procedure from the beginning once more encoded symbols are
  received, but instead, we can re-use the decoding work that has
  already been performed in the previous decoding attempt(s).

  Another property of using an incremental decoding strategy is that it
  leads to spreading the CPU-intensive decoding work that would only be
  initiated at the end of the packet reception process in the monograph
  version of the decoding process out more evenly over the duration of
  the packet reception process.  If there is a large time interval between
  the reception of the initial encoded symbol and the final encoded symbol,
  the conjectured (but as of yet unverified) advantage of this approach
  is that it will hopefully cause the time interval between the reception
  of the final symbol and the completion of the decoding process to be
  smaller than in the monograph version of the decoding process, in
  other words, it will hopefully improve our decoding latency.

- The core Raptor decoder added by this PR is implemented such that it
  does not touch any of the encoded or decoded data.  You invoke a
  decoder method every time a new encoded symbol is received, and in
  response, it provides you with a list of XOR operations that you have
  to perform on the data ("XOR the buffer that encoded symbol N was
  received in with the buffer that encoded symbol M was received in"),
  and once the decoding process is done, it gives you the source data
  fragment to buffer mapping, which you can then use to produce a
  linearized version of the source data if you need one.

  This interface is a bit too bare-bones for RaptorCast use, so there is
  also a managed wrapped around this decoder (ManagedDecoder), which
  does the buffer management and source data linearization for you, and
  RaptorCast and raptor_bench use the decoder via this wrapper.

Some future work involves:

- The decoder has a decision to make regarding at which number of
  received encoded symbols to initiate inactivation decoding, and this
  involves a trade-off between allowing recovery of the source data with
  fewer received encoded symbols by starting the decoding process early,
  and saving CPU by allowing more of the intermediate symbol recovery to
  be done using belief propagation and less of it using inactivation
  decoding by starting the decoding process late.

  We currently start inactivation decoding when we will have received
  a number of encoded symbols that is 1.5 times the number of source
  symbols in the application message, and this seems to give relatively
  good decoding performance based on some quick-and-dirty testing, but
  there is no proper justification for this particular choice of
  threshold, and we should spend some effort on picking a good threshold.

- Since the new decoder is more efficient, a larger proportion of the
  spent time is now used by the cryptographic primitives, so while
  further decoder optimizations are possible, it might also be worth
  looking into e.g. increasing the RaptorCast Merkle tree depth to see
  what effect that will have on performance.

- The managed decoder currently enforces that all received encoded
  symbols have the same length by asserting if that is not the case,
  and this could potentially be exploited by a malicious proposer, and
  we need to detect this case and potentially report it as a slashable
  offense via some standard API.

  The other case I can think of where a proposer can potentially also
  cause assertion failures in the decoder is by sending an oversized
  proposal, i.e. consisting of more than the Raptor-10 specified maximum
  number of 8192 source symbols.  The Raptor(Cast) code needs to be
  audited for more such cases.

- When performing inactivation decoding, we currently semi-randomly
  choose an intermediate symbol to inactivate, but there is a better
  way to do this, described in section 5.5.2.2. of RFC 5053, and I
  need to try out this algorithm.

- There are a few more tests I want to import, and a pure Raptor
  encoding/decoding bench I want to add.