### PR TITLE
Reject reserved ips in peer discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5619,6 +5619,7 @@ dependencies = [
  "monad-types",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "rstest",
  "test-case",
  "tokio-util",
  "toml",

--- a/monad-peer-discovery/Cargo.toml
+++ b/monad-peer-discovery/Cargo.toml
@@ -24,5 +24,6 @@ monad-testutil = { workspace = true }
 
 clap = { workspace = true, features = ["derive"] }
 hex = { workspace = true }
+rstest = { workspace = true }
 test-case = { workspace = true }
 toml = { workspace = true }

--- a/monad-peer-discovery/src/discovery.rs
+++ b/monad-peer-discovery/src/discovery.rs
@@ -33,6 +33,7 @@ use crate::{
     MonadNameRecord, NameRecord, PeerDiscoveryAlgo, PeerDiscoveryAlgoBuilder, PeerDiscoveryCommand,
     PeerDiscoveryEvent, PeerDiscoveryMessage, PeerDiscoveryMetricsCommand,
     PeerDiscoveryTimerCommand, PeerLookupRequest, PeerLookupResponse, Ping, Pong, TimerKind,
+    ipv4_validation::{IpCheckError, validate_socket_ipv4_address},
 };
 
 /// Maximum number of peers to be included in a PeerLookupResponse
@@ -221,7 +222,9 @@ impl<ST: CertificateSignatureRecoverable> PeerDiscoveryAlgoBuilder for PeerDisco
         self.bootstrap_peers
             .into_iter()
             .for_each(|(peer_id, name_record)| {
-                cmds.extend(state.insert_peer_to_pending(peer_id, name_record));
+                if let Ok(cmds_from_insert) = state.insert_peer_to_pending(peer_id, name_record) {
+                    cmds.extend(cmds_from_insert);
+                }
             });
 
         cmds.extend(state.refresh());
@@ -326,10 +329,22 @@ impl<ST: CertificateSignatureRecoverable> PeerDiscovery<ST> {
         &mut self,
         peer_id: NodeId<CertificateSignaturePubKey<ST>>,
         name_record: MonadNameRecord<ST>,
-    ) -> Vec<PeerDiscoveryCommand<ST>> {
+    ) -> Result<Vec<PeerDiscoveryCommand<ST>>, IpCheckError> {
         // make sure self record is never inserted
         if peer_id == self.self_id {
-            return vec![];
+            return Ok(vec![]);
+        }
+
+        // check if the peer ip address is valid
+        if let Err(err) =
+            validate_socket_ipv4_address(&name_record.address(), &self.self_record.address())
+        {
+            warn!(
+                ?peer_id,
+                ?name_record,
+                "peer ip address failed check, ignoring"
+            );
+            return Err(err);
         }
 
         // only accept new name record or name record with higher sequence number
@@ -342,14 +357,14 @@ impl<ST: CertificateSignatureRecoverable> PeerDiscovery<ST> {
                     ?current_name_record,
                     "name record already exists with same or lower seq in routing info"
                 );
-                return vec![];
+                return Ok(vec![]);
             }
         }
         if let Some(info) = self.pending_queue.get(&peer_id) {
             if name_record.seq() <= info.name_record.seq() {
                 // no updates are required, exit
                 debug!(?peer_id, ?name_record, ?info.name_record, "name record already exists with same or lower seq in pending queue");
-                return vec![];
+                return Ok(vec![]);
             }
         }
 
@@ -366,7 +381,7 @@ impl<ST: CertificateSignatureRecoverable> PeerDiscovery<ST> {
         self.metrics[GAUGE_PEER_DISC_NUM_PENDING_PEERS] = self.pending_queue.len() as u64;
 
         // send ping to the peer, which will also insert the peer into pending queue
-        self.send_ping(peer_id, name_record.address(), ping_msg)
+        Ok(self.send_ping(peer_id, name_record.address(), ping_msg))
     }
 
     fn remove_peer_from_pending(
@@ -618,7 +633,10 @@ where
                     .is_ok_and(|recovered_node_id| recovered_node_id == from);
 
                 if verified {
-                    cmds.extend(self.insert_peer_to_pending(from, peer_name_record));
+                    match self.insert_peer_to_pending(from, peer_name_record) {
+                        Ok(cmds_from_insert) => cmds.extend(cmds_from_insert),
+                        Err(_) => return cmds,
+                    }
                 } else {
                     debug!("invalid signature in ping.local_name_record");
                     return cmds;
@@ -875,7 +893,10 @@ where
                 }
             };
 
-            cmds.extend(self.insert_peer_to_pending(node_id, name_record));
+            match self.insert_peer_to_pending(node_id, name_record) {
+                Ok(cmds_from_insert) => cmds.extend(cmds_from_insert),
+                Err(_) => continue,
+            }
         }
 
         // drop from outstanding requests
@@ -1326,7 +1347,10 @@ where
                 .recover_pubkey()
                 .is_ok_and(|recovered_node_id| recovered_node_id == node_id);
             if verified {
-                cmds.extend(self.insert_peer_to_pending(node_id, name_record));
+                match self.insert_peer_to_pending(node_id, name_record) {
+                    Ok(cmds_from_insert) => cmds.extend(cmds_from_insert),
+                    Err(_) => continue,
+                }
             } else {
                 warn!(?node_id, "invalid name record signature");
             }
