### PR TITLE
Refactor rpc to use chainstate 

### DIFF
--- a/monad-rpc/src/chainstate/mod.rs
+++ b/monad-rpc/src/chainstate/mod.rs
@@ -1,0 +1,583 @@
+use alloy_consensus::{Header as RlpHeader, Transaction as _};
+use alloy_primitives::{FixedBytes, U256};
+use alloy_rpc_types::{Block, BlockTransactions, Header, Transaction, TransactionReceipt};
+use monad_archive::{
+    model::BlockDataReader,
+    prelude::{ArchiveReader, IndexReader, TxEnvelopeWithSender},
+};
+use monad_triedb_utils::triedb_env::{BlockKey, FinalizedBlockKey, TransactionLocation, Triedb};
+use monad_types::SeqNum;
+use tracing::{error, warn};
+
+use crate::eth_json_types::{BlockTagOrHash, BlockTags};
+
+#[derive(Clone)]
+pub struct ChainState<T: Triedb> {
+    triedb_env: T,
+    archive_reader: Option<ArchiveReader>,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Triedb(String),
+    ResourceNotFound,
+}
+
+pub fn get_block_key_from_tag<T: Triedb>(triedb_env: &T, tag: BlockTags) -> BlockKey {
+    match tag {
+        BlockTags::Number(n) => triedb_env.get_block_key(SeqNum(n.0)),
+        BlockTags::Latest => triedb_env.get_latest_voted_block_key(),
+        BlockTags::Safe => triedb_env.get_latest_voted_block_key(),
+        BlockTags::Finalized => BlockKey::Finalized(triedb_env.get_latest_finalized_block_key()),
+    }
+}
+
+impl<T: Triedb> ChainState<T> {
+    pub fn new(triedb_env: T, archive_reader: Option<ArchiveReader>) -> Self {
+        ChainState {
+            triedb_env,
+            archive_reader,
+        }
+    }
+
+    pub fn get_latest_block_number(&self) -> u64 {
+        self.triedb_env.get_latest_voted_block_key().seq_num().0
+    }
+
+    pub async fn get_transaction_receipt(
+        &self,
+        hash: [u8; 32],
+    ) -> Result<TransactionReceipt, Error> {
+        let latest_block_key = get_block_key_from_tag(&self.triedb_env, BlockTags::Latest);
+        if let Some(TransactionLocation {
+            tx_index,
+            block_num,
+        }) = self
+            .triedb_env
+            .get_transaction_location_by_hash(latest_block_key, hash)
+            .await
+            .map_err(Error::Triedb)?
+        {
+            let block_key = self.triedb_env.get_block_key(SeqNum(block_num));
+            if let Some(receipt) =
+                get_receipt_from_triedb(&self.triedb_env, block_key, tx_index).await?
+            {
+                return Ok(receipt);
+            }
+        }
+
+        // try archive if transaction hash not found and archive reader specified
+        if let Some(archive_reader) = &self.archive_reader {
+            if let Ok(tx_data) = archive_reader.get_tx_indexed_data(&hash.into()).await {
+                let receipt = crate::handlers::eth::txn::parse_tx_receipt(
+                    tx_data.header_subset.base_fee_per_gas,
+                    Some(tx_data.header_subset.block_timestamp),
+                    tx_data.header_subset.block_hash,
+                    tx_data.tx,
+                    tx_data.header_subset.gas_used,
+                    tx_data.receipt,
+                    tx_data.header_subset.block_number,
+                    tx_data.header_subset.tx_index,
+                );
+
+                return Ok(receipt);
+            }
+        }
+
+        Err(Error::ResourceNotFound)
+    }
+
+    pub async fn get_transaction_with_block_and_index(
+        &self,
+        block: BlockTagOrHash,
+        index: u64,
+    ) -> Result<Transaction, Error> {
+        match block {
+            BlockTagOrHash::BlockTags(block) => {
+                let block_key = get_block_key_from_tag(&self.triedb_env, block);
+                if let Some(tx) =
+                    get_transaction_from_triedb(&self.triedb_env, block_key, index).await?
+                {
+                    return Ok(tx);
+                }
+
+                // try archive if block header not found and archive reader specified
+                if let (Some(archive_reader), BlockKey::Finalized(FinalizedBlockKey(block_num))) =
+                    (&self.archive_reader, block_key)
+                {
+                    if let Ok(block) = archive_reader
+                        .get_block_by_number(block_num.0)
+                        .await
+                        .inspect_err(|e| {
+                            warn!("Error getting block by number from archive: {e:?}");
+                        })
+                    {
+                        if let Some(tx) = block.body.transactions.get(index as usize) {
+                            return Ok(parse_tx_content(
+                                block.header.hash_slow(),
+                                block.header.number,
+                                block.header.base_fee_per_gas,
+                                tx.clone(),
+                                index,
+                            ));
+                        }
+                    }
+                }
+            }
+            BlockTagOrHash::Hash(hash) => {
+                let latest_block_key = get_block_key_from_tag(&self.triedb_env, BlockTags::Latest);
+                if let Some(block_num) = self
+                    .triedb_env
+                    .get_block_number_by_hash(latest_block_key, hash.0)
+                    .await
+                    .map_err(Error::Triedb)?
+                {
+                    let block_key = self.triedb_env.get_block_key(SeqNum(block_num));
+                    if let Some(tx) =
+                        get_transaction_from_triedb(&self.triedb_env, block_key, index).await?
+                    {
+                        return Ok(tx);
+                    }
+                }
+
+                // try archive if block hash not found and archive reader specified
+                if let Some(archive_reader) = &self.archive_reader {
+                    if let Ok(block) = archive_reader.get_block_by_hash(&hash.0.into()).await {
+                        if let Some(tx) = block.body.transactions.get(index as usize) {
+                            return Ok(parse_tx_content(
+                                hash.0.into(),
+                                block.header.number,
+                                block.header.base_fee_per_gas,
+                                tx.clone(),
+                                index,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        Err(Error::ResourceNotFound)
+    }
+
+    pub async fn get_transaction(&self, hash: [u8; 32]) -> Result<Transaction, Error> {
+        let latest_block_key = get_block_key_from_tag(&self.triedb_env, BlockTags::Latest);
+        if let Some(TransactionLocation {
+            tx_index,
+            block_num,
+        }) = self
+            .triedb_env
+            .get_transaction_location_by_hash(latest_block_key, hash)
+            .await
+            .map_err(Error::Triedb)?
+        {
+            let block_key = self.triedb_env.get_block_key(SeqNum(block_num));
+            if let Some(tx) =
+                get_transaction_from_triedb(&self.triedb_env, block_key, tx_index).await?
+            {
+                return Ok(tx);
+            };
+        }
+
+        // try archive if transaction hash not found and archive reader specified
+        if let Some(archive_reader) = &self.archive_reader {
+            if let Ok((tx, header_subset)) =
+                archive_reader.get_tx(&hash.into()).await.inspect_err(|e| {
+                    warn!("Error getting tx from archive: {e:?}");
+                })
+            {
+                return Ok(parse_tx_content(
+                    header_subset.block_hash,
+                    header_subset.block_number,
+                    header_subset.base_fee_per_gas,
+                    tx,
+                    header_subset.tx_index,
+                ));
+            }
+        }
+
+        Err(Error::ResourceNotFound)
+    }
+
+    pub async fn get_block_header(
+        &self,
+        block: BlockTagOrHash,
+    ) -> Result<alloy_consensus::Header, Error> {
+        let block_key = match block {
+            BlockTagOrHash::BlockTags(tag) => get_block_key_from_tag(&self.triedb_env, tag),
+            BlockTagOrHash::Hash(hash) => {
+                let latest_block_key = get_block_key_from_tag(&self.triedb_env, BlockTags::Latest);
+                if let Some(block_num) = self
+                    .triedb_env
+                    .get_block_number_by_hash(latest_block_key, hash.0)
+                    .await
+                    .map_err(Error::Triedb)?
+                {
+                    self.triedb_env.get_block_key(SeqNum(block_num))
+                } else {
+                    return Err(Error::ResourceNotFound);
+                }
+            }
+        };
+
+        if let Some(header) = self
+            .triedb_env
+            .get_block_header(block_key)
+            .await
+            .map_err(Error::Triedb)?
+        {
+            return Ok(header.header);
+        }
+
+        if let (Some(archive_reader), BlockKey::Finalized(FinalizedBlockKey(block_num))) =
+            (&self.archive_reader, block_key)
+        {
+            if let Ok(block) = archive_reader
+                .get_block_by_number(block_num.0)
+                .await
+                .inspect_err(|e| {
+                    error!("Error getting block by number from archive: {e:?}");
+                })
+            {
+                return Ok(block.header);
+            }
+        }
+
+        Err(Error::ResourceNotFound)
+    }
+
+    pub async fn get_block(
+        &self,
+        block: BlockTagOrHash,
+        return_full_txns: bool,
+    ) -> Result<Block, Error> {
+        let block_key = match block {
+            BlockTagOrHash::BlockTags(tag) => get_block_key_from_tag(&self.triedb_env, tag),
+            BlockTagOrHash::Hash(hash) => {
+                let latest_block_key = get_block_key_from_tag(&self.triedb_env, BlockTags::Latest);
+                if let Some(block_num) = self
+                    .triedb_env
+                    .get_block_number_by_hash(latest_block_key, hash.0)
+                    .await
+                    .map_err(Error::Triedb)?
+                {
+                    self.triedb_env.get_block_key(SeqNum(block_num))
+                } else {
+                    return Err(Error::ResourceNotFound);
+                }
+            }
+        };
+
+        if let Some(header) = self
+            .triedb_env
+            .get_block_header(block_key)
+            .await
+            .map_err(Error::Triedb)?
+        {
+            if let Ok(transactions) = self.triedb_env.get_transactions(block_key).await {
+                return Ok(parse_block_content(
+                    header.hash,
+                    header.header,
+                    transactions,
+                    return_full_txns,
+                ));
+            }
+        }
+
+        if let (Some(archive_reader), BlockKey::Finalized(FinalizedBlockKey(block_num))) =
+            (&self.archive_reader, block_key)
+        {
+            if let Ok(block) = archive_reader
+                .get_block_by_number(block_num.0)
+                .await
+                .inspect_err(|e| {
+                    error!("Error getting block by number from archive: {e:?}");
+                })
+            {
+                return Ok(parse_block_content(
+                    block.header.hash_slow(),
+                    block.header,
+                    block.body.transactions,
+                    return_full_txns,
+                ));
+            }
+        }
+
+        Err(Error::ResourceNotFound)
+    }
+
+    /// Returns raw transaction receipts for a block.
+    pub async fn get_raw_receipts(
+        &self,
+        block: BlockTags,
+    ) -> Result<Vec<alloy_consensus::ReceiptEnvelope>, Error> {
+        let block_key = get_block_key_from_tag(&self.triedb_env, block);
+        if let Ok(receipts) = self.triedb_env.get_receipts(block_key).await {
+            let receipts: Vec<alloy_consensus::ReceiptEnvelope> = receipts
+                .into_iter()
+                .map(|receipt_with_log_index| receipt_with_log_index.receipt)
+                .collect();
+            return Ok(receipts);
+        };
+
+        if let (Some(archive_reader), BlockKey::Finalized(FinalizedBlockKey(block_num))) =
+            (&self.archive_reader, block_key)
+        {
+            if let Ok(receipts) = archive_reader
+                .get_block_receipts(block_num.0)
+                .await
+                .inspect_err(|e| {
+                    error!("Error getting block by number from archive: {e:?}");
+                })
+            {
+                let receipts: Vec<alloy_consensus::ReceiptEnvelope> = receipts
+                    .into_iter()
+                    .map(|receipt_with_log_index| receipt_with_log_index.receipt)
+                    .collect();
+                return Ok(receipts);
+            }
+        }
+
+        Err(Error::ResourceNotFound)
+    }
+
+    /// Returns transaction receipts mapped to their block and transaction info.
+    pub async fn get_block_receipts(
+        &self,
+        block: BlockTagOrHash,
+    ) -> Result<Vec<crate::eth_json_types::MonadTransactionReceipt>, Error> {
+        if let Ok(block_key) = crate::handlers::eth::block::get_block_key_from_tag_or_hash(
+            &self.triedb_env,
+            block.clone(),
+        )
+        .await
+        {
+            if let Some(header) = self
+                .triedb_env
+                .get_block_header(block_key)
+                .await
+                .map_err(Error::Triedb)?
+            {
+                // if block header is present but transactions are not, the block is statesynced
+                if let Ok(transactions) = self.triedb_env.get_transactions(block_key).await {
+                    if let Ok(receipts) = self.triedb_env.get_receipts(block_key).await {
+                        let block_receipts = crate::handlers::eth::block::map_block_receipts(
+                            transactions,
+                            receipts,
+                            &header.header,
+                            header.hash,
+                            crate::eth_json_types::MonadTransactionReceipt,
+                        )
+                        .map_err(|_| Error::ResourceNotFound)?;
+                        return Ok(block_receipts);
+                    }
+                }
+            }
+        }
+        // try archive if header or transactions not found and archive reader specified
+        if let Some(archive_reader) = &self.archive_reader {
+            let block = match block {
+                BlockTagOrHash::BlockTags(tag) => {
+                    match get_block_key_from_tag(&self.triedb_env, tag) {
+                        BlockKey::Finalized(FinalizedBlockKey(block_num)) => archive_reader
+                            .get_block_by_number(block_num.0)
+                            .await
+                            .inspect_err(|e| {
+                                error!("Error getting block by number from archive: {e:?}");
+                            })
+                            .ok(),
+                        BlockKey::Proposed(_) => None,
+                    }
+                }
+                BlockTagOrHash::Hash(hash) => archive_reader
+                    .get_block_by_hash(&hash.0.into())
+                    .await
+                    .inspect_err(|e| {
+                        error!("Error getting block by hash from archive: {e:?}");
+                    })
+                    .ok(),
+            };
+            if let Some(block) = block {
+                if let Ok(receipts_with_log_index) = archive_reader
+                    .get_block_receipts(block.header.number)
+                    .await
+                    .inspect_err(|e| {
+                        error!("Error getting block receipts from archive: {e:?}");
+                    })
+                {
+                    let block_receipts = crate::handlers::eth::block::map_block_receipts(
+                        block.body.transactions,
+                        receipts_with_log_index,
+                        &block.header,
+                        block.header.hash_slow(),
+                        crate::eth_json_types::MonadTransactionReceipt,
+                    )
+                    .map_err(|_| Error::ResourceNotFound)?;
+                    return Ok(block_receipts);
+                }
+            }
+        }
+
+        Err(Error::ResourceNotFound)
+    }
+}
+
+fn parse_block_content(
+    block_hash: FixedBytes<32>,
+    header: RlpHeader,
+    transactions: Vec<TxEnvelopeWithSender>,
+    return_full_txns: bool,
+) -> Block {
+    // parse transactions
+    let transactions = if return_full_txns {
+        let txs = transactions
+            .into_iter()
+            .enumerate()
+            .map(|(idx, tx)| {
+                parse_tx_content(
+                    block_hash,
+                    header.number,
+                    header.base_fee_per_gas,
+                    tx,
+                    idx as u64,
+                )
+            })
+            .collect();
+
+        BlockTransactions::Full(txs)
+    } else {
+        BlockTransactions::Hashes(transactions.iter().map(|tx| *tx.tx.tx_hash()).collect())
+    };
+
+    // NOTE: no withdrawals currently in monad-bft
+    Block {
+        header: Header {
+            total_difficulty: Some(header.difficulty),
+            hash: block_hash,
+            size: Some(U256::from(header.size())),
+            inner: header,
+        },
+        transactions,
+        uncles: vec![],
+        withdrawals: None,
+    }
+}
+
+pub fn parse_tx_content(
+    block_hash: FixedBytes<32>,
+    block_number: u64,
+    base_fee: Option<u64>,
+    tx: TxEnvelopeWithSender,
+    tx_index: u64,
+) -> Transaction {
+    // unpack transaction
+    let sender = tx.sender;
+    let tx = tx.tx;
+
+    // effective gas price is calculated according to eth json rpc specification
+    let effective_gas_price = tx.effective_gas_price(base_fee);
+
+    Transaction {
+        inner: tx,
+        from: sender,
+        block_hash: Some(block_hash),
+        block_number: Some(block_number),
+        effective_gas_price: Some(effective_gas_price),
+        transaction_index: Some(tx_index),
+    }
+}
+
+#[tracing::instrument(level = "debug")]
+async fn get_transaction_from_triedb<T: Triedb>(
+    triedb_env: &T,
+    block_key: BlockKey,
+    tx_index: u64,
+) -> Result<Option<Transaction>, Error> {
+    let header = match triedb_env
+        .get_block_header(block_key)
+        .await
+        .map_err(Error::Triedb)?
+    {
+        Some(header) => header,
+        None => return Ok(None),
+    };
+
+    match triedb_env
+        .get_transaction(block_key, tx_index)
+        .await
+        .map_err(Error::Triedb)?
+    {
+        Some(tx) => Ok(Some(parse_tx_content(
+            header.hash,
+            header.header.number,
+            header.header.base_fee_per_gas,
+            tx,
+            tx_index,
+        ))),
+        None => Ok(None),
+    }
+}
+
+#[tracing::instrument(level = "debug")]
+async fn get_receipt_from_triedb<T: Triedb>(
+    triedb_env: &T,
+    block_key: BlockKey,
+    tx_index: u64,
+) -> Result<Option<TransactionReceipt>, Error> {
+    let header = match triedb_env
+        .get_block_header(block_key)
+        .await
+        .map_err(Error::Triedb)?
+    {
+        Some(header) => header,
+        None => return Ok(None),
+    };
+
+    let tx = match triedb_env
+        .get_transaction(block_key, tx_index)
+        .await
+        .map_err(Error::Triedb)?
+    {
+        Some(tx) => tx,
+        None => return Ok(None),
+    };
+
+    match triedb_env
+        .get_receipt(block_key, tx_index)
+        .await
+        .map_err(Error::Triedb)?
+    {
+        Some(receipt) => {
+            // Get the previous receipt's cumulative gas used to calculate gas used
+            let gas_used = if tx_index > 0 {
+                match triedb_env
+                    .get_receipt(block_key, tx_index - 1)
+                    .await
+                    .map_err(Error::Triedb)?
+                {
+                    Some(prev_receipt) => {
+                        receipt.receipt.cumulative_gas_used()
+                            - prev_receipt.receipt.cumulative_gas_used()
+                    }
+                    None => return Err(Error::Triedb("error getting receipt".into())),
+                }
+            } else {
+                receipt.receipt.cumulative_gas_used()
+            };
+
+            let receipt = crate::handlers::eth::txn::parse_tx_receipt(
+                header.header.base_fee_per_gas,
+                Some(header.header.timestamp),
+                header.hash,
+                tx,
+                gas_used,
+                receipt,
+                block_key.seq_num().0,
+                tx_index,
+            );
+
+            Ok(Some(receipt))
+        }
+        None => Ok(None),
+    }
+}

--- a/monad-rpc/src/handlers/debug.rs
+++ b/monad-rpc/src/handlers/debug.rs
@@ -9,16 +9,17 @@ use alloy_primitives::{
 use alloy_rlp::{Decodable, Encodable};
 use monad_archive::prelude::{ArchiveReader, BlockDataReader, IndexReader};
 use monad_rpc_docs::rpc;
-use monad_triedb_utils::triedb_env::{BlockKey, FinalizedBlockKey, TransactionLocation, Triedb};
+use monad_triedb_utils::triedb_env::{BlockKey, FinalizedBlockKey, Triedb};
 use monad_types::SeqNum;
 use serde::{Deserialize, Serialize};
 use tracing::{error, trace};
 
 use crate::{
+    chainstate::{get_block_key_from_tag, ChainState},
     eth_json_types::{
-        BlockTags, EthAddress, EthHash, FixedData, MonadU256, Quantity, UnformattedData,
+        BlockTagOrHash, BlockTags, EthAddress, EthHash, FixedData, MonadU256, Quantity,
+        UnformattedData,
     },
-    handlers::eth::block::get_block_key_from_tag,
     hex,
     jsonrpc::{JsonRpcError, JsonRpcResult},
 };
@@ -32,12 +33,10 @@ pub struct DebugBlockParams {
 #[allow(non_snake_case)]
 /// Returns an RLP-encoded block.
 pub async fn monad_debug_getRawBlock<T: Triedb>(
-    triedb_env: &T,
-    archive_reader: &Option<ArchiveReader>,
+    chain_state: &ChainState<T>,
     params: DebugBlockParams,
 ) -> JsonRpcResult<String> {
     trace!("monad_debug_getRawBlock: {params:?}");
-    let block_key = get_block_key_from_tag(triedb_env, params.block);
 
     let encode_block = |block: Block<TxEnvelope>| {
         let mut res = Vec::new();
@@ -45,67 +44,34 @@ pub async fn monad_debug_getRawBlock<T: Triedb>(
         Ok(hex::encode(&res))
     };
 
-    if let Some(header) = triedb_env
-        .get_block_header(block_key)
+    match chain_state
+        .get_block(BlockTagOrHash::BlockTags(params.block), true)
         .await
-        .map_err(JsonRpcError::internal_error)?
     {
-        if let Ok(transactions) = triedb_env.get_transactions(block_key).await {
-            let transactions = transactions
-                .into_iter()
-                .map(|recovered_tx| recovered_tx.tx)
-                .collect();
-            return encode_block(Block {
-                header: header.header,
-                body: BlockBody {
-                    transactions,
-                    ommers: vec![],
-                    withdrawals: None,
-                },
-            });
-        }
-    };
-
-    if let (Some(archive_reader), BlockKey::Finalized(FinalizedBlockKey(block_num))) =
-        (archive_reader, block_key)
-    {
-        if let Ok(block) = archive_reader
-            .get_block_by_number(block_num.0)
-            .await
-            .inspect_err(|e| {
-                error!("Error getting block by number from archive: {e:?}");
-            })
-        {
-            let transactions = block
-                .body
-                .transactions
-                .into_iter()
-                .map(|recovered_tx| recovered_tx.tx)
-                .collect();
-            return encode_block(Block {
-                header: block.header,
-                body: BlockBody {
-                    transactions,
-                    ommers: vec![],
-                    withdrawals: None,
-                },
-            });
-        }
+        Ok(block) => encode_block(Block {
+            header: block.header.inner,
+            body: BlockBody {
+                transactions: block
+                    .transactions
+                    .into_transactions()
+                    .map(|tx| tx.into())
+                    .collect(),
+                ommers: vec![],
+                withdrawals: None,
+            },
+        }),
+        Err(_) => Err(JsonRpcError::internal_error("block data not found".into())),
     }
-
-    Err(JsonRpcError::internal_error("block data not found".into()))
 }
 
 #[rpc(method = "debug_getRawHeader")]
 #[allow(non_snake_case)]
 /// Returns an RLP-encoded header.
 pub async fn monad_debug_getRawHeader<T: Triedb>(
-    triedb_env: &T,
-    archive_reader: &Option<ArchiveReader>,
+    chain_state: &ChainState<T>,
     params: DebugBlockParams,
 ) -> JsonRpcResult<String> {
     trace!("monad_debug_getRawHeader: {params:?}");
-    let block_key = get_block_key_from_tag(triedb_env, params.block);
 
     let encode_header = |header: Header| {
         let mut res = Vec::new();
@@ -113,29 +79,13 @@ pub async fn monad_debug_getRawHeader<T: Triedb>(
         Ok(hex::encode(&res))
     };
 
-    if let Some(header) = triedb_env
-        .get_block_header(block_key)
+    match chain_state
+        .get_block_header(BlockTagOrHash::BlockTags(params.block))
         .await
-        .map_err(JsonRpcError::internal_error)?
     {
-        return encode_header(header.header);
-    };
-
-    if let (Some(archive_reader), BlockKey::Finalized(FinalizedBlockKey(block_num))) =
-        (archive_reader, block_key)
-    {
-        if let Ok(block) = archive_reader
-            .get_block_by_number(block_num.0)
-            .await
-            .inspect_err(|e| {
-                error!("Error getting block by number from archive: {e:?}");
-            })
-        {
-            return encode_header(block.header);
-        }
+        Ok(header) => encode_header(header),
+        Err(_) => Err(JsonRpcError::internal_error("block data not found".into())),
     }
-
-    Err(JsonRpcError::internal_error("block data not found".into()))
 }
 
 #[derive(Serialize, Debug, schemars::JsonSchema)]
@@ -148,14 +98,12 @@ pub struct MonadDebugGetRawReceiptsResult {
 #[allow(non_snake_case)]
 /// Returns an array of EIP-2718 binary-encoded receipts.
 pub async fn monad_debug_getRawReceipts<T: Triedb>(
-    triedb_env: &T,
-    archive_reader: &Option<ArchiveReader>,
+    chain_state: &ChainState<T>,
     params: DebugBlockParams,
 ) -> JsonRpcResult<MonadDebugGetRawReceiptsResult> {
     trace!("monad_debug_getRawReceipts: {params:?}");
-    let block_key = get_block_key_from_tag(triedb_env, params.block);
 
-    let encode_receipts = |receipts: Vec<ReceiptEnvelope>| {
+    let encode_receipts = |receipts: Vec<ReceiptEnvelope<alloy_primitives::Log>>| {
         let receipts = receipts
             .into_iter()
             .map(|r| {
@@ -167,33 +115,10 @@ pub async fn monad_debug_getRawReceipts<T: Triedb>(
         Ok(MonadDebugGetRawReceiptsResult { receipts })
     };
 
-    if let Ok(receipts) = triedb_env.get_receipts(block_key).await {
-        let receipts: Vec<ReceiptEnvelope> = receipts
-            .into_iter()
-            .map(|receipt_with_log_index| receipt_with_log_index.receipt)
-            .collect();
-        return encode_receipts(receipts);
-    };
-
-    if let (Some(archive_reader), BlockKey::Finalized(FinalizedBlockKey(block_num))) =
-        (archive_reader, block_key)
-    {
-        if let Ok(receipts) = archive_reader
-            .get_block_receipts(block_num.0)
-            .await
-            .inspect_err(|e| {
-                error!("Error getting block by number from archive: {e:?}");
-            })
-        {
-            let receipts: Vec<ReceiptEnvelope> = receipts
-                .into_iter()
-                .map(|receipt_with_log_index| receipt_with_log_index.receipt)
-                .collect();
-            return encode_receipts(receipts);
-        }
+    match chain_state.get_raw_receipts(params.block).await {
+        Ok(receipts) => encode_receipts(receipts),
+        Err(_) => Err(JsonRpcError::internal_error("block data not found".into())),
     }
-
-    Err(JsonRpcError::internal_error("block data not found".into()))
 }
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
@@ -205,48 +130,20 @@ pub struct MonadDebugGetRawTransactionParams {
 #[allow(non_snake_case)]
 /// Returns an array of EIP-2718 binary-encoded transactions.
 pub async fn monad_debug_getRawTransaction<T: Triedb>(
-    triedb_env: &T,
-    archive_reader: &Option<ArchiveReader>,
+    chain_state: &ChainState<T>,
     params: MonadDebugGetRawTransactionParams,
 ) -> JsonRpcResult<String> {
     trace!("monad_debug_getRawTransaction: {params:?}");
-    let latest_block_key = get_block_key_from_tag(triedb_env, BlockTags::Latest);
 
-    if let Some(TransactionLocation {
-        tx_index,
-        block_num,
-    }) = triedb_env
-        .get_transaction_location_by_hash(latest_block_key, params.tx_hash.0)
-        .await
-        .map_err(JsonRpcError::internal_error)?
-    {
-        let block_key = triedb_env.get_block_key(SeqNum(block_num));
-        if let Some(tx) = triedb_env
-            .get_transaction(block_key, tx_index)
-            .await
-            .map_err(JsonRpcError::internal_error)?
-        {
+    match chain_state.get_transaction(params.tx_hash.0).await {
+        Ok(tx) => {
             let mut res = Vec::new();
-            tx.tx.encode_2718(&mut res);
-            return Ok(hex::encode(&res));
-        };
-    }
-
-    if let Some(archive_reader) = archive_reader {
-        if let Ok((tx, _)) = archive_reader
-            .get_tx(&params.tx_hash.0.into())
-            .await
-            .inspect_err(|e| {
-                error!("Error getting tx from archive: {e:?}");
-            })
-        {
-            let mut res = Vec::new();
-            tx.tx.encode_2718(&mut res);
-            return Ok(hex::encode(&res));
+            let tx: TxEnvelope = tx.into();
+            tx.encode_2718(&mut res);
+            Ok(hex::encode(&res))
         }
+        Err(_) => Err(JsonRpcError::internal_error("block data not found".into())),
     }
-
-    Err(JsonRpcError::internal_error("transaction not found".into()))
 }
 
 #[derive(Clone, Debug)]

--- a/monad-rpc/src/handlers/eth/gas.rs
+++ b/monad-rpc/src/handlers/eth/gas.rs
@@ -15,11 +15,9 @@ use tokio::sync::Mutex;
 use tracing::trace;
 
 use crate::{
-    eth_json_types::{BlockTags, MonadFeeHistory, Quantity},
-    handlers::eth::{
-        block::get_block_key_from_tag,
-        call::{fill_gas_params, CallRequest},
-    },
+    chainstate::{get_block_key_from_tag, ChainState},
+    eth_json_types::{BlockTagOrHash, BlockTags, MonadFeeHistory, Quantity},
+    handlers::eth::call::{fill_gas_params, CallRequest},
     jsonrpc::{JsonRpcError, JsonRpcResult},
 };
 
@@ -333,25 +331,16 @@ pub async fn suggested_priority_fee() -> Result<u64, JsonRpcError> {
 #[rpc(method = "eth_gasPrice")]
 #[allow(non_snake_case)]
 /// Returns the current price per gas in wei.
-pub async fn monad_eth_gasPrice<T: Triedb>(triedb_env: &T) -> JsonRpcResult<Quantity> {
+pub async fn monad_eth_gasPrice<T: Triedb>(chain_state: &ChainState<T>) -> JsonRpcResult<Quantity> {
     trace!("monad_eth_gasPrice");
 
-    let block_key = get_block_key_from_tag(triedb_env, BlockTags::Latest);
-    let header = match triedb_env
-        .get_block_header(block_key)
+    let header = chain_state
+        .get_block_header(BlockTagOrHash::BlockTags(BlockTags::Latest))
         .await
-        .map_err(JsonRpcError::internal_error)?
-    {
-        Some(header) => header,
-        None => {
-            return Err(JsonRpcError::internal_error(
-                "error getting latest block header".into(),
-            ))
-        }
-    };
+        .map_err(|_| JsonRpcError::internal_error("could not get block data".into()))?;
 
     // Obtain base fee from latest block header
-    let base_fee_per_gas = header.header.base_fee_per_gas.unwrap_or_default();
+    let base_fee_per_gas = header.base_fee_per_gas.unwrap_or_default();
 
     // Obtain suggested priority fee
     let priority_fee = suggested_priority_fee().await.unwrap_or_default();
@@ -362,7 +351,7 @@ pub async fn monad_eth_gasPrice<T: Triedb>(triedb_env: &T) -> JsonRpcResult<Quan
 #[rpc(method = "eth_maxPriorityFeePerGas")]
 #[allow(non_snake_case)]
 /// Returns the current maxPriorityFeePerGas per gas in wei.
-pub async fn monad_eth_maxPriorityFeePerGas<T: Triedb>(triedb_env: &T) -> JsonRpcResult<Quantity> {
+pub async fn monad_eth_maxPriorityFeePerGas() -> JsonRpcResult<Quantity> {
     trace!("monad_eth_maxPriorityFeePerGas");
 
     let priority_fee = suggested_priority_fee().await.unwrap_or_default();
@@ -382,7 +371,7 @@ pub struct MonadEthHistoryParams {
 /// Transaction fee history
 /// Returns transaction base fee per gas and effective priority fee per gas for the requested/supported block range.
 pub async fn monad_eth_feeHistory<T: Triedb>(
-    triedb_env: &T,
+    chain_state: &ChainState<T>,
     params: MonadEthHistoryParams,
 ) -> JsonRpcResult<MonadFeeHistory> {
     trace!("monad_eth_feeHistory");
@@ -395,24 +384,15 @@ pub async fn monad_eth_feeHistory<T: Triedb>(
         ));
     }
 
-    let block_key = get_block_key_from_tag(triedb_env, params.newest_block);
-    let header = match triedb_env
-        .get_block_header(block_key)
+    let header = chain_state
+        .get_block_header(BlockTagOrHash::BlockTags(params.newest_block))
         .await
-        .map_err(JsonRpcError::internal_error)?
-    {
-        Some(header) => header,
-        None => {
-            return Err(JsonRpcError::internal_error(
-                "Unable to retrieve specified block".into(),
-            ))
-        }
-    };
+        .map_err(|_| JsonRpcError::internal_error("could not get block data".into()))?;
 
-    let base_fee_per_gas = header.header.base_fee_per_gas.unwrap_or_default();
-    let gas_used_ratio = (header.header.gas_used as f64).div(header.header.gas_limit as f64);
-    let blob_gas_used = header.header.blob_gas_used.unwrap_or_default();
-    let blob_gas_used_ratio = (blob_gas_used as f64).div(header.header.gas_limit as f64);
+    let base_fee_per_gas = header.base_fee_per_gas.unwrap_or_default();
+    let gas_used_ratio = (header.gas_used as f64).div(header.gas_limit as f64);
+    let blob_gas_used = header.blob_gas_used.unwrap_or_default();
+    let blob_gas_used_ratio = (blob_gas_used as f64).div(header.gas_limit as f64);
 
     let reward = match params.reward_percentiles {
         Some(percentiles) => {
@@ -446,7 +426,7 @@ pub async fn monad_eth_feeHistory<T: Triedb>(
         // TODO: proper calculation of blob fee
         base_fee_per_blob_gas: vec![base_fee_per_gas.into(); (block_count + 1) as usize],
         blob_gas_used_ratio: vec![blob_gas_used_ratio; block_count as usize],
-        oldest_block: header.header.number.saturating_sub(block_count),
+        oldest_block: header.number.saturating_sub(block_count),
         reward,
     }))
 }

--- a/monad-rpc/src/handlers/mod.rs
+++ b/monad-rpc/src/handlers/mod.rs
@@ -187,9 +187,9 @@ async fn debug_getRawBlock(
     app_state: &MonadRpcResources,
     params: Value,
 ) -> Result<Value, JsonRpcError> {
-    let triedb_env = app_state.triedb_reader.as_ref().method_not_supported()?;
+    let chain_state = app_state.chain_state.as_ref().method_not_supported()?;
     let params = serde_json::from_value(params).invalid_params()?;
-    monad_debug_getRawBlock(triedb_env, &app_state.archive_reader, params)
+    monad_debug_getRawBlock(chain_state, params)
         .await
         .map(serialize_result)?
 }
@@ -200,9 +200,9 @@ async fn debug_getRawHeader(
     app_state: &MonadRpcResources,
     params: Value,
 ) -> Result<Value, JsonRpcError> {
-    let triedb_env = app_state.triedb_reader.as_ref().method_not_supported()?;
+    let chain_state = app_state.chain_state.as_ref().method_not_supported()?;
     let params = serde_json::from_value(params).invalid_params()?;
-    monad_debug_getRawHeader(triedb_env, &app_state.archive_reader, params)
+    monad_debug_getRawHeader(chain_state, params)
         .await
         .map(serialize_result)?
 }
@@ -213,9 +213,9 @@ async fn debug_getRawReceipts(
     app_state: &MonadRpcResources,
     params: Value,
 ) -> Result<Value, JsonRpcError> {
-    let triedb_env = app_state.triedb_reader.as_ref().method_not_supported()?;
+    let chain_state = app_state.chain_state.as_ref().method_not_supported()?;
     let params = serde_json::from_value(params).invalid_params()?;
-    monad_debug_getRawReceipts(triedb_env, &app_state.archive_reader, params)
+    monad_debug_getRawReceipts(chain_state, params)
         .await
         .map(serialize_result)?
 }
@@ -226,9 +226,9 @@ async fn debug_getRawTransaction(
     app_state: &MonadRpcResources,
     params: Value,
 ) -> Result<Value, JsonRpcError> {
-    let triedb_env = app_state.triedb_reader.as_ref().method_not_supported()?;
+    let chain_state = app_state.chain_state.as_ref().method_not_supported()?;
     let params = serde_json::from_value(params).invalid_params()?;
-    monad_debug_getRawTransaction(triedb_env, &app_state.archive_reader, params)
+    monad_debug_getRawTransaction(chain_state, params)
         .await
         .map(serialize_result)?
 }
@@ -395,9 +395,9 @@ async fn eth_getTransactionByHash(
     app_state: &MonadRpcResources,
     params: Value,
 ) -> Result<Value, JsonRpcError> {
-    if let Some(triedb_env) = app_state.triedb_reader.as_ref() {
+    if let Some(chain_state) = app_state.chain_state.as_ref() {
         let params = serde_json::from_value(params).invalid_params()?;
-        monad_eth_getTransactionByHash(triedb_env, &app_state.archive_reader, params)
+        monad_eth_getTransactionByHash(chain_state, params)
             .await
             .map(serialize_result)?
     } else {
@@ -411,9 +411,9 @@ async fn eth_getBlockByHash(
     app_state: &MonadRpcResources,
     params: Value,
 ) -> Result<Value, JsonRpcError> {
-    if let Some(triedb_env) = &app_state.triedb_reader {
+    if let Some(chain_state) = &app_state.chain_state {
         let params = serde_json::from_value(params).invalid_params()?;
-        monad_eth_getBlockByHash(triedb_env, &app_state.archive_reader, params)
+        monad_eth_getBlockByHash(chain_state, params)
             .await
             .map(serialize_result)?
     } else {
@@ -427,9 +427,9 @@ async fn eth_getBlockByNumber(
     app_state: &MonadRpcResources,
     params: Value,
 ) -> Result<Value, JsonRpcError> {
-    if let Some(reader) = &app_state.triedb_reader {
+    if let Some(chain_state) = &app_state.chain_state {
         let params = serde_json::from_value(params).invalid_params()?;
-        monad_eth_getBlockByNumber(reader, &app_state.archive_reader, params)
+        monad_eth_getBlockByNumber(chain_state, params)
             .await
             .map(serialize_result)?
     } else {
@@ -443,9 +443,9 @@ async fn eth_getTransactionByBlockHashAndIndex(
     app_state: &MonadRpcResources,
     params: Value,
 ) -> Result<Value, JsonRpcError> {
-    if let Some(triedb_env) = &app_state.triedb_reader {
+    if let Some(chain_state) = &app_state.chain_state {
         let params = serde_json::from_value(params).invalid_params()?;
-        monad_eth_getTransactionByBlockHashAndIndex(triedb_env, &app_state.archive_reader, params)
+        monad_eth_getTransactionByBlockHashAndIndex(chain_state, params)
             .await
             .map(serialize_result)?
     } else {
@@ -459,9 +459,9 @@ async fn eth_getTransactionByBlockNumberAndIndex(
     app_state: &MonadRpcResources,
     params: Value,
 ) -> Result<Value, JsonRpcError> {
-    if let Some(triedb_env) = &app_state.triedb_reader {
+    if let Some(chain_state) = &app_state.chain_state {
         let params = serde_json::from_value(params).invalid_params()?;
-        monad_eth_getTransactionByBlockNumberAndIndex(triedb_env, &app_state.archive_reader, params)
+        monad_eth_getTransactionByBlockNumberAndIndex(chain_state, params)
             .await
             .map(serialize_result)?
     } else {
@@ -475,9 +475,9 @@ async fn eth_getBlockTransactionCountByHash(
     app_state: &MonadRpcResources,
     params: Value,
 ) -> Result<Value, JsonRpcError> {
-    if let Some(triedb_env) = app_state.triedb_reader.as_ref() {
+    if let Some(chain_state) = app_state.chain_state.as_ref() {
         let params = serde_json::from_value(params).invalid_params()?;
-        monad_eth_getBlockTransactionCountByHash(triedb_env, &app_state.archive_reader, params)
+        monad_eth_getBlockTransactionCountByHash(chain_state, params)
             .await
             .map(serialize_result)?
     } else {
@@ -491,9 +491,9 @@ async fn eth_getBlockTransactionCountByNumber(
     app_state: &MonadRpcResources,
     params: Value,
 ) -> Result<Value, JsonRpcError> {
-    if let Some(triedb_env) = app_state.triedb_reader.as_ref() {
+    if let Some(chain_state) = app_state.chain_state.as_ref() {
         let params = serde_json::from_value(params).invalid_params()?;
-        monad_eth_getBlockTransactionCountByNumber(triedb_env, &app_state.archive_reader, params)
+        monad_eth_getBlockTransactionCountByNumber(chain_state, params)
             .await
             .map(serialize_result)?
     } else {
@@ -571,8 +571,10 @@ async fn eth_blockNumber(
     app_state: &MonadRpcResources,
     _params: Value,
 ) -> Result<Value, JsonRpcError> {
-    if let Some(reader) = &app_state.triedb_reader {
-        monad_eth_blockNumber(reader).await.map(serialize_result)?
+    if let Some(chain_state) = &app_state.chain_state {
+        monad_eth_blockNumber(chain_state)
+            .await
+            .map(serialize_result)?
     } else {
         Err(JsonRpcError::method_not_supported())
     }
@@ -652,21 +654,8 @@ async fn eth_gasPrice(
     app_state: &MonadRpcResources,
     _params: Value,
 ) -> Result<Value, JsonRpcError> {
-    if let Some(triedb_env) = &app_state.triedb_reader {
-        monad_eth_gasPrice(triedb_env).await.map(serialize_result)?
-    } else {
-        Err(JsonRpcError::method_not_supported())
-    }
-}
-
-#[allow(non_snake_case)]
-async fn eth_maxPriorityFeePerGas(
-    _: RequestId,
-    app_state: &MonadRpcResources,
-    _params: Value,
-) -> Result<Value, JsonRpcError> {
-    if let Some(triedb_env) = &app_state.triedb_reader {
-        monad_eth_maxPriorityFeePerGas(triedb_env)
+    if let Some(chain_state) = &app_state.chain_state {
+        monad_eth_gasPrice(chain_state)
             .await
             .map(serialize_result)?
     } else {
@@ -675,14 +664,25 @@ async fn eth_maxPriorityFeePerGas(
 }
 
 #[allow(non_snake_case)]
+async fn eth_maxPriorityFeePerGas(
+    _: RequestId,
+    _app_state: &MonadRpcResources,
+    _params: Value,
+) -> Result<Value, JsonRpcError> {
+    monad_eth_maxPriorityFeePerGas()
+        .await
+        .map(serialize_result)?
+}
+
+#[allow(non_snake_case)]
 async fn eth_feeHistory(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
 ) -> Result<Value, JsonRpcError> {
-    if let Some(triedb_env) = &app_state.triedb_reader {
+    if let Some(chain_state) = &app_state.chain_state {
         let params = serde_json::from_value(params).invalid_params()?;
-        monad_eth_feeHistory(triedb_env, params)
+        monad_eth_feeHistory(chain_state, params)
             .await
             .map(serialize_result)?
     } else {
@@ -696,12 +696,12 @@ async fn eth_getTransactionReceipt(
     app_state: &MonadRpcResources,
     params: Value,
 ) -> Result<Value, JsonRpcError> {
-    let Some(triedb_reader) = &app_state.triedb_reader else {
+    let Some(chain_state) = &app_state.chain_state else {
         return Err(JsonRpcError::method_not_supported());
     };
 
     let params = serde_json::from_value(params).invalid_params()?;
-    monad_eth_getTransactionReceipt(triedb_reader, &app_state.archive_reader, params)
+    monad_eth_getTransactionReceipt(chain_state, params)
         .await
         .map(serialize_result)?
 }
@@ -712,9 +712,9 @@ async fn eth_getBlockReceipts(
     app_state: &MonadRpcResources,
     params: Value,
 ) -> Result<Value, JsonRpcError> {
-    let triedb_reader = app_state.triedb_reader.as_ref().method_not_supported()?;
+    let chain_state = app_state.chain_state.as_ref().method_not_supported()?;
     let params = serde_json::from_value(params).invalid_params()?;
-    monad_eth_getBlockReceipts(triedb_reader, &app_state.archive_reader, params)
+    monad_eth_getBlockReceipts(chain_state, params)
         .await
         .map(serialize_result)?
 }

--- a/monad-rpc/src/handlers/resources.rs
+++ b/monad-rpc/src/handlers/resources.rs
@@ -14,7 +14,8 @@ use tracing_actix_web::RootSpanBuilder;
 
 use super::eth::call::EthCallStatsTracker;
 use crate::{
-    fee::FixedFee, metrics::Metrics, txpool::EthTxPoolBridgeClient, websocket::Disconnect,
+    chainstate::ChainState, fee::FixedFee, metrics::Metrics, txpool::EthTxPoolBridgeClient,
+    websocket::Disconnect,
 };
 
 #[derive(Clone)]
@@ -27,6 +28,7 @@ pub struct MonadRpcResources {
     pub archive_reader: Option<ArchiveReader>,
     pub base_fee_per_gas: FixedFee,
     pub chain_id: u64,
+    pub chain_state: Option<ChainState<TriedbEnv>>,
     pub batch_request_limit: u16,
     pub max_response_size: u32,
     pub allow_unprotected_txs: bool,
@@ -59,6 +61,7 @@ impl MonadRpcResources {
         archive_reader: Option<ArchiveReader>,
         fixed_base_fee: u128,
         chain_id: u64,
+        chain_state: Option<ChainState<TriedbEnv>>,
         batch_request_limit: u16,
         max_response_size: u32,
         allow_unprotected_txs: bool,
@@ -86,6 +89,7 @@ impl MonadRpcResources {
             archive_reader,
             base_fee_per_gas: FixedFee::new(fixed_base_fee),
             chain_id,
+            chain_state,
             batch_request_limit,
             max_response_size,
             allow_unprotected_txs,

--- a/monad-rpc/src/lib.rs
+++ b/monad-rpc/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod chainstate;
 pub mod docs;
 pub mod eth_json_types;
 pub mod fee;

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -8,6 +8,7 @@ use monad_ethcall::EthCallExecutor;
 use monad_node_config::MonadNodeConfig;
 use monad_pprof::start_pprof_server;
 use monad_rpc::{
+    chainstate::ChainState,
     handlers::{
         resources::{MonadJsonRootSpanBuilder, MonadRpcResources},
         rpc_handler,
@@ -222,6 +223,10 @@ async fn main() -> std::io::Result<()> {
         .as_ref()
         .map(|provider| metrics::Metrics::new(provider.clone().meter("opentelemetry")));
 
+    let chain_state = triedb_env
+        .clone()
+        .map(|t| ChainState::new(t, archive_reader.clone()));
+
     let app_state = MonadRpcResources::new(
         txpool_bridge_client,
         triedb_env,
@@ -230,6 +235,7 @@ async fn main() -> std::io::Result<()> {
         archive_reader,
         BASE_FEE_PER_GAS.into(),
         node_config.chain_id,
+        chain_state,
         args.batch_request_limit,
         args.max_response_size,
         args.allow_unprotected_txs,
@@ -320,6 +326,7 @@ mod tests {
             archive_reader: None,
             base_fee_per_gas: FixedFee::new(2000),
             chain_id: 1337,
+            chain_state: None,
             batch_request_limit: 5,
             max_response_size: 25_000_000,
             allow_unprotected_txs: false,

--- a/monad-rpc/src/websocket.rs
+++ b/monad-rpc/src/websocket.rs
@@ -123,6 +123,7 @@ mod tests {
             archive_reader: None,
             base_fee_per_gas: FixedFee::new(2000),
             chain_id: 41454,
+            chain_state: None,
             batch_request_limit: 1000,
             max_response_size: 25_000_000,
             allow_unprotected_txs: false,


### PR DESCRIPTION
Introduces ChainState type that abstracts triedb and archive readers in order to make handler code more readable