### PR TITLE
Fix RaptorcastSecondary panic from malformed PrepareGroup messages

### DIFF
--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -591,12 +591,15 @@ mod tests {
             vec![nid(0), nid(1), nid(2)],
             &nid(1), // self_id
             nid(3),  // validator
-            RoundSpan::new(Round(3), Round(8)),
+            RoundSpan::new(Round(3), Round(8)).unwrap(),
         );
         assert_eq!(group.size_excl_self(), 2);
         assert_eq!(group.get_validator_id(), &nid(3));
         assert_eq!(group.get_other_peers(), &vec![nid(0), nid(2)]);
-        assert_eq!(group.get_round_span(), &RoundSpan::new(Round(3), Round(8)));
+        assert_eq!(
+            group.get_round_span(),
+            &RoundSpan::new(Round(3), Round(8)).unwrap()
+        );
         let empty_iter: Vec<_> = group.empty_iterator().collect();
         assert!(empty_iter.is_empty());
 
@@ -627,12 +630,15 @@ mod tests {
             vec![nid(0), nid(1), nid(2)],
             &nid(3), // self_id
             nid(3),  // validator id
-            RoundSpan::new(Round(3), Round(8)),
+            RoundSpan::new(Round(3), Round(8)).unwrap(),
         );
         assert_eq!(group.size_excl_self(), 3);
         assert_eq!(group.get_validator_id(), &nid(3));
         assert_eq!(group.get_other_peers(), &vec![nid(0), nid(1), nid(2)]);
-        assert_eq!(group.get_round_span(), &RoundSpan::new(Round(3), Round(8)));
+        assert_eq!(
+            group.get_round_span(),
+            &RoundSpan::new(Round(3), Round(8)).unwrap()
+        );
         let empty_iter: Vec<_> = group.empty_iterator().collect();
         assert!(empty_iter.is_empty());
 
@@ -656,12 +662,15 @@ mod tests {
             vec![nid(1)],
             &nid(1), // self_id
             nid(3),  // validator id
-            RoundSpan::new(Round(3), Round(8)),
+            RoundSpan::new(Round(3), Round(8)).unwrap(),
         );
         assert_eq!(group.size_excl_self(), 0);
         assert_eq!(group.get_validator_id(), &nid(3));
         assert_eq!(group.get_other_peers(), &vec![]);
-        assert_eq!(group.get_round_span(), &RoundSpan::new(Round(3), Round(8)));
+        assert_eq!(
+            group.get_round_span(),
+            &RoundSpan::new(Round(3), Round(8)).unwrap()
+        );
         let empty_iter: Vec<_> = group.empty_iterator().collect();
         assert!(empty_iter.is_empty());
 
@@ -710,7 +719,7 @@ mod tests {
             vec![nid(0), nid(1), nid(2), nid(3), nid(4)],
             &nid(0),  // self_id
             nid(100), // validator id
-            RoundSpan::new(Round(3), Round(8)),
+            RoundSpan::new(Round(3), Round(8)).unwrap(),
         );
 
         // Non-"randomized" iteration (but sorted)

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -98,13 +98,23 @@ pub struct RoundSpan {
 }
 
 impl RoundSpan {
-    pub fn new(start: Round, end: Round) -> Self {
-        assert!(start <= end);
-        Self { start, end }
+    pub fn new(start: Round, end: Round) -> Option<Self> {
+        if start >= end {
+            return None;
+        }
+        Some(Self { start, end })
     }
-    pub fn single(start: Round) -> Self {
-        Self::new(start, start + Round(1))
+
+    pub fn single(start: Round) -> Option<Self> {
+        if start >= Round::MAX {
+            return None;
+        }
+        Some(Self {
+            start,
+            end: start + Round(1),
+        })
     }
+
     pub fn contains(&self, round: Round) -> bool {
         self.start <= round && round < self.end
     }


### PR DESCRIPTION
Fix two bugs reported by Asymmetric Research:

- raptorcast-secondary: FullNodesGroupMessage::PrepareGroup Bandwidth check bypass
- raptorcast-secondary: Single-packet DoS / Remote node panic via malformed group message