### PR TITLE
raptorcast, discovery: update trusted ip addresses when validator ip changes

### DIFF
--- a/monad-peer-disc-swarm/src/driver.rs
+++ b/monad-peer-disc-swarm/src/driver.rs
@@ -197,6 +197,7 @@ where
                 self.algo.update_peer_participation(end_round, peers)
             }
             PeerDiscoveryEvent::Refresh => self.algo.refresh(),
+            PeerDiscoveryEvent::ValidatorIpChanged { .. } => vec![],
         };
 
         self.filter_and_exec(cmds)
@@ -223,6 +224,9 @@ where
                 }),
                 PeerDiscoveryCommand::TimerCommand(peer_discovery_timer_command) => {
                     self.timer.exec(vec![peer_discovery_timer_command]);
+                }
+                PeerDiscoveryCommand::Event(_) => {
+                    // ignore event in swarm
                 }
             }
         }

--- a/monad-peer-discovery/src/discovery.rs
+++ b/monad-peer-discovery/src/discovery.rs
@@ -611,6 +611,27 @@ impl<ST: CertificateSignatureRecoverable, C: governor::clock::Clock> PeerDiscove
         let mut cmds = Vec::new();
 
         let old_name_record = self.routing_info.insert(peer, name_record.clone());
+        if self.check_validator_membership(&peer) {
+            match &old_name_record {
+                Some(current_name_record) if current_name_record.seq() != name_record.seq() => {
+                    debug!(?peer, "validator name record updated");
+                    cmds.push(Self::validator_ip_changed_event(
+                        peer,
+                        Some(current_name_record.clone()),
+                        name_record.clone(),
+                    ));
+                }
+                None => {
+                    debug!(?peer, addr = ?name_record.udp_address(), "new validator added");
+                    cmds.push(Self::validator_ip_changed_event(
+                        peer,
+                        None,
+                        name_record.clone(),
+                    ));
+                }
+                _ => {}
+            }
+        }
         self.participation_info
             .entry(peer)
             .and_modify(|info| {
@@ -881,6 +902,18 @@ impl<ST: CertificateSignatureRecoverable, C: governor::clock::Clock> PeerDiscove
             return false;
         }
         true
+    }
+
+    fn validator_ip_changed_event(
+        node_id: NodeId<CertificateSignaturePubKey<ST>>,
+        old_name_record: Option<MonadNameRecord<ST>>,
+        new_name_record: MonadNameRecord<ST>,
+    ) -> PeerDiscoveryCommand<ST> {
+        PeerDiscoveryCommand::Event(PeerDiscoveryEvent::ValidatorIpChanged {
+            node_id,
+            old_name_record,
+            new_name_record,
+        })
     }
 }
 

--- a/monad-peer-discovery/src/driver.rs
+++ b/monad-peer-discovery/src/driver.rs
@@ -42,6 +42,7 @@ pub enum PeerDiscoveryEmit<ST: CertificateSignatureRecoverable> {
         name_record: crate::NameRecord,
         message: PeerDiscoveryMessage<ST>,
     },
+    Event(PeerDiscoveryEvent<ST>),
 }
 
 struct PeerDiscTimers<ST: CertificateSignatureRecoverable> {
@@ -222,6 +223,7 @@ impl<PD: PeerDiscoveryAlgo> PeerDiscoveryDriver<PD> {
                 self.pd.update_peer_participation(end_round, peers)
             }
             PeerDiscoveryEvent::Refresh => self.pd.refresh(),
+            PeerDiscoveryEvent::ValidatorIpChanged { .. } => vec![],
         };
 
         self.exec(cmds);
@@ -258,6 +260,14 @@ impl<PD: PeerDiscoveryAlgo> PeerDiscoveryDriver<PD> {
                 }
                 PeerDiscoveryCommand::TimerCommand(timer_cmd) => {
                     timer_cmds.push(timer_cmd);
+                }
+                PeerDiscoveryCommand::Event(event) => {
+                    self.pending_emits
+                        .push_back(PeerDiscoveryEmit::Event(event));
+
+                    if let Some(waker) = self.waker.take() {
+                        waker.wake();
+                    }
                 }
             }
         }

