### PR TITLE
remove unused reserve_balance_check_mode

### DIFF
--- a/docker/devnet/monad/config/node.toml
+++ b/docker/devnet/monad/config/node.toml
@@ -43,5 +43,3 @@ block_txn_limit = 10_000
 block_gas_limit = 1_000_000_000
 max_reserve_balance = 9_223_372_036_854_775_807
 execution_delay = 10
-reserve_balance_check_mode = 0
-

--- a/monad-consensus-state/benches/state_machine.rs
+++ b/monad-consensus-state/benches/state_machine.rs
@@ -352,7 +352,7 @@ fn setup<
 
                 state_root_validator: state_root(),
                 block_validator: EthValidator::new(10_000, u64::MAX, 1337),
-                block_policy: EthBlockPolicy::new(GENESIS_SEQ_NUM, 0, 0, 0, 1337),
+                block_policy: EthBlockPolicy::new(GENESIS_SEQ_NUM, 0, 0, 1337),
                 state_backend: InMemoryStateInner::genesis(u128::MAX, SeqNum(0)),
                 block_timestamp: BlockTimestamp::new(
                     100,

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -4552,7 +4552,6 @@ mod test {
                     GENESIS_SEQ_NUM,
                     u128::MAX,
                     NopStateRoot {}.get_delay().0,
-                    0,
                     1337,
                 )
             },
@@ -4619,7 +4618,6 @@ mod test {
                     GENESIS_SEQ_NUM,
                     u128::MAX,
                     NopStateRoot {}.get_delay().0,
-                    0,
                     1337,
                 )
             },
@@ -4687,7 +4685,6 @@ mod test {
                     GENESIS_SEQ_NUM,
                     u128::MAX,
                     NopStateRoot {}.get_delay().0,
-                    0,
                     1337,
                 )
             },
@@ -4778,7 +4775,6 @@ mod test {
                     GENESIS_SEQ_NUM,
                     u128::MAX,
                     NopStateRoot {}.get_delay().0,
-                    0,
                     1337,
                 )
             },
@@ -4902,7 +4898,6 @@ mod test {
                     GENESIS_SEQ_NUM,
                     u128::MAX,
                     NopStateRoot {}.get_delay().0,
-                    0,
                     1337,
                 )
             },
@@ -5021,7 +5016,6 @@ mod test {
                     GENESIS_SEQ_NUM,
                     u128::MAX,
                     NopStateRoot {}.get_delay().0,
-                    0,
                     1337,
                 )
             },

