### PR TITLE
Rpc chainstate

### DIFF
--- a/monad-rpc/src/chainstate/mod.rs
+++ b/monad-rpc/src/chainstate/mod.rs
@@ -883,8 +883,8 @@ async fn get_logs_with_index(
 
     let filtered_params = FilteredParams::new(Some(filter.clone()));
 
-    // Note: we an limit returned (and queried!) data by using `query_logs_index_streamed`
-    // and take_while we're under the response size limit
+    // Note: we can limit returned (and queried!) data by using `query_logs_index_streamed`
+    // while we're under the response size limit
     let potential_matches = log_index
         .query_logs(from_block, to_block, filter.address.iter(), &filter.topics)
         .await?;


### PR DESCRIPTION
I added code from line 1105 to line 1395 to create async functions for reading the blockchain state and also creating an archive reader, if receipts are not found in the triedb

The code is meant to get block header, transactions, receipts, and blocks, sending them to the archive, returning an error and logging the same if it fails, ultimately reverting it to its main chainstate.

I also corrected typos in lines 886 and 887