### PR TITLE
Fix round+1 push (minus unit tests)

### DIFF
--- a/monad-raptorcast/src/raptorcast_secondary/client.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/client.rs
@@ -124,15 +124,16 @@ where
         self.pending_confirms.retain(|&key, _| key > curr_round);
 
         // Send out group information to the Primary instance, so that it can
-        // re-broadcast raptorcast chunks. This is the normal path when we are
+        // re-broadcast RaptorCast chunks. This is the normal path when we are
         // receiving proposals and thus the round increases.
-        let consume_end = curr_round + Round(1);
+        let next_round = curr_round + Round(1);
+        let consume_end = next_round + Round(1);
         let mut current_group_count = 0;
-        for group in self.confirmed_groups.values(curr_round..consume_end) {
+        for group in self.confirmed_groups.values(next_round..consume_end) {
             current_group_count += 1;
             if let Err(error) = self.group_sink_channel.send(group.clone()) {
                 error!(
-                    "Failed to send group to secondary Raptorcast instance: {}",
+                    "Failed to send group to RaptorCastSecondary instance: {}",
                     error
                 );
             }

--- a/monad-raptorcast/src/raptorcast_secondary/publisher.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/publisher.rs
@@ -1481,7 +1481,8 @@ mod tests {
         // RaptorCast group from v0 should be down now, as it only covered rounds [5, 7)
         // Here we should see a group gap
         group_map.update(&clt);
-        assert!(group_map.is_empty(&clt));
+        let rc_grp = &group_map.get_rc_group_peers(&clt, &nid(0));
+        assert!(group_map.is_empty(&clt)); // nid_18, nid_10
 
         //-------------------------------------------------------------------[8]
         clt.enter_round(Round(8));

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -403,9 +403,9 @@ where
     }
 }
 
-// This is an abstraction of a peer list that interfaces receive-side of RaptorCast
-// The send side, i.e. initiating a RaptorCast proposal, is represented with
-// struct `EpochValidators` instead.
+// This is an abstraction of a peer list that interfaces receive-side of RaptorCast.
+// The peer list for the send side, i.e. the side initiating a RaptorCast proposal,
+// is instead represented with a struct `EpochValidators`.
 #[derive(Debug)]
 pub struct ReBroadcastGroupMap<ST>
 where


### PR DESCRIPTION
Outside flexnet (e.g. testnet) a small round gap of 1 is sometimes observed in fullnodes.
This is because the group client was only "activating" round group when it `UpdateCurrentRound(round)` is processed.
This fixes it so that the group current_round+1 is pushed when `UpdateCurrentRound(round)` is processed.

Only tested on Flexnet, and should be tested on stressnet first where the small gap is sometimes observed.
Also still need to fix the unit tests