### PR TITLE
Remove unnecessary lock around request submission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5293,7 +5293,6 @@ dependencies = [
  "monad-chain-config",
  "monad-cxx",
  "serde",
- "tokio",
  "tracing",
 ]
 

--- a/monad-ethcall/Cargo.toml
+++ b/monad-ethcall/Cargo.toml
@@ -20,7 +20,6 @@ alloy-sol-types = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-tokio = { workspace = true }
 tracing = { workspace = true }
 
 [build-dependencies]

--- a/monad-rpc/src/handlers/eth/call.rs
+++ b/monad-rpc/src/handlers/eth/call.rs
@@ -618,7 +618,7 @@ impl CallParams {
 #[tracing::instrument(level = "debug")]
 async fn prepare_eth_call<T: Triedb + TriedbPath>(
     triedb_env: &T,
-    eth_call_executor: Arc<Mutex<EthCallExecutor>>,
+    eth_call_executor: Arc<EthCallExecutor>,
     chain_id: u64,
     eth_call_provider_gas_limit: u64,
     mut params: CallParams,
@@ -735,7 +735,7 @@ async fn prepare_eth_call<T: Triedb + TriedbPath>(
 #[rpc(method = "eth_call", ignore = "chain_id", ignore = "eth_call_executor")]
 pub async fn monad_eth_call<T: Triedb + TriedbPath>(
     triedb_env: &T,
-    eth_call_executor: Arc<Mutex<EthCallExecutor>>,
+    eth_call_executor: Arc<EthCallExecutor>,
     chain_id: u64,
     eth_call_provider_gas_limit: u64,
     params: MonadEthCallParams,
@@ -771,7 +771,7 @@ pub async fn monad_eth_call<T: Triedb + TriedbPath>(
 #[allow(non_snake_case)]
 pub async fn monad_debug_traceCall<T: Triedb + TriedbPath>(
     triedb_env: &T,
-    eth_call_executor: Arc<Mutex<EthCallExecutor>>,
+    eth_call_executor: Arc<EthCallExecutor>,
     chain_id: u64,
     eth_call_gas_limit: u64,
     params: MonadDebugTraceCallParams,

--- a/monad-rpc/src/handlers/resources.rs
+++ b/monad-rpc/src/handlers/resources.rs
@@ -23,7 +23,7 @@ use actix_web::{
 use monad_archive::prelude::ArchiveReader;
 use monad_ethcall::EthCallExecutor;
 use monad_triedb_utils::triedb_env::TriedbEnv;
-use tokio::sync::{Mutex, Semaphore};
+use tokio::sync::Semaphore;
 use tracing_actix_web::RootSpanBuilder;
 
 use super::eth::call::EthCallStatsTracker;
@@ -36,7 +36,7 @@ use crate::{
 pub struct MonadRpcResources {
     pub txpool_bridge_client: EthTxPoolBridgeClient,
     pub triedb_reader: Option<TriedbEnv>,
-    pub eth_call_executor: Option<Arc<Mutex<EthCallExecutor>>>,
+    pub eth_call_executor: Option<Arc<EthCallExecutor>>,
     pub eth_call_executor_fibers: usize,
     pub eth_call_stats_tracker: Option<Arc<EthCallStatsTracker>>,
     pub archive_reader: Option<ArchiveReader>,
@@ -62,7 +62,7 @@ impl MonadRpcResources {
     pub fn new(
         txpool_bridge_client: EthTxPoolBridgeClient,
         triedb_reader: Option<TriedbEnv>,
-        eth_call_executor: Option<Arc<Mutex<EthCallExecutor>>>,
+        eth_call_executor: Option<Arc<EthCallExecutor>>,
         eth_call_executor_fibers: usize,
         archive_reader: Option<ArchiveReader>,
         chain_id: u64,

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -270,12 +270,12 @@ async fn main() -> std::io::Result<()> {
     };
 
     let eth_call_executor = args.triedb_path.clone().as_deref().map(|path| {
-        Arc::new(tokio::sync::Mutex::new(EthCallExecutor::new(
+        Arc::new(EthCallExecutor::new(
             low_pool_config,
             high_pool_config,
             args.eth_call_executor_node_lru_max_mem,
             path,
-        )))
+        ))
     });
 
     let meter_provider: Option<opentelemetry_sdk::metrics::SdkMeterProvider> =

--- a/monad-triedb-utils/src/decode.rs
+++ b/monad-triedb-utils/src/decode.rs
@@ -47,7 +47,7 @@ pub fn rlp_decode_account(account_rlp: Vec<u8>) -> Option<EthAccount> {
         return None;
     };
 
-    let mut is_delegated = false;
+    let is_delegated = false;
     let code_hash = if buf.is_empty() {
         None
     } else {


### PR DESCRIPTION
There is no need to lock the executor to submit request to pool. The submission channel is MPMC queue which handles synchronization internally. There was a non-atomic counter of requests processed, this was fixed in execution.