### PR TITLE
Add serialization benchmarks to RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,10 +397,12 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-trie",
+ "arbitrary",
  "auto_impl",
  "c-kzg",
  "derive_more 1.0.0",
  "k256",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -426,6 +428,8 @@ checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "arbitrary",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -437,8 +441,10 @@ checksum = "4c986539255fb839d1533c128e190e557e52ff652c9ef62939e233a81dd93f7e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "arbitrary",
  "derive_more 1.0.0",
  "k256",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -453,6 +459,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "arbitrary",
  "c-kzg",
  "derive_more 1.0.0",
  "once_cell",
@@ -531,9 +538,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "788bb18e8f61d5d9340b52143f27771daf7e1dccbaf2741621d2493f9debf52e"
 dependencies = [
  "alloy-rlp",
+ "arbitrary",
  "bytes",
  "cfg-if",
  "const-hex",
+ "derive_arbitrary",
  "derive_more 1.0.0",
  "foldhash",
  "hashbrown 0.15.4",
@@ -543,6 +552,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
+ "proptest-derive",
  "rand 0.8.5",
  "ruint",
  "rustc-hash 2.1.1",
@@ -652,6 +662,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
+ "arbitrary",
  "derive_more 1.0.0",
  "itertools 0.13.0",
  "serde",
@@ -679,6 +690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5851bf8d5ad33014bd0c45153c603303e730acc8a209450a7ae6b4a12c2789e2"
 dependencies = [
  "alloy-primitives",
+ "arbitrary",
  "serde",
  "serde_json",
 ]
@@ -911,6 +923,15 @@ name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "ark-ff"
@@ -2621,6 +2642,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3841,6 +3873,7 @@ version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
+ "arbitrary",
  "equivalent",
  "hashbrown 0.15.4",
  "serde",
@@ -5315,8 +5348,10 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-signer",
  "alloy-signer-local",
+ "arbitrary",
  "bytes",
  "clap 4.5.40",
+ "criterion",
  "dashmap",
  "env_logger 0.10.2",
  "flume",
@@ -6579,6 +6614,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7082,6 +7128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11256b5fe8c68f56ac6f39ef0720e592f33d2367a4782740d9c9142e889c7fb4"
 dependencies = [
  "alloy-rlp",
+ "arbitrary",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,8 +80,8 @@ monad-validator = { path = "./monad-validator" }
 monad-wal = { path = "./monad-wal" }
 
 actix = "0.13"
-actix-server = "2.5.1"
 actix-http = "3.6.0"
+actix-server = "2.5.1"
 actix-test = "0.1"
 actix-web = "4.5.1"
 actix-web-actors = "4.3.0"
@@ -102,6 +102,7 @@ alloy-sol-macro = "0.8"
 alloy-sol-types = "0.8"
 alloy-transport = "0.8"
 alloy-transport-http = "0.8"
+arbitrary = "1.4.1"
 as-any = "0.3.1"
 async-graphql = "7.0"
 auto_impl = "1.2"

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -77,12 +77,20 @@ optional = true
 [dev-dependencies]
 monad-eth-testutil = { workspace = true }
 
+alloy-consensus = { workspace = true, features = ["arbitrary"] }
 alloy-rpc-client = { workspace = true }
+alloy-rpc-types = { workspace = true, features = ["arbitrary", "k256"] }
 alloy-signer = { workspace = true }
 alloy-signer-local = { workspace = true }
+arbitrary = { workspace = true }
+criterion = { workspace = true }
 reqwest = { workspace = true }
 test-case = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 
 [build-dependencies]
 vergen-git2 = { workspace = true }
+
+[[bench]]
+name = "serialize"
+harness = false

--- a/monad-rpc/benches/serialize.rs
+++ b/monad-rpc/benches/serialize.rs
@@ -1,0 +1,104 @@
+use alloy_primitives::B256;
+use alloy_rpc_types::{Block, BlockTransactions, Log, Transaction, TransactionReceipt};
+use arbitrary::{Arbitrary, Unstructured};
+use criterion::{
+    black_box, criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup,
+    Criterion, Throughput,
+};
+use itertools::Itertools;
+use monad_rpc::{
+    eth_json_types::{serialize_result, MonadBlock, MonadLog, MonadTransactionReceipt},
+    jsonrpc::{Response, ResponseWrapper},
+};
+use serde::Serialize;
+
+fn serialize<T>(value: &T) -> String
+where
+    T: Serialize,
+{
+    let result = serialize_result(value);
+
+    let response = ResponseWrapper::Single(Response::from_result(
+        serde_json::Value::Number(serde_json::Number::from(0u64)),
+        result,
+    ));
+
+    // HttpResponse::Ok().json(&response) in monad-rpc/src/handlers/mod.rs
+    serde_json::to_string(&response).unwrap()
+}
+
+fn bench_serialize<T, M>(g: &mut BenchmarkGroup<'_, M>, name: &'static str, value: &T)
+where
+    T: Serialize,
+    M: Measurement,
+{
+    g.throughput(Throughput::Bytes(serialize(value).as_bytes().len() as u64));
+    g.bench_function(name, |b| {
+        b.iter(|| serialize(black_box(value)));
+    });
+}
+
+fn bench(c: &mut Criterion) {
+    let mut g = c.benchmark_group("serialize");
+
+    g.sample_size(1_000);
+    g.nresamples(1_000_000);
+
+    bench_serialize(
+        &mut g,
+        "block_hashes_1k",
+        &MonadBlock(Block {
+            header: Unstructured::new(&[0]).arbitrary().unwrap(),
+            uncles: vec![],
+            transactions: BlockTransactions::Hashes(
+                (0..1_000u64)
+                    .map(|idx| B256::arbitrary(&mut Unstructured::new(&idx.to_le_bytes())).unwrap())
+                    .collect(),
+            ),
+            withdrawals: None,
+        }),
+    );
+
+    bench_serialize(
+        &mut g,
+        "block_full_1k",
+        &MonadBlock(Block {
+            header: Unstructured::new(&[0]).arbitrary().unwrap(),
+            uncles: vec![],
+            transactions: BlockTransactions::Full(
+                (0..1_000u64)
+                    .map(|idx| {
+                        Transaction::arbitrary(&mut Unstructured::new(&idx.to_le_bytes())).unwrap()
+                    })
+                    .collect(),
+            ),
+            withdrawals: None,
+        }),
+    );
+
+    bench_serialize(
+        &mut g,
+        "block_receipts_1k",
+        &(0..1_000u64)
+            .map(|idx| {
+                MonadTransactionReceipt(
+                    TransactionReceipt::arbitrary(&mut Unstructured::new(&idx.to_le_bytes()))
+                        .unwrap(),
+                )
+            })
+            .collect_vec(),
+    );
+
+    bench_serialize(
+        &mut g,
+        "logs_1k",
+        &(0..1_000u64)
+            .map(|idx| {
+                MonadLog(Log::arbitrary(&mut Unstructured::new(&idx.to_le_bytes())).unwrap())
+            })
+            .collect_vec(),
+    );
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);


### PR DESCRIPTION
These benchmarks are used in subsequent PRs to demonstrate a significant increase in serialization performance.

# Benchmarks
```
serialize/block_hashes_1k
                        time:   [47.971 µs 48.093 µs 48.215 µs]
                        thrpt:  [1.3589 GiB/s 1.3623 GiB/s 1.3658 GiB/s]

serialize/block_full_1k time:   [2.3149 ms 2.3159 ms 2.3168 ms]
                        thrpt:  [181.67 MiB/s 181.75 MiB/s 181.82 MiB/s]

serialize/block_receipts_1k
                        time:   [1.6927 ms 1.6970 ms 1.7011 ms]
                        thrpt:  [487.19 MiB/s 488.39 MiB/s 489.61 MiB/s]

serialize/logs_1k
                        time:   [895.73 µs 895.99 µs 896.30 µs]
                        thrpt:  [208.58 MiB/s 208.66 MiB/s 208.72 MiB/s]
```