### PR TITLE
Switch away from using a const generic symbol length in the R10 encoder

### DIFF
--- a/monad-raptor/src/xor_eq.rs
+++ b/monad-raptor/src/xor_eq.rs
@@ -1,70 +1,76 @@
 pub const MAX_SOURCES: usize = 6;
 
-fn xor_eq1<const LEN: usize>(dst: &mut [u8; LEN], a: &[u8; LEN]) {
-    for i in 0..LEN {
+fn xor_eq1(dst: &mut [u8], a: &[u8]) {
+    assert_eq!(dst.len(), a.len());
+
+    for i in 0..dst.len() {
         dst[i] ^= a[i];
     }
 }
 
-fn xor_eq2<const LEN: usize>(dst: &mut [u8; LEN], a: &[u8; LEN], b: &[u8; LEN]) {
-    for i in 0..LEN {
+fn xor_eq2(dst: &mut [u8], a: &[u8], b: &[u8]) {
+    assert_eq!(dst.len(), a.len());
+    assert_eq!(dst.len(), b.len());
+
+    for i in 0..dst.len() {
         dst[i] ^= a[i] ^ b[i];
     }
 }
 
-fn xor_eq3<const LEN: usize>(dst: &mut [u8; LEN], a: &[u8; LEN], b: &[u8; LEN], c: &[u8; LEN]) {
-    for i in 0..LEN {
+fn xor_eq3(dst: &mut [u8], a: &[u8], b: &[u8], c: &[u8]) {
+    assert_eq!(dst.len(), a.len());
+    assert_eq!(dst.len(), b.len());
+    assert_eq!(dst.len(), c.len());
+
+    for i in 0..dst.len() {
         dst[i] ^= a[i] ^ b[i] ^ c[i];
     }
 }
 
-fn xor_eq4<const LEN: usize>(
-    dst: &mut [u8; LEN],
-    a: &[u8; LEN],
-    b: &[u8; LEN],
-    c: &[u8; LEN],
-    d: &[u8; LEN],
-) {
-    for i in 0..LEN {
+fn xor_eq4(dst: &mut [u8], a: &[u8], b: &[u8], c: &[u8], d: &[u8]) {
+    assert_eq!(dst.len(), a.len());
+    assert_eq!(dst.len(), b.len());
+    assert_eq!(dst.len(), c.len());
+    assert_eq!(dst.len(), d.len());
+
+    for i in 0..dst.len() {
         dst[i] ^= a[i] ^ b[i] ^ c[i] ^ d[i];
     }
 }
 
-fn xor_eq5<const LEN: usize>(
-    dst: &mut [u8; LEN],
-    a: &[u8; LEN],
-    b: &[u8; LEN],
-    c: &[u8; LEN],
-    d: &[u8; LEN],
-    e: &[u8; LEN],
-) {
-    for i in 0..LEN {
+fn xor_eq5(dst: &mut [u8], a: &[u8], b: &[u8], c: &[u8], d: &[u8], e: &[u8]) {
+    assert_eq!(dst.len(), a.len());
+    assert_eq!(dst.len(), b.len());
+    assert_eq!(dst.len(), c.len());
+    assert_eq!(dst.len(), d.len());
+    assert_eq!(dst.len(), e.len());
+
+    for i in 0..dst.len() {
         dst[i] ^= a[i] ^ b[i] ^ c[i] ^ d[i] ^ e[i];
     }
 }
 
-fn xor_eq6<const LEN: usize>(
-    dst: &mut [u8; LEN],
-    a: &[u8; LEN],
-    b: &[u8; LEN],
-    c: &[u8; LEN],
-    d: &[u8; LEN],
-    e: &[u8; LEN],
-    f: &[u8; LEN],
-) {
-    for i in 0..LEN {
+fn xor_eq6(dst: &mut [u8], a: &[u8], b: &[u8], c: &[u8], d: &[u8], e: &[u8], f: &[u8]) {
+    assert_eq!(dst.len(), a.len());
+    assert_eq!(dst.len(), b.len());
+    assert_eq!(dst.len(), c.len());
+    assert_eq!(dst.len(), d.len());
+    assert_eq!(dst.len(), e.len());
+    assert_eq!(dst.len(), f.len());
+
+    for i in 0..dst.len() {
         dst[i] ^= a[i] ^ b[i] ^ c[i] ^ d[i] ^ e[i] ^ f[i];
     }
 }
 
-pub fn xor_eq<const LEN: usize>(dst: &mut [u8; LEN], src: &[&[u8; LEN]]) {
+pub fn xor_eq(dst: &mut [u8], src: &[&[u8]]) {
     match src.len() {
-        1 => xor_eq1::<LEN>(dst, src[0]),
-        2 => xor_eq2::<LEN>(dst, src[0], src[1]),
-        3 => xor_eq3::<LEN>(dst, src[0], src[1], src[2]),
-        4 => xor_eq4::<LEN>(dst, src[0], src[1], src[2], src[3]),
-        5 => xor_eq5::<LEN>(dst, src[0], src[1], src[2], src[3], src[4]),
-        6 => xor_eq6::<LEN>(dst, src[0], src[1], src[2], src[3], src[4], src[5]),
+        1 => xor_eq1(dst, src[0]),
+        2 => xor_eq2(dst, src[0], src[1]),
+        3 => xor_eq3(dst, src[0], src[1], src[2]),
+        4 => xor_eq4(dst, src[0], src[1], src[2], src[3]),
+        5 => xor_eq5(dst, src[0], src[1], src[2], src[3], src[4]),
+        6 => xor_eq6(dst, src[0], src[1], src[2], src[3], src[4], src[5]),
         _ => panic!(),
     }
 }

--- a/monad-raptor/tests/managed_decoder.rs
+++ b/monad-raptor/tests/managed_decoder.rs
@@ -6,7 +6,7 @@ use rand::{prelude::SliceRandom, thread_rng, Rng, RngCore};
 const SYMBOL_LEN: usize = 4;
 
 fn test_single_decode(src: Vec<u8>) {
-    let encoder: Encoder<SYMBOL_LEN> = Encoder::new(&src).unwrap();
+    let encoder: Encoder = Encoder::new(&src, SYMBOL_LEN).unwrap();
 
     let num_source_symbols = encoder.num_source_symbols();
 
@@ -17,15 +17,15 @@ fn test_single_decode(src: Vec<u8>) {
 
     for esi in &esis {
         let mut buf: Box<[u8]> = vec![0; SYMBOL_LEN].into_boxed_slice();
-        encoder.encode_symbol(<&mut [u8; SYMBOL_LEN]>::try_from(&mut *buf).unwrap(), *esi);
+        encoder.encode_symbol(&mut buf, *esi);
 
         // We feed some encoded symbols back into the decoder twice to test the
         // Redundant buffer handling paths.
         if rand::thread_rng().gen_ratio(1, 100) {
-            decoder.received_encoded_symbol(&buf[..], *esi);
+            decoder.received_encoded_symbol(&buf, *esi);
         }
 
-        decoder.received_encoded_symbol(&buf[..], *esi);
+        decoder.received_encoded_symbol(&buf, *esi);
 
         if decoder.try_decode() {
             break;

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -398,7 +398,7 @@ where
         }
     };
 
-    let encoder = match monad_raptor::Encoder::<{ DATA_SIZE as usize }>::new(&app_message) {
+    let encoder = match monad_raptor::Encoder::new(&app_message, usize::from(DATA_SIZE)) {
         Ok(encoder) => encoder,
         Err(err) => {
             // TODO: signal this error to the caller
@@ -422,9 +422,7 @@ where
         cursor_chunk_id.copy_from_slice(&chunk_id.to_le_bytes());
         let (cursor_chunk_payload, _cursor) = cursor.split_at_mut(chunk_len.into());
         encoder.encode_symbol(
-            (&mut cursor_chunk_payload[..chunk_len.into()])
-                .try_into()
-                .unwrap(),
+            &mut cursor_chunk_payload[..chunk_len.into()],
             chunk_id.into(),
         );
     }


### PR DESCRIPTION
The R10 encoder as originally implemented and imported into the monad-bft
repository required the encoding symbol length to be a const generic.

This makes the assembly code generated for the buffer XORing functions
look clean and optimal, but unfortunately, it is too restrictive for
real-world use, as the payload (symbol) portion of RaptorCast packets
doesn't have a fixed size known at compile time, mainly for the reason
that the RaptorCast header length depends on the chosen Merkle tree depth
for this message, and the Merkle tree depth isn't necessarily fixed.

To be able to use the current version of the R10 encoder in RaptorCast,
we've temporarily fixed the Merkle tree depth for all outgoing messages
to 6 when we imported the encoder, and we would really like to lift
this restriction again.

This patch changes the encoder to make the symbol length a run-time
determinable variable, and adapts all users of the encoder to match.
A follow-up patch will restore the previous RaptorCast logic to
determine the Merkle tree depth at run time based on the packet type.