### PR TITLE
Use proposal latency to compute timestamp adjustment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4401,6 +4401,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-blocktimestamp"
+version = "0.1.0"
+dependencies = [
+ "alloy-rlp",
+ "monad-consensus-types",
+ "monad-crypto",
+ "monad-proto",
+ "monad-testutil",
+ "monad-types",
+ "sorted-vec",
+ "tracing",
+]
+
+[[package]]
 name = "monad-blocktree"
 version = "0.1.0"
 dependencies = [
@@ -4490,6 +4504,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-consensus",
  "itertools 0.10.5",
+ "monad-blocktimestamp",
  "monad-blocktree",
  "monad-chain-config",
  "monad-consensus",
@@ -4503,7 +4518,6 @@ dependencies = [
  "monad-testutil",
  "monad-types",
  "monad-validator",
- "sorted-vec",
  "test-case",
  "tracing",
  "tracing-test",
@@ -4866,6 +4880,7 @@ dependencies = [
  "criterion",
  "futures",
  "monad-blocksync",
+ "monad-blocktimestamp",
  "monad-consensus",
  "monad-consensus-types",
  "monad-crypto",
@@ -5279,6 +5294,7 @@ dependencies = [
  "bytes",
  "itertools 0.10.5",
  "monad-blocksync",
+ "monad-blocktimestamp",
  "monad-blocktree",
  "monad-bls",
  "monad-chain-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4410,6 +4410,7 @@ dependencies = [
  "monad-proto",
  "monad-testutil",
  "monad-types",
+ "rand 0.8.5",
  "sorted-vec",
  "tracing",
 ]

--- a/monad-blocktimestamp/Cargo.toml
+++ b/monad-blocktimestamp/Cargo.toml
@@ -16,6 +16,7 @@ monad-proto = { workspace = true }
 
 alloy-rlp = { workspace = true }
 sorted-vec = { workspace = true }
+rand = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/monad-blocktimestamp/Cargo.toml
+++ b/monad-blocktimestamp/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "monad-blocktimestamp"
+version = "0.1.0"
+edition = "2021"
+
+# this is necessary for criterion bench options
+# https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+[lib]
+bench = false
+
+[dependencies]
+monad-consensus-types = { workspace = true }
+monad-crypto = { workspace = true }
+monad-types = { workspace = true }
+monad-proto = { workspace = true }
+
+alloy-rlp = { workspace = true }
+sorted-vec = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+monad-testutil = { workspace = true }

--- a/monad-blocktimestamp/src/convert/message.rs
+++ b/monad-blocktimestamp/src/convert/message.rs
@@ -1,0 +1,49 @@
+use monad_proto::{
+    error::ProtoError,
+    proto::blocktimestamp::{ProtoPingRequest, ProtoPingResponse},
+};
+
+use crate::messages::message::{PingRequestMessage, PingResponseMessage};
+
+impl From<&PingResponseMessage> for ProtoPingResponse {
+    fn from(value: &PingResponseMessage) -> Self {
+        let PingResponseMessage {
+            sequence,
+            avg_wait_ns,
+        } = value;
+        Self {
+            sequence: *sequence,
+            avg_wait_ns: *avg_wait_ns,
+        }
+    }
+}
+
+impl TryFrom<ProtoPingResponse> for PingResponseMessage {
+    type Error = ProtoError;
+
+    fn try_from(value: ProtoPingResponse) -> Result<Self, Self::Error> {
+        Ok(Self {
+            sequence: value.sequence,
+            avg_wait_ns: value.avg_wait_ns,
+        })
+    }
+}
+
+impl From<&PingRequestMessage> for ProtoPingRequest {
+    fn from(value: &PingRequestMessage) -> Self {
+        let PingRequestMessage { sequence } = value;
+        Self {
+            sequence: *sequence,
+        }
+    }
+}
+
+impl TryFrom<ProtoPingRequest> for PingRequestMessage {
+    type Error = ProtoError;
+
+    fn try_from(value: ProtoPingRequest) -> Result<Self, Self::Error> {
+        Ok(Self {
+            sequence: value.sequence,
+        })
+    }
+}

--- a/monad-blocktimestamp/src/convert/mod.rs
+++ b/monad-blocktimestamp/src/convert/mod.rs
@@ -1,0 +1,1 @@
+pub mod message;

--- a/monad-blocktimestamp/src/lib.rs
+++ b/monad-blocktimestamp/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod convert;
+pub mod messages;
+pub mod timestamp;
+pub mod timestamp_adjuster;

--- a/monad-blocktimestamp/src/messages/message.rs
+++ b/monad-blocktimestamp/src/messages/message.rs
@@ -1,0 +1,12 @@
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+pub struct PingResponseMessage {
+    pub sequence: u64,
+    pub avg_wait_ns: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+pub struct PingRequestMessage {
+    pub sequence: u64,
+}

--- a/monad-blocktimestamp/src/messages/mod.rs
+++ b/monad-blocktimestamp/src/messages/mod.rs
@@ -1,0 +1,1 @@
+pub mod message;

--- a/monad-blocktimestamp/src/timestamp.rs
+++ b/monad-blocktimestamp/src/timestamp.rs
@@ -4,6 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+// use rust_decimal::{self, Decimal, MathematicalOps, prelude::ToPrimitive};
 use monad_consensus_types::{
     clock::{Clock, TimestampAdjusterConfig},
     quorum_certificate::{TimestampAdjustment, TimestampAdjustmentDirection},
@@ -12,11 +13,13 @@ use monad_consensus_types::{
 };
 use monad_crypto::certificate_signature::PubKey;
 use monad_types::{Epoch, NodeId, PingSequence, Round};
+use sorted_vec::SortedVec;
 use tracing::debug;
 
-use crate::timestamp_adjuster::TimestampAdjuster;
+use crate::{messages::message::PingResponseMessage, timestamp_adjuster::TimestampAdjuster};
 
-const MAX_LATENCY_SAMPLES: usize = 100;
+const MAX_LATENCY_SAMPLES: usize = 11;
+const MAX_PROPOSAL_SAMPLES: usize = 11;
 
 pub const PING_PERIOD_SEC: usize = 30;
 
@@ -28,6 +31,40 @@ pub enum Error {
     OutOfBounds, // timestamp is out of bounds compared to local time
 }
 
+// TODO: make it a _Running_ median
+#[derive(Debug, Clone)]
+struct RunningMedian<T: Ord + Copy> {
+    last_median: Option<T>,
+    period: usize,
+    samples: SortedVec<T>,
+}
+
+// TODO: unify with timestamp_adjuster and compute running median.
+impl<T: Ord + Copy> RunningMedian<T> {
+    pub fn new(period: usize) -> Self {
+        assert!(period % 2 == 1, "median accuracy expects odd period");
+        Self {
+            last_median: None,
+            period,
+            samples: SortedVec::new(),
+        }
+    }
+
+    pub fn add_sample(&mut self, sample: T) {
+        self.samples.insert(sample);
+        if self.samples.len() == self.period {
+            let i = self.samples.len() / 2;
+            self.last_median = Some(self.samples[i]);
+            self.samples.clear();
+        }
+    }
+
+    pub fn get_median(&self) -> Option<T> {
+        self.last_median
+    }
+}
+
+// TODO: move RunningAverage and RunningMedian to the seaparate modules.
 #[derive(Debug, Clone)]
 struct RunningAverage {
     sum: Duration,
@@ -50,6 +87,7 @@ impl RunningAverage {
     }
 
     pub fn add_sample(&mut self, sample: Duration) {
+        // add some simple and inefficient (WIP) cut out fat tails
         if self.samples.len() == self.max_samples {
             self.sum -= self.samples[self.next_index];
             self.samples[self.next_index] = sample;
@@ -69,9 +107,10 @@ impl RunningAverage {
 /// Ping state per validator
 #[derive(Debug, Clone)]
 pub struct ValidatorPingState {
-    sequence: PingSequence,       // sequence number of the last ping sent
-    ping_latency: RunningAverage, // average latency of the last pings
-    last_ping_time: Instant,      // time of the last ping sent
+    sequence: PingSequence,           // sequence number of the last ping sent
+    ping_latency: RunningAverage,     // average latency of the last pings
+    last_ping_time: Instant,          // time of the last ping sent
+    proposal_latency: RunningAverage, // average latency of proposal
 }
 
 impl Default for ValidatorPingState {
@@ -81,6 +120,7 @@ impl Default for ValidatorPingState {
             sequence: PingSequence(0),
             ping_latency: RunningAverage::new(MAX_LATENCY_SAMPLES),
             last_ping_time: now,
+            proposal_latency: RunningAverage::new(MAX_LATENCY_SAMPLES),
         }
     }
 }
@@ -96,8 +136,8 @@ impl ValidatorPingState {
         self.sequence
     }
 
-    pub fn pong_received(&mut self, sequence: PingSequence) -> Option<Duration> {
-        if sequence != self.sequence {
+    pub fn pong_received(&mut self, sequence: u64) -> Option<Duration> {
+        if sequence != self.sequence.0 {
             return None;
         }
         // estimate latency as half the round trip time
@@ -111,7 +151,18 @@ impl ValidatorPingState {
     }
 
     fn update_latency(&mut self, latency: Duration) {
+        debug!(?latency, "add ping latency");
         self.ping_latency.add_sample(latency);
+    }
+    // approximate the time the broadcasted proposal was sent from the time direct ping
+    // was received and the average ping latency
+    fn update_proposal_latency(&mut self, elapsed_since_last_vote: Duration) {
+        self.proposal_latency.add_sample(elapsed_since_last_vote);
+        debug!(?elapsed_since_last_vote, "add proposal latency");
+    }
+
+    pub fn proposal_latency(&self) -> Option<Duration> {
+        self.proposal_latency.get_avg()
     }
 }
 
@@ -135,10 +186,12 @@ impl<P: PubKey> PingState<P> {
         }
     }
 
-    pub fn pong_received(&mut self, node_id: NodeId<P>, sequence: PingSequence) {
+    pub fn pong_received(&mut self, node_id: NodeId<P>, sequence: u64) {
+        debug!(?sequence, ?node_id, "Pong received");
         if let Some(validator_state) = self.validators.get_mut(&node_id) {
             if let Some(elapsed) = validator_state.pong_received(sequence) {
-                debug!(?node_id, elapsed_ms = ?elapsed.as_millis(), avg_latency_ms = ?validator_state.avg_latency().unwrap_or_default().as_millis(), "ping latency");
+                let avg_latency_ns = validator_state.avg_latency().unwrap_or_default().as_nanos();
+                debug!(?node_id, delta = elapsed.as_nanos() - avg_latency_ns, elapsed_ns = ?elapsed.as_nanos(), ?avg_latency_ns, "pong_received latency_tracing");
             }
         }
     }
@@ -205,6 +258,7 @@ impl<P: PubKey> PingState<P> {
             let idx = (hasher.finish() as usize) % self.schedule.len();
             self.schedule[idx].push(*validator);
         }
+        debug!("updating validators {:?}", self.schedule);
     }
 
     // returns list of nodes to send pings to on this tick
@@ -222,12 +276,86 @@ impl<P: PubKey> PingState<P> {
     fn get_latency(&self, node_id: &NodeId<P>) -> Option<Duration> {
         self.validators.get(node_id).and_then(|v| v.avg_latency())
     }
+
+    pub fn update_proposal_latency(&mut self, node_id: &NodeId<P>, latency: Duration) {
+        let validator_state = self.validators.entry(*node_id).or_default();
+        validator_state.update_proposal_latency(latency);
+        debug!(?node_id, ?latency, "Update proposal latency");
+    }
+
+    fn get_proposal_latency(&self, node_id: &NodeId<P>) -> Option<Duration> {
+        self.validators
+            .get(node_id)
+            .and_then(|v| v.proposal_latency())
+    }
 }
 
-#[derive(Debug)]
-struct SentVote {
+#[derive(Debug, Copy, Clone)]
+struct WaitState {
+    last_vote_received: Instant,
+    last_vote_round: Round,
+    avg: Option<u128>,
+    sum: Duration,
+    last_sample: Duration,
+    num_samples: u128,
+    max_samples: u128,
+}
+
+impl WaitState {
+    pub fn new(max_samples: u128, round: Round) -> Self {
+        assert!(max_samples > 0);
+        Self {
+            last_vote_received: Instant::now(),
+            last_vote_round: round,
+            sum: Default::default(),
+            avg: None,
+            last_sample: Default::default(),
+            num_samples: 0,
+            max_samples,
+        }
+    }
+
+    pub fn vote_received(&mut self, round: Round) {
+        self.last_vote_received = Instant::now();
+        self.last_vote_round = round;
+    }
+
+    pub fn qc_computed(&mut self, round: Round) {
+        if self.last_vote_round != round {
+            return;
+        }
+        let sample = self.last_vote_received.elapsed();
+        match self.num_samples.cmp(&self.max_samples) {
+            std::cmp::Ordering::Equal => {
+                assert!(self.num_samples == self.max_samples);
+                self.sum -= self.last_sample;
+                self.last_sample = sample;
+                self.sum += sample;
+                self.avg = Some(self.sum.as_nanos() / self.num_samples);
+            }
+            std::cmp::Ordering::Less => {
+                self.num_samples += 1;
+                self.sum += sample;
+                self.last_sample = sample;
+                self.avg = Some(self.sum.as_nanos() / self.num_samples);
+            }
+            std::cmp::Ordering::Greater => {
+                unreachable!("can not have more samples when max");
+            }
+        }
+        debug!(?sample, ?round, avg_wait_qc = self.avg, "qc_computed");
+    }
+
+    pub fn get_avg(&self) -> Option<u128> {
+        self.avg
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+struct SentVote<P: PubKey> {
+    node_id: NodeId<P>,
     round: Round,
-    timestamp: Instant,
+    timestamp: Duration,
 }
 #[derive(Debug)]
 pub struct BlockTimestamp<P: PubKey, T: Clock> {
@@ -235,10 +363,15 @@ pub struct BlockTimestamp<P: PubKey, T: Clock> {
     max_delta_ns: u128,
     ping_state: PingState<P>,
 
-    last_sent_vote: Option<SentVote>, // last voted round and timestamp
+    last_sent_vote: Option<SentVote<P>>, // last voted round and timestamp
+    last_received_proposal: Option<SentVote<P>>, // last received proposal and timestamp
 
     default_latency_estimate_ns: u128,
+    create_proposal_time_ns: RunningMedian<u128>,
     adjuster: Option<TimestampAdjuster>,
+
+    avg_wait_for_qc_self: BTreeMap<NodeId<P>, WaitState>,
+    avg_wait_for_qc: BTreeMap<NodeId<P>, u128>,
 }
 
 impl<P: PubKey, T: Clock> BlockTimestamp<P, T> {
@@ -248,31 +381,35 @@ impl<P: PubKey, T: Clock> BlockTimestamp<P, T> {
         adjuster_config: TimestampAdjusterConfig,
     ) -> Self {
         assert!(default_latency_estimate_ns > 0);
-        println!("adjuster_config: {:?}", adjuster_config);
+        debug!("adjuster_config: {:?}", adjuster_config);
         Self {
             clock: T::new(),
             max_delta_ns,
             default_latency_estimate_ns,
             ping_state: PingState::new(),
             last_sent_vote: None,
+            last_received_proposal: None,
+            create_proposal_time_ns: RunningMedian::new(MAX_PROPOSAL_SAMPLES),
             adjuster: match adjuster_config {
                 TimestampAdjusterConfig::Disabled => None,
                 TimestampAdjusterConfig::Enabled {
-                    max_delta,
+                    max_delta_ns,
                     adjustment_period,
-                } => Some(TimestampAdjuster::new(max_delta, adjustment_period)),
+                } => Some(TimestampAdjuster::new(max_delta_ns, adjustment_period)),
             },
+            avg_wait_for_qc_self: Default::default(),
+            avg_wait_for_qc: Default::default(),
         }
     }
 
-    fn is_valid_bounds(&self, timestamp: u128, vote_delay_ns: u128) -> bool {
+    fn is_valid_bounds(&self, timestamp_ns: u128, vote_delay_ns: u128) -> bool {
         let adjusted_now = self.get_adjusted_time();
         let max_delta_ns = self.max_delta_ns.saturating_add(vote_delay_ns);
 
-        let lower_bound = adjusted_now.saturating_sub(max_delta_ns);
-        let upper_bound = adjusted_now.saturating_add(max_delta_ns);
+        let lower_bound = adjusted_now.saturating_sub(Duration::from_nanos(max_delta_ns as u64));
+        let upper_bound = adjusted_now.saturating_add(Duration::from_nanos(max_delta_ns as u64));
 
-        lower_bound <= timestamp && timestamp <= upper_bound
+        lower_bound.as_nanos() <= timestamp_ns && timestamp_ns <= upper_bound.as_nanos()
     }
 
     fn handle_adjustment(&mut self, delta: TimestampAdjustment) {
@@ -281,22 +418,24 @@ impl<P: PubKey, T: Clock> BlockTimestamp<P, T> {
         }
     }
 
-    fn get_current_time(&self) -> u128 {
+    fn get_current_time(&self) -> Duration {
         self.clock.get()
     }
 
-    pub fn update_time(&mut self, time: u128) {
-        self.clock.update(time);
+    pub fn update_time(&mut self, time_ns: u64) {
+        self.clock.update(Duration::from_nanos(time_ns));
     }
 
-    pub fn get_adjusted_time(&self) -> u128 {
+    pub fn get_adjusted_time(&self) -> Duration {
         let now = self.get_current_time();
+
         if let Some(adjuster) = &self.adjuster {
             let adjustment = adjuster.get_adjustment();
             if adjustment >= 0 {
-                now.checked_add(adjustment as u128).unwrap_or(now)
+                now.checked_add(Duration::from_nanos(adjustment as u64))
+                    .unwrap_or(now)
             } else {
-                now.saturating_sub(adjustment.unsigned_abs() as u128)
+                now.saturating_sub(Duration::from_nanos(adjustment.unsigned_abs()))
             }
         } else {
             now
@@ -319,41 +458,76 @@ impl<P: PubKey, T: Clock> BlockTimestamp<P, T> {
         Ok(())
     }
 
-    fn compute_block_timestamp_adjustment(
-        &self,
-        curr_block_ts: u128,
-        author: &NodeId<P>,
-    ) -> Result<Option<TimestampAdjustment>, Error> {
-        // adjust for estimated latency
-        let latency = self
+    fn compute_clock_adjustment(&self, proposed_block_ts_ns: u128) -> Option<TimestampAdjustment> {
+        // return the delta between expected block time and actual block time for adjustment
+        let vote = self.last_sent_vote.unwrap();
+        let proposal = self.last_received_proposal.unwrap();
+
+        assert!(vote.node_id == proposal.node_id);
+        assert!(vote.round + Round(1) == proposal.round);
+        let proposal_local_ts_ns = proposal.timestamp.as_nanos();
+        let vote_ts_ns = vote.timestamp.as_nanos();
+
+        let net_latency_ns = self
             .ping_state
-            .get_latency(author)
+            .get_latency(&vote.node_id)
             .unwrap_or(Duration::from_nanos(
-                self.default_latency_estimate_ns.try_into().unwrap(),
-            ));
+                self.default_latency_estimate_ns as u64,
+            ))
+            .as_nanos();
 
-        let now = self.get_current_time();
-        // TODO: add proposal estimated time
-        let expected_block_ts = now.saturating_sub(latency.as_nanos());
+        let create_proposal_ns = self.create_proposal_time_ns.get_median().unwrap_or(0);
+        let proposal_full_latency_ns = proposal.timestamp.saturating_sub(vote.timestamp).as_nanos();
 
-        debug!(
-            ?curr_block_ts,
-            ?expected_block_ts,
-            ?now,
-            ?latency,
-            "Compute block ts adjustment"
-        );
-        if curr_block_ts > expected_block_ts {
-            Ok(Some(TimestampAdjustment {
-                delta: curr_block_ts - expected_block_ts,
+        let default_wait_for_qc: u128 = 0;
+        let wait_for_qc = *self
+            .avg_wait_for_qc
+            .get(&vote.node_id)
+            .unwrap_or(&default_wait_for_qc);
+        let expected_block_ts = vote
+            .timestamp
+            .as_nanos()
+            .saturating_add(net_latency_ns)
+            .saturating_add(wait_for_qc);
+        let estimated_raptorcast_latency_ns =
+            proposal_local_ts_ns.saturating_sub(expected_block_ts);
+
+        let delta = if proposed_block_ts_ns > expected_block_ts {
+            Some(TimestampAdjustment {
+                delta: proposed_block_ts_ns - expected_block_ts,
                 direction: TimestampAdjustmentDirection::Forward,
-            }))
+            })
         } else {
-            Ok(Some(TimestampAdjustment {
-                delta: expected_block_ts - curr_block_ts,
+            Some(TimestampAdjustment {
+                delta: expected_block_ts - proposed_block_ts_ns,
                 direction: TimestampAdjustmentDirection::Backward,
-            }))
-        }
+            })
+        };
+
+        let proposal_round = proposal.round;
+        let proposal_node_id = proposal.node_id;
+        let adjusted_now = self.get_adjusted_time().as_nanos();
+        debug!(
+            ?vote.node_id,
+            ?wait_for_qc,
+            now = self.clock.get().as_nanos(),
+            ?adjusted_now,
+            ?proposal_round,
+            ?proposal_node_id,
+            ?delta,
+            delta_ns = proposed_block_ts_ns - expected_block_ts,
+            ?vote_ts_ns,
+            ?proposed_block_ts_ns,
+            ?proposal_local_ts_ns,
+            ?create_proposal_ns,
+            ?net_latency_ns,
+            ?proposal_full_latency_ns,
+            ?estimated_raptorcast_latency_ns,
+            ?expected_block_ts,
+            "compute_clock_adjustment latency_tracing"
+        );
+
+        delta
     }
 
     pub fn update_validators<SCT>(
@@ -370,15 +544,26 @@ impl<P: PubKey, T: Clock> BlockTimestamp<P, T> {
         self.ping_state.tick()
     }
 
-    pub fn pong_received(&mut self, node_id: NodeId<P>, sequence: PingSequence) {
-        self.ping_state.pong_received(node_id, sequence);
+    pub fn pong_received(&mut self, sender: NodeId<P>, message: PingResponseMessage) {
+        self.ping_state.pong_received(sender, message.sequence);
+        debug!(?message, ?sender, "pong_received");
+        match self.avg_wait_for_qc.entry(sender) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(message.avg_wait_ns as u128);
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                *entry.get_mut() = message.avg_wait_ns as u128;
+            }
+        }
     }
 
-    pub fn vote_sent(&mut self, round: Round) {
+    pub fn vote_sent(&mut self, node_id: &NodeId<P>, round: Round) {
         self.last_sent_vote = Some(SentVote {
+            node_id: *node_id,
             round,
-            timestamp: Instant::now(),
+            timestamp: self.get_adjusted_time(),
         });
+        self.last_received_proposal = None;
     }
 
     pub fn enter_epoch(&mut self, epoch: Epoch) {
@@ -393,13 +578,73 @@ impl<P: PubKey, T: Clock> BlockTimestamp<P, T> {
         }
     }
 
-    pub fn proposal_received(&mut self, round: Round, received_block_ts: u128, author: &NodeId<P>) {
-        debug!(?round, ?author, ?received_block_ts, "Proposal received",);
-        // TODO: validate and add proposal data
-        if let Ok(Some(delta)) = self.compute_block_timestamp_adjustment(received_block_ts, &author)
-        {
-            self.handle_adjustment(delta);
+    pub fn proposal_received(
+        &mut self,
+        proposal_round: Round,
+        proposed_block_ts_ns: u128,
+        author: &NodeId<P>,
+    ) {
+        debug!(
+            ?proposal_round,
+            ?author,
+            ?proposed_block_ts_ns,
+            "Proposal received",
+        );
+        if let Some(vote) = self.last_sent_vote {
+            if vote.round + Round(1) == proposal_round && vote.node_id == *author {
+                let now = self.get_adjusted_time();
+                self.last_received_proposal = Some(SentVote {
+                    node_id: *author,
+                    round: proposal_round,
+                    timestamp: now,
+                });
+                let latency = now.saturating_sub(vote.timestamp);
+
+                debug!(
+                    ?author,
+                    ?proposed_block_ts_ns,
+                    last_vote_ns = vote.timestamp.as_nanos(),
+                    latency_ns = latency.as_nanos(),
+                    "latency_tracing proposal_received",
+                );
+                self.ping_state.update_proposal_latency(author, latency);
+                if let Some(delta) = self.compute_clock_adjustment(proposed_block_ts_ns) {
+                    debug!(
+                        ?author,
+                        ?delta,
+                        "latency_tracing proposal received, adding delta for timestamp"
+                    );
+                    self.handle_adjustment(delta);
+                }
+            }
         }
+    }
+
+    pub fn update_create_proposal_ns(&mut self, _round: Round, elapsed_ns: u128) {
+        self.create_proposal_time_ns.add_sample(elapsed_ns);
+    }
+
+    pub fn vote_received(&mut self, author: &NodeId<P>, round: Round) {
+        match self.avg_wait_for_qc_self.entry(*author) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(WaitState::new(101, round));
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                entry.get_mut().vote_received(round);
+            }
+        };
+    }
+    pub fn qc_ready(&mut self, round: Round) {
+        self.avg_wait_for_qc_self
+            .iter_mut()
+            .for_each(|(k, v)| v.qc_computed(round));
+    }
+
+    pub fn get_vote_wait(&self, sender: &NodeId<P>) -> Option<u128> {
+        if let Some(wait_state) = self.avg_wait_for_qc_self.get(sender) {
+            return wait_state.get_avg();
+        }
+        None
     }
 }
 
@@ -408,7 +653,7 @@ mod test {
     use std::{collections::BTreeSet, time::Duration};
 
     use monad_consensus_types::{
-        clock::TestClock,
+        clock::{TestClock, TimestampAdjusterConfig},
         quorum_certificate::{TimestampAdjustment, TimestampAdjustmentDirection},
         validator_data::{ValidatorData, ValidatorSetData, ValidatorSetDataWithEpoch},
     };
@@ -419,18 +664,21 @@ mod test {
     use monad_types::{Epoch, NodeId, Round, Stake};
 
     use super::{Error, PING_PERIOD_SEC};
-    use crate::{
-        timestamp::{PingState, TimestampAdjusterConfig, ValidatorPingState},
-        BlockTimestamp,
-    };
+    use crate::timestamp::{BlockTimestamp, PingState, ValidatorPingState, MAX_PROPOSAL_SAMPLES};
 
     type SignatureType = NopSignature;
     type SignatureCollection = MockSignatures<SignatureType>;
 
     #[test]
     fn test_block_timestamp_validate() {
-        let mut b =
-            BlockTimestamp::<NopPubKey, TestClock>::new(10, 1, TimestampAdjusterConfig::Disabled);
+        let mut b = BlockTimestamp::<NopPubKey, TestClock>::new(
+            10,
+            1,
+            TimestampAdjusterConfig::Enabled {
+                max_delta_ns: 100,
+                adjustment_period: 11,
+            },
+        );
         let author = NodeId::new(NopKeyPair::from_bytes(&mut [0; 32]).unwrap().pubkey());
         b.update_time(0);
 
@@ -458,7 +706,7 @@ mod test {
             .update_latency(Duration::from_nanos(1));
 
         b.update_time(10);
-        b.vote_sent(Round(0));
+        b.vote_sent(&author, Round(0));
 
         assert!(matches!(
             b.validate_block_timestamp(11, 11, 0).err().unwrap(),
@@ -479,32 +727,67 @@ mod test {
         let mut b =
             BlockTimestamp::<NopPubKey, TestClock>::new(10, 1, TimestampAdjusterConfig::Disabled);
         let author = NodeId::new(NopKeyPair::from_bytes(&mut [0; 32]).unwrap().pubkey());
+
+        // In the tests below the proposal latency is 0 since the time is not updated between vote_sent and proposal_received.
         b.update_time(12);
+        b.vote_sent(&author, Round(1));
 
-        // the tests below compute adjustment based on the default_latency set in the BlockTimestamp::new()
-        // and assuming that the time set in the update_time is the time when the proposal has arrived.
+        b.proposal_received(Round(2), 20, &author);
         assert!(matches!(
-            b.compute_block_timestamp_adjustment(20, &author),
-            Ok(Some(TimestampAdjustment {
-                delta: 9,
+            b.compute_clock_adjustment(20),
+            Some(TimestampAdjustment {
+                delta: 7,
                 direction: TimestampAdjustmentDirection::Forward
-            }))
+            })
         ));
 
+        b.proposal_received(Round(2), 13, &author);
         assert!(matches!(
-            b.compute_block_timestamp_adjustment(12, &author),
-            Ok(Some(TimestampAdjustment {
-                delta: 1,
-                direction: TimestampAdjustmentDirection::Forward
-            }))
-        ));
-
-        assert!(matches!(
-            b.compute_block_timestamp_adjustment(10, &author),
-            Ok(Some(TimestampAdjustment {
-                delta: 1,
+            b.compute_clock_adjustment(13),
+            Some(TimestampAdjustment {
+                delta: 0,
                 direction: TimestampAdjustmentDirection::Backward
-            }))
+            })
+        ));
+
+        b.proposal_received(Round(2), 10, &author);
+        assert!(matches!(
+            b.compute_clock_adjustment(10),
+            Some(TimestampAdjustment {
+                delta: 3,
+                direction: TimestampAdjustmentDirection::Backward
+            })
+        ));
+        // In the tests below the proposal latency is 5 since the time is between vote_sent and proposal_received is 5ns.
+        b.update_time(15);
+        b.vote_sent(&author, Round(1));
+        b.update_time(20);
+
+        b.proposal_received(Round(2), 22, &author);
+        assert!(matches!(
+            b.compute_clock_adjustment(22),
+            Some(TimestampAdjustment {
+                delta: 6,
+                direction: TimestampAdjustmentDirection::Forward
+            })
+        ));
+
+        b.proposal_received(Round(2), 12, &author);
+        assert!(matches!(
+            b.compute_clock_adjustment(16),
+            Some(TimestampAdjustment {
+                delta: 0,
+                direction: TimestampAdjustmentDirection::Backward
+            })
+        ));
+
+        b.proposal_received(Round(2), 10, &author);
+        assert!(matches!(
+            b.compute_clock_adjustment(10),
+            Some(TimestampAdjustment {
+                delta: 6,
+                direction: TimestampAdjustmentDirection::Backward
+            })
         ));
     }
 
@@ -530,18 +813,15 @@ mod test {
         );
 
         assert_eq!(
-            state.avg_latency().unwrap(),
-            state.ping_latency.sum / state.ping_latency.samples.len() as u32
+            state.avg_latency().unwrap().as_nanos(),
+            state.ping_latency.sum.as_nanos() / state.ping_latency.samples.len() as u128
         );
 
-        for _ in 0..50 {
-            state.update_latency(Duration::from_millis(50));
+        for i in 0..MAX_PROPOSAL_SAMPLES - 1 {
+            state.update_latency(Duration::from_millis(i as u64));
         }
 
-        assert_eq!(
-            state.ping_latency.sum,
-            state.ping_latency.samples.iter().sum::<Duration>()
-        );
+        assert_eq!(state.avg_latency().unwrap().as_millis(), 5);
 
         assert_eq!(
             state.avg_latency().unwrap(),

--- a/monad-blocktimestamp/src/timestamp_adjuster.rs
+++ b/monad-blocktimestamp/src/timestamp_adjuster.rs
@@ -2,7 +2,7 @@ use monad_consensus_types::quorum_certificate::{
     TimestampAdjustment, TimestampAdjustmentDirection,
 };
 use sorted_vec::SortedVec;
-use tracing::{info, trace};
+use tracing::{debug, info};
 
 #[derive(Debug)]
 pub struct TimestampAdjuster {
@@ -32,18 +32,21 @@ impl TimestampAdjuster {
     }
 
     pub fn add_delta(&mut self, delta: i64) {
-        trace!(delta, "add delta");
+        debug!(delta, "add delta");
         self.deltas.insert(delta);
         if self.deltas.len() == self.adjustment_period {
             let i = self.deltas.len() / 2;
-            self.adjustment += self.deltas[i];
+            let adjustment = self.deltas[i];
 
             info!(
+                median_idx = i,
                 median_delta = self.deltas[i],
-                adjustment = self.adjustment,
-                "local timestamper adjustment"
+                old_adjustment = self.adjustment,
+                new_adjustment = adjustment,
+                "Set block timestamper adjustment"
             );
 
+            self.adjustment = adjustment;
             self.deltas.clear();
         }
     }

--- a/monad-consensus-state/Cargo.toml
+++ b/monad-consensus-state/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 bench = false
 
 [dependencies]
+monad-blocktimestamp = { workspace = true }
 monad-blocktree = { workspace = true }
 monad-chain-config = { workspace = true }
 monad-consensus = { workspace = true }
@@ -19,7 +20,6 @@ monad-state-backend = { workspace = true }
 monad-types = { workspace = true }
 monad-validator = { workspace = true }
 
-sorted-vec = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/monad-consensus-types/src/clock.rs
+++ b/monad-consensus-types/src/clock.rs
@@ -1,10 +1,10 @@
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 #[derive(Debug)]
 pub enum TimestampAdjusterConfig {
     Disabled,
     Enabled {
-        max_delta: u128,
+        max_delta_ns: u128,
         adjustment_period: usize,
     },
 }
@@ -12,9 +12,9 @@ pub enum TimestampAdjusterConfig {
 pub trait Clock {
     fn new() -> Self;
 
-    fn get(&self) -> u128;
+    fn get(&self) -> Duration;
 
-    fn update(&mut self, time: u128);
+    fn update(&mut self, time: Duration);
 }
 
 #[derive(Debug)]
@@ -25,30 +25,31 @@ impl Clock for SystemClock {
         Self {}
     }
 
-    fn get(&self) -> u128 {
+    fn get(&self) -> Duration {
         SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
-            .as_nanos()
     }
 
-    fn update(&mut self, _time: u128) {}
+    fn update(&mut self, _time: Duration) {}
 }
 
 #[derive(Debug)]
 pub struct TestClock {
-    time: u128,
+    time: Duration,
 }
 
 impl Clock for TestClock {
     fn new() -> Self {
-        Self { time: 0 }
+        Self {
+            time: Duration::from_nanos(0),
+        }
     }
-    fn get(&self) -> u128 {
+    fn get(&self) -> Duration {
         self.time
     }
 
-    fn update(&mut self, time: u128) {
+    fn update(&mut self, time: Duration) {
         self.time = time;
     }
 }

--- a/monad-debugger/src/graphql.rs
+++ b/monad-debugger/src/graphql.rs
@@ -240,8 +240,8 @@ impl<'s> From<&'s MonadEventType> for GraphQLMonadEvent<'s> {
                 Self::ControlPanelEvent(GraphQLControlPanelEvent(event))
             }
             MonadEvent::TimestampUpdateEvent(event) => {
-                Self::TimestampEvent(GraphQLTimestampEvent(*event as u64)) // TODO: this is wrong but protobuf is not used in
-                                                                           // protocol and will be deleted
+                Self::TimestampEvent(GraphQLTimestampEvent(*event)) // TODO: this is wrong but protobuf is not used in
+                                                                    // protocol and will be deleted
             }
             MonadEvent::StateSyncEvent(event) => Self::StateSyncEvent(GraphQLStateSyncEvent(event)),
             MonadEvent::ConfigEvent(event) => Self::ConfigEvent(GraphQLConfigEvent(event)),

--- a/monad-eth-txpool-executor/src/lib.rs
+++ b/monad-eth-txpool-executor/src/lib.rs
@@ -179,9 +179,10 @@ where
                     ) {
                         Ok(proposed_execution_inputs) => {
                             let elapsed = create_proposal_start.elapsed();
+                            let elapsed_ns = elapsed.as_nanos();
 
                             self.metrics.create_proposal += 1;
-                            self.metrics.create_proposal_elapsed_ns += elapsed.as_nanos() as u64;
+                            self.metrics.create_proposal_elapsed_ns += elapsed_ns as u64;
 
                             self.events_tx
                                 .send(MempoolEvent::Proposal {
@@ -194,6 +195,7 @@ where
                                     delayed_execution_results,
                                     proposed_execution_inputs,
                                     last_round_tc,
+                                    elapsed_ns,
                                 })
                                 .expect("events never dropped");
                         }

--- a/monad-executor-glue/Cargo.toml
+++ b/monad-executor-glue/Cargo.toml
@@ -10,6 +10,7 @@ bench = false
 
 [dependencies]
 monad-blocksync = { workspace = true }
+monad-blocktimestamp = { workspace = true }
 monad-consensus = { workspace = true }
 monad-consensus-types = { workspace = true }
 monad-crypto = { workspace = true }

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -393,7 +393,9 @@ impl<S: SwarmRelation> MockExecutor<S> {
                 }
                 ExecutorEventType::Timestamp => {
                     let event = self.timestamper.next_tick();
-                    MockExecutorEvent::Event(MonadEvent::TimestampUpdateEvent(event.as_nanos()))
+                    MockExecutorEvent::Event(MonadEvent::TimestampUpdateEvent(
+                        event.as_nanos() as u64
+                    ))
                 }
                 ExecutorEventType::StateSync => {
                     return self.statesync.pop().map(MockExecutorEvent::Event)

--- a/monad-mock-swarm/src/node.rs
+++ b/monad-mock-swarm/src/node.rs
@@ -130,7 +130,7 @@ impl<S: SwarmRelation> NodeBuilder<S> {
                 block_sync_override_peers: self.state_builder.block_sync_override_peers,
                 consensus_config: self.state_builder.consensus_config,
                 adjuster_config: TimestampAdjusterConfig::Enabled {
-                    max_delta: 10000,
+                    max_delta_ns: 10000,
                     adjustment_period: 9,
                 },
                 _phantom: PhantomData,

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -358,7 +358,10 @@ async fn run(node_state: NodeState, reload_handle: ReloadHandle) -> Result<(), (
             timestamp_latency_estimate_ns: 20_000_000,
             _phantom: Default::default(),
         },
-        adjuster_config: TimestampAdjusterConfig::Disabled,
+        adjuster_config: TimestampAdjusterConfig::Enabled {
+            max_delta_ns: 499_000_000,
+            adjustment_period: 201,
+        },
         _phantom: PhantomData,
     };
 

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -359,7 +359,7 @@ async fn run(node_state: NodeState, reload_handle: ReloadHandle) -> Result<(), (
             _phantom: Default::default(),
         },
         adjuster_config: TimestampAdjusterConfig::Enabled {
-            max_delta_ns: 499_000_000,
+            max_delta_ns: 10_000_000_000,
             adjustment_period: 201,
         },
         _phantom: PhantomData,

--- a/monad-proto/proto/blocktimestamp.proto
+++ b/monad-proto/proto/blocktimestamp.proto
@@ -6,13 +6,12 @@ package monad_proto.blocktimestamp;
 import "basic.proto";
 
 message ProtoPingRequest {
-  monad_proto.basic.ProtoNodeId sender = 1;
-  uint64 sequence = 2;
+  uint64 sequence = 1;
 }
 
 message ProtoPingResponse {
-  monad_proto.basic.ProtoNodeId sender = 1;
-  uint64 sequence = 2;
+  uint64 sequence = 1;
+  uint64 avg_wait_ns = 2;
 }
 
 message ProtoPingTick { }

--- a/monad-proto/proto/event.proto
+++ b/monad-proto/proto/event.proto
@@ -105,6 +105,7 @@ message ProtoProposal {
   repeated bytes delayed_execution_results = 7;
   monad_proto.block.ProtoProposedExecutionInputs proposed_execution_inputs = 8;
   optional monad_proto.timeout.ProtoTimeoutCertificate last_round_tc = 9;
+  uint64 elapsed_ns = 10;
 }
 
 message ProtoForwardedTxs {
@@ -257,10 +258,20 @@ message ProtoConfigEvent {
   }
 }
 
+message ProtoPingRequestWithSender {
+  monad_proto.basic.ProtoNodeId sender = 1;
+  monad_proto.blocktimestamp.ProtoPingRequest request = 2;
+}
+
+message ProtoPingResponseWithSender {
+  monad_proto.basic.ProtoNodeId sender = 1;
+  monad_proto.blocktimestamp.ProtoPingResponse response = 2;
+}
+
 message ProtoBlockTimestampEvent {
   oneof event {
-    monad_proto.blocktimestamp.ProtoPingRequest ping_request = 1;
-    monad_proto.blocktimestamp.ProtoPingResponse ping_response = 2;
+    ProtoPingRequestWithSender ping_request = 1;
+    ProtoPingResponseWithSender ping_response = 2;
     monad_proto.blocktimestamp.ProtoPingTick ping_tick = 3;
     monad_proto.blocktimestamp.ProtoTimestampEnterEpoch timestamp_enter_epoch = 4;
   }

--- a/monad-proto/proto/message.proto
+++ b/monad-proto/proto/message.proto
@@ -5,6 +5,7 @@ package monad_proto.message;
 import "basic.proto";
 import "block.proto";
 import "blocksync.proto";
+import "blocktimestamp.proto";
 import "discovery.proto";
 import "signing.proto";
 import "timeout.proto";
@@ -115,8 +116,8 @@ message ProtoMonadMessage {
     ProtoBlockSyncResponseMessage block_sync_response = 3;
     ProtoForwardedTx forwarded_tx = 5;
     ProtoStateSyncNetworkMessage state_sync_message = 6;
-    ProtoPingRequest ping_request = 7;
-    ProtoPingResponse ping_response = 8;
+    monad_proto.blocktimestamp.ProtoPingRequest ping_request = 7;
+    monad_proto.blocktimestamp.ProtoPingResponse ping_response = 8;
   }
 }
 message ProtoDiscoveryRequest {
@@ -140,12 +141,4 @@ message ProtoRouterMessage {
     bytes app_message = 7;
     ProtoDiscoveryMessage discovery_message = 8;
   }
-}
-
-message ProtoPingRequest {
-  uint64 sequence = 1;
-}
-
-message ProtoPingResponse {
-  uint64 sequence = 1;
 }

--- a/monad-state/Cargo.toml
+++ b/monad-state/Cargo.toml
@@ -10,6 +10,7 @@ bench = false
 
 [dependencies]
 monad-blocksync = { workspace = true }
+monad-blocktimestamp = { workspace = true }
 monad-blocktree = { workspace = true }
 monad-chain-config = { workspace = true }
 monad-consensus = { workspace = true }

--- a/monad-state/src/consensus.rs
+++ b/monad-state/src/consensus.rs
@@ -296,6 +296,7 @@ where
                 delayed_execution_results,
                 proposed_execution_inputs,
                 last_round_tc,
+                elapsed_ns,
             } => {
                 consensus.metrics.consensus_events.creating_proposal += 1;
                 let block_body = ConsensusBlockBody::new(ConsensusBlockBodyInner {
@@ -314,6 +315,9 @@ where
                     round_signature,
                 );
 
+                consensus
+                    .block_timestamp
+                    .update_create_proposal_ns(round, elapsed_ns);
                 let p = ProposalMessage {
                     block_header,
                     block_body,

--- a/monad-state/src/convert/message.rs
+++ b/monad-state/src/convert/message.rs
@@ -3,7 +3,7 @@ use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_proto::{error::ProtoError, proto::message::*};
-use monad_types::{ExecutionProtocol, PingSequence};
+use monad_types::ExecutionProtocol;
 
 use crate::{MonadMessage, VerifiedMonadMessage};
 
@@ -34,14 +34,10 @@ where
                     proto_monad_message::OneofMessage::StateSyncMessage(msg.into())
                 }
                 VerifiedMonadMessage::PingRequest(msg) => {
-                    proto_monad_message::OneofMessage::PingRequest(ProtoPingRequest {
-                        sequence: msg.0,
-                    })
+                    proto_monad_message::OneofMessage::PingRequest(msg.into())
                 }
                 VerifiedMonadMessage::PingResponse(msg) => {
-                    proto_monad_message::OneofMessage::PingResponse(ProtoPingResponse {
-                        sequence: msg.0,
-                    })
+                    proto_monad_message::OneofMessage::PingResponse(msg.into())
                 }
             }),
         }
@@ -74,10 +70,10 @@ where
                 MonadMessage::StateSyncMessage(msg.try_into()?)
             }
             Some(proto_monad_message::OneofMessage::PingRequest(msg)) => {
-                MonadMessage::PingRequest(PingSequence(msg.sequence))
+                MonadMessage::PingRequest(msg.try_into()?)
             }
             Some(proto_monad_message::OneofMessage::PingResponse(msg)) => {
-                MonadMessage::PingResponse(PingSequence(msg.sequence))
+                MonadMessage::PingResponse(msg.try_into()?)
             }
             None => Err(ProtoError::MissingRequiredField(
                 "MonadMessage.oneofmessage".to_owned(),

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1128,7 +1128,7 @@ where
                     tracing::debug!(?sender, ?message, "received ping request");
                     let mut vote_wait: u128 = 0;
                     if let Some(avg_vote_wait) = self.block_timestamp.get_vote_wait(&sender) {
-                        vote_wait = avg_vote_wait;
+                        vote_wait = avg_vote_wait.as_nanos();
                     }
                     let message = PingResponseMessage {
                         sequence: message.sequence,

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -112,7 +112,7 @@ pub fn make_state_configs<S: SwarmRelation>(
             },
 
             adjuster_config: TimestampAdjusterConfig::Enabled {
-                max_delta: 10000,
+                max_delta_ns: 10000,
                 adjustment_period: 9,
             },
             _phantom: PhantomData,

--- a/monad-twins/utils/src/twin_reader.rs
+++ b/monad-twins/utils/src/twin_reader.rs
@@ -138,7 +138,7 @@ where
 
                 consensus_config: self.state_config.consensus_config,
                 adjuster_config: TimestampAdjusterConfig::Enabled {
-                    max_delta: 100,
+                    max_delta_ns: 100,
                     adjustment_period: 10001,
                 },
                 _phantom: PhantomData,
@@ -390,7 +390,7 @@ where
             },
 
             adjuster_config: TimestampAdjusterConfig::Enabled {
-                max_delta: 100,
+                max_delta_ns: 100,
                 adjustment_period: 10001,
             },
             _phantom: PhantomData,

--- a/monad-updaters/src/tokio_timestamp.rs
+++ b/monad-updaters/src/tokio_timestamp.rs
@@ -47,7 +47,7 @@ where
                 let epoch_time = start
                     .duration_since(UNIX_EPOCH)
                     .expect("Clock may have gone backwards");
-                let t = epoch_time.as_nanos();
+                let t = epoch_time.as_nanos() as u64;
                 Poll::Ready(Some(MonadEvent::TimestampUpdateEvent(t)))
             }
             Poll::Pending => Poll::Pending,

--- a/monad-updaters/src/txpool.rs
+++ b/monad-updaters/src/txpool.rs
@@ -140,6 +140,7 @@ where
     type Command = TxPoolCommand<ST, SCT, MockExecutionProtocol, BPT, SBT>;
 
     fn exec(&mut self, commands: Vec<Self::Command>) {
+        let elapsed_ns: u128 = 0;
         for command in commands {
             match command {
                 TxPoolCommand::CreateProposal {
@@ -170,6 +171,7 @@ where
                             body: MockExecutionBody::default(),
                         },
                         last_round_tc,
+                        elapsed_ns,
                     });
 
                     if let Some(waker) = self.waker.take() {
@@ -208,6 +210,7 @@ where
         let mut event_tracker = EthTxPoolEventTracker::new(&mut self.metrics, &mut events);
 
         for command in commands {
+            let elapsed_ns: u128 = 0;
             match command {
                 TxPoolCommand::CreateProposal {
                     epoch,
@@ -250,6 +253,7 @@ where
                         delayed_execution_results,
                         proposed_execution_inputs,
                         last_round_tc,
+                        elapsed_ns,
                     });
 
                     if let Some(waker) = self.waker.take() {


### PR DESCRIPTION
Compute estimated timestamp of the current block as  `VoteSent ts +  NetworkLatency + average estimated wait for qc`.

This is the 3rd PR out of the 3 PRs implementing clock adjustment for accurate timestamp estimation. 
the other 2 are:

1st: "Implement periodic pings to calculate network latency" : https://github.com/category-labs/monad-bft/pull/1675
2nd: "Use OS time directly for block timestamp" : https://github.com/category-labs/monad-bft/pull/1777