### PR TITLE
monad-dataplane: add udp socket for explicit direct messages

### DIFF
--- a/monad-dataplane/src/udp.rs
+++ b/monad-dataplane/src/udp.rs
@@ -29,6 +29,12 @@ use tracing::{debug, error, warn};
 use super::{RecvUdpMsg, UdpMsg};
 use crate::buffer_ext::SocketBufferExt;
 
+#[derive(Debug, Clone)]
+pub(crate) enum UdpMessageType {
+    Broadcast,
+    Direct,
+}
+
 // When running in docker with vpnkit, the maximum safe MTU is 1480, as per:
 // https://github.com/moby/vpnkit/tree/v0.5.0/src/hostnet/slirp.ml#L17-L18
 pub const DEFAULT_MTU: u16 = 1480;
@@ -44,72 +50,122 @@ pub const DEFAULT_SEGMENT_SIZE: u16 = segment_size_for_mtu(DEFAULT_MTU);
 const ETHERNET_MTU: u16 = 1500;
 const ETHERNET_SEGMENT_SIZE: u16 = segment_size_for_mtu(ETHERNET_MTU);
 
-pub fn spawn_tasks(
+fn configure_socket(socket: &UdpSocket, buffer_size: Option<usize>) {
+    if let Some(size) = buffer_size {
+        set_socket_buffer_sizes(socket, size);
+    }
+    set_mtu_discovery(socket);
+}
+
+fn set_socket_buffer_sizes(socket: &UdpSocket, requested_size: usize) {
+    set_recv_buffer_size(socket, requested_size);
+    set_send_buffer_size(socket, requested_size);
+}
+
+fn set_recv_buffer_size(socket: &UdpSocket, requested_size: usize) {
+    if let Err(e) = socket.set_recv_buffer_size(requested_size) {
+        panic!("set_recv_buffer_size to {requested_size} failed with: {e}");
+    }
+    let actual_size = socket.recv_buffer_size().expect("get recv buffer size");
+    if actual_size < requested_size {
+        panic!("unable to set udp receive buffer size to {requested_size}. Got {actual_size} instead. Set net.core.rmem_max to at least {requested_size}");
+    }
+}
+
+fn set_send_buffer_size(socket: &UdpSocket, requested_size: usize) {
+    if let Err(e) = socket.set_send_buffer_size(requested_size) {
+        panic!("set_send_buffer_size to {requested_size} failed with: {e}");
+    }
+    let actual_size = socket.send_buffer_size().expect("get send buffer size");
+    if actual_size < requested_size {
+        panic!("unable to set udp send buffer size to {requested_size}. got {actual_size} instead. set net.core.wmem_max to at least {requested_size}");
+    }
+}
+
+fn set_mtu_discovery(socket: &UdpSocket) {
+    const MTU_DISCOVER: libc::c_int = libc::IP_PMTUDISC_OMIT;
+    let raw_fd = socket.as_raw_fd();
+
+    if unsafe {
+        libc::setsockopt(
+            raw_fd,
+            libc::SOL_IP,
+            libc::IP_MTU_DISCOVER,
+            &MTU_DISCOVER as *const _ as _,
+            std::mem::size_of_val(&MTU_DISCOVER) as _,
+        )
+    } != 0
+    {
+        panic!(
+            "set IP_MTU_DISCOVER failed with: {}",
+            Error::last_os_error()
+        );
+    }
+}
+
+pub(crate) fn spawn_tasks(
     local_addr: SocketAddr,
+    direct_socket_port: Option<u16>,
     udp_ingress_tx: mpsc::Sender<RecvUdpMsg>,
+    udp_direct_ingress_tx: mpsc::Sender<RecvUdpMsg>,
     udp_egress_rx: mpsc::Receiver<(SocketAddr, UdpMsg)>,
     up_bandwidth_mbps: u64,
     buffer_size: Option<usize>,
 ) {
-    // Bind the UDP socket and clone it for use in different tasks.
-    let udp_socket_rx = UdpSocket::bind(local_addr).unwrap();
+    let (udp_socket_rx, udp_socket_tx) = create_socket_pair(local_addr, buffer_size);
+    let (direct_socket_rx, direct_socket_tx) = direct_socket_port
+        .map(|port| {
+            let mut direct_addr = local_addr;
+            direct_addr.set_port(port);
+            let (rx, tx) = create_socket_pair(direct_addr, buffer_size);
+            (Some(rx), Some(tx))
+        })
+        .unwrap_or((None, None));
 
-    if let Some(requested_buffer_size) = buffer_size {
-        if let Err(e) = udp_socket_rx.set_recv_buffer_size(requested_buffer_size) {
-            panic!("set_recv_buffer_size to {requested_buffer_size} failed with: {e}");
-        }
-        let actual_buffer_size = udp_socket_rx
-            .recv_buffer_size()
-            .expect("get recv buffer size");
-        if actual_buffer_size < requested_buffer_size {
-            panic!("unable to set udp receive buffer size to {requested_buffer_size}. Got {actual_buffer_size} instead. Set net.core.rmem_max to at least {requested_buffer_size}");
-        }
-    }
-    if let Some(requested_buffer_size) = buffer_size {
-        if let Err(e) = udp_socket_rx.set_send_buffer_size(requested_buffer_size) {
-            panic!("set_send_buffer_size to {requested_buffer_size} failed with: {e}");
-        }
-        let actual_buffer_size = udp_socket_rx
-            .send_buffer_size()
-            .expect("get send buffer size");
-        if actual_buffer_size < requested_buffer_size {
-            panic!("unable to set udp send buffer size to {requested_buffer_size}. got {actual_buffer_size} instead. set net.core.wmem_max to at least {requested_buffer_size}");
-        }
-    }
-
-    let raw_fd = udp_socket_rx.as_raw_fd();
-    let udp_socket_tx =
-        UdpSocket::from_std(unsafe { std::net::UdpSocket::from_raw_fd(raw_fd) }).unwrap();
-
-    {
-        const MTU_DISCOVER: libc::c_int = libc::IP_PMTUDISC_OMIT;
-
-        if unsafe {
-            libc::setsockopt(
-                raw_fd,
-                libc::SOL_IP,
-                libc::IP_MTU_DISCOVER,
-                &MTU_DISCOVER as *const _ as _,
-                std::mem::size_of_val(&MTU_DISCOVER) as _,
-            )
-        } != 0
-        {
-            panic!(
-                "set IP_MTU_DISCOVER failed with: {}",
-                Error::last_os_error()
-            );
-        }
-    }
-
-    spawn(rx(udp_socket_rx, udp_ingress_tx));
-    spawn(tx(udp_socket_tx, udp_egress_rx, up_bandwidth_mbps));
+    spawn(rx(
+        udp_socket_rx,
+        direct_socket_rx,
+        udp_ingress_tx,
+        udp_direct_ingress_tx,
+    ));
+    spawn(tx(
+        udp_socket_tx,
+        direct_socket_tx,
+        udp_egress_rx,
+        up_bandwidth_mbps,
+    ));
 }
 
-async fn rx(udp_socket_rx: UdpSocket, udp_ingress_tx: mpsc::Sender<RecvUdpMsg>) {
+fn create_socket_pair(addr: SocketAddr, buffer_size: Option<usize>) -> (UdpSocket, UdpSocket) {
+    let rx = UdpSocket::bind(addr).unwrap();
+    configure_socket(&rx, buffer_size);
+    let tx =
+        UdpSocket::from_std(unsafe { std::net::UdpSocket::from_raw_fd(rx.as_raw_fd()) }).unwrap();
+    (rx, tx)
+}
+
+async fn rx(
+    udp_socket_rx: UdpSocket,
+    direct_socket_rx: Option<UdpSocket>,
+    udp_ingress_tx: mpsc::Sender<RecvUdpMsg>,
+    udp_direct_ingress_tx: mpsc::Sender<RecvUdpMsg>,
+) {
+    match direct_socket_rx {
+        Some(direct_socket) => {
+            spawn(rx_single_socket(udp_socket_rx, udp_ingress_tx));
+            spawn(rx_single_socket(direct_socket, udp_direct_ingress_tx));
+        }
+        None => {
+            rx_single_socket(udp_socket_rx, udp_ingress_tx).await;
+        }
+    }
+}
+
+async fn rx_single_socket(socket: UdpSocket, udp_ingress_tx: mpsc::Sender<RecvUdpMsg>) {
     loop {
         let buf = BytesMut::with_capacity(ETHERNET_SEGMENT_SIZE.into());
 
-        match udp_socket_rx.recv_from(buf).await {
+        match socket.recv_from(buf).await {
             (Ok((len, src_addr)), buf) => {
                 let payload = buf.freeze();
 
@@ -125,7 +181,7 @@ async fn rx(udp_socket_rx: UdpSocket, udp_ingress_tx: mpsc::Sender<RecvUdpMsg>) 
                 }
             }
             (Err(err), _buf) => {
-                warn!("udp_socket_rx.recv_from() error {}", err);
+                warn!("socket.recv_from() error {}", err);
             }
         }
     }
@@ -135,16 +191,20 @@ const PACING_SLEEP_OVERSHOOT_DETECTION_WINDOW: Duration = Duration::from_millis(
 
 async fn tx(
     socket_tx: UdpSocket,
+    direct_socket_tx: Option<UdpSocket>,
     mut udp_egress_rx: mpsc::Receiver<(SocketAddr, UdpMsg)>,
     up_bandwidth_mbps: u64,
 ) {
     let mut udp_segment_size: u16 = DEFAULT_SEGMENT_SIZE;
     set_udp_segment_size(&socket_tx, udp_segment_size);
+    if let Some(ref direct_socket) = direct_socket_tx {
+        set_udp_segment_size(direct_socket, udp_segment_size);
+    }
     let mut max_chunk: u16 = max_write_size_for_segment_size(udp_segment_size);
 
     let mut next_transmit = Instant::now();
 
-    let mut messages_to_send: VecDeque<(SocketAddr, Bytes, u16)> = VecDeque::new();
+    let mut messages_to_send: VecDeque<(SocketAddr, Bytes, u16, UdpMessageType)> = VecDeque::new();
 
     loop {
         while messages_to_send.is_empty() || !udp_egress_rx.is_empty() {
@@ -152,10 +212,10 @@ async fn tx(
                 return;
             };
 
-            messages_to_send.push_back((addr, udp_msg.payload, udp_msg.stride));
+            messages_to_send.push_back((addr, udp_msg.payload, udp_msg.stride, udp_msg.msg_type));
         }
 
-        let (addr, mut payload, stride) = messages_to_send.pop_front().unwrap();
+        let (addr, mut payload, stride, msg_type) = messages_to_send.pop_front().unwrap();
 
         if udp_segment_size != stride {
             udp_segment_size = stride;
@@ -179,14 +239,19 @@ async fn tx(
             }
         }
 
-        let (ret, chunk) = socket_tx.send_to(chunk, addr).await;
+        let socket = match (&msg_type, &direct_socket_tx) {
+            (UdpMessageType::Direct, Some(direct_socket)) => direct_socket,
+            _ => &socket_tx,
+        };
+
+        let (ret, chunk) = socket.send_to(chunk, addr).await;
 
         if let Err(err) = &ret {
             match err.kind() {
                 // ENETUNREACH is returned when trying to send to an IPv4 address from a
                 // socket bound to a local IPv6 address.
                 ErrorKind::NetworkUnreachable => debug!(
-                    local_addr =? socket_tx.local_addr().unwrap(),
+                    local_addr =? socket.local_addr().unwrap(),
                     ?addr,
                     "send address family mismatch. message is dropped"
                 ),
@@ -195,7 +260,7 @@ async fn tx(
                 // back to disabling GSO for this chunk and transmitting the constituent
                 // segments individually.
                 ErrorKind::InvalidInput => warn!(
-                    local_addr =? socket_tx.local_addr().unwrap(),
+                    local_addr =? socket.local_addr().unwrap(),
                     udp_segment_size,
                     max_chunk,
                     ?addr,
@@ -211,13 +276,13 @@ async fn tx(
                 _ => {
                     if is_eafnosupport(err) {
                         debug!(
-                            local_addr =? socket_tx.local_addr().unwrap(),
+                            local_addr =? socket.local_addr().unwrap(),
                             ?addr,
                             "send address family mismatch. message is dropped"
                         );
                     } else {
                         error!(
-                            local_addr =? socket_tx.local_addr().unwrap(),
+                            local_addr =? socket.local_addr().unwrap(),
                             udp_segment_size,
                             max_chunk,
                             ?addr,
@@ -237,7 +302,7 @@ async fn tx(
 
             // Re-queue (addr, payload) at the end of the list if there are bytes left to transmit.
             if !payload.is_empty() {
-                messages_to_send.push_back((addr, payload, stride));
+                messages_to_send.push_back((addr, payload, stride, msg_type));
             }
         }
     }


### PR DESCRIPTION
dataplane listens on two sockets and tags traffic that it sends to the consumer.
for sending we just select direct socket as source address if user specifies it over api, but otherwise the destination is selected in raptorcast