### PR TITLE
monad-raptorcast: fallback to uncomressed if zstd fails to compress

### DIFF
--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -602,27 +602,21 @@ where
         {
             match peer_disc_emit {
                 PeerDiscoveryEmit::RouterCommand { target, message } => {
-                    match OutboundRouterMessage::try_serialize(
-                        OutboundRouterMessage::<OM, ST>::PeerDiscoveryMessage(message),
-                    ) {
-                        Ok(router_message) => {
-                            let current_epoch = this.current_epoch;
-                            let unicast_msg = udp_build(
-                                &current_epoch,
-                                BuildTarget::<ST>::PointToPoint(&target),
-                                router_message,
-                                this.mtu,
-                                &this.key,
-                                this.redundancy,
-                                &this.peer_discovery_driver.get_known_addresses(),
-                            );
-                            this.dataplane.udp_write_unicast(unicast_msg);
-                        }
-                        Err(e) => {
-                            warn!("unable to serialize peer discovery message {:?}", e);
-                            continue;
-                        }
-                    }
+                    let router_message =
+                        OutboundRouterMessage::serialize(
+                            OutboundRouterMessage::<OM, ST>::PeerDiscoveryMessage(message),
+                        );
+                    let current_epoch = this.current_epoch;
+                    let unicast_msg = udp_build(
+                        &current_epoch,
+                        BuildTarget::<ST>::PointToPoint(&target),
+                        router_message,
+                        this.mtu,
+                        &this.key,
+                        this.redundancy,
+                        &this.peer_discovery_driver.get_known_addresses(),
+                    );
+                    this.dataplane.udp_write_unicast(unicast_msg);
                 }
             }
         }

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -177,16 +177,7 @@ where
     ) {
         let router_msg: OutboundRouterMessage<OM, ST> =
             OutboundRouterMessage::FullNodesGroup(group_msg);
-        let msg_bytes = match router_msg.try_serialize() {
-            Ok(bytes) => bytes,
-            Err(e) => {
-                tracing::error!(
-                    "RaptorCastSecondary failed to serialize during send_single_msg: {:?}",
-                    e
-                );
-                return;
-            }
-        };
+        let msg_bytes = router_msg.serialize();
         let udp_messages = Self::udp_build(
             &self.curr_epoch,
             BuildTarget::<ST>::PointToPoint(dest_node),


### PR DESCRIPTION
primarily to avoid dropping message if compressed size is larger than uncompressed.
added a warn log as i generally don't expect messages to be uncompressable, so it should bring some awareness if it happens

closes: https://github.com/category-labs/monad-bft/issues/1895