### PR TITLE
Blockwatcher and eip1559 gas oracle 

### DIFF
--- a/monad-rpc/src/block_watcher.rs
+++ b/monad-rpc/src/block_watcher.rs
@@ -1,0 +1,163 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{FutureExt, Stream};
+use pin_project::pin_project;
+use reth_primitives::Block;
+use reth_rpc_types::TransactionReceipt;
+
+#[pin_project::pin_project(project = StateProj)]
+enum State {
+    GetBlock(u64),
+    GetBlockResult {
+        task: std::pin::Pin<Box<dyn futures::Future<Output = Block> + Send + Sync>>,
+    },
+    BlockAndReceipts {
+        block: Block,
+        task:
+            std::pin::Pin<Box<dyn futures::Future<Output = Vec<TransactionReceipt>> + Send + Sync>>,
+    },
+}
+
+// TODO: remove this trait when triedb contains blocks
+pub trait BlockState: Send {
+    fn get_block(&self, block_num: u64) -> impl Future<Output = Block> + Send + Sync;
+    fn get_receipts(
+        &self,
+        block_num: u64,
+    ) -> impl Future<Output = Vec<TransactionReceipt>> + Send + Sync;
+}
+
+#[derive(Clone)]
+pub struct MockBlockState {
+    blocks: Vec<Block>,
+}
+
+impl MockBlockState {
+    pub fn new() -> Self {
+        Self { blocks: Vec::new() }
+    }
+
+    pub fn set_blocks(&mut self, blocks: Vec<Block>) {
+        self.blocks = blocks;
+    }
+}
+
+impl BlockState for MockBlockState {
+    async fn get_block(&self, block_num: u64) -> Block {
+        if self.blocks.is_empty() || block_num > self.blocks.len() as u64 {
+            Block::default()
+        } else {
+            self.blocks
+                .get(block_num as usize)
+                .cloned()
+                .unwrap_or_default()
+        }
+    }
+
+    async fn get_receipts(&self, _block_num: u64) -> Vec<TransactionReceipt> {
+        vec![]
+    }
+}
+
+#[pin_project]
+pub struct BlockWatcher<B: BlockState + Clone> {
+    triedb: B,
+    interval: tokio::time::Interval,
+    #[pin]
+    state: State,
+}
+
+impl<B: BlockState + Clone> BlockWatcher<B> {
+    pub fn new(triedb: B, current_height: u64) -> Self {
+        Self {
+            triedb,
+            interval: tokio::time::interval(std::time::Duration::from_secs(1)),
+            state: State::GetBlock(current_height),
+        }
+    }
+}
+
+pub struct BlockWithReceipts {
+    block: Block,
+    receipts: Vec<TransactionReceipt>,
+}
+
+impl<B: BlockState + Clone + Send + Sync + 'static> Stream for BlockWatcher<B> {
+    type Item = BlockWithReceipts;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.as_mut().project();
+        let mut state = this.state.as_mut();
+
+        match state.as_mut().project() {
+            StateProj::GetBlock(height) => match this.interval.poll_tick(cx) {
+                Poll::Ready(_) => {
+                    let triedb = this.triedb.clone();
+                    let height = *height;
+                    let task = async move { triedb.get_block(height).await };
+                    let task = Box::pin(task);
+                    state.set(State::GetBlockResult { task });
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+                Poll::Pending => Poll::Pending,
+            },
+            StateProj::GetBlockResult { task } => match task.poll_unpin(cx) {
+                Poll::Ready(block) => {
+                    let triedb = this.triedb.clone();
+                    let height = block.header.number;
+                    let task = async move { triedb.get_receipts(height).await };
+                    let task = Box::pin(task);
+                    state.set(State::BlockAndReceipts { block, task });
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+                Poll::Pending => Poll::Pending,
+            },
+            StateProj::BlockAndReceipts { block, task } => match task.poll_unpin(cx) {
+                Poll::Ready(receipts) => {
+                    let height = block.header.number;
+                    let block = block.clone();
+                    state.set(State::GetBlock(height + 1));
+                    Poll::Ready(Some(BlockWithReceipts { block, receipts }))
+                }
+                Poll::Pending => Poll::Pending,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use futures::StreamExt;
+    use reth_primitives::Header;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_block_stream() {
+        let mut mock = MockBlockState::new();
+        let mut blocks = Vec::new();
+        for i in 0..3 {
+            let block = Block {
+                header: Header {
+                    number: i,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            blocks.push(block);
+        }
+        mock.set_blocks(blocks);
+        let mut watcher = BlockWatcher::new(mock, 0);
+
+        for i in 0..3 {
+            let block = watcher.next().await;
+            assert_eq!(block.unwrap().block.number, i)
+        }
+    }
+}

--- a/monad-rpc/src/gas_oracle.rs
+++ b/monad-rpc/src/gas_oracle.rs
@@ -1,0 +1,362 @@
+use std::{
+    cmp::{max, Ordering},
+    collections::VecDeque,
+    sync::Arc,
+};
+
+use reth_primitives::{Block, TransactionSigned};
+use reth_rpc_types::TransactionReceipt;
+use tracing::warn;
+
+// Defined in [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)
+const BASE_FEE_MAX_CHANGE_DENOMINATOR: u64 = 8;
+// Defined in [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)
+const ELASTICITY_MULTIPLIER: u64 = 2;
+
+/// Number of transactions to sample in a block
+const BLOCK_TX_SAMPLE_SIZE: usize = 3;
+
+/// Number of blocks to sample
+const BLOCK_SAMPLE_SIZE: usize = 20;
+
+/// Gas price percentile
+const GAS_PRICE_PERCENTILE: f64 = 0.60;
+
+/// Gas tips below this price in wei are ignored
+// Constant defined in geth https://github.com/ethereum/go-ethereum/blob/25bc07749ce21376e1023a6e16ec173fa3fc4e43/eth/gasprice/gasprice.go#L40
+const IGNORE_PRICE: u128 = 2;
+
+/// Number of recent blocks to cache
+const CACHE_CAPACITY: usize = 100;
+
+pub struct Oracle {
+    cache: Arc<std::sync::Mutex<VecDeque<ProcessedBlock>>>,
+    block_sample_size: usize,
+}
+
+pub trait GasOracle: Send + Sync {
+    // Adds a block to the gas oracle's cache to process tips and base fees.
+    fn process_block(
+        &self,
+        block: Block,
+        receipts: Vec<TransactionReceipt>,
+    ) -> Result<(), GasOracleError>;
+    // Returns the expected base fee for the next block.
+    fn base_fee(&self) -> Option<u64>;
+    // Returns the suggested priority tip block inclusion.
+    fn tip(&self) -> Option<u64>;
+}
+
+impl Oracle {
+    pub fn new(block_sample_size: Option<usize>) -> Self {
+        Self {
+            cache: Arc::new(std::sync::Mutex::new(VecDeque::with_capacity(
+                CACHE_CAPACITY,
+            ))),
+            block_sample_size: block_sample_size.unwrap_or(BLOCK_SAMPLE_SIZE),
+        }
+    }
+}
+
+impl GasOracle for Oracle {
+    fn tip(&self) -> Option<u64> {
+        let Ok(cache) = self.cache.lock() else {
+            return None;
+        };
+        if cache.len() < self.block_sample_size {
+            return None;
+        }
+
+        let mut prices: Vec<u64> = cache
+            .iter()
+            .take(self.block_sample_size)
+            .flat_map(|block| &block.sampled_tips)
+            .cloned()
+            .collect();
+
+        prices.sort();
+        prices
+            .get((GAS_PRICE_PERCENTILE * prices.len() as f64) as usize)
+            .cloned()
+    }
+
+    fn process_block(
+        &self,
+        block: Block,
+        receipts: Vec<TransactionReceipt>,
+    ) -> Result<(), GasOracleError> {
+        let processed_block = process_block(block, receipts)?;
+
+        let Ok(mut cache) = self.cache.lock() else {
+            warn!("could not access gas oracle cache");
+            return Err(GasOracleError::AddToCache);
+        };
+        cache.push_front(processed_block);
+
+        if cache.len() > CACHE_CAPACITY {
+            cache.pop_back();
+        };
+
+        Ok(())
+    }
+
+    // Base fee specification defined in [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)
+    fn base_fee(&self) -> Option<u64> {
+        let block = if let Ok(cache) = self.cache.try_lock() {
+            cache.front().cloned()
+        } else {
+            None
+        };
+
+        let block = block.as_ref()?;
+
+        let gas_target = block.block_gas_limit / ELASTICITY_MULTIPLIER;
+        let base_fee = block.base_fee;
+        let gas_used = block.block_gas_used;
+
+        match gas_used.cmp(&gas_target) {
+            Ordering::Equal => Some(base_fee),
+            Ordering::Greater => {
+                let delta = gas_used - gas_target;
+                let delta = max(
+                    base_fee * delta / gas_target / BASE_FEE_MAX_CHANGE_DENOMINATOR,
+                    1,
+                );
+                Some(base_fee + delta)
+            }
+            Ordering::Less => {
+                let delta = gas_target - gas_used;
+                let delta = base_fee * delta / gas_target / BASE_FEE_MAX_CHANGE_DENOMINATOR;
+                Some(base_fee.saturating_sub(delta))
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum GasOracleError {
+    MissingBaseFee,
+    AddToCache,
+    TransactionReceiptMissing,
+}
+
+#[derive(Clone)]
+pub struct ProcessedBlock {
+    block_gas_limit: u64,
+    block_gas_used: u64,
+    // Sampled list of tips
+    sampled_tips: Vec<u64>,
+    // Base fees for block
+    base_fee: u64,
+    // Gas used ratios for each transaction
+    gas_used_ratios: Vec<f64>,
+    // effective priority fees per gas for each transaction
+    rewards: Vec<u128>,
+}
+
+fn process_block(
+    block: Block,
+    receipts: Vec<TransactionReceipt>,
+) -> Result<ProcessedBlock, GasOracleError> {
+    let base_fee = block
+        .base_fee_per_gas
+        .ok_or(GasOracleError::MissingBaseFee)?;
+
+    let mut transactions = block.body.iter().collect::<Vec<&TransactionSigned>>();
+    transactions.sort_by_cached_key(|tx| tx.effective_tip_per_gas(Some(base_fee)));
+
+    let mut prices = Vec::new();
+    let mut rewards = Vec::new();
+    let mut gas_used_ratios = Vec::new();
+    for (idx, tx) in transactions.iter().enumerate() {
+        let tip = if let Some(tip) = tx.effective_tip_per_gas(Some(base_fee)) {
+            rewards.push(tip);
+            tip
+        } else {
+            warn!("could not calculate effective tip for {:?}", tx.hash());
+            continue;
+        };
+
+        // For each receipt, calculate gas_used_ratio
+        let receipt = receipts
+            .get(idx)
+            .ok_or(GasOracleError::TransactionReceiptMissing)?;
+        let Some(gas_used) = receipt.gas_used else {
+            warn!(
+                "receipt for {:#?} is missing gas_used",
+                receipt.transaction_hash
+            );
+            continue;
+        };
+
+        let gas_used: f64 = gas_used.into();
+        let gas_used_ratio = gas_used / block.gas_limit as f64;
+        gas_used_ratios.push(gas_used_ratio);
+
+        if tip < IGNORE_PRICE {
+            continue;
+        }
+
+        match tip.try_into() {
+            Ok(price) => prices.push(price),
+            Err(_) => continue,
+        }
+
+        if prices.len() > BLOCK_TX_SAMPLE_SIZE {
+            break;
+        }
+    }
+
+    Ok(ProcessedBlock {
+        block_gas_limit: block.gas_limit,
+        block_gas_used: block.gas_used,
+        sampled_tips: prices,
+        base_fee,
+        gas_used_ratios,
+        rewards,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use reth_primitives::{Header, Signature, TxEip1559, U256};
+
+    use super::*;
+
+    fn make_tx(price: u128) -> TransactionSigned {
+        TransactionSigned {
+            transaction: reth_primitives::Transaction::Eip1559(TxEip1559 {
+                max_priority_fee_per_gas: price - 1000,
+                max_fee_per_gas: price,
+                ..Default::default()
+            }),
+            signature: Signature {
+                odd_y_parity: false,
+                r: U256::from_str_radix(
+                    "b129895435986f95c27e02bfae5f32e83aa09465154ed216b9534164ecab1016",
+                    16,
+                )
+                .unwrap(),
+                s: U256::from_str_radix(
+                    "732a1eaaaa968aeedcfdf67fe34ee6157c169e7b6f5267601ec89a62a8b836c9",
+                    16,
+                )
+                .unwrap(),
+            },
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn oracle_gas_tip() {
+        let blocks = [
+            Block {
+                header: Header {
+                    base_fee_per_gas: Some(1000),
+                    number: 0,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            Block {
+                header: Header {
+                    base_fee_per_gas: Some(1000),
+                    number: 1,
+                    ..Default::default()
+                },
+                body: vec![make_tx(1100), make_tx(1101), make_tx(1102)],
+                ..Default::default()
+            },
+            Block {
+                header: Header {
+                    base_fee_per_gas: Some(1000),
+                    number: 2,
+                    ..Default::default()
+                },
+                body: vec![make_tx(1103), make_tx(1104), make_tx(1105)],
+                ..Default::default()
+            },
+        ];
+
+        let oracle = Oracle::new(Some(2));
+
+        for block in blocks {
+            let mut receipts = Vec::new();
+            for _ in block.body.iter() {
+                receipts.push(TransactionReceipt {
+                    gas_used: Some(U256::from(21_000)),
+                    ..Default::default()
+                });
+            }
+            oracle.process_block(block, receipts).unwrap();
+        }
+
+        let tip = oracle.tip().unwrap();
+        assert_eq!(tip, 103);
+    }
+
+    #[test]
+    fn oracle_base_fee_changes() {
+        let oracle = Oracle::new(Some(2));
+
+        // Block that is less than half full.
+        let block0 = Block {
+            header: Header {
+                gas_used: 21_000 * 2,
+                base_fee_per_gas: Some(1_000),
+                number: 0,
+                gas_limit: 100_000,
+                ..Default::default()
+            },
+            body: vec![make_tx(1000), make_tx(1002)],
+            ..Default::default()
+        };
+        let receipts = vec![
+            TransactionReceipt {
+                gas_used: Some(U256::from(21_000)),
+                ..Default::default()
+            },
+            TransactionReceipt {
+                gas_used: Some(U256::from(21_000)),
+                ..Default::default()
+            },
+        ];
+
+        oracle.process_block(block0, receipts).unwrap();
+        assert_eq!(oracle.base_fee().unwrap(), 980); // Block is half full, base fee drops
+        assert_eq!(oracle.tip(), None); // Transactions so far do not have tips above IGNORE_PRICE.
+
+        // Block that more than half full.
+        let block1 = Block {
+            header: Header {
+                gas_used: 21_000 * 3,
+                base_fee_per_gas: Some(980),
+                number: 1,
+                gas_limit: 100_000,
+                ..Default::default()
+            },
+            body: vec![make_tx(1100), make_tx(1101), make_tx(1102)],
+            ..Default::default()
+        };
+
+        let receipts = vec![
+            TransactionReceipt {
+                gas_used: Some(U256::from(21_000)),
+                ..Default::default()
+            },
+            TransactionReceipt {
+                gas_used: Some(U256::from(21_000)),
+                ..Default::default()
+            },
+            TransactionReceipt {
+                gas_used: Some(U256::from(21_000)),
+                ..Default::default()
+            },
+        ];
+
+        oracle.process_block(block1, receipts).unwrap();
+        assert_eq!(oracle.base_fee().unwrap(), 1011); // Base fee increases
+        let tip = oracle.tip().unwrap();
+        assert_eq!(tip, 101);
+    }
+}

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -61,6 +61,7 @@ use crate::{
 
 mod account_handlers;
 mod block_handlers;
+mod block_watcher;
 mod call;
 mod cli;
 mod debug;
@@ -68,6 +69,7 @@ pub mod docs;
 mod eth_json_types;
 mod eth_txn_handlers;
 mod gas_handlers;
+mod gas_oracle;
 mod hex;
 mod jsonrpc;
 mod mempool_tx;


### PR DESCRIPTION
Blockwatcher will stream blocks to virtual mempool in order to evict or promote transactions. It is currently a basic implementation that does not yet use triedb.

Gas Oracle provides methods for calculating the base fee for the next block according to eip1559 rules. 