### PR TITLE
Update coherency before checking coherency

### DIFF
--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -1224,6 +1224,7 @@ where
         }
 
         // check that we have path to root and block is coherent
+        cmds.extend(self.try_update_coherency(self.consensus.high_qc.get_block_id()));
         if !self
             .consensus
             .pending_block_tree


### PR DESCRIPTION
This is mostly a nop. The only difference is that we now always call try_update_coherency before proposing if we enter a round via TC.

After dc6a8b2527c4c4ac4bc9299e6b4a8cd1a7bd8138, execution results are no longer pumped asynchronously so this is more important.