### PR TITLE
monad-dataplane, monad-raptorcast: integrate disconnect / trusted peers api

### DIFF
--- a/monad-dataplane/src/ban_expiry.rs
+++ b/monad-dataplane/src/ban_expiry.rs
@@ -144,7 +144,7 @@ mod tests {
         addr: IpAddr,
     ) {
         let now = Instant::now();
-        addrlist.ban(addr, now);
+        addrlist.ban(&addr, now);
         tx.send((addr, now)).unwrap();
 
         let mut ban_expiry_future = pin!(ban_expiry::task(addrlist.clone(), rx, ban_duration));
@@ -169,7 +169,7 @@ mod tests {
         addr: IpAddr,
     ) {
         let now = Instant::now();
-        addrlist.ban(addr, now);
+        addrlist.ban(&addr, now);
         tx.send((addr, now)).unwrap();
 
         let mut ban_expiry_future = pin!(ban_expiry::task(addrlist.clone(), rx, ban_duration));
@@ -179,7 +179,7 @@ mod tests {
         sleep(ban_duration / 2).await;
 
         let now = Instant::now();
-        addrlist.ban(addr, now);
+        addrlist.ban(&addr, now);
         tx.send((addr, now)).unwrap();
         assert_eq!(poll!(&mut ban_expiry_future), Poll::Pending);
 

--- a/monad-node-config/src/network.rs
+++ b/monad-node-config/src/network.rs
@@ -34,6 +34,18 @@ pub struct NodeNetworkConfig {
 
     #[serde(default = "default_udp_message_max_age_ms")]
     pub udp_message_max_age_ms: u64,
+
+    #[serde(default = "default_tcp_connections_limit")]
+    pub tcp_connections_limit: usize,
+
+    #[serde(default = "default_tcp_per_ip_connections_limit")]
+    pub tcp_per_ip_connections_limit: usize,
+
+    #[serde(default = "default_tcp_rate_limit_rps")]
+    pub tcp_rate_limit_rps: u32,
+
+    #[serde(default = "default_tcp_rate_limit_burst")]
+    pub tcp_rate_limit_burst: u32,
 }
 
 // When running in docker with vpnkit, the maximum safe MTU is 1480, as per:
@@ -49,4 +61,20 @@ fn default_buffer_size() -> Option<usize> {
 
 fn default_udp_message_max_age_ms() -> u64 {
     10_000 // 10 seconds in milliseconds
+}
+
+fn default_tcp_connections_limit() -> usize {
+    1000
+}
+
+fn default_tcp_per_ip_connections_limit() -> usize {
+    5
+}
+
+fn default_tcp_rate_limit_rps() -> u32 {
+    1000
+}
+
+fn default_tcp_rate_limit_burst() -> u32 {
+    200
 }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -613,6 +613,15 @@ where
     if let Some(buffer_size) = network_config.buffer_size {
         dp_builder = dp_builder.with_udp_buffer_size(buffer_size);
     }
+    dp_builder = dp_builder
+        .with_tcp_connections_limit(
+            network_config.tcp_connections_limit,
+            network_config.tcp_per_ip_connections_limit,
+        )
+        .with_tcp_rps_burst(
+            network_config.tcp_rate_limit_rps,
+            network_config.tcp_rate_limit_burst,
+        );
 
     let self_id = NodeId::new(identity.pubkey());
     let self_record = NameRecord {

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -16,8 +16,9 @@
 use std::{
     collections::{BTreeMap, HashMap, VecDeque},
     future::Future as _,
+    iter::once,
     marker::PhantomData,
-    net::{SocketAddr, SocketAddrV4},
+    net::{IpAddr, SocketAddr, SocketAddrV4},
     ops::DerefMut,
     pin::{pin, Pin},
     sync::{Arc, Mutex},
@@ -323,6 +324,25 @@ where
                 RouterCommand::UpdateCurrentRound(epoch, round) => {
                     if self.current_epoch < epoch {
                         tracing::trace!(?epoch, ?round, "RaptorCast UpdateCurrentRound");
+
+                        {
+                            let pd_driver = self.peer_discovery_driver.lock().unwrap();
+                            let added: Vec<_> = self
+                                .epoch_validators
+                                .get(&epoch)
+                                .into_iter()
+                                .flat_map(|val| iter_ips(val, &*pd_driver))
+                                .collect();
+                            let removed: Vec<_> = self
+                                .epoch_validators
+                                .get(&self.current_epoch)
+                                .into_iter()
+                                .flat_map(|val| iter_ips(val, &*pd_driver))
+                                .collect();
+                            drop(pd_driver);
+                            self.dataplane_writer.update_trusted(added, removed);
+                        }
+
                         self.current_epoch = epoch;
                         self.rebroadcast_map.delete_expired_groups(epoch, round);
                         while let Some(entry) = self.epoch_validators.first_entry() {
@@ -570,6 +590,17 @@ where
     }
 }
 
+fn iter_ips<'a, ST: CertificateSignatureRecoverable, PD: PeerDiscoveryAlgo<SignatureType = ST>>(
+    validators: &'a EpochValidators<ST>,
+    peer_discovery: &'a PeerDiscoveryDriver<PD>,
+) -> impl Iterator<Item = IpAddr> + 'a {
+    validators
+        .validators
+        .iter()
+        .filter_map(|(node_id, _)| peer_discovery.get_addr(node_id))
+        .map(|socket| socket.ip())
+}
+
 impl<ST, M, OM, E, PD> Stream for RaptorCast<ST, M, OM, E, PD>
 where
     ST: CertificateSignatureRecoverable,
@@ -732,6 +763,7 @@ where
                     ?src_addr,
                     "invalid message, message length less than signature size"
                 );
+                this.dataplane_writer.disconnect(src_addr);
                 continue;
             }
             let signature_bytes = &payload[..SIGNATURE_SIZE];
@@ -739,6 +771,7 @@ where
                 Ok(signature) => signature,
                 Err(err) => {
                     warn!(?err, ?src_addr, "invalid signature");
+                    this.dataplane_writer.disconnect(src_addr);
                     continue;
                 }
             };
@@ -748,6 +781,7 @@ where
                     Ok(message) => message,
                     Err(err) => {
                         warn!(?err, ?src_addr, "failed to deserialize message");
+                        this.dataplane_writer.disconnect(src_addr);
                         continue;
                     }
                 };
@@ -757,6 +791,7 @@ where
                 Ok(from) => from,
                 Err(err) => {
                     warn!(?err, ?src_addr, "failed to recover pubkey");
+                    this.dataplane_writer.disconnect(src_addr);
                     continue;
                 }
             };
@@ -774,11 +809,13 @@ where
                         ?message,
                         "dropping peer discovery message, should come through udp channel"
                     );
+                    this.dataplane_writer.disconnect(src_addr);
                     continue;
                 }
                 InboundRouterMessage::FullNodesGroup(_group_message) => {
                     // pass TCP message to MultiRouter
                     warn!("FullNodesGroup protocol via TCP not implemented");
+                    this.dataplane_writer.disconnect(src_addr);
                     continue;
                 }
             }


### PR DESCRIPTION
this change ingegrates with discovery to update dataplane with trusted ips anytime
when epoch changes or when validator has a change in its api address.
connections from trusted ips will bypass total and per ip connections limits.

the other change is to disconnect peer that sent invalid message
