### PR TITLE
Add --unsafe-skip-bad-blocks

### DIFF
--- a/monad-archive/src/bin/monad-archiver/cli.rs
+++ b/monad-archive/src/bin/monad-archiver/cli.rs
@@ -35,6 +35,13 @@ pub struct Cli {
     #[arg(long)]
     pub stop_block: Option<u64>,
 
+    /// Skip bad blocks
+    /// If set, archiver will skip blocks that fail to archive
+    /// and log an error
+    /// DO NOT ENABLE UNDER NORMAL OPERATION
+    #[arg(long)]
+    pub unsafe_skip_bad_blocks: bool,
+
     /// Path to folder containing bft blocks
     /// If set, archiver will upload these files to blob store provided in archive_sink
     #[arg(long)]

--- a/monad-archive/src/bin/monad-archiver/main.rs
+++ b/monad-archive/src/bin/monad-archiver/main.rs
@@ -99,6 +99,7 @@ async fn main() -> Result<()> {
         args.max_concurrent_blocks,
         args.start_block,
         args.stop_block,
+        args.unsafe_skip_bad_blocks,
         metrics,
     ))
     .await


### PR DESCRIPTION
This allows continueing archiving past known bad
blocks.
This option should not be enabled during normal operation