### PR TITLE
Bugfix raptorcast fullnode bootstrap ejecting current group

### DIFF
--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -57,7 +57,7 @@ where
 {
     signing_key: Arc<ST::KeyPairType>,
     redundancy: Redundancy,
-    is_fullnode: bool,
+    is_dynamic_fullnode: bool,
 
     // Raptorcast group with stake information. For the send side (i.e., initiating proposals)
     epoch_validators: BTreeMap<Epoch, EpochValidators<ST>>,
@@ -113,17 +113,17 @@ where
             );
         }
         let self_id = NodeId::new(config.shared_key.pubkey());
-        let is_fullnode = matches!(
+        let is_dynamic_fullnode = matches!(
             config.secondary_instance.mode,
             config::SecondaryRaptorCastModeConfig::Client(_)
         );
-        tracing::trace!(
-            ?is_fullnode, ?self_id, ?config.mtu, "RaptorCast::new",
+        tracing::debug!(
+            ?is_dynamic_fullnode, ?self_id, ?config.mtu, "RaptorCast::new",
         );
         Self {
-            is_fullnode,
+            is_dynamic_fullnode,
             epoch_validators: Default::default(),
-            rebroadcast_map: ReBroadcastGroupMap::new(self_id, is_fullnode),
+            rebroadcast_map: ReBroadcastGroupMap::new(self_id, is_dynamic_fullnode),
             dedicated_full_nodes: FullNodes::new(
                 config.primary_instance.fullnode_dedicated.clone(),
             ),
@@ -158,7 +158,7 @@ where
         channel_from_secondary: UnboundedReceiver<Group<ST>>,
     ) -> Self {
         self.channel_to_secondary = Some(channel_to_secondary);
-        if self.is_fullnode {
+        if self.is_dynamic_fullnode {
             self.channel_from_secondary = Some(channel_from_secondary);
         }
         self

--- a/monad-raptorcast/src/raptorcast_secondary/client.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/client.rs
@@ -371,6 +371,13 @@ where
                     error
                 );
             }
+            // Pulse a heartbeat, giving the new group above some time to be
+            // picked up by UDP state and be used. Without this pulse, there's
+            // a risk that the same validator will send us an invite for a
+            // future group before we receive the first proposal via raptorcast,
+            // causing the `is_receiving_proposals` check above to eagerly send
+            // the future group to primary and eject the current one.
+            self.last_round_heartbeat = Instant::now();
         }
 
         self.metrics[CLIENT_RECEIVED_CONFIRMS] += 1;

--- a/monad-raptorcast/src/raptorcast_secondary/publisher.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/publisher.rs
@@ -167,7 +167,7 @@ where
 
         // Remove all groups that have ended.
         self.group_schedule
-            .retain(|_, group| group.end_round > round);
+            .retain(|_, group| group.end_round >= round);
 
         let Some(next_group) = self.group_schedule.first_entry() else {
             // We didn't manage to form a group in time for the new round.
@@ -1465,6 +1465,7 @@ mod tests {
 
         // RaptorCast group from v0 should be down now, as it only covered rounds [5, 7)
         // Here we should see a group gap
+        group_map.update(&clt);
         assert!(group_map.is_empty(&clt));
 
         //-------------------------------------------------------------------[8]

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -492,7 +492,7 @@ where
 //
 //     data: Bytes,
 // }
-pub const HEADER_LEN: u16 = SIGNATURE_SIZE as u16 // Sender signature
+pub const HEADER_LEN: u16 = SIGNATURE_SIZE as u16 // Sender signature (65 bytes)
             + 2  // Version
             + 1  // Broadcast bit, 7 bits for Merkle Tree Depth
             + 8  // Epoch #


### PR DESCRIPTION
This PR fixes a bug where a dynamic full node (i.e. a full-node that is not setup as a dedicated/static one) could drop its current and future groups before receiving the first proposal message via raptorcast.

The example scenario where this bug would be triggered for a dynamic full-node:

1. A validator `v0` sends us a group invite for rounds [25, 30). 
2. We don't know what the current round is, and because `is_receiving_proposals` evaluates to false, the client will eagerly send this group to primary's map (i.e. `ReBroadcastGroupMap`, the group map that is passed to UDP state when receiving raptorcast chunks)
3. The group would be inserted into primary's group map:  `v0` -> [25, 30)
4. The validator `v0` sends us a new group invite for future rounds [30, 35)
5. `is_receiving_proposals` still evaluates to zero, because we still didn't receive the first proposal yet
6. Because of 5. above, the client eagerly sends also this new group to Primary raptorcast instance's group map
7. The group map overwrites  `v0` -> [30, 35), ejecting the old group `v0` -> [25, 30) off the map
8. When UDP state finally receives the raptorcast chunk for group round 25, the state machine enters round 25 and drops group [30, 35) because 25 is not contained in range [30, 35), causing UDP state to drop future messages
9. If the validator keeps inviting us for future rounds, the cycle can keep repeating the the full-node won't bootstrap. This will happen if `v0` is configured to always invites us to raptorcast groups (prioritized full-node)

Here this bug is fixed by resetting `is_receiving_proposals` as soon as the client "accepts" a bootstrapping group (i.e. sends it to the primary raptorcast instance).

Also, `ReBroadcastGroupMap.delete_expired_groups()` was change to only purge groups which round_end >= current_round, rather than purging groups that do not contain current_round.

A **simplified scenario** for the bugs fixed here, as prioritized full-node, is:
1. recv invite for rounds (25, 30)
2. recv invite for rounds (30, 35) <-- this would replace group (25, 30)
3. recv raptorcast (accepted)
4. enter_round(25) <-- this would cause group (30, 35) to be dropped
5. recv raptorcast would reject chunks because group map is empty

