### PR TITLE
Block validation makes sure no nonce gap

### DIFF
--- a/monad-eth-block-validator/src/lib.rs
+++ b/monad-eth-block-validator/src/lib.rs
@@ -82,9 +82,9 @@ where
                     let maybe_old_nonce = nonces.insert(EthAddress(signer), eth_txn.nonce());
                     // txn iteration is following the same order as they are in the
                     // block. A block is invalid if we see a smaller or equal nonce
-                    // after the first
+                    // after the first or if there is a nonce gap
                     if let Some(old_nonce) = maybe_old_nonce {
-                        if old_nonce >= eth_txn.nonce() {
+                        if eth_txn.nonce() != old_nonce + 1 {
                             return Err(BlockValidationError::TxnError);
                         }
                     }


### PR DESCRIPTION
I _think_ in block validation, we also want to make sure that there is no nonce gap between transactions, otherwise a malicious proposer can create a block with nonce gap which passes consensus validation but will crash execution