### PR TITLE
Backpressure statesync responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5160,6 +5160,7 @@ dependencies = [
  "bytes",
  "chrono",
  "criterion",
+ "futures",
  "monad-blocksync",
  "monad-consensus",
  "monad-consensus-types",
@@ -5733,6 +5734,7 @@ name = "monad-types"
 version = "0.1.0"
 dependencies = [
  "alloy-rlp",
+ "futures",
  "hex",
  "monad-crypto",
  "monad-proto",

--- a/monad-control-panel/src/ipc.rs
+++ b/monad-control-panel/src/ipc.rs
@@ -146,9 +146,11 @@ where
                 ControlPanelCommand::Read(r) => match r {
                     ReadCommand::GetValidatorSet(v) => match v {
                         GetValidatorSet::Request => {
-                            let event =
-                                MonadEvent::ControlPanelEvent(ControlPanelEvent::GetValidatorSet);
-                            let Ok(_) = event_channel.send(event.clone()).await else {
+                            let event = ControlPanelEvent::GetValidatorSet;
+                            let Ok(_) = event_channel
+                                .send(MonadEvent::ControlPanelEvent(event.clone()))
+                                .await
+                            else {
                                 error!("failed to forward request {:?} to executor, closing connection", &event);
                                 break;
                             };
@@ -157,9 +159,11 @@ where
                     },
                     ReadCommand::GetMetrics(m) => match m {
                         GetMetrics::Request => {
-                            let event =
-                                MonadEvent::ControlPanelEvent(ControlPanelEvent::GetMetricsEvent);
-                            let Ok(_) = event_channel.send(event.clone()).await else {
+                            let event = ControlPanelEvent::GetMetricsEvent;
+                            let Ok(_) = event_channel
+                                .send(MonadEvent::ControlPanelEvent(event.clone()))
+                                .await
+                            else {
                                 error!("failed to forward request {:?} to executor, closing connection", &event);
                                 break;
                             };
@@ -168,10 +172,11 @@ where
                     },
                     ReadCommand::GetPeers(l) => match l {
                         GetPeers::Request => {
-                            let event = MonadEvent::ControlPanelEvent(ControlPanelEvent::GetPeers(
-                                GetPeers::Request,
-                            ));
-                            let Ok(_) = event_channel.send(event.clone()).await else {
+                            let event = ControlPanelEvent::GetPeers(GetPeers::Request);
+                            let Ok(_) = event_channel
+                                .send(MonadEvent::ControlPanelEvent(event.clone()))
+                                .await
+                            else {
                                 error!("failed to forward request {:?} to executor, closing connection", &event);
                                 break;
                             };
@@ -180,10 +185,11 @@ where
                     },
                     ReadCommand::GetFullNodes(get_full_nodes) => match get_full_nodes {
                         GetFullNodes::Request => {
-                            let event = MonadEvent::ControlPanelEvent(
-                                ControlPanelEvent::GetFullNodes(GetFullNodes::Request),
-                            );
-                            let Ok(_) = event_channel.send(event.clone()).await else {
+                            let event = ControlPanelEvent::GetFullNodes(GetFullNodes::Request);
+                            let Ok(_) = event_channel
+                                .send(MonadEvent::ControlPanelEvent(event.clone()))
+                                .await
+                            else {
                                 error!("failed to forward request {:?} to executor, closing connection", &event);
                                 break;
                             };
@@ -194,9 +200,11 @@ where
                 ControlPanelCommand::Write(w) => match w {
                     WriteCommand::ClearMetrics(clear_metrics) => match clear_metrics {
                         ClearMetrics::Request => {
-                            let event =
-                                MonadEvent::ControlPanelEvent(ControlPanelEvent::ClearMetricsEvent);
-                            let Ok(_) = event_channel.send(event.clone()).await else {
+                            let event = ControlPanelEvent::ClearMetricsEvent;
+                            let Ok(_) = event_channel
+                                .send(MonadEvent::ControlPanelEvent(event.clone()))
+                                .await
+                            else {
                                 error!("failed to forward request {:?} to executor, closing connection", &event);
                                 break;
                             };
@@ -206,10 +214,12 @@ where
                     WriteCommand::UpdateValidatorSet(update_validator_set) => {
                         match update_validator_set {
                             UpdateValidatorSet::Request(parsed_validator_set) => {
-                                let event = MonadEvent::ControlPanelEvent(
-                                    ControlPanelEvent::UpdateValidators(parsed_validator_set),
-                                );
-                                let Ok(_) = event_channel.send(event.clone()).await else {
+                                let event =
+                                    ControlPanelEvent::UpdateValidators(parsed_validator_set);
+                                let Ok(_) = event_channel
+                                    .send(MonadEvent::ControlPanelEvent(event.clone()))
+                                    .await
+                                else {
                                     error!("failed to forward request {:?} to executor, closing connection", &event);
                                     break;
                                 };
@@ -218,10 +228,11 @@ where
                         }
                     }
                     WriteCommand::UpdateLogFilter(filter) => {
-                        let event = MonadEvent::ControlPanelEvent(
-                            ControlPanelEvent::UpdateLogFilter(filter),
-                        );
-                        let Ok(_) = event_channel.send(event.clone()).await else {
+                        let event = ControlPanelEvent::UpdateLogFilter(filter);
+                        let Ok(_) = event_channel
+                            .send(MonadEvent::ControlPanelEvent(event.clone()))
+                            .await
+                        else {
                             error!(
                                 "failed to forward request {:?} to executor, closing connection",
                                 &event
@@ -231,10 +242,11 @@ where
                     }
                     WriteCommand::ReloadConfig(reload_config) => match reload_config {
                         ReloadConfig::Request => {
-                            let event = MonadEvent::ControlPanelEvent(
-                                ControlPanelEvent::ReloadConfig(ReloadConfig::Request),
-                            );
-                            let Ok(_) = event_channel.send(event.clone()).await else {
+                            let event = ControlPanelEvent::ReloadConfig(ReloadConfig::Request);
+                            let Ok(_) = event_channel
+                                .send(MonadEvent::ControlPanelEvent(event.clone()))
+                                .await
+                            else {
                                 error!("failed to forward request {:?} to executor, closing connection", &event);
                                 break;
                             };

--- a/monad-dataplane/examples/node.rs
+++ b/monad-dataplane/examples/node.rs
@@ -9,7 +9,7 @@ use std::{
 use bytes::{Bytes, BytesMut};
 use futures::{executor, Stream};
 use futures_util::FutureExt;
-use monad_dataplane::{udp::DEFAULT_SEGMENT_SIZE, BroadcastMsg, Dataplane, RecvMsg};
+use monad_dataplane::{udp::DEFAULT_SEGMENT_SIZE, BroadcastMsg, Dataplane, RecvMsg, TcpMsg};
 use rand::Rng;
 
 const NODE_ONE_ADDR: &str = "127.0.0.1:60000";
@@ -72,8 +72,13 @@ fn main() {
             })
         }
 
-        tx.network
-            .tcp_write(tx.target, Bytes::from(&b"Hello world"[..]));
+        tx.network.tcp_write(
+            tx.target,
+            TcpMsg {
+                msg: Bytes::from(&b"Hello world"[..]),
+                completion: None,
+            },
+        );
 
         std::thread::sleep(std::time::Duration::from_secs(5));
     });

--- a/monad-dataplane/src/tcp/mod.rs
+++ b/monad-dataplane/src/tcp/mod.rs
@@ -8,6 +8,8 @@ use zerocopy::{
     AsBytes, FromBytes,
 };
 
+use super::TcpMsg;
+
 mod rx;
 mod tx;
 
@@ -40,7 +42,7 @@ impl TcpMsgHdr {
 pub fn spawn_tasks(
     local_addr: SocketAddr,
     tcp_ingress_tx: mpsc::Sender<(SocketAddr, Bytes)>,
-    tcp_egress_rx: mpsc::Receiver<(SocketAddr, Bytes)>,
+    tcp_egress_rx: mpsc::Receiver<(SocketAddr, TcpMsg)>,
 ) {
     spawn(rx::task(local_addr, tcp_ingress_tx));
     spawn(tx::task(tcp_egress_rx));

--- a/monad-dataplane/tests/tests.rs
+++ b/monad-dataplane/tests/tests.rs
@@ -1,7 +1,9 @@
 use std::{sync::Once, thread::sleep, time::Duration};
 
 use futures::executor;
-use monad_dataplane::{udp::DEFAULT_SEGMENT_SIZE, BroadcastMsg, Dataplane, RecvMsg, UnicastMsg};
+use monad_dataplane::{
+    udp::DEFAULT_SEGMENT_SIZE, BroadcastMsg, Dataplane, RecvMsg, TcpMsg, UnicastMsg,
+};
 use ntest::timeout;
 use rand::Rng;
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -105,7 +107,13 @@ fn tcp_slow() {
         .collect();
 
     for _ in 0..num_msgs {
-        tx.tcp_write(rx_addr, payload.clone().into());
+        tx.tcp_write(
+            rx_addr,
+            TcpMsg {
+                msg: payload.clone().into(),
+                completion: None,
+            },
+        );
         sleep(Duration::from_millis(10));
     }
 
@@ -136,7 +144,13 @@ fn tcp_rapid() {
         .collect();
 
     for _ in 0..num_msgs {
-        tx.tcp_write(rx_addr, payload.clone().into());
+        tx.tcp_write(
+            rx_addr,
+            TcpMsg {
+                msg: payload.clone().into(),
+                completion: None,
+            },
+        );
     }
 
     for _ in 0..num_msgs {

--- a/monad-executor-glue/Cargo.toml
+++ b/monad-executor-glue/Cargo.toml
@@ -23,6 +23,7 @@ alloy-rlp = { workspace = true }
 bincode = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
+futures = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 

--- a/monad-executor-glue/src/convert/event.rs
+++ b/monad-executor-glue/src/convert/event.rs
@@ -758,7 +758,12 @@ where
                     },
                 )),
             },
-            StateSyncEvent::Outbound(to, message) => Self {
+            StateSyncEvent::Outbound(
+                to,
+                message,
+                // a serialized completion doesn't mean anything
+                _completion,
+            ) => Self {
                 event: Some(proto_state_sync_event::Event::Outbound(
                     ProtoOutboundStateMessage {
                         recipient: Some(to.into()),
@@ -931,6 +936,7 @@ where
                             "OutboundStateMessage::message".to_owned(),
                         ))?
                         .try_into()?,
+                    None, // a deserialized completion doesn't mean anything
                 ),
                 proto_state_sync_event::Event::DoneSync(done_sync) => StateSyncEvent::DoneSync(
                     done_sync

--- a/monad-mock-swarm/src/node.rs
+++ b/monad-mock-swarm/src/node.rs
@@ -256,11 +256,12 @@ impl<S: SwarmRelation> Node<S> {
                             let node_span =
                                 tracing::trace_span!("node", id = format!("{}", self.id));
                             let _guard = node_span.enter();
-                            let commands = self.state.update(event.clone());
+                            let event_clone = event.lossy_clone();
+                            let commands = self.state.update(event);
 
                             self.executor.exec(commands);
 
-                            (tick, event)
+                            (tick, event_clone)
                         }
                         Some(MockExecutorEvent::Send(to, serialized)) => {
                             let lm = LinkMessage {

--- a/monad-router-scheduler/src/lib.rs
+++ b/monad-router-scheduler/src/lib.rs
@@ -135,7 +135,13 @@ where
                         .map(|to| (time, RouterEvent::Tx(*to, message.clone()))),
                 );
             }
-            RouterTarget::PointToPoint(to) | RouterTarget::TcpPointToPoint(to) => {
+            RouterTarget::PointToPoint(to) => {
+                self.events.push_back((time, RouterEvent::Tx(to, message)));
+            }
+            RouterTarget::TcpPointToPoint { to, completion } => {
+                if let Some(completion) = completion {
+                    let _ = completion.send(());
+                }
                 self.events.push_back((time, RouterEvent::Tx(to, message)));
             }
         }
@@ -246,7 +252,13 @@ where
                         .map(|to| (time, RouterEvent::Tx(*to, message.clone()))),
                 );
             }
-            RouterTarget::PointToPoint(to) | RouterTarget::TcpPointToPoint(to) => {
+            RouterTarget::PointToPoint(to) => {
+                self.events.push_back((time, RouterEvent::Tx(to, message)));
+            }
+            RouterTarget::TcpPointToPoint { to, completion } => {
+                if let Some(completion) = completion {
+                    let _ = completion.send(());
+                }
                 self.events.push_back((time, RouterEvent::Tx(to, message)));
             }
         }

--- a/monad-state/src/blocksync.rs
+++ b/monad-state/src/blocksync.rs
@@ -163,7 +163,10 @@ where
         match wrapped.command {
             BlockSyncCommand::SendRequest { to, request } => {
                 vec![Command::RouterCommand(RouterCommand::Publish {
-                    target: RouterTarget::TcpPointToPoint(to),
+                    target: RouterTarget::TcpPointToPoint {
+                        to,
+                        completion: None,
+                    },
                     message: VerifiedMonadMessage::BlockSyncRequest(request),
                 })]
             }
@@ -181,7 +184,10 @@ where
             }
             BlockSyncCommand::SendResponse { to, response } => {
                 vec![Command::RouterCommand(RouterCommand::Publish {
-                    target: RouterTarget::TcpPointToPoint(to),
+                    target: RouterTarget::TcpPointToPoint {
+                        to,
+                        completion: None,
+                    },
                     message: VerifiedMonadMessage::BlockSyncResponse(response),
                 })]
             }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -883,9 +883,9 @@ where
                         sender, message,
                     )))]
                 }
-                StateSyncEvent::Outbound(to, message) => {
+                StateSyncEvent::Outbound(to, message, completion) => {
                     vec![Command::RouterCommand(RouterCommand::Publish {
-                        target: RouterTarget::TcpPointToPoint(to),
+                        target: RouterTarget::TcpPointToPoint { to, completion },
                         message: VerifiedMonadMessage::StateSyncMessage(message),
                     })]
                 }

--- a/monad-types/Cargo.toml
+++ b/monad-types/Cargo.toml
@@ -13,6 +13,7 @@ monad-crypto = { path = "../monad-crypto" }
 monad-proto = { path = "../monad-proto" }
 
 alloy-rlp = { workspace = true, features = ["derive"] }
+futures = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 zerocopy = { workspace = true }

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -461,12 +461,15 @@ impl<S: Clone> Deserializable<S> for S {
 // FIXME-4: move to monad-executor-glue after spaghetti fixed
 /// RouterTarget specifies the particular node(s) that the router should send
 /// the message toward
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug)]
 pub enum RouterTarget<P: PubKey> {
     Broadcast(Epoch),
     Raptorcast(Epoch), // sharded raptor-aware broadcast
     PointToPoint(NodeId<P>),
-    TcpPointToPoint(NodeId<P>),
+    TcpPointToPoint {
+        to: NodeId<P>,
+        completion: Option<futures::channel::oneshot::Sender<()>>,
+    },
 }
 
 /// Trait for use in tests to populate structs where the value of the fields is not relevant

--- a/monad-updaters/src/local_router.rs
+++ b/monad-updaters/src/local_router.rs
@@ -125,9 +125,19 @@ where
                             tx.send((now, self.me, message.clone())).unwrap();
                         }
                     }
-                    RouterTarget::PointToPoint(peer) | RouterTarget::TcpPointToPoint(peer) => {
+                    RouterTarget::PointToPoint(peer) => {
                         self.txs
                             .get(&peer)
+                            .unwrap()
+                            .send((now, self.me, message.into()))
+                            .unwrap();
+                    }
+                    RouterTarget::TcpPointToPoint { to, completion } => {
+                        if let Some(completion) = completion {
+                            let _ = completion.send(());
+                        }
+                        self.txs
+                            .get(&to)
                             .unwrap()
                             .send((now, self.me, message.into()))
                             .unwrap();

--- a/monad-updaters/src/statesync.rs
+++ b/monad-updaters/src/statesync.rs
@@ -108,6 +108,7 @@ where
                         MonadEvent::StateSyncEvent(StateSyncEvent::Outbound(
                             *peer,
                             StateSyncNetworkMessage::Request(request),
+                            None, // don't care about completion for mock
                         ))
                     }))
                 }
@@ -146,6 +147,7 @@ where
                             .push_back(MonadEvent::StateSyncEvent(StateSyncEvent::Outbound(
                                 from,
                                 StateSyncNetworkMessage::Response(response),
+                                None, // don't care about completion for mock
                             )))
                     }
                     StateSyncNetworkMessage::Response(response) => {

--- a/monad-wal/examples/wal-tool.rs
+++ b/monad-wal/examples/wal-tool.rs
@@ -250,7 +250,7 @@ impl EventCountsWidget {
         let monad_events: Vec<WalEvent> = self
             .wrapped_events
             .iter()
-            .map(|a| a.event.clone())
+            .map(|a| a.event.lossy_clone())
             .collect();
         self.counts = counter(&monad_events);
     }


### PR DESCRIPTION
This commit adds a backpressure mechanism for statesync responses.

There's now a MAX_PENDING_RESPONSES constant which tells the statesync server task when to start applying backpressure on the statesync ipc socket. This is threaded through by adding a `completion` oneshot channel to the TcpPointToPoint RouterTarget, that gets resolved in monad-dataplane once the message is completely written to the socket.

We set MAX_PENDING_RESPONSES to a number higher than 1 so that monad-dataplane will know not to immediately terminate the TCP connection.