### PR TITLE
Add configuration options for high eth call pool

### DIFF
--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -450,7 +450,7 @@ async fn run(node_state: NodeState, reload_handle: Box<dyn TracingReload>) -> Re
         .map(|provider| provider.meter("opentelemetry"));
 
     let mut gauge_cache = HashMap::new();
-    let mut process_start = Instant::now();
+    let process_start = Instant::now();
     let mut total_state_update_elapsed = Duration::ZERO;
 
     let mut sigterm = signal(SignalKind::terminate()).expect("in tokio rt");

--- a/monad-rpc/src/cli.rs
+++ b/monad-rpc/src/cli.rs
@@ -100,6 +100,18 @@ pub struct Cli {
     #[arg(long, default_value_t = 64)]
     pub eth_call_executor_fibers: u32,
 
+    /// Set the max concurrent requests for eth_call and eth_estimateGas with high gas cost
+    #[arg(long, default_value_t = 20)]
+    pub eth_call_high_max_concurrent_requests: u32,
+
+    /// Set the number of threads used for executing eth_call and eth_estimateGas with high gas cost
+    #[arg(long, default_value_t = 1)]
+    pub eth_call_high_executor_threads: u32,
+
+    /// Set the number of fibers used for executing eth_call and eth_estimateGas with high gas cost
+    #[arg(long, default_value_t = 2)]
+    pub eth_call_high_executor_fibers: u32,
+
     /// Set the memory limit of the node cache when executing eth_call and eth_estimateGas
     #[arg(long, default_value_t = 100 << 20)] // 100 MB
     pub eth_call_executor_node_lru_max_mem: u64,
@@ -116,8 +128,12 @@ pub struct Cli {
     #[arg(long, default_value_t = false)]
     pub enable_admin_eth_call_statistics: bool,
 
-    /// Set the maximum timeout (in seconds) for queuing when executing eth_call and eth_estimateGas
+    /// Set the maximum timeout (in seconds) for queuing when executing eth_call with high gas cost
     #[arg(long, default_value_t = 30)]
+    pub eth_call_high_executor_queuing_timeout: u32,
+
+    /// Set the maximum timeout (in seconds) for queuing when executing eth_call and eth_estimateGas
+    #[arg(long, default_value_t = 2)]
     pub eth_call_executor_queuing_timeout: u32,
 
     /// Set the memory limit of the node cache for RPC requests other than eth_call and eth_estimateGas

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -254,12 +254,24 @@ async fn main() -> std::io::Result<()> {
         }
     };
 
+    let low_pool_config = monad_ethcall::PoolConfig {
+        num_threads: args.eth_call_executor_threads,
+        num_fibers: args.eth_call_executor_fibers,
+        timeout_sec: args.eth_call_executor_queuing_timeout,
+        queue_limit: args.eth_call_max_concurrent_requests,
+    };
+    let high_pool_config = monad_ethcall::PoolConfig {
+        num_threads: args.eth_call_high_executor_threads,
+        num_fibers: args.eth_call_high_executor_fibers,
+        timeout_sec: args.eth_call_high_executor_queuing_timeout,
+        queue_limit: args.eth_call_high_max_concurrent_requests,
+    };
+
     let eth_call_executor = args.triedb_path.clone().as_deref().map(|path| {
         Arc::new(tokio::sync::Mutex::new(EthCallExecutor::new(
-            args.eth_call_executor_threads,
-            args.eth_call_executor_fibers,
+            low_pool_config,
+            high_pool_config,
             args.eth_call_executor_node_lru_max_mem,
-            args.eth_call_executor_queuing_timeout,
             path,
         )))
     });


### PR DESCRIPTION
Some eth call pool parameters were hard coded. Add cli options to configure both low and high eth call pools.

Minor refactoring to reduce number of function parameters.