### PR TITLE
Disable live to statesync transition

### DIFF
--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -57,8 +57,6 @@ where
         root: RootInfo,
         high_qc: QuorumCertificate<SCT>,
     },
-    /// Can only be called *once*
-    StartExecution,
     /// Checkpoints periodically can upload/backup the ledger and garbage collect persisted events
     /// if necessary
     CheckpointSave(Checkpoint<SCT>),

--- a/monad-mock-swarm/tests/forkpoint.rs
+++ b/monad-mock-swarm/tests/forkpoint.rs
@@ -77,6 +77,7 @@ fn test_forkpoint_restart_f_simple_blocksync() {
         epoch_length,
         statesync_threshold,
         statesync_service_window,
+        false,
     );
 }
 
@@ -94,6 +95,7 @@ fn test_forkpoint_restart_f_simple_statesync() {
         epoch_length,
         statesync_threshold,
         statesync_service_window,
+        true,
     );
 }
 
@@ -115,6 +117,7 @@ fn test_forkpoint_restart_f_target_reset_statesync() {
         epoch_length,
         statesync_threshold,
         statesync_service_window,
+        false,
     );
 }
 
@@ -132,6 +135,7 @@ fn test_forkpoint_restart_f_epoch_boundary_statesync() {
         epoch_length,
         statesync_threshold,
         statesync_service_window,
+        true,
     );
 }
 
@@ -160,6 +164,7 @@ fn test_forkpoint_restart_f() {
                     epoch_length,
                     statesync_threshold,
                     statesync_service_window,
+                    false,
                 );
             })
         });
@@ -176,6 +181,7 @@ fn forkpoint_restart_f(
     epoch_length: SeqNum,
     statesync_threshold: SeqNum,
     statesync_service_window: SeqNum,
+    fresh_forkpoint: bool,
 ) {
     let delta = Duration::from_millis(100);
     let vote_pace = Duration::from_millis(0);
@@ -323,8 +329,19 @@ fn forkpoint_restart_f(
             .is_some()
         {}
 
-        // Restart node from old forkpoint and join network
-        let forkpoint = failed_node.get_forkpoint();
+        let forkpoint = if fresh_forkpoint {
+            // Restart node from fresh forkpoint
+            swarm
+                .states()
+                .first_key_value()
+                .unwrap()
+                .1
+                .get_forkpoint()
+                .clone()
+        } else {
+            // Restart node from old forkpoint
+            failed_node.get_forkpoint()
+        };
         assert_eq!(
             forkpoint.validate(
                 state_root_delay,

--- a/monad-state/src/consensus.rs
+++ b/monad-state/src/consensus.rs
@@ -23,8 +23,8 @@ use monad_crypto::certificate_signature::{
 use monad_eth_types::EthAddress;
 use monad_executor_glue::{
     BlockSyncEvent, CheckpointCommand, Command, ConsensusEvent, LedgerCommand, LoopbackCommand,
-    MempoolEvent, MonadEvent, RouterCommand, StateRootHashCommand, StateSyncCommand,
-    StateSyncEvent, TimeoutVariant, TimerCommand, TimestampCommand,
+    MempoolEvent, MonadEvent, RouterCommand, StateRootHashCommand, StateSyncEvent, TimeoutVariant,
+    TimerCommand, TimestampCommand,
 };
 use monad_state_backend::StateBackend;
 use monad_types::{NodeId, SeqNum};
@@ -409,9 +409,6 @@ where
                 parent_cmds.push(Command::LoopbackCommand(LoopbackCommand::Forward(
                     MonadEvent::StateSyncEvent(StateSyncEvent::RequestSync { root, high_qc }),
                 )));
-            }
-            ConsensusCommand::StartExecution => {
-                parent_cmds.push(Command::StateSyncCommand(StateSyncCommand::StartExecution));
             }
             ConsensusCommand::LedgerCommit(blocks) => {
                 let last_block = blocks.iter().last().expect("LedgerCommit no blocks");

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1224,6 +1224,7 @@ where
         );
         tracing::info!(?root, ?high_qc, "done syncing, initializing consensus");
         self.consensus = ConsensusMode::Live(consensus);
+        commands.push(Command::StateSyncCommand(StateSyncCommand::StartExecution));
         commands.extend(self.update(MonadEvent::ConsensusEvent(ConsensusEvent::Timeout)));
         for (sender, proposal) in cached_proposals {
             // handle proposals in reverse order because later blocks are more likely to pass


### PR DESCRIPTION
We don't want to support the live to statesync state transition, as statesync has different trust assumptions than live mode. Specifically, statesync requires an honest majority assumption.