### PR TITLE
Remove proposal iteration comment

### DIFF
--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1304,10 +1304,6 @@ where
             ))),
         );
         for (sender, proposal) in cached_proposals {
-            // handle proposals in reverse order because later blocks are more likely to pass
-            // timestamp validation
-            //
-            // earlier proposals will then get short-circuited via blocksync codepath if certified
             let mut consensus = ConsensusChildState::new(self);
             commands.extend(
                 consensus

--- a/monad-state/src/statesync.rs
+++ b/monad-state/src/statesync.rs
@@ -114,7 +114,7 @@ where
         Some(root.get_execution_results())
     }
 
-    /// returns a new sync_target is applicable.
+    /// returns a new sync_target if applicable.
     ///
     /// concretely, if new_root > current_root + resync_threshold
     pub fn handle_proposal(


### PR DESCRIPTION
Proposal iteration should be forward to avoid issuing excess blocksync requests

https://github.com/category-labs/monad-bft/issues/1556