### PR TITLE
Remove execution delay from node.toml

### DIFF
--- a/docker/devnet/monad/config/node.toml
+++ b/docker/devnet/monad/config/node.toml
@@ -69,9 +69,3 @@ bind_address_host = "0.0.0.0"
 bind_address_port = 8000
 max_rtt_ms = 300
 max_mbps = 1000
-
-#########################################################
-# Network-wide configuration
-#########################################################
-[consensus]
-execution_delay = 10

--- a/monad-chain-config/src/revision.rs
+++ b/monad-chain-config/src/revision.rs
@@ -72,5 +72,6 @@ mod test {
     #[test]
     fn chain_revision_ord() {
         assert!(MonadChainRevision::V_0_7_0 < MonadChainRevision::V_0_8_0);
+        assert!(MonadChainRevision::V_0_8_0 < MonadChainRevision::V_0_10_0);
     }
 }

--- a/monad-node-config/src/consensus.rs
+++ b/monad-node-config/src/consensus.rs
@@ -1,7 +1,0 @@
-use serde::Deserialize;
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct NodeConsensusConfig {
-    pub execution_delay: u64,
-}

--- a/monad-node-config/src/lib.rs
+++ b/monad-node-config/src/lib.rs
@@ -12,7 +12,6 @@ use serde::Deserialize;
 
 pub use self::{
     bootstrap::{NodeBootstrapConfig, NodeBootstrapPeerConfig},
-    consensus::NodeConsensusConfig,
     fullnode::{FullNodeConfig, FullNodeIdentityConfig},
     network::NodeNetworkConfig,
     peers::PeerDiscoveryConfig,
@@ -20,7 +19,6 @@ pub use self::{
 };
 
 mod bootstrap;
-mod consensus;
 mod fullnode;
 mod network;
 mod peers;
@@ -67,7 +65,6 @@ pub struct NodeConfig<ST: CertificateSignatureRecoverable> {
     // NETWORK-WIDE CONFIGURATION //
     ////////////////////////////////
     pub chain_id: u64,
-    pub consensus: NodeConsensusConfig,
 }
 
 pub type SignatureType = SecpSignature;


### PR DESCRIPTION
Execution delay is now hardcoded in the node binary. Properly moving it to ChainConfig requires some work on txpool side, as it has no notion of round yet