### PR TITLE
monad-dataplane: set socket buffers to 62500000 by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "slab",
- "socket2 0.5.7",
+ "socket2 0.5.9",
  "tokio",
 ]
 
@@ -164,7 +164,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio 0.8.9",
- "socket2 0.5.7",
+ "socket2 0.5.9",
  "tokio",
  "tracing",
 ]
@@ -267,7 +267,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.5.7",
+ "socket2 0.5.9",
  "time",
  "url",
 ]
@@ -3550,7 +3550,7 @@ dependencies = [
  "http-body 1.0.1",
  "hyper 1.4.1",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.5.9",
  "tokio",
  "tower 0.4.13",
  "tower-service",
@@ -3859,7 +3859,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.7",
+ "socket2 0.5.9",
  "widestring",
  "windows-sys 0.48.0",
  "winreg 0.50.0",
@@ -4029,9 +4029,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libgit2-sys"
@@ -4568,6 +4568,7 @@ dependencies = [
  "monoio",
  "ntest",
  "rand 0.8.5",
+ "socket2 0.5.9",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5594,7 +5595,7 @@ dependencies = [
  "serde_with",
  "sha-1",
  "sha2",
- "socket2 0.5.7",
+ "socket2 0.5.9",
  "stringprep",
  "strsim 0.11.1",
  "take_mut",
@@ -5637,7 +5638,7 @@ dependencies = [
  "nix",
  "once_cell",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.5.9",
  "threadpool",
  "windows-sys 0.48.0",
 ]
@@ -6550,7 +6551,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.0",
  "rustls 0.23.21",
- "socket2 0.5.7",
+ "socket2 0.5.9",
  "thiserror 2.0.9",
  "tokio",
  "tracing",
@@ -6585,7 +6586,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.7",
+ "socket2 0.5.9",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -7657,9 +7658,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -8130,7 +8131,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.7",
+ "socket2 0.5.9",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,6 +173,7 @@ serde_json = "1.0"
 serial_test = "3.2.0"
 sha2 = "0.10"
 simple-xml-builder = "1.1"
+socket2 = "0.5.9"
 sorted_vector_map = "0.2.0"
 sorted-vec = "0.8.3"
 syn = { version = "1.0.0", features = ["full"] }

--- a/monad-dataplane/Cargo.toml
+++ b/monad-dataplane/Cargo.toml
@@ -16,6 +16,7 @@ futures-util = { workspace = true }
 libc = { workspace = true }
 monoio = { workspace = true }
 rand = { workspace = true }
+socket2 = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 zerocopy = { workspace = true }

--- a/monad-dataplane/examples/node.rs
+++ b/monad-dataplane/examples/node.rs
@@ -9,7 +9,9 @@ use std::{
 use bytes::{Bytes, BytesMut};
 use futures::{executor, Stream};
 use futures_util::FutureExt;
-use monad_dataplane::{udp::DEFAULT_SEGMENT_SIZE, BroadcastMsg, Dataplane, RecvMsg, TcpMsg};
+use monad_dataplane::{
+    udp::DEFAULT_SEGMENT_SIZE, BroadcastMsg, Dataplane, DataplaneBuilder, RecvMsg, TcpMsg,
+};
 use rand::Rng;
 
 const NODE_ONE_ADDR: &str = "127.0.0.1:60000";
@@ -97,7 +99,7 @@ struct Node {
 impl Node {
     pub fn new(addr: &SocketAddr, target_addr: &str) -> Self {
         Self {
-            network: Dataplane::new(addr, 1_000),
+            network: DataplaneBuilder::new(addr, 1_000).build(),
             target: target_addr.parse().unwrap(),
         }
     }

--- a/monad-dataplane/src/buffer_ext.rs
+++ b/monad-dataplane/src/buffer_ext.rs
@@ -1,0 +1,42 @@
+use std::{
+    io,
+    os::fd::{AsRawFd, FromRawFd, IntoRawFd},
+};
+
+pub(crate) trait SocketBufferExt {
+    fn set_recv_buffer_size(&self, size: usize) -> io::Result<()>;
+    fn recv_buffer_size(&self) -> io::Result<usize>;
+
+    fn set_send_buffer_size(&self, size: usize) -> io::Result<()>;
+    fn send_buffer_size(&self) -> io::Result<usize>;
+}
+
+impl<T: AsRawFd> SocketBufferExt for T {
+    fn set_recv_buffer_size(&self, size: usize) -> io::Result<()> {
+        let sock = unsafe { socket2::Socket::from_raw_fd(self.as_raw_fd()) };
+        let rst = sock.set_recv_buffer_size(size);
+        _ = sock.into_raw_fd(); // defuse drop
+        rst
+    }
+
+    fn recv_buffer_size(&self) -> io::Result<usize> {
+        let sock = unsafe { socket2::Socket::from_raw_fd(self.as_raw_fd()) };
+        let rst = sock.recv_buffer_size();
+        _ = sock.into_raw_fd(); // defuse drop
+        rst
+    }
+
+    fn set_send_buffer_size(&self, size: usize) -> io::Result<()> {
+        let sock = unsafe { socket2::Socket::from_raw_fd(self.as_raw_fd()) };
+        let rst = sock.set_send_buffer_size(size);
+        _ = sock.into_raw_fd(); // defuse drop
+        rst
+    }
+
+    fn send_buffer_size(&self) -> io::Result<usize> {
+        let sock = unsafe { socket2::Socket::from_raw_fd(self.as_raw_fd()) };
+        let rst = sock.send_buffer_size();
+        _ = sock.into_raw_fd(); // defuse drop
+        rst
+    }
+}

--- a/monad-dataplane/src/tcp/mod.rs
+++ b/monad-dataplane/src/tcp/mod.rs
@@ -40,9 +40,10 @@ pub fn spawn_tasks(
     local_addr: SocketAddr,
     tcp_ingress_tx: mpsc::Sender<(SocketAddr, Bytes)>,
     tcp_egress_rx: mpsc::Receiver<(SocketAddr, TcpMsg)>,
+    buffer_size: Option<usize>,
 ) {
-    spawn(rx::task(local_addr, tcp_ingress_tx));
-    spawn(tx::task(tcp_egress_rx));
+    spawn(rx::task(local_addr, tcp_ingress_tx, buffer_size));
+    spawn(tx::task(tcp_egress_rx, buffer_size));
 }
 
 // Minimum message receive/transmit speed in bytes per second.  Messages that are

--- a/monad-dataplane/tests/address_family_mismatch.rs
+++ b/monad-dataplane/tests/address_family_mismatch.rs
@@ -1,6 +1,6 @@
 use std::{thread::sleep, time::Duration};
 
-use monad_dataplane::{udp::DEFAULT_SEGMENT_SIZE, BroadcastMsg, Dataplane};
+use monad_dataplane::{udp::DEFAULT_SEGMENT_SIZE, BroadcastMsg, DataplaneBuilder};
 use tracing::debug;
 
 /// 1_000 = 1 Gbps, 10_000 = 10 Gbps
@@ -25,7 +25,8 @@ fn address_family_mismatch() {
     }));
 
     for addr in BIND_ADDRS {
-        let mut dataplane = Dataplane::new(&addr.parse().unwrap(), UP_BANDWIDTH_MBPS);
+        let mut dataplane =
+            DataplaneBuilder::new(&addr.parse().unwrap(), UP_BANDWIDTH_MBPS).build();
 
         // Allow Dataplane thread to set itself up.
         sleep(Duration::from_millis(10));

--- a/monad-dataplane/tests/tests.rs
+++ b/monad-dataplane/tests/tests.rs
@@ -4,7 +4,7 @@ use futures::{channel::oneshot, executor};
 use monad_dataplane::{
     tcp::tx::{MSG_WAIT_TIMEOUT, QUEUED_MESSAGE_LIMIT},
     udp::DEFAULT_SEGMENT_SIZE,
-    BroadcastMsg, Dataplane, RecvMsg, TcpMsg, UnicastMsg,
+    BroadcastMsg, DataplaneBuilder, RecvMsg, TcpMsg, UnicastMsg,
 };
 use ntest::timeout;
 use rand::Rng;
@@ -33,8 +33,8 @@ fn udp_broadcast() {
     let tx_addr = "127.0.0.1:9001".parse().unwrap();
     let num_msgs = 10;
 
-    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS);
-    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS);
+    let mut rx = DataplaneBuilder::new(&rx_addr, UP_BANDWIDTH_MBPS).build();
+    let mut tx = DataplaneBuilder::new(&tx_addr, UP_BANDWIDTH_MBPS).build();
 
     // Allow Dataplane threads to set themselves up.
     sleep(Duration::from_millis(10));
@@ -66,8 +66,8 @@ fn udp_unicast() {
     let tx_addr = "127.0.0.1:9003".parse().unwrap();
     let num_msgs = 10;
 
-    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS);
-    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS);
+    let mut rx = DataplaneBuilder::new(&rx_addr, UP_BANDWIDTH_MBPS).build();
+    let mut tx = DataplaneBuilder::new(&tx_addr, UP_BANDWIDTH_MBPS).build();
 
     // Allow Dataplane threads to set themselves up.
     sleep(Duration::from_millis(10));
@@ -100,8 +100,8 @@ fn tcp_very_slow() {
     let tx_addr = "127.0.0.1:9005".parse().unwrap();
     let num_msgs = 2;
 
-    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS);
-    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS);
+    let mut rx = DataplaneBuilder::new(&rx_addr, UP_BANDWIDTH_MBPS).build();
+    let mut tx = DataplaneBuilder::new(&tx_addr, UP_BANDWIDTH_MBPS).build();
 
     // Allow Dataplane threads to set themselves up.
     sleep(Duration::from_millis(10));
@@ -143,8 +143,8 @@ fn tcp_slow() {
     let tx_addr = "127.0.0.1:9007".parse().unwrap();
     let num_msgs = 10;
 
-    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS);
-    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS);
+    let mut rx = DataplaneBuilder::new(&rx_addr, UP_BANDWIDTH_MBPS).build();
+    let mut tx = DataplaneBuilder::new(&tx_addr, UP_BANDWIDTH_MBPS).build();
 
     // Allow Dataplane threads to set themselves up.
     sleep(Duration::from_millis(10));
@@ -183,8 +183,8 @@ fn tcp_rapid() {
     let tx_addr = "127.0.0.1:9009".parse().unwrap();
     let num_msgs = 1024;
 
-    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS);
-    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS);
+    let mut rx = DataplaneBuilder::new(&rx_addr, UP_BANDWIDTH_MBPS).build();
+    let mut tx = DataplaneBuilder::new(&tx_addr, UP_BANDWIDTH_MBPS).build();
 
     // Allow Dataplane threads to set themselves up.
     sleep(Duration::from_millis(10));
