### PR TITLE
Add C/C++ filetypes to CI license check

### DIFF
--- a/.github/workflows/license.sh
+++ b/.github/workflows/license.sh
@@ -19,7 +19,7 @@ LICENSE_HEADER_LEN=$(("${#LICENSE_HEADER}" + 2))
 
 exit_code=0
 
-for file in $(git ls-files '*.rs'); do
+for file in $(git ls-files -- '*.rs' '*.h' '*.hpp' '*.c' '*.cpp'); do
     contents=$(head -c $LICENSE_HEADER_LEN "$file")
 
     if [ "$contents" == "$LICENSE_HEADER" ]; then

--- a/monad-raptorcast/wireshark/raptorcast.c
+++ b/monad-raptorcast/wireshark/raptorcast.c
@@ -1,3 +1,18 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 /*
  * TODO:
  * - include more information in protocol title


### PR DESCRIPTION
While working on the execution events SDK, I realized that we also need to check license headers for C/C++ files & headers (like `wrapper.h`). Although there don't seem to be any `hpp`, `c`, or `cpp` files in the consensus repo right now, feels reasonable to also add them here just in case.

EDIT: Turns out there was already a `c` file with a missing header!