### PR TITLE
fix: change submodule URLs to HTTPS for easier cloning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "monad-cxx/monad-execution"]
-	path = monad-cxx/monad-execution
-	url = git@github.com:category-labs/monad.git
+    path = monad-cxx/monad-execution
+    url = https://github.com/category-labs/monad.git
+
 [submodule "manytrace"]
-	path = manytrace
-	url = git@github.com:category-labs/manytrace.git
+    path = manytrace
+    url = https://github.com/category-labs/manytrace.git


### PR DESCRIPTION
### Problem
The current `.gitmodules` file uses SSH URLs (`git@github.com:...`) for submodules. This causes errors for users who do not have SSH keys set up:

```bash
git submodule update --init --recursive
# -> fatal: repository not found
