### PR TITLE
RaptorCast: Modular packet assembly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5635,6 +5635,7 @@ dependencies = [
 name = "monad-raptorcast"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "alloy-rlp",
  "bitvec",
  "bytes",

--- a/monad-merkle/src/lib.rs
+++ b/monad-merkle/src/lib.rs
@@ -36,6 +36,7 @@ impl MerkleProof {
             siblings,
         })
     }
+
     pub fn compute_root(&self, leaf: &Hash) -> Option<MerkleHash> {
         let mut merkle_hash = hash_to_merkle(leaf);
         let mut current_idx = Some(self.tree_leaf_idx as usize);

--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 monad-testutil = { workspace = true }
+alloy-primitives = { workspace = true }
 
 clap = { workspace = true, features = ["derive"] }
 rstest = { workspace = true }
@@ -51,6 +52,10 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [[bench]]
 name = "raptor_bench"
+harness = false
+
+[[bench]]
+name = "encode_bench"
 harness = false
 
 [[example]]

--- a/monad-raptorcast/benches/encode_bench.rs
+++ b/monad-raptorcast/benches/encode_bench.rs
@@ -1,0 +1,160 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{collections::HashMap, net::SocketAddr, str::FromStr};
+
+use bytes::Bytes;
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use itertools::Itertools as _;
+use monad_crypto::certificate_signature::{CertificateSignature, CertificateSignaturePubKey};
+use monad_dataplane::udp::DEFAULT_SEGMENT_SIZE;
+use monad_raptorcast::{
+    packet, udp,
+    util::{BuildTarget, EpochValidators, Redundancy},
+};
+use monad_secp::SecpSignature;
+use monad_testutil::signing::get_key;
+use monad_types::{NodeId, Stake};
+
+const NUM_NODES: usize = 100;
+
+pub fn bench(c: &mut Criterion) {
+    bench_build_messages(c, "Raptorcast 128K", 128 * 1024, "raptorcast");
+    bench_build_messages(c, "Raptorcast 2M", 2 * 1024 * 1024, "raptorcast");
+
+    bench_build_messages(c, "Broadcast 128K", 128 * 1024, "broadcast");
+    // 2M broadcast yields more than 65535 packets, so we only
+    // benchmark for 128K.
+}
+
+pub fn bench_build_messages(c: &mut Criterion, name: &str, message_size: usize, target: &str) {
+    let message: Bytes = vec![123_u8; message_size].into();
+
+    let mut group = c.benchmark_group(name);
+
+    let (author, build_target, known_addrs) = match target {
+        "raptorcast" => {
+            group.throughput(Throughput::Bytes(message_size as u64));
+            setup_raptorcast()
+        }
+        "broadcast" => {
+            group.throughput(Throughput::Bytes((message_size * NUM_NODES) as u64));
+            setup_broadcast()
+        }
+        _ => panic!("unsupported target"),
+    };
+
+    group.bench_function("udp::build_messages", |b| {
+        b.iter(|| {
+            let _ = udp::build_messages(
+                &author,
+                DEFAULT_SEGMENT_SIZE, // segment_size
+                message.clone(),
+                Redundancy::from_u8(2),
+                0, // epoch_no
+                0, // unix_ts_ms
+                build_target.clone(),
+                &known_addrs,
+            );
+        });
+    });
+
+    group.bench_function("packet::build_messages", |b| {
+        b.iter(|| {
+            let _ = packet::build_messages(
+                &author,
+                DEFAULT_SEGMENT_SIZE, // segment_size
+                message.clone(),
+                Redundancy::from_u8(2),
+                0, // epoch_no
+                0, // unix_ts_ms
+                build_target.clone(),
+                &known_addrs,
+                &mut rand::thread_rng(),
+            );
+        });
+    });
+
+    group.finish();
+}
+
+type ST = SecpSignature;
+type PT = CertificateSignaturePubKey<ST>;
+type KeyPair = <ST as CertificateSignature>::KeyPairType;
+
+fn setup_raptorcast() -> (
+    KeyPair,
+    BuildTarget<'static, ST>,
+    HashMap<NodeId<PT>, SocketAddr>,
+) {
+    let mut keys = (0..(NUM_NODES as u64)).map(get_key::<ST>).collect_vec();
+
+    // leak the value to get a 'static reference
+    let validators = Box::leak(Box::new(EpochValidators {
+        validators: keys
+            .iter()
+            .map(|key| (NodeId::new(key.pubkey()), Stake::ONE))
+            .collect(),
+    }));
+
+    let addr = SocketAddr::from_str("127.0.0.1:9999").unwrap();
+    let known_addresses = keys
+        .iter()
+        .map(|key| (NodeId::new(key.pubkey()), addr))
+        .collect();
+
+    let author = keys.pop().unwrap();
+    let epoch_validators = validators.view_without(vec![&NodeId::new(author.pubkey())]);
+
+    (
+        author,
+        BuildTarget::Raptorcast(epoch_validators),
+        known_addresses,
+    )
+}
+
+fn setup_broadcast() -> (
+    KeyPair,
+    BuildTarget<'static, ST>,
+    HashMap<NodeId<PT>, SocketAddr>,
+) {
+    let mut keys = (0..100).map(get_key::<ST>).collect_vec();
+
+    // leak the value to get a 'static reference
+    let validators = Box::leak(Box::new(EpochValidators {
+        validators: keys
+            .iter()
+            .map(|key| (NodeId::new(key.pubkey()), Stake::ONE))
+            .collect(),
+    }));
+
+    let addr = SocketAddr::from_str("127.0.0.1:9999").unwrap();
+    let known_addresses = keys
+        .iter()
+        .map(|key| (NodeId::new(key.pubkey()), addr))
+        .collect();
+
+    let author = keys.pop().unwrap();
+    let epoch_validators = validators.view_without(vec![&NodeId::new(author.pubkey())]);
+
+    (
+        author,
+        BuildTarget::Broadcast(epoch_validators.into()),
+        known_addresses,
+    )
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/monad-raptorcast/src/decoding.rs
+++ b/monad-raptorcast/src/decoding.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #![allow(clippy::manual_range_contains)]
+#![allow(clippy::identity_op)]
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     hash::Hash,

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -66,6 +66,7 @@ use util::{
 pub mod config;
 pub mod decoding;
 pub mod message;
+pub mod packet;
 pub mod raptorcast_secondary;
 pub mod udp;
 pub mod util;

--- a/monad-raptorcast/src/packet/assembler.rs
+++ b/monad-raptorcast/src/packet/assembler.rs
@@ -1,0 +1,768 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#![allow(clippy::identity_op)]
+use std::{cell::OnceCell, net::SocketAddr, ops::Range, rc::Rc};
+
+use bytes::{Bytes, BytesMut};
+use monad_crypto::{
+    certificate_signature::{CertificateSignature, CertificateSignaturePubKey, PubKey},
+    hasher::{Hash, Hasher as _, HasherType},
+    signing_domain,
+};
+use monad_merkle::{MerkleHash, MerkleTree};
+use monad_raptor::Encoder;
+use monad_types::NodeId;
+
+use super::{
+    assigner::ChunkOrder, BuildError, ChunkAssigner, Collector, PeerAddrLookup, Result, UdpMessage,
+};
+use crate::{
+    message::MAX_MESSAGE_SIZE,
+    udp::{MAX_NUM_PACKETS, MAX_REDUNDANCY, MIN_CHUNK_LENGTH},
+    util::Redundancy,
+    SIGNATURE_SIZE,
+};
+
+#[derive(Default, Clone, Copy, PartialEq, Eq)]
+pub enum AssembleMode {
+    // Compatible with existing build_messages logic, does not support
+    // streaming per merkle batch
+    #[default]
+    GsoFull,
+
+    // Gso concatenated chunks only within a merkle batch.
+    GsoBestEffort,
+
+    // Each recipient gets its own packet in round-robin order.
+    RoundRobin,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn assemble<ST, CA, PL>(
+    key: &ST::KeyPairType,
+    // the size of each udp packet
+    segment_len: usize,
+    app_message: Bytes,
+    redundancy: Redundancy,
+    epoch: u64,
+    unix_ts_ms: u64,
+    broadcast_type: BroadcastType,
+    mode: AssembleMode,
+    peer_lookup: &PL,
+    assigner: &CA,
+    collector: &mut impl Collector<UdpMessage>,
+) -> Result<()>
+where
+    ST: CertificateSignature,
+    // ?Sized to allow for passing trait objects
+    CA: ChunkAssigner<CertificateSignaturePubKey<ST>> + ?Sized,
+    PL: PeerAddrLookup<CertificateSignaturePubKey<ST>>,
+{
+    let merkle_tree_depth = 6; // TODO: calculate the actual merkle tree depth
+
+    debug_assert!(segment_len > MIN_CHUNK_LENGTH);
+    debug_assert!(merkle_tree_depth > 0 && merkle_tree_depth <= 15);
+
+    // run sanity checks
+    match () {
+        _ if app_message.is_empty() => {
+            tracing::warn!("empty application message");
+            return Ok(());
+        }
+        _ if app_message.len() > MAX_MESSAGE_SIZE => {
+            return Err(BuildError::AppMessageTooLarge);
+        }
+        _ if redundancy > MAX_REDUNDANCY => {
+            return Err(BuildError::RedundancyTooHigh);
+        }
+        _ => { /* ok */ }
+    }
+
+    // step 1. calculate chunk layout
+    let layout = PacketLayout::new(segment_len, merkle_tree_depth);
+    let num_symbols = layout
+        .calc_num_symbols(app_message.len(), redundancy)
+        .ok_or(BuildError::TooManyChunks)?;
+
+    // step 2. generate chunks
+    let order = mode.expected_chunk_order();
+    let mut assignment = assigner.assign_chunks(num_symbols, order)?;
+    assignment.ensure_order(order);
+
+    match () {
+        _ if assignment.is_empty() => {
+            tracing::warn!(app_msg_len = ?app_message.len(), "no chunk generated");
+            return Ok(());
+        }
+        _ if assignment.total_chunks() > MAX_NUM_PACKETS => {
+            return Err(BuildError::TooManyChunks);
+        }
+        _ => { /* ok */ }
+    }
+
+    let mut chunks = assignment.generate(layout);
+
+    // step 3. encode and write raptor symbols to each chunk
+    if assignment.unique_chunk_id() {
+        encode_unique_symbols(&app_message, &mut chunks, layout)?;
+    } else {
+        encode_symbols(&app_message, &mut chunks, layout)?;
+    }
+
+    // step 4. build header (sans signature)
+    let header_buf = build_header(
+        0, // fixed version
+        broadcast_type,
+        merkle_tree_depth,
+        epoch,
+        unix_ts_ms,
+        &app_message,
+    )?;
+    debug_assert_eq!(header_buf.len(), layout.header_sans_signature_range().len());
+
+    // step 5. lookup recipient addresses
+    lookup_recipient_addrs(&chunks, peer_lookup);
+
+    if mode.stream_mode() {
+        for mut batch in owned_merkle_batches(chunks, layout) {
+            // step 6. sign and write headers for this merkle batch
+            let merkle_batch = MerkleBatch::from(&mut batch[..]);
+            merkle_batch.write_header::<ST>(layout, key, &header_buf)?;
+
+            // step 7. assemble udp messages
+            mode.assemble_udp_messages_into(collector, batch, layout);
+        }
+    } else {
+        // step 6. sign and write headers for this merkle batch
+        for batch in merkle_batches(&mut chunks, layout) {
+            batch.write_header::<ST>(layout, key, &header_buf)?;
+        }
+
+        // step 7. assemble udp messages
+        mode.assemble_udp_messages_into(collector, chunks, layout);
+    }
+
+    Ok(())
+}
+
+pub(crate) struct Chunk<PT: PubKey> {
+    chunk_id: usize,
+    recipient: Recipient<PT>,
+    payload: BytesMut,
+}
+
+impl<PT: PubKey> Chunk<PT> {
+    pub fn new(chunk_id: usize, recipient: Recipient<PT>, payload: BytesMut) -> Self {
+        Self {
+            chunk_id,
+            recipient,
+            payload,
+        }
+    }
+}
+
+// A cheaply cloned wrapper around a node_id with pre-calculated hash
+// and a lazy socket address.
+//
+// Change to Arc if we need parallel processing.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct Recipient<PT: PubKey>(Rc<RecipientInner<PT>>);
+
+impl<PT: PubKey> std::hash::Hash for Recipient<PT> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.node_hash.hash(state);
+    }
+}
+
+impl<PT: PubKey> std::fmt::Debug for Recipient<PT> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<node-{}>", &hex::encode(&self.0.node_hash[..6]))?;
+        if let Some(addr) = self.0.addr.get() {
+            if let Some(addr) = addr {
+                write!(f, "@{}", addr)?;
+            } else {
+                write!(f, "@<unknown>")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Eq)]
+struct RecipientInner<PT: PubKey> {
+    node_id: NodeId<PT>,
+    node_hash: [u8; 20],
+    addr: OnceCell<Option<SocketAddr>>,
+}
+
+impl<PT: PubKey> PartialEq for RecipientInner<PT> {
+    fn eq(&self, other: &Self) -> bool {
+        self.node_hash == other.node_hash
+    }
+}
+
+impl<PT: PubKey> Recipient<PT> {
+    pub fn new(node_id: NodeId<PT>) -> Self {
+        let node_hash = crate::util::compute_hash(&node_id).0;
+        let addr = OnceCell::new();
+        let inner = RecipientInner {
+            node_id,
+            node_hash,
+            addr,
+        };
+        Self(Rc::new(inner))
+    }
+
+    pub(super) fn node_hash(&self) -> &[u8; 20] {
+        &self.0.node_hash
+    }
+
+    // Expect `lookup` or `set_addr` performed earlier, otherwise panic.
+    pub(super) fn get_addr(&self) -> Option<SocketAddr> {
+        *self.0.addr.get().expect("get addr called before lookup")
+    }
+
+    fn lookup(&self, handle: &impl PeerAddrLookup<PT>) -> &Option<SocketAddr> {
+        self.0.addr.get_or_init(|| {
+            let addr = handle.lookup(&self.0.node_id);
+            if addr.is_none() {
+                tracing::warn!("raptorcast: unknown address for node {}", self.0.node_id);
+            }
+            addr
+        })
+    }
+}
+
+pub const HEADER_LEN: usize = 0
+    + SIGNATURE_SIZE // Sender signature (65 bytes)
+    + 2  // Version
+    + 1  // Broadcast bit, Secondary Broadcast bit, 2 unused bits, 4 bits for Merkle Tree Depth
+    + 8  // Epoch #
+    + 8  // Unix timestamp
+    + 20 // AppMessage hash
+    + 4; // AppMessage length
+
+pub const CHUNK_HEADER_LEN: usize = 0
+    + 20 // Chunk recipient hash
+    + 1  // Chunk's merkle leaf idx
+    + 1  // reserved
+    + 2; // Chunk idx
+
+// the size of individual merkle hash
+const MERKLE_HASH_LEN: usize = 20;
+
+#[derive(Clone, Copy)]
+pub(crate) struct PacketLayout {
+    chunk_header_start: usize,
+    segment_len: usize,
+}
+
+impl PacketLayout {
+    pub const fn new(segment_len: usize, merkle_tree_depth: u8) -> Self {
+        let merkle_hash_count = merkle_tree_depth as usize - 1;
+        let merkle_proof_len = merkle_hash_count * MERKLE_HASH_LEN;
+        let chunk_header_start = HEADER_LEN + merkle_proof_len;
+
+        Self {
+            chunk_header_start,
+            segment_len,
+        }
+    }
+
+    pub const fn calc_num_symbols(
+        &self,
+        app_message_len: usize,
+        redundancy: Redundancy,
+    ) -> Option<usize> {
+        let base_num_symbols = app_message_len.div_ceil(self.symbol_len());
+        redundancy.scale(base_num_symbols)
+    }
+
+    pub const fn signature_range(&self) -> Range<usize> {
+        0..SIGNATURE_SIZE
+    }
+
+    pub const fn header_sans_signature_range(&self) -> Range<usize> {
+        SIGNATURE_SIZE..HEADER_LEN
+    }
+
+    pub const fn merkle_proof_range(&self) -> Range<usize> {
+        HEADER_LEN..self.chunk_header_start
+    }
+
+    pub const fn merkle_hashed_range(&self) -> Range<usize> {
+        self.chunk_header_start..self.segment_len
+    }
+
+    pub const fn chunk_header_range(&self) -> Range<usize> {
+        self.chunk_header_start..(self.chunk_header_start + CHUNK_HEADER_LEN)
+    }
+
+    pub const fn symbol_range(&self) -> Range<usize> {
+        let symbol_start = self.chunk_header_start + CHUNK_HEADER_LEN;
+        symbol_start..self.segment_len
+    }
+
+    pub const fn symbol_len(&self) -> usize {
+        let symbol_start = self.chunk_header_start + CHUNK_HEADER_LEN;
+        self.segment_len - symbol_start
+    }
+
+    pub const fn segment_len(&self) -> usize {
+        self.segment_len
+    }
+
+    pub const fn merkle_tree_depth(&self) -> u8 {
+        let proof_len = self.chunk_header_start - HEADER_LEN;
+        debug_assert!(proof_len < u8::MAX as usize * MERKLE_HASH_LEN);
+        debug_assert!(proof_len % MERKLE_HASH_LEN == 0);
+        (proof_len / MERKLE_HASH_LEN) as u8 + 1
+    }
+
+    pub const fn merkle_batch_len(&self) -> usize {
+        2usize
+            .checked_pow((self.merkle_tree_depth() - 1) as u32)
+            .expect("merkle tree depth too large")
+    }
+}
+
+impl<PT: PubKey> Chunk<PT> {
+    fn chunk_hash(&self, layout: PacketLayout) -> Hash {
+        let mut hasher = HasherType::new();
+        hasher.update(&self.payload[layout.merkle_hashed_range()]);
+        hasher.hash()
+    }
+
+    fn symbol(&self, layout: PacketLayout) -> &[u8] {
+        &self.payload[layout.symbol_range()]
+    }
+
+    fn symbol_mut(&mut self, layout: PacketLayout) -> &mut [u8] {
+        &mut self.payload[layout.symbol_range()]
+    }
+
+    fn chunk_header_mut(&mut self, layout: PacketLayout) -> &mut [u8] {
+        &mut self.payload[layout.chunk_header_range()]
+    }
+
+    fn merkle_proof_mut(&mut self, layout: PacketLayout) -> &mut [u8] {
+        &mut self.payload[layout.merkle_proof_range()]
+    }
+
+    #[inline]
+    fn write_chunk_header(&mut self, layout: PacketLayout, merkle_leaf_index: u8) -> Result<()> {
+        let recipient_hash = *self.recipient.node_hash();
+        let chunk_id: [u8; 2] = u16::try_from(self.chunk_id)
+            .map_err(|_| BuildError::ChunkIdOverflow)?
+            .to_le_bytes();
+
+        let buffer = self.chunk_header_mut(layout);
+        debug_assert_eq!(buffer.len(), CHUNK_HEADER_LEN);
+
+        buffer[0..20].copy_from_slice(&recipient_hash); // node_id hash
+        buffer[20] = merkle_leaf_index;
+        // buffer[21] = 0; // reserved
+        buffer[22..24].copy_from_slice(&chunk_id);
+
+        Ok(())
+    }
+
+    fn write_merkle_proof(&mut self, layout: PacketLayout, proof: &[MerkleHash]) {
+        let buffer = &mut self.merkle_proof_mut(layout);
+        debug_assert_eq!(buffer.len() % MERKLE_HASH_LEN, 0);
+
+        for (idx, hash) in proof.iter().enumerate() {
+            let start = idx * MERKLE_HASH_LEN;
+            let end = (idx + 1) * MERKLE_HASH_LEN;
+            buffer[start..end].copy_from_slice(hash);
+        }
+    }
+
+    fn write_header(
+        &mut self,
+        layout: PacketLayout,
+        signature: &[u8; SIGNATURE_SIZE],
+        header: &Bytes,
+    ) {
+        self.payload[layout.signature_range()].copy_from_slice(signature);
+        self.payload[layout.header_sans_signature_range()].copy_from_slice(header);
+    }
+}
+
+pub(super) struct MerkleBatch<'a, PT: PubKey> {
+    chunks: &'a mut [Chunk<PT>],
+}
+
+pub(super) fn merkle_batches<PT: PubKey>(
+    all_chunks: &mut [Chunk<PT>],
+    layout: PacketLayout,
+) -> impl Iterator<Item = MerkleBatch<PT>> {
+    let batch_len = layout.merkle_batch_len();
+    debug_assert!(batch_len > 0);
+    all_chunks.chunks_mut(batch_len).map(MerkleBatch::from)
+}
+
+fn owned_merkle_batches<PT: PubKey>(
+    mut chunks: Vec<Chunk<PT>>,
+    layout: PacketLayout,
+) -> impl Iterator<Item = Vec<Chunk<PT>>> {
+    let batch_len = layout.merkle_batch_len();
+    debug_assert!(batch_len > 0);
+
+    std::iter::from_fn(move || {
+        if chunks.is_empty() {
+            return None;
+        }
+
+        // After split_off, `chunks` stores the merkle batch and
+        // `rest` stores the rest of the chunks. We take `chunks` out
+        // to get the merkle batch for returning and swap `rest` into
+        // `chunks` for next iteration.
+        let actual_batch_len = batch_len.min(chunks.len());
+        let rest = chunks.split_off(actual_batch_len);
+        let batch = std::mem::replace(&mut chunks, rest);
+
+        Some(batch)
+    })
+}
+
+impl<'a, 'b, PT: PubKey> From<&'b mut [Chunk<PT>]> for MerkleBatch<'a, PT>
+where
+    'b: 'a,
+{
+    fn from(chunks: &'b mut [Chunk<PT>]) -> Self {
+        Self { chunks }
+    }
+}
+
+impl<'a, PT: PubKey> MerkleBatch<'a, PT> {
+    fn write_header<ST>(
+        mut self,
+        layout: PacketLayout,
+        key: &ST::KeyPairType,
+        header: &Bytes,
+    ) -> Result<()>
+    where
+        ST: CertificateSignature,
+    {
+        // write chunk header and calculate chunk hash to build the
+        // merkle tree.
+        let merkle_tree = self.build_merkle_tree(layout)?;
+        let signature = self.sign::<ST>(key, header, merkle_tree.root());
+
+        for (leaf_index, chunk) in self.chunks.iter_mut().enumerate() {
+            // write signature and the rest of the header
+            chunk.write_header(layout, &signature, header);
+
+            // write merkle proof
+            let proof = merkle_tree.proof(leaf_index as u8);
+            chunk.write_merkle_proof(layout, proof.siblings());
+        }
+
+        Ok(())
+    }
+
+    fn build_merkle_tree(&mut self, layout: PacketLayout) -> Result<MerkleTree> {
+        let mut hashes = Vec::with_capacity(self.chunks.len());
+        let depth = layout.merkle_tree_depth();
+        debug_assert!(self.chunks.len() <= 2usize.pow((depth - 1) as u32));
+
+        for (leaf_index, chunk) in self.chunks.iter_mut().enumerate() {
+            let leaf_index = u8::try_from(leaf_index).map_err(|_| BuildError::MerkleTreeTooDeep)?;
+            chunk.write_chunk_header(layout, leaf_index)?;
+            hashes.push(chunk.chunk_hash(layout));
+        }
+
+        Ok(MerkleTree::new_with_depth(&hashes, depth))
+    }
+
+    fn sign<ST>(
+        &self,
+        key: &ST::KeyPairType,
+        header: &Bytes,
+        merkle_root: &[u8; MERKLE_HASH_LEN],
+    ) -> [u8; SIGNATURE_SIZE]
+    where
+        ST: CertificateSignature,
+    {
+        let mut buffer = BytesMut::with_capacity(header.len() + MERKLE_HASH_LEN);
+        buffer.extend_from_slice(header);
+        buffer.extend_from_slice(merkle_root);
+
+        let signature = ST::sign::<signing_domain::RaptorcastChunk>(&buffer, key);
+        let signature = CertificateSignature::serialize(&signature);
+        debug_assert_eq!(signature.len(), SIGNATURE_SIZE);
+        signature.try_into().expect("invalid signature size")
+    }
+}
+
+fn encode_unique_symbols<PT: PubKey>(
+    app_message: &[u8],
+    chunks: &mut [Chunk<PT>],
+    layout: PacketLayout,
+) -> Result<()> {
+    let symbol_len = layout.symbol_len();
+    let encoder =
+        Encoder::new(app_message, symbol_len).map_err(|_| BuildError::EncoderCreationFailed)?;
+    for chunk in chunks.iter_mut() {
+        let chunk_id = chunk.chunk_id;
+        let symbol_buffer = chunk.symbol_mut(layout);
+        encoder.encode_symbol(symbol_buffer, chunk_id);
+    }
+    Ok(())
+}
+
+fn encode_symbols<PT: PubKey>(
+    app_message: &[u8],
+    chunks: &mut [Chunk<PT>],
+    layout: PacketLayout,
+) -> Result<()> {
+    let symbol_len = layout.symbol_len();
+    let encoder =
+        Encoder::new(app_message, symbol_len).map_err(|_| BuildError::EncoderCreationFailed)?;
+
+    // A map from chunk_id to index to `chunks` slice. Stores the
+    // 1+index of the chunk of a given symbol.
+    //
+    // Over-allocated to avoid re-allocation on the premise that
+    // |chunks| >= max(chunk_id). Switch to a proper Map if the
+    // premise no longer holds.
+    let mut symbol_chunks = vec![0; chunks.len()];
+
+    for i in 0..chunks.len() {
+        let chunk_id = chunks[i].chunk_id;
+
+        debug_assert!(chunk_id < usize::MAX); // or 1+index will overflow.
+        debug_assert!(chunk_id < chunks.len()); // or symbol_chunks access is OOB.
+
+        match symbol_chunks[chunk_id] {
+            0 => {
+                // This is the first encounter of symbol `chunk_id`.
+                let symbol_buffer = chunks[i].symbol_mut(layout);
+                encoder.encode_symbol(symbol_buffer, chunk_id);
+                symbol_chunks[chunk_id] = i + 1;
+            }
+            j => {
+                // If the symbol has been encoded, reuse the result
+                // to avoid the (somewhat) expensive encoding again.
+                let [src_chunk, dst_chunk] = chunks
+                    .get_disjoint_mut([j - 1, i])
+                    .expect("the two chunk index never overlap");
+
+                let dst_buffer = dst_chunk.symbol_mut(layout);
+                let src_buffer = src_chunk.symbol(layout);
+                dst_buffer.copy_from_slice(src_buffer);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) enum BroadcastType {
+    Secondary,
+    Primary,
+    Unspecified,
+}
+
+// return the shared header for all chunks sans the signature.
+fn build_header(
+    version: u16,
+    broadcast_type: BroadcastType,
+    merkle_tree_depth: u8,
+    epoch_no: u64,
+    unix_ts_ms: u64,
+    app_message: &[u8],
+) -> Result<Bytes> {
+    // 2  // Version
+    // 1  // Broadcast bit
+    //       Secondary broadcast bit,
+    //       2 unused bits,
+    //       4 bits for Merkle Tree Depth
+    // 8  // Epoch #
+    // 8  // Unix timestamp
+    // 20 // AppMessage hash
+    // 4  // AppMessage length
+    let mut buffer = BytesMut::zeroed(HEADER_LEN - SIGNATURE_SIZE);
+    let cursor = &mut buffer;
+
+    let (cursor_version, cursor) = cursor.split_at_mut_checked(2).expect("header to short");
+    cursor_version.copy_from_slice(&version.to_le_bytes());
+
+    let (cursor_broadcast_merkle_depth, cursor) =
+        cursor.split_at_mut_checked(1).expect("header to short");
+    let mut broadcast_byte: u8 = match broadcast_type {
+        BroadcastType::Primary => 0b10 << 6,
+        BroadcastType::Secondary => 0b01 << 6,
+        BroadcastType::Unspecified => 0b00 << 6,
+    };
+    // tree_depth max 4 bits
+    if (merkle_tree_depth & 0b1111_0000) != 0 {
+        return Err(BuildError::MerkleTreeTooDeep);
+    }
+    broadcast_byte |= merkle_tree_depth & 0b0000_1111;
+    cursor_broadcast_merkle_depth[0] = broadcast_byte;
+
+    let (cursor_epoch_no, cursor) = cursor.split_at_mut_checked(8).expect("header too short");
+    cursor_epoch_no.copy_from_slice(&epoch_no.to_le_bytes());
+
+    let (cursor_unix_ts_ms, cursor) = cursor.split_at_mut_checked(8).expect("header too short");
+    cursor_unix_ts_ms.copy_from_slice(&unix_ts_ms.to_le_bytes());
+
+    let (cursor_app_message_hash, cursor) =
+        cursor.split_at_mut_checked(20).expect("header too short");
+    let app_message_hash = calc_full_hash(app_message);
+    cursor_app_message_hash.copy_from_slice(&app_message_hash[..20]);
+
+    let (cursor_app_message_len, cursor) =
+        cursor.split_at_mut_checked(4).expect("header too short");
+    let app_message_len: u32 = app_message
+        .len()
+        .try_into()
+        .map_err(|_| BuildError::AppMessageTooLarge)?;
+    cursor_app_message_len.copy_from_slice(&app_message_len.to_le_bytes());
+
+    // should have consumed the whole buffer
+    debug_assert_eq!(cursor.len(), 0);
+
+    Ok(buffer.freeze())
+}
+
+fn lookup_recipient_addrs<PT: PubKey, PL: PeerAddrLookup<PT>>(
+    chunks: &Vec<Chunk<PT>>,
+    handle: &PL,
+) {
+    for chunk in chunks {
+        chunk.recipient.lookup(handle);
+    }
+}
+
+fn calc_full_hash(bytes: &[u8]) -> Hash {
+    let mut hasher = HasherType::new();
+    hasher.update(bytes);
+    hasher.hash()
+}
+
+impl AssembleMode {
+    fn expected_chunk_order(self) -> Option<ChunkOrder> {
+        match self {
+            AssembleMode::GsoFull => Some(ChunkOrder::GsoFriendly),
+            AssembleMode::GsoBestEffort => None,
+            AssembleMode::RoundRobin => Some(ChunkOrder::RoundRobin),
+        }
+    }
+
+    fn stream_mode(self) -> bool {
+        match self {
+            AssembleMode::GsoFull => false,
+            AssembleMode::RoundRobin | AssembleMode::GsoBestEffort => true,
+        }
+    }
+
+    fn assemble_udp_messages_into<PT: PubKey>(
+        self,
+        collector: &mut impl Collector<UdpMessage>,
+        chunks: Vec<Chunk<PT>>,
+        layout: PacketLayout,
+    ) {
+        match self {
+            AssembleMode::GsoFull | AssembleMode::GsoBestEffort => {
+                Self::assemble_gso_udp_messages_into(collector, chunks, layout);
+            }
+            AssembleMode::RoundRobin => {
+                Self::assemble_standalone_udp_messages_into(collector, chunks, layout);
+            }
+        }
+    }
+
+    fn assemble_standalone_udp_messages_into<PT: PubKey>(
+        collector: &mut impl Collector<UdpMessage>,
+        chunks: Vec<Chunk<PT>>,
+        layout: PacketLayout,
+    ) {
+        collector.reserve(chunks.len());
+        for chunk in chunks {
+            let Some(dest) = chunk.recipient.get_addr() else {
+                continue;
+            };
+            collector.push(UdpMessage {
+                dest,
+                payload: chunk.payload.freeze(),
+                stride: layout.segment_len(),
+            });
+        }
+    }
+
+    fn assemble_gso_udp_messages_into<PT: PubKey>(
+        collector: &mut impl Collector<UdpMessage>,
+        chunks: Vec<Chunk<PT>>,
+        layout: PacketLayout,
+    ) {
+        struct AggregatedChunk {
+            dest: SocketAddr,
+            payload: BytesMut,
+        }
+
+        impl AggregatedChunk {
+            fn from_chunk<PT: PubKey>(chunk: Chunk<PT>, dest: SocketAddr) -> Self {
+                Self {
+                    dest,
+                    payload: chunk.payload,
+                }
+            }
+
+            fn into_udp_message(self, stride: usize) -> UdpMessage {
+                UdpMessage {
+                    dest: self.dest,
+                    payload: self.payload.freeze(),
+                    stride,
+                }
+            }
+        }
+
+        let stride = layout.segment_len();
+        let mut agg_chunk = None;
+
+        for chunk in chunks {
+            let Some(dest) = chunk.recipient.get_addr() else {
+                // skip chunks with unknown recipient
+                continue;
+            };
+
+            let Some(agg) = &mut agg_chunk else {
+                // first chunk, start a new aggregation
+                agg_chunk = Some(AggregatedChunk::from_chunk(chunk, dest));
+                continue;
+            };
+
+            if agg.dest == dest {
+                // same recipient, merge the payload BytesMut::unsplit
+                // is O(1) when the chunk payload are consecutive.
+                agg.payload.unsplit(chunk.payload);
+                continue;
+            }
+
+            // different recipient, flush the previous message
+            let next_agg = AggregatedChunk::from_chunk(chunk, dest);
+            let udp_msg = std::mem::replace(agg, next_agg).into_udp_message(stride);
+            collector.push(udp_msg);
+        }
+
+        if let Some(agg) = agg_chunk.take() {
+            collector.push(agg.into_udp_message(stride));
+        }
+    }
+}

--- a/monad-raptorcast/src/packet/assigner.rs
+++ b/monad-raptorcast/src/packet/assigner.rs
@@ -1,0 +1,725 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{collections::HashMap, ops::Range};
+
+use bytes::BytesMut;
+use monad_crypto::certificate_signature::PubKey;
+use monad_types::{NodeId, Stake};
+
+use super::{BuildError, Chunk, PacketLayout, Recipient, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChunkOrder {
+    // A roughly GSO-concatenation friendly ordering, such that each
+    // recipients' chunks are continuous
+    GsoFriendly,
+
+    // Each recipient receives chunks in round-robin order
+    RoundRobin,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChunkSlice<'a, PT: PubKey> {
+    recipient: &'a Recipient<PT>,
+    chunk_id_range: Range<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChunkAssignment<'a, PT: PubKey> {
+    // The number of chunks (=packets) to be generated
+    total_chunks: usize,
+    assignments: Vec<ChunkSlice<'a, PT>>,
+
+    // The following fields are hints for performance optimization
+    // purposes. Unspecified or inaccurate hints will not result in
+    // faulty chunk generation.
+
+    // the order of the chunk slices, used in reordering
+    order: Option<ChunkOrder>,
+
+    // used in reordering allocation
+    num_recipients: Option<usize>,
+
+    // used in reused symbol encoding optimization
+    unique_symbol_id: Option<bool>,
+}
+
+type NodeHash<'a> = &'a [u8; 20];
+
+impl<'a, PT: PubKey> ChunkAssignment<'a, PT> {
+    fn empty() -> Self {
+        Self {
+            total_chunks: 0,
+            assignments: Vec::new(),
+
+            num_recipients: None,
+            order: None,
+            unique_symbol_id: None,
+        }
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            total_chunks: 0,
+            assignments: Vec::with_capacity(capacity),
+
+            num_recipients: None,
+            order: None,
+            unique_symbol_id: None,
+        }
+    }
+
+    fn hint_num_recipients(&mut self, num_recipients: usize) {
+        self.num_recipients = Some(num_recipients);
+    }
+
+    fn hint_unique_symbol_id(&mut self, unique: bool) {
+        self.unique_symbol_id = Some(unique);
+    }
+
+    fn hint_order(&mut self, order: ChunkOrder) {
+        self.order = Some(order);
+    }
+
+    pub fn total_chunks(&self) -> usize {
+        self.total_chunks
+    }
+
+    // Return true if the generated chunk each has unique chunk id.
+    // Used to provide hint for optimized symbol encoding.
+    pub fn unique_chunk_id(&self) -> bool {
+        self.unique_symbol_id.unwrap_or(false)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_chunks == 0
+    }
+
+    fn push(&mut self, recipient: &'a Recipient<PT>, chunk_id_range: Range<usize>) {
+        let slice = ChunkSlice {
+            recipient,
+            chunk_id_range,
+        };
+        self.push_slice(slice);
+    }
+
+    fn push_slice(&mut self, slice: ChunkSlice<'a, PT>) {
+        if slice.chunk_id_range.is_empty() {
+            return;
+        }
+
+        self.total_chunks += slice.chunk_id_range.len();
+
+        // we expect no allocation to occur for performance reasons.
+        debug_assert!(self.assignments.len() < self.assignments.capacity());
+        self.assignments.push(slice);
+    }
+
+    pub fn ensure_order(&mut self, expected_order: Option<ChunkOrder>) {
+        let Some(expected_order) = expected_order else {
+            // no order specified, nothing to do.
+            return;
+        };
+
+        if self.order.is_some_and(|o| o == expected_order) {
+            // already in the expected order, nothing to do.
+            return;
+        }
+
+        if self.assignments.is_empty() {
+            // empty assignment is compatible with any ordering
+            self.order = Some(expected_order);
+            return;
+        }
+
+        match expected_order {
+            ChunkOrder::GsoFriendly => {
+                self.assignments = Self::reorder_to_gso(
+                    std::mem::take(&mut self.assignments),
+                    self.num_recipients,
+                );
+            }
+            ChunkOrder::RoundRobin => {
+                self.assignments = Self::reorder_to_round_robin(
+                    std::mem::take(&mut self.assignments),
+                    self.total_chunks,
+                    self.num_recipients,
+                );
+            }
+        }
+    }
+
+    // This method is best effort, as it may not always produce the
+    // optimal GSO grouping if the chunk slices's chunk range are not
+    // ordered.
+    fn reorder_to_gso(
+        chunk_slices: Vec<ChunkSlice<'a, PT>>,
+        hint_num_recipients: Option<usize>,
+    ) -> Vec<ChunkSlice<'a, PT>> {
+        use std::collections::hash_map::Entry;
+
+        let num_recipients = hint_num_recipients.unwrap_or(chunk_slices.len());
+        let mut messages: HashMap<NodeHash, (&'a Recipient<_>, Vec<Range<usize>>)> =
+            HashMap::with_capacity(num_recipients);
+
+        let mut out_slices_count = 0;
+
+        for chunk_slice in chunk_slices {
+            let recipient = chunk_slice.recipient;
+            let key = recipient.node_hash();
+
+            match messages.entry(key) {
+                Entry::Vacant(e) => {
+                    out_slices_count += 1;
+                    e.insert((recipient, vec![chunk_slice.chunk_id_range]));
+                }
+                Entry::Occupied(mut e) => {
+                    let (_recipient, ranges) = e.get_mut();
+                    let last = ranges.last_mut().expect("occupied entry never empty");
+                    if last.end + 1 == chunk_slice.chunk_id_range.start {
+                        last.end = chunk_slice.chunk_id_range.end;
+                        continue;
+                    }
+
+                    out_slices_count += 1;
+                    ranges.push(chunk_slice.chunk_id_range);
+                }
+            }
+        }
+
+        let mut reordered = Vec::with_capacity(out_slices_count);
+        for (recipient, ranges) in messages.into_values() {
+            for range in ranges {
+                reordered.push(ChunkSlice {
+                    recipient,
+                    chunk_id_range: range,
+                });
+            }
+        }
+        reordered
+    }
+
+    fn reorder_to_round_robin(
+        chunk_slices: Vec<ChunkSlice<'a, PT>>,
+        total_chunks: usize,
+        hint_num_recipients: Option<usize>,
+    ) -> Vec<ChunkSlice<'a, PT>> {
+        use std::collections::VecDeque;
+
+        let num_recipients = hint_num_recipients.unwrap_or(chunk_slices.len());
+        let mut buckets: HashMap<NodeHash, VecDeque<ChunkSlice<_>>> =
+            HashMap::with_capacity(num_recipients);
+
+        // Group by recipients
+        for slice in chunk_slices {
+            buckets
+                .entry(slice.recipient.node_hash())
+                .or_default()
+                .push_back(slice);
+        }
+
+        // Each recipient get their own queue of chunks.
+        let mut queues: Vec<VecDeque<ChunkSlice<_>>> = buckets.into_values().collect();
+
+        // Optimized algorithm:
+        //
+        // 1. go through each recipient's queue in order
+        // 2. if the queue is not empty, add the front chunk into the output
+        // 3. otherwise, delete the empty queue from the Vec of queues
+        // 4. repeat until there is no queue left
+        let mut output = Vec::with_capacity(total_chunks);
+
+        while !queues.is_empty() {
+            queues.retain_mut(|queue| {
+                let Some(front) = queue.front_mut() else {
+                    return false; // drop the empty queue
+                };
+
+                if front.chunk_id_range.is_empty() {
+                    queue.pop_front();
+                    return !queue.is_empty(); // drop queue if empty
+                }
+
+                let start = front.chunk_id_range.start;
+                let chunk_id_range = start..(start + 1);
+                front.chunk_id_range.start = start + 1;
+
+                output.push(ChunkSlice {
+                    recipient: front.recipient,
+                    chunk_id_range,
+                });
+
+                true // keep the non-empty queue
+            });
+        }
+
+        output
+    }
+
+    pub fn generate(&self, layout: PacketLayout) -> Vec<Chunk<PT>> {
+        let mut buffer = BytesMut::zeroed(self.total_chunks * layout.segment_len());
+        let mut all_chunks = Vec::with_capacity(self.total_chunks);
+
+        for slice in &self.assignments {
+            split_off_chunks_into(
+                &mut all_chunks,
+                &mut buffer,
+                slice.recipient,
+                slice.chunk_id_range.clone(),
+                layout.segment_len(),
+            );
+        }
+
+        debug_assert_eq!(all_chunks.len(), self.total_chunks);
+        debug_assert!(buffer.is_empty());
+
+        all_chunks
+    }
+
+    // Two assignments are equivalent if their normalized chunks are
+    // equal. Used in testing.
+    //
+    // Internally, it breaks down the underlying chunk slices into a
+    // single-chunk slices and sorted in a consistent order.
+    #[cfg(test)]
+    pub fn normalized_chunks(&self) -> Vec<ChunkSlice<'a, PT>> {
+        let mut slices = Vec::with_capacity(self.total_chunks);
+        for slice in &self.assignments {
+            for chunk_id in slice.chunk_id_range.clone() {
+                slices.push(ChunkSlice {
+                    recipient: slice.recipient,
+                    chunk_id_range: chunk_id..(chunk_id + 1),
+                })
+            }
+        }
+        slices.sort_unstable_by_key(|s| (s.chunk_id_range.start, s.recipient.node_hash()));
+        slices
+    }
+}
+
+pub(crate) struct Replicated<PT: PubKey> {
+    // each recipient receives all the same chunks, used by broadcast
+    // target and point-to-point target
+    recipients: Vec<Recipient<PT>>,
+}
+
+impl<PT: PubKey> Replicated<PT> {
+    pub fn from_unicast(node_id: NodeId<PT>) -> Self {
+        Self {
+            recipients: vec![Recipient::new(node_id)],
+        }
+    }
+
+    pub fn from_broadcast(recipients: Vec<NodeId<PT>>) -> Self {
+        Self {
+            recipients: recipients.into_iter().map(Recipient::new).collect(),
+        }
+    }
+}
+
+pub(crate) trait ChunkAssigner<PT: PubKey> {
+    fn assign_chunks(
+        &self,
+        num_symbols: usize,
+        preferred_order: Option<ChunkOrder>,
+    ) -> Result<ChunkAssignment<PT>>;
+}
+
+impl<PT: PubKey> ChunkAssigner<PT> for Replicated<PT> {
+    fn assign_chunks(
+        &self,
+        num_symbols: usize,
+        preferred_order: Option<ChunkOrder>,
+    ) -> Result<ChunkAssignment<PT>> {
+        if self.recipients.is_empty() {
+            tracing::warn!("no recipients specified for chunk assigner");
+            return Ok(ChunkAssignment::empty());
+        }
+
+        let total_chunks = num_symbols * self.recipients.len();
+        let mut assignment;
+
+        match preferred_order {
+            None | Some(ChunkOrder::GsoFriendly) => {
+                assignment = ChunkAssignment::with_capacity(self.recipients.len());
+                assignment.hint_order(ChunkOrder::GsoFriendly);
+                for recipient in &self.recipients {
+                    assignment.push(recipient, 0..num_symbols);
+                }
+            }
+            Some(ChunkOrder::RoundRobin) => {
+                assignment = ChunkAssignment::with_capacity(total_chunks);
+                assignment.hint_order(ChunkOrder::RoundRobin);
+                for chunk_id in 0..num_symbols {
+                    for recipient in &self.recipients {
+                        assignment.push(recipient, chunk_id..(chunk_id + 1));
+                    }
+                }
+            }
+        };
+
+        debug_assert_eq!(assignment.total_chunks(), total_chunks);
+        assignment.hint_num_recipients(self.recipients.len());
+        assignment.hint_unique_symbol_id(self.recipients.len() <= 1);
+        Ok(assignment)
+    }
+}
+
+pub(crate) struct Partitioned<PT: PubKey> {
+    weighted_nodes: Vec<(Recipient<PT>, Stake)>,
+    total_stake: Stake,
+}
+
+impl<PT: PubKey> Partitioned<PT> {
+    pub fn from_validator_set(validator_set: Vec<(NodeId<PT>, Stake)>) -> Self {
+        let mut total_stake = Stake::ZERO;
+        let weighted_nodes = validator_set
+            .into_iter()
+            .map(|(nid, stake)| {
+                total_stake += stake;
+                (Recipient::new(nid), stake)
+            })
+            .collect();
+
+        Self {
+            weighted_nodes,
+            total_stake,
+        }
+    }
+
+    pub fn from_homogeneous_peers(peers: Vec<NodeId<PT>>) -> Self {
+        let weighted_nodes: Vec<_> = peers
+            .into_iter()
+            .map(|p| (Recipient::new(p), Stake::ONE))
+            .collect();
+        let total_stake = Stake::from(weighted_nodes.len() as u64);
+        Self {
+            weighted_nodes,
+            total_stake,
+        }
+    }
+
+    fn assign_gso(&self, num_symbols: usize) -> ChunkAssignment<PT> {
+        let num_nodes = self.weighted_nodes.len();
+        let mut assignment = ChunkAssignment::with_capacity(num_nodes);
+        assignment.hint_order(ChunkOrder::GsoFriendly);
+        assignment.hint_num_recipients(num_nodes);
+        assignment.hint_unique_symbol_id(true);
+
+        let mut running_stake = Stake::ZERO;
+        for (recipient, stake) in &self.weighted_nodes {
+            let start_id = (num_symbols as f64 * (running_stake / self.total_stake)) as usize;
+            running_stake += *stake;
+            let end_id = (num_symbols as f64 * (running_stake / self.total_stake)) as usize;
+            assignment.push(recipient, start_id..end_id);
+        }
+
+        assignment
+    }
+}
+
+impl<PT: PubKey> ChunkAssigner<PT> for Partitioned<PT> {
+    fn assign_chunks(
+        &self,
+        num_symbols: usize,
+        _preferred_order: Option<ChunkOrder>,
+    ) -> Result<ChunkAssignment<PT>> {
+        if self.weighted_nodes.is_empty() {
+            tracing::warn!("no nodes specified for partitioned chunk assigner");
+            return Ok(ChunkAssignment::empty());
+        }
+        if self.total_stake == Stake::ZERO {
+            return Err(BuildError::ZeroTotalStake);
+        }
+
+        Ok(self.assign_gso(num_symbols))
+    }
+}
+
+// each validator gets an additional rounding chunk
+pub(crate) struct StakeBasedWithRC<PT: PubKey> {
+    validator_set: Vec<(Recipient<PT>, Stake)>,
+    total_stake: Stake,
+}
+
+impl<PT: PubKey> StakeBasedWithRC<PT> {
+    #[cfg_attr(not(test), expect(unused))]
+    pub fn from_validator_set(validator_set: Vec<(NodeId<PT>, Stake)>) -> Self {
+        let mut total_stake = Stake::ZERO;
+        let validator_set = validator_set
+            .into_iter()
+            .map(|(nid, stake)| {
+                total_stake += stake;
+                (Recipient::new(nid), stake)
+            })
+            .collect();
+        Self {
+            validator_set,
+            total_stake,
+        }
+    }
+}
+
+impl<PT: PubKey> ChunkAssigner<PT> for StakeBasedWithRC<PT> {
+    fn assign_chunks(
+        &self,
+        num_symbols: usize,
+        _preferred_order: Option<ChunkOrder>,
+    ) -> Result<ChunkAssignment<PT>> {
+        if self.validator_set.is_empty() {
+            tracing::warn!("no nodes specified for partitioned chunk assigner");
+            return Ok(ChunkAssignment::empty());
+        }
+        if self.total_stake == Stake::ZERO {
+            return Err(BuildError::ZeroTotalStake);
+        }
+
+        let num_validators = self.validator_set.len();
+        let obligations = self
+            .validator_set
+            .iter()
+            .map(|(_, s)| num_symbols as f64 * (*s / self.total_stake));
+
+        let mut ic = vec![0usize; num_validators];
+        let mut rc = vec![false; num_validators];
+
+        for (i, o) in obligations.enumerate() {
+            ic[i] = o as usize; // ic := floor(o)
+            rc[i] = o.fract() > 0.0; // rc := ceil(o - floor(o))
+        }
+
+        let mut assignment = ChunkAssignment::with_capacity(num_validators * 2);
+        assignment.hint_order(ChunkOrder::GsoFriendly);
+        assignment.hint_num_recipients(num_validators);
+        assignment.hint_unique_symbol_id(true);
+
+        let mut curr_chunk_id = 0;
+        for (i, (recipient, _stake)) in self.validator_set.iter().enumerate() {
+            let next_chunk_id = curr_chunk_id + ic[i] + rc[i] as usize;
+            assignment.push(recipient, curr_chunk_id..next_chunk_id);
+            curr_chunk_id = next_chunk_id;
+        }
+
+        Ok(assignment)
+    }
+}
+
+fn split_off_chunks_into<PT: PubKey>(
+    output: &mut Vec<Chunk<PT>>,
+    buffer: &mut BytesMut,
+    recipient: &Recipient<PT>,
+    chunk_ids: Range<usize>,
+    segment_len: usize,
+) {
+    debug_assert!(
+        buffer.len() >= segment_len * chunk_ids.len(),
+        "insufficient buffer space"
+    );
+
+    for chunk_id in chunk_ids {
+        let segment = buffer.split_to(segment_len);
+        let chunk = Chunk::new(chunk_id, recipient.clone(), segment);
+        output.push(chunk);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, ops::Range};
+
+    use alloy_primitives::U256;
+    use itertools::Itertools as _;
+    use monad_crypto::certificate_signature::CertificateSignaturePubKey;
+    use monad_secp::SecpSignature;
+    use monad_testutil::signing::get_key;
+    use monad_types::{NodeId, Stake};
+    use rand::{seq::SliceRandom, Rng as _};
+
+    use super::{ChunkAssignment, ChunkOrder, Partitioned, StakeBasedWithRC};
+    use crate::{
+        packet::{assigner::Replicated, ChunkAssigner as _, PacketLayout, Recipient},
+        util::Redundancy,
+    };
+
+    const DEFAULT_SEGMENT_LEN: usize = 1400;
+    const DEFAULT_MERKLE_TREE_DEPTH: u8 = 6;
+    const DEFAULT_LAYOUT: PacketLayout =
+        PacketLayout::new(DEFAULT_SEGMENT_LEN, DEFAULT_MERKLE_TREE_DEPTH);
+    const DEFAULT_SYMBOL_LEN: usize = DEFAULT_LAYOUT.symbol_len();
+
+    type ST = SecpSignature;
+    type PT = CertificateSignaturePubKey<ST>;
+
+    type NodeNum = u64;
+    fn node_id(seed: NodeNum) -> NodeId<PT> {
+        let key_pair = get_key::<ST>(seed);
+        NodeId::new(key_pair.pubkey())
+    }
+
+    struct StaticAssigner {
+        slices: Vec<(Recipient<PT>, Range<usize>)>,
+    }
+
+    impl StaticAssigner {
+        fn from_template(slices: &[(NodeNum, Range<usize>)]) -> Self {
+            let recipients: HashMap<NodeNum, Recipient<_>> = slices
+                .iter()
+                .map(|(n, _)| n)
+                .unique()
+                .map(|n| (*n, Recipient::new(node_id(*n))))
+                .collect();
+            let slices = slices
+                .iter()
+                .map(|(n, range)| (recipients[n].clone(), range.clone()))
+                .collect();
+            Self { slices }
+        }
+
+        fn assign_chunks(&self) -> ChunkAssignment<PT> {
+            let mut assignment = ChunkAssignment::with_capacity(self.slices.len());
+            for slice in &self.slices {
+                assignment.push(&slice.0, slice.1.clone());
+            }
+            assignment
+        }
+    }
+
+    fn rand_validator_set(rng: &mut impl rand::Rng, max_n: usize) -> Vec<(NodeId<PT>, Stake)> {
+        let n: usize = rng.gen_range(1..max_n);
+        let mut validator_set = Vec::with_capacity(n);
+        loop {
+            let mut total_stake = Stake::ZERO;
+
+            for i in 1..=n {
+                // divide by n to ensure the sum never overflows.
+                let stake = Stake::from(rng.gen::<U256>() / U256::from(n));
+                // NOTE: we don't forbid individual stake to be zero,
+                // as long as total stake is non-zero. we do this to
+                // test the robustness of assignment algorithm.
+                total_stake += stake;
+                validator_set.push((node_id(i as u64), stake));
+            }
+
+            if total_stake != Stake::ZERO {
+                break;
+            }
+        }
+
+        validator_set.shuffle(rng);
+        validator_set
+    }
+
+    fn rand_node_set(rng: &mut impl rand::Rng, max_n: usize) -> Vec<NodeId<PT>> {
+        let n: usize = rng.gen_range(1..max_n);
+        let mut node_set = Vec::with_capacity(n);
+
+        for i in 1..=n {
+            node_set.push(node_id(i as u64));
+        }
+
+        node_set.shuffle(rng);
+        node_set
+    }
+
+    #[test]
+    fn test_replicated_assignment() {
+        let rng = &mut rand::thread_rng();
+
+        for _ in 0..1000 {
+            let node_set = rand_node_set(rng, 2000);
+            let assigner = Replicated::from_broadcast(node_set);
+            let num_symbols = rng.gen_range(0..10);
+
+            let assignment_1 = assigner
+                .assign_chunks(num_symbols, Some(ChunkOrder::GsoFriendly))
+                .expect("should assign successfully");
+            let assignment_2 = assigner
+                .assign_chunks(num_symbols, Some(ChunkOrder::RoundRobin))
+                .expect("should assign successfully");
+
+            assert_eq!(
+                assignment_1.normalized_chunks(),
+                assignment_2.normalized_chunks()
+            );
+        }
+    }
+
+    #[test]
+    fn test_partitioned_assignment() {
+        let rng = &mut rand::thread_rng();
+
+        for _ in 0..300 {
+            let validator_set = rand_validator_set(rng, 2000);
+            let assigner = Partitioned::from_validator_set(validator_set);
+            let num_symbols = rng.gen_range(0..1000);
+
+            let assignment_1 = assigner
+                .assign_chunks(num_symbols, Some(ChunkOrder::GsoFriendly))
+                .expect("should assign successfully");
+            let assignment_2 = assigner
+                .assign_chunks(num_symbols, Some(ChunkOrder::RoundRobin))
+                .expect("should assign successfully");
+
+            assert_eq!(
+                assignment_1.normalized_chunks(),
+                assignment_2.normalized_chunks()
+            );
+        }
+    }
+
+    #[test]
+    fn test_stake_with_rc() {
+        // test the numerical stability of stakes on different scales
+        for scale in [
+            U256::from(1),
+            U256::from(u64::MAX),
+            U256::MAX / U256::from(16),
+        ] {
+            // c_h = 20
+            let message_len = DEFAULT_SYMBOL_LEN * 10;
+            let redundancy = Redundancy::from_u8(2);
+
+            // total stake = 16*scale
+            let validator_set = vec![
+                // get floor(1/16*20) chunks + 1 rounding chunk (total: 2)
+                (node_id(1), Stake::from(U256::from(1) * scale)),
+                // get floor(4/16*20) chunks (total: 5)
+                (node_id(2), Stake::from(U256::from(4) * scale)),
+                // get floor(5/16*20) chunks + 1 rounding chunk (total: 7)
+                (node_id(3), Stake::from(U256::from(5) * scale)),
+                // get floor(6/16*20) chunks + 1 rounding chunk (total: 8)
+                (node_id(4), Stake::from(U256::from(6) * scale)),
+            ];
+
+            let num_symbols = DEFAULT_LAYOUT
+                .calc_num_symbols(message_len, redundancy)
+                .expect("should not overflow");
+            let assigner = StakeBasedWithRC::from_validator_set(validator_set);
+            let assignment = assigner
+                .assign_chunks(num_symbols, None)
+                .expect("should assign successfully");
+
+            let expected_assigner =
+                StaticAssigner::from_template(&[(1, 0..2), (2, 2..7), (3, 7..14), (4, 14..22)]);
+            let expected_assignment = expected_assigner.assign_chunks();
+
+            assert_eq!(
+                assignment.normalized_chunks(),
+                expected_assignment.normalized_chunks()
+            );
+        }
+    }
+}

--- a/monad-raptorcast/src/packet/mod.rs
+++ b/monad-raptorcast/src/packet/mod.rs
@@ -1,0 +1,417 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+mod assembler;
+mod assigner;
+
+use std::{collections::HashMap, net::SocketAddr};
+
+use assembler::AssembleMode;
+use bytes::Bytes;
+use monad_crypto::certificate_signature::{
+    CertificateKeyPair as _, CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
+};
+use monad_types::NodeId;
+use rand::seq::SliceRandom as _;
+
+pub(crate) use self::{
+    assembler::{assemble, BroadcastType, Chunk, PacketLayout, Recipient},
+    assigner::ChunkAssigner,
+};
+use crate::util::{BuildTarget, Redundancy};
+
+#[derive(Debug)]
+pub struct UdpMessage {
+    pub dest: SocketAddr,
+    pub payload: Bytes,
+    pub stride: usize,
+}
+
+#[derive(Debug)]
+pub enum BuildError {
+    // merkle tree depth does not fit in u4
+    MerkleTreeTooDeep,
+    // chunk id does not fit in u16
+    ChunkIdOverflow,
+    // failed to create encoder
+    EncoderCreationFailed,
+    // too many chunks
+    TooManyChunks,
+    // app message is too large
+    AppMessageTooLarge,
+    // total stake is zero
+    ZeroTotalStake,
+    // redundancy is too high
+    RedundancyTooHigh,
+}
+
+pub(crate) trait PeerAddrLookup<PT: PubKey> {
+    fn lookup(&self, node_id: &NodeId<PT>) -> Option<SocketAddr>;
+}
+
+// Similar to std::iter::Extend trait but implemented for FnMut as
+// well.
+pub(crate) trait Collector<T> {
+    fn push(&mut self, item: T);
+    fn reserve(&mut self, _additional: usize) {}
+}
+
+type Result<A, E = BuildError> = std::result::Result<A, E>;
+
+// A compatible interface to crate::udp::build_messages that uses
+// packet::assemble underneath.
+#[allow(clippy::too_many_arguments)]
+pub fn build_messages<ST>(
+    key: &ST::KeyPairType,
+    segment_size: u16,
+    app_message: Bytes,
+    redundancy: Redundancy,
+    epoch_no: u64,
+    unix_ts_ms: u64,
+    build_target: BuildTarget<ST>,
+    known_addresses: &HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddr>,
+    rng: &mut impl rand::Rng,
+) -> Vec<(SocketAddr, Bytes)>
+where
+    ST: CertificateSignatureRecoverable,
+{
+    use self::assigner::{Partitioned, Replicated};
+
+    let broadcast_type = match build_target {
+        BuildTarget::Raptorcast { .. } => BroadcastType::Primary,
+        BuildTarget::FullNodeRaptorCast { .. } => BroadcastType::Secondary,
+        _ => BroadcastType::Unspecified,
+    };
+    let peer_lookup = known_addresses;
+
+    let assigner: Box<dyn ChunkAssigner<_>> = match build_target {
+        BuildTarget::PointToPoint(to) => Box::new(Replicated::from_unicast(*to)),
+        BuildTarget::Broadcast(ref nodes_view) => Box::new(Replicated::from_broadcast(
+            nodes_view.iter().copied().collect(),
+        )),
+        BuildTarget::Raptorcast(ref validators_view) => {
+            let mut validator_set: Vec<_> = validators_view
+                .iter()
+                .map(|(node_id, stake)| (*node_id, stake))
+                .collect();
+            validator_set.shuffle(rng);
+            Box::new(Partitioned::from_validator_set(validator_set))
+        }
+        BuildTarget::FullNodeRaptorCast(group) => {
+            let self_id = NodeId::new(key.pubkey());
+            let seed = rng.gen::<usize>();
+            let nodes = group
+                .iter_skip_self_and_author(&self_id, seed)
+                .copied()
+                .collect();
+            Box::new(Partitioned::from_homogeneous_peers(nodes))
+        }
+    };
+
+    let app_message_len = app_message.len();
+    let mut packets = Vec::new();
+    let result = assemble::<ST, _, _>(
+        key,
+        segment_size as usize,
+        app_message,
+        redundancy,
+        epoch_no,
+        unix_ts_ms,
+        broadcast_type,
+        AssembleMode::GsoFull,
+        peer_lookup,
+        &*assigner,
+        &mut packets,
+    );
+
+    let packets = match result {
+        Ok(()) => packets,
+        Err(BuildError::TooManyChunks) => {
+            tracing::error!(
+                ?app_message_len,
+                ?redundancy,
+                ?build_target,
+                "Too many chunks generated."
+            );
+            return vec![];
+        }
+        Err(BuildError::AppMessageTooLarge) => {
+            tracing::error!(?app_message_len, "App message too large");
+            return vec![];
+        }
+        Err(BuildError::ZeroTotalStake) => {
+            tracing::error!(?build_target, "Total stake is zero");
+            return vec![];
+        }
+        Err(BuildError::RedundancyTooHigh) => {
+            tracing::error!(?redundancy, ?build_target, "Redundancy too high");
+            return vec![];
+        }
+        Err(e) => {
+            tracing::error!("Failed to build packets: {:?}", e);
+            return vec![];
+        }
+    };
+
+    packets
+        .into_iter()
+        .map(|msg| (msg.dest, msg.payload))
+        .collect()
+}
+
+impl<PT: PubKey> PeerAddrLookup<PT> for HashMap<NodeId<PT>, SocketAddr> {
+    fn lookup(&self, node_id: &NodeId<PT>) -> Option<SocketAddr> {
+        self.get(node_id).copied()
+    }
+}
+
+impl<T> Collector<T> for Vec<T> {
+    fn push(&mut self, item: T) {
+        Vec::push(self, item)
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        Vec::reserve(self, additional)
+    }
+}
+
+impl<F, T> Collector<T> for F
+where
+    F: FnMut(T),
+{
+    fn push(&mut self, item: T) {
+        self(item)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use bytes::{Bytes, BytesMut};
+    use monad_crypto::certificate_signature::CertificateSignature;
+    use monad_secp::SecpSignature;
+    use monad_testutil::signing::get_key;
+    use monad_types::{Round, RoundSpan, Stake};
+    use rand::{rngs::StdRng, seq::IteratorRandom as _, Rng as _, RngCore as _, SeedableRng as _};
+
+    use super::{
+        assembler::{CHUNK_HEADER_LEN, HEADER_LEN},
+        build_messages as build_new, *,
+    };
+    use crate::{
+        udp::build_messages_with_rng as build_old,
+        util::{EpochValidators, Group},
+        SIGNATURE_SIZE,
+    };
+
+    const DEFAULT_SEGMENT_LEN: usize = 1400;
+    const DEFAULT_PROOF_LEN: usize = 100; // 5 * 20
+    const DEFAULT_DATA_LEN: usize =
+        DEFAULT_SEGMENT_LEN - HEADER_LEN - CHUNK_HEADER_LEN - DEFAULT_PROOF_LEN;
+
+    const EPOCH: u64 = 5;
+    const UNIX_TS_MS: u64 = 5;
+
+    type ST = SecpSignature;
+    type PT = CertificateSignaturePubKey<ST>;
+
+    fn key_pair(seed: u64) -> <ST as CertificateSignature>::KeyPairType {
+        get_key::<ST>(seed)
+    }
+
+    fn node_id(seed: u64) -> NodeId<PT> {
+        let key_pair = get_key::<ST>(seed);
+        NodeId::new(key_pair.pubkey())
+    }
+
+    #[test]
+    fn test_compatibility() {
+        let rng = &mut rand::thread_rng();
+
+        let node_addr = |i: u64| {
+            SocketAddr::from((
+                ((i & 0xffffffff0000 >> 16) as u32).to_le_bytes(),
+                (i & 0xffff) as u16,
+            ))
+        };
+        let rand_stake = || Stake::from(rand::thread_rng().gen_range(1..1000000u64));
+        let rand_validators = |n: usize| EpochValidators {
+            validators: (1..n).map(|i| (node_id(i as u64), rand_stake())).collect(),
+        };
+        let known_addresses = (1..5).map(|i| (node_id(i), node_addr(i))).collect();
+
+        for num_pkts in [0, 1, 100, 2000] {
+            let mut trail_lens = (2..(DEFAULT_SEGMENT_LEN - 1)).choose_multiple(rng, 10);
+            // always test for these boundary cases.
+            trail_lens.push(0);
+            trail_lens.push(1);
+            trail_lens.push(DEFAULT_DATA_LEN - 1);
+            trail_lens.push(DEFAULT_DATA_LEN);
+            trail_lens.push(DEFAULT_DATA_LEN + 1);
+            trail_lens.push(DEFAULT_SEGMENT_LEN - 1);
+            trail_lens.push(DEFAULT_SEGMENT_LEN);
+            trail_lens.push(DEFAULT_SEGMENT_LEN + 1);
+
+            for trail_len in trail_lens {
+                for redundancy in [1.0, 1.3, 3.0, 7.0] {
+                    let app_msg_len = DEFAULT_SEGMENT_LEN * num_pkts + trail_len;
+                    let mut app_msg = BytesMut::zeroed(app_msg_len);
+                    rng.fill_bytes(&mut app_msg);
+                    let app_msg = app_msg.freeze();
+
+                    // validator #5 and up will have no known addresses
+                    let num_validators = rng.gen_range(2..8);
+                    let validators = rand_validators(num_validators);
+                    let self_id = (1..(num_validators + 1)).choose(rng).unwrap() as u64;
+                    let self_node_id = node_id(self_id);
+                    let self_key = key_pair(self_id);
+
+                    let assert_compatible = |target| {
+                        assert_build_compatible(
+                            &self_key,
+                            &app_msg,
+                            redundancy,
+                            &target,
+                            &known_addresses,
+                        )
+                    };
+
+                    {
+                        let epoch_validators = validators.view_without(vec![&self_node_id]);
+                        let build_target = BuildTarget::Raptorcast(epoch_validators);
+                        assert_compatible(build_target);
+                    }
+
+                    // skip broadcast cases that are too slow to test on ci
+                    if num_pkts < 30 && redundancy < 3.0 {
+                        let epoch_validators = validators.view_without(vec![&self_node_id]);
+                        let build_target = BuildTarget::Broadcast(epoch_validators.into());
+                        assert_compatible(build_target);
+                    }
+
+                    for node in validators.validators.keys() {
+                        let build_target = BuildTarget::PointToPoint(node);
+                        assert_compatible(build_target);
+                    }
+
+                    {
+                        // we pretend the validators form a fullnode group
+                        let group = Group::new_fullnode_group(
+                            validators.validators.keys().cloned().collect(),
+                            &self_node_id,
+                            self_node_id,
+                            RoundSpan::single(Round(1)).unwrap(),
+                        );
+                        let build_target = BuildTarget::FullNodeRaptorCast(&group);
+                        assert_compatible(build_target);
+                    }
+                }
+            }
+        }
+    }
+
+    fn assert_build_compatible(
+        key: &<ST as CertificateSignature>::KeyPairType,
+        app_msg: &Bytes,
+        redundancy: f32,
+        build_target: &BuildTarget<ST>,
+        known_addresses: &HashMap<NodeId<PT>, SocketAddr>,
+    ) {
+        let make_rng = || StdRng::seed_from_u64(42);
+        let redundancy = Redundancy::from_f32(redundancy).expect("bad redundancy");
+
+        let new = build_new(
+            key,
+            DEFAULT_SEGMENT_LEN as u16,
+            app_msg.clone(),
+            redundancy,
+            EPOCH,
+            UNIX_TS_MS,
+            build_target.clone(),
+            known_addresses,
+            &mut make_rng(),
+        );
+
+        let old = build_old(
+            key,
+            DEFAULT_SEGMENT_LEN as u16,
+            app_msg.clone(),
+            redundancy,
+            EPOCH,
+            UNIX_TS_MS,
+            build_target.clone(),
+            known_addresses,
+            &mut make_rng(),
+        );
+
+        assert_compatible_eq(&old, &new);
+    }
+
+    type Packets = Vec<(SocketAddr, Bytes)>;
+
+    // We loosen up two constraints for comparing the output from old
+    // and new implementations:
+    //
+    // 1. we allow the packets to be reordered (new implementation
+    // uses a HashMap when assembling packets, which scrambles the
+    // order.)
+    //
+    // 2. we allow the signature to differ because the signature is
+    // non-deterministic.
+    fn normalize(packets: &Packets) -> Packets {
+        let mut normalized_packets = BTreeSet::new();
+        for (addr, payload) in packets {
+            let payload_without_signature = payload.slice(SIGNATURE_SIZE..);
+            normalized_packets.insert((*addr, payload_without_signature));
+        }
+
+        normalized_packets.into_iter().collect()
+    }
+
+    #[allow(unreachable_code)]
+    fn assert_compatible_eq(expected: &Packets, actual: &Packets) {
+        assert_eq!(expected.len(), actual.len());
+
+        // Set the environment variable to show detailed difference in
+        // packet bytes.
+        let (expected, actual) = (normalize(expected), normalize(actual));
+        if option_env!("SCRUTINIZE_PACKET") != Some("1") {
+            assert_eq!(expected, actual);
+            return;
+        }
+
+        for ((e_addr, e_payload), (a_addr, a_payload)) in expected.iter().zip(actual.iter()) {
+            // The recipient's socket address is the same.
+            if e_addr != a_addr {
+                println!("{:?} {:?}", e_addr, a_addr);
+                println!("{:?}\n-----\n{:?}", e_payload, a_payload);
+                assert_eq!(e_addr, a_addr);
+            }
+
+            // The signatures are different even when signing the same
+            // message with the same key.
+            assert_eq!(e_payload.len(), a_payload.len());
+
+            for (i, (be, ba)) in e_payload.iter().zip(a_payload.iter()).enumerate() {
+                assert_eq!(
+                    be, ba,
+                    "payloads differ at byte {}: 0x{:02x} != 0x{:02x}",
+                    i, be, ba
+                );
+            }
+        }
+    }
+}

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -721,11 +721,13 @@ impl Redundancy {
         self.0.to_num()
     }
 
-    pub fn scale(&self, base: usize) -> Option<usize> {
+    pub const fn scale(&self, base: usize) -> Option<usize> {
         if base > Self::MAX_MULTIPLIER {
             return None;
         }
-        let scaled = (self.0.to_bits() as usize).checked_mul(base)?;
+        let Some(scaled) = (self.0.to_bits() as usize).checked_mul(base) else {
+            return None;
+        };
         Some(scaled.div_ceil(1 << Self::FRAC_BITS))
     }
 }

--- a/monad-raptorcast/tests/raptorcast_instance.rs
+++ b/monad-raptorcast/tests/raptorcast_instance.rs
@@ -197,7 +197,7 @@ pub fn oversized_message() {
         validators: BTreeMap::from([(rx_nodeid, Stake::ONE), (tx_nodeid, Stake::ONE)]),
     };
 
-    let epoch_validators = validators.view_without(vec![&tx_nodeid]);
+    let epoch_validators = EpochValidators::view_without(&validators, vec![&tx_nodeid]);
 
     let messages = build_messages_with_length::<SignatureType>(
         &tx_keypair,
@@ -211,6 +211,7 @@ pub fn oversized_message() {
         0, // unix_ts_ms
         BuildTarget::Raptorcast(epoch_validators),
         &known_addresses,
+        &mut rand::thread_rng(),
     );
 
     // Sending a single packet of an oversized message is sufficient to crash the


### PR DESCRIPTION
Design doc: https://www.notion.so/Modular-packet-assembly-28075b0ba8408067b8f9ecf9092d56d4

Benchmark result:

| Test Case              | Time (mean) | Throughput (mean) |
|------------------------|-------------|-------------------|
| Raptorcast 128K / old  | 546.91 µs   | 228.56 MiB/s      |
| Raptorcast 128K / new  | 551.27 µs   | 226.75 MiB/s      |
| Raptorcast 2M / old    | 9.0575 ms   | 220.81 MiB/s      |
| Raptorcast 2M / new    | 8.9950 ms   | 222.34 MiB/s      |
| Broadcast 128K / old   | 52.624 ms   | 237.53 MiB/s      |
| Broadcast 128K / new   | 50.306 ms   | 248.48 MiB/s      |

<details>
<summary>Full Benchmark Logs</summary>

```
Raptorcast 128K/udp::build_messages
                        time:   [541.17 µs 546.91 µs 555.23 µs]
                        thrpt:  [225.13 MiB/s 228.56 MiB/s 230.98 MiB/s]
                 change:
                        time:   [+0.8834% +2.1325% +4.2982%] (p = 0.00 < 0.05)
                        thrpt:  [-4.1210% -2.0880% -0.8757%]
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  5 (5.00%) high mild
  8 (8.00%) high severe
Raptorcast 128K/packet::build_messages
                        time:   [549.25 µs 551.27 µs 554.04 µs]
                        thrpt:  [225.62 MiB/s 226.75 MiB/s 227.58 MiB/s]
                 change:
                        time:   [+0.9739% +1.6640% +2.7696%] (p = 0.00 < 0.05)
                        thrpt:  [-2.6949% -1.6368% -0.9645%]
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe

Raptorcast 2M/udp::build_messages
                        time:   [8.9445 ms 9.0575 ms 9.1865 ms]
                        thrpt:  [217.71 MiB/s 220.81 MiB/s 223.60 MiB/s]
                 change:
                        time:   [-0.9076% +0.9565% +2.8338%] (p = 0.33 > 0.05)
                        thrpt:  [-2.7557% -0.9474% +0.9159%]
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
Raptorcast 2M/packet::build_messages
                        time:   [8.9289 ms 8.9950 ms 9.0688 ms]
                        thrpt:  [220.54 MiB/s 222.34 MiB/s 223.99 MiB/s]
                 change:
                        time:   [-2.3773% -0.6885% +0.9216%] (p = 0.43 > 0.05)
                        thrpt:  [-0.9132% +0.6932% +2.4352%]
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  7 (7.00%) high mild
  8 (8.00%) high severe

Benchmarking Broadcast 128K/udp::build_messages: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.3s, or reduce sample count to 90.
Broadcast 128K/udp::build_messages
                        time:   [52.438 ms 52.624 ms 52.810 ms]
                        thrpt:  [236.70 MiB/s 237.53 MiB/s 238.38 MiB/s]
                 change:
                        time:   [-2.7506% -1.1749% -0.1138%] (p = 0.07 > 0.05)
                        thrpt:  [+0.1139% +1.1888% +2.8284%]
                        No change in performance detected.
Benchmarking Broadcast 128K/packet::build_messages: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.1s, or reduce sample count to 90.
Broadcast 128K/packet::build_messages
                        time:   [50.093 ms 50.306 ms 50.522 ms]
                        thrpt:  [247.42 MiB/s 248.48 MiB/s 249.54 MiB/s]
                 change:
                        time:   [-0.1627% +0.6978% +1.4534%] (p = 0.09 > 0.05)
                        thrpt:  [-1.4326% -0.6929% +0.1629%]
                        No change in performance detected.
```
</details>

How it's tested:

- existing features are tested to be compatible with the old `udp::build_message` function, which itself is extensively tested in `udp.rs`
- benchmarking metrics is attached above to show no performance regression
- new features are checked with unit tests
  + round-robin packet assembly (implements https://github.com/category-labs/monad-bft/pull/2318)
  + stake-based with rounding (implements https://github.com/category-labs/monad-bft/pull/2215)