@@ -232,8 +232,8 @@ fn tcp_connect_fail() {
     let rx_addr = "127.0.0.1:9010".parse().unwrap();
     let tx_addr = "127.0.0.1:9011".parse().unwrap();
 
-    // let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS);
-    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS);
+    // let mut rx = DataplaneBuilder::new(&rx_addr, UP_BANDWIDTH_MBPS).build();
+    let mut tx = DataplaneBuilder::new(&tx_addr, UP_BANDWIDTH_MBPS).build();
 
     // Allow Dataplane threads to set themselves up.
     sleep(Duration::from_millis(10));
@@ -264,8 +264,8 @@ fn tcp_exceed_queue_limits() {
     let tx_addr = "127.0.0.1:9013".parse().unwrap();
     let num_msgs = 100 * QUEUED_MESSAGE_LIMIT;
 
-    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS);
-    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS);
+    let mut rx = DataplaneBuilder::new(&rx_addr, UP_BANDWIDTH_MBPS).build();
+    let mut tx = DataplaneBuilder::new(&tx_addr, UP_BANDWIDTH_MBPS).build();
 
     // Allow Dataplane threads to set themselves up.
     sleep(Duration::from_millis(10));
@@ -322,8 +322,10 @@ fn broadcast_all_strides() {
     let rx_addr = "127.0.0.1:9014".parse().unwrap();
     let tx_addr = "127.0.0.1:9015".parse().unwrap();
 
-    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS);
-    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS);
+    let mut rx = DataplaneBuilder::new(&rx_addr, UP_BANDWIDTH_MBPS)
+        .with_buffer_size(400 << 10)
+        .build();
+    let mut tx = DataplaneBuilder::new(&tx_addr, UP_BANDWIDTH_MBPS).build();
 
     // Allow Dataplane threads to set themselves up.
     sleep(Duration::from_millis(10));
