### PR TITLE
Validate transaction chain_id in rpc eth_call

### DIFF
--- a/monad-rpc/src/handlers/eth/call.rs
+++ b/monad-rpc/src/handlers/eth/call.rs
@@ -618,7 +618,14 @@ async fn prepare_eth_call<T: Triedb + TriedbPath>(
     )
     .await?;
 
-    if params.tx().chain_id.is_none() {
+    if let Some(tx_chain_id) = params.tx().chain_id {
+        if tx_chain_id != U64::from(chain_id) {
+            return Err(JsonRpcError::invalid_chain_id(
+                chain_id,
+                tx_chain_id.to::<u64>(),
+            ));
+        }
+    } else {
         params.tx().chain_id = Some(U64::from(chain_id));
     }
 

--- a/monad-rpc/src/handlers/eth/gas.rs
+++ b/monad-rpc/src/handlers/eth/gas.rs
@@ -292,7 +292,14 @@ pub async fn monad_eth_estimateGas<T: Triedb>(
     )
     .await?;
 
-    if params.tx.chain_id.is_none() {
+    if let Some(tx_chain_id) = params.tx.chain_id {
+        if tx_chain_id != U64::from(chain_id) {
+            return Err(JsonRpcError::invalid_chain_id(
+                chain_id,
+                tx_chain_id.to::<u64>(),
+            ));
+        }
+    } else {
         params.tx.chain_id = Some(U64::from(chain_id));
     }
 

--- a/monad-rpc/src/handlers/eth/txn.rs
+++ b/monad-rpc/src/handlers/eth/txn.rs
@@ -236,6 +236,12 @@ pub async fn monad_eth_sendRawTransaction<T: Triedb>(
                 ));
             }
 
+            if let Some(tx_chain_id) = tx.chain_id() {
+                if tx_chain_id != chain_id {
+                    return Err(JsonRpcError::invalid_chain_id(chain_id, tx_chain_id));
+                }
+            }
+
             if !base_fee_validation(tx.max_fee_per_gas(), base_fee_per_gas) {
                 return Err(JsonRpcError::custom(
                     "maxFeePerGas too low to be include in upcoming blocks".to_string(),

--- a/monad-rpc/src/jsonrpc.rs
+++ b/monad-rpc/src/jsonrpc.rs
@@ -238,6 +238,14 @@ impl JsonRpcError {
         }
     }
 
+    pub fn invalid_chain_id(expected: u64, got: u64) -> Self {
+        Self {
+            code: -32000,
+            message: format!("Invalid chain ID: expected {}, got {}", expected, got),
+            data: None,
+        }
+    }
+
     // application errors
     pub fn custom(message: String) -> Self {
         Self {


### PR DESCRIPTION
Fixes https://github.com/category-labs/monad-bft/issues/1989