### PR TITLE
Remove txpool promoted event

### DIFF
--- a/monad-eth-txpool-types/src/lib.rs
+++ b/monad-eth-txpool-types/src/lib.rs
@@ -33,9 +33,6 @@ pub enum EthTxPoolEventType {
         tracked: bool,
     },
 
-    /// The tx was promoted from the txpool's pending tx list to it's tracked tx list.
-    Promote,
-
     /// The tx was committed and is thus finalized.
     Commit,
 

--- a/monad-eth-txpool/src/event_tracker.rs
+++ b/monad-eth-txpool/src/event_tracker.rs
@@ -216,21 +216,28 @@ impl<'a> EthTxPoolEventTracker<'a> {
         }
     }
 
-    pub fn pending_promote(&mut self, tx_hashes: impl Iterator<Item = TxHash>) {
+    pub fn pending_promote<'b>(
+        &mut self,
+        txs: impl Iterator<Item = (bool, &'b Recovered<TxEnvelope>)>,
+    ) {
         self.metrics
             .pending
             .promote_addresses
             .fetch_add(1, Ordering::SeqCst);
 
-        for tx_hash in tx_hashes {
+        for (owned, tx) in txs {
             self.metrics
                 .pending
                 .promote_txs
                 .fetch_add(1, Ordering::SeqCst);
 
             self.events.push(EthTxPoolEvent {
-                tx_hash: tx_hash.to_owned(),
-                action: EthTxPoolEventType::Promote,
+                tx_hash: *tx.tx_hash(),
+                action: EthTxPoolEventType::Insert {
+                    address: tx.signer(),
+                    owned,
+                    tracked: true,
+                },
             });
         }
     }

--- a/monad-eth-txpool/src/pool/tracked/list.rs
+++ b/monad-eth-txpool/src/pool/tracked/list.rs
@@ -65,7 +65,7 @@ impl TrackedTxList {
             return None;
         }
 
-        event_tracker.pending_promote(txs.values().map(ValidEthTransaction::hash));
+        event_tracker.pending_promote(txs.values().map(|tx| (tx.is_owned(), tx.raw())));
 
         Some(Self {
             account_nonce,

--- a/monad-rpc/src/txpool/state.rs
+++ b/monad-rpc/src/txpool/state.rs
@@ -211,9 +211,6 @@ impl EthTxPoolBridgeState {
                         .or_default()
                         .insert(tx_hash);
                 }
-                EthTxPoolEventType::Promote => {
-                    insert(tx_hash, TxStatus::Tracked);
-                }
                 EthTxPoolEventType::Commit => {
                     insert(tx_hash, TxStatus::Committed);
                 }
@@ -482,7 +479,11 @@ mod test {
                         &mut eviction_queue,
                         vec![EthTxPoolEvent {
                             tx_hash: tx.tx_hash().to_owned(),
-                            action: EthTxPoolEventType::Promote,
+                            action: EthTxPoolEventType::Insert {
+                                address: tx.recover_signer().unwrap(),
+                                owned: true,
+                                tracked: true,
+                            },
                         }],
                     );
                     assert_eq!(


### PR DESCRIPTION
The `Promoted` event variant was added to minimize event size but requires maintaining state from when the transaction was `Inserted`. To keep things simple, the event can be removed. The motivation for this change is to allow keying events by tx hash to deduplicate event patterns like `[Insert, Promote]` (which after this change would become `[Insert (Pending), Insert (Tracked)]`.