### PR TITLE
Consolidate recover_authority usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5260,6 +5260,7 @@ name = "monad-eth-types"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "monad-crypto",

--- a/monad-eth-block-validator/Cargo.toml
+++ b/monad-eth-block-validator/Cargo.toml
@@ -22,6 +22,7 @@ monad-types = { workspace = true }
 monad-validator = { workspace = true }
 
 alloy-consensus = { workspace = true }
+alloy-eips = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }
 rayon = { workspace = true }

--- a/monad-eth-block-validator/src/lib.rs
+++ b/monad-eth-block-validator/src/lib.rs
@@ -24,6 +24,7 @@ use alloy_consensus::{
     transaction::{Recovered, Transaction},
     TxEnvelope, EMPTY_OMMER_ROOT_HASH,
 };
+use alloy_eips::eip7702::{RecoveredAuthority, RecoveredAuthorization};
 use alloy_rlp::Encodable;
 use monad_chain_config::{
     revision::{ChainParams, ChainRevision},
@@ -44,7 +45,9 @@ use monad_eth_block_policy::{
     validation::static_validate_transaction,
     EthBlockPolicy, EthValidatedBlock,
 };
-use monad_eth_types::{EthBlockBody, EthExecutionProtocol, ExtractEthAddress, ProposedEthHeader};
+use monad_eth_types::{
+    EthBlockBody, EthExecutionProtocol, ExtractEthAddress, ProposedEthHeader, ValidatedTx,
+};
 use monad_secp::RecoverableAddress;
 use monad_state_backend::StateBackend;
 use monad_system_calls::{
@@ -52,11 +55,11 @@ use monad_system_calls::{
 };
 use monad_types::Balance;
 use monad_validator::signature_collection::{SignatureCollection, SignatureCollectionPubKeyType};
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use tracing::{debug, trace, trace_span, warn};
 
 type SystemTransactions = Vec<SystemTransaction>;
-type ValidatedTxns = Vec<Recovered<TxEnvelope>>;
+type ValidatedTxns = Vec<ValidatedTx>;
 
 /// Validates transactions as valid Ethereum transactions and also validates that
 /// the list of transactions will create a valid Ethereum block
@@ -275,6 +278,12 @@ where
             return Err(BlockValidationError::TxnError);
         }
 
+        // early return if sum of transaction gas limits exceed block gas limit
+        let total_gas: u64 = transactions.iter().map(|tx| tx.gas_limit()).sum();
+        if total_gas > chain_params.proposal_gas_limit {
+            return Err(BlockValidationError::TxnError);
+        }
+
         // recovering the signers verifies that these are valid signatures
         let recovered_txns: VecDeque<Recovered<TxEnvelope>> = transactions
             .into_par_iter()
@@ -299,6 +308,21 @@ where
                     return Err(BlockValidationError::SystemTxnError);
                 }
             };
+
+        // early return if proposal size exceed limit
+        let system_txns_size: usize = system_txns.iter().map(|tx| tx.length()).sum();
+        let user_txns_size: usize = eth_txns.iter().map(|tx| tx.length()).sum();
+        let proposal_size = system_txns_size + user_txns_size;
+        debug!(
+            total_gas,
+            proposal_size,
+            txs = eth_txns.len(),
+            "proposal stats"
+        );
+
+        if proposal_size as u64 > chain_params.proposal_byte_limit {
+            return Err(BlockValidationError::TxnError);
+        }
 
         let mut nonce_usages = NonceUsageMap::default();
 
@@ -326,15 +350,47 @@ where
             }
         }
 
-        let mut txn_fees: TxnFees = TxnFees::default();
-
+        // early return if any user transaction fails static validation
         for eth_txn in eth_txns.iter() {
             if static_validate_transaction(eth_txn, chain_id, chain_params, execution_chain_params)
                 .is_err()
             {
                 return Err(BlockValidationError::TxnError);
             }
+        }
 
