### PR TITLE
Clear obsolete extending block txs from txpool

### DIFF
--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -788,6 +788,7 @@ where
                     // epoch manager records
                     self.metrics.consensus_events.commit_block += 1;
                     self.block_policy.update_committed_block(block);
+                    self.tx_pool.update_committed_block(block);
                     if !block.is_empty_block() {
                         self.epoch_manager
                             .schedule_epoch_start(block.get_seq_num(), block.get_round());

--- a/monad-consensus-types/src/txpool.rs
+++ b/monad-consensus-types/src/txpool.rs
@@ -55,6 +55,10 @@ where
         state_backend: &SBT,
     ) -> Result<FullTransactionList, StateBackendError>;
 
+    /// Optional callback on block commit
+    /// Can be used for clearing of stale txs from txpool
+    fn update_committed_block(&mut self, committed_block: &BPT::ValidatedBlock);
+
     /// Reclaims memory used by internal TxPool datastructures
     fn clear(&mut self);
 }
@@ -113,4 +117,10 @@ where
     }
 
     fn clear(&mut self) {}
+
+    fn update_committed_block(
+        &mut self,
+        _committed_block: &<PassthruBlockPolicy as BlockPolicy<SCT, InMemoryState>>::ValidatedBlock,
+    ) {
+    }
 }

--- a/monad-eth-block-policy/src/lib.rs
+++ b/monad-eth-block-policy/src/lib.rs
@@ -123,6 +123,7 @@ impl<SCT: SignatureCollection> EthValidatedBlock<SCT> {
         self.validated_txns.iter().map(|t| t.hash()).collect()
     }
 
+    /// Returns the highest tx nonce per account in the block
     pub fn get_nonces(&self) -> &BTreeMap<EthAddress, u64> {
         &self.nonces
     }


### PR DESCRIPTION
This lowers the amount of unnecessary state accesses we need to do. This is because a nontrivial amount of txs in the proposer's txpool likely had already been included in the prior block due to the virtual mempool.