### PR TITLE
Add limit to websocket subscriptions

### DIFF
--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -30,7 +30,7 @@ monad-eth-types = { workspace = true }
 monad-ethcall = { workspace = true }
 monad-event-ring = { workspace = true }
 monad-exec-events = { workspace = true, features = ["alloy"] }
-monad-node-config = { workspace = true }
+monad-node-config = { workspace = true, features = ["crypto"] }
 monad-rpc-docs = { workspace = true }
 monad-tracing-timing = { workspace = true }
 monad-triedb-utils = { workspace = true }

--- a/monad-rpc/README.md
+++ b/monad-rpc/README.md
@@ -5,6 +5,6 @@ The prerequisite to starting the RPC server is to first [start a Monad consensus
 Run the following in the repo root directory:
 1. `export RUST_LOG=info`
     - The logging level can be adjusted as needed.
-2. `CXX=/usr/bin/g++-13 CC=/usr/bin/gcc-15 ASMFLAGS=-march=haswell CFLAGS="-march=haswell" CXXFLAGS="-march=haswell -DQUILL_ACTIVE_LOG_LEVEL=QUILL_LOG_LEVEL_CRITICAL" TRIEDB_TARGET=triedb_driver cargo run --bin monad-rpc -- --ipc-path docker/devnet/monad/mempool.sock --triedb-path <path_to_triedb_directory> --node_config <path_to_node_toml>`
+2. `CXX=/usr/bin/g++-15 CC=/usr/bin/gcc-15 ASMFLAGS=-march=haswell CFLAGS="-march=haswell" CXXFLAGS="-march=haswell -DQUILL_ACTIVE_LOG_LEVEL=QUILL_LOG_LEVEL_CRITICAL" TRIEDB_TARGET=triedb_driver cargo run --bin monad-rpc -- --ipc-path docker/devnet/monad/mempool.sock --triedb-path <path_to_triedb_directory> --node_config <path_to_node_toml>`
     - The `--ipc-path` must point to the same file and directories passed to the Monad consensus client.
     - The `--triedb-path` must point to a directory containing only a single triedb file.

--- a/monad-rpc/src/cli.rs
+++ b/monad-rpc/src/cli.rs
@@ -56,6 +56,10 @@ pub struct Cli {
     #[arg(long, default_value_t = 500)]
     pub ws_conn_limit: usize,
 
+    /// Set the subscription limit for each connection
+    #[arg(long, default_value_t = 100)]
+    pub ws_sub_per_conn_limit: u16,
+
     /// Set the max number of requests in a batch request
     #[arg(long, default_value_t = 5000)]
     pub batch_request_limit: u16,

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -354,6 +354,7 @@ async fn main() -> std::io::Result<()> {
     let ws_server_handle = if let Some(events_client) = events_client {
         let ws_app_data = app_state.clone();
         let conn_limit = websocket::handler::ConnectionLimit::new(args.ws_conn_limit);
+        let sub_limit = websocket::handler::SubscriptionLimit(args.ws_sub_per_conn_limit);
 
         args.ws_enabled.then(|| {
             HttpServer::new(move || {
@@ -361,6 +362,7 @@ async fn main() -> std::io::Result<()> {
                     .app_data(web::Data::new(conn_limit.clone()))
                     .app_data(web::Data::new(events_client.clone()))
                     .app_data(web::Data::new(ws_app_data.clone()))
+                    .app_data(web::Data::new(sub_limit.clone()))
                     .service(
                         web::resource("/").route(web::get().to(websocket::handler::ws_handler)),
                     )


### PR DESCRIPTION
Adds a cli flag for operators to limit the number of subscriptions per WebSocket connection. The current default is `100` which is a very conservative default based on our most recent load testing results. 