### PR TITLE
Add TFM validator to static tx validation

### DIFF
--- a/monad-eth-txpool-types/src/lib.rs
+++ b/monad-eth-txpool-types/src/lib.rs
@@ -49,6 +49,7 @@ pub enum TransactionError {
     InvalidChainId,
     MaxPriorityFeeTooHigh,
     InitCodeLimitExceeded,
+    EncodedLengthLimitExceeded,
     GasLimitTooLow,
     GasLimitTooHigh,
     UnsupportedTransactionType,
@@ -81,6 +82,7 @@ impl EthTxPoolDropReason {
                 TransactionError::InvalidChainId => "Invalid chain ID",
                 TransactionError::MaxPriorityFeeTooHigh => "Max priority fee too high",
                 TransactionError::InitCodeLimitExceeded => "Init code size limit exceeded",
+                TransactionError::EncodedLengthLimitExceeded => "Encoded length limit exceeded",
                 TransactionError::GasLimitTooLow => "Gas limit too low",
                 TransactionError::GasLimitTooHigh => "Exceeds block gas limit",
                 TransactionError::UnsupportedTransactionType => {


### PR DESCRIPTION
This change introduces the 30M tx gas limit from the TFM spec. Additionally, a 192KB encoded tx length limit is added since max contract size is 128KB and, without support for blob data, there is likely no reasonable way to exceed this limit.