### PR TITLE
TXgen updates

### DIFF
--- a/monad-eth-testutil/examples/txgen/cli.rs
+++ b/monad-eth-testutil/examples/txgen/cli.rs
@@ -18,6 +18,20 @@ use url::Url;
 
 use crate::prelude::*;
 
+fn parse_priority_fee_range(range_str: &str) -> Option<(u64, u64)> {
+    let parts: Vec<&str> = range_str.split(',').collect();
+    if parts.len() != 2 {
+        return None;
+    }
+    let min = parts[0].parse().ok()?;
+    let max = parts[1].parse().ok()?;
+    if min <= max {
+        Some((min, max))
+    } else {
+        None
+    }
+}
+
 #[derive(Debug, Parser, Clone)]
 #[command(name = "monad-node", about, long_about = None)]
 pub struct CliConfig {
@@ -132,6 +146,26 @@ pub struct CliConfig {
     /// Otel replica name
     #[arg(long, global = true)]
     pub otel_replica_name: Option<String>,
+
+    /// Gas limit for contract deployment transactions
+    #[arg(long, global = true)]
+    pub gas_limit_contract_deployment: Option<u64>,
+
+    /// Gas limit for contract call transactions (native and ERC20)
+    #[arg(long, global = true)]
+    pub set_tx_gas_limit: Option<u64>,
+
+    /// Static priority fee for transactions (native and ERC20)
+    #[arg(long, global = true)]
+    pub priority_fee: Option<u64>,
+
+    /// Range for random priority fee (format: min,max in wei)
+    #[arg(long, global = true)]
+    pub random_priority_fee_range: Option<String>,
+
+    /// Override for native contract address
+    #[arg(long, global = true)]
+    pub native_contract: Option<String>,
 }
 
 pub enum RequiredContract {
@@ -152,7 +186,10 @@ pub enum CliGenMode {
         tx_type: TxType,
     },
     Duplicates,
-    RandomPriorityFee,
+    RandomPriorityFee {
+        #[clap(long, default_value = "native")]
+        tx_type: TxType,
+    },
     HighCallData,
     HighCallDataLowGasLimit,
     SelfDestructs,
@@ -169,7 +206,9 @@ impl From<CliGenMode> for GenMode {
             CliGenMode::FewToMany { tx_type } => GenMode::FewToMany(FewToManyConfig { tx_type }),
             CliGenMode::ManyToMany { tx_type } => GenMode::ManyToMany(ManyToManyConfig { tx_type }),
             CliGenMode::Duplicates => GenMode::Duplicates,
-            CliGenMode::RandomPriorityFee => GenMode::RandomPriorityFee,
+            CliGenMode::RandomPriorityFee { tx_type } => {
+                GenMode::RandomPriorityFee(RandomPriorityFeeConfig { tx_type })
+            }
             CliGenMode::HighCallData => GenMode::HighCallData,
             CliGenMode::HighCallDataLowGasLimit => GenMode::HighCallDataLowGasLimit,
             CliGenMode::SelfDestructs => GenMode::SelfDestructs,
@@ -232,6 +271,26 @@ impl From<CliConfig> for Config {
         }
         if let Some(otel_replica_name) = value.otel_replica_name {
             config.otel_replica_name = otel_replica_name;
+        }
+        if let Some(gas_limit) = value.gas_limit_contract_deployment {
+            config.gas_limit_contract_deployment = Some(gas_limit);
+        }
+        if let Some(gas_limit) = value.set_tx_gas_limit {
+            config.set_tx_gas_limit = Some(gas_limit);
+        }
+        if let Some(priority_fee) = value.priority_fee {
+            config.priority_fee = Some(priority_fee);
+        }
+        if let Some(range_str) = value.random_priority_fee_range {
+            if let Some((min, max)) = parse_priority_fee_range(&range_str) {
+                config.random_priority_fee_range = Some((min, max));
+            }
+        }
+        if let Some(erc20_contract) = value.erc20_contract {
+            config.erc20_contract = Some(erc20_contract);
+        }
+        if let Some(native_contract) = value.native_contract {
+            config.native_contract = Some(native_contract);
         }
         config
     }

--- a/monad-eth-testutil/examples/txgen/config.rs
+++ b/monad-eth-testutil/examples/txgen/config.rs
@@ -74,6 +74,24 @@ pub struct Config {
 
     /// Otel replica name
     pub otel_replica_name: String,
+
+    /// Gas limit for contract deployment transactions
+    pub gas_limit_contract_deployment: Option<u64>,
+
+    /// Gas limit for contract call transactions (native and ERC20)
+    pub set_tx_gas_limit: Option<u64>,
+
+    /// Static priority fee for transactions (native and ERC20)
+    pub priority_fee: Option<u64>,
+
+    /// Range for random priority fee (min,max in wei)
+    pub random_priority_fee_range: Option<(u64, u64)>,
+
+    /// Override for ERC20 contract address
+    pub erc20_contract: Option<String>,
+
+    /// Override for native contract address
+    pub native_contract: Option<String>,
 }
 
 impl Default for Config {
@@ -101,6 +119,12 @@ impl Default for Config {
             use_static_tps_interval: false,
             otel_endpoint: None,
             otel_replica_name: "default".to_string(),
+            gas_limit_contract_deployment: None,
+            set_tx_gas_limit: None,
+            priority_fee: None,
+            random_priority_fee_range: None,
+            erc20_contract: None,
+            native_contract: None,
         }
     }
 }
@@ -114,7 +138,7 @@ impl TrafficGen {
             GenMode::FewToMany(..) => 500,
             GenMode::ManyToMany(..) => 10,
             GenMode::Duplicates => 10,
-            GenMode::RandomPriorityFee => 10,
+            GenMode::RandomPriorityFee(..) => 10,
             GenMode::HighCallData => 10,
             GenMode::SelfDestructs => 10,
             GenMode::NonDeterministicStorage => 10,
@@ -138,7 +162,7 @@ impl TrafficGen {
             GenMode::FewToMany(..) => 100,
             GenMode::ManyToMany(..) => 100,
             GenMode::Duplicates => 100,
-            GenMode::RandomPriorityFee => 100,
+            GenMode::RandomPriorityFee(..) => 100,
             GenMode::NonDeterministicStorage => 100,
             GenMode::StorageDeletes => 100,
             GenMode::NullGen => 10,
@@ -162,7 +186,7 @@ impl TrafficGen {
             GenMode::FewToMany(..) => 1000,
             GenMode::ManyToMany(..) => 2500,
             GenMode::Duplicates => 2500,
-            GenMode::RandomPriorityFee => 2500,
+            GenMode::RandomPriorityFee(..) => 2500,
             GenMode::NonDeterministicStorage => 2500,
             GenMode::StorageDeletes => 2500,
             GenMode::NullGen => 100,
@@ -190,7 +214,10 @@ impl TrafficGen {
                 TxType::Native => None,
             },
             GenMode::Duplicates => ERC20,
-            GenMode::RandomPriorityFee => ERC20,
+            GenMode::RandomPriorityFee(config) => match config.tx_type {
+                TxType::ERC20 => ERC20,
+                TxType::Native => None,
+            },
             GenMode::HighCallData => None,
             GenMode::HighCallDataLowGasLimit => None,
             GenMode::SelfDestructs => None,
@@ -357,7 +384,7 @@ pub enum GenMode {
     FewToMany(FewToManyConfig),
     ManyToMany(ManyToManyConfig),
     Duplicates,
-    RandomPriorityFee,
+    RandomPriorityFee(RandomPriorityFeeConfig),
     HighCallData,
     HighCallDataLowGasLimit,
     SelfDestructs,
@@ -387,6 +414,12 @@ pub struct ManyToManyConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RandomPriorityFeeConfig {
+    #[serde(default = "default_tx_type_native")]
+    pub tx_type: TxType,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SystemSpamConfig {
     pub call_type: SystemCallType,
 }
@@ -401,6 +434,10 @@ pub enum SystemCallType {
 
 fn default_tx_type() -> TxType {
     TxType::ERC20
+}
+
+fn default_tx_type_native() -> TxType {
+    TxType::Native
 }
 
 #[derive(Deserialize, Clone, Copy, Debug, Serialize, PartialEq, Eq, clap::ValueEnum)]

--- a/monad-eth-testutil/examples/txgen/generators/ecmul.rs
+++ b/monad-eth-testutil/examples/txgen/generators/ecmul.rs
@@ -31,7 +31,13 @@ impl Generator for ECMulGenerator {
 
         for sender in accts {
             for _ in 0..self.tx_per_sender {
-                let tx = self.ecmul.construct_tx(sender, ctx.base_fee, ctx.chain_id);
+                let tx = self.ecmul.construct_tx(
+                    sender,
+                    ctx.base_fee,
+                    ctx.chain_id,
+                    ctx.set_tx_gas_limit,
+                    ctx.priority_fee,
+                );
                 txs.push((tx, self.ecmul.addr));
             }
         }

--- a/monad-eth-testutil/examples/txgen/generators/non_deterministic_storage.rs
+++ b/monad-eth-testutil/examples/txgen/generators/non_deterministic_storage.rs
@@ -50,6 +50,8 @@ impl Generator for NonDeterministicStorageTxGenerator {
                             },
                             ctx.base_fee,
                             ctx.chain_id,
+                            ctx.set_tx_gas_limit,
+                            ctx.priority_fee,
                         ),
                         from.addr,
                     ));
@@ -61,6 +63,8 @@ impl Generator for NonDeterministicStorageTxGenerator {
                             IERC20::addFriendCall { friend: to },
                             ctx.base_fee,
                             ctx.chain_id,
+                            ctx.set_tx_gas_limit,
+                            ctx.priority_fee,
                         ),
                         to,
                     ));

--- a/monad-eth-testutil/examples/txgen/generators/reserve_balance.rs
+++ b/monad-eth-testutil/examples/txgen/generators/reserve_balance.rs
@@ -57,7 +57,7 @@ impl Generator for ReserveBalanceGenerator {
                         let tx = TxEip1559 {
                             chain_id: ctx.chain_id,
                             nonce: sender.nonce,
-                            gas_limit: 21_000,
+                            gas_limit: 42_000, // raised 2x from 21k
                             max_fee_per_gas,
                             max_priority_fee_per_gas: 0,
                             to: TxKind::Call(to),

--- a/monad-eth-testutil/examples/txgen/generators/self_destruct.rs
+++ b/monad-eth-testutil/examples/txgen/generators/self_destruct.rs
@@ -53,7 +53,13 @@ impl Generator for SelfDestructTxGenerator {
                     );
 
                     txs.push((
-                        contract.self_destruct_tx(sender, ctx.base_fee, ctx.chain_id),
+                        contract.self_destruct_tx(
+                            sender,
+                            ctx.base_fee,
+                            ctx.chain_id,
+                            ctx.set_tx_gas_limit,
+                            ctx.priority_fee,
+                        ),
                         contract.addr,
                     ))
                 } else {

--- a/monad-eth-testutil/examples/txgen/generators/storage_deletes.rs
+++ b/monad-eth-testutil/examples/txgen/generators/storage_deletes.rs
@@ -48,6 +48,8 @@ impl Generator for StorageDeletesTxGenerator {
                         IERC20::resetCall { addr: to },
                         ctx.base_fee,
                         ctx.chain_id,
+                        ctx.set_tx_gas_limit,
+                        ctx.priority_fee,
                     )
                 } else {
                     self.erc20.construct_tx(
@@ -58,6 +60,8 @@ impl Generator for StorageDeletesTxGenerator {
                         },
                         ctx.base_fee,
                         ctx.chain_id,
+                        ctx.set_tx_gas_limit,
+                        ctx.priority_fee,
                     )
                 };
 

--- a/monad-eth-testutil/examples/txgen/generators/uniswap.rs
+++ b/monad-eth-testutil/examples/txgen/generators/uniswap.rs
@@ -32,9 +32,13 @@ impl Generator for UniswapGenerator {
         // for each sender, provide liquidity in uniswap pools
         for sender in accts {
             for _ in 0..self.tx_per_sender {
-                let tx = self
-                    .uniswap
-                    .construct_tx(sender, ctx.base_fee, ctx.chain_id);
+                let tx = self.uniswap.construct_tx(
+                    sender,
+                    ctx.base_fee,
+                    ctx.chain_id,
+                    ctx.set_tx_gas_limit,
+                    ctx.priority_fee,
+                );
                 txs.push((tx, self.uniswap.addr));
             }
         }

--- a/monad-eth-testutil/examples/txgen/run.rs
+++ b/monad-eth-testutil/examples/txgen/run.rs
@@ -213,6 +213,10 @@ fn run_traffic_gen(
         &base_fee,
         config.chain_id,
         traffic_gen.gen_mode.clone(),
+        config.gas_limit_contract_deployment,
+        config.set_tx_gas_limit,
+        config.priority_fee,
+        config.random_priority_fee_range,
         Arc::clone(shutdown),
     );
 
@@ -329,6 +333,18 @@ async fn load_or_deploy_contracts(
     match contract_to_ensure {
         RequiredContract::None => Ok(DeployedContract::None),
         RequiredContract::ERC20 => {
+            // Check CLI override first
+            if let Some(addr_str) = &config.erc20_contract {
+                if let Ok(addr) = addr_str.parse::<Address>() {
+                    if verify_contract_code(client, addr).await? {
+                        info!("Using ERC20 contract from CLI: {}", addr);
+                        return Ok(DeployedContract::ERC20(ERC20 { addr }));
+                    } else {
+                        warn!("ERC20 contract from CLI has no code, falling back to auto-deploy");
+                    }
+                }
+            }
+
             match open_deployed_contracts_file(PATH) {
                 Ok(DeployedContractFile {
                     erc20: Some(erc20), ..
@@ -346,7 +362,14 @@ async fn load_or_deploy_contracts(
             }
 
             // if not found, deploy new contract
-            let erc20 = ERC20::deploy(&deployer, client, max_fee_per_gas, chain_id).await?;
+            let erc20 = ERC20::deploy(
+                &deployer,
+                client,
+                max_fee_per_gas,
+                chain_id,
+                config.gas_limit_contract_deployment,
+            )
+            .await?;
 
             let deployed = DeployedContractFile {
                 erc20: Some(erc20.addr),
@@ -375,7 +398,14 @@ async fn load_or_deploy_contracts(
             }
 
             // if not found, deploy new contract
-            let ecmul = ECMul::deploy(&deployer, client, max_fee_per_gas, chain_id).await?;
+            let ecmul = ECMul::deploy(
+                &deployer,
+                client,
+                max_fee_per_gas,
+                chain_id,
+                config.gas_limit_contract_deployment,
+            )
+            .await?;
 
             let deployed = DeployedContractFile {
                 erc20: None,
@@ -405,7 +435,14 @@ async fn load_or_deploy_contracts(
             }
 
             // if not found, deploy new contract
-            let uniswap = Uniswap::deploy(&deployer, client, max_fee_per_gas, chain_id).await?;
+            let uniswap = Uniswap::deploy(
+                &deployer,
+                client,
+                max_fee_per_gas,
+                chain_id,
+                config.gas_limit_contract_deployment,
+            )
+            .await?;
 
             let deployed = DeployedContractFile {
                 erc20: None,

--- a/monad-eth-testutil/examples/txgen/shared/ecmul.rs
+++ b/monad-eth-testutil/examples/txgen/shared/ecmul.rs
@@ -43,6 +43,7 @@ impl ECMul {
         client: &ReqwestClient,
         max_fee_per_gas: u128,
         chain_id: u64,
+        gas_limit: Option<u64>,
     ) -> Result<Self> {
         let nonce = client.get_transaction_count(&deployer.0).await?;
         let tx = Self::deploy_tx(nonce, &deployer.1, max_fee_per_gas, chain_id);
@@ -90,6 +91,8 @@ impl ECMul {
         sender: &mut SimpleAccount,
         max_fee_per_gas: u128,
         chain_id: u64,
+        gas_limit: Option<u64>,
+        priority_fee: Option<u64>,
     ) -> TxEnvelope {
         let input = IECMul::performzksyncECMulsCall {
             iterations: U256::from(200),
@@ -99,9 +102,9 @@ impl ECMul {
         let tx = TxEip1559 {
             chain_id,
             nonce: sender.nonce,
-            gas_limit: 2_000_000,
+            gas_limit: gas_limit.unwrap_or(2_000_000),
             max_fee_per_gas,
-            max_priority_fee_per_gas: 0,
+            max_priority_fee_per_gas: priority_fee.unwrap_or(0),
             to: TxKind::Call(self.addr),
             value: U256::ZERO,
             access_list: Default::default(),

--- a/monad-eth-testutil/examples/txgen/shared/uniswap.rs
+++ b/monad-eth-testutil/examples/txgen/shared/uniswap.rs
@@ -50,6 +50,7 @@ impl Uniswap {
         client: &ReqwestClient,
         max_fee_per_gas: u128,
         chain_id: u64,
+        gas_limit: Option<u64>,
     ) -> Result<Self> {
         let nonce = client.get_transaction_count(&deployer.0).await?;
 
@@ -280,6 +281,8 @@ impl Uniswap {
         sender: &mut SimpleAccount,
         max_fee_per_gas: u128,
         chain_id: u64,
+        gas_limit: Option<u64>,
+        priority_fee: Option<u64>,
     ) -> TxEnvelope {
         // price point of 300.0 has a tick value of 57000
         // with tick spacing of 60, lower tick is 10 ticks below current tick
@@ -294,9 +297,9 @@ impl Uniswap {
         let tx = TxEip1559 {
             chain_id,
             nonce: sender.nonce,
-            gas_limit: 400_000,
+            gas_limit: gas_limit.unwrap_or(400_000),
             max_fee_per_gas,
-            max_priority_fee_per_gas: 0,
+            max_priority_fee_per_gas: priority_fee.unwrap_or(0),
             to: TxKind::Call(self.addr),
             value: U256::ZERO,
             access_list: Default::default(),

--- a/monad-eth-testutil/examples/txgen/workers/gen_harness.rs
+++ b/monad-eth-testutil/examples/txgen/workers/gen_harness.rs
@@ -33,6 +33,10 @@ pub trait Generator {
 pub struct GenCtx {
     pub base_fee: u128,
     pub chain_id: u64,
+    pub gas_limit_contract_deployment: Option<u64>,
+    pub set_tx_gas_limit: Option<u64>,
+    pub priority_fee: Option<u64>,
+    pub random_priority_fee_range: Option<(u64, u64)>,
 }
 
 impl GenCtx {
@@ -59,6 +63,12 @@ pub struct GeneratorHarness {
     pub chain_id: u64,
     pub gen_mode: GenMode,
 
+    // New config fields
+    pub gas_limit_contract_deployment: Option<u64>,
+    pub set_tx_gas_limit: Option<u64>,
+    pub priority_fee: Option<u64>,
+    pub random_priority_fee_range: Option<(u64, u64)>,
+
     pub shutdown: Arc<AtomicBool>,
 }
 
@@ -74,6 +84,10 @@ impl GeneratorHarness {
         base_fee: &Arc<Mutex<u128>>,
         chain_id: u64,
         gen_mode: GenMode,
+        gas_limit_contract_deployment: Option<u64>,
+        set_tx_gas_limit: Option<u64>,
+        priority_fee: Option<u64>,
+        random_priority_fee_range: Option<(u64, u64)>,
         shutdown: Arc<AtomicBool>,
     ) -> Self {
         Self {
@@ -88,6 +102,10 @@ impl GeneratorHarness {
             base_fee: Arc::clone(base_fee),
             chain_id,
             gen_mode,
+            gas_limit_contract_deployment,
+            set_tx_gas_limit,
+            priority_fee,
+            random_priority_fee_range,
             shutdown,
         }
     }
@@ -118,6 +136,10 @@ impl GeneratorHarness {
                 &GenCtx {
                     base_fee,
                     chain_id: self.chain_id,
+                    gas_limit_contract_deployment: self.gas_limit_contract_deployment,
+                    set_tx_gas_limit: self.set_tx_gas_limit,
+                    priority_fee: self.priority_fee,
+                    random_priority_fee_range: self.random_priority_fee_range,
                 },
             );
 
@@ -135,6 +157,10 @@ impl GeneratorHarness {
                             &GenCtx {
                                 base_fee,
                                 chain_id: self.chain_id,
+                                gas_limit_contract_deployment: self.gas_limit_contract_deployment,
+                                set_tx_gas_limit: self.set_tx_gas_limit,
+                                priority_fee: self.priority_fee,
+                                random_priority_fee_range: self.random_priority_fee_range,
                             },
                         );
                         txs.push((tx, acct.addr));


### PR DESCRIPTION
Summary of Changes:

1. Raised gas limits -- Simply Doubling them in the TX case and adding 200K in the contract deployment case
* Contract deployment: 800k → 1M gas
* Contract calls: 100k → 200k gas
* Native transfers: 21k → 42k gas

2. Added CLI flags
* --gas-limit-contract-deployment: Override deployment gas limit
* --set-tx-gas-limit: Override transaction gas limit
* --priority-fee: Static priority fee for both native and ERC20
* --random-priority-fee-range: Custom range (format: "min,max")
* --native-contract: For future native contract usage

3. Enhanced random-priority-fee generator
* Added ERC20 support via --tx-type erc20
* Uses configurable range from --random-priority-fee-range

4. Fixed --erc20-contract flag
* Now properly wired to skip auto-deployment when provided
* Validates contract code exists before using