### PR TITLE
Full-node Raptorcast: Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ test-keys
 .cargo/config.toml
 /*.log
 .gdbinit
+/venv
+/logs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5135,6 +5135,7 @@ dependencies = [
  "monad-consensus-types",
  "monad-control-panel",
  "monad-crypto",
+ "monad-dataplane",
  "monad-eth-block-policy",
  "monad-eth-block-validator",
  "monad-eth-txpool-executor",
@@ -5147,6 +5148,7 @@ dependencies = [
  "monad-pprof",
  "monad-raptorcast",
  "monad-router-filter",
+ "monad-router-multi",
  "monad-secp",
  "monad-state",
  "monad-state-backend",
@@ -5319,6 +5321,21 @@ dependencies = [
  "monad-executor-glue",
  "monad-state",
  "monad-types",
+]
+
+[[package]]
+name = "monad-router-multi"
+version = "0.1.0"
+dependencies = [
+ "alloy-rlp",
+ "futures",
+ "monad-crypto",
+ "monad-dataplane",
+ "monad-executor",
+ "monad-executor-glue",
+ "monad-peer-discovery",
+ "monad-raptorcast",
+ "tracing",
 ]
 
 [[package]]
@@ -5518,6 +5535,7 @@ dependencies = [
  "rand 0.8.5",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]
@@ -8546,6 +8564,18 @@ dependencies = [
  "pin-project",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ monad-pprof = { path = "./monad-pprof" }
 monad-raptor = { path = "./monad-raptor" }
 monad-raptorcast = { path = "./monad-raptorcast" }
 monad-router-filter = { path = "./monad-router-filter" }
+monad-router-multi = { path = "./monad-router-multi" }
 monad-router-scheduler = { path = "./monad-router-scheduler" }
 monad-rpc-docs = { path = "./monad-rpc/monad-rpc-docs" }
 monad-rpc-docs-derive = { path = "./monad-rpc/monad-rpc-docs/monad-rpc-docs-derive" }
@@ -192,6 +193,7 @@ tokio-util = "0.7"
 toml = "0.7"
 tracing = "0.1"
 tracing-actix-web = "0.7"
+tracing-appender = "0.2"
 tracing-opentelemetry = "0.30"
 tracing-subscriber = "0.3"
 tracing-test = "0.2"

--- a/monad-executor/src/metrics.rs
+++ b/monad-executor/src/metrics.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{Index, IndexMut},
 };
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone)]
 pub struct ExecutorMetrics(HashMap<&'static str, u64>);
 
 impl Index<&'static str> for ExecutorMetrics {

--- a/monad-node-config/src/fullnode_raptorcast.rs
+++ b/monad-node-config/src/fullnode_raptorcast.rs
@@ -9,7 +9,7 @@ use super::fullnode::FullNodeConfig;
 pub enum SecondaryRaptorCastModeConfig {
     Client,
     Publisher,
-    // No "None" option, as FullNodeRaptorCastConfig is now wrapped in Option<>
+    None, // Disables secondary raptorcast
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -34,4 +34,5 @@ pub struct FullNodeRaptorCastConfig<P: PubKey> {
     pub bandwidth_capacity: u64,
     pub invite_future_dist_min: Round,
     pub invite_future_dist_max: Round,
+    pub invite_accept_heartbeat_ms: u64,
 }

--- a/monad-node/Cargo.toml
+++ b/monad-node/Cargo.toml
@@ -15,6 +15,7 @@ monad-consensus-state = { workspace = true }
 monad-consensus-types = { workspace = true }
 monad-control-panel = { workspace = true }
 monad-crypto = { workspace = true }
+monad-dataplane = { workspace = true }
 monad-eth-block-policy = { workspace = true }
 monad-eth-block-validator = { workspace = true }
 monad-eth-txpool-executor = { workspace = true }
@@ -26,6 +27,7 @@ monad-node-config = { workspace = true, features = ["crypto"] }
 monad-peer-discovery = { workspace = true }
 monad-raptorcast = { workspace = true }
 monad-router-filter = { workspace = true, optional = true }
+monad-router-multi = { workspace = true}
 monad-secp = { workspace = true }
 monad-state = { workspace = true }
 monad-state-backend = { workspace = true }

--- a/monad-peer-disc-swarm/src/driver.rs
+++ b/monad-peer-disc-swarm/src/driver.rs
@@ -184,6 +184,9 @@ where
                 PeerDiscoveryCommand::TimerCommand(peer_discovery_timer_command) => {
                     self.timer.exec(vec![peer_discovery_timer_command]);
                 }
+                PeerDiscoveryCommand::MetricsCommand(_) => {
+                    // ignore metrics command in swarm
+                }
             }
         }
         router_cmds

--- a/monad-peer-discovery/src/discovery.rs
+++ b/monad-peer-discovery/src/discovery.rs
@@ -16,8 +16,8 @@ use tracing::{debug, info, trace, warn};
 
 use crate::{
     MonadNameRecord, NameRecord, PeerDiscoveryAlgo, PeerDiscoveryAlgoBuilder, PeerDiscoveryCommand,
-    PeerDiscoveryEvent, PeerDiscoveryMessage, PeerDiscoveryTimerCommand, PeerLookupRequest,
-    PeerLookupResponse, Ping, Pong, TimerKind,
+    PeerDiscoveryEvent, PeerDiscoveryMessage, PeerDiscoveryMetricsCommand,
+    PeerDiscoveryTimerCommand, PeerLookupRequest, PeerLookupResponse, Ping, Pong, TimerKind,
 };
 
 /// Maximum number of peers to be included in a PeerLookupResponse
@@ -737,6 +737,11 @@ where
 
         // reset timer to schedule for the next refresh
         cmds.extend(self.reset_refresh_timer());
+
+        // export metrics
+        cmds.push(PeerDiscoveryCommand::MetricsCommand(
+            PeerDiscoveryMetricsCommand(self.metrics.clone()),
+        ));
 
         cmds
     }

--- a/monad-peer-discovery/src/driver.rs
+++ b/monad-peer-discovery/src/driver.rs
@@ -26,6 +26,7 @@ pub enum PeerDiscoveryEmit<ST: CertificateSignatureRecoverable> {
         target: NodeId<CertificateSignaturePubKey<ST>>,
         message: PeerDiscoveryMessage<ST>,
     },
+    MetricsCommand(ExecutorMetrics),
 }
 
 struct PeerDiscTimers<ST: CertificateSignatureRecoverable> {
@@ -130,6 +131,12 @@ where
     pending_emits: VecDeque<PeerDiscoveryEmit<PD::SignatureType>>,
 }
 
+impl<PD: PeerDiscoveryAlgo> std::fmt::Debug for PeerDiscoveryDriver<PD> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PeerDiscoveryDriver").finish()
+    }
+}
+
 impl<PD: PeerDiscoveryAlgo> PeerDiscoveryDriver<PD> {
     pub fn new<B: PeerDiscoveryAlgoBuilder<PeerDiscoveryAlgoType = PD>>(builder: B) -> Self {
         let (peer_discovery, init_cmds) = builder.build();
@@ -192,6 +199,11 @@ impl<PD: PeerDiscoveryAlgo> PeerDiscoveryDriver<PD> {
                 }
                 PeerDiscoveryCommand::TimerCommand(timer_cmd) => {
                     timer_cmds.push(timer_cmd);
+                }
+                PeerDiscoveryCommand::MetricsCommand(peer_discovery_metrics_command) => {
+                    emits.push(PeerDiscoveryEmit::MetricsCommand(
+                        peer_discovery_metrics_command.0,
+                    ));
                 }
             }
         }

--- a/monad-peer-discovery/src/lib.rs
+++ b/monad-peer-discovery/src/lib.rs
@@ -157,12 +157,16 @@ pub enum PeerDiscoveryTimerCommand<E, ST: CertificateSignatureRecoverable> {
 }
 
 #[derive(Debug)]
+pub struct PeerDiscoveryMetricsCommand(ExecutorMetrics);
+
+#[derive(Debug)]
 pub enum PeerDiscoveryCommand<ST: CertificateSignatureRecoverable> {
     RouterCommand {
         target: NodeId<CertificateSignaturePubKey<ST>>,
         message: PeerDiscoveryMessage<ST>,
     },
     TimerCommand(PeerDiscoveryTimerCommand<PeerDiscoveryEvent<ST>, ST>),
+    MetricsCommand(PeerDiscoveryMetricsCommand),
 }
 
 pub trait PeerDiscoveryAlgo {

--- a/monad-raptorcast/examples/service.rs
+++ b/monad-raptorcast/examples/service.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     net::{SocketAddr, SocketAddrV4},
     num::ParseIntError,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -13,11 +14,9 @@ use monad_crypto::certificate_signature::{
     CertificateKeyPair, CertificateSignature, CertificateSignaturePubKey,
     CertificateSignatureRecoverable, PubKey,
 };
-use monad_dataplane::udp::DEFAULT_MTU;
 use monad_executor::Executor;
 use monad_executor_glue::{Message, RouterCommand};
-use monad_peer_discovery::mock::{NopDiscovery, NopDiscoveryBuilder};
-use monad_raptorcast::{RaptorCast, RaptorCastConfig, RaptorCastEvent};
+use monad_raptorcast::{new_defaulted_raptorcast_for_tests, RaptorCastEvent};
 use monad_secp::SecpSignature;
 use monad_types::{Deserializable, Epoch, NodeId, RouterTarget, Serializable, Stake};
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -46,7 +45,6 @@ pub fn main() {
 
 type SignatureType = SecpSignature;
 type PubKeyType = CertificateSignaturePubKey<SignatureType>;
-type PeerDiscoveryType = NopDiscovery<SignatureType>;
 
 fn service(
     num_rt: usize,
@@ -55,6 +53,7 @@ fn service(
     num_broadcast: u32,
     message_len: usize,
 ) {
+    // Configure peers (5 in the example)
     assert!(message_len >= 4);
     let num_peers = addresses.len() as u32;
     let keys: Vec<_> = (0..num_peers)
@@ -94,7 +93,7 @@ fn service(
         std::sync::mpsc::channel::<(NodeId<PubKeyType>, <MockMessage as Message>::Event)>();
 
     let rts: Vec<_> = std::iter::repeat_with(|| {
-        tokio::runtime::Builder::new_multi_thread()
+        tokio::runtime::Builder::new_multi_thread() // The MultiThread builder spawn a thread
             .enable_all()
             .worker_threads(threads_per_rt)
             .build()
@@ -102,7 +101,7 @@ fn service(
     })
     .take(num_rt)
     .collect();
-
+    // Iterate the 2 runtime cycles
     rts.iter()
         .cycle()
         .zip(keys.into_iter().zip(tx_reader))
@@ -114,33 +113,21 @@ fn service(
             let known_addresses = known_addresses.clone();
 
             rt.spawn(async move {
-                let service_config = RaptorCastConfig {
-                    key,
-                    full_nodes: Default::default(),
-                    peer_discovery_builder: NopDiscoveryBuilder {
-                        known_addresses,
-                        ..Default::default()
-                    },
-                    redundancy: 2,
-                    local_addr: server_address,
-                    up_bandwidth_mbps: 1_000,
-                    mtu: DEFAULT_MTU,
-                    buffer_size: None,
-                };
-
-                let mut service = RaptorCast::<
+                let mut service = new_defaulted_raptorcast_for_tests::<
                     SignatureType,
                     MockMessage,
                     MockMessage,
                     <MockMessage as Message>::Event,
-                    PeerDiscoveryType,
-                >::new(service_config);
+                >(server_address, known_addresses, Arc::new(key));
+
                 service.exec(vec![RouterCommand::AddEpochValidatorSet {
                     epoch: Epoch(0),
-                    validator_set: all_peers.iter().map(|peer| (*peer, Stake(0))).collect(),
+                    validator_set: all_peers.iter().map(|peer| (*peer, Stake(1))).collect(),
                 }]);
+
                 loop {
                     tokio::select! {
+                        // service.next() retrieves the next event from the RaptorCast service.
                         maybe_message = service.next() => {
                             let message = maybe_message.expect("never terminates");
                             rx_writer
@@ -158,18 +145,19 @@ fn service(
         });
 
     let (tx_peer, tx_router) = tx_writer.first_key_value().expect("at least 1 tx");
-
+    // Here: 1 `service` main thread + `9 `tokio-runtime-w` threads
     std::thread::sleep(Duration::from_secs(1));
 
     let start = Instant::now();
     let mut expected_message_ids = HashMap::new();
     for broadcast_id in 0..num_broadcast {
         let message = MockMessage::new(broadcast_id, message_len);
+        let command = RouterCommand::Publish {
+            target: RouterTarget::Raptorcast(Epoch(0)),
+            message,
+        };
         tx_router
-            .send(RouterCommand::Publish {
-                target: RouterTarget::Broadcast(Epoch(0)),
-                message,
-            })
+            .send(command)
             .expect("reader should never be dropped");
         expected_message_ids.insert(message.id, num_peers);
     }

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -1,10 +1,13 @@
 use std::{
-    cell::RefCell,
     collections::{BTreeMap, HashMap, VecDeque},
     marker::PhantomData,
-    net::SocketAddr,
+    net::{SocketAddr, SocketAddrV4},
     ops::DerefMut,
     pin::{pin, Pin},
+    sync::{
+        mpsc::{Receiver, Sender},
+        Arc, Mutex,
+    },
     task::{Context, Poll, Waker},
     time::Duration,
 };
@@ -12,13 +15,15 @@ use std::{
 use alloy_rlp::{Decodable, Encodable};
 use bytes::{Bytes, BytesMut};
 use futures::{channel::oneshot, FutureExt, Stream, StreamExt};
+use itertools::Itertools;
 use message::{InboundRouterMessage, OutboundRouterMessage};
 use monad_consensus_types::signature_collection::SignatureCollection;
 use monad_crypto::certificate_signature::{
     CertificateKeyPair, CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_dataplane::{
-    udp::segment_size_for_mtu, BroadcastMsg, Dataplane, DataplaneBuilder, TcpMsg, UnicastMsg,
+    udp::{segment_size_for_mtu, DEFAULT_MTU},
+    BroadcastMsg, Dataplane, DataplaneBuilder, RecvMsg, TcpMsg, UnicastMsg,
 };
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{
@@ -26,39 +31,22 @@ use monad_executor_glue::{
 };
 use monad_peer_discovery::{
     driver::{PeerDiscoveryDriver, PeerDiscoveryEmit},
-    PeerDiscoveryAlgo, PeerDiscoveryAlgoBuilder, PeerDiscoveryEvent,
+    mock::{NopDiscovery, NopDiscoveryBuilder},
+    PeerDiscoveryAlgo, PeerDiscoveryEvent,
 };
 use monad_types::{DropTimer, Epoch, ExecutionProtocol, NodeId, RouterTarget};
 use tracing::{debug, error, warn};
+use util::{BuildTarget, EpochValidators, FullNodes, Group, ReBroadcastGroupMap, Validator};
 
 pub mod config;
 pub mod message;
 pub mod raptorcast_secondary;
 pub mod udp;
 pub mod util;
-use util::{BuildTarget, EpochValidators, FullNodes, ReBroadcastGroupMap, Validator};
+
+use raptorcast_secondary::group_message::FullNodesGroupMessage;
 
 const SIGNATURE_SIZE: usize = 65;
-
-pub struct RaptorCastConfig<ST, B>
-where
-    ST: CertificateSignatureRecoverable,
-{
-    pub full_nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
-    pub peer_discovery_builder: B,
-
-    pub key: ST::KeyPairType,
-    /// amount of redundancy to send
-    /// a value of 2 == send 2x total payload size total
-    pub redundancy: u8,
-
-    pub local_addr: SocketAddr,
-
-    /// 1_000 = 1 Gbps, 10_000 = 10 Gbps
-    pub up_bandwidth_mbps: u64,
-    pub mtu: u16,
-    pub buffer_size: Option<usize>,
-}
 
 pub struct RaptorCast<ST, M, OM, SE, PD>
 where
@@ -67,27 +55,31 @@ where
     OM: Encodable + Into<M> + Clone,
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
 {
-    key: ST::KeyPairType,
+    signing_key: Arc<ST::KeyPairType>,
     redundancy: u8,
+    is_fullnode: bool,
 
     // Raptorcast group with stake information. For the send side (i.e., initiating proposals)
     epoch_validators: BTreeMap<Epoch, EpochValidators<ST>>,
     rebroadcast_map: ReBroadcastGroupMap<ST>,
 
-    // TODO support dynamic updating
-    full_nodes: FullNodes<CertificateSignaturePubKey<ST>>,
-    peer_discovery_driver: PeerDiscoveryDriver<PD>,
+    dedicated_full_nodes: FullNodes<CertificateSignaturePubKey<ST>>,
+    peer_discovery_driver: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
 
     current_epoch: Epoch,
 
     udp_state: udp::UdpState<ST>,
     mtu: u16,
 
-    dataplane: Dataplane,
+    dataplane: Arc<Mutex<Dataplane>>,
     pending_events: VecDeque<RaptorCastEvent<M::Event, ST>>,
+
+    channel_to_secondary: Option<Sender<FullNodesGroupMessage<ST>>>,
+    channel_from_secondary: Option<Receiver<Group<ST>>>,
 
     waker: Option<Waker>,
     metrics: ExecutorMetrics,
+    peer_discovery_metrics: ExecutorMetrics,
     _phantom: PhantomData<(OM, SE)>,
 }
 
@@ -108,27 +100,40 @@ where
     OM: Encodable + Into<M> + Clone,
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
 {
-    pub fn new<B>(config: RaptorCastConfig<ST, B>) -> Self
-    where
-        B: PeerDiscoveryAlgoBuilder<PeerDiscoveryAlgoType = PD>,
-    {
-        assert!(config.redundancy >= 1);
-        let self_id = NodeId::new(config.key.pubkey());
-        let mut builder = DataplaneBuilder::new(&config.local_addr, config.up_bandwidth_mbps);
-        if let Some(buffer_size) = config.buffer_size {
-            builder = builder.with_udp_buffer_size(buffer_size);
+    pub fn new(
+        config: config::RaptorCastConfig<ST>,
+        dataplane: Arc<Mutex<Dataplane>>,
+        peer_discovery_driver: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
+    ) -> Self {
+        if config.primary_instance.raptor10_redundancy < 1 {
+            panic!(
+                "Configuration value raptor10_redundancy must be equal or greater than 1, \
+                but got {}. This is a bug in the configuration for the primary instance.",
+                config.primary_instance.raptor10_redundancy
+            );
         }
-        let dataplane = builder.build();
-        let is_fullnode = false; // This will come from the config in upcoming PR
-
+        let self_id = NodeId::new(config.shared_key.pubkey());
+        let is_fullnode = matches!(
+            config.secondary_instance,
+            config::SecondaryRaptorCastModeConfig::Client(_)
+        );
+        tracing::trace!(
+            "RaptorCast - is_fullnode: {}, self_id: {:?}, mtu: {}",
+            is_fullnode,
+            self_id,
+            config.mtu
+        );
         Self {
+            is_fullnode,
             epoch_validators: Default::default(),
             rebroadcast_map: ReBroadcastGroupMap::new(self_id, is_fullnode),
-            full_nodes: FullNodes::new(config.full_nodes),
-            peer_discovery_driver: PeerDiscoveryDriver::new(config.peer_discovery_builder),
+            dedicated_full_nodes: FullNodes::new(
+                config.primary_instance.fullnode_dedicated.clone(),
+            ),
+            peer_discovery_driver,
 
-            key: config.key,
-            redundancy: config.redundancy,
+            signing_key: config.shared_key.clone(),
+            redundancy: config.primary_instance.raptor10_redundancy,
 
             current_epoch: Epoch(0),
 
@@ -137,10 +142,41 @@ where
 
             dataplane,
             pending_events: Default::default(),
+            channel_to_secondary: None,
+            channel_from_secondary: None,
 
             waker: None,
             metrics: Default::default(),
+            peer_discovery_metrics: Default::default(),
             _phantom: PhantomData,
+        }
+    }
+
+    // If we are a validator, then we don't need `channel_from_secondary`, since
+    // we won't be receiving groups from secondary.
+    // If we are a full-node, then we need both channels.
+    pub fn bind_channel_to_secondary_raptorcast(
+        mut self,
+        channel_to_secondary: Sender<FullNodesGroupMessage<ST>>,
+        channel_from_secondary: Receiver<Group<ST>>,
+    ) -> Self {
+        self.channel_to_secondary = Some(channel_to_secondary);
+        if self.is_fullnode {
+            self.channel_from_secondary = Some(channel_from_secondary);
+        }
+        self
+    }
+
+    fn enqueue_message_to_self(
+        message: OM,
+        pending_events: &mut VecDeque<RaptorCastEvent<M::Event, ST>>,
+        waker: &mut Option<Waker>,
+        self_id: NodeId<CertificateSignaturePubKey<ST>>,
+    ) {
+        let message: M = message.into();
+        pending_events.push_back(RaptorCastEvent::Message(message.event(self_id)));
+        if let Some(waker) = waker.take() {
+            waker.wake()
         }
     }
 
@@ -150,20 +186,23 @@ where
         make_app_message: impl FnOnce() -> Bytes,
         completion: Option<oneshot::Sender<()>>,
     ) {
-        match self.peer_discovery_driver.get_addr(to) {
+        match self.peer_discovery_driver.lock().unwrap().get_addr(to) {
             None => {
-                warn!(?to, "not sending message, address unknown");
+                warn!(
+                    ?to,
+                    "RaptorCastPrimary TcpPointToPoint not sending message, address unknown"
+                );
             }
             Some(address) => {
                 let app_message = make_app_message();
                 // TODO make this more sophisticated
                 // include timestamp, etc
                 let mut signed_message = BytesMut::zeroed(SIGNATURE_SIZE + app_message.len());
-                let signature = ST::sign(&app_message, &self.key).serialize();
+                let signature = ST::sign(&app_message, &self.signing_key).serialize();
                 assert_eq!(signature.len(), SIGNATURE_SIZE);
                 signed_message[..SIGNATURE_SIZE].copy_from_slice(&signature);
                 signed_message[SIGNATURE_SIZE..].copy_from_slice(&app_message);
-                self.dataplane.tcp_write(
+                self.dataplane.lock().unwrap().tcp_write(
                     address,
                     TcpMsg {
                         msg: signed_message.freeze(),
@@ -173,6 +212,71 @@ where
             }
         };
     }
+
+    // Prepares an app message (e.g. proposal) to be sent out via UDP, by signing
+    // it and then splitting into raptorcast chunks fitting MTU (depending on build_target)
+    fn udp_build(
+        epoch: &Epoch,
+        build_target: BuildTarget<ST>,
+        outbound_message: Bytes,
+        mtu: u16,
+        signing_key: &Arc<ST::KeyPairType>,
+        redundancy: u8,
+        known_addresses: &HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddr>,
+    ) -> UnicastMsg {
+        let segment_size = segment_size_for_mtu(mtu);
+
+        let unix_ts_ms = std::time::UNIX_EPOCH
+            .elapsed()
+            .expect("time went backwards")
+            .as_millis()
+            .try_into()
+            .expect("unix epoch doesn't fit in u64");
+
+        let messages = udp::build_messages::<ST>(
+            signing_key,
+            segment_size,
+            outbound_message,
+            redundancy,
+            epoch.0,
+            unix_ts_ms,
+            build_target,
+            known_addresses,
+        );
+
+        UnicastMsg {
+            msgs: messages,
+            stride: segment_size,
+        }
+    }
+}
+
+pub fn new_defaulted_raptorcast_for_tests<ST, M, OM, SE>(
+    local_addr: SocketAddr,
+    known_addresses: HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddrV4>,
+    shared_key: Arc<ST::KeyPairType>,
+) -> RaptorCast<ST, M, OM, SE, NopDiscovery<ST>>
+where
+    ST: CertificateSignatureRecoverable,
+    M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
+    OM: Encodable + Into<M> + Clone,
+{
+    let peer_discovery_builder = NopDiscoveryBuilder {
+        known_addresses,
+        ..Default::default()
+    };
+    let up_bandwidth_mbps = 1_000;
+    let dp_builder = DataplaneBuilder::new(&local_addr, up_bandwidth_mbps);
+    let shared_dataplane = Arc::new(Mutex::new(dp_builder.build()));
+    let config = config::RaptorCastConfig {
+        shared_key,
+        mtu: DEFAULT_MTU,
+        primary_instance: Default::default(),
+        secondary_instance: config::SecondaryRaptorCastModeConfig::None,
+    };
+    let pd = PeerDiscoveryDriver::new(peer_discovery_builder);
+    let shared_pd = Arc::new(Mutex::new(pd));
+    RaptorCast::<ST, M, OM, SE, NopDiscovery<ST>>::new(config, shared_dataplane, shared_pd)
 }
 
 impl<ST, M, OM, SE, PD> Executor for RaptorCast<ST, M, OM, SE, PD>
@@ -185,27 +289,33 @@ where
     type Command = RouterCommand<ST, OM>;
 
     fn exec(&mut self, commands: Vec<Self::Command>) {
-        let self_id = NodeId::new(self.key.pubkey());
+        let self_id = NodeId::new(self.signing_key.pubkey());
+
         for command in commands {
             match command {
                 RouterCommand::UpdateCurrentRound(epoch, round) => {
-                    assert!(epoch >= self.current_epoch);
-                    self.current_epoch = epoch;
-                    self.rebroadcast_map.delete_expired_groups(epoch, round);
-                    while let Some(entry) = self.epoch_validators.first_entry() {
-                        if *entry.key() + Epoch(1) < self.current_epoch {
-                            entry.remove();
-                        } else {
-                            break;
+                    if self.current_epoch < epoch {
+                        tracing::trace!(?epoch, ?round, "RaptorCast UpdateCurrentRound");
+                        self.current_epoch = epoch;
+                        self.rebroadcast_map.delete_expired_groups(epoch, round);
+                        while let Some(entry) = self.epoch_validators.first_entry() {
+                            if *entry.key() + Epoch(1) < self.current_epoch {
+                                entry.remove();
+                            } else {
+                                break;
+                            }
                         }
+                        self.peer_discovery_driver
+                            .lock()
+                            .unwrap()
+                            .update(PeerDiscoveryEvent::UpdateCurrentEpoch { epoch });
                     }
-                    self.peer_discovery_driver
-                        .update(PeerDiscoveryEvent::UpdateCurrentEpoch { epoch });
                 }
                 RouterCommand::AddEpochValidatorSet {
                     epoch,
                     validator_set,
                 } => {
+                    tracing::trace!(?epoch, ?validator_set, "RaptorCast AddEpochValidatorSet");
                     self.rebroadcast_map
                         .push_group_validator_set(validator_set.clone(), epoch);
                     if let Some(epoch_validators) = self.epoch_validators.get(&epoch) {
@@ -238,19 +348,25 @@ where
                         );
                         assert!(removed.is_none());
                     }
-                    self.peer_discovery_driver
-                        .update(PeerDiscoveryEvent::UpdateValidatorSet {
+                    self.peer_discovery_driver.lock().unwrap().update(
+                        PeerDiscoveryEvent::UpdateValidatorSet {
                             epoch,
                             validators: validator_set.into_iter().map(|(id, _)| id).collect(),
-                        });
+                        },
+                    );
                 }
                 RouterCommand::Publish { target, message } => {
+                    tracing::trace!(?target, "RaptorCast Publish AppMessage");
                     let _timer = DropTimer::start(Duration::from_millis(20), |elapsed| {
                         warn!(?elapsed, "long time to publish message")
                     });
 
                     // TODO: perhaps pass this directly to udp_build to avoid calling on every exec
-                    let known_addresses = self.peer_discovery_driver.get_known_addresses();
+                    let known_addresses = self
+                        .peer_discovery_driver
+                        .lock()
+                        .unwrap()
+                        .get_known_addresses();
 
                     // send message to self if applicable
                     match target {
@@ -265,16 +381,16 @@ where
                             };
 
                             if epoch_validators.validators.contains_key(&self_id) {
-                                let message: M = message.clone().into();
-                                self.pending_events
-                                    .push_back(RaptorCastEvent::Message(message.event(self_id)));
-                                if let Some(waker) = self.waker.take() {
-                                    waker.wake()
-                                }
+                                Self::enqueue_message_to_self(
+                                    message.clone(),
+                                    &mut self.pending_events,
+                                    &mut self.waker,
+                                    self_id,
+                                );
                             }
                             let epoch_validators_without_self =
                                 epoch_validators.view_without(vec![&self_id]);
-                            let full_nodes_view = self.full_nodes.view();
+                            let full_nodes_view = self.dedicated_full_nodes.view();
 
                             if epoch_validators_without_self.view().is_empty()
                                 && full_nodes_view.view().is_empty()
@@ -297,49 +413,51 @@ where
                             };
                             let outbound_message =
                                 OutboundRouterMessage::<OM, ST>::AppMessage(message).serialize();
-                            let unicast_msg = udp_build(
+                            let rc_chunks: UnicastMsg = Self::udp_build(
                                 &epoch,
                                 build_target,
                                 outbound_message,
                                 self.mtu,
-                                &self.key,
+                                &self.signing_key,
                                 self.redundancy,
                                 &known_addresses,
                             );
-                            self.dataplane.udp_write_unicast(unicast_msg);
+                            self.dataplane.lock().unwrap().udp_write_unicast(rc_chunks);
                         }
+
                         RouterTarget::PointToPoint(to) => {
                             if to == self_id {
-                                let message: M = message.into();
-                                self.pending_events
-                                    .push_back(RaptorCastEvent::Message(message.event(self_id)));
-                                if let Some(waker) = self.waker.take() {
-                                    waker.wake()
-                                }
+                                Self::enqueue_message_to_self(
+                                    message,
+                                    &mut self.pending_events,
+                                    &mut self.waker,
+                                    self_id,
+                                );
                             } else {
                                 let outbound_message =
                                     OutboundRouterMessage::<OM, ST>::AppMessage(message)
                                         .serialize();
-                                let unicast_msg = udp_build(
+                                let rc_chunks: UnicastMsg = Self::udp_build(
                                     &self.current_epoch,
                                     BuildTarget::<ST>::PointToPoint(&to),
                                     outbound_message,
                                     self.mtu,
-                                    &self.key,
+                                    &self.signing_key,
                                     self.redundancy,
                                     &known_addresses,
                                 );
-                                self.dataplane.udp_write_unicast(unicast_msg);
+                                self.dataplane.lock().unwrap().udp_write_unicast(rc_chunks);
                             }
                         }
+
                         RouterTarget::TcpPointToPoint { to, completion } => {
                             if to == self_id {
-                                let message: M = message.into();
-                                self.pending_events
-                                    .push_back(RaptorCastEvent::Message(message.event(self_id)));
-                                if let Some(waker) = self.waker.take() {
-                                    waker.wake()
-                                }
+                                Self::enqueue_message_to_self(
+                                    message,
+                                    &mut self.pending_events,
+                                    &mut self.waker,
+                                    self_id,
+                                );
                             } else {
                                 let app_message =
                                     OutboundRouterMessage::<OM, ST>::AppMessage(message);
@@ -350,7 +468,11 @@ where
                 }
                 RouterCommand::PublishToFullNodes { .. } => {}
                 RouterCommand::GetPeers => {
-                    let name_records = self.peer_discovery_driver.get_name_records();
+                    let name_records = self
+                        .peer_discovery_driver
+                        .lock()
+                        .unwrap()
+                        .get_name_records();
                     let peer_list = name_records
                         .iter()
                         .map(|(node_id, name_record)| PeerEntry {
@@ -367,61 +489,29 @@ where
                 }
                 RouterCommand::UpdatePeers(peers) => {
                     self.peer_discovery_driver
+                        .lock()
+                        .unwrap()
                         .update(PeerDiscoveryEvent::UpdatePeers { peers });
                 }
                 RouterCommand::GetFullNodes => {
-                    let full_nodes = self.full_nodes.list.clone();
+                    let full_nodes = self.dedicated_full_nodes.list.clone();
                     self.pending_events
                         .push_back(RaptorCastEvent::PeerManagerResponse(
                             PeerManagerResponse::FullNodes(full_nodes),
                         ));
                 }
                 RouterCommand::UpdateFullNodes(new_full_nodes) => {
-                    self.full_nodes.list = new_full_nodes;
+                    self.dedicated_full_nodes.list = new_full_nodes;
                 }
             }
         }
     }
 
     fn metrics(&self) -> ExecutorMetricsChain {
+        // FIXME: avoid copying metrics
         ExecutorMetricsChain::default()
             .push(self.metrics.as_ref())
-            .push(self.peer_discovery_driver.metrics())
-    }
-}
-
-fn udp_build<ST: CertificateSignatureRecoverable>(
-    epoch: &Epoch,
-    build_target: BuildTarget<ST>,
-    outbound_message: Bytes,
-    mtu: u16,
-    key: &ST::KeyPairType,
-    redundancy: u8,
-    known_addresses: &HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddr>,
-) -> UnicastMsg {
-    let segment_size = segment_size_for_mtu(mtu);
-
-    let unix_ts_ms = std::time::UNIX_EPOCH
-        .elapsed()
-        .expect("time went backwards")
-        .as_millis()
-        .try_into()
-        .expect("unix epoch doesn't fit in u64");
-
-    let messages = udp::build_messages::<ST>(
-        key,
-        segment_size,
-        outbound_message,
-        redundancy,
-        epoch.0,
-        unix_ts_ms,
-        build_target,
-        known_addresses,
-    );
-
-    UnicastMsg {
-        msgs: messages,
-        stride: segment_size,
+            .push(self.peer_discovery_metrics.as_ref())
     }
 }
 
@@ -449,17 +539,27 @@ where
         }
 
         let full_node_addrs = this
-            .full_nodes
+            .dedicated_full_nodes
             .list
             .iter()
-            .filter_map(|node_id| this.peer_discovery_driver.get_addr(node_id))
+            .filter_map(|node_id| this.peer_discovery_driver.lock().unwrap().get_addr(node_id))
             .collect::<Vec<_>>();
 
         loop {
-            // while let doesn't compile
-            let Poll::Ready(message) = pin!(this.dataplane.udp_read()).poll_unpin(cx) else {
-                break;
-            };
+            let message: RecvMsg;
+            {
+                let mut dataplane = this.dataplane.lock().unwrap();
+                let Poll::Ready(msg) = pin!(dataplane.udp_read()).poll_unpin(cx) else {
+                    break;
+                };
+                message = msg;
+            }
+
+            tracing::trace!(
+                "RaptorCastPrimary rx message len {} from: {}",
+                message.payload.len(),
+                message.src_addr
+            );
 
             // Enter the received raptorcast chunk into the udp_state for reassembly.
             // If the field "first-hop recipient" in the chunk has our node Id, then
@@ -469,33 +569,50 @@ where
             // Stream the chunks to our dedicated full-nodes as we receive them.
             let decoded_app_messages = {
                 // FIXME: pass dataplane as arg to handle_message
-                let dataplane = RefCell::new(&mut this.dataplane);
                 this.udp_state.handle_message(
-                    &this.rebroadcast_map,
+                    &this.rebroadcast_map, // contains the NodeIds for all the RC participants for each epoch
                     |targets, payload, bcast_stride| {
                         // Callback for re-broadcasting raptorcast chunks to other RaptorCast participants (validator peers)
                         let target_addrs: Vec<SocketAddr> = targets
                             .into_iter()
-                            .filter_map(|target| this.peer_discovery_driver.get_addr(&target))
+                            .filter_map(|target| {
+                                this.peer_discovery_driver.lock().unwrap().get_addr(&target)
+                            })
                             .collect();
 
-                        dataplane.borrow_mut().udp_write_broadcast(BroadcastMsg {
-                            targets: target_addrs,
-                            payload,
-                            stride: bcast_stride,
-                        });
+                        this.dataplane
+                            .lock()
+                            .unwrap()
+                            .udp_write_broadcast(BroadcastMsg {
+                                targets: target_addrs,
+                                payload,
+                                stride: bcast_stride,
+                            });
                     },
                     |payload, bcast_stride| {
-                        // callback for forwarding chunks to full nodes
-                        dataplane.borrow_mut().udp_write_broadcast(BroadcastMsg {
-                            targets: full_node_addrs.clone(),
-                            payload,
-                            stride: bcast_stride,
-                        });
+                        // Callback for forwarding chunks to full nodes
+                        this.dataplane
+                            .lock()
+                            .unwrap()
+                            .udp_write_broadcast(BroadcastMsg {
+                                targets: full_node_addrs.clone(),
+                                payload,
+                                stride: bcast_stride,
+                            });
                     },
                     message,
                 )
             };
+
+            tracing::trace!(
+                "RaptorCastPrimary rx decoded {} messages, sized: {:?}",
+                decoded_app_messages.len(),
+                decoded_app_messages
+                    .iter()
+                    .map(|(_node_id, bytes)| bytes.len())
+                    .collect_vec()
+            );
+
             let deserialized_app_messages =
                 decoded_app_messages
                     .into_iter()
@@ -503,16 +620,38 @@ where
                         match InboundRouterMessage::<M, ST>::try_deserialize(&decoded) {
                             Ok(inbound) => match inbound {
                                 InboundRouterMessage::AppMessage(app_message) => {
+                                    tracing::trace!("RaptorCastPrimary rx deserialized AppMessage");
                                     Some(app_message.event(from))
                                 }
                                 InboundRouterMessage::PeerDiscoveryMessage(peer_disc_message) => {
+                                    tracing::trace!("RaptorCastPrimary rx deserialized PeerDiscoveryMessage: {:?}", peer_disc_message);
                                     // handle peer discovery message in driver
-                                    this.peer_discovery_driver
+                                    this.peer_discovery_driver.lock().unwrap()
                                         .update(peer_disc_message.event(from));
                                     None
                                 }
-                                InboundRouterMessage::FullNodesGroup(_full_nodes_group_message) => {
-                                    warn!("Handling of FullNodesGroup implemented in upcoming PR");
+                                InboundRouterMessage::FullNodesGroup(full_nodes_group_message) => {
+                                    tracing::trace!("RaptorCastPrimary rx deserialized {:?}", full_nodes_group_message);
+                                    match &this.channel_to_secondary {
+                                        Some(channel) => {
+                                            if let Err(err) = channel.send(full_nodes_group_message)
+                                            {
+                                                tracing::error!(
+                                                    "Could not send InboundRouterMessage to \
+                                    secondary Raptorcast instance: {}",
+                                                    err
+                                                );
+                                            }
+                                        }
+                                        None => {
+                                            tracing::debug!(
+                                                ?from,
+                                                "Received FullNodesGroup message but the primary \
+                                Raptorcast instance is not setup to forward messages \
+                                to a secondary instance."
+                                            );
+                                        }
+                                    }
                                     None
                                 }
                             },
@@ -534,7 +673,8 @@ where
             }
         }
 
-        while let Poll::Ready((from_addr, message)) = pin!(this.dataplane.tcp_read()).poll_unpin(cx)
+        while let Poll::Ready((from_addr, message)) =
+            pin!(this.dataplane.lock().unwrap().tcp_read()).poll_unpin(cx)
         {
             // check message length to prevent panic during message slicing
             if message.len() < SIGNATURE_SIZE {
@@ -592,25 +732,51 @@ where
             }
         }
 
-        while let Poll::Ready(Some(peer_disc_emit)) = this.peer_discovery_driver.poll_next_unpin(cx)
         {
-            match peer_disc_emit {
-                PeerDiscoveryEmit::RouterCommand { target, message } => {
-                    let router_message =
-                        OutboundRouterMessage::serialize(
+            let mut pd_driver = this.peer_discovery_driver.lock().unwrap();
+            while let Poll::Ready(Some(peer_disc_emit)) = pd_driver.poll_next_unpin(cx) {
+                match peer_disc_emit {
+                    PeerDiscoveryEmit::RouterCommand { target, message } => {
+                        let router_message = OutboundRouterMessage::serialize(
                             OutboundRouterMessage::<OM, ST>::PeerDiscoveryMessage(message),
                         );
-                    let current_epoch = this.current_epoch;
-                    let unicast_msg = udp_build(
-                        &current_epoch,
-                        BuildTarget::<ST>::PointToPoint(&target),
-                        router_message,
-                        this.mtu,
-                        &this.key,
-                        this.redundancy,
-                        &this.peer_discovery_driver.get_known_addresses(),
-                    );
-                    this.dataplane.udp_write_unicast(unicast_msg);
+                        let current_epoch = this.current_epoch;
+                        let unicast_msg = Self::udp_build(
+                            &current_epoch,
+                            BuildTarget::<ST>::PointToPoint(&target),
+                            router_message,
+                            this.mtu,
+                            &this.signing_key,
+                            this.redundancy,
+                            &pd_driver.get_known_addresses(),
+                        );
+                        this.dataplane
+                            .lock()
+                            .unwrap()
+                            .udp_write_unicast(unicast_msg);
+                    }
+                    PeerDiscoveryEmit::MetricsCommand(executor_metrics) => {
+                        this.peer_discovery_metrics = executor_metrics;
+                    }
+                }
+            }
+        }
+
+        // The secondary Raptorcast instance (Client) will be periodically sending us
+        // updates about new rc groups that we should use when re-broadcasting
+        if let Some(channel_from_secondary) = &this.channel_from_secondary {
+            loop {
+                match channel_from_secondary.try_recv() {
+                    Ok(group) => {
+                        this.rebroadcast_map.push_group_fullnodes(group);
+                    }
+                    Err(err) => {
+                        // Error may also be TryRecvError::Empty
+                        if let std::sync::mpsc::TryRecvError::Disconnected = err {
+                            tracing::error!("RaptorCast secondary->primary channel disconnected.");
+                        }
+                        break;
+                    }
                 }
             }
         }

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -24,10 +24,10 @@ use monad_crypto::certificate_signature::{
     CertificateKeyPair, CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_dataplane::{udp::segment_size_for_mtu, Dataplane, UnicastMsg};
-// use monad_peer_discovery::{MonadNameRecord, NameRecord};
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
-use monad_executor_glue::{Message, RouterCommand};
-use monad_types::{Deserializable, DropTimer, Epoch, NodeId, Serializable};
+use monad_executor_glue::{Message, PeerEntry, RouterCommand};
+use monad_peer_discovery::{driver::PeerDiscoveryDriver, PeerDiscoveryAlgo, PeerDiscoveryEvent};
+use monad_types::{DropTimer, Epoch, NodeId};
 use publisher::Publisher;
 
 use super::{
@@ -49,15 +49,13 @@ where
     Client(Client<ST>),
 }
 
-pub struct RaptorCastSecondary<ST, M, OM, SE>
+pub struct RaptorCastSecondary<ST, M, OM, SE, PD>
 where
     ST: CertificateSignatureRecoverable,
-    M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Deserializable<Bytes> + Decodable,
-    OM: Serializable<Bytes> + Into<M> + Clone + Encodable,
+    M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
+    OM: Encodable + Into<M> + Clone,
+    PD: PeerDiscoveryAlgo<SignatureType = ST>,
 {
-    // Our id, regardless of role as publisher (validator) or client (full-node)
-    node_id: NodeId<CertificateSignaturePubKey<ST>>,
-
     // Main state machine, depending on wether we are playing the publisher role
     // (i.e. we are a validator) or a client role (full-node raptor-casted to)
     // Represents only the group logic, excluding everything network related.
@@ -68,12 +66,10 @@ where
     raptor10_redundancy: u8,
     curr_epoch: Epoch,
 
-    // These are populated from inbound group confirmation messages.
-    // Self SockAddr is removed.
-    known_addresses: HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddr>,
-
     mtu: u16,
     dataplane: Arc<Mutex<Dataplane>>,
+    peer_discovery_driver: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
+
     pending_events: VecDeque<RaptorCastEvent<M::Event, ST>>,
     channel_from_primary: Receiver<FullNodesGroupMessage<ST>>,
     waker: Option<Waker>,
@@ -81,21 +77,23 @@ where
     _phantom: PhantomData<(OM, SE)>,
 }
 
-impl<ST, M, OM, SE> RaptorCastSecondary<ST, M, OM, SE>
+impl<ST, M, OM, SE, PD> RaptorCastSecondary<ST, M, OM, SE, PD>
 where
     ST: CertificateSignatureRecoverable,
-    M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Deserializable<Bytes> + Decodable,
-    OM: Serializable<Bytes> + Into<M> + Clone + Encodable,
+    M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
+    OM: Encodable + Into<M> + Clone,
+    PD: PeerDiscoveryAlgo<SignatureType = ST>,
 {
     pub fn new(
-        config: &RaptorCastConfig<ST>,
-        shared_dataplane: Arc<Mutex<Dataplane>>,
+        config: RaptorCastConfig<ST>,
+        dataplane: Arc<Mutex<Dataplane>>,
+        peer_discovery_driver: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
         channel_from_primary: Receiver<FullNodesGroupMessage<ST>>,
         channel_to_primary: Sender<Group<ST>>,
     ) -> Self {
         let node_id = NodeId::new(config.shared_key.pubkey());
         let sec_config = config.secondary_instance.clone();
-        let mut raptor10_redundancy = 0;
+        let raptor10_redundancy;
 
         // Instantiate either publisher or client state machine
         let role = match sec_config {
@@ -105,6 +103,7 @@ where
                 Role::Publisher(publisher)
             }
             super::config::SecondaryRaptorCastModeConfig::Client(client_cfg) => {
+                raptor10_redundancy = client_cfg.raptor10_redundancy;
                 let client = Client::new(node_id, channel_to_primary, client_cfg);
                 Role::Client(client)
             }
@@ -114,15 +113,29 @@ where
             ),
         };
 
-        Self {
+        tracing::trace!(
+            "RaptorCastSecondary::new() - self_id: {:?}, mtu: {}, raptor10_redundancy: {}",
             node_id,
+            config.mtu,
+            raptor10_redundancy
+        );
+
+        if raptor10_redundancy < 1 {
+            panic!(
+                "Configuration value raptor10_redundancy must be equal or greater than 1, \
+                but got {}. This is a bug in the configuration for the secondary instance.",
+                raptor10_redundancy
+            );
+        }
+
+        Self {
             role,
             signing_key: config.shared_key.clone(),
             raptor10_redundancy,
             curr_epoch: Epoch(0),
-            known_addresses: config.known_addresses.clone(),
             mtu: config.mtu,
-            dataplane: shared_dataplane,
+            dataplane,
+            peer_discovery_driver,
             pending_events: Default::default(),
             channel_from_primary,
             waker: None,
@@ -134,15 +147,15 @@ where
     fn udp_build(
         epoch: &Epoch,
         build_target: BuildTarget<ST>,
-        app_message: Bytes,
+        outbound_message: Bytes,
         mtu: u16,
         signing_key: &Arc<ST::KeyPairType>,
         redundancy: u8,
         known_addresses: &HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddr>,
     ) -> UnicastMsg {
-        let app_message_len = app_message.len();
+        let outbound_message_len = outbound_message.len();
         let _timer = DropTimer::start(Duration::from_millis(10), |elapsed| {
-            tracing::warn!(?elapsed, app_message_len, "long time to udp_build")
+            tracing::warn!(?elapsed, outbound_message_len, "long time to udp_build")
         });
         let segment_size = segment_size_for_mtu(mtu);
 
@@ -153,10 +166,18 @@ where
             .try_into()
             .expect("unix epoch doesn't fit in u64");
 
+        tracing::trace!(
+            ?mtu,
+            ?outbound_message_len,
+            ?redundancy,
+            ?segment_size,
+            "RaptorCastSecondary::udp_build()"
+        );
+
         let messages = udp::build_messages::<ST>(
             signing_key,
             segment_size,
-            app_message,
+            outbound_message,
             redundancy,
             epoch.0,
             unix_ts_ms,
@@ -174,7 +195,13 @@ where
         &self,
         group_msg: FullNodesGroupMessage<ST>,
         dest_node: &NodeId<CertificateSignaturePubKey<ST>>,
+        known_addresses: &HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddr>,
     ) {
+        tracing::trace!(
+            ?dest_node,
+            ?group_msg,
+            "RaptorCastSecondary send_single_msg"
+        );
         let router_msg: OutboundRouterMessage<OM, ST> =
             OutboundRouterMessage::FullNodesGroup(group_msg);
         let msg_bytes = router_msg.serialize();
@@ -185,7 +212,7 @@ where
             self.mtu,
             &self.signing_key,
             self.raptor10_redundancy,
-            &self.known_addresses,
+            known_addresses,
         );
         self.dataplane
             .lock()
@@ -197,31 +224,61 @@ where
         &self,
         group_msg: FullNodesGroupMessage<ST>,
         dest_node_ids: FullNodes<CertificateSignaturePubKey<ST>>,
+        known_addresses: &HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddr>,
     ) {
+        tracing::trace!(
+            ?dest_node_ids,
+            ?group_msg,
+            "RaptorCastSecondary send_group_msg"
+        );
         let _timer = DropTimer::start(Duration::from_millis(100), |elapsed| {
             tracing::warn!(?elapsed, "long time to send_group_msg")
         });
-        let group_msg = self.try_fill_name_records(group_msg);
+        let group_msg = self.try_fill_name_records(group_msg, &dest_node_ids);
         // Can udp_write_broadcast() be used? Optimize later
         for nid in dest_node_ids.list {
-            self.send_single_msg(group_msg.clone(), &nid);
+            self.send_single_msg(group_msg.clone(), &nid, known_addresses);
         }
     }
 
     fn try_fill_name_records(
         &self,
         group_msg: FullNodesGroupMessage<ST>,
+        dest_node_ids: &FullNodes<CertificateSignaturePubKey<ST>>,
     ) -> FullNodesGroupMessage<ST> {
+        if let FullNodesGroupMessage::ConfirmGroup(confirm_msg) = &group_msg {
+            let name_records = {
+                self.peer_discovery_driver
+                    .lock()
+                    .unwrap()
+                    .get_name_records()
+            };
+            let mut filled_confirm_msg = confirm_msg.clone();
+            filled_confirm_msg.name_records = Vec::default();
+            for node_id in &dest_node_ids.list {
+                if let Some(name_record) = name_records.get(node_id) {
+                    filled_confirm_msg.name_records.push(*name_record);
+                } else {
+                    // Maybe can happen if peer discovery gets pruned just
+                    // before sending a ConfirmGroup message.
+                    tracing::warn!(
+                        "RaptorCastSecondary: No name record found for node_id {:?} when sending out ConfirmGroup message: {:?}",
+                        node_id, group_msg
+                    );
+                }
+            }
+            return FullNodesGroupMessage::ConfirmGroup(filled_confirm_msg);
+        }
         group_msg
-        // TODO: ask peer recovery for ConfirmGroup::name_records
     }
 }
 
-impl<ST, M, OM, SE> Executor for RaptorCastSecondary<ST, M, OM, SE>
+impl<ST, M, OM, SE, PD> Executor for RaptorCastSecondary<ST, M, OM, SE, PD>
 where
     ST: CertificateSignatureRecoverable,
-    M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Deserializable<Bytes> + Decodable,
-    OM: Serializable<Bytes> + Into<M> + Clone + Encodable,
+    M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
+    OM: Encodable + Into<M> + Clone,
+    PD: PeerDiscoveryAlgo<SignatureType = ST>,
 {
     type Command = RouterCommand<ST, OM>;
 
@@ -249,24 +306,46 @@ where
 
                 Self::Command::UpdateCurrentRound(epoch, round) => match &mut self.role {
                     Role::Client(client) => {
+                        tracing::trace!("RaptorCastSecondary UpdateCurrentRound (Client): epoch: {:?}, round: {:?}", epoch, round);
                         client.enter_round(round);
                     }
                     Role::Publisher(publisher) => {
+                        tracing::trace!("RaptorCastSecondary UpdateCurrentRound (Publisher): epoch: {:?}, round: {:?}", epoch, round);
                         self.curr_epoch = epoch;
+                        // The publisher needs to be periodically informed about new nodes out there,
+                        // so that it can randomize when creating new groups.
+                        {
+                            let known_addresses = {
+                                self.peer_discovery_driver
+                                    .lock()
+                                    .unwrap()
+                                    .get_known_addresses()
+                            };
+                            let nodes: Vec<_> = known_addresses.keys().copied().collect();
+                            tracing::trace!(
+                                "RaptorCastSecondary updating {} full nodes from PeerDiscovery",
+                                nodes.len()
+                            );
+                            publisher.upsert_peer_disc_full_nodes(FullNodes::new(nodes));
+                        }
+
                         if let Some((group_msg, fn_set)) =
                             publisher.enter_round_and_step_until(round)
                         {
-                            self.send_group_msg(group_msg, fn_set);
+                            let known_addresses = {
+                                self.peer_discovery_driver
+                                    .lock()
+                                    .unwrap()
+                                    .get_known_addresses()
+                            };
+                            self.send_group_msg(group_msg, fn_set, &known_addresses);
                         }
                     }
                 },
 
                 Self::Command::PublishToFullNodes { epoch, message } => {
-                    let app_message = message.serialize();
-                    let app_message_len = app_message.len();
-
                     let _timer = DropTimer::start(Duration::from_millis(20), |elapsed| {
-                        tracing::warn!(?elapsed, app_message_len, "long time to publish message")
+                        tracing::warn!(?elapsed, "long time to publish message")
                     });
 
                     let curr_group: &Group<ST> = match &mut self.role {
@@ -275,40 +354,48 @@ where
                         }
                         Role::Publisher(publisher) => {
                             match publisher.get_current_raptorcast_group() {
-                                Some(group) => group,
-                                None => continue,
+                                Some(group) => {
+                                    tracing::trace!("RaptorCastSecondary PublishToFullNodes; group: {:?}, size_excl_self: {}",
+                                        group, group.size_excl_self());
+                                    group
+                                }
+                                None => {
+                                    tracing::trace!(
+                                        "RaptorCastSecondary PublishToFullNodes; group: NONE"
+                                    );
+                                    continue;
+                                }
                             }
                         }
                     };
 
+                    if curr_group.size_excl_self() < 1 {
+                        tracing::trace!("RaptorCastSecondary PublishToFullNodes; Not sending anything because size_excl_self = 0");
+                        continue;
+                    }
+
                     let build_target = BuildTarget::FullNodeRaptorCast(curr_group);
 
-                    // Split app_message into raptorcast chunks that we can
-                    // send to full nodes.
-                    let rc_chunks = {
-                        let segment_size = segment_size_for_mtu(self.mtu);
-                        let unix_ts_ms = std::time::UNIX_EPOCH
-                            .elapsed()
-                            .expect("time went backwards")
-                            .as_millis()
-                            .try_into()
-                            .expect("unix epoch doesn't fit in u64");
-                        let messages = udp::build_messages::<ST>(
-                            &self.signing_key,
-                            segment_size,
-                            app_message,
-                            self.raptor10_redundancy,
-                            epoch.0, // gets embedded into raptorcast message
-                            unix_ts_ms,
-                            build_target,
-                            &self.known_addresses,
-                        );
+                    let known_addresses = self
+                        .peer_discovery_driver
+                        .lock()
+                        .unwrap()
+                        .get_known_addresses();
 
-                        UnicastMsg {
-                            msgs: messages,
-                            stride: segment_size,
-                        }
-                    };
+                    let outbound_message =
+                        OutboundRouterMessage::<OM, ST>::AppMessage(message).serialize();
+
+                    // Split outbound_message into raptorcast chunks that we can
+                    // send to full nodes.
+                    let rc_chunks: UnicastMsg = Self::udp_build(
+                        &epoch,
+                        build_target,
+                        outbound_message,
+                        self.mtu,
+                        &self.signing_key,
+                        self.raptor10_redundancy,
+                        &known_addresses,
+                    );
 
                     // Send the raptorcast chunks via UDP to all peers in group
                     self.dataplane.lock().unwrap().udp_write_unicast(rc_chunks);
@@ -321,12 +408,13 @@ where
         self.metrics.as_ref().into()
     }
 }
-impl<ST, M, OM, E> Stream for RaptorCastSecondary<ST, M, OM, E>
+impl<ST, M, OM, E, PD> Stream for RaptorCastSecondary<ST, M, OM, E, PD>
 where
     ST: CertificateSignatureRecoverable,
-    M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Deserializable<Bytes> + Decodable,
-    OM: Serializable<Bytes> + Into<M> + Clone + Encodable,
+    M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
+    OM: Encodable + Into<M> + Clone,
     E: From<RaptorCastEvent<M::Event, ST>>,
+    PD: PeerDiscoveryAlgo<SignatureType = ST>,
     Self: Unpin,
 {
     type Item = E;
@@ -351,12 +439,54 @@ where
                 }
 
                 Role::Client(client) => {
+                    tracing::trace!("RaptorCastSecondary received group message");
                     // Received group message from validator
+                    if let FullNodesGroupMessage::ConfirmGroup(confirm_msg) = &inbound_grp_msg {
+                        let num_mappings = confirm_msg.name_records.len();
+                        if num_mappings > 0 {
+                            if num_mappings == confirm_msg.peers.len() {
+                                let mut peers: Vec<PeerEntry<ST>> = Vec::new();
+                                // FIXME: bind name records with peers and ask peer discovery to verify
+                                for ii in 0..num_mappings {
+                                    let rec = &confirm_msg.name_records[ii];
+                                    let peer_entry = PeerEntry {
+                                        pubkey: confirm_msg.peers[ii].pubkey(),
+                                        addr: rec.name_record.address,
+                                        signature: rec.signature,
+                                        record_seq_num: rec.name_record.seq,
+                                    };
+                                    peers.push(peer_entry);
+                                }
+                                let mut pd = this.peer_discovery_driver.lock().unwrap();
+                                pd.update(PeerDiscoveryEvent::UpdatePeers { peers });
+                            } else {
+                                tracing::warn!(
+                                    "Number of peers {} does not match the number \
+                                    of name records {} in ConfirmGroup message: {:?}. \
+                                    Skipping PeerDiscovery update",
+                                    confirm_msg.peers.len(),
+                                    confirm_msg.name_records.len(),
+                                    confirm_msg
+                                );
+                            }
+                        }
+                    }
                     if let Some((response_msg, validator_id)) =
                         client.on_receive_group_message(inbound_grp_msg)
                     {
                         // Send back a response to the validator
-                        this.send_single_msg(response_msg, &validator_id);
+                        tracing::trace!(
+                            "RaptorCastSecondary sending back response for group message"
+                        );
+
+                        let known_addresses = {
+                            this.peer_discovery_driver
+                                .lock()
+                                .unwrap()
+                                .get_known_addresses()
+                        };
+
+                        this.send_single_msg(response_msg, &validator_id, &known_addresses);
                     }
                 }
             },

--- a/monad-router-multi/Cargo.toml
+++ b/monad-router-multi/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "monad-router-multi"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+monad-crypto = { workspace = true }
+monad-dataplane = { workspace = true }
+monad-executor = { workspace = true }
+monad-executor-glue = { workspace = true }
+monad-peer-discovery = { workspace = true }
+monad-raptorcast = { workspace = true }
+
+alloy-rlp = { workspace = true }
+futures = { workspace = true }
+tracing = { workspace = true }

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -1,0 +1,187 @@
+use std::{
+    marker::PhantomData,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::Poll,
+};
+
+use alloy_rlp::{Decodable, Encodable};
+use futures::{Stream, StreamExt};
+use monad_crypto::certificate_signature::{
+    CertificateSignaturePubKey, CertificateSignatureRecoverable,
+};
+use monad_dataplane::DataplaneBuilder;
+use monad_executor::{Executor, ExecutorMetricsChain};
+use monad_executor_glue::{Message, RouterCommand};
+use monad_peer_discovery::{
+    driver::PeerDiscoveryDriver, PeerDiscoveryAlgo, PeerDiscoveryAlgoBuilder,
+};
+use monad_raptorcast::{
+    config::{RaptorCastConfig, SecondaryRaptorCastModeConfig},
+    raptorcast_secondary::{group_message::FullNodesGroupMessage, RaptorCastSecondary},
+    util::Group,
+    RaptorCast, RaptorCastEvent,
+};
+pub use tracing::{debug, error, info, warn, Level};
+
+//==============================================================================
+pub struct MultiRouter<ST, M, OM, SE, PD>
+where
+    ST: CertificateSignatureRecoverable,
+    M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
+    OM: Encodable + Into<M> + Clone,
+    PD: PeerDiscoveryAlgo<SignatureType = ST>,
+{
+    rc_primary: RaptorCast<ST, M, OM, SE, PD>,
+    rc_secondary: Option<RaptorCastSecondary<ST, M, OM, SE, PD>>,
+    phantom: PhantomData<(OM, SE)>,
+}
+
+impl<ST, M, OM, SE, PD> MultiRouter<ST, M, OM, SE, PD>
+where
+    ST: CertificateSignatureRecoverable,
+    M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
+    OM: Encodable + Into<M> + Clone,
+    PD: PeerDiscoveryAlgo<SignatureType = ST>,
+{
+    pub fn new<B>(
+        cfg: RaptorCastConfig<ST>,
+        dataplane_builder: DataplaneBuilder,
+        peer_discovery_builder: B,
+    ) -> Self
+    where
+        B: PeerDiscoveryAlgoBuilder<PeerDiscoveryAlgoType = PD>,
+    {
+        // Peer discovery needs to be shared among primary and secondary
+        let pdd = PeerDiscoveryDriver::new(peer_discovery_builder);
+        let shared_pdd = Arc::new(Mutex::new(pdd));
+
+        let dp = dataplane_builder.build();
+        let shared_dataplane = Arc::new(Mutex::new(dp));
+
+        // Create a Channels between primary and secondary raptorcast instances.
+        // Fundamentally this is needed because, while both can send, only the
+        // primary can receive data from the network.
+        let (send_net_messages, recv_net_messages) =
+            std::sync::mpsc::channel::<FullNodesGroupMessage<ST>>();
+        let (send_group_infos, recv_group_infos) = std::sync::mpsc::channel::<Group<ST>>();
+
+        let rc_secondary = match &cfg.secondary_instance {
+            SecondaryRaptorCastModeConfig::None => None,
+            _ => Some(RaptorCastSecondary::new(
+                cfg.clone(),
+                shared_dataplane.clone(),
+                shared_pdd.clone(),
+                recv_net_messages,
+                send_group_infos,
+            )),
+        };
+
+        let rc_primary = RaptorCast::new(cfg, shared_dataplane, shared_pdd)
+            .bind_channel_to_secondary_raptorcast(send_net_messages, recv_group_infos);
+
+        Self {
+            rc_primary,
+            rc_secondary,
+            phantom: PhantomData,
+        }
+    }
+}
+
+//==============================================================================
+impl<ST, M, OM, SE, PD> Executor for MultiRouter<ST, M, OM, SE, PD>
+where
+    ST: CertificateSignatureRecoverable,
+    M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
+    OM: Encodable + Into<M> + Clone,
+    PD: PeerDiscoveryAlgo<SignatureType = ST>,
+    RaptorCast<ST, M, OM, SE, PD>: Unpin,
+{
+    type Command = RouterCommand<ST, OM>;
+
+    fn exec(&mut self, a_commands: Vec<Self::Command>) {
+        let mut validator_cmds = Vec::new();
+        let mut fullnodes_cmds = Vec::new();
+        for cmd in a_commands {
+            match cmd {
+                RouterCommand::Publish { .. } => validator_cmds.push(cmd),
+                RouterCommand::AddEpochValidatorSet { .. } => validator_cmds.push(cmd),
+                RouterCommand::GetPeers => validator_cmds.push(cmd),
+                RouterCommand::UpdatePeers { .. } => validator_cmds.push(cmd),
+
+                RouterCommand::PublishToFullNodes { .. } => fullnodes_cmds.push(cmd),
+                RouterCommand::GetFullNodes => validator_cmds.push(cmd),
+                RouterCommand::UpdateFullNodes { .. } => validator_cmds.push(cmd),
+
+                RouterCommand::UpdateCurrentRound(epoch, round) => {
+                    let cmd_cpy = RouterCommand::UpdateCurrentRound(epoch, round);
+                    validator_cmds.push(cmd);
+                    fullnodes_cmds.push(cmd_cpy);
+                }
+            }
+        }
+        self.rc_primary.exec(validator_cmds);
+        if self.rc_secondary.is_some() {
+            self.rc_secondary.as_mut().unwrap().exec(fullnodes_cmds);
+        }
+    }
+
+    fn metrics(&self) -> ExecutorMetricsChain {
+        let m1 = self.rc_primary.metrics();
+        let res: ExecutorMetricsChain = if self.rc_secondary.is_some() {
+            let m2 = self.rc_secondary.as_ref().unwrap().metrics();
+            m1.chain(m2)
+        } else {
+            m1
+        };
+        res
+    }
+}
+
+//==============================================================================
+impl<ST, M, OM, E, PD> Stream for MultiRouter<ST, M, OM, E, PD>
+where
+    ST: CertificateSignatureRecoverable,
+    M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
+    OM: Encodable + Into<M> + Clone,
+    E: From<RaptorCastEvent<M::Event, ST>>,
+    Self: Unpin,
+    RaptorCast<ST, M, OM, E, PD>: Unpin,
+    RaptorCastSecondary<ST, M, OM, E, PD>: Unpin,
+    PD: PeerDiscoveryAlgo<SignatureType = ST>,
+    PeerDiscoveryDriver<PD>: Unpin,
+{
+    type Item = E;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let pinned_this = self.as_mut().get_mut();
+
+        // Primary RC instance polls for inbound TCP, UDP raptorcast
+        // and FullNodesGroupMessage intended for the secondary RC instance.
+        match pinned_this.rc_primary.poll_next_unpin(cx) {
+            Poll::Ready(Some(event)) => return Poll::Ready(Some(event)),
+            Poll::Ready(None) => {
+                error!("Primary RaptorCast stream ended unexpectedly.");
+            }
+            Poll::Pending => {}
+        }
+
+        // Secondary RC instance polls for FullNodesGroupMessage coming in from
+        // the Channel Primary->Secondary.
+        if self.rc_secondary.is_some() {
+            let fn_stream = self.rc_secondary.as_mut().unwrap();
+            match fn_stream.poll_next_unpin(cx) {
+                Poll::Ready(Some(event)) => return Poll::Ready(Some(event)),
+                Poll::Ready(None) => {
+                    error!("Secondary RaptorCast stream ended unexpectedly.");
+                }
+                Poll::Pending => {}
+            }
+        }
+
+        Poll::Pending
+    }
+}

--- a/monad-testground/Cargo.toml
+++ b/monad-testground/Cargo.toml
@@ -38,5 +38,6 @@ opentelemetry-semantic-conventions = { workspace = true }
 rand = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing = { workspace = true, features = ["log"] }
+tracing-appender = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }


### PR DESCRIPTION
This activates full-node Raptorcast, integrates it with Peer discovery and primary Raptorcast instance.
Tested on flexnet, with associated PR on `monad-integration`
