### PR TITLE
Tighter bounds for allowed values of RaptorCast Merkle tree depth

### DIFF
--- a/monad-merkle/src/lib.rs
+++ b/monad-merkle/src/lib.rs
@@ -14,7 +14,7 @@ pub struct MerkleProof {
 impl MerkleProof {
     pub fn new_from_leaf_idx(siblings: Vec<MerkleHash>, leaf_idx: u8) -> Option<Self> {
         let num_leaves = 2_u16.checked_pow(siblings.len() as u32)?;
-        let tree_len = 2 * num_leaves - 1;
+        let tree_len = 2_u16.checked_mul(num_leaves)?.checked_sub(1)?;
         let tree_leaf_start_idx = tree_len - num_leaves;
         Some(Self {
             tree_leaf_idx: tree_leaf_start_idx + u16::from(leaf_idx),


### PR DESCRIPTION
@felix-asym suggested that we address a potential u16 overflow in
`MerkleProof::new_from_leaf_idx` :

https://github.com/category-labs/monad-bft/issues/1324

This patch folds in @felix-asym 's suggested fix.

In theory, this can be triggered by a remote attacker, by sending
us a RaptorCast frame with `raptorcast.merkle_tree_depth == 16`, which
will cause a `siblings: Vec<MerkleHash>` of length 15 to be populated
from packet contents, will cause `num_leaves: u16` to become 32768, and
the next line will then multiply this value by 2, causing an integer
overflow, as 65536 does not fit in an u16.

I tried writing a test to trigger this, to see if it is really a
remotely-triggerable issue, but RaptorCast's `build_messages()` won't
allow us to construct a RaptorCast packet with `tree_depth == 16` without
a number of other changes, which I am still working on, and will submit
later, along with a test for this case, if this indeed turns out to be
remotely triggerable.

In the meantime, what we can do is tighten the `tree_depth` bounds both
on ingress and on egress, which this patch also does.  The tightest
possible bounds are:

- `tree_depth >= 1`.  For the case where every transmitted symbol is
  its own Merkle tree, `tree_depth == 1`, and this is the minimum value
  we should allow.

- `tree_depth <= 9`.  For a tree depth of 9, the index of the rightmost
  Merkle tree leaf will be `0xff`, and the Merkle leaf index field is 8
  bits wide, and so, `tree_depth == 9` is the maximum value we can allow.

I've tested `tree_depth == 1` and `tree_depth == 9`, and both cases seem to
work fine (where for `tree_depth == 9` in the egress direction we require
the included type change for `chunks_per_merkle_batch` from `u8` to a wider
type), and nodes can exchange proposals with other nodes in both cases.