### PR TITLE
Implement periodic pings to calculate network latency

### DIFF
--- a/monad-consensus-state/benches/state_machine.rs
+++ b/monad-consensus-state/benches/state_machine.rs
@@ -192,7 +192,7 @@ where
     block_validator: EthValidator,
     block_policy: EthBlockPolicy,
     state_backend: InMemoryState,
-    block_timestamp: BlockTimestamp,
+    block_timestamp: BlockTimestamp<SCT::NodeIdPubKey>,
     beneficiary: EthAddress,
     nodeid: NodeId<CertificateSignaturePubKey<ST>>,
     consensus_config: ConsensusConfig,

--- a/monad-consensus-state/src/timestamp.rs
+++ b/monad-consensus-state/src/timestamp.rs
@@ -1,24 +1,201 @@
-use monad_consensus_types::quorum_certificate::{
-    TimestampAdjustment, TimestampAdjustmentDirection,
+use std::{
+    collections::HashMap,
+    hash::{DefaultHasher, Hash, Hasher},
+    time::{Duration, Instant},
 };
 
+use monad_consensus_types::{
+    quorum_certificate::{TimestampAdjustment, TimestampAdjustmentDirection},
+    signature_collection::SignatureCollection,
+    validator_data::ValidatorData,
+};
+use monad_crypto::certificate_signature::PubKey;
+use monad_types::{NodeId, PingSequence, Round};
+use tracing::info;
+
+const MAX_LATENCY_SAMPLES: usize = 100;
+
+const PING_PERIOD: Duration = Duration::from_secs(30);
+
+pub const PING_TICK_DURATION: Duration = Duration::from_secs(1);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Error {
+    Invalid,     // timestamp did not increment compared to previous block
+    OutOfBounds, // timestamp is out of bounds compared to local time
+}
+
+/// Ping state per validator
 #[derive(Debug)]
-pub struct BlockTimestamp {
+pub struct ValidatorPingState {
+    sequence: PingSequence,        // sequence number of the last ping sent
+    latencies: Vec<Duration>,      // latencies of the last pings
+    sum: Duration,                 // sum of the last latencies
+    next_index: usize,             // index of the next latency to be replaced
+    last_ping_time: Instant,       // time of the last ping sent
+    avg_latency: Option<Duration>, // average latency
+}
+
+impl Default for ValidatorPingState {
+    fn default() -> Self {
+        Self {
+            sequence: PingSequence(0),
+            next_index: 0,
+            sum: Default::default(),
+            latencies: Vec::new(),
+            last_ping_time: Instant::now(),
+            avg_latency: None,
+        }
+    }
+}
+
+impl ValidatorPingState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // initiate a new ping
+    pub fn start_next(&mut self) -> PingSequence {
+        self.sequence.0 += 1;
+        self.last_ping_time = Instant::now();
+        self.sequence
+    }
+
+    fn update_latency(&mut self, latency: Duration) {
+        if self.latencies.len() == MAX_LATENCY_SAMPLES {
+            self.sum -= self.latencies[self.next_index];
+            self.latencies[self.next_index] = latency;
+            self.next_index = (self.next_index + 1) % MAX_LATENCY_SAMPLES;
+        } else {
+            self.latencies.push(latency);
+        }
+        self.sum += latency;
+        self.avg_latency = Some(self.sum / self.latencies.len() as u32);
+    }
+
+    pub fn pong_received(&mut self, sequence: PingSequence) {
+        if sequence != self.sequence {
+            return;
+        }
+        // estimate latency as half the round trip time
+        self.update_latency(self.last_ping_time.elapsed() / 2);
+    }
+
+    pub fn avg_latency(&self) -> Option<Duration> {
+        self.avg_latency
+    }
+}
+
+#[derive(Debug)]
+struct PingState<P: PubKey> {
+    validators: HashMap<NodeId<P>, ValidatorPingState>, // ping state per validator
+    schedule: Vec<Vec<NodeId<P>>>, // schedule of validators to ping, length is period
+    tick: usize,                   // current tick index into schedule
+    period: usize,                 // number of ticks in full schedule
+}
+
+impl<P: PubKey> PingState<P> {
+    pub fn new() -> Self {
+        let period = PING_PERIOD.as_secs() as usize;
+        Self {
+            validators: HashMap::new(),
+            schedule: vec![Vec::new(); period],
+            tick: 0,
+            period,
+        }
+    }
+
+    pub fn pong_received(&mut self, node_id: NodeId<P>, sequence: PingSequence) {
+        if let Some(validator_state) = self.validators.get_mut(&node_id) {
+            validator_state.pong_received(sequence);
+            info!(
+                "node {:?} latency {:?}",
+                node_id,
+                validator_state.avg_latency()
+            );
+        }
+    }
+
+    fn update_validators<SCT>(&mut self, validators: &Vec<ValidatorData<SCT>>, my_node: &NodeId<P>)
+    where
+        SCT: SignatureCollection<NodeIdPubKey = P>,
+    {
+        let removed_nodes = self
+            .validators
+            .keys()
+            .filter(|node_id| !validators.iter().any(|v| v.node_id == **node_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        for node_id in removed_nodes {
+            self.validators.remove(&node_id);
+        }
+        for validator in validators {
+            if validator.node_id == *my_node {
+                continue;
+            }
+            self.validators
+                .entry(NodeId::new(validator.node_id.pubkey()))
+                .or_default();
+        }
+
+        // map validators to schedule slots by hashing node id
+        for s in self.schedule.iter_mut() {
+            s.clear();
+        }
+        for node in self.validators.keys() {
+            let mut hasher = DefaultHasher::new();
+            node.hash(&mut hasher);
+            let idx = (hasher.finish() as usize) % self.period;
+            self.schedule[idx].push(*node);
+        }
+    }
+
+    // returns list of nodes to send pings to on this tick
+    fn tick(&mut self) -> Vec<(NodeId<P>, PingSequence)> {
+        let mut pings = Vec::new();
+        for node_id in self.schedule[self.tick].iter() {
+            let validator_state = self.validators.get_mut(node_id).unwrap();
+            let sequence = validator_state.start_next();
+            pings.push((*node_id, sequence));
+        }
+        self.tick = (self.tick + 1) % self.period;
+        pings
+    }
+
+    fn get_latency(&self, node_id: &NodeId<P>) -> Option<Duration> {
+        self.validators.get(node_id).and_then(|v| v.avg_latency())
+    }
+}
+
+#[derive(Debug)]
+struct SentVote {
+    round: Round,
+    timestamp: Instant,
+}
+
+#[derive(Debug)]
+pub struct BlockTimestamp<P: PubKey> {
     local_time: u64,
 
     max_delta: u64,
+
+    ping_state: PingState<P>,
+
+    sent_vote: Option<SentVote>, // last voted round and timestamp
 
     /// TODO: this needs an upper-bound
     latency_estimate_ms: u64,
 }
 
-impl BlockTimestamp {
+impl<P: PubKey> BlockTimestamp<P> {
     pub fn new(max_delta: u64, latency_estimate_ms: u64) -> Self {
         assert!(latency_estimate_ms > 0);
         Self {
             local_time: 0,
             max_delta,
             latency_estimate_ms,
+            ping_state: PingState::new(),
+            sent_vote: None,
         }
     }
 
@@ -49,71 +226,245 @@ impl BlockTimestamp {
         &self,
         prev_block_ts: u64,
         curr_block_ts: u64,
-    ) -> Option<TimestampAdjustment> {
-        let delta = curr_block_ts.checked_sub(prev_block_ts);
-        match delta {
+        round: Round,
+        author: &NodeId<P>,
+    ) -> Result<Option<TimestampAdjustment>, Error> {
+        if curr_block_ts <= prev_block_ts {
             // block timestamp must be strictly monotonically increasing
-            None => None,
-            Some(0) => None,
-            // check that its not higher than the valid upper bound
-            Some(_) => {
-                if !self.valid_bounds(curr_block_ts) {
-                    None
+            return Err(Error::Invalid);
+        }
+        if !self.valid_bounds(curr_block_ts) {
+            return Err(Error::OutOfBounds);
+        }
+        // return the delta between expected block time and actual block time for adjustment
+        match &self.sent_vote {
+            Some(vote) if vote.round + Round(1) == round => {
+                let latency = self
+                    .ping_state
+                    .get_latency(author)
+                    .unwrap_or(Duration::from_millis(self.latency_estimate_ms));
+                let expected_block_ts = self.local_time.saturating_sub(
+                    vote.timestamp.elapsed().saturating_sub(latency).as_millis() as u64,
+                );
+                if curr_block_ts > expected_block_ts {
+                    Ok(Some(TimestampAdjustment {
+                        delta: curr_block_ts - expected_block_ts,
+                        direction: TimestampAdjustmentDirection::Forward,
+                    }))
                 } else {
-                    // return the delta between local time and block time for adjustment
-                    let mut adjustment = self.local_time.abs_diff(curr_block_ts);
-                    // adjust for estimated latency
-                    adjustment = adjustment.saturating_sub(self.latency_estimate_ms);
-                    if curr_block_ts > self.local_time {
-                        Some(TimestampAdjustment {
-                            delta: adjustment,
-                            direction: TimestampAdjustmentDirection::Forward,
-                        })
-                    } else {
-                        Some(TimestampAdjustment {
-                            delta: adjustment,
-                            direction: TimestampAdjustmentDirection::Backward,
-                        })
-                    }
+                    Ok(Some(TimestampAdjustment {
+                        delta: expected_block_ts - curr_block_ts,
+                        direction: TimestampAdjustmentDirection::Backward,
+                    }))
                 }
             }
+            _ => Ok(None),
         }
+    }
+
+    pub fn update_validators<SCT>(
+        &mut self,
+        validators: &Vec<ValidatorData<SCT>>,
+        my_node: &NodeId<P>,
+    ) where
+        SCT: SignatureCollection<NodeIdPubKey = P>,
+    {
+        self.ping_state.update_validators(validators, my_node);
+    }
+
+    pub fn tick(&mut self) -> Vec<(NodeId<P>, PingSequence)> {
+        self.ping_state.tick()
+    }
+
+    pub fn pong_received(&mut self, node_id: NodeId<P>, sequence: PingSequence) {
+        self.ping_state.pong_received(node_id, sequence);
+    }
+
+    pub fn vote_sent(&mut self, round: Round) {
+        self.sent_vote = Some(SentVote {
+            round,
+            timestamp: Instant::now(),
+        });
     }
 }
 
 #[cfg(test)]
 mod test {
+    use std::time::Duration;
+
     use monad_consensus_types::quorum_certificate::{
         TimestampAdjustment, TimestampAdjustmentDirection,
     };
+    use monad_crypto::{
+        certificate_signature::CertificateKeyPair, NopKeyPair, NopPubKey, NopSignature,
+    };
+    use monad_testutil::signing::create_keys;
+    use monad_types::{NodeId, Round, Stake};
 
-    use crate::BlockTimestamp;
+    use crate::{
+        timestamp::{PingState, ValidatorPingState},
+        BlockTimestamp, ValidatorData,
+    };
 
     #[test]
     fn test_block_timestamp_validate() {
-        let mut b = BlockTimestamp::new(10, 1);
-        b.update_time(0);
+        let mut b = BlockTimestamp::<NopPubKey>::new(10, 1);
+        let author = NodeId::new(NopKeyPair::from_bytes(&mut [0; 32]).unwrap().pubkey());
 
-        assert!(b.valid_block_timestamp(1, 1).is_none());
-        assert!(b.valid_block_timestamp(2, 1).is_none());
-        assert!(b.valid_block_timestamp(0, 11).is_none());
-
-        assert!(matches!(
-            b.valid_block_timestamp(1, 2),
-            Some(TimestampAdjustment {
-                delta: 1,
-                direction: TimestampAdjustmentDirection::Forward
-            })
-        ));
+        b.ping_state
+            .validators
+            .insert(author, ValidatorPingState::new());
+        b.ping_state
+            .validators
+            .get_mut(&author)
+            .unwrap()
+            .update_latency(Duration::from_millis(1));
 
         b.update_time(10);
+        b.vote_sent(Round(0));
+
+        assert!(b.valid_block_timestamp(11, 11, Round(1), &author).is_err());
+        assert!(b.valid_block_timestamp(12, 11, Round(1), &author).is_err());
+        assert!(b.valid_block_timestamp(9, 21, Round(1), &author).is_err());
+
+        b.update_time(12);
+        std::thread::sleep(Duration::from_millis(2));
 
         assert!(matches!(
-            b.valid_block_timestamp(5, 8),
-            Some(TimestampAdjustment {
+            b.valid_block_timestamp(9, 12, Round(1), &author),
+            Ok(Some(TimestampAdjustment {
+                delta: 1,
+                direction: TimestampAdjustmentDirection::Forward
+            }))
+        ));
+
+        assert!(matches!(
+            b.valid_block_timestamp(5, 10, Round(1), &author),
+            Ok(Some(TimestampAdjustment {
                 delta: 1,
                 direction: TimestampAdjustmentDirection::Backward
-            })
+            }))
         ));
+    }
+
+    #[test]
+    fn test_ping_state() {
+        let mut state = ValidatorPingState::new();
+        let seq = state.start_next();
+        state.update_latency(Duration::from_millis(1));
+
+        assert_eq!(state.avg_latency().unwrap().as_millis(), 1);
+        state.update_latency(Duration::from_millis(3));
+        assert_eq!(state.avg_latency().unwrap().as_millis(), 2);
+        state.update_latency(Duration::from_millis(6));
+        assert_eq!(state.avg_latency().unwrap().as_millis(), 3);
+
+        for _ in 0..100 {
+            state.update_latency(Duration::from_millis(10));
+        }
+
+        assert_eq!(state.sum, state.latencies.iter().sum::<Duration>());
+        assert_eq!(
+            state.avg_latency().unwrap(),
+            state.sum / state.latencies.len() as u32
+        );
+
+        for _ in 0..50 {
+            state.update_latency(Duration::from_millis(50));
+        }
+
+        assert_eq!(state.sum, state.latencies.iter().sum::<Duration>());
+        assert_eq!(
+            state.avg_latency().unwrap(),
+            state.sum / state.latencies.len() as u32
+        );
+    }
+
+    use monad_testutil::signing::MockSignatures;
+
+    use super::PING_PERIOD;
+
+    type SignatureType = NopSignature;
+    type SignatureCollection = MockSignatures<SignatureType>;
+
+    #[test]
+    fn test_update_validators() {
+        let mut s = PingState::<NopPubKey>::new();
+
+        let keys = create_keys::<NopSignature>(3);
+        let nodes: Vec<_> = keys.iter().map(|k| NodeId::new(k.pubkey())).collect();
+
+        let my_key = keys[0].pubkey();
+        let my_node = nodes[0];
+
+        let validators = vec![
+            ValidatorData::<SignatureCollection> {
+                node_id: nodes[1],
+                stake: Stake(1),
+                cert_pubkey: nodes[1].pubkey(),
+            },
+            ValidatorData {
+                node_id: nodes[2],
+                stake: Stake(1),
+                cert_pubkey: nodes[1].pubkey(),
+            },
+        ];
+
+        s.update_validators(&validators, &my_node);
+
+        assert_eq!(s.validators.len(), 2);
+
+        let validators_1 = vec![validators[0].clone()];
+
+        s.update_validators(&validators_1, &my_node);
+
+        assert_eq!(s.validators.len(), 1);
+        assert!(s.validators.contains_key(&nodes[1]));
+
+        let validators_2 = vec![validators[1].clone()];
+        s.update_validators(&validators_2, &my_node);
+
+        assert_eq!(s.validators.len(), 1);
+        assert!(s.validators.contains_key(&nodes[2]));
+    }
+
+    #[test]
+    fn test_ticks() {
+        let mut s = PingState::<NopPubKey>::new();
+
+        let my_key = NopKeyPair::from_bytes(&mut [0; 32]).unwrap().pubkey();
+        let my_node = NodeId::new(my_key);
+
+        let k_1 = NopKeyPair::from_bytes(&mut [1; 32]).unwrap().pubkey();
+        let node_1 = NodeId::new(k_1);
+
+        let k_2 = NopKeyPair::from_bytes(&mut [2; 32]).unwrap().pubkey();
+        let node_2 = NodeId::new(k_2);
+
+        let validators = vec![
+            ValidatorData::<SignatureCollection> {
+                node_id: node_1,
+                stake: Stake(1),
+                cert_pubkey: node_1.pubkey(),
+            },
+            ValidatorData {
+                node_id: node_2,
+                stake: Stake(1),
+                cert_pubkey: node_2.pubkey(),
+            },
+        ];
+
+        s.update_validators(&validators, &my_node);
+
+        let mut pings = Vec::new();
+        for _ in 0..PING_PERIOD.as_secs() {
+            pings.extend(s.tick());
+        }
+
+        assert_eq!(
+            pings.len(),
+            validators.len(),
+            "number of pings in total period should match number of validators"
+        );
     }
 }

--- a/monad-debugger/src/graphql.rs
+++ b/monad-debugger/src/graphql.rs
@@ -242,6 +242,9 @@ impl<'s> From<&'s MonadEventType> for GraphQLMonadEvent<'s> {
                 Self::TimestampEvent(GraphQLTimestampEvent(*event))
             }
             MonadEvent::StateSyncEvent(event) => Self::StateSyncEvent(GraphQLStateSyncEvent(event)),
+            MonadEvent::PingRequestEvent(_)
+            | MonadEvent::PingResponseEvent(_)
+            | MonadEvent::PingTickEvent => todo!(),
         }
     }
 }

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -25,7 +25,7 @@ use monad_consensus_types::{
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
 };
-use monad_types::{Epoch, NodeId, Round, RouterTarget, SeqNum, Stake};
+use monad_types::{Epoch, NodeId, PingSequence, Round, RouterTarget, SeqNum, Stake};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug)]
@@ -62,6 +62,7 @@ pub enum TimeoutVariant {
     Pacemaker,
     BlockSync(BlockSyncRequestMessage),
     SendVote,
+    Ping,
 }
 
 #[derive(Debug)]
@@ -548,6 +549,12 @@ pub enum StateSyncEvent<SCT: SignatureCollection> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PingEvent<SCT: SignatureCollection> {
+    pub sender: NodeId<SCT::NodeIdPubKey>,
+    pub sequence: PingSequence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ControlPanelEvent<SCT>
 where
     SCT: SignatureCollection,
@@ -588,6 +595,9 @@ where
     TimestampUpdateEvent(u64),
     /// Events to statesync
     StateSyncEvent(StateSyncEvent<SCT>),
+    PingRequestEvent(PingEvent<SCT>),
+    PingResponseEvent(PingEvent<SCT>),
+    PingTickEvent,
 }
 
 impl<ST, SCT> monad_types::Deserializable<[u8]> for MonadEvent<ST, SCT>
@@ -654,6 +664,13 @@ where
             MonadEvent::ControlPanelEvent(_) => "CONTROLPANELEVENT".to_string(),
             MonadEvent::TimestampUpdateEvent(t) => format!("MempoolEvent::TimestampUpdate: {t}"),
             MonadEvent::StateSyncEvent(_) => "STATESYNC".to_string(),
+            MonadEvent::PingRequestEvent(e) => {
+                format!("PingRequestEvent: {} {}", e.sender, e.sequence.0)
+            }
+            MonadEvent::PingResponseEvent(e) => {
+                format!("PingResponseEvent: {} {}", e.sender, e.sequence.0)
+            }
+            MonadEvent::PingTickEvent => "PingTickEvent".to_string(),
         };
 
         write!(f, "{}", s)

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -247,7 +247,7 @@ impl<S: SwarmRelation> MockExecutor<S> {
                     .ready()
                     .then_some((self.tick, ExecutorEventType::StateSync)),
             )
