### PR TITLE
Clean up logs and current number of groups metric

### DIFF
--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -198,12 +198,6 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
                     &parsed_message.author,
                     broadcast_mode,
                 ) {
-                    tracing::debug!(
-                        src_addr = ?message.src_addr,
-                        author =? parsed_message.author,
-                        epoch =? parsed_message.epoch,
-                        "not in raptorcast group"
-                    );
                     continue;
                 }
             } else if self_hash != parsed_message.recipient_hash {


### PR DESCRIPTION
`CLIENT_NUM_CURRENT_GROUPS` is not showing up correctly because an interval in `confirmed_groups` is removed immediately when entering round. 