### PR TITLE
Archive: aws timeout adjustment and use aws sdk retries over manual

### DIFF
--- a/monad-archive/src/bin/monad-archive-checker/main.rs
+++ b/monad-archive/src/bin/monad-archive-checker/main.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<()> {
 
     // Get AWS configuration
     info!("Configuring AWS with region: {:?}", args.region);
-    let aws_config = get_aws_config(args.region.clone()).await;
+    let aws_config = get_aws_config(args.region.clone(), 30).await;
 
     // Initialize S3 bucket
     info!("Initializing S3 bucket: {}", args.bucket);


### PR DESCRIPTION
Recently trace sizes have grown larger and ltu <-> us-east-2 requests have begun timing out. This pr increases default aws sdk timeouts.

Additionally, it configures the aws sdk to perform retries for transient errors and removes the application level retries, improving code clarity.