### PR TITLE
Generate openrpc docs from rpc code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -299,7 +299,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -310,7 +310,7 @@ checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -437,7 +437,7 @@ checksum = "1a047897373be4bbb0224c1afdabca92648dc57a9c9ef6e7b0be3aff7a859c83"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -503,16 +503,15 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is_terminal_polyfill",
  "utf8parse",
 ]
 
@@ -780,7 +779,7 @@ dependencies = [
  "futures-util",
  "handlebars",
  "http 1.1.0",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "mime",
  "multer",
  "num-traits",
@@ -808,7 +807,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum 0.25.0",
- "syn 2.0.72",
+ "syn 2.0.71",
  "thiserror",
 ]
 
@@ -831,7 +830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516317bb55d143cc47941c0cb952134dd207c5ab3c839ee226eedd6dd9a96f43"
 dependencies = [
  "bytes",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "serde",
  "serde_json",
 ]
@@ -855,7 +854,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -866,7 +865,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -946,7 +945,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.72",
+ "syn 2.0.71",
  "which",
 ]
 
@@ -959,7 +958,7 @@ dependencies = [
  "autocxx-engine",
  "env_logger 0.9.3",
  "indexmap 1.9.3",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -986,7 +985,7 @@ dependencies = [
  "rustversion",
  "serde_json",
  "strum_macros 0.24.3",
- "syn 2.0.72",
+ "syn 2.0.71",
  "tempfile",
  "thiserror",
  "version_check",
@@ -1002,7 +1001,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1019,7 +1018,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.72",
+ "syn 2.0.71",
  "thiserror",
 ]
 
@@ -1194,7 +1193,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.72",
+ "syn 2.0.71",
  "which",
 ]
 
@@ -1217,7 +1216,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.72",
+ "syn 2.0.71",
  "which",
 ]
 
