### PR TITLE
A few typos. #2118

### DIFF
--- a/monad-eth-txpool-ipc/src/lib.rs
+++ b/monad-eth-txpool-ipc/src/lib.rs
@@ -159,7 +159,7 @@ impl EthTxPoolIpcClient {
         let snapshot_bytes = stream.next().await.ok_or_else(|| {
             io::Error::new(
                 ErrorKind::InvalidData,
-                "EthTxPoolIpcClient must recieve snapshot on connectino",
+                "EthTxPoolIpcClient must receive snapshot on connectino",
             )
         })??;
 

--- a/monad-updaters/src/txpool.rs
+++ b/monad-updaters/src/txpool.rs
@@ -196,7 +196,7 @@ where
                 TxPoolCommand::BlockCommit(_) | TxPoolCommand::Reset { .. } => {}
                 TxPoolCommand::InsertForwardedTxs { .. } => {
                     unimplemented!(
-                        "MockTxPoolExecutor should never recieve txs with MockExecutionProtocol"
+                        "MockTxPoolExecutor should never receive txs with MockExecutionProtocol"
                     );
                 }
                 TxPoolCommand::EnterRound { .. } => {}


### PR DESCRIPTION
A few typos. #2118
Fixed

File : modad-updaters > src > txpool.rs
line 199 : MockTxPoolExecutor should never recieve txs with MockExecutionProtocol
recieve > receive

File : monad-eth-txpool-ipc > src > lib.rs
line 162 : EthTxPoolIpcClient must receive snapshot on connection
recieve > receive