### PR TITLE
fix performance issues with leader election

### DIFF
--- a/monad-raptorcast/benches/raptor_bench.rs
+++ b/monad-raptorcast/benches/raptor_bench.rs
@@ -131,10 +131,12 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                             message.split_to(MONAD_GSO_SIZE),
                         )
                         .expect("valid message");
-                        decoder.received_encoded_symbol(
-                            &parsed_message.chunk,
-                            parsed_message.chunk_id.into(),
-                        );
+                        decoder
+                            .received_encoded_symbol(
+                                &parsed_message.chunk,
+                                parsed_message.chunk_id.into(),
+                            )
+                            .unwrap();
                         if decoder.try_decode() {
                             decode_success = true;
                             break;

--- a/monad-validator/src/weighted_round_robin.rs
+++ b/monad-validator/src/weighted_round_robin.rs
@@ -1,6 +1,9 @@
 use std::{collections::BTreeMap, marker::PhantomData};
 
-use monad_crypto::certificate_signature::PubKey;
+use monad_crypto::{
+    certificate_signature::PubKey,
+    hasher::{Hasher, HasherType},
+};
 use monad_types::{NodeId, Round, Stake};
 
 use crate::leader_election::LeaderElection;
@@ -18,48 +21,52 @@ impl<PT: PubKey> Default for WeightedRoundRobin<PT> {
     }
 }
 
