### PR TITLE
Remove configurable request timeout

### DIFF
--- a/docker/devnet/monad/config/node.toml
+++ b/docker/devnet/monad/config/node.toml
@@ -18,7 +18,6 @@ ipc_queued_batches_watermark = 3
 
 statesync_threshold = 600
 statesync_max_concurrent_requests = 5
-statesync_request_timeout_ms = 2000
 
 #########################################################
 # Network-wide configuration

--- a/monad-node-config/src/lib.rs
+++ b/monad-node-config/src/lib.rs
@@ -38,7 +38,6 @@ pub struct NodeConfig<P: PubKey> {
 
     pub statesync_threshold: u16,
     pub statesync_max_concurrent_requests: u8,
-    pub statesync_request_timeout_ms: u16,
 
     #[serde(bound = "P:PubKey")]
     pub bootstrap: NodeBootstrapConfig<P>,

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -60,6 +60,7 @@ type ReloadHandle =
     tracing_subscriber::reload::Handle<tracing_subscriber::EnvFilter, tracing_subscriber::Registry>;
 
 const CLIENT_VERSION: &str = env!("VERGEN_GIT_DESCRIBE");
+const STATESYNC_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 fn main() {
     let mut cmd = Cli::command();
@@ -257,8 +258,8 @@ async fn run(node_state: NodeState, reload_handle: ReloadHandle) -> Result<(), (
                 .node_config
                 .statesync_max_concurrent_requests
                 .into(),
-            Duration::from_millis(node_state.node_config.statesync_request_timeout_ms.into()),
-            Duration::from_millis(node_state.node_config.statesync_request_timeout_ms.into()),
+            STATESYNC_REQUEST_TIMEOUT,
+            STATESYNC_REQUEST_TIMEOUT,
             node_state
                 .statesync_ipc_path
                 .to_str()


### PR DESCRIPTION
It makes stuff harder to debug if these are set inconsistently. In addition, the prior value (2s) was set too low, as traversing 1M upserts takes ~2s. We had originally set this timeout to be so low because we didn't support configurable statesync peers before.