### PR TITLE
raptorcast: expose priority api for publishing to validators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4983,6 +4983,7 @@ dependencies = [
  "futures-util",
  "governor",
  "libc",
+ "monad-types",
  "monoio",
  "ntest",
  "rand 0.8.5",

--- a/monad-dataplane/Cargo.toml
+++ b/monad-dataplane/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2021"
 bench = false
 
 [dependencies]
+monad-types = { workspace = true }
+
 bytes = { workspace = true }
 env_logger = { workspace = true }
 futures = { workspace = true }

--- a/monad-dataplane/src/lib.rs
+++ b/monad-dataplane/src/lib.rs
@@ -27,6 +27,7 @@ use std::{
 use addrlist::Addrlist;
 use bytes::Bytes;
 use futures::channel::oneshot;
+use monad_types::UdpPriority;
 use monoio::{spawn, time::Instant, IoUringDriver, RuntimeBuilder};
 use tcp::{TcpConfig, TcpControl, TcpRateLimit};
 use tokio::sync::mpsc::{self, error::TrySendError};
@@ -39,13 +40,6 @@ pub mod tcp;
 pub mod udp;
 
 pub(crate) use udp::UdpMessageType;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(usize)]
-pub enum UdpPriority {
-    High = 0,
-    Regular = 1,
-}
 
 pub struct DataplaneBuilder {
     local_addr: SocketAddr,

--- a/monad-dataplane/src/udp.rs
+++ b/monad-dataplane/src/udp.rs
@@ -27,25 +27,13 @@ use monoio::{net::udp::UdpSocket, spawn, time};
 use tokio::sync::mpsc;
 use tracing::{debug, error, trace, warn};
 
-use super::{RecvUdpMsg, UdpMsg, UdpPriority};
+use super::{RecvUdpMsg, UdpMsg};
 use crate::buffer_ext::SocketBufferExt;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum UdpMessageType {
     Broadcast,
     Direct,
-}
-
-impl TryFrom<usize> for UdpPriority {
-    type Error = &'static str;
-
-    fn try_from(value: usize) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(UdpPriority::High),
-            1 => Ok(UdpPriority::Regular),
-            _ => Err("invalid priority index"),
-        }
-    }
 }
 
 struct PriorityQueues {

--- a/monad-dataplane/tests/tests.rs
+++ b/monad-dataplane/tests/tests.rs
@@ -26,8 +26,9 @@ use futures::{channel::oneshot, executor, FutureExt};
 use monad_dataplane::{
     tcp::tx::{MSG_WAIT_TIMEOUT, QUEUED_MESSAGE_LIMIT},
     udp::DEFAULT_SEGMENT_SIZE,
-    BroadcastMsg, DataplaneBuilder, RecvUdpMsg, TcpMsg, UdpPriority, UnicastMsg,
+    BroadcastMsg, DataplaneBuilder, RecvUdpMsg, TcpMsg, UnicastMsg,
 };
+use monad_types::UdpPriority;
 use ntest::timeout;
 use rand::Rng;
 use rstest::*;

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -60,6 +60,12 @@ pub enum RouterCommand<ST: CertificateSignatureRecoverable, OM> {
         target: RouterTarget<CertificateSignaturePubKey<ST>>,
         message: OM,
     },
+    PublishWithPriority {
+        // NOTE(dshulyak) priority for tcp messages is ignored
+        target: RouterTarget<CertificateSignaturePubKey<ST>>,
+        message: OM,
+        priority: monad_types::UdpPriority,
+    },
     PublishToFullNodes {
         epoch: Epoch, // Epoch gets embedded into the raptorcast message
         message: OM,
@@ -87,6 +93,15 @@ impl<ST: CertificateSignatureRecoverable, OM> Debug for RouterCommand<ST, OM> {
             Self::Publish { target, message: _ } => {
                 f.debug_struct("Publish").field("target", target).finish()
             }
+            Self::PublishWithPriority {
+                target,
+                message: _,
+                priority,
+            } => f
+                .debug_struct("PublishWithPriority")
+                .field("target", target)
+                .field("priority", priority)
+                .finish(),
             Self::PublishToFullNodes { epoch, message: _ } => f
                 .debug_struct("PublishToFullNodes")
                 .field("epoch", epoch)

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -400,6 +400,13 @@ impl<S: SwarmRelation> Executor for MockExecutor<S> {
                 RouterCommand::PublishToFullNodes { .. } => {
                     // TODO
                 }
+                RouterCommand::PublishWithPriority {
+                    target,
+                    message,
+                    priority: _,
+                } => {
+                    self.router.send_outbound(self.tick, target, message);
+                }
             }
         }
     }

--- a/monad-peer-disc-swarm/src/lib.rs
+++ b/monad-peer-disc-swarm/src/lib.rs
@@ -148,6 +148,11 @@ impl<S: PeerDiscSwarmRelation> Executor for MockPeerDiscExecutor<S> {
                 RouterCommand::Publish { target, message } => {
                     self.router.send_outbound(self.tick, target, message)
                 }
+                RouterCommand::PublishWithPriority {
+                    target,
+                    message,
+                    priority: _,
+                } => self.router.send_outbound(self.tick, target, message),
                 RouterCommand::AddEpochValidatorSet { .. } => {}
                 RouterCommand::UpdateCurrentRound(..) => {}
                 RouterCommand::GetPeers => {}

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -308,6 +308,9 @@ where
                 Self::Command::Publish { .. } => {
                     panic!("Command routed to secondary RaptorCast: Publish")
                 }
+                Self::Command::PublishWithPriority { .. } => {
+                    panic!("Command routed to secondary RaptorCast: PublishWithPriority")
+                }
                 Self::Command::AddEpochValidatorSet { .. } => {
                     panic!("Command routed to secondary RaptorCast: AddEpochValidatorSet")
                 }

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -269,6 +269,7 @@ where
         for cmd in a_commands {
             match cmd {
                 RouterCommand::Publish { .. } => validator_cmds.push(cmd),
+                RouterCommand::PublishWithPriority { .. } => validator_cmds.push(cmd),
                 RouterCommand::AddEpochValidatorSet {
                     epoch,
                     validator_set,

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -620,6 +620,25 @@ pub enum RouterTarget<P: PubKey> {
     },
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(usize)]
+pub enum UdpPriority {
+    High = 0,
+    Regular = 1,
+}
+
+impl TryFrom<usize> for UdpPriority {
+    type Error = &'static str;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(UdpPriority::High),
+            1 => Ok(UdpPriority::Regular),
+            _ => Err("invalid priority index"),
+        }
+    }
+}
+
 /// Trait for use in tests to populate structs where the value of the fields is not relevant
 pub trait DontCare {
     fn dont_care() -> Self;


### PR DESCRIPTION
requires:  https://github.com/category-labs/monad-bft/pull/2352
this  change adds priority API and tests, in the follow up consensus
will be modified to use this API.

tested  that  this API is effective  by running two concurrent instances of raptorcast and  measuring latency.

<img width="2673" height="758" alt="image" src="https://github.com/user-attachments/assets/6eb4d2fd-d9db-490c-ad7f-9dba0753b508" />

  | Priority | Count | Mean   | Std Dev | Min    | P25    | P50 (Median) | P75    | P90    | P95    | P99    | Max    |
  |----------|-------|--------|---------|--------|--------|--------------|--------|--------|--------|--------|--------|
  | High     | 1,899 | 126.95 | 10.67   | 100.33 | 119.83 | 126.56       | 134.12 | 141.32 | 144.49 | 151.28 | 165.13 |
  | Regular  | 1,899 | 180.63 | 12.16   | 142.96 | 172.56 | 180.58       | 188.99 | 196.33 | 199.91 | 207.92 | 220.47 | 
