### PR TITLE
Extend RaptorCast message tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4190,6 +4190,7 @@ dependencies = [
  "criterion",
  "futures",
  "futures-util",
+ "hex",
  "itertools 0.10.5",
  "lru",
  "monad-crypto",

--- a/monad-raptor/src/r10/nonsystematic/decoder/receive_symbol.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/receive_symbol.rs
@@ -17,8 +17,6 @@ impl Decoder {
 
             if (num_buffers_received % 100) == 0 {
                 tracing::debug!(?num_buffers_received, "received_encoded_symbol");
-            } else {
-                tracing::trace!(?num_buffers_received, "received_encoded_symbol");
             }
         }
 

--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -22,6 +22,7 @@ monad-types = { path = "../monad-types" }
 
 bytes = { workspace = true }
 futures = { workspace = true }
+hex = { workspace = true }
 itertools = { workspace = true }
 lru = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
To be able to debug an issue seen in production involving unexpectedly
high proposal propagation latencies, we found that we lack tracing
instrumentation for certain RaptorCast events of interest.

This patch adds the tracing that ultimately allowed us to root-cause
this proposal latency issue, which involved:

- Removing the per-symbol arrival logging in the Raptor decoder in
  favor of logging symbol arrival in the RaptorCast module, where we
  have additional information available that we would like to include
  in tracing events, such as the author of the message, the timestamp
  of the message, and the message application hash.

  We also add the encoding symbol ID to the tracing event data, so
  that we will have the ability in the future to trace the paths of
  individual symbols through the network by correlating logs from
  different nodes.

- Add the message author, message timestamp and message application
  hash to the event we emit when a > 10 KB message is reconstructed.

- Emit an event whenever we construct a RaptorCast message, so that we
  have a creation timestamp that we can reference other events related
  to this message to.

Also, this patch adds the RaptorCast instance ID to 'rebroadcasting
chunks' trace events, to allow disambiguating these messages when
running multiple RaptorCast instances in the same process, for example
when running monad-testground, or when running the RaptorCast service
example.