### PR TITLE
Improve statesync response encoding performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5159,6 +5159,7 @@ dependencies = [
  "bincode",
  "bytes",
  "chrono",
+ "criterion",
  "monad-blocksync",
  "monad-consensus",
  "monad-consensus-types",

--- a/monad-executor-glue/Cargo.toml
+++ b/monad-executor-glue/Cargo.toml
@@ -25,3 +25,10 @@ bytes = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 prost = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+criterion = { workspace = true }
+
+[[bench]]
+name = "rlp_bench"
+harness = false

--- a/monad-executor-glue/benches/rlp_bench.rs
+++ b/monad-executor-glue/benches/rlp_bench.rs
@@ -1,0 +1,63 @@
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use monad_executor_glue::{
+    StateSyncNetworkMessage, StateSyncRequest, StateSyncResponse, StateSyncUpsertType,
+    StateSyncUpsertV1, SELF_STATESYNC_VERSION,
+};
+
+#[derive(Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+pub struct Wrapped<T>(T);
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let num_upserts = 1_000_000;
+    let upsert_size = 100_usize;
+
+    let statesync_response: Wrapped<_> = Wrapped(Wrapped(Wrapped(Wrapped(Wrapped(Wrapped(
+        StateSyncNetworkMessage::Response(StateSyncResponse {
+            version: SELF_STATESYNC_VERSION,
+            nonce: 0,
+            response_index: 0,
+            request: StateSyncRequest {
+                version: SELF_STATESYNC_VERSION,
+                prefix: 0,
+                prefix_bytes: 0,
+                target: 0,
+                from: 0,
+                until: 0,
+                old_target: 0,
+            },
+            response: (0..num_upserts)
+                .map(|_| StateSyncUpsertV1 {
+                    upsert_type: StateSyncUpsertType::Account,
+                    data: vec![0_u8; upsert_size].into(),
+                })
+                .collect::<Vec<_>>(),
+            response_n: 0,
+        }),
+    ))))));
+    let serialized_statesync_response = alloy_rlp::encode(&statesync_response);
+
+    let mut group = c.benchmark_group("statesync_response");
+    group.throughput(Throughput::Bytes(serialized_statesync_response.len() as u64));
+    group.bench_function("encoder", |b| {
+        b.iter(|| {
+            let serialized = alloy_rlp::encode(&statesync_response);
+            if serialized_statesync_response != serialized {
+                panic!("failed to roundtrip")
+            }
+        });
+    });
+    group.bench_function("decoder", |b| {
+        b.iter(|| {
+            let deserialized: Wrapped<_> = alloy_rlp::decode_exact(&serialized_statesync_response)
+                .expect("failed to roundtrip");
+            if statesync_response != deserialized {
+                panic!("failed to roundtrip")
+            }
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/monad-executor-glue/src/convert/event.rs
+++ b/monad-executor-glue/src/convert/event.rs
@@ -1,7 +1,7 @@
 use std::{net::SocketAddr, str::FromStr};
 
 use alloy_rlp::{Decodable, Encodable};
-use bytes::{Bytes, BytesMut};
+use bytes::BytesMut;
 use monad_consensus_types::{
     convert::signing::{certificate_signature_to_proto, proto_to_certificate_signature},
     payload::RoundSignature,
@@ -20,8 +20,8 @@ use monad_types::ExecutionProtocol;
 use crate::{
     BlockSyncEvent, ConfigEvent, ConfigUpdate, ControlPanelEvent, GetFullNodes, GetPeers,
     KnownPeersUpdate, MempoolEvent, MonadEvent, ReloadConfig, StateSyncEvent,
-    StateSyncNetworkMessage, StateSyncRequest, StateSyncResponse, StateSyncUpsert,
-    StateSyncUpsertType, StateSyncVersion, ValidatorEvent,
+    StateSyncNetworkMessage, StateSyncRequest, StateSyncResponse, StateSyncUpsertType,
+    StateSyncUpsertV1, StateSyncVersion, ValidatorEvent,
 };
 
 impl<ST, SCT, EPT> From<&MonadEvent<ST, SCT, EPT>> for ProtoMonadEvent
@@ -720,7 +720,7 @@ impl From<&StateSyncResponse> for monad_proto::proto::message::ProtoStateSyncRes
                         &upsert.upsert_type,
                     )
                     .into(),
-                    data: Bytes::copy_from_slice(&upsert.data),
+                    data: upsert.data.clone(),
                 })
                 .collect(),
             n: response.response_n,
@@ -878,9 +878,9 @@ impl TryFrom<monad_proto::proto::message::ProtoStateSyncNetworkMessage>
                                     ProtoError::DeserializeError("unknown upsert type".to_owned())
                                 })?
                                 .into();
-                            Ok(StateSyncUpsert {
+                            Ok(StateSyncUpsertV1 {
                                 upsert_type,
-                                data: Vec::from(upsert.data),
+                                data: upsert.data,
                             })
                         })
                         .collect::<Result<_, ProtoError>>()?,

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -454,6 +454,36 @@ where
             }
         }
     }
