### PR TITLE
Reduce full node churn

### DIFF
--- a/docker/devnet/monad/config/node.toml
+++ b/docker/devnet/monad/config/node.toml
@@ -45,8 +45,8 @@ ping_period = 30
 refresh_period = 120
 request_timeout = 5
 prune_threshold = 5
-min_active_connections = 0
-max_active_connections = 200
+min_num_peers = 0
+max_num_peers = 200
 
 [fullnode_dedicated]
 identities = []

--- a/monad-node-config/src/peers.rs
+++ b/monad-node-config/src/peers.rs
@@ -17,6 +17,6 @@ pub struct PeerDiscoveryConfig<ST: CertificateSignatureRecoverable> {
     pub refresh_period: u64,
     pub request_timeout: u64,
     pub prune_threshold: u32,
-    pub min_active_connections: usize,
-    pub max_active_connections: usize,
+    pub min_num_peers: usize,
+    pub max_num_peers: usize,
 }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -34,7 +34,7 @@ use monad_node_config::{
     PeerDiscoveryConfig, SignatureCollectionType, SignatureType,
 };
 use monad_peer_discovery::{
-    discovery::{PeerDiscovery, PeerDiscoveryBuilder, PeerInfo},
+    discovery::{PeerDiscovery, PeerDiscoveryBuilder},
     MonadNameRecord, NameRecord,
 };
 use monad_pprof::start_pprof_server;
@@ -564,7 +564,7 @@ where
     );
 
     // initial set of peers
-    let peer_info = bootstrap_nodes
+    let routing_info = bootstrap_nodes
         .peers
         .iter()
         .filter_map(|peer| {
@@ -593,13 +593,9 @@ where
             {
                 Ok(_) => Some((
                     node_id,
-                    PeerInfo {
-                        last_ping: None,
-                        unresponsive_pings: 0,
-                        name_record: MonadNameRecord {
-                            name_record,
-                            signature: peer.name_record_sig,
-                        },
+                    MonadNameRecord {
+                        name_record,
+                        signature: peer.name_record_sig,
                     },
                 )),
                 Err(_) => {
@@ -689,13 +685,13 @@ where
         current_epoch,
         epoch_validators,
         pinned_full_nodes,
-        peer_info,
+        routing_info,
         ping_period: Duration::from_secs(peer_discovery_config.ping_period),
         refresh_period: Duration::from_secs(peer_discovery_config.refresh_period),
         request_timeout: Duration::from_secs(peer_discovery_config.request_timeout),
         prune_threshold: peer_discovery_config.prune_threshold,
-        min_active_connections: peer_discovery_config.min_active_connections,
-        max_active_connections: peer_discovery_config.max_active_connections,
+        min_num_peers: peer_discovery_config.min_num_peers,
+        max_num_peers: peer_discovery_config.max_num_peers,
         rng: ChaCha8Rng::from_entropy(),
     };
 


### PR DESCRIPTION
Main changes: 
- Split peer information into `peer_info` and `connection_info`, where `peer_info` contains just the name records and `connection_info` contains information of peers where a ping/pong connection is maintained. I am thinking eventually we will store ConfirmGroup information in `connection_info` too, as a heuristics to determine which full nodes to keep/prune
- A node no longer accept incoming name records if current peer list exceeds `max_num_peers`
- A validators will maintain a ping/pong connection with all other validators, while a full node will only maintain a ping/pong connection with 3 (currently hardcoded but can be configurable) upstream validators

Some risks:
- If bootstrap nodes have peers exceeding `max_num_peers`, it will no longer be able to serve bootstrap requests