### PR TITLE
Avoid Dataplane panic in case of unsupportable address family mismatch

### DIFF
--- a/monad-dataplane/tests/address_family_mismatch.rs
+++ b/monad-dataplane/tests/address_family_mismatch.rs
@@ -1,0 +1,46 @@
+use std::{thread::sleep, time::Duration};
+
+use monad_dataplane::{udp::DEFAULT_SEGMENT_SIZE, BroadcastMsg, Dataplane};
+use tracing::debug;
+
+/// 1_000 = 1 Gbps, 10_000 = 10 Gbps
+const UP_BANDWIDTH_MBPS: u64 = 1_000;
+
+const BIND_ADDRS: [&str; 3] = ["0.0.0.0:9100", "127.0.0.1:9101", "[::1]:9102"];
+
+const TX_ADDRS: [&str; 2] = ["127.0.0.1:9200", "[::1]:9201"];
+
+#[test]
+fn address_family_mismatch() {
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    // Cause the test to fail if any of the Dataplane threads panic.  Taken from:
+    // https://stackoverflow.com/questions/35988775/how-can-i-cause-a-panic-on-a-thread-to-immediately-end-the-main-thread/36031130#36031130
+    let orig_panic_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        orig_panic_hook(panic_info);
+        std::process::exit(1);
+    }));
+
+    for addr in BIND_ADDRS {
+        let mut dataplane = Dataplane::new(&addr.parse().unwrap(), UP_BANDWIDTH_MBPS);
+
+        // Allow Dataplane thread to set itself up.
+        sleep(Duration::from_millis(10));
+
+        for tx_addr in TX_ADDRS {
+            debug!("sending to {} from {}", tx_addr, addr);
+
+            dataplane.udp_write_broadcast(BroadcastMsg {
+                targets: vec![tx_addr.parse().unwrap(); 1],
+                payload: vec![0; DEFAULT_SEGMENT_SIZE.into()].into(),
+                stride: DEFAULT_SEGMENT_SIZE,
+            });
+        }
+
+        // Allow Dataplane thread to catch up.
+        sleep(Duration::from_millis(10));
+    }
+}


### PR DESCRIPTION
On a Dataplane instance bound to an unspecified or a specific IPv4
address, transmitting an UDP datagram to any IPv6 address will currently
panic with:

    thread '<unnamed>' panicked at monad-dataplane/src/udp.rs:149:17:
    send error Address family not supported by protocol (os error 97)

On a Dataplane instance bound to a specific IPv6 address, transmitting
an UDP datagram to any IPv4 address will currently panic with:

    thread '<unnamed>' panicked at monad-dataplane/src/udp.rs:149:17:
    send error Network is unreachable (os error 101)

We don't necessarily want to completely prohibit the use of IPv6
addresses in Dataplane, because certain combinations of IPv4 and IPv6
addressing are possible -- for example, it is possible for a dual-stack
validator to serve an IPv6 full node, and a validator operator might
want to locally set things up that way.

What we want to avoid, however, is having an unsupportable combination
of IPv4 and IPv6 addresses panic!()ing our Dataplane instance.  It
doesn't look like monad-node filters the results of the DNS lookups it
performs to map its validator and full node peer host names to
SocketAddrs, and it may therefore be possible for a rogue validator to
panic every other validator in the network by pointing its own host
name to an IPv6 (AAAA) address record.

This patch adds some checks to avoid panic!()ing on a UDP send error if
that send error is due to an unsupportable address family mismatch, and
if that happens, we will log a debug message instead.  It also adds a
test to exercise all the address combinations that would previously lead
to Dataplane panics.