@@ -1424,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292"
 dependencies = [
  "jobserver",
  "libc",
@@ -1524,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.7"
+version = "4.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+checksum = "41fffed7514f420abec6d183b1d3acfd9099c79c3a10a06ade4f8203f1411272"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1534,26 +1533,26 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.7"
+version = "4.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+checksum = "63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.1",
- "strsim 0.11.1",
+ "clap_lex 0.6.0",
+ "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.5"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1567,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "cmake"
@@ -1590,7 +1589,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1929,7 +1928,7 @@ dependencies = [
  "codespan-reporting",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1946,7 +1945,7 @@ checksum = "b45506e3c66512b0a65d291a6b452128b7b1dd9841e20d1e151addbd2c00ea50"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1969,8 +1968,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
- "syn 2.0.72",
+ "strsim",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1981,7 +1980,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2089,7 +2088,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2169,7 +2168,7 @@ checksum = "c2ad8cef1d801a4686bfd8919f0b30eac4c8e48968c437a6405ded4fb5272d2b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2413,7 +2412,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2523,7 +2522,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.11",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2542,7 +2541,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2940,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -3031,12 +3030,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
-
-[[package]]
 name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3089,9 +3082,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -3171,11 +3164,11 @@ checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3186,9 +3179,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libloading"
@@ -3223,9 +3216,9 @@ checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "lmdb-master-sys"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5142795c220effa4c8f4813537bd4c88113a07e45e93100ccb2adc5cec6c7f3"
+checksum = "472c3760e2a8d0f61f322fb36788021bb36d573c502b50fa3e2bcaac3ec326c9"
 dependencies = [
  "cc",
  "doxygen-rs",
@@ -3344,7 +3337,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3594,7 +3587,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "bincode",
- "clap 4.5.7",
+ "clap 4.4.10",
  "futures",
  "inquire",
  "monad-bls",
@@ -3865,7 +3858,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-rlp",
  "bytes",
- "clap 4.5.7",
+ "clap 4.4.10",
  "futures",
  "hex",
  "itertools 0.10.5",
@@ -3890,7 +3883,7 @@ name = "monad-keystore"
 version = "0.1.0"
 dependencies = [
  "aes",
- "clap 4.5.7",
+ "clap 4.4.10",
  "ctr",
  "dialoguer",
  "hdwallet",
@@ -3914,7 +3907,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "clap 4.5.7",
+ "clap 4.4.10",
  "futures",
  "monad-blockdb",
  "monad-consensus",
@@ -4014,7 +4007,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "chrono",
- "clap 4.5.7",
+ "clap 4.4.10",
  "futures-util",
  "hex",
  "monad-async-state-verify",
@@ -4085,7 +4078,7 @@ name = "monad-quic"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "clap 4.5.7",
+ "clap 4.4.10",
  "futures",
  "futures-util",
  "monad-crypto",
@@ -4136,7 +4129,7 @@ name = "monad-raptorcast"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "clap 4.5.7",
+ "clap 4.4.10",
  "criterion",
  "futures",
  "futures-util",
@@ -4178,7 +4171,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
- "clap 4.5.7",
+ "clap 4.4.10",
  "env_logger 0.10.1",
  "flume",
  "futures",
@@ -4187,6 +4180,7 @@ dependencies = [
  "monad-blockdb",
  "monad-blockdb-utils",
  "monad-cxx",
+ "monad-rpc-docs",
  "monad-triedb",
  "monad-triedb-utils",
  "monad-types",
@@ -4195,6 +4189,7 @@ dependencies = [
  "rayon",
  "reth-primitives",
  "reth-rpc-types",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",
@@ -4203,6 +4198,27 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "monad-rpc-docs"
+version = "0.1.0"
+dependencies = [
+ "inventory",
+ "monad-rpc-docs-derive",
+ "once_cell",
+ "schemars",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "monad-rpc-docs-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4283,7 +4299,7 @@ dependencies = [
 name = "monad-testground"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.7",
+ "clap 4.4.10",
  "futures-util",
  "monad-async-state-verify",
  "monad-blocktree",
@@ -4369,7 +4385,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bindgen 0.69.4",
- "clap 4.5.7",
+ "clap 4.4.10",
  "cmake",
  "futures",
  "monad-eth-testutil",
@@ -4544,7 +4560,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "chrono",
- "clap 4.5.7",
+ "clap 4.4.10",
  "criterion",
  "crossterm 0.27.0",
  "itertools 0.10.5",
@@ -4820,7 +4836,7 @@ dependencies = [
  "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4856,9 +4872,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
@@ -4889,7 +4905,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5172,7 +5188,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5193,7 +5209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
 ]
 
 [[package]]
@@ -5226,7 +5242,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5255,7 +5271,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5333,7 +5349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5466,7 +5482,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-types 0.12.6",
  "regex",
- "syn 2.0.72",
+ "syn 2.0.71",
  "tempfile",
 ]
 
@@ -5480,7 +5496,7 @@ dependencies = [
  "itertools 0.12.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5493,7 +5509,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6174,6 +6190,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.71",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6309,9 +6349,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
@@ -6328,22 +6368,33 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "itoa",
  "memchr",
  "ryu",
@@ -6381,7 +6432,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "serde",
  "serde_json",
  "serde_with_macros",
@@ -6397,7 +6448,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6620,12 +6671,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6666,7 +6711,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6679,7 +6724,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6723,9 +6768,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6832,7 +6877,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6843,7 +6888,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
  "test-case-core",
 ]
 
@@ -6870,7 +6915,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -7002,7 +7047,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -7076,7 +7121,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7089,7 +7134,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "toml_datetime",
  "winnow",
 ]
@@ -7176,7 +7221,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -7449,7 +7494,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
  "wasm-bindgen-shared",
 ]
 
@@ -7483,7 +7528,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7779,7 +7824,7 @@ checksum = "855e0f6af9cd72b87d8a6c586f3cb583f5cdcc62c2c80869d8cd7e96fdf7ee20"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -7790,7 +7835,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -7810,7 +7855,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.71",
 ]
 
 [[package]]

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -17,6 +17,7 @@ monad-cxx = { path = "../monad-cxx" }
 monad-triedb = { path = "../monad-triedb" }
 monad-triedb-utils = { path = "../monad-triedb-utils" }
 monad-types = { path = "../monad-types" }
+monad-rpc-docs = { path = "./monad-rpc-docs" }
 
 actix = { workspace = true }
 actix-codec = { workspace = true }
@@ -45,6 +46,7 @@ tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 notify = "6.1.1"
 pin-project = "1.1.5"
+schemars = "0.8.21"
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/monad-rpc/monad-rpc-docs/Cargo.toml
+++ b/monad-rpc/monad-rpc-docs/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "monad-rpc-docs"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+bench = false
+
+[dependencies]
+inventory.workspace = true
+once_cell = "1.19.0"
+serde_json.workspace = true
+serde = { workspace = true, features = ["derive"] }
+schemars = "0.8.21"
+monad-rpc-docs-derive = { path = "./monad-rpc-docs-derive" }

--- a/monad-rpc/monad-rpc-docs/monad-rpc-docs-derive/Cargo.toml
+++ b/monad-rpc/monad-rpc-docs/monad-rpc-docs-derive/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "monad-rpc-docs-derive"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0.36"
+syn = "1.0.0"
+proc-macro2 = "1.0.86"

--- a/monad-rpc/monad-rpc-docs/monad-rpc-docs-derive/src/lib.rs
+++ b/monad-rpc/monad-rpc-docs/monad-rpc-docs-derive/src/lib.rs
@@ -1,0 +1,262 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{quote, ToTokens};
+use syn::{
+    parse_macro_input, parse_quote, Attribute, AttributeArgs, FnArg, GenericArgument, Ident,
+    ItemFn, Lit, Meta, NestedMeta, PatType, PathArguments, ReturnType, Type,
+};
+
+/// Decorates an rpc function with a helper function to generate open-rpc documentation.
+/// It is expected that schemars::JsonSchema is derived for inputs and outputs passed to the function.
+/// `rpc(method_name = "my_method")` can be used to override the default method name.
+/// `rpc(ignore = variable)` can be used to ignore a variable from the documentation.
+/// Reference types are ignored by default.
+#[proc_macro_attribute]
+pub fn rpc(attr_args: TokenStream, decorated: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(decorated as ItemFn);
+
+    let fn_name = &input.sig.ident;
+    let inputs = &input.sig.inputs;
+
+    let attr_args: AttributeArgs = parse_macro_input!(attr_args);
+    let attr_args = extract_attrs(&attr_args);
+    let method_name = attr_args.method_name.unwrap_or(fn_name.to_string());
+    let input_infos = extract_input_info(inputs, &attr_args.ignore_inputs);
+    let output = &input.sig.output;
+    let output_info = extract_output_info(output.clone());
+
+    let docs = extract_docs(&input.attrs);
+
+    let name_ident: Ident = Ident::new(
+        &to_upper_camel_case(format!("{}_NAME", fn_name).as_str()),
+        fn_name.span(),
+    );
+    let info_ident = Ident::new(
+        &to_upper_camel_case(format!("{}_INFO", fn_name).as_str()),
+        fn_name.span(),
+    );
+
+    let input_types: Vec<Type> = input_infos.iter().map(|(_, typ, _)| typ.clone()).collect();
+    let input_schemas: Vec<TokenStream2> = input_infos
+        .iter()
+        .map(|(_, _, schema)| schema.clone())
+        .collect();
+
+    let output_type: Type = output_info
+        .as_ref()
+        .map(|(_, typ, _)| typ.clone())
+        .unwrap_or(parse_quote!(()));
+    let output_schema: TokenStream2 = output_info
+        .as_ref()
+        .map(|(_, _, schema)| schema.clone())
+        .unwrap_or(parse_quote!(None));
+
+    let default_input = parse_quote!([u8; 0]);
+    let input_type = input_types.first().unwrap_or(&default_input);
+    let default_schema = parse_quote!(None);
+    let input_schema = input_schemas.first().unwrap_or(&default_schema);
+    TokenStream::from(quote! {
+        #input
+
+        #[doc(hidden)]
+        struct #name_ident;
+
+        #[doc(hidden)]
+        impl monad_rpc_docs::RpcMethod for #name_ident {
+            type Input = #input_type;
+            type Output = #output_type;
+            const NAME: &'static str = #method_name;
+
+            fn input_schema() -> Option<schemars::schema::RootSchema> {
+                #input_schema
+            }
+
+            fn output_schema() -> Option<schemars::schema::RootSchema> {
+                #output_schema
+            }
+        }
+
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        pub static #info_ident: monad_rpc_docs::RpcMethodInfo = ::monad_rpc_docs::RpcMethodInfo {
+            name: #method_name,
+            docs: #docs,
+            input_schema: <#name_ident as monad_rpc_docs::RpcMethod>::input_schema,
+            output_schema: <#name_ident as monad_rpc_docs::RpcMethod>::output_schema,
+        };
+
+        monad_rpc_docs::inventory::submit! {
+            #info_ident
+        }
+    })
+}
+
+fn extract_docs(attrs: &[Attribute]) -> String {
+    attrs
+        .iter()
+        .filter(|attr| attr.path.is_ident("doc"))
+        .filter_map(|attr| {
+            if let Ok(syn::Meta::NameValue(nv)) = attr.parse_meta() {
+                if let syn::Lit::Str(lit) = nv.lit {
+                    Some(lit.value())
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[derive(Debug, Default)]
+struct Args {
+    method_name: Option<String>,
+    ignore_inputs: Vec<String>,
+}
+
+fn extract_attrs(attrs: &[NestedMeta]) -> Args {
+    let mut args = Args::default();
+
+    for attr in attrs {
+        if let NestedMeta::Meta(Meta::NameValue(nv)) = attr {
+            if nv.path.is_ident("method") {
+                if let Lit::Str(lit) = &nv.lit {
+                    args.method_name = Some(lit.value());
+                }
+            }
+
+            if nv.path.is_ident("ignore") {
+                if let Lit::Str(lit) = &nv.lit {
+                    args.ignore_inputs.push(lit.value());
+                }
+            }
+        }
+    }
+
+    args
+}
+
+fn extract_input_info(
+    inputs: &syn::punctuated::Punctuated<FnArg, syn::token::Comma>,
+    ignore_inputs: &[String],
+) -> Vec<(String, Type, TokenStream2)> {
+    inputs
+        .iter()
+        .filter_map(|arg| {
+            if let FnArg::Typed(PatType { pat, ty, .. }) = arg {
+                let name = pat.to_token_stream().to_string();
+
+                if ignore_inputs.contains(&name) {
+                    return None;
+                }
+
+                if !matches!(&**ty, Type::Path(_)) {
+                    return None;
+                }
+
+                let schema_expr: TokenStream2 = generate_schema_expr(ty);
+                Some((name, (**ty).clone(), schema_expr))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn extract_output_info(output: ReturnType) -> Option<(String, Type, TokenStream2)> {
+    match output {
+        ReturnType::Default => None,
+        ReturnType::Type(_, ty) => match *ty {
+            Type::Path(type_path) => {
+                let mut segments = type_path.path.segments.iter();
+                let result = segments.next()?;
+                let mut args = match &result.arguments {
+                    PathArguments::AngleBracketed(args) => args.args.iter(),
+                    _ => return None,
+                };
+
+                match args.next() {
+                    Some(GenericArgument::Type(inner_ty)) => {
+                        let type_ident = match &type_path.path.segments.last() {
+                            Some(segment) => &segment.ident,
+                            None => return None,
+                        };
+
+                        let name = type_ident.to_string();
+
+                        // Check if inner_ty is Option<T>
+                        if let Type::Path(inner_path) = inner_ty {
+                            if let Some(last_segment) = inner_path.path.segments.last() {
+                                if last_segment.ident == "Option" {
+                                    if let PathArguments::AngleBracketed(inner_args) =
+                                        &last_segment.arguments
+                                    {
+                                        if let Some(GenericArgument::Type(option_inner_ty)) =
+                                            inner_args.args.first()
+                                        {
+                                            let schema_expr = generate_schema_expr(option_inner_ty);
+                                            return Some((
+                                                name,
+                                                (*option_inner_ty).clone(),
+                                                schema_expr,
+                                            ));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        let schema_expr = generate_schema_expr(inner_ty);
+                        Some((name, (*inner_ty).clone(), schema_expr))
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        },
+    }
+}
+
+fn generate_schema_expr(ty: &Type) -> TokenStream2 {
+    match ty {
+        Type::Path(type_path) => {
+            let type_ident = match &type_path.path.segments.last() {
+                Some(segment) => &segment.ident,
+                None => return quote! { None },
+            };
+            quote! {
+                Some(schemars::schema_for!(#type_ident))
+            }
+        }
+        Type::Reference(type_reference) => {
+            if let Type::Path(type_path) = &*type_reference.elem {
+                let type_ident = match &type_path.path.segments.last() {
+                    Some(segment) => &segment.ident,
+                    None => return quote! { None },
+                };
+                quote! {
+                    Some(schemars::schema_for!(#type_ident))
+                }
+            } else {
+                quote! { None }
+            }
+        }
+        _ => quote! { None },
+    }
+}
+
+fn to_upper_camel_case(s: &str) -> String {
+    s.split("_")
+        .flat_map(|word| {
+            word.chars().enumerate().map(|(i, c)| {
+                if i == 0 {
+                    c.to_uppercase().next().unwrap()
+                } else {
+                    c.to_lowercase().next().unwrap()
+                }
+            })
+        })
+        .collect()
+}

--- a/monad-rpc/monad-rpc-docs/src/lib.rs
+++ b/monad-rpc/monad-rpc-docs/src/lib.rs
@@ -1,0 +1,80 @@
+use std::collections::HashMap;
+
+pub use inventory;
+pub use monad_rpc_docs_derive::rpc;
+pub use once_cell::sync::Lazy;
+use serde::Serialize;
+
+inventory::collect!(RpcMethodInfo);
+
+pub static FUNCTION_MAP: Lazy<HashMap<String, &RpcMethodInfo>> = Lazy::new(|| {
+    let mut map = HashMap::new();
+    for info in inventory::iter::<RpcMethodInfo> {
+        map.insert(info.name.to_string(), info);
+    }
+    map
+});
+
+pub trait RpcMethod {
+    type Input;
+    type Output;
+
+    const NAME: &'static str;
+
+    fn input_schema() -> Option<schemars::schema::RootSchema>;
+    fn output_schema() -> Option<schemars::schema::RootSchema>;
+}
+
+#[derive(Clone, Copy)]
+pub struct RpcMethodInfo {
+    pub name: &'static str,
+    pub docs: &'static str,
+    pub input_schema: fn() -> Option<schemars::schema::RootSchema>,
+    pub output_schema: fn() -> Option<schemars::schema::RootSchema>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OpenRpc {
+    pub openrpc: String,
+    pub info: Info,
+    pub components: Components,
+    pub methods: Vec<Method>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Info {
+    pub version: String,
+    pub title: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Method {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    pub params: Vec<Params>,
+    pub result: MethodResult,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MethodResult {
+    pub name: String,
+    pub description: String,
+    pub schema: schemars::schema::Schema,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Components {
+    pub schemas: HashMap<String, schemars::schema::Schema>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Params {
+    pub name: String,
+    pub description: String,
+    pub required: bool,
+    pub schema: schemars::schema::Schema,
+}

--- a/monad-rpc/src/call.rs
+++ b/monad-rpc/src/call.rs
@@ -3,16 +3,16 @@ use std::{cmp::min, path::Path};
 use alloy_primitives::{Address, Uint, U256, U64, U8};
 use monad_blockdb_utils::BlockDbEnv;
 use monad_cxx::StateOverrideSet;
+use monad_rpc_docs::rpc;
 use monad_triedb_utils::{TriedbEnv, TriedbResult};
 use reth_primitives::Block;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
 use tracing::debug;
 
 use crate::{
     eth_json_types::{deserialize_block_tags, BlockTags},
     hex,
-    jsonrpc::JsonRpcError,
+    jsonrpc::{JsonRpcError, JsonRpcResult},
 };
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -35,6 +35,37 @@ pub struct CallRequest {
     pub blob_versioned_hashes: Option<Vec<U256>>,
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub transaction_type: Option<U8>,
+}
+
+impl schemars::JsonSchema for CallRequest {
+    fn schema_name() -> String {
+        "CallRequest".to_string()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed(concat!(module_path!(), "::NonGenericType"))
+    }
+
+    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        let schema = schemars::schema_for_value!(CallRequest {
+            from: None,
+            to: None,
+            gas: None,
+            gas_price_details: GasPriceDetails::Eip1559 {
+                max_fee_per_gas: Some(U256::default()),
+                max_priority_fee_per_gas: Some(U256::default())
+            },
+            value: None,
+            input: CallInput::default(),
+            nonce: None,
+            chain_id: None,
+            access_list: None,
+            max_fee_per_blob_gas: None,
+            blob_versioned_hashes: None,
+            transaction_type: None,
+        });
+        schema.schema.into()
+    }
 }
 
 impl CallRequest {
@@ -272,30 +303,26 @@ pub async fn sender_gas_allowance(
     }
 }
 
-#[derive(Debug, Deserialize)]
-struct MonadEthCallParams {
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct MonadEthCallParams {
     transaction: CallRequest,
     #[serde(deserialize_with = "deserialize_block_tags")]
     block: BlockTags,
+    #[schemars(skip)] // TODO: move StateOverrideSet from monad-cxx
     #[serde(default)]
     state_overrides: StateOverrideSet, // empty = no state overrides
 }
 
 /// Executes a new message call immediately without creating a transaction on the block chain.
+#[rpc(method = "eth_call", ignore = "chain_id")]
 pub async fn monad_eth_call(
     blockdb_env: &BlockDbEnv,
     triedb_path: &Path,
     execution_ledger_path: &Path,
     chain_id: u64,
-    params: Value,
-) -> Result<Value, JsonRpcError> {
-    let mut params: MonadEthCallParams = match serde_json::from_value(params) {
-        Ok(s) => s,
-        Err(e) => {
-            debug!("invalid params {e}");
-            return Err(JsonRpcError::invalid_params());
-        }
-    };
+    params: MonadEthCallParams,
+) -> JsonRpcResult<String> {
+    let mut params = params;
     params.transaction.input.input = match (
         params.transaction.input.input.take(),
         params.transaction.input.data.take(),
@@ -383,7 +410,7 @@ pub async fn monad_eth_call(
         state_overrides,
     ) {
         monad_cxx::CallResult::Success(monad_cxx::SuccessCallResult { output_data, .. }) => {
-            Ok(json!(hex::encode(&output_data)))
+            Ok(hex::encode(&output_data))
         }
         monad_cxx::CallResult::Failure(error) => {
             Err(JsonRpcError::eth_call_error(error.message, error.data))

--- a/monad-rpc/src/debug.rs
+++ b/monad-rpc/src/debug.rs
@@ -1,78 +1,68 @@
 use alloy_rlp::Encodable;
 use monad_blockdb::EthTxKey;
 use monad_blockdb_utils::BlockDbEnv;
+use monad_rpc_docs::rpc;
 use monad_triedb_utils::{TriedbEnv, TriedbResult};
 use reth_primitives::B256;
-use serde::Deserialize;
-use serde_json::Value;
+use serde::{Deserialize, Serialize};
 
 use crate::{
-    eth_json_types::{
-        deserialize_block_tags, deserialize_fixed_data, serialize_result, BlockTags, EthHash,
-    },
+    eth_json_types::{deserialize_fixed_data, BlockTags, EthHash, MonadU256},
     hex,
     jsonrpc::{JsonRpcError, JsonRpcResult, JsonRpcResultExt},
+    trace::{TraceCallObject, TracerObject},
 };
 
-#[derive(Deserialize, Debug)]
-pub struct MonadDebugGetRawBlockParams {
-    #[serde(deserialize_with = "deserialize_block_tags")]
-    block_tag: BlockTags,
-}
-
+#[rpc(method = "debug_getRawBlock")]
 #[allow(non_snake_case)]
 /// Returns an RLP-encoded block.
 pub async fn monad_debug_getRawBlock(
     blockdb_env: &BlockDbEnv,
-    params: MonadDebugGetRawBlockParams,
-) -> JsonRpcResult<Value> {
+    params: BlockTags,
+) -> JsonRpcResult<String> {
     let block = blockdb_env
-        .get_block_by_tag(params.block_tag.into())
+        .get_block_by_tag(params.into())
         .await
         .block_not_found()?;
 
     let mut buf = Vec::default();
     block.block.encode(&mut buf);
-    serialize_result(hex::encode(&buf))
+    Ok(hex::encode(&buf))
 }
 
-#[derive(Deserialize, Debug)]
-pub struct MonadDebugGetRawHeaderParams {
-    #[serde(deserialize_with = "deserialize_block_tags")]
-    block_tag: BlockTags,
-}
-
+#[rpc(method = "debug_getRawHeader")]
 #[allow(non_snake_case)]
 /// Returns an RLP-encoded header.
 pub async fn monad_debug_getRawHeader(
     blockdb_env: &BlockDbEnv,
-    params: MonadDebugGetRawHeaderParams,
-) -> JsonRpcResult<Value> {
+    params: BlockTags,
+) -> JsonRpcResult<String> {
     let value = blockdb_env
-        .get_block_by_tag(params.block_tag.into())
+        .get_block_by_tag(params.into())
         .await
         .block_not_found()?;
 
     let mut buf = Vec::default();
     value.block.header.encode(&mut buf);
-    serialize_result(hex::encode(&buf))
+    Ok(hex::encode(&buf))
 }
 
-#[derive(Deserialize, Debug)]
-pub struct MonadDebugGetRawReceiptsParams {
-    #[serde(deserialize_with = "deserialize_block_tags")]
-    block_tag: BlockTags,
+#[derive(Serialize, Debug, schemars::JsonSchema)]
+#[serde(transparent)]
+pub struct MonadDebugGetRawReceiptsResult {
+    receipts: Vec<String>,
 }
 
+#[rpc(method = "debug_getRawReceipts")]
 #[allow(non_snake_case)]
 /// Returns an array of EIP-2718 binary-encoded receipts.
 pub async fn monad_debug_getRawReceipts(
     blockdb_env: &BlockDbEnv,
     triedb_env: &TriedbEnv,
-    params: MonadDebugGetRawReceiptsParams,
-) -> JsonRpcResult<Value> {
+    params: BlockTags,
+) -> JsonRpcResult<MonadDebugGetRawReceiptsResult> {
     let block = blockdb_env
-        .get_block_by_tag(params.block_tag.into())
+        .get_block_by_tag(params.into())
         .await
         .block_not_found()?;
 
@@ -91,21 +81,22 @@ pub async fn monad_debug_getRawReceipts(
         }
     }
 
-    serialize_result(receipts)
+    Ok(MonadDebugGetRawReceiptsResult { receipts })
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadDebugGetRawTransactionParams {
     #[serde(deserialize_with = "deserialize_fixed_data")]
     tx_hash: EthHash,
 }
 
+#[rpc(method = "debug_getRawTransaction")]
 #[allow(non_snake_case)]
 /// Returns an array of EIP-2718 binary-encoded transactions.
 pub async fn monad_debug_getRawTransaction(
     blockdb_env: &BlockDbEnv,
     params: MonadDebugGetRawTransactionParams,
-) -> JsonRpcResult<Value> {
+) -> JsonRpcResult<String> {
     let key = EthTxKey(B256::new(params.tx_hash.0));
     let result = blockdb_env.get_txn(key).await.block_not_found()?;
 
@@ -123,5 +114,58 @@ pub async fn monad_debug_getRawTransaction(
 
     let mut buf = Vec::default();
     transaction.encode_enveloped(&mut buf);
-    serialize_result(hex::encode(&buf))
+    Ok(hex::encode(&buf))
+}
+
+#[rpc(method = "debug_traceBlockByHash")]
+#[allow(non_snake_case)]
+/// Returns the tracing result by executing all transactions in the block specified by the block hash with a tracer.
+pub async fn monad_debug_traceBlockByHash(
+    blockdb_env: &BlockDbEnv,
+    params: EthHash,
+) -> JsonRpcResult<String> {
+    Err(JsonRpcError::method_not_supported())
+}
+
+#[rpc(method = "debug_traceBlockByNumber")]
+#[allow(non_snake_case)]
+/// Returns the tracing result by executing all transactions in the block specified by the block number with a tracer.
+pub async fn monad_debug_traceBlockByNumber(
+    blockdb_env: &BlockDbEnv,
+    params: MonadU256,
+) -> JsonRpcResult<String> {
+    Err(JsonRpcError::method_not_supported())
+}
+
+#[derive(Deserialize, Debug, schemars::JsonSchema)]
+pub struct DebugTraceCallParams {
+    pub call: Vec<TraceCallObject>,
+    pub block: BlockTags,
+    pub tracer: TracerObject,
+}
+
+#[rpc(method = "debug_traceCall")]
+#[allow(non_snake_case)]
+/// Returns the tracing result by executing an eth call within the context of the given block execution.
+pub async fn monad_debug_traceCall(
+    triedb_env: &TriedbEnv,
+    params: DebugTraceCallParams,
+) -> JsonRpcResult<String> {
+    Err(JsonRpcError::method_not_supported())
+}
+
+#[derive(Deserialize, Debug, schemars::JsonSchema)]
+pub struct DebugTraceTransactionParams {
+    pub tx: EthHash,
+    pub tracer: TracerObject,
+}
+
+#[rpc(method = "debug_traceTransaction")]
+#[allow(non_snake_case)]
+/// Returns all traces of a given transaction.
+pub async fn monad_debug_traceTransaction(
+    triedb_env: &TriedbEnv,
+    params: DebugTraceTransactionParams,
+) -> JsonRpcResult<String> {
+    Err(JsonRpcError::method_not_supported())
 }

--- a/monad-rpc/src/docs.rs
+++ b/monad-rpc/src/docs.rs
@@ -1,0 +1,252 @@
+use std::{borrow::BorrowMut, collections::HashMap};
+
+use monad_rpc_docs::OpenRpc;
+
+use crate::{
+    account_handlers::StorageProof,
+    call::CallRequest,
+    eth_json_types::{
+        BlockTagKey, BlockTags, EthAddress, EthHash, MonadBlock, MonadLog, MonadTransaction,
+        MonadTransactionReceipt, MonadU256, Quantity, UnformattedData,
+    },
+    eth_txn_handlers::{AddressValueOrArray, FilterParams, LogFilter},
+    trace::{TraceCallObject, Tracer, TracerObject},
+};
+
+pub fn as_openrpc() -> OpenRpc {
+    let method_map = &monad_rpc_docs::FUNCTION_MAP;
+
+    let mut components = monad_rpc_docs::Components {
+        schemas: HashMap::new(),
+    };
+
+    let quantity_schema = schemars::schema_for!(Quantity);
+    components
+        .schemas
+        .insert("Quantity".to_string(), quantity_schema.schema.into());
+    let hash_schema = schemars::schema_for!(EthHash);
+    components
+        .schemas
+        .insert("EthHash".to_string(), hash_schema.schema.into());
+    let address_schema = schemars::schema_for!(EthAddress);
+    components
+        .schemas
+        .insert("EthAddress".to_string(), address_schema.schema.into());
+    let monad_u256 = schemars::schema_for!(MonadU256);
+    components
+        .schemas
+        .insert("MonadU256".to_string(), monad_u256.schema.into());
+    let monad_block = schemars::schema_for!(MonadBlock);
+    components
+        .schemas
+        .insert("MonadBlock".to_string(), monad_block.schema.into());
+    let monad_receipt = schemars::schema_for!(MonadTransactionReceipt);
+    components.schemas.insert(
+        "MonadTransactionReceipt".to_string(),
+        monad_receipt.schema.into(),
+    );
+    let monad_transaction = schemars::schema_for!(MonadTransaction);
+    components.schemas.insert(
+        "MonadTransaction".to_string(),
+        monad_transaction.schema.into(),
+    );
+    let unformatted_data = schemars::schema_for!(UnformattedData);
+    components.schemas.insert(
+        "UnformattedData".to_string(),
+        unformatted_data.schema.into(),
+    );
+    let mut blocktags = schemars::schema_for!(BlockTags).schema.into();
+    clean_schema_refs(&mut blocktags);
+    components
+        .schemas
+        .insert("BlockTags".to_string(), blocktags);
+    let call_request = schemars::schema_for!(CallRequest);
+    components
+        .schemas
+        .insert("CallRequest".to_string(), call_request.schema.into());
+    components.schemas.insert(
+        "BlockTagKey".to_string(),
+        schemars::schema_for!(BlockTagKey).schema.into(),
+    );
+    let storage_proof = schemars::schema_for!(StorageProof);
+    let mut storage_proof = storage_proof.schema.into();
+    clean_schema_refs(&mut storage_proof);
+    components
+        .schemas
+        .insert("StorageProof".to_string(), storage_proof);
+    components.schemas.insert(
+        "MonadLog".to_string(),
+        schemars::schema_for!(MonadLog).schema.into(),
+    );
+    let mut tracer = schemars::schema_for!(Tracer).schema.into();
+    clean_schema_refs(&mut tracer);
+    components.schemas.insert("Tracer".to_string(), tracer);
+    let mut tracer_obj = schemars::schema_for!(TracerObject).schema.into();
+    clean_schema_refs(&mut tracer_obj);
+    components
+        .schemas
+        .insert("TracerObject".to_string(), tracer_obj);
+    let mut tracer_call_obj = schemars::schema_for!(TraceCallObject).schema.into();
+    clean_schema_refs(&mut tracer_call_obj);
+    components
+        .schemas
+        .insert("TraceCallObject".to_string(), tracer_call_obj);
+    let mut filter_params = schemars::schema_for!(FilterParams).schema.into();
+    clean_schema_refs(&mut filter_params);
+    components
+        .schemas
+        .insert("FilterParams".to_string(), filter_params);
+    let mut address_value_or_array = schemars::schema_for!(AddressValueOrArray).schema.into();
+    clean_schema_refs(&mut address_value_or_array);
+    components
+        .schemas
+        .insert("AddressValueOrArray".to_string(), address_value_or_array);
+    let mut log_filter = schemars::schema_for!(LogFilter).schema.into();
+    clean_schema_refs(&mut log_filter);
+    components
+        .schemas
+        .insert("LogFilter".to_string(), log_filter);
+
+    let mut methods = Vec::new();
+    for (name, info) in method_map.iter() {
+        println!("{name}");
+
+        let mut params: Vec<monad_rpc_docs::Params> = Vec::new();
+        if let Some(in_schema) = (info.input_schema)() {
+            let in_schema_title = in_schema.schema.clone().metadata().clone().title.unwrap();
+            let mut in_sub_schema: schemars::schema::Schema = in_schema.schema.into();
+            clean_schema_refs(&mut in_sub_schema);
+
+            let inputs = in_sub_schema
+                .clone()
+                .into_object()
+                .object()
+                .clone()
+                .properties;
+
+            for (k, v) in &inputs {
+                components
+                    .schemas
+                    .insert(k.clone(), v.clone().into_object().into());
+            }
+
+            for (k, v) in inputs {
+                let param = monad_rpc_docs::Params {
+                    name: k.clone(),
+                    description: "".to_string(),
+                    required: true,
+                    schema: v.clone(),
+                };
+                params.push(param);
+            }
+
+            components
+                .schemas
+                .insert(in_schema_title.clone(), in_sub_schema.clone());
+        }
+
+        let out_schema = ((info.output_schema)()).unwrap();
+        let out_schema_title = out_schema.schema.clone().metadata().clone().title.unwrap();
+        let mut out_sub_schema: schemars::schema::Schema = out_schema.schema.into();
+        clean_schema_refs(&mut out_sub_schema);
+
+        components
+            .schemas
+            .insert(out_schema_title.clone(), out_sub_schema.clone());
+
+        methods.push(monad_rpc_docs::Method {
+            name: name.to_string(),
+            summary: Some(info.docs.to_string()),
+            description: None,
+            params,
+            result: monad_rpc_docs::MethodResult {
+                name: out_schema_title.to_string(),
+                description: "".to_string(),
+                schema: out_sub_schema.clone(),
+            },
+        })
+    }
+
+    monad_rpc_docs::OpenRpc {
+        openrpc: "1.0.0".to_string(),
+        info: monad_rpc_docs::Info {
+            version: "1.0.0".to_string(),
+            description: "Monad RPC".to_string(),
+            title: "Monad RPC".to_string(),
+        },
+        methods,
+        components,
+    }
+}
+
+fn clean_schema_refs(schema: &mut schemars::schema::Schema) {
+    if let schemars::schema::Schema::Object(ref mut o) = schema {
+        o.array().items.iter_mut().for_each(|item| match item {
+            schemars::schema::SingleOrVec::Single(s) => {
+                if let schemars::schema::Schema::Object(ref mut o) = s.as_mut() {
+                    if let Some(reference) = &o.reference {
+                        let reference = reference.split("/").last().unwrap().to_string();
+                        o.reference = Some(format!("#/components/schemas/{reference}"));
+
+                        o.object().properties.iter_mut().for_each(|(_, v)| {
+                            if v.is_ref() {
+                                if let schemars::schema::Schema::Object(ref mut o) = v.borrow_mut()
+                                {
+                                    let reference = o
+                                        .reference
+                                        .as_ref()
+                                        .unwrap()
+                                        .split("/")
+                                        .last()
+                                        .unwrap()
+                                        .to_string();
+                                    o.reference = Some(format!("#/components/schemas/{reference}"));
+                                }
+                            }
+                        });
+                    }
+
+                    o.object().properties.iter_mut().for_each(|(_, v)| {
+                        clean_schema_refs(v);
+                    });
+                }
+            }
+            schemars::schema::SingleOrVec::Vec(v) => v.iter_mut().for_each(|item| {
+                clean_schema_refs(item);
+            }),
+        });
+
+        o.object().properties.iter_mut().for_each(|(_, v)| {
+            if let schemars::schema::Schema::Object(ref mut o) = v {
+                if let Some(reference) = &o.reference {
+                    let reference = reference.split("/").last().unwrap().to_string();
+                    o.reference = Some(format!("#/components/schemas/{reference}"));
+                }
+            }
+        });
+
+        o.subschemas().any_of.iter_mut().for_each(|v| {
+            for item in v.iter_mut() {
+                clean_schema_refs(item);
+            }
+        });
+
+        o.object().properties.iter_mut().for_each(|(_, v)| {
+            clean_schema_refs(v);
+        });
+    }
+
+    if schema.is_ref() {
+        if let schemars::schema::Schema::Object(ref mut o) = schema {
+            let reference = o
+                .reference
+                .as_ref()
+                .unwrap()
+                .split("/")
+                .last()
+                .unwrap()
+                .to_string();
+            o.reference = Some(format!("#/components/schemas/{reference}"));
+        }
+    }
+}

--- a/monad-rpc/src/jsonrpc.rs
+++ b/monad-rpc/src/jsonrpc.rs
@@ -54,7 +54,7 @@ impl Request {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
 pub struct Response {
     pub jsonrpc: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -93,7 +93,7 @@ impl Response {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
 pub struct JsonRpcError {
     pub code: i32,
     pub message: String,

--- a/monad-rpc/src/trace.rs
+++ b/monad-rpc/src/trace.rs
@@ -1,0 +1,80 @@
+use monad_blockdb_utils::BlockDbEnv;
+use monad_rpc_docs::rpc;
+use serde::Deserialize;
+
+use crate::{
+    eth_json_types::{BlockTags, EthAddress, EthHash, MonadU256, Quantity},
+    jsonrpc::{JsonRpcError, JsonRpcResult},
+};
+
+#[derive(Deserialize, Debug, schemars::JsonSchema)]
+pub struct TracerObject {
+    tracer: Tracer,
+}
+
+#[derive(Deserialize, Debug, schemars::JsonSchema)]
+pub enum Tracer {
+    #[serde(rename = "callTracer")]
+    CallTracer,
+    #[serde(rename = "prestateTracer")]
+    PreStateTracer,
+}
+
+#[derive(Deserialize, Debug, schemars::JsonSchema)]
+pub struct TraceCallObject {
+    pub from: Option<EthAddress>,
+    pub to: EthAddress,
+    pub gas: Option<MonadU256>,
+    pub gas_price: Option<MonadU256>,
+    pub value: Option<MonadU256>,
+    pub data: Option<String>,
+}
+
+#[rpc(method = "trace_block")]
+#[allow(non_snake_case)]
+pub async fn monad_trace_block(
+    blockdb_env: &BlockDbEnv,
+    params: BlockTags,
+) -> JsonRpcResult<String> {
+    Err(JsonRpcError::method_not_supported())
+}
+
+#[derive(Deserialize, Debug, schemars::JsonSchema)]
+pub struct TraceCallParams {
+    pub calls: Vec<TraceCallObject>,
+    pub block: BlockTags,
+}
+
+#[rpc(method = "trace_call")]
+#[allow(non_snake_case)]
+/// Executes a new message call and returns a number of possible traces.
+pub async fn monad_trace_call(params: TraceCallParams) -> JsonRpcResult<String> {
+    Err(JsonRpcError::method_not_supported())
+}
+
+#[rpc(method = "trace_callMany")]
+#[allow(non_snake_case)]
+/// Executes multiple message calls within the same block and returns a number of possible traces.
+pub async fn monad_trace_callMany() -> JsonRpcResult<String> {
+    Err(JsonRpcError::method_not_supported())
+}
+
+#[derive(Deserialize, Debug, schemars::JsonSchema)]
+pub struct TraceGetParams {
+    transaction: EthHash,
+    indexes: Vec<Quantity>,
+}
+
+#[rpc(method = "trace_get")]
+#[allow(non_snake_case)]
+/// Returns trace at given position.
+pub async fn monad_trace_get(params: TraceGetParams) -> JsonRpcResult<String> {
+    Err(JsonRpcError::method_not_supported())
+}
+
+#[rpc(method = "trace_transaction")]
+#[allow(non_snake_case)]
+/// Returns all traces of given transaction.
+pub async fn monad_trace_transaction(params: EthHash) -> JsonRpcResult<String> {
+    Err(JsonRpcError::method_not_supported())
+}

--- a/monad-rpc/src/txpool.rs
+++ b/monad-rpc/src/txpool.rs
@@ -1,0 +1,27 @@
+use monad_rpc_docs::rpc;
+
+use crate::jsonrpc::{JsonRpcError, JsonRpcResult};
+
+#[rpc(method = "txpool_content")]
+#[allow(non_snake_case)]
+pub async fn monad_txpool_content() -> JsonRpcResult<String> {
+    Err(JsonRpcError::method_not_supported())
+}
+
+#[rpc(method = "txpool_contentFrom")]
+#[allow(non_snake_case)]
+pub async fn monad_txpool_contentFrom() -> JsonRpcResult<String> {
+    Err(JsonRpcError::method_not_supported())
+}
+
+#[rpc(method = "txpool_inspect")]
+#[allow(non_snake_case)]
+pub async fn monad_txpool_inspect() -> JsonRpcResult<String> {
+    Err(JsonRpcError::method_not_supported())
+}
+
+#[rpc(method = "txpool_status")]
+#[allow(non_snake_case)]
+pub async fn monad_txpool_status() -> JsonRpcResult<String> {
+    Err(JsonRpcError::method_not_supported())
+}


### PR DESCRIPTION
Adds a `rpc(method="")` macro to decorate functions with openrpc compatible schemas that we can use to generate docs for docs.monad.xyz. The proc macro can read function name, docstrings, and generate json schemas for inputs and outputs. 

Also includes remaining methods to be supported as temporary stubs so that they show up in docs.