### PR TITLE
Bump concurrent triedb reads limit and make it configurable

### DIFF
--- a/monad-rpc/src/cli.rs
+++ b/monad-rpc/src/cli.rs
@@ -48,4 +48,8 @@ pub struct Cli {
     /// Set the max concurrent requests for eth_call and eth_estimateGas
     #[arg(long, default_value_t = 1000)]
     pub eth_call_max_concurrent_requests: u32,
+
+    /// Set the max concurrent requests for triedb reads
+    #[arg(long, default_value_t = 20_000)]
+    pub triedb_max_concurrent_requests: u32,
 }

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -625,7 +625,10 @@ async fn main() -> std::io::Result<()> {
 
     let resources = MonadRpcResources::new(
         ipc_sender.clone(),
-        args.triedb_path.clone().as_deref().map(TriedbEnv::new),
+        args.triedb_path
+            .clone()
+            .as_deref()
+            .map(|path| TriedbEnv::new(path, args.triedb_max_concurrent_requests as usize)),
         Some(args.execution_ledger_path),
         args.chain_id,
         args.batch_request_limit,

--- a/monad-rpc/src/triedb.rs
+++ b/monad-rpc/src/triedb.rs
@@ -27,8 +27,6 @@ use crate::{
     jsonrpc::{JsonRpcError, JsonRpcResult},
 };
 
-const MAX_CONCURRENT_TRIEDB_REQUESTS: usize = 10_000;
-
 type EthAddress = [u8; 20];
 type EthStorageKey = [u8; 32];
 type EthCodeHash = [u8; 32];
@@ -223,10 +221,9 @@ pub struct TriedbEnv {
 }
 
 impl TriedbEnv {
-    pub fn new(triedb_path: &Path) -> Self {
+    pub fn new(triedb_path: &Path, max_concurrent_triedb_reads: usize) -> Self {
         // create a mpsc channel where sender are incoming requests, and the receiver is the triedb poller
-        let (sender, receiver) =
-            mpsc::sync_channel::<TriedbRequest>(MAX_CONCURRENT_TRIEDB_REQUESTS);
+        let (sender, receiver) = mpsc::sync_channel::<TriedbRequest>(max_concurrent_triedb_reads);
 
         // spawn the polling thread in a dedicated thread
         let triedb_path_cloned = triedb_path.to_path_buf();


### PR DESCRIPTION
Bumping up the default backpressure limit for reading from triedb. 1k TPS indexed by a blockscout instance hits the original limit quite frequently, tested and we are able to support higher limits. Making it a configurable flag too so rpc providers can adjust as needed