### PR TITLE
Full nodes connection

### DIFF
--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     marker::PhantomData,
     net::{IpAddr, SocketAddr, ToSocketAddrs},
     process,
@@ -53,7 +53,7 @@ use monad_node_config::{
     PeerDiscoveryConfig, SignatureCollectionType, SignatureType,
 };
 use monad_peer_discovery::{
-    discovery::{PeerDiscovery, PeerDiscoveryBuilder},
+    discovery::{PeerDiscovery, PeerDiscoveryBuilder, PeerDiscoveryRole},
     MonadNameRecord, NameRecord,
 };
 use monad_pprof::start_pprof_server;
@@ -671,25 +671,33 @@ where
         })
         .collect();
 
-    let epoch_validators = locked_epoch_validators
-        .iter()
-        .map(|epoch_validators| {
-            (
-                epoch_validators.epoch,
-                epoch_validators
-                    .validators
-                    .0
-                    .iter()
-                    .map(|validator| validator.node_id)
-                    .collect(),
-            )
-        })
-        .collect();
+    let epoch_validators: BTreeMap<Epoch, BTreeSet<NodeId<CertificateSignaturePubKey<ST>>>> =
+        locked_epoch_validators
+            .iter()
+            .map(|epoch_validators| {
+                (
+                    epoch_validators.epoch,
+                    epoch_validators
+                        .validators
+                        .0
+                        .iter()
+                        .map(|validator| validator.node_id)
+                        .collect(),
+                )
+            })
+            .collect();
     let mut pinned_full_nodes: BTreeSet<_> = full_nodes
         .iter()
         .map(|full_node| NodeId::new(full_node.secp256k1_pubkey))
         .collect();
 
