### PR TITLE
Enforce minimum dataplane TCP message throughput of 1 MB/sec

### DIFF
--- a/monad-dataplane/src/tcp/tx.rs
+++ b/monad-dataplane/src/tcp/tx.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, enabled, trace, warn, Level};
 use zerocopy::AsBytes;
 
-use super::{TcpMsg, TcpMsgHdr, TCP_MESSAGE_TIMEOUT};
+use super::{message_timeout, TcpMsg, TcpMsgHdr};
 
 const QUEUED_MESSAGE_WARN_LIMIT: usize = 10;
 
@@ -108,7 +108,7 @@ async fn task_peer(tx_state: TxState, addr: SocketAddr) {
         // TODO: When we experience a transmission failure, we should consider zapping
         // all outbound messages that are linked to this one (i.e. that are part of the
         // same (large, multi-message) blocksync or statesync response).
-        if timeout(TCP_MESSAGE_TIMEOUT, send_message(conn_id, addr, message))
+        if timeout(message_timeout(len), send_message(conn_id, addr, message))
             .await
             .is_err()
         {


### PR DESCRIPTION
A side-effect of the recent dataplane v2 and statesync backpressure
changes is that we now keep a statesync server busy until all
response messages corresponding to an inbound statesync request have
been transferred to the requesting client.  This makes it all the
more important to kill ongoing TCP transfers when they are running
unacceptably slowly.

This patch makes the TCP message transfer timeout a function of the
message size, such that we expect the message to be transferred at a
rate of at least 1 megabyte per second, but with a minimum time of 10
seconds, so that smaller messages don't get prematurely nuked because
of TCP slow start.