+        let validated_txns: Vec<ValidatedTx> = eth_txns
+            .into_par_iter()
+            .map(|eth_txn| {
+                if let Some(txn_7702) = eth_txn.as_eip7702() {
+                    let authorizations_7702: Vec<RecoveredAuthorization> = txn_7702
+                        .tx()
+                        .authorization_list
+                        .par_iter()
+                        .filter_map(|signed_auth| {
+                            signed_auth.recover_authority().ok().map(|authority| {
+                                RecoveredAuthorization::new_unchecked(
+                                    signed_auth.inner().clone(),
+                                    RecoveredAuthority::Valid(authority),
+                                )
+                            })
+                        })
+                        .collect();
+                    ValidatedTx {
+                        tx: eth_txn,
+                        authorizations_7702,
+                    }
+                } else {
+                    ValidatedTx {
+                        tx: eth_txn,
+                        authorizations_7702: Vec::new(),
+                    }
+                }
+            })
+            .collect();
+
+        let mut txn_fees: TxnFees = TxnFees::default();
+        for eth_txn in validated_txns.iter() {
             let block_base_fee = header
                 .base_fee
                 .unwrap_or(monad_tfm::base_fee::PRE_TFM_BASE_FEE);
@@ -386,71 +442,50 @@ where
             trace!(seq_num = ?header.seq_num, address = ?eth_txn.signer(), nonce = ?eth_txn.nonce(), ?txn_fee_entry, "TxnFeeEntry");
 
             if eth_txn.is_eip7702() {
-                if let Some(auth_list) = eth_txn.authorization_list() {
-                    for (authority, authorization) in auth_list.iter().flat_map(|authorization| {
-                        authorization
-                            .recover_authority()
-                            .ok()
-                            .map(|authority| (authority, authorization.inner()))
-                    }) {
-                        trace!(address =? authorization.address, nonce =? authorization.nonce, ?authority, "Signed authority");
+                for recovered_auth in eth_txn.authorizations_7702.iter() {
+                    // skip invalid authority
+                    let Some(authority) = recovered_auth.authority() else {
+                        continue;
+                    };
 
-                        // do not allow system account from sending authorization
-                        if authority == SYSTEM_SENDER_ETH_ADDRESS {
-                            return Err(BlockValidationError::TxnError);
-                        }
+                    trace!(address =? recovered_auth.address(), nonce =? recovered_auth.nonce(), ?authority, "Signed authority");
 
-                        if authorization.chain_id != 0_u64
-                            && authorization.chain_id != chain_config.chain_id()
-                        {
-                            continue;
-                        }
-
-                        match nonce_usages.entry(authority) {
-                            BTreeMapEntry::Occupied(nonce_usage) => match nonce_usage.into_mut() {
-                                NonceUsage::Known(nonce) => {
-                                    if *nonce + 1 == authorization.nonce {
-                                        *nonce += 1;
-                                    }
-                                }
-                                NonceUsage::Possible(possible_nonces) => {
-                                    possible_nonces.push_back(authorization.nonce);
-                                }
-                            },
-                            BTreeMapEntry::Vacant(nonce_usage) => {
-                                nonce_usage.insert(NonceUsage::Possible(VecDeque::from_iter([
-                                    authorization.nonce,
-                                ])));
-                            }
-                        }
-
-                        let txn_fee = txn_fees.entry(authority).or_default();
-                        txn_fee.is_delegated = true;
+                    // do not allow system account from sending authorization
+                    if authority == SYSTEM_SENDER_ETH_ADDRESS {
+                        return Err(BlockValidationError::TxnError);
                     }
+
+                    if recovered_auth.chain_id() != 0_u64
+                        && recovered_auth.chain_id() != chain_config.chain_id()
+                    {
+                        continue;
+                    }
+
+                    match nonce_usages.entry(authority) {
+                        BTreeMapEntry::Occupied(nonce_usage) => match nonce_usage.into_mut() {
+                            NonceUsage::Known(nonce) => {
+                                if *nonce + 1 == recovered_auth.nonce() {
+                                    *nonce += 1;
+                                }
+                            }
+                            NonceUsage::Possible(possible_nonces) => {
+                                possible_nonces.push_back(recovered_auth.nonce());
+                            }
+                        },
+                        BTreeMapEntry::Vacant(nonce_usage) => {
+                            nonce_usage.insert(NonceUsage::Possible(VecDeque::from_iter([
+                                recovered_auth.nonce(),
+                            ])));
+                        }
+                    }
+
+                    let txn_fee = txn_fees.entry(authority).or_default();
+                    txn_fee.is_delegated = true;
                 }
             }
         }
 
-        let total_gas: u64 = eth_txns.iter().map(|tx| tx.gas_limit()).sum();
-        let system_txns_size: usize = system_txns.iter().map(|tx| tx.length()).sum();
-        let user_txns_size: usize = eth_txns.iter().map(|tx| tx.length()).sum();
-        let proposal_size = system_txns_size + user_txns_size;
-        debug!(
-            total_gas,
-            proposal_size,
-            txs = transactions.len(),
-            "proposal stats"
-        );
-
-        if total_gas > chain_params.proposal_gas_limit {
-            return Err(BlockValidationError::TxnError);
-        }
-
-        if proposal_size as u64 > chain_params.proposal_byte_limit {
-            return Err(BlockValidationError::TxnError);
-        }
-
-        Ok((system_txns, eth_txns, nonce_usages, txn_fees))
+        Ok((system_txns, validated_txns, nonce_usages, txn_fees))
     }
 }
 