--- a/monad-peer-discovery/src/lib.rs
+++ b/monad-peer-discovery/src/lib.rs
@@ -396,6 +396,10 @@ impl<ST: CertificateSignatureRecoverable> MonadNameRecord<ST> {
         self.name_record.direct_udp_socket()
     }
 
+    pub fn tcp_address(&self) -> SocketAddrV4 {
+        self.name_record.tcp_socket()
+    }
+
     pub fn all_udp_sockets(&self) -> impl Iterator<Item = SocketAddrV4> + '_ {
         [
             self.udp_address(),
@@ -644,6 +648,11 @@ pub enum PeerDiscoveryEvent<ST: CertificateSignatureRecoverable> {
         end_round: Round,
         peers: BTreeSet<NodeId<CertificateSignaturePubKey<ST>>>,
     },
+    ValidatorIpChanged {
+        node_id: NodeId<CertificateSignaturePubKey<ST>>,
+        old_name_record: Option<MonadNameRecord<ST>>,
+        new_name_record: MonadNameRecord<ST>,
+    },
     Refresh,
 }
 
@@ -682,6 +691,7 @@ pub enum PeerDiscoveryCommand<ST: CertificateSignatureRecoverable> {
         message: PeerDiscoveryMessage<ST>,
     },
     TimerCommand(PeerDiscoveryTimerCommand<PeerDiscoveryEvent<ST>, ST>),
+    Event(PeerDiscoveryEvent<ST>),
 }
 
 pub trait PeerDiscoveryAlgo {

--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -61,7 +61,7 @@ opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
 rstest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tikv-jemallocator = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "test-util"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "test-util", "io-util", "net"] }
 toml = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -977,18 +977,16 @@ where
 
                         {
                             let pd_driver = self.peer_discovery_driver.lock().unwrap();
-                            let added: Vec<_> = self
+                            let added = self
                                 .epoch_validators
                                 .get(&epoch)
-                                .into_iter()
-                                .flat_map(|val| iter_ips(val, &*pd_driver))
-                                .collect();
-                            let removed: Vec<_> = self
+                                .map(|val| iter_ips(val, &*pd_driver))
+                                .unwrap_or_default();
+                            let removed = self
                                 .epoch_validators
                                 .get(&self.current_epoch)
-                                .into_iter()
-                                .flat_map(|val| iter_ips(val, &*pd_driver))
-                                .collect();
+                                .map(|val| iter_ips(val, &*pd_driver))
+                                .unwrap_or_default();
                             drop(pd_driver);
                             self.dataplane_control.update_trusted(added, removed);
                         }
@@ -1189,14 +1187,17 @@ where
     }
 }
 
-fn iter_ips<'a, ST: CertificateSignatureRecoverable, PD: PeerDiscoveryAlgo<SignatureType = ST>>(
-    validators: &'a ValidatorSet<CertificateSignaturePubKey<ST>>,
-    peer_discovery: &'a PeerDiscoveryDriver<PD>,
-) -> impl Iterator<Item = IpAddr> + 'a {
+fn iter_ips<ST: CertificateSignatureRecoverable, PD: PeerDiscoveryAlgo<SignatureType = ST>>(
+    validators: &ValidatorSet<CertificateSignaturePubKey<ST>>,
+    peer_discovery: &PeerDiscoveryDriver<PD>,
+) -> Vec<IpAddr> {
+    let name_records = peer_discovery.get_name_records();
     validators
         .get_members()
         .keys()
-        .filter_map(|node_id| peer_discovery.get_ip(node_id))
+        .filter_map(|node_id| name_records.get(node_id))
+        .map(|record| IpAddr::V4(*record.tcp_address().ip()))
+        .collect()
 }
 
 const RAPTORCAST_POLL_QUOTA: usize = 256;
