### PR TITLE
Concurrent eth_call request updates

### DIFF
--- a/monad-rpc/src/cli.rs
+++ b/monad-rpc/src/cli.rs
@@ -73,6 +73,10 @@ pub struct Cli {
     #[arg(long, default_value_t = 30_000_000)]
     pub eth_estimate_gas_gas_limit: u64,
 
+    /// Enable admin_ethCallStatistics method
+    #[arg(long, default_value_t = false)]
+    pub enable_admin_eth_call_statistics: bool,
+
     /// Set the max concurrent requests for triedb reads
     #[arg(long, default_value_t = 20_000)]
     pub triedb_max_buffered_read_requests: u32,

--- a/monad-rpc/src/lib.rs
+++ b/monad-rpc/src/lib.rs
@@ -11,6 +11,7 @@ mod gas_oracle;
 mod hex;
 mod jsonrpc;
 mod meta;
+mod timing;
 mod trace;
 mod trace_handlers;
 mod txpool;

--- a/monad-rpc/src/timing.rs
+++ b/monad-rpc/src/timing.rs
@@ -31,7 +31,7 @@ where
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct RequestId {
     id: u64,
 }

--- a/monad-rpc/src/websocket.rs
+++ b/monad-rpc/src/websocket.rs
@@ -105,7 +105,8 @@ mod tests {
     use tracing_actix_web::TracingLogger;
 
     use crate::{
-        txpool::EthTxPoolBridgeClient, FixedFee, MonadJsonRootSpanBuilder, MonadRpcResources,
+        call::EthCallStatsTracker, txpool::EthTxPoolBridgeClient, FixedFee,
+        MonadJsonRootSpanBuilder, MonadRpcResources,
     };
 
     fn create_test_server() -> actix_test::TestServer {
@@ -113,6 +114,8 @@ mod tests {
             txpool_bridge_client: EthTxPoolBridgeClient::for_testing(),
             triedb_reader: None,
             eth_call_executor: None,
+            eth_call_executor_fibers: 64,
+            eth_call_stats_tracker: Some(Arc::new(EthCallStatsTracker::new())),
             archive_reader: None,
             base_fee_per_gas: FixedFee::new(2000),
             chain_id: 41454,
@@ -120,12 +123,14 @@ mod tests {
             max_response_size: 25_000_000,
             allow_unprotected_txs: false,
             rate_limiter: Arc::new(Semaphore::new(1000)),
+            total_permits: 1000,
             logs_max_block_range: 1000,
             eth_call_gas_limit: u64::MAX,
             eth_estimate_gas_gas_limit: u64::MAX,
             dry_run_get_logs_index: false,
             use_eth_get_logs_index: false,
             max_finalized_block_cache_len: 200,
+            enable_eth_call_statistics: true,
         };
 
         actix_test::start(move || {


### PR DESCRIPTION
- Replaces the concurrent call CLI arg with using the same value as the number of fibers in the executor
- Adds an opt-in RPC method to check how many slots are available for eth_call requests