### PR TITLE
Remove the "received encoded symbol (100th)" RaptorCast debug trace event

### DIFF
--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -298,20 +298,6 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
 
             try_rebroadcast_symbol();
 
-            let num_buffers_received = decoder_state.decoder.num_encoded_symbols_received() + 1;
-
-            if (num_buffers_received % 100) == 0 {
-                tracing::debug!(
-                    self_id =? self.self_id,
-                    author =? parsed_message.author,
-                    unix_ts_ms = parsed_message.unix_ts_ms,
-                    app_message_hash =? parsed_message.app_message_hash,
-                    encoding_symbol_id,
-                    num_buffers_received,
-                    "received encoded symbol (100th)"
-                );
-            }
-
             // can we assert!(!decoder_state.decoder.decoding_done()) ?
 
             decoder_state


### PR DESCRIPTION
We added these trace events to try to debug symbol propagation delay
problems, but the better way to do this is to make packet captures of
the relevant RaptorCast traffic and running that through the Wireshark
RaptorCast dissector and/or running the RaptorCast pcap analysis
tooling on them -- so this debug message is pretty much useless now and
should just be removed.