### PR TITLE
Fix dataplane tests

### DIFF
--- a/monad-dataplane/tests/address_family_mismatch.rs
+++ b/monad-dataplane/tests/address_family_mismatch.rs
@@ -21,9 +21,9 @@ use tracing::debug;
 /// 1_000 = 1 Gbps, 10_000 = 10 Gbps
 const UP_BANDWIDTH_MBPS: u64 = 1_000;
 
-const BIND_ADDRS: [&str; 3] = ["0.0.0.0:9100", "127.0.0.1:9101", "[::1]:9102"];
+const BIND_ADDRS: [&str; 2] = ["0.0.0.0:19100", "127.0.0.1:19101"];
 
-const TX_ADDRS: [&str; 2] = ["127.0.0.1:9200", "[::1]:9201"];
+const TX_ADDRS: [&str; 2] = ["127.0.0.1:19200", "[::1]:19201"];
 
 #[test]
 fn address_family_mismatch() {

--- a/monad-dataplane/tests/tests.rs
+++ b/monad-dataplane/tests/tests.rs
@@ -460,7 +460,7 @@ fn tcp_accept_max_size_message() {
 fn tcp_rx_reject_oversized_header() {
     once_setup();
 
-    let rx_addr = "127.0.0.1:9022".parse().unwrap();
+    let rx_addr = "127.0.0.1:19022".parse().unwrap();
 
     let mut rx = DataplaneBuilder::new(&rx_addr, UP_BANDWIDTH_MBPS).build();
     assert!(rx.block_until_ready(Duration::from_secs(1)));


### PR DESCRIPTION
Port 9100/9022 is occupied on dev machines, causing dataplane tests to fail. Changed to different ports

ipv6 is not supported by dataplane or on dev machines. Removed ipv6 bind address from tests