### PR TITLE
Fix epoch boundary checkpoint edge condition

### DIFF
--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -387,7 +387,7 @@ where
             .expect("proposal author exists in validator_mapping");
         let block = match self
             .block_validator
-            .validate(p.block, p.payload, author_pubkey)
+            .validate(p.block, p.payload, Some(author_pubkey))
         {
             Ok(block) => block,
             Err(BlockValidationError::TxnError) => {
@@ -619,7 +619,7 @@ where
             .expect("blocksync'd block author should be in validator set");
         let block = self
             .block_validator
-            .validate(block, payload, author_pubkey)
+            .validate(block, payload, Some(author_pubkey))
             .expect("majority extended invalid block"); //FIXME: header payload could mismatch if
                                                         //they respond with incorrect thing. DONT
                                                         //UNWRAP THIS

--- a/monad-consensus-types/src/block_validator.rs
+++ b/monad-consensus-types/src/block_validator.rs
@@ -27,11 +27,21 @@ where
     BPT: BlockPolicy<SCT, SBT>,
     SBT: StateBackend,
 {
+    // TODO it would be less jank if the BLS pubkey was included in the block payload.
+    //
+    // It's weird that we need to pass in the expected author's BLS pubkey just to validate the
+    // randao payload.
+    //
+    // If the BLS pubkey was included as part of the block, then this validate function could just
+    // assert that randao_reveal is internally consistent.
+    //
+    // Then, separately, the BLS pubkey could be validated alongside the SECP pubkey when leader
+    // checks are done.
     fn validate(
         &self,
         block: Block<SCT>,
         payload: Payload,
-        author_pubkey: &SignatureCollectionPubKeyType<SCT>,
+        author_pubkey: Option<&SignatureCollectionPubKeyType<SCT>>,
     ) -> Result<BPT::ValidatedBlock, BlockValidationError>;
 }
 
@@ -46,7 +56,7 @@ where
         &self,
         block: Block<SCT>,
         payload: Payload,
-        _author_pubkey: &SignatureCollectionPubKeyType<SCT>,
+        _author_pubkey: Option<&SignatureCollectionPubKeyType<SCT>>,
     ) -> Result<
         <PassthruBlockPolicy as BlockPolicy<SCT, InMemoryState>>::ValidatedBlock,
         BlockValidationError,

--- a/monad-mock-swarm/tests/forkpoint.rs
+++ b/monad-mock-swarm/tests/forkpoint.rs
@@ -106,6 +106,21 @@ fn test_forkpoint_restart_f_simple_statesync() {
     );
 }
 
+#[test]
+fn test_forkpoint_restart_f_epoch_boundary_statesync() {
+    let epoch_length = SeqNum(200);
+    let statesync_threshold = SeqNum(100);
+
+    let blocks_before_failure = SeqNum(275);
+    let recovery_time = SeqNum(statesync_threshold.0 * 3 / 2);
+    forkpoint_restart_f(
+        blocks_before_failure,
+        recovery_time,
+        epoch_length,
+        statesync_threshold,
+    );
+}
+
 // This test takes too long to run. Ignore for PR CI runs
 #[ignore]
 #[test]

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1173,19 +1173,13 @@ where
         let root_parent_chain: Vec<_> = root_parent_chain
             .into_iter()
             .map(|full_block| {
-                // FIXME forkpoint validator doesn't assert that these epochs exist
-                let author_pubkey = self
-                    .val_epoch_map
-                    .get_cert_pubkeys(&full_block.get_epoch())
-                    .expect("statesync sync'd block epoch should exist in mapping")
-                    .map
-                    .get(&full_block.get_author())
-                    .expect("committed block author should exist in epoch mapping");
                 self.block_validator
                     .validate(
                         full_block.block.clone(),
                         full_block.payload.clone(),
-                        author_pubkey,
+                        // we don't need to validate bls pubkey fields (randao)
+                        // this is because these blocks are already committed by majority
+                        None,
                     )
                     .expect("majority committed invalid block")
             })


### PR DESCRIPTION
Previously, it was never valid to statesync to a checkpoint within 256 + delay blocks of the start of an epoch. This is because the canonical checkpoints for this set of blocks would not include the validator set for the previous epoch, which would be necessary to validate the previous blocks.

This commit contains the minimal set of changes required to fix this edge case, but these changes not ideal.

It's weird that we need to pass in the expected author's BLS pubkey just to validate the randao payload.

If the BLS pubkey was included as part of the block, then this validate function could just assert that randao_reveal is internally consistent.

Then, separately, the BLS pubkey could be validated alongside the SECP pubkey in the same place that leader checks are done in handle_proposal_message.