### PR TITLE
archive-checker: update to use the .env

### DIFF
--- a/debian/usr/lib/systemd/system/monad-checker.service
+++ b/debian/usr/lib/systemd/system/monad-checker.service
@@ -8,7 +8,7 @@ WorkingDirectory=/home/monad
 Type=simple
 ExecStart=/usr/local/bin/monad-archive-checker \
     --bucket "${ARCHIVE_BUCKET}" \
-    --otel-endpoint http://monad-otel-collector-1:4317 \
+    --otel-endpoint ${OTEL_ENDPOINT} \
     --max-compute-threads 2 \
     checker \
     --recheck-freq-min 50 \


### PR DESCRIPTION
Backstory:
- archive checker had an old `systemd` unit file that was based on docker
- we wanted to make it match what archiver has