### PR TITLE
Send vote(r) to leader(r) in addition to leader(r+1)

### DIFF
--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -26,8 +26,8 @@ use monad_consensus::{
     messages::{
         consensus_message::{ConsensusMessage, ProtocolMessage},
         message::{
-            NoEndorsementMessage, ProposalMessage, RoundRecoveryMessage, TimeoutMessage,
-            VoteMessage,
+            AdvanceRoundMessage, NoEndorsementMessage, ProposalMessage, RoundRecoveryMessage,
+            TimeoutMessage, VoteMessage,
         },
     },
     no_endorsement_state::NoEndorsementState,
@@ -715,11 +715,12 @@ where
         vote_msg: VoteMessage<SCT>,
     ) -> Vec<ConsensusCommand<ST, SCT, EPT, BPT, SBT>> {
         debug!(?author, ?vote_msg, "vote message");
-        if vote_msg.vote.round < self.consensus.pacemaker.get_current_round() {
+        let vote_round = vote_msg.vote.round;
+        if vote_round < self.consensus.pacemaker.get_current_round() {
             self.metrics.consensus_events.old_vote_received += 1;
             return Default::default();
         }
-        if vote_msg.vote.round > self.consensus.pacemaker.get_current_round() + FUTURE_VOTE_BOUND {
+        if vote_round > self.consensus.pacemaker.get_current_round() + FUTURE_VOTE_BOUND {
             self.metrics.consensus_events.future_vote_received += 1;
             return Default::default();
         }
@@ -729,7 +730,7 @@ where
 
         let epoch = self
             .epoch_manager
-            .get_epoch(vote_msg.vote.round)
+            .get_epoch(vote_round)
             .expect("epoch verified");
         let validator_set = self
             .val_epoch_map
@@ -753,6 +754,27 @@ where
 
             cmds.extend(self.process_qc(&qc));
             cmds.extend(self.try_propose());
+
+            let vote_round_leader = self
+                .election
+                .get_leader(vote_round, validator_set.get_members());
+            if self.nodeid == &vote_round_leader {
+                // Note that if we're also the leader of (vote_round + 1), we'll send QC(r) in
+                // both AdvanceRound(QC(r)) and Proposal(r+1). This is fine, as AdvanceRound(r)
+                // will be propagated faster than Proposal(r+1) due to it being direct broadcast.
+                //
+                // Also note that this broadcasts to the (qc.round + 1) validator set
+                cmds.push(ConsensusCommand::Publish {
+                    target: RouterTarget::Broadcast(self.consensus.get_current_epoch()),
+                    message: ConsensusMessage {
+                        message: ProtocolMessage::AdvanceRound(AdvanceRoundMessage {
+                            last_round_certificate: RoundCertificate::Qc(qc),
+                        }),
+                        version: self.version,
+                    }
+                    .sign(self.keypair),
+                });
+            }
         };
 
         cmds
@@ -994,6 +1016,20 @@ where
         cmds
     }
 
+    #[must_use]
+    pub fn handle_advance_round_message(
+        &mut self,
+        author: NodeId<SCT::NodeIdPubKey>,
+        advance_round_msg: AdvanceRoundMessage<ST, SCT, EPT>,
+    ) -> Vec<ConsensusCommand<ST, SCT, EPT, BPT, SBT>> {
+        debug!(?author, ?advance_round_msg, "advance round message");
+        self.metrics.consensus_events.handle_advance_round += 1;
+        match &advance_round_msg.last_round_certificate {
+            RoundCertificate::Tc(tc) => self.process_tc(tc),
+            RoundCertificate::Qc(qc) => self.process_qc(qc),
+        }
+    }
+
     /// invariant: handle_block_sync must only be passed blocks that were previously requested
     ///
     /// it is possible that a requested block failed to be added to the tree
@@ -1068,36 +1104,48 @@ where
         round: Round,
         vote: Vote,
     ) -> Vec<ConsensusCommand<ST, SCT, EPT, BPT, SBT>> {
+        let mut cmds = Vec::new();
         let vote_msg = VoteMessage::<SCT>::new(vote, self.cert_keypair);
-
-        // TODO this grouping should be enforced by epoch_manager/val_epoch_map to be less
-        // error-prone
-        let (next_round, next_validator_set) = {
-            let next_round = round + Round(1);
-            let next_epoch = self
-                .epoch_manager
-                .get_epoch(next_round)
-                .expect("higher epoch always exists");
-            let Some(next_validator_set) = self.val_epoch_map.get_val_set(&next_epoch) else {
-                todo!("handle non-existent validatorset for next round epoch");
-            };
-            (next_round, next_validator_set.get_members())
-        };
-        let next_leader = self.election.get_leader(next_round, next_validator_set);
-        let msg = ConsensusMessage {
+        let message = ConsensusMessage {
             version: self.version,
             message: ProtocolMessage::Vote(vote_msg),
         }
         .sign(self.keypair);
-        let send_cmd = ConsensusCommand::Publish {
-            target: RouterTarget::PointToPoint(next_leader),
-            message: msg,
-        };
-        debug!(?round, ?vote, ?next_leader, "created vote");
+
         self.metrics.consensus_events.created_vote += 1;
 
+        let get_leader = |round: Round| {
+            // TODO this grouping should be enforced by epoch_manager/val_epoch_map to be less
+            // error-prone
+            let epoch = self
+                .epoch_manager
+                .get_epoch(round)
+                .expect("looked up leader for invalid round");
+            let validator_set = self
+                .val_epoch_map
+                .get_val_set(&epoch)
+                .expect("looked up leader for invalid round");
+            self.election.get_leader(round, validator_set.get_members())
+        };
+        // leader for next round must be known
+        let next_leader = get_leader(round + Round(1));
+        cmds.push(ConsensusCommand::Publish {
+            target: RouterTarget::PointToPoint(next_leader),
+            message: message.clone(),
+        });
+        // leader for current round must be known
+        let current_leader = get_leader(round);
+        if current_leader != next_leader {
+            cmds.push(ConsensusCommand::Publish {
+                target: RouterTarget::PointToPoint(current_leader),
+                message,
+            });
+        }
+
+        debug!(?round, ?vote, ?current_leader, ?next_leader, "sending vote");
+
         // start the vote-timer for the next round
-        let vote_timer_cmd = ConsensusCommand::ScheduleVote {
+        cmds.push(ConsensusCommand::ScheduleVote {
             duration: self
                 .config
                 .chain_config
@@ -1105,10 +1153,10 @@ where
                 .chain_params()
                 .vote_pace,
             round: round + Round(1),
-        };
-
+        });
         self.consensus.scheduled_vote = None;
-        vec![send_cmd, vote_timer_cmd]
+
+        cmds
     }
 
     /// If the qc has a commit_state_hash, commit the parent block and prune the
@@ -3016,7 +3064,8 @@ mod test {
         // proposal and qc have non-consecutive rounds
         // vote after a timeout happens immediately and is therefore extracted from the output cmds
         let p3_votes = extract_vote_msgs(cmds);
-        assert!(p3_votes.len() == 1);
+        assert!(p3_votes.len() == 2);
+        assert_eq!(p3_votes[0].vote, p3_votes[1].vote);
         let p3_vote = p3_votes[0].vote;
         assert_eq!(p3_vote.round, Round(3));
     }
@@ -3443,8 +3492,9 @@ mod test {
                             .send_vote_and_reset_timer(vote.round, vote);
 
                         let v = extract_vote_msgs(cmds);
-                        assert_eq!(v.len(), 1);
+                        assert_eq!(v.len(), 2);
                         assert_eq!(v[0].vote.round, Round(10));
+                        assert_eq!(v[0].vote, v[1].vote);
 
                         proposal_10_votes.push((node.nodeid, v[0]));
                     }
@@ -3657,7 +3707,7 @@ mod test {
                     .send_vote_and_reset_timer(vote.round, vote);
 
                 let v = extract_vote_msgs(cmds);
-                assert_eq!(v.len(), 1);
+                assert_eq!(v.len(), 2);
                 votes.push((node.nodeid, v[0]));
             } else {
                 leader_index = i;

--- a/monad-consensus-types/src/metrics.rs
+++ b/monad-consensus-types/src/metrics.rs
@@ -128,7 +128,8 @@ metrics!(
             handle_no_endorsement,
             old_no_endorsement_received,
             future_no_endorsement_received,
-            created_nec
+            created_nec,
+            handle_advance_round
         ]
     ),
     (

--- a/monad-consensus/src/messages/consensus_message.rs
+++ b/monad-consensus/src/messages/consensus_message.rs
@@ -24,7 +24,8 @@ use monad_types::{ExecutionProtocol, Round};
 
 use crate::{
     messages::message::{
-        NoEndorsementMessage, ProposalMessage, RoundRecoveryMessage, TimeoutMessage, VoteMessage,
+        AdvanceRoundMessage, NoEndorsementMessage, ProposalMessage, RoundRecoveryMessage,
+        TimeoutMessage, VoteMessage,
     },
     validation::signing::{Validated, Verified},
 };
@@ -50,6 +51,10 @@ where
 
     RoundRecovery(RoundRecoveryMessage<ST, SCT, EPT>),
     NoEndorsement(NoEndorsementMessage<SCT>),
+
+    /// This message is broadcasted upon locally constructing QC(r)
+    /// This helps other nodes advance their round faster
+    AdvanceRound(AdvanceRoundMessage<ST, SCT, EPT>),
 }
 
 impl<ST, SCT, EPT> Debug for ProtocolMessage<ST, SCT, EPT>
@@ -65,6 +70,7 @@ where
             ProtocolMessage::Timeout(t) => f.debug_tuple("").field(&t).finish(),
             ProtocolMessage::RoundRecovery(r) => f.debug_tuple("").field(&r).finish(),
             ProtocolMessage::NoEndorsement(n) => f.debug_tuple("").field(&n).finish(),
+            ProtocolMessage::AdvanceRound(l) => f.debug_tuple("").field(&l).finish(),
         }
     }
 }
