### PR TITLE
Disable self name record signature check

### DIFF
--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -563,10 +563,11 @@ where
         seq: peer_discovery_config.self_record_seq_num,
     };
     let self_record = MonadNameRecord::new(self_record, &identity);
-    assert!(
-        self_record.signature == peer_discovery_config.self_name_record_sig,
-        "self name record signature mismatch"
-    );
+    // TODO: re-enable this check when peer discovery is activated
+    // assert!(
+    //     self_record.signature == peer_discovery_config.self_name_record_sig,
+    //     "self name record signature mismatch"
+    // );
 
     // initial set of peers
     let peer_info = peer_discovery_config


### PR DESCRIPTION
Simplifies testnet-2 genesis workflow. It will be re-enabled when we activate peer discovery