### PR TITLE
Add apt-get update to Rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
       - name: Install dependencies
         run: |
-          sudo apt-get install -y \
+          sudo apt-get update && sudo apt-get install -y \
             libboost-fiber1.83.0 \
             libboost-json1.83.0 \
             libboost-stacktrace1.83.0 \


### PR DESCRIPTION
Currently, the Rust pipeline isn't working due to a broken apt package reference - make sure to update before performing install