### PR TITLE
Concurrent reads for archive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4919,6 +4919,7 @@ dependencies = [
  "flume",
  "futures",
  "futures-util",
+ "itertools 0.10.5",
  "monad-archive",
  "monad-cxx",
  "monad-eth-block-policy",

--- a/docker/devnet/monad/config/node.toml
+++ b/docker/devnet/monad/config/node.toml
@@ -49,7 +49,6 @@ peers = []
 # [[statesync.peers]]
 # secp256k1_pubkey = "..."
 
-
 [network]
 bind_address_host = "0.0.0.0"
 bind_address_port = 8000

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -34,6 +34,7 @@ env_logger = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
+itertools = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 tokio-util = { workspace = true, features = ["codec"] }

--- a/monad-rpc/src/block_handlers.rs
+++ b/monad-rpc/src/block_handlers.rs
@@ -299,7 +299,7 @@ pub async fn monad_eth_getBlockTransactionCountByNumber<T: Triedb>(
     Ok(None)
 }
 
-pub async fn map_block_receipts<R>(
+pub fn map_block_receipts<R>(
     transactions: Vec<TxEnvelopeWithSender>,
     receipts: Vec<ReceiptWithLogIndex>,
     block_header: &RlpHeader,
@@ -318,7 +318,7 @@ pub async fn map_block_receipts<R>(
 
     transactions
         .iter()
-        .zip(receipts.into_iter())
+        .zip(receipts)
         .enumerate()
         .map(|(tx_index, (tx, receipt))| -> Result<R, JsonRpcError> {
             let prev_receipt = prev_receipt.replace(receipt.to_owned());
@@ -344,7 +344,7 @@ pub async fn map_block_receipts<R>(
         .collect()
 }
 
-pub async fn block_receipts(
+pub fn block_receipts(
     transactions: Vec<TxEnvelopeWithSender>,
     receipts: Vec<ReceiptWithLogIndex>,
     block_header: &RlpHeader,
@@ -357,7 +357,6 @@ pub async fn block_receipts(
         block_hash,
         |receipt| receipt,
     )
-    .await
 }
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
@@ -415,8 +414,7 @@ pub async fn monad_eth_getBlockReceipts<T: Triedb>(
             &header.header,
             header.hash,
             MonadTransactionReceipt,
-        )
-        .await?;
+        )?;
         return Ok(Some(MonadEthGetBlockReceiptsResult(block_receipts)));
     }
 
@@ -430,8 +428,7 @@ pub async fn monad_eth_getBlockReceipts<T: Triedb>(
                     &block.header,
                     block.header.hash_slow(),
                     MonadTransactionReceipt,
-                )
-                .await?;
+                )?;
                 return Ok(Some(MonadEthGetBlockReceiptsResult(block_receipts)));
             }
         }

--- a/monad-rpc/src/block_watcher.rs
+++ b/monad-rpc/src/block_watcher.rs
@@ -95,8 +95,7 @@ impl<T: Triedb + Send + Sync> BlockState for TrieDbBlockState<T> {
             bloom_receipts,
             &header.header,
             header.hash,
-        )
-        .await?;
+        )?;
 
         let result: Vec<_> = transactions.into_iter().zip(receipts).collect();
         Ok(result)

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -142,9 +142,10 @@ pub async fn rpc_handler(
     match serde_json::to_vec(&response) {
         Ok(bytes) => {
             if bytes.len() > app_state.max_response_size as usize {
-                debug!("response exceed size limit: {body:?} => {response:?}");
-                return HttpResponse::Ok()
-                    .json(Response::from_error(JsonRpcError::invalid_request()));
+                info!("response exceed size limit: {body:?}");
+                return HttpResponse::Ok().json(Response::from_error(JsonRpcError::custom(
+                    "response exceed size limit".to_string(),
+                )));
             }
         }
         Err(e) => {


### PR DESCRIPTION
if we are worried about concurrent triedb reads during eth_getLogs, here is another PR that mostly does concurrent reads for archive (max 100 concurrent reads for archive). setting 10 concurrent reads for triedb. 