### PR TITLE
Add archive read support for RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4747,6 +4747,7 @@ dependencies = [
  "flume",
  "futures",
  "futures-util",
+ "monad-archive",
  "monad-cxx",
  "monad-eth-block-policy",
  "monad-rpc-docs",

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -11,6 +11,7 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+monad-archive = { path = "../monad-archive" }
 monad-cxx = { path = "../monad-cxx" }
 monad-eth-block-policy = { path = "../monad-eth-block-policy" }
 monad-triedb-utils = { path = "../monad-triedb-utils" }

--- a/monad-rpc/src/block_handlers.rs
+++ b/monad-rpc/src/block_handlers.rs
@@ -2,9 +2,10 @@ use alloy_primitives::{
     aliases::{U256, U64},
     FixedBytes,
 };
+use monad_archive::archive_reader::ArchiveReader;
 use monad_rpc_docs::rpc;
 use monad_triedb_utils::triedb_env::Triedb;
-use reth_primitives::{Header as RlpHeader, TransactionSigned};
+use reth_primitives::{Header as RlpHeader, ReceiptWithBloom, TransactionSigned};
 use reth_rpc_types::{Block, BlockTransactions, Header, Transaction, TransactionReceipt};
 use serde::{Deserialize, Serialize};
 use tracing::trace;
@@ -35,7 +36,7 @@ fn parse_block_content(
     rlp_header: RlpHeader,
     transactions: Vec<TransactionSigned>,
     return_full_txns: bool,
-) -> Result<Block, JsonRpcError> {
+) -> JsonRpcResult<Option<MonadEthGetBlock>> {
     let size = rlp_header.size();
 
     // parse block header
@@ -95,7 +96,9 @@ fn parse_block_content(
         other: Default::default(),
     };
 
-    Ok(retval)
+    Ok(Some(MonadEthGetBlock {
+        block: MonadBlock(retval),
+    }))
 }
 
 #[rpc(method = "eth_blockNumber")]
@@ -137,43 +140,49 @@ pub struct MonadEthGetBlock {
 /// Returns information about a block by hash.
 pub async fn monad_eth_getBlockByHash<T: Triedb>(
     triedb_env: &T,
+    archive_reader: &Option<ArchiveReader>,
     params: MonadEthGetBlockByHashParams,
 ) -> JsonRpcResult<Option<MonadEthGetBlock>> {
     trace!("monad_eth_getBlockByHash: {params:?}");
 
     let latest_block_num = get_block_num_from_tag(triedb_env, BlockTags::Latest).await?;
-    let Some(block_num) = triedb_env
+    if let Some(block_num) = triedb_env
         .get_block_number_by_hash(params.block_hash.0, latest_block_num)
         .await
         .map_err(JsonRpcError::internal_error)?
-    else {
-        return Ok(None);
-    };
-
-    let header = match triedb_env
-        .get_block_header(block_num)
-        .await
-        .map_err(JsonRpcError::internal_error)?
     {
-        Some(header) => header,
-        None => return Ok(None),
-    };
-    let transactions = triedb_env
-        .get_transactions(block_num)
-        .await
-        .map_err(JsonRpcError::internal_error)?;
+        if let Some(header) = triedb_env
+            .get_block_header(block_num)
+            .await
+            .map_err(JsonRpcError::internal_error)?
+        {
+            let transactions = triedb_env
+                .get_transactions(block_num)
+                .await
+                .map_err(JsonRpcError::internal_error)?;
+            return parse_block_content(
+                header.hash,
+                header.header,
+                transactions,
+                params.return_full_txns,
+            );
+        }
+    }
 
-    parse_block_content(
-        params.block_hash.0.into(),
-        header.header,
-        transactions,
-        params.return_full_txns,
-    )
-    .map(|block| {
-        Some(MonadEthGetBlock {
-            block: MonadBlock(block),
-        })
-    })
+    // try archive if header not found and archive reader specified
+    if let Some(archive_reader) = archive_reader {
+        if let Ok(block) = archive_reader.get_block_by_hash(&params.block_hash.0).await {
+            return parse_block_content(
+                block.header.hash_slow(),
+                block.header,
+                block.body,
+                params.return_full_txns,
+            );
+        }
+    }
+
+    // return none if both triedb and archive fails
+    Ok(None)
 }
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
@@ -187,36 +196,44 @@ pub struct MonadEthGetBlockByNumberParams {
 /// Returns information about a block by number.
 pub async fn monad_eth_getBlockByNumber<T: Triedb>(
     triedb_env: &T,
+    archive_reader: &Option<ArchiveReader>,
     params: MonadEthGetBlockByNumberParams,
 ) -> JsonRpcResult<Option<MonadEthGetBlock>> {
     trace!("monad_eth_getBlockByNumber: {params:?}");
 
     let block_num = get_block_num_from_tag(triedb_env, params.block_number).await?;
 
-    let header = match triedb_env
+    if let Some(header) = triedb_env
         .get_block_header(block_num)
         .await
         .map_err(JsonRpcError::internal_error)?
     {
-        Some(header) => header,
-        None => return Ok(None),
-    };
-    let transactions = triedb_env
-        .get_transactions(block_num)
-        .await
-        .map_err(JsonRpcError::internal_error)?;
+        let transactions = triedb_env
+            .get_transactions(block_num)
+            .await
+            .map_err(JsonRpcError::internal_error)?;
+        return parse_block_content(
+            header.hash,
+            header.header,
+            transactions,
+            params.return_full_txns,
+        );
+    }
 
-    parse_block_content(
-        header.hash,
-        header.header,
-        transactions,
-        params.return_full_txns,
-    )
-    .map(|block| {
-        Some(MonadEthGetBlock {
-            block: MonadBlock(block),
-        })
-    })
+    // try archive if header not found and archive reader specified
+    if let Some(archive_reader) = archive_reader {
+        if let Ok(block) = archive_reader.get_block_by_number(block_num).await {
+            return parse_block_content(
+                block.header.hash_slow(),
+                block.header,
+                block.body,
+                params.return_full_txns,
+            );
+        }
+    }
+
+    // return none if both triedb and archive fails
+    Ok(None)
 }
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
@@ -229,24 +246,32 @@ pub struct MonadEthGetBlockTransactionCountByHashParams {
 /// Returns the number of transactions in a block from a block matching the given block hash.
 pub async fn monad_eth_getBlockTransactionCountByHash<T: Triedb>(
     triedb_env: &T,
+    archive_reader: &Option<ArchiveReader>,
     params: MonadEthGetBlockTransactionCountByHashParams,
 ) -> JsonRpcResult<Option<String>> {
     trace!("monad_eth_getBlockTransactionCountByHash: {params:?}");
 
     let latest_block_num = get_block_num_from_tag(triedb_env, BlockTags::Latest).await?;
-    let Some(block_num) = triedb_env
+    if let Some(block_num) = triedb_env
         .get_block_number_by_hash(params.block_hash.0, latest_block_num)
         .await
         .map_err(JsonRpcError::internal_error)?
-    else {
-        return Ok(None);
-    };
+    {
+        let transactions = triedb_env
+            .get_transactions(block_num)
+            .await
+            .map_err(JsonRpcError::internal_error)?;
+        return Ok(Some(format!("0x{:x}", transactions.len())));
+    }
 
-    let transactions = triedb_env
-        .get_transactions(block_num)
-        .await
-        .map_err(JsonRpcError::internal_error)?;
-    Ok(Some(format!("0x{:x}", transactions.len())))
+    // try archive if block hash not found and archive reader specified
+    if let Some(archive_reader) = archive_reader {
+        if let Ok(block) = archive_reader.get_block_by_hash(&params.block_hash.0).await {
+            return Ok(Some(format!("0x{:x}", block.body.len())));
+        }
+    }
+
+    Ok(None)
 }
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
@@ -259,43 +284,43 @@ pub struct MonadEthGetBlockTransactionCountByNumberParams {
 /// Returns the number of transactions in a block matching the given block number.
 pub async fn monad_eth_getBlockTransactionCountByNumber<T: Triedb>(
     triedb_env: &T,
+    archive_reader: &Option<ArchiveReader>,
     params: MonadEthGetBlockTransactionCountByNumberParams,
 ) -> JsonRpcResult<Option<String>> {
     trace!("monad_eth_getBlockTransactionCountByNumber: {params:?}");
 
     let block_num = get_block_num_from_tag(triedb_env, params.block_tag).await?;
-
-    let Some(_) = triedb_env
+    if triedb_env
         .get_block_header(block_num)
         .await
         .map_err(JsonRpcError::internal_error)?
-    else {
-        return Ok(None);
-    };
+        .is_some()
+    {
+        let transactions = triedb_env
+            .get_transactions(block_num)
+            .await
+            .map_err(JsonRpcError::internal_error)?;
+        return Ok(Some(format!("0x{:x}", transactions.len())));
+    }
 
-    let transactions = triedb_env
-        .get_transactions(block_num)
-        .await
-        .map_err(JsonRpcError::internal_error)?;
-    Ok(Some(format!("0x{:x}", transactions.len())))
+    // try archive if block number not found and archive reader specified
+    if let Some(archive_reader) = archive_reader {
+        if let Ok(block) = archive_reader.get_block_by_number(block_num).await {
+            return Ok(Some(format!("0x{:x}", block.body.len())));
+        }
+    }
+
+    Ok(None)
 }
 
-pub async fn map_block_receipts<T: Triedb, R>(
-    triedb_env: &T,
+pub async fn map_block_receipts<R>(
+    transactions: &[TransactionSigned],
+    receipts: Vec<ReceiptWithBloom>,
     block_header: &RlpHeader,
     block_hash: FixedBytes<32>,
     f: impl Fn(TransactionReceipt) -> R,
 ) -> Result<Vec<R>, JsonRpcError> {
     let block_num: u64 = block_header.number;
-
-    let transactions = triedb_env
-        .get_transactions(block_num)
-        .await
-        .map_err(JsonRpcError::internal_error)?;
-    let receipts = triedb_env
-        .get_receipts(block_num)
-        .await
-        .map_err(JsonRpcError::internal_error)?;
 
     if transactions.len() != receipts.len() {
         Err(JsonRpcError::internal_error(
@@ -306,20 +331,25 @@ pub async fn map_block_receipts<T: Triedb, R>(
     let mut prev_receipt = None;
 
     transactions
-        .into_iter()
+        .iter()
         .zip(receipts.into_iter())
         .enumerate()
         .map(|(tx_index, (tx, receipt))| -> Result<R, JsonRpcError> {
             let prev_receipt = prev_receipt.replace(receipt.receipt.to_owned());
+            let gas_used = if let Some(prev_receipt) = prev_receipt {
+                receipt.receipt.cumulative_gas_used - prev_receipt.cumulative_gas_used
+            } else {
+                receipt.receipt.cumulative_gas_used
+            };
 
             let parsed_receipt = parse_tx_receipt(
-                block_header,
+                block_header.base_fee_per_gas,
                 block_hash,
                 tx,
-                prev_receipt,
+                gas_used,
                 receipt,
                 block_num,
-                tx_index,
+                tx_index as u64,
             )?;
 
             Ok(f(parsed_receipt))
@@ -327,12 +357,20 @@ pub async fn map_block_receipts<T: Triedb, R>(
         .collect()
 }
 
-pub async fn block_receipts<T: Triedb>(
-    triedb_env: &T,
+pub async fn block_receipts(
+    transactions: &[TransactionSigned],
+    receipts: Vec<ReceiptWithBloom>,
     block_header: &RlpHeader,
     block_hash: FixedBytes<32>,
 ) -> Result<Vec<TransactionReceipt>, JsonRpcError> {
-    map_block_receipts(triedb_env, block_header, block_hash, |receipt| receipt).await
+    map_block_receipts(
+        transactions,
+        receipts,
+        block_header,
+        block_hash,
+        |receipt| receipt,
+    )
+    .await
 }
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
@@ -348,6 +386,7 @@ pub struct MonadEthGetBlockReceiptsResult(Vec<MonadTransactionReceipt>);
 /// Returns the receipts of a block by number or hash.
 pub async fn monad_eth_getBlockReceipts<T: Triedb>(
     triedb_env: &T,
+    archive_reader: &Option<ArchiveReader>,
     params: MonadEthGetBlockReceiptsParams,
 ) -> JsonRpcResult<Option<MonadEthGetBlockReceiptsResult>> {
     trace!("monad_eth_getBlockReceipts: {params:?}");
@@ -369,22 +408,46 @@ pub async fn monad_eth_getBlockReceipts<T: Triedb>(
         }
     };
 
-    let header = match triedb_env
+    if let Some(header) = triedb_env
         .get_block_header(block_num)
         .await
         .map_err(JsonRpcError::internal_error)?
     {
-        Some(header) => header,
-        None => return Ok(None),
-    };
+        let transactions = triedb_env
+            .get_transactions(block_num)
+            .await
+            .map_err(JsonRpcError::internal_error)?;
+        let receipts = triedb_env
+            .get_receipts(block_num)
+            .await
+            .map_err(JsonRpcError::internal_error)?;
+        let block_receipts = map_block_receipts(
+            &transactions,
+            receipts,
+            &header.header,
+            header.hash,
+            MonadTransactionReceipt,
+        )
+        .await?;
+        return Ok(Some(MonadEthGetBlockReceiptsResult(block_receipts)));
+    }
 
-    let block_receipts = map_block_receipts(
-        triedb_env,
-        &header.header,
-        header.hash,
-        MonadTransactionReceipt,
-    )
-    .await?;
+    // try archive if header not found and archive reader specified
+    if let Some(archive_reader) = archive_reader {
+        if let Ok(bloom_receipts) = archive_reader.get_block_receipts(block_num).await {
+            if let Ok(block) = archive_reader.get_block_by_number(block_num).await {
+                let block_receipts = map_block_receipts(
+                    &block.body,
+                    bloom_receipts,
+                    &block.header,
+                    block.hash_slow(),
+                    MonadTransactionReceipt,
+                )
+                .await?;
+                return Ok(Some(MonadEthGetBlockReceiptsResult(block_receipts)));
+            }
+        }
+    }
 
-    Ok(Some(MonadEthGetBlockReceiptsResult(block_receipts)))
+    Ok(None)
 }

--- a/monad-rpc/src/block_watcher.rs
+++ b/monad-rpc/src/block_watcher.rs
@@ -82,7 +82,13 @@ impl<T: Triedb + Send + Sync> BlockState for TrieDbBlockState<T> {
             .get_transactions(block_num)
             .await
             .map_err(JsonRpcError::internal_error)?;
-        let receipts = block_receipts(&self.inner, &header.header, header.hash).await?;
+        let bloom_receipts = self
+            .inner
+            .get_receipts(block_num)
+            .await
+            .map_err(JsonRpcError::internal_error)?;
+        let receipts =
+            block_receipts(&transactions, bloom_receipts, &header.header, header.hash).await?;
 
         let result: Vec<(TransactionSigned, TransactionReceipt)> =
             transactions.into_iter().zip(receipts).collect();

--- a/monad-rpc/src/cli.rs
+++ b/monad-rpc/src/cli.rs
@@ -57,4 +57,16 @@ pub struct Cli {
     /// This capacity is set for each sub-pool, and entries are dropped once the capacity is reached.
     #[arg(long, default_value_t = 20_000)]
     pub vpool_capacity: usize,
+
+    /// Set the s3 bucket to read archive data from
+    #[arg(long)]
+    pub s3_bucket: Option<String>,
+
+    /// Set the dynamodb table to read archive data from
+    #[arg(long)]
+    pub index_table: Option<String>,
+
+    /// Set the s3 region to read archive data from
+    #[arg(long)]
+    pub region: Option<String>,
 }

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -9,6 +9,7 @@ use actix_web::{
 use clap::Parser;
 use eth_json_types::serialize_result;
 use futures::{SinkExt, StreamExt};
+use monad_archive::{archive_reader::ArchiveReader, metrics::Metrics};
 use monad_triedb_utils::triedb_env::TriedbEnv;
 use opentelemetry::metrics::MeterProvider;
 use reth_primitives::TransactionSigned;
@@ -194,14 +195,14 @@ async fn rpc_select(
         "debug_traceBlockByHash" => {
             let triedb_env = app_state.triedb_reader.as_ref().method_not_supported()?;
             let params = serde_json::from_value(params).invalid_params()?;
-            monad_debug_traceBlockByHash(triedb_env, params)
+            monad_debug_traceBlockByHash(triedb_env, &app_state.archive_reader, params)
                 .await
                 .map(serialize_result)?
         }
         "debug_traceBlockByNumber" => {
             let triedb_env = app_state.triedb_reader.as_ref().method_not_supported()?;
             let params = serde_json::from_value(params).invalid_params()?;
-            monad_debug_traceBlockByNumber(triedb_env, params)
+            monad_debug_traceBlockByNumber(triedb_env, &app_state.archive_reader, params)
                 .await
                 .map(serialize_result)?
         }
@@ -215,7 +216,7 @@ async fn rpc_select(
         "debug_traceTransaction" => {
             let triedb_env = app_state.triedb_reader.as_ref().method_not_supported()?;
             let params = serde_json::from_value(params).invalid_params()?;
-            monad_debug_traceTransaction(triedb_env, params)
+            monad_debug_traceTransaction(triedb_env, &app_state.archive_reader, params)
                 .await
                 .map(serialize_result)?
         }
@@ -257,14 +258,14 @@ async fn rpc_select(
             let triedb_env = app_state.triedb_reader.as_ref().method_not_supported()?;
 
             let params = serde_json::from_value(params).invalid_params()?;
-            monad_eth_getLogs(triedb_env, params)
+            monad_eth_getLogs(triedb_env, &app_state.archive_reader, params)
                 .await
                 .map(serialize_result)?
         }
         "eth_getTransactionByHash" => {
             if let Some(triedb_env) = app_state.triedb_reader.as_ref() {
                 let params = serde_json::from_value(params).invalid_params()?;
-                monad_eth_getTransactionByHash(triedb_env, params)
+                monad_eth_getTransactionByHash(triedb_env, &app_state.archive_reader, params)
                     .await
                     .map(serialize_result)?
             } else {
@@ -272,9 +273,9 @@ async fn rpc_select(
             }
         }
         "eth_getBlockByHash" => {
-            if let Some(triedb_env) = app_state.triedb_reader.as_ref() {
+            if let Some(triedb_env) = &app_state.triedb_reader {
                 let params = serde_json::from_value(params).invalid_params()?;
-                monad_eth_getBlockByHash(triedb_env, params)
+                monad_eth_getBlockByHash(triedb_env, &app_state.archive_reader, params)
                     .await
                     .map(serialize_result)?
             } else {
@@ -284,7 +285,7 @@ async fn rpc_select(
         "eth_getBlockByNumber" => {
             if let Some(reader) = &app_state.triedb_reader {
                 let params = serde_json::from_value(params).invalid_params()?;
-                monad_eth_getBlockByNumber(reader, params)
+                monad_eth_getBlockByNumber(reader, &app_state.archive_reader, params)
                     .await
                     .map(serialize_result)?
             } else {
@@ -294,9 +295,13 @@ async fn rpc_select(
         "eth_getTransactionByBlockHashAndIndex" => {
             if let Some(triedb_env) = &app_state.triedb_reader {
                 let params = serde_json::from_value(params).invalid_params()?;
-                monad_eth_getTransactionByBlockHashAndIndex(triedb_env, params)
-                    .await
-                    .map(serialize_result)?
+                monad_eth_getTransactionByBlockHashAndIndex(
+                    triedb_env,
+                    &app_state.archive_reader,
+                    params,
+                )
+                .await
+                .map(serialize_result)?
             } else {
                 Err(JsonRpcError::method_not_supported())
             }
@@ -304,9 +309,13 @@ async fn rpc_select(
         "eth_getTransactionByBlockNumberAndIndex" => {
             if let Some(triedb_env) = &app_state.triedb_reader {
                 let params = serde_json::from_value(params).invalid_params()?;
-                monad_eth_getTransactionByBlockNumberAndIndex(triedb_env, params)
-                    .await
-                    .map(serialize_result)?
+                monad_eth_getTransactionByBlockNumberAndIndex(
+                    triedb_env,
+                    &app_state.archive_reader,
+                    params,
+                )
+                .await
+                .map(serialize_result)?
             } else {
                 Err(JsonRpcError::method_not_supported())
             }
@@ -314,9 +323,13 @@ async fn rpc_select(
         "eth_getBlockTransactionCountByHash" => {
             if let Some(triedb_env) = app_state.triedb_reader.as_ref() {
                 let params = serde_json::from_value(params).invalid_params()?;
-                monad_eth_getBlockTransactionCountByHash(triedb_env, params)
-                    .await
-                    .map(serialize_result)?
+                monad_eth_getBlockTransactionCountByHash(
+                    triedb_env,
+                    &app_state.archive_reader,
+                    params,
+                )
+                .await
+                .map(serialize_result)?
             } else {
                 Err(JsonRpcError::method_not_supported())
             }
@@ -324,9 +337,13 @@ async fn rpc_select(
         "eth_getBlockTransactionCountByNumber" => {
             if let Some(triedb_env) = app_state.triedb_reader.as_ref() {
                 let params = serde_json::from_value(params).invalid_params()?;
-                monad_eth_getBlockTransactionCountByNumber(triedb_env, params)
-                    .await
-                    .map(serialize_result)?
+                monad_eth_getBlockTransactionCountByNumber(
+                    triedb_env,
+                    &app_state.archive_reader,
+                    params,
+                )
+                .await
+                .map(serialize_result)?
             } else {
                 Err(JsonRpcError::method_not_supported())
             }
@@ -439,14 +456,14 @@ async fn rpc_select(
             };
 
             let params = serde_json::from_value(params).invalid_params()?;
-            monad_eth_getTransactionReceipt(triedb_reader, params)
+            monad_eth_getTransactionReceipt(triedb_reader, &app_state.archive_reader, params)
                 .await
                 .map(serialize_result)?
         }
         "eth_getBlockReceipts" => {
             let triedb_reader = app_state.triedb_reader.as_ref().method_not_supported()?;
             let params = serde_json::from_value(params).invalid_params()?;
-            monad_eth_getBlockReceipts(triedb_reader, params)
+            monad_eth_getBlockReceipts(triedb_reader, &app_state.archive_reader, params)
                 .await
                 .map(serialize_result)?
         }
@@ -504,6 +521,7 @@ struct ExecutionLedgerPath(pub Option<PathBuf>);
 struct MonadRpcResources {
     mempool_sender: flume::Sender<TransactionSigned>,
     triedb_reader: Option<TriedbEnv>,
+    archive_reader: Option<ArchiveReader>,
     execution_ledger_path: ExecutionLedgerPath,
     chain_id: u64,
     batch_request_limit: u16,
@@ -525,6 +543,7 @@ impl MonadRpcResources {
     pub fn new(
         mempool_sender: flume::Sender<TransactionSigned>,
         triedb_reader: Option<TriedbEnv>,
+        archive_reader: Option<ArchiveReader>,
         execution_ledger_path: Option<PathBuf>,
         chain_id: u64,
         batch_request_limit: u16,
@@ -536,6 +555,7 @@ impl MonadRpcResources {
         Self {
             mempool_sender,
             triedb_reader,
+            archive_reader,
             execution_ledger_path: ExecutionLedgerPath(execution_ledger_path),
             chain_id,
             batch_request_limit,
@@ -643,6 +663,17 @@ async fn main() -> std::io::Result<()> {
         .as_deref()
         .map(|path| TriedbEnv::new(path, args.triedb_max_concurrent_requests as usize));
 
+    // Initialize archive reader if specified. If not specified, RPC can only read the latest <history_length> blocks from chain tip
+    let archive_reader = match (args.s3_bucket, args.index_table, args.region) {
+        (Some(s3_bucket), Some(index_table), Some(region)) => Some(
+            async move {
+                ArchiveReader::new(s3_bucket, index_table, Some(region), 5, Metrics::none()).await
+            }
+            .await,
+        ),
+        _ => None,
+    };
+
     // We need to spawn a task to handle changes to the base fee, and block updates
     let tx_pool2 = tx_pool.clone();
     let triedb_env2 = triedb_env.clone();
@@ -657,6 +688,7 @@ async fn main() -> std::io::Result<()> {
     let resources = MonadRpcResources::new(
         ipc_sender.clone(),
         triedb_env,
+        archive_reader,
         Some(args.execution_ledger_path),
         args.chain_id,
         args.batch_request_limit,
@@ -753,6 +785,7 @@ mod tests {
         let app = test::init_service(create_app(MonadRpcResources {
             mempool_sender: ipc_sender.clone(),
             triedb_reader: None,
+            archive_reader: None,
             execution_ledger_path: ExecutionLedgerPath(None),
             chain_id: 1337,
             batch_request_limit: 5,

--- a/monad-rpc/src/websocket.rs
+++ b/monad-rpc/src/websocket.rs
@@ -112,6 +112,7 @@ mod tests {
         let resources = MonadRpcResources {
             mempool_sender: ipc_sender.clone(),
             triedb_reader: None,
+            archive_reader: None,
             execution_ledger_path: ExecutionLedgerPath(None),
             chain_id: 41454,
             batch_request_limit: 1000,


### PR DESCRIPTION
Supported archive endpoints: 
- eth_getBlockByNumber
- eth_getBlockByHash
- eth_getBlockReceipts
- eth_getLogs
- eth_getTransactionByHash
- eth_getTransactionReceipt
- eth_getTransactionByBlockHashAndIndex
- eth_getTransactonByBlockNumberAndIndex
- eth_getBlockTransactionCountByHash
- eth_getBlockTransactionCountByNumber
- debug_traceTransaction
- debug_traceBlockByHash
- debug_traceBlockByNumber
