### PR TITLE
Add support for configurable upload pacing

### DIFF
--- a/monad-dataplane/examples/node.rs
+++ b/monad-dataplane/examples/node.rs
@@ -91,7 +91,7 @@ struct Node {
 impl Node {
     pub fn new(addr: &str, target_addr: &str) -> Self {
         Self {
-            network: Dataplane::new(addr),
+            network: Dataplane::new(addr, 1_000),
             target: target_addr.parse().unwrap(),
         }
     }

--- a/monad-dataplane/src/event_loop.rs
+++ b/monad-dataplane/src/event_loop.rs
@@ -198,7 +198,8 @@ fn make_producer_consumer<T>(size: usize) -> (WakeableProducer<T>, WakeableConsu
 }
 
 impl Dataplane {
-    pub fn new(local_addr: &str) -> Self {
+    /// 1_000 = 1 Gbps, 10_000 = 10 Gbps
+    pub fn new(local_addr: &str, up_bandwidth_mbps: u64) -> Self {
         let (udp_ing_producer, udp_ing_consumer) = make_producer_consumer(12_800);
         let (tcp_ing_producer, tcp_ing_consumer) = make_producer_consumer(32);
 
@@ -226,7 +227,7 @@ impl Dataplane {
             egress_bcast_receiver: egr_bcast_recv,
             egress_ucast_receiver: egr_ucast_recv,
             egress_tcp_receiver: egr_tcp_recv,
-            udp_socket: NetworkSocket::new(local_addr),
+            udp_socket: NetworkSocket::new(local_addr, up_bandwidth_mbps),
 
             tcp_listening_socket,
             tcp_incoming_connections: [const { None }; TCP_INCOMING_MAX_CONNECTIONS],

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -534,6 +534,7 @@ where
             network_config.bind_address_port,
         ))
         .to_string(),
+        up_bandwidth_mbps: network_config.max_mbps.into(),
     })
 }
 

--- a/monad-raptorcast/examples/service.rs
+++ b/monad-raptorcast/examples/service.rs
@@ -114,6 +114,7 @@ fn service(
                     known_addresses,
                     redundancy: 2,
                     local_addr: server_address.to_string(),
+                    up_bandwidth_mbps: 1_000,
                 };
 
                 let mut service =

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -37,6 +37,9 @@ where
     pub redundancy: u8,
 
     pub local_addr: String,
+
+    /// 1_000 = 1 Gbps, 10_000 = 10 Gbps
+    pub up_bandwidth_mbps: u64,
 }
 
 pub struct RaptorCast<ST, M, OM>
@@ -71,7 +74,7 @@ where
 {
     pub fn new(config: RaptorCastConfig<ST>) -> Self {
         let self_id = NodeId::new(config.key.pubkey());
-        let dataplane = Dataplane::new(&config.local_addr);
+        let dataplane = Dataplane::new(&config.local_addr, config.up_bandwidth_mbps);
         Self {
             epoch_validators: Default::default(),
             known_addresses: config.known_addresses,

--- a/monad-raptorcast/tests/malformed_inputs.rs
+++ b/monad-raptorcast/tests/malformed_inputs.rs
@@ -284,6 +284,7 @@ pub fn set_up_test(
                 known_addresses,
                 redundancy: 2,
                 local_addr: rx_addr,
+                up_bandwidth_mbps: 1_000,
             };
 
             let mut service =

--- a/monad-state/src/blocksync.rs
+++ b/monad-state/src/blocksync.rs
@@ -303,7 +303,7 @@ where
         };
         cmds.into_iter()
             .map(|command| WrappedBlockSyncCommand {
-                request_timeout: *self.delta * 3,
+                request_timeout: *self.delta * 5,
                 command,
             })
             .collect()
@@ -345,7 +345,7 @@ where
             }
             BlockSyncCommand::SendResponse { to, response } => {
                 vec![Command::RouterCommand(RouterCommand::Publish {
-                    target: RouterTarget::PointToPoint(to),
+                    target: RouterTarget::TcpPointToPoint(to),
                     message: VerifiedMonadMessage::BlockSyncResponse(response),
                 })]
             }

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -347,6 +347,7 @@ where
                             known_addresses: known_addresses.clone(),
                             redundancy: 3,
                             local_addr: address.parse::<SocketAddr>().unwrap().to_string(),
+                            up_bandwidth_mbps: 1_000,
                         }),
                     },
                     ledger_config: match args.ledger {


### PR DESCRIPTION
This is particularly important for very stake-uneven networks, as a few nodes may bear the majority of the network's upload burden.