### PR TITLE
Replace reserve balance validation with max txn fee validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3874,6 +3874,7 @@ dependencies = [
  "monad-eth-tx",
  "monad-eth-types",
  "monad-state-backend",
+ "reth-primitives",
  "tracing",
 ]
 

--- a/monad-consensus-state/benches/state_machine.rs
+++ b/monad-consensus-state/benches/state_machine.rs
@@ -359,7 +359,7 @@ fn setup<
 
                 state_root_validator: state_root(),
                 block_validator: EthValidator::new(10_000, u64::MAX, 1337),
-                block_policy: EthBlockPolicy::new(GENESIS_SEQ_NUM, 0, 0, 1337),
+                block_policy: EthBlockPolicy::new(GENESIS_SEQ_NUM, 0, 1337),
                 state_backend: InMemoryStateInner::genesis(u128::MAX, SeqNum(0)),
                 block_timestamp: BlockTimestamp::new(
                     100,

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -1253,7 +1253,7 @@ where
                         )
                     }
                     Err(err) => {
-                        // TODO: add metrics for different carriage cost validation errors
+                        // TODO: add metrics for different transaction fee validation errors
                         debug!(?err, "Creating Proposal error, proposing empty block");
                         self.metrics.consensus_events.creating_empty_block_proposal += 1;
                         // An empty block uses the same SeqNum and state root as its
@@ -4628,14 +4628,7 @@ mod test {
             num_states as u32,
             ValidatorSetFactory::default(),
             SimpleRoundRobin::default(),
-            || {
-                EthBlockPolicy::new(
-                    GENESIS_SEQ_NUM,
-                    u128::MAX,
-                    NopStateRoot {}.get_delay().0,
-                    1337,
-                )
-            },
+            || EthBlockPolicy::new(GENESIS_SEQ_NUM, NopStateRoot {}.get_delay().0, 1337),
             || {
                 InMemoryStateInner::new(
                     u128::MAX,
@@ -4694,14 +4687,7 @@ mod test {
             num_states as u32,
             ValidatorSetFactory::default(),
             SimpleRoundRobin::default(),
-            || {
-                EthBlockPolicy::new(
-                    GENESIS_SEQ_NUM,
-                    u128::MAX,
-                    NopStateRoot {}.get_delay().0,
-                    1337,
-                )
-            },
+            || EthBlockPolicy::new(GENESIS_SEQ_NUM, NopStateRoot {}.get_delay().0, 1337),
             || {
                 InMemoryStateInner::new(
                     u128::MAX,
@@ -4761,14 +4747,7 @@ mod test {
             num_states as u32,
             ValidatorSetFactory::default(),
             SimpleRoundRobin::default(),
-            || {
-                EthBlockPolicy::new(
-                    GENESIS_SEQ_NUM,
-                    u128::MAX,
-                    NopStateRoot {}.get_delay().0,
-                    1337,
-                )
-            },
+            || EthBlockPolicy::new(GENESIS_SEQ_NUM, NopStateRoot {}.get_delay().0, 1337),
             || {
                 InMemoryStateInner::new(
                     u128::MAX,
@@ -4851,14 +4830,7 @@ mod test {
             num_states as u32,
             ValidatorSetFactory::default(),
             SimpleRoundRobin::default(),
-            || {
-                EthBlockPolicy::new(
-                    GENESIS_SEQ_NUM,
-                    u128::MAX,
-                    NopStateRoot {}.get_delay().0,
-                    1337,
-                )
-            },
+            || EthBlockPolicy::new(GENESIS_SEQ_NUM, NopStateRoot {}.get_delay().0, 1337),
             || {
                 InMemoryStateInner::new(
                     u128::MAX,
@@ -4974,14 +4946,7 @@ mod test {
             num_states as u32,
             ValidatorSetFactory::default(),
             SimpleRoundRobin::default(),
-            || {
-                EthBlockPolicy::new(
-                    GENESIS_SEQ_NUM,
-                    u128::MAX,
-                    NopStateRoot {}.get_delay().0,
-                    1337,
-                )
-            },
+            || EthBlockPolicy::new(GENESIS_SEQ_NUM, NopStateRoot {}.get_delay().0, 1337),
             || {
                 InMemoryStateInner::new(
                     u128::MAX,
@@ -5092,14 +5057,7 @@ mod test {
             num_states as u32,
             ValidatorSetFactory::default(),
             SimpleRoundRobin::default(),
-            || {
-                EthBlockPolicy::new(
-                    GENESIS_SEQ_NUM,
-                    u128::MAX,
-                    NopStateRoot {}.get_delay().0,
-                    1337,
-                )
-            },
+            || EthBlockPolicy::new(GENESIS_SEQ_NUM, NopStateRoot {}.get_delay().0, 1337),
             || InMemoryStateInner::genesis(u128::MAX, SeqNum(4)),
             || EthValidator::new(10000, u64::MAX, 1337),
             EthTxPool::default(),

--- a/monad-eth-block-policy/Cargo.toml
+++ b/monad-eth-block-policy/Cargo.toml
@@ -14,9 +14,9 @@ monad-state-backend = { path = "../monad-state-backend" }
 monad-eth-types = { path = "../monad-eth-types" }
 monad-types = { path = "../monad-types" }
 alloy-primitives = { workspace = true }
+reth-primitives = { workspace = true }
 itertools = { workspace = true }
 sorted_vector_map = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-reth-primitives = { workspace = true }

--- a/monad-eth-block-validator/Cargo.toml
+++ b/monad-eth-block-validator/Cargo.toml
@@ -15,6 +15,7 @@ monad-state-backend = { path = "../monad-state-backend" }
 
 alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }
+reth-primitives = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/monad-eth-txpool/benches/clear.rs
+++ b/monad-eth-txpool/benches/clear.rs
@@ -2,7 +2,6 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use itertools::Itertools;
 use monad_consensus_types::txpool::TxPool;
 use monad_eth_block_policy::EthBlockPolicy;
-use monad_eth_types::Balance;
 use monad_state_backend::InMemoryState;
 use monad_types::{SeqNum, GENESIS_SEQ_NUM};
 
@@ -13,7 +12,7 @@ mod common;
 fn criterion_benchmark(c: &mut Criterion) {
     // TODO: change this to something more meaningful, i.e. what's is the block
     // policy state we want to benchmark
-    let block_policy = EthBlockPolicy::new(GENESIS_SEQ_NUM, Balance::MAX, EXECUTION_DELAY, 1337);
+    let block_policy = EthBlockPolicy::new(GENESIS_SEQ_NUM, EXECUTION_DELAY, 1337);
 
     run_txpool_benches(
         c,

--- a/monad-eth-txpool/benches/create_proposal.rs
+++ b/monad-eth-txpool/benches/create_proposal.rs
@@ -2,7 +2,6 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use itertools::Itertools;
 use monad_consensus_types::txpool::TxPool;
 use monad_eth_block_policy::EthBlockPolicy;
-use monad_eth_types::Balance;
 use monad_state_backend::InMemoryState;
 use monad_types::{SeqNum, GENESIS_SEQ_NUM};
 
@@ -13,7 +12,7 @@ mod common;
 fn criterion_benchmark(c: &mut Criterion) {
     // TODO: change this to something more meaningful, i.e. what's is the block
     // policy state we want to benchmark
-    let block_policy = EthBlockPolicy::new(GENESIS_SEQ_NUM, Balance::MAX, EXECUTION_DELAY, 1337);
+    let block_policy = EthBlockPolicy::new(GENESIS_SEQ_NUM, EXECUTION_DELAY, 1337);
 
     run_txpool_benches(
         c,

--- a/monad-eth-txpool/benches/insert.rs
+++ b/monad-eth-txpool/benches/insert.rs
@@ -4,7 +4,6 @@ use itertools::Itertools;
 use monad_consensus_types::txpool::TxPool;
 use monad_eth_block_policy::EthBlockPolicy;
 use monad_eth_txpool::EthTxPool;
-use monad_eth_types::Balance;
 use monad_state_backend::InMemoryState;
 use monad_types::GENESIS_SEQ_NUM;
 
@@ -15,7 +14,7 @@ mod common;
 fn criterion_benchmark(c: &mut Criterion) {
     // TODO: change this to something more meaningful, i.e. what's is the block
     // policy state we want to benchmark
-    let block_policy = EthBlockPolicy::new(GENESIS_SEQ_NUM, Balance::MAX, EXECUTION_DELAY, 1337);
+    let block_policy = EthBlockPolicy::new(GENESIS_SEQ_NUM, EXECUTION_DELAY, 1337);
 
     run_txpool_benches(
         c,

--- a/monad-eth-txpool/tests/txpool.rs
+++ b/monad-eth-txpool/tests/txpool.rs
@@ -54,7 +54,7 @@ type QC = QuorumCertificate<MockSignatures<SignatureType>>;
 type Pool = dyn TxPool<MockSignatures<SignatureType>, EthBlockPolicy, StateBackendType>;
 
 fn make_test_block_policy() -> EthBlockPolicy {
-    EthBlockPolicy::new(GENESIS_SEQ_NUM, u128::MAX, EXECUTION_DELAY, 1337)
+    EthBlockPolicy::new(GENESIS_SEQ_NUM, EXECUTION_DELAY, 1337)
 }
 
 enum TxPoolTestEvent<'a> {
@@ -730,7 +730,7 @@ fn test_invalid_chain_id() {
     let tx1 = make_tx(S1, BASE_FEE, GAS_LIMIT, 1, 10);
 
     run_custom_eth_txpool_test(
-        EthBlockPolicy::new(GENESIS_SEQ_NUM, u128::MAX, 0, 1),
+        EthBlockPolicy::new(GENESIS_SEQ_NUM, 0, 1),
         None,
         [
             TxPoolTestEvent::InsertTxs {

--- a/monad-mock-swarm/tests/forkpoint.rs
+++ b/monad-mock-swarm/tests/forkpoint.rs
@@ -169,7 +169,6 @@ fn forkpoint_restart_f(
         || {
             EthBlockPolicy::new(
                 GENESIS_SEQ_NUM,
-                1_000_000, // reserve balance
                 state_root_delay.0,
                 10, // chain_id
             )
@@ -204,7 +203,6 @@ fn forkpoint_restart_f(
             || {
                 EthBlockPolicy::new(
                     GENESIS_SEQ_NUM,
-                    1_000_000, // reserve balance
                     state_root_delay.0,
                     10, // chain_id
                 )
@@ -228,7 +226,6 @@ fn forkpoint_restart_f(
             || {
                 EthBlockPolicy::new(
                     GENESIS_SEQ_NUM,
-                    1_000_000, // reserve balance
                     state_root_delay.0,
                     10, // chain_id
                 )
@@ -487,7 +484,6 @@ fn forkpoint_restart_below_all(
         || {
             EthBlockPolicy::new(
                 GENESIS_SEQ_NUM,
-                1_000_000, // reserve balance
                 state_root_delay.0,
                 10, // chain_id
             )
@@ -532,7 +528,6 @@ fn forkpoint_restart_below_all(
             || {
                 EthBlockPolicy::new(
                     GENESIS_SEQ_NUM,
-                    1_000_000, // reserve balance
                     state_root_delay.0,
                     10, // chain_id
                 )
@@ -556,7 +551,6 @@ fn forkpoint_restart_below_all(
             || {
                 EthBlockPolicy::new(
                     GENESIS_SEQ_NUM,
-                    1_000_000, // reserve balance
                     state_root_delay.0,
                     10, // chain_id
                 )

--- a/monad-mock-swarm/tests/nonces.rs
+++ b/monad-mock-swarm/tests/nonces.rs
@@ -109,7 +109,7 @@ mod test {
             SimpleRoundRobin::default,
             EthTxPool::default,
             || EthValidator::new(10_000, 1_000_000, 1337),
-            || EthBlockPolicy::new(GENESIS_SEQ_NUM, Balance::MAX, execution_delay.0, 1337),
+            || EthBlockPolicy::new(GENESIS_SEQ_NUM, execution_delay.0, 1337),
             || {
                 InMemoryStateInner::new(
                     Balance::MAX,

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -322,7 +322,6 @@ async fn run(
         // mode
         block_policy: EthBlockPolicy::new(
             GENESIS_SEQ_NUM, // FIXME: MonadStateBuilder is responsible for updating this to forkpoint root if necessary
-            node_state.node_config.consensus.max_reserve_balance.into(),
             node_state.node_config.consensus.execution_delay,
             node_state.node_config.chain_id,
         ),

--- a/monad-state-backend/src/lib.rs
+++ b/monad-state-backend/src/lib.rs
@@ -61,9 +61,9 @@ pub struct InMemoryStateInner {
     states: BTreeMap<SeqNum, InMemoryBlockState>,
     commits: BTreeSet<SeqNum>,
     /// InMemoryState doesn't have access to an execution engine. It returns
-    /// `max_reserve_balance` as the balance every time so txn reserve balance
-    /// will pass if the sum doesn't exceed the max reserve
-    max_reserve_balance: Balance,
+    /// `max_account_balance` as the balance every time so txn fee balance check
+    /// will pass if the sum doesn't exceed the max account balance
+    max_account_balance: Balance,
     execution_delay: SeqNum,
 }
 
@@ -83,7 +83,7 @@ impl InMemoryBlockState {
 }
 
 impl InMemoryStateInner {
-    pub fn genesis(max_reserve_balance: Balance, execution_delay: SeqNum) -> InMemoryState {
+    pub fn genesis(max_account_balance: Balance, execution_delay: SeqNum) -> InMemoryState {
         Arc::new(Mutex::new(Self {
             states: std::iter::once((
                 GENESIS_SEQ_NUM,
@@ -91,19 +91,19 @@ impl InMemoryStateInner {
             ))
             .collect(),
             commits: std::iter::once(GENESIS_SEQ_NUM).collect(),
-            max_reserve_balance,
+            max_account_balance,
             execution_delay,
         }))
     }
     pub fn new(
-        max_reserve_balance: Balance,
+        max_account_balance: Balance,
         execution_delay: SeqNum,
         init_state: InMemoryBlockState,
     ) -> InMemoryState {
         Arc::new(Mutex::new(Self {
             states: std::iter::once((init_state.block, init_state)).collect(),
             commits: std::iter::once(GENESIS_SEQ_NUM).collect(),
-            max_reserve_balance,
+            max_account_balance,
             execution_delay,
         }))
     }
@@ -153,7 +153,7 @@ impl StateBackend for InMemoryStateInner {
         let nonce = self.states.get(&block)?.nonces.get(address)?;
         Some(EthAccount {
             nonce: *nonce,
-            balance: self.max_reserve_balance,
+            balance: self.max_account_balance,
             code_hash: None,
         })
     }


### PR DESCRIPTION
This PR changes the txn validation. The code path that was validating reserve balance is changed to compute the low bound of an account balance. The account balance is computed as the "account balance K blocks ago"  - (max gas * max_gas_fee + tx value) for all transactions in recent K blocks.
the max cost of transactions in insert, create and validate proposal is validated  to be not greater than the computed balance.