### PR TITLE
Graceful rpc error handling

### DIFF
--- a/monad-rpc/src/account_handlers.rs
+++ b/monad-rpc/src/account_handlers.rs
@@ -56,7 +56,7 @@ pub async fn monad_eth_getCode<T: Triedb>(
         .get_account(params.account.0, params.block_number.clone().into())
         .await
     {
-        TriedbResult::Null => return Ok(format!("0x")),
+        TriedbResult::Null => return Ok("0x".to_string()),
         TriedbResult::Account(_, _, code_hash) => code_hash,
         _ => return Err(JsonRpcError::internal_error("error reading from db".into())),
     };
@@ -65,7 +65,7 @@ pub async fn monad_eth_getCode<T: Triedb>(
         .get_code(code_hash, params.block_number.into())
         .await
     {
-        TriedbResult::Null => Ok(format!("0x")),
+        TriedbResult::Null => Ok("0x".to_string()),
         TriedbResult::Code(code) => Ok(hex::encode(&code)),
         _ => Err(JsonRpcError::internal_error("error reading from db".into())),
     }
@@ -95,7 +95,9 @@ pub async fn monad_eth_getStorageAt<T: Triedb>(
         )
         .await
     {
-        TriedbResult::Null => Ok(format!("0x{:x}", 0)),
+        TriedbResult::Null => {
+            Ok("0x0000000000000000000000000000000000000000000000000000000000000000".to_string())
+        }
         TriedbResult::Storage(storage) => Ok(hex::encode(&storage)),
         _ => Err(JsonRpcError::internal_error("error reading from db".into())),
     }

--- a/monad-rpc/src/block_util.rs
+++ b/monad-rpc/src/block_util.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::Read, path::PathBuf};
+use std::path::PathBuf;
 
 use alloy_rlp::{Decodable, Error as AlloyError};
 use monad_types::{BlockId, Hash};
@@ -59,19 +59,6 @@ pub struct TxnValue {
 impl FileBlockReader {
     pub fn new(eth_block_dir_path: PathBuf) -> Self {
         Self { eth_block_dir_path }
-    }
-
-    pub fn read_encoded_eth_block(&self, block_num: u64) -> std::io::Result<Vec<u8>> {
-        let filename = block_num.to_string();
-        let mut file_path = PathBuf::from(&self.eth_block_dir_path);
-        file_path.push(format!("{}", filename));
-        let mut file = File::open(file_path)?;
-
-        let size = file.metadata().unwrap().len();
-        let mut buf = vec![0; size as usize];
-        file.read_exact(&mut buf).unwrap();
-
-        Ok(buf)
     }
 
     pub async fn async_read_encoded_eth_block(&self, block_num: u64) -> std::io::Result<Vec<u8>> {

--- a/monad-rpc/src/call.rs
+++ b/monad-rpc/src/call.rs
@@ -269,8 +269,7 @@ pub async fn sender_gas_allowance<T: Triedb>(
     block: &Block,
     request: &CallRequest,
 ) -> Result<u64, JsonRpcError> {
-    if request.from.is_some() && request.max_fee_per_gas().is_some() {
-        let from = request.from.expect("sender address");
+    if let (Some(from), Some(gas_price)) = (request.from, request.max_fee_per_gas()) {
         let TriedbResult::Account(_, balance, _) = triedb_env
             .get_account(
                 from.into(),
@@ -284,7 +283,6 @@ pub async fn sender_gas_allowance<T: Triedb>(
             ));
         };
 
-        let gas_price = request.max_fee_per_gas().expect("max_fee_per_gas");
         let gas_limit = U256::from(balance)
             .checked_sub(request.value.unwrap_or_default())
             .ok_or_else(|| {

--- a/monad-rpc/src/eth_json_types.rs
+++ b/monad-rpc/src/eth_json_types.rs
@@ -371,17 +371,12 @@ impl Serialize for EthHash {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, schemars::JsonSchema)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, schemars::JsonSchema)]
 #[serde(untagged)]
 pub enum BlockTags {
     Number(Quantity),
+    #[default]
     Latest,
-}
-
-impl Default for BlockTags {
-    fn default() -> Self {
-        BlockTags::Latest
-    }
 }
 
 impl FromStr for BlockTags {

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -36,7 +36,7 @@ use trace::{
     monad_trace_block, monad_trace_call, monad_trace_callMany, monad_trace_get,
     monad_trace_transaction,
 };
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use tracing_subscriber::{
     fmt::{format::FmtSpan, Layer as FmtLayer},
     layer::SubscriberExt,
@@ -656,7 +656,9 @@ async fn main() -> std::io::Result<()> {
             .expect("failed to create ipc sender");
 
         while let Ok(tx) = ipc_receiver.recv_async().await {
-            sender.send(tx).await.expect("IPC send failed");
+            if let Err(e) = sender.send(tx).await {
+                warn!("IPC send failed, monad-bft likely crashed: {}", e);
+            }
         }
     });
 


### PR DESCRIPTION
Closes https://github.com/monad-crypto/monad-internal/issues/553 We want to make sure RPC doesn't crash in production, even if there are potential issues. Forwarding error logs to Loki instead.

Remaining crashing points listed here: https://www.notion.so/monad-labs/Scenario-where-RPC-could-crash-1211413dee6e80d6abadcec127f34484 which are initialization issues, which I think make sense to not let RPC start properly if certain parameters are not well formed.