### PR TITLE
Include last_round_qc if necessary

### DIFF
--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -129,7 +129,7 @@ where
             PacemakerCommand::EnterRound(epoch, round) => {
                 ConsensusCommand::EnterRound(epoch, round)
             }
-            PacemakerCommand::PrepareTimeout(timeout, high_extend, last_round_tc) => {
+            PacemakerCommand::PrepareTimeout(timeout, high_extend, last_round_certificate) => {
                 ConsensusCommand::Publish {
                     // TODO should this be sent to epoch of next round?
                     target: RouterTarget::Broadcast(timeout.epoch),
@@ -139,7 +139,7 @@ where
                             cert_keypair,
                             timeout,
                             high_extend,
-                            last_round_tc,
+                            last_round_certificate,
                         )),
                     }
                     .sign(keypair),

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -486,25 +486,7 @@ where
 
         if let Some(last_round_tc) = p.last_round_tc.as_ref() {
             self.metrics.consensus_events.proposal_with_tc += 1;
-            let advance_round_cmds = self
-                .consensus
-                .pacemaker
-                .process_certificate(
-                    self.metrics,
-                    self.epoch_manager,
-                    &mut self.consensus.safety,
-                    RoundCertificate::Tc(last_round_tc.clone()),
-                )
-                .into_iter()
-                .map(|cmd| {
-                    ConsensusCommand::from_pacemaker_command(
-                        self.keypair,
-                        self.cert_keypair,
-                        self.version,
-                        cmd,
-                    )
-                });
-            cmds.extend(advance_round_cmds);
+            cmds.extend(self.process_tc(last_round_tc));
         }
 
         // author, leader, round checks
@@ -823,25 +805,7 @@ where
 
         if let Some(last_round_tc) = timeout.last_round_tc.as_ref() {
             self.metrics.consensus_events.remote_timeout_msg_with_tc += 1;
-            let advance_round_cmds = self
-                .consensus
-                .pacemaker
-                .process_certificate(
-                    self.metrics,
-                    self.epoch_manager,
-                    &mut self.consensus.safety,
-                    RoundCertificate::Tc(last_round_tc.clone()),
-                )
-                .into_iter()
-                .map(|cmd| {
-                    ConsensusCommand::from_pacemaker_command(
-                        self.keypair,
-                        self.cert_keypair,
-                        self.version,
-                        cmd,
-                    )
-                });
-            cmds.extend(advance_round_cmds);
+            cmds.extend(self.process_tc(last_round_tc));
         }
 
         let remote_timeout_cmds = self
@@ -893,25 +857,7 @@ where
         // handling the proposal certificate
         let _original_round = self.consensus.pacemaker.get_current_round();
 
-        let advance_round_cmds = self
-            .consensus
-            .pacemaker
-            .process_certificate(
-                self.metrics,
-                self.epoch_manager,
-                &mut self.consensus.safety,
-                RoundCertificate::Tc(round_recovery.tc.clone()),
-            )
-            .into_iter()
-            .map(|cmd| {
-                ConsensusCommand::from_pacemaker_command(
-                    self.keypair,
-                    self.cert_keypair,
-                    self.version,
-                    cmd,
-                )
-            });
-        cmds.extend(advance_round_cmds);
+        cmds.extend(self.process_tc(&round_recovery.tc));
 
         // author, leader, round checks
         let pacemaker_round = self.consensus.pacemaker.get_current_round();
@@ -1225,6 +1171,32 @@ where
             .start_new_round(self.consensus.pacemaker.get_current_round());
 
         cmds
+    }
+
+    #[must_use]
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub fn process_tc(
+        &mut self,
+        tc: &TimeoutCertificate<ST, SCT, EPT>,
+    ) -> Vec<ConsensusCommand<ST, SCT, EPT, BPT, SBT>> {
+        self.consensus
+            .pacemaker
+            .process_certificate(
+                self.metrics,
+                self.epoch_manager,
+                &mut self.consensus.safety,
+                RoundCertificate::Tc(tc.clone()),
+            )
+            .into_iter()
+            .map(|cmd| {
+                ConsensusCommand::from_pacemaker_command(
+                    self.keypair,
+                    self.cert_keypair,
+                    self.version,
+                    cmd,
+                )
+            })
+            .collect()
     }
 
     #[must_use]

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -803,9 +803,17 @@ where
             cmds.extend(handle_vote_cmds);
         }
 
-        if let Some(last_round_tc) = timeout.last_round_tc.as_ref() {
-            self.metrics.consensus_events.remote_timeout_msg_with_tc += 1;
-            cmds.extend(self.process_tc(last_round_tc));
+        match &timeout.last_round_certificate {
+            Some(RoundCertificate::Tc(tc)) => {
+                self.metrics.consensus_events.remote_timeout_msg_with_tc += 1;
+                cmds.extend(self.process_tc(tc));
+            }
+            Some(RoundCertificate::Qc(qc)) => {
+                cmds.extend(self.process_qc(qc));
+            }
+            None => {
+                // don't do anything
+            }
         }
 
         let remote_timeout_cmds = self

--- a/monad-consensus-types/src/timeout.rs
+++ b/monad-consensus-types/src/timeout.rs
@@ -33,6 +33,7 @@ use crate::{
     },
     tip::ConsensusTip,
     voting::{ValidatorMapping, Vote},
+    RoundCertificate,
 };
 
 /// Timeout message to broadcast to other nodes after a local timeout
