### PR TITLE
Full-node Raptorcast: Refactored Group message de/serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5140,6 +5140,7 @@ dependencies = [
  "monad-executor",
  "monad-executor-glue",
  "monad-merkle",
+ "monad-peer-discovery",
  "monad-raptor",
  "monad-secp",
  "monad-testutil",

--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -16,6 +16,7 @@ monad-dataplane = { workspace = true }
 monad-executor = { workspace = true }
 monad-executor-glue = { workspace = true }
 monad-merkle = { workspace = true }
+monad-peer-discovery = { workspace = true }
 monad-raptor = { workspace = true }
 monad-secp = { workspace = true }
 monad-types = { workspace = true }

--- a/monad-raptorcast/src/raptorcast_secondary/group_message.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/group_message.rs
@@ -1,0 +1,93 @@
+use alloy_rlp::{Decodable, Encodable, Header, RlpDecodable, RlpEncodable};
+use bytes::BufMut;
+use monad_crypto::certificate_signature::{
+    CertificateSignaturePubKey, CertificateSignatureRecoverable,
+};
+use monad_peer_discovery::MonadNameRecord;
+use monad_types::{NodeId, Round};
+
+#[derive(RlpEncodable, RlpDecodable, Debug, PartialEq, Clone)]
+pub struct PrepareGroup<ST: CertificateSignatureRecoverable> {
+    pub validator_id: NodeId<CertificateSignaturePubKey<ST>>,
+    pub max_group_size: usize,
+    pub start_round: Round,
+    pub end_round: Round,
+}
+
+#[derive(Debug, Clone, RlpEncodable, RlpDecodable)]
+pub struct PrepareGroupResponse<ST: CertificateSignatureRecoverable> {
+    pub req: PrepareGroup<ST>,
+    pub node_id: NodeId<CertificateSignaturePubKey<ST>>,
+    pub accept: bool,
+}
+
+#[derive(Debug, Clone, RlpEncodable, RlpDecodable)]
+#[rlp(trailing)]
+pub struct ConfirmGroup<ST: CertificateSignatureRecoverable> {
+    pub prepare: PrepareGroup<ST>,
+    pub peers: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
+    pub name_records: Option<Vec<MonadNameRecord<ST>>>,
+}
+
+const GROUP_MSG_VERSION: u8 = 1;
+
+const MESSAGE_TYPE_PREP_REQ: u8 = 1;
+const MESSAGE_TYPE_PREP_RES: u8 = 2;
+const MESSAGE_TYPE_CONF_GRP: u8 = 3;
+
+#[derive(Debug, Clone)]
+pub enum FullNodesGroupMessage<ST: CertificateSignatureRecoverable> {
+    PrepareGroup(PrepareGroup<ST>), // MESSAGE_TYPE_PREP_REQ
+    PrepareGroupResponse(PrepareGroupResponse<ST>), // MESSAGE_TYPE_PREP_RES
+    ConfirmGroup(ConfirmGroup<ST>), // MESSAGE_TYPE_CONF_GRP
+}
+
+impl<ST: CertificateSignatureRecoverable> Encodable for FullNodesGroupMessage<ST> {
+    fn length(&self) -> usize {
+        size_of_val(&GROUP_MSG_VERSION)
+            + size_of_val(&MESSAGE_TYPE_PREP_REQ)
+            + match self {
+                Self::PrepareGroup(prep_req) => prep_req.length(),
+                Self::PrepareGroupResponse(prep_res) => prep_res.length(),
+                Self::ConfirmGroup(conf_grp) => conf_grp.length(),
+            }
+    }
+
+    fn encode(&self, out: &mut dyn BufMut) {
+        GROUP_MSG_VERSION.encode(out);
+        match self {
+            Self::PrepareGroup(prep_req) => {
+                MESSAGE_TYPE_PREP_REQ.encode(out);
+                prep_req.encode(out);
+            }
+            Self::PrepareGroupResponse(prep_res) => {
+                MESSAGE_TYPE_PREP_RES.encode(out);
+                prep_res.encode(out);
+            }
+            Self::ConfirmGroup(conf_grp) => {
+                MESSAGE_TYPE_CONF_GRP.encode(out);
+                conf_grp.encode(out);
+            }
+        }
+    }
+}
+
+impl<ST: CertificateSignatureRecoverable> Decodable for FullNodesGroupMessage<ST> {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let mut payload = Header::decode_bytes(buf, true)?;
+        let version = u8::decode(&mut payload)?;
+        if version > GROUP_MSG_VERSION {
+            return Err(alloy_rlp::Error::Custom("Unknown group message version"));
+        }
+        match u8::decode(&mut payload)? {
+            MESSAGE_TYPE_PREP_REQ => Ok(Self::PrepareGroup(PrepareGroup::decode(&mut payload)?)),
+            MESSAGE_TYPE_PREP_RES => Ok(Self::PrepareGroupResponse(PrepareGroupResponse::decode(
+                &mut payload,
+            )?)),
+            MESSAGE_TYPE_CONF_GRP => Ok(Self::ConfirmGroup(ConfirmGroup::decode(&mut payload)?)),
+            _ => Err(alloy_rlp::Error::Custom(
+                "Unknown FullNodesGroupMessage enum variant",
+            )),
+        }
+    }
+}

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -1,0 +1,1 @@
+pub mod group_message;

