### PR TITLE
Update txpool to emit internal drop error when not ready

### DIFF
--- a/monad-eth-txpool-types/src/lib.rs
+++ b/monad-eth-txpool-types/src/lib.rs
@@ -70,6 +70,7 @@ pub enum EthTxPoolDropReason {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EthTxPoolInternalDropReason {
     StateBackendError,
+    NotReady,
 }
 
 impl EthTxPoolDropReason {

--- a/monad-eth-txpool/benches/common/controller.rs
+++ b/monad-eth-txpool/benches/common/controller.rs
@@ -66,7 +66,7 @@ impl<'a> BenchController<'a> {
 
         let state_backend = Self::generate_state_backend_for_txs(&txs);
 
-        let mut metrics = EthTxPoolMetrics::default();
+        let metrics = EthTxPoolMetrics::default();
         let pool = Self::create_pool(block_policy, txs, &metrics);
 
         Self {

--- a/monad-eth-txpool/benches/update.rs
+++ b/monad-eth-txpool/benches/update.rs
@@ -25,7 +25,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             );
             assert!(pending_txs.is_empty());
 
-            let mut metrics = EthTxPoolMetrics::default();
+            let metrics = EthTxPoolMetrics::default();
 
             let pool = BenchController::create_pool(&block_policy, Vec::default(), &metrics);
 

--- a/monad-eth-txpool/src/event_tracker.rs
+++ b/monad-eth-txpool/src/event_tracker.rs
@@ -136,6 +136,11 @@ impl<'a> EthTxPoolEventTracker<'a> {
                     .drop_internal_state_backend_error
                     .fetch_add(1, Ordering::SeqCst);
             }
+            EthTxPoolDropReason::Internal(EthTxPoolInternalDropReason::NotReady) => {
+                self.metrics
+                    .drop_internal_not_ready
+                    .fetch_add(1, Ordering::SeqCst);
+            }
         }
 
         self.events.push(EthTxPoolEvent::Drop { tx_hash, reason });

--- a/monad-eth-txpool/src/metrics.rs
+++ b/monad-eth-txpool/src/metrics.rs
@@ -17,6 +17,7 @@ pub struct EthTxPoolMetrics {
     pub drop_pool_full: AtomicU64,
     pub drop_pool_not_ready: AtomicU64,
     pub drop_internal_state_backend_error: AtomicU64,
+    pub drop_internal_not_ready: AtomicU64,
 
     pub create_proposal: AtomicU64,
     pub create_proposal_txs: AtomicU64,
@@ -52,6 +53,8 @@ impl EthTxPoolMetrics {
         metrics["monad.bft.txpool.pool.drop_internal_state_backend_error"] = self
             .drop_internal_state_backend_error
             .load(Ordering::SeqCst);
+        metrics["monad.bft.txpool.pool.drop_internal_not_ready"] =
+            self.drop_internal_not_ready.load(Ordering::SeqCst);
 
         metrics["monad.bft.txpool.pool.create_proposal"] =
             self.create_proposal.load(Ordering::SeqCst);

--- a/monad-eth-txpool/tests/forward.rs
+++ b/monad-eth-txpool/tests/forward.rs
@@ -38,7 +38,7 @@ fn with_txpool(
     );
     let mut pool = EthTxPool::default_testing();
 
-    let mut metrics = EthTxPoolMetrics::default();
+    let metrics = EthTxPoolMetrics::default();
     let mut ipc_events = Vec::default();
     let mut event_tracker = EthTxPoolEventTracker::new(&metrics, &mut ipc_events);
 
@@ -58,7 +58,7 @@ fn with_txpool(
         0
     );
 
-    let mut metrics = EthTxPoolMetrics::default();
+    let metrics = EthTxPoolMetrics::default();
     let mut ipc_events = Vec::default();
     let mut event_tracker = EthTxPoolEventTracker::new(&metrics, &mut ipc_events);
 

--- a/monad-eth-txpool/tests/pool.rs
+++ b/monad-eth-txpool/tests/pool.rs
@@ -124,7 +124,7 @@ fn run_custom_iter<const N: usize>(
     };
 
     let mut pool = EthTxPool::default_testing();
-    let mut metrics = EthTxPoolMetrics::default();
+    let metrics = EthTxPoolMetrics::default();
     let mut ipc_events = Vec::default();
     let mut event_tracker = EthTxPoolEventTracker::new(&metrics, &mut ipc_events);
 


### PR DESCRIPTION
When starting up full nodes that are not directly connected to a validator node, there is a "startup" phase where the txpool is alive but no blocks have been committed. During this period, the full node will spam warning messages that there was an attempt to promote transactions when the pool is not ready. This change moves the warning to only trigger if there is actually a transaction to promote and correctly produces the IPC error to notify RPC (if connected).