### PR TITLE
Add support for system transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5042,6 +5042,7 @@ dependencies = [
  "monad-eth-txpool-types",
  "monad-eth-types",
  "monad-state-backend",
+ "monad-system-calls",
  "monad-testutil",
  "monad-types",
  "proptest",
@@ -5063,7 +5064,9 @@ dependencies = [
  "monad-eth-types",
  "monad-secp",
  "monad-state-backend",
+ "monad-system-calls",
  "monad-testutil",
+ "monad-types",
  "rayon",
  "tracing",
 ]
@@ -5153,6 +5156,7 @@ dependencies = [
  "monad-executor",
  "monad-perf-util",
  "monad-state-backend",
+ "monad-system-calls",
  "monad-testutil",
  "monad-types",
  "rand 0.8.5",
@@ -5811,6 +5815,24 @@ dependencies = [
  "rand 0.8.5",
  "tempfile",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "monad-system-calls"
+version = "0.1.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
+ "monad-consensus-types",
+ "monad-crypto",
+ "monad-eth-testutil",
+ "monad-eth-types",
+ "monad-testutil",
+ "monad-types",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ monad-secp = { path = "./monad-secp" }
 monad-state = { path = "./monad-state" }
 monad-state-backend = { path = "./monad-state-backend" }
 monad-statesync = { path = "./monad-statesync" }
+monad-system-calls = { path = "./monad-system-calls" }
 monad-testutil = { path = "./monad-testutil" }
 monad-tracing-timing = { path = "./monad-tracing-timing" }
 monad-transformer = { path = "./monad-transformer" }

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -625,6 +625,16 @@ where
             *max_code_size,
         ) {
             Ok(block) => block,
+            Err(BlockValidationError::SystemTxnError) => {
+                warn!(
+                    ?block_round,
+                    ?block_author,
+                    ?seq_num,
+                    "dropping proposal, system transaction validation failed"
+                );
+                self.metrics.consensus_events.failed_txn_validation += 1;
+                return None;
+            }
             Err(BlockValidationError::TxnError) => {
                 warn!(
                     ?block_round,

--- a/monad-consensus-types/src/block_validator.rs
+++ b/monad-consensus-types/src/block_validator.rs
@@ -35,6 +35,7 @@ use crate::{
 // we care enough
 #[derive(Debug)]
 pub enum BlockValidationError {
+    SystemTxnError,
     TxnError,
     RandaoError,
     HeaderError,

--- a/monad-eth-block-policy/Cargo.toml
+++ b/monad-eth-block-policy/Cargo.toml
@@ -14,6 +14,7 @@ monad-crypto = { workspace = true }
 monad-eth-txpool-types = { workspace = true }
 monad-eth-types = { workspace = true }
 monad-state-backend = { workspace = true }
+monad-system-calls = { workspace = true }
 monad-types = { workspace = true }
 
 alloy-consensus = { workspace = true }

--- a/monad-eth-block-validator/Cargo.toml
+++ b/monad-eth-block-validator/Cargo.toml
@@ -15,6 +15,7 @@ monad-eth-block-policy = { workspace = true }
 monad-eth-types = { workspace = true }
 monad-secp = { workspace = true }
 monad-state-backend = { workspace = true }
+monad-system-calls = { workspace = true }
 
 alloy-consensus = { workspace = true }
 alloy-primitives = { workspace = true }
@@ -25,3 +26,4 @@ tracing = { workspace = true }
 [dev-dependencies]
 monad-eth-testutil = { workspace = true }
 monad-testutil = { workspace = true }
+monad-types = { workspace = true }

--- a/monad-eth-testutil/src/lib.rs
+++ b/monad-eth-testutil/src/lib.rs
@@ -167,6 +167,7 @@ pub fn generate_block_with_txs(
 
     EthValidatedBlock {
         block: ConsensusFullBlock::new(header, body).expect("header doesn't match body"),
+        system_txns: Vec::new(),
         validated_txns: txs,
         nonces,
         txn_fees,

--- a/monad-eth-txpool/Cargo.toml
+++ b/monad-eth-txpool/Cargo.toml
@@ -16,6 +16,7 @@ monad-eth-txpool-types = { workspace = true }
 monad-eth-types = { workspace = true }
 monad-executor = { workspace = true }
 monad-state-backend = { workspace = true }
+monad-system-calls = { workspace = true }
 monad-types = { workspace = true }
 
 alloy-consensus = { workspace = true, features = ["k256"] }

--- a/monad-system-calls/Cargo.toml
+++ b/monad-system-calls/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "monad-system-calls"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+monad-consensus-types = { workspace = true }
+monad-crypto = { workspace = true }
+monad-eth-types = { workspace = true }
+
+alloy-consensus = { workspace = true }
+alloy-primitives = { workspace = true }
+alloy-signer = { workspace = true }
+alloy-signer-local = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+monad-eth-testutil = { workspace = true }
+monad-testutil = { workspace = true }
+monad-types = { workspace = true }
+
+alloy-eips = { workspace = true }

--- a/monad-system-calls/src/lib.rs
+++ b/monad-system-calls/src/lib.rs
@@ -1,0 +1,135 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! This library is used to generate and validate expected system calls
+//! for a block and generate transactions for them from the system sender.
+//! To generate system calls for a block, `generate_system_calls()` should
+//! be used which can then be converted into SystemTransaction(s) and
+//! added to the block.
+
+use alloy_primitives::{Address, B256, Bytes, hex};
+use monad_consensus_types::{
+    block::ConsensusBlockHeader, signature_collection::SignatureCollection,
+};
+use monad_crypto::certificate_signature::{
+    CertificateSignaturePubKey, CertificateSignatureRecoverable,
+};
+use monad_eth_types::EthExecutionProtocol;
+
+pub mod validator;
+
+// Private key used to sign system transactions
+const SYSTEM_SENDER_PRIV_KEY: B256 = B256::new(hex!(
+    "b0358e6d701a955d9926676f227e40172763296b317ff554e49cdf2c2c35f8a7"
+));
+const SYSTEM_SENDER_ETH_ADDRESS: Address =
+    Address::new(hex!("0x6f49a8F621353f12378d0046E7d7e4b9B249DC9e"));
+
+// A system call is a destination address, system call function selector
+// and function input data
+pub struct SystemCall(SystemCallInner);
+
+enum SystemCallInner {}
+
+impl SystemCall {
+    fn get_dest_address(&self) -> Address {
+        Address::new([0_u8; 20])
+    }
+
+    fn get_function_selector(&self) -> Bytes {
+        Bytes::new()
+    }
+
+    fn get_input_data(&self) -> Bytes {
+        Bytes::new()
+    }
+}
+
+// Used by a round leader to generate system calls for the proposing block
+pub fn generate_system_calls() -> Vec<SystemCall> {
+    Vec::new()
+}
+
+// Used by a validator to generate expected system calls for a block
+fn generate_system_calls_from_header<ST, SCT>(
+    block_header: &ConsensusBlockHeader<ST, SCT, EthExecutionProtocol>,
+) -> Vec<SystemCall>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+{
+    Vec::new()
+}
+
+#[derive(Debug, Clone)]
+pub struct SystemTransaction(SystemTransactionInner);
+
+#[derive(Debug, Clone)]
+enum SystemTransactionInner {}
+
+impl SystemTransaction {
+    pub fn signer(&self) -> Address {
+        SYSTEM_SENDER_ETH_ADDRESS
+    }
+
+    pub fn nonce(&self) -> u64 {
+        // TODO use actual nonce from transaction
+        0
+    }
+
+    pub fn length(&self) -> usize {
+        // TODO use actual rlp length
+        0
+    }
+}
+
+impl From<SystemCall> for SystemTransaction {
+    fn from(sys_call: SystemCall) -> Self {
+        match sys_call {}
+    }
+}
+
+#[cfg(test)]
+mod test_utils {
+    use alloy_consensus::{SignableTransaction, TxEnvelope, TxLegacy, transaction::Recovered};
+    use alloy_primitives::{Address, Bytes, TxKind};
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::LocalSigner;
+
+    use crate::{SYSTEM_SENDER_ETH_ADDRESS, SYSTEM_SENDER_PRIV_KEY};
+
+    pub fn get_valid_system_transaction() -> TxLegacy {
+        TxLegacy {
+            chain_id: Some(1337),
+            nonce: 0,
+            gas_price: 0,
+            gas_limit: 0,
+            to: TxKind::Call(Address::new([0_u8; 20])),
+            value: Default::default(),
+            input: Bytes::new(),
+        }
+    }
+
+    pub fn sign_with_system_sender(transaction: TxLegacy) -> Recovered<TxEnvelope> {
+        let signature_hash = transaction.signature_hash();
+        let local_signer = LocalSigner::from_bytes(&SYSTEM_SENDER_PRIV_KEY).unwrap();
+        let signature = local_signer.sign_hash_sync(&signature_hash).unwrap();
+
+        Recovered::new_unchecked(
+            TxEnvelope::Legacy(transaction.into_signed(signature)),
+            SYSTEM_SENDER_ETH_ADDRESS,
+        )
+    }
+}

--- a/monad-system-calls/src/validator.rs
+++ b/monad-system-calls/src/validator.rs
@@ -1,0 +1,332 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! This module is used to validate that a block contains the expected
+//! valid systems transactions with the information from the block header.
+//! `validate_and_extract_system_transactions()` is used to extract the
+//! expected valid system transactions and verify that the user transactions
+//! are not from the system sender and don't invoke any system calls.
+//! `is_system_sender` and `is_restricted_system_call` should be used to reject
+//! invalid transactions before they are included in a proposal (TxPool)
+
+use std::collections::VecDeque;
+
+use alloy_consensus::{Transaction, TxEnvelope, transaction::Recovered};
+use alloy_primitives::{Address, Bytes, TxKind, U256};
+use monad_consensus_types::{
+    block::ConsensusBlockHeader, signature_collection::SignatureCollection,
+};
+use monad_crypto::certificate_signature::{
+    CertificateSignaturePubKey, CertificateSignatureRecoverable,
+};
+use monad_eth_types::EthExecutionProtocol;
+use tracing::debug;
+
+use crate::{
+    SYSTEM_SENDER_ETH_ADDRESS, SystemCall, SystemTransaction, generate_system_calls_from_header,
+};
+
+#[derive(Debug)]
+pub enum SystemTransactionError {
+    UnexpectedSenderAddress,
+    InvalidTxType,
+    NonZeroGasPrice,
+    NonZeroGasLimit,
+    InvalidTxKind,
+    NonZeroValue,
+    UnexpectedDestAddress { expected: Address },
+    UnexpectedInput { expected: Bytes },
+}
+
+#[derive(Debug)]
+pub enum SystemTransactionValidationError {
+    MissingSystemTransaction,
+    UnexpectedSystemTransaction,
+    NonSequentialNonces,
+    SystemTransactionError(SystemTransactionError),
+}
+
+pub struct SystemTransactionValidator {}
+
+impl SystemTransactionValidator {
+    pub fn is_system_sender(address: Address) -> bool {
+        address == SYSTEM_SENDER_ETH_ADDRESS
+    }
+
+    // used to check if a user transaction calls a restricted function
+    pub fn is_restricted_system_call(txn: &Recovered<TxEnvelope>) -> bool {
+        // TODO check if txn invokes any supported system call
+        false
+    }
+
+    fn static_validate_system_transaction(
+        txn: &Recovered<TxEnvelope>,
+    ) -> Result<(), SystemTransactionError> {
+        if !Self::is_system_sender(txn.signer()) {
+            return Err(SystemTransactionError::UnexpectedSenderAddress);
+        }
+
+        if !txn.tx().is_legacy() {
+            return Err(SystemTransactionError::InvalidTxType);
+        }
+
+        if txn.tx().gas_price() != Some(0) {
+            return Err(SystemTransactionError::NonZeroGasPrice);
+        }
+
+        if txn.tx().gas_limit() != 0 {
+            return Err(SystemTransactionError::NonZeroGasLimit);
+        }
+
+        if !matches!(txn.tx().kind(), TxKind::Call(_)) {
+            return Err(SystemTransactionError::InvalidTxKind);
+        }
+
+        if txn.tx().value() != U256::ZERO {
+            return Err(SystemTransactionError::NonZeroValue);
+        }
+
+        Ok(())
+    }
+
+    fn validate_system_transaction_input(
+        expected_sys_call: SystemCall,
+        sys_txn: &Recovered<TxEnvelope>,
+    ) -> Result<SystemTransaction, SystemTransactionError> {
+        // verify destination address, function selector and function input
+
+        // TODO remove error
+        Err(SystemTransactionError::NonZeroValue)
+    }
+
+    fn validate_system_transaction(
+        expected_sys_call: SystemCall,
+        sys_txn: &Recovered<TxEnvelope>,
+    ) -> Result<SystemTransaction, SystemTransactionError> {
+        Self::static_validate_system_transaction(sys_txn)?;
+
+        Self::validate_system_transaction_input(expected_sys_call, sys_txn)
+    }
+
+    pub fn validate_and_extract_system_transactions<ST, SCT>(
+        block_header: &ConsensusBlockHeader<ST, SCT, EthExecutionProtocol>,
+        mut txns: VecDeque<Recovered<TxEnvelope>>,
+    ) -> Result<
+        (Vec<SystemTransaction>, Vec<Recovered<TxEnvelope>>),
+        SystemTransactionValidationError,
+    >
+    where
+        ST: CertificateSignatureRecoverable,
+        SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    {
+        let mut validated_sys_txns = Vec::new();
+
+        let expected_sys_calls = generate_system_calls_from_header(block_header);
+        let mut curr_sys_sender_nonce = None;
+        for expected_sys_call in expected_sys_calls {
+            let Some(sys_txn) = txns.pop_front() else {
+                return Err(SystemTransactionValidationError::MissingSystemTransaction);
+            };
+
+            match Self::validate_system_transaction(expected_sys_call, &sys_txn) {
+                Ok(validated_sys_txn) => {
+                    validated_sys_txns.push(validated_sys_txn);
+                }
+                Err(err) => {
+                    return Err(SystemTransactionValidationError::SystemTransactionError(
+                        err,
+                    ));
+                }
+            }
+
+            // system sender nonce must be sequential
+            if let Some(old_nonce) = curr_sys_sender_nonce {
+                if sys_txn.nonce() != old_nonce + 1 {
+                    debug!(?sys_txn, "invalid system transaction nonce");
+                    return Err(SystemTransactionValidationError::NonSequentialNonces);
+                }
+            }
+            curr_sys_sender_nonce = Some(sys_txn.nonce())
+        }
+
+        for user_txn in &txns {
+            if Self::is_system_sender(user_txn.signer()) {
+                return Err(SystemTransactionValidationError::UnexpectedSystemTransaction);
+            }
+
+            if Self::is_restricted_system_call(user_txn) {
+                return Err(SystemTransactionValidationError::UnexpectedSystemTransaction);
+            }
+        }
+
+        Ok((validated_sys_txns, txns.into()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloy_consensus::{SignableTransaction, TxEip1559, TxEnvelope, transaction::Recovered};
+    use alloy_eips::eip2930::AccessList;
+    use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::LocalSigner;
+    use monad_consensus_types::{
+        block::ConsensusBlockHeader,
+        payload::{ConsensusBlockBodyId, RoundSignature},
+        quorum_certificate::QuorumCertificate,
+    };
+    use monad_crypto::{NopKeyPair, NopSignature, certificate_signature::CertificateKeyPair};
+    use monad_eth_testutil::make_legacy_tx;
+    use monad_eth_types::{EthExecutionProtocol, ProposedEthHeader};
+    use monad_testutil::signing::MockSignatures;
+    use monad_types::{Epoch, GENESIS_SEQ_NUM, Hash, NodeId, Round, SeqNum};
+
+    use crate::{
+        SYSTEM_SENDER_ETH_ADDRESS, SYSTEM_SENDER_PRIV_KEY,
+        test_utils::{get_valid_system_transaction, sign_with_system_sender},
+        validator::{
+            SystemTransactionError, SystemTransactionValidationError, SystemTransactionValidator,
+        },
+    };
+
+    #[test]
+    fn test_invalid_sender() {
+        let tx = get_valid_system_transaction();
+        let signature_hash = tx.signature_hash();
+        let local_signer = LocalSigner::from_bytes(&B256::repeat_byte(1)).unwrap();
+        let signature = local_signer.sign_hash_sync(&signature_hash).unwrap();
+        let invalid_tx = Recovered::new_unchecked(
+            TxEnvelope::Legacy(tx.into_signed(signature)),
+            local_signer.address(),
+        );
+
+        assert!(matches!(
+            SystemTransactionValidator::static_validate_system_transaction(&invalid_tx),
+            Err(SystemTransactionError::UnexpectedSenderAddress)
+        ));
+    }
+
+    #[test]
+    fn test_invalid_tx_type() {
+        let transaction = TxEip1559 {
+            chain_id: 1337,
+            nonce: 0,
+            max_fee_per_gas: 0,
+            max_priority_fee_per_gas: 0,
+            gas_limit: 0,
+            to: TxKind::Call(Address::new([0_u8; 20])),
+            value: Default::default(),
+            access_list: AccessList(Vec::new()),
+            input: Bytes::new(),
+        };
+
+        let signature_hash = transaction.signature_hash();
+        let local_signer = LocalSigner::from_bytes(&SYSTEM_SENDER_PRIV_KEY).unwrap();
+        let signature = local_signer.sign_hash_sync(&signature_hash).unwrap();
+
+        let recovered = Recovered::new_unchecked(
+            TxEnvelope::Eip1559(transaction.into_signed(signature)),
+            SYSTEM_SENDER_ETH_ADDRESS,
+        );
+
+        assert!(matches!(
+            SystemTransactionValidator::static_validate_system_transaction(&recovered),
+            Err(SystemTransactionError::InvalidTxType)
+        ));
+    }
+
+    #[test]
+    fn test_invalid_gas_price() {
+        let mut tx = get_valid_system_transaction();
+        tx.gas_price = 1;
+        let invalid_tx = sign_with_system_sender(tx);
+        assert!(matches!(
+            SystemTransactionValidator::static_validate_system_transaction(&invalid_tx),
+            Err(SystemTransactionError::NonZeroGasPrice)
+        ));
+    }
+
+    #[test]
+    fn test_invalid_gas_limit() {
+        let mut tx = get_valid_system_transaction();
+        tx.gas_limit = 1;
+        let invalid_tx = sign_with_system_sender(tx);
+        assert!(matches!(
+            SystemTransactionValidator::static_validate_system_transaction(&invalid_tx),
+            Err(SystemTransactionError::NonZeroGasLimit)
+        ));
+    }
+
+    #[test]
+    fn test_invalid_tx_kind() {
+        let mut tx = get_valid_system_transaction();
+        tx.to = TxKind::Create;
+        let invalid_tx = sign_with_system_sender(tx);
+        assert!(matches!(
+            SystemTransactionValidator::static_validate_system_transaction(&invalid_tx),
+            Err(SystemTransactionError::InvalidTxKind)
+        ));
+    }
+
+    #[test]
+    fn test_invalid_value() {
+        let mut tx = get_valid_system_transaction();
+        tx.value = U256::ONE;
+        let invalid_tx = sign_with_system_sender(tx);
+        assert!(matches!(
+            SystemTransactionValidator::static_validate_system_transaction(&invalid_tx),
+            Err(SystemTransactionError::NonZeroValue)
+        ));
+    }
+
+    #[test]
+    fn test_unexpected_system_txn() {
+        let unsigned_tx1 = make_legacy_tx(B256::repeat_byte(0xAu8), 0, 0, 0, 10);
+        let signer = unsigned_tx1.recover_signer().unwrap();
+        let tx1 = Recovered::new_unchecked(unsigned_tx1, signer);
+
+        let tx2 = sign_with_system_sender(get_valid_system_transaction());
+
+        let txs = vec![tx1, tx2].into();
+
+        // no expected system calls generated with this block header
+        let nop_keypair = NopKeyPair::from_bytes(&mut [0_u8; 32]).unwrap();
+        let block_header: ConsensusBlockHeader<
+            NopSignature,
+            MockSignatures<NopSignature>,
+            EthExecutionProtocol,
+        > = ConsensusBlockHeader::new(
+            NodeId::new(nop_keypair.pubkey()),
+            Epoch(1),
+            Round(1),
+            Vec::new(), // delayed_execution_results
+            ProposedEthHeader::default(),
+            ConsensusBlockBodyId(Hash([0_u8; 32])),
+            QuorumCertificate::genesis_qc(),
+            GENESIS_SEQ_NUM + SeqNum(1),
+            1,
+            RoundSignature::new(Round(1), &nop_keypair),
+        );
+
+        let result = SystemTransactionValidator::validate_and_extract_system_transactions(
+            &block_header,
+            txs,
+        );
+        assert!(matches!(
+            result,
+            Err(SystemTransactionValidationError::UnexpectedSystemTransaction)
+        ));
+    }
+}


### PR DESCRIPTION
We need a special type of transaction for consensus to be able to communicate with execution about network related changes (epoch change for example). This PR adds the infrastructure on the consensus side to be able to generate such transactions and validate them differently than regular user transactions.

I've added unit tests for checking the validity of the system transactions based on transaction parameters. State specific tests will be added as system calls are added.