### PR TITLE
Feature: round up RaptorCast chunk assignments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5609,6 +5609,7 @@ dependencies = [
 name = "monad-raptorcast"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "alloy-rlp",
  "bitvec",
  "bytes",

--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -35,6 +35,7 @@ rand_chacha = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
+alloy-primitives.workspace = true
 
 [dev-dependencies]
 monad-testutil = { workspace = true }

--- a/monad-raptorcast/tests/raptorcast_instance.rs
+++ b/monad-raptorcast/tests/raptorcast_instance.rs
@@ -36,7 +36,7 @@ use monad_peer_discovery::mock::NopDiscovery;
 use monad_raptor::SOURCE_SYMBOLS_MAX;
 use monad_raptorcast::{
     new_defaulted_raptorcast_for_tests,
-    udp::{build_messages, build_messages_with_length, MAX_REDUNDANCY},
+    udp::{build_messages, build_messages_with_length},
     util::{BuildTarget, EpochValidators, Redundancy},
     RaptorCast, RaptorCastEvent,
 };
@@ -278,9 +278,9 @@ pub fn valid_rebroadcast() {
         &tx_keypair,
         DEFAULT_SEGMENT_SIZE,
         message,
-        MAX_REDUNDANCY, // redundancy,
-        0,              // epoch_no
-        0,              // unix_ts_ms
+        Redundancy::from_u8(3), // redundancy,
+        0,                      // epoch_no
+        0,                      // unix_ts_ms
         BuildTarget::Raptorcast(epoch_validators),
         &known_addresses,
     );


### PR DESCRIPTION
**Round up the number of chunks assigned to each validator in the first phase of validator-to-validator RaptorCast.**  
This change is required to guarantee Byzantine Fault Tolerance. It implements the [publicly documented behavior](https://www.category.xyz/blogs/raptorcast-designing-a-messaging-layer) of RaptorCast, ensuring documentation and implementation are aligned.

This feature only affects the leader when sending out a block proposal using RaptorCast. The leader operates as follows:

- First, we compute the number of packets (`num_packets`) without rounding up. This is essentially the payload size divided by the payload per chunk times the redundancy factor.
- For each validator, we determine their _obligation_: the number of chunks they should be assigned, calculated as `num_packets * stake / total_stake`. This value is a float.
- Each validator receives a number of chunks equal to their obligation, rounded up. We distinguish between _initial chunks_ (the obligation rounded down, denoted `ic[i]`) and a _rounding chunk_ (each validator receives exactly one). While this distinction is not currently important, it may become relevant in the future.
- The new total number of packets is the sum of all `ic[i]` plus the number of validators `n` (since each receives one rounding chunk).

As a safeguard, we check that the rounded-up total `rounded_up_num_packets` falls between the original `num_packets` and `num_packets + n`. This should always be true; if not, we issue a warning. In case `num_packets` is larger, we use that value instead.

### Other minor features

- The validator stake map is shuffled deterministically for chunk assignment using a seed. This does not yet affect chunk assignment, but will likely be important in future updates.

### Performance impact
The solution of rounding up requires sending up to `n` more chunks than necessary -- each one of which will get re-broadcasted by a validator. Each validator sends and receives `~n` more chunks than required. For small messages, the overhead is very large. As such, it is only a temporary solution; a more permanent solution is planned.

We simulated the overhead created by rounding up. The following graph shows the additional bandwidth consumed at validators due to rounding up, for various values of `num_packets` and numbers of validators `n`. 4740 chunks represents a full block, whereas 474 chunks present a block that is only 10% full. (Note that the graph says "current RaptorCast", but this is actually the solution proposed in this PR.)

For the leader's block proposal message, the additional overhead is likely not prohibitive for small-medium network sizes (e.g., `n = 200`).
<img width="1189" height="690" alt="image" src="https://github.com/user-attachments/assets/f7d6ebb9-7455-4dc2-8f85-28b00a84b21d" />

### Required actions before merge
- Before deploying this feature, we must ensure that this only affects the leader's block proposal message, and not any other messages, in particular, if they are sent more frequently than block proposals.
- Testing could be extended. Manual testing has been done locally on monad-testground, with 5-8 validators, and various payload sizes (yielding 6-100 packets). These tests were all successful, i.e., I confirmed manually that every validator received the expected number of packets. No testing has been done outside of these parameters yet.
- Need to think about whether this should affect the `encoded_symbol_capacity` in the decoder. Right now, this capacity is calculated as `max(app_message_len / symbol_len, SOURCE_SYMBOLS_MIN) * MAX_REDUNDANCY`. Due to rounding up, for small messages, more chunks than that could be created, and they would not be added to the decoder state. I think this might not be an issue, because (i) those chunks are not required for decoding and (ii) we still broadcast those chunks if they are assigned to us (`self_hash == parsed_message.recipient_hash`), even if we don't end up storing them.

Closes https://github.com/category-labs/category-internal/issues/898 (but a follow-up issue is needed, to address the inefficiency of rounding up).