@@ -103,6 +109,10 @@ where
                 let enc: [&dyn Encodable; 3] = [&name, &5u8, &m];
                 encode_list::<_, dyn Encodable>(&enc, out);
             }
+            ProtocolMessage::AdvanceRound(m) => {
+                let enc: [&dyn Encodable; 3] = [&name, &6u8, &m];
+                encode_list::<_, dyn Encodable>(&enc, out);
+            }
         }
     }
 }
@@ -136,6 +146,9 @@ where
             5 => Ok(ProtocolMessage::NoEndorsement(
                 NoEndorsementMessage::decode(&mut payload)?,
             )),
+            6 => Ok(ProtocolMessage::AdvanceRound(AdvanceRoundMessage::decode(
+                &mut payload,
+            )?)),
             _ => Err(alloy_rlp::Error::Custom(
                 "failed to decode unknown ProtocolMessage",
             )),
@@ -183,6 +196,7 @@ where
             ProtocolMessage::Timeout(t) => t.0.tminfo.round,
             ProtocolMessage::RoundRecovery(r) => r.round,
             ProtocolMessage::NoEndorsement(n) => n.msg.round,
+            ProtocolMessage::AdvanceRound(n) => n.last_round_certificate.round(),
         }
     }
 }

--- a/monad-consensus/src/messages/message.rs
+++ b/monad-consensus/src/messages/message.rs
@@ -150,6 +150,18 @@ where
     pub last_round_tc: Option<TimeoutCertificate<ST, SCT, EPT>>,
 }
 
