### PR TITLE
Set txpool forwarding max byte limit to pool limit

### DIFF
--- a/monad-eth-txpool-executor/src/lib.rs
+++ b/monad-eth-txpool-executor/src/lib.rs
@@ -54,7 +54,7 @@ use self::{
     reset::EthTxPoolResetTrigger,
 };
 
-mod forward;
+pub mod forward;
 mod ipc;
 mod metrics;
 mod preload;
@@ -164,7 +164,7 @@ where
                         events_tx,
                         events,
 
-                        forwarding_manager: Box::pin(EthTxPoolForwardingManager::new()),
+                        forwarding_manager: Box::pin(EthTxPoolForwardingManager::default()),
                         preload_manager: Box::pin(EthTxPoolPreloadManager::default()),
                         promote_pending_timer,
 
@@ -566,7 +566,10 @@ where
             cx.waker().wake_by_ref();
         }
 
-        if let Poll::Ready(forward_txs) = forwarding_manager.as_mut().poll_egress(cx) {
+        if let Poll::Ready(forward_txs) = forwarding_manager
+            .as_mut()
+            .poll_egress(pool.current_revision().1.execution_chain_params(), cx)
+        {
             return Poll::Ready(Some(MonadEvent::MempoolEvent(MempoolEvent::ForwardTxs(
                 forward_txs,
             ))));

--- a/monad-eth-txpool/src/pool/mod.rs
+++ b/monad-eth-txpool/src/pool/mod.rs
@@ -117,6 +117,10 @@ where
             .expect("pool size does not overflow")
     }
 
+    pub fn current_revision(&self) -> (&CRT, &MonadExecutionRevision) {
+        (&self.chain_revision, &self.execution_revision)
+    }
+
     pub fn insert_txs(
         &mut self,
         event_tracker: &mut EthTxPoolEventTracker<'_>,


### PR DESCRIPTION
Previously, the `EGRESS_MAX_SIZE_BYTES` limit was soft in nature to allow a single large tx that exceeds the size limit to still get forwarded.

Since there is a tx limit checked in `ValidEthTransaction`, this change makes `EGRESS_MAX_SIZE_BYTES` a function of that max limit, raising the previous limit of 256KB to 384KB. Now, exceeding this limit will cause the tx to get dropped with a warn (as this would constitute a forwarding bug).

Resolves https://github.com/category-labs/category-internal/issues/1914.