### PR TITLE
Remove polling interval and triedb cleanup

### DIFF
--- a/monad-triedb-utils/src/lib.rs
+++ b/monad-triedb-utils/src/lib.rs
@@ -10,7 +10,7 @@ use decode::rlp_decode_storage_slot;
 use futures::{channel::oneshot, executor::block_on, future::join_all, FutureExt};
 use monad_eth_types::{EthAccount, EthAddress};
 use monad_state_backend::{StateBackend, StateBackendError};
-use monad_triedb::Handle;
+use monad_triedb::TriedbHandle;
 use monad_types::SeqNum;
 use tracing::{debug, warn};
 
@@ -26,12 +26,12 @@ const MAX_TRIEDB_ASYNC_POLLS: usize = 640_000;
 
 #[derive(Clone)]
 pub struct TriedbReader {
-    handle: Handle,
+    handle: TriedbHandle,
 }
 
 impl TriedbReader {
     pub fn try_new(triedb_path: &Path) -> Option<Self> {
-        Handle::try_new(triedb_path).map(|handle| Self { handle })
+        TriedbHandle::try_new(triedb_path).map(|handle| Self { handle })
     }
 
     pub fn get_latest_block(&self) -> u64 {

--- a/monad-triedb/src/lib.rs
+++ b/monad-triedb/src/lib.rs
@@ -19,9 +19,8 @@ mod bindings {
 
 const STATE_NIBBLE: u8 = 0x0;
 
-// TODO: rename to TriedbHandle
 #[derive(Clone, Debug)]
-pub struct Handle {
+pub struct TriedbHandle {
     db_ptr: *mut bindings::triedb,
 }
 
@@ -59,7 +58,7 @@ pub unsafe extern "C" fn read_async_callback(
     let _ = sender_context.sender.send(result);
 }
 
-impl Handle {
+impl TriedbHandle {
     pub fn try_new(dbdir_path: &Path) -> Option<Self> {
         let path = CString::new(dbdir_path.to_str().expect("invalid path"))
             .expect("failed to create CString");
@@ -198,7 +197,7 @@ impl Handle {
     }
 }
 
-impl Drop for Handle {
+impl Drop for TriedbHandle {
     fn drop(&mut self) {
         let result = unsafe { bindings::triedb_close(self.db_ptr) };
         assert_eq!(result, 0);
@@ -209,11 +208,11 @@ impl Drop for Handle {
 mod test {
     use std::path::Path;
 
-    use crate::Handle;
+    use crate::TriedbHandle;
 
     #[test]
     fn read() {
-        let handle = Handle::try_new(Path::new("/dummy")).unwrap();
+        let handle = TriedbHandle::try_new(Path::new("/dummy")).unwrap();
 
         // this key is hardcoded into mock triedb
         let result = handle.read(&[1, 2, 3], 6, 0);
@@ -230,7 +229,7 @@ mod test {
     #[test]
     #[should_panic]
     fn read_invalid() {
-        let handle = Handle::try_new(Path::new("/dummy")).unwrap();
+        let handle = TriedbHandle::try_new(Path::new("/dummy")).unwrap();
 
         // too many nibbles
         let _ = handle.read(&[1, 2, 3], 7, 0);
@@ -238,7 +237,7 @@ mod test {
 
     #[test]
     fn read_latest_block() {
-        let handle = Handle::try_new(Path::new("/dummy")).unwrap();
+        let handle = TriedbHandle::try_new(Path::new("/dummy")).unwrap();
 
         // this value is hardcoded into mock triedb
         let result = handle.latest_block();

--- a/monad-updaters/src/triedb_state_root_hash.rs
+++ b/monad-updaters/src/triedb_state_root_hash.rs
@@ -16,7 +16,7 @@ use monad_consensus_types::{
 use monad_crypto::{certificate_signature::CertificateSignatureRecoverable, hasher::Hash};
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{MonadEvent, StateRootHashCommand};
-use monad_triedb::Handle as TriedbHandle;
+use monad_triedb::TriedbHandle;
 use monad_types::{Epoch, SeqNum};
 use tracing::{debug, error, warn};
 


### PR DESCRIPTION
as per vicky's feedback, removed the 200 microseconds polling interval for rpc triedb async reads. benchmarking performance is similar