### PR TITLE
monad-pprof, monad-rpc: jemallocator to use in monad-rpc and pprof integration for heap profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f32d40287d3f402ae0028a9d54bef51af15c8769492826a69d28f81893151d"
+checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
 dependencies = [
  "actix-macros",
  "futures-core",
@@ -154,16 +154,16 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.3.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb13e7eef0423ea6eab0e59f6c72e7cb46d33691ad56a726b3cd07ddec2c2d4"
+checksum = "6398974fd4284f4768af07965701efbbb5fdc0616bff20cade1bb14b77675e24"
 dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
  "futures-core",
  "futures-util",
- "mio 0.8.9",
+ "mio 1.0.1",
  "socket2 0.5.9",
  "tokio",
  "tracing",
@@ -2771,9 +2771,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2800,9 +2800,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fastrlp"
@@ -3867,7 +3867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.9",
- "rustix",
+ "rustix 0.38.25",
  "windows-sys 0.48.0",
 ]
 
@@ -3912,6 +3912,23 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "jemalloc_pprof"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5622af6d21ff86ed7797ef98e11b8f302da25ec69a7db9f6cde8e2e1c8df9992"
+dependencies = [
+ "anyhow",
+ "libc",
+ "mappings",
+ "once_cell",
+ "pprof_util",
+ "tempfile",
+ "tikv-jemalloc-ctl",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "jobserver"
@@ -4075,6 +4092,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4199,6 +4222,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mappings"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e434981a332777c2b3062652d16a55f8e74fa78e6b1882633f0d77399c84fc2a"
+dependencies = [
+ "anyhow",
+ "libc",
+ "once_cell",
+ "pprof_util",
+ "tracing",
+]
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4288,6 +4324,7 @@ checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -5054,6 +5091,16 @@ name = "monad-perf-util"
 version = "0.1.0"
 
 [[package]]
+name = "monad-pprof"
+version = "0.1.0"
+dependencies = [
+ "actix-server",
+ "actix-web",
+ "jemalloc_pprof",
+ "serde",
+]
+
+[[package]]
 name = "monad-proto"
 version = "0.1.0"
 dependencies = [
@@ -5182,6 +5229,7 @@ dependencies = [
  "monad-eth-types",
  "monad-ethcall",
  "monad-node-config",
+ "monad-pprof",
  "monad-rpc-docs",
  "monad-tracing-timing",
  "monad-triedb-utils",
@@ -5198,6 +5246,7 @@ dependencies = [
  "serde",
  "serde_json",
  "test-case",
+ "tikv-jemallocator",
  "tokio",
  "toml 0.7.8",
  "tracing",
@@ -5782,13 +5831,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.4"
+name = "num"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "autocfg",
+ "num-bigint",
+ "num-complex",
  "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -5800,19 +5871,40 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -6305,6 +6397,19 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "pprof_util"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa015c78eed2130951e22c58d2095849391e73817ab2e74f71b0b9f63dd8416"
+dependencies = [
+ "anyhow",
+ "flate2",
+ "num",
+ "paste",
+ "prost 0.13.1",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -7048,8 +7153,21 @@ dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.11",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.4.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7903,15 +8021,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.8.1"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys 0.48.0",
+ "getrandom 0.3.2",
+ "once_cell",
+ "rustix 1.0.7",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8019,6 +8137,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21f216790c8df74ce3ab25b534e0718da5a1916719771d3fec23315c99e468b"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -8848,7 +8997,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.25",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ monad-node-config = { path = "./monad-node-config" }
 monad-peer-disc-swarm = { path = "./monad-peer-disc-swarm" }
 monad-peer-discovery = { path = "./monad-peer-discovery" }
 monad-perf-util = { path = "./monad-perf-util" }
+monad-pprof = { path = "./monad-pprof" }
 monad-proto = { path = "./monad-proto" }
 monad-raptor = { path = "./monad-raptor" }
 monad-raptorcast = { path = "./monad-raptorcast" }
@@ -78,6 +79,7 @@ monad-validator = { path = "./monad-validator" }
 monad-wal = { path = "./monad-wal" }
 
 actix = "0.13"
+actix-server = "2.5.1"
 actix-http = "3.6.0"
 actix-test = "0.1"
 actix-web = "4.5.1"
@@ -135,6 +137,7 @@ indexmap = "2.4.0"
 inotify = "0.11"
 inventory = "0.3"
 itertools = "0.10"
+jemalloc_pprof = "0.7"
 libc = "0.2.153"
 lru = "0.12"
 lz4 = "1.28"
@@ -182,6 +185,7 @@ syn = { version = "1.0.0", features = ["full"] }
 tempfile = "3.5"
 test-case = "3.0"
 thiserror = "1.0"
+tikv-jemallocator = "0.6"
 tiny-bip39 = "1.0"
 tiny-keccak = "2"
 tokio = { version = "1.39", features = ["sync"] }

--- a/monad-pprof/Cargo.toml
+++ b/monad-pprof/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "monad-pprof"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+actix-web = { workspace = true }
+actix-server = { workspace = true }
+serde = { workspace = true }
+jemalloc_pprof = { workspace = true, optional = true }
+
+[features]
+jemallocator = ["dep:jemalloc_pprof"]

--- a/monad-pprof/README.md
+++ b/monad-pprof/README.md
@@ -1,0 +1,19 @@
+## How to use
+
+### Install pprof
+
+```bash
+go install github.com/google/pprof@latest
+```
+
+Or follow guidelines from [pprof](https://github.com/google/pprof)
+
+### Collect profile
+
+```bash
+pprof -http=0.0.0.0:8080 http://0.0.0.0:32808/debug/pprof/heap
+```
+
+When collecting profile pprof will try to find binaries and static libs
+for symbolization. If you built and running application in docker container,
+copy them and point to the directory with `export PPROF_BINARY_PATH=~/monad-binaries`.

--- a/monad-pprof/src/heap.rs
+++ b/monad-pprof/src/heap.rs
@@ -1,0 +1,63 @@
+use actix_web::{HttpResponse, Responder, web};
+
+pub(crate) async fn handle_get_heap() -> impl Responder {
+    #[cfg(not(feature = "jemallocator"))]
+    return HttpResponse::NotImplemented()
+        .body("Heap profiling is not available: jemallocator feature is not enabled");
+
+    #[cfg(feature = "jemallocator")]
+    {
+        let mut prof_ctl = jemalloc_pprof::PROF_CTL.as_ref().unwrap().lock().await;
+        if prof_ctl.activated() {
+            match prof_ctl.dump_pprof() {
+                Ok(pprof) => HttpResponse::Ok().body(pprof),
+                Err(err) => HttpResponse::InternalServerError().body(err.to_string()),
+            }
+        } else {
+            HttpResponse::Conflict().body("heap profiling not activated")
+        }
+    }
+}
+
+#[derive(serde::Deserialize)]
+pub(crate) struct ProfilingConfig {
+    active: Option<bool>,
+}
+
+pub(crate) async fn handle_update_prof_config(
+    config: web::Json<ProfilingConfig>,
+) -> impl Responder {
+    #[cfg(not(feature = "jemallocator"))]
+    return HttpResponse::NotImplemented()
+        .body("Profiling configuration is not available: jemallocator feature is not enabled");
+
+    #[cfg(feature = "jemallocator")]
+    {
+        let mut prof_ctl = jemalloc_pprof::PROF_CTL.as_ref().unwrap().lock().await;
+        let mut updates = Vec::new();
+
+        if let Some(active) = config.active {
+            if active {
+                match prof_ctl.activate() {
+                    Ok(_) => updates.push("profiling enabled"),
+                    Err(err) => return HttpResponse::InternalServerError().body(err.to_string()),
+                }
+            } else {
+                match prof_ctl.deactivate() {
+                    Ok(_) => updates.push("profiling disabled"),
+                    Err(err) => return HttpResponse::InternalServerError().body(err.to_string()),
+                }
+            }
+        }
+
+        if updates.is_empty() {
+            return HttpResponse::BadRequest()
+                .body("No valid configuration parameters provided. Expected JSON with 'active'");
+        }
+
+        HttpResponse::Ok().body(format!(
+            "Successfully updated profiling configuration: {}",
+            updates.join(", ")
+        ))
+    }
+}

--- a/monad-pprof/src/lib.rs
+++ b/monad-pprof/src/lib.rs
@@ -1,0 +1,18 @@
+use actix_server::Server;
+use actix_web::{App, HttpServer, web};
+
+mod heap;
+
+pub fn start_pprof_server(addr: String) -> std::io::Result<Server> {
+    Ok(HttpServer::new(|| {
+        App::new()
+            .route("/debug/pprof/heap", web::get().to(heap::handle_get_heap))
+            .route(
+                "/debug/pprof/heap/config",
+                web::post().to(heap::handle_update_prof_config),
+            )
+    })
+    .bind(addr)?
+    .workers(1)
+    .run())
+}

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -17,6 +17,10 @@ path = "./bin/docs.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["jemallocator"]
+jemallocator = ["tikv-jemallocator", "monad-pprof/jemallocator"]
+
 [dependencies]
 monad-chain-config = { workspace = true }
 monad-archive = { workspace = true }
@@ -26,9 +30,10 @@ monad-eth-types = { workspace = true }
 monad-ethcall = { workspace = true }
 monad-node-config = { workspace = true }
 monad-rpc-docs = { workspace = true }
+monad-tracing-timing = { workspace = true }
 monad-triedb-utils = { workspace = true }
 monad-types = { workspace = true }
-monad-tracing-timing = { workspace = true }
+monad-pprof = { workspace = true }
 
 actix = { workspace = true }
 actix-http = { workspace = true }
@@ -63,6 +68,10 @@ toml = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
 tracing-actix-web = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
+[target.'cfg(not(target_env = "msvc"))'.dependencies.tikv-jemallocator]
+workspace = true
+features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"]
+optional = true
 
 [dev-dependencies]
 monad-eth-testutil = { workspace = true }

--- a/monad-rpc/src/cli.rs
+++ b/monad-rpc/src/cli.rs
@@ -139,4 +139,11 @@ pub struct Cli {
     /// Dry run using mongo index for eth_getLogs
     #[arg(long)]
     pub dry_run_get_logs_index: bool,
+
+    #[arg(
+        long,
+        help = "listen address for pprof server. pprof server won't be enabled if address is empty",
+        default_value = ""
+    )]
+    pub pprof: String,
 }


### PR DESCRIPTION
- [x] followup to integrate with monad-node

it allows to expose heap profile over http api. instructions are available in readme.
but also jemmalloc is known to be more efficient than the std allocator, for example here is a latency distribution of getBalance requests. 

![image](https://github.com/user-attachments/assets/8717f265-5e19-4bd6-a902-68a05daecae4)
