### PR TITLE
monad-rpc: temporarily disable otel spans reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5228,7 +5228,6 @@ dependencies = [
  "toml 0.7.8",
  "tracing",
  "tracing-actix-web",
- "tracing-opentelemetry",
  "tracing-subscriber",
  "vergen-git2",
 ]

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -61,7 +61,6 @@ tokio = { workspace = true, features = ["net", "macros", "rt-multi-thread", "fs"
 toml = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
 tracing-actix-web = { workspace = true }
-tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 
 [dev-dependencies]


### PR DESCRIPTION
fallback solution to unblock release if we won't find a root cause of the problem.

monad-rpc heap consistently grows at high rate when DEBUG log enabled

![image](https://github.com/user-attachments/assets/2f43ff48-7fcc-49a7-bf03-72c2bc62c012)

we restarted container with jemallocator pprof enabled and it clearly shows that the leak in otel exporter

![image](https://github.com/user-attachments/assets/faceec19-ccb5-446b-ae88-f5a7ab76ff28)
 