### PR TITLE
Fix up logging of app_message_hash in 'raptorcasting message' trace e…

### DIFF
--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -446,11 +446,11 @@ where
     };
 
     let mut message = BytesMut::zeroed(gso_size as usize * num_packets);
-    let app_message_hash: [u8; 20] = {
+    let app_message_hash: AppMessageHash = HexBytes({
         let mut hasher = HasherType::new();
         hasher.update(&app_message);
         hasher.hash().0[..20].try_into().unwrap()
-    };
+    });
 
     let mut chunk_datas = message
         .chunks_mut(gso_size.into())
@@ -628,7 +628,7 @@ where
                 let (cursor_unix_ts_ms, cursor) = cursor.split_at_mut(8);
                 cursor_unix_ts_ms.copy_from_slice(&unix_ts_ms.to_le_bytes());
                 let (cursor_app_message_hash, cursor) = cursor.split_at_mut(20);
-                cursor_app_message_hash.copy_from_slice(&app_message_hash);
+                cursor_app_message_hash.copy_from_slice(&app_message_hash.0);
                 let (cursor_app_message_len, cursor) = cursor.split_at_mut(4);
                 cursor_app_message_len.copy_from_slice(&app_message_len.to_le_bytes());
 


### PR DESCRIPTION
Commit cb2cca315a9b ("Hex format app_message_hash and node_id_hash")
(inadvertently) changed the 'raptorcasting message' trace event to log
the app_message_hash as a byte array:

2024-10-23T18:12:06.694753Z TRACE monad_raptorcast::udp: raptorcasting
 message self_id=036b2d6f5ae599245e4749c6c716527e79813811e301ff6266124
74512486a1706 unix_ts_ms=1729707126693 app_message_len=4000000 redunda
ncy=2 data_size=1220 num_packets=6558 app_message_hash=[200, 57, 79, 2
46, 183, 227, 188, 222, 30, 189, 65, 39, 112, 81, 79, 209, 121, 155, 1
45, 179]

This patch changes it back to hex format:

2024-10-23T18:14:14.417775Z TRACE monad_raptorcast::udp: raptorcasting
 message self_id=036b2d6f5ae599245e4749c6c716527e79813811e301ff6266124
74512486a1706 unix_ts_ms=1729707254413 app_message_len=4000000 redunda
ncy=2 data_size=1220 num_packets=6558 app_message_hash=0x720cd8077e69e
8160c1ef7763296a49fe6708825