### PR TITLE
monad-rpc: refactor dispatch loop and add histogram to track latency by method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5183,6 +5183,7 @@ dependencies = [
  "monad-ethcall",
  "monad-node-config",
  "monad-rpc-docs",
+ "monad-tracing-timing",
  "monad-triedb-utils",
  "monad-types",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ monad-state = { path = "./monad-state" }
 monad-state-backend = { path = "./monad-state-backend" }
 monad-statesync = { path = "./monad-statesync" }
 monad-testutil = { path = "./monad-testutil" }
+monad-tracing-timing = { path = "./monad-tracing-timing" }
 monad-transformer = { path = "./monad-transformer" }
 monad-triedb = { path = "./monad-triedb" }
 monad-triedb-cache = { path = "./monad-triedb-cache" }

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -28,6 +28,7 @@ monad-node-config = { workspace = true }
 monad-rpc-docs = { workspace = true }
 monad-triedb-utils = { workspace = true }
 monad-types = { workspace = true }
+monad-tracing-timing = { workspace = true }
 
 actix = { workspace = true }
 actix-http = { workspace = true }

--- a/monad-rpc/src/handlers/resources.rs
+++ b/monad-rpc/src/handlers/resources.rs
@@ -13,7 +13,9 @@ use tracing::debug;
 use tracing_actix_web::RootSpanBuilder;
 
 use super::eth::call::EthCallStatsTracker;
-use crate::{fee::FixedFee, txpool::EthTxPoolBridgeClient, websocket::Disconnect};
+use crate::{
+    fee::FixedFee, metrics::Metrics, txpool::EthTxPoolBridgeClient, websocket::Disconnect,
+};
 
 #[derive(Clone)]
 pub struct MonadRpcResources {
@@ -37,6 +39,7 @@ pub struct MonadRpcResources {
     pub use_eth_get_logs_index: bool,
     pub max_finalized_block_cache_len: u64,
     pub enable_eth_call_statistics: bool,
+    pub metrics: Option<Metrics>,
 }
 
 impl Handler<Disconnect> for MonadRpcResources {
@@ -68,6 +71,7 @@ impl MonadRpcResources {
         use_eth_get_logs_index: bool,
         max_finalized_block_cache_len: u64,
         enable_eth_call_statistics: bool,
+        metrics: Option<Metrics>,
     ) -> Self {
         Self {
             txpool_bridge_client,
@@ -94,6 +98,7 @@ impl MonadRpcResources {
             use_eth_get_logs_index,
             max_finalized_block_cache_len,
             enable_eth_call_statistics,
+            metrics,
         }
     }
 }

--- a/monad-rpc/src/lib.rs
+++ b/monad-rpc/src/lib.rs
@@ -5,6 +5,7 @@ pub mod gas_oracle;
 pub mod handlers;
 pub mod hex;
 pub mod jsonrpc;
+pub mod metrics;
 pub mod timing;
 pub mod trace;
 pub mod txpool;

--- a/monad-rpc/src/websocket.rs
+++ b/monad-rpc/src/websocket.rs
@@ -135,6 +135,7 @@ mod tests {
             use_eth_get_logs_index: false,
             max_finalized_block_cache_len: 200,
             enable_eth_call_statistics: true,
+            metrics: None,
         };
 
         actix_test::start(move || {


### PR DESCRIPTION
splitted rpc_select into separate functions with macro-generated enum. primarily so that i can define span with &'static method name in a single place. 

enables latency distribution per method

![image](https://github.com/user-attachments/assets/92004c53-b543-4e8e-9098-e54214375799)

rate per method

![image](https://github.com/user-attachments/assets/09c6a09b-47f9-4819-afd2-88f9ee451791)

and allows to determine if any time spent on cpu in actix handlers. wait time here means waiting on a database execution

![image](https://github.com/user-attachments/assets/b4a9cf53-6017-4bce-b871-77a845330556)

will add that as dashboards once merged
