### PR TITLE
Simplify EthBlockPolicy nonce retrieval

### DIFF
--- a/monad-eth-txpool/src/pool/mod.rs
+++ b/monad-eth-txpool/src/pool/mod.rs
@@ -482,7 +482,6 @@ where
         // exposing SYSTEM_SENDER_ETH_ADDRESS outside the crate
         let next_system_txn_nonce = *block_policy
             .get_account_base_nonces(
-                proposed_seq_num,
                 state_backend,
                 extending_blocks,
                 [SYSTEM_SENDER_ETH_ADDRESS].iter(),

--- a/monad-eth-txpool/src/pool/tracked/mod.rs
+++ b/monad-eth-txpool/src/pool/tracked/mod.rs
@@ -234,7 +234,6 @@ where
                     sequencer.addresses(),
                 )?,
                 block_policy.get_account_base_nonces(
-                    proposed_seq_num,
                     state_backend,
                     &extending_blocks,
                     authority_addresses.iter(),
@@ -349,12 +348,7 @@ where
 
         let addresses = to_insert.keys().cloned().collect_vec();
 
-        // BlockPolicy only guarantees that data is available for seqnum (N-k, N] for some execution
-        // delay k. Since block_policy looks up seqnum - execution_delay, passing the last commit
-        // seqnum will result in a lookup outside that range. As a fix, we add 1 so the seqnum is on
-        // the edge of the range.
         let account_nonces = match block_policy.get_account_base_nonces(
-            last_commit_seq_num + SeqNum(1),
             state_backend,
             &Vec::default(),
             addresses.iter(),

--- a/monad-eth-txpool/tests/pool.rs
+++ b/monad-eth-txpool/tests/pool.rs
@@ -373,7 +373,6 @@ fn run_custom_iter<const N: usize>(
             } => {
                 let mut nonces = eth_block_policy
                     .get_account_base_nonces(
-                        SeqNum(current_seq_num),
                         &state_backend,
                         &pending_blocks.iter().collect_vec(),
                         [&address].into_iter(),


### PR DESCRIPTION
The `seq_num` param for `get_account_base_nonces` was an unfortunate side effect of a previous invariant of the committed cache where it sometimes wouldn't have enough blocks and would require passing the desired sequence number + 1 to force the underlying triedb lookup to always succeed. Now that the committed cache stores all blocks within the range (N-2k, N], this parameter is no longer required.