### PR TITLE
Implement generic test runner for eth txpool

### DIFF
--- a/monad-eth-txpool/src/lib.rs
+++ b/monad-eth-txpool/src/lib.rs
@@ -336,11 +336,15 @@ where
 
 #[cfg(test)]
 mod test {
+    use std::collections::BTreeMap;
+
     use alloy_primitives::{hex, B256};
     use alloy_rlp::Decodable;
     use bytes::Bytes;
+    use itertools::Itertools;
     use monad_consensus_types::txpool::TxPool;
     use monad_crypto::NopSignature;
+    use monad_eth_block_policy::EthValidatedBlock;
     use monad_eth_testutil::{generate_random_block_with_txns, make_tx};
     use monad_eth_tx::EthSignedTransaction;
     use monad_eth_types::{Balance, EthAddress};
@@ -355,707 +359,514 @@ mod test {
     const BASE_FEE: u128 = 1000;
     const GAS_LIMIT: u64 = 30000;
 
+    // pubkey starts with AAA
+    const S1: B256 = B256::new(hex!(
+        "0ed2e19e3aca1a321349f295837988e9c6f95d4a6fc54cfab6befd5ee82662ad"
+    ));
+
+    // pubkey starts with BBB
+    const S2: B256 = B256::new(hex!(
+        "009ac901cf45a2e92e7e7bdf167dc52e3a6232be3c56cc3b05622b247c2c716a"
+    ));
+
+    // pubkey starts with CCC
+    const S3: B256 = B256::new(hex!(
+        "0d756f31a3e98f1ae46475687cbfe3085ec74b3abdd712decff3e1e5e4c697a2"
+    ));
+
+    // pubkey starts with DDD
+    const S4: B256 = B256::new(hex!(
+        "871683e86bef90f2e790e60e4245916c731f540eec4a998697c2cbab4e156868"
+    ));
+
+    // pubkey starts with EEE
+    const S5: B256 = B256::new(hex!(
+        "9c82e5ab4dda8da5391393c5eb7cb8b79ca8e03b3028be9ba1e31f2480e17dc8"
+    ));
+
     type Pool = dyn TxPool<MultiSig<NopSignature>, EthBlockPolicy, InMemoryState>;
 
     fn make_test_block_policy() -> EthBlockPolicy {
         EthBlockPolicy::new(GENESIS_SEQ_NUM, u128::MAX, EXECUTION_DELAY, 1337)
     }
 
+    enum TxPoolTestEvent<'a> {
+        InsertTxs {
+            txs: Vec<(&'a EthSignedTransaction, bool)>,
+            expected_pool_size_change: usize,
+        },
+        CreateProposal {
+            tx_limit: usize,
+            gas_limit: u64,
+            expected_txs: Vec<&'a EthSignedTransaction>,
+        },
+        SetPendingBlocks {
+            pending_blocks: Vec<EthValidatedBlock<MultiSig<NopSignature>>>,
+        },
+        Block(Box<dyn FnOnce(&mut EthTxPool)>),
+    }
+
+    fn run_custom_eth_txpool_test<const N: usize>(
+        eth_block_policy: EthBlockPolicy,
+        nonces_override: Option<BTreeMap<EthAddress, u64>>,
+        events: [TxPoolTestEvent<'_>; N],
+    ) {
+        let state_backend = {
+            let nonces = if let Some(nonces) = nonces_override {
+                nonces
+            } else {
+                events
+                    .iter()
+                    .flat_map(|event| match event {
+                        TxPoolTestEvent::InsertTxs {
+                            txs,
+                            expected_pool_size_change: _,
+                        } => txs
+                            .iter()
+                            .map(|(tx, _)| tx.recover_signer().expect("signer is recoverable"))
+                            .collect::<Vec<_>>(),
+                        _ => vec![],
+                    })
+                    .map(|address| (EthAddress(address), 0))
+                    .collect()
+            };
+
+            InMemoryStateInner::new(Balance::MAX, SeqNum(4), InMemoryBlockState::genesis(nonces))
+        };
+
+        let mut pool = EthTxPool::default();
+        let mut pending_blocks = Vec::default();
+
+        for event in events {
+            match event {
+                TxPoolTestEvent::InsertTxs {
+                    txs,
+                    expected_pool_size_change,
+                } => {
+                    let pool_previous_num_txs = pool.pool.num_txs();
+
+                    for (tx, inserted) in txs {
+                        let inserted_txs = Pool::insert_tx(
+                            &mut pool,
+                            vec![Bytes::from(tx.envelope_encoded())],
+                            &eth_block_policy,
+                            &state_backend,
+                        );
+
+                        if inserted {
+                            assert_eq!(inserted_txs, vec![Bytes::from(tx.envelope_encoded())]);
+                        } else {
+                            assert!(inserted_txs.is_empty());
+                        }
+                    }
+
+                    assert_eq!(
+                        pool.pool.num_txs(),
+                        pool_previous_num_txs
+                            .checked_add(expected_pool_size_change)
+                            .expect("pool size change does not overflow")
+                    );
+                }
+                TxPoolTestEvent::CreateProposal {
+                    tx_limit,
+                    gas_limit,
+                    expected_txs,
+                } => {
+                    let encoded_txns = Pool::create_proposal(
+                        &mut pool,
+                        SeqNum(0),
+                        tx_limit,
+                        gas_limit,
+                        &eth_block_policy,
+                        pending_blocks.iter().collect_vec(),
+                        &state_backend,
+                    )
+                    .expect("create proposal succeeds");
+
+                    let decoded_txns =
+                        Vec::<EthSignedTransaction>::decode(&mut encoded_txns.as_ref()).unwrap();
+
+                    let expected_txs = expected_txs.into_iter().cloned().collect_vec();
+
+                    assert_eq!(decoded_txns, expected_txs);
+                }
+                TxPoolTestEvent::SetPendingBlocks {
+                    pending_blocks: new_pending_blocks,
+                } => {
+                    pending_blocks = new_pending_blocks;
+                }
+                TxPoolTestEvent::Block(f) => f(&mut pool),
+            }
+        }
+    }
+
+    fn run_eth_txpool_test<const N: usize>(events: [TxPoolTestEvent<'_>; N]) {
+        run_custom_eth_txpool_test(make_test_block_policy(), None, events);
+    }
+
     #[test]
     #[traced_test]
     fn test_create_proposal_with_insufficient_tx_limit() {
-        let tx = make_tx(B256::repeat_byte(0xAu8), BASE_FEE, GAS_LIMIT, 0, 10);
-        let mut pool = EthTxPool::default();
-        let eth_block_policy = make_test_block_policy();
-        let acc = std::iter::once((EthAddress(tx.recover_signer().unwrap()), 0));
-        let state_backend = InMemoryStateInner::new(
-            Balance::MAX,
-            SeqNum(4),
-            InMemoryBlockState::genesis(acc.collect()),
-        );
-        assert!(!Pool::insert_tx(
-            &mut pool,
-            vec![tx.envelope_encoded().into()],
-            &eth_block_policy,
-            &state_backend,
-        )
-        .is_empty());
-        assert_eq!(pool.pool.num_addresses(), 1);
-        assert_eq!(pool.pool.num_txs(), 1);
+        let tx = make_tx(S1, BASE_FEE, GAS_LIMIT, 0, 10);
 
-        let encoded_txns = Pool::create_proposal(
-            &mut pool,
-            SeqNum(0),
-            0,
-            1_000_000,
-            &eth_block_policy,
-            Vec::new(),
-            &state_backend,
-        )
-        .unwrap();
-
-        let decoded_txns = Vec::<EthSignedTransaction>::decode(&mut encoded_txns.as_ref()).unwrap();
-        assert_eq!(decoded_txns, vec![]);
-        assert!(pool.pool.is_empty());
+        run_eth_txpool_test([
+            TxPoolTestEvent::InsertTxs {
+                txs: vec![(&tx, true)],
+                expected_pool_size_change: 1,
+            },
+            TxPoolTestEvent::CreateProposal {
+                tx_limit: 0,
+                gas_limit: GAS_LIMIT,
+                expected_txs: vec![],
+            },
+            TxPoolTestEvent::Block(Box::new(|pool| {
+                assert!(pool.pool.is_empty());
+            })),
+        ]);
     }
 
     #[test]
     #[traced_test]
     fn test_create_proposal_with_insufficient_gas_limit() {
-        let tx = make_tx(B256::repeat_byte(0xAu8), BASE_FEE, GAS_LIMIT + 1, 0, 10);
-        let mut pool = EthTxPool::default();
-        let eth_block_policy = make_test_block_policy();
-        let acc = std::iter::once((EthAddress(tx.recover_signer().unwrap()), 0));
-        let state_backend = InMemoryStateInner::new(
-            Balance::MAX,
-            SeqNum(4),
-            InMemoryBlockState::genesis(acc.collect()),
-        );
-        assert!(!Pool::insert_tx(
-            &mut pool,
-            vec![tx.envelope_encoded().into()],
-            &eth_block_policy,
-            &state_backend,
-        )
-        .is_empty());
-        assert_eq!(pool.pool.num_addresses(), 1);
-        assert_eq!(pool.pool.num_txs(), 1);
+        let tx = make_tx(S1, BASE_FEE, GAS_LIMIT + 1, 0, 10);
 
-        let encoded_txns = Pool::create_proposal(
-            &mut pool,
-            SeqNum(0),
-            1,
-            GAS_LIMIT,
-            &eth_block_policy,
-            Vec::new(),
-            &state_backend,
-        )
-        .unwrap();
-
-        let decoded_txns = Vec::<EthSignedTransaction>::decode(&mut encoded_txns.as_ref()).unwrap();
-        assert_eq!(decoded_txns, vec![]);
-        assert!(pool.pool.is_empty());
+        run_eth_txpool_test([
+            TxPoolTestEvent::InsertTxs {
+                txs: vec![(&tx, true)],
+                expected_pool_size_change: 1,
+            },
+            TxPoolTestEvent::CreateProposal {
+                tx_limit: 1,
+                gas_limit: GAS_LIMIT,
+                expected_txs: vec![],
+            },
+            TxPoolTestEvent::Block(Box::new(|pool| {
+                assert!(pool.pool.is_empty());
+            })),
+        ]);
     }
 
     #[test]
     #[traced_test]
     fn test_create_partial_proposal_with_insufficient_gas_limit() {
-        let t1 = make_tx(B256::repeat_byte(0xAu8), BASE_FEE, GAS_LIMIT, 0, 10);
-        let t2 = make_tx(B256::repeat_byte(0xAu8), BASE_FEE, GAS_LIMIT, 1, 10);
-        let t3 = make_tx(B256::repeat_byte(0xAu8), BASE_FEE, GAS_LIMIT, 2, 10);
-        let expected_txs = vec![
-            make_tx(B256::repeat_byte(0xAu8), BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(B256::repeat_byte(0xAu8), BASE_FEE, GAS_LIMIT, 1, 10),
-        ];
-        let mut pool = EthTxPool::default();
-        let eth_block_policy = make_test_block_policy();
-        let acc = std::iter::once((EthAddress(t1.recover_signer().unwrap()), 0));
-        let state_backend = InMemoryStateInner::new(
-            Balance::MAX,
-            SeqNum(4),
-            InMemoryBlockState::genesis(acc.collect()),
-        );
+        let tx1 = make_tx(S1, BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx2 = make_tx(S1, BASE_FEE, GAS_LIMIT, 1, 10);
+        let tx3 = make_tx(S1, BASE_FEE, GAS_LIMIT, 2, 10);
 
-        let txns = vec![
-            t1.envelope_encoded().into(),
-            t2.envelope_encoded().into(),
-            t3.envelope_encoded().into(),
-        ];
-
-        assert!(!Pool::insert_tx(&mut pool, txns, &eth_block_policy, &state_backend,).is_empty());
-        assert_eq!(pool.pool.num_addresses(), 1);
-        assert_eq!(pool.pool.num_txs(), 3);
-
-        let encoded_txns = Pool::create_proposal(
-            &mut pool,
-            SeqNum(0),
-            2,
-            GAS_LIMIT * 2,
-            &eth_block_policy,
-            Vec::new(),
-            &state_backend,
-        )
-        .unwrap();
-        let decoded_txns = Vec::<EthSignedTransaction>::decode(&mut encoded_txns.as_ref()).unwrap();
-        assert_eq!(decoded_txns, expected_txs);
+        run_eth_txpool_test([
+            TxPoolTestEvent::InsertTxs {
+                txs: vec![(&tx1, true), (&tx2, true), (&tx3, true)],
+                expected_pool_size_change: 3,
+            },
+            TxPoolTestEvent::CreateProposal {
+                tx_limit: 3,
+                gas_limit: GAS_LIMIT * 2,
+                expected_txs: vec![&tx1, &tx2],
+            },
+            TxPoolTestEvent::Block(Box::new(|pool| {
+                assert!(pool.pool.is_empty());
+            })),
+        ]);
     }
 
     #[test]
     fn test_basic_price_priority() {
-        let s1 = B256::repeat_byte(0xAu8); // 0xC171033d5CBFf7175f29dfD3A63dDa3d6F8F385E
-        let s2 = B256::repeat_byte(0xBu8); // 0xf288ECAF15790EfcAc528946963A6Db8c3f8211d
-        let txs = vec![
-            make_tx(s1, BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s2, 2 * BASE_FEE, 2 * GAS_LIMIT, 0, 10),
-        ];
+        let tx1 = make_tx(S1, BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx2 = make_tx(S2, 2 * BASE_FEE, 2 * GAS_LIMIT, 0, 10);
 
-        let a1 = EthAddress(txs[0].recover_signer().unwrap());
-        let a2 = EthAddress(txs[1].recover_signer().unwrap());
-
-        let expected_txs = vec![
-            make_tx(s2, 2 * BASE_FEE, 2 * GAS_LIMIT, 0, 10),
-            make_tx(s1, BASE_FEE, GAS_LIMIT, 0, 10),
-        ];
-        let mut pool = EthTxPool::default();
-        let eth_block_policy = make_test_block_policy();
-        let state_backend = InMemoryStateInner::new(
-            Balance::MAX,
-            SeqNum(4),
-            InMemoryBlockState::genesis(vec![(a1, 0), (a2, 0)].into_iter().collect()),
-        );
-
-        let txns: Vec<Bytes> = txs
-            .iter()
-            .map(|t| t.clone().envelope_encoded().into())
-            .collect();
-        assert!(!Pool::insert_tx(&mut pool, txns, &eth_block_policy, &state_backend,).is_empty());
-
-        let encoded_txns = Pool::create_proposal(
-            &mut pool,
-            SeqNum(0),
-            2,
-            GAS_LIMIT * 3,
-            &eth_block_policy,
-            Vec::new(),
-            &state_backend,
-        )
-        .unwrap();
-        let decoded_txns = Vec::<EthSignedTransaction>::decode(&mut encoded_txns.as_ref()).unwrap();
-        assert_eq!(decoded_txns, expected_txs);
+        run_eth_txpool_test([
+            TxPoolTestEvent::InsertTxs {
+                txs: vec![(&tx1, true), (&tx2, true)],
+                expected_pool_size_change: 2,
+            },
+            TxPoolTestEvent::CreateProposal {
+                tx_limit: 2,
+                gas_limit: GAS_LIMIT * 3,
+                expected_txs: vec![&tx2, &tx1],
+            },
+            TxPoolTestEvent::Block(Box::new(|pool| {
+                assert!(pool.pool.is_empty());
+            })),
+        ]);
     }
 
     #[test]
     #[traced_test]
     fn test_resubmit_with_better_price() {
-        let s1 = B256::repeat_byte(0xAu8); // 0xC171033d5CBFf7175f29dfD3A63dDa3d6F8F385E
-        let txs = vec![
-            make_tx(s1, BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s1, 2 * BASE_FEE, 2 * GAS_LIMIT, 0, 10),
-        ];
-        let a1 = EthAddress(txs[0].recover_signer().unwrap());
-        let expected_txs = vec![make_tx(s1, 2 * BASE_FEE, 2 * GAS_LIMIT, 0, 10)];
+        let tx1 = make_tx(S1, BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx2 = make_tx(S1, 2 * BASE_FEE, 2 * GAS_LIMIT, 0, 10);
 
-        let mut pool = EthTxPool::default();
-        let eth_block_policy = make_test_block_policy();
-        let state_backend = InMemoryStateInner::new(
-            Balance::MAX,
-            SeqNum(4),
-            InMemoryBlockState::genesis(vec![(a1, 0)].into_iter().collect()),
-        );
-        let txns: Vec<Bytes> = txs
-            .iter()
-            .map(|t| t.clone().envelope_encoded().into())
-            .collect();
-        assert!(!Pool::insert_tx(&mut pool, txns, &eth_block_policy, &state_backend,).is_empty());
-        let encoded_txns = Pool::create_proposal(
-            &mut pool,
-            SeqNum(0),
-            2,
-            3 * GAS_LIMIT,
-            &eth_block_policy,
-            Vec::new(),
-            &state_backend,
-        )
-        .unwrap();
-        let decoded_txns = Vec::<EthSignedTransaction>::decode(&mut encoded_txns.as_ref()).unwrap();
-        assert_eq!(decoded_txns, expected_txs);
+        run_eth_txpool_test([
+            TxPoolTestEvent::InsertTxs {
+                txs: vec![(&tx1, true), (&tx2, true)],
+                expected_pool_size_change: 1,
+            },
+            TxPoolTestEvent::CreateProposal {
+                tx_limit: 2,
+                gas_limit: GAS_LIMIT * 3,
+                expected_txs: vec![&tx2],
+            },
+        ]);
     }
 
     #[test]
     #[traced_test]
     fn nontrivial_example() {
-        let s1: B256 =
-            hex!("0ed2e19e3aca1a321349f295837988e9c6f95d4a6fc54cfab6befd5ee82662ad").into(); // pubkey starts with AAA
-        let s2: B256 =
-            hex!("009ac901cf45a2e92e7e7bdf167dc52e3a6232be3c56cc3b05622b247c2c716a").into(); // pubkey starts with BBB
-        let s3: B256 =
-            hex!("0d756f31a3e98f1ae46475687cbfe3085ec74b3abdd712decff3e1e5e4c697a2").into(); // pubkey starts with CCC
-        let txs = vec![
-            make_tx(s1, 10 * BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s1, 5 * BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s1, 3 * BASE_FEE, GAS_LIMIT, 2, 10),
-            make_tx(s2, 5 * BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s2, 3 * BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s2, 1 * BASE_FEE, GAS_LIMIT, 2, 10),
-            make_tx(s3, 8 * BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s3, 9 * BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s3, 10 * BASE_FEE, GAS_LIMIT, 2, 10),
-        ];
-        let expected_txs = vec![
-            make_tx(s1, 10 * BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s3, 8 * BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s3, 9 * BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s3, 10 * BASE_FEE, GAS_LIMIT, 2, 10),
-            make_tx(s1, 5 * BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s2, 5 * BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s2, 3 * BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s1, 3 * BASE_FEE, GAS_LIMIT, 2, 10),
-            make_tx(s2, 1 * BASE_FEE, GAS_LIMIT, 2, 10),
-        ];
-        let acc = txs
-            .iter()
-            .map(|tx| (EthAddress(tx.recover_signer().unwrap()), 0));
-        let mut pool = EthTxPool::default();
-        let eth_block_policy = make_test_block_policy();
-        let state_backend = InMemoryStateInner::new(
-            Balance::MAX,
-            SeqNum(4),
-            InMemoryBlockState::genesis(acc.collect()),
-        );
-        let txns: Vec<Bytes> = txs
-            .iter()
-            .map(|t| t.clone().envelope_encoded().into())
-            .collect();
-        assert!(!Pool::insert_tx(&mut pool, txns, &eth_block_policy, &state_backend,).is_empty());
-        let encoded_txns = Pool::create_proposal(
-            &mut pool,
-            SeqNum(0),
-            200,
-            300 * GAS_LIMIT,
-            &eth_block_policy,
-            Vec::new(),
-            &state_backend,
-        )
-        .unwrap();
-        let decoded_txns = Vec::<EthSignedTransaction>::decode(&mut encoded_txns.as_ref()).unwrap();
-        assert_eq!(decoded_txns, expected_txs);
+        let tx1 = make_tx(S1, 10 * BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx2 = make_tx(S1, 5 * BASE_FEE, GAS_LIMIT, 1, 10);
+        let tx3 = make_tx(S1, 3 * BASE_FEE, GAS_LIMIT, 2, 10);
+        let tx4 = make_tx(S2, 5 * BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx5 = make_tx(S2, 3 * BASE_FEE, GAS_LIMIT, 1, 10);
+        let tx6 = make_tx(S2, 1 * BASE_FEE, GAS_LIMIT, 2, 10);
+        let tx7 = make_tx(S3, 8 * BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx8 = make_tx(S3, 9 * BASE_FEE, GAS_LIMIT, 1, 10);
+        let tx9 = make_tx(S3, 10 * BASE_FEE, GAS_LIMIT, 2, 10);
+
+        run_eth_txpool_test([
+            TxPoolTestEvent::InsertTxs {
+                txs: vec![&tx1, &tx2, &tx3, &tx4, &tx5, &tx6, &tx7, &tx8, &tx9]
+                    .into_iter()
+                    .map(|tx| (tx, true))
+                    .collect_vec(),
+                expected_pool_size_change: 9,
+            },
+            TxPoolTestEvent::CreateProposal {
+                tx_limit: 128,
+                gas_limit: 1024 * GAS_LIMIT,
+                expected_txs: vec![&tx1, &tx7, &tx8, &tx9, &tx2, &tx4, &tx5, &tx3, &tx6],
+            },
+        ]);
     }
 
     #[test]
     #[traced_test]
     fn another_non_trivial_example() {
-        let s1: B256 =
-            hex!("0ed2e19e3aca1a321349f295837988e9c6f95d4a6fc54cfab6befd5ee82662ad").into(); // pubkey starts with AAA
-        let s2: B256 =
-            hex!("009ac901cf45a2e92e7e7bdf167dc52e3a6232be3c56cc3b05622b247c2c716a").into(); // pubkey starts with BBB
-        let s3: B256 =
-            hex!("0d756f31a3e98f1ae46475687cbfe3085ec74b3abdd712decff3e1e5e4c697a2").into(); // pubkey starts with CCC
-        let txs = vec![
-            make_tx(s1, 10 * BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s1, 5 * BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s2, 5 * BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s2, 3 * BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s3, 8 * BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s3, 9 * BASE_FEE, GAS_LIMIT, 1, 10),
-        ];
-        let expected_txs = vec![
-            make_tx(s1, 10 * BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s3, 8 * BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s3, 9 * BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s1, 5 * BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s2, 5 * BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s2, 3 * BASE_FEE, GAS_LIMIT, 1, 10),
-        ];
+        let tx1 = make_tx(S1, 10 * BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx2 = make_tx(S1, 5 * BASE_FEE, GAS_LIMIT, 1, 10);
+        let tx3 = make_tx(S2, 5 * BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx4 = make_tx(S2, 3 * BASE_FEE, GAS_LIMIT, 1, 10);
+        let tx5 = make_tx(S3, 8 * BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx6 = make_tx(S3, 9 * BASE_FEE, GAS_LIMIT, 1, 10);
 
-        let acc = txs
-            .iter()
-            .map(|tx| (EthAddress(tx.recover_signer().unwrap()), 0));
-        let mut pool = EthTxPool::default();
-        let eth_block_policy = make_test_block_policy();
-        let state_backend = InMemoryStateInner::new(
-            Balance::MAX,
-            SeqNum(4),
-            InMemoryBlockState::genesis(acc.collect()),
-        );
-        let txns: Vec<Bytes> = txs
-            .iter()
-            .map(|t| t.clone().envelope_encoded().into())
-            .collect();
-        assert!(!Pool::insert_tx(&mut pool, txns, &eth_block_policy, &state_backend,).is_empty());
-        let encoded_txns = Pool::create_proposal(
-            &mut pool,
-            SeqNum(0),
-            200,
-            300 * GAS_LIMIT,
-            &eth_block_policy,
-            Vec::new(),
-            &state_backend,
-        )
-        .unwrap();
-        let decoded_txns = Vec::<EthSignedTransaction>::decode(&mut encoded_txns.as_ref()).unwrap();
-        assert_eq!(decoded_txns, expected_txs);
+        run_eth_txpool_test([
+            TxPoolTestEvent::InsertTxs {
+                txs: vec![&tx1, &tx2, &tx3, &tx4, &tx5, &tx6]
+                    .into_iter()
+                    .map(|tx| (tx, true))
+                    .collect_vec(),
+                expected_pool_size_change: 6,
+            },
+            TxPoolTestEvent::CreateProposal {
+                tx_limit: 128,
+                gas_limit: 1024 * GAS_LIMIT,
+                expected_txs: vec![&tx1, &tx5, &tx6, &tx2, &tx3, &tx4],
+            },
+        ]);
     }
 
     #[test]
     #[traced_test]
     fn attacker_tries_to_include_transaction_with_large_gas_limit_to_exit_proposal_creation_early()
     {
-        let s1: B256 =
-            hex!("0ed2e19e3aca1a321349f295837988e9c6f95d4a6fc54cfab6befd5ee82662ad").into(); // pubkey starts with AAA
-        let s2: B256 =
-            hex!("009ac901cf45a2e92e7e7bdf167dc52e3a6232be3c56cc3b05622b247c2c716a").into(); // pubkey starts with BBB
-        let txs = vec![
-            make_tx(s1, 10 * BASE_FEE, 100 * GAS_LIMIT, 0, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 2, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 3, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 4, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 5, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 6, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 7, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 8, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 9, 10),
-        ];
-        let expected_txs = vec![
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 2, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 3, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 4, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 5, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 6, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 7, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 8, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 9, 10),
-        ];
+        let tx1 = make_tx(S1, 10 * BASE_FEE, 100 * GAS_LIMIT, 0, 10);
+        let tx2 = make_tx(S2, BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx3 = make_tx(S2, BASE_FEE, GAS_LIMIT, 1, 10);
+        let tx4 = make_tx(S2, BASE_FEE, GAS_LIMIT, 2, 10);
+        let tx5 = make_tx(S2, BASE_FEE, GAS_LIMIT, 3, 10);
+        let tx6 = make_tx(S2, BASE_FEE, GAS_LIMIT, 4, 10);
+        let tx7 = make_tx(S2, BASE_FEE, GAS_LIMIT, 5, 10);
+        let tx8 = make_tx(S2, BASE_FEE, GAS_LIMIT, 6, 10);
+        let tx9 = make_tx(S2, BASE_FEE, GAS_LIMIT, 7, 10);
+        let tx10 = make_tx(S2, BASE_FEE, GAS_LIMIT, 8, 10);
+        let tx11 = make_tx(S2, BASE_FEE, GAS_LIMIT, 9, 10);
 
-        let acc = txs
-            .iter()
-            .map(|tx| (EthAddress(tx.recover_signer().unwrap()), 0));
-        let mut pool = EthTxPool::default();
-        let eth_block_policy = make_test_block_policy();
-        let state_backend = InMemoryStateInner::new(
-            Balance::MAX,
-            SeqNum(4),
-            InMemoryBlockState::genesis(acc.collect()),
-        );
-        let txns: Vec<Bytes> = txs
-            .iter()
-            .map(|t| t.clone().envelope_encoded().into())
-            .collect();
-        assert!(!Pool::insert_tx(&mut pool, txns, &eth_block_policy, &state_backend,).is_empty());
-        let encoded_txns = Pool::create_proposal(
-            &mut pool,
-            SeqNum(0),
-            200,
-            10 * GAS_LIMIT,
-            &eth_block_policy,
-            Vec::new(),
-            &state_backend,
-        )
-        .unwrap();
-        let decoded_txns = Vec::<EthSignedTransaction>::decode(&mut encoded_txns.as_ref()).unwrap();
-        assert_eq!(decoded_txns, expected_txs);
+        run_eth_txpool_test([
+            TxPoolTestEvent::InsertTxs {
+                txs: vec![
+                    &tx1, &tx2, &tx3, &tx4, &tx5, &tx6, &tx7, &tx8, &tx9, &tx10, &tx11,
+                ]
+                .into_iter()
+                .map(|tx| (tx, true))
+                .collect_vec(),
+                expected_pool_size_change: 11,
+            },
+            TxPoolTestEvent::CreateProposal {
+                tx_limit: 128,
+                gas_limit: 10 * GAS_LIMIT,
+                expected_txs: vec![&tx2, &tx3, &tx4, &tx5, &tx6, &tx7, &tx8, &tx9, &tx10, &tx11],
+            },
+        ]);
     }
 
     #[test]
     #[traced_test]
     fn suboptimal_block() {
-        let s1: B256 =
-            hex!("0ed2e19e3aca1a321349f295837988e9c6f95d4a6fc54cfab6befd5ee82662ad").into(); // pubkey starts with AAA
-        let s2: B256 =
-            hex!("009ac901cf45a2e92e7e7bdf167dc52e3a6232be3c56cc3b05622b247c2c716a").into(); // pubkey starts with BBB
-        let txs = vec![
-            make_tx(s1, 2 * BASE_FEE, 10 * GAS_LIMIT, 0, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 2, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 3, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 4, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 5, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 6, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 7, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 8, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 9, 10),
-        ];
-        let expected_txs = vec![
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 2, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 3, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 4, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 5, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 6, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 7, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 8, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 9, 10),
-        ];
+        let tx1 = make_tx(S1, 2 * BASE_FEE, 10 * GAS_LIMIT, 0, 10);
+        let tx2 = make_tx(S2, BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx3 = make_tx(S2, BASE_FEE, GAS_LIMIT, 1, 10);
+        let tx4 = make_tx(S2, BASE_FEE, GAS_LIMIT, 2, 10);
+        let tx5 = make_tx(S2, BASE_FEE, GAS_LIMIT, 3, 10);
+        let tx6 = make_tx(S2, BASE_FEE, GAS_LIMIT, 4, 10);
+        let tx7 = make_tx(S2, BASE_FEE, GAS_LIMIT, 5, 10);
+        let tx8 = make_tx(S2, BASE_FEE, GAS_LIMIT, 6, 10);
+        let tx9 = make_tx(S2, BASE_FEE, GAS_LIMIT, 7, 10);
+        let tx10 = make_tx(S2, BASE_FEE, GAS_LIMIT, 8, 10);
+        let tx11 = make_tx(S2, BASE_FEE, GAS_LIMIT, 9, 10);
 
-        let acc = txs
-            .iter()
-            .map(|tx| (EthAddress(tx.recover_signer().unwrap()), 0));
-        let mut pool = EthTxPool::default();
-        let eth_block_policy = make_test_block_policy();
-        let state_backend = InMemoryStateInner::new(
-            Balance::MAX,
-            SeqNum(4),
-            InMemoryBlockState::genesis(acc.collect()),
-        );
-        let txns: Vec<Bytes> = txs
-            .iter()
-            .map(|t| t.clone().envelope_encoded().into())
-            .collect();
-        assert!(!Pool::insert_tx(&mut pool, txns, &eth_block_policy, &state_backend,).is_empty());
-        let encoded_txns = Pool::create_proposal(
-            &mut pool,
-            SeqNum(0),
-            10,
-            10 * GAS_LIMIT,
-            &eth_block_policy,
-            Default::default(),
-            &state_backend,
-        )
-        .unwrap();
-        let decoded_txns = Vec::<EthSignedTransaction>::decode(&mut encoded_txns.as_ref()).unwrap();
-        assert_eq!(decoded_txns, expected_txs);
+        run_eth_txpool_test([
+            TxPoolTestEvent::InsertTxs {
+                txs: vec![
+                    &tx1, &tx2, &tx3, &tx4, &tx5, &tx6, &tx7, &tx8, &tx9, &tx10, &tx11,
+                ]
+                .into_iter()
+                .map(|tx| (tx, true))
+                .collect_vec(),
+                expected_pool_size_change: 11,
+            },
+            TxPoolTestEvent::CreateProposal {
+                tx_limit: 10,
+                gas_limit: 10 * GAS_LIMIT,
+                expected_txs: vec![&tx2, &tx3, &tx4, &tx5, &tx6, &tx7, &tx8, &tx9, &tx10, &tx11],
+            },
+        ]);
     }
 
     #[test]
     #[traced_test]
     fn zero_gas_limit() {
-        let s1: B256 =
-            hex!("0ed2e19e3aca1a321349f295837988e9c6f95d4a6fc54cfab6befd5ee82662ad").into(); // pubkey starts with AAA
-        let txs = vec![make_tx(s1, BASE_FEE, 0, 0, 10)];
-        let acc = txs
-            .iter()
-            .map(|tx| (EthAddress(tx.recover_signer().unwrap()), 0));
-        let mut pool = EthTxPool::default();
-        let eth_block_policy = make_test_block_policy();
-        let state_backend = InMemoryStateInner::new(
-            Balance::MAX,
-            SeqNum(4),
-            InMemoryBlockState::genesis(acc.collect()),
-        );
-        let txns: Vec<Bytes> = txs
-            .iter()
-            .map(|t| t.clone().envelope_encoded().into())
-            .collect();
-        assert!(Pool::insert_tx(&mut pool, txns, &eth_block_policy, &state_backend,).is_empty());
+        let tx1 = make_tx(S1, BASE_FEE, 0, 0, 10);
+
+        run_eth_txpool_test([TxPoolTestEvent::InsertTxs {
+            txs: vec![(&tx1, false)],
+            expected_pool_size_change: 0,
+        }]);
     }
 
     #[test]
     #[traced_test]
     fn nondeterminism() {
-        let s1: B256 =
-            hex!("0ed2e19e3aca1a321349f295837988e9c6f95d4a6fc54cfab6befd5ee82662ad").into(); // pubkey starts with AAA
-        let s2: B256 =
-            hex!("009ac901cf45a2e92e7e7bdf167dc52e3a6232be3c56cc3b05622b247c2c716a").into(); // pubkey starts with BBB
-        let s3: B256 =
-            hex!("29b6132c13a004a476484efd02bbd0614527f8f34b94a360201c611b111deac9").into(); // pubkey starts with CCC
-        let s4: B256 =
-            hex!("871683e86bef90f2e790e60e4245916c731f540eec4a998697c2cbab4e156868").into(); // pubkey starts with DDD
-        let s5: B256 =
-            hex!("9c82e5ab4dda8da5391393c5eb7cb8b79ca8e03b3028be9ba1e31f2480e17dc8").into(); // pubkey starts with EEE
-        let txs = vec![
-            make_tx(s1, BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s1, BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s3, BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s3, BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s4, BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s4, BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s5, BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s5, BASE_FEE, GAS_LIMIT, 1, 10),
-        ];
-        let expected_txs = vec![
-            make_tx(s5, BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s5, BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s4, BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s4, BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s3, BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s3, BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s2, BASE_FEE, GAS_LIMIT, 1, 10),
-            make_tx(s1, BASE_FEE, GAS_LIMIT, 0, 10),
-            make_tx(s1, BASE_FEE, GAS_LIMIT, 1, 10),
-        ];
+        let tx1 = make_tx(S1, BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx2 = make_tx(S1, BASE_FEE, GAS_LIMIT, 1, 10);
+        let tx3 = make_tx(S2, BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx4 = make_tx(S2, BASE_FEE, GAS_LIMIT, 1, 10);
+        let tx5 = make_tx(S3, BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx6 = make_tx(S3, BASE_FEE, GAS_LIMIT, 1, 10);
+        let tx7 = make_tx(S4, BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx8 = make_tx(S4, BASE_FEE, GAS_LIMIT, 1, 10);
+        let tx9 = make_tx(S5, BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx10 = make_tx(S5, BASE_FEE, GAS_LIMIT, 1, 10);
 
-        let acc = txs
-            .iter()
-            .map(|tx| (EthAddress(tx.recover_signer().unwrap()), 0));
-        let mut pool = EthTxPool::default();
-        let eth_block_policy = make_test_block_policy();
-        let state_backend = InMemoryStateInner::new(
-            Balance::MAX,
-            SeqNum(4),
-            InMemoryBlockState::genesis(acc.collect()),
-        );
-        let txns: Vec<Bytes> = txs
-            .iter()
-            .map(|t| t.clone().envelope_encoded().into())
-            .collect();
-        assert!(!Pool::insert_tx(&mut pool, txns, &eth_block_policy, &state_backend,).is_empty());
-        let encoded_txns = Pool::create_proposal(
-            &mut pool,
-            SeqNum(0),
-            10,
-            10 * GAS_LIMIT,
-            &eth_block_policy,
-            Vec::new(),
-            &state_backend,
-        )
-        .unwrap();
-        let decoded_txns = Vec::<EthSignedTransaction>::decode(&mut encoded_txns.as_ref()).unwrap();
-        assert_eq!(expected_txs, decoded_txns);
+        run_eth_txpool_test([
+            TxPoolTestEvent::InsertTxs {
+                txs: vec![&tx1, &tx2, &tx3, &tx4, &tx5, &tx6, &tx7, &tx8, &tx9, &tx10]
+                    .into_iter()
+                    .map(|tx| (tx, true))
+                    .collect_vec(),
+                expected_pool_size_change: 10,
+            },
+            TxPoolTestEvent::CreateProposal {
+                tx_limit: 10,
+                gas_limit: 10 * GAS_LIMIT,
+                expected_txs: vec![&tx9, &tx10, &tx7, &tx8, &tx5, &tx6, &tx3, &tx4, &tx1, &tx2],
+            },
+        ]);
     }
 
     #[test]
     fn test_zero_nonce_included_in_block() {
         // The first transaction from an account with 0 nonce should be including in the block
 
-        let sender_1_key = B256::random();
-        let txn_nonce_zero = make_tx(sender_1_key, BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx1 = make_tx(S1, BASE_FEE, GAS_LIMIT, 0, 10);
 
-        let acc = vec![(EthAddress(txn_nonce_zero.recover_signer().unwrap()), 0)];
-        let mut eth_tx_pool = EthTxPool::default();
-        let eth_block_policy = make_test_block_policy();
-        let state_backend = InMemoryStateInner::new(
-            Balance::MAX,
-            SeqNum(4),
-            InMemoryBlockState::genesis(acc.into_iter().collect()),
-        );
-
-        let txns = vec![txn_nonce_zero.envelope_encoded().into()];
-
-        assert!(
-            !Pool::insert_tx(&mut eth_tx_pool, txns, &eth_block_policy, &state_backend,).is_empty()
-        );
-
-        let encoded_txns = Pool::create_proposal(
-            &mut eth_tx_pool,
-            SeqNum(0),
-            10_000,
-            50_000,
-            &eth_block_policy,
-            Vec::new(),
-            &state_backend,
-        )
-        .unwrap();
-        let decoded_txns = Vec::<EthSignedTransaction>::decode(&mut encoded_txns.as_ref()).unwrap();
-        assert_eq!(decoded_txns, vec![txn_nonce_zero]);
+        run_eth_txpool_test([
+            TxPoolTestEvent::InsertTxs {
+                txs: vec![(&tx1, true)],
+                expected_pool_size_change: 1,
+            },
+            TxPoolTestEvent::CreateProposal {
+                tx_limit: 128,
+                gas_limit: 10 * GAS_LIMIT,
+                expected_txs: vec![&tx1],
+            },
+        ]);
     }
 
     #[test]
     fn test_invalid_nonce_not_in_block() {
-        // A transaction with nonce 3 should not be included in the block if the la
+        // A transaction with nonce 3 should not be included in the block if a tx with nonce 2 is missing
 
-        let sender_1_key = B256::random();
-        // Txn with nonce = 0
-        let txn_nonce_zero = make_tx(sender_1_key, BASE_FEE, GAS_LIMIT, 0, 10);
-        // Txn with nonce = 1
-        let txn_nonce_one = make_tx(sender_1_key, BASE_FEE, GAS_LIMIT, 1, 10);
-        // Txn with nonce = 3
-        let txn_nonce_three = make_tx(sender_1_key, BASE_FEE, GAS_LIMIT, 3, 10);
-        let sender_1_address = EthAddress(txn_nonce_zero.recover_signer().unwrap());
+        let tx1 = make_tx(S1, BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx2 = make_tx(S1, BASE_FEE, GAS_LIMIT, 1, 10);
+        let tx3 = make_tx(S1, BASE_FEE, GAS_LIMIT, 3, 10);
 
-        let mut eth_tx_pool = EthTxPool::default();
-        let eth_block_policy = make_test_block_policy();
-        let state_backend = InMemoryStateInner::new(
-            Balance::MAX,
-            SeqNum(4),
-            InMemoryBlockState::genesis(std::iter::once((sender_1_address, 0)).collect()),
-        );
-
-        let txns = vec![
-            txn_nonce_zero.envelope_encoded().into(),
-            txn_nonce_one.envelope_encoded().into(),
-            txn_nonce_three.envelope_encoded().into(),
-        ];
-
-        assert!(
-            !Pool::insert_tx(&mut eth_tx_pool, txns, &eth_block_policy, &state_backend,).is_empty()
-        );
-
-        let encoded_txns = Pool::create_proposal(
-            &mut eth_tx_pool,
-            SeqNum(0),
-            10_000,
-            1_000_000_000,
-            &eth_block_policy,
-            Vec::new(),
-            &state_backend,
-        )
-        .unwrap();
-        let decoded_txns = Vec::<EthSignedTransaction>::decode(&mut encoded_txns.as_ref()).unwrap();
-
-        // only transactions with nonce 0 and 1 should be included
-        assert_eq!(decoded_txns, vec![txn_nonce_zero, txn_nonce_one]);
+        run_eth_txpool_test([
+            TxPoolTestEvent::InsertTxs {
+                txs: vec![(&tx1, true), (&tx2, true), (&tx3, true)],
+                expected_pool_size_change: 3,
+            },
+            TxPoolTestEvent::CreateProposal {
+                tx_limit: 128,
+                gas_limit: 10 * GAS_LIMIT,
+                expected_txs: vec![&tx1, &tx2],
+            },
+        ]);
     }
 
     #[test]
     fn test_nonce_exists_in_committed_block() {
         // A transaction with nonce 0 should not be included in the block if the latest nonce of the account is 0
 
-        let sender_1_key = B256::random();
-        let txn_nonce_zero = make_tx(sender_1_key, BASE_FEE, GAS_LIMIT, 0, 10);
-        let txn_nonce_one = make_tx(sender_1_key, BASE_FEE, GAS_LIMIT, 1, 10);
-        let sender_1_address = EthAddress(txn_nonce_zero.recover_signer().unwrap());
+        let tx1 = make_tx(S1, BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx2 = make_tx(S1, BASE_FEE, GAS_LIMIT, 1, 10);
 
-        let mut eth_tx_pool = EthTxPool::default();
-        let eth_block_policy = make_test_block_policy();
-        let state_backend = InMemoryStateInner::new(
-            Balance::MAX,
-            SeqNum(4),
-            InMemoryBlockState::genesis(std::iter::once((sender_1_address, 1)).collect()),
+        let nonces = [(
+            EthAddress(tx1.recover_signer().expect("signer is recoverable")),
+            1,
+        )]
+        .into_iter()
+        .collect();
+
+        run_custom_eth_txpool_test(
+            make_test_block_policy(),
+            Some(nonces),
+            [
+                TxPoolTestEvent::InsertTxs {
+                    txs: vec![(&tx1, true), (&tx2, true)],
+                    expected_pool_size_change: 2,
+                },
+                TxPoolTestEvent::CreateProposal {
+                    tx_limit: 128,
+                    gas_limit: 10 * GAS_LIMIT,
+                    expected_txs: vec![&tx2],
+                },
+            ],
         );
-
-        let txns = vec![
-            txn_nonce_zero.envelope_encoded().into(),
-            txn_nonce_one.envelope_encoded().into(),
-        ];
-        assert!(
-            !Pool::insert_tx(&mut eth_tx_pool, txns, &eth_block_policy, &state_backend,).is_empty()
-        );
-
-        let encoded_txns = Pool::create_proposal(
-            &mut eth_tx_pool,
-            SeqNum(0),
-            10_000,
-            1_000_000_000,
-            &eth_block_policy,
-            Vec::new(),
-            &state_backend,
-        )
-        .unwrap();
-        let decoded_txns = Vec::<EthSignedTransaction>::decode(&mut encoded_txns.as_ref()).unwrap();
-
-        assert_eq!(decoded_txns, vec![txn_nonce_one]);
     }
 
     #[test]
     fn test_nonce_exists_in_pending_block() {
         // A transaction with nonce 0 should not be included in the block if the latest nonce of the account is 0
 
-        let sender_1_key = B256::random();
         // generate two transactions, both with nonce = 0
-        let txn_1_nonce_zero = make_tx(sender_1_key, BASE_FEE, GAS_LIMIT, 0, 10);
-        let txn_2_nonce_zero = make_tx(sender_1_key, BASE_FEE, GAS_LIMIT, 0, 1000);
-        let txn_nonce_one = make_tx(sender_1_key, BASE_FEE, GAS_LIMIT, 1, 10);
+        let tx1 = make_tx(S1, BASE_FEE, GAS_LIMIT, 0, 10);
+        let tx2 = make_tx(S1, BASE_FEE, GAS_LIMIT, 0, 1000);
 
-        let acc = vec![(EthAddress(txn_1_nonce_zero.recover_signer().unwrap()), 0)];
-        let mut eth_tx_pool = EthTxPool::default();
-        let eth_block_policy = make_test_block_policy();
-        let state_backend = InMemoryStateInner::new(
-            Balance::MAX,
-            SeqNum(4),
-            InMemoryBlockState::genesis(acc.into_iter().collect()),
-        );
-        // create the extending block with txn 1
-        let extending_block = generate_random_block_with_txns(vec![txn_1_nonce_zero]);
+        let tx3 = make_tx(S1, BASE_FEE, GAS_LIMIT, 1, 10);
 
-        let txns = vec![
-            txn_2_nonce_zero.envelope_encoded().into(),
-            txn_nonce_one.envelope_encoded().into(),
-        ];
-        assert!(
-            !Pool::insert_tx(&mut eth_tx_pool, txns, &eth_block_policy, &state_backend,).is_empty()
-        );
-
-        let encoded_txns = Pool::create_proposal(
-            &mut eth_tx_pool,
-            SeqNum(0),
-            10_000,
-            1_000_000_000,
-            &eth_block_policy,
-            vec![&extending_block],
-            &state_backend,
-        )
-        .unwrap();
-        let decoded_txns = Vec::<EthSignedTransaction>::decode(&mut encoded_txns.as_ref()).unwrap();
-
-        assert_eq!(decoded_txns, vec![txn_nonce_one]);
+        run_eth_txpool_test([
+            TxPoolTestEvent::SetPendingBlocks {
+                pending_blocks: vec![generate_random_block_with_txns(vec![tx1])],
+            },
+            TxPoolTestEvent::InsertTxs {
+                txs: vec![(&tx2, true), (&tx3, true)],
+                expected_pool_size_change: 2,
+            },
+            TxPoolTestEvent::CreateProposal {
+                tx_limit: 128,
+                gas_limit: 10 * GAS_LIMIT,
+                expected_txs: vec![&tx3],
+            },
+        ]);
     }
 
     #[traced_test]
@@ -1063,75 +874,58 @@ mod test {
     fn test_combine_nonces_of_blocks() {
         // TxPool should combine the nonces of commited block and pending blocks to check nonce
 
-        let sender_1_key = B256::random();
+        let tx1 = make_tx(S1, BASE_FEE, GAS_LIMIT, 1, 10);
+        let tx2 = make_tx(S1, BASE_FEE, GAS_LIMIT, 2, 10);
+        let tx3 = make_tx(S1, BASE_FEE, GAS_LIMIT, 3, 10);
 
-        // txn with nonce = 1
-        let txn_nonce_one = make_tx(sender_1_key, BASE_FEE, GAS_LIMIT, 1, 10);
-        // txn with nonce = 2
-        let txn_nonce_two = make_tx(sender_1_key, BASE_FEE, GAS_LIMIT, 2, 10);
-        // txn with nonce = 3
-        let txn_nonce_three = make_tx(sender_1_key, BASE_FEE, GAS_LIMIT, 3, 10);
+        let nonces = [(
+            EthAddress(tx1.recover_signer().expect("signer is recoverable")),
+            1,
+        )]
+        .into_iter()
+        .collect();
 
-        let mut eth_tx_pool = EthTxPool::default();
-        let sender_1_address = EthAddress(txn_nonce_one.recover_signer().unwrap());
-
-        let eth_block_policy = make_test_block_policy();
-        let state_backend = InMemoryStateInner::new(
-            Balance::MAX,
-            SeqNum(4),
-            InMemoryBlockState::genesis(std::iter::once((sender_1_address, 1)).collect()),
+        run_custom_eth_txpool_test(
+            make_test_block_policy(),
+            Some(nonces),
+            [
+                TxPoolTestEvent::InsertTxs {
+                    txs: vec![(&tx1, true), (&tx2, true), (&tx3, true)],
+                    expected_pool_size_change: 3,
+                },
+                TxPoolTestEvent::SetPendingBlocks {
+                    pending_blocks: vec![
+                        generate_random_block_with_txns(vec![tx1.clone()]),
+                        generate_random_block_with_txns(vec![tx2.clone()]),
+                    ],
+                },
+                TxPoolTestEvent::CreateProposal {
+                    tx_limit: 128,
+                    gas_limit: 10 * GAS_LIMIT,
+                    expected_txs: vec![&tx3],
+                },
+            ],
         );
-
-        let txns = vec![
-            txn_nonce_one.envelope_encoded().into(),
-            txn_nonce_two.envelope_encoded().into(),
-            txn_nonce_three.envelope_encoded().into(),
-        ];
-
-        assert!(
-            !Pool::insert_tx(&mut eth_tx_pool, txns, &eth_block_policy, &state_backend,).is_empty()
-        );
-
-        // create the extending block 1 with txn 1
-        let extending_block_1 = generate_random_block_with_txns(vec![txn_nonce_one]);
-        // create the extending block 2 with txn 2
-        let extending_block_2 = generate_random_block_with_txns(vec![txn_nonce_two]);
-
-        let encoded_txns = eth_tx_pool
-            .create_proposal(
-                SeqNum(0),
-                10_000,
-                1_000_000_000,
-                &eth_block_policy,
-                vec![&extending_block_1, &extending_block_2],
-                &state_backend,
-            )
-            .unwrap();
-        let decoded_txns = Vec::<EthSignedTransaction>::decode(&mut encoded_txns.as_ref()).unwrap();
-
-        assert_eq!(decoded_txns, vec![txn_nonce_three]);
     }
 
     #[test]
     fn test_invalid_chain_id() {
-        let sender_1_key = B256::random();
-        let txn_nonce_one = make_tx(sender_1_key, BASE_FEE, GAS_LIMIT, 1, 10);
+        let tx1 = make_tx(S1, BASE_FEE, GAS_LIMIT, 1, 10);
 
-        let mut eth_tx_pool = EthTxPool::default();
-        let sender_1_address = EthAddress(txn_nonce_one.recover_signer().unwrap());
-
-        // eth block policy has a different chain id than the transaction
-        let eth_block_policy = EthBlockPolicy::new(GENESIS_SEQ_NUM, u128::MAX, 0, 1);
-        let state_backend = InMemoryStateInner::new(
-            Balance::MAX,
-            SeqNum(4),
-            InMemoryBlockState::genesis(std::iter::once((sender_1_address, 0)).collect()),
+        run_custom_eth_txpool_test(
+            EthBlockPolicy::new(GENESIS_SEQ_NUM, u128::MAX, 0, 1),
+            None,
+            [
+                TxPoolTestEvent::InsertTxs {
+                    txs: vec![(&tx1, false)],
+                    expected_pool_size_change: 0,
+                },
+                TxPoolTestEvent::CreateProposal {
+                    tx_limit: 128,
+                    gas_limit: 10 * GAS_LIMIT,
+                    expected_txs: vec![],
+                },
+            ],
         );
-
-        let txns = vec![txn_nonce_one.envelope_encoded().into()];
-        let result = Pool::insert_tx(&mut eth_tx_pool, txns, &eth_block_policy, &state_backend);
-
-        // transaction should not be inserted into the pool
-        assert!(result.is_empty());
     }
 }


### PR DESCRIPTION
Cleaned up txpool tests so that they are shorter and easier to read/understand, and to prevent typos in existing and future tests.