### PR TITLE
Add metrics for elapsed CPU time

### DIFF
--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -137,6 +137,7 @@ where
     };
 
     ParentExecutor {
+        metrics: Default::default(),
         router: match config.router_config {
             RouterConfig::Local(router) => Updater::boxed(router),
 


### PR DESCRIPTION
These metrics can be used as a canary for the main thread being overwhelmed. Concretely, (PARENT_TOTAL_EXEC_US + PARENT_TOTAL_POLL_US + STATE_TOTAL_UPDATE_US) / GAUGE_TOTAL_UPTIME_US is approximately how busy the main thread is.