### PR TITLE
Optimize eth_getLogs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4881,6 +4881,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "pin-project",
+ "rayon",
  "reqwest 0.11.27",
  "scc",
  "schemars",

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -41,6 +41,7 @@ tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 notify = "6.1.1"
 pin-project = "1.1.5"
+rayon = { workspace = true }
 scc = { workspace = true }
 schemars = "0.8.21"
 opentelemetry = { workspace = true, features = ["metrics"] }

--- a/monad-rpc/src/block_watcher.rs
+++ b/monad-rpc/src/block_watcher.rs
@@ -85,8 +85,13 @@ impl<T: Triedb + Send + Sync> BlockState for TrieDbBlockState<T> {
             .get_receipts(block_num)
             .await
             .map_err(JsonRpcError::internal_error)?;
-        let receipts =
-            block_receipts(&transactions, bloom_receipts, &header.header, header.hash).await?;
+        let receipts = block_receipts(
+            transactions.clone(),
+            bloom_receipts,
+            &header.header,
+            header.hash,
+        )
+        .await?;
 
         let result: Vec<_> = transactions.into_iter().zip(receipts).collect();
         Ok(result)

--- a/monad-rpc/src/eth_txn_handlers.rs
+++ b/monad-rpc/src/eth_txn_handlers.rs
@@ -1,14 +1,13 @@
-use std::cmp::min;
-
 use alloy_consensus::{
     transaction::Recovered, ReceiptEnvelope, ReceiptWithBloom, Transaction as _, TxEnvelope,
 };
-use alloy_primitives::{FixedBytes, TxKind};
+use alloy_primitives::{Address, FixedBytes, TxKind};
 use alloy_rlp::Decodable;
 use alloy_rpc_types::{
     BlockNumberOrTag, Filter, FilterBlockOption, FilteredParams, Log, Receipt, Transaction,
     TransactionReceipt,
 };
+use futures::stream::{self, StreamExt};
 use monad_archive::prelude::{BlockDataReader, IndexStoreReader};
 use monad_eth_block_policy::{static_validate_transaction, TransactionError};
 use monad_rpc_docs::rpc;
@@ -40,12 +39,7 @@ pub fn parse_tx_content(
     };
 
     // effective gas price is calculated according to eth json rpc specification
-    let base_fee: u128 = base_fee.unwrap_or_default().into();
-    let effective_gas_price = base_fee
-        + min(
-            tx.max_fee_per_gas() - base_fee,
-            tx.max_priority_fee_per_gas().unwrap_or_default(),
-        );
+    let effective_gas_price = tx.effective_gas_price(base_fee);
 
     Ok(Transaction {
         inner: tx,
@@ -67,18 +61,10 @@ pub fn parse_tx_receipt(
     block_num: u64,
     tx_index: u64,
     num_prev_logs: usize,
+    sender: Address,
 ) -> Result<TransactionReceipt, JsonRpcError> {
-    let Ok(address) = tx.recover_signer() else {
-        error!("transaction sender should exist");
-        return Err(JsonRpcError::txn_decode_error());
-    };
-    let base_fee_per_gas = base_fee_per_gas.unwrap_or_default() as u128;
     // effective gas price is calculated according to eth json rpc specification
-    let effective_gas_price = base_fee_per_gas
-        + min(
-            tx.max_fee_per_gas() - base_fee_per_gas,
-            tx.max_priority_fee_per_gas().unwrap_or_default(),
-        );
+    let effective_gas_price = tx.effective_gas_price(base_fee_per_gas);
 
     let block_hash = Some(block_hash);
     let block_number = Some(block_num);
@@ -100,19 +86,25 @@ pub fn parse_tx_receipt(
         .collect();
 
     let contract_address = match tx.kind() {
-        TxKind::Create => Some(address.create(tx.nonce())),
+        TxKind::Create => Some(sender.create(tx.nonce())),
         _ => None,
     };
 
-    // TODO: support other transaction types
-    let inner_receipt: ReceiptEnvelope<Log> = ReceiptEnvelope::Eip1559(ReceiptWithBloom {
+    let receipt_with_bloom = ReceiptWithBloom {
         receipt: Receipt {
             status: receipt.status().into(),
             cumulative_gas_used: receipt.cumulative_gas_used(),
             logs,
         },
         logs_bloom: *receipt.logs_bloom(),
-    });
+    };
+    let inner_receipt: ReceiptEnvelope<Log> = match receipt {
+        ReceiptEnvelope::Legacy(_) => ReceiptEnvelope::Legacy(receipt_with_bloom),
+        ReceiptEnvelope::Eip2930(_) => ReceiptEnvelope::Eip2930(receipt_with_bloom),
+        ReceiptEnvelope::Eip1559(_) => ReceiptEnvelope::Eip1559(receipt_with_bloom),
+        ReceiptEnvelope::Eip4844(_) => ReceiptEnvelope::Eip4844(receipt_with_bloom),
+        _ => ReceiptEnvelope::Eip1559(receipt_with_bloom),
+    };
 
     let tx_receipt = TransactionReceipt {
         inner: inner_receipt,
@@ -120,12 +112,12 @@ pub fn parse_tx_receipt(
         transaction_index: Some(tx_index),
         block_hash,
         block_number,
-        from: address,
+        from: sender,
         to: tx.to(),
         contract_address,
         gas_used,
         effective_gas_price,
-        // TODO: EIP4844 fields
+        // TODO: EIP4844 and EIP7702 fields
         blob_gas_used: None,
         blob_gas_price: None,
         authorization_list: None,
@@ -152,9 +144,8 @@ impl From<FilterError> for JsonRpcError {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(transparent)]
 pub struct MonadEthGetLogsParams {
-    filters: Vec<Filter>,
+    filters: Filter,
 }
 
 #[derive(Serialize, Debug, schemars::JsonSchema)]
@@ -169,148 +160,152 @@ pub async fn monad_eth_getLogs<T: Triedb>(
 ) -> JsonRpcResult<MonadEthGetLogsResult> {
     trace!("monad_eth_getLogs: {p:?}");
 
-    let mut logs = Vec::new();
+    let filter = p.filters;
+    let (from_block, to_block) = match filter.block_option {
+        FilterBlockOption::Range {
+            from_block,
+            to_block,
+        } => {
+            let into_block_tag = |block: Option<BlockNumberOrTag>| -> BlockTags {
+                match block {
+                    None => BlockTags::default(),
+                    Some(b) => match b {
+                        BlockNumberOrTag::Number(q) => BlockTags::Number(Quantity(q)),
+                        _ => BlockTags::Latest,
+                    },
+                }
+            };
+            let from_block_tag = into_block_tag(from_block);
+            let to_block_tag = into_block_tag(to_block);
 
-    for req in p.filters {
-        let filter: Filter = req.clone();
-        let (from_block, to_block) = match req.block_option {
-            FilterBlockOption::Range {
-                from_block,
-                to_block,
-            } => {
-                let into_block_tag = |block: Option<BlockNumberOrTag>| -> BlockTags {
-                    match block {
-                        None => BlockTags::default(),
-                        Some(b) => match b {
-                            BlockNumberOrTag::Number(q) => BlockTags::Number(Quantity(q)),
-                            _ => BlockTags::Latest,
-                        },
-                    }
-                };
-                let from_block_tag = into_block_tag(from_block);
-                let to_block_tag = into_block_tag(to_block);
+            let from_block = get_block_num_from_tag(triedb_env, from_block_tag)
+                .await
+                .map_err(|_| {
+                    JsonRpcError::internal_error("could not get starting block range".to_string())
+                })?;
+            let to_block = get_block_num_from_tag(triedb_env, to_block_tag)
+                .await
+                .map_err(|_| {
+                    JsonRpcError::internal_error("could not get ending block range".to_string())
+                })?;
+            (from_block, to_block)
+        }
+        FilterBlockOption::AtBlockHash(block_hash) => {
+            let latest_block_num = get_block_num_from_tag(triedb_env, BlockTags::Latest).await?;
 
-                let from_block = get_block_num_from_tag(triedb_env, from_block_tag)
-                    .await
-                    .map_err(|_| {
-                        JsonRpcError::internal_error(
-                            "could not get starting block range".to_string(),
-                        )
-                    })?;
-                let to_block = get_block_num_from_tag(triedb_env, to_block_tag)
-                    .await
-                    .map_err(|_| {
-                        JsonRpcError::internal_error("could not get ending block range".to_string())
-                    })?;
-                (from_block, to_block)
-            }
-            FilterBlockOption::AtBlockHash(block_hash) => {
-                let latest_block_num =
-                    get_block_num_from_tag(triedb_env, BlockTags::Latest).await?;
-
-                let block = triedb_env
-                    .get_block_number_by_hash(block_hash.into(), latest_block_num)
-                    .await
-                    .map_err(|_| {
-                        JsonRpcError::internal_error("could not get block hash".to_string())
-                    })?;
-                let block_num = match block {
-                    Some(block_num) => block_num,
-                    None => {
-                        // retry from archive reader if block hash not available in triedb
-                        if let Some(archive_reader) = archive_reader {
-                            if let Ok(block) = archive_reader.get_block_by_hash(&block_hash).await {
-                                block.header.number
-                            } else {
-                                return Ok(MonadEthGetLogsResult(vec![]));
-                            }
+            let block = triedb_env
+                .get_block_number_by_hash(block_hash.into(), latest_block_num)
+                .await
+                .map_err(|_| {
+                    JsonRpcError::internal_error("could not get block hash".to_string())
+                })?;
+            let block_num = match block {
+                Some(block_num) => block_num,
+                None => {
+                    // retry from archive reader if block hash not available in triedb
+                    if let Some(archive_reader) = archive_reader {
+                        if let Ok(block) = archive_reader.get_block_by_hash(&block_hash).await {
+                            block.header.number
                         } else {
                             return Ok(MonadEthGetLogsResult(vec![]));
                         }
+                    } else {
+                        return Ok(MonadEthGetLogsResult(vec![]));
                     }
-                };
-                (block_num, block_num)
-            }
-        };
-
-        if from_block > to_block {
-            return Err(FilterError::InvalidBlockRange.into());
+                }
+            };
+            (block_num, block_num)
         }
-        if to_block - from_block > 1000 {
-            return Err(FilterError::RangeTooLarge.into());
-        }
+    };
 
-        let filtered_params = FilteredParams::new(Some(filter.clone()));
+    if from_block > to_block {
+        return Err(FilterError::InvalidBlockRange.into());
+    }
+    if to_block - from_block > 1000 {
+        return Err(FilterError::RangeTooLarge.into());
+    }
 
-        for block_num in from_block..=to_block {
-            // TODO: check block's log_bloom against the filter
-            let receipts: Vec<TransactionReceipt> = if let Some(header) = triedb_env
-                .get_block_header(block_num)
-                .await
-                .map_err(JsonRpcError::internal_error)?
-            {
-                // try fetching from triedb
-                let transactions = triedb_env
-                    .get_transactions(block_num)
+    let filtered_params = FilteredParams::new(Some(filter.clone()));
+    let block_range = from_block..=to_block;
+    let receipts = stream::iter(block_range)
+        .map(|block_num| {
+            async move {
+                let receipts: Vec<TransactionReceipt> = if let Some(header) = triedb_env
+                    .get_block_header(block_num)
                     .await
-                    .map_err(JsonRpcError::internal_error)?;
-                let bloom_receipts = triedb_env
-                    .get_receipts(block_num)
-                    .await
-                    .map_err(JsonRpcError::internal_error)?;
-                block_receipts(&transactions, bloom_receipts, &header.header, header.hash).await?
-            } else if let Some(archive_reader) = archive_reader {
-                // fallback to archive reader if header not available in triedb
-                let block = archive_reader
-                    .get_block_by_number(block_num)
-                    .await
-                    .map_err(|_| {
-                        JsonRpcError::internal_error("error getting block header".into())
-                    })?;
-                let bloom_receipts =
-                    archive_reader
+                    .map_err(JsonRpcError::internal_error)?
+                {
+                    // try fetching from triedb
+                    let transactions = triedb_env
+                        .get_transactions(block_num)
+                        .await
+                        .map_err(JsonRpcError::internal_error)?;
+                    let bloom_receipts = triedb_env
+                        .get_receipts(block_num)
+                        .await
+                        .map_err(JsonRpcError::internal_error)?;
+                    block_receipts(transactions, bloom_receipts, &header.header, header.hash)
+                        .await?
+                } else if let Some(archive_reader) = archive_reader {
+                    // fallback to archive reader if header not available in triedb
+                    let block = archive_reader
+                        .get_block_by_number(block_num)
+                        .await
+                        .map_err(|_| {
+                            JsonRpcError::internal_error("error getting block header".into())
+                        })?;
+                    let bloom_receipts = archive_reader
                         .get_block_receipts(block_num)
                         .await
                         .map_err(|_| {
                             JsonRpcError::internal_error("error getting block receipts".into())
                         })?;
-                block_receipts(
-                    &block.body.transactions,
-                    bloom_receipts,
-                    &block.header,
-                    block.header.hash_slow(),
-                )
-                .await?
-            } else {
-                return Err(JsonRpcError::internal_error(
-                    "error getting block header".into(),
-                ));
-            };
+                    block_receipts(
+                        block.body.transactions,
+                        bloom_receipts,
+                        &block.header,
+                        block.header.hash_slow(),
+                    )
+                    .await?
+                } else {
+                    return Err(JsonRpcError::internal_error(
+                        "error getting block header".into(),
+                    ));
+                };
 
-            let mut receipt_logs: Vec<Log> = receipts
-                .into_iter()
-                .flat_map(|receipt| {
-                    let logs: Vec<Log> = receipt
-                        .inner
-                        .logs()
-                        .iter()
-                        .filter(|log: &&Log| {
-                            !(filtered_params.filter.is_some()
-                                && (!filtered_params.filter_address(&log.address())
-                                    || !filtered_params.filter_topics(log.topics())))
-                        })
-                        .cloned()
-                        .collect();
-                    logs
+                Ok::<Vec<TransactionReceipt>, JsonRpcError>(receipts)
+            }
+        })
+        .buffered(100)
+        .collect::<Vec<_>>()
+        .await;
+    let receipts: Vec<TransactionReceipt> = receipts
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flatten()
+        .collect();
+
+    let receipt_logs: Vec<Log> = receipts
+        .into_iter()
+        .flat_map(|receipt| {
+            let logs: Vec<Log> = receipt
+                .inner
+                .logs()
+                .iter()
+                .filter(|log: &&Log| {
+                    !(filtered_params.filter.is_some()
+                        && (!filtered_params.filter_address(&log.address())
+                            || !filtered_params.filter_topics(log.topics())))
                 })
+                .cloned()
                 .collect();
-
-            logs.append(&mut receipt_logs);
-        }
-    }
+            logs
+        })
+        .collect();
 
     Ok(MonadEthGetLogsResult(
-        logs.into_iter().map(MonadLog).collect(),
+        receipt_logs.into_iter().map(MonadLog).collect(),
     ))
 }
 
@@ -437,6 +432,11 @@ pub async fn monad_eth_getTransactionReceipt<T: Triedb>(
                 0
             };
 
+            let Ok(sender) = tx_data.tx.recover_signer() else {
+                error!("transaction sender should exist");
+                return Err(JsonRpcError::txn_decode_error());
+            };
+
             let receipt = parse_tx_receipt(
                 tx_data.header_subset.base_fee_per_gas,
                 None, // FIXME block timestamp
@@ -447,6 +447,7 @@ pub async fn monad_eth_getTransactionReceipt<T: Triedb>(
                 tx_data.header_subset.block_number,
                 tx_data.header_subset.tx_index,
                 num_prev_logs,
+                sender,
             )?;
 
             return Ok(Some(MonadTransactionReceipt(receipt)));
@@ -653,6 +654,11 @@ async fn get_receipt_from_triedb<T: Triedb>(
                 0
             };
 
+            let Ok(sender) = tx.recover_signer() else {
+                error!("transaction sender should exist");
+                return Err(JsonRpcError::txn_decode_error());
+            };
+
             let receipt = parse_tx_receipt(
                 header.header.base_fee_per_gas,
                 Some(header.header.timestamp),
@@ -663,6 +669,7 @@ async fn get_receipt_from_triedb<T: Triedb>(
                 block_num,
                 tx_index,
                 num_prev_logs,
+                sender,
             )?;
 
             Ok(Some(MonadTransactionReceipt(receipt)))

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -134,9 +134,10 @@ async fn rpc_handler(body: bytes::Bytes, app_state: web::Data<MonadRpcResources>
     match serde_json::to_vec(&response) {
         Ok(bytes) => {
             if bytes.len() > app_state.max_response_size as usize {
-                debug!("response exceed size limit: {body:?} => {response:?}");
-                return HttpResponse::Ok()
-                    .json(Response::from_error(JsonRpcError::invalid_request()));
+                info!("response exceed size limit: {body:?}");
+                return HttpResponse::Ok().json(Response::from_error(JsonRpcError::custom(
+                    "response exceed size limit".to_string(),
+                )));
             }
         }
         Err(e) => {


### PR DESCRIPTION
attempt 2: https://github.com/category-labs/category-internal/issues/1130
previous PR: https://github.com/category-labs/monad-bft/pull/1444

there has been previous discussions that we shouldn't let a single RPC call fills up the triedb reads in front of other requests. in this PR we still do concurrent reads but limited at 100 reads at a time. there is also a separate optimization on sender address recovery. 