### PR TITLE
add protocol overview for Monad-BFT in docs folder

### DIFF
--- a/docs/01_protocol-overview.md
+++ b/docs/01_protocol-overview.md
@@ -1,0 +1,28 @@
+# Protocol Overview
+
+## What is Monad-BFT?
+Monad-BFT is a Byzantine Fault Tolerant (BFT) consensus protocol designed to provide fast finality and strong safety guarantees, with a novel focus on *tail-fork resistance* to mitigate malicious reorgs and unfair MEV extraction.
+
+## Core Innovations
+
+1. **Speculative Finality**: Validators speculatively commit a block after one round of voting, achieving low-latency confirmation.  
+2. **Tail-Fork Resistance**: Unlike classic BFT protocols, Monad prevents malicious leaders from creating disruptive forks at the tail of the chain by embedding equivocation-proof-based safety controls.  
+3. **Quadratic Timeout Certificates**: A fallback mechanism that uses dynamically increasing timeouts to guarantee liveness without sacrificing safety.
+
+## Why Monad-BFT Matters
+
+- **Low Latency**: Speculative commits reduce confirmation times closer to one network round-trip.  
+- **MEV Mitigation**: Tail-fork resistance defends against validators racing to extract value at the expense of network consistency.  
+- **Robustness**: Timeout certificates ensure progress even under high latency or partial network partitions.
+
+## Relationship to Other Protocols
+
+| Feature                      | HotStuff         | Tendermint      | Monad-BFT               |
+|------------------------------|------------------|-----------------|-------------------------|
+| Rounds to Finality           | 3                | 2               | 1 speculative + 1 TC    |
+| Equivocation Safety          | Yes              | Yes             | Yes (enhanced)          |
+| Tail-Fork Resistance         | No               | No              | Yes                     |
+| Timeout Mechanism            | Linear           | Linear          | Quadratic               |
+
+
+*Next up: a detailed step-by-step consensus flow with sequence diagrams.*  


### PR DESCRIPTION
### 📄 Overview

This PR introduces a new top-level documentation file, `docs/01_protocol-overview.md`, that gives a comprehensive high-level introduction to the Monad-BFT consensus protocol. It covers:

- **Protocol Definition:** What Monad-BFT is and its design goals.  
- **Core Innovations:**  
  1. Speculative finality (1-round commit)  
  2. Tail-fork resistance to prevent malicious reorgs  
  3. Quadratic timeout certificates for robust liveness  
- **Key Benefits:**  
  - Low-latency confirmation  
  - MEV mitigation  
  - Resilience under network partitions  
- **Comparative Table:** Contrasts Monad-BFT with HotStuff and Tendermint on finality rounds, safety, and timeout mechanics.

---

### 🛠 Changes

- Created `docs/01_protocol-overview.md`  
- Added detailed descriptions of each core feature  
- Included a comparison table highlighting unique design points

---

### 🤝 Rationale

- **Onboarding:** Eases new contributors into the protocol’s concepts.  
- **Foundation:** Sets the stage for deeper docs (consensus flow, timeout logic, code-tour).  
- **Visibility:** Fills a documentation gap—no standalone protocol overview existed before.

---

### 🚀 Next Steps

1. Draft `docs/02_consensus-flow.md` with sequence diagrams.  
2. Document tail-fork scenarios in `docs/03_tail-fork-resistance.md`.  
3. Expand on timeout-certificate logic in `docs/04_timeout-and-TCs.md`.  
