### PR TITLE
Remove UpdatePeers and UpdateFullNodes commands from debug-node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4805,7 +4805,6 @@ dependencies = [
  "monad-executor-glue",
  "monad-node-config",
  "monad-secp",
- "monad-types",
  "serde_json",
  "tokio",
  "tokio-util",

--- a/monad-control-panel/src/ipc.rs
+++ b/monad-control-panel/src/ipc.rs
@@ -12,8 +12,7 @@ use monad_crypto::certificate_signature::{
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{
     ClearMetrics, ControlPanelCommand, ControlPanelEvent, GetFullNodes, GetMetrics, GetPeers,
-    GetValidatorSet, MonadEvent, ReadCommand, ReloadConfig, UpdateFullNodes, UpdatePeers,
-    UpdateValidatorSet, WriteCommand,
+    GetValidatorSet, MonadEvent, ReadCommand, ReloadConfig, UpdateValidatorSet, WriteCommand,
 };
 use monad_types::ExecutionProtocol;
 use tokio::{
@@ -230,30 +229,6 @@ where
                             break;
                         };
                     }
-                    WriteCommand::UpdatePeers(update_peers) => match update_peers {
-                        UpdatePeers::Request(vec) => {
-                            let event = MonadEvent::ControlPanelEvent(
-                                ControlPanelEvent::UpdatePeers(UpdatePeers::Request(vec)),
-                            );
-                            let Ok(_) = event_channel.send(event.clone()).await else {
-                                error!("failed to forward request {:?} to executor, closing connection", &event);
-                                break;
-                            };
-                        }
-                        m => error!("unhandled message {:?}", m),
-                    },
-                    WriteCommand::UpdateFullNodes(update_full_nodes) => match update_full_nodes {
-                        UpdateFullNodes::Request(vec) => {
-                            let event = MonadEvent::ControlPanelEvent(
-                                ControlPanelEvent::UpdateFullNodes(UpdateFullNodes::Request(vec)),
-                            );
-                            let Ok(_) = event_channel.send(event.clone()).await else {
-                                error!("failed to forward request {:?} to executor, closing connection", &event);
-                                break;
-                            };
-                        }
-                        m => error!("unhandled message {:?}", m),
-                    },
                     WriteCommand::ReloadConfig(reload_config) => match reload_config {
                         ReloadConfig::Request => {
                             let event = MonadEvent::ControlPanelEvent(

--- a/monad-debug-node/Cargo.toml
+++ b/monad-debug-node/Cargo.toml
@@ -18,7 +18,6 @@ monad-crypto = { path = "../monad-crypto" }
 monad-executor-glue = { path = "../monad-executor-glue" }
 monad-node-config = { path = "../monad-node-config" }
 monad-secp = { path = "../monad-secp" }
-monad-types = { path = "../monad-types" }
 
 clap = { workspace = true, features = ["derive"] }
 futures = { workspace = true }

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -190,20 +190,6 @@ pub enum ClearMetrics {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub enum UpdatePeers<PT: PubKey> {
-    #[serde(bound = "PT: PubKey")]
-    Request(Vec<(NodeId<PT>, SocketAddr)>),
-    Response,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub enum UpdateFullNodes<PT: PubKey> {
-    #[serde(bound = "PT: PubKey")]
-    Request(Vec<NodeId<PT>>),
-    Response,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ReloadConfig {
     Request,
     Response(String),
@@ -215,10 +201,6 @@ pub enum WriteCommand<SCT: SignatureCollection> {
     UpdateValidatorSet(UpdateValidatorSet<SCT>),
     ClearMetrics(ClearMetrics),
     UpdateLogFilter(String),
-    #[serde(bound = "SCT: SignatureCollection")]
-    UpdatePeers(UpdatePeers<SCT::NodeIdPubKey>),
-    #[serde(bound = "SCT: SignatureCollection")]
-    UpdateFullNodes(UpdateFullNodes<SCT::NodeIdPubKey>),
     ReloadConfig(ReloadConfig),
 }
 
@@ -809,9 +791,7 @@ where
     UpdateValidators(ValidatorSetDataWithEpoch<SCT>),
     UpdateLogFilter(String),
     GetPeers(GetPeers<SCT::NodeIdPubKey>),
-    UpdatePeers(UpdatePeers<SCT::NodeIdPubKey>),
     GetFullNodes(GetFullNodes<SCT::NodeIdPubKey>),
-    UpdateFullNodes(UpdateFullNodes<SCT::NodeIdPubKey>),
     ReloadConfig(ReloadConfig),
 }
 

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -167,19 +167,6 @@ message ProtoGetPeersEvent {
   }
 }
 
-message ProtoUpdatePeersReq {
-  repeated ProtoPeerRecord records = 1;
-}
-
-message ProtoUpdatePeersResp {}
-
-message ProtoUpdatePeersEvent {
-  oneof req_resp {
-    ProtoUpdatePeersReq req = 1;
-    ProtoUpdatePeersResp resp = 2;
-  }
-}
-
 message ProtoGetFullNodeReq {}
 
 message ProtoGetFullNodeResp {
@@ -191,19 +178,6 @@ message ProtoGetFullNodesEvent {
   oneof req_resp {
     ProtoGetFullNodeReq req = 1;
     ProtoGetFullNodeResp resp = 2;
-  }
-}
-
-message ProtoUpdateFullNodesReq {
-  repeated monad_proto.basic.ProtoNodeId node_ids = 1;
-}
-
-message ProtoUpdateFullNodesResp {}
-
-message ProtoUpdateFullNodesEvent {
-  oneof req_resp {
-    ProtoUpdateFullNodesReq req = 1;
-    ProtoUpdateFullNodesResp resp = 2;
   }
 }
 
@@ -221,6 +195,7 @@ message ProtoReloadConfigEvent {
 }
 
 message ProtoControlPanelEvent {
+  reserved 7,9;
   oneof event {
     ProtoGetValidatorSetEvent get_validator_set_event = 1;
     ProtoClearMetricsEvent clear_metrics_event = 2;
@@ -228,9 +203,7 @@ message ProtoControlPanelEvent {
     ProtoUpdateLogFilter update_log_filter = 4;
     ProtoGetMetricsEvent get_metrics_event = 5;
     ProtoGetPeersEvent get_peers_event = 6;
-    ProtoUpdatePeersEvent update_peers_event = 7;
     ProtoGetFullNodesEvent get_full_nodes_event = 8;
-    ProtoUpdateFullNodesEvent update_full_nodes_event = 9;
     ProtoReloadConfigEvent reload_config_event = 10;
   }
 }

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -22,8 +22,7 @@ use monad_dataplane::{
 use monad_discovery::message::InboundRouterMessage;
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{
-    ControlPanelEvent, GetFullNodes, GetPeers, Message, MonadEvent, RouterCommand, UpdateFullNodes,
-    UpdatePeers,
+    ControlPanelEvent, GetFullNodes, GetPeers, Message, MonadEvent, RouterCommand,
 };
 use monad_types::{
     Deserializable, DropTimer, Epoch, ExecutionProtocol, NodeId, RouterTarget, Serializable,
@@ -84,9 +83,7 @@ where
 
 pub enum PeerManagerResponse<P: PubKey> {
     PeerList(Vec<(NodeId<P>, SocketAddr)>),
-    UpdatePeersSuccess,
     FullNodes(Vec<NodeId<P>>),
-    UpdateFullNodesSuccess,
 }
 
 pub enum RaptorCastEvent<E, P: PubKey> {
@@ -334,10 +331,6 @@ where
                 }
                 RouterCommand::UpdatePeers(new_peers) => {
                     self.known_addresses = new_peers.into_iter().collect();
-                    self.pending_events
-                        .push_back(RaptorCastEvent::PeerManagerResponse(
-                            PeerManagerResponse::UpdatePeersSuccess,
-                        ));
                 }
                 RouterCommand::GetFullNodes => {
                     let full_nodes = self.full_nodes.list.clone();
@@ -348,10 +341,6 @@ where
                 }
                 RouterCommand::UpdateFullNodes(new_full_nodes) => {
                     self.full_nodes.list = new_full_nodes;
-                    self.pending_events
-                        .push_back(RaptorCastEvent::PeerManagerResponse(
-                            PeerManagerResponse::UpdateFullNodesSuccess,
-                        ));
                 }
             }
         }
@@ -537,14 +526,8 @@ where
                     PeerManagerResponse::PeerList(peer_list) => MonadEvent::ControlPanelEvent(
                         ControlPanelEvent::GetPeers(GetPeers::Response(peer_list)),
                     ),
-                    PeerManagerResponse::UpdatePeersSuccess => MonadEvent::ControlPanelEvent(
-                        ControlPanelEvent::UpdatePeers(UpdatePeers::Response),
-                    ),
                     PeerManagerResponse::FullNodes(full_nodes) => MonadEvent::ControlPanelEvent(
                         ControlPanelEvent::GetFullNodes(GetFullNodes::Response(full_nodes)),
-                    ),
-                    PeerManagerResponse::UpdateFullNodesSuccess => MonadEvent::ControlPanelEvent(
-                        ControlPanelEvent::UpdateFullNodes(UpdateFullNodes::Response),
                     ),
                 }
             }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -36,7 +36,7 @@ use monad_executor_glue::{
     ControlPanelCommand, ControlPanelEvent, GetFullNodes, GetMetrics, GetPeers, GetValidatorSet,
     LedgerCommand, MempoolEvent, Message, MonadEvent, ReadCommand, ReloadConfig, RouterCommand,
     StateRootHashCommand, StateSyncCommand, StateSyncEvent, StateSyncNetworkMessage, TxPoolCommand,
-    UpdateFullNodes, UpdatePeers, ValidatorEvent, WriteCommand,
+    ValidatorEvent, WriteCommand,
 };
 use monad_state_backend::StateBackend;
 use monad_types::{
@@ -1013,16 +1013,6 @@ where
                         ))]
                     }
                 },
-                ControlPanelEvent::UpdatePeers(req_resp) => match req_resp {
-                    UpdatePeers::Request(vec) => {
-                        vec![Command::RouterCommand(RouterCommand::UpdatePeers(vec))]
-                    }
-                    UpdatePeers::Response => {
-                        vec![Command::ControlPanelCommand(ControlPanelCommand::Write(
-                            WriteCommand::UpdatePeers(UpdatePeers::Response),
-                        ))]
-                    }
-                },
                 ControlPanelEvent::GetFullNodes(req_resp) => match req_resp {
                     GetFullNodes::Request => {
                         vec![Command::RouterCommand(RouterCommand::GetFullNodes)]
@@ -1030,16 +1020,6 @@ where
                     GetFullNodes::Response(vec) => {
                         vec![Command::ControlPanelCommand(ControlPanelCommand::Read(
                             ReadCommand::GetFullNodes(GetFullNodes::Response(vec)),
-                        ))]
-                    }
-                },
-                ControlPanelEvent::UpdateFullNodes(req_resp) => match req_resp {
-                    UpdateFullNodes::Request(vec) => {
-                        vec![Command::RouterCommand(RouterCommand::UpdateFullNodes(vec))]
-                    }
-                    UpdateFullNodes::Response => {
-                        vec![Command::ControlPanelCommand(ControlPanelCommand::Write(
-                            WriteCommand::UpdateFullNodes(UpdateFullNodes::Response),
                         ))]
                     }
                 },


### PR DESCRIPTION
`reload-config` uses UpdatePeers and UpdateFullNodes router commands. Those commands each triggers a response from the router, which debug-node isn't expecting. This commit removes those responses and individual update-peers and update-full-nodes commands. Those functionalities are included in reload-config