-            .min()
+            .min_by(|(a, _), (b, _)| a.cmp(b))
     }
 
     pub fn peek_tick(&self) -> Option<Duration> {

--- a/monad-mock-swarm/src/transformer.rs
+++ b/monad-mock-swarm/src/transformer.rs
@@ -60,8 +60,10 @@ where
             VerifiedMonadMessage::BlockSyncRequest(_)
             | VerifiedMonadMessage::BlockSyncResponse(_) => self.drop_block_sync,
             VerifiedMonadMessage::PeerStateRootMessage(_) => self.drop_state_root,
-            VerifiedMonadMessage::ForwardedTx(_) => false,
-            VerifiedMonadMessage::StateSyncMessage(_) => false,
+            VerifiedMonadMessage::ForwardedTx(_)
+            | VerifiedMonadMessage::StateSyncMessage(_)
+            | VerifiedMonadMessage::PingRequest(_)
+            | VerifiedMonadMessage::PingResponse(_) => false,
         };
 
         if should_drop {
@@ -160,6 +162,8 @@ where
                 TwinsCapture::Drop
             }
             VerifiedMonadMessage::StateSyncMessage(_) => TwinsCapture::Spread(pid),
+            VerifiedMonadMessage::PingRequest(_) => TwinsCapture::Spread(pid),
+            VerifiedMonadMessage::PingResponse(_) => TwinsCapture::Spread(pid),
         };
 
         match capture {

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -247,6 +247,20 @@ message ProtoStateSyncEvent {
   }
 }
 
