### PR TITLE
Archive: Fix incorrect DynamoDB key for backwards compatibility 

### DIFF
--- a/monad-archive/src/storage/dynamodb.rs
+++ b/monad-archive/src/storage/dynamodb.rs
@@ -57,7 +57,7 @@ impl KVStore for DynamoDBArchive {
             .into_iter()
             .filter_map(|(key, data)| {
                 let attribute_map: HashMap<String, AttributeValue> = HashMap::from_iter([
-                    ("key".to_owned(), AttributeValue::S(key)),
+                    ("tx_hash".to_owned(), AttributeValue::S(key)),
                     ("data".to_owned(), AttributeValue::B(data.into())),
                 ]);
                 match PutRequest::builder().set_item(Some(attribute_map)).build() {


### PR DESCRIPTION
The existing dynamodb tables are keyed by "tx_hash" attribute. When I was refactoring I changed it to "key" and set up fallback decoding in the rust client, however I forgot that dynamodb has a schema and we would have to update all the existing dbs
