### PR TITLE
Rate limit for eth_call and eth_estimateGas

### DIFF
--- a/monad-rpc/src/cli.rs
+++ b/monad-rpc/src/cli.rs
@@ -45,9 +45,15 @@ pub struct Cli {
     #[arg(long, default_value_t = 25_000_000)]
     pub max_response_size: u32,
 
+    /// Otel endpoint to collect metrics data
     #[arg(long)]
     pub otel_endpoint: Option<String>,
 
+    /// Allow pre EIP-155 transactions
     #[arg(long, default_value_t = false)]
     pub allow_unprotected_txs: bool,
+
+    /// Set the max concurrent requests for eth_call and eth_estimateGas
+    #[arg(long, default_value_t = 1000)]
+    pub eth_call_max_concurrent_requests: u32,
 }

--- a/monad-rpc/src/websocket.rs
+++ b/monad-rpc/src/websocket.rs
@@ -95,10 +95,13 @@ impl StreamHandler<Result<WebsocketMessage, ProtocolError>> for WebsocketSession
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use actix_http::{ws, ws::Frame};
     use bytes::Bytes;
     use futures_util::{SinkExt as _, StreamExt as _};
     use reth_primitives::TransactionSigned;
+    use tokio::sync::Semaphore;
 
     use crate::{
         create_app, tests::MonadRpcResourcesState, ExecutionLedgerPath, MonadRpcResources,
@@ -115,6 +118,7 @@ mod tests {
             batch_request_limit: 1000,
             max_response_size: 25_000_000,
             allow_unprotected_txs: false,
+            rate_limiter: Arc::new(Semaphore::new(1000)),
         };
         (
             MonadRpcResourcesState { ipc_receiver },


### PR DESCRIPTION
Setting default rate limit for eth_call and eth_estimateGas to prevent RPC from crashing when being spammed. Default currently set as 1000 concurrent requests which is around 3k RPS when spammed under much higher load. 

Relevant issue: https://github.com/monad-crypto/monad-internal/issues/617