+message PingRequestEvent {
+  monad_proto.basic.ProtoNodeId sender = 1;
+  uint64 sequence = 2;
+}
+
+message PingResponseEvent {
+  monad_proto.basic.ProtoNodeId sender = 1;
+  uint64 sequence = 2;
+}
+
+message PingTickEvent {
+
+}
+
 message ProtoMonadEvent{
   oneof event {
     ProtoConsensusEvent consensus_event = 1;
@@ -258,5 +272,8 @@ message ProtoMonadEvent{
     ProtoControlPanelEvent control_panel_event = 7;
     ProtoTimestampUpdate timestamp_update_event = 8;
     ProtoStateSyncEvent state_sync_event = 9;
+    PingRequestEvent ping_request = 10;
+    PingResponseEvent ping_response = 11;
+    PingTickEvent ping_tick = 12;
   }
 }

--- a/monad-proto/proto/message.proto
+++ b/monad-proto/proto/message.proto
@@ -103,6 +103,14 @@ message ProtoStateSyncNetworkMessage {
   }
 }
 
+message ProtoPingRequest {
+  uint64 sequence = 1;
+}
+
+message ProtoPingResponse {
+  uint64 sequence = 1;
+}
+
 message ProtoMonadMessage {
   oneof OneofMessage {
     ProtoUnverifiedConsensusMessage consensus = 1;
@@ -111,6 +119,8 @@ message ProtoMonadMessage {
     ProtoPeerStateRootMessage peer_state_root = 4;
     ProtoForwardedTx forwarded_tx = 5;
     ProtoStateSyncNetworkMessage state_sync_message = 6;
+    ProtoPingRequest ping_request = 7;
+    ProtoPingResponse ping_response = 8;
   }
 }
 message ProtoDiscoveryRequest {

--- a/monad-router-filter/src/lib.rs
+++ b/monad-router-filter/src/lib.rs
@@ -53,6 +53,8 @@ where
                     VerifiedMonadMessage::PeerStateRootMessage(_) => None,
                     VerifiedMonadMessage::ForwardedTx(_) => Some(cmd),
                     VerifiedMonadMessage::StateSyncMessage(_) => Some(cmd),
+                    VerifiedMonadMessage::PingRequest(_) => Some(cmd),
+                    VerifiedMonadMessage::PingResponse(_) => Some(cmd),
                 },
                 RouterCommand::AddEpochValidatorSet { .. } => Some(cmd),
                 RouterCommand::UpdateCurrentRound(..) => Some(cmd),

--- a/monad-state/src/consensus.rs
+++ b/monad-state/src/consensus.rs
@@ -64,7 +64,7 @@ where
     version: &'a MonadVersion,
 
     state_root_validator: &'a SVT,
-    block_timestamp: &'a BlockTimestamp,
+    block_timestamp: &'a mut BlockTimestamp<SCT::NodeIdPubKey>,
     block_validator: &'a BVT,
     beneficiary: &'a EthAddress,
     nodeid: &'a NodeId<CertificateSignaturePubKey<ST>>,
@@ -106,7 +106,7 @@ where
             version: &monad_state.version,
 
             state_root_validator: &monad_state.state_root_validator,
-            block_timestamp: &monad_state.block_timestamp,
+            block_timestamp: &mut monad_state.block_timestamp,
             block_validator: &monad_state.block_validator,
             beneficiary: &monad_state.beneficiary,
             nodeid: &monad_state.nodeid,

--- a/monad-state/src/convert/message.rs
+++ b/monad-state/src/convert/message.rs
@@ -3,6 +3,7 @@ use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_proto::{error::ProtoError, proto::message::*};
+use monad_types::PingSequence;
 
 use crate::{MonadMessage, VerifiedMonadMessage};
 
@@ -33,6 +34,16 @@ where
                 }
                 VerifiedMonadMessage::StateSyncMessage(msg) => {
                     proto_monad_message::OneofMessage::StateSyncMessage(msg.into())
+                }
+                VerifiedMonadMessage::PingRequest(msg) => {
+                    proto_monad_message::OneofMessage::PingRequest(ProtoPingRequest {
+                        sequence: msg.0,
+                    })
+                }
+                VerifiedMonadMessage::PingResponse(msg) => {
+                    proto_monad_message::OneofMessage::PingResponse(ProtoPingResponse {
+                        sequence: msg.0,
+                    })
                 }
             }),
         }
