### PR TITLE
Add startup time gap in devnet integration script

### DIFF
--- a/docker/flexnet/nets/devnet-integration/compose.yaml
+++ b/docker/flexnet/nets/devnet-integration/compose.yaml
@@ -17,7 +17,9 @@ services:
     image: monad-execution-builder:latest
     command: monad --chain monad_devnet --db /monad/triedb/test.db --block_db /monad/ledger --genesis /monad/config/genesis.json --log_level ERROR
     depends_on:
-      - build_triedb
+      build_triedb:
+        condition: service_completed_successfully
+        required: false
     volumes:
       - ./node:/monad
     security_opt:


### PR DESCRIPTION
The change fixes the intermittent Jenkins monad-bft/integration-test
The root cause is the `monad_execution` starts while `monad_mpt` is not fully initialized