### PR TITLE
use named threads for easier identification

### DIFF
--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -78,6 +78,7 @@ fn main() {
 
     rayon::ThreadPoolBuilder::new()
         .num_threads(8)
+        .thread_name(|i| format!("monad-bft-rn-{}", i))
         .build_global()
         .map_err(Into::into)
         .unwrap_or_else(|e: NodeSetupError| cmd.error(e.kind(), e).exit());

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -832,6 +832,7 @@ async fn main() -> std::io::Result<()> {
 
     // Used for compute heavy tasks
     rayon::ThreadPoolBuilder::new()
+        .thread_name(|i| format!("monad-rpc-rn-{i}"))
         .num_threads(args.compute_threadpool_size)
         .build_global()
         .unwrap();

--- a/monad-statesync/src/ffi.rs
+++ b/monad-statesync/src/ffi.rs
@@ -4,6 +4,7 @@ use std::{
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context, Poll},
+    thread,
     time::Duration,
 };
 
@@ -158,7 +159,7 @@ impl<PT: PubKey> StateSync<PT> {
         let progress = Arc::new(Mutex::new(Progress::default()));
         let progress_clone = Arc::clone(&progress);
 
-        std::thread::spawn(move || {
+        thread::Builder::new().name("monad-statesync".to_string()).spawn(move || {
             let db_paths_ptrs: Vec<*const i8> = db_paths.iter().map(|s| s.as_ptr()).collect();
             let db_paths_ptr = db_paths_ptrs.as_ptr();
             let num_db_paths = db_paths_ptrs.len();
@@ -317,7 +318,7 @@ impl<PT: PubKey> StateSync<PT> {
             }
             // this loop exits when execution is about to start
             assert!(sync_ctx.ctx.is_none());
-        });
+        }).expect("failed to spawn statesync thread");
 
         Self {
             state_sync_peers: state_sync_peers.to_vec(),


### PR DESCRIPTION
easier to identify in tooling. some thread names are shortened to fit in 15 limit, otherwise they will be truncated at that limit.
there are still some threads that are not named at creation, but i think they are in monad code, i will try to adjust them there.
and i didn't touch threads created by tokio or actix, they are already named differently and easy to identify

![image](https://github.com/user-attachments/assets/047bb8e4-0b8a-4b9d-9063-f054246a4f14)