+
+    fn length(&self) -> usize {
+        let monad_version = MonadVersion::version();
+
+        match self {
+            Self::Consensus(m) => {
+                let wire: Unverified<ST, Unvalidated<ConsensusMessage<ST, SCT, EPT>>> =
+                    m.clone().into();
+                let enc: Vec<&dyn Encodable> = vec![&monad_version, &1u8, &wire];
+                Encodable::length(&enc)
+            }
+            Self::BlockSyncRequest(m) => {
+                let enc: Vec<&dyn Encodable> = vec![&monad_version, &2u8, &m];
+                Encodable::length(&enc)
+            }
+            Self::BlockSyncResponse(m) => {
+                let enc: Vec<&dyn Encodable> = vec![&monad_version, &3u8, &m];
+                Encodable::length(&enc)
+            }
+            Self::ForwardedTx(m) => {
+                let enc: Vec<&dyn Encodable> = vec![&monad_version, &4u8, &m];
+                // TODO does tx bytes need a prefix?
+                Encodable::length(&enc)
+            }
+            Self::StateSyncMessage(m) => {
+                let enc: Vec<&dyn Encodable> = vec![&monad_version, &5u8, &m];
+                Encodable::length(&enc)
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/monad-statesync/src/ipc.rs
+++ b/monad-statesync/src/ipc.rs
@@ -7,7 +7,7 @@ use std::{
 use futures::FutureExt;
 use monad_crypto::certificate_signature::PubKey;
 use monad_executor_glue::{
-    StateSyncRequest, StateSyncResponse, StateSyncUpsert, StateSyncUpsertType,
+    StateSyncRequest, StateSyncResponse, StateSyncUpsertType, StateSyncUpsertV1,
     SELF_STATESYNC_VERSION,
 };
 use monad_types::NodeId;
@@ -191,7 +191,7 @@ impl<'a, PT: PubKey> StreamState<'a, PT> {
                 wip_response
                     .response
                     .response
-                    .push(StateSyncUpsert::new(upsert_type, data));
+                    .push(StateSyncUpsertV1::new(upsert_type, data.into()));
                 if wip_response.response.response.len() == MAX_UPSERTS_PER_RESPONSE {
                     // send batch
                     let response = StateSyncResponse {

--- a/monad-updaters/src/statesync.rs
+++ b/monad-updaters/src/statesync.rs
@@ -12,7 +12,7 @@ use monad_crypto::certificate_signature::{
 use monad_executor::{Executor, ExecutorMetricsChain};
 use monad_executor_glue::{
     MonadEvent, StateSyncCommand, StateSyncEvent, StateSyncNetworkMessage, StateSyncRequest,
-    StateSyncResponse, StateSyncUpsert, StateSyncUpsertType, SELF_STATESYNC_VERSION,
+    StateSyncResponse, StateSyncUpsertType, StateSyncUpsertV1, SELF_STATESYNC_VERSION,
 };
 use monad_state_backend::{InMemoryState, StateBackend};
 use monad_types::{ExecutionProtocol, FinalizedHeader, NodeId, SeqNum, GENESIS_SEQ_NUM};
@@ -136,9 +136,9 @@ where
                             response_index: 0,
 
                             request,
-                            response: vec![StateSyncUpsert::new(
+                            response: vec![StateSyncUpsertV1::new(
                                 StateSyncUpsertType::Code,
-                                serialized,
+                                serialized.into(),
                             )],
                             response_n: 1,
                         };


### PR DESCRIPTION
- serialize statesync upserts as str instead of list
- implement alloy_rlp::Encodable::length for Encodable types