### PR TITLE
Archive bft blocks

### DIFF
--- a/monad-archive/src/archive_block_data.rs
+++ b/monad-archive/src/archive_block_data.rs
@@ -13,7 +13,8 @@ use aws_sdk_s3::{
 use bytes::Bytes;
 use enum_dispatch::enum_dispatch;
 use eyre::{Context, Result};
-use futures::try_join;
+use futures::{try_join, Stream};
+use monad_triedb_utils::triedb_env::BlockHeader;
 use tokio::time::Duration;
 use tokio_retry::{
     strategy::{jitter, ExponentialBackoff},
@@ -25,8 +26,6 @@ use crate::{
     archive_reader::LatestKind, get_aws_config, metrics::Metrics, BlobStoreErased, BlockDataReader,
     BlockDataReaderArgs, S3Bucket,
 };
-
-use monad_triedb_utils::triedb_env::BlockHeader;
 pub type Block = AlloyBlock<TxEnvelope, Header>;
 
 const BLOCK_PADDING_WIDTH: usize = 12;
@@ -34,6 +33,8 @@ const BLOCK_PADDING_WIDTH: usize = 12;
 #[enum_dispatch]
 pub trait BlobStore: BlobReader {
     async fn upload(&self, key: &str, data: Vec<u8>) -> Result<()>;
+
+    async fn scan_prefix(&self, prefix: &str) -> Result<Vec<String>>;
     fn bucket_name(&self) -> &str;
 }
 
@@ -44,7 +45,7 @@ pub trait BlobReader: Clone {
 
 #[derive(Clone)]
 pub struct BlockDataArchive<Store = BlobStoreErased> {
-    pub bucket: Store,
+    pub store: Store,
 
     pub latest_uploaded_table_key: &'static str,
     pub latest_indexed_table_key: &'static str,
@@ -64,7 +65,7 @@ pub struct BlockDataArchive<Store = BlobStoreErased> {
 
 impl<Store: BlobStore> BlockDataReader for BlockDataArchive<Store> {
     fn get_bucket(&self) -> &str {
-        &self.bucket.bucket_name()
+        &self.store.bucket_name()
     }
 
     async fn get_latest(&self, latest_kind: LatestKind) -> Result<u64> {
@@ -73,7 +74,7 @@ impl<Store: BlobStore> BlockDataReader for BlockDataArchive<Store> {
             LatestKind::Indexed => &self.latest_indexed_table_key,
         };
 
-        let value = self.bucket.read(key).await?;
+        let value = self.store.read(key).await?;
 
         let value_str = String::from_utf8(value.to_vec()).wrap_err("Invalid UTF-8 sequence")?;
 
@@ -90,7 +91,7 @@ impl<Store: BlobStore> BlockDataReader for BlockDataArchive<Store> {
     async fn get_block_receipts(&self, block_number: u64) -> Result<Vec<ReceiptEnvelope>> {
         let receipts_key = self.receipts_key(block_number);
 
-        let rlp_receipts = self.bucket.read(&receipts_key).await?;
+        let rlp_receipts = self.store.read(&receipts_key).await?;
         let mut rlp_receipts_slice: &[u8] = &rlp_receipts;
 
         let receipts = Vec::decode(&mut rlp_receipts_slice).wrap_err("Cannot decode block")?;
@@ -101,7 +102,7 @@ impl<Store: BlobStore> BlockDataReader for BlockDataArchive<Store> {
     async fn get_block_traces(&self, block_number: u64) -> Result<Vec<Vec<u8>>> {
         let traces_key = self.traces_key(block_number);
 
-        let rlp_traces = self.bucket.read(&traces_key).await?;
+        let rlp_traces = self.store.read(&traces_key).await?;
         let mut rlp_traces_slice: &[u8] = &rlp_traces;
 
         let traces = Vec::decode(&mut rlp_traces_slice).wrap_err("Cannot decode block")?;
@@ -113,7 +114,7 @@ impl<Store: BlobStore> BlockDataReader for BlockDataArchive<Store> {
         let block_hash_key_suffix = hex::encode(block_hash);
         let block_hash_key = format!("{}/{}", self.block_hash_table_prefix, block_hash_key_suffix);
 
-        let block_num_bytes = self.bucket.read(&block_hash_key).await?;
+        let block_num_bytes = self.store.read(&block_hash_key).await?;
 
         let block_num_str =
             String::from_utf8(block_num_bytes.to_vec()).wrap_err("Invalid UTF-8 sequence")?;
@@ -129,7 +130,7 @@ impl<Store: BlobStore> BlockDataReader for BlockDataArchive<Store> {
 impl<Store: BlobStore> BlockDataArchive<Store> {
     pub fn new(archive: Store) -> Self {
         BlockDataArchive {
-            bucket: archive,
+            store: archive,
             block_table_prefix: "block",
             block_hash_table_prefix: "block_hash",
             receipts_table_prefix: "receipts",
@@ -140,7 +141,7 @@ impl<Store: BlobStore> BlockDataArchive<Store> {
     }
 
     pub async fn read_block(&self, block_num: u64) -> Result<Block> {
-        let bytes = self.bucket.read(&self.block_key(block_num)).await?;
+        let bytes = self.store.read(&self.block_key(block_num)).await?;
         let mut bytes: &[u8] = &bytes;
         let block = Block::decode(&mut bytes)?;
         Ok(block)
@@ -179,7 +180,7 @@ impl<Store: BlobStore> BlockDataArchive<Store> {
             LatestKind::Indexed => &self.latest_indexed_table_key,
         };
         let latest_value = format!("{:0width$}", block_num, width = BLOCK_PADDING_WIDTH);
-        self.bucket
+        self.store
             .upload(key, latest_value.as_bytes().to_vec())
             .await
     }
@@ -200,8 +201,8 @@ impl<Store: BlobStore> BlockDataArchive<Store> {
 
         // 3) Join futures
         try_join!(
-            self.bucket.upload(&block_key, rlp_block),
-            self.bucket
+            self.store.upload(&block_key, rlp_block),
+            self.store
                 .upload(&block_hash_key, block_hash_value.to_vec())
         )?;
         Ok(())
@@ -222,7 +223,7 @@ impl<Store: BlobStore> BlockDataArchive<Store> {
 
         let mut rlp_receipts = Vec::new();
         receipts.encode(&mut rlp_receipts);
-        self.bucket.upload(&receipts_key, rlp_receipts).await
+        self.store.upload(&receipts_key, rlp_receipts).await
     }
 
     pub async fn archive_traces(&self, traces: Vec<Vec<u8>>, block_num: u64) -> Result<()> {
@@ -236,6 +237,6 @@ impl<Store: BlobStore> BlockDataArchive<Store> {
         let mut rlp_traces = vec![];
         traces.encode(&mut rlp_traces);
 
-        self.bucket.upload(&traces_key, rlp_traces).await
+        self.store.upload(&traces_key, rlp_traces).await
     }
 }

--- a/monad-archive/src/archive_reader.rs
+++ b/monad-archive/src/archive_reader.rs
@@ -38,13 +38,11 @@ impl<BStore: BlockDataReader, IStore: IndexStoreReader> ArchiveReader<BStore, IS
     ) -> Result<ArchiveReader<BlockDataArchive, CloudProxyReader>> {
         let url = url::Url::parse(url)?;
         let cloud_proxy_reader = CloudProxyReader::new(api_key, url, bucket.clone(), concurrency)?;
-        let block_data_reader = BlockDataArchive::new(BlobStoreErased::S3Bucket(
-            S3Bucket::new(
-                bucket,
-                &get_aws_config(region).await,
-                Metrics::none(),
-            )
-        ));
+        let block_data_reader = BlockDataArchive::new(BlobStoreErased::S3Bucket(S3Bucket::new(
+            bucket,
+            &get_aws_config(region).await,
+            Metrics::none(),
+        )));
 
         Ok(ArchiveReader::new(block_data_reader, cloud_proxy_reader))
     }

--- a/monad-archive/src/archive_tx_index.rs
+++ b/monad-archive/src/archive_tx_index.rs
@@ -1,9 +1,5 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use crate::{
-    dynamodb::DynamoDBArchive, BlobStore, BlobStoreErased, Block, BlockDataArchive,
-    BlockDataReader, IndexStoreErased,
-};
 use alloy_consensus::{ReceiptEnvelope, TxEnvelope};
 use alloy_primitives::{BlockHash, TxHash};
 use alloy_rlp::{Decodable, Encodable, RlpDecodable, RlpEncodable};
@@ -22,6 +18,11 @@ use tokio_retry::{
     Retry,
 };
 use tracing::error;
+
+use crate::{
+    dynamodb::DynamoDBArchive, BlobStore, BlobStoreErased, Block, BlockDataArchive,
+    BlockDataReader, IndexStoreErased,
+};
 
 #[enum_dispatch]
 pub trait IndexStore: IndexStoreReader {

--- a/monad-archive/src/bin/monad-archive-checker/main.rs
+++ b/monad-archive/src/bin/monad-archive-checker/main.rs
@@ -6,6 +6,7 @@ use alloy_consensus::ReceiptEnvelope;
 use clap::Parser;
 use eyre::Result;
 use futures::{future::join_all, join};
+use monad_archive::*;
 use tokio::{
     sync::Semaphore,
     time::{sleep, Duration},

--- a/monad-archive/src/bin/monad-archiver/bft_block_archiver.rs
+++ b/monad-archive/src/bin/monad-archiver/bft_block_archiver.rs
@@ -1,0 +1,157 @@
+use std::{
+    collections::HashSet,
+    ffi::OsString,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use eyre::{Context, Result};
+use futures::StreamExt;
+use monad_archive::BlobStoreErased;
+use tokio::time::sleep;
+use tracing::{debug, error, info};
+
+use crate::{BlobStore, Metrics};
+
+const BFT_BLOCK_PREFIX: &'static str = "bft_block/";
+
+pub async fn parallel_upload_iter(
+    uploaded: &mut HashSet<OsString>,
+    s3: BlobStoreErased,
+    fnames: Vec<PathBuf>,
+) -> usize {
+    futures::stream::iter(fnames)
+        .filter_map(|path| {
+            let s3 = s3.clone();
+            spawning_upload(s3, path)
+        })
+        .buffer_unordered(20)
+        .map(|file_name_uploaded| {
+            info!(?file_name_uploaded, "Uploaded bft block");
+            uploaded.insert(file_name_uploaded);
+            futures::future::ready(())
+        })
+        .count()
+        .await
+}
+
+async fn spawning_upload(
+    s3: BlobStoreErased,
+    path: PathBuf,
+) -> Option<futures::future::Ready<OsString>> {
+    tokio::spawn(upload(s3, path)).await.ok()?
+}
+
+async fn upload(s3: BlobStoreErased, path: PathBuf) -> Option<futures::future::Ready<OsString>> {
+    let fname_os = path.file_name()?.to_os_string();
+    let fname = fname_os.to_str()?;
+
+    let data = match tokio::fs::read(&path).await {
+        Ok(x) => x,
+        Err(e) => {
+            error!(?e, ?path, "Failed to read bft block file from folder");
+            return None;
+        }
+    };
+
+    match s3.upload(&format!("{BFT_BLOCK_PREFIX}{fname}"), data).await {
+        Ok(_) => Some(futures::future::ready(fname_os)),
+        Err(e) => {
+            error!(?e, fname, "Failed to archive bft block");
+            None
+        }
+    }
+}
+
+pub async fn bft_block_archive_worker(
+    s3: BlobStoreErased,
+    header_path: PathBuf,
+    body_path: PathBuf,
+    poll_frequency: Duration,
+    metrics: Metrics,
+) -> Result<()> {
+    info!("Fetching set of already uploaded bft blocks...");
+    let mut uploaded = initialize_uploaded_set(&s3)
+        .await
+        .wrap_err("Failed to fetch set of already uploaded bft blocks")?;
+
+    loop {
+        sleep(poll_frequency).await;
+        info!("Checking for bft blocks to upload...");
+
+        let to_upload = match find_unuploaded_blocks(&mut uploaded, &header_path, &body_path).await
+        {
+            Ok(x) => x,
+            Err(e) => {
+                error!(
+                    ?e,
+                    ?header_path,
+                    ?body_path,
+                    "Failed to scan directory for bft blocks, sleeping..."
+                );
+                continue;
+            }
+        };
+        let num_to_upload = to_upload.len();
+        if num_to_upload == 0 {
+            continue;
+        }
+        info!(num_to_upload, "Found bft blocks to upload");
+
+        let num_uploaded = parallel_upload_iter(&mut uploaded, s3.clone(), to_upload).await;
+
+        if num_uploaded > 0 {
+            info!(num_uploaded, num_to_upload, "Uploaded bft blocks");
+        } else {
+            info!(num_to_upload)
+        }
+        metrics.gauge("bft_blocks_uploaded", uploaded.len() as u64);
+    }
+}
+
+async fn find_unuploaded_blocks(
+    uploaded: &HashSet<OsString>,
+    header_path: &Path,
+    body_path: &Path,
+) -> Result<Vec<PathBuf>> {
+    let mut to_upload = Vec::new();
+    let mut read_dir = tokio::fs::read_dir(header_path).await?;
+    while let Some(entry) = read_dir.next_entry().await? {
+        let meta = entry.metadata().await?;
+        let fname = entry.file_name();
+        if meta.is_file() && fname != "wal" && !uploaded.contains(&fname) {
+            debug!(?fname, "Found file to upload");
+            to_upload.push(entry.path());
+        } else {
+            debug!(?fname, "Found file, won't upload");
+        }
+    }
+
+    if body_path != header_path {
+        let mut read_dir = tokio::fs::read_dir(header_path).await?;
+        while let Some(entry) = read_dir.next_entry().await? {
+            let meta = entry.metadata().await?;
+            let fname = entry.file_name();
+            if meta.is_file() && fname != "wal" && !uploaded.contains(&fname) {
+                debug!(?fname, "Found file to upload");
+                to_upload.push(entry.path());
+            } else {
+                debug!(?fname, "Found file, won't upload");
+            }
+        }
+    }
+
+    Ok(to_upload)
+}
+
+async fn initialize_uploaded_set(s3: &impl BlobStore) -> Result<HashSet<OsString>> {
+    Ok(s3
+        .scan_prefix(BFT_BLOCK_PREFIX)
+        .await?
+        .into_iter()
+        .map(|object| {
+            let block_hash = object.trim_start_matches(BFT_BLOCK_PREFIX);
+            OsString::from(block_hash)
+        })
+        .collect())
+}

--- a/monad-archive/src/bin/monad-archiver/cli.rs
+++ b/monad-archive/src/bin/monad-archiver/cli.rs
@@ -6,9 +6,13 @@ use monad_archive::{ArchiveArgs, BlockDataReaderArgs};
 #[derive(Debug, Parser)]
 #[command(name = "monad-archive", about, long_about = None)]
 pub struct Cli {
+    /// Where blocks, receipts and traces are read from
+    /// For triedb: 'triedb <triedb_path> <concurrent_requests>'
     #[arg(long, value_parser = clap::value_parser!(BlockDataReaderArgs))]
     pub block_data_source: BlockDataReaderArgs,
 
+    /// Where archive data is written to
+    /// For aws: 'aws <bucket_name> <concurrent_requests>'
     #[arg(long, value_parser = clap::value_parser!(ArchiveArgs))]
     pub archive_sink: ArchiveArgs,
 
@@ -21,6 +25,27 @@ pub struct Cli {
     /// Override block number to start at
     #[arg(long)]
     pub start_block: Option<u64>,
+
+    /// Path to folder containing bft block bodies
+    /// If set, archiver will upload these files to blob store provided in archive_sink
+    #[arg(long)]
+    pub bft_block_body_path: Option<PathBuf>,
+
+    /// Override for bft header path
+    /// Will default to `bft_block_path` otherwise
+    #[arg(long)]
+    pub bft_block_header_path: Option<PathBuf>,
+
+    #[arg(long, default_value_t = 5)]
+    pub bft_block_poll_freq_secs: u64,
+
+    /// Path to wal for checkpoint'ing
+    /// If set, archiver will save a copy of this file every wal_checkpoint_interval seconds
+    #[arg(long)]
+    pub wal_path: Option<PathBuf>,
+
+    #[arg(long, default_value_t = 3600)]
+    pub wal_checkpoint_freq_secs: u64,
 
     #[arg(long)]
     pub otel_endpoint: Option<String>,

--- a/monad-archive/src/bin/monad-archiver/main.rs
+++ b/monad-archive/src/bin/monad-archiver/main.rs
@@ -2,25 +2,28 @@
 
 use std::{ops::RangeInclusive, time::Instant};
 
+use bft_block_archiver::bft_block_archive_worker;
 use clap::Parser;
 use eyre::Result;
-use futures::{join, StreamExt, TryStreamExt};
+use futures::{StreamExt, TryStreamExt};
 use metrics::Metrics;
+use monad_archive::*;
 use tokio::{
     time::{sleep, Duration},
     try_join,
 };
 use tracing::{error, info, warn, Level};
+use wal_checkpoint::wal_checkpoint_worker;
 
-use monad_archive::*;
+mod bft_block_archiver;
 mod cli;
+mod wal_checkpoint;
 
-#[tokio::main]
+#[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt().with_max_level(Level::INFO).init();
 
     let args = cli::Cli::parse();
-
     info!(?args);
 
     let metrics = Metrics::new(
@@ -30,8 +33,27 @@ async fn main() -> Result<()> {
     )?;
 
     let block_data_source = args.block_data_source.build(&metrics).await?;
-
     let archive_writer = args.archive_sink.build_block_data_archive(&metrics).await?;
+
+    if let Some(path) = args.bft_block_body_path {
+        info!("Spawning bft block archive worker...");
+        tokio::spawn(bft_block_archive_worker(
+            archive_writer.store.clone(),
+            args.bft_block_header_path.unwrap_or(path.clone()),
+            path,
+            Duration::from_secs(args.bft_block_poll_freq_secs),
+            metrics.clone(),
+        ));
+    }
+
+    if let Some(path) = args.wal_path {
+        info!("Spawning wal checkpoint worker...");
+        tokio::spawn(wal_checkpoint_worker(
+            archive_writer.store.clone(),
+            path,
+            Duration::from_secs(args.wal_checkpoint_freq_secs),
+        ));
+    }
 
     tokio::spawn(archive_worker(
         block_data_source,

--- a/monad-archive/src/bin/monad-archiver/wal_checkpoint.rs
+++ b/monad-archive/src/bin/monad-archiver/wal_checkpoint.rs
@@ -1,0 +1,41 @@
+use std::{path::PathBuf, time::Duration};
+
+use eyre::{Context, Result};
+
+use monad_archive::{BlobStore, BlobStoreErased};
+use tracing::error;
+
+const WAL_PREFIX: &'static str = "wal/";
+
+pub async fn wal_checkpoint_worker(
+    store: BlobStoreErased,
+    path: PathBuf,
+    poll_frequency: Duration,
+) {
+    let mut interval = tokio::time::interval(poll_frequency);
+
+    loop {
+        interval.tick().await;
+
+        if let Err(e) = read_and_upload(&store, &path).await {
+            error!(path = ?&path, ?e);
+        }
+    }
+}
+
+async fn read_and_upload(store: &BlobStoreErased, path: &PathBuf) -> Result<()> {
+    let buf = tokio::fs::read(&path)
+        .await
+        .wrap_err("Failed to read wal file")?;
+
+    let key = format!("{WAL_PREFIX}{}", get_timestamp());
+    store
+        .upload(&key, buf)
+        .await
+        .wrap_err("Failed to upload wal to blob store")
+}
+
+fn get_timestamp() -> String {
+    let now = chrono::Local::now();
+    now.format("%d/%m/%Y_%H:%M:%S").to_string()
+}

--- a/monad-archive/src/bin/monad-indexer/cli.rs
+++ b/monad-archive/src/bin/monad-indexer/cli.rs
@@ -10,7 +10,8 @@ pub struct Cli {
     #[arg(long, value_parser = clap::value_parser!(BlockDataReaderArgs))]
     pub block_data_source: BlockDataReaderArgs,
 
-    /// Sink to write index data
+    /// Where archive data is written to
+    /// For aws: 'aws <bucket_name> <concurrent_requests>'
     #[arg(long, value_parser = clap::value_parser!(ArchiveArgs))]
     pub archive_sink: ArchiveArgs,
 

--- a/monad-archive/src/storage/mod.rs
+++ b/monad-archive/src/storage/mod.rs
@@ -4,24 +4,24 @@ pub mod rocksdb_storage;
 pub mod s3;
 pub mod triedb_reader;
 
-use crate::{
-    archive_block_data::BlockDataArchive, triedb_reader::TriedbReader, ArchiveReader, BlobStore,
-    Block, LatestKind, Metrics, TxIndexArchiver, IndexStoreReader, TxIndexedData, IndexStore
-};
+use std::{collections::HashMap, str::FromStr};
+
 use alloy_consensus::ReceiptEnvelope;
 use alloy_primitives::{BlockHash, TxHash};
 use clap::{Parser, Subcommand};
+pub use cloud_proxy::*;
+pub use dynamodb::*;
 use enum_dispatch::enum_dispatch;
 use eyre::{bail, ContextCompat, OptionExt, Result};
 use futures::FutureExt;
-use std::collections::HashMap;
-use std::str::FromStr;
-use tokio::{join, try_join};
-
-pub use cloud_proxy::*;
-pub use dynamodb::*;
 pub use rocksdb_storage::*;
 pub use s3::*;
+use tokio::{join, try_join};
+
+use crate::{
+    archive_block_data::BlockDataArchive, triedb_reader::TriedbReader, ArchiveReader, BlobStore,
+    Block, IndexStore, IndexStoreReader, LatestKind, Metrics, TxIndexArchiver, TxIndexedData,
+};
 
 #[enum_dispatch(BlockDataReader)]
 #[derive(Clone)]
@@ -219,8 +219,9 @@ impl TrieDbCliArgs {
     }
 }
 
-use crate::archive_block_data::BlobReader;
 use bytes::Bytes;
+
+use crate::archive_block_data::BlobReader;
 
 #[enum_dispatch(BlobReader, BlobStore)]
 #[derive(Clone)]

--- a/monad-archive/src/storage/triedb_reader.rs
+++ b/monad-archive/src/storage/triedb_reader.rs
@@ -5,9 +5,8 @@ use alloy_primitives::BlockHash;
 use eyre::{eyre, OptionExt, Result};
 use monad_triedb_utils::triedb_env::{BlockHeader, Triedb, TriedbEnv};
 
-use crate::{Block, LatestKind};
-
 use super::{BlockDataReader, TrieDbCliArgs};
+use crate::{Block, LatestKind};
 
 #[derive(Clone)]
 pub struct TriedbReader {


### PR DESCRIPTION
First pass at archiving bft blocks for data retention purposes. Tested with stressnet-gra004-4 bucket

This compares the files found in `bft-block-path` (and `bft-block-header-path` if not the same) to those already archived and uploads those not found.

Indexing these files will be left for a follow-up pr.

https://github.com/category-labs/category-internal/issues/1048
https://github.com/category-labs/category-internal/issues/1047