### PR TITLE
Optimize the Raptor(Cast) encoding of short messages

### DIFF
--- a/monad-raptor/src/matrix/invert.rs
+++ b/monad-raptor/src/matrix/invert.rs
@@ -1,0 +1,8 @@
+use crate::matrix::DenseMatrix;
+
+impl DenseMatrix {
+    // Check whether self is invertible.
+    pub fn check_invertible(self) -> bool {
+        self.rowwise_elimination_gaussian(|_| {}).is_ok()
+    }
+}

--- a/monad-raptor/src/matrix/mod.rs
+++ b/monad-raptor/src/matrix/mod.rs
@@ -1,5 +1,6 @@
 mod dense_matrix;
 mod gaussian;
+mod invert;
 mod rc_permutation;
 mod rc_swap_matrix;
 mod row_operation;

--- a/monad-raptor/src/r10/a.rs
+++ b/monad-raptor/src/r10/a.rs
@@ -1,0 +1,54 @@
+use crate::r10::CodeParameters;
+
+impl CodeParameters {
+    // Implant the common part of the matrix A according to RFC 5053 section 5.4.2.4.2:
+    //
+    //               K               S       H
+    //   +-----------------------+-------+-------+
+    //   |                       |       |       |
+    // S |        G_LDPC         |  I_S  | 0_SxH |
+    //   |                       |       |       |
+    //   +-----------------------+-------+-------+
+    //   |                               |       |
+    // H |        G_Half                 |  I_H  |
+    //   |                               |       |
+    //   +-------------------------------+-------+
+    #[allow(clippy::redundant_closure)]
+    pub fn a_common(&self, mut set_element: impl FnMut(usize, usize)) {
+        // G_LDPC
+        self.g_ldpc(|i, j| set_element(i, j));
+
+        // I_S
+        for i in 0..self.num_ldpc_symbols() {
+            set_element(i, self.num_source_symbols() + i);
+        }
+
+        // G_Half
+        self.g_half(|i, j| set_element(self.num_ldpc_symbols() + i, j));
+
+        // I_H
+        for i in 0..self.num_half_symbols() {
+            set_element(
+                self.num_ldpc_symbols() + i,
+                self.num_source_symbols() + self.num_ldpc_symbols() + i,
+            );
+        }
+    }
+
+    // Generate an A matrix with a bottom G_LT part consisting of 'num_encoded_symbols' rows.
+    fn a_with_g_lt(&self, num_encoded_symbols: usize, mut set_element: impl FnMut(usize, usize)) {
+        self.a_common(&mut set_element);
+
+        // G_LT
+        self.g_lt(
+            |i, j| set_element(self.num_ldpc_symbols() + self.num_half_symbols() + i, j),
+            num_encoded_symbols,
+        );
+    }
+
+    // Generate the A matrix which when inverted produces the intermediate symbols from
+    // the constraint symbols and the source symbols for systematic R10 codes.
+    pub fn a_systematic_intermediate(&self, set_element: impl FnMut(usize, usize)) {
+        self.a_with_g_lt(self.num_source_symbols(), set_element);
+    }
+}

--- a/monad-raptor/src/r10/matrix.rs
+++ b/monad-raptor/src/r10/matrix.rs
@@ -1,0 +1,17 @@
+use crate::{matrix::DenseMatrix, r10::CodeParameters};
+
+impl CodeParameters {
+    pub fn a_systematic_intermediate_matrix(&self) -> DenseMatrix {
+        let mut a = DenseMatrix::from_element(
+            self.num_intermediate_symbols(),
+            self.num_intermediate_symbols(),
+            false,
+        );
+
+        self.a_systematic_intermediate(|i, j| {
+            a[(i, j)] = true;
+        });
+
+        a
+    }
+}

--- a/monad-raptor/src/r10/mod.rs
+++ b/monad-raptor/src/r10/mod.rs
@@ -1,10 +1,12 @@
 // Copies of various lookup tables and implementations of various parameter generation
 // functions for the Raptor code described in RFC 5053.
 
