### PR TITLE
Cleanup rpc deserialize impls

### DIFF
--- a/monad-rpc/src/account_handlers.rs
+++ b/monad-rpc/src/account_handlers.rs
@@ -6,10 +6,7 @@ use serde_json::Value;
 use tracing::trace;
 
 use crate::{
-    eth_json_types::{
-        deserialize_block_tags, deserialize_fixed_data, deserialize_u256, serialize_result,
-        BlockTags, EthAddress, EthHash, MonadU256,
-    },
+    eth_json_types::{serialize_result, BlockTags, EthAddress, EthHash, MonadU256},
     hex,
     jsonrpc::{JsonRpcError, JsonRpcResult},
     triedb::{TriedbEnv, TriedbResult},
@@ -17,9 +14,7 @@ use crate::{
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthGetBalanceParams {
-    #[serde(deserialize_with = "deserialize_fixed_data")]
     account: EthAddress,
-    #[serde(deserialize_with = "deserialize_block_tags")]
     block_number: BlockTags,
 }
 
@@ -44,9 +39,7 @@ pub async fn monad_eth_getBalance(
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthGetCodeParams {
-    #[serde(deserialize_with = "deserialize_fixed_data")]
     account: EthAddress,
-    #[serde(deserialize_with = "deserialize_block_tags")]
     block_number: BlockTags,
 }
 
@@ -60,7 +53,7 @@ pub async fn monad_eth_getCode(
     trace!("monad_eth_getCode: {params:?}");
 
     let code_hash = match triedb_env
-        .get_account(params.account.0, params.block_number.into())
+        .get_account(params.account.0, params.block_number.clone().into())
         .await
     {
         TriedbResult::Null => return Ok(format!("0x")),
@@ -80,11 +73,8 @@ pub async fn monad_eth_getCode(
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthGetStorageAtParams {
-    #[serde(deserialize_with = "deserialize_fixed_data")]
     account: EthAddress,
-    #[serde(deserialize_with = "deserialize_u256")]
     position: MonadU256,
-    #[serde(deserialize_with = "deserialize_block_tags")]
     block_number: BlockTags,
 }
 
@@ -113,9 +103,7 @@ pub async fn monad_eth_getStorageAt(
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthGetTransactionCountParams {
-    #[serde(deserialize_with = "deserialize_fixed_data")]
     account: EthAddress,
-    #[serde(deserialize_with = "deserialize_block_tags")]
     block_number: BlockTags,
 }
 
@@ -158,10 +146,8 @@ pub async fn monad_eth_accounts(triedb_env: &TriedbEnv) -> Result<Value, JsonRpc
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthGetProofParams {
-    #[serde(deserialize_with = "deserialize_fixed_data")]
     account: EthAddress,
     keys: Vec<EthHash>,
-    #[serde(deserialize_with = "deserialize_block_tags")]
     block_number: BlockTags,
 }
 

--- a/monad-rpc/src/block_handlers.rs
+++ b/monad-rpc/src/block_handlers.rs
@@ -9,10 +9,7 @@ use tracing::trace;
 
 use crate::{
     block_util::{get_block_from_num, get_block_num_from_tag, BlockResult, FileBlockReader},
-    eth_json_types::{
-        deserialize_block_tags, deserialize_fixed_data, BlockTags, EthHash, MonadBlock,
-        MonadTransactionReceipt, Quantity,
-    },
+    eth_json_types::{BlockTags, EthHash, MonadBlock, MonadTransactionReceipt, Quantity},
     eth_txn_handlers::{parse_tx_content, parse_tx_receipt},
     jsonrpc::{JsonRpcError, JsonRpcResult},
     receipt::{decode_receipt, ReceiptDetails},
@@ -118,7 +115,6 @@ pub async fn monad_eth_chainId(chain_id: u64) -> JsonRpcResult<Quantity> {
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthGetBlockByHashParams {
-    #[serde(deserialize_with = "deserialize_fixed_data")]
     block_hash: EthHash,
     return_full_txns: bool,
 }
@@ -151,7 +147,6 @@ pub async fn monad_eth_getBlockByHash(
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthGetBlockByNumberParams {
-    #[serde(deserialize_with = "deserialize_block_tags")]
     block_number: BlockTags,
     return_full_txns: bool,
 }
@@ -183,7 +178,6 @@ pub async fn monad_eth_getBlockByNumber(
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthGetBlockTransactionCountByHashParams {
-    #[serde(deserialize_with = "deserialize_fixed_data")]
     block_hash: EthHash,
 }
 
@@ -210,7 +204,6 @@ pub async fn monad_eth_getBlockTransactionCountByHash(
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthGetBlockTransactionCountByNumberParams {
-    #[serde(deserialize_with = "deserialize_block_tags")]
     block_tag: BlockTags,
 }
 
@@ -283,7 +276,6 @@ pub async fn block_receipts(
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthGetBlockReceiptsParams {
-    #[serde(deserialize_with = "deserialize_block_tags")]
     block_tag: BlockTags,
 }
 

--- a/monad-rpc/src/call.rs
+++ b/monad-rpc/src/call.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 
 use crate::{
     block_util::{get_block_from_num, get_block_num_from_tag, BlockResult, FileBlockReader},
-    eth_json_types::{deserialize_block_tags, BlockTags, Quantity},
+    eth_json_types::{BlockTags, Quantity},
     hex,
     jsonrpc::{JsonRpcError, JsonRpcResult},
     triedb::{TriedbEnv, TriedbResult},
@@ -306,7 +306,6 @@ pub async fn sender_gas_allowance(
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct MonadEthCallParams {
     transaction: CallRequest,
-    #[serde(deserialize_with = "deserialize_block_tags")]
     block: BlockTags,
     #[schemars(skip)] // TODO: move StateOverrideSet from monad-cxx
     #[serde(default)]

--- a/monad-rpc/src/debug.rs
+++ b/monad-rpc/src/debug.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     block_util::{get_block_from_num, get_block_num_from_tag, BlockResult, FileBlockReader},
-    eth_json_types::{deserialize_fixed_data, BlockTags, EthHash, MonadU256},
+    eth_json_types::{BlockTags, EthHash, MonadU256},
     hex,
     jsonrpc::{JsonRpcError, JsonRpcResult},
     trace::{TraceCallObject, TracerObject},
@@ -91,7 +91,6 @@ pub async fn monad_debug_getRawReceipts(
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadDebugGetRawTransactionParams {
-    #[serde(deserialize_with = "deserialize_fixed_data")]
     tx_hash: EthHash,
 }
 

--- a/monad-rpc/src/eth_txn_handlers.rs
+++ b/monad-rpc/src/eth_txn_handlers.rs
@@ -17,9 +17,8 @@ use crate::{
     block_handlers::block_receipts,
     block_util::{get_block_from_num, get_block_num_from_tag, BlockResult, FileBlockReader},
     eth_json_types::{
-        deserialize_block_tags, deserialize_fixed_data, deserialize_quantity,
-        deserialize_unformatted_data, BlockTags, EthAddress, EthHash, MonadLog, MonadTransaction,
-        MonadTransactionReceipt, Quantity, UnformattedData,
+        BlockTags, EthAddress, EthHash, MonadLog, MonadTransaction, MonadTransactionReceipt,
+        Quantity, UnformattedData,
     },
     jsonrpc::{JsonRpcError, JsonRpcResult},
     receipt::{decode_receipt, ReceiptDetails},
@@ -228,13 +227,10 @@ impl<'de> Deserialize<'de> for FilterParams {
 #[serde(untagged, rename_all_fields = "camelCase")]
 pub enum LogFilter {
     Range {
-        #[serde(deserialize_with = "deserialize_block_tags")]
         from_block: BlockTags,
-        #[serde(deserialize_with = "deserialize_block_tags")]
         to_block: BlockTags,
     },
     BlockHash {
-        #[serde(deserialize_with = "deserialize_fixed_data")]
         block_hash: EthHash,
     },
 }
@@ -366,7 +362,6 @@ pub async fn monad_eth_getLogs(
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthSendRawTransactionParams {
-    #[serde(deserialize_with = "deserialize_unformatted_data")]
     hex_tx: UnformattedData,
 }
 
@@ -403,7 +398,6 @@ pub async fn monad_eth_sendRawTransaction(
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthGetTransactionReceiptParams {
-    #[serde(deserialize_with = "deserialize_fixed_data")]
     tx_hash: EthHash,
 }
 
@@ -460,7 +454,6 @@ pub async fn monad_eth_getTransactionReceipt(
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthGetTransactionByHashParams {
-    #[serde(deserialize_with = "deserialize_fixed_data")]
     tx_hash: EthHash,
 }
 
@@ -495,9 +488,7 @@ pub async fn monad_eth_getTransactionByHash(
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthGetTransactionByBlockHashAndIndexParams {
-    #[serde(deserialize_with = "deserialize_fixed_data")]
     block_hash: EthHash,
-    #[serde(deserialize_with = "deserialize_quantity")]
     index: Quantity,
 }
 
@@ -529,9 +520,7 @@ pub async fn monad_eth_getTransactionByBlockHashAndIndex(
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthGetTransactionByBlockNumberAndIndexParams {
-    #[serde(deserialize_with = "deserialize_block_tags")]
     block_tag: BlockTags,
-    #[serde(deserialize_with = "deserialize_quantity")]
     index: Quantity,
 }
 

--- a/monad-rpc/src/gas_handlers.rs
+++ b/monad-rpc/src/gas_handlers.rs
@@ -11,9 +11,7 @@ use tracing::{debug, trace};
 use crate::{
     block_util::{get_block_from_num, get_block_num_from_tag, BlockResult, FileBlockReader},
     call::{sender_gas_allowance, CallRequest},
-    eth_json_types::{
-        deserialize_block_tags, deserialize_quantity, BlockTags, MonadFeeHistory, Quantity,
-    },
+    eth_json_types::{BlockTags, MonadFeeHistory, Quantity},
     jsonrpc::{JsonRpcError, JsonRpcResult},
     triedb::{TriedbEnv, TriedbResult},
 };
@@ -21,7 +19,6 @@ use crate::{
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthEstimateGasParams {
     tx: CallRequest,
-    #[serde(default, deserialize_with = "deserialize_block_tags")]
     block: BlockTags,
     #[schemars(skip)] // TODO: move StateOverrideSet from monad-cxx
     #[serde(default)]
@@ -250,9 +247,7 @@ pub async fn monad_eth_maxPriorityFeePerGas() -> JsonRpcResult<Quantity> {
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthHistoryParams {
-    #[serde(deserialize_with = "deserialize_quantity")]
     block_count: Quantity,
-    #[serde(deserialize_with = "deserialize_block_tags")]
     newest_block: BlockTags,
     reward_percentiles: Vec<f64>,
 }


### PR DESCRIPTION
Relying on serde(deserialize_with) is error prone since its easy to omit 