--- a/monad-eth-block-policy/src/lib.rs
+++ b/monad-eth-block-policy/src/lib.rs
@@ -376,12 +376,6 @@ pub struct EthBlockPolicy {
 
     /// Chain ID
     chain_id: u64,
-
-    /// lowest-order bit 0 set: enable check for insert_tx
-    /// lowest-order bit 1 set: enable check for create_proposal
-    /// lowest-order bit 2 set: enable check for validation
-    /// i.e. 0b00000111 all reserve balance checks are enabled
-    reserve_balance_check_mode: u8,
 }
 
 impl EthBlockPolicy {
@@ -389,7 +383,6 @@ impl EthBlockPolicy {
         last_commit: SeqNum,
         max_reserve_balance: u128,
         execution_delay: u64,
-        reserve_balance_check_mode: u8,
         chain_id: u64,
     ) -> Self {
         Self {
@@ -397,7 +390,6 @@ impl EthBlockPolicy {
             last_commit,
             max_reserve_balance,
             execution_delay: SeqNum(execution_delay),
-            reserve_balance_check_mode,
             chain_id,
         }
     }
@@ -456,14 +448,6 @@ impl EthBlockPolicy {
 
     pub fn get_last_commit(&self) -> SeqNum {
         self.last_commit
-    }
-
-    pub fn reserve_balance_check_enabled(&self, mode: ReserveBalanceCheck) -> bool {
-        match mode {
-            ReserveBalanceCheck::Insert => self.reserve_balance_check_mode & 0b00000001 > 0,
-            ReserveBalanceCheck::Propose => self.reserve_balance_check_mode & 0b00000010 > 0,
-            ReserveBalanceCheck::Validate => self.reserve_balance_check_mode & 0b00000100 > 0,
-        }
     }
 
     // Computes reserve balance available for the account

--- a/monad-eth-txpool/benches/proposal_bench.rs
+++ b/monad-eth-txpool/benches/proposal_bench.rs
@@ -57,7 +57,7 @@ fn create_pool_and_transactions() -> BenchController {
     // TODO: change this to something more meaningful, i.e. what's is the block
     // policy state we want to benchmark
     let eth_block_policy =
-        EthBlockPolicy::new(GENESIS_SEQ_NUM, Balance::MAX, EXECUTION_DELAY, 0, 1337);
+        EthBlockPolicy::new(GENESIS_SEQ_NUM, Balance::MAX, EXECUTION_DELAY, 1337);
 
     let mut rng = ChaCha8Rng::seed_from_u64(420);
 

--- a/monad-eth-txpool/src/lib.rs
+++ b/monad-eth-txpool/src/lib.rs
@@ -499,7 +499,7 @@ mod test {
     type Pool = dyn TxPool<MultiSig<NopSignature>, EthBlockPolicy, InMemoryState>;
 
     fn make_test_block_policy() -> EthBlockPolicy {
-        EthBlockPolicy::new(GENESIS_SEQ_NUM, u128::MAX, EXECUTION_DELAY, 0, 1337)
+        EthBlockPolicy::new(GENESIS_SEQ_NUM, u128::MAX, EXECUTION_DELAY, 1337)
     }
 
     #[test]
@@ -1262,7 +1262,7 @@ mod test {
         let sender_1_address = EthAddress(txn_nonce_one.recover_signer().unwrap());
 
         // eth block policy has a different chain id than the transaction
-        let eth_block_policy = EthBlockPolicy::new(GENESIS_SEQ_NUM, u128::MAX, 0, 0, 1);
+        let eth_block_policy = EthBlockPolicy::new(GENESIS_SEQ_NUM, u128::MAX, 0, 1);
         let state_backend = InMemoryStateInner::new(
             Balance::MAX,
             SeqNum(4),

--- a/monad-mock-swarm/tests/nonces.rs
+++ b/monad-mock-swarm/tests/nonces.rs
@@ -109,7 +109,7 @@ mod test {
             SimpleRoundRobin::default,
             EthTxPool::default,
             || EthValidator::new(10_000, 1_000_000, 1337),
-            || EthBlockPolicy::new(GENESIS_SEQ_NUM, Balance::MAX, execution_delay.0, 0, 1337),
+            || EthBlockPolicy::new(GENESIS_SEQ_NUM, Balance::MAX, execution_delay.0, 1337),
             || {
                 InMemoryStateInner::new(
                     Balance::MAX,

--- a/monad-node/src/config/consensus.rs
+++ b/monad-node/src/config/consensus.rs
@@ -7,5 +7,4 @@ pub struct NodeConsensusConfig {
     pub block_gas_limit: u64,
     pub execution_delay: u64,
     pub max_reserve_balance: u64,
-    pub reserve_balance_check_mode: u8,
 }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -293,7 +293,6 @@ async fn run(
             GENESIS_SEQ_NUM, // FIXME: MonadStateBuilder is responsible for updating this to forkpoint root if necessary
             node_state.node_config.consensus.max_reserve_balance.into(),
             node_state.node_config.consensus.execution_delay,
-            node_state.node_config.consensus.reserve_balance_check_mode,
             node_state.node_config.chain_id,
         ),
         state_backend: StateBackendCache::new(


### PR DESCRIPTION
The reserve_balance_check_mode is unused and hence should be removed.  If approved pushing this to main should be coordinated with monad-intergration and devnet updates