### PR TITLE
Refactor EthTxPoolEvent tx_hash

### DIFF
--- a/monad-eth-txpool-executor/src/lib.rs
+++ b/monad-eth-txpool-executor/src/lib.rs
@@ -34,7 +34,7 @@ use monad_crypto::certificate_signature::{
 };
 use monad_eth_block_policy::EthBlockPolicy;
 use monad_eth_txpool::{EthTxPool, EthTxPoolEventTracker};
-use monad_eth_txpool_types::{EthTxPoolDropReason, EthTxPoolEvent};
+use monad_eth_txpool_types::{EthTxPoolDropReason, EthTxPoolEvent, EthTxPoolEventType};
 use monad_eth_types::EthExecutionProtocol;
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{MempoolEvent, MonadEvent, TxPoolCommand};
@@ -476,9 +476,11 @@ where
                             Ok(signer) => {
                                 rayon::iter::Either::Left(Recovered::new_unchecked(tx, signer))
                             }
-                            Err(_) => rayon::iter::Either::Right(EthTxPoolEvent::Drop {
+                            Err(_) => rayon::iter::Either::Right(EthTxPoolEvent {
                                 tx_hash: *tx.tx_hash(),
-                                reason: EthTxPoolDropReason::InvalidSignature,
+                                action: EthTxPoolEventType::Drop {
+                                    reason: EthTxPoolDropReason::InvalidSignature,
+                                },
                             }),
                         }
                     });
@@ -524,9 +526,11 @@ where
                             Ok(signer) => {
                                 rayon::iter::Either::Left(Recovered::new_unchecked(tx, signer))
                             }
-                            Err(_) => rayon::iter::Either::Right(EthTxPoolEvent::Drop {
+                            Err(_) => rayon::iter::Either::Right(EthTxPoolEvent {
                                 tx_hash: *tx.tx_hash(),
-                                reason: EthTxPoolDropReason::InvalidSignature,
+                                action: EthTxPoolEventType::Drop {
+                                    reason: EthTxPoolDropReason::InvalidSignature,
+                                },
                             }),
                         }
                     });

