### PR TITLE
Trace chunks received from each rebroadcaster when decoding fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4189,7 +4189,6 @@ dependencies = [
  "criterion",
  "futures",
  "futures-util",
- "hex",
  "itertools 0.10.5",
  "lru",
  "monad-crypto",

--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -22,7 +22,6 @@ monad-types = { path = "../monad-types" }
 
 bytes = { workspace = true }
 futures = { workspace = true }
-hex = { workspace = true }
 itertools = { workspace = true }
 lru = { workspace = true }
 tracing = { workspace = true }

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -85,11 +85,26 @@ pub enum BuildTarget<'a, ST: CertificateSignatureRecoverable> {
     PointToPoint(&'a NodeId<CertificateSignaturePubKey<ST>>),
 }
 
-pub fn compute_hash<PT>(id: &NodeId<PT>) -> [u8; 20]
+pub fn compute_hash<PT>(id: &NodeId<PT>) -> NodeIdHash
 where
     PT: PubKey,
 {
     let mut hasher = HasherType::new();
     hasher.update(id.pubkey().bytes());
-    hasher.hash().0[..20].try_into().expect("20 bytes")
+    HexBytes(hasher.hash().0[..20].try_into().expect("20 bytes"))
 }
+
+#[derive(Copy, Clone, Hash, Eq, Ord, PartialEq, PartialOrd)]
+pub struct HexBytes<const N: usize>(pub [u8; N]);
+impl<const N: usize> std::fmt::Debug for HexBytes<N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "0x")?;
+        for byte in self.0 {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+pub type NodeIdHash = HexBytes<20>;
+pub type AppMessageHash = HexBytes<20>;


### PR DESCRIPTION
When we fail to decode an incoming message due to not having received
enough symbols to proceed with the decoding, it would be good to know
which rebroadcasters we did receive symbols from and how many, so that
we can deduce which rebroadcasters we did not receive any symbols from,
and which rebroadcasters we received fewer than the expected number of
symbols from.  This patch implements this.

When an incomplete message is pruned out of the pending_message_cache,
we will now get a debug trace event like the following:

2024-10-22T20:42:00.322803Z DEBUG monad_raptorcast::udp: dropped unfin
ished ManagedDecoder num_source_symbols=3279 num_encoded_symbols_recei
ved=1639 inactivation_symbol_threshold=4918 recipient_chunks={[123, 10
8, 35, 236, 181, 193, 101, 75, 198, 230, 115, 200, 17, 167, 114, 19, 1
67, 182, 147, 206]: 1639} key=MessageCacheKey { unix_ts_ms: 1729629713
015, author: 036b2d6f5ae599245e4749c6c716527e79813811e301ff62661247451
2486a1706, app_message_hash: [24, 206, 5, 90, 182, 104, 201, 46, 137,
196, 158, 196, 47, 128, 13, 254, 130, 216, 48, 254], app_message_len:
4000000 }

(Where recipient_chunks is a BTreeMap mapping each rebroadcaster to the
number of symbols we have received from that rebroadcaster.)