### PR TITLE
Conditionally include Vote(r) in Timeout(r)

### DIFF
--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -141,7 +141,12 @@ where
                 });
                 cmds
             }
-            PacemakerCommand::PrepareTimeout(timeout, high_extend, last_round_certificate) => {
+            PacemakerCommand::PrepareTimeout(
+                timeout,
+                high_extend,
+                safe_to_vote,
+                last_round_certificate,
+            ) => {
                 vec![ConsensusCommand::Publish {
                     // TODO should this be sent to epoch of next round?
                     target: RouterTarget::Broadcast(timeout.epoch),
@@ -151,6 +156,7 @@ where
                             cert_keypair,
                             timeout,
                             high_extend,
+                            safe_to_vote,
                             last_round_certificate,
                         )),
                     }

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -809,7 +809,7 @@ where
         let process_certificate_cmds = self.process_qc(timeout.high_extend.qc());
         cmds.extend(process_certificate_cmds);
 
-        if let HighExtendVote::Tip(tip, vote_signature) = &timeout.high_extend {
+        if let HighExtendVote::Tip(tip, Some(vote_signature)) = &timeout.high_extend {
             let handle_vote_cmds = self.handle_vote_message(
                 author,
                 VoteMessage {
@@ -3051,10 +3051,10 @@ mod test {
 
         let broadcast_cmd = pacemaker_cmds
             .iter()
-            .find(|cmd| matches!(cmd, PacemakerCommand::PrepareTimeout(_, _, _)))
+            .find(|cmd| matches!(cmd, PacemakerCommand::PrepareTimeout(_, _, _, _)))
             .unwrap();
 
-        let tmo = if let PacemakerCommand::PrepareTimeout(tmo, _, _) = broadcast_cmd {
+        let tmo = if let PacemakerCommand::PrepareTimeout(tmo, _, _, _) = broadcast_cmd {
             tmo
         } else {
             panic!()

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -1648,6 +1648,7 @@ mod test {
                 &certkeys[0],
                 timeout,
                 HighExtend::Qc(qc),
+                true,
                 Some(RoundCertificate::Tc(tc)),
             );
 
@@ -1716,7 +1717,7 @@ mod test {
             SignatureCollectionType,
             ExecutionProtocolType,
         >::new(
-            &certkeys[0], timeout, HighExtend::Qc(qc), None
+            &certkeys[0], timeout, HighExtend::Qc(qc), true, None
         );
 
         let epoch_manager = EpochManager::new(SeqNum(2000), Round(50), &[(Epoch(1), Round(0))]);
@@ -1916,6 +1917,7 @@ mod test {
             author_cert_key,
             timeout,
             HighExtend::Qc(QuorumCertificate::genesis_qc()),
+            true,
             None,
         );
 
@@ -1973,6 +1975,7 @@ mod test {
             author_cert_key,
             timeout,
             HighExtend::Qc(QuorumCertificate::genesis_qc()),
+            true,
             None,
         );
 

--- a/monad-testutil/src/proposal.rs
+++ b/monad-testutil/src/proposal.rs
@@ -247,6 +247,7 @@ where
                 certkey,
                 tminfo.clone(),
                 HighExtend::Qc(self.high_qc.clone()),
+                true, // safe_to_vote
                 Some(RoundCertificate::Tc(tc.clone())),
             );
             tmo_msgs.push(Verified::<ST, _>::new(timeout.into(), key));


### PR DESCRIPTION
We should only include Vote(r) in Timeout(r) if either:
1. We haven't sent NE(r)
2. We've sent NE(r) AND high_tip.round == r

This is necessary to ensure that NEC(r) and QC(r) don't form for conflicting tips in the same round.