### PR TITLE
Update 0x-prefix hex deserialization

### DIFF
--- a/monad-consensus-types/src/quorum_certificate.rs
+++ b/monad-consensus-types/src/quorum_certificate.rs
@@ -55,11 +55,12 @@ where
     D: Deserializer<'de>,
 {
     let buf = <std::string::String as Deserialize>::deserialize(deserializer)?;
-    let bytes = if let Some(("", hex_str)) = buf.split_once("0x") {
-        hex::decode(hex_str.to_owned()).map_err(<D::Error as serde::de::Error>::custom)?
-    } else {
+
+    let Some(hex_str) = buf.strip_prefix("0x") else {
         return Err(<D::Error as serde::de::Error>::custom("Missing hex prefix"));
     };
+
+    let bytes = hex::decode(hex_str.to_owned()).map_err(<D::Error as serde::de::Error>::custom)?;
 
     SCT::deserialize(bytes.as_ref()).map_err(<D::Error as serde::de::Error>::custom)
 }

--- a/monad-consensus-types/src/validator_data.rs
+++ b/monad-consensus-types/src/validator_data.rs
@@ -66,11 +66,12 @@ where
     D: Deserializer<'de>,
 {
     let buf = String::deserialize(deserializer)?;
-    let bytes = if let Some(("", hex_str)) = buf.split_once("0x") {
-        hex::decode(hex_str.to_owned()).map_err(<D::Error as serde::de::Error>::custom)?
-    } else {
+
+    let Some(hex_str) = buf.strip_prefix("0x") else {
         return Err(<D::Error as serde::de::Error>::custom("Missing hex prefix"));
     };
+
+    let bytes = hex::decode(hex_str.to_owned()).map_err(<D::Error as serde::de::Error>::custom)?;
 
     SignatureCollectionPubKeyType::<SCT>::from_bytes(&bytes)
         .map_err(<D::Error as serde::de::Error>::custom)
@@ -205,11 +206,12 @@ where
     SCT: SignatureCollection,
 {
     let buf = <String as Deserialize>::deserialize(deserializer)?;
-    let bytes = if let Some(("", hex_str)) = buf.split_once("0x") {
-        hex::decode(hex_str.to_owned()).map_err(<D::Error as serde::de::Error>::custom)?
-    } else {
+
+    let Some(hex_str) = buf.strip_prefix("0x") else {
         return Err(<D::Error as serde::de::Error>::custom("Missing hex prefix"));
     };
+
+    let bytes = hex::decode(hex_str.to_owned()).map_err(<D::Error as serde::de::Error>::custom)?;
 
     Ok(NodeId::new(
         <SCT as SignatureCollection>::NodeIdPubKey::from_bytes(&bytes)

--- a/monad-crypto/src/hasher.rs
+++ b/monad-crypto/src/hasher.rs
@@ -55,11 +55,12 @@ where
     D: Deserializer<'de>,
 {
     let buf = String::deserialize(deserializer)?;
-    let bytes = if let Some(("", hex_str)) = buf.split_once("0x") {
-        hex::decode(hex_str.to_owned()).map_err(<D::Error as serde::de::Error>::custom)?
-    } else {
+
+    let Some(hex_str) = buf.strip_prefix("0x") else {
         return Err(<D::Error as serde::de::Error>::custom("Missing hex prefix"));
     };
+
+    let bytes = hex::decode(hex_str.to_owned()).map_err(<D::Error as serde::de::Error>::custom)?;
 
     bytes.try_into().map_err(|e: Vec<u8>| {
         <D::Error as serde::de::Error>::custom(format!(

--- a/monad-node/src/config/util.rs
+++ b/monad-node/src/config/util.rs
@@ -8,7 +8,7 @@ where
 {
     let mut hex_str: String = Deserialize::deserialize(deserializer)?;
 
-    if let Some(("", hex_str_suffix)) = hex_str.split_once("0x") {
+    if let Some(hex_str_suffix) = hex_str.strip_prefix("0x") {
         hex_str = hex_str_suffix.to_owned();
     }
 
@@ -23,7 +23,7 @@ where
 {
     let mut hex_str: String = Deserialize::deserialize(deserializer)?;
 
-    if let Some(("", hex_str_suffix)) = hex_str.split_once("0x") {
+    if let Some(hex_str_suffix) = hex_str.strip_prefix("0x") {
         hex_str = hex_str_suffix.to_owned();
     }
 

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -269,11 +269,12 @@ where
     P: PubKey,
 {
     let buf = <String as Deserialize>::deserialize(deserializer)?;
-    let bytes = if let Some(("", hex_str)) = buf.split_once("0x") {
-        hex::decode(hex_str.to_owned()).map_err(<D::Error as serde::de::Error>::custom)?
-    } else {
+
+    let Some(hex_str) = buf.strip_prefix("0x") else {
         return Err(<D::Error as serde::de::Error>::custom("Missing hex prefix"));
     };
+
+    let bytes = hex::decode(hex_str.to_owned()).map_err(<D::Error as serde::de::Error>::custom)?;
 
     P::from_bytes(&bytes).map_err(<D::Error as serde::de::Error>::custom)
 }


### PR DESCRIPTION
The `strip_prefix` function is a more "specialized" version of the `split_once` function and should be more efficient.