### PR TITLE
Configurable rpc namespaces

### DIFF
--- a/monad-rpc/src/cli.rs
+++ b/monad-rpc/src/cli.rs
@@ -16,6 +16,7 @@
 use std::path::PathBuf;
 
 use clap::Parser;
+use monad_rpc::handlers::MethodGroup;
 
 #[derive(Debug, Parser)]
 #[command(name = "monad-node", about, long_about = None)]
@@ -39,6 +40,10 @@ pub struct Cli {
     /// Set the node config path
     #[arg(long)]
     pub node_config: PathBuf,
+
+    /// Enable namespace for rpc (admin, debug)
+    #[arg(long, value_enum, value_delimiter = ',')]
+    pub rpc_namespaces: Vec<MethodGroup>,
 
     /// Enable the WebSocket server
     #[arg(long, default_value_t = false)]

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -28,8 +28,9 @@ use monad_rpc::{
     comparator::RpcComparator,
     event::EventServer,
     handlers::{
+        enable_group,
         resources::{MonadJsonRootSpanBuilder, MonadRpcResources},
-        rpc_handler,
+        rpc_handler, MethodGroup,
     },
     metrics,
     timing::TimingMiddleware,
@@ -324,6 +325,10 @@ async fn main() -> std::io::Result<()> {
         .rpc_comparison_endpoint
         .as_ref()
         .map(|endpoint| RpcComparator::new(endpoint.to_string(), node_config.node_name));
+
+    for grp in args.rpc_namespaces.into_iter() {
+        enable_group(grp);
+    }
 
     let app_state = MonadRpcResources::new(
         txpool_bridge_client,


### PR DESCRIPTION
Allow rpc operators to enable debug or admin namespaces. By default, methods in those groups are disabled. 

FIXES https://github.com/category-labs/monad-bft/issues/2332