### PR TITLE
Add RPC block cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5635,6 +5635,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
 ]
 

--- a/monad-triedb-utils/Cargo.toml
+++ b/monad-triedb-utils/Cargo.toml
@@ -22,6 +22,7 @@ alloy-rlp = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["rt"] }
 tracing = { workspace = true, features = ["log"] }
 
 [dev-dependencies]
@@ -33,3 +34,4 @@ rand = { workspace = true }
 rand_distr = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/monad-triedb-utils/examples/triedb-bench.rs
+++ b/monad-triedb-utils/examples/triedb-bench.rs
@@ -67,7 +67,8 @@ fn generate_event_times(rng: impl Rng, test_duration: Duration, rps: f64) -> Vec
     event_times
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let args = Args::parse();
     let mut rng = StdRng::seed_from_u64(args.seed);
 
@@ -160,7 +161,10 @@ fn main() {
         }
     }
 
-    while !poll_futs(&mut futs, &mut response_times) {}
+    while let Some(request_result) = futs.next().await {
+        let request = request_result.expect("request failed");
+        response_times.insert(request, Instant::now());
+    }
 
     assert_eq!(num_events, response_times.len());
 


### PR DESCRIPTION
Adds a block cache in front of triedb. For now, only caches transactions. Also, the cache is not hydrated on startup.