### PR TITLE
Fix waker usage

### DIFF
--- a/monad-statesync/src/lib.rs
+++ b/monad-statesync/src/lib.rs
@@ -272,7 +272,9 @@ where
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.deref_mut();
 
-        if this.waker.is_none() {
+        if let Some(waker) = this.waker.as_mut() {
+            waker.clone_from(cx.waker());
+        } else {
             this.waker = Some(cx.waker().clone());
         }
 

--- a/monad-updaters/src/loopback.rs
+++ b/monad-updaters/src/loopback.rs
@@ -81,11 +81,15 @@ where
         let this = self.deref_mut();
 
         if let Some(e) = this.buffer.pop_front() {
-            Poll::Ready(Some(e))
+            return Poll::Ready(Some(e));
+        }
+
+        if let Some(waker) = this.waker.as_mut() {
+            waker.clone_from(cx.waker());
         } else {
             this.waker = Some(cx.waker().clone());
-            Poll::Pending
         }
+        Poll::Pending
     }
 }
 

--- a/monad-updaters/src/statesync.rs
+++ b/monad-updaters/src/statesync.rs
@@ -91,9 +91,6 @@ where
 
     fn exec(&mut self, cmds: Vec<Self::Command>) {
         for cmd in cmds {
-            if let Some(waker) = self.waker.take() {
-                waker.wake();
-            }
             match cmd {
                 StateSyncCommand::StartExecution => {
                     assert!(!self.started_execution);
@@ -195,6 +192,12 @@ where
                 },
             }
         }
+
+        if self.ready() {
+            if let Some(waker) = self.waker.take() {
+                waker.wake();
+            }
+        }
     }
 
     fn metrics(&self) -> ExecutorMetricsChain<'_> {
@@ -258,7 +261,13 @@ where
         if let Some(event) = self.events.pop_front() {
             return Poll::Ready(Some(event));
         }
-        self.waker = Some(cx.waker().clone());
+
+        if let Some(waker) = self.waker.as_mut() {
+            waker.clone_from(cx.waker());
+        } else {
+            self.waker = Some(cx.waker().clone());
+        }
+
         Poll::Pending
     }
 }

--- a/monad-updaters/src/timer.rs
+++ b/monad-updaters/src/timer.rs
@@ -118,7 +118,12 @@ where
             };
         }
 
-        self.waker = Some(cx.waker().clone());
+        if let Some(waker) = this.waker.as_mut() {
+            waker.clone_from(cx.waker());
+        } else {
+            this.waker = Some(cx.waker().clone());
+        }
+
         Poll::Pending
     }
 }

--- a/monad-updaters/src/txpool.rs
+++ b/monad-updaters/src/txpool.rs
@@ -500,7 +500,12 @@ where
             return Poll::Ready(Some(MonadEvent::MempoolEvent(event)));
         }
 
-        self.waker = Some(cx.waker().clone());
+        if let Some(waker) = self.waker.as_mut() {
+            waker.clone_from(cx.waker());
+        } else {
+            self.waker = Some(cx.waker().clone());
+        }
+
         Poll::Pending
     }
 }

--- a/monad-updaters/src/val_set.rs
+++ b/monad-updaters/src/val_set.rs
@@ -148,17 +148,15 @@ where
     type Command = ValSetCommand;
 
     fn exec(&mut self, commands: Vec<Self::Command>) {
-        let mut wake = false;
-
         for command in commands {
             match command {
                 ValSetCommand::NotifyFinalized(seq_num) => {
                     self.jank_update_valset(seq_num);
-                    wake = true;
                 }
             }
         }
-        if wake {
+
+        if self.ready() {
             if let Some(waker) = self.waker.take() {
                 waker.wake()
             };
@@ -186,23 +184,19 @@ where
             return Poll::Pending;
         }
 
-        let event = if let Some(next_val_data) = this.next_val_data.take() {
-            Poll::Ready(Some(MonadEvent::ValidatorEvent(
+        if let Some(next_val_data) = this.next_val_data.take() {
+            return Poll::Ready(Some(MonadEvent::ValidatorEvent(
                 monad_executor_glue::ValidatorEvent::<SCT>::UpdateValidators(next_val_data),
-            )))
-        } else {
-            Poll::Pending
-        };
+            )));
+        }
 
-        if this.waker.is_none() {
+        if let Some(waker) = this.waker.as_mut() {
+            waker.clone_from(cx.waker());
+        } else {
             this.waker = Some(cx.waker().clone());
         }
 
-        if this.ready() {
-            this.waker.take().unwrap().wake();
-        }
-
-        event
+        Poll::Pending
     }
 }
 
@@ -319,17 +313,15 @@ where
     type Command = ValSetCommand;
 
     fn exec(&mut self, commands: Vec<Self::Command>) {
-        let mut wake = false;
-
         for command in commands {
             match command {
                 ValSetCommand::NotifyFinalized(seq_num) => {
                     self.jank_update_valset(seq_num);
-                    wake = true;
                 }
             }
         }
-        if wake {
+
+        if self.ready() {
             if let Some(waker) = self.waker.take() {
                 waker.wake()
             };
@@ -353,22 +345,18 @@ where
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.deref_mut();
 
-        let event = if let Some(next_val_data) = this.next_val_data.take() {
-            Poll::Ready(Some(MonadEvent::ValidatorEvent(
+        if let Some(next_val_data) = this.next_val_data.take() {
+            return Poll::Ready(Some(MonadEvent::ValidatorEvent(
                 monad_executor_glue::ValidatorEvent::<SCT>::UpdateValidators(next_val_data),
-            )))
-        } else {
-            Poll::Pending
-        };
+            )));
+        }
 
-        if this.waker.is_none() {
+        if let Some(waker) = this.waker.as_mut() {
+            waker.clone_from(cx.waker());
+        } else {
             this.waker = Some(cx.waker().clone());
         }
 
-        if this.ready() {
-            this.waker.take().unwrap().wake();
-        }
-
-        event
+        Poll::Pending
     }
 }


### PR DESCRIPTION
- use clone_from when updater has a waker in place
- wake up the task when relevant internal state changes

https://github.com/category-labs/category-internal/issues/1727
https://github.com/category-labs/monad-bft/issues/1940