### PR TITLE
monad-secp: add k256 dep to the crate

### DIFF
--- a/monad-secp/Cargo.toml
+++ b/monad-secp/Cargo.toml
@@ -12,7 +12,7 @@ bench = false
 monad-crypto = { workspace = true }
 
 alloy-consensus = { workspace = true }
-alloy-primitives = { workspace = true }
+alloy-primitives = { workspace = true, features = ["k256"] }
 alloy-rlp = { workspace = true }
 secp256k1 = { workspace = true, features = ["global-context", "recovery"] }
 zeroize = { workspace = true }


### PR DESCRIPTION
cargo build -p monad-raptorcast was failing as it transitively pulls monad-secp, but recid() is feature gated on k256

monad-node/monad-rpc doesn't fail since another dependency enables this feature, and cargo doesn't build twice.

tests didn't fail on merge because of alloy-signer in dev-dependencies