### PR TITLE
monad-dataplane: do not set rcv/snd buffer sizes for tcp sockets

### DIFF
--- a/monad-dataplane/src/lib.rs
+++ b/monad-dataplane/src/lib.rs
@@ -14,7 +14,7 @@ pub struct DataplaneBuilder {
     local_addr: SocketAddr,
     /// 1_000 = 1 Gbps, 10_000 = 10 Gbps
     up_bandwidth_mbps: u64,
-    buffer_size: Option<usize>,
+    udp_buffer_size: Option<usize>,
 }
 
 impl DataplaneBuilder {
@@ -22,14 +22,14 @@ impl DataplaneBuilder {
         Self {
             local_addr: *local_addr,
             up_bandwidth_mbps,
-            buffer_size: None,
+            udp_buffer_size: None,
         }
     }
 
-    /// with_buffer_size sets the buffer size for udp and tcp sockets that are managed by dataplane
+    /// with_udp_buffer_size sets the buffer size for udp socket that is managed by dataplane
     /// to a requested value.
-    pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
-        self.buffer_size = Some(buffer_size);
+    pub fn with_udp_buffer_size(mut self, buffer_size: usize) -> Self {
+        self.udp_buffer_size = Some(buffer_size);
         self
     }
 
@@ -37,7 +37,7 @@ impl DataplaneBuilder {
         let DataplaneBuilder {
             local_addr,
             up_bandwidth_mbps,
-            buffer_size,
+            udp_buffer_size: buffer_size,
         } = self;
 
         let (tcp_ingress_tx, tcp_ingress_rx) = mpsc::channel(TCP_INGRESS_CHANNEL_SIZE);
@@ -53,7 +53,7 @@ impl DataplaneBuilder {
                     .build()
                     .expect("Failed building the Runtime")
                     .block_on(async move {
-                        tcp::spawn_tasks(local_addr, tcp_ingress_tx, tcp_egress_rx, buffer_size);
+                        tcp::spawn_tasks(local_addr, tcp_ingress_tx, tcp_egress_rx);
 
                         udp::spawn_tasks(
                             local_addr,

--- a/monad-dataplane/src/tcp/mod.rs
+++ b/monad-dataplane/src/tcp/mod.rs
@@ -40,10 +40,9 @@ pub fn spawn_tasks(
     local_addr: SocketAddr,
     tcp_ingress_tx: mpsc::Sender<(SocketAddr, Bytes)>,
     tcp_egress_rx: mpsc::Receiver<(SocketAddr, TcpMsg)>,
-    buffer_size: Option<usize>,
 ) {
-    spawn(rx::task(local_addr, tcp_ingress_tx, buffer_size));
-    spawn(tx::task(tcp_egress_rx, buffer_size));
+    spawn(rx::task(local_addr, tcp_ingress_tx));
+    spawn(tx::task(tcp_egress_rx));
 }
 
 // Minimum message receive/transmit speed in bytes per second.  Messages that are

--- a/monad-dataplane/src/tcp/rx.rs
+++ b/monad-dataplane/src/tcp/rx.rs
@@ -19,7 +19,6 @@ use tracing::{debug, enabled, trace, warn, Level};
 use zerocopy::FromBytes;
 
 use super::{message_timeout, TcpMsgHdr, HEADER_MAGIC, HEADER_VERSION, TCP_MESSAGE_LENGTH_LIMIT};
-use crate::buffer_ext::SocketBufferExt;
 
 const PER_PEER_CONNECTION_LIMIT: usize = 100;
 
@@ -70,11 +69,7 @@ struct RxStateInner {
     num_connections: BTreeMap<IpAddr, usize>,
 }
 
-pub async fn task(
-    local_addr: SocketAddr,
-    tcp_ingress_tx: mpsc::Sender<(SocketAddr, Bytes)>,
-    buffer_size: Option<usize>,
-) {
+pub async fn task(local_addr: SocketAddr, tcp_ingress_tx: mpsc::Sender<(SocketAddr, Bytes)>) {
     let opts = ListenerOpts::new().reuse_addr(true);
     let tcp_listener = TcpListener::bind_with_config(local_addr, &opts).unwrap();
     let rx_state = RxState::new();
@@ -93,7 +88,6 @@ pub async fn task(
                         addr,
                         tcp_stream,
                         tcp_ingress_tx.clone(),
-                        buffer_size,
                     ));
                 }
                 Err(()) => {
@@ -119,27 +113,7 @@ async fn task_connection(
     addr: SocketAddr,
     mut tcp_stream: TcpStream,
     tcp_ingress_tx: mpsc::Sender<(SocketAddr, Bytes)>,
-    buffer_size: Option<usize>,
 ) {
-    if let Some(requested_buffer_size) = buffer_size {
-        tcp_stream
-            .set_recv_buffer_size(requested_buffer_size)
-            .expect("unable to set receive buffer size");
-        let actual_buffer_size = tcp_stream
-            .recv_buffer_size()
-            .expect("unable to get receive buffer size");
-        if actual_buffer_size < requested_buffer_size {
-            panic!(
-                "unable to set tcp receive buffer size for connection {:?} to address {:?}. requested {}, actual {}. maximal net.ipv4.tcp_wmem should be set to at least {}",
-                conn_id,
-                addr,
-                requested_buffer_size,
-                actual_buffer_size,
-                requested_buffer_size
-            );
-        }
-    }
-
     let mut message_id: u64 = 0;
 
     while let Some(message) = read_message(conn_id, addr, message_id, &mut tcp_stream).await {

--- a/monad-dataplane/src/tcp/tx.rs
+++ b/monad-dataplane/src/tcp/tx.rs
@@ -22,7 +22,6 @@ use tracing::{debug, enabled, trace, warn, Level};
 use zerocopy::AsBytes;
 
 use super::{message_timeout, TcpMsg, TcpMsgHdr};
-use crate::buffer_ext::SocketBufferExt;
 
 // These are per-peer limits.
 pub const QUEUED_MESSAGE_WARN_LIMIT: usize = 100;
@@ -121,10 +120,7 @@ struct TxStateInner {
     peer_channels: BTreeMap<SocketAddr, mpsc::Sender<TcpMsg>>,
 }
 
-pub async fn task(
-    mut tcp_egress_rx: mpsc::Receiver<(SocketAddr, TcpMsg)>,
-    buffer_size: Option<usize>,
-) {
+pub async fn task(mut tcp_egress_rx: mpsc::Receiver<(SocketAddr, TcpMsg)>) {
     let tx_state = TxState::new();
 
     let mut conn_id: u64 = 0;
@@ -144,7 +140,6 @@ pub async fn task(
                 addr,
                 msg_receiver,
                 tx_state_peer_handle,
-                buffer_size,
             ));
 
             conn_id += 1;
@@ -157,7 +152,6 @@ async fn task_connection(
     addr: SocketAddr,
     mut msg_receiver: mpsc::Receiver<TcpMsg>,
     _tx_state_peer_handle: TxStatePeerHandle,
-    buffer_size: Option<usize>,
 ) {
     trace!(
         conn_id,
@@ -165,9 +159,7 @@ async fn task_connection(
         "starting TCP transmit connection task for peer"
     );
 
-    if let Err(err) =
-        connect_and_send_messages(conn_id, &addr, &mut msg_receiver, buffer_size).await
-    {
+    if let Err(err) = connect_and_send_messages(conn_id, &addr, &mut msg_receiver).await {
         let mut additional_messages_dropped = 0;
 
         // Throw away (and fail) all remaining queued messages immediately.
@@ -198,7 +190,6 @@ async fn connect_and_send_messages(
     conn_id: u64,
     addr: &SocketAddr,
     msg_receiver: &mut mpsc::Receiver<TcpMsg>,
-    buffer_size: Option<usize>,
 ) -> Result<(), Error> {
     let mut stream = timeout(TCP_CONNECT_TIMEOUT, TcpStream::connect(addr))
         .await
@@ -209,21 +200,6 @@ async fn connect_and_send_messages(
                 format!("error connecting to remote host: {}", err),
             )
         })?;
-
-    if let Some(requested_buffer_size) = buffer_size {
-        stream.set_send_buffer_size(requested_buffer_size)?;
-        let actual_buffer_size = stream.send_buffer_size()?;
-        if actual_buffer_size < requested_buffer_size {
-            panic!(
-                "unable to set tcp send buffer size for connection {:?} to address {:?}. requested {}, actual {}. maximal net.ipv4.tcp_rmem should be set to at least {}",
-                conn_id,
-                addr,
-                requested_buffer_size,
-                actual_buffer_size,
-                requested_buffer_size
-            );
-        }
-    }
 
     trace!(conn_id, ?addr, "outbound TCP connection established");
 

--- a/monad-dataplane/tests/tests.rs
+++ b/monad-dataplane/tests/tests.rs
@@ -323,7 +323,7 @@ fn broadcast_all_strides() {
     let tx_addr = "127.0.0.1:9015".parse().unwrap();
 
     let mut rx = DataplaneBuilder::new(&rx_addr, UP_BANDWIDTH_MBPS)
-        .with_buffer_size(400 << 10)
+        .with_udp_buffer_size(400 << 10)
         .build();
     let mut tx = DataplaneBuilder::new(&tx_addr, UP_BANDWIDTH_MBPS).build();
 
@@ -368,7 +368,7 @@ fn unicast_all_strides() {
     let tx_addr = "127.0.0.1:9017".parse().unwrap();
 
     let mut rx = DataplaneBuilder::new(&rx_addr, UP_BANDWIDTH_MBPS)
-        .with_buffer_size(400 << 10)
+        .with_udp_buffer_size(400 << 10)
         .build();
     let mut tx = DataplaneBuilder::new(&tx_addr, UP_BANDWIDTH_MBPS).build();
 

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -123,7 +123,7 @@ where
         let self_id = NodeId::new(config.key.pubkey());
         let mut builder = DataplaneBuilder::new(&config.local_addr, config.up_bandwidth_mbps);
         if let Some(buffer_size) = config.buffer_size {
-            builder = builder.with_buffer_size(buffer_size);
+            builder = builder.with_udp_buffer_size(buffer_size);
         }
         let dataplane = builder.build();
         let is_fullnode = false; // This will come from the config in upcoming PR


### PR DESCRIPTION
closes: https://github.com/category-labs/category-internal/issues/1587

i tested it with different combinations of bandwidth limits/latency/requested throughput using https://github.com/category-labs/monad-bft/pull/1827 . kernel will scale up buffers based on requested limits as long as there is available bandwidth and memory.
i think it is safe to update recommendation to set default value lower, maybe 512kb

with udp there is no such autoscaler in place, so if default value configured to be low there will be packet drops
so it is safer to enforce it. also it is set only for single socket so it is not a concern