### PR TITLE
Validate OpenRPC document and fix doc issues

### DIFF
--- a/.github/workflows/openrpc.yml
+++ b/.github/workflows/openrpc.yml
@@ -1,0 +1,38 @@
+name: Validate OpenRPC documentation
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+    paths:
+      - "monad-rpc/**"
+
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-32
+
+    steps:
+      - name: Generate a token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.REPO_READONLY_GITHUB_APP_ID }}
+          private_key: ${{ secrets.REPO_READONLY_GITHUB_APP_KEY }}
+          permissions: >-
+            {"contents": "read"}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ steps.generate_token.outputs.token }}
+      - name: Generate OpenRPC documentation
+        run: cargo run --bin monad-rpc-docs > openrpc.json
+      - name: Validate OpenRPC documentation
+        uses: philipglazman/openrpc-validation@v1
+        with:
+          file-path: openrpc.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7227,6 +7227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
  "dyn-clone",
+ "indexmap 1.9.3",
  "schemars_derive",
  "serde",
  "serde_json",

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -10,6 +10,13 @@ edition = "2021"
 name = "monad-rpc"
 bench = false
 
+[[bin]]
+name = "monad-rpc-docs"
+bench = false
+path = "./bin/docs.rs"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 [dependencies]
 monad-archive = { workspace = true }
 monad-eth-txpool-ipc = { workspace = true }
@@ -46,7 +53,7 @@ opentelemetry-otlp = { workspace = true }
 pin-project = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
-schemars = { workspace = true }
+schemars = { workspace = true, features = ["preserve_order"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["net", "macros", "rt-multi-thread", "fs"] }

--- a/monad-rpc/bin/docs.rs
+++ b/monad-rpc/bin/docs.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let openrpc = monad_rpc::docs::as_openrpc();
+    println!(
+        "{}",
+        serde_json::to_string(&openrpc).expect("failed to serialize OpenRPC document")
+    );
+}

--- a/monad-rpc/monad-rpc-docs/monad-rpc-docs-derive/src/lib.rs
+++ b/monad-rpc/monad-rpc-docs/monad-rpc-docs-derive/src/lib.rs
@@ -74,6 +74,30 @@ pub fn rpc(attr_args: TokenStream, decorated: TokenStream) -> TokenStream {
             fn output_schema() -> Option<schemars::schema::RootSchema> {
                 #output_schema
             }
+
+            fn register_components(components: &mut monad_rpc_docs::Components) {
+                // Register input schema components
+                if let Some(schema) = Self::input_schema() {
+                    let definitions = schema.definitions;
+                    let schemas: std::collections::HashMap<_, _> = definitions.into_iter().map(|(k,v)| {
+                        let mut v = v.clone();
+                        monad_rpc_docs::clean_schema_refs(&mut v);
+                        (k, v)
+                     }).collect();
+                    components.schemas.extend(schemas);
+                };
+
+                // Register output schema components
+                if let Some(schema) = Self::output_schema() {
+                    let definitions = schema.definitions;
+                    let schemas: std::collections::HashMap<_, _> = definitions.into_iter().map(|(k,v)| {
+                        let mut v = v.clone();
+                        monad_rpc_docs::clean_schema_refs(&mut v);
+                        (k, v)
+                     }).collect();
+                    components.schemas.extend(schemas);
+                };
+            }
         }
 
         #[doc(hidden)]
