### PR TITLE
Prune nodes when above max active connections

### DIFF
--- a/docker/devnet/monad/config/node.toml
+++ b/docker/devnet/monad/config/node.toml
@@ -42,6 +42,7 @@ refresh_period = 120
 request_timeout = 5
 prune_threshold = 5
 min_active_connections = 0
+max_active_connections = 200
 peers = []
 # [[peer_discovery.peers]]
 # address = "x.x.x.x:xxxx"

--- a/monad-node-config/src/peers.rs
+++ b/monad-node-config/src/peers.rs
@@ -25,6 +25,7 @@ pub struct PeerConfig<ST: CertificateSignatureRecoverable> {
     pub request_timeout: u64,
     pub prune_threshold: u32,
     pub min_active_connections: usize,
+    pub max_active_connections: usize,
 
     #[serde(bound = "ST: CertificateSignatureRecoverable")]
     pub peers: Vec<PeerDiscoveryConfig<ST>>,

--- a/monad-peer-disc-swarm/src/driver.rs
+++ b/monad-peer-disc-swarm/src/driver.rs
@@ -157,6 +157,12 @@ where
                 target,
                 lookup_id,
             } => self.algo.handle_peer_lookup_timeout(to, target, lookup_id),
+            PeerDiscoveryEvent::UpdateCurrentEpoch { epoch } => {
+                self.algo.update_current_epoch(epoch)
+            }
+            PeerDiscoveryEvent::UpdateValidatorSet { epoch, validators } => {
+                self.algo.update_validator_set(epoch, validators)
+            }
             PeerDiscoveryEvent::Refresh => self.algo.refresh(),
         };
 

--- a/monad-peer-discovery/src/driver.rs
+++ b/monad-peer-discovery/src/driver.rs
@@ -165,6 +165,10 @@ impl<PD: PeerDiscoveryAlgo> PeerDiscoveryDriver<PD> {
                 target,
                 lookup_id,
             } => self.pd.handle_peer_lookup_timeout(to, target, lookup_id),
+            PeerDiscoveryEvent::UpdateCurrentEpoch { epoch } => self.pd.update_current_epoch(epoch),
+            PeerDiscoveryEvent::UpdateValidatorSet { epoch, validators } => {
+                self.pd.update_validator_set(epoch, validators)
+            }
             PeerDiscoveryEvent::Refresh => self.pd.refresh(),
         };
 

--- a/monad-peer-discovery/src/lib.rs
+++ b/monad-peer-discovery/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeSet, HashMap},
     net::{Ipv4Addr, SocketAddrV4},
     time::Duration,
 };
@@ -9,7 +9,7 @@ use message::{PeerLookupRequest, PeerLookupResponse, Ping, Pong};
 use monad_crypto::certificate_signature::{
     CertificateSignature, CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
-use monad_types::NodeId;
+use monad_types::{Epoch, NodeId};
 use tracing::warn;
 
 pub mod discovery;
@@ -121,6 +121,13 @@ pub enum PeerDiscoveryEvent<ST: CertificateSignatureRecoverable> {
         target: NodeId<CertificateSignaturePubKey<ST>>,
         lookup_id: u32,
     },
+    UpdateCurrentEpoch {
+        epoch: Epoch,
+    },
+    UpdateValidatorSet {
+        epoch: Epoch,
+        validators: BTreeSet<NodeId<CertificateSignaturePubKey<ST>>>,
+    },
     Refresh,
 }
 
@@ -208,6 +215,17 @@ pub trait PeerDiscoveryAlgo {
     ) -> Vec<PeerDiscoveryCommand<Self::SignatureType>>;
 
     fn refresh(&mut self) -> Vec<PeerDiscoveryCommand<Self::SignatureType>>;
+
+    fn update_current_epoch(
+        &mut self,
+        epoch: Epoch,
+    ) -> Vec<PeerDiscoveryCommand<Self::SignatureType>>;
+
+    fn update_validator_set(
+        &mut self,
+        epoch: Epoch,
+        validators: BTreeSet<NodeId<CertificateSignaturePubKey<Self::SignatureType>>>,
+    ) -> Vec<PeerDiscoveryCommand<Self::SignatureType>>;
 
     fn metrics(&self) -> &PeerDiscMetrics;
 

--- a/monad-peer-discovery/src/mock.rs
+++ b/monad-peer-discovery/src/mock.rs
@@ -1,9 +1,13 @@
-use std::{collections::HashMap, marker::PhantomData, net::SocketAddrV4};
+use std::{
+    collections::{BTreeSet, HashMap},
+    marker::PhantomData,
+    net::SocketAddrV4,
+};
 
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
-use monad_types::NodeId;
+use monad_types::{Epoch, NodeId};
 use tracing::debug;
 
 use crate::{
@@ -96,7 +100,7 @@ where
         &mut self,
         to: NodeId<CertificateSignaturePubKey<ST>>,
         target: NodeId<CertificateSignaturePubKey<ST>>,
-        open_discovery: bool,
+        _open_discovery: bool,
     ) -> Vec<PeerDiscoveryCommand<ST>> {
         debug!(?to, ?target, "sending peer lookup request");
 
@@ -136,6 +140,22 @@ where
 
     fn refresh(&mut self) -> Vec<PeerDiscoveryCommand<ST>> {
         debug!("pruning unresponsive peer nodes");
+
+        Vec::new()
+    }
+
+    fn update_current_epoch(&mut self, epoch: Epoch) -> Vec<PeerDiscoveryCommand<ST>> {
+        debug!(?epoch, "updating current epoch");
+
+        Vec::new()
+    }
+
+    fn update_validator_set(
+        &mut self,
+        _epoch: Epoch,
+        _validators: BTreeSet<NodeId<CertificateSignaturePubKey<ST>>>,
+    ) -> Vec<PeerDiscoveryCommand<ST>> {
+        debug!("updating validator set");
 
         Vec::new()
     }


### PR DESCRIPTION
A few changes: 
- Only prune non validators node
- When servicing peer lookup response, prioritize sending validator nodes
- When above max active connections, prune full nodes