### PR TITLE
Kai/debug reserve balance

### DIFF
--- a/monad-eth-block-policy/src/lib.rs
+++ b/monad-eth-block-policy/src/lib.rs
@@ -259,6 +259,7 @@ where
 
         let mut next_validate = emptying_txn_check_block_range.start;
         for (_, block) in self.blocks.range(emptying_txn_check_block_range) {
+            assert_eq!(next_validate, block.seq_num);
             if block.fees.get(eth_address).is_some()
                 && account_balance.block_seqnum_of_latest_txn < block.seq_num
             {
@@ -268,6 +269,7 @@ where
         }
 
         for (_, block) in self.blocks.range(reserve_balance_check_block_range) {
+            assert_eq!(next_validate, block.seq_num);
             if let Some(block_txn_fees) = block.fees.get(eth_address) {
                 let mut validator =
                     EthBlockPolicyBlockValidator::new(block.seq_num, execution_delay)?;
@@ -777,6 +779,7 @@ where
                             .skip_while(move |block| block.get_seq_num() < next_validate);
 
                         for extending_block in next_blocks {
+                            assert_eq!(next_validate, extending_block.get_seq_num());
                             if let Some(txn_fee) = extending_block.txn_fees.get(&address) {
                                 // if still within check emptying range, update latest tx seq num
                                 // otherwise check for reserve balance

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1308,11 +1308,6 @@ where
 
         // commit blocks
         for block in last_delay_committed_blocks {
-            if let Some(latest_seq_num) = self.state_backend.raw_read_latest_finalized_block() {
-                if block.get_seq_num() <= latest_seq_num {
-                    continue; //already finalized
-                }
-            }
             commands.push(Command::LedgerCommand(LedgerCommand::LedgerCommit(
                 OptimisticCommit::Proposed(block.deref().to_owned()),
             )));


### PR DESCRIPTION
failures:

---- test_forkpoint_restart_f_simple_statesync stdout ----

thread 'test_forkpoint_restart_f_simple_statesync' panicked at /home/eerkaijun/monad-bft/monad-state-backend/src/in_memory.rs:159:9:
assertion failed: seq_num >=
    self.raw_read_latest_finalized_block().expect("latest_finalized doesn't exist")
        + SeqNum(1)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- test_forkpoint_restart_f_target_reset_statesync stdout ----

thread 'test_forkpoint_restart_f_target_reset_statesync' panicked at /home/eerkaijun/monad-bft/monad-state-backend/src/in_memory.rs:159:9:
assertion failed: seq_num >=
    self.raw_read_latest_finalized_block().expect("latest_finalized doesn't exist")
        + SeqNum(1)

---- test_forkpoint_restart_f_epoch_boundary_statesync stdout ----

thread 'test_forkpoint_restart_f_epoch_boundary_statesync' panicked at /home/eerkaijun/monad-bft/monad-state-backend/src/in_memory.rs:159:9:
assertion failed: seq_num >=
    self.raw_read_latest_finalized_block().expect("latest_finalized doesn't exist")
        + SeqNum(1)


failures:
    test_forkpoint_restart_f_epoch_boundary_statesync
    test_forkpoint_restart_f_simple_statesync
    test_forkpoint_restart_f_target_reset_statesync
