### PR TITLE
Committed block timestamp in Unix seconds instead of milliseconds

### DIFF
--- a/monad-ledger/src/lib.rs
+++ b/monad-ledger/src/lib.rs
@@ -3,7 +3,7 @@ use std::{
     fs::{self, File},
     io::{ErrorKind, Write},
     marker::PhantomData,
-    ops::Deref,
+    ops::{Deref, Div},
     path::PathBuf,
     pin::Pin,
     task::{Context, Poll},
@@ -361,7 +361,9 @@ fn generate_header<SCT: SignatureCollection>(
         number: seq_num.0,
         gas_limit: header_param.gas_limit,
         gas_used: 0,
-        timestamp: monad_block.get_timestamp(),
+        // timestamp in consensus proposal is in Unix milliseconds
+        // but we commit the block in Unix seconds for integration compatibility
+        timestamp: monad_block.get_timestamp().div(1000),
         mix_hash: randao_reveal_hasher.hash().0.into(),
         nonce: 0,
         // TODO: calculate base fee according to EIP1559

--- a/monad-rpc/src/block_handlers.rs
+++ b/monad-rpc/src/block_handlers.rs
@@ -1,5 +1,3 @@
-use std::ops::Div;
-
 use alloy_primitives::aliases::{U256, U64};
 use monad_rpc_docs::rpc;
 use reth_primitives::Block as EthBlock;
@@ -32,9 +30,7 @@ fn parse_block_content(value: &EthBlock, return_full_txns: bool) -> Option<Block
         gas_limit: U256::from(value.header.gas_limit),
         extra_data: value.header.clone().extra_data,
         logs_bloom: value.header.logs_bloom,
-        // timestamp in block header is in Unix milliseconds but we parse it
-        // to be in Unix seconds here for integration compatability
-        timestamp: U256::from(value.header.timestamp.div(1000)),
+        timestamp: U256::from(value.header.timestamp),
         difficulty: value.header.difficulty,
         mix_hash: Some(value.header.mix_hash),
         nonce: Some(value.header.nonce.to_be_bytes().into()),


### PR DESCRIPTION
Corresponding issue and discussion: https://github.com/monad-crypto/monad-internal/issues/530

Consensus proposal still maintains unix milliseconds for accuracy