@@ -65,6 +76,12 @@ where
             }
             Some(proto_monad_message::OneofMessage::StateSyncMessage(msg)) => {
                 MonadMessage::StateSyncMessage(msg.try_into()?)
+            }
+            Some(proto_monad_message::OneofMessage::PingRequest(msg)) => {
+                MonadMessage::PingRequest(PingSequence(msg.sequence))
+            }
+            Some(proto_monad_message::OneofMessage::PingResponse(msg)) => {
+                MonadMessage::PingResponse(PingSequence(msg.sequence))
             }
             None => Err(ProtoError::MissingRequiredField(
                 "MonadMessage.oneofmessage".to_owned(),

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -17,7 +17,10 @@ use monad_consensus::{
     messages::{consensus_message::ConsensusMessage, message::PeerStateRootMessage},
     validation::signing::{verify_qc, Unvalidated, Unverified, Validated, Verified},
 };
-use monad_consensus_state::{timestamp::BlockTimestamp, ConsensusConfig, ConsensusState};
+use monad_consensus_state::{
+    timestamp::{BlockTimestamp, PING_TICK_DURATION},
+    ConsensusConfig, ConsensusState,
+};
 use monad_consensus_types::{
     block::{BlockPolicy, BlockType},
     block_validator::BlockValidator,
@@ -39,12 +42,12 @@ use monad_eth_types::EthAddress;
 use monad_executor_glue::{
     AsyncStateVerifyEvent, BlockSyncEvent, ClearMetrics, Command, ConsensusEvent,
     ControlPanelCommand, ControlPanelEvent, GetFullNodes, GetMetrics, GetPeers, GetValidatorSet,
-    LedgerCommand, MempoolEvent, Message, MonadEvent, ReadCommand, RouterCommand,
+    LedgerCommand, MempoolEvent, Message, MonadEvent, PingEvent, ReadCommand, RouterCommand,
     StateRootHashCommand, StateSyncCommand, StateSyncEvent, StateSyncNetworkMessage,
-    UpdateFullNodes, UpdatePeers, ValidatorEvent, WriteCommand,
+    TimeoutVariant, TimerCommand, UpdateFullNodes, UpdatePeers, ValidatorEvent, WriteCommand,
 };
 use monad_state_backend::StateBackend;
-use monad_types::{Epoch, NodeId, Round, RouterTarget, SeqNum, GENESIS_SEQ_NUM};
+use monad_types::{Epoch, NodeId, PingSequence, Round, RouterTarget, SeqNum, GENESIS_SEQ_NUM};
 use monad_validator::{
     epoch_manager::EpochManager,
     leader_election::LeaderElection,
@@ -479,7 +482,7 @@ where
     async_state_verify: ASVT,
 
     state_root_validator: SVT,
-    block_timestamp: BlockTimestamp,
+    block_timestamp: BlockTimestamp<SCT::NodeIdPubKey>,
     block_validator: BVT,
     block_policy: BPT,
     state_backend: SBT,
@@ -558,6 +561,8 @@ where
     PeerStateRootMessage(Validated<PeerStateRootMessage<SCT>>),
     ForwardedTx(Vec<Bytes>),
     StateSyncMessage(StateSyncNetworkMessage),
+    PingRequest(PingSequence),
+    PingResponse(PingSequence),
 }
 
 impl<ST, SCT> From<Verified<ST, Validated<ConsensusMessage<SCT>>>> for VerifiedMonadMessage<ST, SCT>
@@ -593,6 +598,10 @@ where
 
     /// State Sync msgs
     StateSyncMessage(StateSyncNetworkMessage),
+
+    PingRequest(PingSequence),
+
+    PingResponse(PingSequence),
 }
 
 impl<ST, SCT> monad_types::Serializable<Bytes> for VerifiedMonadMessage<ST, SCT>
@@ -620,6 +629,8 @@ where
             }
             VerifiedMonadMessage::ForwardedTx(msg) => MonadMessage::ForwardedTx(msg),
             VerifiedMonadMessage::StateSyncMessage(msg) => MonadMessage::StateSyncMessage(msg),
+            VerifiedMonadMessage::PingRequest(seq) => MonadMessage::PingRequest(seq),
+            VerifiedMonadMessage::PingResponse(seq) => MonadMessage::PingResponse(seq),
         }
     }
 }
