### PR TITLE
Fix event rings to adjust for the C API renaming

### DIFF
--- a/monad-event-ring/src/decoder.rs
+++ b/monad-event-ring/src/decoder.rs
@@ -39,7 +39,7 @@ pub trait EventDecoder: 'static {
     ///
     /// # Panics
     ///
-    /// Panics if [`ring_ctype()`](EventDecoder::ring_ctype) is invalid.
+    /// Panics if [`ring_content_ctype()`](EventDecoder::ring_content_ctype) is invalid.
     fn ring_ctype_name() -> String {
         let content_ctype = Self::ring_content_ctype();
 

--- a/monad-event-ring/src/ffi.rs
+++ b/monad-event-ring/src/ffi.rs
@@ -22,12 +22,12 @@ use std::{
 };
 
 pub(crate) use self::bindings::{
-    g_monad_event_ring_type_names, monad_event_descriptor, monad_event_iter_result,
-    monad_event_iterator, monad_event_ring, MONAD_EVENT_GAP, MONAD_EVENT_NOT_READY,
-    MONAD_EVENT_RING_TYPE_COUNT, MONAD_EVENT_RING_TYPE_NONE, MONAD_EVENT_SUCCESS,
+    g_monad_event_content_type_names, monad_event_descriptor, monad_event_iter_result,
+    monad_event_iterator, monad_event_ring, MONAD_EVENT_CONTENT_TYPE_COUNT,
+    MONAD_EVENT_CONTENT_TYPE_NONE, MONAD_EVENT_GAP, MONAD_EVENT_NOT_READY, MONAD_EVENT_SUCCESS,
 };
 pub use self::bindings::{
-    monad_event_ring_type, MONAD_EVENT_RING_TYPE_EXEC, MONAD_EVENT_RING_TYPE_TEST,
+    monad_event_content_type, MONAD_EVENT_CONTENT_TYPE_EXEC, MONAD_EVENT_CONTENT_TYPE_TEST,
 };
 
 #[allow(dead_code, non_camel_case_types, non_upper_case_globals)]
@@ -78,16 +78,16 @@ pub(crate) fn monad_event_ring_mmap(
     get_last_ring_library_error(r).map(|()| c_event_ring)
 }
 
-pub(crate) fn monad_event_ring_check_type(
+pub(crate) fn monad_event_ring_check_content_type(
     c_event_ring: &monad_event_ring,
-    c_event_ring_type: monad_event_ring_type,
-    metadata_hash: &[u8; 32],
+    c_event_content_type: monad_event_content_type,
+    schema_hash: &[u8; 32],
 ) -> Result<(), String> {
     let r = unsafe {
-        self::bindings::monad_event_ring_check_type(
+        self::bindings::monad_event_ring_check_content_type(
             c_event_ring,
-            c_event_ring_type,
-            metadata_hash.as_ptr(),
+            c_event_content_type,
+            schema_hash.as_ptr(),
         )
     };
 

--- a/monad-event-ring/src/ring/mod.rs
+++ b/monad-event-ring/src/ring/mod.rs
@@ -49,7 +49,7 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EventRing")
             .field("raw", &self.raw)
-            .field("type", &D::ring_ctype())
+            .field("type", &D::ring_content_ctype())
             .finish()
     }
 }

--- a/monad-event-ring/src/ring/raw.rs
+++ b/monad-event-ring/src/ring/raw.rs
@@ -45,7 +45,7 @@ impl RawEventRing {
     where
         D: EventDecoder,
     {
-        D::check_ring_type(&self.inner)
+        D::check_ring_content_type(&self.inner)
     }
 }
 

--- a/monad-exec-events/src/events/mod.rs
+++ b/monad-exec-events/src/events/mod.rs
@@ -14,13 +14,13 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use monad_event_ring::{
-    ffi::{monad_event_ring_type, MONAD_EVENT_RING_TYPE_EXEC},
+    ffi::{monad_event_content_type, MONAD_EVENT_CONTENT_TYPE_EXEC},
     EventDecoder, EventDescriptorInfo,
 };
 
 use self::bytes::{ref_from_bytes, ref_from_bytes_with_trailing};
 use crate::ffi::{
-    self, g_monad_exec_event_metadata_hash, monad_exec_account_access,
+    self, g_monad_exec_event_schema_hash, monad_exec_account_access,
     monad_exec_account_access_list_header, monad_exec_block_end, monad_exec_block_finalized,
     monad_exec_block_qc, monad_exec_block_reject, monad_exec_block_start,
     monad_exec_block_verified, monad_exec_evm_error, monad_exec_storage_access,
@@ -208,12 +208,12 @@ pub struct ExecEventRingFlowInfo {
 }
 
 impl EventDecoder for ExecEventDecoder {
-    fn ring_ctype() -> monad_event_ring_type {
-        MONAD_EVENT_RING_TYPE_EXEC
+    fn ring_content_ctype() -> monad_event_content_type {
+        MONAD_EVENT_CONTENT_TYPE_EXEC
     }
 
-    fn ring_metadata_hash() -> &'static [u8; 32] {
-        unsafe { &g_monad_exec_event_metadata_hash }
+    fn ring_schema_hash() -> &'static [u8; 32] {
+        unsafe { &g_monad_exec_event_schema_hash }
     }
 
     type FlowInfo = ExecEventRingFlowInfo;

--- a/monad-exec-events/src/ffi.rs
+++ b/monad-exec-events/src/ffi.rs
@@ -16,7 +16,7 @@
 //! This module contains low-level bindings to the monad execution client event types.
 
 pub(crate) use self::bindings::{
-    g_monad_exec_event_metadata_hash, MONAD_EXEC_ACCOUNT_ACCESS,
+    g_monad_exec_event_schema_hash, MONAD_EXEC_ACCOUNT_ACCESS,
     MONAD_EXEC_ACCOUNT_ACCESS_LIST_HEADER, MONAD_EXEC_BLOCK_END, MONAD_EXEC_BLOCK_FINALIZED,
     MONAD_EXEC_BLOCK_PERF_EVM_ENTER, MONAD_EXEC_BLOCK_PERF_EVM_EXIT, MONAD_EXEC_BLOCK_QC,
     MONAD_EXEC_BLOCK_REJECT, MONAD_EXEC_BLOCK_START, MONAD_EXEC_BLOCK_VERIFIED,

--- a/monad-exec-events/src/ffi.rs
+++ b/monad-exec-events/src/ffi.rs
@@ -35,7 +35,13 @@ pub use self::bindings::{
     MONAD_TXN_EIP2930, MONAD_TXN_LEGACY,
 };
 
-#[allow(dead_code, missing_docs, non_camel_case_types, non_upper_case_globals)]
+#[allow(
+    dead_code,
+    missing_docs,
+    non_camel_case_types,
+    non_upper_case_globals,
+    rustdoc::broken_intra_doc_links
+)]
 mod bindings {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }

--- a/monad-exec-events/src/lib.rs
+++ b/monad-exec-events/src/lib.rs
@@ -70,7 +70,7 @@
 //!
 //! # Block-Oriented Updates
 //!
-//! The [`ExecEventRingType`] enables an `EventRing` to produce individual `monad` execution events.
+//! The [`ExecEventRing`] enables an `EventRing` to produce individual `monad` execution events.
 //! While many applications may benefit from operating on individual events or by observing them
 //! as quickly as possible, many would prefer to process entire blocks. This library provides the
 //! [`ExecutedBlockBuilder`] utility to reconstruct blocks from an event stream produced by an


### PR DESCRIPTION
The execution event payloads and ring structures are still ABI compatible with the v0.10.0 branches, only the source code identifiers are spelled differently