@@ -511,6 +546,57 @@ mod test {
             Some(BASE_FEE_TREND),
             Some(BASE_FEE_MOMENT),
         )
+    }
+
+    #[test]
+    fn test_validated_tx_extraction() {
+        let txn1 = make_legacy_tx(B256::repeat_byte(0xAu8), BASE_FEE, 30_000, 1, 10);
+
+        let authorization_list = vec![
+            make_signed_authorization(
+                B256::repeat_byte(0xCu8),
+                secret_to_eth_address(B256::repeat_byte(0x1u8)),
+                50,
+            ),
+            make_signed_authorization(
+                B256::repeat_byte(0xDu8),
+                secret_to_eth_address(B256::repeat_byte(0x2u8)),
+                2,
+            ),
+        ];
+        let txn2 = make_eip7702_tx(
+            B256::repeat_byte(0xBu8),
+            BASE_FEE,
+            0,
+            1_000_000,
+            2,
+            authorization_list,
+            0,
+        );
+
+        // create a block with the above transactions
+        let txs = vec![txn1, txn2];
+        let payload = ConsensusBlockBody::new(ConsensusBlockBodyInner {
+            execution_body: EthBlockBody {
+                transactions: txs,
+                ommers: Vec::new(),
+                withdrawals: Vec::new(),
+            },
+        });
+        let header = get_header(payload.get_id());
+
+        let result =
+            EthBlockValidator::<NopSignature, MockSignatures<NopSignature>>::validate_block_body(
+                &header,
+                &payload,
+                &MockChainConfig::DEFAULT,
+            );
+        assert!(result.is_ok());
+
+        let (_, validated_txns, _, _) = result.unwrap();
+        assert_eq!(validated_txns.len(), 2);
+        assert_eq!(validated_txns[0].authorizations_7702.len(), 0);
+        assert_eq!(validated_txns[1].authorizations_7702.len(), 2);
     }
 
     #[test]
@@ -832,7 +918,12 @@ mod test {
                 Ok(block) => {
                     assert!(expect_success);
 
-                    let expected_nonce_usages = compute_expected_nonce_usages(&block.validated_txns);
+                    let txns: Vec<Recovered<TxEnvelope>> = block
+                        .validated_txns
+                        .iter()
+                        .map(|vtx| vtx.tx.clone())
+                        .collect();
+                    let expected_nonce_usages = compute_expected_nonce_usages(&txns);
 
                     assert_eq!(block.nonce_usages, expected_nonce_usages);
                 }

--- a/monad-eth-types/Cargo.toml
+++ b/monad-eth-types/Cargo.toml
@@ -14,6 +14,7 @@ monad-secp = { workspace = true }
 monad-types = { workspace = true }
 
 alloy-consensus = { workspace = true }
+alloy-eips = { workspace = true }
 alloy-primitives = { workspace = true, features = ["serde"] }
 alloy-rlp = { workspace = true, features = ["derive"] }
 serde = { workspace = true }

--- a/monad-eth-types/src/lib.rs
+++ b/monad-eth-types/src/lib.rs
@@ -13,9 +13,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::fmt::Debug;
+use std::{fmt::Debug, ops::Deref};
 
-use alloy_consensus::{Header, TxEnvelope};
+use alloy_consensus::{transaction::Recovered, Header, TxEnvelope};
+use alloy_eips::eip7702::RecoveredAuthorization;
 use alloy_primitives::{Address, B256};
 use alloy_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
 use monad_crypto::NopPubKey;
@@ -108,4 +109,18 @@ impl ExecutionProtocol for EthExecutionProtocol {
     type ProposedHeader = ProposedEthHeader;
     type FinalizedHeader = EthHeader;
     type Body = EthBlockBody;
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedTx {
+    pub tx: Recovered<TxEnvelope>,
+    pub authorizations_7702: Vec<RecoveredAuthorization>,
+}
+
+impl Deref for ValidatedTx {
+    type Target = Recovered<TxEnvelope>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.tx
+    }
 }


### PR DESCRIPTION
recover_authority is an expensive operation, we should not redo them across monad-eth-block-policy and monad-eth-block-validator