### PR TITLE
monad-raptorcast: switch to round robin ordering

### DIFF
--- a/monad-raptorcast/src/packet/assembler.rs
+++ b/monad-raptorcast/src/packet/assembler.rs
@@ -36,7 +36,7 @@ use crate::{util::Redundancy, SIGNATURE_SIZE};
 pub enum AssembleMode {
     // Compatible with existing build_messages logic, does not support
     // streaming per merkle batch
-    #[default]
+    #[expect(unused)]
     GsoFull,
 
     // Gso concatenated chunks only within a merkle batch.
@@ -44,7 +44,7 @@ pub enum AssembleMode {
     GsoBestEffort,
 
     // Each recipient gets its own packet in round-robin order.
-    #[expect(unused)]
+    #[default]
     RoundRobin,
 }
 

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -933,7 +933,6 @@ mod tests {
 
         let mut used_ids: HashMap<SocketAddr, HashSet<_>> = HashMap::new();
 
-        let messages_len = messages.len();
         for (to, mut aggregate_message) in messages {
             while !aggregate_message.is_empty() {
                 let message = aggregate_message.split_to(DEFAULT_SEGMENT_SIZE.into());
@@ -948,7 +947,6 @@ mod tests {
             }
         }
 
-        assert_eq!(used_ids.len(), messages_len);
         let ids = used_ids.values().next().unwrap().clone();
         assert!(used_ids.values().all(|x| x == &ids)); // check that all recipients are sent same ids
         assert!(ids.contains(&0)); // check that starts from idx 0


### PR DESCRIPTION
requires: https://github.com/category-labs/monad-bft/pull/2317

to test it i was running simulation on 100 raptorcast processes, and measured delivery latency. in the simulation processes
are divided into 10 buckets, with 20ms latency between each bucket, and proportional latency based on the distance.
so for example from bucket 1 to bucket 5 the latency is 4 * 20ms, 80ms.

distribution across all nodes

<img width="2680" height="761" alt="image" src="https://github.com/user-attachments/assets/a9b32800-c93f-4236-82e5-14f184390974" />

statistics across all nodes

  | Config               | Count  | Mean  | Std  | P50   | P70   | P90   | P95   | P99   |
  |----------------------|--------|-------|------|-------|-------|-------|-------|-------|
  | Original 2MB 20ms    | 16,533 | 277.4 | 28.1 | 278.1 | 295.6 | 315.0 | 321.4 | 332.9 |
  | Round Robin 2MB 20ms | 46,115 | 260.5 | 28.5 | 261.4 | 277.2 | 296.8 | 304.4 | 321.6 |

   