### PR TITLE
Remove duplicated 7702 check

### DIFF
--- a/monad-eth-block-policy/src/validation.rs
+++ b/monad-eth-block-policy/src/validation.rs
@@ -49,17 +49,6 @@ pub fn static_validate_transaction(
     // includes EIP-7623 validation
     EthPragueForkValidation::validate(tx, execution_chain_params)?;
 
-    if tx.is_eip7702() {
-        match tx.authorization_list() {
-            Some(auth_list) => {
-                if auth_list.is_empty() {
-                    return Err(TransactionError::AuthorizationListEmpty);
-                }
-            }
-            None => return Err(TransactionError::AuthorizationListEmpty),
-        }
-    }
-
     Ok(())
 }
 


### PR DESCRIPTION
Cleanup: we already check 7702 authorization list length in `EthPragueForkValidation::validate` so we can remove this duplicated check.

Credits to Magnus for pointing this out