@@ -83,6 +107,7 @@ pub fn rpc(attr_args: TokenStream, decorated: TokenStream) -> TokenStream {
             docs: #docs,
             input_schema: <#name_ident as monad_rpc_docs::RpcMethod>::input_schema,
             output_schema: <#name_ident as monad_rpc_docs::RpcMethod>::output_schema,
+            register_components: <#name_ident as monad_rpc_docs::RpcMethod>::register_components,
         };
 
         monad_rpc_docs::inventory::submit! {

--- a/monad-rpc/src/account_handlers.rs
+++ b/monad-rpc/src/account_handlers.rs
@@ -1,13 +1,12 @@
 use alloy_primitives::B256;
 use monad_rpc_docs::rpc;
 use monad_triedb_utils::triedb_env::Triedb;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde::Deserialize;
 use tracing::trace;
 
 use crate::{
     block_handlers::get_block_key_from_tag_or_hash,
-    eth_json_types::{serialize_result, BlockTagOrHash, BlockTags, EthAddress, EthHash, MonadU256},
+    eth_json_types::{BlockTagOrHash, EthAddress, MonadU256},
     jsonrpc::{JsonRpcError, JsonRpcResult},
 };
 
@@ -143,46 +142,11 @@ pub async fn monad_eth_getTransactionCount<T: Triedb>(
 
 #[allow(non_snake_case)]
 /// Returns an object with data about the sync status or false.
-pub async fn monad_eth_syncing() -> Result<Value, JsonRpcError> {
+#[rpc(method = "eth_syncing")]
+pub async fn monad_eth_syncing() -> JsonRpcResult<bool> {
     trace!("monad_eth_syncing");
 
-    serialize_result(serde_json::Value::Bool(false))
-}
-
-#[derive(Deserialize, Debug, schemars::JsonSchema)]
-pub struct MonadEthGetProofParams {
-    account: EthAddress,
-    keys: Vec<EthHash>,
-    block_number: BlockTags,
-}
-
-#[derive(Serialize, Debug, schemars::JsonSchema)]
-pub struct StorageProof {
-    key: EthHash,
-    value: EthHash,
-    proof: Vec<EthHash>,
-}
-
-#[derive(Serialize, Debug, schemars::JsonSchema)]
-pub struct MonadEthGetProofResult {
-    balance: MonadU256,
-    code_hash: EthHash,
-    nonce: u128,
-    storage_hash: EthHash,
-    account_proof: Vec<EthHash>,
-    storage_proof: Vec<StorageProof>,
-}
-
-#[rpc(method = "eth_getProof")]
-#[allow(non_snake_case)]
-/// Returns the account and storage values of the specified account including the Merkle-proof.
-// TODO: this is a stub to support rpc docs, need to implement
-pub async fn monad_eth_getProof<T: Triedb>(
-    triedb_env: &T,
-    params: MonadEthGetProofParams,
-) -> JsonRpcResult<MonadEthGetProofResult> {
-    trace!("monad_eth_getProof");
-    Err(JsonRpcError::method_not_supported())
+    Ok(false)
 }
 
 #[cfg(test)]

--- a/monad-rpc/src/eth_json_types.rs
+++ b/monad-rpc/src/eth_json_types.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use alloy_consensus::TxEnvelope;
 use alloy_primitives::{Address, FixedBytes, LogData, U256};
 use alloy_rpc_types::{Block, FeeHistory, Header, Log, Transaction, TransactionReceipt};
+use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 use tracing::debug;
@@ -15,8 +16,8 @@ use crate::{
 pub type EthAddress = FixedData<20>;
 pub type EthHash = FixedData<32>;
 
-#[derive(Debug)]
-pub struct MonadU256(pub U256);
+#[derive(Debug, JsonSchema)]
+pub struct MonadU256(#[schemars(with = "u128")] pub U256);
 
 impl Serialize for MonadU256 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -39,183 +40,67 @@ impl<'de> Deserialize<'de> for MonadU256 {
     }
 }
 
-#[derive(Debug, Serialize)]
-pub struct MonadLog(pub Log<LogData>);
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct MonadLog(#[schemars(schema_with = "schema_for_log")] pub Log<LogData>);
 
-impl schemars::JsonSchema for MonadLog {
-    fn schema_name() -> String {
-        "MonadLog".to_string()
-    }
-
-    fn schema_id() -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed(concat!(module_path!(), "::NonGenericType"))
-    }
-
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        let schema = schemars::schema_for_value!(Log::<LogData>::default());
-        schema.schema.into()
-    }
-}
-
-#[derive(Debug, Serialize)]
-pub struct MonadTransaction(pub Transaction<TxEnvelope>);
-
-impl schemars::JsonSchema for MonadTransaction {
-    fn schema_name() -> String {
-        "MonadTransaction".to_string()
-    }
-
-    fn schema_id() -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed(concat!(module_path!(), "::NonGenericType"))
-    }
-
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        let rpc_tx = r#"{"blockHash":"0x883f974b17ca7b28cb970798d1c80f4d4bb427473dc6d39b2a7fe24edc02902d","blockNumber":"0xe26e6d","hash":"0x0e07d8b53ed3d91314c80e53cf25bcde02084939395845cbb625b029d568135c","accessList":[],"transactionIndex":"0xad","type":"0x2","nonce":"0x16d","input":"0x5ae401dc00000000000000000000000000000000000000000000000000000000628ced5b000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000016000000000000000000000000000000000000000000000000000000000000000e442712a6700000000000000000000000000000000000000000000b3ff1489674e11c40000000000000000000000000000000000000000000000000000004a6ed55bbcc18000000000000000000000000000000000000000000000000000000000000000800000000000000000000000003cf412d970474804623bb4e3a42de13f9bca54360000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000003a75941763f31c930b19c041b709742b0b31ebb600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000412210e8a00000000000000000000000000000000000000000000000000000000","r":"0x7f2153019a74025d83a73effdd91503ceecefac7e35dd933adc1901c875539aa","s":"0x334ab2f714796d13c825fddf12aad01438db3a8152b2fe3ef7827707c25ecab3","chainId":"0x1","v":"0x0","gas":"0x46a02","maxPriorityFeePerGas":"0x59682f00","from":"0x3cf412d970474804623bb4e3a42de13f9bca5436","to":"0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45","maxFeePerGas":"0x7fc1a20a8","value":"0x4a6ed55bbcc180","gasPrice":"0x50101df3a"}"#;
-        let tx = serde_json::from_str::<Transaction<TxEnvelope>>(rpc_tx).unwrap();
-        let schema = schemars::schema_for_value!(tx);
-        schema.schema.into()
-    }
-}
-
-#[derive(Debug, Serialize)]
-pub struct MonadTransactionReceipt(pub TransactionReceipt);
-
-impl schemars::JsonSchema for MonadTransactionReceipt {
-    fn schema_name() -> String {
-        "MonadTransactionReceipt".to_string()
-    }
-
-    fn schema_id() -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed(concat!(module_path!(), "::NonGenericType"))
-    }
-
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        let json_str = r#"{"transactionHash":"0x21f6554c28453a01e7276c1db2fc1695bb512b170818bfa98fa8136433100616","blockHash":"0x4acbdefb861ef4adedb135ca52865f6743451bfbfa35db78076f881a40401a5e","blockNumber":"0x129f4b9","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000200000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000800000000000000000000000000000000004000000000000000000800000000100000020000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000010000000000000000000000000000","gasUsed":"0xbde1","contractAddress":null,"cumulativeGasUsed":"0xa42aec","transactionIndex":"0x7f","from":"0x9a53bfba35269414f3b2d20b52ca01b15932c7b2","to":"0xdac17f958d2ee523a2206206994597c13d831ec7","type":"0x2","effectiveGasPrice":"0xfb0f6e8c9","logs":[{"blockHash":"0x4acbdefb861ef4adedb135ca52865f6743451bfbfa35db78076f881a40401a5e","address":"0xdac17f958d2ee523a2206206994597c13d831ec7","logIndex":"0x118","data":"0x00000000000000000000000000000000000000000052b7d2dcc80cd2e4000000","removed":false,"topics":["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925","0x0000000000000000000000009a53bfba35269414f3b2d20b52ca01b15932c7b2","0x00000000000000000000000039e5dbb9d2fead31234d7c647d6ce77d85826f76"],"blockNumber":"0x129f4b9","transactionIndex":"0x7f","transactionHash":"0x21f6554c28453a01e7276c1db2fc1695bb512b170818bfa98fa8136433100616"}],"status":"0x1"}"#;
-        let receipt: TransactionReceipt = serde_json::from_str(json_str).unwrap();
-        let schema = schemars::schema_for_value!(receipt);
-        schema.schema.into()
-    }
-}
-
-#[derive(Debug, Serialize)]
-pub struct MonadBlock(pub Block<Transaction<TxEnvelope>, Header>);
-
-impl schemars::JsonSchema for MonadBlock {
-    fn schema_name() -> String {
-        "MonadBlock".to_string()
-    }
-
-    fn schema_id() -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed(concat!(module_path!(), "::NonGenericType"))
-    }
-
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        let schema =
-            schemars::schema_for_value!(Block::<Transaction<TxEnvelope>, Header>::default());
-        schema.schema.into()
-    }
-}
-
-impl schemars::JsonSchema for EthAddress {
-    fn schema_name() -> String {
-        "EthAddress".to_string()
-    }
-
-    fn schema_id() -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed(concat!(module_path!(), "::NonGenericType"))
-    }
-
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        schemars::schema::SchemaObject {
-            instance_type: Some(schemars::schema::InstanceType::String.into()),
-            format: Some("hex".to_owned()),
-            ..Default::default()
-        }
+fn schema_for_log(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    schemars::schema_for_value!(Log::<LogData>::default())
+        .schema
         .into()
-    }
 }
 
