### PR TITLE
Remove TriedbCache get_account_statuses unwrap

### DIFF
--- a/monad-triedb-cache/src/lib.rs
+++ b/monad-triedb-cache/src/lib.rs
@@ -92,10 +92,10 @@ where
         if cache.len() > self.execution_delay.0 as usize * 2 {
             let (evicted, _) = cache.pop_first().expect("nonempty");
             if evicted == block {
-                let (latest, _) = cache.last_key_value().expect("nonempty");
+                let maybe_latest = cache.last_key_value().map(|(latest, _)| latest);
                 tracing::warn!(
                     ?evicted,
-                    ?latest,
+                    ?maybe_latest,
                     "unexpected cache thrashing? only expect queries on the 2*delay latest blocks"
                 );
             }


### PR DESCRIPTION
This unwrap cannot happen on master, because execution_delay >= 1, so the cache always has at least 2 elements at time of eviction.

We remove the unwrap anyways because it's error prone in case the eviction policy changes, as is the case with the optimistic execution changes.