### PR TITLE
fix: replace deprecated #[clap(...)] with #[command(...)] and #[arg(…)]

### DIFF
--- a/monad-archive/examples/get_logs_benchmarks.rs
+++ b/monad-archive/examples/get_logs_benchmarks.rs
@@ -29,9 +29,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 #[derive(Debug, Parser)]
-#[clap(about = "Tool for benchmarking eth_getLogs")]
+#[command(about = "Tool for benchmarking eth_getLogs")]
 struct Args {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Commands,
 }
 
@@ -49,67 +49,67 @@ enum Commands {
 
 #[derive(Debug, Parser)]
 struct GenerateArgs {
-    #[clap(short, long, default_value = "requests.json")]
+    #[arg(short, long, default_value = "requests.json")]
     output_file: PathBuf,
 
-    #[clap(short, long, default_value = "5000000")]
+    #[arg(short, long, default_value = "5000000")]
     min_block: u64,
 
-    #[clap(short, long, default_value = "8000000")]
+    #[arg(short, long, default_value = "8000000")]
     max_block: u64,
 
-    #[clap(short, long, default_value = "100")]
+    #[arg(short, long, default_value = "100")]
     min_range: u64,
 
-    #[clap(short, long, default_value = "101")]
+    #[arg(short, long, default_value = "101")]
     max_range: u64,
 
-    #[clap(short, long, default_value = "10")]
+    #[arg(short, long, default_value = "10")]
     num_requests: usize,
 
-    #[clap(short, long)]
+    #[arg(short, long)]
     frequency_file: Option<PathBuf>,
 
-    #[clap(short = 'T', long, default_value = "3")]
+    #[arg(short = 'T', long, default_value = "3")]
     top_topics: usize,
 
-    #[clap(short = 'A', long, default_value = "3")]
+    #[arg(short = 'A', long, default_value = "3")]
     top_addresses: usize,
 
-    #[clap(long, default_value = "25")]
+    #[arg(long, default_value = "25")]
     address_filter_percent: u8,
 
-    #[clap(long, default_value = "30")]
+    #[arg(long, default_value = "30")]
     topic_filter_percent: u8,
 }
 
 #[derive(Debug, Parser)]
 struct BenchmarkArgs {
-    #[clap(short, long)]
+    #[arg(short, long)]
     request_file: PathBuf,
 
-    #[clap(short, long, default_value = "results.json")]
+    #[arg(short, long, default_value = "results.json")]
     output_file: PathBuf,
 
-    #[clap(short = 'f', long, default_value = "frequency.json")]
+    #[arg(short = 'f', long, default_value = "frequency.json")]
     frequency_file: PathBuf,
 
-    #[clap(short, long, default_value = "http://localhost:8080")]
+    #[arg(short, long, default_value = "http://localhost:8080")]
     url: String,
 
-    #[clap(short, long, default_value = "4")]
+    #[arg(short, long, default_value = "4")]
     timeout_seconds: u64,
 }
 
 #[derive(Debug, Parser)]
 struct CompareArgs {
-    #[clap(short = '1', long, help = "First benchmark result file")]
+    #[arg(short = '1', long, help = "First benchmark result file")]
     first_file: PathBuf,
 
-    #[clap(short = '2', long, help = "Second benchmark result file")]
+    #[arg(short = '2', long, help = "Second benchmark result file")]
     second_file: PathBuf,
 
-    #[clap(
+    #[arg(
         short,
         long,
         default_value = "comparison.json",

--- a/monad-archive/src/bin/monad-archive-checker/cli.rs
+++ b/monad-archive/src/bin/monad-archive-checker/cli.rs
@@ -136,23 +136,23 @@ pub struct Rechecker {
 pub struct FaultFixerArgs {
     /// Commit changes to replicas
     /// Otherwise runs in dry-run mode
-    #[clap(long)]
+    #[arg(long)]
     pub commit_changes: bool,
 
     /// Verify fixed blocks after repair
-    #[clap(long)]
+    #[arg(long)]
     pub verify: bool,
 
     /// Comma-separated list of specific replicas to fix (defaults to all)
-    #[clap(long, value_delimiter = ',')]
+    #[arg(long, value_delimiter = ',')]
     pub replicas: Option<Vec<String>>,
 
     /// Start block (inclusive)
-    #[clap(long)]
+    #[arg(long)]
     pub start: Option<u64>,
 
     /// End block (inclusive)
-    #[clap(long)]
+    #[arg(long)]
     pub end: Option<u64>,
 
     /// How many blocks to process in parallel

--- a/monad-debug-node/src/main.rs
+++ b/monad-debug-node/src/main.rs
@@ -48,7 +48,7 @@ struct Cli {
 }
 
 #[derive(Debug, Args)]
-#[clap(group(ArgGroup::new("method").required(true).args(&["filter", "file"])))]
+#[command(group(ArgGroup::new("method").required(true).args(&["filter", "file"])))]
 struct UpdateLogFilter {
     #[arg(long, value_name = "FILTER")]
     filter: Option<String>,

--- a/monad-eth-testutil/examples/txgen/cli.rs
+++ b/monad-eth-testutil/examples/txgen/cli.rs
@@ -84,36 +84,36 @@ pub struct Config {
 
     /// How many txs should be generated per sender per cycle.
     /// Or put another way, how many txs should be generated before refreshing the nonce from chain state
-    #[clap(long, global = true)]
+    #[arg(long, global = true)]
     pub tx_per_sender: Option<usize>,
 
     /// Override for erc20 contract address
-    #[clap(long, global = true)]
+    #[arg(long, global = true)]
     pub erc20_contract: Option<String>,
 
     /// Override for ecmul contract address.
-    #[clap(long, global = true)]
+    #[arg(long, global = true)]
     pub ecmul_contract: Option<String>,
 
     /// Override for uniswap contract address
-    #[clap(long, global = true)]
+    #[arg(long, global = true)]
     pub uniswap_contract: Option<String>,
 
     /// Queries rpc for receipts of each sent tx when set. Queries per txhash, prefer `use_receipts_by_block` for efficiency
-    #[clap(long, global = true, default_value = "false")]
+    #[arg(long, global = true, default_value = "false")]
     pub use_receipts: bool,
 
     /// Queries rpc for receipts for each committed block and filters against txs sent by this txgen.
     /// More efficient
-    #[clap(long, global = true, default_value = "false")]
+    #[arg(long, global = true, default_value = "false")]
     pub use_receipts_by_block: bool,
 
     /// Fetches logs for each tx sent
-    #[clap(long, global = true, default_value = "false")]
+    #[arg(long, global = true, default_value = "false")]
     pub use_get_logs: bool,
 
     /// Base fee used when calculating gas costs and value
-    #[clap(long, global = true, default_value_t = 50)]
+    #[arg(long, global = true, default_value_t = 50)]
     pub base_fee_gwei: u128,
 
     /// Chain id
@@ -280,11 +280,11 @@ impl DeployedContract {
 #[derive(Debug, Subcommand)]
 pub enum GenMode {
     FewToMany {
-        #[clap(long, default_value = "erc20")]
+        #[arg(long, default_value = "erc20")]
         tx_type: TxType,
     },
     ManyToMany {
-        #[clap(long, default_value = "erc20")]
+        #[arg(long, default_value = "erc20")]
         tx_type: TxType,
     },
     Duplicates,


### PR DESCRIPTION
Closes #2231

This PR updates deprecated #[clap(...)] attributes to their modern equivalents in clap 4.x.
The current codebase still uses outdated syntax that has been deprecated since version 4.0.
By making this update, we ensure compatibility with future versions and maintain code quality.

