### PR TITLE
Archive setup

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -277,3 +277,50 @@ jobs:
           file: docker/txgen/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+    
+  publish-monad-archive:
+    runs-on: ubuntu-24.04-32
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Generate a token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.REPO_READONLY_GITHUB_APP_ID }}
+          private_key: ${{ secrets.REPO_READONLY_GITHUB_APP_KEY }}
+          permissions: >-
+            {"contents": "read"}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Log in to the Peach10 Container registry
+        uses: docker/login-action@v3.1.0
+        with:
+          registry: peach10.devcore4.com
+          username: ${{ secrets.PRIVATE_REGISTRY_USERNAME }}
+          password: ${{ secrets.PRIVATE_REGISTRY_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: |
+            peach10.devcore4.com/monad-crypto/monad-archiver
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: .
+          push: true
+          file: docker/archive/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,6 +1205,380 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-config"
+version = "1.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6448cfb224dd6a9b9ac734f58622dd0d4751f3589f3b777345745f46b2eb14"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 0.2.11",
+ "ring 0.17.8",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10d5c055aa540164d9561a0e2e74ad30f0dcf7393c3a92f6733ddf9c5762468"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.11",
+ "http-body 0.4.5",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0656a79cf5e6ab0d4bb2465cd750a7a2fd7ea26c062183ed94225f5782e22365"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac",
+ "http 0.2.11",
+ "http-body 0.4.5",
+ "lru",
+ "once_cell",
+ "percent-encoding",
+ "regex-lite",
+ "sha2",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8776850becacbd3a82a4737a9375ddb5c6832a51379f24443a98e61513f852c"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.11",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0007b5b8004547133319b6c4e87193eee2a0bcb3e4c18c75d09febe9dab7b383"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.11",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fffaa356e7f1c725908b75136d53207fa714e348f365671df14e95a60530ad3"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "http 0.2.11",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5619742a0d8f253be760bfbb8e8e8368c69e3587e4637af5754e488a611499b1"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "crypto-bigint 0.5.5",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.11",
+ "http 1.1.0",
+ "once_cell",
+ "p256",
+ "percent-encoding",
+ "ring 0.17.8",
+ "sha2",
+ "subtle",
+ "time",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.60.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1a71073fca26775c8b5189175ea8863afb1c9ea2cceb02a5de5ad9dfbaa795"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc32c",
+ "crc32fast",
+ "hex",
+ "http 0.2.11",
+ "http-body 0.4.5",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef7d0a272725f87e51ba2bf89f8c21e4df61b9e49ae1ac367a6d69916ef7c90"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.60.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.11",
+ "http-body 0.4.5",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be28bd063fa91fd871d131fc8b68d7cd4c5fa0869bea68daca50dcb1cbd76be2"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "h2 0.3.26",
+ "http 0.2.11",
+ "http-body 0.4.5",
+ "http-body 1.0.1",
+ "httparse",
+ "hyper 0.14.27",
+ "hyper-rustls",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.11",
+ "http 1.1.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c9cdc179e6afbf5d391ab08c85eac817b51c87e1892a5edb5f7bbdc64314b4"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.11",
+ "http 1.1.0",
+ "http-body 0.4.5",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version 0.4.0",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,6 +1642,12 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
+name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
@@ -1289,6 +1669,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -1504,6 +1894,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
 ]
 
 [[package]]
@@ -1866,6 +2266,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version 0.4.0",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,6 +2391,18 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "crypto-bigint"
@@ -2106,6 +2527,16 @@ dependencies = [
 
 [[package]]
 name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
@@ -2195,16 +2626,28 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.8",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2215,19 +2658,39 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest 0.10.7",
+ "ff 0.12.1",
+ "generic-array",
+ "group 0.12.1",
+ "pkcs8 0.9.0",
+ "rand_core",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.0",
  "generic-array",
- "group",
- "pkcs8",
+ "group 0.13.0",
+ "pkcs8 0.10.2",
  "rand_core",
- "sec1",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -2344,6 +2807,16 @@ dependencies = [
  "arrayvec",
  "auto_impl",
  "bytes",
+]
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -2586,11 +3059,22 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff 0.12.1",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.0",
  "rand_core",
  "subtle",
 ]
@@ -2678,7 +3162,7 @@ checksum = "5a03ba7d4c9ea41552cd4351965ff96883e629693ae85005c501bb4b9e1c48a7"
 dependencies = [
  "lazy_static",
  "rand_core",
- "ring",
+ "ring 0.16.20",
  "secp256k1 0.26.0",
  "thiserror",
 ]
@@ -2860,6 +3344,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.11",
+ "hyper 0.14.27",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -3155,11 +3655,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "once_cell",
  "sha2",
- "signature",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -3328,6 +3828,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3429,6 +3939,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "monad-archive"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives 0.6.0",
+ "alloy-rlp",
+ "aws-config",
+ "aws-sdk-s3",
+ "bytes",
+ "clap 4.4.10",
+ "eyre",
+ "futures",
+ "hex",
+ "monad-triedb",
+ "monad-triedb-utils",
+ "reth-primitives",
+ "schemars",
+ "tokio",
+ "tokio-retry",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4919,10 +5452,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
+name = "outref"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2",
+]
 
 [[package]]
 name = "parity-scale-codec"
