### PR TITLE
Relax statesync short-circuit to root executed

### DIFF
--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -234,22 +234,6 @@ where
     pub _phantom: PhantomData<CRT>,
 }
 
-/// Actions after state root validation
-#[derive(Debug)]
-pub enum StateRootAction {
-    /// StateRoot validation is successful, proceed to next steps
-    Proceed,
-    /// StateRoot validation is unsuccessful - there's a mismatch of StateRoots.
-    /// Reject the proposal immediately
-    Reject,
-    /// StateRoot validation is undecided - we haven't collect enough
-    /// information. Either the state root is missing because we haven't
-    /// received a majority quorum on the state root, or the state root is
-    /// out-of-range. It's ok to insert to the block tree and observe if a QC
-    /// forms on the block. But we shouldn't vote on the block
-    Defer,
-}
-
 impl<ST, SCT, EPT, BPT, SBT, CCT, CRT> ConsensusState<ST, SCT, EPT, BPT, SBT, CCT, CRT>
 where
     ST: CertificateSignatureRecoverable,

--- a/monad-mock-swarm/tests/forkpoint.rs
+++ b/monad-mock-swarm/tests/forkpoint.rs
@@ -138,7 +138,6 @@ fn test_forkpoint_restart_f_simple_blocksync() {
     );
 }
 
-#[ignore]
 // execution is delayed longer than state_root_delay
 // ensure that we don't statesync
 #[test]
@@ -483,7 +482,9 @@ fn forkpoint_restart_f(
             NoSerRouterConfig::new(all_peers.clone()).build(),
             MockValSetUpdaterNop::new(validators.clone(), epoch_length),
             MockTxPoolExecutor::new(create_block_policy(), restart_builder_state_backend.clone()),
-            MockLedger::new(restart_builder_state_backend.clone()),
+            MockLedger::new(restart_builder_state_backend.clone())
+                .with_finalization_delay(finalization_delay)
+                .with_blocks(failed_node.executor.ledger()),
             MockStateSyncExecutor::new(
                 restart_builder_state_backend,
                 validators

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -62,7 +62,7 @@ use monad_executor_glue::{
 use monad_state_backend::StateBackend;
 use monad_types::{
     Epoch, ExecutionProtocol, MonadVersion, NodeId, Round, RouterTarget, SeqNum, GENESIS_BLOCK_ID,
-    GENESIS_ROUND,
+    GENESIS_ROUND, GENESIS_SEQ_NUM,
 };
 use monad_validator::{
     epoch_manager::EpochManager,
@@ -1026,20 +1026,8 @@ where
                     match maybe_target {
                         Some(target) if n >= target => {
                             assert_eq!(n, target);
-                            assert!(
-                                self.state_backend
-                                    .raw_read_earliest_finalized_block()
-                                    .expect("earliest_finalized doesn't exist")
-                                    <= n
-                            );
-                            assert!(
-                                self.state_backend
-                                    .raw_read_latest_finalized_block()
-                                    .expect("latest_finalized doesn't exist")
-                                    >= n
-                            );
 
-                            tracing::info!(?n, "done db statesync");
+                            tracing::info!(?target, ?n, "done db statesync");
                             *db_status = DbSyncStatus::Done;
 
                             self.maybe_start_consensus()
@@ -1200,48 +1188,59 @@ where
 
         if db_status == &DbSyncStatus::Waiting {
             *db_status = DbSyncStatus::Started;
+
             let delay = self.consensus_config.execution_delay;
-            let state_root_seq_num = root_seq_num.max(delay) - delay;
+            let delay_seq_num = root_seq_num.max(delay) - delay;
 
-            let latest_block = self.state_backend.raw_read_latest_finalized_block();
-            assert!(
-                latest_block.unwrap_or(SeqNum(0)) <= root_seq_num,
-                "tried to statesync backwards: {latest_block:?} <= {root_seq_num:?}"
-            );
+            let delay_block_id = {
+                let delay_child_seq_num = delay_seq_num + SeqNum(1);
 
-            if latest_block.is_none()
-                || latest_block.is_some_and(|latest_block| latest_block < state_root_seq_num)
-            {
-                let delayed_execution_result = block_buffer
-                    .root_delayed_execution_result()
-                    .expect("is DB state empty? use execution to populate genesis if so");
-                assert_eq!(
-                    delayed_execution_result.len(),
-                    1,
-                    "always 1 execution result after first k-1 blocks for now"
-                );
-                self.metrics.consensus_events.trigger_state_sync += 1;
-                return vec![Command::StateSyncCommand(StateSyncCommand::RequestSync(
-                    delayed_execution_result
-                        .first()
-                        .expect("asserted 1 execution result")
-                        .clone(),
-                ))];
-            } else {
-                // if latest_block > state_root_seq_num, we can't RequestSync because we
-                // would be trying to sync backwards.
+                let delay_child_block = root_parent_chain
+                    .iter()
+                    .find(|block| block.get_seq_num() == delay_child_seq_num);
 
-                assert!(
-                    self.state_backend
-                        .raw_read_earliest_finalized_block()
-                        .expect("latest_finalized_block exists")
-                        <= state_root_seq_num
-                );
+                delay_child_block
+                    .map(|block| block.get_parent_id())
+                    .unwrap_or_else(|| {
+                        assert_eq!(
+                            root_seq_num,
+                            GENESIS_SEQ_NUM,
+                            "Root parent chain always contains `delay` blocks when `root_seq_num >= delay`"
+                        );
+
+                        GENESIS_BLOCK_ID
+                    })
+            };
+
+            // We use get_execution_result as a proxy to determine if the delay_block has been executed.
+            let delay_executed = self
+                .state_backend
+                .get_execution_result(&delay_block_id, &delay_seq_num, true)
+                .is_ok();
+
+            if delay_executed {
                 // TODO assert state root matches?
                 return self.update(MonadEvent::StateSyncEvent(StateSyncEvent::DoneSync(
-                    state_root_seq_num,
+                    delay_seq_num,
                 )));
             }
+
+            let delayed_execution_result = block_buffer
+                .root_delayed_execution_result()
+                .expect("is DB state empty? use execution to populate genesis if so");
+            assert_eq!(
+                delayed_execution_result.len(),
+                1,
+                "always 1 execution result after first k-1 blocks for now"
+            );
+
+            self.metrics.consensus_events.trigger_state_sync += 1;
+            return vec![Command::StateSyncCommand(StateSyncCommand::RequestSync(
+                delayed_execution_result
+                    .first()
+                    .expect("asserted 1 execution result")
+                    .clone(),
+            ))];
         } else if db_status == &DbSyncStatus::Started {
             tracing::info!(
                 ?db_status,

--- a/monad-updaters/src/ledger.rs
+++ b/monad-updaters/src/ledger.rs
@@ -124,6 +124,12 @@ where
         }
     }
 
+    pub fn with_blocks(mut self, old_ledger: &Self) -> Self {
+        self.blocks = old_ledger.blocks.clone();
+        self.committed_blocks = old_ledger.committed_blocks.clone();
+        self
+    }
+
     pub fn with_finalization_delay(mut self, finalization_delay: SeqNum) -> Self {
         self.finalization_delay = finalization_delay;
         self


### PR DESCRIPTION
Previously on startup, nodes would check if they had already finalized the current state root. This bound can be relaxed to checking whether the state root has been executed, as the proposed block will eventually get finalized after starting up. This change is expected to reduce the number of unnecessary statesyncs when restarting nodes.