### PR TITLE
Adjust user gas limit to provider gas limit

### DIFF
--- a/monad-rpc/src/handlers/eth/gas.rs
+++ b/monad-rpc/src/handlers/eth/gas.rs
@@ -251,10 +251,7 @@ pub async fn monad_eth_estimateGas<T: Triedb>(
     };
 
     if params.tx.gas > Some(U256::from(provider_gas_limit)) {
-        return Err(JsonRpcError::eth_call_error(
-            "user-specified gas exceeds provider limit".to_string(),
-            None,
-        ));
+        params.tx.gas = Some(U256::from(provider_gas_limit));
     }
 
     let block_key = get_block_key_from_tag(triedb_env, params.block);


### PR DESCRIPTION
Geth adjusts the gas limit to the block gas limit. We currently return an error without attempting estimation. To conform with Geth, we should silently limit the user's gas limit to the provider gas limit. I'm not aware of any workflows that break, so its a minor conformance issue.