### PR TITLE
Make all epochs equal length

### DIFF
--- a/monad-mock-swarm/tests/epoch.rs
+++ b/monad-mock-swarm/tests/epoch.rs
@@ -239,7 +239,7 @@ mod test {
 
         let mut nodes = swarm_config.build();
 
-        let update_block_num = val_set_update_interval;
+        let update_block_num = val_set_update_interval - SeqNum(1);
         // terminates when any node produced more than `until_block` blocks. we
         // want the longest ledger to be shorter than update_block_num
         let mut term_before_update_block =
@@ -346,7 +346,7 @@ mod test {
 
         let mut nodes = swarm_config.build();
 
-        let update_block_num = val_set_update_interval;
+        let update_block_num = val_set_update_interval - SeqNum(1);
 
         let mut term_before_update_block =
             UntilTerminator::new().until_block((update_block_num.0 - 2) as usize);
@@ -539,7 +539,7 @@ mod test {
 
         let mut nodes = swarm_config.build();
 
-        let update_block_num_end_1 = val_set_update_interval;
+        let update_block_num_end_1 = val_set_update_interval - SeqNum(1);
 
         let mut term_on_schedule_epoch_2 =
             UntilTerminator::new().until_block(update_block_num_end_1.0 as usize + 1);
@@ -561,7 +561,7 @@ mod test {
         // all nodes must have advanced to next epoch
         verify_nodes_in_epoch(nodes.states().values().collect_vec(), Epoch(2));
 
-        let update_block_num_end_2 = SeqNum(val_set_update_interval.0 * 2);
+        let update_block_num_end_2 = SeqNum(val_set_update_interval.0 * 2) - SeqNum(1);
 
         let mut term_on_schedule_epoch_3 =
             UntilTerminator::new().until_block(update_block_num_end_2.0 as usize + 1);
@@ -583,7 +583,7 @@ mod test {
         // all nodes must have advanced to next epoch
         verify_nodes_in_epoch(nodes.states().values().collect_vec(), Epoch(3));
 
-        let update_block_num_end_3 = SeqNum(val_set_update_interval.0 * 3);
+        let update_block_num_end_3 = SeqNum(val_set_update_interval.0 * 3) - SeqNum(1);
 
         let mut term_on_schedule_epoch_4 =
             UntilTerminator::new().until_block(update_block_num_end_3.0 as usize + 1);

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -233,21 +233,16 @@ impl SeqNum {
     /// Compute the epoch that the sequence number belong to. It does NOT mean
     /// that the block is proposed in the epoch
     ///
-    /// [0, val_set_update_interval] -> Epoch 1
-    /// [val_set_update_interval + 1, 2 * val_set_update_interval] -> Epoch 2
-    /// ... The first epoch is one block longer than all other ones
+    /// [0, val_set_update_interval-1] -> Epoch 1
+    /// [val_set_update_interval, (2 * val_set_update_interval)-1] -> Epoch 2
     pub fn to_epoch(&self, val_set_update_interval: SeqNum) -> Epoch {
-        Epoch((self.0.saturating_sub(1) / val_set_update_interval.0) + 1)
+        Epoch((self.0 / val_set_update_interval.0) + 1)
     }
 
-    /// The first epoch starts with SeqNum 0 and end with 100. Every epoch
-    /// afterwards starts at SeqNum (X * interval) + 1 and end with (X *
-    /// interval + interval)
-    ///
     /// This tells us what the boundary block of the epoch is. Note that this only indicates when
     /// the next epoch's round is scheduled.
     pub fn is_epoch_end(&self, val_set_update_interval: SeqNum) -> bool {
-        *self % val_set_update_interval == SeqNum(0) && *self != SeqNum(0)
+        *self % val_set_update_interval == val_set_update_interval - SeqNum(1)
     }
 
     /// Get the epoch number whose validator set is locked by this block. Should


### PR DESCRIPTION
I think this was an artifact of some other change related to genesis block seq num that no longer exists (something about making the first committed block have seqnum 0?). Does not seem relevant anymore. 

resolves category-labs/category-internal#353