### PR TITLE
Add TriedbEnv backpressure mechanism and use it in monad-rpc

### DIFF
--- a/monad-archive/src/cli.rs
+++ b/monad-archive/src/cli.rs
@@ -234,16 +234,22 @@ impl RocksDbCliArgs {
 #[derive(Clone, Debug)]
 pub struct TrieDbCliArgs {
     pub triedb_path: String,
-    pub max_concurrent_requests: usize,
+    pub max_buffered_read_requests: usize,
+    pub max_triedb_async_read_concurrency: usize,
+    pub max_buffered_traverse_requests: usize,
+    pub max_triedb_async_traverse_concurrency: usize,
 }
 
 impl TrieDbCliArgs {
     pub fn parse(mut next: impl FnMut(&'static str) -> Result<String>) -> Result<TrieDbCliArgs> {
         Ok(TrieDbCliArgs {
             triedb_path: next("storage args missing db path")?,
-            max_concurrent_requests: usize::from_str(&next(
-                "args missing max_concurrent_requests",
+            max_buffered_read_requests: usize::from_str(&next(
+                "args missing max_buffered_read_requests",
             )?)?,
+            max_triedb_async_read_concurrency: 10000,
+            max_buffered_traverse_requests: 40,
+            max_triedb_async_traverse_concurrency: 20,
         })
     }
 }

--- a/monad-archive/src/kvstore/triedb_reader.rs
+++ b/monad-archive/src/kvstore/triedb_reader.rs
@@ -14,7 +14,13 @@ pub struct TriedbReader {
 impl TriedbReader {
     pub fn new(args: &TrieDbCliArgs) -> TriedbReader {
         Self {
-            db: TriedbEnv::new(args.triedb_path.as_ref(), args.max_concurrent_requests),
+            db: TriedbEnv::new(
+                args.triedb_path.as_ref(),
+                args.max_buffered_read_requests,
+                args.max_triedb_async_read_concurrency,
+                args.max_buffered_traverse_requests,
+                args.max_triedb_async_traverse_concurrency,
+            ),
         }
     }
 }

--- a/monad-rpc/src/cli.rs
+++ b/monad-rpc/src/cli.rs
@@ -51,7 +51,21 @@ pub struct Cli {
 
     /// Set the max concurrent requests for triedb reads
     #[arg(long, default_value_t = 20_000)]
-    pub triedb_max_concurrent_requests: u32,
+    pub triedb_max_buffered_read_requests: u32,
+
+    /// Set the max number of concurrently executing async triedb read requests before we
+    /// start exerting backpressure
+    #[arg(long, default_value_t = 10_000)]
+    pub triedb_max_async_read_concurrency: u32,
+
+    /// Set the max concurrent requests for triedb traversals
+    #[arg(long, default_value_t = 40)]
+    pub triedb_max_buffered_traverse_requests: u32,
+
+    /// Set the max number of concurrently executing async triedb traverse requests before we
+    /// start exerting backpressure
+    #[arg(long, default_value_t = 20)]
+    pub triedb_max_async_traverse_concurrency: u32,
 
     /// Set the s3 bucket name to read archive data from
     #[arg(long)]

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -663,11 +663,15 @@ async fn main() -> std::io::Result<()> {
         }
     });
 
-    let triedb_env = args
-        .triedb_path
-        .clone()
-        .as_deref()
-        .map(|path| TriedbEnv::new(path, args.triedb_max_concurrent_requests as usize));
+    let triedb_env = args.triedb_path.clone().as_deref().map(|path| {
+        TriedbEnv::new(
+            path,
+            args.triedb_max_buffered_read_requests as usize,
+            args.triedb_max_async_read_concurrency as usize,
+            args.triedb_max_buffered_traverse_requests as usize,
+            args.triedb_max_async_traverse_concurrency as usize,
+        )
+    });
 
     // Used for compute heavy tasks
     rayon::ThreadPoolBuilder::new()

--- a/monad-triedb-utils/examples/triedb-bench.rs
+++ b/monad-triedb-utils/examples/triedb-bench.rs
@@ -28,8 +28,14 @@ struct Args {
     #[arg(long, default_value_t = 1_000)]
     pub max_num_blocks: u64,
 
-    #[arg(long, default_value_t = 1_000)]
-    pub triedb_request_channel_size: usize,
+    #[arg(long, default_value_t = 20_000)]
+    pub max_buffered_read_requests: usize,
+    #[arg(long, default_value_t = 10_000)]
+    pub max_async_read_concurrency: usize,
+    #[arg(long, default_value_t = 40)]
+    pub max_buffered_traverse_requests: usize,
+    #[arg(long, default_value_t = 20)]
+    pub max_async_traverse_concurrency: usize,
 
     #[arg(long, default_value_t = 0.0)]
     pub tx_traverse_rps: f64,
@@ -77,7 +83,13 @@ fn main() {
         earliest_block..=latest_block
     };
 
-    let triedb_handle = TriedbEnv::new(&args.triedb_path, args.triedb_request_channel_size);
+    let triedb_handle = TriedbEnv::new(
+        &args.triedb_path,
+        args.max_buffered_read_requests,
+        args.max_async_read_concurrency,
+        args.max_buffered_traverse_requests,
+        args.max_async_traverse_concurrency,
+    );
 
     let test_duration = Duration::from_secs_f64(args.duration_s);
 

--- a/monad-triedb-utils/src/lib.rs
+++ b/monad-triedb-utils/src/lib.rs
@@ -206,6 +206,7 @@ impl TriedbReader {
                 seq_num.0,
                 completed_counter.clone(),
                 sender,
+                Arc::new(()),
             );
             receiver.map(|receiver_result| {
                 // Receiver should not fail


### PR DESCRIPTION
This commit makes the TriedbEnv polling thread maintain a count of
currently executing async triedb requests, and makes it temporarily
stop pulling requests off its ingress request channel if that count
hits a configurable limit.

This should cause backpressure to build up in this receive channel
if we are saturating our triedb I/O channel, and that should, in
combination with the (also configurable) channel size limit, cause RPC
requests to start failing if we are saturating our I/O channel,
instead of an infinite backlog of RPC requests to start building up.

We add the triedb_max_async_concurrency command line argument to
monad-rpc to configure this limit.  We set the default value to the
very high value of 10_000, which we are never expecting to hit, so
that this concurrency limiting mechanism will only kick in if it will
have been configured explicitly, and we can determine via testing in
stressnet what a sensible concurrency limit is.

For the archiver, which also uses this code, we seem to be using custom
command line argument parsing, and so, we're not adding a corresponding
command line argument to the archiver, because we don't want to break
existing invocations.