### PR TITLE
Set MTU discovery mode to ignore spoofed ICMP frag_needed

### DIFF
--- a/monad-dataplane/src/network.rs
+++ b/monad-dataplane/src/network.rs
@@ -124,6 +124,23 @@ impl<'a> NetworkSocket<'a> {
             panic!("set GRO failed with: {}", std::io::Error::last_os_error());
         }
 
+        let r = unsafe {
+            const MTU_DISCOVER: libc::c_int = libc::IP_PMTUDISC_OMIT;
+            libc::setsockopt(
+                socket.as_raw_fd(),
+                libc::SOL_IP,
+                libc::IP_MTU_DISCOVER,
+                &MTU_DISCOVER as *const _ as _,
+                std::mem::size_of_val(&MTU_DISCOVER) as _,
+            )
+        };
+        if r != 0 {
+            panic!(
+                "set MTU discover failed with: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+
         let local_sock_addr = socket.local_addr().unwrap();
 
         unsafe {


### PR DESCRIPTION
See discussions on this in https://github.com/monad-crypto/monad-internal/issues/742

This resolves the vulnerability where an arbitrary user on the network can spoof ICMP fragmentation needed packets between every pair of nodes to cause EINVAL errors. However, I think there is still some testing that would be worthwhile to determine what would happen to a node that legitimately has a lower MTU. But, this testing is difficult to do with our currently available testing setups.