### PR TITLE
Check sender balance if gas price is provided in eth_call

### DIFF
--- a/monad-rpc/src/jsonrpc.rs
+++ b/monad-rpc/src/jsonrpc.rs
@@ -229,6 +229,14 @@ impl JsonRpcError {
         }
     }
 
+    pub fn insufficient_funds() -> Self {
+        Self {
+            code: -32003,
+            message: "Insufficient funds for gas * price + value".into(),
+            data: None,
+        }
+    }
+
     pub fn code_size_too_large(size: usize) -> Self {
         Self {
             code: -32603,


### PR DESCRIPTION
Fixes https://github.com/category-labs/category-internal/issues/1119 

Geth (and all other major evm implementations) will check that the sender's balance can cover gas in eth_call if gas price is provided. Otherwise, it will not check the sender balance. 

This returns the correct error code and message when the sender has insufficient balance to cover gas.