### PR TITLE
chore: fix badge on the main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Monad BFT
 
-![Nightly Tests][tests-badge]
-
 ## Overview
 
 This repository contains implementation for the Monad consensus client and JsonRpc server. Monad consensus collects transactions and produces blocks which are written to a ledger filestream. These blocks are consumed by Monad execution, which then updates the state of the blockchain. The [triedb](monad-triedb/README.md) is a database which stores block information and the blockchain state.


### PR DESCRIPTION
The `randomized.yml` has been deleted in https://github.com/category-labs/monad-bft/pull/1705/files

I don‘t think we should keep the badge here.

And close https://github.com/category-labs/monad-bft/issues/2115