### PR TITLE
Switch to stable sort implementation for monad_secp::PubKey

### DIFF
--- a/monad-secp/src/secp.rs
+++ b/monad-secp/src/secp.rs
@@ -3,7 +3,7 @@ use secp256k1::Secp256k1;
 use zeroize::Zeroize;
 
 /// secp256k1 public key
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialOrd, Ord)]
 pub struct PubKey(secp256k1::PublicKey);
 /// secp256k1 keypair
 pub struct KeyPair(secp256k1::KeyPair);
@@ -41,18 +41,6 @@ impl std::cmp::PartialEq for PubKey {
 }
 
 impl std::cmp::Eq for PubKey {}
-
-impl std::cmp::Ord for PubKey {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0.cmp_fast_unstable(&other.0)
-    }
-}
-
-impl std::cmp::PartialOrd for PubKey {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
 
 /// Faster to use the transmuted memory values, but might not be stable across
 /// library versions


### PR DESCRIPTION
Right now, we're using the secp256k1::PublicKey::cmp_fast_unstable()
method for sorting secp public keys, and that has a couple of issues:

- Sort order is not guaranteed across library versions, which means
  that if different validators use different versions of secp256k1
  that have different memory layouts for PublicKey and compare them
  differently, those validators can end up with different/conflicting
  leader schedules.

- The sort order used by cmp_fast_unstable() corresponds neither to
  compressed public key byte order nor to uncompressed public key byte
  order, which makes it difficult, if not impossible, to, given a set of
  node IDs, determine what the sorted order of those node IDs will be.

  We ran into this issue when trying to determine the RaptorCast
  proposal propagation schedule for a given validator set consisting
  of a set of (node ID, stake) tuples, but this would probably be an
  issue for other kinds of debugging work as well.

Rolling out this change will require some care, because of the first
point above, but this change is deemed to be a necessary change.