### PR TITLE
Move long-running triedb job to dedicated thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4509,7 +4509,6 @@ dependencies = [
  "ntest",
  "rand",
  "rand_chacha",
- "rayon",
  "serde_json",
  "sorted-vec",
  "thiserror",

--- a/monad-updaters/Cargo.toml
+++ b/monad-updaters/Cargo.toml
@@ -26,7 +26,6 @@ bytes = { workspace = true }
 futures = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-rayon = { workspace = true }
 serde_json = { workspace = true }
 sorted-vec = { workspace = true }
 thiserror = { workspace = true }

--- a/monad-updaters/src/triedb_state_root_hash.rs
+++ b/monad-updaters/src/triedb_state_root_hash.rs
@@ -54,7 +54,7 @@ impl<ST, SCT: SignatureCollection> StateRootHashTriedbPoll<ST, SCT> {
         let cancel_below_clone = cancel_below.clone();
 
         let path = triedb_path.to_path_buf();
-        rayon::spawn(move || {
+        std::thread::spawn(move || {
             // FIXME: handle error, maybe retry
             let handle = TriedbHandle::try_new(path.as_path()).unwrap();
 


### PR DESCRIPTION
The triedb state root hash poller is currently running on a long-running rayon task, which permanently eats up a thread from the Rayon pool. The tredb state root hash poller is IO (and not CPU) bound.