### PR TITLE
Tag round on timeout event

### DIFF
--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -45,8 +45,9 @@ where
         epoch: Epoch,
         message: Verified<ST, Validated<ConsensusMessage<ST, SCT, EPT>>>,
     },
-    /// Schedule a timeout event to be emitted in `duration`
+    /// Schedule a timeout event for `round` to be emitted in `duration`
     Schedule {
+        round: Round,
         duration: Duration,
     },
     /// Cancel scheduled (if exists) timeout event
@@ -129,7 +130,9 @@ where
                     .sign(keypair),
                 }
             }
-            PacemakerCommand::Schedule { duration } => ConsensusCommand::Schedule { duration },
+            PacemakerCommand::Schedule { round, duration } => {
+                ConsensusCommand::Schedule { round, duration }
+            }
             PacemakerCommand::ScheduleReset => ConsensusCommand::ScheduleReset,
         }
     }

--- a/monad-consensus/src/pacemaker.rs
+++ b/monad-consensus/src/pacemaker.rs
@@ -94,7 +94,7 @@ where
     ),
 
     /// schedule a local round timeout event after duration
-    Schedule { duration: Duration },
+    Schedule { round: Round, duration: Duration },
 
     /// cancel the current local round timeout
     ScheduleReset,
@@ -193,6 +193,7 @@ where
         vec![
             PacemakerCommand::EnterRound(self.current_epoch, self.get_current_round()),
             PacemakerCommand::Schedule {
+                round: self.get_current_round(),
                 duration: self.get_round_timer(self.get_current_round()),
             },
         ]
@@ -245,6 +246,7 @@ where
             PacemakerCommand::ScheduleReset,
             PacemakerCommand::PrepareTimeout(timeout, high_extend, last_round_tc.cloned()),
             PacemakerCommand::Schedule {
+                round: current_round,
                 duration: self.get_round_timer(current_round),
             },
         ]
@@ -582,6 +584,7 @@ mod test {
             vec![
                 PacemakerCommand::EnterRound(Epoch(1), Round(2)),
                 PacemakerCommand::Schedule {
+                    round: Round(2),
                     duration: Duration::from_secs(3),
                 },
             ]
@@ -836,6 +839,7 @@ mod test {
             vec![
                 PacemakerCommand::EnterRound(Epoch(1), Round(2)),
                 PacemakerCommand::Schedule {
+                    round: Round(2),
                     duration: Duration::from_secs(3),
                 },
             ]

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -54,6 +54,7 @@ pub struct MockExecutor<S: SwarmRelation> {
     router: S::RouterScheduler,
 }
 
+#[derive(Debug)]
 pub struct TimerEvent<E> {
     pub variant: TimeoutVariant,
     pub callback: Option<E>,
@@ -308,6 +309,10 @@ impl<S: SwarmRelation> Executor for MockExecutor<S> {
                     variant,
                     on_timeout,
                 } => {
+                    // only one timeout variant may be armed at any time
+                    // scheduling a new timer automatically resets the previous
+                    // one
+                    self.timer.remove(&TimerEvent::new(variant));
                     self.timer.push(
                         TimerEvent::new(variant).with_call_back(on_timeout),
                         Reverse(self.tick + duration),

--- a/monad-state/src/consensus.rs
+++ b/monad-state/src/consensus.rs
@@ -246,7 +246,7 @@ where
                     }
                 }
             }
-            ConsensusEvent::Timeout => consensus.handle_timeout_expiry(),
+            ConsensusEvent::Timeout(round) => consensus.handle_timeout_expiry(round),
             ConsensusEvent::BlockSync {
                 block_range,
                 full_blocks,
@@ -611,11 +611,11 @@ where
                     message: VerifiedMonadMessage::Consensus(message),
                 }))
             }
-            ConsensusCommand::Schedule { duration } => {
+            ConsensusCommand::Schedule { round, duration } => {
                 parent_cmds.push(Command::TimerCommand(TimerCommand::Schedule {
                     duration,
                     variant: TimeoutVariant::Pacemaker,
-                    on_timeout: MonadEvent::ConsensusEvent(ConsensusEvent::Timeout),
+                    on_timeout: MonadEvent::ConsensusEvent(ConsensusEvent::Timeout(round)),
                 }))
             }
             ConsensusCommand::ScheduleReset => parent_cmds.push(Command::TimerCommand(

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1268,6 +1268,7 @@ where
             root_info,
             high_certificate.clone(),
         );
+        let current_round = consensus.get_current_round();
         tracing::info!(
             ?root_info,
             ?high_certificate,
@@ -1275,7 +1276,11 @@ where
         );
         self.consensus = ConsensusMode::Live(consensus);
         commands.push(Command::StateSyncCommand(StateSyncCommand::StartExecution));
-        commands.extend(self.update(MonadEvent::ConsensusEvent(ConsensusEvent::Timeout)));
+        commands.extend(
+            self.update(MonadEvent::ConsensusEvent(ConsensusEvent::Timeout(
+                current_round,
+            ))),
+        );
         for (sender, proposal) in cached_proposals {
             // handle proposals in reverse order because later blocks are more likely to pass
             // timestamp validation


### PR DESCRIPTION
If consensus state enters a new round when timer task completes, the new round will be timed out immediately. Tagging round on timeout event ensures timeout is never misinterpreted for a different round than what it's scheduled for

https://docs.rs/tokio/latest/tokio/task/struct.AbortHandle.html#method.abort
> Awaiting a cancelled task might complete as usual if the task was already completed at the time it was cancelled