### PR TITLE
Add more logging around RPC request/response size and timing

### DIFF
--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -52,6 +52,7 @@ use crate::{
         monad_eth_maxPriorityFeePerGas,
     },
     jsonrpc::{JsonRpcError, JsonRpcResultExt, Request, RequestWrapper, Response, ResponseWrapper},
+    timing::TimingMiddleware,
     trace::{
         monad_trace_block, monad_trace_call, monad_trace_callMany, monad_trace_get,
         monad_trace_transaction,
@@ -78,6 +79,7 @@ mod gas_oracle;
 mod hex;
 mod jsonrpc;
 mod metrics;
+mod timing;
 mod trace;
 mod trace_handlers;
 mod txpool;
@@ -889,6 +891,7 @@ async fn main() -> std::io::Result<()> {
             App::new()
                 .wrap(metrics.clone())
                 .wrap(TracingLogger::<MonadJsonRootSpanBuilder>::new())
+                .wrap(TimingMiddleware)
                 .app_data(web::PayloadConfig::default().limit(args.max_request_size))
                 .app_data(web::Data::new(resources.clone()))
                 .service(web::resource("/").route(web::post().to(rpc_handler)))
@@ -901,6 +904,7 @@ async fn main() -> std::io::Result<()> {
         None => HttpServer::new(move || {
             App::new()
                 .wrap(TracingLogger::<MonadJsonRootSpanBuilder>::new())
+                .wrap(TimingMiddleware)
                 .app_data(web::PayloadConfig::default().limit(args.max_request_size))
                 .app_data(web::Data::new(resources.clone()))
                 .service(web::resource("/").route(web::post().to(rpc_handler)))

--- a/monad-rpc/src/timing.rs
+++ b/monad-rpc/src/timing.rs
@@ -1,0 +1,95 @@
+use std::{
+    future::{ready, Ready},
+    time::Instant,
+};
+
+use actix_web::{
+    body::{BoxBody, MessageBody},
+    dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform},
+    Error,
+};
+use futures::future::LocalBoxFuture;
+use tracing::debug;
+
+pub struct TimingMiddleware;
+
+impl<S, B> Transform<S, ServiceRequest> for TimingMiddleware
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: MessageBody + 'static,
+{
+    type Response = ServiceResponse<BoxBody>;
+    type Error = Error;
+    type InitError = ();
+    type Transform = TimingMiddlewareService<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(TimingMiddlewareService { service }))
+    }
+}
+
+pub struct TimingMiddlewareService<S> {
+    service: S,
+}
+
+impl<S, B> Service<ServiceRequest> for TimingMiddlewareService<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: MessageBody + 'static,
+{
+    type Response = ServiceResponse<BoxBody>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    forward_ready!(service);
+
+    fn call(&self, mut req: ServiceRequest) -> Self::Future {
+        let start_time = Instant::now();
+
+        let request_size = req
+            .request()
+            .headers()
+            .get("content-length")
+            .and_then(|h| h.to_str().ok())
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(0);
+        let client_ip = req
+            .connection_info()
+            .realip_remote_addr()
+            .unwrap_or("unknown")
+            .to_string();
+        let fut = self.service.call(req);
+
+        Box::pin(async move {
+            let resp = fut.await;
+            let processing_end = Instant::now();
+
+            let response_size = match &resp {
+                Ok(resp) => match resp.response().body().size() {
+                    actix_web::body::BodySize::None => 0,
+                    actix_web::body::BodySize::Sized(size) => size,
+                    actix_web::body::BodySize::Stream => 0,
+                },
+                Err(_) => 0,
+            };
+
+            debug!(
+                request_size_bytes = request_size,
+                response_size_bytes = response_size,
+                processing_time = format!("{:?}", processing_end.duration_since(start_time)),
+                client_ip,
+                status = match &resp {
+                    Ok(r) => r.status().as_u16(),
+                    Err(_) => 500,
+                },
+                success = resp.is_ok(),
+                "Request timing information"
+            );
+
+            resp.map(|r| r.map_into_boxed_body())
+        })
+    }
+}


### PR DESCRIPTION
In response to https://category-labs.slack.com/archives/C08ANB698F4/p1742187352497099

Unfortunately, I tried for a while to get information on how long it takes to receive the data from the network and transmit the response, as requested in that message, but was not able to find any way to do this, since this is a middleware that's getting called after Actix has received the data, and before Actix transmits the data. But I did add information on request and response sizes, and the time it takes to process the request, at least.