@@ -5141,12 +5691,22 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.8",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -5545,6 +6105,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5764,6 +6330,17 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
@@ -5782,9 +6359,24 @@ dependencies = [
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5895,12 +6487,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.5",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring 0.17.8",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6005,6 +6631,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
 name = "sdd"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6012,14 +6648,28 @@ checksum = "60a7b59a5d9b0099720b417b6325d91a52cbf5b3dcb5041d864be53eefa58abc"
 
 [[package]]
 name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct 0.1.1",
+ "der 0.6.1",
+ "generic-array",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.8",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -6306,6 +6956,16 @@ dependencies = [
 
 [[package]]
 name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core",
+]
+
+[[package]]
+name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
@@ -6404,12 +7064,22 @@ dependencies = [
 
 [[package]]
 name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.8",
 ]
 
 [[package]]
@@ -6506,9 +7176,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sucds"
@@ -6824,6 +7494,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
  "tokio",
 ]
 
@@ -7161,6 +7852,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7172,10 +7869,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 
 [[package]]
 name = "valuable"
@@ -7194,6 +7903,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"
@@ -7536,6 +8251,12 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+    "monad-archive",
     "monad-async-state-verify",
     "monad-block-persist",
     "monad-blocksync",
@@ -90,6 +91,8 @@ async-graphql = "7.0"
 auto_impl = "1.1.0"
 autocxx = "0.26"
 autocxx-build = "0.26"
+aws-config = "1.5.9"
+aws-sdk-s3 = "1.58.0"
 bincode = "1.3"
 bindgen = "0.69"
 bitvec = "1.0"
@@ -159,6 +162,7 @@ thiserror = "1.0"
 tiny-bip39 = "1.0"
 tiny-keccak = "2"
 tokio = "1.39"
+tokio-retry = "0.3.0"
 tokio-util = "0.7"
 toml = "0.7"
 tracing = "0.1"

--- a/docker/archive/Dockerfile
+++ b/docker/archive/Dockerfile
@@ -1,0 +1,90 @@
+FROM ubuntu:24.04 AS base
+
+WORKDIR /usr/src/monad-bft
+
+RUN apt update && apt install -y \
+  binutils \
+  iproute2 \
+  clang \
+  curl \
+  make \
+  ca-certificates \
+  pkg-config \
+  gnupg \
+  software-properties-common \
+  wget \
+  cgroup-tools \
+  libstdc++-13-dev \
+  gcc-13 \
+  g++-13
+
+RUN apt update && apt install -y \
+  libboost-atomic1.83.0 \
+  libboost-container1.83.0 \
+  libboost-fiber1.83.0 \
+  libboost-filesystem1.83.0 \
+  libboost-graph1.83.0 \
+  libboost-json1.83.0 \
+  libboost-regex1.83.0 \
+  libboost-stacktrace1.83.0
+
+RUN apt update && apt install -y \
+  libabsl-dev \
+  libarchive-dev \
+  libbenchmark-dev \
+  libbrotli-dev \
+  libcap-dev \
+  libcgroup-dev \
+  libcli11-dev \
+  libgmock-dev \
+  libgmp-dev \
+  libgtest-dev \
+  libmimalloc-dev \
+  libtbb-dev \
+  liburing-dev \
+  libzstd-dev
+
+FROM base AS builder
+
+RUN apt update && apt install -y \
+  cmake \
+  clang \
+  libssl-dev
+
+RUN apt update && apt install -y \
+  libboost-fiber1.83-dev \
+  libboost-graph1.83-dev \
+  libboost-json1.83-dev \
+  libboost-stacktrace1.83-dev \
+  libboost1.83-dev
+
+# install cargo
+ARG CARGO_ROOT="/root/.cargo"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+ENV PATH="${CARGO_ROOT}/bin:$PATH"
+ARG TRIEDB_TARGET=triedb_driver
+
+# Builder
+COPY . .
+RUN --mount=type=cache,target=${CARGO_ROOT}/registry    \
+    --mount=type=cache,target=${CARGO_ROOT}/git          \
+    --mount=type=cache,target=/usr/src/monad-bft/target \
+    ASMFLAGS="-march=haswell" CFLAGS="-march=haswell" CXXFLAGS="-march=haswell" \
+    CC=gcc-13 CXX=g++-13 cargo build --release --bin monad-archive && \
+    mv target/release/monad-archive archive && \
+    cp `ls -Lt $(find target/release | grep -e "libtriedb_driver.so") | awk -F/ '!seen[$NF]++'` . 
+    
+
+RUN strip \
+    archive \
+    *.so 
+
+# Runner
+FROM base AS runner
+WORKDIR /usr/src/monad-bft
+
+ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
+COPY --from=builder /usr/src/monad-bft/archive /usr/local/bin/monad-archive
+COPY --from=builder /usr/src/monad-bft/*.so /usr/local/lib
+
+ENV RUST_LOG=info

--- a/monad-archive/Cargo.toml
+++ b/monad-archive/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "monad-archive"
+description = "Monad archive solution"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "monad-archive"
+bench = false
+
+[lib]
+bench = false
+
+[dependencies]
+monad-triedb = { path = "../monad-triedb" }
+monad-triedb-utils = { path = "../monad-triedb-utils" }
+
+alloy-primitives = { workspace = true }
+alloy-rlp = { workspace = true }
+aws-config = { workspace = true }
+aws-sdk-s3 = { workspace = true }
+bytes = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+eyre = { workspace = true }
+hex = { workspace = true }
+schemars = "0.8.21"
+tokio = { workspace = true, features = ["net", "macros", "rt-multi-thread", "fs", "sync"] }
+tokio-retry = { workspace = true }
+tracing = { workspace = true, features = ["log"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
+futures = { workspace = true }
+reth-primitives = { workspace = true }

--- a/monad-archive/src/archive_interface.rs
+++ b/monad-archive/src/archive_interface.rs
@@ -1,0 +1,39 @@
+use reth_primitives::{ReceiptWithBloom, TransactionSigned};
+
+use crate::{errors::ArchiveError, triedb::BlockHeader};
+
+pub trait ArchiveWriterInterface {
+    // Get the latest stored block
+    async fn get_latest(&self) -> Result<u64, ArchiveError>;
+
+    // Update latest processed block
+    async fn update_latest(&self, block_num: u64) -> Result<(), ArchiveError>;
+
+    /*
+        Archive Block
+        1) Table1: key = block_number, value = RLP(block)
+        2) Table2: key = block_hash, value = block_number
+    */
+    async fn archive_block(
+        &self,
+        block_header: BlockHeader,
+        transactions: Vec<TransactionSigned>,
+        block_num: u64,
+    ) -> Result<(), ArchiveError>;
+
+    /*
+        Archive Receipt
+        Table: key = block_number, value = RLP(Vec<Receipt>)
+    */
+    async fn archive_receipts(
+        &self,
+        receipts: Vec<ReceiptWithBloom>,
+        block_num: u64,
+    ) -> Result<(), ArchiveError>;
+
+    async fn archive_traces(
+        &self,
+        traces: Vec<Vec<u8>>,
+        block_num: u64,
+    ) -> Result<(), ArchiveError>;
+}

