### PR TITLE
Update validators via triedb state root hash executor

### DIFF
--- a/monad-async-state-verify/src/peer.rs
+++ b/monad-async-state-verify/src/peer.rs
@@ -240,7 +240,9 @@ where
         // add to pending votes
         let info_hash = HasherType::hash_object(&info);
         let pending_roots = block_state.pending_roots.entry(info_hash).or_default();
-        pending_roots.insert(peer, sig);
+        if validators.get_members().contains_key(&peer) {
+            pending_roots.insert(peer, sig);
+        }
 
         match self.consensus_update_config {
             AsyncStateVerifyUpdateConfig::Local => {}

--- a/monad-consensus-types/src/validator_data.rs
+++ b/monad-consensus-types/src/validator_data.rs
@@ -238,20 +238,18 @@ pub struct ParsedValidatorData<SCT: SignatureCollection> {
     #[serde(bound = "SCT: SignatureCollection")]
     pub validators: Vec<Validator<SCT>>,
 }
-impl<SCT: SignatureCollection> From<ValidatorSetDataWithEpoch<SCT>> for ParsedValidatorData<SCT> {
-    fn from(validator_set_data: ValidatorSetDataWithEpoch<SCT>) -> Self {
+
+impl<SCT: SignatureCollection> From<Validator<SCT>> for ValidatorData<SCT> {
+    fn from(value: Validator<SCT>) -> Self {
+        let Validator {
+            node_id,
+            stake,
+            cert_pubkey,
+        } = value;
         Self {
-            epoch: validator_set_data.epoch,
-            validators: validator_set_data
-                .validators
-                .0
-                .iter()
-                .map(|v| Validator {
-                    node_id: v.node_id,
-                    stake: v.stake,
-                    cert_pubkey: v.cert_pubkey,
-                })
-                .collect::<Vec<_>>(),
+            node_id,
+            stake,
+            cert_pubkey,
         }
     }
 }

--- a/monad-debugger/src/graphql.rs
+++ b/monad-debugger/src/graphql.rs
@@ -293,8 +293,7 @@ impl<'s> GraphQLAsyncStateVerifyEvent<'s> {
         format!("{:?}", self.0)
     }
 }
-
-struct GraphQLControlPanelEvent<'s>(&'s ControlPanelEvent);
+struct GraphQLControlPanelEvent<'s>(&'s ControlPanelEvent<SignatureCollectionType>);
 
 #[Object]
 impl<'s> GraphQLControlPanelEvent<'s> {

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -83,9 +83,13 @@ pub enum CheckpointCommand<SCT: SignatureCollection> {
     Save(Checkpoint<SCT>),
 }
 
-pub enum StateRootHashCommand {
+pub enum StateRootHashCommand<SCT>
+where
+    SCT: SignatureCollection,
+{
     Request(SeqNum),
     CancelBelow(SeqNum),
+    UpdateValidators((ValidatorSetData<SCT>, Epoch)),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -157,7 +161,7 @@ pub enum Command<E, OM, SCT: SignatureCollection> {
 
     LedgerCommand(LedgerCommand<SCT>),
     CheckpointCommand(CheckpointCommand<SCT>),
-    StateRootHashCommand(StateRootHashCommand),
+    StateRootHashCommand(StateRootHashCommand<SCT>),
     LoopbackCommand(LoopbackCommand<E>),
     ControlPanelCommand(ControlPanelCommand<SCT>),
     TimestampCommand(TimestampCommand),
@@ -172,7 +176,7 @@ impl<E, OM, SCT: SignatureCollection> Command<E, OM, SCT> {
         Vec<TimerCommand<E>>,
         Vec<LedgerCommand<SCT>>,
         Vec<CheckpointCommand<SCT>>,
-        Vec<StateRootHashCommand>,
+        Vec<StateRootHashCommand<SCT>>,
         Vec<LoopbackCommand<E>>,
         Vec<ControlPanelCommand<SCT>>,
         Vec<TimestampCommand>,
@@ -413,9 +417,13 @@ pub enum StateSyncEvent<SCT: SignatureCollection> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ControlPanelEvent {
+pub enum ControlPanelEvent<SCT>
+where
+    SCT: SignatureCollection,
+{
     GetValidatorSet,
     ClearMetricsEvent,
+    UpdateValidators((ValidatorSetData<SCT>, Epoch)),
 }
 
 /// MonadEvent are inputs to MonadState
@@ -438,7 +446,7 @@ where
     /// Events to async state verification
     AsyncStateVerifyEvent(AsyncStateVerifyEvent<SCT>),
     /// Events for the debug control panel
-    ControlPanelEvent(ControlPanelEvent),
+    ControlPanelEvent(ControlPanelEvent<SCT>),
     /// Events to update the block timestamper
     TimestampUpdateEvent(u64),
     /// Events to state sync

--- a/monad-mock-swarm/src/swarm_relation.rs
+++ b/monad-mock-swarm/src/swarm_relation.rs
@@ -189,7 +189,7 @@ impl SwarmRelation for DebugSwarmRelation {
         dyn MockableStateRootHash<
                 Event = MonadEvent<Self::SignatureType, Self::SignatureCollectionType>,
                 SignatureCollection = Self::SignatureCollectionType,
-                Command = StateRootHashCommand,
+                Command = StateRootHashCommand<Self::SignatureCollectionType>,
                 Item = MonadEvent<Self::SignatureType, Self::SignatureCollectionType>,
             > + Send
             + Sync,

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -132,6 +132,7 @@ message ProtoControlPanelEvent {
   oneof event {
     ProtoGetValidatorSetEvent get_validator_set_event = 1;
     ProtoClearMetricsEvent clear_metrics_event = 2;
+    ProtoUpdateValidatorsEvent update_validators_event = 3;
   }
 }
 

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1092,6 +1092,11 @@ where
                         WriteCommand::ClearMetrics(ClearMetrics::Response(self.metrics)),
                     ))]
                 }
+                ControlPanelEvent::UpdateValidators((validators, epoch)) => {
+                    vec![Command::StateRootHashCommand(
+                        StateRootHashCommand::UpdateValidators((validators, epoch)),
+                    )]
+                }
             },
             MonadEvent::TimestampUpdateEvent(t) => {
                 self.block_timestamp.update_time(t);

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -95,7 +95,7 @@ pub fn make_monad_executor<ST, SCT>(
     TokioTimer<MonadEvent<ST, SCT>>,
     MockLedger<ST, SCT>,
     MockCheckpoint<SCT>,
-    BoxUpdater<'static, StateRootHashCommand, MonadEvent<ST, SCT>>,
+    BoxUpdater<'static, StateRootHashCommand<SCT>, MonadEvent<ST, SCT>>,
     IpcReceiver<ST, SCT>,
     ControlPanelIpcReceiver<ST, SCT>,
     LoopbackExecutor<MonadEvent<ST, SCT>>,

--- a/monad-updaters/src/parent.rs
+++ b/monad-updaters/src/parent.rs
@@ -38,7 +38,7 @@ where
 
     CE: Executor<Command = CheckpointCommand<SCT>>,
     LE: Executor<Command = LedgerCommand<SCT>>,
-    SE: Executor<Command = StateRootHashCommand>,
+    SE: Executor<Command = StateRootHashCommand<SCT>>,
     CPE: Executor<Command = ControlPanelCommand<SCT>>,
     LOE: Executor<Command = LoopbackCommand<E>>,
     TSE: Executor<Command = TimestampCommand>,

--- a/monad-updaters/src/state_root_hash.rs
+++ b/monad-updaters/src/state_root_hash.rs
@@ -21,7 +21,9 @@ use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
 use tracing::{debug, error};
 
 pub trait MockableStateRootHash:
-    Executor<Command = StateRootHashCommand> + Stream<Item = Self::Event> + Unpin
+    Executor<Command = StateRootHashCommand<Self::SignatureCollection>>
+    + Stream<Item = Self::Event>
+    + Unpin
 {
     type Event;
     type SignatureCollection: SignatureCollection;
@@ -143,7 +145,7 @@ where
     ST: CertificateSignatureRecoverable + Unpin,
     SCT: SignatureCollection + Unpin,
 {
-    type Command = StateRootHashCommand;
+    type Command = StateRootHashCommand<SCT>;
 
     fn exec(&mut self, commands: Vec<Self::Command>) {
         let mut wake = false;
@@ -179,6 +181,9 @@ where
                         });
                     }
 
+                    wake = true;
+                }
+                StateRootHashCommand::UpdateValidators(_) => {
                     wake = true;
                 }
             }
@@ -338,7 +343,7 @@ where
     ST: CertificateSignatureRecoverable + Unpin,
     SCT: SignatureCollection + Unpin,
 {
-    type Command = StateRootHashCommand;
+    type Command = StateRootHashCommand<SCT>;
 
     fn exec(&mut self, commands: Vec<Self::Command>) {
         let mut wake = false;
@@ -379,6 +384,9 @@ where
                             })
                         };
                     }
