### PR TITLE
Decode delegated flag

### DIFF
--- a/monad-eth-block-policy/src/lib.rs
+++ b/monad-eth-block-policy/src/lib.rs
@@ -876,12 +876,13 @@ where
                 maybe_status.map_or(
                     AccountBalanceState::new(base_max_reserve_balance),
                     |status| {
+                        let is_delegated = status.is_delegated.unwrap_or(false);
                         AccountBalanceState {
                             balance: status.balance,
                             remaining_reserve_balance: status.balance.min(base_max_reserve_balance),
                             max_reserve_balance: base_max_reserve_balance,
                             block_seqnum_of_latest_txn: base_seq_num, // most pessimistic assumption
-                            is_delegated: status.is_delegated,
+                            is_delegated,
                         }
                     },
                 )

--- a/monad-eth-types/src/lib.rs
+++ b/monad-eth-types/src/lib.rs
@@ -48,7 +48,7 @@ pub struct EthAccount {
     pub nonce: Nonce,
     pub balance: Balance,
     pub code_hash: Option<B256>,
-    pub is_delegated: bool,
+    pub is_delegated: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable, Default)]

--- a/monad-state-backend/src/in_memory.rs
+++ b/monad-state-backend/src/in_memory.rs
@@ -294,7 +294,7 @@ where
                     nonce: *nonce,
                     balance: self.max_account_balance,
                     code_hash: None,
-                    is_delegated: false,
+                    is_delegated: Some(false),
                 })
             })
             .collect())

--- a/monad-state-backend/src/mock.rs
+++ b/monad-state-backend/src/mock.rs
@@ -49,7 +49,7 @@ where
                     balance: self.balances.get(address).cloned().unwrap_or_default(),
                     nonce: self.nonces.get(address).cloned().unwrap_or_default(),
                     code_hash: None,
-                    is_delegated: false,
+                    is_delegated: Some(false),
                 })
             })
             .collect())


### PR DESCRIPTION
Implemented reading delegated flag that does not require sync with db changes. It supports the current format with synchronous reading account code from the db.