### PR TITLE
Switch monad-raptorcast build_messages() back to a dynamic gso_size

### DIFF
--- a/monad-raptorcast/benches/raptor_bench.rs
+++ b/monad-raptorcast/benches/raptor_bench.rs
@@ -52,6 +52,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             let epoch_validators = validators.view_without(vec![&NodeId::new(keys[0].pubkey())]);
             let _ = build_messages::<SecpSignature>(
                 &keys[0],
+                MONAD_GSO_SIZE.try_into().unwrap(), // gso_size
                 message.clone(),
                 2, // redundancy,
                 0, // epoch_no
@@ -92,6 +93,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         let messages = build_messages::<SecpSignature>(
             &keys[0],
+            MONAD_GSO_SIZE.try_into().unwrap(), // gso_size
             message.clone(),
             2, // redundancy,
             0, // epoch_no

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -193,6 +193,9 @@ where
                             .expect("unix epoch doesn't fit in u64");
                         let messages = udp::build_messages::<ST>(
                             &self.key,
+                            monad_dataplane::network::MONAD_GSO_SIZE
+                                .try_into()
+                                .expect("GSO size too big"),
                             app_message,
                             self.redundancy,
                             epoch.0,

--- a/monad-raptorcast/tests/encoder_error.rs
+++ b/monad-raptorcast/tests/encoder_error.rs
@@ -54,8 +54,11 @@ pub fn encoder_error() {
 
     let epoch_validators = validators.view_without(vec![&NodeId::new(keys[0].pubkey())]);
 
+    const GSO_SIZE: u16 = 1500;
+
     let _ = build_messages::<SecpSignature>(
         &keys[0],
+        GSO_SIZE,
         message,
         1, // redundancy,
         0, // epoch_no


### PR DESCRIPTION
Commit 7e18cf414442 ("Switch monad-raptorcast over to custom Raptor
encoder") made the gso_size used by monad-raptorcast a const, as the
Raptor encoder we imported required the desired encoded symbol length
to be a const generic.  This unfortunately involved the loss of the
ability to dynamically choose a per-message Merkle tree depth.

Now that our Raptor encoder no longer requires a const generic symbol
length, we can revert the part of the abovementioned commit that made
the gso_size a const, thereby regaining the ability to flexibly choose
a Merkle tree depth specifically for each transmitted message.