### PR TITLE
Statesync IPC perf improvement + bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1756,6 +1756,7 @@ dependencies = [
  "ciborium",
  "clap 3.2.25",
  "criterion-plot",
+ "futures",
  "itertools 0.10.5",
  "lazy_static",
  "num-traits",
@@ -1767,6 +1768,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -4285,6 +4287,7 @@ version = "0.1.0"
 dependencies = [
  "bindgen 0.69.4",
  "cmake",
+ "criterion",
  "futures",
  "monad-consensus-types",
  "monad-crypto",
@@ -4292,6 +4295,7 @@ dependencies = [
  "monad-executor-glue",
  "monad-types",
  "rand",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/monad-statesync/Cargo.toml
+++ b/monad-statesync/Cargo.toml
@@ -20,6 +20,14 @@ rand = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "net", "rt", "sync", "time"] }
 tracing = { workspace = true }
 
+[dev-dependencies]
+criterion = { workspace = true, features = ["async_tokio"] }
+tempfile = { workspace = true }
+
 [build-dependencies]
 bindgen = { workspace = true }
 cmake = { workspace = true }
+
+[[bench]]
+name = "ipc_bench"
+harness = false

--- a/monad-statesync/benches/ipc_bench.rs
+++ b/monad-statesync/benches/ipc_bench.rs
@@ -1,0 +1,83 @@
+use std::{path::PathBuf, sync::Arc};
+
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader},
+    net::{UnixListener, UnixStream},
+    task::JoinHandle,
+};
+
+const MIN_PAYLOAD_SIZE: usize = 128 * 1024;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .expect("failed to init tokio rt");
+
+    let buffer = {
+        let mut buffer: Vec<u8> = Vec::new();
+        while buffer.len() < MIN_PAYLOAD_SIZE {
+            // fill buffer with upserts
+            let len = rand::random::<u8>() % 32;
+            buffer.push(len);
+            buffer.extend(0..len);
+        }
+        Arc::new(buffer)
+    };
+
+    let mut group = c.benchmark_group("ipc");
+    group.throughput(Throughput::Bytes(buffer.len() as u64));
+    group.bench_function("raw", |b| {
+        b.to_async(&rt)
+            .iter(|| async { ipc(buffer.clone(), |s| s).await.expect("io err") })
+    });
+
+    group.bench_function("buffered", |b| {
+        b.to_async(&rt)
+            .iter(|| async { ipc(buffer.clone(), BufReader::new).await.expect("io err") })
+    });
+}
+
+async fn ipc<S: AsyncRead + Unpin>(
+    buffer: Arc<Vec<u8>>,
+    read_stream_wrapper: impl FnOnce(UnixStream) -> S,
+) -> tokio::io::Result<()> {
+    let tempdir = tempfile::tempdir().expect("failed to create tempdir");
+    let path = {
+        let mut path = PathBuf::new();
+        path.push(tempdir.path());
+        path.push("bench.sock");
+        Arc::new(path)
+    };
+    let sock_server = UnixListener::bind(&*path)?;
+
+    let buffer_clone = buffer.clone();
+    let client_handle: JoinHandle<tokio::io::Result<()>> = tokio::spawn(async move {
+        let mut sock_client_stream = UnixStream::connect(&*path).await?;
+        sock_client_stream.write_all(&buffer_clone).await?;
+        Ok(())
+    });
+
+    let (sock_server_stream, _) = sock_server.accept().await?;
+    let mut sock_server_stream = read_stream_wrapper(sock_server_stream);
+
+    let mut read_buffer = Vec::new();
+    while read_buffer.len() < MIN_PAYLOAD_SIZE {
+        let len = sock_server_stream.read_u8().await?;
+        read_buffer.push(len);
+        read_buffer.extend((0..).take(len.into()));
+        let read_buffer_len = read_buffer.len();
+        sock_server_stream
+            .read_exact(&mut read_buffer[(read_buffer_len - len as usize)..])
+            .await?;
+    }
+
+    client_handle.await??;
+
+    assert_eq!(&*buffer, &read_buffer);
+    Ok(())
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
```
ipc/raw                 time:   [7.7571 ms 7.7588 ms 7.7606 ms]
                        thrpt:  [16.108 MiB/s 16.112 MiB/s 16.116 MiB/s]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
ipc/buffered            time:   [227.43 µs 228.06 µs 229.06 µs]
                        thrpt:  [545.76 MiB/s 548.14 MiB/s 549.67 MiB/s]
Found 18 outliers among 100 measurements (18.00%)
  5 (5.00%) high mild
  13 (13.00%) high severe
```