### PR TITLE
Fix peer discovery round update

### DIFF
--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -355,11 +355,11 @@ where
                                 break;
                             }
                         }
-                        self.peer_discovery_driver
-                            .lock()
-                            .unwrap()
-                            .update(PeerDiscoveryEvent::UpdateCurrentRound { round, epoch });
                     }
+                    self.peer_discovery_driver
+                        .lock()
+                        .unwrap()
+                        .update(PeerDiscoveryEvent::UpdateCurrentRound { round, epoch });
                 }
                 RouterCommand::AddEpochValidatorSet {
                     epoch,


### PR DESCRIPTION
observed on stressnet that peer discovery only updates round number when epoch is bumped, which is incorrect