@@ -365,8 +367,10 @@ fn unicast_all_strides() {
     let rx_addr = "127.0.0.1:9016".parse().unwrap();
     let tx_addr = "127.0.0.1:9017".parse().unwrap();
 
-    let mut rx = Dataplane::new(&rx_addr, UP_BANDWIDTH_MBPS);
-    let mut tx = Dataplane::new(&tx_addr, UP_BANDWIDTH_MBPS);
+    let mut rx = DataplaneBuilder::new(&rx_addr, UP_BANDWIDTH_MBPS)
+        .with_buffer_size(400 << 10)
+        .build();
+    let mut tx = DataplaneBuilder::new(&tx_addr, UP_BANDWIDTH_MBPS).build();
 
     // Allow Dataplane threads to set themselves up.
     sleep(Duration::from_millis(10));

--- a/monad-node-config/src/network.rs
+++ b/monad-node-config/src/network.rs
@@ -11,6 +11,9 @@ pub struct NodeNetworkConfig {
     pub max_rtt_ms: u64,
     pub max_mbps: u16,
 
+    #[serde(default = "default_buffer_size")]
+    pub buffer_size: Option<usize>,
+
     #[serde(default = "default_mtu")]
     pub mtu: u16,
 }
@@ -19,4 +22,9 @@ pub struct NodeNetworkConfig {
 // https://github.com/moby/vpnkit/tree/v0.5.0/src/hostnet/slirp.ml#L17-L18
 fn default_mtu() -> u16 {
     1480
+}
+
+fn default_buffer_size() -> Option<usize> {
+    // recommended value at the time of the commit
+    Some(62_500_000)
 }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -520,6 +520,7 @@ where
         )),
         up_bandwidth_mbps: network_config.max_mbps.into(),
         mtu: network_config.mtu,
