### PR TITLE
Switch dataplane/raptorcast over to using SocketAddr for addresses

### DIFF
--- a/monad-dataplane/examples/node.rs
+++ b/monad-dataplane/examples/node.rs
@@ -17,8 +17,8 @@ const NODE_TWO_ADDR: &str = "127.0.0.1:60001";
 
 fn main() {
     env_logger::init();
-    let mut tx = Node::new(NODE_ONE_ADDR, NODE_TWO_ADDR);
-    let mut rx = Node::new(NODE_TWO_ADDR, NODE_ONE_ADDR);
+    let mut tx = Node::new(&NODE_ONE_ADDR.parse().unwrap(), NODE_TWO_ADDR);
+    let mut rx = Node::new(&NODE_TWO_ADDR.parse().unwrap(), NODE_ONE_ADDR);
 
     let num_pkts = 10;
     let pkt_size = 96342;
@@ -89,7 +89,7 @@ struct Node {
 }
 
 impl Node {
-    pub fn new(addr: &str, target_addr: &str) -> Self {
+    pub fn new(addr: &SocketAddr, target_addr: &str) -> Self {
         Self {
             network: Dataplane::new(addr, 1_000),
             target: target_addr.parse().unwrap(),

--- a/monad-dataplane/src/event_loop.rs
+++ b/monad-dataplane/src/event_loop.rs
@@ -199,7 +199,7 @@ fn make_producer_consumer<T>(size: usize) -> (WakeableProducer<T>, WakeableConsu
 
 impl Dataplane {
     /// 1_000 = 1 Gbps, 10_000 = 10 Gbps
-    pub fn new(local_addr: &str, up_bandwidth_mbps: u64) -> Self {
+    pub fn new(local_addr: &SocketAddr, up_bandwidth_mbps: u64) -> Self {
         let (udp_ing_producer, udp_ing_consumer) = make_producer_consumer(12_800);
         let (tcp_ing_producer, tcp_ing_consumer) = make_producer_consumer(32);
 

--- a/monad-dataplane/src/network.rs
+++ b/monad-dataplane/src/network.rs
@@ -94,7 +94,7 @@ static mut BUF_PTR: *mut [[u8; BUF_SIZE]; NUM_RX_MSGHDR] = std::ptr::null_mut();
 
 impl NetworkSocket<'_> {
     /// 1_000 = 1 Gbps, 10_000 = 10 Gbps
-    pub fn new(sock_addr: &str, up_bandwidth_mbps: u64) -> Self {
+    pub fn new(sock_addr: &SocketAddr, up_bandwidth_mbps: u64) -> Self {
         let socket = std::net::UdpSocket::bind(sock_addr).unwrap();
         let r = unsafe {
             const GSO_SIZE: libc::c_int = MONAD_GSO_SIZE as i32;

--- a/monad-dataplane/tests/tests.rs
+++ b/monad-dataplane/tests/tests.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, sync::Once, thread::sleep, time::Duration};
+use std::{sync::Once, thread::sleep, time::Duration};
 
 use futures::executor;
 use monad_dataplane::{
@@ -28,14 +28,12 @@ fn once_setup() {
 fn udp_broadcast() {
     once_setup();
 
-    let rx_addr = "127.0.0.1:9000";
-    let tx_addr = "127.0.0.1:9001";
+    let rx_addr = "127.0.0.1:9000".parse().unwrap();
+    let tx_addr = "127.0.0.1:9001".parse().unwrap();
     let num_msgs = 10;
 
-    let mut rx = Dataplane::new(rx_addr, UP_BANDWIDTH_MBPS);
-    let mut tx = Dataplane::new(tx_addr, UP_BANDWIDTH_MBPS);
-    let rx_socketaddr: SocketAddr = rx_addr.parse().unwrap();
-    let tx_socketaddr: SocketAddr = tx_addr.parse().unwrap();
+    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS);
+    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS);
 
     // Allow Dataplane threads to set themselves up.
     sleep(Duration::from_millis(10));
@@ -45,14 +43,14 @@ fn udp_broadcast() {
         .collect();
 
     tx.udp_write_broadcast(BroadcastMsg {
-        targets: vec![rx_socketaddr; num_msgs],
+        targets: vec![rx_addr; num_msgs],
         payload: payload.clone().into(),
     });
 
     for _ in 0..num_msgs {
         let msg: RecvMsg = executor::block_on(rx.udp_read());
 
-        assert_eq!(msg.src_addr, tx_socketaddr);
+        assert_eq!(msg.src_addr, tx_addr);
         assert_eq!(msg.payload, payload);
     }
 }
@@ -62,14 +60,12 @@ fn udp_broadcast() {
 fn udp_unicast() {
     once_setup();
 
-    let rx_addr = "127.0.0.1:9002";
-    let tx_addr = "127.0.0.1:9003";
+    let rx_addr = "127.0.0.1:9002".parse().unwrap();
+    let tx_addr = "127.0.0.1:9003".parse().unwrap();
     let num_msgs = 10;
 
-    let mut rx = Dataplane::new(rx_addr, UP_BANDWIDTH_MBPS);
-    let mut tx = Dataplane::new(tx_addr, UP_BANDWIDTH_MBPS);
-    let rx_socketaddr: SocketAddr = rx_addr.parse().unwrap();
-    let tx_socketaddr: SocketAddr = tx_addr.parse().unwrap();
+    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS);
+    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS);
 
     // Allow Dataplane threads to set themselves up.
     sleep(Duration::from_millis(10));
@@ -79,13 +75,13 @@ fn udp_unicast() {
         .collect();
 
     tx.udp_write_unicast(UnicastMsg {
-        msgs: vec![(rx_socketaddr, payload.clone().into()); num_msgs],
+        msgs: vec![(rx_addr, payload.clone().into()); num_msgs],
     });
 
     for _ in 0..num_msgs {
         let msg: RecvMsg = executor::block_on(rx.udp_read());
 
-        assert_eq!(msg.src_addr, tx_socketaddr);
+        assert_eq!(msg.src_addr, tx_addr);
         assert_eq!(msg.payload, payload);
     }
 }
@@ -95,13 +91,12 @@ fn udp_unicast() {
 fn tcp_slow() {
     once_setup();
 
-    let rx_addr = "127.0.0.1:9004";
-    let tx_addr = "127.0.0.1:9005";
+    let rx_addr = "127.0.0.1:9004".parse().unwrap();
+    let tx_addr = "127.0.0.1:9005".parse().unwrap();
     let num_msgs = 10;
 
-    let mut rx = Dataplane::new(rx_addr, UP_BANDWIDTH_MBPS);
-    let mut tx = Dataplane::new(tx_addr, UP_BANDWIDTH_MBPS);
-    let rx_socketaddr: SocketAddr = rx_addr.parse().unwrap();
+    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS);
+    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS);
 
     // Allow Dataplane threads to set themselves up.
     sleep(Duration::from_millis(10));
@@ -111,7 +106,7 @@ fn tcp_slow() {
         .collect();
 
     for _ in 0..num_msgs {
-        tx.tcp_write(rx_socketaddr, payload.clone().into());
+        tx.tcp_write(rx_addr, payload.clone().into());
         sleep(Duration::from_millis(10));
     }
 
@@ -127,13 +122,12 @@ fn tcp_slow() {
 fn tcp_rapid() {
     once_setup();
 
-    let rx_addr = "127.0.0.1:9006";
-    let tx_addr = "127.0.0.1:9007";
+    let rx_addr = "127.0.0.1:9006".parse().unwrap();
+    let tx_addr = "127.0.0.1:9007".parse().unwrap();
     let num_msgs = 32;
 
-    let mut rx = Dataplane::new(rx_addr, UP_BANDWIDTH_MBPS);
-    let mut tx = Dataplane::new(tx_addr, UP_BANDWIDTH_MBPS);
-    let rx_socketaddr: SocketAddr = rx_addr.parse().unwrap();
+    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS);
+    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS);
 
     // Allow Dataplane threads to set themselves up.
     sleep(Duration::from_millis(10));
@@ -143,7 +137,7 @@ fn tcp_rapid() {
         .collect();
 
     for _ in 0..num_msgs {
-        tx.tcp_write(rx_socketaddr, payload.clone().into());
+        tx.tcp_write(rx_addr, payload.clone().into());
     }
 
     for _ in 0..num_msgs {

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -505,8 +505,7 @@ where
         local_addr: SocketAddr::V4(SocketAddrV4::new(
             network_config.bind_address_host,
             network_config.bind_address_port,
-        ))
-        .to_string(),
+        )),
         up_bandwidth_mbps: network_config.max_mbps.into(),
     })
 }

--- a/monad-raptorcast/examples/service.rs
+++ b/monad-raptorcast/examples/service.rs
@@ -114,7 +114,7 @@ fn service(
                     full_nodes: Default::default(),
                     known_addresses,
                     redundancy: 2,
-                    local_addr: server_address.to_string(),
+                    local_addr: server_address,
                     up_bandwidth_mbps: 1_000,
                 };
 

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -43,7 +43,7 @@ where
     /// a value of 2 == send 2x total payload size total
     pub redundancy: u8,
 
-    pub local_addr: String,
+    pub local_addr: SocketAddr,
 
     /// 1_000 = 1 Gbps, 10_000 = 10 Gbps
     pub up_bandwidth_mbps: u64,

--- a/monad-raptorcast/tests/malformed_inputs.rs
+++ b/monad-raptorcast/tests/malformed_inputs.rs
@@ -30,10 +30,10 @@ type PubKeyType = CertificateSignaturePubKey<SignatureType>;
 // A previous version of the R10 managed decoder did not handle this correctly and would panic.
 #[test]
 pub fn different_symbol_sizes() {
-    let rx_addr = "127.0.0.1:10000";
-    let tx_addr = "127.0.0.1:10001";
+    let rx_addr = "127.0.0.1:10000".parse().unwrap();
+    let tx_addr = "127.0.0.1:10001".parse().unwrap();
 
-    let (rx_nodeid, tx_nodeid, tx_keypair, known_addresses) = set_up_test(rx_addr, tx_addr);
+    let (rx_nodeid, tx_nodeid, tx_keypair, known_addresses) = set_up_test(&rx_addr, &tx_addr);
 
     let message: Bytes = vec![0; 100 * 1000].into();
 
@@ -98,10 +98,10 @@ pub fn different_symbol_sizes() {
 // of buffer indices in the decoder and panic the decoder.
 #[test]
 pub fn buffer_count_overflow() {
-    let rx_addr = "127.0.0.1:10002";
-    let tx_addr = "127.0.0.1:10003";
+    let rx_addr = "127.0.0.1:10002".parse().unwrap();
+    let tx_addr = "127.0.0.1:10003".parse().unwrap();
 
-    let (rx_nodeid, tx_nodeid, tx_keypair, known_addresses) = set_up_test(rx_addr, tx_addr);
+    let (rx_nodeid, tx_nodeid, tx_keypair, known_addresses) = set_up_test(&rx_addr, &tx_addr);
 
     let message: Bytes = vec![0; 4 * 1000].into();
 
@@ -152,10 +152,10 @@ pub fn buffer_count_overflow() {
 // would fail.
 #[test]
 pub fn oversized_message() {
-    let rx_addr = "127.0.0.1:10004";
-    let tx_addr = "127.0.0.1:10005";
+    let rx_addr = "127.0.0.1:10004".parse().unwrap();
+    let tx_addr = "127.0.0.1:10005".parse().unwrap();
 
-    let (rx_nodeid, tx_nodeid, tx_keypair, known_addresses) = set_up_test(rx_addr, tx_addr);
+    let (rx_nodeid, tx_nodeid, tx_keypair, known_addresses) = set_up_test(&rx_addr, &tx_addr);
 
     let message: Bytes = vec![0; 4 * 1000].into();
 
@@ -203,10 +203,10 @@ pub fn oversized_message() {
 // which would then call .step_by(0) on (0..0), which panics.
 #[test]
 pub fn zero_sized_packet() {
-    let rx_addr = "127.0.0.1:10006";
-    let tx_addr = "127.0.0.1:10007";
+    let rx_addr = "127.0.0.1:10006".parse().unwrap();
+    let tx_addr = "127.0.0.1:10007".parse().unwrap();
 
-    let (_rx_nodeid, _tx_nodeid, _tx_keypair, _known_addresses) = set_up_test(rx_addr, tx_addr);
+    let (_rx_nodeid, _tx_nodeid, _tx_keypair, _known_addresses) = set_up_test(&rx_addr, &tx_addr);
 
     let message = [0; 10];
 
@@ -223,8 +223,8 @@ pub fn zero_sized_packet() {
 static ONCE_SETUP: Once = Once::new();
 
 pub fn set_up_test(
-    rx_addr: &str,
-    tx_addr: &str,
+    rx_addr: &SocketAddr,
+    tx_addr: &SocketAddr,
 ) -> (
     NodeId<PubKeyType>,
     NodeId<PubKeyType>,
@@ -262,10 +262,8 @@ pub fn set_up_test(
     };
     let tx_nodeid = NodeId::new(tx_keypair.pubkey());
 
-    let known_addresses: HashMap<NodeId<PubKeyType>, SocketAddr> = HashMap::from([
-        (rx_nodeid, rx_addr.parse().unwrap()),
-        (tx_nodeid, tx_addr.parse().unwrap()),
-    ]);
+    let known_addresses: HashMap<NodeId<PubKeyType>, SocketAddr> =
+        HashMap::from([(rx_nodeid, *rx_addr), (tx_nodeid, *tx_addr)]);
 
     let validator_set = vec![(rx_nodeid, Stake(1)), (tx_nodeid, Stake(1))];
 

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::HashMap,
-    net::SocketAddr,
     time::{Duration, Instant},
 };
 
@@ -277,7 +276,7 @@ where
                             known_addresses: known_addresses.clone(),
                             full_nodes: Default::default(),
                             redundancy: 3,
-                            local_addr: address.parse::<SocketAddr>().unwrap().to_string(),
+                            local_addr: address.parse().unwrap(),
                             up_bandwidth_mbps: 1_000,
                         }),
                     },


### PR DESCRIPTION
In monad-dataplane and in monad-raptorcast, we currently use String
in a few places to represent addresses, where we should really be
using SocketAddr instead.  This PR switches both of these over to using
SocketAddr, and moves the responsibility for converting address strings
into SocketAddr types to the caller(s).