### PR TITLE
Limit amount of memory allocated on the statesync client

### DIFF
--- a/monad-proto/proto/message.proto
+++ b/monad-proto/proto/message.proto
@@ -95,11 +95,16 @@ message ProtoStateSyncBadVersion {
   uint32 max_version = 2;
 }
 
+message ProtoStateSyncCompletion {
+  uint64 session_id = 1;
+}
+
 message ProtoStateSyncNetworkMessage {
   oneof OneofMessage {
     ProtoStateSyncRequest request = 1;
     ProtoStateSyncResponse response = 2;
     ProtoStateSyncBadVersion bad_version = 3;
+    ProtoStateSyncCompletion completion = 4;
   }
 }
 

--- a/monad-rpc/src/timing.rs
+++ b/monad-rpc/src/timing.rs
@@ -71,7 +71,7 @@ where
 
     forward_ready!(service);
 
-    fn call(&self, mut req: ServiceRequest) -> Self::Future {
+    fn call(&self, req: ServiceRequest) -> Self::Future {
         let start_time = Instant::now();
 
         let request_id = RequestId::new();

--- a/monad-updaters/src/statesync.rs
+++ b/monad-updaters/src/statesync.rs
@@ -167,6 +167,7 @@ where
                         }
                     }
                     StateSyncNetworkMessage::BadVersion(_) => {}
+                    StateSyncNetworkMessage::Completion(_) => {}
                 },
             }
         }


### PR DESCRIPTION
Send completion message after processing server responses. Limit messages outstanding to the client without receiving completion messages. This puts a limit on the amount of memory that can be used on the client.

Timeout the client session if the client fails to acknowledge messages within certain period.

Handle server having mismatched version. If server does not support clients maximum version, downgrade version and retry requests.