### PR TITLE
Add trace_block rpc method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4712,6 +4712,7 @@ dependencies = [
  "alloy-primitives 0.6.0",
  "alloy-rlp",
  "alloy-rpc-client",
+ "alloy-sol-types 0.6.0",
  "bytes",
  "clap 4.4.10",
  "env_logger 0.10.1",

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -24,6 +24,7 @@ actix-web = { workspace = true }
 actix-web-actors = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }
+alloy-sol-types = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 env_logger = { workspace = true }

--- a/monad-rpc/src/eth_json_types.rs
+++ b/monad-rpc/src/eth_json_types.rs
@@ -17,7 +17,7 @@ use crate::{
 pub type EthAddress = FixedData<20>;
 pub type EthHash = FixedData<32>;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MonadU256(pub U256);
 
 impl Serialize for MonadU256 {
@@ -218,7 +218,7 @@ impl schemars::JsonSchema for EthHash {
 }
 
 // https://ethereum.org/developers/docs/apis/json-rpc#unformatted-data-encoding
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UnformattedData(pub Vec<u8>);
 
 impl UnformattedData {
@@ -338,7 +338,7 @@ impl<'de> Deserialize<'de> for Quantity {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FixedData<const N: usize>(pub [u8; N]);
 
 impl<const N: usize> std::fmt::Display for FixedData<N> {

--- a/monad-rpc/src/trace.rs
+++ b/monad-rpc/src/trace.rs
@@ -29,12 +29,6 @@ pub struct TraceCallObject {
     pub data: Option<String>,
 }
 
-#[rpc(method = "trace_block")]
-#[allow(non_snake_case)]
-pub async fn monad_trace_block(params: BlockTags) -> JsonRpcResult<String> {
-    Err(JsonRpcError::method_not_supported())
-}
-
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct TraceCallParams {
     pub calls: Vec<TraceCallObject>,


### PR DESCRIPTION
Adds `trace_block` rpc method. `traceAddress` response is not implemented yet. I need to build a bigger callgraph in flexnet contracts to test against anvil. 