### PR TITLE
Fix Raptorcast waker usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5409,6 +5409,7 @@ dependencies = [
  "monad-executor-glue",
  "monad-peer-discovery",
  "monad-raptorcast",
+ "tokio",
  "tracing",
 ]
 

--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -34,6 +34,7 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 monad-testutil = { workspace = true }

--- a/monad-raptorcast/src/raptorcast_secondary/client.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/client.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, sync::mpsc::Sender, time::Instant};
+use std::{collections::BTreeMap, time::Instant};
 
 use iset::IntervalMap;
 use monad_crypto::certificate_signature::{
@@ -6,6 +6,7 @@ use monad_crypto::certificate_signature::{
 };
 use monad_executor::ExecutorMetrics;
 use monad_types::{NodeId, Round, RoundSpan, GENESIS_ROUND};
+use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, error, warn};
 
 use super::{
@@ -46,7 +47,7 @@ where
         BTreeMap<Round, BTreeMap<NodeId<CertificateSignaturePubKey<ST>>, PrepareGroup<ST>>>,
 
     // Once a group is confirmed, it is sent to this channel
-    group_sink_channel: Sender<GroupAsClient<ST>>,
+    group_sink_channel: UnboundedSender<GroupAsClient<ST>>,
 
     // For avoiding accepting invites/confirms for rounds we've already started
     curr_round: Round,
@@ -66,7 +67,7 @@ where
 {
     pub fn new(
         client_node_id: NodeId<CertificateSignaturePubKey<ST>>,
-        group_sink_channel: Sender<GroupAsClient<ST>>,
+        group_sink_channel: UnboundedSender<GroupAsClient<ST>>,
         config: RaptorCastConfigSecondaryClient,
     ) -> Self {
         // There's no Instant::zero(). Use a value such that we will accept the

--- a/monad-router-multi/Cargo.toml
+++ b/monad-router-multi/Cargo.toml
@@ -14,3 +14,4 @@ monad-raptorcast = { workspace = true }
 alloy-rlp = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
+tokio = { workspace = true }

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -22,6 +22,7 @@ use monad_raptorcast::{
     util::Group,
     RaptorCast, RaptorCastEvent,
 };
+use tokio::sync::mpsc::unbounded_channel;
 pub use tracing::{debug, error, info, warn, Level};
 
 //==============================================================================
@@ -63,8 +64,8 @@ where
         // Fundamentally this is needed because, while both can send, only the
         // primary can receive data from the network.
         let (send_net_messages, recv_net_messages) =
-            std::sync::mpsc::channel::<FullNodesGroupMessage<ST>>();
-        let (send_group_infos, recv_group_infos) = std::sync::mpsc::channel::<Group<ST>>();
+            unbounded_channel::<FullNodesGroupMessage<ST>>();
+        let (send_group_infos, recv_group_infos) = unbounded_channel::<Group<ST>>();
 
         let rc_secondary = match &cfg.secondary_instance.mode {
             SecondaryRaptorCastModeConfig::None => None,


### PR DESCRIPTION
Part 2 in https://github.com/category-labs/category-internal/issues/1727.

Issues not addressed in this PR:

- Deserializing in `poll_next`
  + supposedly the note suggests that deserialization is expensive and should be offloaded to dedicated blocking threads.
  + not sure how to fix this
- Using `try_recv` from sync channel in a `Stream` instead of an async variant
  + raptorcast uses std::sync::mpsc instead of the tokio's variant so there is no async variant. `try_recv` usage is fine here since it's non-blocking. it's unclear how to make the sender wake the receiving task with std::sync::mpsc.
  + Q: should we switch to tokio and use async mpsc for communication between primary and secondary?
  + implemented in https://github.com/category-labs/monad-bft/pull/1961/commits/3d2d705493144af1b40044da41c59f4b46fd6ef6. please review if such change is desirable.
