### PR TITLE
Handle peer set with zero stake in raptorcast

### DIFF
--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -372,7 +372,8 @@ where
                 .view()
                 .values()
                 .map(|validator| validator.stake.0)
-                .sum();
+                .sum::<i64>()
+                .max(1);
             let mut running_stake = 0;
             for (node_id, validator) in epoch_validators.view().iter() {
                 let start_idx: usize = (num_packets as i64 * running_stake / total_stake) as usize;


### PR DESCRIPTION
This edge case is hit when a node tries to raptor broadcast to a set of peers whose stake is zero. This was encountered when testing if we support zero staked nodes.