### PR TITLE
Add raptorcast known_addresses peer dynamically

### DIFF
--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod convert;
 
-use std::fmt::Debug;
+use std::{fmt::Debug, net::SocketAddr};
 
 use bytes::{BufMut, Bytes, BytesMut};
 use chrono::{DateTime, Utc};
@@ -39,6 +39,10 @@ pub enum RouterCommand<PT: PubKey, OM> {
         validator_set: Vec<(NodeId<PT>, Stake)>,
     },
     UpdateCurrentRound(Epoch, Round),
+    AddPeer {
+        node_id: NodeId<PT>,
+        socket_address: SocketAddr,
+    },
 }
 
 pub trait Message: Clone + Send + Sync {

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -316,6 +316,9 @@ impl<S: SwarmRelation> Executor for MockExecutor<S> {
                 RouterCommand::UpdateCurrentRound(_, _) => {
                     // TODO
                 }
+                RouterCommand::AddPeer { .. } => {
+                    // TODO
+                }
             }
         }
     }

--- a/monad-quic/src/endpoint.rs
+++ b/monad-quic/src/endpoint.rs
@@ -381,6 +381,7 @@ where
                                     .entered();
                             this.gossip.send(current_time, target, message);
                         }
+                        RouterCommand::AddPeer { .. } => {}
                     }
                 }
                 continue;

--- a/monad-updaters/src/local_router.rs
+++ b/monad-updaters/src/local_router.rs
@@ -133,6 +133,7 @@ where
                             .unwrap();
                     }
                 },
+                RouterCommand::AddPeer { .. } => {}
             }
         }
     }


### PR DESCRIPTION
Introduce AddPeer router command

Peer discovery needs the router to learn of new addresses at runtime so
we introduce a new command to allow this. Clearing stale addresses in
the raptorcast router is left as a TODO.

It is to be decided how the following routers will handle the AddPeer
command.

- SyncEndpoint (monad-quic) might be deprecated soon
- MockExecutor (monad-mock-swarm) more thinking needs to go into how to
  support dynamic peers in mock swarm
- LocalPeerRouter (monad-testground) was replaced by the raptorcast
  router in https://github.com/monad-crypto/monad-bft/commit/af3f39ded846c3ebd42e120f02ee94a745cfe6b8