-impl schemars::JsonSchema for MonadU256 {
-    fn schema_name() -> String {
-        "MonadU256".to_string()
-    }
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct MonadTransaction(
+    #[schemars(schema_with = "schema_for_transaction")] pub Transaction<TxEnvelope>,
+);
 
-    fn schema_id() -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed(concat!(module_path!(), "::NonGenericType"))
-    }
+fn schema_for_transaction(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    let rpc_tx = r#"{"blockHash":"0x883f974b17ca7b28cb970798d1c80f4d4bb427473dc6d39b2a7fe24edc02902d","blockNumber":"0xe26e6d","hash":"0x0e07d8b53ed3d91314c80e53cf25bcde02084939395845cbb625b029d568135c","accessList":[],"transactionIndex":"0xad","type":"0x2","nonce":"0x16d","input":"0x5ae401dc00000000000000000000000000000000000000000000000000000000628ced5b000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000016000000000000000000000000000000000000000000000000000000000000000e442712a6700000000000000000000000000000000000000000000b3ff1489674e11c40000000000000000000000000000000000000000000000000000004a6ed55bbcc18000000000000000000000000000000000000000000000000000000000000000800000000000000000000000003cf412d970474804623bb4e3a42de13f9bca54360000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000003a75941763f31c930b19c041b709742b0b31ebb600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000412210e8a00000000000000000000000000000000000000000000000000000000","r":"0x7f2153019a74025d83a73effdd91503ceecefac7e35dd933adc1901c875539aa","s":"0x334ab2f714796d13c825fddf12aad01438db3a8152b2fe3ef7827707c25ecab3","chainId":"0x1","v":"0x0","gas":"0x46a02","maxPriorityFeePerGas":"0x59682f00","from":"0x3cf412d970474804623bb4e3a42de13f9bca5436","to":"0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45","maxFeePerGas":"0x7fc1a20a8","value":"0x4a6ed55bbcc180","gasPrice":"0x50101df3a"}"#;
+    let tx = serde_json::from_str::<Transaction<TxEnvelope>>(rpc_tx).unwrap();
+    schemars::schema_for_value!(tx).schema.into()
+}
 
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        schemars::schema::SchemaObject {
-            instance_type: Some(schemars::schema::InstanceType::Integer.into()),
-            ..Default::default()
-        }
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct MonadTransactionReceipt(
+    #[schemars(schema_with = "schema_for_transaction_receipt")] pub TransactionReceipt,
+);
+
+fn schema_for_transaction_receipt(
+    _: &mut schemars::gen::SchemaGenerator,
+) -> schemars::schema::Schema {
+    let json_str = r#"{"transactionHash":"0x21f6554c28453a01e7276c1db2fc1695bb512b170818bfa98fa8136433100616","blockHash":"0x4acbdefb861ef4adedb135ca52865f6743451bfbfa35db78076f881a40401a5e","blockNumber":"0x129f4b9","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000200000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000800000000000000000000000000000000004000000000000000000800000000100000020000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000010000000000000000000000000000","gasUsed":"0xbde1","contractAddress":null,"cumulativeGasUsed":"0xa42aec","transactionIndex":"0x7f","from":"0x9a53bfba35269414f3b2d20b52ca01b15932c7b2","to":"0xdac17f958d2ee523a2206206994597c13d831ec7","type":"0x2","effectiveGasPrice":"0xfb0f6e8c9","logs":[{"blockHash":"0x4acbdefb861ef4adedb135ca52865f6743451bfbfa35db78076f881a40401a5e","address":"0xdac17f958d2ee523a2206206994597c13d831ec7","logIndex":"0x118","data":"0x00000000000000000000000000000000000000000052b7d2dcc80cd2e4000000","removed":false,"topics":["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925","0x0000000000000000000000009a53bfba35269414f3b2d20b52ca01b15932c7b2","0x00000000000000000000000039e5dbb9d2fead31234d7c647d6ce77d85826f76"],"blockNumber":"0x129f4b9","transactionIndex":"0x7f","transactionHash":"0x21f6554c28453a01e7276c1db2fc1695bb512b170818bfa98fa8136433100616"}],"status":"0x1"}"#;
+    let receipt: TransactionReceipt = serde_json::from_str(json_str).unwrap();
+    schemars::schema_for_value!(receipt).schema.into()
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct MonadBlock(
+    #[schemars(schema_with = "schema_for_block")] pub Block<Transaction<TxEnvelope>, Header>,
+);
+
+fn schema_for_block(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    schemars::schema_for_value!(Block::<Transaction<TxEnvelope>, Header>::default())
+        .schema
         .into()
-    }
 }
 
