### PR TITLE
Track txpool events by tx hash

### DIFF
--- a/monad-eth-txpool-types/src/lib.rs
+++ b/monad-eth-txpool-types/src/lib.rs
@@ -15,12 +15,12 @@
 
 use std::collections::HashSet;
 
-use alloy_primitives::{Address, TxHash, B256};
+use alloy_primitives::{Address, TxHash};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EthTxPoolEvent {
-    pub tx_hash: B256,
+    pub tx_hash: TxHash,
     pub action: EthTxPoolEventType,
 }
 

--- a/monad-eth-txpool/benches/common/controller.rs
+++ b/monad-eth-txpool/benches/common/controller.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::BTreeMap;
+
 use alloy_consensus::{transaction::Recovered, Transaction, TxEnvelope};
 use alloy_primitives::{Uint, B256};
 use alloy_rlp::Encodable;
@@ -110,7 +112,7 @@ impl<'a> BenchController<'a> {
         let mut pool = Pool::default_testing();
 
         pool.update_committed_block(
-            &mut EthTxPoolEventTracker::new(metrics, &mut Vec::default()),
+            &mut EthTxPoolEventTracker::new(metrics, &mut BTreeMap::default()),
             generate_block_with_txs(Round(0), block_policy.get_last_commit(), txs),
         );
 

--- a/monad-eth-txpool/benches/create_proposal.rs
+++ b/monad-eth-txpool/benches/create_proposal.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::BTreeMap;
+
 use criterion::{criterion_group, criterion_main, Criterion};
 use monad_consensus_types::{block::GENESIS_TIMESTAMP, payload::RoundSignature};
 use monad_crypto::{certificate_signature::CertificateKeyPair, NopKeyPair};
@@ -45,7 +47,7 @@ fn criterion_benchmark(c: &mut Criterion) {
              proposal_byte_limit,
          }| {
             pool.create_proposal(
-                &mut EthTxPoolEventTracker::new(metrics, &mut Vec::default()),
+                &mut EthTxPoolEventTracker::new(metrics, &mut BTreeMap::default()),
                 block_policy.get_last_commit() + SeqNum(pending_blocks.len() as u64),
                 *proposal_tx_limit,
                 *proposal_gas_limit,

--- a/monad-eth-txpool/benches/insert.rs
+++ b/monad-eth-txpool/benches/insert.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::BTreeMap;
+
 use common::SignatureType;
 use criterion::{criterion_group, criterion_main, Criterion};
 use monad_eth_block_policy::EthBlockPolicy;
@@ -50,7 +52,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         },
         |(pool, txs, state_backend)| {
             pool.insert_txs(
-                &mut EthTxPoolEventTracker::new(&EthTxPoolMetrics::default(), &mut Vec::default()),
+                &mut EthTxPoolEventTracker::new(
+                    &EthTxPoolMetrics::default(),
+                    &mut BTreeMap::default(),
+                ),
                 &block_policy,
                 state_backend,
                 txs.to_owned(),

--- a/monad-eth-txpool/benches/update.rs
+++ b/monad-eth-txpool/benches/update.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::BTreeMap;
+
 use criterion::{criterion_group, criterion_main, Criterion};
 use monad_eth_block_policy::EthBlockPolicy;
 use monad_eth_testutil::generate_block_with_txs;
@@ -52,7 +54,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         },
         |(pool, metrics, block)| {
             pool.update_committed_block(
-                &mut EthTxPoolEventTracker::new(metrics, &mut Vec::default()),
+                &mut EthTxPoolEventTracker::new(metrics, &mut BTreeMap::default()),
                 block.to_owned(),
             );
         },

--- a/monad-eth-txpool/tests/forward.rs
+++ b/monad-eth-txpool/tests/forward.rs
@@ -58,7 +58,7 @@ fn with_txpool(
     let mut pool = EthTxPool::default_testing();
 
     let metrics = EthTxPoolMetrics::default();
-    let mut ipc_events = Vec::default();
+    let mut ipc_events = BTreeMap::default();
     let mut event_tracker = EthTxPoolEventTracker::new(&metrics, &mut ipc_events);
 
     assert!(pool
@@ -78,7 +78,7 @@ fn with_txpool(
     );
 
     let metrics = EthTxPoolMetrics::default();
-    let mut ipc_events = Vec::default();
+    let mut ipc_events = BTreeMap::default();
     let mut event_tracker = EthTxPoolEventTracker::new(&metrics, &mut ipc_events);
 
     pool.insert_txs(

--- a/monad-eth-txpool/tests/pool.rs
+++ b/monad-eth-txpool/tests/pool.rs
@@ -140,7 +140,7 @@ fn run_custom_iter<const N: usize>(
 
     let mut pool = EthTxPool::default_testing();
     let metrics = EthTxPoolMetrics::default();
-    let mut ipc_events = Vec::default();
+    let mut ipc_events = BTreeMap::default();
     let mut event_tracker = EthTxPoolEventTracker::new(&metrics, &mut ipc_events);
 
     pool.update_committed_block(
@@ -183,10 +183,7 @@ fn run_custom_iter<const N: usize>(
                     );
 
                     if should_insert && !was_inserted {
-                        panic!(
-                            "tx should have been inserted but was not! last event: {:?}",
-                            ipc_events.last()
-                        );
+                        panic!("tx should have been inserted but was not! events: {ipc_events:?}",);
                     }
                 }
 

--- a/monad-updaters/src/txpool.rs
+++ b/monad-updaters/src/txpool.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{
-    collections::VecDeque,
+    collections::{BTreeMap, VecDeque},
     task::{Poll, Waker},
 };
 
@@ -219,7 +219,7 @@ where
     fn exec(&mut self, commands: Vec<Self::Command>) {
         let (pool, block_policy, state_backend) = self.eth.as_mut().unwrap();
 
-        let mut events = Vec::default();
+        let mut events = BTreeMap::default();
         let mut event_tracker = EthTxPoolEventTracker::new(&self.metrics, &mut events);
 
         for command in commands {
@@ -412,7 +412,7 @@ where
         let tx = Recovered::new_unchecked(tx, signer);
 
         pool.insert_txs(
-            &mut EthTxPoolEventTracker::new(&self.metrics, &mut Vec::default()),
+            &mut EthTxPoolEventTracker::new(&self.metrics, &mut BTreeMap::default()),
             block_policy,
             state_backend,
             vec![tx],


### PR DESCRIPTION
This change keys txpool events by tx hash which enables deduplicating double events like `[Insert (Pending), Insert (Tracked)]` or `[Insert (Pending), Drop (some drop reason)]`.

This should improve more nuanced RPC `eth_sendTransaction` and `eth_sendRawTransaction` responses since RPC will respond with the first event received from txpool. In a situation like `[Insert (Pending), Drop (some drop reason)]`, previously, the event would not get deduplicated resulting in an `Ok` response. Now that events are tracked by tx hash, the `Drop` event will overwrite the `Insert` and thus the error will be immediately returned to the user.