### PR TITLE
Mixed MTU Values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4347,6 +4347,7 @@ dependencies = [
  "futures",
  "futures-util",
  "libc",
+ "lru",
  "ntest",
  "rand",
  "rtrb",

--- a/monad-dataplane/Cargo.toml
+++ b/monad-dataplane/Cargo.toml
@@ -16,6 +16,7 @@ env_logger = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 libc = { workspace = true }
+lru = { workspace = true }
 rand = { workspace = true }
 rtrb = { workspace = true }
 socket2 = { workspace = true }

--- a/monad-dataplane/examples/node.rs
+++ b/monad-dataplane/examples/node.rs
@@ -68,6 +68,7 @@ fn main() {
             tx.network.udp_write_broadcast(BroadcastMsg {
                 targets: vec![tx.target],
                 payload: b.slice(i * pkt_size..(i + 1) * pkt_size),
+                stride: pkt_size,
             })
         }
 
@@ -91,7 +92,7 @@ struct Node {
 impl Node {
     pub fn new(addr: &SocketAddr, target_addr: &str) -> Self {
         Self {
-            network: Dataplane::new(addr, 1_000),
+            network: Dataplane::new(addr, 1_000, 1480),
             target: target_addr.parse().unwrap(),
         }
     }

--- a/monad-dataplane/tests/tests.rs
+++ b/monad-dataplane/tests/tests.rs
@@ -3,7 +3,7 @@ use std::{sync::Once, thread::sleep, time::Duration};
 use futures::executor;
 use monad_dataplane::{
     event_loop::{BroadcastMsg, Dataplane, RecvMsg, UnicastMsg},
-    network::MONAD_GSO_SIZE,
+    network::gso_size,
 };
 use ntest::timeout;
 use rand::Rng;
@@ -23,6 +23,9 @@ fn once_setup() {
     });
 }
 
+const MONAD_MTU: usize = 1480;
+const GSO_SIZE: usize = gso_size(MONAD_MTU);
+
 #[test]
 #[timeout(1000)]
 fn udp_broadcast() {
@@ -32,25 +35,26 @@ fn udp_broadcast() {
     let tx_addr = "127.0.0.1:9001".parse().unwrap();
     let num_msgs = 10;
 
-    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS);
-    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS);
+    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS, MONAD_MTU.try_into().unwrap());
+    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS, MONAD_MTU.try_into().unwrap());
 
     // Allow Dataplane threads to set themselves up.
     sleep(Duration::from_millis(10));
 
-    let payload: Vec<u8> = (0..MONAD_GSO_SIZE)
+    let payload: Vec<u8> = (0..GSO_SIZE)
         .map(|_| rand::thread_rng().gen_range(0..255))
         .collect();
 
     tx.udp_write_broadcast(BroadcastMsg {
         targets: vec![rx_addr; num_msgs],
         payload: payload.clone().into(),
+        stride: GSO_SIZE,
     });
 
     for _ in 0..num_msgs {
         let msg: RecvMsg = executor::block_on(rx.udp_read());
 
-        assert_eq!(msg.src_addr, tx_addr);
+        assert_eq!(msg.src_addr.ip(), tx_addr.ip());
         assert_eq!(msg.payload, payload);
     }
 }
@@ -64,13 +68,13 @@ fn udp_unicast() {
     let tx_addr = "127.0.0.1:9003".parse().unwrap();
     let num_msgs = 10;
 
-    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS);
-    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS);
+    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS, MONAD_MTU.try_into().unwrap());
+    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS, MONAD_MTU.try_into().unwrap());
 
     // Allow Dataplane threads to set themselves up.
     sleep(Duration::from_millis(10));
 
-    let payload: Vec<u8> = (0..MONAD_GSO_SIZE)
+    let payload: Vec<u8> = (0..GSO_SIZE)
         .map(|_| rand::thread_rng().gen_range(0..255))
         .collect();
 
@@ -81,7 +85,7 @@ fn udp_unicast() {
     for _ in 0..num_msgs {
         let msg: RecvMsg = executor::block_on(rx.udp_read());
 
-        assert_eq!(msg.src_addr, tx_addr);
+        assert_eq!(msg.src_addr.ip(), tx_addr.ip());
         assert_eq!(msg.payload, payload);
     }
 }
@@ -95,13 +99,13 @@ fn tcp_slow() {
     let tx_addr = "127.0.0.1:9005".parse().unwrap();
     let num_msgs = 10;
 
-    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS);
-    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS);
+    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS, MONAD_MTU.try_into().unwrap());
+    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS, MONAD_MTU.try_into().unwrap());
 
     // Allow Dataplane threads to set themselves up.
     sleep(Duration::from_millis(10));
 
-    let payload: Vec<u8> = (0..MONAD_GSO_SIZE)
+    let payload: Vec<u8> = (0..GSO_SIZE)
         .map(|_| rand::thread_rng().gen_range(0..255))
         .collect();
 
