### PR TITLE
Remove authority nonce lookup during proposal creation

### DIFF
--- a/monad-eth-txpool/src/pool/mod.rs
+++ b/monad-eth-txpool/src/pool/mod.rs
@@ -273,7 +273,6 @@ where
         self.tracked.evict_expired_txs(event_tracker);
 
         let timestamp_seconds = timestamp_ns_to_secs(timestamp_ns);
-        let execution_revision = chain_config.get_execution_chain_revision(timestamp_seconds);
 
         {
             let chain_id = chain_config.chain_id();
@@ -286,6 +285,7 @@ where
             }
 
             let chain_revision = chain_config.get_chain_revision(round);
+            let execution_revision = chain_config.get_execution_chain_revision(timestamp_seconds);
 
             if chain_revision.chain_params() != self.chain_revision.chain_params()
                 || self.execution_revision != execution_revision
@@ -344,7 +344,11 @@ where
             withdrawals: Vec::new(),
         };
 
-        let maybe_request_hash = if execution_revision.execution_chain_params().prague_enabled {
+        let maybe_request_hash = if self
+            .execution_revision
+            .execution_chain_params()
+            .prague_enabled
+        {
             Some([0_u8; 32])
         } else {
             None

--- a/monad-eth-txpool/tests/pool.rs
+++ b/monad-eth-txpool/tests/pool.rs
@@ -1548,6 +1548,39 @@ fn test_eip7702_authorization_nonce_higher() {
 }
 
 #[test]
+fn test_eip7702_authorization_nonce_equal() {
+    let tx1 = make_eip7702_tx(
+        S1,
+        BASE_FEE + 1,
+        1,
+        GAS_LIMIT_EIP_7702,
+        0,
+        vec![make_signed_authorization(S1, secret_to_eth_address(S1), 0)],
+        10,
+    );
+    let tx2 = make_legacy_tx(S1, BASE_FEE, GAS_LIMIT, 1, 0);
+
+    run_simple([
+        TxPoolTestEvent::InsertTxs {
+            txs: vec![(&tx1, true), (&tx2, true)],
+            expected_pool_size_change: 2,
+        },
+        TxPoolTestEvent::CreateProposal {
+            base_fee: BASE_FEE_PER_GAS,
+            tx_limit: 2,
+            gas_limit: GAS_LIMIT + GAS_LIMIT_EIP_7702,
+            byte_limit: PROPOSAL_SIZE_LIMIT,
+            expected_txs: vec![&tx1, &tx2],
+            add_to_blocktree: true,
+        },
+        TxPoolTestEvent::AssertNonce {
+            address: secret_to_eth_address(S1),
+            nonce: 2,
+        },
+    ]);
+}
+
+#[test]
 fn test_eip7702_authorization_nonce_lower() {
     let tx1 = make_eip7702_tx(
         S1,


### PR DESCRIPTION
During proposal creation, possible nonce usages from authorizations need to be handled to avoid building an invalid tx proposal list. Previously, this was done by loading the nonces of all authorization authorities so that when an authorization is included, we can immediately determine if the nonce of the authority gets increased.

Similar to the NonceUsage change however, instead of resolving the nonce increase immediately, we can store the possible nonce usages in a map and if a tx from the same signer is included, we can then resolve the nonce usages using the invariant that the heap always produces txs that are valid for inclusion after the provided extending blocks and thus the next tx for a signer must have the signer's current account nonce. This reduces the need to lookup the authority nonces, thus bounding the number of lookups at proposal time back to `tx_limit`.

TLDR: This change resolves authority nonce changes in the sequencer, removing the need to query authorization authority nonces and re-bounding the number of lookups at proposal time to `tx_limit`.