--- a/monad-archive/src/cli.rs
+++ b/monad-archive/src/cli.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+#[command(name = "monad-archive", about, long_about = None)]
+pub struct Cli {
+    #[arg(long)]
+    pub triedb_path: PathBuf,
+
+    #[arg(long)]
+    pub s3_bucket: String,
+
+    #[arg(long)]
+    pub s3_region: Option<String>,
+
+    /// Set the max response size in bytes (the same as monad-rpc)
+    #[arg(long, default_value_t = 25_000_000)]
+    pub max_response_size: u32,
+
+    /// Set the concurrent blocks
+    #[arg(long, default_value_t = 10)]
+    pub max_concurrent_blocks: usize,
+
+    /// Set max block processed per iter
+    #[arg(long, default_value_t = 100)]
+    pub max_blocks_per_iteration: u64,
+}

--- a/monad-archive/src/errors.rs
+++ b/monad-archive/src/errors.rs
@@ -1,0 +1,1 @@
+pub type ArchiveError = eyre::ErrReport;

--- a/monad-archive/src/lib.rs
+++ b/monad-archive/src/lib.rs
@@ -1,0 +1,7 @@
+#![allow(async_fn_in_trait)]
+
+pub mod archive_interface;
+pub mod cli;
+pub mod errors;
+pub mod s3_archive;
+pub mod triedb;

