### PR TITLE
Optimize r10 decoder creation by not pre-initializing buffer weight state

### DIFF
--- a/monad-raptor/src/r10/nonsystematic/decoder/init.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/init.rs
@@ -90,14 +90,14 @@ impl Decoder {
             intermediate_symbol_state[intermediate_symbol_id].active_push(buffer_index);
         }
 
-        let mut buffers_active_usable = BufferWeightMap::<MAX_TRIPLES>::new();
+        let mut buffers_active_usable = BufferWeightMap::new(MAX_TRIPLES);
 
         for (i, buffer_state) in buffer_state.iter().enumerate() {
             buffers_active_usable
                 .insert_buffer_weight(i, NonZeroU16::new(buffer_state.active_used_weight).unwrap());
         }
 
-        let buffers_inactivated = BufferWeightMap::<MAX_TRIPLES>::new();
+        let buffers_inactivated = BufferWeightMap::new(MAX_TRIPLES);
 
         let decoder = Decoder {
             params,

--- a/monad-raptor/src/r10/nonsystematic/decoder/mod.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/mod.rs
@@ -23,7 +23,7 @@ pub use buffer_weight_map::BufferWeightMap;
 pub use intermediate_symbol::IntermediateSymbol;
 pub use managed_decoder::ManagedDecoder;
 
-use crate::r10::{lt::MAX_TRIPLES, CodeParameters};
+use crate::r10::CodeParameters;
 
 #[derive(Debug)]
 pub struct Decoder {
@@ -39,10 +39,10 @@ pub struct Decoder {
     intermediate_symbol_state: Vec<IntermediateSymbol>,
 
     // Usable and Active buffers ordered according to their Active/Used intermediate symbol weight.
-    buffers_active_usable: BufferWeightMap<MAX_TRIPLES>,
+    buffers_active_usable: BufferWeightMap,
 
     // Inactivated buffers ordered according to their total intermediate symbol weight.
-    buffers_inactivated: BufferWeightMap<MAX_TRIPLES>,
+    buffers_inactivated: BufferWeightMap,
 
     // The number of buffers we have that are in the Redundant state.
     num_redundant_buffers: u16,


### PR DESCRIPTION
This patch reduces the CPU cost of initializing an r10 decoder context
by avoiding zero-initialization of various large arrays that are part
of the decoder context.

The r10 decoder context contains two minheaps that index subsets of the
buffer pool by their buffer weights (where a buffer's weight is the
number of intermediate symbols still XORd into that buffer), and these
minheaps are currently dimensioned by the largest number of encoded
symbols that can ever be produced by an r10 encoder, which is 65521.
For each of these 65521 potentially active buffers, we keep 6 bytes of
state for buffer weight tracking per minheap, and we have two such
minheaps per decoder context, which means that we allocate slightly
less than 768 KiB of state for these two minheaps per decoder context.

The code before this patch would zero-initialize all of this state when
the r10 decoder is created, which means that creation of an r10 decoder
context would cause ~768 KiB of memory to be written to.

While proposals are expected to be large, many of our other RaptorCast
messages are small, and zero-initialization of the state for tens of
thousands of buffers when creating a decoder context is wasteful if we
expect that decoder context to only ever see a handful of buffers.

It should also be a goal to minimize the amount of local CPU consumption
that a malicious proposer or an on-path attacker can trigger, and it is
currently potentially possible for a remote host to trigger the creation
of an r10 decoder context by (partially) replaying an older RaptorCast
message, and while the layers above RaptorCast are robust in the face of
message replays, it is undesirable for remote hosts to have the ability
to easily cause excessive local CPU consumption.

This patch changes the buffer weight tracking code to only initialize
buffer weight state entries when the corresponding buffer is entered
into our accounting, which avoids the cost of up-front zeroing of all
of the per-decoder buffer weight tracking state.  With raptor_bench
modified to use the minimum possible message_size of 4 * 1220 bytes,
instead of its current 10_000 * 400 bytes, this reduces RaptorCast
message decoding time on my laptop from:

```
encoder/decoder/Decoding
                        time:   [116.07 µs 116.25 µs 116.47 µs]
                        thrpt:  [39.959 MiB/s 40.035 MiB/s 40.094 MiB/s]
```

to:

```
encoder/decoder/Decoding
                        time:   [106.45 µs 106.66 µs 106.92 µs]
                        thrpt:  [43.528 MiB/s 43.632 MiB/s 43.718 MiB/s]
                 change:
                        time:   [-8.6854% -8.5112% -8.3251%] (p = 0.00 < 0.05)
                        thrpt:  [+9.0811% +9.3030% +9.5116%]
                        Performance has improved.
```

Note that this includes all of the other RaptorCast decoding overhead,
and for the case of an attacker trying to trigger excessive amounts of
local decoder context creations, the improvement will be even more
significant than this.

We currently still pre-allocate 65521 buffers worth of weight tracking
state per decoder, to avoid potentially pathological behavior associated
with growing the relevant arrays by one element at a time, but we can
reduce decoder memory consumption by pre-allocating for a much smaller
number of buffers if the received message is small, and that will be
addressed by a follow-up patch.

Partially addresses https://github.com/monad-crypto/monad-internal/issues/486 .