### PR TITLE
Data collection from logs

### DIFF
--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -1043,7 +1043,7 @@ where
                 target: RouterTarget::PointToPoint(next_leader),
                 message: msg,
             };
-            debug!(vote = ?v, ?next_leader, "created vote");
+            debug!(?round, vote = ?v, ?next_leader, "created vote");
             self.metrics.consensus_events.created_vote += 1;
             cmds.push(send_cmd);
         }

--- a/monad-eth-txpool/src/lib.rs
+++ b/monad-eth-txpool/src/lib.rs
@@ -452,7 +452,8 @@ where
         let full_tx_list = EthFullTransactionList(txs).rlp_encode();
 
         info!(
-            proposal_num_tx,
+            ?proposed_seq_num,
+            ?proposal_num_tx,
             proposal_total_gas = total_gas,
             proposal_tx_bytes = full_tx_list.len(),
             "created proposal"

--- a/monad-scripts/python/.gitignore
+++ b/monad-scripts/python/.gitignore
@@ -1,2 +1,3 @@
-/venv
+venv
 __pycache__
+*.png

--- a/monad-scripts/python/cli.py
+++ b/monad-scripts/python/cli.py
@@ -3,14 +3,12 @@ from log.monad_bft import BftLog
 
 if __name__ == "__main__":
     log = BftLog.from_json(sys.stdin)
-    print("Log Dataframe")
-    print(log.df)
-    ledger_commit_df = log.ledger_commit_df()
-    print("\nLedger Commit Dataframe")
-    print(ledger_commit_df)
-    tx_per_second = ledger_commit_df["num_tx"].resample("s").sum()
-    print("\nTransactions Per Second")
-    print(tx_per_second)
-    blocks_per_second = ledger_commit_df.resample("s").size()
-    print("\nBlocks Per Second")
-    print(blocks_per_second)
+
+    # TODO: interactive cli to allow users to choose what data to look at
+
+    log.plot_block_commit()
+    log.plot_received_proposal()
+    log.plot_received_votes()
+    log.missing_proposal_or_vote_df()
+    log.plot_create_proposal()
+    log.plot_timeout()

--- a/monad-scripts/python/log/monad_bft.py
+++ b/monad-scripts/python/log/monad_bft.py
@@ -1,21 +1,272 @@
 import pandas as pd
-
+import matplotlib.pyplot as plt
 
 class BftLog:
     def __init__(self, df):
-        df["timestamp"] = pd.to_datetime(df["timestamp"])
-        df["message"] = df["fields"].apply(lambda x: x.pop("message"))
+        df['timestamp'] = pd.to_datetime(df['timestamp'])
+        df['message'] = df['fields'].apply(lambda x: x.pop('message'))
         self.df = df
 
-    def ledger_commit_df(self):
+
+    ##############################################################################
+    #                     DATA PARSING HELPER FUNCTIONS                          #
+    ##############################################################################
+
+    # collect duration between committed blocks
+    def block_commit_df(self):
         df = self.df[
-            (self.df["target"] == "monad_ledger")
-            & (self.df["message"] == "committed block")
+            (self.df['target'] == 'monad_ledger')
+            & (self.df['message'] == 'committed block')
         ]
-        df = df.join(pd.json_normalize(df.pop("fields")))
-        df = df.set_index(df["timestamp"])
-        df = df.drop("timestamp", axis=1)
+        df = df[['timestamp', 'fields']]
+        df['num_tx'] = df['fields'].apply(lambda x: x.get('num_tx'))
+        df['block_num'] = df['fields'].apply(lambda x: x.get('block_num'))
+        df = df.drop('fields', axis=1)
+
+        # calculate duration between each committed block (in milliseconds)
+        df['duration'] = df['timestamp'].diff().dt.total_seconds() * 1000
+        df = df.dropna(subset=['duration'])
+
         return df
+
+
+    # collect duration between receiving consecutive proposals
+    def received_proposal_df(self):
+        df = self.df[
+            (self.df['target'] == 'monad_consensus_state')
+            & (self.df['message'] == 'Received Proposal')
+        ]
+        df = df[['timestamp', 'fields']]
+        df['round'] = df['fields'].apply(lambda x: x.get('round')).astype(int)
+        df = df.drop('fields', axis=1)
+
+        # calculate duration between receiving proposals (in milliseconds)
+        df['duration'] = df['timestamp'].diff().dt.total_seconds() * 1000
+        df = df.dropna(subset=['duration'])
+
+        return df
+
+
+    # collect data when the node is the block leader and collect votes from its peers
+    # shows the duration to collect the votes and the total number of votes collected
+    def received_votes_df(self):
+        df = self.df[
+            (self.df['target'] == 'monad_consensus::vote_state')
+            & (self.df['message'] == 'collecting vote')
+        ]
+        df = df[['timestamp', 'target', 'fields']]
+        df['round'] = df['fields'].apply(lambda x: x.get('round')).astype(int)
+        df = df.drop('fields', axis=1)
+
+        # group by round and aggregate
+        df_grouped = df.groupby('round').agg({
+            'timestamp': ['min', 'max', 'count']
+        }).reset_index()
+        df_grouped.columns = ['round', 'min_timestamp', 'max_timestamp', 'total_votes']
+
+        # calculate duration to obtain total votes
+        df_grouped['timestamp_diff'] = df_grouped['max_timestamp'] - df_grouped['min_timestamp']
+
+        # only keep selected columns
+        df = df_grouped[['total_votes', 'round', 'timestamp_diff']]
+
+        # convert duration to milliseconds
+        df = df.copy()
+        df['duration'] = df['timestamp_diff'].dt.total_seconds() * 1000
+        df['duration'] = df['duration'].round(2)
+        df = df.drop('timestamp_diff', axis=1)
+
+        return df
+
+
+    # collect data when the node is the block leader and create a proposal
+    # shows the duration to collect transaction and create proposal
+    def create_proposal_df(self):
+        df = self.df[
+            (
+                (self.df['target'] == 'monad_consensus_state') & 
+                (self.df['message'] == 'Creating Proposal')
+            ) | (
+                (self.df['target'] == 'monad_eth_txpool') & 
+                (self.df['message'] == 'created proposal')
+            )
+        ]
+        df = df[['timestamp', 'fields']]
+        df['seq_num'] = df['fields'].apply(lambda x: x.get('proposed_seq_num')).astype(int)
+        df = df.drop('fields', axis=1)
+
+        # group by round and aggregate
+        df_grouped = df.groupby('seq_num').agg({
+            'timestamp': ['min', 'max']
+        }).reset_index()
+        df_grouped.columns = ['seq_num', 'min_timestamp', 'max_timestamp']
+
+        # calculate duration to create proposal
+        df_grouped['timestamp_diff'] = df_grouped['max_timestamp'] - df_grouped['min_timestamp']
+
+        # only keep selected columns
+        df = df_grouped[['seq_num', 'timestamp_diff']]
+
+        # convert duration to milliseconds
+        df = df.copy()
+        df['duration'] = df['timestamp_diff'].dt.total_seconds() * 1000
+        df['duration'] = df['duration'].round(2)
+        df = df.drop('timestamp_diff', axis=1)
+
+        return df
+
+
+    # flag the round numbers where the node does not receive a proposal or create a vote
+    def missing_proposal_or_vote_df(self):
+        df_proposal = self.df[
+            (self.df['target'] == 'monad_consensus_state') &
+            (self.df['message'] == 'Received Proposal')
+        ]
+        df_vote = self.df[
+            (self.df['target'] == 'monad_consensus_state') &
+            (self.df['message'] == 'created vote')
+        ]
+        rounds_proposal = df_proposal['fields'].apply(lambda x: x.get('round')).astype(int)
+        rounds_vote = df_vote['fields'].apply(lambda x: x.get('round')).astype(int)
+
+        # identity missing rounds for proposal
+        full_range = set(range(rounds_proposal.min(), rounds_proposal.max() + 1))
+        missing_rounds = sorted(full_range - set(rounds_proposal))
+        print("Missing proposal rounds:", missing_rounds)
+
+        # identify missing rounds for voting
+        full_range = set(range(rounds_vote.min(), rounds_vote.max() + 1))
+        missing_rounds = sorted(full_range - set(rounds_vote))
+        print("Missing voting rounds:", missing_rounds)
+
+
+    # collect duration between a local timeout to receving next proposal
+    def timeout_df(self):
+        df = self.df[
+            (
+                (self.df['target'] == 'monad_consensus_state') & 
+                (self.df['message'] == 'local timeout')
+            ) | (
+                (self.df['target'] == 'monad_consensus_state') & 
+                (self.df['message'] == 'Received Proposal')
+            )
+        ]
+        df = df[['timestamp', 'message', 'fields']]
+        df['round'] = df['fields'].apply(lambda x: x.get('round')).astype(int)
+        df = df.drop('fields', axis=1).reset_index()
+
+        last_timeout_index = None
+        last_timeout_timestamp = None
+        last_timeout_round = None
+        results = []
+
+        for index, row in df.iterrows():
+            if row['message'] == 'local timeout':
+                if last_timeout_index is None:
+                    last_timeout_timestamp = df.loc[index, 'timestamp']
+                    last_timeout_round = df.loc[index, 'round']
+                # else consecutive timeout rounds so do not update last_timeout_timestamp
+                last_timeout_index = index
+            elif row['message'] == 'Received Proposal' and last_timeout_index is not None:
+                # calculate the duration
+                proposal_timestamp = row['timestamp']
+                duration = (proposal_timestamp - last_timeout_timestamp).total_seconds() * 1000
+                results.append({
+                    'timeout_timestamp': last_timeout_timestamp,
+                    'proposal_timestamp': proposal_timestamp,
+                    'round': last_timeout_round,
+                    'duration': duration
+                })
+                last_timeout_index = None
+                last_timeout_timestamp = None
+
+        result_df = pd.DataFrame(results)
+
+        return result_df
+
+
+    ##############################################################################
+    #                     VISUALIZATION HELPER FUNCTIONS                         #
+    ##############################################################################
+
+    # plot the duration between committed blocks
+    def plot_block_commit(self):
+        df = self.block_commit_df()
+
+        plt.figure(figsize=(12, 6))
+        plt.scatter(df['block_num'], df['duration'], color='blue', s=5)
+        plt.xlabel('Block Number')
+        plt.ylabel('Duration (ms)')
+        plt.title('Duration between consecutive blocks')
+        plt.savefig('block_time.png')
+        plt.close()
+
+
+    # plot the graph of proposal duration between each round
+    def plot_received_proposal(self):
+        df = self.received_proposal_df()
+
+        plt.figure(figsize=(12, 6))
+        plt.scatter(df['round'], df['duration'], color='blue', s=5)
+        plt.xlabel('Round')
+        plt.ylabel('Duration (ms)')
+        plt.title('Duration between consecutive proposals')
+        plt.savefig('proposal_time.png')
+        plt.close()
+
+
+    # plot the duration to collect the votes and the total number of votes collected
+    def plot_received_votes(self):
+        df = self.received_votes_df()
+
+        # create a figure and axis objects
+        fig, ax1 = plt.subplots(figsize=(12, 6))
+
+        # primary y-axis
+        color = 'tab:blue'
+        ax1.set_xlabel('Round')
+        ax1.set_ylabel('Duration (ms)', color=color)
+        ax1.plot(df['round'], df['duration'], color=color)
+        ax1.tick_params(axis='y', labelcolor=color)
+
+        # secondary y-axis
+        ax2 = ax1.twinx()
+        color = 'tab:orange'
+        ax2.set_ylabel('Total Votes', color=color)
+        ax2.plot(df['round'], df['total_votes'], color=color)
+        ax2.tick_params(axis='y', labelcolor=color)
+
+        plt.title('Duration taken to collect votes by leader')
+        fig.tight_layout()
+        plt.savefig('vote_collection.png')
+        plt.close()
+
+
+    # plot the duration to collect transaction and create proposal
+    def plot_create_proposal(self):
+        df = self.create_proposal_df()
+
+        plt.figure(figsize=(12, 6))
+        plt.plot(df['seq_num'], df['duration'], color='blue')
+        plt.xlabel('Sequence number')
+        plt.ylabel('Duration (ms)')
+        plt.title('Duration for creating proposals')
+        plt.savefig('proposal_creation.png')
+        plt.close()
+
+
+    # plot the graph of duration of timeouts to next proposal
+    def plot_timeout(self):
+        df = self.timeout_df()
+
+        plt.figure(figsize=(12, 6))
+        plt.scatter(df['round'], df['duration'], color='blue', s=50)
+        plt.xlabel('Round')
+        plt.ylabel('Duration (ms)')
+        plt.title('Duration between timeouts and next proposal')
+        plt.savefig('timeout_duration.png')
+        plt.close()
+
 
     @staticmethod
     def from_json(filepath_or_buffer):

--- a/monad-scripts/python/requirements.txt
+++ b/monad-scripts/python/requirements.txt
@@ -1,3 +1,4 @@
+matplotlib==3.9.1.post1
 numpy==2.0.1
 pandas==2.2.2
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
Currently collect a few things: 

1. shows the duration to collect the votes and the total number of votes collected

![vote_collection](https://github.com/user-attachments/assets/4a9c1b8c-2ea6-4a77-bf00-6e0ced0c9641)

2. flag the round numbers where the node does not receive a proposal or create a vote. prints out missing rounds

3. duration between committed blocks

![block_time](https://github.com/user-attachments/assets/e83027fa-f6cb-451c-97f0-ca9b775f07c7)

4. duration between receiving consecutive proposals

![proposal_time](https://github.com/user-attachments/assets/7d42d3b2-c021-469a-ac9f-56edde263b1a)

5. time taken for collecting transactions and creating a proposal

![proposal_creation](https://github.com/user-attachments/assets/9f6837f6-4d84-4f59-a35b-e48a1fcc6876)

6. duration between timeout (or timeouts) to the next received proposal

![timeout_duration](https://github.com/user-attachments/assets/bf4f5340-bf62-4d53-94a3-a1b38e6c5466)






