### PR TITLE
Hit archive if block hash present but not transactions

### DIFF
--- a/monad-rpc/src/trace_handlers.rs
+++ b/monad-rpc/src/trace_handlers.rs
@@ -201,45 +201,20 @@ pub async fn monad_debug_traceBlockByHash<T: Triedb>(
         .map_err(JsonRpcError::internal_error)?
     {
         let block_key = triedb_env.get_block_key(SeqNum(block_num));
-        let mut resp = Vec::new();
-
-        let tx_ids = triedb_env
-            .get_transactions(block_key)
-            .await
-            .map_err(JsonRpcError::internal_error)?
-            .iter()
-            .map(|tx| *tx.tx.tx_hash())
-            .collect::<Vec<_>>();
-        let call_frames = triedb_env
-            .get_call_frames(block_key)
-            .await
-            .map_err(JsonRpcError::internal_error)?;
-
-        for (call_frame, tx_id) in call_frames.iter().zip(tx_ids.into_iter()) {
-            let rlp_call_frame = &mut call_frame.as_slice();
-            let Some(traces) =
-                decode_call_frame(triedb_env, rlp_call_frame, block_key, &params.tracer).await?
-            else {
-                return Err(JsonRpcError::internal_error("traces not found".to_string()));
-            };
-            resp.push(MonadDebugTraceBlockResult {
-                tx_hash: FixedData::<32>::from(tx_id),
-                result: traces,
-            });
+        if let Ok(result) = get_call_frames_from_triedb(triedb_env, block_key, &params.tracer).await
+        {
+            return Ok(result);
         }
-
-        return Ok(resp);
     }
 
     // try archive if block hash not found and archive reader specified
+    let mut resp = Vec::new();
     if let Some(archive_reader) = archive_reader {
         if let Ok(block) = archive_reader
             .get_block_by_hash(&params.block_hash.0.into())
             .await
         {
             if let Ok(call_frames) = archive_reader.get_block_traces(block.header.number).await {
-                let mut resp = Vec::new();
-
                 let tx_ids = block
                     .body
                     .transactions
@@ -298,41 +273,12 @@ pub async fn monad_debug_traceBlockByNumber<T: Triedb>(
     trace!("monad_debugTraceBlockByNumber: {params:?}");
 
     let block_key = get_block_key_from_tag(triedb_env, params.block_number);
-    let mut resp = Vec::new();
-    if triedb_env
-        .get_block_header(block_key)
-        .await
-        .map_err(JsonRpcError::internal_error)?
-        .is_some()
-    {
-        if let Ok(transactions) = triedb_env.get_transactions(block_key).await {
-            let tx_ids = transactions
-                .iter()
-                .map(|tx| *tx.tx.tx_hash())
-                .collect::<Vec<_>>();
-            let call_frames = triedb_env
-                .get_call_frames(block_key)
-                .await
-                .map_err(JsonRpcError::internal_error)?;
-
-            for (call_frame, tx_id) in call_frames.iter().zip(tx_ids.into_iter()) {
-                let rlp_call_frame = &mut call_frame.as_slice();
-                let Some(traces) =
-                    decode_call_frame(triedb_env, rlp_call_frame, block_key, &params.tracer)
-                        .await?
-                else {
-                    return Err(JsonRpcError::internal_error("traces not found".to_string()));
-                };
-                resp.push(MonadDebugTraceBlockResult {
-                    tx_hash: FixedData::<32>::from(tx_id),
-                    result: traces,
-                });
-            }
-            return Ok(resp);
-        }
+    if let Ok(result) = get_call_frames_from_triedb(triedb_env, block_key, &params.tracer).await {
+        return Ok(result);
     }
 
     // try archive if block number or transactions not found and archive reader specified
+    let mut resp = Vec::new();
     if let (Some(archive_reader), BlockKey::Finalized(FinalizedBlockKey(block_num))) =
         (archive_reader, block_key)
     {
@@ -410,6 +356,41 @@ pub async fn monad_debug_traceTransaction<T: Triedb>(
     }
 
     Ok(None)
+}
+
+async fn get_call_frames_from_triedb<T: Triedb>(
+    triedb_env: &T,
+    block_key: BlockKey,
+    tracer: &TracerObject,
+) -> JsonRpcResult<Vec<MonadDebugTraceBlockResult>> {
+    let mut resp = Vec::new();
+    let transactions = triedb_env
+        .get_transactions(block_key)
+        .await
+        .map_err(JsonRpcError::internal_error)?;
+
+    let tx_ids = transactions
+        .iter()
+        .map(|tx| *tx.tx.tx_hash())
+        .collect::<Vec<_>>();
+
+    let call_frames = triedb_env
+        .get_call_frames(block_key)
+        .await
+        .map_err(JsonRpcError::internal_error)?;
+
+    for (call_frame, tx_id) in call_frames.iter().zip(tx_ids.into_iter()) {
+        let rlp_call_frame = &mut call_frame.as_slice();
+        let Some(traces) = decode_call_frame(triedb_env, rlp_call_frame, block_key, tracer).await?
+        else {
+            return Err(JsonRpcError::internal_error("traces not found".to_string()));
+        };
+        resp.push(MonadDebugTraceBlockResult {
+            tx_hash: FixedData::<32>::from(tx_id),
+            result: traces,
+        });
+    }
+    Ok(resp)
 }
 
 async fn decode_call_frame<T: Triedb>(


### PR DESCRIPTION
block hash expires slower than other items in triedb (e.g. transactions, receipts, traces, block headers). if block hash is present but other items such as transactions are not, we should hit archive