### PR TITLE
Populate tn2 fork round

### DIFF
--- a/monad-chain-config/src/lib.rs
+++ b/monad-chain-config/src/lib.rs
@@ -138,7 +138,7 @@ const MONAD_TESTNET2_CHAIN_CONFIG: MonadChainConfig = MonadChainConfig {
     chain_id: MONAD_TESTNET2_CHAIN_ID,
     v_0_7_0_activation: Round::MIN,
     v_0_8_0_activation: Round::MIN,
-    v_0_10_0_activation: Round::MIN, // TODO fill in real round later
+    v_0_10_0_activation: Round(6487752), // 2025-07-29T13:30:00.000Z
 
     execution_v_one_activation: 0,
     execution_v_two_activation: 0,


### PR DESCRIPTION
After halt:
```
monad@bue-004:~$ cat monad-bft/config/forkpoint/forkpoint.toml
root = "0x8906d1ccba2be50ac8469bc13e05a15e0d62f64730e85ad44dc80c5a25c7f055"

[high_qc]
signatures = "0x0a6ca4656f72646572736269747665633a3a6f726465723a3a4c7362306468656164a26577696474680865696e64657800646269747318ba6464617461981818cd18ff188f18f318d9182f18f518b818fe18ba18fb184f18c9186d18f518fb187e189a18fc18e4186518d218330312c0010b52f62ad9d6111cc126f1f9f103c632cb7b6120dc97ea597463f33afacec8c6567370ec5a76c1cc7cb36c7dde5e34950f22b28cd681d7971d7840103a3c2576c3b1547d76fab84e972e497b70aab3b53f2d044c7cfb1991c4f2d3a599e976ce14375e85f6020b4df99210b757646935a79a00b95c32795e6c96be976b7364bbac9d79bee82fc5daf93771fbe0889ffd07e2439cc0495e417fea467492fe3a8e6f7ba661197e2187b63749619bc3aae4b91800336981bc0a60cb1f04bf6b44de"

[high_qc.info]
id = "0x9c80e57456628d3cc922089ad65464131944cbee40d07815b845b286816f47a0"
round = 6487752
epoch = 120
parent_id = "0x8906d1ccba2be50ac8469bc13e05a15e0d62f64730e85ad44dc80c5a25c7f055"
parent_round = 6487751

[[validator_sets]]
epoch = 120
round = 6463618

[[validator_sets]]
epoch = 121
```