### PR TITLE
Rpc uses txpool ipc socket to decide if bft is syncing

### DIFF
--- a/monad-rpc/src/account_handlers.rs
+++ b/monad-rpc/src/account_handlers.rs
@@ -146,8 +146,6 @@ pub async fn monad_eth_getTransactionCount<T: Triedb>(
 pub async fn monad_eth_syncing() -> Result<Value, JsonRpcError> {
     trace!("monad_eth_syncing");
 
-    // TODO. TBD where this data actually comes from
-
     serialize_result(serde_json::Value::Bool(false))
 }
 


### PR DESCRIPTION
Flexnet test to demonstrate behavior: https://github.com/category-labs/monad-integration/pull/234

Fixes https://github.com/category-labs/category-internal/issues/1135