### PR TITLE
Move monad-node binaries instead of directories to output Docker image

### DIFF
--- a/docker/devnet/Dockerfile
+++ b/docker/devnet/Dockerfile
@@ -90,9 +90,9 @@ ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=1
 
-COPY --from=builder /usr/src/monad-bft/monad-node /usr/local/bin/monad-node
+COPY --from=builder /usr/src/monad-bft/monad-node/monad-node /usr/local/bin/monad-node
 COPY --from=builder /usr/src/monad-bft/keystore /usr/local/bin/keystore
-COPY --from=builder /usr/src/monad-bft/monad-debug-node /usr/local/bin/monad-debug-node
+COPY --from=builder /usr/src/monad-bft/monad-debug-node/monad-debug-node /usr/local/bin/monad-debug-node
 COPY --from=builder /usr/src/monad-bft/ledger-tail /usr/local/bin/ledger-tail
 COPY --from=builder /usr/src/monad-bft/wal2json /usr/local/bin/wal2json
 COPY --from=builder /usr/src/monad-bft/wal-tool /usr/local/bin/wal-tool

--- a/docker/devnet/fullnode.Dockerfile
+++ b/docker/devnet/fullnode.Dockerfile
@@ -90,9 +90,9 @@ ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=1
 
-COPY --from=builder /usr/src/monad-bft/monad-node /usr/local/bin/monad-full-node
+COPY --from=builder /usr/src/monad-bft/monad-node/monad-node /usr/local/bin/monad-full-node
 COPY --from=builder /usr/src/monad-bft/keystore /usr/local/bin/keystore
-COPY --from=builder /usr/src/monad-bft/monad-debug-node /usr/local/bin/monad-debug-node
+COPY --from=builder /usr/src/monad-bft/monad-debug-node/monad-debug-node /usr/local/bin/monad-debug-node
 COPY --from=builder /usr/src/monad-bft/ledger-tail /usr/local/bin/ledger-tail
 COPY --from=builder /usr/src/monad-bft/wal2json /usr/local/bin/wal2json
 COPY --from=builder /usr/src/monad-bft/wal-tool /usr/local/bin/wal-tool


### PR DESCRIPTION
https://github.com/category-labs/monad-bft/commit/37a2cde8d8e20d2e7fcadd924cf19fafb768df5a#diff-19de6207f10d0b818b2c5e0ae35894d4841b412c2903a7361914ecdfb5a2b35b did some refactors of how things get built, and as a side effect, what was originally a binary is now a directory containing the binary. This copies the binary itself to the final image instead of the whole directory