### PR TITLE
ci(actions): fix Test Command workflow by defining required build env vars

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -4,6 +4,16 @@ on:
   issue_comment:
     types: [created]
 
+env:
+  CARGO_TERM_COLOR: always
+
+  ASMFLAGS: -march=haswell
+  CC: gcc-15
+  CFLAGS: -march=haswell
+  CXX: g++-15
+  CXXFLAGS: -march=haswell -DQUILL_ACTIVE_LOG_LEVEL=QUILL_LOG_LEVEL_CRITICAL
+  TRIEDB_TARGET: triedb_driver
+
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
Context:
The Test Command workflow was failing during the build because several expected environment variables were not defined in the runner context (toolchain + flags used by our build scripts and C/C++ deps).

What changed:
Define the minimal set of build variables at the job level so all steps inherit them:

CARGO_TERM_COLOR=always

CC=gcc-15, CXX=g++-15
CFLAGS=-march=haswell, CXXFLAGS=-march=haswell -DQUILL_ACTIVE_LOG_LEVEL=QUILL_LOG_LEVEL_CRITICAL
ASMFLAGS=-march=haswell
TRIEDB_TARGET=triedb_driver

Why:
Unblocks CI: resolves “missing env/undefined toolchain” failures.

