### PR TITLE
Simplify pacemaker

### DIFF
--- a/monad-consensus-types/src/lib.rs
+++ b/monad-consensus-types/src/lib.rs
@@ -1,3 +1,13 @@
+use monad_crypto::certificate_signature::{
+    CertificateSignaturePubKey, CertificateSignatureRecoverable,
+};
+use monad_types::{ExecutionProtocol, Round};
+
+use crate::{
+    quorum_certificate::QuorumCertificate, signature_collection::SignatureCollection,
+    timeout::TimeoutCertificate,
+};
+
 pub mod block;
 pub mod block_validator;
 pub mod checkpoint;
@@ -9,3 +19,28 @@ pub mod timeout;
 pub mod validation;
 pub mod validator_data;
 pub mod voting;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RoundCertificate<ST, SCT, EPT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    EPT: ExecutionProtocol,
+{
+    Qc(QuorumCertificate<SCT>),
+    Tc(TimeoutCertificate<ST, SCT, EPT>),
+}
+
+impl<ST, SCT, EPT> RoundCertificate<ST, SCT, EPT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    EPT: ExecutionProtocol,
+{
+    pub fn round(&self) -> Round {
+        match &self {
+            Self::Qc(qc) => qc.info.round,
+            Self::Tc(tc) => tc.round,
+        }
+    }
+}

--- a/monad-consensus/src/validation/safety.rs
+++ b/monad-consensus/src/validation/safety.rs
@@ -68,7 +68,7 @@ where
     /// A block is safe to vote on if it's strictly higher than the highest
     /// voted round, and it must be correctly extending a QC or TC from the
     /// previous round
-    fn safe_to_vote(
+    pub fn safe_to_vote(
         &self,
         block_round: Round,
         qc_round: Round,


### PR DESCRIPTION
Fold consensus.high_qc into pacemaker, and maintain high_certificate in pacemaker.

The only functional change is that Pacemaker::advance_epoch no longer exists. This would only be useful if we entered a round that’s after epoch_start_delay, but before the boundary block is committed. We don't support this use-case, so it's safe to delete.