### PR TITLE
Tests for trace rpcs

### DIFF
--- a/monad-cxx/src/lib.rs
+++ b/monad-cxx/src/lib.rs
@@ -255,7 +255,7 @@ pub fn eth_call(
                 let message = String::from("execution reverted");
                 let error_message = decode_revert_message(&output_data);
                 CallResult::Failure(FailureCallResult {
-                    message: message + &error_message,
+                    message: message + ": " + &error_message,
                     data: Some(format!("0x{}", hex::encode(&output_data))),
                 })
             }
@@ -281,11 +281,7 @@ pub fn decode_revert_message(output_data: &[u8]) -> String {
             let message_bytes = &output_data[message_start_index..message_end_index];
 
             // attempt to decode the message bytes as UTF-8
-            let message = match String::from_utf8(message_bytes.to_vec()) {
-                Ok(message) => String::from(": ") + &message,
-                Err(_) => String::new(),
-            };
-            return message;
+            return String::from_utf8(message_bytes.to_vec()).unwrap_or_default();
         }
     }
     String::new()

--- a/monad-triedb-utils/src/triedb_env.rs
+++ b/monad-triedb-utils/src/triedb_env.rs
@@ -89,7 +89,7 @@ pub struct BlockHeader {
     pub header: Header,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct TransactionLocation {
     pub tx_index: u64,
     pub block_num: u64,


### PR DESCRIPTION
Adds some tests to callframe trace related rpcs. 

Fixes a todo for returning an error string in the call frame. 

fixes https://github.com/category-labs/category-internal/issues/1329