### PR TITLE
monad-dataplane: Restart system calls on EINTR

### DIFF
--- a/monad-dataplane/src/lib.rs
+++ b/monad-dataplane/src/lib.rs
@@ -1,3 +1,35 @@
 pub mod epoll;
 pub mod event_loop;
 pub mod network;
+
+// Helper logic to automatically restart system calls when EINTR is returned.
+// Inspired by cvt() / cvt_r() in sys::std::unix.
+trait IsMinusOne {
+    fn is_minus_one(&self) -> bool;
+}
+
+macro_rules! impl_is_minus_one {
+    ($($t:ident)*) => ($(impl IsMinusOne for $t {
+        fn is_minus_one(&self) -> bool {
+            *self == -1
+        }
+    })*)
+}
+
+impl_is_minus_one! { i8 i16 i32 i64 isize }
+
+pub fn retry_eintr<T, F>(mut f: F) -> T
+where
+    T: IsMinusOne,
+    F: FnMut() -> T,
+{
+    loop {
+        let ret = f();
+
+        if !ret.is_minus_one()
+            || std::io::Error::last_os_error().kind() != std::io::ErrorKind::Interrupted
+        {
+            return ret;
+        }
+    }
+}


### PR DESCRIPTION
When attaching to the monad-raptorcast `service` example using
`strace -p <pid>`, the example dies with a panic that looks like this:

```
thread 'thread '<unnamed><unnamed>' panicked at ' panicked at monad-dataplane/src/event_loop.rsmonad-dataplane/src/event_loop.rs:162::16255:
:called `Result::unwrap()` on an `Err` value: Os { code: 4, kind: Interrupted, message: "Interrupted system call" }55
:
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
called `Result::unwrap()` on an `Err` value: Os { code: 4, kind: Interrupted, message: "Interrupted system call" }
Aborted (core dumped)
```

This happens because monad-raptorcast dies when a system call returns
EINTR instead of restarting the system call, and this makes debugging
problems using strace somewhat difficult.

This commit adds a helper function `retry_eintr()` which wraps the
invocation of a system call and which automatically restarts that system
call if EINTR is returned.  With this change, the `service` example
successfully survives being attached to using `strace -p <pid>` several
times in a row.
