### PR TITLE
Fix double serialize for RPC responses

### DIFF
--- a/monad-rpc/benches/serialize.rs
+++ b/monad-rpc/benches/serialize.rs
@@ -23,8 +23,13 @@ where
         result,
     ));
 
-    // HttpResponse::Ok().json(&response) in monad-rpc/src/handlers/mod.rs
-    serde_json::to_string(&response).unwrap()
+    let response_raw_value = serde_json::value::to_raw_value(&response).unwrap();
+
+    // HttpResponse::Ok().json(response_raw_value) in monad-rpc/src/handlers/mod.rs
+    let ret = serde_json::to_string(&response_raw_value).unwrap();
+    assert_eq!(ret.as_str(), response_raw_value.get());
+
+    ret
 }
 
 fn bench_serialize<T, M>(g: &mut BenchmarkGroup<'_, M>, name: &'static str, value: &T)


### PR DESCRIPTION
At `monad-rpc/src/handlers/mod.rs:142`, we call `serde_json::to_vec(&response)` to check that the JSON body does not exceed the configured `max_response_size`. Afterwards, we return `HttpResponse::Ok().json(&response)` and actix unnecessarily reserializes `response` meaning each request incurs double the serialization cost.

If we use `serde_json::to_string(&response)` to first check the size and then pass the result of that to `.json(...)`, actix will reserialize the string as a JSON string which will wrap each response in double quotes (ie `"{ ... }"` becomes `"\"{ ... }\""`).

Using `serde_json::value::RawValue`, we can call `get()` to retrieve the underlying string to check the length and calling `serde_json::to_string(...)` on a `serde_json::value::RawValue` produces the underlying JSON string through effectively a memcpy and importantly without the double quotes (as demonstrated in the benchmark code).

# Benchmark

Benchmark was updated to call `serde_json` twice like in the new handler method.
Even when compared to previous benchmark results which only serialized once, no change in performance detected.
This implies RPC serialization time should get cut in half.

# Stressnet

The following metrics show the before/after performance of the 1918/1919/1920 changeset. Two methods were repeatedly called, `eth_blockNumber` followed by `eth_getBlockByNumber` for the produced block number.

`eth_getBlockByNumber`: P50 shows a 35% reduction from 2.31ms to 1.50ms with P90 showing a 55% reduction from 4.56ms to 2.05ms.

From the bottom request duration, we observe that previously although some execution for `eth_getBlockByNumber` would fall in the 1-2ms bucket, the overall request would always fall in the 2-5ms bucket. This was due to the reserialization done outside the RPC method handlers when returning the final response (single/batch). The new version's request duration consistently falls in the 1-2ms bucket since the serialization cost is significantly reduced allowing the execution alone to fall within 1-2ms and the reserialization cost for the outside final response has been reduced close to zero.

![serde_raw_value_performance](https://github.com/user-attachments/assets/ff4549f5-7d4d-48dc-a409-7deade145a50)
