### PR TITLE
Deflake raptorcast tests

### DIFF
--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -292,8 +292,9 @@ where
         ..Default::default()
     };
     let up_bandwidth_mbps = 1_000;
-    let dp_builder = DataplaneBuilder::new(&local_addr, up_bandwidth_mbps);
-    let (dp_reader, dp_writer) = dp_builder.build().split();
+    let dp = DataplaneBuilder::new(&local_addr, up_bandwidth_mbps).build();
+    assert!(dp.block_until_ready(Duration::from_secs(1)));
+    let (dp_reader, dp_writer) = dp.split();
     let config = config::RaptorCastConfig {
         shared_key,
         mtu: DEFAULT_MTU,

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -18,6 +18,7 @@ use std::{
     pin::Pin,
     sync::{Arc, Mutex},
     task::Poll,
+    time::Duration,
 };
 
 use alloy_rlp::{Decodable, Encodable};
@@ -72,7 +73,9 @@ where
         let pdd = PeerDiscoveryDriver::new(peer_discovery_builder);
         let shared_pdd = Arc::new(Mutex::new(pdd));
 
-        let (dp_reader, dp_writer) = dataplane_builder.build().split();
+        let dp = dataplane_builder.build();
+        assert!(dp.block_until_ready(Duration::from_secs(1)));
+        let (dp_reader, dp_writer) = dp.split();
 
         // Create a channel between primary and secondary raptorcast instances.
         // Fundamentally this is needed because, while both can send, only the


### PR DESCRIPTION
Tested with:
```bash
while true; do RUST_LOG=info cargo test -p monad-raptorcast --test raptorcast_instance --release -- publish_to_full --nocapture; done
```