### PR TITLE
Full-node Raptorcast: State Sync & Command

### DIFF
--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -41,6 +41,10 @@ where
         target: RouterTarget<SCT::NodeIdPubKey>,
         message: Verified<ST, Validated<ConsensusMessage<ST, SCT, EPT>>>,
     },
+    PublishToFullNodes {
+        epoch: Epoch,
+        message: Verified<ST, Validated<ConsensusMessage<ST, SCT, EPT>>>,
+    },
     /// Schedule a timeout event to be emitted in `duration`
     Schedule {
         duration: Duration,

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -43,6 +43,10 @@ pub enum RouterCommand<PT: PubKey, OM> {
         target: RouterTarget<PT>,
         message: OM,
     },
+    PublishToFullNodes {
+        epoch: Epoch, // Epoch gets embedded into the raptorcast message
+        message: OM,
+    },
     AddEpochValidatorSet {
         epoch: Epoch,
         validator_set: Vec<(NodeId<PT>, Stake)>,

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -348,6 +348,9 @@ impl<S: SwarmRelation> Executor for MockExecutor<S> {
                 RouterCommand::UpdateFullNodes(_vec) => {
                     // TODO
                 }
+                RouterCommand::PublishToFullNodes { .. } => {
+                    // TODO
+                }
             }
         }
     }

--- a/monad-peer-disc-swarm/src/lib.rs
+++ b/monad-peer-disc-swarm/src/lib.rs
@@ -138,6 +138,7 @@ impl<S: PeerDiscSwarmRelation> Executor for MockPeerDiscExecutor<S> {
                 RouterCommand::UpdatePeers(_) => {}
                 RouterCommand::GetFullNodes => {}
                 RouterCommand::UpdateFullNodes(_) => {}
+                RouterCommand::PublishToFullNodes { .. } => {}
             }
         }
     }

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -346,6 +346,7 @@ where
                         }
                     };
                 }
+                RouterCommand::PublishToFullNodes { .. } => {}
                 RouterCommand::GetPeers => {
                     let peer_list = self
                         .known_addresses

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -269,7 +269,7 @@ where
                         }
                     }
                 },
-                /*
+
                 Self::Command::PublishToFullNodes { epoch, message } => {
                     let app_message = message.serialize();
                     let app_message_len = app_message.len();
@@ -282,7 +282,12 @@ where
                         Role::Client(_) => {
                             continue;
                         }
-                        Role::Publisher(publisher) => publisher.get_current_raptorcast_group(),
+                        Role::Publisher(publisher) => {
+                            match publisher.get_current_raptorcast_group() {
+                                Some(group) => group,
+                                None => continue,
+                            }
+                        }
                     };
 
                     let build_target = BuildTarget::FullNodeRaptorCast(curr_group);
@@ -317,7 +322,6 @@ where
                     // Send the raptorcast chunks via UDP to all peers in group
                     self.dataplane.lock().unwrap().udp_write_unicast(rc_chunks);
                 }
-                */
             }
         }
     }

--- a/monad-router-filter/src/lib.rs
+++ b/monad-router-filter/src/lib.rs
@@ -60,6 +60,7 @@ where
                     VerifiedMonadMessage::ForwardedTx(_) => Some(cmd),
                     VerifiedMonadMessage::StateSyncMessage(_) => Some(cmd),
                 },
+                RouterCommand::PublishToFullNodes { .. } => None,
                 RouterCommand::AddEpochValidatorSet { .. } => Some(cmd),
                 RouterCommand::UpdateCurrentRound(..) => Some(cmd),
                 RouterCommand::GetPeers => Some(cmd),

--- a/monad-updaters/src/local_router.rs
+++ b/monad-updaters/src/local_router.rs
@@ -118,6 +118,7 @@ where
             match command {
                 RouterCommand::AddEpochValidatorSet { .. } => {}
                 RouterCommand::UpdateCurrentRound(_, _) => {}
+                RouterCommand::PublishToFullNodes { .. } => {}
                 RouterCommand::Publish { target, message } => match target {
                     RouterTarget::Broadcast(_) | RouterTarget::Raptorcast(_) => {
                         let message = message.into();
@@ -146,7 +147,7 @@ where
                 RouterCommand::GetPeers => {}
                 RouterCommand::UpdatePeers(_) => {}
                 RouterCommand::GetFullNodes => {}
-                RouterCommand::UpdateFullNodes(_) => {}
+                RouterCommand::UpdateFullNodes(_vec) => {}
             }
         }
     }


### PR DESCRIPTION
This is part of a PR series that splits the original, larger Full-node RaptorCast PR.
This one contains just the changes to the monad-state and the new command to publish to full-nodes.
The crucial change is in `ConsensusChildState::update` 