### PR TITLE
Cleanup metrics using macros

### DIFF
--- a/monad-consensus-types/Cargo.toml
+++ b/monad-consensus-types/Cargo.toml
@@ -23,9 +23,9 @@ hex = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
+serde = { workspace = true, features = ["serde_derive"] }
 tracing = { workspace = true }
 zerocopy = { workspace = true }
-serde = { workspace = true, features = ["serde_derive"] }
 
 [dev-dependencies]
 test-case = { workspace = true }


### PR DESCRIPTION
This change reduces adding a new metric to a one line change with the name of the metric in the appropriate metric subcategory. The macro introduced guaranteed that the field is added to the corresponding metric subcategory struct and that it is included in the metrics() function.