### PR TITLE
Speedup rpc txpool bridge cleanup process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5268,6 +5268,7 @@ dependencies = [
  "futures-util",
  "itertools 0.10.5",
  "monad-archive",
+ "monad-eth-testutil",
  "monad-eth-txpool-ipc",
  "monad-eth-txpool-types",
  "monad-eth-types",

--- a/monad-eth-txpool-types/src/lib.rs
+++ b/monad-eth-txpool-types/src/lib.rs
@@ -44,7 +44,7 @@ pub enum EthTxPoolEvent {
 }
 
 // allow for more fine grain debugging if needed
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TransactionError {
     InvalidChainId,
     MaxPriorityFeeTooHigh,
@@ -54,7 +54,7 @@ pub enum TransactionError {
     UnsupportedTransactionType,
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EthTxPoolDropReason {
     NotWellFormed(TransactionError),
     InvalidSignature,
@@ -67,7 +67,7 @@ pub enum EthTxPoolDropReason {
     Internal(EthTxPoolInternalDropReason),
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EthTxPoolInternalDropReason {
     StateBackendError,
 }
@@ -100,7 +100,7 @@ impl EthTxPoolDropReason {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EthTxPoolEvictReason {
     Expired,
 }

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -56,11 +56,14 @@ tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 
 [dev-dependencies]
+monad-eth-testutil = { workspace = true }
+
 alloy-rpc-client = { workspace = true }
 alloy-signer = { workspace = true }
 alloy-signer-local = { workspace = true }
 reqwest = { workspace = true }
 test-case = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 
 [build-dependencies]
 vergen-git2 = { workspace = true }

--- a/monad-rpc/src/txpool/state.rs
+++ b/monad-rpc/src/txpool/state.rs
@@ -1,12 +1,12 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     sync::Arc,
     time::Duration,
 };
 
 use alloy_consensus::TxEnvelope;
 use alloy_primitives::{Address, TxHash};
-use dashmap::DashMap;
+use dashmap::{DashMap, Entry};
 use monad_eth_txpool_types::{EthTxPoolEvent, EthTxPoolSnapshot};
 use tokio::time::Instant;
 
@@ -14,39 +14,30 @@ use super::TxStatus;
 
 const TX_EVICT_DURATION_SECONDS: u64 = 15 * 60;
 
-struct TxStatusEntry {
-    pub status: TxStatus,
-    pub last_updated: Instant,
-}
-
-impl TxStatusEntry {
-    pub fn new(status: TxStatus, last_updated: Instant) -> Self {
-        Self {
-            status,
-            last_updated,
-        }
-    }
-}
+pub(super) type EthTxPoolBridgeEvictionQueue = VecDeque<(Instant, TxHash)>;
 
 #[derive(Clone)]
 pub struct EthTxPoolBridgeStateView {
-    status: Arc<DashMap<TxHash, TxStatusEntry>>,
+    status: Arc<DashMap<TxHash, TxStatus>>,
     hash_address: Arc<DashMap<TxHash, Address>>,
     address_hashes: Arc<DashMap<Address, HashSet<TxHash>>>,
 }
 
 impl EthTxPoolBridgeStateView {
     pub fn get_status_by_hash(&self, hash: &TxHash) -> Option<TxStatus> {
-        Some(self.status.get(hash)?.value().status.to_owned())
+        Some(self.status.get(hash)?.value().to_owned())
     }
 
-    pub fn get_status_by_address(&self, address: &Address) -> Option<HashMap<TxHash, TxStatus>> {
+    pub(super) fn get_status_by_address(
+        &self,
+        address: &Address,
+    ) -> Option<HashMap<TxHash, TxStatus>> {
         let hashes = self.address_hashes.get(address)?.value().to_owned();
 
         let statuses = hashes
             .into_iter()
             .flat_map(|hash| {
-                let status = self.status.get(&hash)?.value().status.to_owned();
+                let status = self.status.get(&hash)?.value().to_owned();
                 Some((hash, status))
             })
             .collect();
@@ -67,20 +58,23 @@ impl EthTxPoolBridgeStateView {
 }
 
 pub struct EthTxPoolBridgeState {
-    status: Arc<DashMap<TxHash, TxStatusEntry>>,
+    status: Arc<DashMap<TxHash, TxStatus>>,
     hash_address: Arc<DashMap<TxHash, Address>>,
     address_hashes: Arc<DashMap<Address, HashSet<TxHash>>>,
 }
 
 impl EthTxPoolBridgeState {
-    pub fn new(snapshot: EthTxPoolSnapshot) -> Self {
+    pub fn new(
+        eviction_queue: &mut EthTxPoolBridgeEvictionQueue,
+        snapshot: EthTxPoolSnapshot,
+    ) -> Self {
         let this = Self {
             status: Default::default(),
             hash_address: Default::default(),
             address_hashes: Default::default(),
         };
 
-        this.apply_snapshot(snapshot);
+        this.apply_snapshot(eviction_queue, snapshot);
 
         this
     }
@@ -93,14 +87,21 @@ impl EthTxPoolBridgeState {
         }
     }
 
-    pub(super) fn add_tx(&self, tx: &TxEnvelope) {
+    pub(super) fn add_tx(
+        &self,
+        eviction_queue: &mut EthTxPoolBridgeEvictionQueue,
+        tx: &TxEnvelope,
+    ) {
         let hash = tx.tx_hash();
-        self.status
-            .entry(*hash)
-            .insert(TxStatusEntry::new(TxStatus::Unknown, Instant::now()));
+        self.status.entry(*hash).insert(TxStatus::Unknown);
+        eviction_queue.push_back((Instant::now(), *hash));
     }
 
-    pub(super) fn apply_snapshot(&self, snapshot: EthTxPoolSnapshot) {
+    pub(super) fn apply_snapshot(
+        &self,
+        eviction_queue: &mut EthTxPoolBridgeEvictionQueue,
+        snapshot: EthTxPoolSnapshot,
+    ) {
         let EthTxPoolSnapshot {
             mut pending,
             mut tracked,
@@ -108,45 +109,63 @@ impl EthTxPoolBridgeState {
 
         let now = Instant::now();
 
-        self.status.retain(|hash, status| {
-            if pending.remove(hash) {
-                *status = TxStatusEntry::new(TxStatus::Pending, now);
+        while eviction_queue.pop_front().is_some() {}
+
+        self.status.retain(|tx_hash, status| {
+            if pending.remove(tx_hash) {
+                *status = TxStatus::Pending;
+                eviction_queue.push_back((now, *tx_hash));
                 return true;
             }
 
-            if tracked.remove(hash) {
-                *status = TxStatusEntry::new(TxStatus::Tracked, now);
+            if tracked.remove(tx_hash) {
+                *status = TxStatus::Tracked;
+                eviction_queue.push_back((now, *tx_hash));
                 return true;
             }
 
-            let Some((hash, address)) = self.hash_address.remove(hash) else {
+            let Some((tx_hash, address)) = self.hash_address.remove(tx_hash) else {
                 return false;
             };
 
             self.address_hashes.entry(address).and_modify(|hashes| {
-                hashes.remove(&hash);
+                hashes.remove(&tx_hash);
             });
 
             false
         });
 
         for tx_hash in pending {
-            self.status
-                .insert(tx_hash, TxStatusEntry::new(TxStatus::Pending, now));
+            self.status.insert(tx_hash, TxStatus::Pending);
+            eviction_queue.push_back((now, tx_hash));
         }
 
         for tx_hash in tracked {
-            self.status
-                .insert(tx_hash, TxStatusEntry::new(TxStatus::Tracked, now));
+            self.status.insert(tx_hash, TxStatus::Tracked);
+            eviction_queue.push_back((now, tx_hash));
         }
 
         // note that self.hash_addresses and self.address_hashes aren't populated for snapshots
     }
 
-    pub(super) fn handle_events(&self, events: Vec<EthTxPoolEvent>) {
-        let tx_status = &self.status;
-
+    pub(super) fn handle_events(
+        &self,
+        eviction_queue: &mut EthTxPoolBridgeEvictionQueue,
+        events: Vec<EthTxPoolEvent>,
+    ) {
         let now = Instant::now();
+
+        let mut insert = |tx_hash, status| {
+            match self.status.entry(tx_hash) {
+                Entry::Occupied(mut o) => {
+                    o.insert(status);
+                }
+                Entry::Vacant(v) => {
+                    v.insert(status);
+                    eviction_queue.push_back((now, tx_hash));
+                }
+            };
+        };
 
         for event in events {
             match event {
@@ -156,14 +175,15 @@ impl EthTxPoolBridgeState {
                     owned: _,
                     tracked,
                 } => {
-                    tx_status.entry(tx_hash).insert(TxStatusEntry::new(
+                    insert(
+                        tx_hash,
                         if tracked {
                             TxStatus::Tracked
                         } else {
                             TxStatus::Pending
                         },
-                        now,
-                    ));
+                    );
+
                     self.hash_address.entry(tx_hash).insert(address);
                     self.address_hashes
                         .entry(address)
@@ -176,59 +196,474 @@ impl EthTxPoolBridgeState {
                     new_owned: _,
                     tracked,
                 } => {
-                    tx_status
-                        .entry(old_tx_hash)
-                        .insert(TxStatusEntry::new(TxStatus::Replaced, now));
-                    tx_status.entry(new_tx_hash).insert(TxStatusEntry::new(
+                    insert(old_tx_hash, TxStatus::Replaced);
+                    insert(
+                        new_tx_hash,
                         if tracked {
                             TxStatus::Tracked
                         } else {
                             TxStatus::Pending
                         },
-                        now,
-                    ));
+                    );
                 }
                 EthTxPoolEvent::Drop { tx_hash, reason } => {
-                    tx_status
-                        .entry(tx_hash)
-                        .insert(TxStatusEntry::new(TxStatus::Dropped { reason }, now));
+                    insert(tx_hash, TxStatus::Dropped { reason });
                 }
                 EthTxPoolEvent::Promoted { tx_hash } => {
-                    tx_status
-                        .entry(tx_hash)
-                        .insert(TxStatusEntry::new(TxStatus::Tracked, now));
+                    insert(tx_hash, TxStatus::Tracked);
                 }
                 EthTxPoolEvent::Commit { tx_hash } => {
-                    tx_status
-                        .entry(tx_hash)
-                        .insert(TxStatusEntry::new(TxStatus::Committed, now));
+                    insert(tx_hash, TxStatus::Committed);
                 }
                 EthTxPoolEvent::Evict { tx_hash, reason } => {
-                    tx_status
-                        .entry(tx_hash)
-                        .insert(TxStatusEntry::new(TxStatus::Evicted { reason }, now));
+                    insert(tx_hash, TxStatus::Evicted { reason });
                 }
             }
         }
     }
 
-    pub(super) fn cleanup(&self, now: Instant) {
-        self.status.retain(|hash, status| {
-            if now.duration_since(status.last_updated)
-                < Duration::from_secs(TX_EVICT_DURATION_SECONDS)
-            {
-                return true;
+    pub(super) fn cleanup(&self, eviction_queue: &mut EthTxPoolBridgeEvictionQueue, now: Instant) {
+        while eviction_queue
+            .front()
+            .map(|entry| {
+                now.duration_since(entry.0) >= Duration::from_secs(TX_EVICT_DURATION_SECONDS)
+            })
+            .unwrap_or_default()
+        {
+            let (_, hash) = eviction_queue.pop_front().unwrap();
+
+            if self.status.remove(&hash).is_none() {
+                continue;
             }
 
-            if let Some((hash, address)) = self.hash_address.remove(hash) {
+            if let Some((hash, address)) = self.hash_address.remove(&hash) {
                 if let Some(mut address_hashes) = self.address_hashes.get_mut(&address) {
                     address_hashes.remove(&hash);
                 }
             }
-
-            false
-        });
+        }
 
         self.address_hashes.retain(|_, hashes| !hashes.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{collections::HashSet, time::Duration};
+
+    use alloy_consensus::TxEnvelope;
+    use alloy_primitives::{hex, B256};
+    use monad_eth_testutil::make_legacy_tx;
+    use monad_eth_txpool_types::{
+        EthTxPoolDropReason, EthTxPoolEvent, EthTxPoolEvictReason, EthTxPoolSnapshot,
+    };
+    use monad_eth_types::BASE_FEE_PER_GAS;
+    use tokio::time::Instant;
+
+    use super::EthTxPoolBridgeStateView;
+    use crate::txpool::{
+        state::{EthTxPoolBridgeEvictionQueue, EthTxPoolBridgeState, TX_EVICT_DURATION_SECONDS},
+        TxStatus,
+    };
+
+    // pubkey starts with AAA
+    const S1: B256 = B256::new(hex!(
+        "0ed2e19e3aca1a321349f295837988e9c6f95d4a6fc54cfab6befd5ee82662ad"
+    ));
+
+    fn setup() -> (
+        EthTxPoolBridgeState,
+        EthTxPoolBridgeStateView,
+        EthTxPoolBridgeEvictionQueue,
+        TxEnvelope,
+    ) {
+        let mut eviction_queue = EthTxPoolBridgeEvictionQueue::default();
+        let state = EthTxPoolBridgeState::new(
+            &mut eviction_queue,
+            EthTxPoolSnapshot {
+                pending: HashSet::default(),
+                tracked: HashSet::default(),
+            },
+        );
+        let state_view = state.create_view();
+
+        let tx = make_legacy_tx(S1, BASE_FEE_PER_GAS.into(), 100_000, 0, 0);
+
+        (state, state_view, eviction_queue, tx)
+    }
+
+    #[tokio::test]
+    async fn test_create_view_linked() {
+        let (state, state_view, mut eviction_queue, tx) = setup();
+
+        assert_eq!(state.status.len(), 0);
+        assert_eq!(state_view.status.len(), 0);
+
+        state.add_tx(&mut eviction_queue, &tx);
+
+        assert_eq!(state.status.len(), 1);
+        assert_eq!(state_view.status.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_add_tx() {
+        let (state, state_view, mut eviction_queue, tx) = setup();
+
+        assert_eq!(state_view.get_status_by_hash(tx.tx_hash()), None);
+
+        state.add_tx(&mut eviction_queue, &tx);
+        assert_eq!(
+            state_view.get_status_by_hash(tx.tx_hash()),
+            Some(TxStatus::Unknown)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_events_and_snapshot() {
+        enum TestCases {
+            EmptySnapshot,
+            InsertPending,
+            InsertPendingSnapshot,
+            InsertTracked,
+            InsertTrackedSnapshot,
+            Replace,
+            Drop,
+            Promote,
+            PromoteSnapshot,
+            DemoteSnapshot,
+            Commit,
+            Evict,
+        }
+
+        for test in [
+            TestCases::EmptySnapshot,
+            TestCases::InsertPending,
+            TestCases::InsertPendingSnapshot,
+            TestCases::InsertTracked,
+            TestCases::InsertTrackedSnapshot,
+            TestCases::Replace,
+            TestCases::Drop,
+            TestCases::Promote,
+            TestCases::PromoteSnapshot,
+            TestCases::DemoteSnapshot,
+            TestCases::Commit,
+            TestCases::Evict,
+        ] {
+            let (state, state_view, mut eviction_queue, tx) = setup();
+
+            state.add_tx(&mut eviction_queue, &tx);
+            assert_eq!(
+                state_view.get_status_by_hash(tx.tx_hash()),
+                Some(TxStatus::Unknown)
+            );
+
+            match test {
+                TestCases::EmptySnapshot => {
+                    state.apply_snapshot(
+                        &mut eviction_queue,
+                        EthTxPoolSnapshot {
+                            pending: HashSet::default(),
+                            tracked: HashSet::default(),
+                        },
+                    );
+                    assert_eq!(state_view.get_status_by_hash(tx.tx_hash()), None);
+                }
+                TestCases::InsertPending => {
+                    state.handle_events(
+                        &mut eviction_queue,
+                        vec![EthTxPoolEvent::Insert {
+                            tx_hash: tx.tx_hash().to_owned(),
+                            address: tx.recover_signer().unwrap(),
+                            owned: true,
+                            tracked: false,
+                        }],
+                    );
+                    assert_eq!(
+                        state_view.get_status_by_hash(tx.tx_hash()),
+                        Some(TxStatus::Pending)
+                    );
+                }
+                TestCases::InsertPendingSnapshot => {
+                    state.apply_snapshot(
+                        &mut eviction_queue,
+                        EthTxPoolSnapshot {
+                            pending: HashSet::from_iter(std::iter::once(tx.tx_hash().to_owned())),
+                            tracked: HashSet::default(),
+                        },
+                    );
+                    assert_eq!(
+                        state_view.get_status_by_hash(tx.tx_hash()),
+                        Some(TxStatus::Pending)
+                    );
+                }
+                TestCases::InsertTracked => {
+                    state.handle_events(
+                        &mut eviction_queue,
+                        vec![EthTxPoolEvent::Insert {
+                            tx_hash: tx.tx_hash().to_owned(),
+                            address: tx.recover_signer().unwrap(),
+                            owned: true,
+                            tracked: true,
+                        }],
+                    );
+                    assert_eq!(
+                        state_view.get_status_by_hash(tx.tx_hash()),
+                        Some(TxStatus::Tracked)
+                    );
+                }
+                TestCases::InsertTrackedSnapshot => {
+                    state.apply_snapshot(
+                        &mut eviction_queue,
+                        EthTxPoolSnapshot {
+                            pending: HashSet::default(),
+                            tracked: HashSet::from_iter(std::iter::once(tx.tx_hash().to_owned())),
+                        },
+                    );
+                    assert_eq!(
+                        state_view.get_status_by_hash(tx.tx_hash()),
+                        Some(TxStatus::Tracked)
+                    );
+                }
+                TestCases::Replace => {
+                    state.handle_events(
+                        &mut eviction_queue,
+                        vec![EthTxPoolEvent::Insert {
+                            tx_hash: tx.tx_hash().to_owned(),
+                            address: tx.recover_signer().unwrap(),
+                            owned: true,
+                            tracked: false,
+                        }],
+                    );
+                    assert_eq!(
+                        state_view.get_status_by_hash(tx.tx_hash()),
+                        Some(TxStatus::Pending)
+                    );
+
+                    let new_tx = make_legacy_tx(
+                        S1,
+                        2u128 * Into::<u128>::into(BASE_FEE_PER_GAS),
+                        100_000,
+                        0,
+                        0,
+                    );
+
+                    state.handle_events(
+                        &mut eviction_queue,
+                        vec![EthTxPoolEvent::Replace {
+                            old_tx_hash: tx.tx_hash().to_owned(),
+                            new_tx_hash: new_tx.tx_hash().to_owned(),
+                            new_owned: true,
+                            tracked: true,
+                        }],
+                    );
+                    assert_eq!(
+                        state_view.get_status_by_hash(tx.tx_hash()),
+                        Some(TxStatus::Replaced)
+                    );
+                    assert_eq!(
+                        state_view.get_status_by_hash(new_tx.tx_hash()),
+                        Some(TxStatus::Tracked)
+                    );
+                }
+                TestCases::Drop => {
+                    state.handle_events(
+                        &mut eviction_queue,
+                        vec![EthTxPoolEvent::Drop {
+                            tx_hash: tx.tx_hash().to_owned(),
+                            reason: EthTxPoolDropReason::PoolNotReady,
+                        }],
+                    );
+                    assert_eq!(
+                        state_view.get_status_by_hash(tx.tx_hash()),
+                        Some(TxStatus::Dropped {
+                            reason: EthTxPoolDropReason::PoolNotReady
+                        })
+                    );
+                }
+                TestCases::Promote => {
+                    state.handle_events(
+                        &mut eviction_queue,
+                        vec![EthTxPoolEvent::Insert {
+                            tx_hash: tx.tx_hash().to_owned(),
+                            address: tx.recover_signer().unwrap(),
+                            owned: true,
+                            tracked: false,
+                        }],
+                    );
+                    assert_eq!(
+                        state_view.get_status_by_hash(tx.tx_hash()),
+                        Some(TxStatus::Pending)
+                    );
+
+                    state.handle_events(
+                        &mut eviction_queue,
+                        vec![EthTxPoolEvent::Promoted {
+                            tx_hash: tx.tx_hash().to_owned(),
+                        }],
+                    );
+                    assert_eq!(
+                        state_view.get_status_by_hash(tx.tx_hash()),
+                        Some(TxStatus::Tracked)
+                    );
+                }
+                TestCases::PromoteSnapshot => {
+                    state.handle_events(
+                        &mut eviction_queue,
+                        vec![EthTxPoolEvent::Insert {
+                            tx_hash: tx.tx_hash().to_owned(),
+                            address: tx.recover_signer().unwrap(),
+                            owned: true,
+                            tracked: false,
+                        }],
+                    );
+                    assert_eq!(
+                        state_view.get_status_by_hash(tx.tx_hash()),
+                        Some(TxStatus::Pending)
+                    );
+
+                    state.apply_snapshot(
+                        &mut eviction_queue,
+                        EthTxPoolSnapshot {
+                            pending: HashSet::default(),
+                            tracked: HashSet::from_iter(std::iter::once(tx.tx_hash().to_owned())),
+                        },
+                    );
+                    assert_eq!(
+                        state_view.get_status_by_hash(tx.tx_hash()),
+                        Some(TxStatus::Tracked)
+                    );
+                }
+                TestCases::DemoteSnapshot => {
+                    state.handle_events(
+                        &mut eviction_queue,
+                        vec![EthTxPoolEvent::Insert {
+                            tx_hash: tx.tx_hash().to_owned(),
+                            address: tx.recover_signer().unwrap(),
+                            owned: true,
+                            tracked: true,
+                        }],
+                    );
+                    assert_eq!(
+                        state_view.get_status_by_hash(tx.tx_hash()),
+                        Some(TxStatus::Tracked)
+                    );
+
+                    state.apply_snapshot(
+                        &mut eviction_queue,
+                        EthTxPoolSnapshot {
+                            pending: HashSet::from_iter(std::iter::once(tx.tx_hash().to_owned())),
+                            tracked: HashSet::default(),
+                        },
+                    );
+                    assert_eq!(
+                        state_view.get_status_by_hash(tx.tx_hash()),
+                        Some(TxStatus::Pending)
+                    );
+                }
+                TestCases::Commit => {
+                    state.handle_events(
+                        &mut eviction_queue,
+                        vec![EthTxPoolEvent::Commit {
+                            tx_hash: tx.tx_hash().to_owned(),
+                        }],
+                    );
+                    assert_eq!(
+                        state_view.get_status_by_hash(tx.tx_hash()),
+                        Some(TxStatus::Committed)
+                    );
+
+                    state.apply_snapshot(
+                        &mut eviction_queue,
+                        EthTxPoolSnapshot {
+                            pending: HashSet::default(),
+                            tracked: HashSet::default(),
+                        },
+                    );
+                    assert_eq!(state_view.get_status_by_hash(tx.tx_hash()), None);
+                }
+                TestCases::Evict => {
+                    state.handle_events(
+                        &mut eviction_queue,
+                        vec![EthTxPoolEvent::Evict {
+                            tx_hash: tx.tx_hash().to_owned(),
+                            reason: EthTxPoolEvictReason::Expired,
+                        }],
+                    );
+                    assert_eq!(
+                        state_view.get_status_by_hash(tx.tx_hash()),
+                        Some(TxStatus::Evicted {
+                            reason: EthTxPoolEvictReason::Expired
+                        })
+                    );
+
+                    state.apply_snapshot(
+                        &mut eviction_queue,
+                        EthTxPoolSnapshot {
+                            pending: HashSet::default(),
+                            tracked: HashSet::default(),
+                        },
+                    );
+                    assert_eq!(state_view.get_status_by_hash(tx.tx_hash()), None);
+                }
+            }
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_cleanup() {
+        for add_duplicate_tx in [false, true] {
+            let (state, state_view, mut eviction_queue, tx) = setup();
+
+            assert_eq!(eviction_queue.len(), 0);
+            assert_eq!(state_view.status.len(), 0);
+
+            state.add_tx(&mut eviction_queue, &tx);
+            assert_eq!(eviction_queue.len(), 1);
+            assert_eq!(state_view.status.len(), 1);
+
+            state.cleanup(&mut eviction_queue, Instant::now());
+            assert_eq!(eviction_queue.len(), 1);
+            assert_eq!(state_view.status.len(), 1);
+
+            tokio::time::advance(
+                Duration::from_secs(TX_EVICT_DURATION_SECONDS)
+                    .checked_sub(Duration::from_millis(1))
+                    .unwrap(),
+            )
+            .await;
+
+            state.cleanup(&mut eviction_queue, Instant::now());
+            assert_eq!(eviction_queue.len(), 1);
+            assert_eq!(state_view.status.len(), 1);
+
+            if add_duplicate_tx {
+                state.add_tx(&mut eviction_queue, &tx);
+                assert_eq!(eviction_queue.len(), 2);
+                assert_eq!(state_view.status.len(), 1);
+
+                state.cleanup(&mut eviction_queue, Instant::now());
+                assert_eq!(eviction_queue.len(), 2);
+                assert_eq!(state_view.status.len(), 1);
+            }
+
+            tokio::time::advance(Duration::from_millis(1)).await;
+
+            state.cleanup(&mut eviction_queue, Instant::now());
+            assert_eq!(eviction_queue.len(), if add_duplicate_tx { 1 } else { 0 });
+            assert_eq!(state_view.status.len(), 0);
+
+            if add_duplicate_tx {
+                tokio::time::advance(
+                    Duration::from_secs(TX_EVICT_DURATION_SECONDS)
+                        .checked_sub(Duration::from_millis(1))
+                        .unwrap(),
+                )
+                .await;
+
+                state.cleanup(&mut eviction_queue, Instant::now());
+                assert_eq!(eviction_queue.len(), 0);
+                assert_eq!(state_view.status.len(), 0);
+            }
+        }
     }
 }

--- a/monad-rpc/src/txpool/types.rs
+++ b/monad-rpc/src/txpool/types.rs
@@ -1,6 +1,6 @@
 use monad_eth_txpool_types::{EthTxPoolDropReason, EthTxPoolEvictReason};
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TxStatus {
     // No response
     Unknown,


### PR DESCRIPTION
Previously, every cleanup interval, the txpool task would iterate through the entire tx status map and remove old entries. With high sustained TPS, the size of this map would grow significantly leading to slow iteration times, measured on stressnet between 20-80ms at 4k TPS. Instead, we can push each hash and the current timestamp onto a queue and periodically check the front of the queue, resulting in 1-5us cleanups at 4k TPS as measured on stressnet.

This cleanup process is currently run on the same tokio task that submits txs to monad-bft and thus contributes to "txpool not responding" errors due to the introduced delay. This change, when tested on stressnet, allowed for higher TPS while producing the same number of "txpool not responding" errors as without this change.