### PR TITLE
Add thin lto to release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ opt-level = 1
 
 [profile.release]
 debug = true
+lto = "thin"
 panic = "abort"
 
 [workspace.metadata.cargo-shear]


### PR DESCRIPTION
A long time ago, we debated whether to add`lto = true` (fat lto) because it was extremely slow to compile. This change introduces lto for release builds only through the thin variant which isn't as thorough as fat but adds negligible compile time.

# Rationale

Why add this now?

With the soon to be introduced event ring changes, `monad-rpc` will be iterating over tens of thousands of execution events. Reading each event requires making a call to `monad_event_iterator_try_next` followed by a `monad_event_payload_peek` and finally `monad_event_payload_check`, three calls to a separately compiled C object. Without LTO, performance for tight loops like this across the C boundary (and similarly in other parts of the codebase) suffer.

As an example, here is a benchmark diff where we read the first nibble of every event in an event ring file after enabling thin LTO.
```
snapshot/iter           time:   [2.1958 ms 2.1983 ms 2.2008 ms]
                 change:
                        time:   [-35.558% -35.380% -35.206%] (p = 0.00 < 0.05)
                        thrpt:  [+54.336% +54.750% +55.179%]
                        Performance has improved.
```

Even when memcpying each event into a rust enum (similar to what RPC will be doing), the overhead is present.
```
snapshot/iter_read      time:   [7.5412 ms 7.5502 ms 7.5602 ms]
                 change:
                        time:   [-12.800% -12.655% -12.514%] (p = 0.00 < 0.05)
                        thrpt:  [+14.304% +14.489% +14.679%]
                        Performance has improved.
```

#  Compile Times: monad-node
## Without LTO

Size: 287M
Stripped Size: 16M

### Build from clean target
```
real	1m16.241s
user	12m37.266s
sys	1m39.720s
```

### Build from touched `monad-node/src/main.rs`
```
real	0m10.418s
user	0m45.131s
sys	0m3.816s
```

## With LTO thin

Size: 219M
Stripped Size: 16M

### Build from clean target
```
real	1m14.830s
user	12m21.023s
sys	1m38.965s
```

### Build from touched `monad-node/src/main.rs`
```
real	0m16.982s
user	2m19.933s
sys	0m9.656s
```