### PR TITLE
[monad-event-ring] open files in the event ring dir by default

### DIFF
--- a/monad-exec-events/src/ffi.rs
+++ b/monad-exec-events/src/ffi.rs
@@ -49,3 +49,13 @@ pub use self::bindings::{
 mod bindings {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
+
+#[allow(missing_docs)]
+pub const DEFAULT_FILE_NAME: &str = unsafe {
+    std::str::from_utf8_unchecked(
+        std::ffi::CStr::from_bytes_with_nul_unchecked(
+            self::bindings::MONAD_EVENT_DEFAULT_EXEC_FILE_NAME,
+        )
+        .to_bytes(),
+    )
+};


### PR DESCRIPTION
This changes `EventRing::new_*` to use the C API function `monad_event_open_ring_dir_fd`, which opens the default hugetlbfs-mounted directory to put event rings into, when given a single path component