### PR TITLE
monad-raptorcast: add a validation that outbound messages respect protocol size limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5305,6 +5305,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rstest",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -31,6 +31,7 @@ itertools = { workspace = true }
 lru = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
closes: https://github.com/category-labs/monad-bft/issues/1914