### PR TITLE
More accurate calculation configuration of bandwidth constraints

### DIFF
--- a/monad-node-config/src/fullnode_raptorcast.rs
+++ b/monad-node-config/src/fullnode_raptorcast.rs
@@ -45,8 +45,7 @@ pub struct FullNodeRaptorCastConfig<P: PubKey> {
     pub init_empty_round_span: Round,
 
     // RaptorCastConfigSecondaryClient
-    pub bandwidth_cost_per_group_member: u64,
-    pub bandwidth_capacity: u64,
+    pub max_num_group: usize,
     pub invite_future_dist_min: Round,
     pub invite_future_dist_max: Round,
     pub invite_accept_heartbeat_ms: u64,

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -712,8 +712,8 @@ where
                     RaptorCastConfigSecondary {
                         raptor10_redundancy: cfg_2nd.raptor10_fullnode_redundancy_factor,
                         mode: SecondaryRaptorCastModeConfig::Client(RaptorCastConfigSecondaryClient {
-                            bandwidth_cost_per_group_member: cfg_2nd.bandwidth_cost_per_group_member,
-                            bandwidth_capacity: cfg_2nd.bandwidth_capacity,
+                            max_num_group: cfg_2nd.max_num_group,
+                            max_group_size: cfg_2nd.max_group_size,
                             invite_future_dist_min: cfg_2nd.invite_future_dist_min,
                             invite_future_dist_max: cfg_2nd.invite_future_dist_max,
                             invite_accept_heartbeat: Duration::from_millis(cfg_2nd.invite_accept_heartbeat_ms),

--- a/monad-raptorcast/src/config.rs
+++ b/monad-raptorcast/src/config.rs
@@ -135,10 +135,10 @@ where
 
 #[derive(Clone)]
 pub struct RaptorCastConfigSecondaryClient {
-    // This determines whether we as a full node will accept an invite to join
-    // some validator's temporary raptorcast group.
-    pub bandwidth_cost_per_group_member: u64,
-    pub bandwidth_capacity: u64,
+    // Maximum number of groups a full node will join at a time
+    pub max_num_group: usize,
+    // Maximum number of full nodes in a group
+    pub max_group_size: usize,
     // When being invited to a raptorcast group, we will only accept the invite
     // if the group is not too far or too soon in the future, unless we haven't
     // seen any proposals in `invite_accept_heartbeat`
@@ -150,8 +150,8 @@ pub struct RaptorCastConfigSecondaryClient {
 impl Default for RaptorCastConfigSecondaryClient {
     fn default() -> RaptorCastConfigSecondaryClient {
         RaptorCastConfigSecondaryClient {
-            bandwidth_cost_per_group_member: 1,
-            bandwidth_capacity: u64::MAX,
+            max_num_group: 3,
+            max_group_size: 50,
             invite_future_dist_min: Round(1),
             invite_future_dist_max: Round(600), // ~5 minutes into the future, with current round length of 500ms
             invite_accept_heartbeat: Duration::from_secs(10),

--- a/monad-raptorcast/src/raptorcast_secondary/publisher.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/publisher.rs
@@ -1385,8 +1385,8 @@ mod tests {
             nid(10),
             clt_tx,
             RaptorCastConfigSecondaryClient {
-                bandwidth_cost_per_group_member: 1,
-                bandwidth_capacity: 5,
+                max_num_group: 5,
+                max_group_size: 50,
                 invite_future_dist_min: Round(1),
                 invite_future_dist_max: Round(100),
                 invite_accept_heartbeat: Duration::from_secs(10),
@@ -1512,8 +1512,8 @@ mod tests {
             nid(10),
             clt_tx,
             RaptorCastConfigSecondaryClient {
-                bandwidth_cost_per_group_member: 1,
-                bandwidth_capacity: 5,
+                max_num_group: 5,
+                max_group_size: 50,
                 invite_future_dist_min: Round(1),
                 invite_future_dist_max: Round(100),
                 invite_accept_heartbeat: Duration::from_secs(10),
@@ -1654,8 +1654,8 @@ mod tests {
             nid(me),
             clt_tx,
             RaptorCastConfigSecondaryClient {
-                bandwidth_cost_per_group_member: 1,
-                bandwidth_capacity: 6,
+                max_num_group: 5,
+                max_group_size: 50,
                 invite_future_dist_min: Round(1),
                 invite_future_dist_max: Round(100),
                 invite_accept_heartbeat: Duration::from_secs(10),


### PR DESCRIPTION
Closes https://github.com/category-labs/category-internal/issues/1818
More detailed description in the issue above. Previously we use number of full nodes across different groups to decide whether to join a group.

Tldr regardless of the group size, bandwidth cost is quite similar. Using max number of group that a client will join is a better configuration for bandwidth constraints (and also more intuitive). Unit tested