@@ -1560,6 +1561,28 @@ where
                         message,
                     } => {
                         send_peer_disc_msg(this, target, Some(name_record), message);
+                    }
+                    PeerDiscoveryEmit::Event(event) => {
+                        if let PeerDiscoveryEvent::ValidatorIpChanged {
+                            node_id,
+                            old_name_record,
+                            new_name_record,
+                        } = event
+                        {
+                            if let Some(validators) = this.epoch_validators.get(&this.current_epoch)
+                            {
+                                if validators.get_members().contains_key(&node_id) {
+                                    let old_ip = old_name_record
+                                        .as_ref()
+                                        .map(|record| IpAddr::V4(*record.tcp_address().ip()))
+                                        .into_iter()
+                                        .collect::<Vec<_>>();
+                                    let new_ip =
+                                        vec![IpAddr::V4(*new_name_record.tcp_address().ip())];
+                                    this.dataplane_control.update_trusted(new_ip, old_ip);
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/monad-raptorcast/tests/raptorcast_instance.rs
+++ b/monad-raptorcast/tests/raptorcast_instance.rs
@@ -14,9 +14,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     io::ErrorKind,
-    net::{SocketAddr, SocketAddrV4, UdpSocket},
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4, UdpSocket},
     num::ParseIntError,
     sync::{Arc, Once},
     time::Duration,
@@ -29,13 +29,22 @@ use monad_crypto::certificate_signature::{
     CertificateKeyPair, CertificateSignature, CertificateSignaturePubKey,
     CertificateSignatureRecoverable, PubKey,
 };
-use monad_dataplane::udp::DEFAULT_SEGMENT_SIZE;
+use monad_dataplane::{udp::DEFAULT_SEGMENT_SIZE, DataplaneBuilder, TcpSocketId, UdpSocketId};
 use monad_executor::Executor;
 use monad_executor_glue::{Message, RouterCommand};
-use monad_peer_discovery::{mock::NopDiscovery, MonadNameRecord, NameRecord};
+use monad_node_config::FullNodeConfig;
+use monad_peer_discovery::{
+    discovery::{PeerDiscovery, PeerDiscoveryBuilder},
+    driver::PeerDiscoveryDriver,
+    message::PeerDiscoveryMessage,
+    mock::NopDiscovery,
+    MonadNameRecord, NameRecord,
+};
 use monad_raptorcast::{
-    create_dataplane_for_tests, new_defaulted_raptorcast_for_tests,
-    new_defaulted_raptorcast_for_tests_with_name_records,
+    config::RaptorCastConfig,
+    create_dataplane_for_tests,
+    message::OutboundRouterMessage,
+    new_defaulted_raptorcast_for_tests, new_defaulted_raptorcast_for_tests_with_name_records,
     packet::{build_messages, regular},
     raptorcast_secondary::{
         group_message::FullNodesGroupMessage, SecondaryOutboundMessage,
@@ -52,6 +61,7 @@ use monad_types::{
     Deserializable, Epoch, NodeId, Round, RoundSpan, Serializable, Stake, UdpPriority,
 };
 use monad_validator::validator_set::ValidatorSet;
+use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
 use tokio::sync::mpsc::unbounded_channel;
 use tracing_subscriber::fmt::format::FmtSpan;
 
@@ -1100,4 +1110,277 @@ async fn test_raptorcast_forwarding_priority() {
         received_messages[1].1, 0xBB,
         "regular priority message (0xBB) should be received second"
     );
+}
+
+fn find_unused_address() -> SocketAddr {
+    let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+    socket.local_addr().unwrap()
+}
+
+fn create_dataplane_for_tcp_update_test() -> DataplaneHandles {
+    let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let mut dataplane = DataplaneBuilder::new(1_000)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .with_udp_sockets([
+            (UdpSocketId::AuthenticatedRaptorcast, bind_addr),
+            (UdpSocketId::Raptorcast, bind_addr),
+        ])
+        .with_tcp_connections_limit(0, 0)
+        .build();
+    assert!(dataplane.block_until_ready(Duration::from_secs(2)));
+
+    let tcp_socket = dataplane
+        .tcp_sockets
+        .take(TcpSocketId::Raptorcast)
+        .expect("tcp socket");
+    let tcp_addr = socket_addr_v4(tcp_socket.local_addr());
+
+    let authenticated_socket = dataplane
+        .udp_sockets
+        .take(UdpSocketId::AuthenticatedRaptorcast)
+        .expect("authenticated socket");
+    let auth_addr = socket_addr_v4(authenticated_socket.local_addr());
+
+    let non_authenticated_socket = dataplane
+        .udp_sockets
+        .take(UdpSocketId::Raptorcast)
+        .expect("non-authenticated socket");
+    let non_auth_addr = socket_addr_v4(non_authenticated_socket.local_addr());
+
+    DataplaneHandles {
+        tcp_socket,
+        authenticated_socket,
+        direct_udp_socket: None,
+        non_authenticated_socket,
+        control: dataplane.control,
+        tcp_addr,
+        auth_addr,
+        direct_udp_addr: None,
+        non_auth_addr,
+    }
+}
+
+async fn assert_tcp_write_fails(addr: SocketAddr) {
+    if let Ok(stream) = tokio::net::TcpStream::connect(addr).await {
+        for _ in 0..10 {
+            if stream.try_write(b"test").is_err() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("tcp write should fail with 0 connection limit");
+    }
+}
+
+async fn assert_tcp_write_succeeds(addr: SocketAddr) {
+    for _ in 0..10 {
+        let stream = tokio::net::TcpStream::connect(addr)
+            .await
+            .expect("tcp connection should succeed");
+
+        stream.try_write(b"test").expect("tcp write should succeed");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+async fn wait_for_tcp_write_success(addr: SocketAddr) {
+    for _ in 0..20 {
+        if let Ok(stream) = tokio::net::TcpStream::connect(addr).await {
+            if stream.try_write(b"test").is_ok() {
+                assert_tcp_write_succeeds(addr).await;
+                return;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("tcp connection should succeed after trusted IP update");
+}
+
+async fn send_peer_discovery_ping(
+    from_keypair: &KeyPair,
+    to_nodeid: NodeId<PubKeyType>,
+    to_addr: SocketAddr,
+    updated_record: MonadNameRecord<SignatureType>,
+) {
+    let ping = monad_peer_discovery::message::Ping {
+        id: 1,
+        local_name_record: updated_record,
+    };
+
+    let discovery_msg = PeerDiscoveryMessage::Ping(ping);
+    let router_msg =
+        OutboundRouterMessage::<MockMessage, SignatureType>::PeerDiscoveryMessage(discovery_msg);
+    let serialized_msg = router_msg.try_serialize().unwrap();
+
+    let messages = build_messages::<SignatureType>(
+        from_keypair,
+        DEFAULT_SEGMENT_SIZE,
+        serialized_msg,
+        Redundancy::from_u8(2),
+        0,
+        BuildTarget::point_to_point(Epoch(0), &to_nodeid),
+        &HashMap::from([(to_nodeid, to_addr)]),
+    );
+
+    let socket = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    for (dest, payload) in messages {
+        for chunk in payload.chunks(usize::from(DEFAULT_SEGMENT_SIZE)) {
+            socket.send_to(chunk, dest).await.unwrap();
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_trusted_ip_tcp_update() {
+    ONCE_SETUP.call_once(|| {
+        tracing_subscriber::fmt::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_span_events(FmtSpan::CLOSE)
+            .init();
+    });
+
+    let tx_addr = find_unused_address();
+    let untrusted_ip = Ipv4Addr::new(168, 0, 0, 1);
+    let trusted_ip = Ipv4Addr::new(127, 0, 0, 1);
+
+    let tx_keypair = keypair(70);
+    let rx_keypair = keypair(71);
+    let tx_nodeid = NodeId::new(tx_keypair.pubkey());
+    let rx_nodeid = NodeId::new(rx_keypair.pubkey());
+
+    let dataplane = create_dataplane_for_tcp_update_test();
+    let rx_tcp_addr = dataplane.tcp_addr;
+    let rx_peer_disc_addr = SocketAddr::V4(dataplane.non_auth_addr);
+
+    let tx_name_record = NameRecord::new(
+        untrusted_ip,
+        tx_addr.port(),
+        Some(tx_addr.port()),
+        tx_addr.port(),
+        0,
+        1,
+    );
+    let rx_name_record = NameRecord::new(
+        *rx_tcp_addr.ip(),
+        rx_tcp_addr.port(),
+        Some(dataplane.non_auth_addr.port()),
+        dataplane.auth_addr.port(),
+        0,
+        1,
+    );
+
+    let bootstrap_peers = BTreeMap::from([
+        (
+            tx_nodeid,
+            MonadNameRecord::new(tx_name_record.clone(), &tx_keypair),
+        ),
+        (
+            rx_nodeid,
+            MonadNameRecord::new(rx_name_record.clone(), &rx_keypair),
+        ),
+    ]);
+
+    let pd_builder = PeerDiscoveryBuilder {
+        self_id: rx_nodeid,
+        self_record: MonadNameRecord::new(rx_name_record, &rx_keypair),
+        current_round: Round(0),
+        current_epoch: Epoch(0),
+        epoch_validators: BTreeMap::new(),
+        pinned_full_nodes: BTreeSet::new(),
+        prioritized_full_nodes: BTreeSet::new(),
+        bootstrap_peers,
+        refresh_period: Duration::from_millis(5000),
+        request_timeout: Duration::from_millis(500),
+        unresponsive_prune_threshold: 5,
+        last_participation_prune_threshold: Round(100),
+        min_num_peers: 3,
+        max_num_peers: 50,
+        enable_publisher: false,
+        enable_client: false,
+        max_group_size: 10,
+        rng: ChaCha8Rng::from_seed([0u8; 32]),
+        persisted_peers_path: Default::default(),
+        ping_rate_limit_per_second: 1000,
+    };
+
+    let pd = PeerDiscoveryDriver::new(pd_builder);
+
+    let config: RaptorCastConfig<SignatureType> = RaptorCastConfig {
+        shared_key: Arc::new(rx_keypair),
+        mtu: 1450,
+        udp_message_max_age_ms: 5000,
+        sig_verification_rate_limit: 10_000,
+        primary_instance: Default::default(),
+        secondary_instance: monad_node_config::FullNodeRaptorCastConfig {
+            enable_publisher: false,
+            enable_client: false,
+            raptor10_fullnode_redundancy_factor: 2f32,
+            full_nodes_prioritized: FullNodeConfig { identities: vec![] },
+            round_span: Round(10),
+            invite_lookahead: Round(5),
+            max_invite_wait: Round(3),
+            deadline_round_dist: Round(3),
+            init_empty_round_span: Round(1),
+            max_group_size: 10,
+            max_num_group: 5,
+            invite_future_dist_min: Round(1),
+            invite_future_dist_max: Round(5),
+            invite_accept_heartbeat_ms: 100,
+        },
+        deterministic_protocol_rollout: monad_raptorcast::v1_rollout::CURRENT_STAGE,
+    };
+
+    let mut rx_service = RaptorCast::<
+        SignatureType,
+        MockMessage,
+        MockMessage,
+        <MockMessage as Message>::Event,
+        PeerDiscovery<SignatureType>,
+        monad_raptorcast::auth::NoopAuthProtocol<PubKeyType>,
+        monad_raptorcast::auth::NopScore<NodeId<PubKeyType>>,
+    >::new(
+        config,
+        SecondaryRaptorCastModeConfig::None,
+        dataplane.tcp_socket,
+        (
+            dataplane.authenticated_socket,
+            monad_raptorcast::auth::NoopAuthProtocol::new(),
+        ),
+        None,
+        Some(dataplane.non_authenticated_socket),
+        dataplane.control,
+        Arc::new(std::sync::Mutex::new(pd)),
+        Epoch(0),
+        monad_raptorcast::dummy_proposer_schedule(),
+    );
+
+    rx_service.exec(vec![RouterCommand::AddEpochValidatorSet {
+        epoch: Epoch(0),
+        epoch_start: Round(0),
+        validator_set: vec![(tx_nodeid, Stake::ONE), (rx_nodeid, Stake::ONE)],
+    }]);
+
+    let _handle = tokio::spawn(async move {
+        loop {
+            let _ = rx_service.next().await;
+        }
+    });
+
+    assert_tcp_write_fails(SocketAddr::V4(rx_tcp_addr)).await;
+
+    let updated_record = MonadNameRecord::new(
+        NameRecord::new(
+            trusted_ip,
+            tx_addr.port(),
+            Some(tx_addr.port()),
+            tx_addr.port(),
+            0,
+            2,
+        ),
+        &tx_keypair,
+    );
+
+    send_peer_discovery_ping(&tx_keypair, rx_nodeid, rx_peer_disc_addr, updated_record).await;
+
+    wait_for_tcp_write_success(SocketAddr::V4(rx_tcp_addr)).await;
 }


### PR DESCRIPTION
discovery is extended with additional event to capture when ip address of the validator change. 
raptorcast waits for this event and sends information to dataplane