### PR TITLE
Add insert/evict/drop metrics to txpool

### DIFF
--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -887,7 +887,8 @@ where
             // epoch manager records
             self.metrics.consensus_events.commit_block += 1;
             self.block_policy.update_committed_block(block);
-            self.tx_pool.update_committed_block(block);
+            self.tx_pool
+                .update_committed_block(block, &mut self.metrics.txpool_events);
             if !block.header().is_null {
                 self.epoch_manager
                     .schedule_epoch_start(block.header().seq_num, block.get_round());
@@ -1296,6 +1297,7 @@ where
             self.block_policy,
             pending_blocktree_blocks,
             self.state_backend,
+            &mut self.metrics.txpool_events,
         ) {
             Ok(proposed_execution_inputs) => proposed_execution_inputs,
             Err(err) => {

--- a/monad-consensus-types/src/metrics.rs
+++ b/monad-consensus-types/src/metrics.rs
@@ -114,7 +114,34 @@ metrics!(
     (
         TxPoolEvents,
         txpool_events,
-        [local_inserted_txns, dropped_txns, external_inserted_txns]
+        [
+            // TxPool Insertions
+            insert_mempool_txs,
+            insert_forwarded_txs,
+            drop_invalid_bytes,
+            drop_not_well_formed,
+            drop_nonce_too_low,
+            drop_fee_too_low,
+            drop_insufficient_balance,
+            drop_pool_full,
+            drop_existing_higher_priority,
+            // TxPool Pending Map
+            pending_addresses,
+            pending_txs,
+            pending_promote_addresses,
+            pending_promote_txs,
+            pending_drop_unknown_addresses,
+            pending_drop_unknown_txs,
+            pending_drop_low_nonce_addresses,
+            pending_drop_low_nonce_txs,
+            // TxPool Tracked Map
+            tracked_addresses,
+            tracked_txs,
+            tracked_evict_expired_addresses,
+            tracked_evict_expired_txs,
+            tracked_remove_committed_addresses,
+            tracked_remove_committed_txs,
+        ]
     ),
     (
         BlocktreeEvents,

--- a/monad-eth-txpool/benches/create_proposal.rs
+++ b/monad-eth-txpool/benches/create_proposal.rs
@@ -24,6 +24,7 @@ fn criterion_benchmark(c: &mut Criterion) {
              block_policy,
              pool,
              pending_blocks,
+             metrics,
              proposal_tx_limit,
              gas_limit,
          }| {
@@ -40,6 +41,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 block_policy,
                 pending_blocks.iter().collect_vec(),
                 state_backend,
+                metrics,
             )
             .unwrap();
         },

--- a/monad-eth-txpool/benches/insert.rs
+++ b/monad-eth-txpool/benches/insert.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use common::SignatureType;
 use criterion::{criterion_group, criterion_main, Criterion};
 use itertools::Itertools;
-use monad_consensus_types::txpool::TxPool;
+use monad_consensus_types::{metrics::TxPoolEvents, txpool::TxPool};
 use monad_eth_block_policy::EthBlockPolicy;
 use monad_eth_txpool::EthTxPool;
 use monad_types::GENESIS_SEQ_NUM;
@@ -43,10 +43,14 @@ fn criterion_benchmark(c: &mut Criterion) {
             )
         },
         |state| {
-            assert!(
-                !TxPool::insert_tx(&mut state.0, state.1.to_owned(), &block_policy, &state.2,)
-                    .is_empty()
-            );
+            assert!(!TxPool::insert_tx(
+                &mut state.0,
+                state.1.to_owned(),
+                &block_policy,
+                &state.2,
+                &mut TxPoolEvents::default()
+            )
+            .is_empty());
         },
     );
 }

--- a/monad-eth-txpool/src/pending/mod.rs
+++ b/monad-eth-txpool/src/pending/mod.rs
@@ -26,6 +26,10 @@ impl PendingTxMap {
         self.txs.is_empty()
     }
 
+    pub fn num_addresses(&self) -> usize {
+        self.txs.len()
+    }
+
     pub fn num_txs(&self) -> usize {
         self.num_txs
     }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1074,6 +1074,7 @@ where
                 .iter()
                 .rev()
                 .collect(),
+            &mut self.metrics.txpool_events,
         );
         // commit blocks
         commands.push(Command::LedgerCommand(LedgerCommand::LedgerCommit(


### PR DESCRIPTION
As a hacky solution to get txpool metrics while the metrics upgrades are in progress, this changeset pipes through the txpool events metrics to each txpool call so we can get detailed metrics on insertion rate, tx drop reasons, and many more. These metrics have been tested on devnet15 and have been added to a new TxPool grafana dashboard (https://grafana.devcore4.com/d/aea9wehvok9a8f/txpool).

Closes https://github.com/category-labs/category-internal/issues/1127.
Closes https://github.com/category-labs/category-internal/issues/1128.