+        buffer_size: network_config.buffer_size,
     })
 }
 

--- a/monad-raptorcast/examples/service.rs
+++ b/monad-raptorcast/examples/service.rs
@@ -118,6 +118,7 @@ fn service(
                     local_addr: server_address,
                     up_bandwidth_mbps: 1_000,
                     mtu: DEFAULT_MTU,
+                    buffer_size: None,
                 };
 
                 let mut service = RaptorCast::<

--- a/monad-raptorcast/tests/raptorcast_instance.rs
+++ b/monad-raptorcast/tests/raptorcast_instance.rs
@@ -393,6 +393,7 @@ pub fn set_up_test(
                 local_addr: rx_addr,
                 up_bandwidth_mbps: 1_000,
                 mtu: DEFAULT_MTU,
+                buffer_size: None,
             };
 
             let mut service = RaptorCast::<

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -291,6 +291,7 @@ where
                             local_addr: address.parse().unwrap(),
                             up_bandwidth_mbps: 1_000,
                             mtu: DEFAULT_MTU,
+                            buffer_size: Some(62_500_000),
                         }),
                     },
                     ledger_config: match args.ledger {


### PR DESCRIPTION
closes: https://github.com/category-labs/category-internal/issues/1505

socket buffer sizes are configurable and default to 62_500_000 as recommended in the setup guide.
if `buffer_size` field set to null explicitly in the network config it won't be modified and operator will be able to configure their own sizes. if requested buffer size can't be set (for example if 62500000 is higher than the max allowed) we will print error in the log.

it also sets this buffer to 1MB in two tests as the default buffer may not be sufficient, and in such case udp socket will silently drop incoming messages leading to a halted tests. the other option is to adjust payload, but that seems error prone
