### PR TITLE
deps: update zerocopy to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "version_check",
- "zerocopy 0.8.26",
+ "zerocopy",
 ]
 
 [[package]]
@@ -5004,7 +5004,7 @@ dependencies = [
  "hex",
  "serde",
  "sha2",
- "zerocopy 0.6.6",
+ "zerocopy",
 ]
 
 [[package]]
@@ -5033,7 +5033,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "zerocopy 0.6.6",
+ "zerocopy",
 ]
 
 [[package]]
@@ -6128,7 +6128,7 @@ dependencies = [
  "serde_json",
  "serde_test",
  "test-case",
- "zerocopy 0.6.6",
+ "zerocopy",
 ]
 
 [[package]]
@@ -7076,7 +7076,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.26",
+ "zerocopy",
 ]
 
 [[package]]
@@ -10120,32 +10120,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.6.6",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
- "zerocopy-derive 0.8.26",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,6 @@ unicode-normalization = "0.1"
 url = "2.5.0"
 vergen-git2 = "1.0.5"
 wasm-bindgen = "0.2"
-zerocopy = "0.6"
+zerocopy = { version = "0.8", features = ["derive"] }
 zeroize = "1.3"
 zstd = "0.13"

--- a/monad-crypto/src/hasher.rs
+++ b/monad-crypto/src/hasher.rs
@@ -18,7 +18,7 @@ use std::{fmt::Debug, ops::Deref};
 use alloy_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::Digest;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 /// A 32-byte/256-bit hash
 #[derive(

--- a/monad-dataplane/src/tcp/mod.rs
+++ b/monad-dataplane/src/tcp/mod.rs
@@ -29,7 +29,7 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tracing::trace;
 use zerocopy::{
     byteorder::little_endian::{U32, U64},
-    AsBytes, FromBytes,
+    FromBytes, Immutable, IntoBytes,
 };
 
 use super::{RecvTcpMsg, TcpMsg};
@@ -43,7 +43,7 @@ const TCP_MESSAGE_LENGTH_LIMIT: usize = 3 * 1024 * 1024;
 const HEADER_MAGIC: u32 = 0x434e5353; // "SSNC"
 const HEADER_VERSION: u32 = 1;
 
-#[derive(AsBytes, Debug, FromBytes)]
+#[derive(IntoBytes, Debug, FromBytes, Immutable)]
 #[repr(C)]
 struct TcpMsgHdr {
     magic: U32,

--- a/monad-dataplane/src/tcp/rx.rs
+++ b/monad-dataplane/src/tcp/rx.rs
@@ -288,7 +288,7 @@ async fn read_message(
 
     let header = match timeout(HEADER_TIMEOUT, tcp_stream.read_exact(header_bytes)).await {
         Ok((ret, header_bytes)) => match ret {
-            Ok(_len) => TcpMsgHdr::read_from(&header_bytes[..]).unwrap(),
+            Ok(_len) => TcpMsgHdr::read_from_bytes(&header_bytes[..]).unwrap(),
             Err(err) => {
                 if message_id == 0 || err.kind() != ErrorKind::UnexpectedEof {
                     debug!(

--- a/monad-dataplane/src/tcp/tx.rs
+++ b/monad-dataplane/src/tcp/tx.rs
@@ -34,7 +34,7 @@ use tokio::sync::mpsc::{
     error::{TryRecvError, TrySendError},
 };
 use tracing::{debug, enabled, trace, warn, Level};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use super::{message_timeout, TcpMsg, TcpMsgHdr, TCP_MESSAGE_LENGTH_LIMIT};
 

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -30,7 +30,7 @@ use monad_crypto::certificate_signature::PubKey;
 pub use monad_crypto::hasher::Hash;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 pub const GENESIS_SEQ_NUM: SeqNum = SeqNum(0);
 pub const GENESIS_ROUND: Round = Round(0);
@@ -53,7 +53,7 @@ const SERIALIZE_VERSION: u16 = 1;
     Ord,
     PartialEq,
     PartialOrd,
-    AsBytes,
+    IntoBytes,
     Serialize,
     Deserialize,
     RlpEncodableWrapper,
@@ -171,7 +171,7 @@ impl Default for RoundSpan {
     Ord,
     Serialize,
     Deserialize,
-    AsBytes,
+    IntoBytes,
     RlpEncodableWrapper,
     RlpDecodableWrapper,
 )]
@@ -238,7 +238,7 @@ impl Debug for Epoch {
     Ord,
     PartialEq,
     PartialOrd,
-    AsBytes,
+    IntoBytes,
     Serialize,
     Deserialize,
     RlpEncodableWrapper,


### PR DESCRIPTION
i am using newer zerocopy in some follow up prs, they changed public api between versions so i pulled changes into a separate pr