### PR TITLE
Avoid rebroadcasting invalid symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5364,7 +5364,6 @@ dependencies = [
 name = "monad-raptor"
 version = "0.1.0"
 dependencies = [
- "bitvec",
  "rand",
  "rayon",
 ]
@@ -5373,6 +5372,7 @@ dependencies = [
 name = "monad-raptorcast"
 version = "0.1.0"
 dependencies = [
+ "bitvec",
  "bytes",
  "clap 4.4.10",
  "criterion",

--- a/monad-raptor/Cargo.toml
+++ b/monad-raptor/Cargo.toml
@@ -11,6 +11,5 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitvec = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }

--- a/monad-raptor/tests/managed_decoder.rs
+++ b/monad-raptor/tests/managed_decoder.rs
@@ -10,7 +10,7 @@ fn test_single_decode(src: Vec<u8>) {
 
     let num_source_symbols = encoder.num_source_symbols();
 
-    let mut decoder = ManagedDecoder::new(num_source_symbols, SYMBOL_LEN).unwrap();
+    let mut decoder = ManagedDecoder::new(num_source_symbols, 0, SYMBOL_LEN).unwrap();
 
     let mut esis: Vec<usize> = (0..2 * num_source_symbols).collect();
     esis.shuffle(&mut thread_rng());
@@ -19,11 +19,12 @@ fn test_single_decode(src: Vec<u8>) {
         let mut buf: Box<[u8]> = vec![0; SYMBOL_LEN].into_boxed_slice();
         encoder.encode_symbol(&mut buf, *esi);
 
-        decoder.received_encoded_symbol(&buf, *esi).unwrap();
+        decoder.received_encoded_symbol(&buf, *esi);
 
-        // Make sure that we detect multiple submissions of the same ESI.
+        // We feed some encoded symbols back into the decoder twice to test the
+        // redundant buffer handling paths.
         if rand::thread_rng().gen_ratio(1, 100) {
-            decoder.received_encoded_symbol(&buf, *esi).unwrap_err();
+            decoder.received_encoded_symbol(&buf, *esi);
         }
 
         if decoder.try_decode() {
@@ -57,4 +58,18 @@ fn test_managed_decoder() {
 
         test_single_decode(src);
     }
+}
+
+#[test]
+#[should_panic]
+fn test_invalid_symbol_len() {
+    let src = vec![0u8; 32];
+
+    let encoder: Encoder = Encoder::new(&src, SYMBOL_LEN).unwrap();
+    let num_source_symbols = encoder.num_source_symbols();
+    let mut decoder = ManagedDecoder::new(num_source_symbols, 0, SYMBOL_LEN).unwrap();
+
+    let buf = vec![0; SYMBOL_LEN + 1];
+
+    decoder.received_encoded_symbol(buf.as_slice(), 0);
 }

--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -22,6 +22,7 @@ monad-raptor = { path = "../monad-raptor" }
 monad-secp = { path = "../monad-secp" }
 monad-types = { path = "../monad-types" }
 
+bitvec = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }


### PR DESCRIPTION
Unit tests added in two separate commits https://github.com/category-labs/monad-bft/commit/9025e6aa9bb2672e9aa52cef6a129d22b255f208 and https://github.com/category-labs/monad-bft/commit/2d94a40866469035a2a19ce9085a0354b4fe01d6 which are tested on this branch.