@@ -651,6 +662,8 @@ where
             }
             VerifiedMonadMessage::ForwardedTx(msg) => MonadMessage::ForwardedTx(msg),
             VerifiedMonadMessage::StateSyncMessage(msg) => MonadMessage::StateSyncMessage(msg),
+            VerifiedMonadMessage::PingRequest(seq) => MonadMessage::PingRequest(seq),
+            VerifiedMonadMessage::PingResponse(seq) => MonadMessage::PingResponse(seq),
         }
     }
 }
@@ -703,6 +716,14 @@ where
             MonadMessage::StateSyncMessage(msg) => {
                 MonadEvent::StateSyncEvent(StateSyncEvent::Inbound(from, msg))
             }
+            MonadMessage::PingRequest(sequence) => MonadEvent::PingRequestEvent(PingEvent {
+                sender: from,
+                sequence,
+            }),
+            MonadMessage::PingResponse(sequence) => MonadEvent::PingResponseEvent(PingEvent {
+                sender: from,
+                sequence,
+            }),
         }
     }
 }
@@ -849,6 +870,12 @@ where
             StateSyncEvent::RequestSync { root, high_qc },
         )));
 
+        init_cmds.push(Command::TimerCommand(TimerCommand::Schedule {
+            duration: PING_TICK_DURATION,
+            variant: TimeoutVariant::Ping,
+            on_timeout: MonadEvent::PingTickEvent,
+        }));
+
         (monad_state, init_cmds)
     }
 }
