### PR TITLE
Set service name for rpc metrics

### DIFF
--- a/monad-rpc/src/cli.rs
+++ b/monad-rpc/src/cli.rs
@@ -37,6 +37,10 @@ pub struct Cli {
     #[arg(long)]
     pub otel_endpoint: Option<String>,
 
+    /// Service name to set for metrics
+    #[arg(long)]
+    pub metrics_service_name: Option<String>,
+
     /// Allow pre EIP-155 transactions
     #[arg(long, default_value_t = false)]
     pub allow_unprotected_txs: bool,

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -692,9 +692,14 @@ async fn main() -> std::io::Result<()> {
 
     let meter_provider: Option<opentelemetry_sdk::metrics::SdkMeterProvider> =
         args.otel_endpoint.map(|endpoint| {
+            let svc_name = match args.metrics_service_name {
+                Some(name) => name,
+                None => "monad-rpc".to_string(),
+            };
+
             let provider = metrics::build_otel_meter_provider(
                 &endpoint,
-                "monad-rpc".to_string(),
+                svc_name,
                 std::time::Duration::from_secs(5),
             )
             .expect("failed to build otel meter");

--- a/monad-rpc/src/metrics.rs
+++ b/monad-rpc/src/metrics.rs
@@ -37,6 +37,7 @@ where
 
         let request_metrics = self.inner.clone();
         Box::pin(self.service.call(req).map(move |res| {
+            request_metrics.active_requests.add(-1, &attributes);
             if let Ok(res) = res {
                 let elapsed = timer.elapsed();
 
@@ -45,7 +46,6 @@ where
                     res.status().as_u16() as i64,
                 ));
 
-                request_metrics.active_requests.add(-1, &attributes);
                 request_metrics
                     .request_duration
                     .record(elapsed.as_secs_f64(), &attributes);


### PR DESCRIPTION
Set the service name for otel metrics using rpc cli flag to differentiate between rpc services

Alternatively, we can re-use `node.toml`, but that would require a refactor of the monad-node crate which is probably be worth the effort right now.