### PR TITLE
Fix Rust version pin

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,4 @@
 [toolchain]
-channel = "stable"
-versioned = "1.83.0"
+channel = "1.83.0"
 components = ["clippy"]
 profile = "minimal"


### PR DESCRIPTION
Nightly CI is broken from using the wrong Rust version, and on updating my local stable version, I ended up with the wrong version. Looking at other repositories' rust-toolchain.toml, it seems like I added this with the wrong syntax for stable versioning when I added this file. I verified that this reverted my local version back to 1.83.0.