### PR TITLE
Allow higher provider gas limit than block gas limit

### DIFF
--- a/monad-ethcall/src/lib.rs
+++ b/monad-ethcall/src/lib.rs
@@ -20,7 +20,7 @@ use std::{
     sync::Arc,
 };
 
-use alloy_consensus::{Header, Transaction as _, TxEnvelope};
+use alloy_consensus::{Header, TxEnvelope};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, Bytes, B256, U256, U64};
 use alloy_rlp::Encodable;
@@ -195,15 +195,6 @@ pub async fn eth_call(
     tracer: MonadTracer,
     gas_specified: bool,
 ) -> CallResult {
-    // upper bound gas limit of transaction to block gas limit to prevent abuse of eth_call
-    if transaction.gas_limit() > block_header.gas_limit {
-        return CallResult::Failure(FailureCallResult {
-            error_code: EthCallResult::OtherError,
-            message: "gas limit too high".into(),
-            data: None,
-        });
-    }
-
     let mut rlp_encoded_tx = vec![];
     transaction.encode_2718(&mut rlp_encoded_tx);
 

--- a/monad-rpc/src/handlers/eth/call.rs
+++ b/monad-rpc/src/handlers/eth/call.rs
@@ -484,7 +484,7 @@ pub async fn fill_gas_params<T: Triedb>(
             header.base_fee_per_gas = Some(0);
             tx.fill_gas_prices(U256::ZERO)?;
             if tx.gas.is_none() {
-                tx.gas = Some(U256::from(header.gas_limit).min(eth_call_provider_gas_limit));
+                tx.gas = Some(eth_call_provider_gas_limit);
             }
         }
     }
@@ -662,7 +662,6 @@ async fn prepare_eth_call<T: Triedb + TriedbPath>(
         .tx()
         .gas
         .unwrap_or(U256::from(header.header.gas_limit));
-    let eth_call_provider_gas_limit = eth_call_provider_gas_limit.min(header.header.gas_limit);
     fill_gas_params(
         triedb_env,
         block_key,
@@ -968,7 +967,7 @@ mod tests {
         let mock_triedb = MockTriedb::default();
 
         // when gas price is not populated, then
-        // (1) header base fee is set to zero and (2) tx gas limit is set to block gas limit
+        // (1) header base fee is set to zero and (2) tx gas limit is set to the provider gas limit
         let mut call_request = CallRequest::default();
         let mut header = Header {
             base_fee_per_gas: Some(10_000_000_000),
@@ -988,7 +987,7 @@ mod tests {
         )
         .await;
         assert!(result.is_ok());
-        assert_eq!(call_request.gas, Some(U256::from(300_000_000)));
+        assert_eq!(call_request.gas, Some(U256::MAX));
         assert_eq!(header.base_fee_per_gas, Some(0));
 
         // when gas price is populated but sender address is not populated, then

--- a/monad-rpc/src/handlers/eth/gas.rs
+++ b/monad-rpc/src/handlers/eth/gas.rs
@@ -268,7 +268,6 @@ pub async fn monad_eth_estimateGas<T: Triedb>(
     };
 
     let gas_specified = params.tx.gas.is_some();
-    let provider_gas_limit = provider_gas_limit.min(header.header.gas_limit);
     let original_tx_gas = params.tx.gas.unwrap_or(U256::from(header.header.gas_limit));
     fill_gas_params(
         triedb_env,


### PR DESCRIPTION
Operators can set a higher provider gas limit for eth_call and eth_estimateGas and meter usage themselves.