### PR TITLE
Use gossip router in a 2-node setup

### DIFF
--- a/monad-gossip/src/mock.rs
+++ b/monad-gossip/src/mock.rs
@@ -14,11 +14,6 @@ pub struct MockGossipConfig<PT: PubKey> {
 
 impl<PT: PubKey> MockGossipConfig<PT> {
     pub fn build(self) -> MockGossip<PT> {
-        assert!(
-            self.all_peers.len() == 1 || self.message_delay.is_zero(),
-            "Message delay only enabled for single node"
-        );
-
         MockGossip {
             config: self,
 

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -33,7 +33,7 @@ use monad_statesync::StateSync;
 use monad_triedb_cache::StateBackendCache;
 use monad_triedb_utils::TriedbReader;
 use monad_types::{
-    Deserializable, DropTimer, NodeId, Round, SeqNum, Serializable, GENESIS_SEQ_NUM,
+    Deserializable, DropTimer, NodeId, Round, SeqNum, Serializable, Stake, GENESIS_SEQ_NUM,
 };
 use monad_updaters::{
     checkpoint::FileCheckpoint, loopback::LoopbackExecutor, parent::ParentExecutor,
@@ -147,7 +147,9 @@ async fn run(
     let router: BoxUpdater<_, _> = if node_state.forkpoint_config.validator_sets[0]
         .validators
         .0
-        .len()
+        .iter()
+        .filter(|node| node.stake != Stake(0))
+        .count()
         > 1
     {
         <_ as Updater<_>>::boxed(


### PR DESCRIPTION
We want to add a 0-stake node to `devnet_prime`. Instead of patching raptorcast to handle 2-nodes, we default to the gossip router when using 2 nodes.