+                    wake = true;
+                }
+                StateRootHashCommand::UpdateValidators(_) => {
                     wake = true;
                 }
             }


### PR DESCRIPTION
### Overview 

tracking issue: https://github.com/monad-crypto/monad-internal/issues/121

Builds on #932 . Adds an `update-validators` sub-command where the user provides a TOML file of the following form which gets serialized and sent over IPC socket to an executor that creates an `ValidatorEvent::<SCT>::UpdateValidators` event.

```toml
epoch = 10
[[validators]]
node_id = "0x02093852f554d6196025b0bebe21ea646f73e34f1fd6f154e6ae77c890363ea5be"
stake = 1
cert_pubkey = "0xab1011a17be0921c122fc7362f6e0401f80623c644bb9d9e9eedff0410a4de2259f0d3a36414d4dd9dd748ace56ffb5e"
```

```
Updates the validators using the provided TOML file

Usage: debug-node --control-panel-ipc-path <CONTROL_PANEL_IPC_PATH> update-validators --path <FILE>

Options:
  -p, --path <FILE>  Path to the TOML file
  -h, --help         Print help
```

### Reviewing guide
Special care was taken to ensure that this PR cannot really break staging/prod devnet since it requires explicit action from a user to send a `debug-node` command.

---

1. [Add UpdateValidator support to debug-node and Control Panel IPC executor](https://github.com/monad-crypto/monad-bft/pull/998/commits/cfda415fb5c23bc8e41e048354710b355f4a3a87)
Boilerplate

---
2. [Only include validator in BLS multi-sig](https://github.com/monad-crypto/monad-bft/pull/998/commits/65062ca6cb873abd93e74c0463836897175e05a7) 
Handles an edge case in the BLS multi-sig. Previously, all nodes included in the signature are in the validator set. But now this is no longer the case. A node that is not in the validator set should not be included in the aggregate signature.

---

3. [Add UpdateValidators event](https://github.com/monad-crypto/monad-bft/pull/998/commits/211e59019aca4069da195538f0563402f0def4f1) 
Boilerplate for the `UpdateValidators` event/command

---

4. [Validator set switch logic in StateRootHashTriedbPoll](https://github.com/monad-crypto/monad-bft/pull/998/commits/69c916129770a87abf23275cfc5d782ff493b864)
Dictates the actual set switching logic.
