### PR TITLE
consensus, raptorcast: prioritize consensus messages to validators

### DIFF
--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -47,7 +47,7 @@ use monad_crypto::certificate_signature::{
 use monad_state_backend::StateBackend;
 use monad_types::{
     deserialize_pubkey, serialize_pubkey, Epoch, ExecutionProtocol, NodeId, Round, RouterTarget,
-    SeqNum, Stake,
+    SeqNum, Stake, UdpPriority,
 };
 use monad_validator::signature_collection::SignatureCollection;
 use serde::{Deserialize, Serialize};
@@ -64,7 +64,7 @@ pub enum RouterCommand<ST: CertificateSignatureRecoverable, OM> {
         // NOTE(dshulyak) priority for tcp messages is ignored
         target: RouterTarget<CertificateSignaturePubKey<ST>>,
         message: OM,
-        priority: monad_types::UdpPriority,
+        priority: UdpPriority,
     },
     PublishToFullNodes {
         epoch: Epoch, // Epoch gets embedded into the raptorcast message

--- a/monad-state/src/consensus.rs
+++ b/monad-state/src/consensus.rs
@@ -656,9 +656,10 @@ where
                 }))
             }
             ConsensusCommand::Publish { target, message } => {
-                parent_cmds.push(Command::RouterCommand(RouterCommand::Publish {
+                parent_cmds.push(Command::RouterCommand(RouterCommand::PublishWithPriority {
                     target,
                     message: VerifiedMonadMessage::Consensus(message),
+                    priority: monad_types::UdpPriority::High,
                 }))
             }
             ConsensusCommand::PublishToFullNodes { epoch, message } => {


### PR DESCRIPTION
requires: https://github.com/category-labs/monad-bft/pull/2353
publish all messages from consensus with high priority. rebroacasting to validators is done with high priority by default.