### PR TITLE
fix benchmark CI

### DIFF
--- a/monad-eth-ledger/Cargo.toml
+++ b/monad-eth-ledger/Cargo.toml
@@ -3,6 +3,11 @@ name = "monad-eth-ledger"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+# this is necessary for criterion bench options
+# https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false
+
 [dependencies]
 monad-consensus = { path = "../monad-consensus" }
 monad-consensus-types = { version = "0.1.0", path = "../monad-consensus-types" }


### PR DESCRIPTION
without this thing, `cargo bench` fails early with an error message, but still produces exit code 0, so CI does not recognize it as a failure 