### PR TITLE
Check for max round span in fullnode group invites

### DIFF
--- a/monad-node-config/src/fullnode_raptorcast.rs
+++ b/monad-node-config/src/fullnode_raptorcast.rs
@@ -35,4 +35,5 @@ pub struct FullNodeRaptorCastConfig<P: PubKey> {
     pub invite_future_dist_min: Round,
     pub invite_future_dist_max: Round,
     pub invite_accept_heartbeat_ms: u64,
+    pub invite_round_span_max: Round,
 }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -685,6 +685,7 @@ where
                             invite_future_dist_min: cfg_2nd.invite_future_dist_min,
                             invite_future_dist_max: cfg_2nd.invite_future_dist_max,
                             invite_accept_heartbeat: Duration::from_millis(cfg_2nd.invite_accept_heartbeat_ms),
+                            invite_round_span_max: cfg_2nd.invite_round_span_max,
                         })
                     }
                 }

--- a/monad-raptorcast/src/config.rs
+++ b/monad-raptorcast/src/config.rs
@@ -129,6 +129,7 @@ pub struct RaptorCastConfigSecondaryClient {
     // seen any proposals in `invite_accept_heartbeat`
     pub invite_future_dist_min: Round,
     pub invite_future_dist_max: Round,
+    pub invite_round_span_max: Round,
     pub invite_accept_heartbeat: Duration,
 }
 
@@ -139,6 +140,7 @@ impl Default for RaptorCastConfigSecondaryClient {
             bandwidth_capacity: u64::MAX,
             invite_future_dist_min: Round(1),
             invite_future_dist_max: Round(600), // ~5 minutes into the future, with current round length of 500ms
+            invite_round_span_max: Round(172800), // 24 hours
             invite_accept_heartbeat: Duration::from_secs(10),
         }
     }

--- a/monad-raptorcast/src/raptorcast_secondary/publisher.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/publisher.rs
@@ -1364,6 +1364,7 @@ mod tests {
                 bandwidth_capacity: 5,
                 invite_future_dist_min: Round(1),
                 invite_future_dist_max: Round(100),
+                invite_round_span_max: Round(2000),
                 invite_accept_heartbeat: Duration::from_secs(10),
             },
         );
@@ -1491,6 +1492,7 @@ mod tests {
                 bandwidth_capacity: 5,
                 invite_future_dist_min: Round(1),
                 invite_future_dist_max: Round(100),
+                invite_round_span_max: Round(2000),
                 invite_accept_heartbeat: Duration::from_secs(10),
             },
         );
@@ -1633,6 +1635,7 @@ mod tests {
                 bandwidth_capacity: 6,
                 invite_future_dist_min: Round(1),
                 invite_future_dist_max: Round(100),
+                invite_round_span_max: Round(2000),
                 invite_accept_heartbeat: Duration::from_secs(10),
             },
         );


### PR DESCRIPTION
Add a sanity check for the round span in group invite messages.