### PR TITLE
Archive: Remove unnecessary checkpointing and mongo concurrency fix

### DIFF
--- a/monad-archive/src/bin/monad-indexer/main.rs
+++ b/monad-archive/src/bin/monad-indexer/main.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
         metrics,
         args.start_block,
         args.stop_block,
-        Duration::from_millis(100),
+        Duration::from_millis(500),
     ))
     .await
     .map_err(Into::into)


### PR DESCRIPTION
- Remove in-stream checkpointing. Causes deadlock when used with mongo client if `--max-concurrent-blocks > aws-concurrency`.  Also increases write costs by 2-5% without benefit since more frequent checkpointing can be achieved by setting lower `--max-blocks-per-iteration`.
- increase polling time for new blocks in indexer and archiver
- increase mongo connection pool size. Deadlocks observed when pool size < `max_concurrent_blocks` with in-stream checkpointing. Likely unnecessary now that in-stream checkpointing is removed, but small observed performance improvement during backfilling.
- Remove `bulk_put` in mongo implementation since insert_many does not overwrite existing keys. Fallback to default impl since no replace_many exists in api