+/// This message is broadcasted upon locally constructing QC(r)
+/// This helps other nodes advance their round faster
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+pub struct AdvanceRoundMessage<ST, SCT, EPT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    EPT: ExecutionProtocol,
+{
+    pub last_round_certificate: RoundCertificate<ST, SCT, EPT>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 pub struct RoundRecoveryMessage<ST, SCT, EPT>
 where

--- a/monad-debugger/frontend/src/components/Message.tsx
+++ b/monad-debugger/frontend/src/components/Message.tsx
@@ -74,6 +74,17 @@ const Message: Component<{
                     </div>
                 </div>
             );
+        case "GraphQLAdvanceRound":
+            return (
+                <div class="p-2 lg:p-4 text-nowrap rounded-2xl bg-green-400/35 border border-black shadow-sm">
+                    <div class="text-xl lg:text-2xl">AdvanceRound</div>
+                    <div>
+                        <span class="hidden lg:inline">round=</span>
+                        <span class="inline lg:hidden">r=</span>
+                        {round()}
+                    </div>
+                </div>
+            );
         default:
             assertUnreachable(messageType);
             return <div>Unknown message type</div>;

--- a/monad-debugger/src/lib.rs
+++ b/monad-debugger/src/lib.rs
@@ -101,11 +101,11 @@ pub fn simulation_make() -> *mut Simulation {
                         ),
                         vec![
                             GenericTransformer::Latency(LatencyTransformer::new(
-                                Duration::from_millis(10),
+                                Duration::from_millis(25),
                             )),
                             GenericTransformer::RandLatency(RandLatencyTransformer::new(
                                 0,
-                                Duration::from_millis(40),
+                                Duration::from_millis(25),
                             )),
                             GenericTransformer::Periodic(PeriodicTransformer::new(
                                 Duration::from_millis(1_000),

--- a/monad-mock-swarm/src/transformer.rs
+++ b/monad-mock-swarm/src/transformer.rs
@@ -71,6 +71,7 @@ where
                     ProtocolMessage::Timeout(_) => self.drop_timeout,
                     ProtocolMessage::RoundRecovery(_) => false,
                     ProtocolMessage::NoEndorsement(_) => false,
+                    ProtocolMessage::AdvanceRound(_) => false,
                 }
             }
             VerifiedMonadMessage::BlockSyncRequest(_)
@@ -153,6 +154,9 @@ where
                     ProtocolMessage::Timeout(_) => TwinsCapture::Spread(pid),
                     ProtocolMessage::RoundRecovery(m) => TwinsCapture::Process(pid, m.round),
                     ProtocolMessage::NoEndorsement(m) => TwinsCapture::Process(pid, m.msg.round),
+                    ProtocolMessage::AdvanceRound(m) => {
+                        TwinsCapture::Process(pid, m.last_round_certificate.round() + Round(1))
+                    }
                 }
             }
             VerifiedMonadMessage::BlockSyncRequest(_)

