### PR TITLE
Drop full node pings when above max active connections

### DIFF
--- a/docker/devnet/monad/config/node.toml
+++ b/docker/devnet/monad/config/node.toml
@@ -47,6 +47,7 @@ request_timeout = 5
 prune_threshold = 5
 min_active_connections = 0
 max_active_connections = 200
+drop_full_nodes_ping_probability = 0.8
 
 [fullnode_dedicated]
 identities = []

--- a/monad-node-config/src/peers.rs
+++ b/monad-node-config/src/peers.rs
@@ -19,4 +19,5 @@ pub struct PeerDiscoveryConfig<ST: CertificateSignatureRecoverable> {
     pub prune_threshold: u32,
     pub min_active_connections: usize,
     pub max_active_connections: usize,
+    pub drop_full_nodes_ping_probability: f64,
 }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -601,6 +601,7 @@ where
         prune_threshold: peer_discovery_config.prune_threshold,
         min_active_connections: peer_discovery_config.min_active_connections,
         max_active_connections: peer_discovery_config.max_active_connections,
+        drop_full_nodes_ping_probability: peer_discovery_config.drop_full_nodes_ping_probability,
         rng_seed: 123456,
     };
     RaptorCast::new(RaptorCastConfig {

--- a/monad-peer-disc-swarm/tests/peer_discovery.rs
+++ b/monad-peer-disc-swarm/tests/peer_discovery.rs
@@ -112,6 +112,7 @@ fn test_ping_pong() {
                         prune_threshold: 3,
                         min_active_connections: 5,
                         max_active_connections: 50,
+                        drop_full_nodes_ping_probability: 1.0,
                         rng_seed: 123456,
                     },
                     router_scheduler: NoSerRouterConfig::new(all_peers.keys().cloned().collect())
@@ -207,6 +208,7 @@ fn test_new_node_joining() {
                         prune_threshold: 3,
                         min_active_connections: 5,
                         max_active_connections: 50,
+                        drop_full_nodes_ping_probability: 1.0,
                         rng_seed: 123456,
                     },
                     router_scheduler: NoSerRouterConfig::new(all_peers.keys().cloned().collect())
@@ -278,6 +280,7 @@ fn test_update_name_record() {
                         prune_threshold: 3,
                         min_active_connections: 5,
                         max_active_connections: 50,
+                        drop_full_nodes_ping_probability: 1.0,
                         rng_seed: 123456,
                     },
                     router_scheduler: NoSerRouterConfig::new(all_peers.keys().cloned().collect())
@@ -342,6 +345,7 @@ fn test_update_name_record() {
             prune_threshold: 3,
             min_active_connections: 5,
             max_active_connections: 50,
+            drop_full_nodes_ping_probability: 1.0,
             rng_seed: 123456,
         },
         router_scheduler: NoSerRouterConfig::new(all_peers.keys().cloned().collect()).build(),
@@ -411,6 +415,7 @@ fn test_prune_nodes() {
                         prune_threshold: 3,
                         min_active_connections: 5,
                         max_active_connections: 50,
+                        drop_full_nodes_ping_probability: 1.0,
                         rng_seed: 123456,
                     },
                     router_scheduler: NoSerRouterConfig::new(all_peers.keys().cloned().collect())
@@ -525,6 +530,7 @@ fn test_peer_lookup_random_nodes() {
                         prune_threshold: 3,
                         min_active_connections: 5,
                         max_active_connections: 50,
+                        drop_full_nodes_ping_probability: 1.0,
                         rng_seed: 123456,
                     },
                     router_scheduler: NoSerRouterConfig::new(all_peers.keys().cloned().collect())
@@ -641,6 +647,7 @@ fn test_peer_lookup_retry() {
                         prune_threshold: 3,
                         min_active_connections: 5,
                         max_active_connections: 50,
+                        drop_full_nodes_ping_probability: 1.0,
                         rng_seed: 123456,
                     },
                     router_scheduler: NoSerRouterConfig::new(all_peers.keys().cloned().collect())
@@ -725,6 +732,7 @@ fn test_ping_timeout() {
                         prune_threshold: 3,
                         min_active_connections: 5,
                         max_active_connections: 50,
+                        drop_full_nodes_ping_probability: 1.0,
                         rng_seed: 123456,
                     },
                     router_scheduler: NoSerRouterConfig::new(all_peers.keys().cloned().collect())
@@ -817,6 +825,7 @@ fn test_min_watermark() {
                         prune_threshold: 1,
                         min_active_connections: 2,
                         max_active_connections: 10,
+                        drop_full_nodes_ping_probability: 1.0,
                         rng_seed: 123456,
                     },
                     router_scheduler: NoSerRouterConfig::new(all_peers.keys().cloned().collect())
@@ -907,6 +916,7 @@ fn test_max_watermark() {
                         prune_threshold: 1,
                         min_active_connections: 1,
                         max_active_connections: 2,
+                        drop_full_nodes_ping_probability: 1.0,
                         rng_seed: 123456,
                     },
                     router_scheduler: NoSerRouterConfig::new(all_peers.keys().cloned().collect())


### PR DESCRIPTION
Right now there is a high churn for full nodes because we unconditionally add nodes to our peer list when handling ping request, then prune them again periodically. This is not great as it means there's a high churn and lots of unnecessary signature verification. This PR probabilistically drop incoming pings when above max active connections. This is required rather than dropping all pings as we need validators to be able to add new full nodes in the network for full node broadcasting

More context here: https://github.com/category-labs/category-internal/issues/1619#issuecomment-2961743032