### PR TITLE
Return an error when already servicing statesync request

### DIFF
--- a/monad-executor-glue/benches/rlp_bench.rs
+++ b/monad-executor-glue/benches/rlp_bench.rs
@@ -1,7 +1,7 @@
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use monad_executor_glue::{
-    StateSyncNetworkMessage, StateSyncRequest, StateSyncResponse, StateSyncUpsertType,
+    SessionId, StateSyncNetworkMessage, StateSyncRequest, StateSyncResponse, StateSyncUpsertType,
     StateSyncUpsertV1, SELF_STATESYNC_VERSION,
 };
 
@@ -15,7 +15,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let statesync_response: Wrapped<_> = Wrapped(Wrapped(Wrapped(Wrapped(Wrapped(Wrapped(
         StateSyncNetworkMessage::Response(StateSyncResponse {
             version: SELF_STATESYNC_VERSION,
-            nonce: 0,
+            session_id: SessionId(0),
             response_index: 0,
             request: StateSyncRequest {
                 version: SELF_STATESYNC_VERSION,
@@ -25,6 +25,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 from: 0,
                 until: 0,
                 old_target: 0,
+                session_id: SessionId(123),
             },
             response: (0..num_upserts)
                 .map(|_| StateSyncUpsertV1 {

--- a/monad-proto/proto/message.proto
+++ b/monad-proto/proto/message.proto
@@ -99,12 +99,24 @@ message ProtoStateSyncCompletion {
   uint64 session_id = 1;
 }
 
+enum StateSyncErrorKind {
+  INSUFFICIENT_RESOURCES = 0;
+  EXECUTION_NOT_STARTED = 1;
+  DB_ERROR = 2;
+}
+
+message ProtoStateSyncError {
+  StateSyncErrorKind kind = 1;
+  uint64 session_id = 2;
+}
+
 message ProtoStateSyncNetworkMessage {
   oneof OneofMessage {
     ProtoStateSyncRequest request = 1;
     ProtoStateSyncResponse response = 2;
     ProtoStateSyncBadVersion bad_version = 3;
     ProtoStateSyncCompletion completion = 4;
+    ProtoStateSyncError error = 5;
   }
 }
 

--- a/monad-statesync/src/lib.rs
+++ b/monad-statesync/src/lib.rs
@@ -147,6 +147,22 @@ where
                     };
                     statesync.handle_bad_version(from, bad_version);
                 }
+                StateSyncCommand::Message((
+                    from,
+                    StateSyncNetworkMessage::ResponseError(response_error),
+                )) => {
+                    let statesync = match &mut self.mode {
+                        StateSyncMode::Sync(sync) => sync,
+                        StateSyncMode::Live(_) => {
+                            tracing::trace!(
+                                ?from,
+                                "dropping statesync response error, already done syncing"
+                            );
+                            continue;
+                        }
+                    };
+                    statesync.handle_response_error(from, response_error);
+                }
                 StateSyncCommand::Message((from, StateSyncNetworkMessage::Request(request))) => {
                     let execution_ipc = match &mut self.mode {
                         StateSyncMode::Sync(_) => {

--- a/monad-statesync/src/outbound_requests.rs
+++ b/monad-statesync/src/outbound_requests.rs
@@ -6,15 +6,39 @@ use std::{
 
 use monad_crypto::certificate_signature::PubKey;
 use monad_executor_glue::{
-    StateSyncBadVersion, StateSyncRequest, StateSyncResponse, StateSyncVersion,
-    SELF_STATESYNC_VERSION, STATESYNC_VERSION_MIN,
+    SessionId, StateSyncBadVersion, StateSyncError, StateSyncRequest, StateSyncResponse,
+    StateSyncVersion, SELF_STATESYNC_VERSION, STATESYNC_VERSION_MIN,
 };
 use monad_types::NodeId;
-use rand::seq::IteratorRandom;
+use rand::{seq::IteratorRandom, Rng};
+
+use crate::ffi::MAX_SERVER_REQUESTS;
+
+#[derive(Clone, Copy, Debug)]
+struct Peer {
+    version: StateSyncVersion,
+    outstanding_requests: usize,
+    inactive_until: Option<Instant>,
+}
+
+impl Peer {
+    fn new() -> Self {
+        Self {
+            version: SELF_STATESYNC_VERSION,
+            outstanding_requests: 0,
+            inactive_until: None,
+        }
+    }
+
+    fn available(&self) -> bool {
+        self.outstanding_requests < MAX_SERVER_REQUESTS && self.inactive_until.is_none()
+    }
+}
 
 pub(crate) struct OutboundRequests<PT: PubKey> {
     // List of peers with their negotiated state sync version
-    peers: HashMap<NodeId<PT>, StateSyncVersion>,
+    peers: HashMap<NodeId<PT>, Peer>,
+
     max_parallel_requests: usize,
     request_timeout: Duration,
 
@@ -37,7 +61,7 @@ struct InFlightRequest<PT: PubKey> {
 
     // map from nonce -> num responses received
     // TODO bound size of this
-    seen_nonces: HashMap<u64, usize>,
+    seen_nonces: HashMap<SessionId, usize>,
 
     _pd: PhantomData<PT>,
 }
@@ -67,15 +91,15 @@ impl<PT: PubKey> InFlightRequest<PT> {
         from: &NodeId<PT>,
         response: StateSyncResponse,
     ) -> Vec<StateSyncResponse> {
-        let num_nonce_seen = self.seen_nonces.entry(response.nonce).or_default();
+        let num_nonce_seen = self.seen_nonces.entry(response.session_id).or_default();
         *num_nonce_seen += 1;
         if self
             .responses
             .values()
             .next()
-            .is_some_and(|existing_response| existing_response.nonce != response.nonce)
+            .is_some_and(|existing_response| existing_response.session_id != response.session_id)
         {
-            let existing_response_nonce = self.responses.values().next().unwrap().nonce;
+            let existing_response_nonce = self.responses.values().next().unwrap().session_id;
             if self.last_active.elapsed() > STATESYNC_CHUNKED_RESPONSE_TIMEOUT
                 && num_nonce_seen == &1
             {
@@ -141,6 +165,15 @@ pub(crate) enum RequestPollResult<PT: PubKey> {
     Timer(Option<Instant>),
 }
 
+fn random_backoff() -> Duration {
+    let mut rng = rand::thread_rng();
+    let range = PEER_BACKOFF_MIN.as_millis()..=PEER_BACKOFF_MAX.as_millis();
+    Duration::from_millis(rng.gen_range(range).try_into().unwrap())
+}
+
+const PEER_BACKOFF_MIN: Duration = Duration::from_secs(5);
+const PEER_BACKOFF_MAX: Duration = Duration::from_secs(10);
+
 impl<PT: PubKey> OutboundRequests<PT> {
     pub fn new(
         max_parallel_requests: usize,
@@ -151,10 +184,8 @@ impl<PT: PubKey> OutboundRequests<PT> {
         // Initialize peers with the maximum state sync version, it will be negotiated
         // down if not supported by peer.
         Self {
-            peers: peers
-                .into_iter()
-                .map(|peer| (peer, SELF_STATESYNC_VERSION))
-                .collect(),
+            peers: peers.into_iter().map(|peer| (peer, Peer::new())).collect(),
+
             max_parallel_requests,
             request_timeout,
 
@@ -219,13 +250,47 @@ impl<PT: PubKey> OutboundRequests<PT> {
         if let Some(response) = responses.last() {
             if response.response_n != 0 {
                 in_flight_request.remove();
+                self.dec_outstanding_requests(&from);
             }
         }
         responses
     }
 
+    fn dec_outstanding_requests(&mut self, node: &NodeId<PT>) {
+        if let Some(peer) = self.peers.get_mut(node) {
+            peer.outstanding_requests -= 1;
+        }
+    }
+
+    fn remove_request(&mut self, request: &StateSyncRequest) {
+        if let Some(in_flight_request) = self.in_flight_requests.remove(request) {
+            self.dec_outstanding_requests(&in_flight_request.peer);
+        }
+    }
+
+    // Cancel and retry requests that match the predicate
+    fn cancel_requests(
+        &mut self,
+        predicate: impl Fn(&(&StateSyncRequest, &InFlightRequest<PT>)) -> bool,
+        reason: &str,
+    ) {
+        let requests_to_remove: Vec<_> = self
+            .in_flight_requests
+            .iter()
+            .filter(predicate)
+            .map(|(k, v)| (*k, v.peer))
+            .collect();
+
+        for (request, peer) in requests_to_remove {
+            tracing::warn!("retrying request {:?} peer {}, {}", request, peer, reason);
+            self.remove_request(&request);
+            self.pending_requests.insert(request);
+        }
+    }
+
+    // Cancel all requests to this peer that have version greater than maximum supported
+    // version reported in bad_version
     pub fn handle_bad_version(&mut self, from: NodeId<PT>, bad_version: StateSyncBadVersion) {
-        // Cancel all requests to this peer that have version greater than maximum supported version reported in bad_version
         tracing::debug!(
             ?from,
             ?bad_version,
@@ -241,75 +306,121 @@ impl<PT: PubKey> OutboundRequests<PT> {
                 bad_version
             );
             self.peers.remove(&from);
-        } else {
-            self.peers.insert(from, bad_version.max_version);
+        } else if let Some(peer) = self.peers.get_mut(&from) {
+            peer.version = bad_version.max_version;
         }
-        let requests_to_remove: Vec<_> = self
-            .in_flight_requests
-            .iter()
-            .filter(|(request, in_flight_request)| {
+
+        self.cancel_requests(
+            |(request, in_flight_request)| {
                 in_flight_request.peer == from && request.version > bad_version.max_version
-            })
-            .map(|(request, _)| *request)
-            .collect();
+            },
+            "version mismatch",
+        );
+    }
 
-        for request in requests_to_remove {
-            tracing::debug!("retrying request {:?} because of version mismatch", request);
-            self.in_flight_requests.remove(&request);
-            self.pending_requests.insert(request);
+    pub fn handle_server_error(&mut self, from: NodeId<PT>, error: StateSyncError) {
+        let Some(peer) = self.peers.get_mut(&from) else {
+            tracing::debug!("peer {} not found", from);
+            return;
+        };
+
+        // Schedule peer to be activated after a backoff period
+        peer.inactive_until = Some(Instant::now() + random_backoff());
+
+        // Cancel any in flight requests to this peer
+        self.cancel_requests(
+            |(request, in_flight_request)| {
+                in_flight_request.peer == from && request.session_id == error.session_id
+            },
+            "peer error",
+        );
+    }
+
+    // Activate peers that passed the backoff period
+    pub fn activate_peers(&mut self) {
+        let now = Instant::now();
+        for (_, peer) in self.peers.iter_mut() {
+            if let Some(inactive_until) = peer.inactive_until {
+                if now >= inactive_until {
+                    peer.inactive_until = None;
+                }
+            }
         }
     }
 
-    fn choose_peer(&self, prefix: u64) -> NodeId<PT> {
-        *self
-            .prefix_peers
-            .get(&prefix)
-            .or_else(|| self.peers.keys().choose(&mut rand::thread_rng()))
-            .expect("unable to send statesync request, no peers")
+    /// Choose a peer to send the request to
+    /// If a prefix peer is set, it will be used if available
+    /// Otherwise, a random available peer will be chosen
+    /// If no available peer is found, None is returned
+    fn choose_peer(&self, prefix: u64) -> Option<NodeId<PT>> {
+        if let Some(node) = self.prefix_peers.get(&prefix) {
+            self.peers
+                .get(node)
+                .filter(|peer| peer.available())
+                .map(|_| *node)
+        } else {
+            self.peers
+                .iter()
+                .filter(|(_, peer)| peer.available())
+                .choose(&mut rand::thread_rng())
+                .map(|(node, _)| *node)
+        }
     }
 
-    // Select new peer, update version to the peer's version and insert to inflight requests
-    fn insert_request(&mut self, mut to_send: StateSyncRequest) -> (NodeId<PT>, StateSyncRequest) {
-        let peer = self.choose_peer(to_send.prefix);
-        to_send.version = self.peers.get(&peer).copied().expect("peer not found");
+    // Update version to the peer's version and insert to inflight requests
+    fn insert_request(
+        &mut self,
+        node: NodeId<PT>,
+        mut request: StateSyncRequest,
+    ) -> StateSyncRequest {
+        self.pending_requests.remove(&request);
+        let peer = self.peers.get_mut(&node).expect("peer not found");
+        request.version = peer.version;
+        request.session_id = SessionId(rand::random());
         self.in_flight_requests
-            .insert(to_send, InFlightRequest::new(peer));
-        (peer, to_send)
+            .insert(request, InFlightRequest::new(node));
+        peer.outstanding_requests += 1;
+        request
+    }
+
+    fn timeout_requests(&mut self) {
+        let now = Instant::now();
+        let timeout = self.request_timeout;
+
+        self.cancel_requests(
+            |(_, in_flight_request)| now.duration_since(in_flight_request.last_active) > timeout,
+            "timeout",
+        );
     }
 
     #[must_use]
     pub fn poll(&mut self) -> RequestPollResult<PT> {
+        self.activate_peers();
+
+        self.timeout_requests();
+
         // check if we can immediately queue another request
-        if self.in_flight_requests.len() < self.max_parallel_requests
-            && !self.pending_requests.is_empty()
-        {
-            let to_send = self.pending_requests.pop_first().expect("!is_empty()");
-            let (peer, request) = self.insert_request(to_send);
-            return RequestPollResult::Request(peer, request);
+        // must have available peer and not exceed max parallel requests
+        if self.in_flight_requests.len() < self.max_parallel_requests {
+            if let Some((peer, request)) = self.pending_requests.iter().find_map(|request| {
+                self.choose_peer(request.prefix)
+                    .map(|peer| (peer, *request))
+            }) {
+                return RequestPollResult::Request(peer, self.insert_request(peer, request));
+            }
         }
 
-        // find request that will timeout first
-        let Some((request, in_flight_request)) = self
+        // Calculate the next timeout if can't send a request
+        let request_timeout = self
             .in_flight_requests
-            .iter()
-            .min_by_key(|(_, in_flight_request)| in_flight_request.last_active)
-        else {
-            // no outstanding requests, so yield forever
-            return RequestPollResult::Timer(None);
-        };
-
-        if in_flight_request.last_active.elapsed() < self.request_timeout {
-            // wait until request times out
-            return RequestPollResult::Timer(Some(
-                in_flight_request.last_active + self.request_timeout,
-            ));
-        }
-
-        // Reinitialize request since selecting new peer may change the version
-        let to_send = *request;
-        self.in_flight_requests.remove(&to_send);
-
-        let (peer, request) = self.insert_request(to_send);
-        RequestPollResult::Request(peer, request)
+            .values()
+            .map(|r| r.last_active + self.request_timeout)
+            .min();
+        let activation_timeout = self
+            .peers
+            .values()
+            .filter_map(|peer| peer.inactive_until)
+            .min();
+        RequestPollResult::Timer(request_timeout.min(activation_timeout))
     }
 }

--- a/monad-updaters/src/statesync.rs
+++ b/monad-updaters/src/statesync.rs
@@ -11,8 +11,9 @@ use monad_crypto::certificate_signature::{
 };
 use monad_executor::{Executor, ExecutorMetricsChain};
 use monad_executor_glue::{
-    MonadEvent, StateSyncCommand, StateSyncEvent, StateSyncNetworkMessage, StateSyncRequest,
-    StateSyncResponse, StateSyncUpsertType, StateSyncUpsertV1, SELF_STATESYNC_VERSION,
+    MonadEvent, SessionId, StateSyncCommand, StateSyncEvent, StateSyncNetworkMessage,
+    StateSyncRequest, StateSyncResponse, StateSyncUpsertType, StateSyncUpsertV1,
+    SELF_STATESYNC_VERSION,
 };
 use monad_state_backend::{InMemoryState, StateBackend};
 use monad_types::{ExecutionProtocol, FinalizedHeader, NodeId, SeqNum, GENESIS_SEQ_NUM};
@@ -102,6 +103,7 @@ where
                         prefix_bytes: 1,
                         until: 0,
                         old_target: 0,
+                        session_id: SessionId(0),
                     };
                     self.request = Some(request);
                     self.events.extend(self.peers.iter().map(|peer| {
@@ -133,7 +135,7 @@ where
                         let serialized = serde_json::to_vec(state).unwrap();
                         let response = StateSyncResponse {
                             version: SELF_STATESYNC_VERSION,
-                            nonce: 0,
+                            session_id: SessionId(0),
                             response_index: 0,
 
                             request,
@@ -168,6 +170,7 @@ where
                     }
                     StateSyncNetworkMessage::BadVersion(_) => {}
                     StateSyncNetworkMessage::Completion(_) => {}
+                    StateSyncNetworkMessage::ResponseError(_) => {}
                 },
             }
         }


### PR DESCRIPTION
Instead of queueing statesync requests return an error immediately. Queueing does not really work and can only result in timeout on the client and retry on a different server, causing the same request to be run several times across the cluster.

On the client keep a count of outstanding requests per server and don't send additional requests to the same server. If a server is already executing request from a different client, mark the server temporary inactive and retry request on a different server. Reactivate the server after random backoff time has passed.