### PR TITLE
Get transaction location in block using transaction hash

### DIFF
--- a/monad-rpc/src/block_handlers.rs
+++ b/monad-rpc/src/block_handlers.rs
@@ -316,7 +316,7 @@ pub struct MonadEthGetBlockReceiptsParams {
 #[derive(Serialize, Debug, schemars::JsonSchema)]
 pub struct MonadEthGetBlockReceiptsResult(Vec<MonadTransactionReceipt>);
 
-#[rpc(method = "eth_getBlockReceipts", ignore = "file_ledger_reader")]
+#[rpc(method = "eth_getBlockReceipts")]
 #[allow(non_snake_case)]
 /// Returns the receipts of a block by number or hash.
 pub async fn monad_eth_getBlockReceipts<T: Triedb>(

--- a/monad-rpc/src/debug.rs
+++ b/monad-rpc/src/debug.rs
@@ -35,7 +35,7 @@ pub async fn monad_debug_getRawBlock<T: Triedb>(
     Ok(hex::encode(&raw_block))
 }
 
-#[rpc(method = "debug_getRawHeader", ignore = "file_ledger_reader")]
+#[rpc(method = "debug_getRawHeader")]
 #[allow(non_snake_case)]
 /// Returns an RLP-encoded header.
 pub async fn monad_debug_getRawHeader<T: Triedb>(

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -281,9 +281,9 @@ async fn rpc_select(
                 .map(serialize_result)?
         }
         "eth_getTransactionByHash" => {
-            if let Some(reader) = app_state.file_ledger_reader.as_ref() {
+            if let Some(triedb_env) = app_state.triedb_reader.as_ref() {
                 let params = serde_json::from_value(params).invalid_params()?;
-                monad_eth_getTransactionByHash(reader, params)
+                monad_eth_getTransactionByHash(triedb_env, params)
                     .await
                     .map(serialize_result)?
             } else {
@@ -455,12 +455,8 @@ async fn rpc_select(
                 return Err(JsonRpcError::method_not_supported());
             };
 
-            let Some(file_ledger_reader) = &app_state.file_ledger_reader else {
-                return Err(JsonRpcError::method_not_supported());
-            };
-
             let params = serde_json::from_value(params).invalid_params()?;
-            monad_eth_getTransactionReceipt(file_ledger_reader, triedb_reader, params)
+            monad_eth_getTransactionReceipt(triedb_reader, params)
                 .await
                 .map(serialize_result)?
         }

--- a/monad-triedb-utils/src/decode.rs
+++ b/monad-triedb-utils/src/decode.rs
@@ -83,3 +83,24 @@ pub fn rlp_decode_storage_slot(storage_rlp: Vec<u8>) -> Option<[u8; 32]> {
         }
     }
 }
+
+pub fn rlp_decode_transaction_location(transaction_location_rlp: Vec<u8>) -> Option<(u64, u64)> {
+    let mut buf = transaction_location_rlp.as_slice();
+
+    let Ok(mut buf) = alloy_rlp::Header::decode_bytes(&mut buf, true) else {
+        warn!("rlp decode failed: {:?}", buf);
+        return None;
+    };
+
+    let Ok(block_num) = u64::decode(&mut buf) else {
+        warn!("rlp block number decode failed: {:?}", buf);
+        return None;
+    };
+
+    let Ok(tx_index) = u64::decode(&mut buf) else {
+        warn!("rlp transaction index decode failed: {:?}", buf);
+        return None;
+    };
+
+    Some((block_num, tx_index))
+}

--- a/monad-triedb-utils/src/key.rs
+++ b/monad-triedb-utils/src/key.rs
@@ -200,3 +200,34 @@ pub fn create_block_header_key() -> (Vec<u8>, u8) {
 
     (key, num_nibbles)
 }
+
+pub fn create_transaction_hash_key(tx_hash: &[u8; 32]) -> (Vec<u8>, u8) {
+    let mut key_nibbles: Vec<u8> = vec![];
+
+    let tx_hash_nibble = 7_u8;
+    key_nibbles.push(tx_hash_nibble);
+
+    for byte in tx_hash {
+        key_nibbles.push(*byte >> 4);
+        key_nibbles.push(*byte & 0xF);
+    }
+
+    let num_nibbles: u8 = match key_nibbles.len().try_into() {
+        Ok(len) => len,
+        Err(_) => {
+            warn!("Key too big, returning an empty key");
+            return (vec![], 0);
+        }
+    };
+
+    if num_nibbles % 2 != 0 {
+        key_nibbles.push(0);
+    }
+
+    let key: Vec<_> = key_nibbles
+        .chunks(2)
+        .map(|chunk| (chunk[0] << 4) | chunk[1])
+        .collect();
+
+    (key, num_nibbles)
+}


### PR DESCRIPTION
Recover endpoints that query by transaction hash: https://github.com/monad-crypto/monad-internal/issues/721 

Dependent on https://github.com/monad-crypto/monad/pull/973