### PR TITLE
monad-raptorcast: Gracefully handle Raptor encoder initialization errors

### DIFF
--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -398,10 +398,18 @@ where
         }
     };
 
+    let encoder = match monad_raptor::Encoder::<{ DATA_SIZE as usize }>::new(&app_message) {
+        Ok(encoder) => encoder,
+        Err(err) => {
+            // TODO: signal this error to the caller
+            tracing::warn!(?err, "unable to create Encoder, dropping message");
+            return Vec::new();
+        }
+    };
+
     // populates the following chunk-specific stuff
     // - chunk_id: u16
     // - chunk_payload
-    let encoder = monad_raptor::Encoder::<{ DATA_SIZE as usize }>::new(&app_message).unwrap();
     for (chunk_id, mut chunk_data) in chunk_datas.iter_mut().enumerate() {
         let chunk_id = chunk_id as u16;
         let chunk_len: u16 = DATA_SIZE;

--- a/monad-raptorcast/tests/encoder_error.rs
+++ b/monad-raptorcast/tests/encoder_error.rs
@@ -1,0 +1,66 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use bytes::Bytes;
+use itertools::Itertools;
+use monad_crypto::hasher::{Hasher, HasherType};
+use monad_dataplane::network::MONAD_GSO_SIZE;
+use monad_raptor::SOURCE_SYMBOLS_MAX;
+use monad_raptorcast::{
+    udp::build_messages,
+    util::{BuildTarget, EpochValidators, Validator},
+};
+use monad_secp::{KeyPair, SecpSignature};
+use monad_types::{NodeId, Stake};
+use tracing_subscriber::fmt::format::FmtSpan;
+
+// Try to encode a message that is too large to be encoded, to verify that the encoder
+// errors out instead of panic!()ing.
+#[test]
+pub fn encoder_error() {
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_span_events(FmtSpan::CLOSE)
+        .init();
+
+    let message_size = SOURCE_SYMBOLS_MAX * MONAD_GSO_SIZE + 1;
+
+    let message: Bytes = vec![123_u8; message_size].into();
+
+    let keys = (0_u8..100_u8)
+        .map(|n| {
+            let mut hasher = HasherType::new();
+            hasher.update(n.to_le_bytes());
+            let mut hash = hasher.hash();
+            KeyPair::from_bytes(&mut hash.0).unwrap()
+        })
+        .collect_vec();
+
+    let mut validators = EpochValidators {
+        validators: keys
+            .iter()
+            .map(|key| (NodeId::new(key.pubkey()), Validator { stake: Stake(1) }))
+            .collect(),
+    };
+
+    let known_addresses = keys
+        .iter()
+        .map(|key| {
+            (
+                NodeId::new(key.pubkey()),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+            )
+        })
+        .collect();
+
+    let epoch_validators = validators.view_without(vec![&NodeId::new(keys[0].pubkey())]);
+
+    let _ = build_messages::<SecpSignature>(
+        &keys[0],
+        message,
+        1, // redundancy,
+        0, // epoch_no
+        0, // unix_ts_ms
+        BuildTarget::Raptorcast(epoch_validators),
+        &known_addresses,
+    );
+}


### PR DESCRIPTION
When there is an error initializing a Raptor encoder context, the
current raptorcast code panics, as it calls `unwrap()` on the `Result`
that is returned by `monad_raptor::Encoder::new()`.

Initializing a Raptor encoder can fail if the application message to
be encoded is too small (corresponding to fewer than the R10 minimum
number of 4 encoded symbols) or too large (more than the R10 maximum
number of 8192 encoded symbols).  This is unlikely to happen, but if
it does, we probably don't want to crash the process.

This commit adds a test which without the included fix panics with:

```
---- encoder_error stdout ----
thread 'encoder_error' panicked at /home/buytenh/git/monad-bft/monad-raptorcast/src/udp.rs:404:86:
called `Result::unwrap()` on an `Err` value: Custom { kind: InvalidInput, error: "number of source symbols 9750 not in range 4..=8192" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

And with the included fix, it logs a message but does not panic:

```
$ RUST_LOG=warn cargo test -p monad-raptorcast
[...]
running 1 test
2024-09-09T20:29:18.066602Z  WARN monad_raptorcast::udp: unable to create Encoder, dropping message err=Custom { kind: InvalidInput, error: "number of source symbols 9750 not in range 4..=8192" }
test encoder_error ... ok
```