### PR TITLE
Enable trace_calls

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,17 +3,11 @@ name: Rust
 on:
   merge_group:
     branches: ["master"]
-    paths-ignore:
-      - 'debian/**'
   push:
     branches: ["master"]
-    paths-ignore:
-      - 'debian/**'
   pull_request:
     branches: ["master"]
     types: [ opened, synchronize, reopened, edited ]
-    paths-ignore:
-      - 'debian/**'
 
 concurrency:
   group: >

--- a/debian/usr/lib/systemd/system/monad-execution.service
+++ b/debian/usr/lib/systemd/system/monad-execution.service
@@ -9,6 +9,7 @@ ExecStart=/usr/local/bin/monad \
     --db /dev/triedb \
     --block_db /home/monad/monad-bft/ledger \
     --statesync /home/monad/monad-bft/statesync.sock \
+    --trace_calls \
     --ro_sq_thread_cpu 5 \
     --sq_thread_cpu 6 \
     --log_level INFO


### PR DESCRIPTION
Enable trace_calls so execution populates traces. Also, disable the /debian exclusion rule in CI for now, because that stops PRs from being mergeable.

https://github.com/category-labs/monad/commit/aa5c5fe89664ea31c9ea8eb26c4c11cacc32c56f