### PR TITLE
secp: update secp256k1 to 0.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,6 +1912,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3656,6 +3672,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -8116,18 +8141,20 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.26.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.2",
  "secp256k1-sys",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.8.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4473013577ec77b4ee3668179ef1186df3146e2cf2d927bd200974c6fe60fd99"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,7 @@ reqwest = { version = "0.11", features = ["json"] }
 rstest = "0.25.0"
 schemars = "0.8.21"
 scrypt = { version = "0.11", default-features = false }
-secp256k1 = "0.26"
+secp256k1 = "0.31"
 serde = "1.0"
 serde_cbor = "0.11.2"
 serde_json = "1.0"

--- a/monad-secp/src/secp.rs
+++ b/monad-secp/src/secp.rs
@@ -22,7 +22,7 @@ use monad_crypto::{
     hasher::{Hasher, HasherType},
     signing_domain::SigningDomain,
 };
-use secp256k1::{ffi::CPtr, Secp256k1};
+use secp256k1::Secp256k1;
 use sha2::Sha256;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -30,7 +30,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 #[derive(Copy, Clone, PartialOrd, Ord)]
 pub struct PubKey(secp256k1::PublicKey);
 /// secp256k1 keypair
-pub struct KeyPair(secp256k1::KeyPair);
+pub struct KeyPair(secp256k1::Keypair);
 
 #[derive(ZeroizeOnDrop)]
 pub struct PrivKeyView(Vec<u8>);
@@ -94,16 +94,23 @@ fn msg_hash<SD: SigningDomain>(msg: &[u8]) -> secp256k1::Message {
     hasher.update(msg);
     let hash = hasher.hash();
 
-    secp256k1::Message::from_slice(&hash.0).expect("32 bytes")
+    secp256k1::Message::from_digest(hash.0)
 }
 
 impl KeyPair {
     /// Create a keypair from a secret key slice. The secret is zero-ized after
     /// use. The secret must be 32 byytes.
     pub fn from_bytes(secret: &mut [u8]) -> Result<Self, Error> {
-        let keypair = secp256k1::KeyPair::from_seckey_slice(secp256k1::SECP256K1, secret)
-            .map(Self)
-            .map_err(Error);
+        if secret.len() != 32 {
+            return Err(Error(secp256k1::Error::InvalidSecretKey));
+        }
+        let secret_array: [u8; 32] = secret
+            .try_into()
+            .map_err(|_| Error(secp256k1::Error::InvalidSecretKey))?;
+        let keypair =
+            secp256k1::Keypair::from_seckey_byte_array(secp256k1::SECP256K1, secret_array)
+                .map(Self)
+                .map_err(Error);
         secret.zeroize();
         keypair
     }
@@ -123,7 +130,7 @@ impl KeyPair {
     pub fn sign<SD: SigningDomain>(&self, msg: &[u8]) -> SecpSignature {
         SecpSignature(Secp256k1::sign_ecdsa_recoverable(
             secp256k1::SECP256K1,
-            &msg_hash::<SD>(msg),
+            msg_hash::<SD>(msg),
             &self.0.secret_key(),
         ))
     }
@@ -164,7 +171,7 @@ impl PubKey {
     ) -> Result<(), Error> {
         Secp256k1::verify_ecdsa(
             secp256k1::SECP256K1,
-            &msg_hash::<SD>(msg),
+            msg_hash::<SD>(msg),
             &signature.0.to_standard(),
             &self.0,
         )
@@ -175,7 +182,7 @@ impl PubKey {
 impl SecpSignature {
     /// Recover the pubkey from signature given the message
     pub fn recover_pubkey<SD: SigningDomain>(&self, msg: &[u8]) -> Result<PubKey, Error> {
-        Secp256k1::recover_ecdsa(secp256k1::SECP256K1, &msg_hash::<SD>(msg), &self.0)
+        Secp256k1::recover_ecdsa(secp256k1::SECP256K1, msg_hash::<SD>(msg), &self.0)
             .map(PubKey)
             .map_err(Error)
     }
@@ -185,9 +192,10 @@ impl SecpSignature {
     pub fn serialize(&self) -> [u8; secp256k1::constants::COMPACT_SIGNATURE_SIZE + 1] {
         // recid is 0..3, fit in a single byte (see secp256k1 https://docs.rs/secp256k1/0.27.0/src/secp256k1/ecdsa/recovery.rs.html#39)
         let (recid, sig) = self.0.serialize_compact();
-        assert!((0..=3).contains(&recid.to_i32()));
+        let recid_byte = recid as u8;
+        assert!((0..=3).contains(&recid_byte));
         let mut sig_vec = sig.to_vec();
-        sig_vec.push(recid.to_i32() as u8);
+        sig_vec.push(recid_byte);
         sig_vec.try_into().unwrap()
     }
 
@@ -197,7 +205,7 @@ impl SecpSignature {
             return Err(Error(secp256k1::Error::InvalidSignature));
         }
         let sig_data = &data[..secp256k1::constants::COMPACT_SIGNATURE_SIZE];
-        let recid = secp256k1::ecdsa::RecoveryId::from_i32(
+        let recid = secp256k1::ecdsa::RecoveryId::try_from(
             data[secp256k1::constants::COMPACT_SIGNATURE_SIZE] as i32,
         )
         .map_err(Error)?;
@@ -226,10 +234,7 @@ impl Decodable for SecpSignature {
 
 impl Drop for KeyPair {
     fn drop(&mut self) {
-        let ptr = self.0.as_mut_c_ptr();
-        unsafe {
-            (*ptr).non_secure_erase();
-        }
+        self.0.non_secure_erase();
     }
 }
 


### PR DESCRIPTION
using newer secp in the authentication protocol, there were some changes in api.
also erase can be now used on inner type without additional unsafe block