### PR TITLE
monad-raptorcast: validate udp message timestamp against configured max_age_ms

### DIFF
--- a/monad-node-config/src/network.rs
+++ b/monad-node-config/src/network.rs
@@ -16,6 +16,9 @@ pub struct NodeNetworkConfig {
 
     #[serde(default = "default_mtu")]
     pub mtu: u16,
+
+    #[serde(default = "default_udp_message_max_age_ms")]
+    pub udp_message_max_age_ms: u64,
 }
 
 // When running in docker with vpnkit, the maximum safe MTU is 1480, as per:
@@ -27,4 +30,8 @@ fn default_mtu() -> u16 {
 fn default_buffer_size() -> Option<usize> {
     // recommended value at the time of the commit
     Some(62_500_000)
+}
+
+fn default_udp_message_max_age_ms() -> u64 {
+    10_000 // 10 seconds in milliseconds
 }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -693,6 +693,7 @@ where
         RaptorCastConfig {
             shared_key: Arc::new(identity),
             mtu: network_config.mtu,
+            udp_message_max_age_ms: network_config.udp_message_max_age_ms,
             primary_instance: RaptorCastConfigPrimary {
                 raptor10_redundancy: node_config.raptor10_validator_redundancy_factor,
                 fullnode_dedicated: full_nodes

--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -39,10 +39,10 @@ tracing = { workspace = true }
 monad-testutil = { workspace = true }
 
 clap = { workspace = true, features = ["derive"] }
+rstest = { workspace = true }
 criterion = { workspace = true }
 futures-util = { workspace = true }
 insta = { workspace = true }
-rstest = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 

--- a/monad-raptorcast/benches/raptor_bench.rs
+++ b/monad-raptorcast/benches/raptor_bench.rs
@@ -111,6 +111,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let example_chunk = parse_message::<SecpSignature>(
             &mut LruCache::new(SIGNATURE_CACHE_SIZE),
             messages[0].clone().split_to(DEFAULT_SEGMENT_SIZE.into()),
+            u64::MAX,
         )
         .expect("valid chunk");
 
@@ -134,6 +135,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                         let parsed_message = parse_message::<SecpSignature>(
                             &mut signature_cache,
                             message.split_to(DEFAULT_SEGMENT_SIZE.into()),
+                            u64::MAX,
                         )
                         .expect("valid message");
                         decoder.received_encoded_symbol(

--- a/monad-raptorcast/src/config.rs
+++ b/monad-raptorcast/src/config.rs
@@ -19,6 +19,9 @@ where
     // fit into UDP datagrams for the raptorcast protocol.
     pub mtu: u16,
 
+    // Maximum age of UDP messages in milliseconds. Messages older than this will be rejected.
+    pub udp_message_max_age_ms: u64,
+
     // The primary instance owns the receive side of the UDP traffic used for
     // raptorcast and hence is mandatory in all configuration cases.
     pub primary_instance: RaptorCastConfigPrimary<ST>,
@@ -39,6 +42,7 @@ where
         RaptorCastConfig {
             shared_key: self.shared_key.clone(),
             mtu: self.mtu,
+            udp_message_max_age_ms: self.udp_message_max_age_ms,
             primary_instance: self.primary_instance.clone(),
             secondary_instance: self.secondary_instance.clone(),
         }

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -135,7 +135,7 @@ where
 
             current_epoch: Epoch(0),
 
-            udp_state: udp::UdpState::new(self_id),
+            udp_state: udp::UdpState::new(self_id, config.udp_message_max_age_ms),
             mtu: config.mtu,
 
             dataplane,
@@ -269,6 +269,7 @@ where
     let config = config::RaptorCastConfig {
         shared_key,
         mtu: DEFAULT_MTU,
+        udp_message_max_age_ms: u64::MAX, // No timestamp validation for tests
         primary_instance: Default::default(),
         secondary_instance: config::RaptorCastConfigSecondary {
             raptor10_redundancy: 2,

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -318,6 +318,7 @@ where
                         RouterArgs::RaptorCast => RouterConfig::RaptorCast(RaptorCastConfig {
                             shared_key,
                             mtu: DEFAULT_MTU,
+                            udp_message_max_age_ms: u64::MAX,
                             primary_instance: Default::default(),
                             secondary_instance: RaptorCastConfigSecondary::default(),
                         }),


### PR DESCRIPTION
closes: https://github.com/category-labs/monad-bft/issues/1411

max_age_ms defaults to 10s