### PR TITLE
Relax ledger block decoding assertion

### DIFF
--- a/monad-block-persist/src/lib.rs
+++ b/monad-block-persist/src/lib.rs
@@ -140,11 +140,14 @@ where
         let mut buf = vec![0; size as usize];
         file.read_exact(&mut buf)?;
 
-        // TODO maybe expect is too strict
-        let block =
-            alloy_rlp::decode_exact(&buf).expect("local ledger consensus header decode failed");
+        let header = alloy_rlp::decode_exact(&buf).map_err(|err| {
+            std::io::Error::other(format!(
+                "failed to rlp decode ledger proposed_head bft header, err={:?}",
+                err
+            ))
+        })?;
 
-        Ok(block)
+        Ok(header)
     }
 }
 
@@ -214,11 +217,14 @@ where
         let mut buf = vec![0; size as usize];
         file.read_exact(&mut buf)?;
 
-        // TODO maybe expect is too strict
-        let block =
-            alloy_rlp::decode_exact(&buf).expect("local ledger consensus header decode failed");
+        let header = alloy_rlp::decode_exact(&buf).map_err(|err| {
+            std::io::Error::other(format!(
+                "failed to rlp decode ledger bft header, block_id={:?}, err={:?}",
+                block_id, err
+            ))
+        })?;
 
-        Ok(block)
+        Ok(header)
     }
 
     fn read_bft_body(
@@ -231,9 +237,12 @@ where
         let mut buf = vec![0; size as usize];
         file.read_exact(&mut buf)?;
 
-        // TODO maybe expect is too strict
-        let body =
-            alloy_rlp::decode_exact(&buf).expect("local ledger consensus body decode failed");
+        let body = alloy_rlp::decode_exact(&buf).map_err(|err| {
+            std::io::Error::other(format!(
+                "failed to rlp decode ledger bft body, body_id={:?}, err={:?}",
+                body_id, err
+            ))
+        })?;
 
         Ok(body)
     }


### PR DESCRIPTION
There's no need to assert if rlp decoding a block in the local ledger fails. Ledger-tail operators have reported this failing sporadically in practice. In addition, without this change, there's a potential DOS vector where a malicious node could send blocksyncs for the network tip in an attempt to trip this assertion.