### PR TITLE
Add ST, SCT to StateBackend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4800,6 +4800,7 @@ dependencies = [
  "monad-consensus-types",
  "monad-crypto",
  "monad-types",
+ "monad-validator",
 ]
 
 [[package]]
@@ -4833,6 +4834,7 @@ dependencies = [
  "monad-state-backend",
  "monad-testutil",
  "monad-types",
+ "monad-validator",
 ]
 
 [[package]]
@@ -4844,7 +4846,6 @@ dependencies = [
  "blst",
  "criterion",
  "hex",
- "monad-consensus-types",
  "monad-crypto",
  "monad-testutil",
  "monad-types",
@@ -4931,6 +4932,7 @@ dependencies = [
  "monad-crypto",
  "monad-state-backend",
  "monad-types",
+ "monad-validator",
  "serde",
  "toml",
 ]
@@ -4940,11 +4942,11 @@ name = "monad-control-panel"
 version = "0.1.0"
 dependencies = [
  "futures",
- "monad-consensus-types",
  "monad-crypto",
  "monad-executor",
  "monad-executor-glue",
  "monad-types",
+ "monad-validator",
  "serde_json",
  "tokio",
  "tokio-util",
@@ -5056,6 +5058,7 @@ dependencies = [
  "monad-system-calls",
  "monad-testutil",
  "monad-types",
+ "monad-validator",
  "proptest",
  "sorted_vector_map",
  "tracing",
@@ -5078,6 +5081,7 @@ dependencies = [
  "monad-system-calls",
  "monad-testutil",
  "monad-types",
+ "monad-validator",
  "rayon",
  "tracing",
 ]
@@ -5097,6 +5101,7 @@ dependencies = [
  "monad-state-backend",
  "monad-types",
  "monad-updaters",
+ "monad-validator",
  "tracing",
 ]
 
@@ -5170,6 +5175,7 @@ dependencies = [
  "monad-system-calls",
  "monad-testutil",
  "monad-types",
+ "monad-validator",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
@@ -5204,6 +5210,7 @@ dependencies = [
  "monad-state-backend",
  "monad-types",
  "monad-updaters",
+ "monad-validator",
  "pin-project",
  "rayon",
  "serde",
@@ -5323,6 +5330,7 @@ dependencies = [
  "monad-crypto",
  "monad-state-backend",
  "monad-types",
+ "monad-validator",
  "serde",
 ]
 
@@ -5362,6 +5370,7 @@ dependencies = [
  "monad-executor",
  "monad-executor-glue",
  "monad-types",
+ "monad-validator",
  "tokio",
  "tracing",
 ]
@@ -5422,7 +5431,6 @@ name = "monad-multi-sig"
 version = "0.1.0"
 dependencies = [
  "alloy-rlp",
- "monad-consensus-types",
  "monad-crypto",
  "monad-testutil",
  "monad-types",
@@ -5616,7 +5624,6 @@ dependencies = [
  "itertools 0.10.5",
  "lru",
  "monad-compress",
- "monad-consensus-types",
  "monad-crypto",
  "monad-dataplane",
  "monad-executor",
@@ -5627,6 +5634,7 @@ dependencies = [
  "monad-secp",
  "monad-testutil",
  "monad-types",
+ "monad-validator",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rstest",
@@ -5801,8 +5809,11 @@ version = "0.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
+ "monad-crypto",
  "monad-eth-types",
+ "monad-multi-sig",
  "monad-types",
+ "monad-validator",
  "serde",
  "tracing",
 ]
@@ -5816,13 +5827,13 @@ dependencies = [
  "bindgen 0.71.1",
  "criterion",
  "futures",
- "monad-consensus-types",
  "monad-crypto",
  "monad-cxx",
  "monad-eth-types",
  "monad-executor",
  "monad-executor-glue",
  "monad-types",
+ "monad-validator",
  "rand 0.8.5",
  "tempfile",
  "tokio",
@@ -5844,6 +5855,7 @@ dependencies = [
  "monad-eth-types",
  "monad-testutil",
  "monad-types",
+ "monad-validator",
  "tracing",
 ]
 
@@ -5942,9 +5954,11 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "itertools 0.10.5",
+ "monad-crypto",
  "monad-eth-types",
  "monad-state-backend",
  "monad-types",
+ "monad-validator",
  "tracing",
 ]
 
@@ -5958,8 +5972,10 @@ dependencies = [
  "clap 4.5.41",
  "futures",
  "hex",
+ "monad-bls",
  "monad-eth-testutil",
  "monad-eth-types",
+ "monad-secp",
  "monad-state-backend",
  "monad-triedb",
  "monad-types",
@@ -6040,6 +6056,7 @@ dependencies = [
  "monad-node-config",
  "monad-state-backend",
  "monad-types",
+ "monad-validator",
  "ntest",
  "serde_json",
  "sorted-vec",
@@ -6053,15 +6070,17 @@ name = "monad-validator"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
  "as-any",
  "auto_impl",
+ "hex",
  "itertools 0.10.5",
- "monad-consensus-types",
  "monad-crypto",
  "monad-testutil",
  "monad-types",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "serde",
  "test-case",
  "tracing",
 ]

--- a/monad-block-persist/Cargo.toml
+++ b/monad-block-persist/Cargo.toml
@@ -12,6 +12,7 @@ bench = false
 monad-consensus-types = { workspace = true }
 monad-crypto = { workspace = true }
 monad-types = { workspace = true }
+monad-validator = { workspace = true }
 
 alloy-rlp = {workspace = true }
 hex = { workspace = true }

--- a/monad-block-persist/src/lib.rs
+++ b/monad-block-persist/src/lib.rs
@@ -24,12 +24,12 @@ use std::{
 use monad_consensus_types::{
     block::ConsensusBlockHeader,
     payload::{ConsensusBlockBody, ConsensusBlockBodyId},
-    signature_collection::SignatureCollection,
 };
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_types::{BlockId, ExecutionProtocol, Hash};
+use monad_validator::signature_collection::SignatureCollection;
 
 pub const BLOCKDB_HEADERS_PATH: &str = "headers";
 const BLOCKDB_BODIES_PATH: &str = "bodies";

--- a/monad-blocksync/src/messages/message.rs
+++ b/monad-blocksync/src/messages/message.rs
@@ -17,12 +17,12 @@ use alloy_rlp::{bytes, encode_list, Decodable, Encodable, Header};
 use monad_consensus_types::{
     block::{BlockRange, ConsensusBlockHeader},
     payload::{ConsensusBlockBody, ConsensusBlockBodyId},
-    signature_collection::SignatureCollection,
 };
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_types::ExecutionProtocol;
+use monad_validator::signature_collection::SignatureCollection;
 
 const BLOCK_SYNC_REQUEST_MESSAGE_NAME: &str = "BlockSyncRequestMessage";
 const BLOCK_SYNC_RESPONSE_MESSAGE_NAME: &str = "BlockSyncResponseMessage";

--- a/monad-blocktree/Cargo.toml
+++ b/monad-blocktree/Cargo.toml
@@ -13,6 +13,7 @@ monad-consensus-types = { workspace = true }
 monad-crypto = { workspace = true }
 monad-state-backend = { workspace = true }
 monad-types = { workspace = true }
+monad-validator = { workspace = true }
 
 [dev-dependencies]
 monad-crypto = { workspace = true }

--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -24,13 +24,13 @@ use monad_consensus_types::{
     metrics::Metrics,
     payload::{ConsensusBlockBody, ConsensusBlockBodyId},
     quorum_certificate::QuorumCertificate,
-    signature_collection::SignatureCollection,
 };
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_state_backend::{StateBackend, StateBackendError};
 use monad_types::{BlockId, ExecutionProtocol, Round, SeqNum};
+use monad_validator::signature_collection::SignatureCollection;
 
 use crate::tree::{BlockTreeEntry, Tree};
 
@@ -46,7 +46,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     /// The round and block_id of last committed block
     root: Root,
@@ -61,7 +61,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BlockTree")
@@ -77,7 +77,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     fn eq(&self, other: &Self) -> bool {
         self.root == other.root && self.tree == other.tree
@@ -90,7 +90,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
 }
 
@@ -100,7 +100,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     pub fn new(root: RootInfo) -> Self {
         Self {
@@ -535,22 +535,23 @@ mod test {
     use crate::blocktree::RootInfo;
 
     type SignatureType = NopSignature;
+    type SignatureCollectionType = MockSignatures<SignatureType>;
     type ExecutionProtocolType = MockExecutionProtocol;
-    type StateBackendType = InMemoryState;
+    type StateBackendType = InMemoryState<SignatureType, SignatureCollectionType>;
     type BlockPolicyType = PassthruBlockPolicy;
     type BlockTreeType = BlockTree<
         SignatureType,
-        MockSignatures<SignatureType>,
+        SignatureCollectionType,
         ExecutionProtocolType,
         BlockPolicyType,
         StateBackendType,
     >;
     type PubKeyType = CertificateSignaturePubKey<SignatureType>;
     type Block =
-        ConsensusBlockHeader<SignatureType, MockSignatures<SignatureType>, ExecutionProtocolType>;
+        ConsensusBlockHeader<SignatureType, SignatureCollectionType, ExecutionProtocolType>;
     type FullBlock =
-        ConsensusFullBlock<SignatureType, MockSignatures<SignatureType>, ExecutionProtocolType>;
-    type QC = QuorumCertificate<MockSignatures<SignatureType>>;
+        ConsensusFullBlock<SignatureType, SignatureCollectionType, ExecutionProtocolType>;
+    type QC = QuorumCertificate<SignatureCollectionType>;
 
     fn node_id() -> NodeId<PubKeyType> {
         let mut privkey: [u8; 32] = [127; 32];
@@ -878,7 +879,11 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(Balance::MAX, SeqNum(4));
+        let state_backend =
+            InMemoryStateInner::<NopSignature, MockSignatures<NopSignature>>::genesis(
+                Balance::MAX,
+                SeqNum(4),
+            );
         let block_policy = PassthruBlockPolicy;
         blocktree.add(g.into());
         blocktree.add(b1.clone().into());
@@ -1628,7 +1633,11 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(Balance::MAX, SeqNum(4));
+        let state_backend =
+            InMemoryStateInner::<NopSignature, MockSignatures<NopSignature>>::genesis(
+                Balance::MAX,
+                SeqNum(4),
+            );
         let block_policy = PassthruBlockPolicy;
         blocktree.add(b2.clone().into());
         assert!(blocktree.root.children_blocks.is_empty());

--- a/monad-blocktree/src/tree.rs
+++ b/monad-blocktree/src/tree.rs
@@ -22,13 +22,13 @@ use std::{
 use monad_consensus_types::{
     block::BlockPolicy,
     payload::{ConsensusBlockBody, ConsensusBlockBodyId},
-    signature_collection::SignatureCollection,
 };
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_state_backend::StateBackend;
 use monad_types::{BlockId, ExecutionProtocol};
+use monad_validator::signature_collection::SignatureCollection;
 
 pub struct Tree<ST, SCT, EPT, BPT, SBT>
 where
@@ -36,7 +36,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     tree: HashMap<BlockId, BlockTreeEntry<ST, SCT, EPT, BPT, SBT>>,
     payloads: HashMap<ConsensusBlockBodyId, BlockBodyIndex<EPT>>,
@@ -58,7 +58,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     pub(crate) fn set_coherent(&mut self, block_id: &BlockId, coherent: bool) -> Option<()> {
         self.tree.get_mut(block_id)?.is_coherent = coherent;
@@ -146,7 +146,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     type Target = HashMap<BlockId, BlockTreeEntry<ST, SCT, EPT, BPT, SBT>>;
 
@@ -161,7 +161,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     fn default() -> Self {
         Self {
@@ -177,7 +177,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Tree")
@@ -193,7 +193,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     fn eq(&self, other: &Self) -> bool {
         self.tree == other.tree && self.payloads == other.payloads
@@ -206,7 +206,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
 }
 
@@ -216,7 +216,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     pub validated_block: BPT::ValidatedBlock,
     /// A blocktree entry is coherent if there is a path to root from the entry and it
@@ -232,7 +232,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -249,7 +249,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BlockTreeEntry")
@@ -266,7 +266,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     fn eq(&self, other: &Self) -> bool {
         self.validated_block == other.validated_block
@@ -281,6 +281,6 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
 }

--- a/monad-bls/Cargo.toml
+++ b/monad-bls/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 bench = false
 
 [dependencies]
-monad-consensus-types = { workspace = true }
 monad-crypto = { workspace = true }
 monad-types = { workspace = true }
 monad-validator = { workspace = true }

--- a/monad-bls/benches/bls.rs
+++ b/monad-bls/benches/bls.rs
@@ -15,7 +15,6 @@
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use monad_bls::{BlsSignature, BlsSignatureCollection};
-use monad_consensus_types::signature_collection::SignatureCollection;
 use monad_crypto::{
     certificate_signature::{CertificateKeyPair, CertificateSignature, CertificateSignaturePubKey},
     hasher::{Hasher, HasherType},
@@ -23,7 +22,9 @@ use monad_crypto::{
 };
 use monad_testutil::validators::create_keys_w_validators;
 use monad_types::NodeId;
-use monad_validator::validator_set::ValidatorSetFactory;
+use monad_validator::{
+    signature_collection::SignatureCollection, validator_set::ValidatorSetFactory,
+};
 
 const N: u32 = 1000;
 

--- a/monad-bls/src/aggregation_tree.rs
+++ b/monad-bls/src/aggregation_tree.rs
@@ -20,14 +20,14 @@ use std::{
 
 use alloy_rlp::{encode_list, BytesMut, Decodable, Encodable, RlpDecodable, RlpEncodable};
 use bitvec::prelude::*;
-use monad_consensus_types::{
+use monad_crypto::{certificate_signature::PubKey, signing_domain::SigningDomain};
+use monad_types::NodeId;
+use monad_validator::{
     signature_collection::{
         SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
     },
-    voting::ValidatorMapping,
+    validator_mapping::ValidatorMapping,
 };
-use monad_crypto::{certificate_signature::PubKey, signing_domain::SigningDomain};
-use monad_types::NodeId;
 
 use crate::{bls::BlsAggregatePubKey, BlsAggregateSignature, BlsKeyPair, BlsSignature};
 
@@ -333,9 +333,6 @@ mod test {
 
     use alloy_rlp::Decodable;
     use bitvec::prelude::*;
-    use monad_consensus_types::signature_collection::{
-        SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
-    };
     use monad_crypto::{
         certificate_signature::{
             CertificateKeyPair, CertificateSignature, CertificateSignaturePubKey,
@@ -348,7 +345,12 @@ mod test {
         validators::create_keys_w_validators,
     };
     use monad_types::NodeId;
-    use monad_validator::validator_set::ValidatorSetFactory;
+    use monad_validator::{
+        signature_collection::{
+            SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
+        },
+        validator_set::ValidatorSetFactory,
+    };
     use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
     use test_case::test_case;
 

--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -29,7 +29,6 @@ use monad_consensus_types::{
     no_endorsement::FreshProposalCertificate,
     payload::RoundSignature,
     quorum_certificate::{QuorumCertificate, TimestampAdjustment},
-    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
     timeout::TimeoutCertificate,
 };
 use monad_crypto::certificate_signature::{
@@ -37,6 +36,7 @@ use monad_crypto::certificate_signature::{
 };
 use monad_state_backend::StateBackend;
 use monad_types::{Epoch, ExecutionProtocol, Round, RouterTarget, SeqNum};
+use monad_validator::signature_collection::{SignatureCollection, SignatureCollectionKeyPairType};
 
 /// Command type that the consensus state-machine outputs
 /// This is converted to a monad-executor-glue::Command at the top-level monad-state
@@ -47,7 +47,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     EnterRound(Epoch, Round),
     /// Attempt to send a message to RouterTarget
@@ -117,7 +117,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     pub fn from_pacemaker_command(
         keypair: &ST::KeyPairType,
@@ -171,7 +171,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     fn from(value: VoteStateCommand) -> Self {
         //TODO-3 VoteStateCommand used for evidence collection

--- a/monad-consensus-types/Cargo.toml
+++ b/monad-consensus-types/Cargo.toml
@@ -12,6 +12,7 @@ bench = false
 monad-crypto = { workspace = true }
 monad-state-backend = { workspace = true }
 monad-types = { workspace = true }
+monad-validator = { workspace = true }
 
 alloy-rlp = { workspace = true }
 auto_impl = { workspace = true }

--- a/monad-consensus-types/src/block.rs
+++ b/monad-consensus-types/src/block.rs
@@ -24,13 +24,13 @@ use monad_crypto::{
 };
 use monad_state_backend::{InMemoryState, StateBackend, StateBackendError};
 use monad_types::{BlockId, Epoch, ExecutionProtocol, FinalizedHeader, NodeId, Round, SeqNum};
+use monad_validator::signature_collection::SignatureCollection;
 
 use crate::{
     block_validator::BlockValidationError,
     checkpoint::RootInfo,
     payload::{ConsensusBlockBody, ConsensusBlockBodyId, RoundSignature},
     quorum_certificate::QuorumCertificate,
-    signature_collection::SignatureCollection,
 };
 
 pub const GENESIS_TIMESTAMP: u128 = 0;
@@ -166,7 +166,7 @@ where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     type ValidatedBlock: Sized
         + Clone
@@ -234,7 +234,7 @@ where
     }
 }
 
-impl<ST, SCT, EPT> BlockPolicy<ST, SCT, EPT, InMemoryState> for PassthruBlockPolicy
+impl<ST, SCT, EPT> BlockPolicy<ST, SCT, EPT, InMemoryState<ST, SCT>> for PassthruBlockPolicy
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
@@ -247,7 +247,7 @@ where
         block: &Self::ValidatedBlock,
         extending_blocks: Vec<&Self::ValidatedBlock>,
         blocktree_root: RootInfo,
-        state_backend: &InMemoryState,
+        state_backend: &InMemoryState<ST, SCT>,
     ) -> Result<(), BlockPolicyError> {
         // check coherency against the block being extended or against the root of the blocktree if
         // there is no extending branch
@@ -283,7 +283,7 @@ where
         &self,
         _block_seq_num: SeqNum,
         _extending_blocks: Vec<&Self::ValidatedBlock>,
-        _state_backend: &InMemoryState,
+        _state_backend: &InMemoryState<ST, SCT>,
     ) -> Result<Vec<EPT::FinalizedHeader>, StateBackendError> {
         Ok(Vec::new())
     }
@@ -432,7 +432,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     Proposed(BPT::ValidatedBlock),
     Finalized(BPT::ValidatedBlock),
@@ -455,7 +455,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     fn from(value: &OptimisticPolicyCommit<ST, SCT, EPT, BPT, SBT>) -> Self {
         match value {

--- a/monad-consensus-types/src/block_validator.rs
+++ b/monad-consensus-types/src/block_validator.rs
@@ -21,6 +21,7 @@ use monad_crypto::certificate_signature::{
 };
 use monad_state_backend::{InMemoryState, StateBackend};
 use monad_types::ExecutionProtocol;
+use monad_validator::signature_collection::{SignatureCollection, SignatureCollectionPubKeyType};
 
 use crate::{
     block::{
@@ -28,7 +29,6 @@ use crate::{
         PassthruWrappedBlock,
     },
     payload::ConsensusBlockBody,
-    signature_collection::{SignatureCollection, SignatureCollectionPubKeyType},
 };
 
 // TODO these are eth-specific types... we could make these an associated type of BlockValidator if
@@ -51,7 +51,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     // TODO it would be less jank if the BLS pubkey was included in the block payload.
     //
@@ -78,7 +78,7 @@ where
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
 pub struct MockValidator;
 
-impl<ST, SCT, EPT> BlockValidator<ST, SCT, EPT, PassthruBlockPolicy, InMemoryState>
+impl<ST, SCT, EPT> BlockValidator<ST, SCT, EPT, PassthruBlockPolicy, InMemoryState<ST, SCT>>
     for MockValidator
 where
     ST: CertificateSignatureRecoverable,
@@ -95,7 +95,7 @@ where
         _proposal_byte_limit: u64,
         _max_code_size: usize,
     ) -> Result<
-        <PassthruBlockPolicy as BlockPolicy<ST, SCT, EPT, InMemoryState>>::ValidatedBlock,
+        <PassthruBlockPolicy as BlockPolicy<ST, SCT, EPT, InMemoryState<ST, SCT>>>::ValidatedBlock,
         BlockValidationError,
     > {
         let full_block = ConsensusFullBlock::new(header, body)?;

--- a/monad-consensus-types/src/checkpoint.rs
+++ b/monad-consensus-types/src/checkpoint.rs
@@ -17,9 +17,10 @@ use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_types::{BlockId, Epoch, ExecutionProtocol, Round, SeqNum};
+use monad_validator::signature_collection::SignatureCollection;
 use serde::{Deserialize, Serialize};
 
-use crate::{signature_collection::SignatureCollection, RoundCertificate};
+use crate::RoundCertificate;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RootInfo {

--- a/monad-consensus-types/src/lib.rs
+++ b/monad-consensus-types/src/lib.rs
@@ -18,12 +18,10 @@ use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_types::{ExecutionProtocol, Round};
+use monad_validator::signature_collection::SignatureCollection;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    quorum_certificate::QuorumCertificate, signature_collection::SignatureCollection,
-    timeout::TimeoutCertificate,
-};
+use crate::{quorum_certificate::QuorumCertificate, timeout::TimeoutCertificate};
 
 pub mod block;
 pub mod block_validator;
@@ -32,7 +30,6 @@ pub mod metrics;
 pub mod no_endorsement;
 pub mod payload;
 pub mod quorum_certificate;
-pub mod signature_collection;
 pub mod timeout;
 pub mod tip;
 pub mod validation;

--- a/monad-consensus-types/src/no_endorsement.rs
+++ b/monad-consensus-types/src/no_endorsement.rs
@@ -15,8 +15,9 @@
 
 use alloy_rlp::{Decodable, Encodable, RlpDecodable, RlpEncodable};
 use monad_types::{Epoch, Round};
+use monad_validator::signature_collection::SignatureCollection;
 
-use crate::{signature_collection::SignatureCollection, timeout::NoTipCertificate};
+use crate::timeout::NoTipCertificate;
 
 #[derive(PartialEq, Eq, Clone, Debug, RlpEncodable, RlpDecodable)]
 pub struct NoEndorsement {

--- a/monad-consensus-types/src/quorum_certificate.rs
+++ b/monad-consensus-types/src/quorum_certificate.rs
@@ -19,15 +19,15 @@ use monad_crypto::{
     signing_domain,
 };
 use monad_types::*;
-use serde::{Deserialize, Serialize};
-
-use crate::{
-    block::ConsensusBlockHeader,
+use monad_validator::{
     signature_collection::{
         deserialize_signature_collection, serialize_signature_collection, SignatureCollection,
     },
-    voting::*,
+    validator_mapping::ValidatorMapping,
 };
+use serde::{Deserialize, Serialize};
+
+use crate::{block::ConsensusBlockHeader, voting::Vote};
 
 #[non_exhaustive]
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, RlpEncodable, RlpDecodable)]

--- a/monad-consensus-types/src/timeout.rs
+++ b/monad-consensus-types/src/timeout.rs
@@ -23,17 +23,17 @@ use monad_crypto::{
     signing_domain,
 };
 use monad_types::*;
-use serde::{Deserialize, Serialize};
-
-use crate::{
-    quorum_certificate::QuorumCertificate,
+use monad_validator::{
     signature_collection::{
         deserialize_signature_collection, serialize_signature_collection, SignatureCollection,
         SignatureCollectionError, SignatureCollectionKeyPairType,
     },
-    tip::ConsensusTip,
-    voting::{ValidatorMapping, Vote},
-    RoundCertificate,
+    validator_mapping::ValidatorMapping,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    quorum_certificate::QuorumCertificate, tip::ConsensusTip, voting::Vote, RoundCertificate,
 };
 
 /// Timeout message to broadcast to other nodes after a local timeout

--- a/monad-consensus-types/src/tip.rs
+++ b/monad-consensus-types/src/tip.rs
@@ -19,12 +19,10 @@ use monad_crypto::{
     signing_domain,
 };
 use monad_types::ExecutionProtocol;
+use monad_validator::signature_collection::SignatureCollection;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    block::ConsensusBlockHeader, no_endorsement::FreshProposalCertificate,
-    signature_collection::SignatureCollection,
-};
+use crate::{block::ConsensusBlockHeader, no_endorsement::FreshProposalCertificate};
 
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 #[rlp(trailing)]

--- a/monad-consensus-types/src/validator_data.rs
+++ b/monad-consensus-types/src/validator_data.rs
@@ -20,12 +20,10 @@ use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
 };
 use monad_types::{Epoch, ExecutionProtocol, NodeId, Stake};
+use monad_validator::signature_collection::{SignatureCollection, SignatureCollectionPubKeyType};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::{
-    checkpoint::Checkpoint,
-    signature_collection::{SignatureCollection, SignatureCollectionPubKeyType},
-};
+use crate::checkpoint::Checkpoint;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, RlpEncodable, RlpDecodable)]
 #[rlp(trailing)]

--- a/monad-consensus-types/src/voting.rs
+++ b/monad-consensus-types/src/voting.rs
@@ -13,34 +13,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::BTreeMap;
-
 use alloy_rlp::{RlpDecodable, RlpEncodable};
-use monad_crypto::certificate_signature::{CertificateKeyPair, PubKey};
 use monad_types::*;
 use serde::{Deserialize, Serialize};
-
-/// Map validator NodeId to its Certificate PubKey
-pub struct ValidatorMapping<PT: PubKey, VKT: CertificateKeyPair> {
-    pub map: BTreeMap<NodeId<PT>, VKT::PubKeyType>,
-}
-
-impl<PT: PubKey, VKT: CertificateKeyPair> ValidatorMapping<PT, VKT> {
-    pub fn new(iter: impl IntoIterator<Item = (NodeId<PT>, VKT::PubKeyType)>) -> Self {
-        Self {
-            map: iter.into_iter().collect(),
-        }
-    }
-}
-
-impl<PT: PubKey, VKT: CertificateKeyPair> IntoIterator for ValidatorMapping<PT, VKT> {
-    type Item = (NodeId<PT>, VKT::PubKeyType);
-    type IntoIter = std::collections::btree_map::IntoIter<NodeId<PT>, VKT::PubKeyType>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.map.into_iter()
-    }
-}
 
 /// Vote for consensus proposals
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, RlpDecodable, RlpEncodable)]

--- a/monad-consensus/src/messages/consensus_message.rs
+++ b/monad-consensus/src/messages/consensus_message.rs
@@ -16,11 +16,11 @@
 use std::fmt::Debug;
 
 use alloy_rlp::{encode_list, Decodable, Encodable, Header, RlpDecodable, RlpEncodable};
-use monad_consensus_types::signature_collection::SignatureCollection;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_types::{ExecutionProtocol, Round};
+use monad_validator::signature_collection::SignatureCollection;
 
 use crate::{
     messages::message::{

--- a/monad-consensus/src/messages/message.rs
+++ b/monad-consensus/src/messages/message.rs
@@ -19,7 +19,6 @@ use alloy_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWra
 use monad_consensus_types::{
     no_endorsement::NoEndorsement,
     payload::ConsensusBlockBody,
-    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
     timeout::{HighExtend, Timeout, TimeoutCertificate, TimeoutInfo},
     tip::ConsensusTip,
     voting::Vote,
@@ -32,6 +31,7 @@ use monad_crypto::{
     signing_domain,
 };
 use monad_types::{Epoch, ExecutionProtocol, Round};
+use monad_validator::signature_collection::{SignatureCollection, SignatureCollectionKeyPairType};
 
 /// Consensus protocol vote message
 ///

--- a/monad-consensus/src/no_endorsement_state.rs
+++ b/monad-consensus/src/no_endorsement_state.rs
@@ -15,16 +15,16 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use monad_consensus_types::{
-    no_endorsement::NoEndorsementCertificate,
+use monad_consensus_types::no_endorsement::NoEndorsementCertificate;
+use monad_crypto::signing_domain;
+use monad_types::{NodeId, Round};
+use monad_validator::{
     signature_collection::{
         SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
     },
-    voting::ValidatorMapping,
+    validator_mapping::ValidatorMapping,
+    validator_set::ValidatorSetType,
 };
-use monad_crypto::signing_domain;
-use monad_types::{NodeId, Round};
-use monad_validator::validator_set::ValidatorSetType;
 use tracing::{debug, error, info, warn};
 
 use crate::messages::message::NoEndorsementMessage;

--- a/monad-consensus/src/pacemaker.rs
+++ b/monad-consensus/src/pacemaker.rs
@@ -18,18 +18,21 @@ use std::{collections::BTreeMap, marker::PhantomData, time::Duration};
 use monad_chain_config::{revision::ChainRevision, ChainConfig};
 use monad_consensus_types::{
     metrics::Metrics,
-    signature_collection::{
-        SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
-    },
     timeout::{HighExtend, TimeoutCertificate, TimeoutInfo},
-    voting::ValidatorMapping,
     RoundCertificate,
 };
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_types::{Epoch, ExecutionProtocol, NodeId, Round, GENESIS_ROUND};
-use monad_validator::{epoch_manager::EpochManager, validator_set::ValidatorSetType};
+use monad_validator::{
+    epoch_manager::EpochManager,
+    signature_collection::{
+        SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
+    },
+    validator_mapping::ValidatorMapping,
+    validator_set::ValidatorSetType,
+};
 use tracing::debug;
 
 use crate::{messages::message::TimeoutMessage, validation::safety::Safety};

--- a/monad-consensus/src/validation/certificate_cache.rs
+++ b/monad-consensus/src/validation/certificate_cache.rs
@@ -18,12 +18,13 @@ use std::{marker::PhantomData, num::NonZero};
 use lru::LruCache;
 use monad_consensus_types::{
     no_endorsement::NoEndorsementCertificate, quorum_certificate::QuorumCertificate,
-    signature_collection::SignatureCollection, timeout::TimeoutCertificate,
+    timeout::TimeoutCertificate,
 };
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_types::ExecutionProtocol;
+use monad_validator::signature_collection::SignatureCollection;
 
 pub struct CertificateCache<ST, SCT, EPT>
 where

--- a/monad-consensus/src/validation/safety.rs
+++ b/monad-consensus/src/validation/safety.rs
@@ -15,13 +15,12 @@
 
 use std::collections::BTreeSet;
 
-use monad_consensus_types::{
-    signature_collection::SignatureCollection, tip::ConsensusTip, RoundCertificate,
-};
+use monad_consensus_types::{tip::ConsensusTip, RoundCertificate};
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_types::{ExecutionProtocol, *};
+use monad_validator::signature_collection::SignatureCollection;
 
 /// Max number of handled proposal_rounds to keep track of
 /// This does not affect correctness; it just helps reduce DOS

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -22,11 +22,9 @@ use alloy_rlp::{Decodable, Encodable, RlpDecodable, RlpEncodable};
 use monad_consensus_types::{
     no_endorsement::{FreshProposalCertificate, NoEndorsementCertificate},
     quorum_certificate::QuorumCertificate,
-    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
     timeout::{HighExtend, HighExtendVote, NoTipCertificate, TimeoutCertificate, TimeoutInfo},
     tip::ConsensusTip,
     validation::Error,
-    voting::ValidatorMapping,
     RoundCertificate,
 };
 use monad_crypto::{
@@ -40,6 +38,8 @@ use monad_types::{Epoch, ExecutionProtocol, NodeId, Round, Stake, GENESIS_ROUND}
 use monad_validator::{
     epoch_manager::EpochManager,
     leader_election::LeaderElection,
+    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
+    validator_mapping::ValidatorMapping,
     validator_set::{ValidatorSetError, ValidatorSetType, ValidatorSetTypeFactory},
     validators_epoch_mapping::ValidatorsEpochMapping,
 };
@@ -1174,11 +1174,10 @@ mod test {
         },
         payload::{ConsensusBlockBody, ConsensusBlockBodyInner, RoundSignature},
         quorum_certificate::QuorumCertificate,
-        signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
         timeout::{HighExtend, HighTipRoundSigColTuple, TimeoutCertificate, TimeoutInfo},
         tip::ConsensusTip,
         validation::Error,
-        voting::{ValidatorMapping, Vote},
+        voting::Vote,
         RoundCertificate,
     };
     use monad_crypto::{
@@ -1199,6 +1198,8 @@ mod test {
     };
     use monad_validator::{
         epoch_manager::EpochManager,
+        signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
+        validator_mapping::ValidatorMapping,
         validator_set::{ValidatorSetFactory, ValidatorSetType, ValidatorSetTypeFactory},
         validators_epoch_mapping::ValidatorsEpochMapping,
         weighted_round_robin::WeightedRoundRobin,

--- a/monad-consensus/src/vote_state.rs
+++ b/monad-consensus/src/vote_state.rs
@@ -15,19 +15,19 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use monad_consensus_types::{
-    quorum_certificate::QuorumCertificate,
-    signature_collection::{
-        SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
-    },
-    voting::{ValidatorMapping, Vote},
-};
+use monad_consensus_types::{quorum_certificate::QuorumCertificate, voting::Vote};
 use monad_crypto::{
     certificate_signature::{CertificateSignature, PubKey},
     signing_domain,
 };
 use monad_types::{NodeId, Round};
-use monad_validator::validator_set::ValidatorSetType;
+use monad_validator::{
+    signature_collection::{
+        SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
+    },
+    validator_mapping::ValidatorMapping,
+    validator_set::ValidatorSetType,
+};
 use tracing::{debug, error, info, warn};
 
 use crate::messages::message::VoteMessage;
@@ -203,10 +203,7 @@ where
 mod test {
     use std::collections::HashSet;
 
-    use monad_consensus_types::{
-        signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
-        voting::{ValidatorMapping, Vote},
-    };
+    use monad_consensus_types::voting::Vote;
     use monad_crypto::{
         certificate_signature::{CertificateKeyPair, CertificateSignature},
         hasher::Hash,
@@ -215,7 +212,11 @@ mod test {
     use monad_multi_sig::MultiSig;
     use monad_testutil::{signing::*, validators::create_keys_w_validators};
     use monad_types::{BlockId, Epoch, NodeId, Round, Stake};
-    use monad_validator::validator_set::{ValidatorSetFactory, ValidatorSetTypeFactory};
+    use monad_validator::{
+        signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
+        validator_mapping::ValidatorMapping,
+        validator_set::{ValidatorSetFactory, ValidatorSetTypeFactory},
+    };
 
     use super::VoteState;
     use crate::messages::message::VoteMessage;

--- a/monad-consensus/tests/proposal.rs
+++ b/monad-consensus/tests/proposal.rs
@@ -27,7 +27,6 @@ use monad_consensus_types::{
     no_endorsement::FreshProposalCertificate,
     payload::{ConsensusBlockBody, ConsensusBlockBodyInner, RoundSignature},
     quorum_certificate::QuorumCertificate,
-    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
     timeout::{
         HighExtend, HighTipRoundSigColTuple, NoTipCertificate, TimeoutCertificate, TimeoutInfo,
     },
@@ -52,6 +51,7 @@ use monad_types::{BlockId, Epoch, NodeId, Round, SeqNum, GENESIS_ROUND};
 use monad_validator::{
     epoch_manager::EpochManager,
     leader_election::LeaderElection,
+    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
     validator_set::{ValidatorSetFactory, ValidatorSetType},
     validators_epoch_mapping::ValidatorsEpochMapping,
 };

--- a/monad-consensus/tests/vote_state.rs
+++ b/monad-consensus/tests/vote_state.rs
@@ -14,11 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use monad_consensus::{messages::message::VoteMessage, vote_state::VoteState};
-use monad_consensus_types::{
-    quorum_certificate::QuorumCertificate,
-    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
-    voting::{ValidatorMapping, Vote},
-};
+use monad_consensus_types::{quorum_certificate::QuorumCertificate, voting::Vote};
 use monad_crypto::{
     certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey},
     NopKeyPair, NopSignature,
@@ -26,7 +22,11 @@ use monad_crypto::{
 use monad_multi_sig::MultiSig;
 use monad_testutil::validators::create_keys_w_validators;
 use monad_types::{DontCare, Epoch, NodeId, Round};
-use monad_validator::validator_set::{ValidatorSet, ValidatorSetFactory};
+use monad_validator::{
+    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
+    validator_mapping::ValidatorMapping,
+    validator_set::{ValidatorSet, ValidatorSetFactory},
+};
 use test_case::test_case;
 
 type SignatureType = NopSignature;

--- a/monad-control-panel/Cargo.toml
+++ b/monad-control-panel/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2021"
 bench = false
 
 [dependencies]
-monad-consensus-types = { workspace = true }
 monad-crypto = { workspace = true }
 monad-executor = { workspace = true }
 monad-executor-glue = { workspace = true }
 monad-types = { workspace = true }
+monad-validator = { workspace = true }
 
 futures = { workspace = true }
 serde_json = { workspace = true }

--- a/monad-control-panel/src/ipc.rs
+++ b/monad-control-panel/src/ipc.rs
@@ -20,7 +20,6 @@ use std::{
 };
 
 use futures::{SinkExt, Stream, StreamExt};
-use monad_consensus_types::signature_collection::SignatureCollection;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
@@ -30,6 +29,7 @@ use monad_executor_glue::{
     MonadEvent, ReadCommand, ReloadConfig, WriteCommand,
 };
 use monad_types::ExecutionProtocol;
+use monad_validator::signature_collection::SignatureCollection;
 use tokio::{
     net::{unix::OwnedReadHalf, UnixListener},
     sync::{broadcast, mpsc},

--- a/monad-debugger/src/lib.rs
+++ b/monad-debugger/src/lib.rs
@@ -32,8 +32,8 @@ use monad_transformer::{
 };
 use monad_types::{NodeId, Round, SeqNum};
 use monad_updaters::{
-    ledger::MockLedger, state_root_hash::MockStateRootHashNop, statesync::MockStateSyncExecutor,
-    txpool::MockTxPoolExecutor,
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
 };
 use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 use wasm_bindgen::prelude::*;
@@ -68,7 +68,7 @@ pub fn simulation_make() -> *mut Simulation {
             SeqNum(4),                           // execution_delay
             Duration::from_millis(50),           // delta
             MockChainConfig::new(&CHAIN_PARAMS), // chain config
-            SeqNum(2000),                        // val_set_update_interval
+            SeqNum(2000),                        // epoch_length
             Round(50),                           // epoch_start_delay
             SeqNum(100),                         // state_sync_threshold
         );
@@ -87,7 +87,7 @@ pub fn simulation_make() -> *mut Simulation {
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
                         NoSerRouterConfig::new(all_peers.clone()).build(),
-                        MockStateRootHashNop::new(validators.validators.clone(), SeqNum(2000)),
+                        MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
                         MockTxPoolExecutor::default(),
                         MockLedger::new(state_backend.clone()),
                         MockStateSyncExecutor::new(

--- a/monad-eth-block-policy/Cargo.toml
+++ b/monad-eth-block-policy/Cargo.toml
@@ -16,6 +16,7 @@ monad-eth-types = { workspace = true }
 monad-state-backend = { workspace = true }
 monad-system-calls = { workspace = true }
 monad-types = { workspace = true }
+monad-validator = { workspace = true }
 
 alloy-consensus = { workspace = true }
 alloy-primitives = { workspace = true }

--- a/monad-eth-block-policy/src/lib.rs
+++ b/monad-eth-block-policy/src/lib.rs
@@ -24,7 +24,6 @@ use itertools::Itertools;
 use monad_consensus_types::{
     block::{BlockPolicy, BlockPolicyError, ConsensusFullBlock},
     checkpoint::RootInfo,
-    signature_collection::SignatureCollection,
 };
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
@@ -34,6 +33,7 @@ use monad_eth_types::{Balance, EthAccount, EthExecutionProtocol, EthHeader, Nonc
 use monad_state_backend::{StateBackend, StateBackendError};
 use monad_system_calls::SystemTransaction;
 use monad_types::{BlockId, Round, SeqNum, GENESIS_BLOCK_ID, GENESIS_SEQ_NUM};
+use monad_validator::signature_collection::SignatureCollection;
 use sorted_vector_map::SortedVectorMap;
 use tracing::{trace, warn};
 
@@ -419,7 +419,7 @@ where
     pub fn get_account_base_nonces<'a>(
         &self,
         consensus_block_seq_num: SeqNum,
-        state_backend: &impl StateBackend,
+        state_backend: &impl StateBackend<ST, SCT>,
         extending_blocks: &Vec<&EthValidatedBlock<ST, SCT>>,
         addresses: impl Iterator<Item = &'a Address>,
     ) -> Result<BTreeMap<&'a Address, Nonce>, StateBackendError> {
@@ -513,7 +513,7 @@ where
 
     fn get_account_statuses<'a>(
         &self,
-        state_backend: &impl StateBackend,
+        state_backend: &impl StateBackend<ST, SCT>,
         extending_blocks: &Option<&Vec<&EthValidatedBlock<ST, SCT>>>,
         addresses: impl Iterator<Item = &'a Address>,
         base_seq_num: &SeqNum,
@@ -531,7 +531,7 @@ where
     pub fn compute_account_base_balances<'a>(
         &self,
         consensus_block_seq_num: SeqNum,
-        state_backend: &impl StateBackend,
+        state_backend: &impl StateBackend<ST, SCT>,
         extending_blocks: Option<&Vec<&EthValidatedBlock<ST, SCT>>>,
         addresses: impl Iterator<Item = &'a Address>,
     ) -> Result<BTreeMap<&'a Address, Balance>, StateBackendError>
@@ -645,7 +645,7 @@ impl<ST, SCT, SBT> BlockPolicy<ST, SCT, EthExecutionProtocol, SBT> for EthBlockP
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     type ValidatedBlock = EthValidatedBlock<ST, SCT>;
 

--- a/monad-eth-block-validator/Cargo.toml
+++ b/monad-eth-block-validator/Cargo.toml
@@ -16,6 +16,7 @@ monad-eth-types = { workspace = true }
 monad-secp = { workspace = true }
 monad-state-backend = { workspace = true }
 monad-system-calls = { workspace = true }
+monad-validator = { workspace = true }
 
 alloy-consensus = { workspace = true }
 alloy-primitives = { workspace = true }

--- a/monad-eth-ledger/Cargo.toml
+++ b/monad-eth-ledger/Cargo.toml
@@ -18,6 +18,7 @@ monad-executor-glue = { workspace = true }
 monad-state-backend = { workspace = true }
 monad-types = { workspace = true }
 monad-updaters = { workspace = true }
+monad-validator = { workspace = true }
 
 alloy-consensus = { workspace = true, features = ["k256"] }
 futures = { workspace = true }

--- a/monad-eth-ledger/src/lib.rs
+++ b/monad-eth-ledger/src/lib.rs
@@ -29,7 +29,6 @@ use monad_blocksync::messages::message::{
 use monad_consensus_types::{
     block::{BlockRange, ConsensusFullBlock, OptimisticCommit},
     payload::ConsensusBlockBodyId,
-    signature_collection::SignatureCollection,
 };
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
@@ -40,6 +39,7 @@ use monad_executor_glue::{BlockSyncEvent, LedgerCommand, MonadEvent};
 use monad_state_backend::{InMemoryState, StateBackendTest};
 use monad_types::{BlockId, SeqNum};
 use monad_updaters::ledger::MockableLedger;
+use monad_validator::signature_collection::SignatureCollection;
 use tracing::debug_span;
 
 /// A ledger for commited Monad Blocks
@@ -55,7 +55,7 @@ where
     finalized: BTreeMap<SeqNum, ConsensusFullBlock<ST, SCT, EthExecutionProtocol>>,
     events: VecDeque<BlockSyncEvent<ST, SCT, EthExecutionProtocol>>,
 
-    state: InMemoryState,
+    state: InMemoryState<ST, SCT>,
 
     waker: Option<Waker>,
     _phantom: PhantomData<ST>,
@@ -66,7 +66,7 @@ where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
 {
-    pub fn new(state: InMemoryState) -> Self {
+    pub fn new(state: InMemoryState<ST, SCT>) -> Self {
         MockEthLedger {
             blocks: Default::default(),
             finalized: Default::default(),

--- a/monad-eth-txpool-executor/Cargo.toml
+++ b/monad-eth-txpool-executor/Cargo.toml
@@ -23,6 +23,7 @@ monad-secp = { workspace = true }
 monad-state-backend = { workspace = true }
 monad-types = { workspace = true }
 monad-updaters = { workspace = true, features = ["tokio"] }
+monad-validator = { workspace = true }
 
 alloy-consensus = { workspace = true }
 alloy-primitives = { workspace = true }

--- a/monad-eth-txpool-executor/src/forward.rs
+++ b/monad-eth-txpool-executor/src/forward.rs
@@ -22,12 +22,12 @@ use std::{
 
 use alloy_consensus::{transaction::Recovered, TxEnvelope};
 use bytes::Bytes;
-use monad_consensus_types::signature_collection::SignatureCollection;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_eth_txpool::EthTxPool;
 use monad_state_backend::StateBackend;
+use monad_validator::signature_collection::SignatureCollection;
 use pin_project::pin_project;
 
 const EGRESS_MIN_COMMITTED_SEQ_NUM_DIFF: u64 = 5;
@@ -156,7 +156,7 @@ impl EthTxPoolForwardingManagerProjected<'_> {
     where
         ST: CertificateSignatureRecoverable,
         SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-        SBT: StateBackend,
+        SBT: StateBackend<ST, SCT>,
     {
         let Some(forwardable_txs) =
             pool.get_forwardable_txs::<EGRESS_MIN_COMMITTED_SEQ_NUM_DIFF, EGRESS_MAX_RETRIES>()

--- a/monad-eth-txpool-executor/src/lib.rs
+++ b/monad-eth-txpool-executor/src/lib.rs
@@ -31,7 +31,7 @@ use alloy_primitives::Address;
 use alloy_rlp::Decodable;
 use futures::Stream;
 use monad_chain_config::{revision::ChainRevision, ChainConfig};
-use monad_consensus_types::{block::BlockPolicy, signature_collection::SignatureCollection};
+use monad_consensus_types::block::BlockPolicy;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
@@ -45,6 +45,7 @@ use monad_secp::RecoverableAddress;
 use monad_state_backend::StateBackend;
 use monad_types::DropTimer;
 use monad_updaters::TokioTaskUpdater;
+use monad_validator::signature_collection::SignatureCollection;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use tokio::{sync::mpsc, time::Instant};
 use tracing::{debug, debug_span, error, info, trace_span, warn};
@@ -68,7 +69,7 @@ pub struct EthTxPoolExecutor<ST, SCT, SBT, CCT, CRT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
     CCT: ChainConfig<CRT>,
     CRT: ChainRevision,
 {
@@ -97,7 +98,7 @@ impl<ST, SCT, SBT, CCT, CRT> EthTxPoolExecutor<ST, SCT, SBT, CCT, CRT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    SBT: StateBackend + Send + 'static,
+    SBT: StateBackend<ST, SCT> + Send + 'static,
     CCT: ChainConfig<CRT> + Send + 'static,
     CRT: ChainRevision + Send + 'static,
     Self: Unpin,
@@ -207,7 +208,7 @@ impl<ST, SCT, SBT, CCT, CRT> Executor for EthTxPoolExecutor<ST, SCT, SBT, CCT, C
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
     CCT: ChainConfig<CRT>,
     CRT: ChainRevision,
 {
@@ -429,7 +430,7 @@ impl<ST, SCT, SBT, CCT, CRT> Stream for EthTxPoolExecutor<ST, SCT, SBT, CCT, CRT
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
     CCT: ChainConfig<CRT>,
     CRT: ChainRevision,
 

--- a/monad-eth-txpool-executor/src/preload.rs
+++ b/monad-eth-txpool-executor/src/preload.rs
@@ -23,12 +23,12 @@ use std::{
 use alloy_primitives::Address;
 use futures::FutureExt;
 use indexmap::IndexSet;
-use monad_consensus_types::signature_collection::SignatureCollection;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_eth_block_policy::EthValidatedBlock;
 use monad_types::{Round, SeqNum};
+use monad_validator::signature_collection::SignatureCollection;
 use tokio::time::Sleep;
 use tracing::{debug, warn};
 

--- a/monad-eth-txpool/Cargo.toml
+++ b/monad-eth-txpool/Cargo.toml
@@ -18,6 +18,7 @@ monad-executor = { workspace = true }
 monad-state-backend = { workspace = true }
 monad-system-calls = { workspace = true }
 monad-types = { workspace = true }
+monad-validator = { workspace = true }
 
 alloy-consensus = { workspace = true, features = ["k256"] }
 alloy-primitives = { workspace = true }

--- a/monad-eth-txpool/benches/common/controller.rs
+++ b/monad-eth-txpool/benches/common/controller.rs
@@ -33,7 +33,7 @@ const TRANSACTION_SIZE_BYTES: usize = 400;
 pub type SignatureType = NopSignature;
 pub type SignatureCollectionType = MockSignatures<NopSignature>;
 pub type BlockPolicyType = EthBlockPolicy<SignatureType, SignatureCollectionType>;
-pub type StateBackendType = InMemoryState;
+pub type StateBackendType = InMemoryState<SignatureType, SignatureCollectionType>;
 pub type Pool = EthTxPool<SignatureType, SignatureCollectionType, StateBackendType>;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/monad-eth-txpool/src/pool/mod.rs
+++ b/monad-eth-txpool/src/pool/mod.rs
@@ -21,10 +21,7 @@ use alloy_consensus::{
 use alloy_primitives::Address;
 use alloy_rlp::Encodable;
 use itertools::Itertools;
-use monad_consensus_types::{
-    block::ProposedExecutionInputs, payload::RoundSignature,
-    signature_collection::SignatureCollection,
-};
+use monad_consensus_types::{block::ProposedExecutionInputs, payload::RoundSignature};
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
@@ -34,6 +31,7 @@ use monad_eth_types::{EthBlockBody, EthExecutionProtocol, ProposedEthHeader, BAS
 use monad_state_backend::{StateBackend, StateBackendError};
 use monad_system_calls::generate_system_calls;
 use monad_types::SeqNum;
+use monad_validator::signature_collection::SignatureCollection;
 use tracing::{info, warn};
 
 use self::{pending::PendingTxMap, tracked::TrackedTxMap, transaction::ValidEthTransaction};
@@ -55,7 +53,7 @@ pub struct EthTxPool<ST, SCT, SBT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     do_local_insert: bool,
     pending: PendingTxMap,
@@ -72,7 +70,7 @@ impl<ST, SCT, SBT> EthTxPool<ST, SCT, SBT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     pub fn new(
         do_local_insert: bool,

--- a/monad-eth-txpool/src/pool/tracked/mod.rs
+++ b/monad-eth-txpool/src/pool/tracked/mod.rs
@@ -19,9 +19,7 @@ use alloy_consensus::{transaction::Recovered, TxEnvelope};
 use alloy_primitives::Address;
 use indexmap::{map::Entry as IndexMapEntry, IndexMap};
 use itertools::Itertools;
-use monad_consensus_types::{
-    block::ConsensusBlockHeader, signature_collection::SignatureCollection,
-};
+use monad_consensus_types::block::ConsensusBlockHeader;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
@@ -30,6 +28,7 @@ use monad_eth_txpool_types::{EthTxPoolDropReason, EthTxPoolInternalDropReason};
 use monad_eth_types::{Balance, EthExecutionProtocol};
 use monad_state_backend::{StateBackend, StateBackendError};
 use monad_types::{DropTimer, SeqNum};
+use monad_validator::signature_collection::SignatureCollection;
 use tracing::{debug, error, info, trace, warn};
 use tx_heap::TrackedTxHeapDrainAction;
 
@@ -65,7 +64,7 @@ pub struct TrackedTxMap<ST, SCT, SBT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     last_commit: Option<ConsensusBlockHeader<ST, SCT, EthExecutionProtocol>>,
     soft_tx_expiry: Duration,
@@ -82,7 +81,7 @@ impl<ST, SCT, SBT> TrackedTxMap<ST, SCT, SBT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     pub fn new(soft_tx_expiry: Duration, hard_tx_expiry: Duration) -> Self {
         Self {

--- a/monad-eth-txpool/src/pool/tracked/tx_heap.rs
+++ b/monad-eth-txpool/src/pool/tracked/tx_heap.rs
@@ -17,11 +17,11 @@ use std::collections::{BinaryHeap, VecDeque};
 
 use alloy_primitives::Address;
 use indexmap::IndexMap;
-use monad_consensus_types::signature_collection::SignatureCollection;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_eth_block_policy::{AccountNonceRetrievable, EthValidatedBlock};
+use monad_validator::signature_collection::SignatureCollection;
 
 use super::list::TrackedTxList;
 use crate::pool::transaction::ValidEthTransaction;

--- a/monad-eth-txpool/src/pool/transaction.rs
+++ b/monad-eth-txpool/src/pool/transaction.rs
@@ -18,9 +18,7 @@ use std::cmp::Ordering;
 use alloy_consensus::{transaction::Recovered, Transaction, TxEnvelope};
 use alloy_primitives::{Address, TxHash};
 use alloy_rlp::Encodable;
-use monad_consensus_types::{
-    block::ConsensusBlockHeader, signature_collection::SignatureCollection,
-};
+use monad_consensus_types::block::ConsensusBlockHeader;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
@@ -29,6 +27,7 @@ use monad_eth_txpool_types::EthTxPoolDropReason;
 use monad_eth_types::{Balance, EthExecutionProtocol, Nonce, BASE_FEE_PER_GAS};
 use monad_system_calls::validator::SystemTransactionValidator;
 use monad_types::SeqNum;
+use monad_validator::signature_collection::SignatureCollection;
 use tracing::trace;
 
 use crate::EthTxPoolEventTracker;

--- a/monad-eth-txpool/tests/forward.rs
+++ b/monad-eth-txpool/tests/forward.rs
@@ -39,7 +39,11 @@ const FORWARD_MAX_RETRIES: usize = 2;
 fn with_txpool(
     insert_tx_owned: bool,
     f: impl FnOnce(
-        EthTxPool<SignatureType, SignatureCollectionType, InMemoryState>,
+        EthTxPool<
+            SignatureType,
+            SignatureCollectionType,
+            InMemoryState<SignatureType, SignatureCollectionType>,
+        >,
         &mut EthTxPoolEventTracker,
     ),
 ) {

--- a/monad-eth-txpool/tests/pool.rs
+++ b/monad-eth-txpool/tests/pool.rs
@@ -73,7 +73,7 @@ const S5: B256 = B256::new(hex!(
 
 type SignatureType = NopSignature;
 type SignatureCollectionType = MockSignatures<SignatureType>;
-type StateBackendType = InMemoryState;
+type StateBackendType = InMemoryState<SignatureType, SignatureCollectionType>;
 
 fn make_test_block_policy() -> EthBlockPolicy<SignatureType, SignatureCollectionType> {
     EthBlockPolicy::new(GENESIS_SEQ_NUM, EXECUTION_DELAY, 1337)

--- a/monad-executor-glue/Cargo.toml
+++ b/monad-executor-glue/Cargo.toml
@@ -15,6 +15,7 @@ monad-consensus-types = { workspace = true }
 monad-crypto = { workspace = true }
 monad-state-backend = { workspace = true }
 monad-types = { workspace = true }
+monad-validator = { workspace = true }
 
 alloy-rlp = { workspace = true }
 bincode = { workspace = true }

--- a/monad-ledger/Cargo.toml
+++ b/monad-ledger/Cargo.toml
@@ -17,6 +17,7 @@ monad-eth-types = { workspace = true }
 monad-executor = { workspace = true }
 monad-executor-glue = { workspace = true }
 monad-types = { workspace = true }
+monad-validator = { workspace = true }
 
 futures = { workspace = true }
 tokio = { workspace = true, features = ["macros", "net", "rt", "sync"] }

--- a/monad-ledger/src/lib.rs
+++ b/monad-ledger/src/lib.rs
@@ -30,7 +30,6 @@ use monad_blocksync::messages::message::{
 use monad_consensus_types::{
     block::{BlockRange, ConsensusFullBlock, OptimisticCommit},
     payload::{ConsensusBlockBody, ConsensusBlockBodyId},
-    signature_collection::SignatureCollection,
 };
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
@@ -39,6 +38,7 @@ use monad_eth_types::EthExecutionProtocol;
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{BlockSyncEvent, LedgerCommand, MonadEvent};
 use monad_types::{BlockId, Round, SeqNum, GENESIS_ROUND};
+use monad_validator::signature_collection::SignatureCollection;
 use tracing::{info, trace, warn};
 
 /// A ledger for committed Ethereum blocks

--- a/monad-mock-swarm/benches/two_node_benchmark.rs
+++ b/monad-mock-swarm/benches/two_node_benchmark.rs
@@ -30,8 +30,8 @@ use monad_testutil::swarm::{make_state_configs, swarm_ledger_verification};
 use monad_transformer::{GenericTransformer, LatencyTransformer, ID};
 use monad_types::{NodeId, Round, SeqNum};
 use monad_updaters::{
-    ledger::MockLedger, state_root_hash::MockStateRootHashNop, statesync::MockStateSyncExecutor,
-    txpool::MockTxPoolExecutor,
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
 };
 use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 
@@ -64,7 +64,7 @@ fn two_nodes() {
         SeqNum(4),                           // execution_delay
         Duration::from_millis(2),            // delta
         MockChainConfig::new(&CHAIN_PARAMS), // chain config
-        SeqNum(2000),                        // val_set_update_interval
+        SeqNum(2000),                        // epoch_length
         Round(50),                           // epoch_start_delay
         SeqNum(100),                         // state_sync_threshold
     );
@@ -83,7 +83,7 @@ fn two_nodes() {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockStateRootHashNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
                     MockTxPoolExecutor::default(),
                     MockLedger::new(state_backend.clone()),
                     MockStateSyncExecutor::new(

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -37,8 +37,8 @@ use monad_state::VerifiedMonadMessage;
 use monad_types::NodeId;
 use monad_updaters::{
     checkpoint::MockCheckpoint, ledger::MockableLedger, loopback::LoopbackExecutor,
-    state_root_hash::MockableStateRootHash, statesync::MockableStateSync,
-    timestamp::TimestampAdjuster, txpool::MockableTxPool,
+    statesync::MockableStateSync, timestamp::TimestampAdjuster, txpool::MockableTxPool,
+    val_set::MockableValSetUpdater,
 };
 use priority_queue::PriorityQueue;
 
@@ -48,7 +48,7 @@ pub struct MockExecutor<S: SwarmRelation> {
     ledger: S::Ledger,
     checkpoint:
         MockCheckpoint<S::SignatureType, S::SignatureCollectionType, S::ExecutionProtocolType>,
-    state_root_hash: S::StateRootHashExecutor,
+    val_set: S::ValSetUpdater,
     loopback: LoopbackExecutor<
         MonadEvent<S::SignatureType, S::SignatureCollectionType, S::ExecutionProtocolType>,
     >,
@@ -180,7 +180,7 @@ enum ExecutorEventType {
     Router,
     Ledger,
     Timer,
-    StateRootHash,
+    ValSet,
     TxPool,
     Loopback,
     Timestamp,
@@ -195,7 +195,7 @@ pub struct RoundTimer {
 impl<S: SwarmRelation> MockExecutor<S> {
     pub fn new(
         router: S::RouterScheduler,
-        state_root_hash: S::StateRootHashExecutor,
+        val_set: S::ValSetUpdater,
         txpool: S::TxPoolExecutor,
         ledger: S::Ledger,
         statesync: S::StateSyncExecutor,
@@ -205,7 +205,7 @@ impl<S: SwarmRelation> MockExecutor<S> {
         Self {
             checkpoint: Default::default(),
             ledger,
-            state_root_hash,
+            val_set,
             txpool,
             loopback: Default::default(),
             statesync,
@@ -286,9 +286,9 @@ impl<S: SwarmRelation> MockExecutor<S> {
                     .then_some((self.tick, ExecutorEventType::TxPool)),
             )
             .chain(
-                self.state_root_hash
+                self.val_set
                     .ready()
-                    .then_some((self.tick, ExecutorEventType::StateRootHash)),
+                    .then_some((self.tick, ExecutorEventType::ValSet)),
             )
             .chain(
                 self.loopback
@@ -329,7 +329,7 @@ impl<S: SwarmRelation> Executor for MockExecutor<S> {
             timer_cmds,
             ledger_cmds,
             checkpoint_cmds,
-            state_root_hash_cmds,
+            val_set_cmds,
             timestamp_cmds,
             txpool_cmds,
             _control_panel_cmds,
@@ -371,7 +371,7 @@ impl<S: SwarmRelation> Executor for MockExecutor<S> {
         self.ledger.exec(ledger_cmds);
         self.txpool.exec(txpool_cmds);
         self.checkpoint.exec(checkpoint_cmds);
-        self.state_root_hash.exec(state_root_hash_cmds);
+        self.val_set.exec(val_set_cmds);
         self.loopback.exec(loopback_cmds);
         self.statesync.exec(statesync_cmds);
 
@@ -453,8 +453,8 @@ impl<S: SwarmRelation> MockExecutor<S> {
                     return futures::executor::block_on(self.ledger.next())
                         .map(MockExecutorEvent::Event)
                 }
-                ExecutorEventType::StateRootHash => {
-                    return futures::executor::block_on(self.state_root_hash.next())
+                ExecutorEventType::ValSet => {
+                    return futures::executor::block_on(self.val_set.next())
                         .map(MockExecutorEvent::Event)
                 }
                 ExecutorEventType::Loopback => {
@@ -486,8 +486,8 @@ impl<S: SwarmRelation> MockExecutor<S> {
         &self.ledger
     }
 
-    pub fn state_root_hash_executor(&self) -> &S::StateRootHashExecutor {
-        &self.state_root_hash
+    pub fn val_set_updater(&self) -> &S::ValSetUpdater {
+        &self.val_set
     }
 }
 

--- a/monad-mock-swarm/src/transformer.rs
+++ b/monad-mock-swarm/src/transformer.rs
@@ -17,7 +17,6 @@ use std::{collections::BTreeMap, marker::PhantomData, ops::Deref, time::Duration
 
 use itertools::Itertools;
 use monad_consensus::messages::consensus_message::ProtocolMessage;
-use monad_consensus_types::signature_collection::SignatureCollection;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
 };
@@ -27,6 +26,7 @@ use monad_transformer::{
     Transformer, TransformerStream, XorLatencyTransformer, ID, UNIQUE_ID,
 };
 use monad_types::{ExecutionProtocol, NodeId, Round};
+use monad_validator::signature_collection::SignatureCollection;
 
 #[derive(Debug, Clone)]
 pub struct FilterTransformer<PT: PubKey> {

--- a/monad-mock-swarm/tests/block_sync.rs
+++ b/monad-mock-swarm/tests/block_sync.rs
@@ -48,9 +48,9 @@ mod test {
     use monad_types::{NodeId, Round, SeqNum};
     use monad_updaters::{
         ledger::{MockLedger, MockableLedger},
-        state_root_hash::MockStateRootHashNop,
         statesync::MockStateSyncExecutor,
         txpool::MockTxPoolExecutor,
+        val_set::MockValSetUpdaterNop,
     };
     use monad_validator::{
         simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory,
@@ -77,7 +77,7 @@ mod test {
             SeqNum::MAX,                         // execution_delay
             delta,                               // delta
             MockChainConfig::new(&CHAIN_PARAMS), // chain config
-            SeqNum(2000),                        // val_set_update_interval
+            SeqNum(2000),                        // epoch_length
             Round(50),                           // epoch_start_delay
             SeqNum(1000),                        // state_sync_threshold
         );
@@ -109,7 +109,7 @@ mod test {
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
                         NoSerRouterConfig::new(all_peers.clone()).build(),
-                        MockStateRootHashNop::new(validators.validators.clone(), SeqNum(2000)),
+                        MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
                         MockTxPoolExecutor::default(),
                         MockLedger::new(state_backend.clone()),
                         MockStateSyncExecutor::new(
@@ -200,7 +200,7 @@ mod test {
             SeqNum::MAX,                         // execution_delay
             delta,                               // delta
             MockChainConfig::new(&CHAIN_PARAMS), // chain config
-            SeqNum(2000),                        // val_set_update_interval
+            SeqNum(2000),                        // epoch_length
             Round(50),                           // epoch_start_delay
             SeqNum(100),                         // state_sync_threshold
         );
@@ -226,7 +226,7 @@ mod test {
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
                         NoSerRouterConfig::new(all_peers.clone()).build(),
-                        MockStateRootHashNop::new(validators.validators.clone(), SeqNum(2000)),
+                        MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
                         MockTxPoolExecutor::default(),
                         MockLedger::new(state_backend.clone()),
                         MockStateSyncExecutor::new(
@@ -285,7 +285,7 @@ mod test {
             SeqNum::MAX,                         // execution_delay
             delta,                               // delta
             MockChainConfig::new(&CHAIN_PARAMS), // chain config
-            SeqNum(2000),                        // val_set_update_interval
+            SeqNum(2000),                        // epoch_length
             Round(50),                           // epoch_start_delay
             SeqNum(100),                         // state_sync_threshold
         );
@@ -311,7 +311,7 @@ mod test {
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
                         NoSerRouterConfig::new(all_peers.clone()).build(),
-                        MockStateRootHashNop::new(validators.validators.clone(), SeqNum(2000)),
+                        MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
                         MockTxPoolExecutor::default(),
                         MockLedger::new(state_backend.clone()),
                         MockStateSyncExecutor::new(
@@ -425,7 +425,7 @@ mod test {
             SeqNum::MAX,                         // execution_delay
             delta,                               // delta
             MockChainConfig::new(&CHAIN_PARAMS), // chain config
-            SeqNum(2000),                        // val_set_update_interval
+            SeqNum(2000),                        // epoch_length
             Round(50),                           // epoch_start_delay
             SeqNum(2000),                        // state_sync_threshold
         );
@@ -453,7 +453,7 @@ mod test {
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
                         NoSerRouterConfig::new(all_peers.clone()).build(),
-                        MockStateRootHashNop::new(validators.validators.clone(), SeqNum(2000)),
+                        MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
                         MockTxPoolExecutor::default(),
                         MockLedger::new(state_backend.clone()),
                         MockStateSyncExecutor::new(

--- a/monad-mock-swarm/tests/forkpoint.rs
+++ b/monad-mock-swarm/tests/forkpoint.rs
@@ -41,9 +41,9 @@ use monad_transformer::{GenericTransformer, GenericTransformerPipeline, LatencyT
 use monad_types::{NodeId, Round, SeqNum, GENESIS_SEQ_NUM};
 use monad_updaters::{
     ledger::{MockLedger, MockableLedger},
-    state_root_hash::MockStateRootHashNop,
     statesync::MockStateSyncExecutor,
     txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
 };
 use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 use rayon::prelude::*;
@@ -53,7 +53,7 @@ impl SwarmRelation for ForkpointSwarm {
     type SignatureType = NopSignature;
     type SignatureCollectionType = MultiSig<Self::SignatureType>;
     type ExecutionProtocolType = EthExecutionProtocol;
-    type StateBackendType = InMemoryState;
+    type StateBackendType = InMemoryState<Self::SignatureType, Self::SignatureCollectionType>;
     type BlockPolicyType = EthBlockPolicy<Self::SignatureType, Self::SignatureCollectionType>;
     type ChainConfigType = MockChainConfig;
     type ChainRevisionType = MockChainRevision;
@@ -91,7 +91,7 @@ impl SwarmRelation for ForkpointSwarm {
         Self::TransportMessage,
     >;
 
-    type StateRootHashExecutor = MockStateRootHashNop<
+    type ValSetUpdater = MockValSetUpdaterNop<
         Self::SignatureType,
         Self::SignatureCollectionType,
         Self::ExecutionProtocolType,
@@ -255,7 +255,7 @@ fn forkpoint_restart_f(
         state_root_delay,
         delta,                               // delta
         MockChainConfig::new(&CHAIN_PARAMS), // chain config
-        epoch_length,                        // val_set_update_interval
+        epoch_length,                        // epoch_length
         Round(50),                           // epoch_start_delay
         statesync_threshold,                 // state_sync_threshold
     );
@@ -288,7 +288,7 @@ fn forkpoint_restart_f(
             state_root_delay,                    // execution_delay
             delta,                               // delta
             MockChainConfig::new(&CHAIN_PARAMS), // chain config
-            epoch_length,                        // val_set_update_interval
+            epoch_length,                        // epoch_length
             Round(50),                           // epoch_start_delay
             statesync_threshold,                 // state_sync_threshold
         );
@@ -311,7 +311,7 @@ fn forkpoint_restart_f(
             state_root_delay,                    // execution_delay
             delta,                               // delta
             MockChainConfig::new(&CHAIN_PARAMS), // chain config
-            epoch_length,                        // val_set_update_interval
+            epoch_length,                        // epoch_length
             Round(50),                           // epoch_start_delay
             statesync_threshold,                 // state_sync_threshold
         );
@@ -335,7 +335,7 @@ fn forkpoint_restart_f(
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
                         NoSerRouterConfig::new(all_peers.clone()).build(),
-                        MockStateRootHashNop::new(validators.clone(), epoch_length),
+                        MockValSetUpdaterNop::new(validators.clone(), epoch_length),
                         MockTxPoolExecutor::new(create_block_policy(), state_backend.clone()),
                         MockLedger::new(state_backend.clone()),
                         MockStateSyncExecutor::new(
@@ -430,7 +430,7 @@ fn forkpoint_restart_f(
             ID::new(restart_node_id),
             restart_builder,
             NoSerRouterConfig::new(all_peers.clone()).build(),
-            MockStateRootHashNop::new(validators.clone(), epoch_length),
+            MockValSetUpdaterNop::new(validators.clone(), epoch_length),
             MockTxPoolExecutor::new(create_block_policy(), restart_builder_state_backend.clone()),
             MockLedger::new(restart_builder_state_backend.clone()),
             MockStateSyncExecutor::new(
@@ -576,7 +576,7 @@ fn forkpoint_restart_below_all(
         state_root_delay,                    // execution_delay
         delta,                               // delta
         MockChainConfig::new(&CHAIN_PARAMS), // chain config
-        epoch_length,                        // val_set_update_interval
+        epoch_length,                        // epoch_length
         Round(50),                           // epoch_start_delay
         statesync_threshold,                 // state_sync_threshold
     );
@@ -622,7 +622,7 @@ fn forkpoint_restart_below_all(
             state_root_delay,                    // execution_delay
             delta,                               // delta
             MockChainConfig::new(&CHAIN_PARAMS), // chain config
-            epoch_length,                        // val_set_update_interval
+            epoch_length,                        // epoch_length
             Round(50),                           // epoch_start_delay
             statesync_threshold,                 // state_sync_threshold
         );
@@ -636,7 +636,7 @@ fn forkpoint_restart_below_all(
             state_root_delay,                    // execution_delay
             delta,                               // delta
             MockChainConfig::new(&CHAIN_PARAMS), // chain config
-            epoch_length,                        // val_set_update_interval
+            epoch_length,                        // epoch_length
             Round(50),                           // epoch_start_delay
             statesync_threshold,                 // state_sync_threshold
         );
@@ -655,7 +655,7 @@ fn forkpoint_restart_below_all(
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
                         NoSerRouterConfig::new(all_peers.clone()).build(),
-                        MockStateRootHashNop::new(validators.clone(), epoch_length),
+                        MockValSetUpdaterNop::new(validators.clone(), epoch_length),
                         MockTxPoolExecutor::new(create_block_policy(), state_backend.clone()),
                         MockLedger::new(state_backend.clone()),
                         MockStateSyncExecutor::new(
@@ -766,7 +766,7 @@ fn forkpoint_restart_below_all(
                 ID::new(node_id),
                 builder,
                 NoSerRouterConfig::new(all_peers.clone()).build(),
-                MockStateRootHashNop::new(validators.clone(), epoch_length),
+                MockValSetUpdaterNop::new(validators.clone(), epoch_length),
                 MockTxPoolExecutor::new(create_block_policy(), state_backend.clone()),
                 MockLedger::new(state_backend.clone()),
                 MockStateSyncExecutor::new(

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -32,8 +32,8 @@ use monad_transformer::{
 };
 use monad_types::{NodeId, Round, SeqNum};
 use monad_updaters::{
-    ledger::MockLedger, state_root_hash::MockStateRootHashNop, statesync::MockStateSyncExecutor,
-    txpool::MockTxPoolExecutor,
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
 };
 use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 
@@ -61,7 +61,7 @@ fn many_nodes_noser() {
         SeqNum(4),                           // execution_delay
         delta,                               // delta
         MockChainConfig::new(&CHAIN_PARAMS), // chain config
-        SeqNum(2000),                        // val_set_update_interval
+        SeqNum(2000),                        // epoch_length
         Round(50),                           // epoch_start_delay
         SeqNum(100),                         // state_sync_threshold
     );
@@ -80,7 +80,7 @@ fn many_nodes_noser() {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockStateRootHashNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
                     MockTxPoolExecutor::default(),
                     MockLedger::new(state_backend.clone()),
                     MockStateSyncExecutor::new(
@@ -128,7 +128,7 @@ fn many_nodes_noser_one_offline() {
         SeqNum(4),                           // execution_delay
         delta,                               // delta
         MockChainConfig::new(&CHAIN_PARAMS), // chain config
-        SeqNum(2000),                        // val_set_update_interval
+        SeqNum(2000),                        // epoch_length
         Round(50),                           // epoch_start_delay
         SeqNum(100),                         // state_sync_threshold
     );
@@ -147,7 +147,7 @@ fn many_nodes_noser_one_offline() {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockStateRootHashNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
                     MockTxPoolExecutor::default(),
                     MockLedger::new(state_backend.clone()),
                     MockStateSyncExecutor::new(

--- a/monad-mock-swarm/tests/msg_delays.rs
+++ b/monad-mock-swarm/tests/msg_delays.rs
@@ -34,8 +34,8 @@ use monad_testutil::swarm::{make_state_configs, swarm_ledger_verification};
 use monad_transformer::{GenericTransformer, XorLatencyTransformer, ID};
 use monad_types::{NodeId, Round, SeqNum};
 use monad_updaters::{
-    ledger::MockLedger, state_root_hash::MockStateRootHashNop, statesync::MockStateSyncExecutor,
-    txpool::MockTxPoolExecutor,
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
 };
 use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 
@@ -61,7 +61,7 @@ fn two_nodes() {
         SeqNum(4),                           // execution_delay
         delta,                               // delta
         MockChainConfig::new(&CHAIN_PARAMS), // chain config
-        SeqNum(2000),                        // val_set_update_interval
+        SeqNum(2000),                        // epoch_length
         Round(50),                           // epoch_start_delay
         SeqNum(100),                         // state_sync_threshold
     );
@@ -80,7 +80,7 @@ fn two_nodes() {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockStateRootHashNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
                     MockTxPoolExecutor::default(),
                     MockLedger::new(state_backend.clone()),
                     MockStateSyncExecutor::new(

--- a/monad-mock-swarm/tests/order.rs
+++ b/monad-mock-swarm/tests/order.rs
@@ -40,9 +40,9 @@ use monad_transformer::{
 use monad_types::{NodeId, Round, SeqNum};
 use monad_updaters::{
     ledger::{MockLedger, MockableLedger},
-    state_root_hash::MockStateRootHashNop,
     statesync::MockStateSyncExecutor,
     txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
 };
 use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -114,7 +114,7 @@ fn all_messages_delayed(direction: TransformerReplayOrder) -> Result<(), String>
         SeqNum(1),                           // execution_delay
         delta,                               // delta
         MockChainConfig::new(&CHAIN_PARAMS), // chain config
-        SeqNum(2000),                        // val_set_update_interval
+        SeqNum(2000),                        // epoch_length
         Round(50),                           // epoch_start_delay
         SeqNum(100),                         // state_sync_threshold
     );
@@ -139,7 +139,7 @@ fn all_messages_delayed(direction: TransformerReplayOrder) -> Result<(), String>
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockStateRootHashNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
                     MockTxPoolExecutor::default(),
                     MockLedger::new(state_backend.clone()),
                     MockStateSyncExecutor::new(

--- a/monad-mock-swarm/tests/rand_lat.rs
+++ b/monad-mock-swarm/tests/rand_lat.rs
@@ -41,8 +41,8 @@ use monad_testutil::swarm::{make_state_configs, swarm_ledger_verification};
 use monad_transformer::{GenericTransformer, ID};
 use monad_types::{NodeId, Round, SeqNum};
 use monad_updaters::{
-    ledger::MockLedger, state_root_hash::MockStateRootHashNop, statesync::MockStateSyncExecutor,
-    txpool::MockTxPoolExecutor,
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
 };
 use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -124,7 +124,7 @@ fn nodes_with_random_latency(latency_seed: u64) -> Result<(), String> {
         SeqNum::MAX,                         // execution_delay
         delta,                               // delta
         MockChainConfig::new(&CHAIN_PARAMS), // chain config
-        SeqNum(3000),                        // val_set_update_interval
+        SeqNum(3000),                        // epoch_length
         Round(50),                           // epoch_start_delay
         SeqNum(100),                         // state_sync_threshold
     );
@@ -143,7 +143,7 @@ fn nodes_with_random_latency(latency_seed: u64) -> Result<(), String> {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockStateRootHashNop::new(validators.validators.clone(), SeqNum(3000)),
+                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(3000)),
                     MockTxPoolExecutor::default(),
                     MockLedger::new(state_backend.clone()),
                     MockStateSyncExecutor::new(

--- a/monad-mock-swarm/tests/timestamp_drift.rs
+++ b/monad-mock-swarm/tests/timestamp_drift.rs
@@ -34,8 +34,8 @@ use monad_testutil::swarm::{make_state_configs, swarm_ledger_verification};
 use monad_transformer::{GenericTransformer, LatencyTransformer, ID};
 use monad_types::{NodeId, Round, SeqNum};
 use monad_updaters::{
-    ledger::MockLedger, state_root_hash::MockStateRootHashNop, statesync::MockStateSyncExecutor,
-    txpool::MockTxPoolExecutor,
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
 };
 use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 
@@ -64,7 +64,7 @@ fn drift_one_node() {
         SeqNum(4),                           // execution_delay
         delta,                               // delta
         MockChainConfig::new(&CHAIN_PARAMS), // chain config
-        SeqNum(2000),                        // val_set_update_interval
+        SeqNum(2000),                        // epoch_length
         Round(50),                           // epoch_start_delay
         SeqNum(100),                         // state_sync_threshold
     );
@@ -93,7 +93,7 @@ fn drift_one_node() {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockStateRootHashNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
                     MockTxPoolExecutor::default(),
                     MockLedger::new(state_backend.clone()),
                     MockStateSyncExecutor::new(

--- a/monad-mock-swarm/tests/two_nodes.rs
+++ b/monad-mock-swarm/tests/two_nodes.rs
@@ -34,8 +34,8 @@ use monad_testutil::swarm::{make_state_configs, swarm_ledger_verification};
 use monad_transformer::{GenericTransformer, LatencyTransformer, ID};
 use monad_types::{NodeId, Round, SeqNum};
 use monad_updaters::{
-    ledger::MockLedger, state_root_hash::MockStateRootHashNop, statesync::MockStateSyncExecutor,
-    txpool::MockTxPoolExecutor,
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
 };
 use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 
@@ -59,7 +59,7 @@ fn two_nodes_noser() {
         SeqNum(4),                           // execution_delay
         delta,                               // delta
         MockChainConfig::new(&CHAIN_PARAMS), // chain config
-        SeqNum(2000),                        // val_set_update_interval
+        SeqNum(2000),                        // epoch_length
         Round(50),                           // epoch_start_delay
         SeqNum(100),                         // state_sync_threshold
     );
@@ -78,7 +78,7 @@ fn two_nodes_noser() {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockStateRootHashNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
                     MockTxPoolExecutor::default(),
                     MockLedger::new(state_backend.clone()),
                     MockStateSyncExecutor::new(

--- a/monad-multi-sig/Cargo.toml
+++ b/monad-multi-sig/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 bench = false
 
 [dependencies]
-monad-consensus-types = { workspace = true }
 monad-crypto = { workspace = true }
 monad-types = { workspace = true }
+monad-validator = { workspace = true }
 
 alloy-rlp = { workspace = true }
 tracing = { workspace = true }

--- a/monad-multi-sig/src/lib.rs
+++ b/monad-multi-sig/src/lib.rs
@@ -16,17 +16,17 @@
 use std::collections::{BTreeMap, HashMap};
 
 use alloy_rlp::{BytesMut, Decodable, Encodable, RlpDecodable, RlpEncodable};
-use monad_consensus_types::{
-    signature_collection::{
-        SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
-        SignatureCollectionPubKeyType,
-    },
-    voting::ValidatorMapping,
-};
 use monad_crypto::{
     certificate_signature::CertificateSignatureRecoverable, signing_domain::SigningDomain,
 };
 use monad_types::NodeId;
+use monad_validator::{
+    signature_collection::{
+        SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
+        SignatureCollectionPubKeyType,
+    },
+    validator_mapping::ValidatorMapping,
+};
 use tracing::{error, warn};
 
 #[derive(Clone, Debug, PartialEq, Eq, RlpDecodable, RlpEncodable)]
@@ -184,9 +184,6 @@ impl<S: CertificateSignatureRecoverable> SignatureCollection for MultiSig<S> {
 mod test {
     use std::collections::HashSet;
 
-    use monad_consensus_types::signature_collection::{
-        SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
-    };
     use monad_crypto::{
         certificate_signature::{
             CertificateKeyPair, CertificateSignature, CertificateSignaturePubKey,
@@ -199,7 +196,12 @@ mod test {
         validators::create_keys_w_validators,
     };
     use monad_types::NodeId;
-    use monad_validator::validator_set::ValidatorSetFactory;
+    use monad_validator::{
+        signature_collection::{
+            SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
+        },
+        validator_set::ValidatorSetFactory,
+    };
     use rand::{seq::SliceRandom, SeedableRng};
     use rand_chacha::ChaChaRng;
     use test_case::test_case;

--- a/monad-node/src/error.rs
+++ b/monad-node/src/error.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use clap::error::ErrorKind;
-use monad_consensus_types::signature_collection::SignatureCollection;
+use monad_validator::signature_collection::{SignatureCollection, SignatureCollectionError};
 use opentelemetry_otlp::ExporterBuildError;
 use opentelemetry_sdk::trace::TraceError;
 use thiserror::Error;
@@ -54,7 +54,7 @@ pub enum NodeSetupError {
     #[error(transparent)]
     SignatureCollectionError(
         #[from]
-        monad_consensus_types::signature_collection::SignatureCollectionError<
+        SignatureCollectionError<
             <crate::SignatureCollectionType as SignatureCollection>::NodeIdPubKey,
             <crate::SignatureCollectionType as SignatureCollection>::SignatureType,
         >,

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -35,8 +35,8 @@ use monad_transformer::{
 };
 use monad_types::{NodeId, Round, SeqNum};
 use monad_updaters::{
-    ledger::MockLedger, state_root_hash::MockStateRootHashNop, statesync::MockStateSyncExecutor,
-    txpool::MockTxPoolExecutor,
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
 };
 use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
 
@@ -60,7 +60,7 @@ fn random_latency_test(latency_seed: u64) {
         SeqNum(4),                           // execution_delay
         Duration::from_millis(250),          // delta
         MockChainConfig::new(&CHAIN_PARAMS), // chain config
-        SeqNum(2000),                        // val_set_update_interval
+        SeqNum(2000),                        // epoch_length
         Round(50),                           // epoch_start_delay
         SeqNum(100),                         // state_sync_threshold
     );
@@ -79,7 +79,7 @@ fn random_latency_test(latency_seed: u64) {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockStateRootHashNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
                     MockTxPoolExecutor::default(),
                     MockLedger::new(state_backend.clone()),
                     MockStateSyncExecutor::new(
@@ -128,7 +128,7 @@ fn delayed_message_test(latency_seed: u64) {
         SeqNum(4),                                        // execution_delay
         Duration::from_millis(2),                         // delta
         MockChainConfig::new(&CHAIN_PARAMS_NO_VOTE_PACE), // chain config
-        SeqNum(2000),                                     // val_set_update_interval
+        SeqNum(2000),                                     // epoch_length
         Round(50),                                        // epoch_start_delay
         SeqNum(100),                                      // state_sync_threshold
     );
@@ -152,7 +152,7 @@ fn delayed_message_test(latency_seed: u64) {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockStateRootHashNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
                     MockTxPoolExecutor::default(),
                     MockLedger::new(state_backend.clone()),
                     MockStateSyncExecutor::new(

--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -10,7 +10,6 @@ bench = false
 
 [dependencies]
 monad-compress = { workspace = true }
-monad-consensus-types = { workspace = true }
 monad-crypto = { workspace = true }
 monad-dataplane = { workspace = true }
 monad-executor = { workspace = true }
@@ -20,6 +19,7 @@ monad-peer-discovery = { workspace = true }
 monad-raptor = { workspace = true }
 monad-secp = { workspace = true }
 monad-types = { workspace = true }
+monad-validator = { workspace = true }
 
 alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -30,7 +30,6 @@ use bytes::{Bytes, BytesMut};
 use futures::{channel::oneshot, FutureExt, Stream, StreamExt};
 use itertools::Itertools;
 use message::{InboundRouterMessage, OutboundRouterMessage};
-use monad_consensus_types::signature_collection::SignatureCollection;
 use monad_crypto::{
     certificate_signature::{
         CertificateKeyPair, CertificateSignaturePubKey, CertificateSignatureRecoverable,
@@ -53,6 +52,7 @@ use monad_peer_discovery::{
     PeerDiscoveryAlgo, PeerDiscoveryEvent,
 };
 use monad_types::{DropTimer, Epoch, ExecutionProtocol, NodeId, RouterTarget};
+use monad_validator::signature_collection::SignatureCollection;
 use raptorcast_secondary::group_message::FullNodesGroupMessage;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::{debug, debug_span, error, warn};

--- a/monad-state-backend/Cargo.toml
+++ b/monad-state-backend/Cargo.toml
@@ -9,10 +9,15 @@ edition = "2021"
 bench = false
 
 [dependencies]
+monad-crypto = { workspace = true }
 monad-eth-types = { workspace = true }
 monad-types = { workspace = true }
+monad-validator = { workspace = true }
 
 alloy-consensus = { workspace = true }
 alloy-primitives = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+monad-multi-sig = { workspace = true }

--- a/monad-state-backend/src/lib.rs
+++ b/monad-state-backend/src/lib.rs
@@ -19,8 +19,12 @@ use std::{
 };
 
 use alloy_primitives::Address;
+use monad_crypto::certificate_signature::{
+    CertificateSignaturePubKey, CertificateSignatureRecoverable,
+};
 use monad_eth_types::{EthAccount, EthHeader, Nonce};
-use monad_types::{BlockId, Round, SeqNum};
+use monad_types::{BlockId, Round, SeqNum, Stake};
+use monad_validator::signature_collection::{SignatureCollection, SignatureCollectionPubKeyType};
 
 pub use self::{
     in_memory::{InMemoryBlockState, InMemoryState, InMemoryStateInner},
@@ -39,7 +43,11 @@ pub enum StateBackendError {
 }
 
 /// Backend provider of account data: balance and nonce
-pub trait StateBackend {
+pub trait StateBackend<ST, SCT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+{
     fn get_account_statuses<'a>(
         &self,
         block_id: &BlockId,
@@ -60,10 +68,19 @@ pub trait StateBackend {
     /// Fetches latest block from storage backend
     fn raw_read_latest_finalized_block(&self) -> Option<SeqNum>;
 
+    fn read_next_valset(
+        &self,
+        block_num: SeqNum,
+    ) -> Vec<(SCT::NodeIdPubKey, SignatureCollectionPubKeyType<SCT>, Stake)>;
+
     fn total_db_lookups(&self) -> u64;
 }
 
-pub trait StateBackendTest {
+pub trait StateBackendTest<ST, SCT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+{
     fn ledger_propose(
         &mut self,
         block_id: BlockId,
@@ -76,7 +93,12 @@ pub trait StateBackendTest {
     fn ledger_commit(&mut self, block_id: &BlockId);
 }
 
-impl<T: StateBackend> StateBackend for Arc<Mutex<T>> {
+impl<ST, SCT, T> StateBackend<ST, SCT> for Arc<Mutex<T>>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    T: StateBackend<ST, SCT>,
+{
     fn get_account_statuses<'a>(
         &self,
         block_id: &BlockId,
@@ -108,12 +130,25 @@ impl<T: StateBackend> StateBackend for Arc<Mutex<T>> {
         state.raw_read_latest_finalized_block()
     }
 
+    fn read_next_valset(
+        &self,
+        block_num: SeqNum,
+    ) -> Vec<(SCT::NodeIdPubKey, SignatureCollectionPubKeyType<SCT>, Stake)> {
+        let state = self.lock().unwrap();
+        state.read_next_valset(block_num)
+    }
+
     fn total_db_lookups(&self) -> u64 {
         self.lock().unwrap().total_db_lookups()
     }
 }
 
-impl<T: StateBackendTest> StateBackendTest for Arc<Mutex<T>> {
+impl<ST, SCT, T> StateBackendTest<ST, SCT> for Arc<Mutex<T>>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    T: StateBackendTest<ST, SCT>,
+{
     fn ledger_commit(&mut self, block_id: &BlockId) {
         let mut state = self.lock().unwrap();
         state.ledger_commit(block_id);

--- a/monad-state-backend/src/thread.rs
+++ b/monad-state-backend/src/thread.rs
@@ -13,11 +13,18 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::{mpsc, Arc};
+use std::{
+    marker::PhantomData,
+    sync::{mpsc, Arc},
+};
 
 use alloy_primitives::Address;
+use monad_crypto::certificate_signature::{
+    CertificateSignaturePubKey, CertificateSignatureRecoverable,
+};
 use monad_eth_types::{EthAccount, EthHeader};
-use monad_types::{BlockId, SeqNum};
+use monad_types::{BlockId, SeqNum, Stake};
+use monad_validator::signature_collection::{SignatureCollection, SignatureCollectionPubKeyType};
 use tracing::warn;
 
 use crate::{StateBackend, StateBackendError};
@@ -26,7 +33,11 @@ use crate::{StateBackend, StateBackendError};
 // sync context so a value of 16 allows 16 threads to simulatneously make state backend requests.
 const MAX_INFLIGHT_REQUESTS: usize = 16;
 
-enum StateBackendThreadRequest {
+enum StateBackendThreadRequest<ST, SCT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+{
     GetAccountStatuses {
         block_id: BlockId,
         seq_num: SeqNum,
@@ -46,21 +57,39 @@ enum StateBackendThreadRequest {
     RawReadLatestFinalizedBlock {
         tx: mpsc::SyncSender<Option<SeqNum>>,
     },
+    ReadNextValidatorData {
+        block_num: SeqNum,
+        tx: mpsc::SyncSender<
+            Vec<(
+                CertificateSignaturePubKey<ST>,
+                SignatureCollectionPubKeyType<SCT>,
+                Stake,
+            )>,
+        >,
+    },
     TotalDbLookups {
         tx: mpsc::SyncSender<u64>,
     },
 }
 
 #[derive(Clone)]
-pub struct StateBackendThreadClient {
+pub struct StateBackendThreadClient<ST, SCT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+{
     handle: Arc<std::thread::JoinHandle<()>>,
-    request_tx: mpsc::SyncSender<StateBackendThreadRequest>,
+    request_tx: mpsc::SyncSender<StateBackendThreadRequest<ST, SCT>>,
 }
 
-impl StateBackendThreadClient {
+impl<ST, SCT> StateBackendThreadClient<ST, SCT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+{
     pub fn new<SBT>(state_backend: impl FnOnce() -> SBT + Send + 'static) -> Self
     where
-        SBT: StateBackend,
+        SBT: StateBackend<ST, SCT>,
     {
         let (request_tx, request_rx) = mpsc::sync_channel(MAX_INFLIGHT_REQUESTS);
 
@@ -73,7 +102,7 @@ impl StateBackendThreadClient {
 
     fn send_and_recv_request<T>(
         &self,
-        request: impl FnOnce(mpsc::SyncSender<T>) -> StateBackendThreadRequest,
+        request: impl FnOnce(mpsc::SyncSender<T>) -> StateBackendThreadRequest<ST, SCT>,
     ) -> T {
         if self.handle.is_finished() {
             panic!("StateBackendThread terminated!");
@@ -89,7 +118,11 @@ impl StateBackendThreadClient {
     }
 }
 
-impl StateBackend for StateBackendThreadClient {
+impl<ST, SCT> StateBackend<ST, SCT> for StateBackendThreadClient<ST, SCT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+{
     fn get_account_statuses<'a>(
         &self,
         block_id: &BlockId,
@@ -132,32 +165,50 @@ impl StateBackend for StateBackendThreadClient {
         )
     }
 
+    fn read_next_valset(
+        &self,
+        block_num: SeqNum,
+    ) -> Vec<(SCT::NodeIdPubKey, SignatureCollectionPubKeyType<SCT>, Stake)> {
+        self.send_and_recv_request(|tx| StateBackendThreadRequest::ReadNextValidatorData {
+            block_num,
+            tx,
+        })
+    }
+
     fn total_db_lookups(&self) -> u64 {
         self.send_and_recv_request(|tx| StateBackendThreadRequest::TotalDbLookups { tx })
     }
 }
 
-struct StateBackendThread<SBT>
+struct StateBackendThread<ST, SCT, SBT>
 where
-    SBT: StateBackend,
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    SBT: StateBackend<ST, SCT>,
 {
     state_backend: SBT,
-    request_rx: mpsc::Receiver<StateBackendThreadRequest>,
+    request_rx: mpsc::Receiver<StateBackendThreadRequest<ST, SCT>>,
+
+    _phantom: PhantomData<(ST, SCT)>,
 }
 
-impl<SBT> StateBackendThread<SBT>
+impl<ST, SCT, SBT> StateBackendThread<ST, SCT, SBT>
 where
-    SBT: StateBackend,
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    SBT: StateBackend<ST, SCT>,
 {
     fn new(
         state_backend: impl FnOnce() -> SBT + Send + 'static,
-        request_rx: mpsc::Receiver<StateBackendThreadRequest>,
+        request_rx: mpsc::Receiver<StateBackendThreadRequest<ST, SCT>>,
     ) -> Self {
         let state_backend = state_backend();
 
         Self {
             state_backend,
             request_rx,
+
+            _phantom: PhantomData,
         }
     }
 
@@ -165,6 +216,7 @@ where
         let Self {
             state_backend,
             request_rx,
+            ..
         } = self;
 
         for request in request_rx.iter() {
@@ -201,6 +253,10 @@ where
                     tx.send(state_backend.raw_read_latest_finalized_block())
                         .expect("StateBackendThreadClient is alive");
                 }
+                StateBackendThreadRequest::ReadNextValidatorData { block_num, tx } => {
+                    tx.send(state_backend.read_next_valset(block_num))
+                        .expect("StateBackendThreadClient is alive");
+                }
                 StateBackendThreadRequest::TotalDbLookups { tx } => {
                     tx.send(state_backend.total_db_lookups())
                         .expect("StateBackendThreadClient is alive");
@@ -216,15 +272,21 @@ where
 mod test {
     use std::time::Duration;
 
+    use monad_crypto::NopSignature;
     use monad_eth_types::Balance;
+    use monad_multi_sig::MultiSig;
     use monad_types::{SeqNum, GENESIS_BLOCK_ID, GENESIS_SEQ_NUM};
 
     use crate::{InMemoryStateInner, StateBackend, StateBackendThreadClient};
 
     #[test]
     fn all_requests() {
-        let client =
-            StateBackendThreadClient::new(|| InMemoryStateInner::genesis(Balance::MAX, SeqNum(4)));
+        let client = StateBackendThreadClient::new(|| {
+            InMemoryStateInner::<NopSignature, MultiSig<NopSignature>>::genesis(
+                Balance::MAX,
+                SeqNum(4),
+            )
+        });
 
         {
             let get_account_statuses = client
@@ -255,8 +317,12 @@ mod test {
 
     #[test]
     fn shutdown() {
-        let client =
-            StateBackendThreadClient::new(|| InMemoryStateInner::genesis(Balance::MAX, SeqNum(4)));
+        let client = StateBackendThreadClient::new(|| {
+            InMemoryStateInner::<NopSignature, MultiSig<NopSignature>>::genesis(
+                Balance::MAX,
+                SeqNum(4),
+            )
+        });
 
         let handle = client.handle.clone();
 

--- a/monad-state/src/blocksync.rs
+++ b/monad-state/src/blocksync.rs
@@ -21,7 +21,6 @@ use monad_blocksync::blocksync::{
 use monad_chain_config::{revision::ChainRevision, ChainConfig};
 use monad_consensus_types::{
     block::BlockPolicy, block_validator::BlockValidator, metrics::Metrics,
-    signature_collection::SignatureCollection,
 };
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
@@ -33,8 +32,8 @@ use monad_executor_glue::{
 use monad_state_backend::StateBackend;
 use monad_types::{ExecutionProtocol, NodeId, RouterTarget};
 use monad_validator::{
-    epoch_manager::EpochManager, validator_set::ValidatorSetTypeFactory,
-    validators_epoch_mapping::ValidatorsEpochMapping,
+    epoch_manager::EpochManager, signature_collection::SignatureCollection,
+    validator_set::ValidatorSetTypeFactory, validators_epoch_mapping::ValidatorsEpochMapping,
 };
 
 use crate::{ConsensusMode, MonadState, VerifiedMonadMessage};
@@ -45,7 +44,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
     BVT: BlockValidator<ST, SCT, EPT, BPT, SBT>,
     VTF: ValidatorSetTypeFactory<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
 {
@@ -70,7 +69,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
     BVT: BlockValidator<ST, SCT, EPT, BPT, SBT>,
     VTF: ValidatorSetTypeFactory<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     CCT: ChainConfig<CRT>,
@@ -172,7 +171,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     fn from(wrapped: WrappedBlockSyncCommand<ST, SCT, EPT>) -> Self {
         match wrapped.command {

--- a/monad-state/src/epoch.rs
+++ b/monad-state/src/epoch.rs
@@ -16,10 +16,7 @@
 use std::marker::PhantomData;
 
 use monad_chain_config::{revision::ChainRevision, ChainConfig};
-use monad_consensus_types::{
-    block::BlockPolicy, block_validator::BlockValidator, signature_collection::SignatureCollection,
-    voting::ValidatorMapping,
-};
+use monad_consensus_types::{block::BlockPolicy, block_validator::BlockValidator};
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
 };
@@ -27,6 +24,7 @@ use monad_executor_glue::{Command, MonadEvent, RouterCommand, ValidatorEvent};
 use monad_state_backend::StateBackend;
 use monad_types::{Epoch, ExecutionProtocol, NodeId, Stake};
 use monad_validator::{
+    signature_collection::SignatureCollection, validator_mapping::ValidatorMapping,
     validator_set::ValidatorSetTypeFactory, validators_epoch_mapping::ValidatorsEpochMapping,
 };
 
@@ -38,7 +36,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
     BVT: BlockValidator<ST, SCT, EPT, BPT, SBT>,
     VTF: ValidatorSetTypeFactory<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
 {
@@ -61,7 +59,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
     BVT: BlockValidator<ST, SCT, EPT, BPT, SBT>,
     VTF: ValidatorSetTypeFactory<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     CCT: ChainConfig<CRT>,
@@ -112,7 +110,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
     BPT: BlockPolicy<ST, SCT, EPT, SBT>,
-    SBT: StateBackend,
+    SBT: StateBackend<ST, SCT>,
 {
     fn from(command: EpochCommand<CertificateSignaturePubKey<ST>>) -> Self {
         match command {

--- a/monad-state/src/statesync.rs
+++ b/monad-state/src/statesync.rs
@@ -21,7 +21,6 @@ use monad_consensus_types::{
     checkpoint::RootInfo,
     payload::{ConsensusBlockBody, ConsensusBlockBodyId},
     quorum_certificate::QuorumCertificate,
-    signature_collection::SignatureCollection,
 };
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
@@ -30,6 +29,7 @@ use monad_types::{
     BlockId, Epoch, ExecutionProtocol, NodeId, SeqNum, GENESIS_BLOCK_ID, GENESIS_ROUND,
     GENESIS_SEQ_NUM,
 };
+use monad_validator::signature_collection::SignatureCollection;
 
 /// BlockBuffer is responsible for tracking pending blocks mid-statesync
 /// It performs a function very similar to the blocktree, but specifically for statesync purposes

--- a/monad-statesync/Cargo.toml
+++ b/monad-statesync/Cargo.toml
@@ -9,13 +9,13 @@ edition = "2021"
 bench = false
 
 [dependencies]
-monad-consensus-types = { workspace = true }
 monad-crypto = { workspace = true }
 monad-cxx = { workspace = true }
 monad-eth-types = { workspace = true }
 monad-executor = { workspace = true }
 monad-executor-glue = { workspace = true }
 monad-types = { workspace = true }
+monad-validator = { workspace = true }
 
 alloy-consensus = { workspace = true }
 alloy-rlp = { workspace = true }

--- a/monad-statesync/src/lib.rs
+++ b/monad-statesync/src/lib.rs
@@ -24,7 +24,6 @@ use std::{
 use ffi::SyncRequest;
 use futures::{Stream, StreamExt};
 use ipc::StateSyncIpc;
-use monad_consensus_types::signature_collection::SignatureCollection;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
 };
@@ -32,6 +31,7 @@ use monad_eth_types::EthExecutionProtocol;
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{MonadEvent, StateSyncCommand, StateSyncEvent, StateSyncNetworkMessage};
 use monad_types::{NodeId, SeqNum};
+use monad_validator::signature_collection::SignatureCollection;
 
 #[allow(dead_code, non_camel_case_types, non_upper_case_globals)]
 pub mod bindings {

--- a/monad-system-calls/Cargo.toml
+++ b/monad-system-calls/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 monad-consensus-types = { workspace = true }
 monad-crypto = { workspace = true }
 monad-eth-types = { workspace = true }
+monad-validator = { workspace = true }
 
 alloy-consensus = { workspace = true }
 alloy-primitives = { workspace = true }

--- a/monad-system-calls/src/lib.rs
+++ b/monad-system-calls/src/lib.rs
@@ -20,13 +20,12 @@
 //! added to the block.
 
 use alloy_primitives::{Address, B256, Bytes, hex};
-use monad_consensus_types::{
-    block::ConsensusBlockHeader, signature_collection::SignatureCollection,
-};
+use monad_consensus_types::block::ConsensusBlockHeader;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_eth_types::EthExecutionProtocol;
+use monad_validator::signature_collection::SignatureCollection;
 
 pub mod validator;
 

--- a/monad-system-calls/src/validator.rs
+++ b/monad-system-calls/src/validator.rs
@@ -25,13 +25,12 @@ use std::collections::VecDeque;
 
 use alloy_consensus::{Transaction, TxEnvelope, transaction::Recovered};
 use alloy_primitives::{Address, Bytes, TxKind, U256};
-use monad_consensus_types::{
-    block::ConsensusBlockHeader, signature_collection::SignatureCollection,
-};
+use monad_consensus_types::block::ConsensusBlockHeader;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_eth_types::EthExecutionProtocol;
+use monad_validator::signature_collection::SignatureCollection;
 use tracing::debug;
 
 use crate::{

--- a/monad-testutil/src/proposal.rs
+++ b/monad-testutil/src/proposal.rs
@@ -23,10 +23,9 @@ use monad_consensus_types::{
     block::ConsensusBlockHeader,
     payload::{ConsensusBlockBody, ConsensusBlockBodyInner, RoundSignature},
     quorum_certificate::QuorumCertificate,
-    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
     timeout::{HighExtend, HighTipRoundSigColTuple, Timeout, TimeoutCertificate, TimeoutInfo},
     tip::ConsensusTip,
-    voting::{ValidatorMapping, Vote},
+    voting::Vote,
     RoundCertificate,
 };
 use monad_crypto::{
@@ -40,6 +39,8 @@ use monad_types::{Epoch, ExecutionProtocol, NodeId, Round, SeqNum, GENESIS_ROUND
 use monad_validator::{
     epoch_manager::EpochManager,
     leader_election::LeaderElection,
+    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
+    validator_mapping::ValidatorMapping,
     validator_set::{ValidatorSetType, ValidatorSetTypeFactory},
     validators_epoch_mapping::ValidatorsEpochMapping,
 };

--- a/monad-testutil/src/signing.rs
+++ b/monad-testutil/src/signing.rs
@@ -17,12 +17,6 @@ use std::marker::PhantomData;
 
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 use monad_consensus::validation::signing::{Unvalidated, Unverified};
-use monad_consensus_types::{
-    signature_collection::{
-        SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
-    },
-    voting::ValidatorMapping,
-};
 use monad_crypto::{
     certificate_signature::{
         CertificateKeyPair, CertificateSignaturePubKey, CertificateSignatureRecoverable,
@@ -31,6 +25,12 @@ use monad_crypto::{
     signing_domain::{self, SigningDomain},
 };
 use monad_types::NodeId;
+use monad_validator::{
+    signature_collection::{
+        SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
+    },
+    validator_mapping::ValidatorMapping,
+};
 
 #[derive(Clone, Default, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 pub struct MockSignatures<ST: CertificateSignatureRecoverable> {

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -18,7 +18,6 @@ use std::{collections::BTreeMap, marker::PhantomData, time::Duration};
 use monad_consensus_state::ConsensusConfig;
 use monad_consensus_types::{
     block::ConsensusFullBlock,
-    signature_collection::SignatureCollection,
     validator_data::{ValidatorSetData, ValidatorSetDataWithEpoch},
 };
 use monad_crypto::certificate_signature::{
@@ -28,7 +27,7 @@ use monad_mock_swarm::{mock_swarm::Nodes, swarm_relation::SwarmRelation};
 use monad_state::{Forkpoint, MonadStateBuilder};
 use monad_types::{ExecutionProtocol, Round, SeqNum};
 use monad_updaters::ledger::MockableLedger;
-use monad_validator::validator_set::ValidatorSetType;
+use monad_validator::{signature_collection::SignatureCollection, validator_set::ValidatorSetType};
 
 use crate::validators::create_keys_w_validators;
 
@@ -44,7 +43,7 @@ pub fn make_state_configs<S: SwarmRelation>(
     execution_delay: SeqNum,
     delta: Duration,
     chain_config: S::ChainConfigType,
-    val_set_update_interval: SeqNum,
+    epoch_length: SeqNum,
     epoch_start_delay: Round,
     statesync_threshold: SeqNum,
 ) -> Vec<
@@ -105,7 +104,7 @@ pub fn make_state_configs<S: SwarmRelation>(
             key,
             certkey,
 
-            val_set_update_interval,
+            epoch_length,
             epoch_start_delay,
             beneficiary: Default::default(),
             block_sync_override_peers: Default::default(),

--- a/monad-testutil/src/validators.rs
+++ b/monad-testutil/src/validators.rs
@@ -13,15 +13,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use monad_consensus_types::{
-    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
-    voting::ValidatorMapping,
-};
 use monad_crypto::certificate_signature::{
     CertificateKeyPair, CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_types::{NodeId, Stake};
-use monad_validator::validator_set::ValidatorSetTypeFactory;
+use monad_validator::{
+    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
+    validator_mapping::ValidatorMapping,
+    validator_set::ValidatorSetTypeFactory,
+};
 
 use crate::signing::{create_certificate_keys, create_keys};
 

--- a/monad-triedb-cache/Cargo.toml
+++ b/monad-triedb-cache/Cargo.toml
@@ -9,9 +9,11 @@ edition = "2021"
 bench = false
 
 [dependencies]
+monad-crypto = { workspace = true }
 monad-eth-types = { workspace = true }
 monad-state-backend = { workspace = true }
 monad-types = { workspace = true }
+monad-validator = { workspace = true }
 
 alloy-primitives = { workspace = true }
 itertools = { workspace = true }

--- a/monad-triedb-utils/Cargo.toml
+++ b/monad-triedb-utils/Cargo.toml
@@ -9,7 +9,9 @@ edition = "2021"
 bench = false
 
 [dependencies]
+monad-bls = { workspace = true }
 monad-eth-types = { workspace = true }
+monad-secp = { workspace = true }
 monad-state-backend = { workspace = true }
 monad-triedb = { workspace = true }
 monad-types = { workspace = true }

--- a/monad-triedb-utils/src/lib.rs
+++ b/monad-triedb-utils/src/lib.rs
@@ -26,10 +26,12 @@ use alloy_primitives::Address;
 use alloy_rlp::Decodable;
 use futures::{channel::oneshot, executor::block_on, future::join_all, FutureExt};
 use key::Version;
+use monad_bls::{BlsPubKey, BlsSignatureCollection};
 use monad_eth_types::{EthAccount, EthHeader};
+use monad_secp::{PubKey, SecpSignature};
 use monad_state_backend::{StateBackend, StateBackendError};
 use monad_triedb::TriedbHandle;
-use monad_types::{BlockId, Hash, SeqNum};
+use monad_types::{BlockId, Hash, SeqNum, Stake};
 use tracing::{debug, trace, warn};
 
 use crate::{
@@ -196,7 +198,7 @@ impl TriedbReader {
     }
 }
 
-impl StateBackend for TriedbReader {
+impl StateBackend<SecpSignature, BlsSignatureCollection<PubKey>> for TriedbReader {
     fn get_account_statuses<'a>(
         &self,
         block_id: &BlockId,
@@ -286,6 +288,10 @@ impl StateBackend for TriedbReader {
 
     fn raw_read_latest_finalized_block(&self) -> Option<SeqNum> {
         self.get_latest_finalized_block()
+    }
+
+    fn read_next_valset(&self, _block_num: SeqNum) -> Vec<(PubKey, BlsPubKey, Stake)> {
+        unimplemented!()
     }
 
     fn total_db_lookups(&self) -> u64 {

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -317,16 +317,16 @@ impl SeqNum {
     /// Compute the epoch that the sequence number belong to. It does NOT mean
     /// that the block is proposed in the epoch
     ///
-    /// [0, val_set_update_interval-1] -> Epoch 1
-    /// [val_set_update_interval, (2 * val_set_update_interval)-1] -> Epoch 2
-    pub fn to_epoch(&self, val_set_update_interval: SeqNum) -> Epoch {
-        Epoch((self.0 / val_set_update_interval.0) + 1)
+    /// [0, epoch_length-1] -> Epoch 1
+    /// [epoch_length, (2 * epoch_length)-1] -> Epoch 2
+    pub fn to_epoch(&self, epoch_length: SeqNum) -> Epoch {
+        Epoch((self.0 / epoch_length.0) + 1)
     }
 
     /// This tells us what the boundary block of the epoch is. Note that this only indicates when
     /// the next epoch's round is scheduled.
-    pub fn is_epoch_end(&self, val_set_update_interval: SeqNum) -> bool {
-        *self % val_set_update_interval == val_set_update_interval - SeqNum(1)
+    pub fn is_epoch_end(&self, epoch_length: SeqNum) -> bool {
+        *self % epoch_length == epoch_length - SeqNum(1)
     }
 
     /// Get the epoch number whose validator set is locked by this block. Should
@@ -334,9 +334,9 @@ impl SeqNum {
     ///
     /// Current design locks the info for epoch n + 1 by the end of epoch n. The
     /// validators have epoch_start_delay to prepare themselves for any duties
-    pub fn get_locked_epoch(&self, val_set_update_interval: SeqNum) -> Epoch {
-        assert!(self.is_epoch_end(val_set_update_interval));
-        (*self).to_epoch(val_set_update_interval) + Epoch(1)
+    pub fn get_locked_epoch(&self, epoch_length: SeqNum) -> Epoch {
+        assert!(self.is_epoch_end(epoch_length));
+        (*self).to_epoch(epoch_length) + Epoch(1)
     }
 
     pub fn as_u64(&self) -> u64 {
@@ -755,12 +755,8 @@ mod test {
     #[test_case(SeqNum(199), Epoch(2), SeqNum(100); "sn_199_epoch_2")]
     #[test_case(SeqNum(200), Epoch(3), SeqNum(100); "sn_200_epoch_3")]
 
-    fn test_epoch_conversion(
-        seq_num: SeqNum,
-        expected_epoch: Epoch,
-        val_set_update_interval: SeqNum,
-    ) {
-        assert_eq!(seq_num.to_epoch(val_set_update_interval), expected_epoch);
+    fn test_epoch_conversion(seq_num: SeqNum, expected_epoch: Epoch, epoch_length: SeqNum) {
+        assert_eq!(seq_num.to_epoch(epoch_length), expected_epoch);
     }
 
     #[test]

--- a/monad-updaters/Cargo.toml
+++ b/monad-updaters/Cargo.toml
@@ -20,6 +20,7 @@ monad-executor-glue = { workspace = true }
 monad-node-config = { workspace = true }
 monad-state-backend = { workspace = true }
 monad-types = { workspace = true }
+monad-validator = { workspace = true }
 
 alloy-consensus = { workspace = true }
 alloy-rlp = { workspace = true }

--- a/monad-updaters/src/checkpoint.rs
+++ b/monad-updaters/src/checkpoint.rs
@@ -15,13 +15,13 @@
 
 use std::{marker::PhantomData, path::PathBuf};
 
-use monad_consensus_types::signature_collection::SignatureCollection;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::CheckpointCommand;
 use monad_types::ExecutionProtocol;
+use monad_validator::signature_collection::SignatureCollection;
 
 pub struct MockCheckpoint<ST, SCT, EPT>
 where

--- a/monad-updaters/src/config_loader.rs
+++ b/monad-updaters/src/config_loader.rs
@@ -16,7 +16,6 @@
 use std::{marker::PhantomData, net::SocketAddr, ops::DerefMut, path::PathBuf, task::Poll};
 
 use futures::Stream;
-use monad_consensus_types::signature_collection::SignatureCollection;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
@@ -26,6 +25,7 @@ use monad_executor_glue::{
 };
 use monad_node_config::{NodeBootstrapPeerConfig, NodeConfig};
 use monad_types::{ExecutionProtocol, NodeId};
+use monad_validator::signature_collection::SignatureCollection;
 use tokio::{
     net::lookup_host,
     sync::mpsc::{error::TrySendError, Receiver, Sender},

--- a/monad-updaters/src/ledger.rs
+++ b/monad-updaters/src/ledger.rs
@@ -28,7 +28,6 @@ use monad_blocksync::messages::message::{
 use monad_consensus_types::{
     block::{BlockRange, ConsensusFullBlock, OptimisticCommit},
     payload::ConsensusBlockBodyId,
-    signature_collection::SignatureCollection,
 };
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
@@ -37,6 +36,7 @@ use monad_executor::{Executor, ExecutorMetricsChain};
 use monad_executor_glue::{BlockSyncEvent, LedgerCommand, MonadEvent};
 use monad_state_backend::{InMemoryState, StateBackendTest};
 use monad_types::{BlockId, ExecutionProtocol, Round, SeqNum};
+use monad_validator::signature_collection::SignatureCollection;
 
 pub trait MockableLedger:
     Executor<
@@ -98,7 +98,7 @@ where
 
     events: VecDeque<BlockSyncEvent<ST, SCT, EPT>>,
 
-    state_backend: InMemoryState,
+    state_backend: InMemoryState<ST, SCT>,
 
     waker: Option<Waker>,
     _phantom: PhantomData<ST>,
@@ -110,7 +110,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
 {
-    pub fn new(state_backend: InMemoryState) -> Self {
+    pub fn new(state_backend: InMemoryState<ST, SCT>) -> Self {
         Self {
             blocks: Default::default(),
             block_ids: Default::default(),

--- a/monad-updaters/src/lib.rs
+++ b/monad-updaters/src/lib.rs
@@ -22,16 +22,16 @@ pub mod checkpoint;
 pub mod ledger;
 pub mod loopback;
 pub mod parent;
-pub mod state_root_hash;
 pub mod statesync;
 pub mod timestamp;
 pub mod txpool;
+pub mod val_set;
 
 #[cfg(feature = "tokio")]
 pub mod config_loader;
 
 #[cfg(all(feature = "tokio", feature = "monad-triedb"))]
-pub mod triedb_state_root_hash;
+pub mod triedb_val_set;
 
 #[cfg(feature = "tokio")]
 pub mod timer;

--- a/monad-updaters/src/statesync.rs
+++ b/monad-updaters/src/statesync.rs
@@ -20,7 +20,6 @@ use std::{
 };
 
 use futures::Stream;
-use monad_consensus_types::signature_collection::SignatureCollection;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
@@ -31,6 +30,7 @@ use monad_executor_glue::{
 };
 use monad_state_backend::{InMemoryState, StateBackend};
 use monad_types::{ExecutionProtocol, FinalizedHeader, NodeId, SeqNum, GENESIS_SEQ_NUM};
+use monad_validator::signature_collection::SignatureCollection;
 
 pub trait MockableStateSync:
     Executor<Command = StateSyncCommand<Self::Signature, Self::ExecutionProtocol>> + Unpin
@@ -71,7 +71,7 @@ where
 {
     events: VecDeque<MonadEvent<ST, SCT, EPT>>,
 
-    state_backend: InMemoryState,
+    state_backend: InMemoryState<ST, SCT>,
     peers: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
     max_service_window: SeqNum,
 
@@ -200,7 +200,7 @@ where
     EPT: ExecutionProtocol,
 {
     pub fn new(
-        state_backend: InMemoryState,
+        state_backend: InMemoryState<ST, SCT>,
         peers: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
     ) -> Self {
         Self {

--- a/monad-updaters/src/tokio_timestamp.rs
+++ b/monad-updaters/src/tokio_timestamp.rs
@@ -22,13 +22,13 @@ use std::{
 };
 
 use futures::Stream;
-use monad_consensus_types::signature_collection::SignatureCollection;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{MonadEvent, TimestampCommand};
 use monad_types::ExecutionProtocol;
+use monad_validator::signature_collection::SignatureCollection;
 use tokio::time::{Duration, Interval};
 
 use crate::timestamp::TimestampAdjuster;

--- a/monad-validator/Cargo.toml
+++ b/monad-validator/Cargo.toml
@@ -9,13 +9,15 @@ edition = "2021"
 bench = false
 
 [dependencies]
-monad-consensus-types = { workspace = true }
 monad-crypto = { workspace = true }
 monad-types = { workspace = true }
 
 alloy-primitives = { workspace = true, features = ["rand"] }
+alloy-rlp = { workspace = true }
 as-any = { workspace = true }
 auto_impl = { workspace = true }
+hex = { workspace = true }
+serde = { workspace = true }
 itertools = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }

--- a/monad-validator/src/epoch_manager.rs
+++ b/monad-validator/src/epoch_manager.rs
@@ -22,9 +22,8 @@ use tracing::info;
 /// of each epoch
 #[derive(Debug, Clone)]
 pub struct EpochManager {
-    /// validator set is updated every 'val_set_update_interval'
-    /// blocks
-    pub val_set_update_interval: SeqNum,
+    /// validator set is updated every 'epoch_length' blocks
+    pub epoch_length: SeqNum,
     /// The start of next epoch is 'epoch_start_delay' rounds after
     /// the proposed block
     pub epoch_start_delay: Round,
@@ -35,12 +34,12 @@ pub struct EpochManager {
 
 impl EpochManager {
     pub fn new(
-        val_set_update_interval: SeqNum,
+        epoch_length: SeqNum,
         epoch_start_delay: Round,
         known_epochs: &[(Epoch, Round)],
     ) -> Self {
         let mut epoch_manager = Self {
-            val_set_update_interval,
+            epoch_length,
             epoch_start_delay,
             epoch_starts: BTreeMap::new(),
         };
@@ -69,8 +68,8 @@ impl EpochManager {
 
     /// Schedule next epoch start if the committed block is the last one in the current epoch
     pub fn schedule_epoch_start(&mut self, block_num: SeqNum, block_round: Round) {
-        if block_num.is_epoch_end(self.val_set_update_interval) {
-            let next_epoch = block_num.to_epoch(self.val_set_update_interval) + Epoch(1);
+        if block_num.is_epoch_end(self.epoch_length) {
+            let next_epoch = block_num.to_epoch(self.epoch_length) + Epoch(1);
             let epoch_start_round = block_round + self.epoch_start_delay;
             self.insert_epoch_start(next_epoch, epoch_start_round);
             info!(

--- a/monad-validator/src/lib.rs
+++ b/monad-validator/src/lib.rs
@@ -15,7 +15,9 @@
 
 pub mod epoch_manager;
 pub mod leader_election;
+pub mod signature_collection;
 pub mod simple_round_robin;
+pub mod validator_mapping;
 pub mod validator_set;
 pub mod validators_epoch_mapping;
 pub mod weighted_round_robin;

--- a/monad-validator/src/signature_collection.rs
+++ b/monad-validator/src/signature_collection.rs
@@ -23,7 +23,7 @@ use monad_crypto::{
 use monad_types::NodeId;
 use serde::{Deserialize, Deserializer, Serializer};
 
-use crate::voting::ValidatorMapping;
+use crate::validator_mapping::ValidatorMapping;
 
 pub type SignatureCollectionKeyPairType<SCT> =
     <<SCT as SignatureCollection>::SignatureType as CertificateSignature>::KeyPairType;

--- a/monad-validator/src/validator_mapping.rs
+++ b/monad-validator/src/validator_mapping.rs
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::BTreeMap;
+
+use monad_crypto::certificate_signature::{CertificateKeyPair, PubKey};
+use monad_types::NodeId;
+
+/// Map validator NodeId to its Certificate PubKey
+pub struct ValidatorMapping<PT: PubKey, VKT: CertificateKeyPair> {
+    pub map: BTreeMap<NodeId<PT>, VKT::PubKeyType>,
+}
+
+impl<PT: PubKey, VKT: CertificateKeyPair> ValidatorMapping<PT, VKT> {
+    pub fn new(iter: impl IntoIterator<Item = (NodeId<PT>, VKT::PubKeyType)>) -> Self {
+        Self {
+            map: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl<PT: PubKey, VKT: CertificateKeyPair> IntoIterator for ValidatorMapping<PT, VKT> {
+    type Item = (NodeId<PT>, VKT::PubKeyType);
+    type IntoIter = std::collections::btree_map::IntoIter<NodeId<PT>, VKT::PubKeyType>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.into_iter()
+    }
+}

--- a/monad-validator/src/validators_epoch_mapping.rs
+++ b/monad-validator/src/validators_epoch_mapping.rs
@@ -15,13 +15,13 @@
 
 use std::collections::HashMap;
 
-use monad_consensus_types::{
-    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
-    voting::ValidatorMapping,
-};
 use monad_types::{Epoch, NodeId, Stake};
 
-use crate::validator_set::{ValidatorSetType, ValidatorSetTypeFactory};
+use crate::{
+    signature_collection::{SignatureCollection, SignatureCollectionKeyPairType},
+    validator_mapping::ValidatorMapping,
+    validator_set::{ValidatorSetType, ValidatorSetTypeFactory},
+};
 
 /// A mapping from Epoch -> (Validator Stakes, Validator Certificate Pubkeys).
 pub struct ValidatorsEpochMapping<VTF, SCT>


### PR DESCRIPTION
First PR to be able to read validator set from TrieDB.

- Moved SignatureCollection and ValidatorMapping to `monad-validator`
- Added ST, SCT to StateBackend
- Renamed val_set_update_interval to epoch_length
- Renamed all StateRootHashExecutor (and related types) to ValSetUpdater
