### PR TITLE
Move stateless safety checks to validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4469,7 +4469,6 @@ dependencies = [
  "monad-crypto",
  "monad-multi-sig",
  "monad-secp",
- "monad-state-backend",
  "monad-testutil",
  "monad-types",
  "monad-validator",

--- a/monad-consensus-types/src/timeout.rs
+++ b/monad-consensus-types/src/timeout.rs
@@ -153,7 +153,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
 {
-    pub fn max_round(&self) -> Round {
+    pub fn max_qc_round(&self) -> Round {
         self.high_qc_rounds
             .iter()
             .map(|v| v.high_qc_round.qc_round)

--- a/monad-consensus/Cargo.toml
+++ b/monad-consensus/Cargo.toml
@@ -12,7 +12,6 @@ bench = false
 monad-chain-config = { workspace = true }
 monad-consensus-types = { workspace = true }
 monad-crypto = { workspace = true }
-monad-state-backend = { workspace = true }
 monad-types = { workspace = true }
 monad-validator = { workspace = true }
 

--- a/monad-consensus/src/validation/safety.rs
+++ b/monad-consensus/src/validation/safety.rs
@@ -1,18 +1,18 @@
-use std::{cmp, marker::PhantomData};
+use std::marker::PhantomData;
 
-use monad_consensus_types::{
-    block::BlockPolicy,
-    quorum_certificate::QuorumCertificate,
-    signature_collection::SignatureCollection,
-    timeout::{TimeoutCertificate, TimeoutInfo},
-    voting::Vote,
-};
+use monad_consensus_types::signature_collection::SignatureCollection;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
-use monad_state_backend::StateBackend;
 use monad_types::{ExecutionProtocol, *};
 
+/// The safety module is responsible for all *stateful* safety checks.
+/// This makes sure that we don't double vote, double propose, etc.
+///
+/// Stateless validity checks must be done in the validation module.
+///
+/// For example, validating that a proposal correctly extends included
+/// certificates is outside the scope of this module.
 #[derive(PartialEq, Eq, Debug)]
 pub struct Safety<ST, SCT, EPT>
 where
@@ -20,8 +20,8 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
 {
-    highest_vote_round: Round,
-    highest_qc_round: Round,
+    highest_vote: Round,
+    highest_propose: Round,
 
     _phantom: PhantomData<(ST, SCT, EPT)>,
 }
@@ -34,8 +34,8 @@ where
 {
     fn default() -> Self {
         Self {
-            highest_vote_round: GENESIS_ROUND,
-            highest_qc_round: GENESIS_ROUND,
+            highest_vote: GENESIS_ROUND,
+            highest_propose: GENESIS_ROUND,
 
             _phantom: PhantomData,
         }
@@ -48,125 +48,35 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
 {
-    pub fn new(highest_vote_round: Round, highest_qc_round: Round) -> Self {
+    pub fn new(highest_vote: Round) -> Self {
         Self {
-            highest_vote_round,
-            highest_qc_round,
+            highest_vote,
+            highest_propose: highest_vote,
 
             _phantom: PhantomData,
         }
     }
 
-    fn update_highest_vote_round(&mut self, r: Round) {
-        self.highest_vote_round = cmp::max(r, self.highest_vote_round);
+    pub fn is_safe_to_vote(&self, round: Round) -> bool {
+        round > self.highest_vote
     }
 
-    fn update_highest_qc_round(&mut self, r: Round) {
-        self.highest_qc_round = cmp::max(r, self.highest_qc_round);
+    pub fn vote(&mut self, round: Round) {
+        assert!(self.is_safe_to_vote(round));
+        self.highest_vote = round;
     }
 
-    /// A block is safe to vote on if it's strictly higher than the highest
-    /// voted round, and it must be correctly extending a QC or TC from the
-    /// previous round
-    pub fn safe_to_vote(
-        &self,
-        block_round: Round,
-        qc_round: Round,
-        tc: &Option<TimeoutCertificate<ST, SCT, EPT>>,
-    ) -> bool {
-        if block_round <= cmp::max(self.highest_vote_round, qc_round) {
-            return false;
-        }
-
-        consecutive(block_round, qc_round) || Self::safe_to_extend(block_round, qc_round, tc)
+    pub fn timeout(&mut self, round: Round) {
+        assert!(round >= self.highest_vote);
+        self.highest_vote = round;
     }
 
-    /// A round is safe to timeout if there's no QC formed for that round, and
-    /// we haven't voted for a higher round, which implies a QC/TC is formed for
-    /// the round.
-    fn safe_to_timeout(
-        &self,
-        round: Round,
-        qc_round: Round,
-        tc: &Option<TimeoutCertificate<ST, SCT, EPT>>,
-    ) -> bool {
-        if qc_round < self.highest_qc_round
-            || round + Round(1) <= self.highest_vote_round
-            || round <= qc_round
-        {
-            return false;
-        }
-
-        let consecutive_tc = match tc {
-            Some(t) => consecutive(round, t.round),
-            None => false,
-        };
-
-        consecutive(round, qc_round) || consecutive_tc
+    pub fn is_safe_to_propose(&self, round: Round) -> bool {
+        round > self.highest_propose.max(self.highest_vote)
     }
 
-    /// Make a TimeoutInfo if it's safe to timeout the current round
-    pub fn make_timeout(
-        &mut self,
-        epoch: Epoch,
-        round: Round,
-        high_qc: QuorumCertificate<SCT>,
-        last_tc: &Option<TimeoutCertificate<ST, SCT, EPT>>,
-    ) -> Option<TimeoutInfo<SCT>> {
-        let qc_round = high_qc.get_round();
-        if self.safe_to_timeout(round, qc_round, last_tc) {
-            self.update_highest_vote_round(round);
-            Some(TimeoutInfo {
-                epoch,
-                round,
-                high_qc,
-            })
-        } else {
-            None
-        }
+    pub fn propose(&mut self, round: Round) {
+        assert!(self.is_safe_to_propose(round));
+        self.highest_propose = round;
     }
-
-    /// Make a Vote if it's safe to vote in the round.
-    pub fn make_vote<BPT, SBT>(
-        &mut self,
-        block: &BPT::ValidatedBlock,
-        last_tc: &Option<TimeoutCertificate<ST, SCT, EPT>>,
-    ) -> Option<Vote>
-    where
-        BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-        SBT: StateBackend,
-    {
-        let qc_round = block.get_parent_round();
-        if self.safe_to_vote(block.get_round(), qc_round, last_tc) {
-            self.update_highest_qc_round(qc_round);
-            self.update_highest_vote_round(block.get_round());
-
-            let vote = Vote {
-                id: block.get_id(),
-                epoch: block.get_epoch(),
-                round: block.get_round(),
-                parent_id: block.get_parent_id(),
-                parent_round: block.get_parent_round(),
-            };
-
-            return Some(vote);
-        }
-
-        None
-    }
-
-    fn safe_to_extend(
-        block_round: Round,
-        qc_round: Round,
-        tc: &Option<TimeoutCertificate<ST, SCT, EPT>>,
-    ) -> bool {
-        match tc {
-            Some(t) => consecutive(block_round, t.round) && qc_round >= t.max_round(),
-            None => false,
-        }
-    }
-}
-
-pub(crate) fn consecutive(block_round: Round, round: Round) -> bool {
-    block_round == round + Round(1)
 }

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -342,11 +342,22 @@ where
     /// 1. carries a QC/TC from r-1, proving that the block is proposed on a
     ///    valid round
     fn well_formed_proposal(&self) -> Result<(), Error> {
-        well_formed(
+        let () = well_formed(
             self.obj.block_header.round,
             self.obj.block_header.qc.get_round(),
             &self.obj.last_round_tc,
-        )
+        )?;
+
+        if self
+            .obj
+            .last_round_tc
+            .as_ref()
+            .is_some_and(|tc| self.obj.block_header.qc.get_round() < tc.max_qc_round())
+        {
+            return Err(Error::NotWellFormed);
+        }
+
+        Ok(())
     }
 
     /// Check local epoch manager record for block.round is equal to block.epoch


### PR DESCRIPTION
This commit tightens the scope of the safety module to only be responsible for stateful safety checks. This covers things like double voting, double proposing, etc.

Stateless validity checks, such as validating that a proposal correctly extends included certificates, is outside the scope of this module.