### PR TITLE
Fix txpool account lookup bound

### DIFF
--- a/monad-eth-txpool/src/lib.rs
+++ b/monad-eth-txpool/src/lib.rs
@@ -29,7 +29,7 @@ mod transaction;
 mod utils;
 
 const MAX_TXPOOL_SIZE: usize = 30_000;
-const MAX_PROPOSAL_CHECKED_TXS: usize = 10_000;
+const MAX_PROPOSAL_ADDRESS_LOOKUPS: usize = 10_000;
 
 #[derive(Clone, Debug)]
 pub struct EthTxPool {
@@ -256,9 +256,12 @@ where
             // however, we anyway are emptying the txpool at the end of this function
             self.pool.remove_stale_txs(extending_block)
         }
-        let mut pool_len = self.pool.num_txs();
-        while pool_len > MAX_PROPOSAL_CHECKED_TXS {
-            pool_len -= self.pool.pop_last().expect("pool is not empty");
+
+        let mut pool_addresses = self.pool.num_addresses();
+
+        while pool_addresses > MAX_PROPOSAL_ADDRESS_LOOKUPS {
+            self.pool.pop_last().expect("pool is not empty");
+            pool_addresses -= 1;
         }
 
         if let Err(err) = self.validate_nonces_and_txn_fee(


### PR DESCRIPTION
The txpool was incorrectly bounding the number of account lookups based on the number of transactions in the pool rather than the number of addresses.