### PR TITLE
Pass confirm group to peer discovery for prune heuristics

### DIFF
--- a/docker/devnet/monad/config/node.toml
+++ b/docker/devnet/monad/config/node.toml
@@ -44,7 +44,8 @@ self_name_record_sig = "7911fbf0df1307723c51658349ed396dd6ee28fde925277bae53fcd7
 ping_period = 30
 refresh_period = 120
 request_timeout = 5
-prune_threshold = 5
+unresponsive_prune_threshold = 5
+last_participation_prune_threshold = 5000
 min_num_peers = 0
 max_num_peers = 200
 

--- a/docs/peer_discovery.md
+++ b/docs/peer_discovery.md
@@ -109,5 +109,6 @@ struct PeerLookupResponse {
 
 - Peer pruning is performed periodically/triggered by high watermark to keep peers manageable
 - Nodes that do not respond to consecutive pings beyond a threshold are pruned
+- Nodes that have not participated in secondary raptorcast beyond a threshold are pruned
 - Random full nodes are pruned if we're still above high watermark
 - Currently validators for the current and next epoch, and dedicated full nodes are not pruned even if unresponsive or total number of peers is above high watermark

--- a/monad-node-config/src/peers.rs
+++ b/monad-node-config/src/peers.rs
@@ -1,5 +1,5 @@
 use monad_crypto::certificate_signature::CertificateSignatureRecoverable;
-use monad_types::{deserialize_certificate_signature, serialize_certificate_signature};
+use monad_types::{deserialize_certificate_signature, serialize_certificate_signature, Round};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -16,7 +16,8 @@ pub struct PeerDiscoveryConfig<ST: CertificateSignatureRecoverable> {
     pub ping_period: u64,
     pub refresh_period: u64,
     pub request_timeout: u64,
-    pub prune_threshold: u32,
+    pub unresponsive_prune_threshold: u32,
+    pub last_participation_prune_threshold: Round,
     pub min_num_peers: usize,
     pub max_num_peers: usize,
 }

--- a/monad-peer-disc-swarm/src/driver.rs
+++ b/monad-peer-disc-swarm/src/driver.rs
@@ -152,13 +152,16 @@ where
                 target,
                 lookup_id,
             } => self.algo.handle_peer_lookup_timeout(to, target, lookup_id),
-            PeerDiscoveryEvent::UpdateCurrentEpoch { epoch } => {
-                self.algo.update_current_epoch(epoch)
+            PeerDiscoveryEvent::UpdateCurrentRound { round, epoch } => {
+                self.algo.update_current_round(round, epoch)
             }
             PeerDiscoveryEvent::UpdateValidatorSet { epoch, validators } => {
                 self.algo.update_validator_set(epoch, validators)
             }
             PeerDiscoveryEvent::UpdatePeers { peers } => self.algo.update_peers(peers),
+            PeerDiscoveryEvent::UpdateConfirmGroup { end_round, peers } => {
+                self.algo.update_peer_participation(end_round, peers)
+            }
             PeerDiscoveryEvent::Refresh => self.algo.refresh(),
         };
 

--- a/monad-peer-discovery/src/driver.rs
+++ b/monad-peer-discovery/src/driver.rs
@@ -180,11 +180,16 @@ impl<PD: PeerDiscoveryAlgo> PeerDiscoveryDriver<PD> {
                 target,
                 lookup_id,
             } => self.pd.handle_peer_lookup_timeout(to, target, lookup_id),
-            PeerDiscoveryEvent::UpdateCurrentEpoch { epoch } => self.pd.update_current_epoch(epoch),
+            PeerDiscoveryEvent::UpdateCurrentRound { round, epoch } => {
+                self.pd.update_current_round(round, epoch)
+            }
             PeerDiscoveryEvent::UpdateValidatorSet { epoch, validators } => {
                 self.pd.update_validator_set(epoch, validators)
             }
             PeerDiscoveryEvent::UpdatePeers { peers } => self.pd.update_peers(peers),
+            PeerDiscoveryEvent::UpdateConfirmGroup { end_round, peers } => {
+                self.pd.update_peer_participation(end_round, peers)
+            }
             PeerDiscoveryEvent::Refresh => self.pd.refresh(),
         };
 

--- a/monad-peer-discovery/src/mock.rs
+++ b/monad-peer-discovery/src/mock.rs
@@ -9,7 +9,7 @@ use monad_crypto::certificate_signature::{
 };
 use monad_executor::ExecutorMetrics;
 use monad_executor_glue::PeerEntry;
-use monad_types::{Epoch, NodeId};
+use monad_types::{Epoch, NodeId, Round};
 use tracing::debug;
 
 use crate::{
@@ -152,8 +152,12 @@ where
         Vec::new()
     }
 
-    fn update_current_epoch(&mut self, epoch: Epoch) -> Vec<PeerDiscoveryCommand<ST>> {
-        debug!(?epoch, "updating current epoch");
+    fn update_current_round(
+        &mut self,
+        round: Round,
+        epoch: Epoch,
+    ) -> Vec<PeerDiscoveryCommand<ST>> {
+        debug!(?round, ?epoch, "updating current round");
 
         Vec::new()
     }
@@ -175,6 +179,16 @@ where
             let node_id = NodeId::new(peer.pubkey);
             self.known_addresses.insert(node_id, peer.addr);
         }
+
+        Vec::new()
+    }
+
+    fn update_peer_participation(
+        &mut self,
+        round: Round,
+        peers: BTreeSet<NodeId<CertificateSignaturePubKey<ST>>>,
+    ) -> Vec<PeerDiscoveryCommand<ST>> {
+        debug!(?round, ?peers, "updating peer participation");
 
         Vec::new()
     }

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -309,7 +309,7 @@ where
                         self.peer_discovery_driver
                             .lock()
                             .unwrap()
-                            .update(PeerDiscoveryEvent::UpdateCurrentEpoch { epoch });
+                            .update(PeerDiscoveryEvent::UpdateCurrentRound { round, epoch });
                     }
                 }
                 RouterCommand::AddEpochValidatorSet {


### PR DESCRIPTION
Main changes:
- Pass confirm group to peer discovery. This help a node to prune full nodes that have not participated beyond a threshold (configurable in node.toml).
- Full nodes only send pings to a few upstream validators. Full nodes do not send pings to other full nodes