### PR TITLE
Add support to dynamically reload prioritized full nodes

### DIFF
--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -70,9 +70,15 @@ pub enum RouterCommand<ST: CertificateSignatureRecoverable, OM> {
     },
     UpdateCurrentRound(Epoch, Round),
     GetPeers,
-    UpdatePeers(Vec<PeerEntry<ST>>),
+    UpdatePeers {
+        peer_entries: Vec<PeerEntry<ST>>,
+        pinned_nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
+    },
     GetFullNodes,
-    UpdateFullNodes(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
+    UpdateFullNodes {
+        dedicated_full_nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
+        prioritized_full_nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
+    },
 }
 
 impl<ST: CertificateSignatureRecoverable, OM> Debug for RouterCommand<ST, OM> {
@@ -99,9 +105,23 @@ impl<ST: CertificateSignatureRecoverable, OM> Debug for RouterCommand<ST, OM> {
                 .field(arg1)
                 .finish(),
             Self::GetPeers => write!(f, "GetPeers"),
-            Self::UpdatePeers(arg0) => f.debug_tuple("UpdatePeers").field(arg0).finish(),
+            Self::UpdatePeers {
+                peer_entries,
+                pinned_nodes,
+            } => f
+                .debug_struct("UpdatePeers")
+                .field("peer_entries", peer_entries)
+                .field("pinned_nodes", pinned_nodes)
+                .finish(),
             Self::GetFullNodes => write!(f, "GetFullNodes"),
-            Self::UpdateFullNodes(arg0) => f.debug_tuple("UpdateFullNodes").field(arg0).finish(),
+            Self::UpdateFullNodes {
+                dedicated_full_nodes,
+                prioritized_full_nodes,
+            } => f
+                .debug_struct("UpdateFullNodes")
+                .field("dedicated_full_nodes", dedicated_full_nodes)
+                .field("prioritized_full_nodes", prioritized_full_nodes)
+                .finish(),
         }
     }
 }
@@ -1874,7 +1894,8 @@ pub struct ConfigUpdate<SCT>
 where
     SCT: SignatureCollection,
 {
-    pub full_nodes: Vec<NodeId<SCT::NodeIdPubKey>>,
+    pub dedicated_full_nodes: Vec<NodeId<SCT::NodeIdPubKey>>,
+    pub prioritized_full_nodes: Vec<NodeId<SCT::NodeIdPubKey>>,
     pub blocksync_override_peers: Vec<NodeId<SCT::NodeIdPubKey>>,
 }
 
