### PR TITLE
monad-secp: add function to recover address using secp256k1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4825,6 +4825,7 @@ dependencies = [
  "monad-eth-block-policy",
  "monad-eth-testutil",
  "monad-eth-types",
+ "monad-secp",
  "monad-state-backend",
  "monad-testutil",
  "rayon",
@@ -4947,6 +4948,7 @@ dependencies = [
  "monad-eth-types",
  "monad-executor",
  "monad-executor-glue",
+ "monad-secp",
  "monad-state-backend",
  "monad-types",
  "monad-updaters",
@@ -5482,12 +5484,17 @@ dependencies = [
 name = "monad-secp"
 version = "0.1.0"
 dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
  "alloy-rlp",
+ "alloy-signer",
+ "alloy-signer-local",
  "criterion",
  "hex",
  "monad-crypto",
  "monad-testutil",
  "rand 0.8.5",
+ "rstest",
  "secp256k1 0.26.0",
  "tiny-keccak",
  "zeroize",

--- a/monad-eth-block-validator/Cargo.toml
+++ b/monad-eth-block-validator/Cargo.toml
@@ -13,9 +13,10 @@ monad-consensus-types = { workspace = true }
 monad-crypto = { workspace = true }
 monad-eth-block-policy = { workspace = true }
 monad-eth-types = { workspace = true }
+monad-secp = { workspace = true }
 monad-state-backend = { workspace = true }
 
-alloy-consensus = { workspace = true, features = ["k256"] }
+alloy-consensus = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }
 rayon = { workspace = true }

--- a/monad-eth-block-validator/src/lib.rs
+++ b/monad-eth-block-validator/src/lib.rs
@@ -23,6 +23,7 @@ use monad_eth_block_policy::{
 use monad_eth_types::{
     EthBlockBody, EthExecutionProtocol, Nonce, ProposedEthHeader, BASE_FEE_PER_GAS,
 };
+use monad_secp::RecoverableAddress;
 use monad_state_backend::StateBackend;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use tracing::warn;
@@ -91,10 +92,10 @@ where
         let eth_txns: Vec<Recovered<TxEnvelope>> = transactions
             .into_par_iter()
             .map(|tx| {
-                let signer = tx.recover_signer()?;
+                let signer = tx.secp256k1_recover()?;
                 Ok(Recovered::new_unchecked(tx.clone(), signer))
             })
-            .collect::<Result<_, alloy_primitives::SignatureError>>()
+            .collect::<Result<_, monad_secp::Error>>()
             .map_err(|_err| BlockValidationError::TxnError)?;
 
         // recover the account nonces and txn fee usage in this block

--- a/monad-eth-txpool-executor/Cargo.toml
+++ b/monad-eth-txpool-executor/Cargo.toml
@@ -19,11 +19,12 @@ monad-eth-txpool-types = { workspace = true }
 monad-eth-types = { workspace = true }
 monad-executor = { workspace = true }
 monad-executor-glue = { workspace = true }
+monad-secp = { workspace = true }
 monad-state-backend = { workspace = true }
 monad-types = { workspace = true }
 monad-updaters = { workspace = true, features = ["tokio"] }
 
-alloy-consensus = { workspace = true, features = ["k256"] }
+alloy-consensus = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }
 bytes = { workspace = true }

--- a/monad-eth-txpool-executor/src/lib.rs
+++ b/monad-eth-txpool-executor/src/lib.rs
@@ -26,6 +26,7 @@ use monad_eth_txpool_types::{EthTxPoolDropReason, EthTxPoolEvent};
 use monad_eth_types::EthExecutionProtocol;
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{MempoolEvent, MonadEvent, TxPoolCommand};
+use monad_secp::RecoverableAddress;
 use monad_state_backend::StateBackend;
 use monad_types::DropTimer;
 use monad_updaters::TokioTaskUpdater;
@@ -307,7 +308,7 @@ where
                                 return None;
                             };
 
-                            let Ok(signer) = tx.recover_signer() else {
+                            let Ok(signer) = tx.secp256k1_recover() else {
                                 num_invalid_signer
                                     .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                                 return None;
@@ -469,7 +470,7 @@ where
             let recovered_txs = {
                 let (recovered_txs, dropped_txs): (Vec<_>, Vec<_>) = unvalidated_txs
                     .into_par_iter()
-                    .partition_map(|tx| match tx.recover_signer() {
+                    .partition_map(|tx| match tx.secp256k1_recover() {
                         Ok(signer) => {
                             rayon::iter::Either::Left(Recovered::new_unchecked(tx, signer))
                         }

--- a/monad-secp/Cargo.toml
+++ b/monad-secp/Cargo.toml
@@ -11,6 +11,8 @@ bench = false
 [dependencies]
 monad-crypto = { workspace = true }
 
+alloy-consensus = { workspace = true }
+alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }
 secp256k1 = { workspace = true, features = ["global-context", "recovery"] }
 zeroize = { workspace = true }
@@ -18,9 +20,13 @@ zeroize = { workspace = true }
 [dev-dependencies]
 monad-testutil = { workspace = true }
 
+alloy-consensus = { workspace = true }
+alloy-signer = { workspace = true }
+alloy-signer-local = { workspace = true }
 criterion = { workspace = true }
 hex = { workspace = true }
 rand = { workspace = true }
+rstest = { workspace = true }
 tiny-keccak = { workspace = true, features = ["keccak"] }
 
 [[bench]]

--- a/monad-secp/benches/secp.rs
+++ b/monad-secp/benches/secp.rs
@@ -1,6 +1,10 @@
+use alloy_consensus::{SignableTransaction, Signed, TxEnvelope, TxLegacy};
+use alloy_primitives::{Address, Bytes, PrimitiveSignature, U256};
+use alloy_signer::{k256::ecdsa::SigningKey, SignerSync};
+use alloy_signer_local::PrivateKeySigner;
 use criterion::{criterion_group, criterion_main, Criterion};
 use monad_crypto::hasher::{Hasher, HasherType};
-use monad_secp::{KeyPair, SecpSignature};
+use monad_secp::{KeyPair, RecoverableAddress, SecpSignature};
 use monad_testutil::signing::get_key;
 use rand::{thread_rng, RngCore};
 
@@ -51,6 +55,76 @@ fn criterion_benchmark(c: &mut Criterion) {
             |(sig, pubkey)| pubkey.verify(data.as_ref(), &sig),
             criterion::BatchSize::SmallInput,
         )
+    });
+
+    benchmark_tx_signature_verification(c);
+}
+
+fn create_legacy_tx() -> TxLegacy {
+    let mut rng = thread_rng();
+    let mut to_bytes = [0u8; 20];
+    rng.fill_bytes(&mut to_bytes);
+
+    let mut data = vec![0u8; 200];
+    rng.fill_bytes(&mut data);
+
+    TxLegacy {
+        chain_id: Some(1),
+        nonce: 42,
+        gas_price: 20_000_000_000,
+        gas_limit: 100_000,
+        to: Address::from(to_bytes).into(),
+        value: U256::from(1_000_000_000_000_000_000u64),
+        input: Bytes::from(data),
+    }
+}
+
+fn create_invalid_signature() -> PrimitiveSignature {
+    let invalid_r = U256::from_be_bytes([
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff,
+    ]);
+    let invalid_s = U256::from_be_bytes([
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff,
+    ]);
+    PrimitiveSignature::new(invalid_r, invalid_s, false)
+}
+
+fn benchmark_tx_signature_verification(c: &mut Criterion) {
+    let mut rng = thread_rng();
+
+    c.bench_function("tx_secp256k1_verify_success", |b| {
+        let pk = SigningKey::random(&mut rng);
+        let signer = PrivateKeySigner::from_signing_key(pk);
+        let tx = create_legacy_tx();
+        let signature_hash = tx.signature_hash();
+        let signature = signer.sign_hash_sync(&signature_hash).unwrap();
+        let signed_tx: TxEnvelope = Signed::new_unchecked(tx, signature, signature_hash).into();
+
+        b.iter(|| signed_tx.secp256k1_recover().unwrap())
+    });
+
+    c.bench_function("tx_secp256k1_verify_fail", |b| {
+        let tx = create_legacy_tx();
+        let signature_hash = tx.signature_hash();
+        let invalid_sig = create_invalid_signature();
+        let signed_tx: TxEnvelope = Signed::new_unchecked(tx, invalid_sig, signature_hash).into();
+
+        b.iter(|| signed_tx.secp256k1_recover().is_err())
+    });
+
+    c.bench_function("tx_alloy_recover_success", |b| {
+        let pk = SigningKey::random(&mut rng);
+        let signer = PrivateKeySigner::from_signing_key(pk);
+        let tx = create_legacy_tx();
+        let signature_hash = tx.signature_hash();
+        let signature = signer.sign_hash_sync(&signature_hash).unwrap();
+        let signed_tx: TxEnvelope = Signed::new_unchecked(tx, signature, signature_hash).into();
+
+        b.iter(|| signed_tx.recover_signer().unwrap())
     });
 }
 

--- a/monad-secp/src/lib.rs
+++ b/monad-secp/src/lib.rs
@@ -1,9 +1,12 @@
+mod recoverable_address;
 mod secp;
+
 use alloy_rlp::{Decodable, Encodable};
 use monad_crypto::certificate_signature::{
     self, CertificateKeyPair, CertificateSignature, CertificateSignaturePubKey,
     CertificateSignatureRecoverable,
 };
+pub use recoverable_address::RecoverableAddress;
 pub use secp::{Error, KeyPair, PubKey, SecpSignature};
 
 impl std::fmt::Display for PubKey {

--- a/monad-secp/src/recoverable_address.rs
+++ b/monad-secp/src/recoverable_address.rs
@@ -1,0 +1,213 @@
+use alloy_consensus::TxEnvelope;
+use alloy_primitives::{keccak256, Address};
+use secp256k1::{
+    ecdsa::{RecoverableSignature, RecoveryId},
+    Message, Secp256k1,
+};
+
+use crate::Error;
+
+pub trait RecoverableAddress {
+    fn secp256k1_recover(&self) -> Result<Address, Error>;
+}
+
+impl RecoverableAddress for TxEnvelope {
+    fn secp256k1_recover(&self) -> Result<Address, Error> {
+        let signature_hash = self.signature_hash();
+        let secp_message = Message::from_slice(signature_hash.as_ref())?;
+
+        let secp = Secp256k1::new();
+
+        let signature = self.signature().as_bytes();
+        let recid = self.signature().recid().to_byte();
+
+        let recoverable_sig = RecoverableSignature::from_compact(
+            &signature[0..64],
+            RecoveryId::from_i32(recid as i32)?,
+        )?;
+
+        let recovered_pubkey = secp.recover_ecdsa(&secp_message, &recoverable_sig)?;
+        let recovered_pubkey_bytes = recovered_pubkey.serialize_uncompressed();
+        let recovered_hash = keccak256(&recovered_pubkey_bytes[1..]);
+        Ok(Address::from_slice(&recovered_hash[12..]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::{
+        SignableTransaction, Signed, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip7702,
+        TxLegacy,
+    };
+    use alloy_primitives::{Bytes, PrimitiveSignature, U256};
+    use alloy_signer::{k256::ecdsa::SigningKey, SignerSync};
+    use alloy_signer_local::PrivateKeySigner;
+    use rand::{thread_rng, Rng};
+    use rstest::rstest;
+
+    use super::*;
+
+    fn generate_random_private_key() -> SigningKey {
+        let mut rng = thread_rng();
+        SigningKey::random(&mut rng)
+    }
+
+    fn generate_random_address() -> Address {
+        let mut rng = thread_rng();
+        let mut bytes = [0u8; 20];
+        rng.fill(&mut bytes);
+        Address::from(bytes)
+    }
+
+    fn create_legacy_tx() -> TxLegacy {
+        TxLegacy {
+            chain_id: Some(1),
+            nonce: 42,
+            gas_price: 20_000_000_000,
+            gas_limit: 21_000,
+            to: generate_random_address().into(),
+            value: U256::from(1_000_000_000_000_000_000u64),
+            input: Bytes::from(vec![0x12, 0x34, 0x56, 0x78]),
+        }
+    }
+
+    fn create_eip2930_tx() -> TxEip2930 {
+        TxEip2930 {
+            chain_id: 1,
+            nonce: 42,
+            gas_price: 20_000_000_000,
+            gas_limit: 21_000,
+            to: generate_random_address().into(),
+            value: U256::from(1_000_000_000_000_000_000u64),
+            input: Bytes::from(vec![0x12, 0x34, 0x56, 0x78]),
+            access_list: Default::default(),
+        }
+    }
+
+    fn create_eip1559_tx() -> TxEip1559 {
+        TxEip1559 {
+            chain_id: 1,
+            nonce: 42,
+            max_priority_fee_per_gas: 1_500_000_000,
+            max_fee_per_gas: 30_000_000_000,
+            gas_limit: 100_000,
+            to: generate_random_address().into(),
+            value: U256::from(1_000_000_000_000_000_000u64),
+            input: Bytes::from(vec![0x12, 0x34, 0x56, 0x78]),
+            access_list: Default::default(),
+        }
+    }
+
+    fn create_eip4844_tx() -> TxEip4844 {
+        TxEip4844 {
+            chain_id: 1,
+            nonce: 42,
+            max_priority_fee_per_gas: 1_500_000_000,
+            max_fee_per_gas: 30_000_000_000,
+            gas_limit: 100_000,
+            to: generate_random_address(),
+            value: U256::from(1_000_000_000_000_000_000u64),
+            input: Bytes::from(vec![0x12, 0x34, 0x56, 0x78]),
+            access_list: Default::default(),
+            blob_versioned_hashes: vec![],
+            max_fee_per_blob_gas: 1_000_000_000,
+        }
+    }
+
+    fn create_eip7702_tx() -> TxEip7702 {
+        TxEip7702 {
+            chain_id: 1,
+            nonce: 42,
+            max_priority_fee_per_gas: 1_500_000_000,
+            max_fee_per_gas: 30_000_000_000,
+            gas_limit: 100_000,
+            to: generate_random_address(),
+            value: U256::from(1_000_000_000_000_000_000u64),
+            input: Bytes::from(vec![0x12, 0x34, 0x56, 0x78]),
+            access_list: Default::default(),
+            authorization_list: vec![],
+        }
+    }
+
+    enum TestTransaction {
+        Legacy(TxLegacy),
+        Eip2930(TxEip2930),
+        Eip1559(TxEip1559),
+        Eip4844(TxEip4844),
+        Eip7702(TxEip7702),
+    }
+
+    impl TestTransaction {
+        fn sign(self, signer: &PrivateKeySigner) -> TxEnvelope {
+            fn sign_tx<T: SignableTransaction<PrimitiveSignature>>(
+                tx: T,
+                signer: &PrivateKeySigner,
+            ) -> (T, PrimitiveSignature, alloy_primitives::FixedBytes<32>) {
+                let signature_hash = tx.signature_hash();
+                let signature = signer.sign_hash_sync(&signature_hash).unwrap();
+                (tx, signature, signature_hash)
+            }
+
+            match self {
+                TestTransaction::Legacy(tx) => {
+                    let (tx, sig, hash) = sign_tx(tx, signer);
+                    Signed::new_unchecked(tx, sig, hash).into()
+                }
+                TestTransaction::Eip2930(tx) => {
+                    let (tx, sig, hash) = sign_tx(tx, signer);
+                    Signed::new_unchecked(tx, sig, hash).into()
+                }
+                TestTransaction::Eip1559(tx) => {
+                    let (tx, sig, hash) = sign_tx(tx, signer);
+                    Signed::new_unchecked(tx, sig, hash).into()
+                }
+                TestTransaction::Eip4844(tx) => {
+                    let (tx, sig, hash) = sign_tx(tx, signer);
+                    Signed::new_unchecked(TxEip4844Variant::TxEip4844(tx), sig, hash).into()
+                }
+                TestTransaction::Eip7702(tx) => {
+                    let (tx, sig, hash) = sign_tx(tx, signer);
+                    Signed::new_unchecked(tx, sig, hash).into()
+                }
+            }
+        }
+    }
+
+    #[rstest]
+    #[case::legacy(TestTransaction::Legacy(create_legacy_tx()))]
+    #[case::eip2930(TestTransaction::Eip2930(create_eip2930_tx()))]
+    #[case::eip1559(TestTransaction::Eip1559(create_eip1559_tx()))]
+    #[case::eip4844(TestTransaction::Eip4844(create_eip4844_tx()))]
+    #[case::eip7702(TestTransaction::Eip7702(create_eip7702_tx()))]
+    fn test_tx_envelope_recovery(#[case] test_tx: TestTransaction) {
+        let pk = generate_random_private_key();
+        let signer = PrivateKeySigner::from_signing_key(pk);
+        let expected_address = signer.address();
+
+        let signed_tx = test_tx.sign(&signer);
+
+        let recovered_address = signed_tx.secp256k1_recover().unwrap();
+        assert_eq!(recovered_address, expected_address);
+    }
+
+    #[test]
+    fn test_invalid_signature_recovery() {
+        let tx = create_legacy_tx();
+        let signature_hash = tx.signature_hash();
+
+        let invalid_r = U256::from_be_bytes([
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff,
+        ]);
+        let invalid_s = U256::from_be_bytes([
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff,
+        ]);
+
+        let invalid_sig = PrimitiveSignature::new(invalid_r, invalid_s, false);
+        let signed_tx: TxEnvelope = Signed::new_unchecked(tx, invalid_sig, signature_hash).into();
+        assert!(signed_tx.secp256k1_recover().is_err());
+    }
+}

--- a/monad-secp/src/secp.rs
+++ b/monad-secp/src/secp.rs
@@ -16,6 +16,12 @@ pub struct SecpSignature(secp256k1::ecdsa::RecoverableSignature);
 #[derive(Debug, Clone)]
 pub struct Error(secp256k1::Error);
 
+impl From<secp256k1::Error> for Error {
+    fn from(value: secp256k1::Error) -> Self {
+        Error(value)
+    }
+}
+
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)


### PR DESCRIPTION
related: https://github.com/category-labs/category-internal/issues/1219

for 5000 txs with alloy recover signature verification was taking around ~140ms on 8 workers

<img width="2932" height="761" alt="image" src="https://github.com/user-attachments/assets/cbb47d0a-38ee-4d4f-9ebc-29cfb190b939" />

with secp256k1 it is reduced to ~35ms with 8 workers

<img width="2932" height="761" alt="image" src="https://github.com/user-attachments/assets/709d95ed-0a84-470a-b695-8203628cf676" />

there is also a problem of variability due frequent preemption, additional copying and rayon synchronization overhead. those things also can be tuned.