### PR TITLE
Fix consensus state upcoming leaders filter

### DIFF
--- a/monad-consensus-state/Cargo.toml
+++ b/monad-consensus-state/Cargo.toml
@@ -19,6 +19,7 @@ monad-state-backend = { workspace = true }
 monad-types = { workspace = true }
 monad-validator = { workspace = true }
 
+itertools = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
@@ -28,6 +29,5 @@ monad-multi-sig = { workspace = true }
 monad-testutil = { workspace = true }
 
 alloy-consensus = { workspace = true }
-itertools = { workspace = true }
 test-case = { workspace = true }
 tracing-test = { workspace = true }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1322,7 +1322,7 @@ where
                 };
                 consensus.request_blocks_if_missing_ancestor()
             };
-            let consensus = ConsensusChildState::new(self);
+            let mut consensus = ConsensusChildState::new(self);
             commands.extend(
                 blocksync_cmds
                     .into_iter()


### PR DESCRIPTION
The upcoming leaders filter is used to tell the txpool in which future rounds the node will be proposing so it can preload account balances. Previously, it would produce all rounds regardless of the leader which causes the txpool preload manager to load account balances in every round. This change fixes the filtering condition so the txpool is only given the node's rounds.

Resolves https://github.com/category-labs/monad-bft/issues/2085.