--- a/monad-eth-txpool-types/src/lib.rs
+++ b/monad-eth-txpool-types/src/lib.rs
@@ -19,32 +19,31 @@ use alloy_primitives::{Address, TxHash, B256};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum EthTxPoolEvent {
+pub struct EthTxPoolEvent {
+    pub tx_hash: B256,
+    pub action: EthTxPoolEventType,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum EthTxPoolEventType {
     /// The tx was inserted into the txpool's (pending/tracked) tx list.
     Insert {
-        tx_hash: B256,
         address: Address,
         owned: bool,
         tracked: bool,
     },
 
-    /// The tx was dropped for the attached reason.
-    Drop {
-        tx_hash: B256,
-        reason: EthTxPoolDropReason,
-    },
-
     /// The tx was promoted from the txpool's pending tx list to it's tracked tx list.
-    Promoted { tx_hash: B256 },
+    Promote,
 
     /// The tx was committed and is thus finalized.
-    Commit { tx_hash: B256 },
+    Commit,
+
+    /// The tx was dropped for the attached reason.
+    Drop { reason: EthTxPoolDropReason },
 
     /// The tx timed out and was evicted.
-    Evict {
-        tx_hash: B256,
-        reason: EthTxPoolEvictReason,
-    },
+    Evict { reason: EthTxPoolEvictReason },
 }
 
 // allow for more fine grain debugging if needed

--- a/monad-rpc/src/txpool/state.rs
+++ b/monad-rpc/src/txpool/state.rs
@@ -22,7 +22,7 @@ use std::{
 use alloy_consensus::TxEnvelope;
 use alloy_primitives::{Address, TxHash};
 use dashmap::{DashMap, Entry};
-use monad_eth_txpool_types::{EthTxPoolEvent, EthTxPoolSnapshot};
+use monad_eth_txpool_types::{EthTxPoolEvent, EthTxPoolEventType, EthTxPoolSnapshot};
 use tokio::time::Instant;
 
 use super::TxStatus;
@@ -189,10 +189,9 @@ impl EthTxPoolBridgeState {
             };
         };
 
-        for event in events {
-            match event {
-                EthTxPoolEvent::Insert {
-                    tx_hash,
+        for EthTxPoolEvent { tx_hash, action } in events {
+            match action {
+                EthTxPoolEventType::Insert {
                     address,
                     owned: _,
                     tracked,
@@ -212,16 +211,16 @@ impl EthTxPoolBridgeState {
                         .or_default()
                         .insert(tx_hash);
                 }
-                EthTxPoolEvent::Drop { tx_hash, reason } => {
-                    insert(tx_hash, TxStatus::Dropped { reason });
-                }
-                EthTxPoolEvent::Promoted { tx_hash } => {
+                EthTxPoolEventType::Promote => {
                     insert(tx_hash, TxStatus::Tracked);
                 }
-                EthTxPoolEvent::Commit { tx_hash } => {
+                EthTxPoolEventType::Commit => {
                     insert(tx_hash, TxStatus::Committed);
                 }
-                EthTxPoolEvent::Evict { tx_hash, reason } => {
+                EthTxPoolEventType::Drop { reason } => {
+                    insert(tx_hash, TxStatus::Dropped { reason });
+                }
+                EthTxPoolEventType::Evict { reason } => {
                     insert(tx_hash, TxStatus::Evicted { reason });
                 }
             }
@@ -273,7 +272,8 @@ mod test {
     use alloy_primitives::{hex, B256};
     use monad_eth_testutil::make_legacy_tx;
     use monad_eth_txpool_types::{
-        EthTxPoolDropReason, EthTxPoolEvent, EthTxPoolEvictReason, EthTxPoolSnapshot,
+        EthTxPoolDropReason, EthTxPoolEvent, EthTxPoolEventType, EthTxPoolEvictReason,
+        EthTxPoolSnapshot,
     };
     use monad_eth_types::BASE_FEE_PER_GAS;
     use tokio::time::Instant;
@@ -387,11 +387,13 @@ mod test {
                 TestCases::InsertPending => {
                     state.handle_events(
                         &mut eviction_queue,
-                        vec![EthTxPoolEvent::Insert {
+                        vec![EthTxPoolEvent {
                             tx_hash: tx.tx_hash().to_owned(),
-                            address: tx.recover_signer().unwrap(),
-                            owned: true,
-                            tracked: false,
+                            action: EthTxPoolEventType::Insert {
+                                address: tx.recover_signer().unwrap(),
+                                owned: true,
+                                tracked: false,
+                            },
                         }],
                     );
                     assert_eq!(
@@ -415,11 +417,13 @@ mod test {
                 TestCases::InsertTracked => {
                     state.handle_events(
                         &mut eviction_queue,
-                        vec![EthTxPoolEvent::Insert {
+                        vec![EthTxPoolEvent {
                             tx_hash: tx.tx_hash().to_owned(),
-                            address: tx.recover_signer().unwrap(),
-                            owned: true,
-                            tracked: true,
+                            action: EthTxPoolEventType::Insert {
+                                address: tx.recover_signer().unwrap(),
+                                owned: true,
+                                tracked: true,
+                            },
                         }],
                     );
                     assert_eq!(
@@ -443,9 +447,11 @@ mod test {
                 TestCases::Drop => {
                     state.handle_events(
                         &mut eviction_queue,
-                        vec![EthTxPoolEvent::Drop {
+                        vec![EthTxPoolEvent {
                             tx_hash: tx.tx_hash().to_owned(),
-                            reason: EthTxPoolDropReason::PoolNotReady,
+                            action: EthTxPoolEventType::Drop {
+                                reason: EthTxPoolDropReason::PoolNotReady,
+                            },
                         }],
                     );
                     assert_eq!(
@@ -458,11 +464,13 @@ mod test {
                 TestCases::Promote => {
                     state.handle_events(
                         &mut eviction_queue,
-                        vec![EthTxPoolEvent::Insert {
+                        vec![EthTxPoolEvent {
                             tx_hash: tx.tx_hash().to_owned(),
-                            address: tx.recover_signer().unwrap(),
-                            owned: true,
-                            tracked: false,
+                            action: EthTxPoolEventType::Insert {
+                                address: tx.recover_signer().unwrap(),
+                                owned: true,
+                                tracked: false,
+                            },
                         }],
                     );
                     assert_eq!(
@@ -472,8 +480,9 @@ mod test {
 
                     state.handle_events(
                         &mut eviction_queue,
-                        vec![EthTxPoolEvent::Promoted {
+                        vec![EthTxPoolEvent {
                             tx_hash: tx.tx_hash().to_owned(),
+                            action: EthTxPoolEventType::Promote,
                         }],
                     );
                     assert_eq!(
@@ -484,11 +493,13 @@ mod test {
                 TestCases::PromoteSnapshot => {
                     state.handle_events(
                         &mut eviction_queue,
-                        vec![EthTxPoolEvent::Insert {
+                        vec![EthTxPoolEvent {
                             tx_hash: tx.tx_hash().to_owned(),
-                            address: tx.recover_signer().unwrap(),
-                            owned: true,
-                            tracked: false,
+                            action: EthTxPoolEventType::Insert {
+                                address: tx.recover_signer().unwrap(),
+                                owned: true,
+                                tracked: false,
+                            },
                         }],
                     );
                     assert_eq!(
@@ -511,11 +522,13 @@ mod test {
                 TestCases::DemoteSnapshot => {
                     state.handle_events(
                         &mut eviction_queue,
-                        vec![EthTxPoolEvent::Insert {
+                        vec![EthTxPoolEvent {
                             tx_hash: tx.tx_hash().to_owned(),
-                            address: tx.recover_signer().unwrap(),
-                            owned: true,
-                            tracked: true,
+                            action: EthTxPoolEventType::Insert {
+                                address: tx.recover_signer().unwrap(),
+                                owned: true,
+                                tracked: true,
+                            },
                         }],
                     );
                     assert_eq!(
@@ -538,8 +551,9 @@ mod test {
                 TestCases::Commit => {
                     state.handle_events(
                         &mut eviction_queue,
-                        vec![EthTxPoolEvent::Commit {
+                        vec![EthTxPoolEvent {
                             tx_hash: tx.tx_hash().to_owned(),
+                            action: EthTxPoolEventType::Commit,
                         }],
                     );
                     assert_eq!(
@@ -559,9 +573,11 @@ mod test {
                 TestCases::Evict => {
                     state.handle_events(
                         &mut eviction_queue,
-                        vec![EthTxPoolEvent::Evict {
+                        vec![EthTxPoolEvent {
                             tx_hash: tx.tx_hash().to_owned(),
-                            reason: EthTxPoolEvictReason::Expired,
+                            action: EthTxPoolEventType::Evict {
+                                reason: EthTxPoolEvictReason::Expired,
+                            },
                         }],
                     );
                     assert_eq!(


### PR DESCRIPTION
After https://github.com/category-labs/monad-bft/pull/2061, each event has a single `tx_hash` associated with it that can be pulled out to make the event variants simpler.

The motivation for this change is to allow keying events by tx hash to deduplicate event patterns like `[Insert, Promote]`.