### PR TITLE
change block polling interval to match block creation speed

### DIFF
--- a/monad-rpc/src/block_watcher.rs
+++ b/monad-rpc/src/block_watcher.rs
@@ -133,7 +133,7 @@ impl<B: BlockState + Clone> BlockWatcher<B> {
     pub fn new(triedb: B, current_height: u64) -> Self {
         Self {
             triedb,
-            interval: tokio::time::interval(std::time::Duration::from_secs(1)),
+            interval: tokio::time::interval(std::time::Duration::from_millis(500)),
             state: State::GetBlock(current_height),
         }
     }


### PR DESCRIPTION
The change fixes CI  waiting for receipt timeouts failures.
The problem is that block watcher in rpc needs to poll more frequently than blocks generated in triedb (including empty blocks)  because it updates 1 block at a time.
If the block watcher falls behind then the vpool does not have all the transactions and hence new transactions from the same account end up in the queued pool due to nonce gap and never leave rpc. 