-#[derive(Serialize, Debug)]
-pub struct MonadFeeHistory(pub FeeHistory);
+#[derive(Serialize, Debug, JsonSchema)]
+pub struct MonadFeeHistory(#[schemars(schema_with = "schema_for_fee_history")] pub FeeHistory);
 
-impl schemars::JsonSchema for MonadFeeHistory {
-    fn schema_name() -> String {
-        "FeeHistory".to_string()
-    }
-
-    fn schema_id() -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed(concat!(module_path!(), "::NonGenericType"))
-    }
-
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        let schema = schemars::schema_for_value!(FeeHistory::default());
-        schema.schema.into()
-    }
-}
-
-impl schemars::JsonSchema for EthHash {
-    fn schema_name() -> String {
-        "EthHash".to_string()
-    }
-
-    fn schema_id() -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed(concat!(module_path!(), "::NonGenericType"))
-    }
-
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        schemars::schema::SchemaObject {
-            instance_type: Some(schemars::schema::InstanceType::String.into()),
-            format: Some("hex".to_owned()),
-            ..Default::default()
-        }
+fn schema_for_fee_history(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    schemars::schema_for_value!(FeeHistory::default())
+        .schema
         .into()
-    }
 }
 
 // https://ethereum.org/developers/docs/apis/json-rpc#unformatted-data-encoding
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, JsonSchema)]
+#[schemars(with = "String")]
 pub struct UnformattedData(pub Vec<u8>);
 
 impl UnformattedData {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
-    }
-}
-
-impl schemars::JsonSchema for UnformattedData {
-    fn schema_name() -> String {
-        "UnformattedData".to_string()
-    }
-
-    fn schema_id() -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed(concat!(module_path!(), "::NonGenericType"))
-    }
-
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        schemars::schema::SchemaObject {
-            instance_type: Some(schemars::schema::InstanceType::String.into()),
-            format: Some("hex".to_owned()),
-            ..Default::default()
-        }
-        .into()
     }
 }
 