--- a/monad-mock-swarm/src/verifier.rs
+++ b/monad-mock-swarm/src/verifier.rs
@@ -290,11 +290,12 @@ impl<S: SwarmRelation> MockSwarmVerifier<S> {
                 ledger_len,
             );
             // votes from f peers after receiving 2f+1 votes as a leader
+            // 2x because votes are sent to current and next leader
             // NOTE: malicious votes should be rejected before reaching consensus
             self.metric_maximum(
                 node_ids,
                 fetch_metric!(consensus_events.old_vote_received),
-                (num_blocks_authored + 1) * max_byzantine_nodes,
+                2 * (num_blocks_authored + 1) * max_byzantine_nodes,
             );
             // votes from 2f+1 peers as a leader
             // except if the node is a leader in round 2 when it receives timeouts instead

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -185,7 +185,7 @@ fn many_nodes_noser_one_offline() {
     max_observed_local_timeouts -= 1;
 
     let max_allowed_local_timeouts =
-        (2 * num_rounds * num_offline_nodes as u64).div_ceil(num_nodes.into());
+        (num_rounds * num_offline_nodes as u64).div_ceil(num_nodes.into());
 
     assert!(max_observed_local_timeouts <= max_allowed_local_timeouts);
 }

--- a/monad-state/src/consensus.rs
+++ b/monad-state/src/consensus.rs
@@ -247,6 +247,9 @@ where
                             ProtocolMessage::NoEndorsement(msg) => {
                                 consensus.handle_no_endorsement_message(author, msg)
                             }
+                            ProtocolMessage::AdvanceRound(msg) => {
+                                consensus.handle_advance_round_message(author, msg)
+                            }
                         }
                     }
                     Err(evidence) => {


### PR DESCRIPTION
Sending votes for r to r's leader in addition to r+1's leader, and having leader r broadcast QC(r) saves a lot of time - at least a full timeout period in the happy path.

This is because round r+1 is entered much faster, starting the r+1 timer sooner.