### PR TITLE
Fix gas estimate issue that returns block gas limit

### DIFF
--- a/monad-rpc/src/gas_handlers.rs
+++ b/monad-rpc/src/gas_handlers.rs
@@ -152,7 +152,7 @@ pub async fn monad_eth_estimateGas<T: Triedb + TriedbPath>(
 
         let mid = (upper_bound_gas_limit + lower_bound_gas_limit) / 2;
 
-        params.tx.gas = Some(U256::from((gas_used + gas_refund) * 64 / 63));
+        params.tx.gas = Some(U256::from(mid));
         txn = params.tx.clone().try_into()?;
 
         match monad_cxx::eth_call(


### PR DESCRIPTION
fixes https://github.com/category-labs/category-external/issues/28 

bug introduced during alloy upgrade 
https://github.com/category-labs/monad-bft/blob/v0.7.0/monad-rpc/src/gas_handlers.rs#L147