### PR TITLE
Full-node Raptorcast: config for secondary instance

### DIFF
--- a/docker/devnet/monad/config/node.toml
+++ b/docker/devnet/monad/config/node.toml
@@ -27,6 +27,8 @@ chain_id = 20143
 #########################################################
 # Node-specific configuration
 #########################################################
+raptor10_validator_redundancy_factor = 3
+
 [bootstrap]
 peers = []
 # [[bootstrap.peers]]
@@ -50,9 +52,9 @@ peers = []
 # secp256k1_pubkey = "..."
 # name_record_sig = "..."
 
-[fullnode]
+[fullnode_dedicated]
 identities = []
-# [[fullnode.identities]]
+# [[fullnode_dedicated.identities]]
 # secp256k1_pubkey = "..."
 
 [blocksync_override]

--- a/monad-node-config/src/bootstrap.rs
+++ b/monad-node-config/src/bootstrap.rs
@@ -2,14 +2,14 @@ use monad_crypto::certificate_signature::PubKey;
 use monad_types::{deserialize_pubkey, serialize_pubkey};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct NodeBootstrapConfig<P: PubKey> {
     #[serde(bound = "P:PubKey")]
     pub peers: Vec<NodeBootstrapPeerConfig<P>>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct NodeBootstrapPeerConfig<P: PubKey> {
     pub address: String,

--- a/monad-node-config/src/fullnode.rs
+++ b/monad-node-config/src/fullnode.rs
@@ -2,14 +2,14 @@ use monad_crypto::certificate_signature::PubKey;
 use monad_types::{deserialize_pubkey, serialize_pubkey};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct FullNodeConfig<P: PubKey> {
     #[serde(bound = "P:PubKey")]
     pub identities: Vec<FullNodeIdentityConfig<P>>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct FullNodeIdentityConfig<P: PubKey> {
     // #[serde(deserialize_with = "deserialize_secp256k1_pubkey")]

--- a/monad-node-config/src/fullnode_raptorcast.rs
+++ b/monad-node-config/src/fullnode_raptorcast.rs
@@ -1,0 +1,37 @@
+use monad_crypto::certificate_signature::PubKey;
+use monad_types::Round;
+use serde::{Deserialize, Serialize};
+
+use super::fullnode::FullNodeConfig;
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub enum SecondaryRaptorCastModeConfig {
+    Client,
+    Publisher,
+    // No "None" option, as FullNodeRaptorCastConfig is now wrapped in Option<>
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct FullNodeRaptorCastConfig<P: PubKey> {
+    pub mode: SecondaryRaptorCastModeConfig,
+
+    #[serde(bound = "P:PubKey")]
+    pub full_nodes_prioritized: FullNodeConfig<P>,
+    pub raptor10_fullnode_redundancy_factor: u8, // validator -> full-nodes
+
+    // RaptorCastConfigSecondaryPublisher::GroupSchedulingConfig
+    pub max_group_size: usize,
+    pub round_span: Round,
+    pub invite_lookahead: Round,
+    pub max_invite_wait: Round,
+    pub deadline_round_dist: Round,
+    pub init_empty_round_span: Round,
+
+    // RaptorCastConfigSecondaryClient
+    pub bandwidth_cost_per_group_member: u64,
+    pub bandwidth_capacity: u64,
+    pub invite_future_dist_min: Round,
+    pub invite_future_dist_max: Round,
+}

--- a/monad-node-config/src/lib.rs
+++ b/monad-node-config/src/lib.rs
@@ -24,9 +24,13 @@ mod consensus;
 mod fullnode;
 mod network;
 mod peers;
+
+pub mod fullnode_raptorcast;
+pub use fullnode_raptorcast::FullNodeRaptorCastConfig;
+
 mod sync_peers;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct NodeConfig<ST: CertificateSignatureRecoverable> {
     /////////////////////////////////
@@ -49,7 +53,7 @@ pub struct NodeConfig<ST: CertificateSignatureRecoverable> {
     #[serde(bound = "ST: CertificateSignatureRecoverable")]
     pub bootstrap: NodeBootstrapConfig<CertificateSignaturePubKey<ST>>,
     #[serde(bound = "ST: CertificateSignatureRecoverable")]
-    pub fullnode: FullNodeConfig<CertificateSignaturePubKey<ST>>,
+    pub fullnode_dedicated: FullNodeConfig<CertificateSignaturePubKey<ST>>,
     #[serde(bound = "ST: CertificateSignatureRecoverable")]
     pub blocksync_override: BlockSyncPeersConfig<CertificateSignaturePubKey<ST>>,
     #[serde(bound = "ST: CertificateSignatureRecoverable")]
@@ -59,6 +63,10 @@ pub struct NodeConfig<ST: CertificateSignatureRecoverable> {
     // FIXME: merge this with bootstrap field
     #[serde(bound = "ST: CertificateSignatureRecoverable")]
     pub peer_discovery: PeerConfig<ST>,
+
+    pub raptor10_validator_redundancy_factor: u8, // validator -> validator
+    #[serde(bound = "ST: CertificateSignatureRecoverable")]
+    pub fullnode_raptorcast: Option<FullNodeRaptorCastConfig<CertificateSignaturePubKey<ST>>>,
 
     // TODO split network-wide configuration into separate file
     ////////////////////////////////

--- a/monad-node-config/src/peers.rs
+++ b/monad-node-config/src/peers.rs
@@ -9,7 +9,7 @@ use monad_types::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct PeerConfig<ST: CertificateSignatureRecoverable> {
     pub self_address: SocketAddrV4,
@@ -31,7 +31,7 @@ pub struct PeerConfig<ST: CertificateSignatureRecoverable> {
     pub peers: Vec<PeerDiscoveryConfig<ST>>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct PeerDiscoveryConfig<ST: CertificateSignatureRecoverable> {
     pub address: SocketAddrV4,

--- a/monad-node-config/src/sync_peers.rs
+++ b/monad-node-config/src/sync_peers.rs
@@ -2,21 +2,21 @@ use monad_crypto::certificate_signature::PubKey;
 use monad_types::{deserialize_pubkey, serialize_pubkey};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct BlockSyncPeersConfig<P: PubKey> {
     #[serde(bound = "P:PubKey")]
     pub peers: Vec<SyncPeerIdentityConfig<P>>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct StateSyncPeersConfig<P: PubKey> {
     #[serde(bound = "P:PubKey")]
     pub peers: Vec<SyncPeerIdentityConfig<P>>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct SyncPeerIdentityConfig<P: PubKey> {
     #[serde(serialize_with = "serialize_pubkey::<_, P>")]

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -204,7 +204,7 @@ async fn run(node_state: NodeState, reload_handle: ReloadHandle) -> Result<(), (
                 .cloned()
                 .filter_map(|(node_id, maybe_addr)| Some((node_id, maybe_addr?)))
                 .collect(),
-            &node_state.node_config.fullnode.identities,
+            &node_state.node_config.fullnode_dedicated.identities,
             locked_epoch_validators.clone(),
             current_epoch,
         )

--- a/monad-raptorcast/src/config.rs
+++ b/monad-raptorcast/src/config.rs
@@ -16,7 +16,7 @@ where
     // move the Config when wrapping shared_key into an Arc during the ctor.
     pub shared_key: Arc<ST::KeyPairType>,
 
-    // IP addresses ov the entries in full_nodes_dedicated and full_nodes_prioritized
+    // IP addresses ov the entries in fullnode_dedicated and full_nodes_prioritized
     pub known_addresses: HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddr>,
 
     // For splitting large app messages (e.g. block proposals) into chunks that
@@ -32,7 +32,7 @@ where
     // running as full-node.
     // Validators and full-nodes who do not want to participate in validator-
     // to-full-node raptor-casting may opt out of this.
-    pub secondary_instance: SecondaryRcModeConfig<ST>,
+    pub secondary_instance: SecondaryRaptorCastModeConfig<ST>,
 }
 
 /// Configuration for the primary instance of RaptorCast (group of validators)
@@ -43,13 +43,13 @@ where
 {
     // This refers to the full-nodes we as a validator will be broadcasting full
     // app-messages (e.g. block proposals) directly
-    pub full_nodes_dedicated: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
+    pub fullnode_dedicated: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
 
     /// Amount of redundancy (in Raptor10 encoding) to send.
     /// A value of 2 == send 2x total payload size.
     /// Higher values make the broadcasting more tolerant to UDP packet drops.
     /// This applies to raptor-casting across validator
-    pub raptor10_redundancy: u8, // TODO: rename raptor10_redundancy_validators to match node-config
+    pub raptor10_redundancy: u8,
 }
 
 impl<ST> Default for RaptorCastConfigPrimary<ST>
@@ -58,7 +58,7 @@ where
 {
     fn default() -> RaptorCastConfigPrimary<ST> {
         RaptorCastConfigPrimary {
-            full_nodes_dedicated: Vec::new(),
+            fullnode_dedicated: Vec::new(),
             raptor10_redundancy: 3, // for validators
         }
     }
@@ -66,7 +66,7 @@ where
 
 /// Configuration for the secondary instance of RaptorCast (group of full-nodes)
 #[derive(Clone)]
-pub enum SecondaryRcModeConfig<ST>
+pub enum SecondaryRaptorCastModeConfig<ST>
 where
     ST: CertificateSignatureRecoverable,
 {
@@ -98,7 +98,7 @@ impl Default for RaptorCastConfigSecondaryClient {
     }
 }
 
-// Only relevant to the secondary RC instance, and only when running as full-node
+// Only relevant to the secondary RaptorCast instance, and only when running as full-node
 #[derive(Clone)]
 pub struct RaptorCastConfigSecondaryPublisher<ST>
 where
@@ -113,7 +113,7 @@ where
     pub group_scheduling: GroupSchedulingConfig,
 
     /// This applies to raptor-casting across full-nodes
-    pub raptor10_redundancy: u8, // TODO: rename raptor10_redundancy_fullnodes to match node-config
+    pub raptor10_redundancy: u8,
 }
 
 impl<ST> Default for RaptorCastConfigSecondaryPublisher<ST>

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -479,7 +479,7 @@ where
                 this.udp_state.handle_message(
                     &this.rebroadcast_map,
                     |targets, payload, bcast_stride| {
-                        // Callback for re-broadcasting raptorcast chunks to other RC participants (validator peers)
+                        // Callback for re-broadcasting raptorcast chunks to other RaptorCast participants (validator peers)
                         let target_addrs: Vec<SocketAddr> = targets
                             .into_iter()
                             .filter_map(|target| this.known_addresses.get(&target).copied())

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -99,16 +99,16 @@ where
 
         // Instantiate either publisher or client state machine
         let role = match sec_config {
-            super::config::SecondaryRcModeConfig::Publisher(publisher_cfg) => {
+            super::config::SecondaryRaptorCastModeConfig::Publisher(publisher_cfg) => {
                 raptor10_redundancy = publisher_cfg.raptor10_redundancy;
                 let publisher = Publisher::new(node_id, publisher_cfg);
                 Role::Publisher(publisher)
             }
-            super::config::SecondaryRcModeConfig::Client(client_cfg) => {
+            super::config::SecondaryRaptorCastModeConfig::Client(client_cfg) => {
                 let client = Client::new(node_id, channel_to_primary, client_cfg);
                 Role::Client(client)
             }
-            super::config::SecondaryRcModeConfig::None => panic!(
+            super::config::SecondaryRaptorCastModeConfig::None => panic!(
                 "secondary_instance is not set in config during \
                     instantiation of RaptorCastSecondary"
             ),

--- a/monad-raptorcast/src/raptorcast_secondary/publisher.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/publisher.rs
@@ -26,7 +26,7 @@ type TimePoint = Round;
 // That is, we are a validator sending group invites to random full-nodes for
 // raptor-casting messages to them
 
-// Main state machine for when the secondary RC router is acting as a publisher
+// Main state machine for when the secondary RaptorCast router is acting as a publisher
 pub struct Publisher<ST>
 where
     ST: CertificateSignatureRecoverable,
@@ -1389,14 +1389,14 @@ mod tests {
         //-------------------------------------------------------------------[6]
         clt.enter_round(Round(6));
 
-        // RC group from v0 should still be up
+        // RaptorCast group from v0 should still be up
         let rc_grp = &group_map.get_rc_group_peers(&clt, &nid(0));
         assert!(equal_node_set(rc_grp, &node_ids![15, 10]));
 
         //-------------------------------------------------------------------[6]
         clt.enter_round(Round(7));
 
-        // RC group from v0 should be down now, as it only covered rounds [5, 7)
+        // RaptorCast group from v0 should be down now, as it only covered rounds [5, 7)
         // Here we should see a group gap
         assert!(group_map.is_empty(&clt));
 
@@ -1515,14 +1515,14 @@ mod tests {
         //------------------------------------------------------------------[36]
         clt.enter_round(Round(36));
 
-        // RC group from v0 should still be up
+        // RaptorCast group from v0 should still be up
         let rc_grp = &group_map.get_rc_group_peers(&clt, &nid(0));
         assert!(equal_node_set(rc_grp, &node_ids![45, 10]));
 
         //------------------------------------------------------------------[37]
         clt.enter_round(Round(37));
 
-        // RC group from v0 should be down now, as it only covered rounds [35, 37)
+        // RaptorCast group from v0 should be down now, as it only covered rounds [35, 37)
         // Here we should see a group gap
         assert!(group_map.is_empty(&clt));
 

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -908,7 +908,7 @@ where
     pub app_message_hash: AppMessageHash,
     pub app_message_len: u32,
     pub broadcast: bool,
-    pub recipient_hash: NodeIdHash, // if this matches our node_id, then we need to re-broadcast RC chunks
+    pub recipient_hash: NodeIdHash, // if this matches our node_id, then we need to re-broadcast RaptorCast chunks
     pub chunk_id: u16,
     pub chunk: Bytes, // raptor-coded portion
 }

--- a/monad-updaters/src/config_loader.rs
+++ b/monad-updaters/src/config_loader.rs
@@ -142,7 +142,7 @@ where
 
     fn extract_config_update(&mut self, node_config: NodeConfig<ST>) -> ConfigEvent<SCT> {
         let full_nodes = node_config
-            .fullnode
+            .fullnode_dedicated
             .identities
             .iter()
             .map(|full_node| NodeId::new(full_node.secp256k1_pubkey))


### PR DESCRIPTION
Isolates the config changes needed for the secondary (full-node) raptorcast instance 