### PR TITLE
Disable author-not-sender check

### DIFF
--- a/monad-consensus-types/src/metrics.rs
+++ b/monad-consensus-types/src/metrics.rs
@@ -64,7 +64,6 @@ metrics!(
             invalid_author,
             not_well_formed_sig,
             invalid_signature,
-            author_not_sender,
             invalid_tc_round,
             insufficient_stake,
             invalid_seq_num,

--- a/monad-consensus-types/src/validation.rs
+++ b/monad-consensus-types/src/validation.rs
@@ -6,8 +6,6 @@ pub enum Error {
     NotWellFormed,
     /// Bad signature
     InvalidSignature,
-    /// Signature author doesn't match sender
-    AuthorNotSender,
     /// There are high qc rounds larger than the TC round
     InvalidTcRound,
     /// The SignatureCollection doesn't have supermajority of the stake signed

--- a/monad-crypto/src/certificate_signature.rs
+++ b/monad-crypto/src/certificate_signature.rs
@@ -147,9 +147,18 @@ impl CertificateSignature for NopSignature {
 impl CertificateSignatureRecoverable for NopSignature {
     fn recover_pubkey(
         &self,
-        _msg: &[u8],
+        msg: &[u8],
     ) -> Result<CertificateSignaturePubKey<Self>, <Self as CertificateSignature>::Error> {
-        Ok(self.pubkey)
+        let id = {
+            let mut hasher = DefaultHasher::new();
+            hasher.write(msg);
+            hasher.finish()
+        };
+        if self.id == id {
+            Ok(self.pubkey)
+        } else {
+            Err("signature doesn't match message")
+        }
     }
 }
 

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -73,9 +73,6 @@ pub(crate) fn handle_validation_error(e: validation::Error, metrics: &mut Metric
         validation::Error::InvalidSignature => {
             metrics.validation_errors.invalid_signature += 1;
         }
-        validation::Error::AuthorNotSender => {
-            metrics.validation_errors.author_not_sender += 1;
-        }
         validation::Error::InvalidTcRound => {
             metrics.validation_errors.invalid_tc_round += 1;
         }


### PR DESCRIPTION
The message validation logic is stronger than it needs to be. We currently are asserting that a consensus message sender matches the author of the message. However, nodes might want to forward messages authored by one node to other nodes.

Additionally, the existing message validation logic does not actually prevent a sender from spoofing chunks authored and sent by other nodes.

This commit disables this check.