@@ -1815,7 +1839,7 @@ mod tests {
 
         // should add to pending queue and send ping if record has higher sequence number (seq num incremented to 2)
         let record = generate_name_record(peer1, 2);
-        let cmds = state.insert_peer_to_pending(peer1_pubkey, record);
+        let cmds = state.insert_peer_to_pending(peer1_pubkey, record).unwrap();
         let pings = extract_ping(cmds);
         assert_eq!(pings.len(), 1);
         assert_eq!(pings[0].0, peer1_pubkey);
@@ -1832,7 +1856,9 @@ mod tests {
 
         // should not replace existing entry in pending queue if record has lower sequence number (seq num decremented to 1)
         let invalid_record = generate_name_record(peer1, 1);
-        let cmds = state.insert_peer_to_pending(peer1_pubkey, invalid_record);
+        let cmds = state
+            .insert_peer_to_pending(peer1_pubkey, invalid_record)
+            .unwrap();
         assert!(cmds.is_empty());
 
         // insert into routing info after ping pong round trip
@@ -1845,7 +1871,9 @@ mod tests {
         assert!(!state.pending_queue.contains_key(&peer1_pubkey));
 
         // should not update name record if record has lower sequence number (seq num decremented to 1)
-        let cmds = state.insert_peer_to_pending(peer1_pubkey, invalid_record);
+        let cmds = state
+            .insert_peer_to_pending(peer1_pubkey, invalid_record)
+            .unwrap();
         assert!(cmds.is_empty());
     }
 

--- a/monad-peer-discovery/src/ipv4_validation.rs
+++ b/monad-peer-discovery/src/ipv4_validation.rs
@@ -1,0 +1,101 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::net::SocketAddrV4;
+
+#[derive(Debug, PartialEq)]
+pub enum IpCheckError {
+    UnspecifiedIp,
+    SpecialIP,
+    PrivateIp,
+    LoopbackIp,
+    LinkLocalIp,
+}
+
+pub fn validate_socket_ipv4_address(
+    socket_address: &SocketAddrV4,
+    self_address: &SocketAddrV4,
+) -> Result<(), IpCheckError> {
+    let self_ip = self_address.ip();
+    let peer_ip = socket_address.ip();
+
+    // unspecified address of 0.0.0.0
+    if peer_ip.is_unspecified() {
+        return Err(IpCheckError::UnspecifiedIp);
+    }
+
+    // special use network range includes broadcast, multicast and documentation addresses
+    // multicast address of 224.0.0.0/4
+    if peer_ip.is_multicast() {
+        return Err(IpCheckError::SpecialIP);
+    }
+    // broadcast address of 255.255.255.255
+    if peer_ip.is_broadcast() {
+        return Err(IpCheckError::SpecialIP);
+    }
+    // documentation address of 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24
+    if peer_ip.is_documentation() {
+        return Err(IpCheckError::SpecialIP);
+    }
+
+    // loopback address of 127.0.0.0/8
+    if peer_ip.is_loopback() && !self_ip.is_loopback() {
+        return Err(IpCheckError::LoopbackIp);
+    }
+
+    // private address of 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+    if peer_ip.is_private() && !self_ip.is_private() {
+        return Err(IpCheckError::PrivateIp);
+    }
+
+    // link-local address of 169.254.0.0/16
+    if peer_ip.is_link_local() && !self_ip.is_link_local() {
+        return Err(IpCheckError::LinkLocalIp);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::*;
+
+    use super::*;
+
+    #[rstest]
+    #[case("45.22.13.14", "0.0.0.0", Err(IpCheckError::UnspecifiedIp))] // unspecified ip
+    #[case("45.22.13.14", "224.0.0.1", Err(IpCheckError::SpecialIP))] // multicast ip
+    #[case("45.22.13.14", "255.255.255.255", Err(IpCheckError::SpecialIP))] // broadcast ip
+    #[case("45.22.13.14", "198.51.100.1", Err(IpCheckError::SpecialIP))] // documentation ip
+    #[case("45.22.13.14", "127.0.0.1", Err(IpCheckError::LoopbackIp))] // loopback ip
+    #[case("127.0.0.2", "127.0.0.1", Ok(()))] // loopback ip with loopback self ip
+    #[case("45.22.13.14", "10.0.0.1", Err(IpCheckError::PrivateIp))] // private ip
+    #[case("10.0.0.2", "10.0.0.1", Ok(()))] // private ip with private self ip
+    #[case("45.22.13.14", "169.254.1.1", Err(IpCheckError::LinkLocalIp))] // link-local ip
+    #[case("169.254.1.2", "169.254.1.1", Ok(()))] // link-local ip with link-local self ip
+    #[case("45.22.13.14", "45.22.13.15", Ok(()))] // public ip
+    fn test_validate_socket_ipv4_address(
+        #[case] self_address: &str,
+        #[case] peer_address: &str,
+        #[case] expect: Result<(), IpCheckError>,
+    ) {
+        let self_address = SocketAddrV4::new(self_address.parse().unwrap(), 8080);
+        let peer_address = SocketAddrV4::new(peer_address.parse().unwrap(), 8080);
+        assert_eq!(
+            validate_socket_ipv4_address(&peer_address, &self_address),
+            expect
+        );
+    }
+}

--- a/monad-peer-discovery/src/lib.rs
+++ b/monad-peer-discovery/src/lib.rs
@@ -34,6 +34,7 @@ use tracing::warn;
 
 pub mod discovery;
 pub mod driver;
+pub mod ipv4_validation;
 pub mod message;
 pub mod mock;
 


### PR DESCRIPTION
Closes https://github.com/category-labs/category-internal/issues/1777, audit issue raised by Zellic. This PR rejects IP addresses that are special addresses. For reference, geth also has similar checks https://github.com/ethereum/go-ethereum/blob/master/p2p/netutil/net.go#L185-L222