### PR TITLE
Remove parent_round and parent_id from Vote

### DIFF
--- a/monad-consensus-types/src/block.rs
+++ b/monad-consensus-types/src/block.rs
@@ -81,6 +81,10 @@ where
     pub fn get_parent_id(&self) -> BlockId {
         self.qc.get_block_id()
     }
+
+    pub fn get_parent_round(&self) -> Round {
+        self.qc.get_round()
+    }
 }
 
 impl<ST, SCT, EPT> PartialEq for ConsensusBlockHeader<ST, SCT, EPT>

--- a/monad-consensus-types/src/convert/voting.rs
+++ b/monad-consensus-types/src/convert/voting.rs
@@ -8,8 +8,6 @@ impl From<&Vote> for ProtoVote {
             id: Some((&vi.id).into()),
             epoch: Some((&vi.epoch).into()),
             round: Some((&vi.round).into()),
-            parent_id: Some((&vi.parent_id).into()),
-            parent_round: Some((&vi.parent_round).into()),
         }
     }
 }
@@ -28,18 +26,6 @@ impl TryFrom<ProtoVote> for Vote {
             round: proto_vi
                 .round
                 .ok_or(Self::Error::MissingRequiredField("Vote.round".to_owned()))?
-                .try_into()?,
-            parent_id: proto_vi
-                .parent_id
-                .ok_or(Self::Error::MissingRequiredField(
-                    "Vote.parent_id".to_owned(),
-                ))?
-                .try_into()?,
-            parent_round: proto_vi
-                .parent_round
-                .ok_or(Self::Error::MissingRequiredField(
-                    "Vote.parent_round".to_owned(),
-                ))?
                 .try_into()?,
         })
     }

--- a/monad-consensus-types/src/voting.rs
+++ b/monad-consensus-types/src/voting.rs
@@ -39,10 +39,6 @@ pub struct Vote {
     pub epoch: Epoch,
     /// round of the proposed block
     pub round: Round,
-    /// parent block id of the proposed block
-    pub parent_id: BlockId,
-    /// parent round of the proposed block
-    pub parent_round: Round,
 }
 
 impl Hashable for Vote {
@@ -57,8 +53,6 @@ impl std::fmt::Debug for Vote {
             .field("id", &self.id)
             .field("epoch", &self.epoch)
             .field("r", &self.round)
-            .field("pid", &self.parent_id)
-            .field("pr", &self.parent_round)
             .finish()
     }
 }
@@ -69,8 +63,6 @@ impl DontCare for Vote {
             id: BlockId(Hash([0x0_u8; 32])),
             epoch: Epoch(1),
             round: Round(0),
-            parent_id: BlockId(Hash([0x0_u8; 32])),
-            parent_round: Round(0),
         }
     }
 }

--- a/monad-consensus/src/validation/safety.rs
+++ b/monad-consensus/src/validation/safety.rs
@@ -127,8 +127,6 @@ impl Safety {
                 id: block.get_id(),
                 epoch: block.get_epoch(),
                 round: block.get_round(),
-                parent_id: block.get_parent_id(),
-                parent_round: block.get_parent_round(),
             };
 
             return Some(vote);

--- a/monad-mock-swarm/tests/protobuf.rs
+++ b/monad-mock-swarm/tests/protobuf.rs
@@ -59,8 +59,6 @@ fn test_consensus_message_event_vote_multisig() {
         id: BlockId(Hash([42_u8; 32])),
         epoch: Epoch(1),
         round: Round(1),
-        parent_id: BlockId(Hash([43_u8; 32])),
-        parent_round: Round(2),
     };
 
     let votemsg: ProtocolMessage<SignatureType, SignatureCollectionType, ExecutionProtocolType> =

--- a/monad-proto/proto/voting.proto
+++ b/monad-proto/proto/voting.proto
@@ -8,6 +8,4 @@ message ProtoVote {
   monad_proto.basic.ProtoBlockId id = 1;
   monad_proto.basic.ProtoEpoch epoch = 2;
   monad_proto.basic.ProtoRound round = 3;
-  monad_proto.basic.ProtoBlockId parent_id = 4;
-  monad_proto.basic.ProtoRound parent_round = 5;
 }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -848,7 +848,6 @@ where
                     self.consensus_config.execution_delay,
                     self.forkpoint.root,
                     statesync_to_live_threshold,
-                    SeqNum(2),
                 ),
             ),
             block_sync: BlockSync::default(),

--- a/monad-testutil/src/proposal.rs
+++ b/monad-testutil/src/proposal.rs
@@ -239,8 +239,6 @@ where
             id: block.get_id(),
             epoch: block.epoch,
             round: block.round,
-            parent_id: block.qc.get_block_id(),
-            parent_round: block.qc.get_round(),
         };
 
         let msg = HasherType::hash_object(&vote);


### PR DESCRIPTION
Makes is_committable less error-prone, and removes parent_round/parent_id from QC.

The diff inside `try_commit` looks a lot bigger than it actually is, because I flattened out everything after the commit rule check.