### PR TITLE
Separate triedbenv out from rpc crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4719,7 +4719,6 @@ dependencies = [
  "monad-cxx",
  "monad-eth-block-policy",
  "monad-rpc-docs",
- "monad-triedb",
  "monad-triedb-utils",
  "monad-types",
  "notify",
@@ -4929,11 +4928,13 @@ dependencies = [
  "alloy-rlp",
  "clap 4.4.10",
  "futures",
+ "hex",
  "monad-eth-testutil",
  "monad-eth-types",
  "monad-state-backend",
  "monad-triedb",
  "monad-types",
+ "reth-primitives",
  "tracing",
 ]
 

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -13,7 +13,6 @@ bench = false
 [dependencies]
 monad-cxx = { path = "../monad-cxx" }
 monad-eth-block-policy = { path = "../monad-eth-block-policy" }
-monad-triedb = { path = "../monad-triedb" }
 monad-triedb-utils = { path = "../monad-triedb-utils" }
 monad-types = { path = "../monad-types" }
 monad-rpc-docs = { path = "./monad-rpc-docs" }

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -9,6 +9,7 @@ use actix_web::{
 use clap::Parser;
 use eth_json_types::serialize_result;
 use futures::{SinkExt, StreamExt};
+use monad_triedb_utils::triedb_env::TriedbEnv;
 use opentelemetry::metrics::MeterProvider;
 use reth_primitives::TransactionSigned;
 use serde_json::Value;
@@ -54,7 +55,6 @@ use crate::{
     trace_handlers::{
         monad_debug_traceBlockByHash, monad_debug_traceBlockByNumber, monad_debug_traceTransaction,
     },
-    triedb::TriedbEnv,
     vpool::{
         monad_txpool_content, monad_txpool_contentFrom, monad_txpool_inspect, monad_txpool_status,
     },
@@ -78,7 +78,6 @@ mod mempool_tx;
 mod metrics;
 mod trace;
 mod trace_handlers;
-mod triedb;
 mod vpool;
 mod websocket;
 

--- a/monad-rpc/src/vpool.rs
+++ b/monad-rpc/src/vpool.rs
@@ -436,10 +436,10 @@ mod tests {
     };
 
     use alloy_primitives::FixedBytes;
+    use monad_triedb_utils::triedb_env::BlockHeader;
     use reth_primitives::{hex::FromHex, sign_message, Header, TxEip1559, B256, U256};
 
     use super::*;
-    use crate::triedb::BlockHeader;
 
     fn accounts() -> Vec<(B256, Address)> {
         vec![

--- a/monad-triedb-utils/Cargo.toml
+++ b/monad-triedb-utils/Cargo.toml
@@ -15,6 +15,8 @@ monad-types = { path = "../monad-types" }
 alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }
 futures = { workspace = true }
+hex = { workspace = true }
+reth-primitives = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
 
 [dev-dependencies]

--- a/monad-triedb-utils/src/lib.rs
+++ b/monad-triedb-utils/src/lib.rs
@@ -20,6 +20,7 @@ use crate::{
 
 pub mod decode;
 pub mod key;
+pub mod triedb_env;
 
 const MAX_TRIEDB_ASYNC_POLLS: usize = 640_000;
 


### PR DESCRIPTION
separating this out so it can be used by the archiving process as well cc @tongzhi1998 