### PR TITLE
Concurrent logs read from triedb

### DIFF
--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -134,9 +134,10 @@ async fn rpc_handler(body: bytes::Bytes, app_state: web::Data<MonadRpcResources>
     match serde_json::to_vec(&response) {
         Ok(bytes) => {
             if bytes.len() > app_state.max_response_size as usize {
-                debug!("response exceed size limit: {body:?} => {response:?}");
-                return HttpResponse::Ok()
-                    .json(Response::from_error(JsonRpcError::invalid_request()));
+                info!("response exceed size limit: {body:?}");
+                return HttpResponse::Ok().json(Response::from_error(JsonRpcError::custom(
+                    "response exceed size limit".to_string(),
+                )));
             }
         }
         Err(e) => {


### PR DESCRIPTION
issue: https://github.com/category-labs/category-internal/issues/1130

for a block range of 1000 with ~1k transactions per block, it takes around 15-20s for the request to be fulfilled (was ~3mins before this commit). for a block range of 1000 with almost empty blocks, it takes ~2 seconds. 

I think we can also consider lowering the max block range (currently 1000), since our blocks can be much larger. I would suggest perhaps 200. 