### PR TITLE
Record checkpoint upon finalization

### DIFF
--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -21,7 +21,7 @@ use monad_consensus_state::{
     command::ConsensusCommand, timestamp::BlockTimestamp, ConsensusConfig, ConsensusState,
 };
 use monad_consensus_types::{
-    block::{BlockPolicy, OptimisticCommit},
+    block::{BlockPolicy, OptimisticCommit, OptimisticPolicyCommit},
     block_validator::BlockValidator,
     checkpoint::{Checkpoint, LockedEpoch},
     metrics::Metrics,
@@ -863,7 +863,15 @@ where
 
                 let take_checkpoint = consensus_cmds
                     .iter()
-                    .find(|cmd| matches!(cmd.command, ConsensusCommand::EnterRound(_, _)))
+                    .find(|cmd| {
+                        matches!(
+                            cmd.command,
+                            ConsensusCommand::EnterRound(_, _)
+                                | ConsensusCommand::CommitBlocks(
+                                    OptimisticPolicyCommit::Finalized(_)
+                                )
+                        )
+                    })
                     .is_some();
 
                 let mut cmds = consensus_cmds


### PR DESCRIPTION
We currently only record checkpoints when high_certificate is bumped, and a new round is entered. The checkpoint also includes the blocktree root, so we should also record checkpoints upon finalization.

This matters because it's possible to enter round r through TC(r-1), later observe a QC(r-1), and then finalize blocks from the QC without entering a new round.

Recording the checkpoint atomically upon finalizing guarantees that a graceful shutdown will not leave forkpoint and finalized_head in an inconsistent state.