--- a/monad-raptorcast/src/rlp.rs
+++ b/monad-raptorcast/src/rlp.rs
@@ -1,0 +1,95 @@
+// Contains the common methods used for serializing and deserializing messages
+
+use alloy_rlp::{encode_list, Decodable, Encodable, RlpDecodable, RlpEncodable};
+use bytes::{BufMut, Bytes, BytesMut};
+use monad_compress::{zstd::ZstdCompression, CompressionAlgo};
+
+pub const SERIALIZE_VERSION: u32 = 1;
+// compression versions
+pub const UNCOMPRESSED_VERSION: u32 = 1;
+pub const DEFAULT_ZSTD_VERSION: u32 = 2;
+
+#[derive(RlpEncodable, RlpDecodable)]
+pub struct NetworkMessageVersion {
+    pub serialize_version: u32,
+    pub compression_version: u32,
+}
+
+impl NetworkMessageVersion {
+    pub fn version() -> Self {
+        Self {
+            serialize_version: SERIALIZE_VERSION,
+            compression_version: UNCOMPRESSED_VERSION,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SerializeError(pub String);
+
+pub(crate) fn try_serialize_rlp_message<M: Encodable>(
+    msg_type: u8,
+    rlp_message: M,
+    version: NetworkMessageVersion,
+    out_buf: &mut dyn BufMut,
+) -> Result<(), SerializeError> {
+    if version.compression_version == UNCOMPRESSED_VERSION {
+        // encode as uncompressed message
+        let enc: [&dyn Encodable; 3] = [&version, &msg_type, &rlp_message];
+        encode_list::<_, dyn Encodable>(&enc, out_buf);
+        Ok(())
+    } else if version.compression_version == DEFAULT_ZSTD_VERSION {
+        // Serialize the message into a temporary buffer,
+        // compress, then encode the compressed message.
+        let mut rlp_encoded_msg = BytesMut::new();
+        rlp_message.encode(&mut rlp_encoded_msg);
+
+        let mut compressed_message = Vec::new();
+        ZstdCompression::default()
+            .compress(&rlp_encoded_msg, &mut compressed_message)
+            .map_err(|err| SerializeError(format!("compression error: {:?}", err)))?;
+        let compressed_message = Bytes::from(compressed_message);
+
+        // encode as compressed message
+        let enc: [&dyn Encodable; 3] = [&version, &msg_type, &compressed_message];
+        encode_list::<_, dyn Encodable>(&enc, out_buf);
+        Ok(())
+    } else {
+        unreachable!() // Logic error, invalid compression version?
+    }
+}
+
+#[derive(Debug)]
+pub struct DeserializeError(pub String);
+
+impl From<alloy_rlp::Error> for DeserializeError {
+    fn from(err: alloy_rlp::Error) -> Self {
+        DeserializeError(format!("rlp decode error: {:?}", err))
+    }
+}
+
+pub(crate) fn try_deserialize_rlp_message<M: Decodable>(
+    version: NetworkMessageVersion,
+    payload: &mut &[u8],
+) -> Result<M, DeserializeError> {
+    match version.compression_version {
+        UNCOMPRESSED_VERSION => {
+            // decode as uncompressed message
+            let decoded_msg = M::decode(payload).map_err(DeserializeError::from)?;
+            Ok(decoded_msg)
+        }
+        DEFAULT_ZSTD_VERSION => {
+            let compressed_app_message = Bytes::decode(payload).map_err(DeserializeError::from)?;
+            // decompress message
+            let mut decompressed_app_message = Vec::new();
+            ZstdCompression::default()
+                .decompress(&compressed_app_message, &mut decompressed_app_message)
+                .map_err(|err| DeserializeError(format!("decompression error: {:?}", err)))?;
+
+            let decoded_msg = M::decode(&mut decompressed_app_message.as_ref())
+                .map_err(DeserializeError::from)?;
+            Ok(decoded_msg)
+        }
+        _ => Err(DeserializeError("unknown compression version".into())),
+    }
+}


### PR DESCRIPTION
This is part of a series of PR split from the original Full-node RaptorCast integration.
This PR contains just the Group messages adapted to the new, recent serialization method by Kai