### PR TITLE
BlockSync peers

### DIFF
--- a/docker/devnet/monad/config/node.toml
+++ b/docker/devnet/monad/config/node.toml
@@ -39,6 +39,11 @@ identities = []
 # [[fullnode.identities]]
 # secp256k1_pubkey = "..."
 
+[blocksync_override]
+peers = []
+# [[blocksync_override.peers]]
+# secp256k1_pubkey = "..."
+
 [network]
 bind_address_host = "0.0.0.0"
 bind_address_port = 8000

--- a/monad-mock-swarm/src/node.rs
+++ b/monad-mock-swarm/src/node.rs
@@ -120,6 +120,7 @@ impl<S: SwarmRelation> NodeBuilder<S> {
                 epoch_start_delay: self.state_builder.epoch_start_delay,
                 beneficiary: self.state_builder.beneficiary,
                 forkpoint: self.state_builder.forkpoint,
+                block_sync_override_peers: self.state_builder.block_sync_override_peers,
                 consensus_config: self.state_builder.consensus_config,
 
                 _phantom: PhantomData,

--- a/monad-node/src/config/mod.rs
+++ b/monad-node/src/config/mod.rs
@@ -18,6 +18,10 @@ pub use fullnode::{FullNodeConfig, FullNodeIdentityConfig};
 mod network;
 pub use network::NodeNetworkConfig;
 
+mod sync_peers;
+#[allow(unused_imports)]
+pub use sync_peers::{BlockSyncPeersConfig, SyncPeerIdentityConfig};
+
 pub mod util;
 
 pub(crate) type SignatureType = SecpSignature;
@@ -48,6 +52,7 @@ pub struct NodeConfig {
 
     pub bootstrap: NodeBootstrapConfig,
     pub fullnode: FullNodeConfig,
+    pub blocksync_override: BlockSyncPeersConfig,
     pub network: NodeNetworkConfig,
 
     // TODO split network-wide configuration into separate file

--- a/monad-node/src/config/sync_peers.rs
+++ b/monad-node/src/config/sync_peers.rs
@@ -1,0 +1,18 @@
+use monad_secp::PubKey;
+use serde::{Deserialize, Serialize};
+
+use super::util::{deserialize_secp256k1_pubkey, serialize_secp256k1_pubkey};
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BlockSyncPeersConfig {
+    pub peers: Vec<SyncPeerIdentityConfig>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SyncPeerIdentityConfig {
+    #[serde(deserialize_with = "deserialize_secp256k1_pubkey")]
+    #[serde(serialize_with = "serialize_secp256k1_pubkey")]
+    pub secp256k1_pubkey: PubKey,
+}

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -582,6 +582,7 @@ where
     pub val_set_update_interval: SeqNum,
     pub epoch_start_delay: Round,
     pub beneficiary: [u8; 20],
+    pub block_sync_override_peers: Vec<NodeId<SCT::NodeIdPubKey>>,
 
     pub consensus_config: ConsensusConfig,
 
@@ -640,7 +641,7 @@ where
                     statesync_to_live_threshold,
                 ),
             ),
-            block_sync: BlockSync::default(),
+            block_sync: BlockSync::new(self.block_sync_override_peers),
 
             leader_election: self.leader_election,
             epoch_manager,

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -199,6 +199,7 @@ where
         epoch_start_delay: config.epoch_start_delay,
         beneficiary: Default::default(),
         forkpoint: Forkpoint::genesis(config.validators),
+        block_sync_override_peers: Default::default(),
         consensus_config: config.consensus_config,
 
         _phantom: PhantomData,

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -84,6 +84,7 @@ pub fn make_state_configs<S: SwarmRelation>(
             val_set_update_interval,
             epoch_start_delay,
             beneficiary: Default::default(),
+            block_sync_override_peers: Default::default(),
 
             consensus_config: ConsensusConfig {
                 execution_delay,

--- a/monad-twins/utils/src/twin_reader.rs
+++ b/monad-twins/utils/src/twin_reader.rs
@@ -129,6 +129,7 @@ where
                 val_set_update_interval: self.state_config.val_set_update_interval,
                 epoch_start_delay: self.state_config.epoch_start_delay,
                 beneficiary: self.state_config.beneficiary,
+                block_sync_override_peers: self.state_config.block_sync_override_peers.clone(),
 
                 consensus_config: self.state_config.consensus_config,
 
@@ -344,6 +345,7 @@ where
             val_set_update_interval: SeqNum(2000),
             epoch_start_delay: Round(50),
             beneficiary: Default::default(),
+            block_sync_override_peers: Default::default(),
 
             consensus_config: ConsensusConfig {
                 execution_delay: SeqNum(TWINS_STATE_ROOT_DELAY),


### PR DESCRIPTION
- Adds functionality to update blocksync peers
- Blocksync peers default to validators in bootstrap peers (known ip)


### Test plan
1. added unit tests for `BlockSyncWrapper::handle_update_peers`
2. debug-node functionalities were manually verified
3. created issue for test coverage on debug-node toolchain: https://github.com/monad-crypto/monad-internal/issues/959