--- a/monad-archive/src/main.rs
+++ b/monad-archive/src/main.rs
@@ -1,0 +1,162 @@
+use std::{sync::Arc, time::Instant};
+
+use clap::Parser;
+use futures::future::join_all;
+use monad_archive::{
+    archive_interface::ArchiveWriterInterface,
+    cli::Cli,
+    errors::ArchiveError,
+    s3_archive::{S3Archive, S3ArchiveWriter},
+    triedb::{Triedb, TriedbEnv},
+};
+use tokio::{
+    sync::Semaphore,
+    time::{sleep, Duration},
+    try_join,
+};
+use tracing::{debug, error, info, warn, Level};
+
+#[tokio::main]
+async fn main() -> Result<(), ArchiveError> {
+    tracing_subscriber::fmt().with_max_level(Level::INFO).init();
+
+    let args = Cli::parse();
+
+    let max_concurrent_blocks = args.max_concurrent_blocks;
+    let concurrent_block_semaphore = Arc::new(Semaphore::new(max_concurrent_blocks));
+
+    // This will spin off a polling thread
+    let triedb = TriedbEnv::new(&args.triedb_path);
+
+    // Construct an s3 instance
+    let s3_archive = S3Archive::new(args.s3_bucket, args.s3_region).await?;
+    let s3_archive_writer = S3ArchiveWriter::new(s3_archive).await?;
+
+    // Check for new blocks every 100 ms
+    // Issue requests to triedb, poll data and push to relevant tables
+    loop {
+        sleep(Duration::from_millis(100)).await;
+
+        let trie_db_block_number = match triedb.get_latest_block().await {
+            Ok(number) => number,
+            Err(e) => return Err(e),
+        };
+
+        let latest_processed_block = (s3_archive_writer.get_latest().await).unwrap_or_default();
+
+        if trie_db_block_number <= latest_processed_block {
+            debug!(
+                "Nothing to process. S3 archive progress: {}, triedb progress: {}",
+                latest_processed_block, trie_db_block_number
+            );
+            continue;
+        }
+
+        let start_block_number = if latest_processed_block == 0 {
+            0
+        } else {
+            latest_processed_block + 1
+        };
+
+        let end_block_number =
+            trie_db_block_number.min(start_block_number + args.max_blocks_per_iteration - 1);
+
+        let start = Instant::now();
+        info!(
+            "Processing blocks from {} to {}, start time = {:?}",
+            start_block_number, end_block_number, start
+        );
+
+        let join_handles = (start_block_number..=end_block_number).map(|current_block: u64| {
+            let triedb = triedb.clone();
+            let s3_archive_writer = s3_archive_writer.clone();
+
+            let semaphore = concurrent_block_semaphore.clone();
+            tokio::spawn(async move {
+                let _permit = semaphore
+                    .acquire()
+                    .await
+                    .expect("Got permit to execute a new block");
+                handle_block(&triedb, current_block, &s3_archive_writer).await
+            })
+        });
+
+        let block_results = join_all(join_handles).await;
+        let mut current_join_block = start_block_number;
+        for block_result in block_results {
+            match block_result {
+                Ok(Ok(())) => {
+                    current_join_block += 1;
+                }
+                Ok(Err(e)) => {
+                    if current_join_block != 0 {
+                        if let Err(e) = s3_archive_writer
+                            .update_latest(current_join_block - 1)
+                            .await
+                        {
+                            error!("Error setting latest after handle_block failure: {e}");
+                        }
+                    }
+                    error!(current_join_block, "Failure writing block, {e}");
+                    break;
+                }
+                Err(e) => {
+                    if current_join_block != 0 {
+                        if let Err(e) = s3_archive_writer
+                            .update_latest(current_join_block - 1)
+                            .await
+                        {
+                            error!("Error setting latest after handle_block failure: {e}");
+                        }
+                    }
+                    error!(current_join_block, "Failure writing block, {e}");
+                    break;
+                }
+            }
+        }
+
+        s3_archive_writer.update_latest(end_block_number).await?;
+
+        let duration = start.elapsed();
+        info!("Time spent = {:?}", duration);
+    }
+}
+
+async fn handle_block(
+    triedb: &TriedbEnv,
+    current_block: u64,
+    s3_archive: &S3ArchiveWriter,
+) -> Result<(), ArchiveError> {
+    /*  Store Blocks */
+    let block_header = match triedb.get_block_header(current_block).await? {
+        Some(header) => header,
+        None => {
+            warn!("Can't find block {} in triedb", current_block);
+            return Ok(());
+        }
+    };
+    let transactions = triedb.get_transactions(current_block).await?;
+
+    let f_block = s3_archive.archive_block(block_header, transactions, current_block);
+
+    /* Store Receipts */
+    let receipts = triedb.get_receipts(current_block).await?;
+
+    let f_receipt = s3_archive.archive_receipts(receipts, current_block);
+
+    /* Store Traces */
+    let traces: Vec<Vec<u8>> = triedb.get_call_frames(current_block).await?;
+
+    let f_trace = s3_archive.archive_traces(traces, current_block);
+
+    match try_join!(f_block, f_receipt, f_trace) {
+        Ok(_) => {
+            info!("Successfully archived block {}", current_block);
+        }
+        Err(e) => {
+            error!("Error archiving block {}: {:?}", current_block, e);
+        }
+    }
+
+    Ok(())
+}

