### PR TITLE
Update env in github rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,13 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+  ASMFLAGS: -march=haswell
+  CC: gcc-13
+  CFLAGS: -march=haswell
+  CXX: g++-13
+  CXXFLAGS: -march=haswell -DQUILL_ACTIVE_LOG_LEVEL=QUILL_LOG_LEVEL_CRITICAL
+  TRIEDB_TARGET: triedb_driver
+
 jobs:
   build:
     runs-on: ubuntu-24.04-32
@@ -93,9 +100,9 @@ jobs:
       - name: Check
         run: cargo check --all-targets --all-features
       - name: Run tests
-        run: ASMFLAGS="-march=haswell" CFLAGS="-march=haswell" CXXFLAGS="-march=haswell -DQUILL_ACTIVE_LOG_LEVEL=QUILL_LOG_LEVEL_CRITICAL" CC=gcc-13 CXX=g++-13 TRIEDB_TARGET=triedb_driver cargo test --release --all-targets --all-features
+        run: cargo test --release --all-targets --all-features
       - name: Run doc tests
-        run: ASMFLAGS="-march=haswell" CFLAGS="-march=haswell" CXXFLAGS="-march=haswell -DQUILL_ACTIVE_LOG_LEVEL=QUILL_LOG_LEVEL_CRITICAL" CC=gcc-13 CXX=g++-13 TRIEDB_TARGET=triedb_driver cargo test --release --doc --all-features
+        run: cargo test --release --doc --all-features
       - run: rustup target add wasm32-unknown-unknown
       - name: Check WASM
         run: cargo check --target wasm32-unknown-unknown -p monad-debugger


### PR DESCRIPTION
In an upcoming PR, `cargo clippy` runs bindgen which fails since `CC` defaults to `/usr/bin/cc` instead of `gcc-13`. This change moves the environment variables to the `env` section so they are set for every command.