### PR TITLE
Update Stake to U256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5587,6 +5587,7 @@ dependencies = [
 name = "monad-raptorcast"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "alloy-rlp",
  "bitvec",
  "bytes",
@@ -5989,11 +5990,14 @@ dependencies = [
 name = "monad-types"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "alloy-rlp",
  "futures",
  "hex",
  "monad-crypto",
  "serde",
+ "serde_json",
+ "serde_test",
  "test-case",
  "zerocopy 0.6.6",
 ]
@@ -8112,6 +8116,15 @@ name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_test"
+version = "1.0.177"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f901ee573cab6b3060453d2d5f0bae4e6d628c23c0a962ff9b5f1d7c8d4f1ed"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ scrypt = { version = "0.11", default-features = false }
 secp256k1 = "0.26"
 serde = "1.0"
 serde_json = "1.0"
+serde_test = "1.0.177"
 sha2 = "0.10"
 simple-xml-builder = "1.1"
 socket2 = "0.5.9"

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -4660,13 +4660,13 @@ mod test {
         let epoch_2_leader = NodeId::new(get_key::<SignatureType>(100).pubkey());
         env.val_epoch_map.insert(
             Epoch(2),
-            vec![(epoch_2_leader, Stake(1))],
+            vec![(epoch_2_leader, Stake::ONE)],
             ValidatorMapping::new(vec![(epoch_2_leader, epoch_2_leader.pubkey())]),
         );
         for node in ctx.iter_mut() {
             node.val_epoch_map.insert(
                 Epoch(2),
-                vec![(epoch_2_leader, Stake(1))],
+                vec![(epoch_2_leader, Stake::ONE)],
                 ValidatorMapping::new(vec![(epoch_2_leader, epoch_2_leader.pubkey())]),
             );
         }

--- a/monad-consensus/src/pacemaker.rs
+++ b/monad-consensus/src/pacemaker.rs
@@ -751,16 +751,16 @@ mod test {
         let mut staking_list = keys
             .iter()
             .map(|k| NodeId::new(k.pubkey()))
-            .zip(std::iter::repeat(Stake(1)))
+            .zip(std::iter::repeat(Stake::ONE))
             .collect::<Vec<_>>();
 
         // total stake = 7, f = 2
         // node1 holds f+1 stake
         // node1 + node2 has 2f+1 stake
-        staking_list[0].1 = Stake(1);
-        staking_list[1].1 = Stake(3);
-        staking_list[2].1 = Stake(2);
-        staking_list[3].1 = Stake(1);
+        staking_list[0].1 = Stake::ONE;
+        staking_list[1].1 = Stake::from(3);
+        staking_list[2].1 = Stake::from(2);
+        staking_list[3].1 = Stake::ONE;
 
         let voting_identity = keys
             .iter()

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -1312,7 +1312,7 @@ mod test {
 
         let keypair = get_key::<SignatureType>(6);
         let cert_keypair = get_certificate_key::<SignatureCollectionType>(6);
-        let stake_list = vec![(NodeId::new(keypair.pubkey()), Stake(1))];
+        let stake_list = vec![(NodeId::new(keypair.pubkey()), Stake::ONE)];
         let voting_identity = vec![(NodeId::new(keypair.pubkey()), cert_keypair.pubkey())];
 
         let vset = ValidatorSetFactory::default().create(stake_list).unwrap();
@@ -1356,8 +1356,8 @@ mod test {
 
         let keypairs = create_keys::<SignatureType>(2);
         let vlist = vec![
-            (NodeId::new(keypairs[0].pubkey()), Stake(1)),
-            (NodeId::new(keypairs[1].pubkey()), Stake(2)),
+            (NodeId::new(keypairs[0].pubkey()), Stake::ONE),
+            (NodeId::new(keypairs[1].pubkey()), Stake::from(2)),
         ];
 
         let vset = ValidatorSetFactory::default().create(vlist).unwrap();
@@ -1549,7 +1549,7 @@ mod test {
 
         let keypair = get_key::<SignatureType>(6);
         let cert_keypair = get_certificate_key::<SignatureCollectionType>(6);
-        let stake_list = vec![(NodeId::new(keypair.pubkey()), Stake(1))];
+        let stake_list = vec![(NodeId::new(keypair.pubkey()), Stake::ONE)];
         let voting_identity = vec![(NodeId::new(keypair.pubkey()), cert_keypair.pubkey())];
 
         let vset = ValidatorSetFactory::default().create(stake_list).unwrap();

--- a/monad-consensus/src/vote_state.rs
+++ b/monad-consensus/src/vote_state.rs
@@ -430,11 +430,11 @@ mod test {
         let mut staking_list = keys
             .iter()
             .map(|k| NodeId::new(k.pubkey()))
-            .zip(std::iter::repeat(Stake(1)))
+            .zip(std::iter::repeat(Stake::ONE))
             .collect::<Vec<_>>();
 
         // node2 has supermajority stake by itself
-        staking_list[2].1 = Stake(10);
+        staking_list[2].1 = Stake::from(10);
 
         let voting_identity = keys
             .iter()

--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -21,6 +21,7 @@ monad-raptor = { workspace = true }
 monad-secp = { workspace = true }
 monad-types = { workspace = true }
 
+alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }
 bitvec = { workspace = true }
 bytes = { workspace = true }

--- a/monad-raptorcast/benches/raptor_bench.rs
+++ b/monad-raptorcast/benches/raptor_bench.rs
@@ -49,7 +49,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let mut validators = EpochValidators {
             validators: keys
                 .iter()
-                .map(|key| (NodeId::new(key.pubkey()), Validator { stake: Stake(1) }))
+                .map(|key| (NodeId::new(key.pubkey()), Validator { stake: Stake::ONE }))
                 .collect(),
         };
 
@@ -93,7 +93,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let mut validators = EpochValidators {
             validators: keys
                 .iter()
-                .map(|key| (NodeId::new(key.pubkey()), Validator { stake: Stake(1) }))
+                .map(|key| (NodeId::new(key.pubkey()), Validator { stake: Stake::ONE }))
                 .collect(),
         };
         let epoch_validators = validators.view_without(vec![&NodeId::new(keys[0].pubkey())]);

--- a/monad-raptorcast/examples/service.rs
+++ b/monad-raptorcast/examples/service.rs
@@ -137,7 +137,7 @@ fn service(
 
                 service.exec(vec![RouterCommand::AddEpochValidatorSet {
                     epoch: Epoch(0),
-                    validator_set: all_peers.iter().map(|peer| (*peer, Stake(1))).collect(),
+                    validator_set: all_peers.iter().map(|peer| (*peer, Stake::ONE)).collect(),
                 }]);
 
                 loop {

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -20,6 +20,7 @@ use std::{
     ops::Range,
 };
 
+use alloy_primitives::U256;
 use bitvec::prelude::*;
 use bytes::{Bytes, BytesMut};
 use itertools::Itertools;
@@ -761,12 +762,12 @@ where
             } else {
                 // generate chunks if epoch validators is not empty
                 // FIXME should self be included in total_stake?
-                let total_stake: u64 = epoch_validators
+                let total_stake: U256 = epoch_validators
                     .view()
                     .values()
                     .map(|validator| validator.stake.0)
                     .sum();
-                let mut running_stake = 0;
+                let mut running_stake = U256::ZERO;
                 let mut chunk_idx = 0_u16;
                 let mut nodes: Vec<_> = epoch_validators.view().iter().collect();
                 // Group shuffling so chunks for small proposals aren't always assigned
@@ -774,10 +775,10 @@ where
                 nodes.shuffle(&mut rand::thread_rng());
                 for (node_id, validator) in &nodes {
                     let start_idx: usize =
-                        (num_packets as u64 * running_stake / total_stake) as usize;
+                        (U256::from(num_packets) * running_stake / total_stake).to::<usize>();
                     running_stake += validator.stake.0;
                     let end_idx: usize =
-                        (num_packets as u64 * running_stake / total_stake) as usize;
+                        (U256::from(num_packets) * running_stake / total_stake).to::<usize>();
 
                     if start_idx == end_idx {
                         continue;
@@ -1490,7 +1491,7 @@ mod tests {
         let validators = EpochValidators {
             validators: keys
                 .iter()
-                .map(|key| (NodeId::new(key.pubkey()), Validator { stake: Stake(1) }))
+                .map(|key| (NodeId::new(key.pubkey()), Validator { stake: Stake::ONE }))
                 .collect(),
         };
 

--- a/monad-raptorcast/tests/encoder_error.rs
+++ b/monad-raptorcast/tests/encoder_error.rs
@@ -53,7 +53,7 @@ pub fn encoder_error() {
     let mut validators = EpochValidators {
         validators: keys
             .iter()
-            .map(|key| (NodeId::new(key.pubkey()), Validator { stake: Stake(1) }))
+            .map(|key| (NodeId::new(key.pubkey()), Validator { stake: Stake::ONE }))
             .collect(),
     };
 

--- a/monad-raptorcast/tests/raptorcast_instance.rs
+++ b/monad-raptorcast/tests/raptorcast_instance.rs
@@ -81,8 +81,8 @@ pub fn different_symbol_sizes() {
 
         let mut validators = EpochValidators {
             validators: BTreeMap::from([
-                (rx_nodeid, Validator { stake: Stake(1) }),
-                (tx_nodeid, Validator { stake: Stake(1) }),
+                (rx_nodeid, Validator { stake: Stake::ONE }),
+                (tx_nodeid, Validator { stake: Stake::ONE }),
             ]),
         };
 
@@ -145,8 +145,8 @@ pub fn buffer_count_overflow() {
 
     let mut validators = EpochValidators {
         validators: BTreeMap::from([
-            (rx_nodeid, Validator { stake: Stake(1) }),
-            (tx_nodeid, Validator { stake: Stake(1) }),
+            (rx_nodeid, Validator { stake: Stake::ONE }),
+            (tx_nodeid, Validator { stake: Stake::ONE }),
         ]),
     };
 
@@ -200,8 +200,8 @@ pub fn oversized_message() {
 
     let mut validators = EpochValidators {
         validators: BTreeMap::from([
-            (rx_nodeid, Validator { stake: Stake(1) }),
-            (tx_nodeid, Validator { stake: Stake(1) }),
+            (rx_nodeid, Validator { stake: Stake::ONE }),
+            (tx_nodeid, Validator { stake: Stake::ONE }),
         ]),
     };
 
@@ -281,8 +281,8 @@ pub fn valid_rebroadcast() {
 
     let mut validators = EpochValidators {
         validators: BTreeMap::from([
-            (rx_nodeid, Validator { stake: Stake(1) }),
-            (tx_nodeid, Validator { stake: Stake(1) }),
+            (rx_nodeid, Validator { stake: Stake::ONE }),
+            (tx_nodeid, Validator { stake: Stake::ONE }),
         ]),
     };
 
@@ -375,7 +375,7 @@ pub fn set_up_test(
     let mut known_addresses: HashMap<NodeId<PubKeyType>, SocketAddr> =
         HashMap::from([(tx_nodeid, *tx_addr), (rx_nodeid, *rx_addr)]);
 
-    let mut validator_set = vec![(tx_nodeid, Stake(1)), (rx_nodeid, Stake(1))];
+    let mut validator_set = vec![(tx_nodeid, Stake::ONE), (rx_nodeid, Stake::ONE)];
 
     if let Some(rebroadcast_addr) = rebroadcast_addr {
         let rebroadcast_keypair = {
@@ -388,7 +388,7 @@ pub fn set_up_test(
 
         known_addresses.insert(rebroadcast_nodeid, *rebroadcast_addr);
 
-        validator_set.push((rebroadcast_nodeid, Stake(1)));
+        validator_set.push((rebroadcast_nodeid, Stake::ONE));
     }
 
     {

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1428,7 +1428,7 @@ mod test {
 
         let mut validators = Vec::new();
         for (key, cert_key) in keys.iter().zip(cert_keys.iter()) {
-            validators.push((key.pubkey(), Stake(7), cert_key.pubkey()));
+            validators.push((key.pubkey(), Stake::from(7), cert_key.pubkey()));
         }
         let validator_data = ValidatorSetData::<SignatureCollectionType>::new(validators);
         let validator_sets = forkpoint
@@ -1565,28 +1565,28 @@ mod test {
 
         let validators_config: ValidatorsConfig<SignatureCollectionType> = ValidatorsConfig {
             validators: vec![
-                (Epoch(1), make_val_set_data(Stake(1))),
-                (Epoch(2), make_val_set_data(Stake(2))),
-                (Epoch(4), make_val_set_data(Stake(3))),
-                (Epoch(10), make_val_set_data(Stake(4))),
+                (Epoch(1), make_val_set_data(Stake::ONE)),
+                (Epoch(2), make_val_set_data(Stake::from(2))),
+                (Epoch(4), make_val_set_data(Stake::from(3))),
+                (Epoch(10), make_val_set_data(Stake::from(4))),
             ]
             .into_iter()
             .collect(),
         };
 
         let expected = vec![
-            (Epoch(1), make_val_set_data(Stake(1))),
-            (Epoch(2), make_val_set_data(Stake(2))),
-            (Epoch(3), make_val_set_data(Stake(2))),
-            (Epoch(4), make_val_set_data(Stake(3))),
-            (Epoch(5), make_val_set_data(Stake(3))),
-            (Epoch(6), make_val_set_data(Stake(3))),
-            (Epoch(7), make_val_set_data(Stake(3))),
-            (Epoch(8), make_val_set_data(Stake(3))),
-            (Epoch(9), make_val_set_data(Stake(3))),
-            (Epoch(10), make_val_set_data(Stake(4))),
-            (Epoch(11), make_val_set_data(Stake(4))),
-            (Epoch(12), make_val_set_data(Stake(4))),
+            (Epoch(1), make_val_set_data(Stake::ONE)),
+            (Epoch(2), make_val_set_data(Stake::from(2))),
+            (Epoch(3), make_val_set_data(Stake::from(2))),
+            (Epoch(4), make_val_set_data(Stake::from(3))),
+            (Epoch(5), make_val_set_data(Stake::from(3))),
+            (Epoch(6), make_val_set_data(Stake::from(3))),
+            (Epoch(7), make_val_set_data(Stake::from(3))),
+            (Epoch(8), make_val_set_data(Stake::from(3))),
+            (Epoch(9), make_val_set_data(Stake::from(3))),
+            (Epoch(10), make_val_set_data(Stake::from(4))),
+            (Epoch(11), make_val_set_data(Stake::from(4))),
+            (Epoch(12), make_val_set_data(Stake::from(4))),
         ];
 
         for (epoch, val_set) in &expected {

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -283,7 +283,7 @@ where
             .iter()
             .map(|(keypair, _, cert_keypair)| ValidatorData {
                 node_id: NodeId::new(keypair.pubkey()),
-                stake: Stake(1),
+                stake: Stake::ONE,
                 cert_pubkey: cert_keypair.pubkey(),
             })
             .collect::<Vec<_>>(),

--- a/monad-testutil/src/validators.rs
+++ b/monad-testutil/src/validators.rs
@@ -62,7 +62,7 @@ where
     let staking_list = keys
         .iter()
         .map(|k| NodeId::new(k.pubkey()))
-        .zip(std::iter::repeat(Stake(1)))
+        .zip(std::iter::repeat(Stake::ONE))
         .collect::<Vec<_>>();
 
     let voting_identity = keys

--- a/monad-types/Cargo.toml
+++ b/monad-types/Cargo.toml
@@ -11,11 +11,14 @@ bench = false
 [dependencies]
 monad-crypto = { workspace = true }
 
+alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-rlp = { workspace = true, features = ["derive"] }
 futures = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 zerocopy = { workspace = true }
 
 [dev-dependencies]
+serde_test = { workspace = true }
 test-case = { workspace = true }

--- a/monad-updaters/src/state_root_hash.rs
+++ b/monad-updaters/src/state_root_hash.rs
@@ -251,14 +251,14 @@ where
         let mut val_data_2 = val_data_1.clone();
 
         for validator in val_data_1.iter_mut().take(num_validators / 2) {
-            validator.stake = Stake(0);
+            validator.stake = Stake::ZERO;
         }
         for validator in val_data_2
             .iter_mut()
             .take(num_validators)
             .skip(num_validators / 2)
         {
-            validator.stake = Stake(0);
+            validator.stake = Stake::ZERO;
         }
 
         Self {

--- a/monad-validator/src/simple_round_robin.rs
+++ b/monad-validator/src/simple_round_robin.rs
@@ -37,7 +37,7 @@ impl<PT: PubKey> LeaderElection for SimpleRoundRobin<PT> {
     ) -> NodeId<PT> {
         let validators: Vec<_> = validators
             .iter()
-            .filter_map(|(node_id, stake)| (*stake != Stake(0)).then_some(node_id))
+            .filter_map(|(node_id, stake)| (*stake != Stake::ZERO).then_some(node_id))
             .collect();
         *validators[round.0 as usize % validators.len()]
     }

--- a/monad-validator/src/weighted_round_robin.rs
+++ b/monad-validator/src/weighted_round_robin.rs
@@ -16,6 +16,7 @@
 use std::{collections::BTreeMap, marker::PhantomData};
 
 use alloy_primitives::U256;
+use itertools::Itertools;
 use monad_crypto::certificate_signature::PubKey;
 use monad_types::{NodeId, Round, Stake};
 use rand::Rng;
@@ -41,8 +42,44 @@ fn randomize(x: u64, m: u64) -> u64 {
     gen.gen_range(0..m)
 }
 
-fn randomize_256(x: U256, m: U256) -> U256 {
-    let mut gen = ChaCha20Rng::from_seed(x.to_be_bytes());
+fn generate_random_validator_u64<PT: PubKey>(
+    round: Round,
+    validators: Vec<(&NodeId<PT>, &Stake)>,
+) -> NodeId<PT> {
+    let mut total_stakes = 0_u64;
+    let stake_bounds = validators
+        .iter()
+        .filter_map(|&(node_id, stake)| {
+            // Panics if stake is too big
+            let stake_u64 = stake.0.to::<u64>();
+            if stake_u64 > 0 {
+                total_stakes = total_stakes
+                    .checked_add(stake_u64)
+                    .expect("total stake <= u64::MAX");
+                Some((node_id, total_stakes))
+            } else {
+                None
+            }
+        })
+        .collect_vec();
+    if stake_bounds.is_empty() {
+        panic!("no validator has positive stake");
+    }
+
+    let stake_index = randomize(round.0, total_stakes);
+    let upper_bound = stake_bounds
+        .binary_search_by(|&(_, stake_bound)| {
+            if stake_bound > stake_index {
+                std::cmp::Ordering::Greater
+            } else {
+                std::cmp::Ordering::Less
+            }
+        })
+        .unwrap_err();
+    *stake_bounds[upper_bound].0
+}
+
+pub fn randomize_256_with_rng(gen: &mut impl Rng, m: U256) -> U256 {
     let max = U256::MAX - (U256::MAX - m + U256::from(1)) % m;
     loop {
         let r: U256 = gen.gen();
@@ -50,6 +87,41 @@ fn randomize_256(x: U256, m: U256) -> U256 {
             return r % m;
         }
     }
+}
+
+/// # Panics
+/// Panics if `validators.is_empty()` or if `validators` does not contain an element whose stake is > 0
+pub fn generate_random_validator_with_randomizer<PT: PubKey>(
+    validators: Vec<(&NodeId<PT>, &Stake)>,
+    mut randomize_from_total_stake: impl FnMut(U256) -> U256,
+) -> NodeId<PT> {
+    let mut total_stake = U256::ZERO;
+    let stake_bounds = validators
+        .iter()
+        .filter_map(|&(node_id, stake)| {
+            if stake.0 > U256::ZERO {
+                total_stake += stake.0;
+                Some((node_id, total_stake))
+            } else {
+                None
+            }
+        })
+        .collect_vec();
+    if stake_bounds.is_empty() {
+        panic!("no validator has positive stake");
+    }
+
+    let stake_index = randomize_from_total_stake(total_stake);
+    let upper_bound = stake_bounds
+        .binary_search_by(|&(_, stake_bound)| {
+            if stake_bound > stake_index {
+                std::cmp::Ordering::Greater
+            } else {
+                std::cmp::Ordering::Less
+            }
+        })
+        .unwrap_err();
+    *stake_bounds[upper_bound].0
 }
 
 impl<PT: PubKey> LeaderElection for WeightedRoundRobin<PT> {
@@ -60,33 +132,12 @@ impl<PT: PubKey> LeaderElection for WeightedRoundRobin<PT> {
     /// Panics if `validators.is_empty()` or if `validators` does not contain an element whose stake is > 0, because
     /// there is no sensible choice for leader in either of those cases.
     fn get_leader(&self, round: Round, validators: &BTreeMap<NodeId<PT>, Stake>) -> NodeId<PT> {
-        let mut total_stakes = 0_u64;
-        let stake_bounds: Vec<_> = validators
-            .iter()
-            .filter_map(|(node_id, stake)| {
-                if stake.0 > 0 {
-                    total_stakes += stake.0;
-                    Some((node_id, total_stakes))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        if stake_bounds.is_empty() {
-            panic!("no validator has positive stake");
-        }
+        generate_random_validator_u64(round, validators.iter().collect_vec())
 
-        let stake_index = randomize(round.0, total_stakes);
-        let upper_bound = stake_bounds
-            .binary_search_by(|&(_, stake_bound)| {
-                if stake_bound > stake_index {
-                    std::cmp::Ordering::Greater
-                } else {
-                    std::cmp::Ordering::Less
-                }
-            })
-            .unwrap_err();
-        *stake_bounds[upper_bound].0
+        // TODO switch to U256 gen on fork
+        // let mut gen = ChaCha20Rng::seed_from_u64(round.0);
+        // let randomizer = |total_stake| randomize_256_with_rng(&mut gen, total_stake);
+        // generate_random_validator_with_randomizer(validators.iter().collect_vec(), randomizer)
     }
 }
 
@@ -97,27 +148,33 @@ mod tests {
 
     use super::*;
 
-    #[test_case(vec![('A', 1), ('B', 1), ('C', 1)]; "equal stakes")]
-    #[test_case(vec![('A', 1), ('B', 1), ('C', 1)]; "test equal stakes")]
-    #[test_case(vec![('A', 1), ('B', 0), ('C', 1)];      "test unstaked schedule")]
-    #[test_case(vec![('A', 1), ('B', 2), ('C', 1)]; "test validator with more stake")]
-    #[test_case(vec![('A', 2), ('B', 2), ('C', 2)]; "test equal schedule with more stake")]
-    #[test_case(vec![('A', 1), ('B', 2), ('C', 3)]; "test unequal schedule")]
-    #[test_case(vec![('A', 10), ('B', 2), ('C', 3)]; "test big stake")]
-    fn test_weighted_round_robin(validator_set: Vec<(char, u64)>) {
+    #[test_case(vec![('A', U256::ONE), ('B', U256::ONE), ('C', U256::ONE)]; "equal stakes")]
+    #[test_case(vec![('A', U256::ONE), ('B', U256::ONE), ('C', U256::ONE)]; "test equal stakes")]
+    #[test_case(vec![('A', U256::ONE), ('B', U256::ZERO), ('C', U256::ONE)];      "test unstaked schedule")]
+    #[test_case(vec![('A', U256::ONE), ('B', U256::from(2)), ('C', U256::ONE)]; "test validator with more stake")]
+    #[test_case(vec![('A', U256::from(2)), ('B', U256::from(2)), ('C', U256::from(2))]; "test equal schedule with more stake")]
+    #[test_case(vec![('A', U256::ONE), ('B', U256::from(2)), ('C', U256::from(3))]; "test unequal schedule")]
+    #[test_case(vec![('A', U256::from(10)), ('B', U256::from(2)), ('C', U256::from(3))]; "test big stake")]
+    fn test_weighted_round_robin(validator_set: Vec<(char, U256)>) {
         let num_iterations = 10000_u64;
         let l = WeightedRoundRobin::default();
         let total_stakes = validator_set
             .iter()
-            .filter_map(|(_, stake)| if *stake > 0 { Some(*stake) } else { None })
-            .sum::<u64>();
+            .filter_map(|(_, stake)| {
+                if *stake > U256::ZERO {
+                    Some(*stake)
+                } else {
+                    None
+                }
+            })
+            .sum::<U256>();
         let expected_num_picked = validator_set
             .iter()
             .map(|(validator, stake)| {
                 (
                     NodeId::new(NopPubKey::from_bytes(&[*validator as u8; 32]).unwrap()),
-                    if *stake > 0 {
-                        num_iterations * *stake / total_stakes
+                    if *stake > U256::ZERO {
+                        (U256::from(num_iterations) * *stake / total_stakes).to::<u64>()
                     } else {
                         0
                     },
@@ -156,6 +213,45 @@ mod tests {
                 assert!(num_picked[index] > *expected - 150);
                 assert!(num_picked[index] < *expected + 150);
             }
+        }
+    }
+
+    #[test]
+    fn test_equivalent_leader_schedule() {
+        let stakes = vec![('A', 1), ('B', 2), ('C', 3), ('D', 4)];
+        let expected_schedule = vec![
+            'A', 'D', 'C', 'D', 'C', 'D', 'D', 'A', 'D', 'A', 'D', 'C', 'C', 'B', 'D', 'D', 'C',
+            'B', 'B', 'D', 'D', 'A', 'C', 'B', 'C', 'A', 'B', 'D', 'C', 'D', 'D', 'B', 'D', 'D',
+            'D', 'A', 'D', 'A', 'D', 'D', 'D', 'B', 'C', 'D', 'C', 'A', 'A', 'C', 'B', 'B', 'D',
+            'C', 'C', 'B', 'C', 'B', 'D', 'B', 'B', 'B', 'D', 'A', 'C', 'C', 'B', 'C', 'C', 'C',
+            'A', 'D', 'D', 'D', 'A', 'C', 'C', 'C', 'C', 'D', 'B', 'A', 'D', 'D', 'D', 'D', 'C',
+            'A', 'D', 'D', 'A', 'C', 'D', 'B', 'B', 'D', 'A', 'C', 'C', 'C', 'C', 'C', 'B', 'B',
+            'D', 'C', 'C', 'C', 'C', 'D', 'A', 'C', 'C', 'B', 'B', 'D', 'B', 'D', 'D', 'C', 'D',
+            'C', 'B', 'C', 'C', 'A', 'D', 'B', 'D', 'B', 'C', 'C', 'D', 'C', 'D', 'C', 'D', 'D',
+            'C', 'D', 'D', 'B', 'C', 'D', 'C', 'A', 'D', 'D', 'D', 'B', 'A', 'C', 'D', 'D', 'D',
+            'D', 'B', 'D', 'C', 'D', 'B', 'D', 'B', 'D', 'D', 'C', 'B', 'C', 'D', 'B', 'D', 'C',
+            'D', 'C', 'C', 'C', 'C', 'A', 'C', 'D', 'D', 'B', 'C', 'C', 'B', 'C', 'B', 'B', 'A',
+            'C', 'B', 'D', 'C', 'C', 'C', 'C', 'C', 'C', 'A', 'C', 'A', 'D', 'D', 'D', 'D', 'D',
+            'B', 'D', 'D', 'C', 'C', 'C', 'D', 'D', 'C', 'C', 'C', 'D', 'C', 'A', 'B', 'D', 'C',
+            'D', 'B', 'D', 'B', 'D', 'B', 'A', 'C', 'C', 'D', 'D', 'C', 'B', 'B', 'D', 'D', 'C',
+            'D', 'C', 'A', 'D', 'B', 'D', 'A', 'C', 'D', 'B', 'D', 'A',
+        ];
+
+        let validator_set = stakes
+            .into_iter()
+            .map(|(validator, stake)| {
+                (
+                    NodeId::new(NopPubKey::from_bytes(&[validator as u8; 32]).unwrap()),
+                    Stake(U256::from(stake)),
+                )
+            })
+            .collect();
+
+        let leader_election = WeightedRoundRobin::default();
+        for (round, expected_leader) in expected_schedule.into_iter().enumerate() {
+            let leader = leader_election.get_leader(Round(round as u64), &validator_set);
+            let leader_char = leader.pubkey().bytes()[0] as char;
+            assert_eq!(expected_leader, leader_char);
         }
     }
 }


### PR DESCRIPTION
This PR converts Stake type from u64 to U256 to match with execution. Added a custom serializer and deserializer for U256

Updated existing tests. Added tests for the custom serializer and deserializer. Added test to confirm equivalent leader schedule until fork. 