@@ -897,6 +924,13 @@ where
             }
 
             MonadEvent::ValidatorEvent(validator_event) => {
+                match &validator_event {
+                    ValidatorEvent::UpdateValidators((validators, epoch)) => {
+                        self.block_timestamp
+                            .update_validators(&validators.0, &self.nodeid);
+                    }
+                }
+
                 let validator_cmds = EpochChildState::new(self).update(validator_event);
 
                 validator_cmds
@@ -947,7 +981,7 @@ where
                 }
                 StateSyncEvent::Outbound(to, message) => {
                     vec![Command::RouterCommand(RouterCommand::Publish {
-                        target: RouterTarget::TcpPointToPoint(to),
+                        target: RouterTarget::PointToPoint(to),
                         message: VerifiedMonadMessage::StateSyncMessage(message),
                     })]
                 }
@@ -1185,6 +1219,39 @@ where
             MonadEvent::TimestampUpdateEvent(t) => {
                 self.block_timestamp.update_time(t);
                 vec![]
+            }
+            MonadEvent::PingRequestEvent(PingEvent { sender, sequence }) => {
+                tracing::info!(?sender, ?sequence, "received ping request");
+                vec![Command::RouterCommand(RouterCommand::Publish {
+                    target: RouterTarget::TcpPointToPoint(sender),
+                    message: VerifiedMonadMessage::PingResponse(sequence),
+                })]
+            }
+            MonadEvent::PingResponseEvent(PingEvent { sender, sequence }) => {
+                tracing::info!(?sender, ?sequence, "received ping response");
+                self.block_timestamp.pong_received(sender, sequence);
+                vec![]
+            }
+            MonadEvent::PingTickEvent => {
+                tracing::info!("ping tick");
+                let mut cmds = self
+                    .block_timestamp
+                    .tick()
+                    .into_iter()
+                    .map(|(node, sequence)| {
+                        tracing::info!(?node, ?sequence, "sending ping request");
+                        Command::RouterCommand(RouterCommand::Publish {
+                            target: RouterTarget::TcpPointToPoint(node),
+                            message: VerifiedMonadMessage::PingRequest(sequence),
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                cmds.push(Command::TimerCommand(TimerCommand::Schedule {
+                    duration: std::time::Duration::from_secs(1),
+                    variant: TimeoutVariant::Ping,
+                    on_timeout: MonadEvent::PingTickEvent,
+                }));
+                cmds
             }
         }
     }

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -428,6 +428,9 @@ where
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PingSequence(pub u64);
+
 #[cfg(test)]
 mod test {
     use test_case::test_case;

--- a/monad-wal/examples/wal-tool.rs
+++ b/monad-wal/examples/wal-tool.rs
@@ -453,6 +453,9 @@ impl Widget for &EventListWidget {
                 MonadEvent::ControlPanelEvent(_) => "CONTROLPANEL".to_string(),
                 MonadEvent::TimestampUpdateEvent(_) => "TIMESTAMP".to_string(),
                 MonadEvent::StateSyncEvent(_) => "STATESYNC".to_string(),
+                MonadEvent::PingRequestEvent(_) => "PINGREQUEST".to_string(),
+                MonadEvent::PingResponseEvent(_) => "PINGRESPONSE".to_string(),
+                MonadEvent::PingTickEvent => "PINGTICK".to_string(),
             };
 
             let s = Span::styled(format!("{header_str:<20}"), Style::default().blue());
@@ -595,6 +598,9 @@ fn counter(events: &Vec<WalEvent>) -> HashMap<String, u64> {
             WalEvent::ControlPanelEvent(_) => "controlpanelevent",
             MonadEvent::TimestampUpdateEvent(_) => "timestampupdateevent",
             MonadEvent::StateSyncEvent(_) => "statesyncevent",
+            MonadEvent::PingRequestEvent(_) => "pingrequestevent",
+            MonadEvent::PingResponseEvent(_) => "pingresponseevent",
+            MonadEvent::PingTickEvent => "pingtickevent",
         };
 
         buckets


### PR DESCRIPTION
Periodically ping other validators and calculate average latency over a number of most recent pings.

The resulting latency will be used in calculating of timestamp adjustments.