### PR TITLE
Set testnet vote-pace to 1000ms

### DIFF
--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -313,7 +313,7 @@ async fn run(
             live_to_statesync_threshold: SeqNum(statesync_threshold as u64 * 3 / 2),
             // Live starts execution here
             start_execution_threshold: SeqNum(statesync_threshold as u64 / 2),
-            vote_pace: Duration::from_millis(500),
+            vote_pace: Duration::from_millis(1000),
             timestamp_latency_estimate_ms: 20,
         },
         _phantom: PhantomData,


### PR DESCRIPTION
resolves https://github.com/category-labs/category-internal/issues/1014,

the round-timeout in pacemaker is already a function of vote_pace and delta so shouldn't require any other adjustment