### PR TITLE
Remove replaced event from txpool events

### DIFF
--- a/monad-eth-txpool-types/src/lib.rs
+++ b/monad-eth-txpool-types/src/lib.rs
@@ -28,17 +28,6 @@ pub enum EthTxPoolEvent {
         tracked: bool,
     },
 
-    /// A tx with a higher fee replaced an exixting tx.
-    ///
-    /// Note: The new tx is always placed in the same tx list as the original, preserving promotion
-    /// status.
-    Replace {
-        old_tx_hash: B256,
-        new_tx_hash: B256,
-        new_owned: bool,
-        tracked: bool,
-    },
-
     /// The tx was dropped for the attached reason.
     Drop {
         tx_hash: B256,
@@ -77,6 +66,7 @@ pub enum EthTxPoolDropReason {
     FeeTooLow,
     InsufficientBalance,
     ExistingHigherPriority,
+    ReplacedByHigherPriority { replacement: TxHash },
     PoolFull,
     PoolNotReady,
     Internal(EthTxPoolInternalDropReason),
@@ -107,7 +97,10 @@ impl EthTxPoolDropReason {
             EthTxPoolDropReason::InsufficientBalance => "Signer had insufficient balance",
             EthTxPoolDropReason::PoolFull => "Transaction pool is full",
             EthTxPoolDropReason::ExistingHigherPriority => {
-                "Another transaction has higher priority"
+                "An existing transaction had higher priority"
+            }
+            EthTxPoolDropReason::ReplacedByHigherPriority { .. } => {
+                "A newer transaction had higher priority"
             }
             EthTxPoolDropReason::PoolNotReady => "Transaction pool is not ready",
             EthTxPoolDropReason::Internal(_) => "Internal error",

--- a/monad-eth-txpool/src/event_tracker.rs
+++ b/monad-eth-txpool/src/event_tracker.rs
@@ -16,7 +16,7 @@
 use std::{sync::atomic::Ordering, time::Instant};
 
 use alloy_consensus::{transaction::Recovered, TxEnvelope};
-use alloy_primitives::TxHash;
+use alloy_primitives::{Address, TxHash};
 use monad_eth_txpool_types::{
     EthTxPoolDropReason, EthTxPoolEvent, EthTxPoolEvictReason, EthTxPoolInternalDropReason,
 };
@@ -74,7 +74,13 @@ impl<'a> EthTxPoolEventTracker<'a> {
         });
     }
 
-    pub fn replace_pending(&mut self, old_tx_hash: TxHash, new_tx_hash: TxHash, new_owned: bool) {
+    pub fn replace_pending(
+        &mut self,
+        address: &Address,
+        old_tx_hash: TxHash,
+        new_tx_hash: TxHash,
+        new_owned: bool,
+    ) {
         if new_owned {
             self.metrics.insert_owned_txs.fetch_add(1, Ordering::SeqCst);
         } else {
@@ -83,15 +89,27 @@ impl<'a> EthTxPoolEventTracker<'a> {
                 .fetch_add(1, Ordering::SeqCst);
         }
 
-        self.events.push(EthTxPoolEvent::Replace {
-            old_tx_hash,
-            new_tx_hash,
-            new_owned,
+        self.events.push(EthTxPoolEvent::Drop {
+            tx_hash: old_tx_hash,
+            reason: EthTxPoolDropReason::ReplacedByHigherPriority {
+                replacement: new_tx_hash,
+            },
+        });
+        self.events.push(EthTxPoolEvent::Insert {
+            tx_hash: new_tx_hash,
+            address: *address,
+            owned: new_owned,
             tracked: false,
         });
     }
 
-    pub fn replace_tracked(&mut self, old_tx_hash: TxHash, new_tx_hash: TxHash, new_owned: bool) {
+    pub fn replace_tracked(
+        &mut self,
+        address: &Address,
+        old_tx_hash: TxHash,
+        new_tx_hash: TxHash,
+        new_owned: bool,
+    ) {
         if new_owned {
             self.metrics.insert_owned_txs.fetch_add(1, Ordering::SeqCst);
         } else {
@@ -100,10 +118,16 @@ impl<'a> EthTxPoolEventTracker<'a> {
                 .fetch_add(1, Ordering::SeqCst);
         }
 
-        self.events.push(EthTxPoolEvent::Replace {
-            old_tx_hash,
-            new_tx_hash,
-            new_owned,
+        self.events.push(EthTxPoolEvent::Drop {
+            tx_hash: old_tx_hash,
+            reason: EthTxPoolDropReason::ReplacedByHigherPriority {
+                replacement: new_tx_hash,
+            },
+        });
+        self.events.push(EthTxPoolEvent::Insert {
+            tx_hash: new_tx_hash,
+            address: *address,
+            owned: new_owned,
             tracked: true,
         });
     }
@@ -136,6 +160,11 @@ impl<'a> EthTxPoolEventTracker<'a> {
             EthTxPoolDropReason::ExistingHigherPriority => {
                 self.metrics
                     .drop_existing_higher_priority
+                    .fetch_add(1, Ordering::SeqCst);
+            }
+            EthTxPoolDropReason::ReplacedByHigherPriority { .. } => {
+                self.metrics
+                    .drop_replaced_by_higher_priority
                     .fetch_add(1, Ordering::SeqCst);
             }
             EthTxPoolDropReason::PoolFull => {

--- a/monad-eth-txpool/src/metrics.rs
+++ b/monad-eth-txpool/src/metrics.rs
@@ -29,6 +29,7 @@ pub struct EthTxPoolMetrics {
     pub drop_fee_too_low: AtomicU64,
     pub drop_insufficient_balance: AtomicU64,
     pub drop_existing_higher_priority: AtomicU64,
+    pub drop_replaced_by_higher_priority: AtomicU64,
     pub drop_pool_full: AtomicU64,
     pub drop_pool_not_ready: AtomicU64,
     pub drop_internal_state_backend_error: AtomicU64,
@@ -61,6 +62,8 @@ impl EthTxPoolMetrics {
             self.drop_insufficient_balance.load(Ordering::SeqCst);
         metrics["monad.bft.txpool.pool.drop_existing_higher_priority"] =
             self.drop_existing_higher_priority.load(Ordering::SeqCst);
+        metrics["monad.bft.txpool.pool.drop_replaced_by_higher_priority"] =
+            self.drop_replaced_by_higher_priority.load(Ordering::SeqCst);
         metrics["monad.bft.txpool.pool.drop_pool_full"] =
             self.drop_pool_full.load(Ordering::SeqCst);
         metrics["monad.bft.txpool.pool.drop_pool_not_ready"] =

--- a/monad-eth-txpool/src/pool/pending/list.rs
+++ b/monad-eth-txpool/src/pool/pending/list.rs
@@ -79,7 +79,12 @@ impl PendingTxList {
                     return None;
                 }
 
-                event_tracker.replace_pending(existing_tx.hash(), tx.hash(), tx.is_owned());
+                event_tracker.replace_pending(
+                    tx.signer_ref(),
+                    existing_tx.hash(),
+                    tx.hash(),
+                    tx.is_owned(),
+                );
                 entry.insert(tx);
                 Some((entry.into_mut(), false))
             }

--- a/monad-eth-txpool/src/pool/tracked/list.rs
+++ b/monad-eth-txpool/src/pool/tracked/list.rs
@@ -126,7 +126,12 @@ impl TrackedTxList {
                     return None;
                 }
 
-                event_tracker.replace_tracked(existing_tx.hash(), tx.hash(), tx.is_owned());
+                event_tracker.replace_tracked(
+                    tx.signer_ref(),
+                    existing_tx.hash(),
+                    tx.hash(),
+                    tx.is_owned(),
+                );
                 entry.insert((tx, event_tracker.now));
                 Some(&entry.into_mut().0)
             }

--- a/monad-rpc/src/handlers/eth/txn.rs
+++ b/monad-rpc/src/handlers/eth/txn.rs
@@ -262,7 +262,7 @@ pub async fn monad_eth_sendRawTransaction<T: Triedb>(
 
             match tokio::time::timeout(Duration::from_secs(1), tx_status_recv).await {
                 Ok(Ok(tx_status)) => match tx_status {
-                    TxStatus::Evicted { reason: _ } | TxStatus::Replaced => {
+                    TxStatus::Evicted { reason: _ } => {
                         return Err(JsonRpcError::custom("rejected".to_string()))
                     }
                     TxStatus::Dropped { reason } => {

--- a/monad-rpc/src/txpool/state.rs
+++ b/monad-rpc/src/txpool/state.rs
@@ -212,22 +212,6 @@ impl EthTxPoolBridgeState {
                         .or_default()
                         .insert(tx_hash);
                 }
-                EthTxPoolEvent::Replace {
-                    old_tx_hash,
-                    new_tx_hash,
-                    new_owned: _,
-                    tracked,
-                } => {
-                    insert(old_tx_hash, TxStatus::Replaced);
-                    insert(
-                        new_tx_hash,
-                        if tracked {
-                            TxStatus::Tracked
-                        } else {
-                            TxStatus::Pending
-                        },
-                    );
-                }
                 EthTxPoolEvent::Drop { tx_hash, reason } => {
                     insert(tx_hash, TxStatus::Dropped { reason });
                 }
@@ -360,7 +344,6 @@ mod test {
             InsertPendingSnapshot,
             InsertTracked,
             InsertTrackedSnapshot,
-            Replace,
             Drop,
             Promote,
             PromoteSnapshot,
@@ -375,7 +358,6 @@ mod test {
             TestCases::InsertPendingSnapshot,
             TestCases::InsertTracked,
             TestCases::InsertTrackedSnapshot,
-            TestCases::Replace,
             TestCases::Drop,
             TestCases::Promote,
             TestCases::PromoteSnapshot,
@@ -455,47 +437,6 @@ mod test {
                     );
                     assert_eq!(
                         state_view.get_status_by_hash(tx.tx_hash()),
-                        Some(TxStatus::Tracked)
-                    );
-                }
-                TestCases::Replace => {
-                    state.handle_events(
-                        &mut eviction_queue,
-                        vec![EthTxPoolEvent::Insert {
-                            tx_hash: tx.tx_hash().to_owned(),
-                            address: tx.recover_signer().unwrap(),
-                            owned: true,
-                            tracked: false,
-                        }],
-                    );
-                    assert_eq!(
-                        state_view.get_status_by_hash(tx.tx_hash()),
-                        Some(TxStatus::Pending)
-                    );
-
-                    let new_tx = make_legacy_tx(
-                        S1,
-                        2u128 * Into::<u128>::into(BASE_FEE_PER_GAS),
-                        100_000,
-                        0,
-                        0,
-                    );
-
-                    state.handle_events(
-                        &mut eviction_queue,
-                        vec![EthTxPoolEvent::Replace {
-                            old_tx_hash: tx.tx_hash().to_owned(),
-                            new_tx_hash: new_tx.tx_hash().to_owned(),
-                            new_owned: true,
-                            tracked: true,
-                        }],
-                    );
-                    assert_eq!(
-                        state_view.get_status_by_hash(tx.tx_hash()),
-                        Some(TxStatus::Replaced)
-                    );
-                    assert_eq!(
-                        state_view.get_status_by_hash(new_tx.tx_hash()),
                         Some(TxStatus::Tracked)
                     );
                 }

--- a/monad-rpc/src/txpool/types.rs
+++ b/monad-rpc/src/txpool/types.rs
@@ -27,6 +27,5 @@ pub enum TxStatus {
     // Dead
     Dropped { reason: EthTxPoolDropReason },
     Evicted { reason: EthTxPoolEvictReason },
-    Replaced,
     Committed,
 }

--- a/monad-rpc/src/vpool.rs
+++ b/monad-rpc/src/vpool.rs
@@ -47,7 +47,6 @@ impl From<TxStatus> for TxPoolStatusResult {
                     EthTxPoolEvictReason::Expired => "Transaction expired".to_string(),
                 }),
             ),
-            TxStatus::Replaced => ("replaced", None),
             TxStatus::Committed => ("committed", None),
         };
 


### PR DESCRIPTION
The replaced event in the txpool event stream does not add a significant amount of value and can be modeled as an Insert event and a Drop event. This reduces the number of event variants, making the code simpler.