--- a/monad-archive/src/s3_archive.rs
+++ b/monad-archive/src/s3_archive.rs
@@ -1,0 +1,233 @@
+use core::str;
+use std::sync::Arc;
+
+use alloy_rlp::Encodable;
+use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_s3::{
+    config::{BehaviorVersion, Region},
+    primitives::ByteStream,
+    Client,
+};
+use bytes::Bytes;
+use eyre::Context;
+use futures::try_join;
+use reth_primitives::{Block, ReceiptWithBloom, TransactionSigned};
+use tokio::time::Duration;
+use tokio_retry::{
+    strategy::{jitter, ExponentialBackoff},
+    Retry,
+};
+
+use crate::{archive_interface::ArchiveWriterInterface, errors::ArchiveError, triedb::BlockHeader};
+
+const BLOCK_PADDING_WIDTH: usize = 12;
+
+#[derive(Clone)]
+pub struct S3Archive {
+    pub client: Client,
+    pub bucket: String,
+
+    pub latest_table_key: &'static str,
+
+    // key =  {block}/{block_number}, value = {RLP(Block)}
+    pub block_table_prefix: &'static str,
+
+    // key = {block_hash}/{$block_hash}, value = {str(block_number)}
+    pub block_hash_table_prefix: &'static str,
+
+    // key = {receipts}/{block_number}, value = {RLP(Vec<Receipt>)}
+    pub receipts_table_prefix: &'static str,
+
+    // key = {traces}/{block_number}, value = {RLP(Vec<Vec<u8>>)}
+    pub traces_table_prefix: &'static str,
+}
+
+impl S3Archive {
+    pub async fn new(bucket: String, region: Option<String>) -> Result<Self, ArchiveError> {
+        let region_provider = RegionProviderChain::default_provider().or_else(
+            region
+                .map(Region::new)
+                .unwrap_or_else(|| Region::new("us-east-2")),
+        );
+        let config = aws_config::defaults(BehaviorVersion::latest())
+            .region(region_provider)
+            .load()
+            .await;
+        let client = Client::new(&config);
+        Ok(S3Archive {
+            client,
+            bucket,
+            block_table_prefix: "block",
+            block_hash_table_prefix: "block_hash",
+            receipts_table_prefix: "receipts",
+            traces_table_prefix: "traces",
+            latest_table_key: "latest",
+        })
+    }
+
+    // Upload rlp-encoded bytes with retry
+    pub async fn upload(&self, key: &str, data: Vec<u8>) -> Result<(), ArchiveError> {
+        let retry_strategy = ExponentialBackoff::from_millis(10)
+            .max_delay(Duration::from_secs(1))
+            .map(jitter);
+
+        Retry::spawn(retry_strategy, || {
+            let client = &self.client;
+            let bucket = &self.bucket;
+            let key = key.to_string();
+            let body = ByteStream::from(data.clone());
+
+            async move {
+                client
+                    .put_object()
+                    .bucket(bucket)
+                    .key(&key)
+                    .body(body)
+                    .send()
+                    .await
+                    .wrap_err_with(|| format!("Failed to upload {}. Retrying...", key))
+            }
+        })
+        .await
+        .map(|_| ())
+        .wrap_err_with(|| format!("Failed to upload {}. Retrying...", key))?;
+
+        Ok(())
+    }
+
+    pub async fn read(&self, key: &str) -> Result<Bytes, ArchiveError> {
+        let resp = self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .send()
+            .await
+            .wrap_err_with(|| format!("Failed to read key from s3 {key}"))?;
+
+        let data = resp
+            .body
+            .collect()
+            .await
+            .wrap_err("Unable to collect response data")?;
+
+        Ok(data.into_bytes())
+    }
+}
+
+#[derive(Clone)]
+pub struct S3ArchiveWriter {
+    archive: Arc<S3Archive>,
+}
+
+impl S3ArchiveWriter {
+    pub async fn new(archive: S3Archive) -> Result<Self, ArchiveError> {
+        Ok(S3ArchiveWriter {
+            archive: Arc::new(archive),
+        })
+    }
+}
+
+impl ArchiveWriterInterface for S3ArchiveWriter {
+    async fn get_latest(&self) -> Result<u64, ArchiveError> {
+        let key = &self.archive.latest_table_key;
+
+        let value = self.archive.read(key).await?;
+
+        let value_str = String::from_utf8(value.to_vec()).wrap_err("Invalid UTF-8 sequence")?;
+
+        // Parse the string as u64
+        value_str.parse::<u64>().wrap_err_with(|| {
+            format!("Unable to convert block_number string to number (u64), value: {value_str}")
+        })
+    }
+
+    async fn update_latest(&self, block_num: u64) -> Result<(), ArchiveError> {
+        let key = &self.archive.latest_table_key;
+        let latest_value = format!("{:0width$}", block_num, width = BLOCK_PADDING_WIDTH);
+        self.archive
+            .upload(key, latest_value.as_bytes().to_vec())
+            .await
+    }
+
+    async fn archive_block(
+        &self,
+        block_header: BlockHeader,
+        transactions: Vec<TransactionSigned>,
+        block_num: u64,
+    ) -> Result<(), ArchiveError> {
+        // 1) Insert into block table
+        let block_key = format!(
+            "{}/{:0width$}",
+            self.archive.block_table_prefix,
+            block_num,
+            width = BLOCK_PADDING_WIDTH
+        );
+
+        let block = make_block(block_header.clone(), transactions.clone());
+        let mut rlp_block = Vec::with_capacity(8096);
+        block.encode(&mut rlp_block);
+
+        // 2) Insert into block_hash table
+        let block_hash_key_suffix = hex::encode(block_header.hash);
+        let block_hash_key = format!(
+            "{}/{}",
+            self.archive.block_hash_table_prefix, block_hash_key_suffix
+        );
+        let block_hash_value_string = block_num.to_string();
+        let block_hash_value = block_hash_value_string.as_bytes();
+
+        // 3) Join futures
+        try_join!(
+            self.archive.upload(&block_key, rlp_block),
+            self.archive
+                .upload(&block_hash_key, block_hash_value.to_vec())
+        )?;
+
+        Ok(())
+    }
+
+    async fn archive_receipts(
+        &self,
+        receipts: Vec<ReceiptWithBloom>,
+        block_num: u64,
+    ) -> Result<(), ArchiveError> {
+        // 1) Prepare the receipts upload
+        let receipts_key = format!(
+            "{}/{:0width$}",
+            self.archive.receipts_table_prefix,
+            block_num,
+            width = BLOCK_PADDING_WIDTH
+        );
+
+        let mut rlp_receipts = Vec::new();
+        receipts.encode(&mut rlp_receipts);
+        self.archive.upload(&receipts_key, rlp_receipts).await
+    }
+
+    async fn archive_traces(
+        &self,
+        traces: Vec<Vec<u8>>,
+        block_num: u64,
+    ) -> Result<(), ArchiveError> {
+        let traces_key = format!(
+            "{}/{:0width$}",
+            self.archive.traces_table_prefix,
+            block_num,
+            width = BLOCK_PADDING_WIDTH
+        );
+
+        let mut rlp_traces = vec![];
+        traces.encode(&mut rlp_traces);
+
+        self.archive.upload(&traces_key, rlp_traces).await
+    }
+}
+
+pub fn make_block(block_header: BlockHeader, transactions: Vec<TransactionSigned>) -> Block {
+    Block {
+        header: block_header.header,
+        body: transactions,
+        ..Default::default()
+    }
+}

