### PR TITLE
docker/devnet/clean: Avoid unnecessary error message

### DIFF
--- a/docker/devnet/clean.sh
+++ b/docker/devnet/clean.sh
@@ -34,7 +34,7 @@ if [ -S "$controlpanel_sock" ]; then
     rm "$controlpanel_sock"
 fi
 
-rm ${wal}_* || true
+rm -f ${wal}_*
 
 if [ -f "$forkpoint" ]; then
     rm "$forkpoint"


### PR DESCRIPTION
The `rm … || true` indicates it's acceptable if any of the files don't exist, but that still prints an error message from `rm`, which can be a bit confusing, even though it exits with a correct error code.

Instead, just use `rm -f`, which is quiet and error-free if any of the requested files don't exist.