### PR TITLE
Lift tracing for every 100th received Raptor symbol into raptorcast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4178,7 +4178,6 @@ dependencies = [
  "bitvec",
  "rand",
  "rayon",
- "tracing",
 ]
 
 [[package]]

--- a/monad-raptor/Cargo.toml
+++ b/monad-raptor/Cargo.toml
@@ -14,4 +14,3 @@ bench = false
 bitvec = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
-tracing = { workspace = true }

--- a/monad-raptor/src/r10/nonsystematic/decoder/receive_symbol.rs
+++ b/monad-raptor/src/r10/nonsystematic/decoder/receive_symbol.rs
@@ -11,15 +11,6 @@ impl Decoder {
         encoding_symbol_id: usize,
         mut xor_buffers: impl FnMut(BufferId, BufferId),
     ) {
-        {
-            let num_buffers_received =
-                self.buffer_state.len() - self.num_redundant_intermediate_symbols() + 1;
-
-            if (num_buffers_received % 100) == 0 {
-                tracing::debug!(?num_buffers_received, "received_encoded_symbol");
-            }
-        }
-
         let buffer_index: u16 = self.buffer_state.len().try_into().unwrap();
 
         let mut buffer = Buffer::new();

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -199,6 +199,20 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
                 }
             };
 
+            let num_buffers_received = decoder.num_encoded_symbols_received() + 1;
+
+            if (num_buffers_received % 100) == 0 {
+                tracing::debug!(
+                    self_id =? self.self_id,
+                    author =? parsed_message.author,
+                    unix_ts_ms = parsed_message.unix_ts_ms,
+                    app_message_hash = hex::encode(parsed_message.app_message_hash),
+                    encoding_symbol_id,
+                    num_buffers_received,
+                    "received encoded symbol (100th)"
+                );
+            }
+
             // can we assert!(!decoder.decoding_done()) ?
 
             match decoder.received_encoded_symbol(&parsed_message.chunk, encoding_symbol_id) {


### PR DESCRIPTION
Move the tracing hook that logs every 100th received Raptor symbol from
the Raptor decoder to the raptorcast UDP module.  This allows adding a
few more fields of interest to the tracing event, such as the message
author, the message timestamp, the application message hash, and the
local node ID.