### PR TITLE
Change router message format for peer discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 test-keys
 .vscode
 *.swp
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3834,6 +3834,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-discovery"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "monad-crypto",
+ "monad-proto",
+ "monad-types",
+ "prost 0.12.6",
+ "serde",
+]
+
+[[package]]
 name = "monad-eth-block-policy"
 version = "0.1.0"
 dependencies = [
@@ -4285,6 +4297,7 @@ dependencies = [
  "lru",
  "monad-crypto",
  "monad-dataplane",
+ "monad-discovery",
  "monad-executor",
  "monad-executor-glue",
  "monad-merkle",

--- a/monad-discovery/Cargo.toml
+++ b/monad-discovery/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "monad-discovery"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+bench = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bytes = { workspace = true }
+prost = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+
+
+monad-crypto = { path = "../monad-crypto" }
+monad-proto = { path = "../monad-proto" }
+monad-types = { path = "../monad-types" }

--- a/monad-discovery/src/lib.rs
+++ b/monad-discovery/src/lib.rs
@@ -1,0 +1,154 @@
+pub mod message;
+
+mod nop_discovery;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+use bytes::Bytes;
+use monad_crypto::certificate_signature::PubKey;
+use monad_proto::{
+    error::ProtoError,
+    proto::discovery::{
+        proto_ip_address::Address, ProtoIPv4, ProtoIPv6, ProtoIpAddress, ProtoMonadNameRecord,
+        ProtoNetworkEndpoint,
+    },
+};
+use monad_types::NodeId;
+pub use nop_discovery::NopDiscovery;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct NetworkEndpoint {
+    pub socket_addr: SocketAddr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BootstrapPeer<PT: PubKey> {
+    pub node_id: NodeId<PT>,
+    pub endpoint: NetworkEndpoint,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct MonadNameRecord<PT: PubKey> {
+    pub endpoint: NetworkEndpoint,
+    #[serde(bound = "PT: PubKey")]
+    pub node_id: NodeId<PT>,
+    pub seq_num: u64,
+}
+
+const IPV4_ADDRESS_LEN: usize = 4;
+const IPV6_ADDRESS_LEN: usize = 16;
+
+impl TryFrom<ProtoNetworkEndpoint> for NetworkEndpoint {
+    type Error = ProtoError;
+
+    fn try_from(value: ProtoNetworkEndpoint) -> Result<Self, Self::Error> {
+        let proto_ip = value
+            .ip
+            .ok_or(ProtoError::MissingRequiredField(
+                "ProtoNetworkEndpoint.ip".to_owned(),
+            ))?
+            .address
+            .ok_or(ProtoError::MissingRequiredField(
+                "ProtoIpAddress.address".to_owned(),
+            ))?;
+
+        let ip = match proto_ip {
+            Address::Ipv4(ProtoIPv4 { address }) => {
+                if address.len() != IPV4_ADDRESS_LEN {
+                    return Err(ProtoError::DeserializeError(format!(
+                        "invalid IPV4 address length: {}",
+                        address.len()
+                    )));
+                }
+                let mut addr = [0u8; IPV4_ADDRESS_LEN];
+                addr.copy_from_slice(&address);
+                IpAddr::V4(Ipv4Addr::from(addr))
+            }
+            Address::Ipv6(ProtoIPv6 { address }) => {
+                if address.len() != IPV6_ADDRESS_LEN {
+                    return Err(ProtoError::DeserializeError(format!(
+                        "invalid IPV6 address length: {}",
+                        address.len()
+                    )));
+                }
+                let mut addr = [0u8; IPV6_ADDRESS_LEN];
+                addr.copy_from_slice(&address);
+                IpAddr::V6(Ipv6Addr::from(addr))
+            }
+        };
+
+        Ok(Self {
+            socket_addr: SocketAddr::new(
+                ip,
+                value.port.try_into().map_err(|_| {
+                    ProtoError::DeserializeError("IP port overflowed a u16".to_owned())
+                })?,
+            ),
+        })
+    }
+}
+impl From<&NetworkEndpoint> for ProtoNetworkEndpoint {
+    fn from(value: &NetworkEndpoint) -> Self {
+        match value.socket_addr {
+            SocketAddr::V4(ipv4) => Self {
+                ip: Some(ProtoIpAddress {
+                    address: Some(Address::Ipv4(ProtoIPv4 {
+                        address: Bytes::copy_from_slice(&ipv4.ip().octets()),
+                    })),
+                }),
+                port: ipv4.port() as u32,
+            },
+            SocketAddr::V6(ipv6) => Self {
+                ip: Some(ProtoIpAddress {
+                    address: Some(Address::Ipv6(ProtoIPv6 {
+                        address: Bytes::copy_from_slice(&ipv6.ip().octets()),
+                    })),
+                }),
+                port: ipv6.port() as u32,
+            },
+        }
+    }
+}
+
+impl<PT: PubKey> TryFrom<ProtoMonadNameRecord> for MonadNameRecord<PT> {
+    type Error = ProtoError;
+
+    fn try_from(value: ProtoMonadNameRecord) -> Result<Self, Self::Error> {
+        Ok(Self {
+            endpoint: value
+                .endpoint
+                .ok_or(ProtoError::MissingRequiredField(
+                    "ProtoMonadNameRecord.endpoint".to_owned(),
+                ))?
+                .try_into()?,
+            node_id: value
+                .node_id
+                .ok_or(ProtoError::MissingRequiredField(
+                    "ProtoMonadNameRecord.node_id".to_owned(),
+                ))?
+                .try_into()?,
+            seq_num: value.seq_num,
+        })
+    }
+}
+impl<PT: PubKey> From<&MonadNameRecord<PT>> for ProtoMonadNameRecord {
+    fn from(value: &MonadNameRecord<PT>) -> Self {
+        let MonadNameRecord {
+            endpoint,
+            node_id,
+            seq_num,
+        } = value;
+        Self {
+            endpoint: Some(endpoint.into()),
+            node_id: Some(node_id.into()),
+            seq_num: *seq_num,
+        }
+    }
+}
+
+pub trait Discovery<PT>
+where
+    PT: PubKey,
+{
+    fn bootstrap_peers(&self) -> Vec<BootstrapPeer<PT>>;
+}

--- a/monad-discovery/src/message.rs
+++ b/monad-discovery/src/message.rs
@@ -1,0 +1,190 @@
+use bytes::{Bytes, BytesMut};
+use monad_crypto::certificate_signature::PubKey;
+use monad_proto::{
+    error::ProtoError,
+    proto::message::{
+        proto_discovery_message::Message, ProtoDiscoveryMessage, ProtoDiscoveryRequest,
+        ProtoDiscoveryResponse, ProtoRouterMessage,
+    },
+};
+use monad_types::{Deserializable, Serializable};
+use prost::Message as _;
+
+use crate::MonadNameRecord;
+
+#[derive(Debug)]
+pub struct DiscoveryRequest<PT: PubKey> {
+    pub sender: MonadNameRecord<PT>,
+}
+
+impl<PT: PubKey> TryFrom<ProtoDiscoveryRequest> for DiscoveryRequest<PT> {
+    type Error = ProtoError;
+
+    fn try_from(value: ProtoDiscoveryRequest) -> Result<Self, Self::Error> {
+        let sender = value
+            .self_
+            .ok_or(ProtoError::MissingRequiredField(
+                "ProtoDiscoveryRequest".to_owned(),
+            ))?
+            .try_into()?;
+        Ok(Self { sender })
+    }
+}
+impl<PT: PubKey> From<&DiscoveryRequest<PT>> for ProtoDiscoveryRequest {
+    fn from(value: &DiscoveryRequest<PT>) -> Self {
+        ProtoDiscoveryRequest {
+            self_: Some((&value.sender).into()),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct DiscoveryResponse<PT: PubKey> {
+    pub peers: Vec<MonadNameRecord<PT>>,
+}
+
+impl<PT: PubKey> TryFrom<ProtoDiscoveryResponse> for DiscoveryResponse<PT> {
+    type Error = ProtoError;
+
+    fn try_from(value: ProtoDiscoveryResponse) -> Result<Self, Self::Error> {
+        let peers = value
+            .peers
+            .into_iter()
+            .map(MonadNameRecord::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self { peers })
+    }
+}
+impl<PT: PubKey> From<&DiscoveryResponse<PT>> for ProtoDiscoveryResponse {
+    fn from(value: &DiscoveryResponse<PT>) -> Self {
+        ProtoDiscoveryResponse {
+            peers: value.peers.iter().map(Into::into).collect::<Vec<_>>(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum DiscoveryMessage<PT: PubKey> {
+    Request(DiscoveryRequest<PT>),
+    Response(DiscoveryResponse<PT>),
+}
+
+impl<PT: PubKey> TryFrom<ProtoDiscoveryMessage> for DiscoveryMessage<PT> {
+    type Error = ProtoError;
+
+    fn try_from(value: ProtoDiscoveryMessage) -> Result<Self, Self::Error> {
+        match value.message.ok_or(ProtoError::MissingRequiredField(
+            "ProtoDiscoveryMessage.message".to_owned(),
+        ))? {
+            Message::Request(request) => Ok(DiscoveryMessage::Request(request.try_into()?)),
+            Message::Response(response) => Ok(DiscoveryMessage::Response(response.try_into()?)),
+        }
+    }
+}
+
+impl<PT: PubKey> From<&DiscoveryMessage<PT>> for ProtoDiscoveryMessage {
+    fn from(value: &DiscoveryMessage<PT>) -> Self {
+        match value {
+            DiscoveryMessage::Request(request) => ProtoDiscoveryMessage {
+                message: Some(Message::Request(request.into())),
+            },
+            DiscoveryMessage::Response(response) => ProtoDiscoveryMessage {
+                message: Some(Message::Response(response.into())),
+            },
+        }
+    }
+}
+
+pub enum OutboundRouterMessage<'a, OM, PT: PubKey> {
+    Application(&'a OM),
+    Discovery(DiscoveryMessage<PT>),
+}
+
+impl<'a, OM, PT: PubKey> From<&OutboundRouterMessage<'a, OM, PT>> for ProtoRouterMessage
+where
+    OM: Serializable<Bytes>,
+{
+    fn from(value: &OutboundRouterMessage<'a, OM, PT>) -> Self {
+        match value {
+            OutboundRouterMessage::Application(app_message) => {
+                let serialized_app_message: Bytes = (*app_message).serialize();
+                ProtoRouterMessage {
+                    message: Some(
+                        monad_proto::proto::message::proto_router_message::Message::AppMessage(
+                            serialized_app_message,
+                        ),
+                    ),
+                }
+            }
+            OutboundRouterMessage::Discovery(discovery) => ProtoRouterMessage {
+                message: Some(
+                    monad_proto::proto::message::proto_router_message::Message::DiscoveryMessage(
+                        discovery.into(),
+                    ),
+                ),
+            },
+        }
+    }
+}
+
+impl<OM: Serializable<Bytes>, PT: PubKey> Serializable<Bytes>
+    for OutboundRouterMessage<'_, OM, PT>
+{
+    fn serialize(&self) -> Bytes {
+        let msg: ProtoRouterMessage = self.into();
+
+        let mut buf = BytesMut::new();
+        msg.encode(&mut buf)
+            .expect("message serialization shouldn't fail");
+        buf.into()
+    }
+}
+
+pub enum InboundRouterMessage<M, PT: PubKey> {
+    Application(M),
+    Discovery(DiscoveryMessage<PT>),
+}
+
+impl<M: Deserializable<Bytes>, PT: PubKey> TryFrom<ProtoRouterMessage>
+    for InboundRouterMessage<M, PT>
+{
+    type Error = ProtoError;
+
+    fn try_from(value: ProtoRouterMessage) -> Result<Self, Self::Error> {
+        match value.message.ok_or(ProtoError::MissingRequiredField(
+            "ProtoRouterMessage.message".to_owned(),
+        ))? {
+            monad_proto::proto::message::proto_router_message::Message::AppMessage(app_message) => {
+                let app_message = M::deserialize(&app_message).map_err(|_| {
+                    /*
+                        TODO(rene): This map_err is not ideal because it effectively drops a future
+                        error type for an opaque string error. We can remove this map_err and
+                        convert to ProtoError using ?, but then we would have to specify the
+                        ReadError generic associated type in the Deserializable<Bytes> bound on M
+                        like so
+
+                        M: Deserializable<Bytes, ReadError = ProtoError>
+
+                        but then this bound has to propagate upwards to the RaptorCast type, which
+                        is also not ideal.
+                    */
+                    ProtoError::DeserializeError("unknown deserialization error".to_owned())
+                })?;
+                Ok(InboundRouterMessage::Application(app_message))
+            }
+            monad_proto::proto::message::proto_router_message::Message::DiscoveryMessage(
+                discovery_message,
+            ) => Ok(InboundRouterMessage::Discovery(
+                discovery_message.try_into()?,
+            )),
+        }
+    }
+}
+
+impl<M: Deserializable<Bytes>, PT: PubKey> Deserializable<Bytes> for InboundRouterMessage<M, PT> {
+    type ReadError = ProtoError;
+
+    fn deserialize(message: &Bytes) -> Result<Self, Self::ReadError> {
+        ProtoRouterMessage::decode(message.clone())?.try_into()
+    }
+}

--- a/monad-discovery/src/nop_discovery.rs
+++ b/monad-discovery/src/nop_discovery.rs
@@ -1,0 +1,19 @@
+use std::marker::PhantomData;
+
+use monad_crypto::certificate_signature::PubKey;
+
+use crate::{BootstrapPeer, Discovery};
+
+pub struct NopDiscovery<PT: PubKey>(pub PhantomData<PT>);
+
+impl<PT: PubKey> Default for NopDiscovery<PT> {
+    fn default() -> Self {
+        Self(PhantomData::default())
+    }
+}
+
+impl<PT: PubKey> Discovery<PT> for NopDiscovery<PT> {
+    fn bootstrap_peers(&self) -> Vec<BootstrapPeer<PT>> {
+        vec![]
+    }
+}

--- a/monad-proto/build.rs
+++ b/monad-proto/build.rs
@@ -12,6 +12,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .compile_protos(
             &[
                 "proto/basic.proto",
+                "proto/discovery.proto",
                 "proto/block.proto",
                 "proto/blocksync.proto",
                 "proto/event.proto",

--- a/monad-proto/proto/discovery.proto
+++ b/monad-proto/proto/discovery.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package monad_proto.discovery;
+
+import "basic.proto";
+
+message ProtoIPv4 {
+  bytes address = 1;
+}
+
+message ProtoIPv6 {
+  bytes address = 1;
+}
+
+message ProtoIPAddress {
+  oneof address {
+    ProtoIPv4 ipv4 = 1;
+    ProtoIPv6 ipv6 = 2;
+  }
+}
+
+message ProtoNetworkEndpoint {
+  ProtoIPAddress ip = 1;
+  uint32 port = 2;
+}
+
+message ProtoMonadNameRecord {
+  ProtoNetworkEndpoint endpoint = 1;
+  monad_proto.basic.ProtoNodeId node_id = 2;
+  uint64 seq_num = 3;
+}

--- a/monad-proto/proto/message.proto
+++ b/monad-proto/proto/message.proto
@@ -5,6 +5,7 @@ package monad_proto.message;
 import "basic.proto";
 import "block.proto";
 import "blocksync.proto";
+import "discovery.proto";
 import "signing.proto";
 import "state_root_hash.proto";
 import "timeout.proto";
@@ -104,5 +105,27 @@ message ProtoMonadMessage {
     ProtoPeerStateRootMessage peer_state_root = 4;
     ProtoForwardedTx forwarded_tx = 5;
     ProtoStateSyncNetworkMessage state_sync_message = 6;
+  }
+}
+message ProtoDiscoveryRequest {
+  monad_proto.discovery.ProtoMonadNameRecord self = 1;
+}
+
+message ProtoDiscoveryResponse {
+  repeated monad_proto.discovery.ProtoMonadNameRecord peers = 1;
+}
+
+message ProtoDiscoveryMessage {
+  oneof message {
+    ProtoDiscoveryRequest request = 1;
+    ProtoDiscoveryResponse response = 2;
+  }
+}
+
+message ProtoRouterMessage {
+  oneof message {
+    // keep compatible with ProtoMonadMessage
+    bytes app_message = 7;
+    ProtoDiscoveryMessage discovery_message = 8;
   }
 }

--- a/monad-proto/src/lib.rs
+++ b/monad-proto/src/lib.rs
@@ -18,6 +18,7 @@ pub mod error;
 
 pub mod proto {
     include_proto!(basic);
+    include_proto!(discovery);
     include_proto!(signing);
     include_proto!(voting);
     include_proto!(ledger);

--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -13,6 +13,7 @@ bench = false
 [dependencies]
 monad-crypto = { path = "../monad-crypto" }
 monad-dataplane = { path = "../monad-dataplane" }
+monad-discovery = { path = "../monad-discovery" }
 monad-executor = { path = "../monad-executor" }
 monad-executor-glue = { path = "../monad-executor-glue" }
 monad-merkle = { path = "../monad-merkle" }


### PR DESCRIPTION
This PR makes a backwards-compatible change to the format of messages
between nodes. Previously, nodes exchanged messages of the form

    TCP: Signature || impl Message
    UDP: Signature || RaptorCoded(impl Message)

After this PR, messages will be of the form

    TCP: Signature || impl Message | DiscoveryMessage
    UDP: Signature || RaptorCoded(impl Message | DiscoveryMessage)

The key design design decision that motivated this change was that no
new events should have to be created and passed through the consensus
state machine for peer discovery. However, the router de/serializes
messages with the following bound

    M: Message<_> + Deserializable<Bytes>,
    OM: Serializable<Bytes> + Into<M> + Clone,

and in order for a type to implement the `Message` trait, it has to be
able to emit an associated event, which we wanted to avoid altogether.
To fix this, we introduce two new types.

```rust
    enum InboundRouterMessage<M> {
        Application(M),
        Discovery(DiscoveryMessage),
    }

    enum OutboundRouterMessage<OM> {
        Application(&OM),
        Discovery(DiscoveryMessage),
    }
```

When receiving a message, the server will deserialize as an
`InboundRouterMessage`. When sending a message, the client will
serialize it as an `OutboundRouterMessage`. We also introduce a new
proto message that will wrap the old `ProtoMonadMessage`

```proto
    message ProtoRouterMessage {
      oneof message {
        // keep compatible with ProtoMonadMessage
        bytes app_message = 7;
        ProtoDiscoveryMessage discovery_message = 8;
      }
    }
```

The `bytes app_message = 7` field will be de/serialized to
`MonadMessage` in the same way as the old router. For
backwards-compatible deployment to current nodes, we deploy the changes
to the server side first. The server will be able to transparently
handle the old message format. Once that is complete, we can deploy the
client changes.