### PR TITLE
Switch epoch lock from n+2 to n+1

### DIFF
--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -1262,11 +1262,12 @@ where
 
     #[must_use]
     pub fn checkpoint(&self) -> Checkpoint<ST, SCT, EPT> {
-        let val_set_data = |epoch: Epoch| {
+        let get_locked_epoch = |epoch: Epoch| {
             // return early if validator set isn't locked
             let _ = self.val_epoch_map.get_val_set(&epoch)?;
-
-            let round = self.epoch_manager.epoch_starts.get(&epoch).copied();
+            // return early if next epoch isn't scheduled
+            let round = self.epoch_manager.epoch_starts.get(&epoch).copied()?;
+            // this implies that epoch is scheduled and validator set is ready
             Some(LockedEpoch { epoch, round })
         };
 
@@ -1274,16 +1275,12 @@ where
         Checkpoint {
             root: self.consensus.pending_block_tree.root().block_id,
             high_certificate: self.consensus.pacemaker.high_certificate().clone(),
-            validator_sets: vec![
-                val_set_data(base_epoch)
-                    .expect("checkpoint: no validator set populated for base_epoch"),
-                val_set_data(base_epoch + Epoch(1))
-                    .expect("checkpoint: no validator set populated for base_epoch + 1"),
-            ]
+            validator_sets: vec![get_locked_epoch(base_epoch)
+                .expect("checkpoint: no validator set populated for base_epoch")]
             .into_iter()
             .chain(
-                // third val_set might not be ready
-                val_set_data(base_epoch + Epoch(2)),
+                // next val_set might not be ready
+                get_locked_epoch(base_epoch + Epoch(1)),
             )
             .collect(),
         }

--- a/monad-consensus-types/src/checkpoint.rs
+++ b/monad-consensus-types/src/checkpoint.rs
@@ -50,6 +50,6 @@ where
 pub struct LockedEpoch {
     /// Validator set are active for this epoch
     pub epoch: Epoch,
-    /// By the end of epoch - 1, the next epoch is scheduled to start on round. Otherwise, it's left empty
-    pub round: Option<Round>,
+    /// By the end of epoch - 1, the next epoch is scheduled to start on round.
+    pub round: Round,
 }

--- a/monad-mock-swarm/tests/epoch.rs
+++ b/monad-mock-swarm/tests/epoch.rs
@@ -515,11 +515,10 @@ mod test {
         .iter()
         .map(|vdata| vdata.node_id)
         .collect();
-        let (validators_epoch_3, validators_epoch_4) = genesis_validators.split_at(2);
+        let (validators_epoch_2, validators_epoch_3) = genesis_validators.split_at(2);
         // validators for epoch 1 = genesis_validators
-        // validators for epoch 2 = genesis_validators
+        // validators for epoch 2 = validators_epoch_2
         // validators for epoch 3 = validators_epoch_3
-        // validators for epoch 4 = validators_epoch_4
 
         let all_peers: BTreeSet<_> = state_configs
             .iter()
@@ -567,27 +566,11 @@ mod test {
 
         let mut nodes = swarm_config.build();
 
-        let update_block_num_end_1 = val_set_update_interval - SeqNum(1);
+        let boundary_block_1 = val_set_update_interval - SeqNum(1);
 
         let mut term_on_schedule_epoch_2 =
-            UntilTerminator::new().until_block(update_block_num_end_1.0 as usize + 1);
+            UntilTerminator::new().until_block(boundary_block_1.0 as usize + 1);
         while nodes.step_until(&mut term_on_schedule_epoch_2).is_some() {}
-
-        // all nodes must still be in epoch 1 but schedule epoch 2
-        verify_nodes_in_epoch(nodes.states().values().collect_vec(), Epoch(1));
-        let epoch_2_start_round = verify_nodes_scheduled_epoch(
-            nodes.states().values().collect_vec(),
-            update_block_num_end_1,
-            Epoch(2),
-        );
-
-        // terminate when epoch 2 starts
-        let mut term_in_epoch_2 =
-            UntilTerminator::new().until_round(epoch_2_start_round + Round(1));
-        while nodes.step_until(&mut term_in_epoch_2).is_some() {}
-
-        // all nodes must have advanced to next epoch
-        verify_nodes_in_epoch(nodes.states().values().collect_vec(), Epoch(2));
         for expected_validator in &genesis_validators {
             let (_, node) = nodes
                 .mut_states()
@@ -597,63 +580,19 @@ mod test {
             assert_eq!(node.state.get_role(), Role::Validator);
         }
 
-        let update_block_num_end_2 = SeqNum(val_set_update_interval.0 * 2) - SeqNum(1);
-
-        let mut term_on_schedule_epoch_3 =
-            UntilTerminator::new().until_block(update_block_num_end_2.0 as usize + 1);
-        while nodes.step_until(&mut term_on_schedule_epoch_3).is_some() {}
-
-        // all nodes must still be in the same epoch but schedule next epoch
-        verify_nodes_in_epoch(nodes.states().values().collect_vec(), Epoch(2));
-        let epoch_3_start_round = verify_nodes_scheduled_epoch(
+        // all nodes must still be in epoch 1 but schedule epoch 2
+        verify_nodes_in_epoch(nodes.states().values().collect_vec(), Epoch(1));
+        let epoch_2_start_round = verify_nodes_scheduled_epoch(
             nodes.states().values().collect_vec(),
-            update_block_num_end_2,
-            Epoch(3),
+            boundary_block_1,
+            Epoch(2),
         );
 
-        // terminate when epoch 3 starts
-        let mut term_in_epoch_3 =
-            UntilTerminator::new().until_round(epoch_3_start_round + Round(1));
-        while nodes.step_until(&mut term_in_epoch_3).is_some() {}
-        for expected_validator in validators_epoch_3 {
-            let (_, node) = nodes
-                .mut_states()
-                .iter_mut()
-                .find(|(id, _)| id.get_peer_id() == expected_validator)
-                .unwrap();
-            assert_eq!(node.state.get_role(), Role::Validator);
-        }
-        for expected_full_node in validators_epoch_4 {
-            let (_, node) = nodes
-                .mut_states()
-                .iter_mut()
-                .find(|(id, _)| id.get_peer_id() == expected_full_node)
-                .unwrap();
-            assert_eq!(node.state.get_role(), Role::FullNode);
-        }
-
-        // all nodes must have advanced to next epoch
-        verify_nodes_in_epoch(nodes.states().values().collect_vec(), Epoch(3));
-
-        let update_block_num_end_3 = SeqNum(val_set_update_interval.0 * 3) - SeqNum(1);
-
-        let mut term_on_schedule_epoch_4 =
-            UntilTerminator::new().until_block(update_block_num_end_3.0 as usize + 1);
-        while nodes.step_until(&mut term_on_schedule_epoch_4).is_some() {}
-
-        // all nodes must still be in the same epoch but schedule next epoch
-        verify_nodes_in_epoch(nodes.states().values().collect_vec(), Epoch(3));
-        let epoch_4_start_round = verify_nodes_scheduled_epoch(
-            nodes.states().values().collect_vec(),
-            update_block_num_end_3,
-            Epoch(4),
-        );
-
-        // terminate when epoch 4 starts
-        let mut term_in_epoch_4 =
-            UntilTerminator::new().until_round(epoch_4_start_round + Round(1));
-        while nodes.step_until(&mut term_in_epoch_4).is_some() {}
-        for expected_validator in validators_epoch_4 {
+        // terminate when epoch 2 starts
+        let mut term_in_epoch_2 =
+            UntilTerminator::new().until_round(epoch_2_start_round + Round(2));
+        while nodes.step_until(&mut term_in_epoch_2).is_some() {}
+        for expected_validator in validators_epoch_2 {
             let (_, node) = nodes
                 .mut_states()
                 .iter_mut()
@@ -669,6 +608,47 @@ mod test {
                 .unwrap();
             assert_eq!(node.state.get_role(), Role::FullNode);
         }
+
+        // all nodes must have advanced to next epoch
+        verify_nodes_in_epoch(nodes.states().values().collect_vec(), Epoch(2));
+
+        let boundary_block_2 = SeqNum(val_set_update_interval.0 * 2) - SeqNum(1);
+
+        let mut term_on_schedule_epoch_3 =
+            UntilTerminator::new().until_block(boundary_block_2.0 as usize + 1);
+        while nodes.step_until(&mut term_on_schedule_epoch_3).is_some() {}
+
+        // all nodes must still be in the same epoch but schedule next epoch
+        verify_nodes_in_epoch(nodes.states().values().collect_vec(), Epoch(2));
+        let epoch_3_start_round = verify_nodes_scheduled_epoch(
+            nodes.states().values().collect_vec(),
+            boundary_block_2,
+            Epoch(3),
+        );
+
+        // terminate when epoch 3 starts
+        let mut term_in_epoch_3 =
+            UntilTerminator::new().until_round(epoch_3_start_round + Round(2));
+        while nodes.step_until(&mut term_in_epoch_3).is_some() {}
+        for expected_validator in validators_epoch_3 {
+            let (_, node) = nodes
+                .mut_states()
+                .iter_mut()
+                .find(|(id, _)| id.get_peer_id() == expected_validator)
+                .unwrap();
+            assert_eq!(node.state.get_role(), Role::Validator);
+        }
+        for expected_full_node in validators_epoch_2 {
+            let (_, node) = nodes
+                .mut_states()
+                .iter_mut()
+                .find(|(id, _)| id.get_peer_id() == expected_full_node)
+                .unwrap();
+            assert_eq!(node.state.get_role(), Role::FullNode);
+        }
+
+        // all nodes must have advanced to next epoch
+        verify_nodes_in_epoch(nodes.states().values().collect_vec(), Epoch(3));
 
         let ledgers = nodes
             .states()
@@ -686,14 +666,13 @@ mod test {
 
         for ledger in ledgers {
             for full_block in ledger {
-                if full_block.get_block_round() < epoch_3_start_round {
-                    // the first two epochs both have genesis validators as the
-                    // validator set
+                if full_block.get_block_round() < epoch_2_start_round {
+                    // the first epoch has genesis validators as the validator set
                     assert!(genesis_validators.contains(full_block.get_author()));
-                } else if full_block.get_block_round() < epoch_4_start_round {
-                    assert!(validators_epoch_3.contains(full_block.get_author()));
+                } else if full_block.get_block_round() < epoch_3_start_round {
+                    assert!(validators_epoch_2.contains(full_block.get_author()));
                 } else {
-                    assert!(validators_epoch_4.contains(full_block.get_author()));
+                    assert!(validators_epoch_3.contains(full_block.get_author()));
                 }
             }
         }

--- a/monad-mock-swarm/tests/forkpoint.rs
+++ b/monad-mock-swarm/tests/forkpoint.rs
@@ -412,7 +412,7 @@ fn forkpoint_restart_f(
         let failed_node_high_epoch = forkpoint
             .validator_sets
             .iter()
-            .filter_map(|vset| vset.round.map(|round| (round, vset.epoch)))
+            .map(|vset| (vset.round, vset.epoch))
             .max_by(|x, y| x.0.cmp(&y.0))
             .map(|t| t.1)
             .expect("current epoch must be scheduled");

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -245,6 +245,7 @@ async fn run(node_state: NodeState, reload_handle: Box<dyn TracingReload>) -> Re
     );
 
     let val_set_update_interval = SeqNum(50_000); // TODO configurable
+    let epoch_start_delay = Round(5_000); // TODO configurable
 
     let statesync_threshold: usize = node_state.node_config.statesync_threshold.into();
 
@@ -401,7 +402,7 @@ async fn run(node_state: NodeState, reload_handle: Box<dyn TracingReload>) -> Re
         key: node_state.secp256k1_identity,
         certkey: node_state.bls12_381_identity,
         val_set_update_interval,
-        epoch_start_delay: Round(5000),
+        epoch_start_delay,
         beneficiary: node_state.node_config.beneficiary.into(),
         locked_epoch_validators,
         forkpoint: node_state.forkpoint_config.into(),

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -332,11 +332,11 @@ impl SeqNum {
     /// Get the epoch number whose validator set is locked by this block. Should
     /// only be called on the boundary block sequence number
     ///
-    /// Current design locks the info for epoch n + 2 by the end of epoch n. The
-    /// validators have an entire epoch to prepare themselves for any duties
+    /// Current design locks the info for epoch n + 1 by the end of epoch n. The
+    /// validators have epoch_start_delay to prepare themselves for any duties
     pub fn get_locked_epoch(&self, val_set_update_interval: SeqNum) -> Epoch {
         assert!(self.is_epoch_end(val_set_update_interval));
-        (*self).to_epoch(val_set_update_interval) + Epoch(2)
+        (*self).to_epoch(val_set_update_interval) + Epoch(1)
     }
 
     pub fn as_u64(&self) -> u64 {

--- a/monad-updaters/src/state_root_hash.rs
+++ b/monad-updaters/src/state_root_hash.rs
@@ -116,7 +116,7 @@ where
             let locked_epoch = seq_num.get_locked_epoch(self.val_set_update_interval);
             assert_eq!(
                 locked_epoch,
-                seq_num.to_epoch(self.val_set_update_interval) + Epoch(2)
+                seq_num.to_epoch(self.val_set_update_interval) + Epoch(1)
             );
             self.next_val_data = Some(ValidatorSetDataWithEpoch {
                 epoch: locked_epoch,
@@ -272,9 +272,9 @@ where
             let locked_epoch = seq_num.get_locked_epoch(self.val_set_update_interval);
             assert_eq!(
                 locked_epoch,
-                seq_num.to_epoch(self.val_set_update_interval) + Epoch(2)
+                seq_num.to_epoch(self.val_set_update_interval) + Epoch(1)
             );
-            self.next_val_data = if locked_epoch.0 % 2 == 1 {
+            self.next_val_data = if locked_epoch.0 % 2 == 0 {
                 Some(ValidatorSetDataWithEpoch {
                     epoch: locked_epoch,
                     validators: self.val_data_1.clone(),

--- a/monad-updaters/src/triedb_state_root_hash.rs
+++ b/monad-updaters/src/triedb_state_root_hash.rs
@@ -92,7 +92,7 @@ where
             let locked_epoch = seq_num.get_locked_epoch(self.val_set_update_interval);
             assert_eq!(
                 locked_epoch,
-                seq_num.to_epoch(self.val_set_update_interval) + Epoch(2)
+                seq_num.to_epoch(self.val_set_update_interval) + Epoch(1)
             );
             self.next_val_data = Some(ValidatorSetDataWithEpoch {
                 epoch: locked_epoch,


### PR DESCRIPTION
This PR converts validator set locking at the end of an Epoch(N) from Epoch(N+2) to Epoch(N+1)

Updated forkpoint tests, mock swarm tests, and flexnet configs