### PR TITLE
RPC: Treat Archive NotFound the same as TrieDB NotFound

### DIFF
--- a/monad-archive/src/archive_reader.rs
+++ b/monad-archive/src/archive_reader.rs
@@ -212,7 +212,7 @@ impl IndexReader for ArchiveReader {
     async fn get_tx_indexed_data(
         &self,
         tx_hash: &alloy_primitives::TxHash,
-    ) -> Result<TxIndexedData> {
+    ) -> Result<Option<TxIndexedData>> {
         self.index_executor
             .execute(|idx| idx.get_tx_indexed_data(tx_hash))
             .await
@@ -230,14 +230,14 @@ impl IndexReader for ArchiveReader {
     async fn get_tx(
         &self,
         tx_hash: &alloy_primitives::TxHash,
-    ) -> Result<(TxEnvelopeWithSender, HeaderSubset)> {
+    ) -> Result<Option<(TxEnvelopeWithSender, HeaderSubset)>> {
         self.index_executor.execute(|idx| idx.get_tx(tx_hash)).await
     }
 
     async fn get_trace(
         &self,
         tx_hash: &alloy_primitives::TxHash,
-    ) -> Result<(Vec<u8>, HeaderSubset)> {
+    ) -> Result<Option<(Vec<u8>, HeaderSubset)>> {
         self.index_executor
             .execute(|idx| idx.get_trace(tx_hash))
             .await
@@ -246,7 +246,7 @@ impl IndexReader for ArchiveReader {
     async fn get_receipt(
         &self,
         tx_hash: &alloy_primitives::TxHash,
-    ) -> Result<(ReceiptWithLogIndex, HeaderSubset)> {
+    ) -> Result<Option<(ReceiptWithLogIndex, HeaderSubset)>> {
         self.index_executor
             .execute(|idx| idx.get_receipt(tx_hash))
             .await
@@ -320,10 +320,18 @@ impl BlockDataReader for ArchiveReader {
             .execute(|bdr| bdr.try_get_block_traces(block_number))
             .await
     }
+
+    #[doc = " Get a block by its hash, or return None if not found"]
+    async fn try_get_block_by_hash(&self, block_hash: &BlockHash) -> Result<Option<Block>> {
+        self.block_data_executor
+            .execute(|bdr| bdr.try_get_block_by_hash(block_hash))
+            .await
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicBool;
 
     use super::*;
     use crate::{
@@ -340,6 +348,29 @@ mod tests {
         let bdr = BlockDataArchive::new(fallback.clone());
         let fallback = TxIndexArchiver::new(fallback, bdr, 1000);
         (primary, fallback)
+    }
+
+    fn setup_index_with_should_fail_ptr() -> (
+        TxIndexArchiver,
+        TxIndexArchiver,
+        Arc<AtomicBool>,
+        Arc<AtomicBool>,
+    ) {
+        let primary = MemoryStorage::new("primary");
+        let primary_should_fail_ptr = primary.should_fail.clone();
+        let bdr = BlockDataArchive::new(primary.clone());
+        let primary = TxIndexArchiver::new(primary, bdr, 1000);
+
+        let fallback = MemoryStorage::new("fallback");
+        let fallback_should_fail_ptr = fallback.should_fail.clone();
+        let bdr = BlockDataArchive::new(fallback.clone());
+        let fallback = TxIndexArchiver::new(fallback, bdr, 1000);
+        (
+            primary,
+            fallback,
+            primary_should_fail_ptr,
+            fallback_should_fail_ptr,
+        )
     }
 
     #[tokio::test]
@@ -370,7 +401,7 @@ mod tests {
             None,
         );
 
-        let (tx_ret, _) = reader.get_tx(tx.tx.tx_hash()).await.unwrap();
+        let (tx_ret, _) = reader.get_tx(tx.tx.tx_hash()).await.unwrap().unwrap();
         assert_eq!(tx_ret, tx);
     }
 
@@ -386,8 +417,8 @@ mod tests {
 
         let tx = mock_tx(123);
         let ret = reader.get_tx(tx.tx.tx_hash()).await;
-        assert!(ret.is_err());
-        assert!(ret.err().unwrap().to_string().contains("No data found in index for txhash: 159bcad22109fd9e0d5a3ba10d75a6f32386ca0112fabcc70ed100df937be54d"));
+        assert!(ret.is_ok());
+        assert!(ret.unwrap().is_none())
     }
 
     #[tokio::test]
@@ -408,12 +439,14 @@ mod tests {
 
         let tx = mock_tx(123);
         let ret = reader.get_tx(tx.tx.tx_hash()).await;
-        assert!(ret.is_err());
+        assert!(ret.is_ok());
+        assert!(ret.unwrap().is_none());
     }
 
     #[tokio::test]
     async fn test_get_tx_fallback() {
-        let (primary, fallback) = setup_index();
+        let (primary, fallback, primary_should_fail_ptr, _fallback_should_fail_ptr) =
+            setup_index_with_should_fail_ptr();
 
         let tx = mock_tx(123);
         fallback
@@ -439,7 +472,9 @@ mod tests {
             None,
         );
 
-        let (tx_ret, _) = reader.get_tx(tx.tx.tx_hash()).await.unwrap();
+        primary_should_fail_ptr.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let (tx_ret, _) = reader.get_tx(tx.tx.tx_hash()).await.unwrap().unwrap();
         assert_eq!(tx_ret, tx);
     }
 
@@ -767,10 +802,7 @@ mod tests {
             "Should fail when both primary and fallback fail"
         );
         assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("MemoryStorage simulated failure"),
+            format!("{:?}", result.unwrap_err()).contains("MemoryStorage simulated failure"),
             "Error should indicate storage failure"
         );
 

--- a/monad-archive/src/kvstore/triedb_reader.rs
+++ b/monad-archive/src/kvstore/triedb_reader.rs
@@ -133,4 +133,9 @@ impl BlockDataReader for TriedbReader {
     async fn try_get_block_traces(&self, block_number: u64) -> Result<Option<BlockTraces>> {
         self.get_block_traces(block_number).await.map(Some)
     }
+
+    #[doc = " Get a block by its hash, or return None if not found"]
+    async fn try_get_block_by_hash(&self, block_hash: &BlockHash) -> Result<Option<Block>> {
+        self.get_block_by_hash(block_hash).await.map(Some)
+    }
 }

--- a/monad-archive/src/model/index_repr.rs
+++ b/monad-archive/src/model/index_repr.rs
@@ -161,7 +161,7 @@ impl IndexDataStorageRepr {
                     trace: inline_v0.trace,
                     receipt: receipts
                         .get(inline_v0.header_subset.tx_index as usize)
-                        .context("Failed to find receipt in block data")?
+                        .ok_or_eyre("Failed to find receipt in block data")?
                         .clone(),
                     header_subset: inline_v0.header_subset.convert(block.header.timestamp),
                 }

--- a/monad-archive/src/model/logs_index.rs
+++ b/monad-archive/src/model/logs_index.rs
@@ -197,8 +197,11 @@ impl LogsIndexArchiver {
                 let reader = self.index_reader.clone();
                 let collection = self.collection.clone();
                 async move {
-                    let doc = doc?;
-                    let (_id, bytes) = doc.resolve(&collection).await?;
+                    let doc = doc.wrap_err("Failed to get logs index")?;
+                    let (_id, bytes) = doc
+                        .resolve(&collection)
+                        .await
+                        .wrap_err("Failed to resolve logs index")?;
                     reader
                         .resolve_from_bytes(&bytes)
                         .await

--- a/monad-archive/src/model/mod.rs
+++ b/monad-archive/src/model/mod.rs
@@ -41,17 +41,18 @@ pub trait BlockDataReader: Clone {
     /// Get the latest block number for the given type (uploaded or indexed)
     async fn get_latest(&self, latest_kind: LatestKind) -> Result<Option<u64>>;
 
-    /// Get a block by its number, or return None if not found
-    async fn try_get_block_by_number(&self, block_num: u64) -> Result<Option<Block>>;
-
-    /// Get receipts for a block, or return None if not found
-    async fn try_get_block_receipts(&self, block_number: u64) -> Result<Option<BlockReceipts>>;
-
-    /// Get execution traces for a block, or return None if not found
-    async fn try_get_block_traces(&self, block_number: u64) -> Result<Option<BlockTraces>>;
+    /// Get a block by its hash, or return None if not found
+    async fn try_get_block_by_hash(&self, block_hash: &BlockHash) -> Result<Option<Block>>;
 
     /// Get a block by its hash
-    async fn get_block_by_hash(&self, block_hash: &BlockHash) -> Result<Block>;
+    async fn get_block_by_hash(&self, block_hash: &BlockHash) -> Result<Block> {
+        self.try_get_block_by_hash(block_hash)
+            .await
+            .and_then(|opt| opt.ok_or_eyre("Block not found"))
+    }
+
+    /// Get a block by its number, or return None if not found
+    async fn try_get_block_by_number(&self, block_num: u64) -> Result<Option<Block>>;
 
     /// Get a block by its number
     async fn get_block_by_number(&self, block_num: u64) -> Result<Block> {
@@ -60,12 +61,18 @@ pub trait BlockDataReader: Clone {
             .and_then(|opt| opt.ok_or_eyre("Block not found"))
     }
 
+    /// Get receipts for a block, or return None if not found
+    async fn try_get_block_receipts(&self, block_number: u64) -> Result<Option<BlockReceipts>>;
+
     /// Get receipts for a block
     async fn get_block_receipts(&self, block_number: u64) -> Result<BlockReceipts> {
         self.try_get_block_receipts(block_number)
             .await
             .and_then(|opt| opt.ok_or_eyre("Receipt not found"))
     }
+
+    /// Get execution traces for a block, or return None if not found
+    async fn try_get_block_traces(&self, block_number: u64) -> Result<Option<BlockTraces>>;
 
     /// Get execution traces for a block
     async fn get_block_traces(&self, block_number: u64) -> Result<BlockTraces> {

--- a/monad-archive/src/prelude.rs
+++ b/monad-archive/src/prelude.rs
@@ -24,7 +24,7 @@ pub use std::{
 
 pub use alloy_consensus::{BlockBody, Header, ReceiptEnvelope, ReceiptWithBloom};
 pub use alloy_primitives::{U128, U256, U64};
-pub use eyre::{bail, eyre, Context, ContextCompat, OptionExt, Result};
+pub use eyre::{bail, eyre, Context, ContextCompat, OptionExt, Report, Result};
 pub use futures::{try_join, StreamExt, TryStream, TryStreamExt};
 pub use monad_triedb_utils::triedb_env::{ReceiptWithLogIndex, TxEnvelopeWithSender};
 pub use tokio::time::sleep;

--- a/monad-rpc/src/handlers/mod.rs
+++ b/monad-rpc/src/handlers/mod.rs
@@ -385,7 +385,6 @@ async fn eth_sendRawTransaction(
     params: Value,
 ) -> Result<Box<RawValue>, JsonRpcError> {
     let params = serde_json::from_value(params).invalid_params()?;
-    let triedb_env = app_state.triedb_reader.as_ref().method_not_supported()?;
     monad_eth_sendRawTransaction(
         &app_state.txpool_bridge_client,
         params,

--- a/monad-rpc/src/handlers/resources.rs
+++ b/monad-rpc/src/handlers/resources.rs
@@ -126,8 +126,8 @@ impl RootSpanBuilder for MonadJsonRootSpanBuilder {
     }
 
     fn on_request_end<B: actix_web::body::MessageBody>(
-        span: tracing::Span,
-        outcome: &Result<ServiceResponse<B>, Error>,
+        _span: tracing::Span,
+        _outcome: &Result<ServiceResponse<B>, Error>,
     ) {
     }
 }

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -135,7 +135,7 @@ async fn main() -> std::io::Result<()> {
 
     let mut print_message_timer = tokio::time::interval(Duration::from_secs(60));
     let mut retry_timer = tokio::time::interval(Duration::from_secs(1));
-    let (txpool_bridge_client, txpool_bridge_handle) = loop {
+    let (txpool_bridge_client, _txpool_bridge_handle) = loop {
         tokio::select! {
             _ = print_message_timer.tick() => {
                 info!("Waiting for statesync to complete");

--- a/monad-rpc/src/websocket/handler.rs
+++ b/monad-rpc/src/websocket/handler.rs
@@ -141,7 +141,7 @@ async fn handler(
     msg_stream: actix_ws::MessageStream,
     hostname: &String,
     peer_addr: &Option<String>,
-    mut subscriptions: &mut HashMap<SubscriptionKind, Vec<(SubscriptionId, Option<Filter>)>>,
+    subscriptions: &mut HashMap<SubscriptionKind, Vec<(SubscriptionId, Option<Filter>)>>,
     rx: broadcast::Receiver<EventServerEvent>,
     app_state: &web::Data<MonadRpcResources>,
     subscription_limit: u16,


### PR DESCRIPTION
- Use try_get_x methods instead of get_x on ArchiveReader
- Improve chainstate -> handler mappings for readability via extension traits on error types
- Fix some warns in RPC

fixed https://github.com/category-labs/category-internal/issues/1845