### PR TITLE
Use RawValue in RPC response for faster serialization

### DIFF
--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -61,9 +61,9 @@ pin-project = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 reqwest = { workspace = true }
-schemars = { workspace = true, features = ["preserve_order"] }
+schemars = { workspace = true, features = ["preserve_order", "raw_value"] }
 serde = { workspace = true, features = ["derive", "rc"] }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["raw_value"] }
 tokio = { workspace = true, features = ["net", "macros", "rt-multi-thread", "fs"] }
 toml = { workspace = true }
 tracing = { workspace = true, features = ["log"] }

--- a/monad-rpc/src/eth_json_types.rs
+++ b/monad-rpc/src/eth_json_types.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{Address, FixedBytes, LogData, U256};
 use alloy_rpc_types::{Block, FeeHistory, Header, Log, Transaction, TransactionReceipt};
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_json::Value;
+use serde_json::value::RawValue;
 use tracing::debug;
 
 use crate::{
@@ -359,8 +359,8 @@ impl Default for BlockTagOrHash {
     }
 }
 
-pub fn serialize_result<T: Serialize>(value: T) -> Result<Value, JsonRpcError> {
-    serde_json::to_value(value).map_err(|e| {
+pub fn serialize_result<T: Serialize>(value: T) -> Result<Box<RawValue>, JsonRpcError> {
+    serde_json::value::to_raw_value(&value).map_err(|e| {
         debug!("blockdb serialize error {:?}", e);
         JsonRpcError::internal_error(format!("serialization error: {}", e))
     })

--- a/monad-rpc/src/handlers/mod.rs
+++ b/monad-rpc/src/handlers/mod.rs
@@ -1,7 +1,7 @@
 use actix_web::{web, HttpResponse};
 use monad_tracing_timing::TimingSpanExtension;
 use monad_triedb_utils::triedb_env::Triedb;
-use serde_json::Value;
+use serde_json::{value::RawValue, Value};
 use tracing::{debug, info, trace_span, Instrument, Span};
 use tracing_actix_web::RootSpan;
 
@@ -178,7 +178,7 @@ async fn admin_ethCallStatistics(
     _: RequestId,
     app_state: &MonadRpcResources,
     _params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     if app_state.enable_eth_call_statistics {
         let available_permits = app_state.rate_limiter.available_permits();
         if let Some(tracker) = &app_state.eth_call_stats_tracker {
@@ -205,7 +205,7 @@ async fn debug_getRawBlock(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let chain_state = app_state.chain_state.as_ref().method_not_supported()?;
     let params = serde_json::from_value(params).invalid_params()?;
     monad_debug_getRawBlock(chain_state, params)
@@ -218,7 +218,7 @@ async fn debug_getRawHeader(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let chain_state = app_state.chain_state.as_ref().method_not_supported()?;
     let params = serde_json::from_value(params).invalid_params()?;
     monad_debug_getRawHeader(chain_state, params)
@@ -231,7 +231,7 @@ async fn debug_getRawReceipts(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let chain_state = app_state.chain_state.as_ref().method_not_supported()?;
     let params = serde_json::from_value(params).invalid_params()?;
     monad_debug_getRawReceipts(chain_state, params)
@@ -244,7 +244,7 @@ async fn debug_getRawTransaction(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let chain_state = app_state.chain_state.as_ref().method_not_supported()?;
     let params = serde_json::from_value(params).invalid_params()?;
     monad_debug_getRawTransaction(chain_state, params)
@@ -257,7 +257,7 @@ async fn debug_traceBlockByHash(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let triedb_env = app_state.triedb_reader.as_ref().method_not_supported()?;
     let params = serde_json::from_value(params).invalid_params()?;
     monad_debug_traceBlockByHash(triedb_env, &app_state.archive_reader, params)
@@ -270,7 +270,7 @@ async fn debug_traceBlockByNumber(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let triedb_env = app_state.triedb_reader.as_ref().method_not_supported()?;
     let params = serde_json::from_value(params).invalid_params()?;
     monad_debug_traceBlockByNumber(triedb_env, &app_state.archive_reader, params)
@@ -283,7 +283,7 @@ async fn debug_traceCall(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let triedb_env = app_state.triedb_reader.as_ref().method_not_supported()?;
     let Some(ref eth_call_executor) = app_state.eth_call_executor else {
         return Err(JsonRpcError::method_not_supported());
@@ -311,7 +311,7 @@ async fn debug_traceTransaction(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let triedb_env = app_state.triedb_reader.as_ref().method_not_supported()?;
     let params = serde_json::from_value(params).invalid_params()?;
     monad_debug_traceTransaction(triedb_env, &app_state.archive_reader, params)
@@ -324,7 +324,7 @@ async fn eth_call(
     request_id: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let triedb_env = app_state.triedb_reader.as_ref().method_not_supported()?;
     let Some(ref eth_call_executor) = app_state.eth_call_executor else {
         return Err(JsonRpcError::method_not_supported());
@@ -371,7 +371,7 @@ async fn eth_sendRawTransaction(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let params = serde_json::from_value(params).invalid_params()?;
     let triedb_env = app_state.triedb_reader.as_ref().method_not_supported()?;
     monad_eth_sendRawTransaction(
@@ -391,7 +391,7 @@ async fn eth_getLogs(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let triedb_env = app_state.triedb_reader.as_ref().method_not_supported()?;
 
     let params = serde_json::from_value(params).invalid_params()?;
@@ -413,7 +413,7 @@ async fn eth_getTransactionByHash(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     if let Some(chain_state) = app_state.chain_state.as_ref() {
         let params = serde_json::from_value(params).invalid_params()?;
         monad_eth_getTransactionByHash(chain_state, params)
@@ -429,7 +429,7 @@ async fn eth_getBlockByHash(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     if let Some(chain_state) = &app_state.chain_state {
         let params = serde_json::from_value(params).invalid_params()?;
         monad_eth_getBlockByHash(chain_state, params)
@@ -445,7 +445,7 @@ async fn eth_getBlockByNumber(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     if let Some(chain_state) = &app_state.chain_state {
         let params = serde_json::from_value(params).invalid_params()?;
         monad_eth_getBlockByNumber(chain_state, params)
@@ -461,7 +461,7 @@ async fn eth_getTransactionByBlockHashAndIndex(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     if let Some(chain_state) = &app_state.chain_state {
         let params = serde_json::from_value(params).invalid_params()?;
         monad_eth_getTransactionByBlockHashAndIndex(chain_state, params)
@@ -477,7 +477,7 @@ async fn eth_getTransactionByBlockNumberAndIndex(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     if let Some(chain_state) = &app_state.chain_state {
         let params = serde_json::from_value(params).invalid_params()?;
         monad_eth_getTransactionByBlockNumberAndIndex(chain_state, params)
@@ -493,7 +493,7 @@ async fn eth_getBlockTransactionCountByHash(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     if let Some(chain_state) = app_state.chain_state.as_ref() {
         let params = serde_json::from_value(params).invalid_params()?;
         monad_eth_getBlockTransactionCountByHash(chain_state, params)
@@ -509,7 +509,7 @@ async fn eth_getBlockTransactionCountByNumber(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     if let Some(chain_state) = app_state.chain_state.as_ref() {
         let params = serde_json::from_value(params).invalid_params()?;
         monad_eth_getBlockTransactionCountByNumber(chain_state, params)
@@ -525,7 +525,7 @@ async fn eth_getBalance(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     if let Some(reader) = &app_state.triedb_reader {
         let params = serde_json::from_value(params).invalid_params()?;
         monad_eth_getBalance(reader, params)
@@ -541,7 +541,7 @@ async fn eth_getCode(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     if let Some(reader) = &app_state.triedb_reader {
         let params = serde_json::from_value(params).invalid_params()?;
         monad_eth_getCode(reader, params)
@@ -557,7 +557,7 @@ async fn eth_getStorageAt(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     if let Some(reader) = &app_state.triedb_reader {
         let params = serde_json::from_value(params).invalid_params()?;
         monad_eth_getStorageAt(reader, params)
@@ -573,7 +573,7 @@ async fn eth_getTransactionCount(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     if let Some(reader) = &app_state.triedb_reader {
         let params = serde_json::from_value(params).invalid_params()?;
         monad_eth_getTransactionCount(reader, params)
@@ -589,7 +589,7 @@ async fn eth_blockNumber(
     _: RequestId,
     app_state: &MonadRpcResources,
     _params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     if let Some(chain_state) = &app_state.chain_state {
         monad_eth_blockNumber(chain_state)
             .await
@@ -604,7 +604,7 @@ async fn eth_chainId(
     _: RequestId,
     app_state: &MonadRpcResources,
     _params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     monad_eth_chainId(app_state.chain_id)
         .await
         .map(serialize_result)?
@@ -615,7 +615,7 @@ async fn eth_syncing(
     _: RequestId,
     _app_state: &MonadRpcResources,
     _params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     serialize_result(monad_eth_syncing().await)
 }
 
@@ -624,7 +624,7 @@ async fn eth_estimateGas(
     request_id: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let Some(triedb_env) = &app_state.triedb_reader else {
         return Err(JsonRpcError::method_not_supported());
     };
@@ -672,7 +672,7 @@ async fn eth_gasPrice(
     _: RequestId,
     app_state: &MonadRpcResources,
     _params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     if let Some(chain_state) = &app_state.chain_state {
         monad_eth_gasPrice(chain_state)
             .await
@@ -687,7 +687,7 @@ async fn eth_maxPriorityFeePerGas(
     _: RequestId,
     _app_state: &MonadRpcResources,
     _params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     monad_eth_maxPriorityFeePerGas()
         .await
         .map(serialize_result)?
@@ -698,7 +698,7 @@ async fn eth_feeHistory(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     if let Some(chain_state) = &app_state.chain_state {
         let params = serde_json::from_value(params).invalid_params()?;
         monad_eth_feeHistory(chain_state, params)
@@ -714,7 +714,7 @@ async fn eth_getTransactionReceipt(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let Some(chain_state) = &app_state.chain_state else {
         return Err(JsonRpcError::method_not_supported());
     };
@@ -730,7 +730,7 @@ async fn eth_getBlockReceipts(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let chain_state = app_state.chain_state.as_ref().method_not_supported()?;
     let params = serde_json::from_value(params).invalid_params()?;
     monad_eth_getBlockReceipts(chain_state, params)
@@ -743,7 +743,7 @@ async fn net_version(
     _: RequestId,
     app_state: &MonadRpcResources,
     _params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     monad_net_version(app_state.chain_id).map(serialize_result)?
 }
 
@@ -752,7 +752,7 @@ async fn trace_block(
     _: RequestId,
     _app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let params = serde_json::from_value(params).invalid_params()?;
     monad_trace_block(params).await.map(serialize_result)?
 }
@@ -762,7 +762,7 @@ async fn trace_call(
     _: RequestId,
     _app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let params = serde_json::from_value(params).invalid_params()?;
     monad_trace_call(params).await.map(serialize_result)?
 }
@@ -772,7 +772,7 @@ async fn trace_callMany(
     _: RequestId,
     _app_state: &MonadRpcResources,
     _params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     monad_trace_callMany().await.map(serialize_result)?
 }
 
@@ -781,7 +781,7 @@ async fn trace_get(
     _: RequestId,
     _app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let params = serde_json::from_value(params).invalid_params()?;
     monad_trace_get(params).await.map(serialize_result)?
 }
@@ -791,7 +791,7 @@ async fn trace_transaction(
     _: RequestId,
     _app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let params = serde_json::from_value(params).invalid_params()?;
     monad_trace_transaction(params)
         .await
@@ -803,7 +803,7 @@ async fn txpool_statusByHash(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let params = serde_json::from_value(params).invalid_params()?;
     monad_txpool_statusByHash(&app_state.txpool_bridge_client, params)
         .await
@@ -815,7 +815,7 @@ async fn txpool_statusByAddress(
     _: RequestId,
     app_state: &MonadRpcResources,
     params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let params = serde_json::from_value(params).invalid_params()?;
     monad_txpool_statusByAddress(&app_state.txpool_bridge_client, params)
         .await
@@ -827,7 +827,7 @@ async fn web3_clientVersion(
     _: RequestId,
     _app_state: &MonadRpcResources,
     _params: Value,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     monad_web3_client_version().map(serialize_result)?
 }
 
@@ -870,7 +870,7 @@ macro_rules! enabled_methods {
                 request_id: RequestId,
                 app_state: &MonadRpcResources,
                 params: Value,
-            ) -> Result<Value, JsonRpcError> {
+            ) -> Result<Box<RawValue>, JsonRpcError> {
                 match self {
                     $(
                         EnabledMethod::$method => $method(request_id, app_state, params).await,
@@ -931,7 +931,7 @@ async fn rpc_select(
     method: &str,
     params: Value,
     request_id: RequestId,
-) -> Result<Value, JsonRpcError> {
+) -> Result<Box<RawValue>, JsonRpcError> {
     let method: EnabledMethod = method.try_into()?;
     let mut span = method.span();
     if let Some(metrics) = &app_state.metrics {


### PR DESCRIPTION
Previously, we used `serde_json::Value` to generically pass around in-memory JSON objects and effectively "compose" JSON results. This however has a major downside as every RPC handler result would need to be serialized from `T -> serde_json::Value` and then serialized from `serde_json::Value -> String`. For complex / nested JSON structures (most RPC responses), this results in tons of unnecessary allocations to create `serde_json::Value::Map(...)`s and `serde_json::Value::Array(...)`s in addition to requiring the "double partial serialization" mentioned above.

This PR changes `serde_json::Value` to its sibling type `Box<serde_json::value::RawValue>`. `serde_json::value::RawValue` is a thin wrapper around `str` that is hooked into `serde_json` to allow generically passing around serialized JSON objects. Unlike `str` however, serializing a `serde_json::value::RawValue` produces the JSON object itself rather than being serialized as a JSON string and thus adding double quotes around the child JSON object.

By using `serde_json::value::RawValue`, we still get to compose JSON objects but without the massive performance hit of `serde_json::Value` (see benchmark below). The downside is that calling `to_string_pretty(...)` on an object containing a `serde_json::value::RawValue` will not result in a prettified string (and vice-versa) since the JSON is pre-serialized and thus the serialization is a simple string copy. This is not a concern for RPC.

# Benchmark
```
serialize/block_hashes_1k
                        time:   [37.822 µs 37.834 µs 37.848 µs]
                        thrpt:  [1.7311 GiB/s 1.7317 GiB/s 1.7323 GiB/s]
                 change:
                        time:   [-21.533% -21.330% -21.128%] (p = 0.00 < 0.05)
                        thrpt:  [+26.788% +27.114% +27.442%]

serialize/block_full_1k
                        time:   [823.02 µs 823.37 µs 823.74 µs]
                        thrpt:  [510.96 MiB/s 511.19 MiB/s 511.42 MiB/s]
                 change:
                        time:   [-64.467% -64.446% -64.425%] (p = 0.00 < 0.05)
                        thrpt:  [+181.10% +181.27% +181.43%]

serialize/block_receipts_1k
                        time:   [484.54 µs 484.65 µs 484.78 µs]
                        thrpt:  [1.6695 GiB/s 1.6700 GiB/s 1.6703 GiB/s]
                 change:
                        time:   [-71.511% -71.440% -71.369%] (p = 0.00 < 0.05)
                        thrpt:  [+249.27% +250.14% +251.02%]

serialize/logs_1k
                        time:   [132.28 µs 132.49 µs 132.70 µs]
                        thrpt:  [1.3759 GiB/s 1.3780 GiB/s 1.3802 GiB/s]
                 change:
                        time:   [-85.237% -85.213% -85.191%] (p = 0.00 < 0.05)
                        thrpt:  [+575.25% +576.28% +577.35%]
                        Performance has improved.
```