### PR TITLE
Refactor: Improve Error Handling by Replacing panic! and expect with Result

### DIFF
--- a/monad-consensus-state/src/error.rs
+++ b/monad-consensus-state/src/error.rs
@@ -1,0 +1,24 @@
+use monad_types::{Epoch, Round, SeqNum};
+use thiserror::Error;
+
+/// Defines errors that can occur within the consensus state machine.
+#[derive(Error, Debug, PartialEq)]
+pub enum ConsensusError {
+    /// Returned when the node's state is too far behind the network's high_qc to sync.
+    /// This is considered a fatal, unrecoverable state that requires a restart.
+    #[error("Node is too far behind to sync. Root: {root_seq_num:?}, High QC: {high_qc_seq_num:?}")]
+    FatalOutOfSync {
+        root_seq_num: SeqNum,
+        high_qc_seq_num: SeqNum,
+    },
+
+    /// Returned when processing a message intended for a round in an unknown epoch.
+    #[error("Epoch not found for round {0:?}")]
+    EpochNotFound(Round),
+
+    /// Returned when the validator set for a given epoch cannot be found.
+    #[error("Validator set not found for epoch {0:?}")]
+    ValidatorSetNotFound(Epoch),
+
+    // Other error cases can be added here as more `expect()` calls are refactored.
+}


### PR DESCRIPTION
Currently, the monad-consensus-state crate utilizes panic! and expect() to handle certain failure scenarios within the consensus logic. This approach causes the entire node to crash immediately upon encountering an unrecoverable state or malformed input.

This PR aims to refactor this error handling strategy to be more robust and resilient. By replacing panics with a dedicated Result type, we shift control of how to handle critical errors from the library to the consuming application (the top-level node binary). This prevents a library-level failure from bringing down the entire process, making the node more stable and secure against potential DoS vectors from malicious peers.