@@ -1884,6 +1905,7 @@ where
     ST: CertificateSignatureRecoverable,
 {
     pub known_peers: Vec<PeerEntry<ST>>,
+    pub pinned_nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -388,13 +388,13 @@ impl<S: SwarmRelation> Executor for MockExecutor<S> {
                 RouterCommand::GetPeers => {
                     // TODO
                 }
-                RouterCommand::UpdatePeers(_) => {
+                RouterCommand::UpdatePeers { .. } => {
                     // TODO
                 }
                 RouterCommand::GetFullNodes => {
                     // TODO
                 }
-                RouterCommand::UpdateFullNodes(_vec) => {
+                RouterCommand::UpdateFullNodes { .. } => {
                     // TODO
                 }
                 RouterCommand::PublishToFullNodes { .. } => {

--- a/monad-peer-disc-swarm/src/driver.rs
+++ b/monad-peer-disc-swarm/src/driver.rs
@@ -187,6 +187,9 @@ where
                 self.algo.update_validator_set(epoch, validators)
             }
             PeerDiscoveryEvent::UpdatePeers { peers } => self.algo.update_peers(peers),
+            PeerDiscoveryEvent::UpdatePinnedNodes { pinned_full_nodes } => {
+                self.algo.update_pinned_nodes(pinned_full_nodes)
+            }
             PeerDiscoveryEvent::UpdateConfirmGroup { end_round, peers } => {
                 self.algo.update_peer_participation(end_round, peers)
             }

--- a/monad-peer-disc-swarm/src/lib.rs
+++ b/monad-peer-disc-swarm/src/lib.rs
@@ -151,9 +151,9 @@ impl<S: PeerDiscSwarmRelation> Executor for MockPeerDiscExecutor<S> {
                 RouterCommand::AddEpochValidatorSet { .. } => {}
                 RouterCommand::UpdateCurrentRound(..) => {}
                 RouterCommand::GetPeers => {}
-                RouterCommand::UpdatePeers(_) => {}
+                RouterCommand::UpdatePeers { .. } => {}
                 RouterCommand::GetFullNodes => {}
-                RouterCommand::UpdateFullNodes(_) => {}
+                RouterCommand::UpdateFullNodes { .. } => {}
                 RouterCommand::PublishToFullNodes { .. } => {}
             }
         }

--- a/monad-peer-discovery/src/discovery.rs
+++ b/monad-peer-discovery/src/discovery.rs
@@ -1335,6 +1335,17 @@ where
         cmds
     }
 
+    fn update_pinned_nodes(
+        &mut self,
+        pinned_nodes: BTreeSet<NodeId<CertificateSignaturePubKey<ST>>>,
+    ) -> Vec<PeerDiscoveryCommand<ST>> {
+        debug!(?pinned_nodes, "updating pinned nodes");
+
+        self.pinned_full_nodes = pinned_nodes;
+
+        Vec::new()
+    }
+
     fn update_peer_participation(
         &mut self,
         round: Round,

--- a/monad-peer-discovery/src/driver.rs
+++ b/monad-peer-discovery/src/driver.rs
@@ -214,6 +214,9 @@ impl<PD: PeerDiscoveryAlgo> PeerDiscoveryDriver<PD> {
                 self.pd.update_validator_set(epoch, validators)
             }
             PeerDiscoveryEvent::UpdatePeers { peers } => self.pd.update_peers(peers),
+            PeerDiscoveryEvent::UpdatePinnedNodes { pinned_full_nodes } => {
+                self.pd.update_pinned_nodes(pinned_full_nodes)
+            }
             PeerDiscoveryEvent::UpdateConfirmGroup { end_round, peers } => {
                 self.pd.update_peer_participation(end_round, peers)
             }

--- a/monad-peer-discovery/src/lib.rs
+++ b/monad-peer-discovery/src/lib.rs
@@ -163,6 +163,9 @@ pub enum PeerDiscoveryEvent<ST: CertificateSignatureRecoverable> {
     UpdatePeers {
         peers: Vec<PeerEntry<ST>>,
     },
+    UpdatePinnedNodes {
+        pinned_full_nodes: BTreeSet<NodeId<CertificateSignaturePubKey<ST>>>,
+    },
     UpdateConfirmGroup {
         end_round: Round,
         peers: BTreeSet<NodeId<CertificateSignaturePubKey<ST>>>,
@@ -297,6 +300,11 @@ pub trait PeerDiscoveryAlgo {
     fn update_peers(
         &mut self,
         peers: Vec<PeerEntry<Self::SignatureType>>,
+    ) -> Vec<PeerDiscoveryCommand<Self::SignatureType>>;
+
+    fn update_pinned_nodes(
+        &mut self,
+        pinned_nodes: BTreeSet<NodeId<CertificateSignaturePubKey<Self::SignatureType>>>,
     ) -> Vec<PeerDiscoveryCommand<Self::SignatureType>>;
 
     fn update_peer_participation(

--- a/monad-peer-discovery/src/mock.rs
+++ b/monad-peer-discovery/src/mock.rs
@@ -227,6 +227,15 @@ where
         Vec::new()
     }
 
+    fn update_pinned_nodes(
+        &mut self,
+        pinned_nodes: BTreeSet<NodeId<CertificateSignaturePubKey<ST>>>,
+    ) -> Vec<PeerDiscoveryCommand<ST>> {
+        debug!(?pinned_nodes, "updating pinned nodes");
+
+        Vec::new()
+    }
+
     fn update_peer_participation(
         &mut self,
         round: Round,

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -621,11 +621,20 @@ where
                         waker.wake();
                     }
                 }
-                RouterCommand::UpdatePeers(peers) => {
-                    self.peer_discovery_driver
-                        .lock()
-                        .unwrap()
-                        .update(PeerDiscoveryEvent::UpdatePeers { peers });
+                RouterCommand::UpdatePeers {
+                    peer_entries,
+                    pinned_nodes,
+                } => {
+                    self.peer_discovery_driver.lock().unwrap().update(
+                        PeerDiscoveryEvent::UpdatePeers {
+                            peers: peer_entries,
+                        },
+                    );
+                    self.peer_discovery_driver.lock().unwrap().update(
+                        PeerDiscoveryEvent::UpdatePinnedNodes {
+                            pinned_full_nodes: pinned_nodes.into_iter().collect(),
+                        },
+                    );
                 }
                 RouterCommand::GetFullNodes => {
                     let full_nodes = self.dedicated_full_nodes.list.clone();
@@ -637,8 +646,11 @@ where
                         waker.wake();
                     }
                 }
-                RouterCommand::UpdateFullNodes(new_full_nodes) => {
-                    self.dedicated_full_nodes.list = new_full_nodes;
+                RouterCommand::UpdateFullNodes {
+                    dedicated_full_nodes,
+                    prioritized_full_nodes: _,
+                } => {
+                    self.dedicated_full_nodes.list = dedicated_full_nodes;
                 }
             }
         }

--- a/monad-raptorcast/src/raptorcast_secondary/client.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/client.rs
@@ -335,7 +335,8 @@ where
             return;
         }
 
-        if confirm_msg.peers.len() > confirm_msg.prepare.max_group_size {
+        let confirm_group_size = confirm_msg.peers.len();
+        if confirm_group_size > confirm_msg.prepare.max_group_size {
             warn!(
                 "RaptorCastSecondary ignoring ConfirmGroup that \
                                 is larger ({}) than the promised max_group_size ({}). \
@@ -378,10 +379,11 @@ where
         self.metrics[CLIENT_RECEIVED_CONFIRMS] += 1;
         debug!(
             "RaptorCastSecondary Client confirmed group for \
-             rounds [{:?}, {:?}) from validator {:?}",
+             rounds [{:?}, {:?}) from validator {:?}, group size {}",
             confirm_msg.prepare.start_round,
             confirm_msg.prepare.end_round,
             confirm_msg.prepare.validator_id,
+            confirm_group_size,
         );
 
         self.confirmed_groups

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -44,7 +44,7 @@ use publisher::Publisher;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use tracing::{error, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 use super::{
     config::{RaptorCastConfig, SecondaryRaptorCastMode},
@@ -314,9 +314,25 @@ where
                 Self::Command::GetFullNodes => {
                     panic!("Command routed to secondary RaptorCast: GetFullNodes")
                 }
-                Self::Command::UpdateFullNodes(..) => {
-                    panic!("Command routed to secondary RaptorCast: UpdateFullNodes")
-                }
+                Self::Command::UpdateFullNodes {
+                    dedicated_full_nodes: _,
+                    prioritized_full_nodes,
+                } => match &mut self.role {
+                    Role::Client(_) => {
+                        // client don't care about dedicated and prioritized full nodes
+                        debug!(
+                            ?prioritized_full_nodes,
+                            "RaptorCastSecondary Client ignoring UpdateFullNodes command"
+                        );
+                    }
+                    Role::Publisher(publisher) => {
+                        debug!(
+                            ?prioritized_full_nodes,
+                            "RaptorCastSecondary Publisher updating prioritized full nodes"
+                        );
+                        publisher.update_always_ask_full_nodes(prioritized_full_nodes);
+                    }
+                },
 
                 Self::Command::UpdateCurrentRound(epoch, round) => match &mut self.role {
                     Role::Client(client) => {

--- a/monad-raptorcast/src/raptorcast_secondary/publisher.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/publisher.rs
@@ -337,14 +337,11 @@ where
         }
     }
 
-    // TODO: implement a command to update the always-ask full nodes?
-    // TODO: if we do, to also update pinned_full_nodes in peer discovery
-    #[allow(dead_code)]
     pub fn update_always_ask_full_nodes(
         &mut self,
-        prioritized_full_nodes: FullNodes<CertificateSignaturePubKey<ST>>,
+        prioritized_full_nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
     ) {
-        self.always_ask_full_nodes = prioritized_full_nodes;
+        self.always_ask_full_nodes.list = prioritized_full_nodes;
         // Remove the nodes from always_ask, otherwise we might send two
         // invites to the same node.
         self.peer_disc_full_nodes
@@ -1300,7 +1297,7 @@ mod tests {
         // not affect groups 1, 2, since they were generated during rounds
         // 1 and 6, respectively. This should only affect group 3 (generated
         // during round 11, confirmed at round 15, used at round 18)
-        v0_fsm.update_always_ask_full_nodes(FullNodes::new(node_ids_vec![16]));
+        v0_fsm.update_always_ask_full_nodes(node_ids_vec![16]);
         // Upserting peer-discovered full nodes that already are always-ask
         // should have no effect.
         v0_fsm.upsert_peer_disc_full_nodes(FullNodes::new(node_ids_vec![11, 16]));

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -287,8 +287,17 @@ where
                     fullnodes_cmds.push(cmd);
                 }
                 RouterCommand::GetFullNodes => validator_cmds.push(cmd),
-                RouterCommand::UpdateFullNodes { .. } => validator_cmds.push(cmd),
-
+                RouterCommand::UpdateFullNodes {
+                    ref dedicated_full_nodes,
+                    ref prioritized_full_nodes,
+                } => {
+                    let cmd_cpy = RouterCommand::UpdateFullNodes {
+                        dedicated_full_nodes: dedicated_full_nodes.clone(),
+                        prioritized_full_nodes: prioritized_full_nodes.clone(),
+                    };
+                    validator_cmds.push(cmd_cpy);
+                    fullnodes_cmds.push(cmd);
+                }
                 RouterCommand::UpdateCurrentRound(epoch, round) => {
                     let cmd_cpy = RouterCommand::UpdateCurrentRound(epoch, round);
                     if epoch > self.current_epoch {

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1129,9 +1129,10 @@ where
                     self.block_sync
                         .set_override_peers(config_update.blocksync_override_peers);
                     let mut cmds = Vec::new();
-                    cmds.push(Command::RouterCommand(RouterCommand::UpdateFullNodes(
-                        config_update.full_nodes,
-                    )));
+                    cmds.push(Command::RouterCommand(RouterCommand::UpdateFullNodes {
+                        dedicated_full_nodes: config_update.dedicated_full_nodes,
+                        prioritized_full_nodes: config_update.prioritized_full_nodes,
+                    }));
 
                     cmds.push(Command::ControlPanelCommand(ControlPanelCommand::Write(
                         WriteCommand::ReloadConfig(ReloadConfig::Response("Success".to_string())),
@@ -1145,9 +1146,10 @@ where
                     ))]
                 }
                 ConfigEvent::KnownPeersUpdate(known_peers_update) => {
-                    vec![Command::RouterCommand(RouterCommand::UpdatePeers(
-                        known_peers_update.known_peers,
-                    ))]
+                    vec![Command::RouterCommand(RouterCommand::UpdatePeers {
+                        peer_entries: known_peers_update.known_peers,
+                        pinned_nodes: known_peers_update.pinned_nodes,
+                    })]
                 }
             },
         }

--- a/monad-updaters/src/local_router.rs
+++ b/monad-updaters/src/local_router.rs
@@ -164,9 +164,9 @@ where
                     }
                 },
                 RouterCommand::GetPeers => {}
-                RouterCommand::UpdatePeers(_) => {}
+                RouterCommand::UpdatePeers { .. } => {}
                 RouterCommand::GetFullNodes => {}
-                RouterCommand::UpdateFullNodes(_vec) => {}
+                RouterCommand::UpdateFullNodes { .. } => {}
             }
         }
     }


### PR DESCRIPTION
Closes https://github.com/category-labs/category-internal/issues/1919. Tested on a single node. Extend support for the monad-debug-node reload config functionality such that we can also update prioritized full nodes without needing to restart the node.

Usage:
```
monad-debug-node --control-panel-ipc-path controlpanel.sock reload-config
```