### PR TITLE
Use generic signature instead of pubkey in peer disc swarm

### DIFF
--- a/monad-peer-disc-swarm/src/lib.rs
+++ b/monad-peer-disc-swarm/src/lib.rs
@@ -24,6 +24,7 @@ pub mod driver;
 
 pub type SwarmPubKeyType<S> =
     CertificateSignaturePubKey<<S as PeerDiscSwarmRelation>::SignatureType>;
+pub type SwarmSignatureType<S> = <S as PeerDiscSwarmRelation>::SignatureType;
 
 pub struct Swarm<S>
 where
@@ -34,13 +35,13 @@ where
 
 pub trait PeerDiscSwarmRelation {
     type SignatureType: CertificateSignatureRecoverable;
-    type PeerDiscoveryAlgoType: PeerDiscoveryAlgo<PubKeyType = SwarmPubKeyType<Self>>;
+    type PeerDiscoveryAlgoType: PeerDiscoveryAlgo<SignatureType = SwarmSignatureType<Self>>;
 
     type TransportMessage;
     type RouterSchedulerType: RouterScheduler<
             NodeIdPublicKey = SwarmPubKeyType<Self>,
-            OutboundMessage = PeerDiscoveryMessage<SwarmPubKeyType<Self>>,
-            InboundMessage = PeerDiscoveryMessage<SwarmPubKeyType<Self>>,
+            OutboundMessage = PeerDiscoveryMessage<SwarmSignatureType<Self>>,
+            InboundMessage = PeerDiscoveryMessage<SwarmSignatureType<Self>>,
             TransportMessage = Self::TransportMessage,
         >;
 }
@@ -79,8 +80,8 @@ where
     pub id: NodeId<SwarmPubKeyType<S>>,
     pub peer_disc_driver: MockDiscoveryDriver<
         S::PeerDiscoveryAlgoType,
-        PeerDiscoveryEvent<SwarmPubKeyType<S>>,
-        SwarmPubKeyType<S>,
+        PeerDiscoveryEvent<SwarmSignatureType<S>>,
+        SwarmSignatureType<S>,
     >,
     pub executor: MockPeerDiscExecutor<S>,
     pub pending_inbound_messages:
@@ -137,7 +138,7 @@ impl<S: PeerDiscSwarmRelation> MockPeerDiscExecutor<S> {
         until: Duration,
     ) -> Option<
         MockPeerDiscExecutorEvent<
-            PeerDiscoveryEvent<SwarmPubKeyType<S>>,
+            PeerDiscoveryEvent<SwarmSignatureType<S>>,
             SwarmPubKeyType<S>,
             S::TransportMessage,
         >,

--- a/monad-peer-disc-swarm/tests/ping_pong.rs
+++ b/monad-peer-disc-swarm/tests/ping_pong.rs
@@ -1,11 +1,9 @@
 use std::time::Duration;
 
-use monad_crypto::{
-    NopSignature,
-    certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey},
-};
+use monad_crypto::{NopSignature, certificate_signature::CertificateKeyPair};
 use monad_peer_disc_swarm::{
-    NodeBuilder, PeerDiscSwarmRelation, SwarmPubKeyType, builder::PeerDiscSwarmBuilder,
+    NodeBuilder, PeerDiscSwarmRelation, SwarmPubKeyType, SwarmSignatureType,
+    builder::PeerDiscSwarmBuilder,
 };
 use monad_peer_discovery::{
     algo::{PeerDiscoveryAlgo, PeerDiscoveryMessage},
@@ -20,14 +18,14 @@ struct PingPongPeerDiscSwarm {}
 impl PeerDiscSwarmRelation for PingPongPeerDiscSwarm {
     type SignatureType = NopSignature;
 
-    type PeerDiscoveryAlgoType = PingPongDiscovery<SwarmPubKeyType<Self>>;
+    type PeerDiscoveryAlgoType = PingPongDiscovery<SwarmSignatureType<Self>>;
 
-    type TransportMessage = PeerDiscoveryMessage<SwarmPubKeyType<Self>>;
+    type TransportMessage = PeerDiscoveryMessage<SwarmSignatureType<Self>>;
 
     type RouterSchedulerType = NoSerRouterScheduler<
         SwarmPubKeyType<Self>,
-        PeerDiscoveryMessage<SwarmPubKeyType<Self>>,
-        PeerDiscoveryMessage<SwarmPubKeyType<Self>>,
+        PeerDiscoveryMessage<SwarmSignatureType<Self>>,
+        PeerDiscoveryMessage<SwarmSignatureType<Self>>,
     >;
 }
 
@@ -42,7 +40,7 @@ fn test_ping_pong() {
         .collect::<Vec<_>>();
     let swarm_builder = PeerDiscSwarmBuilder::<
         PingPongPeerDiscSwarm,
-        PingPongDiscoveryBuilder<CertificateSignaturePubKey<SignatureType>>,
+        PingPongDiscoveryBuilder<SignatureType>,
     > {
         builders: keys
             .iter()


### PR DESCRIPTION
This will help with the rebase with the peer discovery crate later. Since peer discovery requires using both `P: PubKey` and `ST: CertificateSignatureRecoverable` trait, and their relationship is `CertificateSignaturePubKey<ST>==P`, we can just use ST as the generic trait 