### PR TITLE
Add WAL event/metadata sum type

### DIFF
--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -185,3 +185,12 @@ message ProtoMonadEvent{
     ProtoStateSyncEvent state_sync_event = 9;
   }
 }
+
+message ProtoMonadEventMetadata {}
+
+message ProtoMonadLogEntry {
+  oneof entry {
+    ProtoMonadEvent event = 1;
+    ProtoMonadEventMetadata metadata = 2;
+  }
+}


### PR DESCRIPTION
original issue https://github.com/monad-crypto/monad-internal/issues/414

This PR changes the WAL format by replacing `MonadEvent` with a sum type `MonadEvent | MonadEventMetadata`. In the main `monad-node` run loop, we continue to serialize events to the WAL. The only change now is that we will also write metadata *after* running the event through the consensus state machine and executing the respective commands. The fields in `MonadEventMetadata` are TBD but will likely contain stats on command start/end time(s).

This PR just contains type definitions/changes. For full diff to get to compile, see #969 