### PR TITLE
Fix EthBlockPolicy reset bug on statesync

### DIFF
--- a/monad-consensus-types/src/block.rs
+++ b/monad-consensus-types/src/block.rs
@@ -341,7 +341,7 @@ where
 
     // TODO delete this function, pass recently committed blocks to check_coherency instead
     // This way, BlockPolicy doesn't need to be mutated
-    fn reset(&mut self, last_delay_committed_blocks: Vec<&Self::ValidatedBlock>);
+    fn reset(&mut self, last_delay_non_null_committed_blocks: Vec<&Self::ValidatedBlock>);
 }
 
 /// A block policy which does not validate the inner contents of the block

--- a/monad-eth-block-policy/src/lib.rs
+++ b/monad-eth-block-policy/src/lib.rs
@@ -686,11 +686,11 @@ where
         self.committed_cache.update_committed_block(block);
     }
 
-    fn reset(&mut self, last_delay_committed_blocks: Vec<&Self::ValidatedBlock>) {
+    fn reset(&mut self, last_delay_non_null_committed_blocks: Vec<&Self::ValidatedBlock>) {
         self.committed_cache = CommittedBlkBuffer::new(self.committed_cache.size);
         // TODO this is error-prone, easy to forget
         // TODO write tests that fail if this doesn't exist
-        let blocks = last_delay_committed_blocks
+        let blocks = last_delay_non_null_committed_blocks
             .into_iter()
             .filter(|block| !block.is_empty_block());
         for block in blocks {

--- a/monad-mock-swarm/tests/forkpoint.rs
+++ b/monad-mock-swarm/tests/forkpoint.rs
@@ -4,16 +4,14 @@ use std::{collections::BTreeSet, time::Duration};
 
 use itertools::Itertools;
 use monad_async_state_verify::{majority_threshold, PeerAsyncStateVerify};
-use monad_consensus_types::{
-    block::{BlockType, PassthruBlockPolicy},
-    block_validator::MockValidator,
-    payload::StateRoot,
-    txpool::MockTxPool,
-};
+use monad_consensus_types::{block::BlockType, payload::StateRoot};
 use monad_crypto::{
     certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey},
     NopSignature,
 };
+use monad_eth_block_policy::EthBlockPolicy;
+use monad_eth_block_validator::EthValidator;
+use monad_eth_txpool::EthTxPool;
 use monad_eth_types::Balance;
 use monad_mock_swarm::{
     mock::TimestamperConfig, mock_swarm::SwarmBuilder, node::NodeBuilder,
@@ -25,7 +23,7 @@ use monad_state::{MonadMessage, VerifiedMonadMessage};
 use monad_state_backend::{InMemoryState, InMemoryStateInner};
 use monad_testutil::swarm::make_state_configs;
 use monad_transformer::{GenericTransformer, GenericTransformerPipeline, LatencyTransformer, ID};
-use monad_types::{NodeId, Round, SeqNum};
+use monad_types::{NodeId, Round, SeqNum, GENESIS_SEQ_NUM};
 use monad_updaters::{
     ledger::{MockLedger, MockableLedger},
     state_root_hash::MockStateRootHashNop,
@@ -42,18 +40,18 @@ impl SwarmRelation for ForkpointSwarm {
     type SignatureType = NopSignature;
     type SignatureCollectionType = MultiSig<Self::SignatureType>;
     type StateBackendType = InMemoryState;
-    type BlockPolicyType = PassthruBlockPolicy;
+    type BlockPolicyType = EthBlockPolicy;
 
     type TransportMessage =
         VerifiedMonadMessage<Self::SignatureType, Self::SignatureCollectionType>;
 
-    type BlockValidator = MockValidator;
+    type BlockValidator = EthValidator;
     type StateRootValidator = StateRoot;
     type ValidatorSetTypeFactory =
         ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
     type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
     type Ledger = MockLedger<Self::SignatureType, Self::SignatureCollectionType>;
-    type TxPool = MockTxPool;
+    type TxPool = EthTxPool;
     type AsyncStateRootVerify = PeerAsyncStateVerify<
         Self::SignatureCollectionType,
         <Self::ValidatorSetTypeFactory as ValidatorSetTypeFactory>::ValidatorSetType,
@@ -166,9 +164,16 @@ fn forkpoint_restart_f(
         4, // num_nodes
         ValidatorSetFactory::default,
         SimpleRoundRobin::default,
-        MockTxPool::default,
-        || MockValidator,
-        || PassthruBlockPolicy,
+        Default::default,
+        Default::default,
+        || {
+            EthBlockPolicy::new(
+                GENESIS_SEQ_NUM,
+                1_000_000, // reserve balance
+                state_root_delay.0,
+                10, // chain_id
+            )
+        },
         || InMemoryStateInner::genesis(Balance::MAX, state_root_delay),
         || StateRoot::new(state_root_delay),
         PeerAsyncStateVerify::new,
@@ -194,9 +199,16 @@ fn forkpoint_restart_f(
             4, // num_nodes
             ValidatorSetFactory::default,
             SimpleRoundRobin::default,
-            MockTxPool::default,
-            || MockValidator,
-            || PassthruBlockPolicy,
+            Default::default,
+            Default::default,
+            || {
+                EthBlockPolicy::new(
+                    GENESIS_SEQ_NUM,
+                    1_000_000, // reserve balance
+                    state_root_delay.0,
+                    10, // chain_id
+                )
+            },
             || InMemoryStateInner::genesis(Balance::MAX, state_root_delay),
             || StateRoot::new(state_root_delay),
             PeerAsyncStateVerify::new,
@@ -211,9 +223,16 @@ fn forkpoint_restart_f(
             4, // num_nodes
             ValidatorSetFactory::default,
             SimpleRoundRobin::default,
-            MockTxPool::default,
-            || MockValidator,
-            || PassthruBlockPolicy,
+            Default::default,
+            Default::default,
+            || {
+                EthBlockPolicy::new(
+                    GENESIS_SEQ_NUM,
+                    1_000_000, // reserve balance
+                    state_root_delay.0,
+                    10, // chain_id
+                )
+            },
             || InMemoryStateInner::genesis(Balance::MAX, state_root_delay),
             || StateRoot::new(state_root_delay),
             PeerAsyncStateVerify::new,
@@ -463,9 +482,16 @@ fn forkpoint_restart_below_all(
         num_nodes,
         ValidatorSetFactory::default,
         SimpleRoundRobin::default,
-        MockTxPool::default,
-        || MockValidator,
-        || PassthruBlockPolicy,
+        Default::default,
+        Default::default,
+        || {
+            EthBlockPolicy::new(
+                GENESIS_SEQ_NUM,
+                1_000_000, // reserve balance
+                state_root_delay.0,
+                10, // chain_id
+            )
+        },
         || InMemoryStateInner::genesis(Balance::MAX, state_root_delay),
         || StateRoot::new(state_root_delay),
         PeerAsyncStateVerify::new,
@@ -501,9 +527,16 @@ fn forkpoint_restart_below_all(
             num_nodes,
             ValidatorSetFactory::default,
             SimpleRoundRobin::default,
-            MockTxPool::default,
-            || MockValidator,
-            || PassthruBlockPolicy,
+            Default::default,
+            Default::default,
+            || {
+                EthBlockPolicy::new(
+                    GENESIS_SEQ_NUM,
+                    1_000_000, // reserve balance
+                    state_root_delay.0,
+                    10, // chain_id
+                )
+            },
             || InMemoryStateInner::genesis(Balance::MAX, state_root_delay),
             || StateRoot::new(state_root_delay),
             PeerAsyncStateVerify::new,
@@ -518,9 +551,16 @@ fn forkpoint_restart_below_all(
             num_nodes,
             ValidatorSetFactory::default,
             SimpleRoundRobin::default,
-            MockTxPool::default,
-            || MockValidator,
-            || PassthruBlockPolicy,
+            Default::default,
+            Default::default,
+            || {
+                EthBlockPolicy::new(
+                    GENESIS_SEQ_NUM,
+                    1_000_000, // reserve balance
+                    state_root_delay.0,
+                    10, // chain_id
+                )
+            },
             || InMemoryStateInner::genesis(Balance::MAX, state_root_delay),
             || StateRoot::new(state_root_delay),
             PeerAsyncStateVerify::new,


### PR DESCRIPTION
Also modifies our statesync tests to use EthBlockPolicy. This wasn't caught because MockBlockPolicy doesn't assert that it's passed `delay` non-null blocks.

Running `cargo test -p monad-mock-swarm --test forkpoint` yields the following on the old buggy patch:
```
    Finished `test` profile [optimized + debuginfo] target(s) in 0.33s
     Running tests/forkpoint.rs (target/debug/deps/forkpoint-421b8a4ecaf08933)

running 5 tests
test test_forkpoint_restart_below_all ... ignored
test test_forkpoint_restart_f ... ignored
test test_forkpoint_restart_f_simple_blocksync ... FAILED
test test_forkpoint_restart_f_simple_statesync ... FAILED
test test_forkpoint_restart_f_epoch_boundary_statesync ... FAILED

failures:

---- test_forkpoint_restart_f_simple_blocksync stdout ----
thread 'test_forkpoint_restart_f_simple_blocksync' panicked at monad-bft/monad-eth-block-policy/src/lib.rs:615:13:
assertion `left == right` failed
  left: 11
 right: 5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- test_forkpoint_restart_f_simple_statesync stdout ----
thread 'test_forkpoint_restart_f_simple_statesync' panicked at monad-bft/monad-eth-block-policy/src/lib.rs:615:13:
assertion `left == right` failed
  left: 159
 right: 5

---- test_forkpoint_restart_f_epoch_boundary_statesync stdout ----
thread 'test_forkpoint_restart_f_epoch_boundary_statesync' panicked at monad-bft/monad-eth-block-policy/src/lib.rs:615:13:
assertion `left == right` failed
  left: 276
 right: 19

failures:
    test_forkpoint_restart_f_epoch_boundary_statesync
    test_forkpoint_restart_f_simple_blocksync
    test_forkpoint_restart_f_simple_statesync

test result: FAILED. 0 passed; 3 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.13s

error: test failed, to rerun pass `-p monad-mock-swarm --test forkpoint`
```