### PR TITLE
Reduce the amount of reserved memory for RaptorCast decoder instances

### DIFF
--- a/monad-raptor/src/r10/nonsystematic/decoder/buffer_weight_map.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/buffer_weight_map.rs
@@ -16,11 +16,11 @@ pub struct BufferWeightMap {
 }
 
 impl BufferWeightMap {
-    pub fn new(num_expected_buffers: usize) -> BufferWeightMap {
+    pub fn with_capacity(capacity: usize) -> BufferWeightMap {
         BufferWeightMap {
-            heap_index_to_buffer_index: Vec::with_capacity(num_expected_buffers),
-            buffer_index_to_weight: Vec::with_capacity(num_expected_buffers),
-            buffer_index_to_heap_index: Vec::with_capacity(num_expected_buffers),
+            heap_index_to_buffer_index: Vec::with_capacity(capacity),
+            buffer_index_to_weight: Vec::with_capacity(capacity),
+            buffer_index_to_heap_index: Vec::with_capacity(capacity),
         }
     }
 

--- a/monad-raptor/src/r10/nonsystematic/decoder/init.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/init.rs
@@ -12,6 +12,10 @@ use crate::r10::{
 
 impl Decoder {
     pub fn new(num_source_symbols: usize) -> Result<Decoder, Error> {
+        Self::with_capacity(num_source_symbols, MAX_TRIPLES)
+    }
+
+    pub fn with_capacity(num_source_symbols: usize, capacity: usize) -> Result<Decoder, Error> {
         if !(SOURCE_SYMBOLS_MIN..=SOURCE_SYMBOLS_MAX).contains(&num_source_symbols) {
             return Err(Error::new(
                 ErrorKind::InvalidInput,
@@ -90,14 +94,14 @@ impl Decoder {
             intermediate_symbol_state[intermediate_symbol_id].active_push(buffer_index);
         }
 
-        let mut buffers_active_usable = BufferWeightMap::new(MAX_TRIPLES);
+        let mut buffers_active_usable = BufferWeightMap::with_capacity(capacity);
 
         for (i, buffer_state) in buffer_state.iter().enumerate() {
             buffers_active_usable
                 .insert_buffer_weight(i, NonZeroU16::new(buffer_state.active_used_weight).unwrap());
         }
 
-        let buffers_inactivated = BufferWeightMap::new(MAX_TRIPLES);
+        let buffers_inactivated = BufferWeightMap::with_capacity(capacity);
 
         let decoder = Decoder {
             params,

--- a/monad-raptor/src/r10/nonsystematic/decoder/managed_decoder.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/managed_decoder.rs
@@ -101,7 +101,7 @@ impl ManagedDecoder {
 
         let seen_esis = bitvec![usize, Lsb0; 0; max_encoded_symbols];
 
-        let decoder = Decoder::new(num_source_symbols)?;
+        let decoder = Decoder::with_capacity(num_source_symbols, max_encoded_symbols)?;
 
         let buffer_set = BufferSet::new(decoder.num_temp_buffers_required(), symbol_len);
 


### PR DESCRIPTION
As mentioned previously in commit 58cfdd36a748 ("Optimize r10 decoder
creation by not pre-initializing buffer weight state"):

> We currently still pre-allocate 65521 buffers worth of weight tracking
> state per decoder, to avoid potentially pathological behavior associated
> with growing the relevant arrays by one element at a time, but we can
> reduce decoder memory consumption by pre-allocating for a much smaller
> number of buffers if the received message is small, and that will be
> addressed by a follow-up patch.

This patch does that, by pre-allocating for 7 (maximum redundancy) *
num_source_symbols entries worth of weight tracking state per weight
map, where 7 * num_source_symbols is the maximum number of encoded
symbols that this decoder instance should ever see, instead of
pre-allocating the full 65521 entries for each instance of the decoder.

For minimum-sized messages (4 symbols), this reduces the amount of
memory allocated for the buffer weight maps from 65521 (maximum number
of encoded symbols) * 2 (two buffer weight maps) * 6 (six bytes of state
per buffer per weight map) = 786252 bytes to 7 (maximum redundancy) * 4
(four source symbols) * 2 (two buffer weight maps) * 6 (six bytes of state
per buffer per weight map) = 336 bytes.