### PR TITLE
Differentiate logging level depending on response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4377,12 +4377,12 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "log",
  "monad-blockdb",
  "monad-blockdb-utils",
  "monad-triedb",
  "rayon",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/monad-node/src/state.rs
+++ b/monad-node/src/state.rs
@@ -4,10 +4,10 @@ use std::{
 };
 
 use clap::{error::ErrorKind, FromArgMatches};
-use log::info;
 use monad_bls::BlsKeyPair;
 use monad_keystore::keystore::Keystore;
 use monad_secp::KeyPair;
+use tracing::info;
 
 use crate::{
     cli::Cli,

--- a/monad-rpc/src/account_handlers.rs
+++ b/monad-rpc/src/account_handlers.rs
@@ -1,9 +1,9 @@
 use alloy_primitives::aliases::{B160, U256};
-use log::{debug, trace};
 use monad_triedb_utils::{TriedbEnv, TriedbResult};
 use reth_primitives::B256;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tracing::{debug, trace};
 
 use crate::{
     eth_json_types::{

--- a/monad-rpc/src/block_handlers.rs
+++ b/monad-rpc/src/block_handlers.rs
@@ -1,13 +1,13 @@
 use std::ops::Div;
 
 use alloy_primitives::aliases::{U256, U64};
-use log::{debug, trace};
 use monad_blockdb::BlockValue;
 use monad_blockdb_utils::BlockDbEnv;
 use monad_triedb_utils::{TriedbEnv, TriedbResult};
 use reth_rpc_types::{Block, BlockTransactions, Header, TransactionReceipt, Withdrawal};
 use serde::Deserialize;
 use serde_json::Value;
+use tracing::{debug, trace};
 
 use crate::{
     eth_json_types::{

--- a/monad-rpc/src/call.rs
+++ b/monad-rpc/src/call.rs
@@ -1,12 +1,12 @@
 use std::{cmp::min, path::Path};
 
 use alloy_primitives::{Address, Uint, U256, U64, U8};
-use log::debug;
 use monad_blockdb_utils::BlockDbEnv;
 use monad_triedb_utils::{TriedbEnv, TriedbResult};
 use reth_primitives::Block;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use tracing::debug;
 
 use crate::{
     eth_json_types::{deserialize_block_tags, BlockTags},

--- a/monad-rpc/src/eth_json_types.rs
+++ b/monad-rpc/src/eth_json_types.rs
@@ -1,10 +1,10 @@
 use std::str::FromStr;
 
-use log::debug;
 use monad_blockdb::BlockTagKey;
 use reth_primitives::{Address, U256};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
+use tracing::debug;
 
 use crate::{
     hex::{decode, decode_quantity, DecodeHexError},

--- a/monad-rpc/src/gas_handlers.rs
+++ b/monad-rpc/src/gas_handlers.rs
@@ -1,7 +1,6 @@
 use std::{ops::Sub, path::Path};
 
 use alloy_primitives::{U256, U64};
-use log::{debug, trace};
 use monad_blockdb::BlockTagKey;
 use monad_blockdb_utils::BlockDbEnv;
 use monad_triedb_utils::{TriedbEnv, TriedbResult};
@@ -9,6 +8,7 @@ use reth_primitives::{Transaction, TransactionKind};
 use reth_rpc_types::FeeHistory;
 use serde::Deserialize;
 use serde_json::Value;
+use tracing::{debug, trace};
 
 use crate::{
     call::{sender_gas_allowance, CallRequest},

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -29,7 +29,7 @@ use monad_blockdb_utils::BlockDbEnv;
 use monad_triedb_utils::TriedbEnv;
 use reth_primitives::TransactionSigned;
 use serde_json::Value;
-use tracing::debug;
+use tracing::{debug, info};
 use tracing_subscriber::{
     fmt::{format::FmtSpan, Layer as FmtLayer},
     layer::SubscriberExt,
@@ -125,7 +125,15 @@ async fn rpc_handler(body: bytes::Bytes, app_state: web::Data<MonadRpcResources>
         }
     };
 
-    debug!(?body, ?response, "rpc_request/response");
+    // log the request and response based on the response content
+    match &response {
+        ResponseWrapper::Single(resp) => match resp.error {
+            Some(_) => info!(?body, ?response, "rpc_request/response error"),
+            None => debug!(?body, ?response, "rpc_request/response successful"),
+        },
+        _ => debug!(?body, ?response, "rpc_batch_request/response"),
+    }
+
     HttpResponse::Ok().json(&response)
 }
 
@@ -369,7 +377,7 @@ async fn rpc_select(
         "eth_signTransaction" => Err(JsonRpcError::method_not_supported()),
         "eth_sign" => Err(JsonRpcError::method_not_supported()),
         "eth_hashrate" => Err(JsonRpcError::method_not_supported()),
-        "net_version" => serialize_result("1"), // TODO: decide on a chain id
+        "net_version" => serialize_result(format!("0x{:x}", app_state.chain_id)),
         "web3_clientVersion" => serialize_result("monad"),
         _ => Err(JsonRpcError::method_not_found()),
     }

--- a/monad-rpc/src/mempool_tx.rs
+++ b/monad-rpc/src/mempool_tx.rs
@@ -7,12 +7,12 @@ use std::{
 };
 
 use futures::{executor::block_on, ready, Future, FutureExt, Sink, SinkExt};
-use log::debug;
 use notify::{Event, RecursiveMode, Watcher};
 use pin_project::pin_project;
 use reth_primitives::TransactionSigned;
 use tokio::{net::UnixStream, pin};
 use tokio_util::codec::{FramedWrite, LengthDelimitedCodec};
+use tracing::debug;
 
 const MEMPOOL_TX_IPC_FILE: &str = "mempool.sock";
 

--- a/monad-rpc/src/websocket.rs
+++ b/monad-rpc/src/websocket.rs
@@ -4,7 +4,7 @@ use actix::prelude::*;
 use actix_http::ws::{Message as WebsocketMessage, ProtocolError};
 use actix_web::{web, HttpRequest, HttpResponse};
 use actix_web_actors::ws;
-use log::debug;
+use tracing::debug;
 
 use crate::MonadRpcResources;
 

--- a/monad-triedb-utils/Cargo.toml
+++ b/monad-triedb-utils/Cargo.toml
@@ -13,7 +13,6 @@ monad-triedb = { path = "../monad-triedb" }
 
 alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }
-log = { workspace = true }
 rayon = { workspace = true }
-tokio.workspace = true
-
+tokio = { workspace = true }
+tracing = { workspace = true, features = ["log"] }

--- a/monad-triedb-utils/src/lib.rs
+++ b/monad-triedb-utils/src/lib.rs
@@ -5,10 +5,10 @@ use std::{
 
 use alloy_primitives::{keccak256, U256};
 use alloy_rlp::{Decodable, Encodable};
-use log::debug;
 use monad_blockdb::BlockTagKey;
 use monad_blockdb_utils::BlockTags;
 use monad_triedb::{key::create_addr_key, Handle};
+use tracing::debug;
 
 pub type EthAddress = [u8; 20];
 pub type EthStorageKey = [u8; 32];


### PR DESCRIPTION
1. standardize using tracing crate
2. differentiate logging level so we can selectively forward logs to Loki -- currently a bit troublesome to debug live devnet