### PR TITLE
fix: `rm` when `wal` has spaces

### DIFF
--- a/docker/devnet/clean.sh
+++ b/docker/devnet/clean.sh
@@ -34,7 +34,7 @@ if [ -S "$controlpanel_sock" ]; then
     rm "$controlpanel_sock"
 fi
 
-rm -f ${wal}_*
+rm -f "${wal}"_*
 
 if [ -f "$forkpoint" ]; then
     rm "$forkpoint"


### PR DESCRIPTION
wrapped `wal` in quotes so files with spaces or weird characters get removed safely. no more accidental deletions.