### PR TITLE
Avoid superfluous system call in dataplane TCP transmission code

### DIFF
--- a/monad-dataplane/src/tcp/tx.rs
+++ b/monad-dataplane/src/tcp/tx.rs
@@ -153,9 +153,9 @@ async fn send_message(conn_id: u64, addr: SocketAddr, message: Bytes) {
 
             conn_cork(raw_fd, false);
 
-            let num_unacked_bytes = num_unacked_bytes(raw_fd);
-
             if enabled!(Level::DEBUG) {
+                let num_unacked_bytes = num_unacked_bytes(raw_fd);
+
                 let duration = Instant::now() - connect_time;
 
                 let duration_ms = duration.as_millis();


### PR DESCRIPTION
As @andr-dev pointed out in his review of this code, there is no need to invoke the TIOCOUTQ ioctl() to retrieve the number of bytes in the TCP socket's send queue if we don't have the DEBUG trace level enabled, as we only use this information for debugging purposes.

I wrapped the code that produces the information for the debug! trace event inside an `if enabled!(Level::DEBUG) {`, but, unfortunately, due to a local mis-merge, we actually still invoke the TIOCOUTQ ioctl() even if the DEBUG trace level is disabled.

This patch moves the ioctl() call inside the `if { ... }` body, so that we now actually avoid invoking the system call if debugging is disabled.

There is no correctness impact associated with this change, only a (very) minor performance improvement.