### PR TITLE
Refactor peer disc swarm test for more readable initial setup

### DIFF
--- a/monad-crypto/src/lib.rs
+++ b/monad-crypto/src/lib.rs
@@ -6,6 +6,7 @@ pub mod hasher;
 
 pub mod certificate_signature;
 
+#[derive(Clone)]
 pub struct NopKeyPair {
     pubkey: NopPubKey,
 }


### PR DESCRIPTION
our peer disc swarm and peer discovery unit tests is getting very messy because lots of copy pasta during test setup. this refactor does not have functional change, just allows more readable test setup using TestConfig, which would be easier when we have different initial setup for validators & full nodes