### PR TITLE
Enable validator to full node role switch

### DIFF
--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -146,7 +146,7 @@ where
         Self {
             is_dynamic_fullnode,
             epoch_validators: Default::default(),
-            rebroadcast_map: ReBroadcastGroupMap::new(self_id, is_dynamic_fullnode),
+            rebroadcast_map: ReBroadcastGroupMap::new(self_id),
             dedicated_full_nodes: FullNodes::new(
                 config.primary_instance.fullnode_dedicated.clone(),
             ),
@@ -192,7 +192,6 @@ where
     pub fn set_is_dynamic_full_node(&mut self, is_dynamic: bool) {
         debug!(?is_dynamic, "updating primary raptorcast");
         self.is_dynamic_fullnode = is_dynamic;
-        self.rebroadcast_map.is_dynamic_fullnode = is_dynamic;
     }
 
     pub fn set_dedicated_full_nodes(&mut self, nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>) {

--- a/monad-raptorcast/src/raptorcast_secondary/publisher.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/publisher.rs
@@ -982,7 +982,7 @@ mod tests {
             rx_from_client: UnboundedReceiver<Group<ST>>,
         ) -> Self {
             Self {
-                group_map: ReBroadcastGroupMap::new(clt_node_id, true),
+                group_map: ReBroadcastGroupMap::new(clt_node_id),
                 rx_from_client,
             }
         }


### PR DESCRIPTION
Approach: if a validator finds out that it's gonna fall out of the active set in the next epoch (this is known when next epoch validator set is available during epoch boundary block), then the validator will switch to FullNodeClient and starts participating in secondary raptorcast. After the epoch switch, it can then transition to a full node. 

Since this allows a node to participate in usual validator raptorcast and secondary raptorcast at the same time, it requires an additional bit to differentiate whether a chunk it receives is for the validator raptorcast or the secondary raptorcast in order to determine which other nodes to rebroadcast to. An additional bit is used in the raptorcast header for this purpose

Tested on stressnet with staking