### PR TITLE
Adding cgroup-tools to dockerfile to use cpuset

### DIFF
--- a/docker/devnet/Dockerfile
+++ b/docker/devnet/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:24.04 AS base
 
 WORKDIR /usr/src/monad-bft
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get update && apt-get install -y clang curl make ca-certificates pkg-config gnupg software-properties-common wget
+RUN apt-get update && apt-get install -y clang curl make ca-certificates pkg-config gnupg software-properties-common wget cgroup-tools
 
 RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN add-apt-repository -y ppa:mhier/libboost-latest

--- a/docker/rpc/Dockerfile
+++ b/docker/rpc/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:24.04 AS base
 RUN apt update
 RUN apt upgrade -y
 RUN apt-get update
-RUN apt install -y ca-certificates curl pkg-config gnupg software-properties-common wget
+RUN apt install -y ca-certificates curl pkg-config gnupg software-properties-common wget cgroup-tools
 
 RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN add-apt-repository -y ppa:mhier/libboost-latest
@@ -68,8 +68,8 @@ ENV PATH="${CARGO_ROOT}/bin:$PATH"
 
 WORKDIR /usr/src/monad-bft
 COPY . .
-    
-ARG ETH_CALL_TARGET=monad_shared 
+
+ARG ETH_CALL_TARGET=monad_shared
 ARG TRIEDB_TARGET=triedb_driver
 
 RUN --mount=type=cache,target=${CARGO_ROOT}/registry    \


### PR DESCRIPTION
Sort of a hacky solution, but to use isolated cpusets we'll have pre-generate cpuset groups and prefix commands using `cgexec -g cpuset:<cgroup-name>.slice` – thus we'll need cgexec in the container.

Need to get added to https://github.com/monad-crypto/monad/blob/main/docker/release.Dockerfile as well.