### PR TITLE
Expose event ring descriptor info

### DIFF
--- a/monad-event-ring/src/descriptor/mod.rs
+++ b/monad-event-ring/src/descriptor/mod.rs
@@ -42,6 +42,11 @@ where
         }
     }
 
+    /// Produces the [`EventDescriptorInfo`] associated with this descriptor.
+    pub fn info(&self) -> EventDescriptorInfo<D> {
+        EventDescriptorInfo::new(self.raw.info())
+    }
+
     /// Attempts to read the payload associated with this event descriptor as the associated
     /// [`T::Event`](EventDecoder::Event) type.
     pub fn try_read(&self) -> EventPayloadResult<D::Event> {
@@ -123,6 +128,9 @@ where
     /// See [`EventDecoder`] for more details.
     pub event_type: u16,
 
+    /// The time at which the event was recorded.
+    pub record_epoch_nanos: u64,
+
     /// The flow information associated with this event descriptor,
     ///
     /// See [`EventDecoder::FlowInfo`] for more details.
@@ -137,6 +145,7 @@ where
         Self {
             seqno: raw.seqno,
             event_type: raw.event_type,
+            record_epoch_nanos: raw.record_epoch_nanos,
             flow_info: D::transmute_flow_info(raw.content_ext),
         }
     }

--- a/monad-event-ring/src/descriptor/raw.rs
+++ b/monad-event-ring/src/descriptor/raw.rs
@@ -35,6 +35,15 @@ impl<'ring> RawEventDescriptor<'ring> {
         }
     }
 
+    pub(crate) fn info(&self) -> RawEventDescriptorInfo {
+        RawEventDescriptorInfo {
+            seqno: self.inner.seqno,
+            event_type: self.inner.event_type,
+            record_epoch_nanos: self.inner.record_epoch_nanos,
+            content_ext: self.inner.content_ext,
+        }
+    }
+
     pub(crate) fn try_filter_map<T>(
         &self,
         f: impl FnOnce(RawEventDescriptorInfo, &[u8]) -> T,
@@ -43,14 +52,9 @@ impl<'ring> RawEventDescriptor<'ring> {
             return EventPayloadResult::Expired;
         };
 
-        let value = f(
-            RawEventDescriptorInfo {
-                seqno: self.inner.seqno,
-                event_type: self.inner.event_type,
-                content_ext: self.inner.content_ext,
-            },
-            bytes,
-        );
+        let info = self.info();
+
+        let value = f(info, bytes);
 
         if monad_event_ring_payload_check(&self.ring.inner, &self.inner) {
             EventPayloadResult::Ready(value)
@@ -64,6 +68,8 @@ pub(crate) struct RawEventDescriptorInfo {
     pub seqno: u64,
 
     pub event_type: u16,
+
+    pub record_epoch_nanos: u64,
 
     pub content_ext: [u64; 4],
 }

--- a/monad-exec-events/src/events/mod.rs
+++ b/monad-exec-events/src/events/mod.rs
@@ -247,9 +247,14 @@ impl<'ring> ExecEventRef<'ring> {
 
 /// Flow info for execution events.
 pub struct ExecEventRingFlowInfo {
-    block_seqno: u64,
-    txn_idx: Option<usize>,
-    account_idx: u64,
+    /// The sequence number of the block associated with this event.
+    pub block_seqno: u64,
+
+    /// The index of the transaction within the block associated with this event.
+    pub txn_idx: Option<usize>,
+
+    /// The index of the account within the block associated with this event.
+    pub account_idx: u64,
 }
 
 impl EventDecoder for ExecEventDecoder {


### PR DESCRIPTION
This change allows SDK users to retrieve the `EventDescriptorInfo` associated with an event descriptor to access fields like `record_epoch_nanos`.