### PR TITLE
feat: configurable transaction expiry timeouts to node config

### DIFF
--- a/monad-node-config/src/lib.rs
+++ b/monad-node-config/src/lib.rs
@@ -75,6 +75,12 @@ pub struct NodeConfig<ST: CertificateSignatureRecoverable> {
     // NETWORK-WIDE CONFIGURATION //
     ////////////////////////////////
     pub chain_id: u64,
+
+    #[serde(default = "default_soft_tx_expiry_secs")]
+    pub soft_tx_expiry_secs: u64,
+
+    #[serde(default = "default_hard_tx_expiry_secs")]
+    pub hard_tx_expiry_secs: u64,
 }
 
 #[cfg(feature = "crypto")]
@@ -91,3 +97,78 @@ pub type ForkpointConfig = monad_consensus_types::checkpoint::Checkpoint<
 >;
 #[cfg(feature = "crypto")]
 pub type MonadNodeConfig = NodeConfig<SignatureType>;
+
+fn default_soft_tx_expiry_secs() -> u64 {
+    15
+}
+
+fn default_hard_tx_expiry_secs() -> u64 {
+    5 * 60
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tx_expiry_fields_are_now_supported_in_toml() {
+        // Using the existing devnet node.toml structure and add tx_expiry fields to validate they're supported
+        let existing_config_with_tx_expiry = r#"
+beneficiary = "0x0000000000000000000000000000000000000000"
+node_name = "dev-node"
+network_name = "devnet"
+ipc_tx_batch_size = 500
+ipc_max_queued_batches = 6
+ipc_queued_batches_watermark = 3
+statesync_threshold = 600
+statesync_max_concurrent_requests = 5
+chain_id = 20143
+raptor10_validator_redundancy_factor = 3
+soft_tx_expiry_secs = 30
+hard_tx_expiry_secs = 600
+
+[bootstrap]
+peers = []
+
+[peer_discovery]
+self_address = "0.0.0.0:8000"
+self_record_seq_num = 0
+self_name_record_sig = "85663053b3d719985357b56270ba320abadd1c51e10ea06430f3990d81393dc7770ff661c331bd631afca705029b0fd77cc0f48d46b37c8d8523c73c6af1242801"
+ping_period = 30
+refresh_period = 120
+request_timeout = 5
+unresponsive_prune_threshold = 5
+last_participation_prune_threshold = 5000
+min_num_peers = 0
+max_num_peers = 200
+
+[fullnode_dedicated]
+identities = []
+
+[blocksync_override]
+peers = []
+
+[statesync]
+peers = []
+
+[network]
+bind_address_host = "0.0.0.0"
+bind_address_port = 8000
+max_rtt_ms = 300
+max_mbps = 1000
+"#;
+
+        // This should now parse the config with tx_expiry fields successfully
+        let result: Result<NodeConfig<SignatureType>, _> =
+            toml::from_str(existing_config_with_tx_expiry);
+        assert!(
+            result.is_ok(),
+            "Config with tx_expiry fields should parse successfully: {:?}",
+            result.err()
+        );
+
+        let config = result.unwrap();
+        assert_eq!(config.soft_tx_expiry_secs, 30);
+        assert_eq!(config.hard_tx_expiry_secs, 600);
+    }
+}

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -334,9 +334,8 @@ async fn run(node_state: NodeState, reload_handle: Box<dyn TracingReload>) -> Re
                     as usize,
             },
             true,
-            // TODO(andr-dev): Add tx_expiry to node config
-            Duration::from_secs(15),
-            Duration::from_secs(5 * 60),
+            Duration::from_secs(node_state.node_config.soft_tx_expiry_secs),
+            Duration::from_secs(node_state.node_config.hard_tx_expiry_secs),
             node_state.chain_config,
             node_state
                 .chain_config


### PR DESCRIPTION
So, basically transaction expiry timeouts were hardcoded as `Duration::from_secs(15)` for soft expiry and `Duration::from_secs(5 * 60)` for hard expiry. This prevented operators from tuning these values like for instance for different network conditions.

## Issue Reproduction
Before this fix, adding tx_expiry fields to node.toml would fail: dding soft_tx_expiry_secs = 30 and hard_tx_expiry_secs = 600 to node.toml would result in "unknown field" TOML parsing errors
```bash
cargo test -p monad-node-config test_tx_expiry_fields_are_now_supported_in_toml
```

## Testing the introduced fix
```bash
cargo test -p monad-node-config --lib --features crypto
cargo check -p monad-node-config
```