### PR TITLE
Fix: Don't block rpc startup on eth_getLogs index creation

### DIFF
--- a/monad-archive/.gitignore
+++ b/monad-archive/.gitignore
@@ -1,1 +1,3 @@
 faults.json
+.*
+!/.gitignore

--- a/monad-archive/src/archive_reader.rs
+++ b/monad-archive/src/archive_reader.rs
@@ -57,7 +57,7 @@ impl ArchiveReader {
         let index_reader = IndexReaderImpl::new(index_store, block_data_reader.clone());
 
         trace!("Creating MongoDB log index store");
-        let log_index = LogsIndexArchiver::from_tx_index_archiver(&index_reader, 50)
+        let log_index = LogsIndexArchiver::from_tx_index_archiver(&index_reader, 50, true)
             .await
             .wrap_err("Failed to create log index reader")?;
 

--- a/monad-archive/src/bin/monad-indexer/main.rs
+++ b/monad-archive/src/bin/monad-indexer/main.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
         KVStoreErased::MongoDbStorage(_storage) => {
             info!("Building log index archiver...");
             Some(
-                LogsIndexArchiver::from_tx_index_archiver(&tx_index_archiver, 50)
+                LogsIndexArchiver::from_tx_index_archiver(&tx_index_archiver, 50, false)
                     .await
                     .wrap_err("Failed to create log index reader")?,
             )


### PR DESCRIPTION
  The ensures that:
  - RPCs no longer block for 12-40 minutes during startup when the index doesn't exist
  - The index will still be created in the background for future eth_getLogs queries
  - Writers/indexers continue to block on index creation as they need it before writing
  - The system maintains backward compatibility

  fixes https://github.com/category-labs/category-internal/issues/1626