+fn randomize(x: u64, m: u64) -> u64 {
+    let mut hasher = HasherType::new();
+    hasher.update(x.to_le_bytes());
+    let hash = hasher.hash().0;
+    (u64::from_le_bytes(hash[0..8].try_into().unwrap())
+        ^ u64::from_le_bytes(hash[8..16].try_into().unwrap())
+        ^ u64::from_le_bytes(hash[16..24].try_into().unwrap())
+        ^ u64::from_le_bytes(hash[24..32].try_into().unwrap()))
+        % m
+}
+
 impl<PT: PubKey> LeaderElection for WeightedRoundRobin<PT> {
     type NodeIdPubKey = PT;
 
-    /// Computes the leader using interleaved weighted round-robin (IWRR) scheduling
+    /// Computes the leader using randomized interleaved weighted round-robin scheduling
     /// # Panics
     /// Panics if `validators.is_empty()` or if `validators` does not contain an element whose stake is > 0, because
     /// there is no sensible choice for leader in either of those cases.
     fn get_leader(&self, round: Round, validators: &BTreeMap<NodeId<PT>, Stake>) -> NodeId<PT> {
-        let max_stake = validators
+        let mut total_stakes = 0_u64;
+        let stake_bounds: Vec<_> = validators
             .iter()
-            .map(|(_, stake)| stake.0)
-            .max()
-            .expect("get_leader called with empty validator set");
-
-        let total_valid_stake: i64 = validators
-            .iter()
-            .filter_map(|(_, stake)| {
-                // we do not include validators with stake <= 0 in the sum because they should not get a chance to vote
+            .filter_map(|(node_id, stake)| {
                 if stake.0 > 0 {
-                    Some(stake.0)
+                    total_stakes += stake.0 as u64;
+                    Some((node_id, total_stakes))
                 } else {
                     None
                 }
             })
-            .sum();
+            .collect();
+        if stake_bounds.is_empty() {
+            panic!("no validator has positive stake");
+        }
 
-        // the size of the complete IWRR schedule is `total_valid_stake`,
-        // so we can think of leader election as round-robin into the computed schedule
-        let schedule_index: usize = (round.0 % total_valid_stake as u64) as usize;
-
-        (1i64..=max_stake)
-            .flat_map(|cycle| {
-                validators.iter().filter_map(move |(validator, stake)| {
-                    if cycle <= stake.0 {
-                        Some(*validator)
-                    } else {
-                        None
-                    }
-                })
+        let stake_index = randomize(round.0, total_stakes);
+        let upper_bound = stake_bounds
+            .binary_search_by(|&(_, stake_bound)| {
+                if stake_bound > stake_index {
+                    std::cmp::Ordering::Greater
+                } else {
+                    std::cmp::Ordering::Less
+                }
             })
-            .nth(schedule_index)
-            .expect("no validator had positive stake")
+            .unwrap_err();
+        *stake_bounds[upper_bound].0
     }
 }
 
@@ -70,17 +77,37 @@ mod tests {
 
     use super::*;
 
-    #[test_case(vec![('A', 1), ('B', 1), ('C', 1)],    vec!['A', 'B', 'C']; "equal stakes")]
-    #[test_case(vec![('A', 1), ('B', 1), ('C', 1)],    vec!['A', 'B', 'C']; "test equal stakes")]
-    #[test_case(vec![('A', 1), ('B', 0), ('C', 1)],    vec!['A', 'C'];      "test unstaked schedule")]
-    #[test_case(vec![('A', 1), ('B', 2), ('C', 1)],    vec!['A', 'B', 'C', 'B']; "test validator with more stake")]
-    #[test_case(vec![],                                vec![]; "test empty schedule")]
-    #[test_case(vec![('A', 2), ('B', 2), ('C', 2)],    vec!['A', 'B', 'C']; "test equal schedule with more stake")]
-    #[test_case(vec![('A', 1), ('B', 2), ('C', 3)],    vec!['A', 'B', 'C', 'B', 'C', 'C']; "test unequal schedule")]
-    #[test_case(vec![('A', 10), ('B', 2), ('C', 3)],   vec![ 'A', 'B', 'C', 'A', 'B', 'C', 'A', 'C', 'A', 'A', 'A', 'A', 'A', 'A', 'A']; "test big stake")]
-    #[test_case(vec![('A', -10), ('B', 2), ('C', 3)],  vec!['B', 'C', 'B', 'C', 'C']; "test negative stake")]
-    fn test_weighted_round_robin(validator_set: Vec<(char, i64)>, expected_schedule: Vec<char>) {
+    #[test_case(vec![('A', 1), ('B', 1), ('C', 1)]; "equal stakes")]
+    #[test_case(vec![('A', 1), ('B', 1), ('C', 1)]; "test equal stakes")]
+    #[test_case(vec![('A', 1), ('B', 0), ('C', 1)];      "test unstaked schedule")]
+    #[test_case(vec![('A', 1), ('B', 2), ('C', 1)]; "test validator with more stake")]
+    #[test_case(vec![('A', 2), ('B', 2), ('C', 2)]; "test equal schedule with more stake")]
+    #[test_case(vec![('A', 1), ('B', 2), ('C', 3)]; "test unequal schedule")]
+    #[test_case(vec![('A', 10), ('B', 2), ('C', 3)]; "test big stake")]
+    #[test_case(vec![('A', -10), ('B', 2), ('C', 3)]; "test negative stake")]
+    fn test_weighted_round_robin(validator_set: Vec<(char, i64)>) {
+        let num_iterations = 10000_u64;
         let l = WeightedRoundRobin::default();
+        let total_stakes = validator_set
+            .iter()
+            .filter_map(|(_, stake)| if *stake > 0 { Some(*stake) } else { None })
+            .sum::<i64>() as u64;
+        let expected_num_picked = validator_set
+            .iter()
+            .map(|(validator, stake)| {
+                (
+                    NodeId::new(NopPubKey::from_bytes(&[*validator as u8; 32]).unwrap()),
+                    if *stake > 0 {
+                        num_iterations * *stake as u64 / total_stakes
+                    } else {
+                        0
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let mut num_picked = vec![0; validator_set.len()];
+
         let validator_set = validator_set
             .into_iter()
             .map(|(validator, stake)| {
@@ -90,17 +117,26 @@ mod tests {
                 )
             })
             .collect();
-        let expected_schedule = expected_schedule
-            .into_iter()
-            .map(|validator| NodeId::new(NopPubKey::from_bytes(&[validator as u8; 32]).unwrap()))
-            .collect::<Vec<_>>();
-        let schedule_size = expected_schedule.len();
 
-        for round in 0..(2 * schedule_size) {
-            assert_eq!(
-                l.get_leader(Round(round as u64), &validator_set),
-                expected_schedule[round % schedule_size]
-            );
+        for i in 0..num_iterations {
+            let leader = l.get_leader(Round(i), &validator_set);
+            let index = validator_set.keys().position(|k| k == &leader).unwrap();
+            num_picked[index] += 1;
+        }
+
+        for (node, expected) in expected_num_picked.iter() {
+            let index = validator_set.keys().position(|k| k == node).unwrap();
+            if *expected == 0 {
+                assert_eq!(num_picked[index], 0);
+            } else {
+                println!(
+                    "expected: {} num_picked[{}]: {}",
+                    *expected, index, num_picked[index]
+                );
+                // Expect number of picks to be within small delta of expected perfect number of picks
+                assert!(num_picked[index] > *expected - 150);
+                assert!(num_picked[index] < *expected + 150);
+            }
         }
     }
 }


### PR DESCRIPTION
Leader election was O(stake value) which could lead to performance issues when stake values were high. Modify the algorithm to provide O(log(len(validators)) performance not depending on particular stake values.

The new algorithm involves pseudo random
number generation to provide approximate interleaving of leaders so it does not result in perfect round robin distribution.