### PR TITLE
Archive: Add common kvstore metrics and source/sink store type

### DIFF
--- a/monad-archive/src/archive_reader.rs
+++ b/monad-archive/src/archive_reader.rs
@@ -46,14 +46,18 @@ impl ArchiveReader {
         reader
     }
 
-    pub async fn init_mongo_reader(url: String, db: String) -> Result<ArchiveReader> {
+    pub async fn init_mongo_reader(
+        url: String,
+        db: String,
+        metrics: Metrics,
+    ) -> Result<ArchiveReader> {
         info!(url, db, "Initializing MongoDB ArchiveReader");
         trace!("Creating MongoDB block store");
-        let block_store = MongoDbStorage::new_block_store(&url, &db, None).await?;
+        let block_store = MongoDbStorage::new_block_store(&url, &db, None, metrics.clone()).await?;
         let block_data_reader = BlockDataArchive::new(block_store);
 
         trace!("Creating MongoDB index store");
-        let index_store = MongoDbStorage::new_index_store(&url, &db, None).await?;
+        let index_store = MongoDbStorage::new_index_store(&url, &db, None, metrics).await?;
         let index_reader = IndexReaderImpl::new(index_store, block_data_reader.clone());
 
         trace!("Creating MongoDB log index store");

--- a/monad-archive/src/bin/monad-archive-checker/checker.rs
+++ b/monad-archive/src/bin/monad-archive-checker/checker.rs
@@ -35,8 +35,8 @@ pub async fn checker_worker(
         let latest_to_check = model.latest_to_check().await?;
         let required_blocks = next_to_check + min_lag_from_tip + CHUNK_SIZE;
 
-        metrics.gauge("latest_to_check", latest_to_check);
-        metrics.gauge("next_to_check", next_to_check);
+        metrics.gauge(MetricNames::LATEST_TO_CHECK, latest_to_check);
+        metrics.gauge(MetricNames::NEXT_TO_CHECK, next_to_check);
 
         if latest_to_check < required_blocks {
             info!(

--- a/monad-archive/src/bin/monad-archive-checker/fault_fixer.rs
+++ b/monad-archive/src/bin/monad-archive-checker/fault_fixer.rs
@@ -115,13 +115,13 @@ pub async fn run_fixer(
         // Update metrics with fix attempt results (even for dry run)
         if !dry_run {
             metrics.counter_with_attrs(
-                "replica_faults__fixed",
+                MetricNames::REPLICA_FAULTS_FIXED,
                 replica_fixed as u64,
                 &[KeyValue::new("replica", replica.clone())],
             );
 
             metrics.counter_with_attrs(
-                "replica_faults__fix_failed",
+                MetricNames::REPLICA_FAULTS_FIX_FAILED,
                 replica_failed as u64,
                 &[KeyValue::new("replica", replica)],
             );
@@ -209,7 +209,7 @@ async fn fix_faults_in_range(
 
             // Report error metric
             metrics.counter_with_attrs(
-                "replica_faults__fix_error",
+                MetricNames::REPLICA_FAULTS_FIX_FAILED,
                 1,
                 &[
                     KeyValue::new("replica", replica.to_owned()),
@@ -228,7 +228,7 @@ async fn fix_faults_in_range(
 
             // Report success metric
             metrics.counter_with_attrs(
-                "replica_faults__fix_success",
+                MetricNames::REPLICA_FAULTS_FIX_SUCCESS,
                 1,
                 &[
                     KeyValue::new("replica", replica.to_owned()),

--- a/monad-archive/src/bin/monad-archive-checker/rechecker.rs
+++ b/monad-archive/src/bin/monad-archive-checker/rechecker.rs
@@ -91,7 +91,7 @@ async fn recheck(model: &CheckerModel, metrics: &Metrics) -> Result<()> {
 
         // Update metrics with current fault counts
         metrics.periodic_gauge_with_attrs(
-            "replica_faults_total",
+            MetricNames::REPLICA_FAULTS_TOTAL,
             total_faults.len() as u64,
             vec![KeyValue::new("replica", replica.to_owned())],
         );
@@ -103,7 +103,7 @@ async fn recheck(model: &CheckerModel, metrics: &Metrics) -> Result<()> {
 
         for (fault, count) in &grouped_by_faults {
             metrics.periodic_gauge_with_attrs(
-                "replica_faults_by_kind",
+                MetricNames::REPLICA_FAULTS_BY_KIND,
                 *count,
                 vec![
                     KeyValue::new("replica", replica.to_owned()),

--- a/monad-archive/src/bin/monad-index-checker/main.rs
+++ b/monad-archive/src/bin/monad-index-checker/main.rs
@@ -130,18 +130,24 @@ async fn handle_blocks(
 
     for block_check in &faults {
         if !block_check.faults.is_empty() {
-            metrics.counter("faults_blocks_with_faults", 1);
+            metrics.counter(MetricNames::FAULTS_BLOCKS_WITH_FAULTS, 1);
         }
         for fault in &block_check.faults {
             match fault {
-                Fault::ErrorChecking { .. } => metrics.counter("faults_error_checking", 1),
-                Fault::CorruptedBlock => metrics.counter("faults_corrupted_blocks", 1),
-                Fault::MissingAllTxHash { num_txs } => {
-                    metrics.counter("faults_blocks_missing_all_txhash", 1);
-                    metrics.counter("faults_missing_txhash", *num_txs as u64);
+                Fault::ErrorChecking { .. } => {
+                    metrics.counter(MetricNames::FAULTS_ERROR_CHECKING, 1)
                 }
-                Fault::MissingTxhash { .. } => metrics.counter("faults_missing_txhash", 1),
-                Fault::IncorrectTxData { .. } => metrics.counter("faults_incorrect_tx_data", 1),
+                Fault::CorruptedBlock => metrics.counter(MetricNames::FAULTS_CORRUPTED_BLOCKS, 1),
+                Fault::MissingAllTxHash { num_txs } => {
+                    metrics.counter(MetricNames::FAULTS_MISSING_ALL_TXHASH, 1);
+                    metrics.counter(MetricNames::FAULTS_MISSING_TXHASH, *num_txs as u64);
+                }
+                Fault::MissingTxhash { .. } => {
+                    metrics.counter(MetricNames::FAULTS_MISSING_TXHASH, 1)
+                }
+                Fault::IncorrectTxData { .. } => {
+                    metrics.counter(MetricNames::FAULTS_INCORRECT_TX_DATA, 1)
+                }
 
                 // Other faults are not DynamoDB faults
                 _ => (),

--- a/monad-archive/src/bin/monad-indexer/main.rs
+++ b/monad-archive/src/bin/monad-indexer/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use monad_archive::{
-    model::logs_index::LogsIndexArchiver, prelude::*, workers::index_worker::index_worker,
+    cli::set_source_and_sink_metrics, model::logs_index::LogsIndexArchiver, prelude::*,
+    workers::index_worker::index_worker,
 };
 use tracing::{info, Level};
 
@@ -20,6 +21,7 @@ async fn main() -> Result<()> {
             .unwrap_or_else(|| args.archive_sink.replica_name()),
         Duration::from_secs(15),
     )?;
+    set_source_and_sink_metrics(&args.archive_sink, &args.block_data_source, &metrics);
 
     let block_data_reader = args.block_data_source.build(&metrics).await?;
     let tx_index_archiver = args

--- a/monad-archive/src/metrics.rs
+++ b/monad-archive/src/metrics.rs
@@ -3,21 +3,123 @@ use std::{sync::Arc, time::Duration};
 use dashmap::DashMap;
 use eyre::Result;
 use opentelemetry::{
-    metrics::{Counter, Gauge, Meter, MeterProvider},
+    metrics::{Counter, Gauge, Histogram, Meter, MeterProvider},
     KeyValue,
 };
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::metrics::{SdkMeterProvider, Temporality};
 use tracing::trace;
 
+#[derive(Eq, Hash, PartialEq, Clone, Copy)]
+#[allow(non_camel_case_types)]
+pub enum MetricNames {
+    // Store Type
+    SINK_STORE_TYPE,
+    SOURCE_STORE_TYPE,
+
+    // KV Store
+    KV_STORE_PUT_DURATION_MS,
+    KV_STORE_PUT_SUCCESS,
+    KV_STORE_PUT_FAILURE,
+    KV_STORE_GET_DURATION_MS,
+    KV_STORE_GET_SUCCESS,
+    KV_STORE_GET_FAILURE,
+
+    // Legacy AWS metrics for backwards compatibility
+    AWS_S3_READS,
+    AWS_S3_WRITES,
+    AWS_S3_ERRORS,
+    AWS_DYNAMODB_READS,
+    AWS_DYNAMODB_WRITES,
+    AWS_DYNAMODB_ERRORS,
+
+    // Archive Or Index Workers
+    TXS_INDEXED,
+    BLOCK_ARCHIVE_WORKER_BLOCK_FALLBACK,
+    BLOCK_ARCHIVE_WORKER_RECEIPTS_FALLBACK,
+    BLOCK_ARCHIVE_WORKER_TRACES_FALLBACK,
+
+    SOURCE_LATEST_BLOCK_NUM,
+    END_BLOCK_NUMBER,
+    START_BLOCK_NUMBER,
+
+    BFT_BLOCKS_UPLOADED,
+
+    // Archive Checker
+    LATEST_TO_CHECK,
+    NEXT_TO_CHECK,
+    REPLICA_FAULTS_FIXED,
+    REPLICA_FAULTS_FIX_FAILED,
+    REPLICA_FAULTS_FIX_SUCCESS,
+    REPLICA_FAULTS_BY_KIND,
+    REPLICA_FAULTS_TOTAL,
+
+    // Index Checker
+    FAULTS_BLOCKS_WITH_FAULTS,
+    FAULTS_ERROR_CHECKING,
+    FAULTS_CORRUPTED_BLOCKS,
+    FAULTS_MISSING_TXHASH,
+    FAULTS_INCORRECT_TX_DATA,
+    FAULTS_MISSING_ALL_TXHASH,
+}
+
+impl MetricNames {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            MetricNames::SINK_STORE_TYPE => "sink_store_type",
+            MetricNames::SOURCE_STORE_TYPE => "source_store_type",
+            MetricNames::KV_STORE_PUT_DURATION_MS => "kv_store_put_duration_ms",
+            MetricNames::KV_STORE_PUT_SUCCESS => "kv_store_put_success",
+            MetricNames::KV_STORE_PUT_FAILURE => "kv_store_put_failure",
+            MetricNames::KV_STORE_GET_DURATION_MS => "kv_store_get_duration_ms",
+            MetricNames::KV_STORE_GET_SUCCESS => "kv_store_get_success",
+            MetricNames::KV_STORE_GET_FAILURE => "kv_store_get_failure",
+            MetricNames::AWS_S3_READS => "aws_s3_reads",
+            MetricNames::AWS_S3_WRITES => "aws_s3_writes",
+            MetricNames::AWS_S3_ERRORS => "aws_s3_errors",
+            MetricNames::AWS_DYNAMODB_READS => "aws_dynamodb_reads",
+            MetricNames::AWS_DYNAMODB_WRITES => "aws_dynamodb_writes",
+            MetricNames::AWS_DYNAMODB_ERRORS => "aws_dynamodb_errors",
+            MetricNames::BLOCK_ARCHIVE_WORKER_BLOCK_FALLBACK => {
+                "block_archive_worker_block_fallback"
+            }
+            MetricNames::BLOCK_ARCHIVE_WORKER_RECEIPTS_FALLBACK => {
+                "block_archive_worker_receipts_fallback"
+            }
+            MetricNames::BLOCK_ARCHIVE_WORKER_TRACES_FALLBACK => {
+                "block_archive_worker_traces_fallback"
+            }
+            MetricNames::TXS_INDEXED => "txs_indexed",
+            MetricNames::LATEST_TO_CHECK => "latest_to_check",
+            MetricNames::NEXT_TO_CHECK => "next_to_check",
+            MetricNames::SOURCE_LATEST_BLOCK_NUM => "source_latest_block_num",
+            MetricNames::END_BLOCK_NUMBER => "end_block_number",
+            MetricNames::START_BLOCK_NUMBER => "start_block_number",
+            MetricNames::REPLICA_FAULTS_FIXED => "replica_faults__fixed",
+            MetricNames::REPLICA_FAULTS_FIX_FAILED => "replica_faults__fix_failed",
+            MetricNames::REPLICA_FAULTS_FIX_SUCCESS => "replica_faults__fix_success",
+            MetricNames::BFT_BLOCKS_UPLOADED => "bft_blocks_uploaded",
+            MetricNames::REPLICA_FAULTS_BY_KIND => "replica_faults__by_kind",
+            MetricNames::REPLICA_FAULTS_TOTAL => "replica_faults__total",
+            MetricNames::FAULTS_BLOCKS_WITH_FAULTS => "faults_blocks_with_faults",
+            MetricNames::FAULTS_ERROR_CHECKING => "faults_error_checking",
+            MetricNames::FAULTS_CORRUPTED_BLOCKS => "faults_corrupted_blocks",
+            MetricNames::FAULTS_MISSING_TXHASH => "faults_missing_txhash",
+            MetricNames::FAULTS_INCORRECT_TX_DATA => "faults_incorrect_tx_data",
+            MetricNames::FAULTS_MISSING_ALL_TXHASH => "faults_missing_all_txhash",
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct Metrics(Option<Arc<MetricsInner>>);
 
 #[derive(Clone)]
 pub struct MetricsInner {
-    pub gauges: Arc<DashMap<&'static str, Gauge<u64>>>,
-    pub periodic_gauges: Arc<DashMap<(&'static str, Vec<KeyValue>), u64>>,
-    pub counters: Arc<DashMap<&'static str, Counter<u64>>>,
+    pub gauges: Arc<DashMap<MetricNames, Gauge<u64>>>,
+    pub periodic_gauges: Arc<DashMap<(MetricNames, Vec<KeyValue>), u64>>,
+    pub counters: Arc<DashMap<MetricNames, Counter<u64>>>,
+    pub histograms: Arc<DashMap<MetricNames, Histogram<f64>>>,
     pub provider: SdkMeterProvider,
     pub meter: Meter,
 }
@@ -38,11 +140,12 @@ impl Metrics {
         let meter = provider.meter("opentelemetry");
 
         let metrics = Metrics(Some(Arc::new(MetricsInner {
-            counters: Arc::new(DashMap::with_capacity(100)),
-            gauges: Arc::new(DashMap::with_capacity(100)),
+            counters: Arc::default(),
+            gauges: Arc::default(),
+            histograms: Arc::default(),
+            periodic_gauges: Arc::default(),
             provider,
             meter,
-            periodic_gauges: Arc::new(DashMap::with_capacity(100)),
         })));
 
         {
@@ -56,7 +159,7 @@ impl Metrics {
                     for map_ref in inner.periodic_gauges.iter() {
                         let (metric, attributes) = map_ref.key();
                         let value = map_ref.value();
-                        metrics.gauge_with_attrs(metric, *value, attributes);
+                        metrics.gauge_with_attrs(*metric, *value, attributes);
                     }
 
                     trace!(
@@ -74,28 +177,42 @@ impl Metrics {
         Metrics(None)
     }
 
-    pub fn inc_counter(&self, metric: &'static str) {
+    pub fn inc_counter(&self, metric: MetricNames) {
         self.counter(metric, 1)
     }
 
-    pub fn counter_with_attrs(&self, metric: &'static str, val: u64, attributes: &[KeyValue]) {
+    pub fn counter_with_attrs(&self, metric: MetricNames, val: u64, attributes: &[KeyValue]) {
         if let Some(inner) = &self.0 {
             let counter = inner
                 .counters
                 .entry(metric)
-                .or_insert_with(|| inner.meter.u64_counter(metric).build());
+                .or_insert_with(|| inner.meter.u64_counter(metric.as_str()).build());
 
             counter.add(val, attributes)
         }
     }
 
-    pub fn counter(&self, metric: &'static str, val: u64) {
+    pub fn counter(&self, metric: MetricNames, val: u64) {
         self.counter_with_attrs(metric, val, &[]);
+    }
+
+    pub fn histogram(&self, metric: MetricNames, value: f64) {
+        self.histogram_with_attrs(metric, value, &[]);
+    }
+
+    pub fn histogram_with_attrs(&self, metric: MetricNames, value: f64, attributes: &[KeyValue]) {
+        if let Some(inner) = &self.0 {
+            let histogram = inner
+                .histograms
+                .entry(metric)
+                .or_insert_with(|| inner.meter.f64_histogram(metric.as_str()).build());
+            histogram.record(value, attributes);
+        }
     }
 
     pub fn periodic_gauge_with_attrs(
         &self,
-        metric: &'static str,
+        metric: MetricNames,
         value: u64,
         attributes: Vec<KeyValue>,
     ) {
@@ -105,17 +222,17 @@ impl Metrics {
         }
     }
 
-    pub fn gauge_with_attrs(&self, metric: &'static str, value: u64, attributes: &[KeyValue]) {
+    pub fn gauge_with_attrs(&self, metric: MetricNames, value: u64, attributes: &[KeyValue]) {
         if let Some(inner) = &self.0 {
             let gauge = inner
                 .gauges
                 .entry(metric)
-                .or_insert_with(|| inner.meter.u64_gauge(metric).build());
+                .or_insert_with(|| inner.meter.u64_gauge(metric.as_str()).build());
             gauge.record(value, attributes);
         }
     }
 
-    pub fn gauge(&self, metric: &'static str, value: u64) {
+    pub fn gauge(&self, metric: MetricNames, value: u64) {
         self.gauge_with_attrs(metric, value, &[]);
     }
 }

--- a/monad-archive/src/model/logs_index.rs
+++ b/monad-archive/src/model/logs_index.rs
@@ -264,6 +264,7 @@ mod tests {
             &format!("mongodb://localhost:{}", container.port),
             "archive-db",
             Some(100_000),
+            Metrics::none(),
         )
         .await?;
         let indexer = TxIndexArchiver::new(

--- a/monad-archive/src/prelude.rs
+++ b/monad-archive/src/prelude.rs
@@ -21,7 +21,7 @@ pub use crate::{
         dynamodb::DynamoDBArchive, s3::S3Bucket, triedb_reader::TriedbReader, KVReader,
         KVReaderErased, KVStore, KVStoreErased,
     },
-    metrics::Metrics,
+    metrics::{MetricNames, Metrics},
     model::{
         block_data_archive::*, tx_index_archive::*, BlockDataReader, BlockDataReaderErased,
         BlockDataWithOffsets, HeaderSubset, TxByteOffsets, TxIndexedData,

--- a/monad-archive/src/workers/bft_block_archiver.rs
+++ b/monad-archive/src/workers/bft_block_archiver.rs
@@ -49,7 +49,7 @@ pub async fn bft_block_archive_worker(
         } else {
             info!(num_to_upload)
         }
-        metrics.gauge("bft_blocks_uploaded", uploaded.len() as u64);
+        metrics.gauge(MetricNames::BFT_BLOCKS_UPLOADED, uploaded.len() as u64);
     }
 }
 

--- a/monad-archive/src/workers/index_worker.rs
+++ b/monad-archive/src/workers/index_worker.rs
@@ -70,9 +70,9 @@ pub async fn index_worker(
             start_block,
             end_block, latest_source, "Indexing group of blocks"
         );
-        metrics.gauge("source_latest_block_num", latest_source);
-        metrics.gauge("end_block_number", end_block);
-        metrics.gauge("start_block_number", start_block);
+        metrics.gauge(MetricNames::SOURCE_LATEST_BLOCK_NUM, latest_source);
+        metrics.gauge(MetricNames::END_BLOCK_NUMBER, end_block);
+        metrics.gauge(MetricNames::START_BLOCK_NUMBER, start_block);
 
         let latest_indexed = index_blocks(
             &block_data_reader,
@@ -130,7 +130,7 @@ async fn index_blocks(
         num_txs_indexed,
         "Finished indexing range",
     );
-    metrics.counter("txs_indexed", num_txs_indexed as u64);
+    metrics.counter(MetricNames::TXS_INDEXED, num_txs_indexed as u64);
 
     if new_latest_indexed != 0 {
         checkpoint_latest(indexer, new_latest_indexed).await;

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -169,7 +169,13 @@ async fn main() -> std::io::Result<()> {
     let archive_reader = match (&args.mongo_db_name, &args.mongo_url) {
         (Some(db_name), Some(url)) => {
             info!(url, db_name, "Initializing MongoDB archive reader");
-            match ArchiveReader::init_mongo_reader(url.clone(), db_name.clone()).await {
+            match ArchiveReader::init_mongo_reader(
+                url.clone(),
+                db_name.clone(),
+                monad_archive::prelude::Metrics::none(),
+            )
+            .await
+            {
                 Ok(mongo_reader) => {
                     let has_aws_fallback = aws_archive_reader.is_some();
                     info!(


### PR DESCRIPTION
Also cleanup base strings and use centralized enum for metric names

- Added common kv_store metrics that is written both by mongo and s3/dynamodb that we discussed earlier this week
- Archiver and Indexer now report sink_store_type and source_store_type with the string as an attribute (value is a int / enum)
- Archiver adds new counters for when it's reading from fallback source instead of primary source

New metrics:
"sink_store_type"
"source_store_type"
"kv_store_put_duration_ms"
"kv_store_put_success"
"kv_store_put_failure"
"kv_store_get_duration_ms"
"kv_store_get_success"
"kv_store_get_failure"
"block_archive_worker_block_fallback"
"block_archive_worker_receipts_fallback"
"block_archive_worker_traces_fallback"