### PR TITLE
Limit eth_call gas limit to prevent abuse

### DIFF
--- a/monad-cxx/src/lib.rs
+++ b/monad-cxx/src/lib.rs
@@ -75,6 +75,14 @@ pub fn eth_call(
     blockdb_path: &Path,
     state_override_set: &StateOverrideSet,
 ) -> CallResult {
+    // upper bound gas limit of transaction to block gas limit to prevent abuse of eth_call
+    if transaction.gas_limit() > block_header.gas_limit {
+        return CallResult::Failure(FailureCallResult {
+            message: "gas limit too high".into(),
+            data: None,
+        });
+    }
+
     // TODO: move the buffer copying into C++ for the reserve/push idiom
     let rlp_encoded_tx: Bytes = {
         let mut buf = BytesMut::new();


### PR DESCRIPTION
We want to limit eth_call gas limit so that it doesn't get dos-ed by executing arbitrarily expensive transactions. A test case in flexnet is in https://github.com/monad-crypto/monad-integration/pull/103

Also a common practice in clients like Geth: https://docs.infura.io/api/networks/ethereum/json-rpc-methods/eth_call