### PR TITLE
Revert "Record EIP2930 access lists in exec events SDK"

### DIFF
--- a/monad-exec-events/src/block.rs
+++ b/monad-exec-events/src/block.rs
@@ -160,7 +160,6 @@ pub struct ExecutedTxn {
     pub sender: monad_c_address,
     pub header: monad_c_eth_txn_header,
     pub input: Box<[u8]>,
-    pub access_list: Box<[ExecutedTxnAccessListEntry]>,
     pub logs: Box<[ExecutedTxnLog]>,
     pub output: monad_exec_txn_evm_output,
     pub call_frames: Option<Box<[ExecutedTxnCallFrame]>>,
@@ -195,24 +194,6 @@ impl ExecutedTxn {
         let value = alloy_primitives::U256::from_limbs(self.header.value.limbs);
         let input = alloy_primitives::Bytes::copy_from_slice(&self.input);
 
-        let access_list = alloy_rpc_types::AccessList(
-            self.access_list
-                .iter()
-                .map(
-                    |ExecutedTxnAccessListEntry {
-                         address,
-                         storage_keys,
-                     }| alloy_rpc_types::AccessListItem {
-                        address: alloy_primitives::Address::from(address.bytes),
-                        storage_keys: storage_keys
-                            .iter()
-                            .map(|storage_key| alloy_primitives::FixedBytes(storage_key.bytes))
-                            .collect(),
-                    },
-                )
-                .collect_vec(),
-        );
-
         match self.header.txn_type {
             ffi::MONAD_TXN_LEGACY => {
                 alloy_consensus::TxEnvelope::Legacy(alloy_consensus::Signed::new_unchecked(
@@ -238,7 +219,10 @@ impl ExecutedTxn {
                         gas_limit: self.header.gas_limit,
                         to,
                         value,
-                        access_list,
+                        access_list: {
+                            // TODO(andr-dev): Add access list
+                            alloy_rpc_types::AccessList(Vec::default())
+                        },
                         input,
                     },
                     txn_signature,
@@ -259,7 +243,10 @@ impl ExecutedTxn {
                         .unwrap(),
                         to,
                         value,
-                        access_list,
+                        access_list: {
+                            // TODO(andr-dev): Add access list
+                            alloy_rpc_types::AccessList(Vec::default())
+                        },
                         input,
                     },
                     txn_signature,
@@ -322,12 +309,4 @@ pub struct ExecutedTxnCallFrame {
     pub call_frame: monad_exec_txn_call_frame,
     pub input: Box<[u8]>,
     pub r#return: Box<[u8]>,
-}
-
-/// Access List entry reconstructed from execution events.
-#[allow(missing_docs)]
-#[derive(Clone, Debug)]
-pub struct ExecutedTxnAccessListEntry {
-    pub address: monad_c_address,
-    pub storage_keys: Box<[monad_c_bytes32]>,
 }

--- a/monad-exec-events/src/block_builder/executed/mod.rs
+++ b/monad-exec-events/src/block_builder/executed/mod.rs
@@ -19,12 +19,9 @@ use monad_event_ring::{EventDescriptor, EventPayloadResult};
 use self::state::{BlockReassemblyState, TxnReassemblyState};
 use super::{BlockBuilderError, BlockBuilderResult, ReassemblyError};
 use crate::{
-    ffi::{
-        monad_c_access_list_entry, monad_c_bytes32, monad_exec_txn_access_list_entry,
-        monad_exec_txn_header_start,
-    },
-    ExecEvent, ExecEventDecoder, ExecEventRef, ExecutedBlock, ExecutedTxn,
-    ExecutedTxnAccessListEntry, ExecutedTxnCallFrame, ExecutedTxnLog,
+    ffi::{monad_c_bytes32, monad_exec_txn_header_start},
+    ExecEvent, ExecEventDecoder, ExecEventRef, ExecutedBlock, ExecutedTxn, ExecutedTxnCallFrame,
+    ExecutedTxnLog,
 };
 
 mod state;
@@ -91,6 +88,7 @@ impl ExecutedBlockBuilder {
             | ExecEventRef::BlockQC(_)
             | ExecEventRef::BlockFinalized(_)
             | ExecEventRef::BlockVerified(_)
+            | ExecEventRef::TxnAccessListEntry { .. }
             | ExecEventRef::TxnAuthListEntry(_)
             | ExecEventRef::TxnHeaderEnd
             | ExecEventRef::AccountAccessListHeader(_)
@@ -117,6 +115,7 @@ impl ExecutedBlockBuilder {
             | ExecEvent::BlockQC(_)
             | ExecEvent::BlockFinalized(_)
             | ExecEvent::BlockVerified(_)
+            | ExecEvent::TxnAccessListEntry { .. }
             | ExecEvent::TxnAuthListEntry(_)
             | ExecEvent::TxnHeaderEnd
             | ExecEvent::AccountAccessListHeader(_)
@@ -177,7 +176,6 @@ impl ExecutedBlockBuilder {
                                  sender,
                                  header,
                                  input,
-                                 access_list,
                                  logs,
                                  output,
                                  call_frames,
@@ -192,7 +190,6 @@ impl ExecutedBlockBuilder {
                                     sender,
                                     header,
                                     input,
-                                    access_list: access_list.into_boxed_slice(),
                                     logs: logs.into_boxed_slice(),
                                     output,
                                     call_frames: call_frames.map(|call_frames| {
@@ -235,54 +232,9 @@ impl ExecutedBlockBuilder {
                     sender,
                     header: txn_header,
                     input: data_bytes,
-                    access_list: Vec::default(),
                     logs: Vec::default(),
                     output: None,
                     call_frames: self.include_call_frames.then(Vec::default),
-                });
-
-                None
-            }
-            ExecEvent::TxnAccessListEntry {
-                txn_index,
-                txn_access_list_entry:
-                    monad_exec_txn_access_list_entry {
-                        index,
-                        entry:
-                            monad_c_access_list_entry {
-                                address,
-                                storage_key_count,
-                            },
-                    },
-                storage_key_bytes,
-            } => {
-                let state = self.state.as_mut()?;
-
-                let txn_ref = state
-                    .txns
-                    .get_mut(TryInto::<usize>::try_into(txn_index).unwrap())
-                    .expect("ExecutedBlockBuilder TxnAccessListEntry txn_index within bounds")
-                    .as_mut()
-                    .expect("ExecutedBlockBuilder TxnAccessListEntry txn_index populated from preceding TxnStart");
-
-                assert_eq!(txn_ref.access_list.len() as u32, index);
-
-                let storage_keys = storage_key_bytes
-                    .into_vec()
-                    .into_iter()
-                    .chunks(std::mem::size_of::<monad_c_bytes32>())
-                    .into_iter()
-                    .map(|chunk| monad_c_bytes32 {
-                        bytes: chunk.collect_vec().try_into().unwrap(),
-                    })
-                    .collect_vec()
-                    .into_boxed_slice();
-
-                assert_eq!(storage_keys.len(), storage_key_count as usize);
-
-                txn_ref.access_list.push(ExecutedTxnAccessListEntry {
-                    address,
-                    storage_keys,
                 });
 
                 None

--- a/monad-exec-events/src/block_builder/executed/state.rs
+++ b/monad-exec-events/src/block_builder/executed/state.rs
@@ -18,7 +18,7 @@ use crate::{
         monad_c_address, monad_c_bytes32, monad_c_eth_txn_header, monad_exec_block_start,
         monad_exec_txn_evm_output,
     },
-    ExecutedTxnAccessListEntry, ExecutedTxnCallFrame, ExecutedTxnLog,
+    ExecutedTxnCallFrame, ExecutedTxnLog,
 };
 
 #[derive(Debug)]
@@ -33,7 +33,6 @@ pub(super) struct TxnReassemblyState {
     pub sender: monad_c_address,
     pub header: monad_c_eth_txn_header,
     pub input: Box<[u8]>,
-    pub access_list: Vec<ExecutedTxnAccessListEntry>,
     pub logs: Vec<ExecutedTxnLog>,
     pub output: Option<monad_exec_txn_evm_output>,
     pub call_frames: Option<Vec<ExecutedTxnCallFrame>>,

--- a/monad-exec-events/src/events/mod.rs
+++ b/monad-exec-events/src/events/mod.rs
@@ -60,7 +60,6 @@ pub enum ExecEvent {
         blob_bytes: Box<[u8]>,
     },
     TxnAccessListEntry {
-        txn_index: usize,
         txn_access_list_entry: monad_exec_txn_access_list_entry,
         storage_key_bytes: Box<[u8]>,
     },
@@ -120,7 +119,6 @@ pub enum ExecEventRef<'ring> {
         blob_bytes: &'ring [u8],
     },
     TxnAccessListEntry {
-        txn_index: usize,
         txn_access_list_entry: &'ring monad_exec_txn_access_list_entry,
         storage_key_bytes: &'ring [u8],
     },
@@ -180,11 +178,9 @@ impl<'ring> ExecEventRef<'ring> {
                 blob_bytes: blobs.to_vec().into_boxed_slice(),
             },
             Self::TxnAccessListEntry {
-                txn_index,
                 txn_access_list_entry,
                 storage_key_bytes: storage_keys,
             } => ExecEvent::TxnAccessListEntry {
-                txn_index,
                 txn_access_list_entry: *txn_access_list_entry,
                 storage_key_bytes: storage_keys.to_vec().into_boxed_slice(),
             },
@@ -347,10 +343,6 @@ impl EventDecoder for ExecEventDecoder {
                     .expect("TxnAccessListEntry event valid");
 
                 ExecEventRef::TxnAccessListEntry {
-                    txn_index: info
-                        .flow_info
-                        .txn_idx
-                        .expect("TxnAccessListEntry event has txn_idx in flow_info"),
                     txn_access_list_entry,
                     storage_key_bytes,
                 }


### PR DESCRIPTION
This reverts commit f5dd511ba7c6eec4d3a96919a8c7abe9b9570ff8.