@@ -126,13 +130,13 @@ fn tcp_rapid() {
     let tx_addr = "127.0.0.1:9007".parse().unwrap();
     let num_msgs = 32;
 
-    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS);
-    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS);
+    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS, MONAD_MTU.try_into().unwrap());
+    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS, MONAD_MTU.try_into().unwrap());
 
     // Allow Dataplane threads to set themselves up.
     sleep(Duration::from_millis(10));
 
-    let payload: Vec<u8> = (0..MONAD_GSO_SIZE)
+    let payload: Vec<u8> = (0..GSO_SIZE)
         .map(|_| rand::thread_rng().gen_range(0..255))
         .collect();
 

--- a/monad-node/src/config/network.rs
+++ b/monad-node/src/config/network.rs
@@ -10,4 +10,13 @@ pub struct NodeNetworkConfig {
 
     pub max_rtt_ms: u64,
     pub max_mbps: u16,
+
+    #[serde(default = "default_mtu")]
+    pub mtu: u16,
+}
+
+// TODO: When running in docker with vpnkit, we seem to occasionally get ICMP frag-neededs
+// for 20 bytes less than the expected MTU -- investigate what's causing this.
+fn default_mtu() -> u16 {
+    1480
 }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -507,6 +507,7 @@ where
             network_config.bind_address_port,
         )),
         up_bandwidth_mbps: network_config.max_mbps.into(),
+        mtu: network_config.mtu,
     })
 }
 

--- a/monad-raptorcast/examples/service.rs
+++ b/monad-raptorcast/examples/service.rs
@@ -116,6 +116,7 @@ fn service(
                     redundancy: 2,
                     local_addr: server_address,
                     up_bandwidth_mbps: 1_000,
+                    mtu: 1480,
                 };
 
                 let mut service = RaptorCast::<

--- a/monad-raptorcast/tests/encoder_error.rs
+++ b/monad-raptorcast/tests/encoder_error.rs
@@ -3,7 +3,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use bytes::Bytes;
 use itertools::Itertools;
 use monad_crypto::hasher::{Hasher, HasherType};
-use monad_dataplane::network::MONAD_GSO_SIZE;
+use monad_dataplane::network::gso_size;
 use monad_raptor::SOURCE_SYMBOLS_MAX;
 use monad_raptorcast::{
     udp::build_messages,
@@ -12,6 +12,9 @@ use monad_raptorcast::{
 use monad_secp::{KeyPair, SecpSignature};
 use monad_types::{NodeId, Stake};
 use tracing_subscriber::fmt::format::FmtSpan;
+
+const MONAD_MTU: usize = 1480;
+const GSO_SIZE: usize = gso_size(MONAD_MTU);
 
 // Try to encode a message that is too large to be encoded, to verify that the encoder
 // errors out instead of panic!()ing.
@@ -22,7 +25,7 @@ pub fn encoder_error() {
         .with_span_events(FmtSpan::CLOSE)
         .init();
 
-    let message_size = SOURCE_SYMBOLS_MAX * MONAD_GSO_SIZE + 1;
+    let message_size = SOURCE_SYMBOLS_MAX * GSO_SIZE + 1;
 
     let message: Bytes = vec![123_u8; message_size].into();
 
@@ -55,11 +58,9 @@ pub fn encoder_error() {
     let epoch_validators = validators.view_without(vec![&NodeId::new(keys[0].pubkey())]);
     let full_nodes = FullNodes::new(Vec::new());
 
-    const GSO_SIZE: u16 = 1500;
-
     let _ = build_messages::<SecpSignature>(
         &keys[0],
-        GSO_SIZE,
+        GSO_SIZE.try_into().unwrap(),
         message,
         1, // redundancy,
         0, // epoch_no

--- a/monad-raptorcast/tests/malformed_inputs.rs
+++ b/monad-raptorcast/tests/malformed_inputs.rs
@@ -287,6 +287,7 @@ pub fn set_up_test(
                 redundancy: 2,
                 local_addr: rx_addr,
                 up_bandwidth_mbps: 1_000,
+                mtu: 1480,
             };
 
             let mut service = RaptorCast::<

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -278,6 +278,7 @@ where
                             redundancy: 3,
                             local_addr: address.parse().unwrap(),
                             up_bandwidth_mbps: 1_000,
+                            mtu: 1480,
                         }),
                     },
                     ledger_config: match args.ledger {


### PR DESCRIPTION
This allows nodes with different values for MONAD_MTU to communicate with each other, changing MTUs as needed during message transmission. This allows for a rolling update of MONAD_MTU values without causing issues in the communication. Additionally, the value has now been moved to `node.toml` to allow for Flexnet to run nodes with differing values without the need to recompile the binary with different values.

Corresponding monad-integration PR: https://github.com/monad-crypto/monad-integration/pull/136