### PR TITLE
Fix dataplane / raptorcast clippy warnings and perform some cleanup

### DIFF
--- a/monad-dataplane/src/epoll.rs
+++ b/monad-dataplane/src/epoll.rs
@@ -155,7 +155,6 @@ impl EventFd {
                 libc::read(self.fd, data as *mut libc::c_void, mem::size_of::<u64>())
             })
         };
-        // debug!("got tx event");
 
         (n, s)
     }
@@ -195,8 +194,11 @@ impl TimerFd {
         let interval_data = &interval as *const libc::itimerspec;
 
         let s = unsafe { libc::timerfd_settime(self.fd, 0, interval_data, std::ptr::null_mut()) };
-
-        Ok(())
+        if s == -1 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
     }
 
     pub fn handle_event(&self) -> isize {

--- a/monad-dataplane/src/event_loop.rs
+++ b/monad-dataplane/src/event_loop.rs
@@ -358,11 +358,6 @@ impl DataplaneEventLoop {
                 // this blocks until something happens
                 let polled_events = self.epoll.wait().unwrap();
 
-                // debug!(
-                //     "event tokens: {:?}",
-                //     polled_events.iter().map(|e| e.token()).collect::<Vec<_>>()
-                // );
-
                 if polled_events.is_empty() {
                     // if a timeout was configured in the call to epoll_wait,
                     // then we can get here if there were no events ready at expiration
@@ -372,8 +367,6 @@ impl DataplaneEventLoop {
                 }
 
                 for e in polled_events {
-                    // debug!("event token: {:?}", e.token());
-
                     'handle_event: loop {
                         if e.token() == UDP_RX_EVENT {
                             match self.handle_rx() {
@@ -474,7 +467,7 @@ impl DataplaneEventLoop {
     }
 
     fn handle_tx(&mut self) {
-        let (n, s) = self.efd.handle_event();
+        let (_n, s) = self.efd.handle_event();
         if s == -1 {
             let r = std::io::Error::last_os_error();
             if r.kind() == std::io::ErrorKind::WouldBlock {
@@ -540,13 +533,7 @@ impl DataplaneEventLoop {
     }
 
     fn tcp_incoming_get_free_connection_slot(&self) -> Option<usize> {
-        for i in 0..TCP_INCOMING_MAX_CONNECTIONS {
-            if self.tcp_incoming_connections[i].is_none() {
-                return Some(i);
-            }
-        }
-
-        None
+        (0..TCP_INCOMING_MAX_CONNECTIONS).find(|&i| self.tcp_incoming_connections[i].is_none())
     }
 
     fn tcp_incoming_arm_timer(&self, slot: usize, duration: Duration) {
@@ -871,13 +858,7 @@ impl DataplaneEventLoop {
     }
 
     fn tcp_outgoing_get_free_connection_slot(&self) -> Option<usize> {
-        for i in 0..TCP_OUTGOING_MAX_CONNECTIONS {
-            if self.tcp_outgoing_connections[i].is_none() {
-                return Some(i);
-            }
-        }
-
-        None
+        (0..TCP_OUTGOING_MAX_CONNECTIONS).find(|&i| self.tcp_outgoing_connections[i].is_none())
     }
 
     fn tcp_outgoing_arm_timer(&self, slot: usize, duration: Duration) {

--- a/monad-dataplane/src/network.rs
+++ b/monad-dataplane/src/network.rs
@@ -227,7 +227,6 @@ impl<'a> NetworkSocket<'a> {
                             &mut stride,
                             1,
                         );
-                        // debug!("cmsg_data = {}", stride);
 
                         assert!(stride as usize <= MONAD_GSO_SIZE);
                     }
@@ -241,8 +240,6 @@ impl<'a> NetworkSocket<'a> {
                 src_addr: NetworkSocket::get_addr(self.recv_ctrl.name[i]),
                 stride,
             });
-            // debug!("from: {}", NetworkSocket::get_addr(self.recv_ctrl.name[i]));
-            // debug!("received: {}", msglen);
         }
 
         Some(retval)
@@ -342,7 +339,7 @@ impl<'a> NetworkSocket<'a> {
 
         assert!(msg.len() < NUM_TX_MSGHDR);
 
-        let msg_clone = msg.clone(); // used just to keep reference counts alive until sendmmsg
+        let _msg_clone = msg.clone(); // used just to keep reference counts alive until sendmmsg
 
         let mut i = 0;
         for (to, mut payload) in msg {

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -341,7 +341,7 @@ where
             assert!(is_broadcast && !is_raptor_broadcast);
             let total_validators = epoch_validators.view().len();
             let mut running_validator_count = 0;
-            for (node_id, validator) in epoch_validators.view().iter() {
+            for (node_id, _validator) in epoch_validators.view().iter() {
                 let start_idx: usize =
                     num_packets as usize * running_validator_count / total_validators;
                 running_validator_count += 1;
@@ -415,12 +415,12 @@ where
         let chunk_len: u16 = DATA_SIZE;
 
         let cursor = &mut chunk_data;
-        let (cursor_chunk_recipient, cursor) = cursor.split_at_mut(20);
-        let (cursor_chunk_merkle_leaf_idx, cursor) = cursor.split_at_mut(1);
-        let (cursor_chunk_reserved, cursor) = cursor.split_at_mut(1);
+        let (_cursor_chunk_recipient, cursor) = cursor.split_at_mut(20);
+        let (_cursor_chunk_merkle_leaf_idx, cursor) = cursor.split_at_mut(1);
+        let (_cursor_chunk_reserved, cursor) = cursor.split_at_mut(1);
         let (cursor_chunk_id, cursor) = cursor.split_at_mut(2);
         cursor_chunk_id.copy_from_slice(&chunk_id.to_le_bytes());
-        let (cursor_chunk_payload, cursor) = cursor.split_at_mut(chunk_len.into());
+        let (cursor_chunk_payload, _cursor) = cursor.split_at_mut(chunk_len.into());
         encoder.encode_symbol(
             (&mut cursor_chunk_payload[..chunk_len.into()])
                 .try_into()
@@ -465,7 +465,7 @@ where
             let mut header_with_root = {
                 let mut data = [0_u8; HEADER_LEN as usize + 20];
                 let cursor = &mut data;
-                let (cursor_signature, cursor) = cursor.split_at_mut(SIGNATURE_SIZE);
+                let (_cursor_signature, cursor) = cursor.split_at_mut(SIGNATURE_SIZE);
                 let (cursor_version, cursor) = cursor.split_at_mut(2);
                 cursor_version.copy_from_slice(&version.to_le_bytes());
                 let (cursor_broadcast_merkle_depth, cursor) = cursor.split_at_mut(1);
@@ -646,7 +646,7 @@ where
     let merkle_proof = MerkleProof::new_from_leaf_idx(merkle_proof, cursor_merkle_idx)
         .ok_or(MessageValidationError::InvalidMerkleProof)?;
 
-    let cursor_reserved = split_off(1)?;
+    let _cursor_reserved = split_off(1)?;
 
     let cursor_chunk_id = split_off(2)?;
     let chunk_id = u16::from_le_bytes(cursor_chunk_id.as_ref().try_into().expect("u16 is 2 bytes"));


### PR DESCRIPTION
This commit:

- Fixes all clippy warnings in monad-dataplane and monad-raptorcast.

  (We fix the warning in dataplane's TimerFd::arm_oneshot_timer() by
  propagating errors up to the caller.  All users of arm_oneshot_timer()
  unwrap its result, but this should be fine as timerfd_settime() should
  always return 0 the way we use it -- and if arming or disarming a
  kernel timer fails for some reason, we don't just want to silently
  ignore that, as it would mess up our TCP state machine.)

- Removes the lines commented out by PR #1027 in monad-dataplane as
  suggested by @michael-yxchen and @omegablitz.