### PR TITLE
Add github action concurrency control

### DIFF
--- a/.github/workflows/openrpc.yml
+++ b/.github/workflows/openrpc.yml
@@ -8,6 +8,14 @@ on:
     paths:
       - "monad-rpc/**"
 
+concurrency:
+  group: >
+    ${{
+      github.event_name == 'pull_request'
+      && format('pr-{0}-openrpc', github.event.pull_request.number)
+      || format('push-{0}-openrpc', github.ref)
+    }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,18 @@ on:
     branches: ["master"]
     types: [ opened, synchronize, reopened, edited ]
 
+concurrency:
+  group: >
+    ${{
+      github.event_name == 'merge_group'
+      && format('merge-group-{0}-rust', github.run_id)
+      ||
+        github.event_name == 'pull_request'
+        && format('pr-{0}-rust', github.event.pull_request.number)
+        || format('push-{0}-rust', github.ref)
+    }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
This change makes it so only one of each `rust` or `openrpc` github action can be queued / running for a given pull request. The net effect of this is that pushing to a branch in a PR will cancel the previous run before starting the next.

Example:
https://github.com/category-labs/monad-bft/actions/runs/15947745149
https://github.com/category-labs/monad-bft/actions/runs/15947777608

Additionally, the "edited" trigger type triggers the github actions to run again after editing PR metadata like title / description. Instead of removing just "edited", the entire line was removed which reverts it back to default behavior, that being the remaining three types.

> By default, a workflow only runs when a pull_request event's activity type is `opened`, `synchronize`, or `reopened`.

https://docs.github.com/en/actions/reference/events-that-trigger-workflows