### PR TITLE
Fix for Publisher large round gap

### DIFF
--- a/monad-peer-discovery/src/driver.rs
+++ b/monad-peer-discovery/src/driver.rs
@@ -260,6 +260,16 @@ impl<PD: PeerDiscoveryAlgo> PeerDiscoveryDriver<PD> {
             .collect()
     }
 
+    pub fn get_fullnode_addrs(
+        &self,
+    ) -> HashMap<NodeId<CertificateSignaturePubKey<PD::SignatureType>>, SocketAddr> {
+        self.pd
+            .get_fullnode_addrs()
+            .into_iter()
+            .map(|(k, v)| (k, SocketAddr::V4(v)))
+            .collect()
+    }
+
     pub fn get_name_records(
         &self,
     ) -> HashMap<

--- a/monad-peer-discovery/src/lib.rs
+++ b/monad-peer-discovery/src/lib.rs
@@ -282,6 +282,10 @@ pub trait PeerDiscoveryAlgo {
         &self,
     ) -> HashMap<NodeId<CertificateSignaturePubKey<Self::SignatureType>>, SocketAddrV4>;
 
+    fn get_fullnode_addrs(
+        &self,
+    ) -> HashMap<NodeId<CertificateSignaturePubKey<Self::SignatureType>>, SocketAddrV4>;
+
     fn get_name_records(
         &self,
     ) -> HashMap<

--- a/monad-peer-discovery/src/mock.rs
+++ b/monad-peer-discovery/src/mock.rs
@@ -220,6 +220,10 @@ where
         self.known_addresses.clone()
     }
 
+    fn get_fullnode_addrs(&self) -> HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddrV4> {
+        HashMap::new()
+    }
+
     fn get_name_records(
         &self,
     ) -> HashMap<NodeId<CertificateSignaturePubKey<ST>>, MonadNameRecord<ST>> {

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -334,18 +334,19 @@ where
                         // The publisher needs to be periodically informed about new nodes out there,
                         // so that it can randomize when creating new groups.
                         {
-                            let known_addresses = {
-                                self.peer_discovery_driver
-                                    .lock()
-                                    .unwrap()
-                                    .get_known_addresses()
-                            };
-                            let nodes: Vec<_> = known_addresses.keys().copied().collect();
+                            let full_nodes: Vec<_> = self
+                                .peer_discovery_driver
+                                .lock()
+                                .unwrap()
+                                .get_fullnode_addrs()
+                                .keys()
+                                .copied()
+                                .collect();
                             trace!(
                                 "RaptorCastSecondary updating {} full nodes from PeerDiscovery",
-                                nodes.len()
+                                full_nodes.len()
                             );
-                            publisher.upsert_peer_disc_full_nodes(FullNodes::new(nodes));
+                            publisher.upsert_peer_disc_full_nodes(FullNodes::new(full_nodes));
                         }
 
                         if let Some((group_msg, full_nodes_set)) =
@@ -355,7 +356,7 @@ where
                                 self.peer_discovery_driver
                                     .lock()
                                     .unwrap()
-                                    .get_known_addresses()
+                                    .get_fullnode_addrs()
                             };
 
                             // if group_msg is a ConfirmGroup message, update peer discovery with the group information


### PR DESCRIPTION
Before fix, publishers (validators) would spend many rounds sending invites to other validators thinking they are full-nodes who want group invites.
This fixes it by adding a `get_known_addrs_fullnodes()` to Peer discovery so that the publisher only gets full-node ids and no validator