--- a/monad-archive/src/triedb.rs
+++ b/monad-archive/src/triedb.rs
@@ -1,0 +1,354 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicUsize, Ordering::SeqCst},
+        mpsc, Arc,
+    },
+    thread,
+};
+
+use alloy_primitives::FixedBytes;
+use alloy_rlp::Decodable;
+use eyre::{bail, Context};
+use futures::channel::oneshot;
+use monad_triedb::TriedbHandle;
+use monad_triedb_utils::key::{create_triedb_key, KeyInput};
+use reth_primitives::{keccak256, Header, ReceiptWithBloom, TransactionSigned};
+use tracing::error;
+
+use crate::errors::ArchiveError;
+
+const MAX_CONCURRENT_TRIEDB_REQUESTS: usize = 1000;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, schemars::JsonSchema)]
+#[serde(untagged)]
+pub enum BlockTags {
+    Number(u64),
+    #[default]
+    Latest,
+}
+
+enum TriedbRequest {
+    BlockNumberRequest(BlockNumberRequest),
+    TraverseRequest(TraverseRequest),
+    AsyncRequest(AsyncRequest),
+}
+
+struct BlockNumberRequest {
+    // a sender to send the block number back to the request handler
+    request_sender: oneshot::Sender<u64>,
+}
+
+// For get_transactions and get_receipts
+struct TraverseRequest {
+    // a sender for the polling thread to send the result back to the request handler
+    request_sender: oneshot::Sender<Option<Vec<Vec<u8>>>>,
+    // triedb_key and key_len_nibbles are used to read items from triedb
+    triedb_key: Vec<u8>,
+    key_len_nibbles: u8,
+    // block number
+    block_tag: BlockTags,
+}
+
+struct AsyncRequest {
+    // a sender for the polling thread to send the result back to the request handler
+    // after polling is completed
+    request_sender: oneshot::Sender<Option<Vec<u8>>>,
+    // counter which is updated when TrieDB processes a single async read to completion
+    completed_counter: Arc<AtomicUsize>,
+    // triedb_key and key_len_nibbles are used to read items from triedb
+    triedb_key: Vec<u8>,
+    key_len_nibbles: u8,
+    // block number
+    block_tag: BlockTags,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct BlockHeader {
+    pub hash: FixedBytes<32>,
+    pub header: Header,
+}
+
+fn polling_thread(triedb_path: PathBuf, receiver: mpsc::Receiver<TriedbRequest>) {
+    // create a new triedb handle for the polling thread
+    let triedb_handle: TriedbHandle =
+        TriedbHandle::try_new(&triedb_path).expect("triedb should exist in path");
+
+    loop {
+        triedb_handle.triedb_poll(false, usize::MAX);
+
+        // spin on receiver
+        match receiver.try_recv() {
+            Ok(triedb_request) => match triedb_request {
+                TriedbRequest::BlockNumberRequest(block_num_request) => {
+                    let block_num = triedb_handle.latest_block();
+                    let _ = block_num_request.request_sender.send(block_num);
+                }
+                TriedbRequest::TraverseRequest(traverse_request) => {
+                    // Parse block tag
+                    let block_num = match traverse_request.block_tag {
+                        BlockTags::Number(q) => q,
+                        BlockTags::Latest => triedb_handle.latest_block(),
+                    };
+                    let rlp_encoded_data = triedb_handle.traverse_triedb(
+                        &traverse_request.triedb_key,
+                        traverse_request.key_len_nibbles,
+                        block_num,
+                    );
+                    let _ = traverse_request.request_sender.send(rlp_encoded_data);
+                }
+                TriedbRequest::AsyncRequest(async_request) => {
+                    // Process the request directly in this thread
+                    process_request(&triedb_handle, async_request);
+                }
+            },
+            Err(_) => {
+                // no message received, continue spinning
+                continue;
+            }
+        }
+    }
+}
+
+fn process_request(triedb_handle: &TriedbHandle, async_request: AsyncRequest) {
+    // Parse block tag
+    let block_num = match async_request.block_tag {
+        BlockTags::Number(q) => q,
+        BlockTags::Latest => triedb_handle.latest_block(),
+    };
+
+    // read_async will send back a future to request_receiver of oneshot channel
+    triedb_handle.read_async(
+        &async_request.triedb_key,
+        async_request.key_len_nibbles,
+        block_num,
+        async_request.completed_counter,
+        async_request.request_sender,
+    );
+}
+
+pub trait Triedb {
+    fn get_latest_block(
+        &self,
+    ) -> impl std::future::Future<Output = Result<u64, ArchiveError>> + Send;
+    fn get_receipts(
+        &self,
+        block_num: u64,
+    ) -> impl std::future::Future<Output = Result<Vec<ReceiptWithBloom>, ArchiveError>> + Send;
+    fn get_transactions(
+        &self,
+        block_num: u64,
+    ) -> impl std::future::Future<Output = Result<Vec<TransactionSigned>, ArchiveError>> + Send;
+    fn get_block_header(
+        &self,
+        block_num: u64,
+    ) -> impl std::future::Future<Output = Result<Option<BlockHeader>, ArchiveError>> + Send;
+    fn get_call_frames(
+        &self,
+        block_num: u64,
+    ) -> impl std::future::Future<Output = Result<Vec<Vec<u8>>, ArchiveError>> + Send;
+}
+
+pub trait TriedbPath {
+    fn path(&self) -> PathBuf;
+}
+
+#[derive(Clone)]
+pub struct TriedbEnv {
+    triedb_path: PathBuf,
+    mpsc_sender: mpsc::SyncSender<TriedbRequest>, // sender for tasks
+}
+
+impl TriedbEnv {
+    pub fn new(triedb_path: &Path) -> Self {
+        // create a mpsc channel where sender are incoming requests, and the receiver is the triedb poller
+        let (sender, receiver) =
+            mpsc::sync_channel::<TriedbRequest>(MAX_CONCURRENT_TRIEDB_REQUESTS);
+
+        // spawn the polling thread in a dedicated thread
+        let triedb_path_cloned = triedb_path.to_path_buf();
+        thread::spawn(move || {
+            polling_thread(triedb_path_cloned, receiver);
+        });
+
+        Self {
+            triedb_path: triedb_path.to_path_buf(),
+            mpsc_sender: sender,
+        }
+    }
+}
+
+impl TriedbPath for TriedbEnv {
+    fn path(&self) -> PathBuf {
+        self.triedb_path.clone()
+    }
+}
+
+impl Triedb for TriedbEnv {
+    async fn get_latest_block(&self) -> Result<u64, ArchiveError> {
+        // create a one shot channel to retrieve the triedb result from the polling thread
+        let (request_sender, request_receiver) = oneshot::channel();
+
+        self.mpsc_sender
+            .try_send(TriedbRequest::BlockNumberRequest(BlockNumberRequest {
+                request_sender,
+            }))
+            .wrap_err(
+                "get_lastest_block: Polling thread channel full, unable to service request",
+            )?;
+
+        request_receiver
+            .await
+            .wrap_err("Error when receiving response from polling thread")
+    }
+
+    async fn get_receipts(&self, block_num: u64) -> Result<Vec<ReceiptWithBloom>, ArchiveError> {
+        // create a one shot channel to retrieve the triedb result from the polling thread
+        let (request_sender, request_receiver) = oneshot::channel();
+
+        // receipt_index set to None to indiciate return all receipts
+        let (triedb_key, key_len_nibbles) = create_triedb_key(KeyInput::ReceiptIndex(None));
+
+        self.mpsc_sender
+            .try_send(TriedbRequest::TraverseRequest(TraverseRequest {
+                request_sender,
+                triedb_key,
+                key_len_nibbles,
+                block_tag: BlockTags::Number(block_num),
+            }))
+            .wrap_err("Polling thread channel full when getting receipts")?;
+
+        // await the result using request_receiver
+        let result = request_receiver
+            .await
+            .wrap_err("get_reciept: triedb channel closed")?;
+        match result {
+            Some(rlp_receipts) => {
+                let receipts = rlp_receipts
+                    .iter()
+                    .filter_map(|rlp_receipt| {
+                        match ReceiptWithBloom::decode(&mut rlp_receipt.as_slice()) {
+                            Ok(r) => Some(r),
+                            Err(e) => {
+                                error!("Failed to decode RLP receipt: {e}");
+                                None
+                            }
+                        }
+                    })
+                    .collect();
+                Ok(receipts)
+            }
+            None => Ok(vec![]),
+        }
+    }
+
+    async fn get_transactions(
+        &self,
+        block_num: u64,
+    ) -> Result<Vec<TransactionSigned>, ArchiveError> {
+        // create a one shot channel to retrieve the triedb result from the polling thread
+        let (request_sender, request_receiver) = oneshot::channel();
+
+        // txn_index set to None to indiciate return all transactions
+        let (triedb_key, key_len_nibbles) = create_triedb_key(KeyInput::TxIndex(None));
+
+        self.mpsc_sender
+            .try_send(TriedbRequest::TraverseRequest(TraverseRequest {
+                request_sender,
+                triedb_key,
+                key_len_nibbles,
+                block_tag: BlockTags::Number(block_num),
+            }))
+            .wrap_err("get_transactions: Polling thread channel full, unable to service request")?;
+
+        // await the result using request_receiver
+        let result = request_receiver
+            .await
+            .wrap_err("get_transactions: channel closed")?;
+        match result {
+            Some(rlp_transactions) => {
+                let signed_transactions = rlp_transactions
+                    .iter()
+                    .filter_map(|rlp_transaction| {
+                        match TransactionSigned::decode_enveloped(&mut rlp_transaction.as_slice()) {
+                            Ok(r) => Some(r),
+                            Err(e) => {
+                                error!("Failed to decode RLP Transaction: {e}");
+                                None
+                            }
+                        }
+                    })
+                    .collect();
+                Ok(signed_transactions)
+            }
+            None => Ok(vec![]),
+        }
+    }
+
+    async fn get_block_header(&self, block_num: u64) -> Result<Option<BlockHeader>, ArchiveError> {
+        // create a one shot channel to retrieve the triedb result from the polling thread
+        let (request_sender, request_receiver) = oneshot::channel();
+
+        let (triedb_key, key_len_nibbles) = create_triedb_key(KeyInput::BlockHeader);
+        let completed_counter = Arc::new(AtomicUsize::new(0));
+
+        self.mpsc_sender
+            .clone()
+            .try_send(TriedbRequest::AsyncRequest(AsyncRequest {
+                request_sender,
+                completed_counter: completed_counter.clone(),
+                triedb_key,
+                key_len_nibbles,
+                block_tag: BlockTags::Number(block_num),
+            }))
+            .wrap_err("get_block_header: Polling thread channel full, unable to service request")?;
+
+        let result = request_receiver
+            .await
+            .wrap_err("get_block_header: channel closed")?;
+
+        // await the result using request_receiver
+        // sanity check to ensure completed_counter is equal to 1
+        if completed_counter.load(SeqCst) != 1 {
+            bail!("Unexpected completed_counter value");
+        }
+
+        match result {
+            Some(rlp_block_header) => {
+                let block_hash = keccak256(&rlp_block_header);
+                let mut rlp_buf = rlp_block_header.as_slice();
+                let block_header =
+                    Header::decode(&mut rlp_buf).wrap_err("decode block header failed")?;
+                Ok(Some(BlockHeader {
+                    hash: block_hash,
+                    header: block_header,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn get_call_frames(&self, block_num: u64) -> Result<Vec<Vec<u8>>, ArchiveError> {
+        let (request_sender, request_receiver) = oneshot::channel();
+
+        let (triedb_key, key_len_nibbles) = create_triedb_key(KeyInput::CallFrame(None));
+
+        self.mpsc_sender
+            .clone()
+            .try_send(TriedbRequest::TraverseRequest(TraverseRequest {
+                request_sender,
+                triedb_key,
+                key_len_nibbles,
+                block_tag: BlockTags::Number(block_num),
+            }))
+            .wrap_err("get_call_frames: Polling thread channel full, unable to service request")?;
+
+        let result = request_receiver
+            .await
+            .wrap_err("get_call_frames: channel closed")?;
+        match result {
+            Some(rlp_call_frames) => Ok(rlp_call_frames),
+            None => Ok(vec![]),
+        }
+    }
+}


### PR DESCRIPTION
`monad-archive` uploads blocks, receipts and traces to s3 blob storage

The latest block number is polled from triedb, compared to the last block
number uploaded and the blocks in between are uploaded in parallel at
configurable concurrency level.

Multiple archiver processes are intended to be run on multiple nodes
simulataneously, each uploading to their own bucket for redundancy.

This version does not expose metrics, check data integrity nor index txhashes,
all will be added in follow up prs.