### PR TITLE
Reject unsupported transaction types

### DIFF
--- a/monad-eth-block-policy/src/lib.rs
+++ b/monad-eth-block-policy/src/lib.rs
@@ -111,6 +111,7 @@ pub enum TransactionError {
     InitCodeLimitExceeded,
     GasLimitTooLow,
     GasLimitTooHigh,
+    UnsupportedTransactionType,
 }
 
 /// Stateless helper function to check validity of an Ethereum transaction
@@ -144,6 +145,10 @@ pub fn static_validate_transaction(tx: &TxEnvelope, chain_id: u64) -> Result<(),
 
     if tx.gas_limit() > PROPOSAL_GAS_LIMIT {
         return Err(TransactionError::GasLimitTooHigh);
+    }
+
+    if tx.is_eip4844() || tx.is_eip7702() {
+        return Err(TransactionError::UnsupportedTransactionType);
     }
 
     Ok(())

--- a/monad-rpc/src/eth_txn_handlers.rs
+++ b/monad-rpc/src/eth_txn_handlers.rs
@@ -343,6 +343,9 @@ pub async fn monad_eth_sendRawTransaction<T: Triedb>(
                     TransactionError::InitCodeLimitExceeded => "Init code size limit exceeded",
                     TransactionError::GasLimitTooLow => "Gas limit too low",
                     TransactionError::GasLimitTooHigh => "Exceeds block gas limit",
+                    TransactionError::UnsupportedTransactionType => {
+                        "EIP4844 and EIP7702 transactions unsupported"
+                    }
                 };
                 return Err(JsonRpcError::custom(error_message.to_string()));
             }


### PR DESCRIPTION
EIP4844 and EIP7702 transactions are types that are supported by Alloy library, but we don't support them yet. Currently these transactions get silently dropped, we should reject them explicitly. 