### PR TITLE
chore: align Rust toolchain to 1.87.0 across CI and Docker

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
           submodules: recursive
           token: ${{ steps.generate_token.outputs.token }}
       - run: rustup toolchain install nightly-2024-12-10 --profile minimal --component rustfmt
-      - run: rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu --profile minimal --component clippy
+      - run: rustup toolchain install 1.87.0-x86_64-unknown-linux-gnu --profile minimal --component clippy
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@main
       - name: Install cargo-shear

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -91,7 +91,7 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
 
       - run: rustup toolchain install nightly-2024-12-10 --profile minimal --component rustfmt
-      - run: rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu --profile minimal --component clippy
+      - run: rustup toolchain install 1.87.0-x86_64-unknown-linux-gnu --profile minimal --component clippy
 
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@main

--- a/docker/archive/Dockerfile
+++ b/docker/archive/Dockerfile
@@ -66,7 +66,7 @@ RUN apt update && apt install -y \
 ARG CARGO_ROOT="/root/.cargo"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 ENV PATH="${CARGO_ROOT}/bin:$PATH"
-RUN rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu
+RUN rustup toolchain install 1.87.0-x86_64-unknown-linux-gnu
 ARG TRIEDB_TARGET=triedb_driver
 
 # Builder

--- a/docker/devnet/Dockerfile
+++ b/docker/devnet/Dockerfile
@@ -66,7 +66,7 @@ RUN apt update && apt install -y \
 ARG CARGO_ROOT="/root/.cargo"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 ENV PATH="${CARGO_ROOT}/bin:$PATH"
-RUN rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu
+RUN rustup toolchain install 1.87.0-x86_64-unknown-linux-gnu
 ARG TRIEDB_TARGET=triedb_driver
 
 # Builder

--- a/docker/rpc-request-gen/Dockerfile
+++ b/docker/rpc-request-gen/Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get install -y \
 ARG CARGO_ROOT="/root/.cargo"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 ENV PATH="${CARGO_ROOT}/bin:$PATH"
-RUN rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu
+RUN rustup toolchain install 1.87.0-x86_64-unknown-linux-gnu
 
 WORKDIR /usr/src/monad-bft
 

--- a/docker/rpc/Dockerfile
+++ b/docker/rpc/Dockerfile
@@ -64,7 +64,7 @@ RUN apt update && apt install -y \
 ARG CARGO_ROOT="/root/.cargo"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 ENV PATH="${CARGO_ROOT}/bin:$PATH"
-RUN rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu
+RUN rustup toolchain install 1.87.0-x86_64-unknown-linux-gnu
 
 ENV TRIEDB_TARGET=triedb_driver
 

--- a/docker/txgen/Dockerfile
+++ b/docker/txgen/Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get install -y \
 ARG CARGO_ROOT="/root/.cargo"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 ENV PATH="${CARGO_ROOT}/bin:$PATH"
-RUN rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu
+RUN rustup toolchain install 1.87.0-x86_64-unknown-linux-gnu
 
 WORKDIR /usr/src/monad-bft
 


### PR DESCRIPTION
Sspecifies Rust 1.87.0 in `rust-toolchain.toml` but CI and Docker builds were still using 1.85.0. This mismatch can cause subtle differences between local development and CI/production environments, potentially leading to build failures or behavioral differences.

Fixes version inconsistency between `rust-toolchain.toml` (1.87.0) and CI/Docker configs (1.85.0).