@@ -253,27 +138,9 @@ impl<'de> Deserialize<'de> for UnformattedData {
 }
 
 // https://ethereum.org/developers/docs/apis/json-rpc#hex-encoding
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[schemars(with = "String")]
 pub struct Quantity(pub u64);
-
-impl schemars::JsonSchema for Quantity {
-    fn schema_name() -> String {
-        "Quantity".to_string()
-    }
-
-    fn schema_id() -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed(concat!(module_path!(), "::NonGenericType"))
-    }
-
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        schemars::schema::SchemaObject {
-            instance_type: Some(schemars::schema::InstanceType::String.into()),
-            format: Some("hex".to_owned()),
-            ..Default::default()
-        }
-        .into()
-    }
-}
 
 impl Serialize for Quantity {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -311,8 +178,8 @@ impl<'de> Deserialize<'de> for Quantity {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct FixedData<const N: usize>(pub [u8; N]);
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
+pub struct FixedData<const N: usize>(#[schemars(with = "String")] pub [u8; N]);
 
 impl<const N: usize> std::fmt::Display for FixedData<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/monad-rpc/src/jsonrpc.rs
+++ b/monad-rpc/src/jsonrpc.rs
@@ -20,7 +20,7 @@ pub enum RequestWrapper<T> {
     /// To be JSON-RPC spec-compliant, `Batch(Vec<T>)` needs to be the first variant in this enum.
     /// To see why, refer to these examples from https://www.jsonrpc.org/specification
     ///
-    /// ```
+    /// ```text
     /// rpc call with an invalid Batch (but not empty):
     /// --> [1]
     /// <-- [

--- a/monad-rpc/src/lib.rs
+++ b/monad-rpc/src/lib.rs
@@ -1,0 +1,17 @@
+mod account_handlers;
+mod block_handlers;
+mod call;
+mod debug;
+pub mod docs;
+mod eth_json_types;
+mod eth_txn_handlers;
+mod fee;
+mod gas_handlers;
+mod gas_oracle;
+mod hex;
+mod jsonrpc;
+mod meta;
+mod trace;
+mod trace_handlers;
+mod txpool;
+mod vpool;

--- a/monad-rpc/src/meta.rs
+++ b/monad-rpc/src/meta.rs
@@ -1,0 +1,15 @@
+use monad_rpc_docs::rpc;
+
+use crate::jsonrpc::JsonRpcResult;
+
+const WEB3_RPC_CLIENT_VERSION: &str = concat!("Monad/", env!("VERGEN_GIT_DESCRIBE"));
+
+#[rpc(method = "net_version", ignore = "chain_id")]
+pub fn monad_net_version(chain_id: u64) -> JsonRpcResult<String> {
+    Ok(chain_id.to_string())
+}
+
+#[rpc(method = "web3_clientVersion")]
+pub fn monad_web3_client_version() -> JsonRpcResult<String> {
+    Ok(WEB3_RPC_CLIENT_VERSION.to_string())
+}

--- a/monad-rpc/src/trace.rs
+++ b/monad-rpc/src/trace.rs
@@ -1,4 +1,3 @@
-use monad_rpc_docs::rpc;
 use serde::Deserialize;
 
 use crate::{
@@ -29,26 +28,23 @@ pub struct TraceCallObject {
     pub data: Option<String>,
 }
 
-#[rpc(method = "trace_block")]
 #[allow(non_snake_case)]
 pub async fn monad_trace_block(params: BlockTags) -> JsonRpcResult<String> {
     Err(JsonRpcError::method_not_supported())
 }
 
-#[derive(Deserialize, Debug, schemars::JsonSchema)]
+#[derive(Deserialize, Debug)]
 pub struct TraceCallParams {
     pub calls: Vec<TraceCallObject>,
     pub block: BlockTags,
 }
 
-#[rpc(method = "trace_call")]
 #[allow(non_snake_case)]
 /// Executes a new message call and returns a number of possible traces.
 pub async fn monad_trace_call(params: TraceCallParams) -> JsonRpcResult<String> {
     Err(JsonRpcError::method_not_supported())
 }
 
-#[rpc(method = "trace_callMany")]
 #[allow(non_snake_case)]
 /// Executes multiple message calls within the same block and returns a number of possible traces.
 pub async fn monad_trace_callMany() -> JsonRpcResult<String> {
@@ -61,14 +57,12 @@ pub struct TraceGetParams {
     indexes: Vec<Quantity>,
 }
 
-#[rpc(method = "trace_get")]
 #[allow(non_snake_case)]
 /// Returns trace at given position.
 pub async fn monad_trace_get(params: TraceGetParams) -> JsonRpcResult<String> {
     Err(JsonRpcError::method_not_supported())
 }
 
-#[rpc(method = "trace_transaction")]
 #[allow(non_snake_case)]
 /// Returns all traces of given transaction.
 pub async fn monad_trace_transaction(params: EthHash) -> JsonRpcResult<String> {

--- a/monad-rpc/src/trace_handlers.rs
+++ b/monad-rpc/src/trace_handlers.rs
@@ -136,6 +136,7 @@ pub struct MonadCallFrame {
     revert_reason: Option<String>,
     // FIXME why Rc<RefCell<_>> ?
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[schemars(skip)] // TODO: handle recursive generation in jsonrpc schema
     calls: Vec<std::rc::Rc<std::cell::RefCell<MonadCallFrame>>>,
 }
 
@@ -179,7 +180,7 @@ impl From<CallFrame> for MonadCallFrame {
 
 #[derive(Serialize, Debug, Clone, schemars::JsonSchema)]
 #[serde(rename_all = "UPPERCASE")]
-enum CallKind {
+pub enum CallKind {
     Call,
     DelegateCall,
     CallCode,


### PR DESCRIPTION
Cleans up openrpc.json generation. Adds a binary to generate openrpc docs using `cargo run --bin monad-rpc-docs`. 