@@ -49,9 +50,9 @@ where
 
     pub high_extend: HighExtendVote<ST, SCT, EPT>,
 
-    /// if the high qc round != tminfo.round-1, then this must be the
-    /// TC for tminfo.round-1. Otherwise it must be None
-    pub last_round_tc: Option<TimeoutCertificate<ST, SCT, EPT>>,
+    /// if the high_extend.qc round != tminfo.round-1, then this must be the
+    /// TC or QC from r-1
+    pub last_round_certificate: Option<RoundCertificate<ST, SCT, EPT>>,
 }
 
 impl<ST, SCT, EPT> Timeout<ST, SCT, EPT>
@@ -64,7 +65,7 @@ where
         cert_keypair: &SignatureCollectionKeyPairType<SCT>,
         timeout: TimeoutInfo,
         high_extend: HighExtend<ST, SCT, EPT>,
-        last_round_tc: Option<TimeoutCertificate<ST, SCT, EPT>>,
+        last_round_certificate: Option<RoundCertificate<ST, SCT, EPT>>,
     ) -> Self {
         let timeout_digest = alloy_rlp::encode(&timeout);
         let timeout_signature = <SCT::SignatureType as CertificateSignature>::sign::<
@@ -89,7 +90,7 @@ where
         Self {
             tminfo: timeout,
             high_extend,
-            last_round_tc,
+            last_round_certificate,
 
             timeout_signature,
         }

--- a/monad-consensus/src/messages/message.rs
+++ b/monad-consensus/src/messages/message.rs
@@ -23,6 +23,7 @@ use monad_consensus_types::{
     timeout::{HighExtend, Timeout, TimeoutCertificate, TimeoutInfo},
     tip::ConsensusTip,
     voting::Vote,
+    RoundCertificate,
 };
 use monad_crypto::{
     certificate_signature::{
@@ -85,13 +86,13 @@ where
         cert_keypair: &SignatureCollectionKeyPairType<SCT>,
         timeout: TimeoutInfo,
         high_extend: HighExtend<ST, SCT, EPT>,
-        last_round_tc: Option<TimeoutCertificate<ST, SCT, EPT>>,
+        last_round_certificate: Option<RoundCertificate<ST, SCT, EPT>>,
     ) -> Self {
         TimeoutMessage(Timeout::new(
             cert_keypair,
             timeout,
             high_extend,
-            last_round_tc,
+            last_round_certificate,
         ))
     }
 }
@@ -231,7 +232,7 @@ mod tests {
             c.high_extend,
             HighExtendVote::Qc(QuorumCertificate::genesis_qc())
         );
-        assert!(c.last_round_tc.is_none());
+        assert!(c.last_round_certificate.is_none());
     }
 
     #[test]
@@ -259,6 +260,6 @@ mod tests {
             c.high_extend,
             HighExtendVote::Qc(QuorumCertificate::genesis_qc())
         );
-        assert!(c.last_round_tc.is_none());
+        assert!(c.last_round_certificate.is_none());
     }
 }

--- a/monad-mock-swarm/src/utils.rs
+++ b/monad-mock-swarm/src/utils.rs
@@ -155,7 +155,7 @@ pub mod test_tool {
         let internal_msg = TimeoutMessage(Timeout {
             tminfo: timeout_info,
             high_extend: HighExtendVote::Qc(QuorumCertificate::genesis_qc()),
-            last_round_tc: None,
+            last_round_certificate: None,
             timeout_signature: NopSignature::sign::<signing_domain::Timeout>(&[0x00_u8, 32], kp),
         });
         ConsensusMessage {

--- a/monad-testutil/src/proposal.rs
+++ b/monad-testutil/src/proposal.rs
@@ -27,6 +27,7 @@ use monad_consensus_types::{
     timeout::{HighExtend, HighTipRoundSigColTuple, Timeout, TimeoutCertificate, TimeoutInfo},
     tip::ConsensusTip,
     voting::{ValidatorMapping, Vote},
+    RoundCertificate,
 };
 use monad_crypto::{
     certificate_signature::{
@@ -245,7 +246,7 @@ where
                 certkey,
                 tminfo.clone(),
                 HighExtend::Qc(self.high_qc.clone()),
-                Some(tc.clone()),
+                Some(RoundCertificate::Tc(tc.clone())),
             );
             tmo_msgs.push(Verified::<ST, _>::new(timeout.into(), key));
         }


### PR DESCRIPTION
When sending a timeout with round=r, it's possible for high_tip.qc.round to be r-2. If the local high_certificate is QC(r-1), we need to support including QC(r-1) instead of TC(r-1).