### PR TITLE
feat: add validators.toml path

### DIFF
--- a/debian/opt/monad/scripts/clear-old-artifacts.sh
+++ b/debian/opt/monad/scripts/clear-old-artifacts.sh
@@ -5,6 +5,7 @@ TARGET_DIR="/home/monad/monad-bft/ledger/"
 NEW_FILES=$(find "$TARGET_DIR" -type f -name "*" -mmin -20)
 if [ -n "$NEW_FILES" ]; then
     find /home/monad/monad-bft/config/forkpoint/ -type f -name "forkpoint.toml.*" -mmin +300 -delete 2>/dev/null
+    find /home/monad/monad-bft/config/validators/ -type f -name "validators.toml.*" -mtime +30 -delete 2>/dev/null
     find /home/monad/monad-bft/ledger/headers -type f -mmin +600 -delete 2>/dev/null
     find /home/monad/monad-bft/ledger/bodies -type f -mmin +600 -delete 2>/dev/null
     find /home/monad/monad-bft/ -type f -name "wal_*" -mmin +300 -delete 2>/dev/null

--- a/debian/opt/monad/scripts/reset-workspace.sh
+++ b/debian/opt/monad/scripts/reset-workspace.sh
@@ -5,6 +5,7 @@ systemctl stop monad-bft monad-execution monad-rpc monad-mpt monad-execution-gen
 mkdir /home/monad/monad-bft/empty-dir
 rsync -r --delete /home/monad/monad-bft/empty-dir/ /home/monad/monad-bft/ledger/
 rsync -r --delete /home/monad/monad-bft/empty-dir/ /home/monad/monad-bft/config/forkpoint/
+rsync -r --delete /home/monad/monad-bft/empty-dir/ /home/monad/monad-bft/config/validators/
 touch /home/monad/monad-bft/ledger/wal
 rm -rf /home/monad/monad-bft/empty-dir
 rm -rf /home/monad/monad-bft/snapshots


### PR DESCRIPTION
- Retain last 30days of `validators.toml` created per epoch
- Clear old `validators.toml` if the node runs hard-reset