### PR TITLE
Refactor keystore

### DIFF
--- a/monad-bls/src/bls.rs
+++ b/monad-bls/src/bls.rs
@@ -276,6 +276,15 @@ impl BlsAggregatePubKey {
 #[derive(ZeroizeOnDrop)]
 struct BlsSecretKey(blst_core::SecretKey);
 
+#[derive(ZeroizeOnDrop)]
+pub struct BlsSecretKeyView(Vec<u8>);
+
+impl std::fmt::Display for BlsSecretKeyView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(&self.0))
+    }
+}
+
 /// BLS keypair
 pub struct BlsKeyPair {
     pubkey: BlsPubKey,
@@ -287,6 +296,10 @@ impl BlsSecretKey {
         let blst_key = blst_core::SecretKey::key_gen(ikm, key_info);
         ikm.zeroize();
         blst_key.map(Self).map_err(BlsError)
+    }
+
+    fn sk_view(&self) -> BlsSecretKeyView {
+        BlsSecretKeyView(self.0.to_bytes().into())
     }
 
     fn sk_to_pk(&self) -> BlsPubKey {
@@ -321,6 +334,10 @@ impl BlsKeyPair {
     pub fn sign<SD: SigningDomain>(&self, msg: &[u8]) -> BlsSignature {
         let msg = [SD::PREFIX, msg].concat();
         self.secretkey.0.sign(&msg, DST, &[]).into()
+    }
+
+    pub fn privkey_view(&self) -> BlsSecretKeyView {
+        self.secretkey.sk_view()
     }
 
     pub fn pubkey(&self) -> BlsPubKey {

--- a/monad-secp/Cargo.toml
+++ b/monad-secp/Cargo.toml
@@ -14,10 +14,11 @@ monad-crypto = { workspace = true }
 alloy-consensus = { workspace = true }
 alloy-primitives = { workspace = true, features = ["k256"] }
 alloy-rlp = { workspace = true }
+hex = { workspace = true }
 k256 = { workspace = true }
 secp256k1 = { workspace = true, features = ["global-context", "recovery"] }
 sha2 = { workspace = true }
-zeroize = { workspace = true }
+zeroize = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 monad-testutil = { workspace = true }
@@ -26,7 +27,6 @@ alloy-consensus = { workspace = true }
 alloy-signer = { workspace = true }
 alloy-signer-local = { workspace = true }
 criterion = { workspace = true }
-hex = { workspace = true }
 insta = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }

--- a/monad-secp/src/secp.rs
+++ b/monad-secp/src/secp.rs
@@ -24,13 +24,23 @@ use monad_crypto::{
 };
 use secp256k1::{ffi::CPtr, Secp256k1};
 use sha2::Sha256;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// secp256k1 public key
 #[derive(Copy, Clone, PartialOrd, Ord)]
 pub struct PubKey(secp256k1::PublicKey);
 /// secp256k1 keypair
 pub struct KeyPair(secp256k1::KeyPair);
+
+#[derive(ZeroizeOnDrop)]
+pub struct PrivKeyView(Vec<u8>);
+
+impl std::fmt::Display for PrivKeyView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(&self.0))
+    }
+}
+
 /// secp256k1 ecdsa recoverable signature
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SecpSignature(secp256k1::ecdsa::RecoverableSignature);
@@ -116,6 +126,10 @@ impl KeyPair {
             &msg_hash::<SD>(msg),
             &self.0.secret_key(),
         ))
+    }
+
+    pub fn privkey_view(&self) -> PrivKeyView {
+        PrivKeyView(self.0.secret_bytes().into())
     }
 
     /// Get the pubkey


### PR DESCRIPTION
- Print the correct private keys for validators to use for staking
- Rename CLI arg (since we only support importing IKMs) and other misleading variable names