### PR TITLE
Clean up keystore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,19 +2201,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "unicode-width",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2664,18 +2651,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dialoguer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
-dependencies = [
- "console",
- "shell-words",
- "tempfile",
- "zeroize",
-]
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,12 +2764,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -4955,7 +4924,6 @@ dependencies = [
  "aes",
  "clap 4.4.10",
  "ctr",
- "dialoguer",
  "hdwallet",
  "hex",
  "monad-bls",
@@ -7571,12 +7539,6 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shell-words"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,6 @@ criterion = { version = "0.4", features = ["html_reports"] }
 crossterm = "0.27.0"
 ctr = "0.9.2"
 dashmap = "6.1.0"
-dialoguer = "0.10"
 enum_dispatch = "0.3.13"
 env_logger = "0.10"
 eyre = "0.6.12"

--- a/monad-keystore/Cargo.toml
+++ b/monad-keystore/Cargo.toml
@@ -20,7 +20,6 @@ monad-secp = { workspace = true }
 aes = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 ctr = { workspace = true }
-dialoguer = { workspace = true }
 hdwallet = { workspace = true }
 hex = { workspace = true }
 pbkdf2 = { workspace = true, features = ["simple"] }


### PR DESCRIPTION
```
$ target/debug/monad-keystore create --keystore-path test --password '' --key-type secp
It is recommended to generate key in air-gapped machine to be secure.
This tool is currently not fit for production use.
Keep your private key securely: "ae020aaae37129ff37463daa3d153f1043ce720e80fe6faa4dc270ad9707ebdc"
Secp public key: 039e817d5b611400387fc8560fd886fc2074913130bda218e4f223b98520773618
Successfully generated keystore file.

$ target/debug/monad-keystore import  --private-key ae020aaae37129ff37463daa3d153f1043ce720e80fe6faa4dc270ad9707ebdc --keystore-path test --password '' --key-type secp
Secp public key: 039e817d5b611400387fc8560fd886fc2074913130bda218e4f223b98520773618
Successfully generated keystore file.
```