### PR TITLE
Bump TCP header timeout to 10 seconds

### DIFF
--- a/monad-dataplane/src/tcp/mod.rs
+++ b/monad-dataplane/src/tcp/mod.rs
@@ -15,8 +15,6 @@ mod tx;
 
 const TCP_MESSAGE_LENGTH_LIMIT: usize = 1024 * 1024 * 1024;
 
-const TCP_HEADER_TIMEOUT: Duration = Duration::from_secs(5);
-
 const HEADER_MAGIC: u32 = 0x434e5353; // "SSNC"
 const HEADER_VERSION: u32 = 1;
 


### PR DESCRIPTION
Bump the TCP header timeout from 5 to 10 seconds so that we can keep
outbound idle TCP connections around for a little bit longer waiting for
new messages to be queued for transmission, which should increase the
chances of pipelining more messages over the same outbound connection.