### PR TITLE
Add random tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4402,6 +4402,7 @@ dependencies = [
  "monad-crypto",
  "monad-proto",
  "serde",
+ "serde_json",
  "test-case",
  "zerocopy 0.6.5",
 ]

--- a/monad-compress/src/brotli.rs
+++ b/monad-compress/src/brotli.rs
@@ -87,6 +87,26 @@ mod test {
     use std::{fs::File, io::Read};
 
     use super::*;
+
+    #[test]
+    fn test_default_compression() {
+        let mut data = Vec::new();
+        File::open("examples/txbatch.rlp")
+            .unwrap()
+            .read_to_end(&mut data)
+            .unwrap();
+
+        let algo = BrotliCompression::default();
+
+        let mut compressed = Vec::new();
+        assert!(algo.compress(&data, &mut compressed).is_ok());
+        assert!(compressed.len() < data.len());
+
+        let mut decompressed = Vec::new();
+        assert!(algo.decompress(&compressed, &mut decompressed).is_ok());
+        assert_eq!(data, decompressed.as_slice());
+    }
+
     #[test]
     fn test_lossless_compression() {
         let mut data = Vec::new();

--- a/monad-compress/src/nop.rs
+++ b/monad-compress/src/nop.rs
@@ -31,3 +31,32 @@ impl CompressionAlgo for NopCompression {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::{fs::File, io::Read};
+
+    use super::*;
+    #[test]
+    fn test_lossless_compression() {
+        let mut data = Vec::new();
+        File::open("examples/txbatch.rlp")
+            .unwrap()
+            .read_to_end(&mut data)
+            .unwrap();
+
+        let algo = NopCompression::new(6, 0, Vec::new());
+
+        let mut compressed = Vec::new();
+        assert!(algo.compress(&data, &mut compressed).is_ok());
+
+        let mut decompressed = Vec::new();
+        assert!(algo.decompress(&compressed, &mut decompressed).is_ok());
+        assert_eq!(data, decompressed.as_slice());
+    }
+
+    #[test]
+    fn test_nop_compression_format() {
+        assert_eq!(format!("{}", NopCompressionError), "NopCompressionError");
+    }
+}

--- a/monad-types/Cargo.toml
+++ b/monad-types/Cargo.toml
@@ -17,4 +17,5 @@ serde = { workspace = true, features = ["derive"] }
 zerocopy = { workspace = true }
 
 [dev-dependencies]
+serde_json = { workspace = true }
 test-case = { workspace = true }

--- a/monad-validator/src/simple_round_robin.rs
+++ b/monad-validator/src/simple_round_robin.rs
@@ -27,3 +27,46 @@ impl<PT: PubKey> LeaderElection for SimpleRoundRobin<PT> {
         *validators[round.0 as usize % validators.len()]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use monad_crypto::NopPubKey;
+    use test_case::test_case;
+
+    use super::*;
+
+    #[test_case(vec![('A', 1), ('B', 1), ('C', 1)],    vec!['A', 'B', 'C', 'A', 'B', 'C']; "equal stakes")]
+    #[test_case(vec![('A', 1), ('B', 1), ('C', 1)],    vec!['A', 'B', 'C', 'A', 'B', 'C']; "test equal stakes")]
+    #[test_case(vec![('A', 1), ('B', 0), ('C', 1)],    vec!['A', 'C', 'A', 'C']; "test unstaked schedule")]
+    #[test_case(vec![('A', 1), ('B', 2), ('C', 1)],    vec!['A', 'B', 'C', 'A', 'B', 'C']; "test validator with more stake")]
+    #[test_case(vec![],                                vec![]; "test empty schedule")]
+    #[test_case(vec![('A', 2), ('B', 2), ('C', 2)],    vec!['A', 'B', 'C', 'A', 'B', 'C']; "test equal schedule with more stake")]
+    #[test_case(vec![('A', 1), ('B', 2), ('C', 3)],    vec!['A', 'B', 'C', 'A', 'B', 'C']; "test unequal schedule")]
+    #[test_case(vec![('A', 10), ('B', 2), ('C', 3)],   vec![ 'A', 'B', 'C', 'A', 'B', 'C', 'A', 'B', 'C', 'A', 'B', 'C', 'A', 'B', 'C']; "test big stake")]
+    #[test_case(vec![('A', -10), ('B', 2), ('C', 3)],  vec!['A', 'B', 'C', 'A', 'B', 'C']; "test negative stake")]
+    fn test_boxed_round_robin(validator_set: Vec<(char, i64)>, expected_schedule: Vec<char>) {
+        let l: Box<dyn LeaderElection<NodeIdPubKey = NopPubKey>> =
+            Box::new(SimpleRoundRobin::default());
+        let validator_set = validator_set
+            .into_iter()
+            .map(|(validator, stake)| {
+                (
+                    NodeId::new(NopPubKey::from_bytes(&[validator as u8; 32]).unwrap()),
+                    Stake(stake),
+                )
+            })
+            .collect();
+        let expected_schedule = expected_schedule
+            .into_iter()
+            .map(|validator| NodeId::new(NopPubKey::from_bytes(&[validator as u8; 32]).unwrap()))
+            .collect::<Vec<_>>();
+        let schedule_size = expected_schedule.len();
+
+        for round in 0..(2 * schedule_size) {
+            assert_eq!(
+                l.get_leader(Round(round as u64), &validator_set),
+                expected_schedule[round % schedule_size]
+            );
+        }
+    }
+}


### PR DESCRIPTION
It's not a whole lot more coverage, but here's a two thirds of a percent of extra code coverage!

I think the biggest things that aren't currently widely covered by unit tests are:
- overarching monad-node crate
- random things in monad-consensus-types
- monad-quic
- RPC
- statesync
- triedb utils

I was trying for a while to get instrumentation through Flexnet tests, since much of that is probably tested through Flexnet, but unfortunately it didn't want to cooperate