### PR TITLE
Recover eip7702 authorities during tx insertion

### DIFF
--- a/monad-eth-txpool-types/src/lib.rs
+++ b/monad-eth-txpool-types/src/lib.rs
@@ -54,6 +54,7 @@ pub enum TransactionError {
     GasLimitTooHigh,
     UnsupportedTransactionType,
     AuthorizationListEmpty,
+    AuthorizationListLengthLimitExceeded,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -88,6 +89,9 @@ impl EthTxPoolDropReason {
                 TransactionError::GasLimitTooHigh => "Exceeds block gas limit",
                 TransactionError::UnsupportedTransactionType => "Unsupported transaction type",
                 TransactionError::AuthorizationListEmpty => "EIP7702 authorization list empty",
+                TransactionError::AuthorizationListLengthLimitExceeded => {
+                    "EIP7702 authorization list length limit exceeded"
+                }
             },
             EthTxPoolDropReason::InvalidSignature => "Transaction signature is invalid",
             EthTxPoolDropReason::NonceTooLow => "Transaction nonce too low",

--- a/monad-eth-txpool/Cargo.toml
+++ b/monad-eth-txpool/Cargo.toml
@@ -29,6 +29,7 @@ alloy-rlp = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 rand = { workspace = true }
+rayon = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
 

--- a/monad-eth-txpool/src/pool/tracked/mod.rs
+++ b/monad-eth-txpool/src/pool/tracked/mod.rs
@@ -193,13 +193,7 @@ where
             return Ok(Vec::new());
         }
 
-        let sequencer = ProposalSequencer::new(
-            &self.txs,
-            &extending_blocks,
-            chain_config.chain_id(),
-            base_fee,
-            tx_limit,
-        );
+        let sequencer = ProposalSequencer::new(&self.txs, &extending_blocks, base_fee, tx_limit);
         let sequencer_len = sequencer.len();
 
         let authority_addresses = sequencer.authority_addresses().cloned().collect_vec();


### PR DESCRIPTION
By recovering authorities during tx insertion (which is paced to not overload the consensus node), this mitigates part of the DoS vector of needing to recover a large number of authorizations at proposal time.

Additionally, the max number of authorizations per tx is limited to 4 in the txpool.