+pub mod a;
 pub mod degree;
 pub mod half;
 pub mod ldpc;
 pub mod lt;
+pub mod matrix;
 pub mod nonsystematic;
 pub mod parameters;
 pub mod rand;

--- a/monad-raptor/src/r10/parameters.rs
+++ b/monad-raptor/src/r10/parameters.rs
@@ -12,7 +12,8 @@ pub struct CodeParameters {
 
 // RFC 5053 section 5.2 suggests a minimum value of 4.
 // RFC 5053 section 5.7 provides systematic indices for values of 4 and higher.
-pub const SOURCE_SYMBOLS_MIN: usize = 4;
+// We provide our own systematic indices for values of 1, 2, and 3.
+pub const SOURCE_SYMBOLS_MIN: usize = 1;
 
 // RFC 5053 section 5.1.2 defines Kmax to be 8192.
 pub const SOURCE_SYMBOLS_MAX: usize = 8192;

--- a/monad-raptor/src/r10/systematic_index.rs
+++ b/monad-raptor/src/r10/systematic_index.rs
@@ -2,6 +2,7 @@ use crate::r10::{CodeParameters, SOURCE_SYMBOLS_MAX, SOURCE_SYMBOLS_MIN};
 
 // The pre-computed systematic indices J(K) defined in RFC 5053 section 5.7.
 const SYSTEMATIC_INDEX: [u16; SOURCE_SYMBOLS_MAX - SOURCE_SYMBOLS_MIN + 1] = [
+    1072, 2062, 57975, // Custom values not specified in RFC 5053.
     18, 14, 61, 46, 14, 22, 20, 40, 48, 1, 29, 40, 43, 46, 18, 8, 20, 2, 61, 26, 13, 29, 36, 19,
     58, 5, 58, 0, 54, 56, 24, 14, 5, 67, 39, 31, 25, 29, 24, 19, 14, 56, 49, 49, 63, 30, 4, 39, 2,
     1, 20, 19, 61, 4, 54, 70, 25, 52, 9, 26, 55, 69, 27, 68, 75, 19, 64, 57, 45, 3, 37, 31, 100,

--- a/monad-raptor/tests/a_inversion.rs
+++ b/monad-raptor/tests/a_inversion.rs
@@ -1,0 +1,29 @@
+use std::cmp::min;
+
+use monad_raptor::r10::{CodeParameters, SOURCE_SYMBOLS_MAX, SOURCE_SYMBOLS_MIN};
+use rayon::prelude::*;
+
+// Verify that the A matrix is invertible for the given range of num_source_symbols values.
+fn check_a_invertible(from: usize, to: usize) {
+    (from..=to).into_par_iter().for_each(|num_source_symbols| {
+        println!("Testing {}", num_source_symbols);
+
+        let params = CodeParameters::new(num_source_symbols).unwrap();
+
+        let a = params.a_systematic_intermediate_matrix();
+        if !a.check_invertible() {
+            panic!("Inverting A matrix for K = {} failed", num_source_symbols);
+        }
+    });
+}
+
+#[test]
+fn check_a_invertible_small() {
+    check_a_invertible(SOURCE_SYMBOLS_MIN, min(128, SOURCE_SYMBOLS_MAX));
+}
+
+#[test]
+#[ignore]
+fn check_a_invertible_all() {
+    check_a_invertible(SOURCE_SYMBOLS_MIN, SOURCE_SYMBOLS_MAX);
+}

--- a/monad-raptor/tests/managed_decoder.rs
+++ b/monad-raptor/tests/managed_decoder.rs
@@ -19,13 +19,12 @@ fn test_single_decode(src: Vec<u8>) {
         let mut buf: Box<[u8]> = vec![0; SYMBOL_LEN].into_boxed_slice();
         encoder.encode_symbol(&mut buf, *esi);
 
-        // We feed some encoded symbols back into the decoder twice to test the
-        // Redundant buffer handling paths.
-        if rand::thread_rng().gen_ratio(1, 100) {
-            decoder.received_encoded_symbol(&buf, *esi);
-        }
+        decoder.received_encoded_symbol(&buf, *esi).unwrap();
 
-        decoder.received_encoded_symbol(&buf, *esi);
+        // Make sure that we detect multiple submissions of the same ESI.
+        if rand::thread_rng().gen_ratio(1, 100) {
+            decoder.received_encoded_symbol(&buf, *esi).unwrap_err();
+        }
 
         if decoder.try_decode() {
             break;


### PR DESCRIPTION
In monad-raptor(cast), we have inherited the R10 limitation that the
number of symbols in an encoded message must be at least 4, which means
that for short messages, we end up padding the message with NUL bytes
until it is 4 packets long, and we then encode that message with a
redundancy of 3, leading to a total encoded message size of 12 packets.
This is rather wasteful, and given that we frequently transmit short
messages, we would like to improve the efficiency of the encoding of
short messages.

R10 specifies that a pseudo-random number generator is to be used as the
source of its Luby Transform parameters, that is, the degree of each of
the encoded symbols and the sets of intermediate symbols to be encoded
into each of the encoded symbols are determined by a PRNG, and because
not every randomly generated set of encoded symbol parameters
necessarily has good encoding properties, R10 also specifies that a PRNG
seed/tweak value is to be used for generating its Luby Transform, and it
specifies specific values for this PRNG seed/tweak value (which it calls
"systematic index") to be used that were determined by the R10 code
designers to cause the resultant Raptor code to have certain desirable
encoding properties.

The R10 specification prescribes systematic indices for message lengths
of 4 or more symbols (packets) only, and the fact that systematic
indices are not prescribed for message lengths of 1, 2, or 3 symbols is
the reason that we need to pad short messages to 4 symbols before we can
encode them.  If we could lift this restriction, which would involve us
choosing suitable values for the missing systematic indices, we could
reduce the encoded message size for short messages from 12 to 3 packets,
and if we choose the relevant systematic indices properly, the reception
of any of these 3 packets will lead to a successful reception of the
message.

This commit:

- Drops SOURCE_SYMBOLS_MIN from 4 to 1 and adds optimized systematic
  indices for the 1, 2, and 3 source symbol cases to the R10 systematic
  index table.  This allows encoding short messages without having to
  pad them to 4 symbols (packets).

- Adds a test that verifies the basic sanity of the systematic indices
  in our systematic index table, by making sure that these systematic
  indices generate invertible (systematic) A matrices, which verifies
  that encoded symbols 0..num_source_symbols are linearly independent
  (and thus, form a decodable set) for a given value of
  num_source_symbols, for a range of num_source_symbols values.

  (Testing all num_source_symbols values (1..=8192) takes too long to
  run in CI, so by default we test for 1..=128 only, with the option to
  test all values by activating a test that is marked as #[ignore].)

- Adds some supporting code for this test.

- Fixes an unrelated clippy warning introduced by a previous commit.

Before this commit, a loopback interface tcpdump of a 2-node raptorcast
service example run with a payload_size of 4 shows:

```
12:10:29.437873 IP 127.0.0.1.10000 > 127.0.0.1.10001: UDP, length 11616
```

And after this commit we get:

```
12:10:48.279686 IP 127.0.0.1.10000 > 127.0.0.1.10001: UDP, length 2904
```

This shows that the number of packets generated for a minimum-sized
raptorcast message has indeed been reduced from 8 packets (11616 / 1452,
where 8 corresponds to the previous 4 symbol minimum multiplied by the
service example default redundancy of 2) to 2 packets (2904 / 1452, this
being a source symbol count of 1 multiplied by the redundancy of 2).

This is a breaking change, in that Monad nodes updated with this commit
will send out shorter encoded short messages, which older nodes will
fail to decode, and older nodes will send out messages that newer nodes
will probably mis-decode, but we can still make breaking changes in this
stage.