+    let mut self_peer_disc_role = match epoch_validators
+        .get(&current_epoch)
+        .and_then(|validators| validators.get(&self_id))
+    {
+        Some(_) => PeerDiscoveryRole::ValidatorNone,
+        None => PeerDiscoveryRole::FullNodeNone,
+    };
     let secondary_instance: RaptorCastConfigSecondary<ST> = {
         if let Some(cfg_2nd) = node_config.fullnode_raptorcast {
             match cfg_2nd.mode {
@@ -700,6 +708,7 @@ where
 
                 monad_node_config::fullnode_raptorcast::SecondaryRaptorCastModeConfig::Client => {
                     debug!("Configured with Secondary RaptorCast instance: Client");
+                    self_peer_disc_role = PeerDiscoveryRole::FullNodeClient;
                     RaptorCastConfigSecondary {
                         raptor10_redundancy: cfg_2nd.raptor10_fullnode_redundancy_factor,
                         mode: SecondaryRaptorCastModeConfig::Client(RaptorCastConfigSecondaryClient {
@@ -714,6 +723,7 @@ where
 
                 monad_node_config::fullnode_raptorcast::SecondaryRaptorCastModeConfig::Publisher => {
                     debug!("Configured with Secondary RaptorCast instance: Publisher");
+                    self_peer_disc_role = PeerDiscoveryRole::ValidatorPublisher;
                     let full_nodes_prioritized: Vec<NodeId<CertificateSignaturePubKey<ST>>> = cfg_2nd
                         .full_nodes_prioritized
                         .identities
@@ -746,6 +756,7 @@ where
 
     let peer_discovery_builder = PeerDiscoveryBuilder {
         self_id,
+        self_role: self_peer_disc_role,
         self_record,
         current_round,
         current_epoch,

--- a/monad-peer-disc-swarm/src/driver.rs
+++ b/monad-peer-disc-swarm/src/driver.rs
@@ -171,6 +171,15 @@ where
                 target,
                 lookup_id,
             } => self.algo.handle_peer_lookup_timeout(to, target, lookup_id),
+            PeerDiscoveryEvent::SendFullNodeRaptorcastRequest { to } => {
+                self.algo.send_full_node_raptorcast_request(to)
+            }
+            PeerDiscoveryEvent::FullNodeRaptorcastRequest { from } => {
+                self.algo.handle_full_node_raptorcast_request(from)
+            }
+            PeerDiscoveryEvent::FullNodeRaptorcastResponse { from } => {
+                self.algo.handle_full_node_raptorcast_response(from)
+            }
             PeerDiscoveryEvent::UpdateCurrentRound { round, epoch } => {
                 self.algo.update_current_round(round, epoch)
             }

--- a/monad-peer-discovery/src/driver.rs
+++ b/monad-peer-discovery/src/driver.rs
@@ -203,6 +203,15 @@ impl<PD: PeerDiscoveryAlgo> PeerDiscoveryDriver<PD> {
                 target,
                 lookup_id,
             } => self.pd.handle_peer_lookup_timeout(to, target, lookup_id),
+            PeerDiscoveryEvent::SendFullNodeRaptorcastRequest { to } => {
+                self.pd.send_full_node_raptorcast_request(to)
+            }
+            PeerDiscoveryEvent::FullNodeRaptorcastRequest { from } => {
+                self.pd.handle_full_node_raptorcast_request(from)
+            }
+            PeerDiscoveryEvent::FullNodeRaptorcastResponse { from } => {
+                self.pd.handle_full_node_raptorcast_response(from)
+            }
             PeerDiscoveryEvent::UpdateCurrentRound { round, epoch } => {
                 self.pd.update_current_round(round, epoch)
             }
@@ -284,11 +293,11 @@ impl<PD: PeerDiscoveryAlgo> PeerDiscoveryDriver<PD> {
             .collect()
     }
 
-    pub fn get_fullnode_addrs(
+    pub fn get_secondary_fullnode_addrs(
         &self,
     ) -> HashMap<NodeId<CertificateSignaturePubKey<PD::SignatureType>>, SocketAddr> {
         self.pd
-            .get_fullnode_addrs()
+            .get_secondary_fullnode_addrs()
             .into_iter()
             .map(|(k, v)| (k, SocketAddr::V4(v)))
             .collect()

--- a/monad-peer-discovery/src/lib.rs
+++ b/monad-peer-discovery/src/lib.rs
@@ -143,6 +143,15 @@ pub enum PeerDiscoveryEvent<ST: CertificateSignatureRecoverable> {
         target: NodeId<CertificateSignaturePubKey<ST>>,
         lookup_id: u32,
     },
+    SendFullNodeRaptorcastRequest {
+        to: NodeId<CertificateSignaturePubKey<ST>>,
+    },
+    FullNodeRaptorcastRequest {
+        from: NodeId<CertificateSignaturePubKey<ST>>,
+    },
+    FullNodeRaptorcastResponse {
+        from: NodeId<CertificateSignaturePubKey<ST>>,
+    },
     UpdateCurrentRound {
         round: Round,
         epoch: Epoch,
@@ -167,6 +176,7 @@ pub enum TimerKind {
     PingTimeout,
     RetryPeerLookup { lookup_id: u32 },
     Refresh,
+    FullNodeRaptorcastRequest,
 }
 
 #[derive(Debug, Clone)]
@@ -255,6 +265,21 @@ pub trait PeerDiscoveryAlgo {
         lookup_id: u32,
     ) -> Vec<PeerDiscoveryCommand<Self::SignatureType>>;
 
+    fn send_full_node_raptorcast_request(
+        &mut self,
+        to: NodeId<CertificateSignaturePubKey<Self::SignatureType>>,
+    ) -> Vec<PeerDiscoveryCommand<Self::SignatureType>>;
+
+    fn handle_full_node_raptorcast_request(
+        &mut self,
+        from: NodeId<CertificateSignaturePubKey<Self::SignatureType>>,
+    ) -> Vec<PeerDiscoveryCommand<Self::SignatureType>>;
+
+    fn handle_full_node_raptorcast_response(
+        &mut self,
+        from: NodeId<CertificateSignaturePubKey<Self::SignatureType>>,
+    ) -> Vec<PeerDiscoveryCommand<Self::SignatureType>>;
+
     fn refresh(&mut self) -> Vec<PeerDiscoveryCommand<Self::SignatureType>>;
 
     fn update_current_round(
@@ -296,7 +321,7 @@ pub trait PeerDiscoveryAlgo {
         &self,
     ) -> HashMap<NodeId<CertificateSignaturePubKey<Self::SignatureType>>, SocketAddrV4>;
 
-    fn get_fullnode_addrs(
+    fn get_secondary_fullnode_addrs(
         &self,
     ) -> HashMap<NodeId<CertificateSignaturePubKey<Self::SignatureType>>, SocketAddrV4>;
 

--- a/monad-peer-discovery/src/mock.rs
+++ b/monad-peer-discovery/src/mock.rs
@@ -163,6 +163,33 @@ where
         Vec::new()
     }
 
+    fn send_full_node_raptorcast_request(
+        &mut self,
+        to: NodeId<CertificateSignaturePubKey<ST>>,
+    ) -> Vec<PeerDiscoveryCommand<ST>> {
+        debug!(?to, "sending full node raptorcast request");
+
+        Vec::new()
+    }
+
+    fn handle_full_node_raptorcast_request(
+        &mut self,
+        from: NodeId<CertificateSignaturePubKey<ST>>,
+    ) -> Vec<PeerDiscoveryCommand<ST>> {
+        debug!(?from, "handling full node raptorcast request");
+
+        Vec::new()
+    }
+
+    fn handle_full_node_raptorcast_response(
+        &mut self,
+        from: NodeId<CertificateSignaturePubKey<ST>>,
+    ) -> Vec<PeerDiscoveryCommand<ST>> {
+        debug!(?from, "handling full node raptorcast response");
+
+        Vec::new()
+    }
+
     fn refresh(&mut self) -> Vec<PeerDiscoveryCommand<ST>> {
         debug!("pruning unresponsive peer nodes");
 
@@ -229,7 +256,9 @@ where
         self.known_addresses.clone()
     }
 
-    fn get_fullnode_addrs(&self) -> HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddrV4> {
+    fn get_secondary_fullnode_addrs(
+        &self,
+    ) -> HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddrV4> {
         HashMap::new()
     }
 


### PR DESCRIPTION
Closes https://github.com/category-labs/category-internal/issues/1772 (more details in the issue linked)
This introduces two new message types in peer discovery for (1) a full node to indicate that it wants to look for an upstream validator running as Publisher and (2) a validator indicating it's running as Publisher and has space

This PR allows a full node to keep looking for upstream validators until it finds 3 upstream that is running as Publisher mode. 

Tested in peer disc swarm