### PR TITLE
respond to statesync requests with incompatible version

### DIFF
--- a/monad-proto/proto/message.proto
+++ b/monad-proto/proto/message.proto
@@ -90,10 +90,16 @@ message ProtoStateSyncResponse {
   uint64 n = 3;
 }
 
+message ProtoStateSyncBadVersion {
+  uint32 min_version = 1;
+  uint32 max_version = 2;
+}
+
 message ProtoStateSyncNetworkMessage {
   oneof OneofMessage {
     ProtoStateSyncRequest request = 1;
     ProtoStateSyncResponse response = 2;
+    ProtoStateSyncBadVersion bad_version = 3;
   }
 }
 

--- a/monad-statesync/src/outbound_requests.rs
+++ b/monad-statesync/src/outbound_requests.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use monad_crypto::certificate_signature::PubKey;
-use monad_executor_glue::{StateSyncRequest, StateSyncResponse};
+use monad_executor_glue::{StateSyncBadVersion, StateSyncRequest, StateSyncResponse};
 use monad_types::NodeId;
 
 pub(crate) struct OutboundRequests<PT: PubKey> {
@@ -204,6 +204,12 @@ impl<PT: PubKey> OutboundRequests<PT> {
             return Some(full_response);
         }
         None
+    }
+
+    pub fn handle_bad_version(&mut self, from: NodeId<PT>, bad_version: StateSyncBadVersion) {
+        // Ignore bad version, this version is always supported
+        // Future version will perform downgrade if client does not understand the current version
+        tracing::debug!("dropping bad version from {}", from);
     }
 
     #[must_use]

--- a/monad-updaters/src/statesync.rs
+++ b/monad-updaters/src/statesync.rs
@@ -166,6 +166,7 @@ where
                             ));
                         }
                     }
+                    StateSyncNetworkMessage::BadVersion(_) => {}
                 },
             }
         }


### PR DESCRIPTION
When statesync request with incompatible version is received, respond with minimum and maximum supported version instead of just dropping the message. This allows clients with higher version to be able to downgrade and complete statesync.