### PR TITLE
Fix confusing monad-raptor debug tracing output

### DIFF
--- a/monad-raptor/src/r10/nonsystematic/decoder/receive_symbol.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/receive_symbol.rs
@@ -11,11 +11,16 @@ impl Decoder {
         encoding_symbol_id: usize,
         mut xor_buffers: impl FnMut(BufferId, BufferId),
     ) {
-        let buffer_index: u16 = self.buffer_state.len().try_into().unwrap();
+        {
+            let num_buffers_received =
+                self.buffer_state.len() - self.num_redundant_intermediate_symbols() + 1;
 
-        if (buffer_index % 100) == 99 {
-            tracing::debug!(?buffer_index, "received_encoded_symbol");
+            if (num_buffers_received % 100) == 0 {
+                tracing::debug!(?num_buffers_received, "received_encoded_symbol");
+            }
         }
+
+        let buffer_index: u16 = self.buffer_state.len().try_into().unwrap();
 
         let mut buffer = Buffer::new();
 


### PR DESCRIPTION
When running the monad-raptorcast service example with `RUST_LOG=debug`,
we get a debug message for every encoded symbol received that has its
buffer index congruent to 99 mod 100:

```
    Finished `release` profile [optimized + debuginfo] target(s) in 4.38s
     Running `target/release/examples/service --addresses '127.0.0.1:10000' '127.0.0.1:10001' '127.0.0.1:10002' '127.0.0.1:10003'`
2024-09-09T22:37:56.345550Z DEBUG monad_raptor::r10::nonsystematic::decoder::receive_symbol: received_encoded_symbol buffer_index=199
2024-09-09T22:37:56.346791Z DEBUG monad_raptor::r10::nonsystematic::decoder::receive_symbol: received_encoded_symbol buffer_index=299
2024-09-09T22:37:56.348231Z DEBUG monad_raptor::r10::nonsystematic::decoder::receive_symbol: received_encoded_symbol buffer_index=399
2024-09-09T22:37:56.349277Z DEBUG monad_raptor::r10::nonsystematic::decoder::receive_symbol: received_encoded_symbol buffer_index=499
2024-09-09T22:37:56.350447Z DEBUG monad_raptor::r10::nonsystematic::decoder::receive_symbol: received_encoded_symbol buffer_index=599
[...]
```

But notice how `buffer_index=99` is missing from the debug output.  Is
the initial burst of encoded symbols getting lost somewhere?

Changing the debug message to trace for every received buffer seems to
suggest that we are indeed losing the first burst of encoded symbols:

```
    Finished `release` profile [optimized + debuginfo] target(s) in 0.22s
     Running `target/release/examples/service --addresses '127.0.0.1:10000' '127.0.0.1:10001'`
2024-09-09T22:41:53.929164Z DEBUG monad_raptor::r10::nonsystematic::decoder::receive_symbol: received_encoded_symbol buffer_index=141
2024-09-09T22:41:53.929210Z DEBUG monad_raptor::r10::nonsystematic::decoder::receive_symbol: received_encoded_symbol buffer_index=142
2024-09-09T22:41:53.929218Z DEBUG monad_raptor::r10::nonsystematic::decoder::receive_symbol: received_encoded_symbol buffer_index=143
2024-09-09T22:41:53.929223Z DEBUG monad_raptor::r10::nonsystematic::decoder::receive_symbol: received_encoded_symbol buffer_index=144
[...]
```

Is still there a packet loss issue when transmitting over the loopback
interface, perhaps caused by a pacing bug?  Or is there a bug where we
fail to transmit the first few superframes of a Raptor-encoded message
in monad-dataplane?

As it turns out, we aren't actually losing any packets/symbols, and the
tracing output is confusing because the decoder allocates the first set
of decoding buffers, 141 buffers in this case, to the constraint symbols
corresponding to the LDPC/Half pre-code symbols, and therefore, the first
symbol received from the network will land in buffer 141 and not in
buffer 0.

Make the tracing output less confusing by taking the number of constraint
symbols into account and subtracting that from the buffer index that is
being logged.

Also change the tracing to log the number of received buffers including
the current one, and to trace for all multiples of 100 buffers, which
will thus not include a trace for 0.

The output will now look like this:

```
    Finished `release` profile [optimized + debuginfo] target(s) in 4.39s
     Running `target/release/examples/service --addresses '127.0.0.1:10000' '127.0.0.1:10001'`
2024-09-09T22:50:58.867969Z DEBUG monad_raptor::r10::nonsystematic::decoder::receive_symbol: received_encoded_symbol num_buffers_received=100
2024-09-09T22:50:58.868472Z DEBUG monad_raptor::r10::nonsystematic::decoder::receive_symbol: received_encoded_symbol num_buffers_received=200
2024-09-09T22:50:58.869131Z DEBUG monad_raptor::r10::nonsystematic::decoder::receive_symbol: received_encoded_symbol num_buffers_received=300
2024-09-09T22:50:58.870911Z DEBUG monad_raptor::r10::nonsystematic::decoder::receive_symbol: received_encoded_symbol num_buffers_received=400
[...]
```