### PR TITLE
Fix Raptorcast dissector crash on secp256k1_context_create()

### DIFF
--- a/monad-raptorcast/wireshark/raptorcast.c
+++ b/monad-raptorcast/wireshark/raptorcast.c
@@ -128,7 +128,7 @@ static enum signature_status recover_author(uint8_t *author, size_t authorlen, c
 	static struct signature_cache_entry cache_entries[256];
 
 	if (ctx == NULL) {
-		ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
+		ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
 	}
 
 	struct signature_cache_entry *entry = &cache_entries[msghash32[0]];


### PR DESCRIPTION
When dissecting Raptorcast messages, wireshark would crash, saying: 

```
[libsecp256k1] illegal argument: secp256k1_ecmult_context_is_built(&ctx->ecmult_ctx) 
```
This was found when running:
```
RUST_BACKTRACE=1 RUST_LOG=trace cargo run -p monad-raptorcast --release --example service -- \
        --addresses             \
        127.0.0.1:8000          \
        127.0.0.2:8000          \
        127.0.0.3:8000          \
        127.0.0.4:8000          \
        127.0.0.5:8000
```