### PR TITLE
Fix confusing monad_secp::PubKey Debug/Display format discrepancy

### DIFF
--- a/monad-secp/src/lib.rs
+++ b/monad-secp/src/lib.rs
@@ -19,12 +19,16 @@ impl Hashable for SecpSignature {
 
 impl std::fmt::Display for PubKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let bytes = self.bytes();
+        let bytes = self.bytes_compressed();
         write!(
             f,
-            "{:>02x}{:>02x}..{:>02x}{:>02x}",
+            "{:>02x}{:>02x}{:>02x}{:>02x}..{:>02x}{:>02x}{:>02x}{:>02x}",
             bytes[0],
             bytes[1],
+            bytes[2],
+            bytes[3],
+            bytes[bytes.len() - 4],
+            bytes[bytes.len() - 3],
             bytes[bytes.len() - 2],
             bytes[bytes.len() - 1]
         )


### PR DESCRIPTION
The following code:

    let mut privkey: [u8; 32] = [1; 32];
    let keypair = monad_secp::KeyPair::from_bytes(&mut privkey).unwrap();
    let pubkey = keypair.pubkey();
    println!("{} {:?}", pubkey, pubkey);

Currently prints this:

    041b..e8d1 031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f

Note how the Debug and Display versions of this PubKey seem to have
nothing in common.  This discrepancy is rather confusing when debugging
issues where some code prints NodeId<>s using {} and other code uses
{:?} to log data structures containing NodeId<>s.

Display for PubKey is implemented as:

    impl std::fmt::Display for PubKey {
        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
            let bytes = self.bytes();
            write!(
                f,
                "{:>02x}{:>02x}..{:>02x}{:>02x}",
                bytes[0],
                bytes[1],
                bytes[bytes.len() - 2],
                bytes[bytes.len() - 1]
            )
        }
    }

Where PubKey::bytes() is implemented as:

    pub fn bytes(&self) -> Vec<u8> {
        self.0.serialize_uncompressed().to_vec()
    }

While Debug for PubKey is implemented as:

    impl std::fmt::Debug for PubKey {
        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
            let ser = self.bytes_compressed();
            for byte in ser {
                write!(f, "{:02x}", byte)?;
            }
            Ok(())
        }
    }

In other words, Debug prints the compressed public key, while Display
prints the first and last few bytes of the uncompressed public key,
which causes this discrepancy.

Given that the uncompressed public key is somewhat unwieldy and causes
spammy output even for Debug standards, switch Display to take the first
and last few bytes of the compressed key instead, to get Debug and Display
in sync with each other.

Also, while we are at it, print a few more bytes in the Display case, as
the first printed byte only has very low information density, and we can
easily print a few more bytes without being too spammy.

Output for the code above after this change:

    031b84c5..d5dd078f 031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f