### PR TITLE
Overload Raptor Chunk Header Epoch

### DIFF
--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -61,6 +61,7 @@ where
     },
     PublishToFullNodes {
         epoch: Epoch,
+        round: Round,
         message: Verified<ST, Validated<ConsensusMessage<ST, SCT, EPT>>>,
     },
     /// Schedule a timeout event for `round` to be emitted in `duration`
@@ -137,6 +138,7 @@ where
                 cmds.push(ConsensusCommand::EnterRound(epoch, round));
                 cmds.push(ConsensusCommand::PublishToFullNodes {
                     epoch,
+                    round: high_certificate.round(),
                     message: ConsensusMessage {
                         version,
                         message: ProtocolMessage::AdvanceRound(AdvanceRoundMessage {

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -66,8 +66,12 @@ pub enum RouterCommand<ST: CertificateSignatureRecoverable, OM> {
         message: OM,
         priority: UdpPriority,
     },
+    // Primary publishing embeds epoch as group_id in chunk header. Secondary
+    // publishing embeds round as group_id in chunk header, as rebroadcasting
+    // periods are defined in rounds
     PublishToFullNodes {
-        epoch: Epoch, // Epoch gets embedded into the raptorcast message
+        epoch: Epoch,
+        round: Round,
         message: OM,
     },
     AddEpochValidatorSet {
@@ -103,9 +107,14 @@ impl<ST: CertificateSignatureRecoverable, OM> Debug for RouterCommand<ST, OM> {
                 .field("target", target)
                 .field("priority", priority)
                 .finish(),
-            Self::PublishToFullNodes { epoch, message: _ } => f
+            Self::PublishToFullNodes {
+                epoch,
+                round,
+                message: _,
+            } => f
                 .debug_struct("PublishToFullNodes")
                 .field("epoch", epoch)
+                .field("round", round)
                 .finish(),
             Self::AddEpochValidatorSet {
                 epoch,

--- a/monad-raptorcast/benches/encode_bench.rs
+++ b/monad-raptorcast/benches/encode_bench.rs
@@ -22,11 +22,12 @@ use monad_crypto::certificate_signature::{CertificateSignature, CertificateSigna
 use monad_dataplane::udp::DEFAULT_SEGMENT_SIZE;
 use monad_raptorcast::{
     packet,
+    udp::GroupId,
     util::{BuildTarget, EpochValidators, Redundancy},
 };
 use monad_secp::SecpSignature;
 use monad_testutil::signing::get_key;
-use monad_types::{NodeId, Stake};
+use monad_types::{Epoch, NodeId, Stake};
 
 const NUM_NODES: usize = 100;
 
@@ -63,8 +64,8 @@ pub fn bench_build_messages(c: &mut Criterion, name: &str, message_size: usize, 
                 DEFAULT_SEGMENT_SIZE, // segment_size
                 message.clone(),
                 Redundancy::from_u8(2),
-                0, // epoch_no
-                0, // unix_ts_ms
+                GroupId::Primary(Epoch(0)), // epoch_no
+                0,                          // unix_ts_ms
                 build_target.clone(),
                 &known_addrs,
             );

--- a/monad-raptorcast/benches/raptor_bench.rs
+++ b/monad-raptorcast/benches/raptor_bench.rs
@@ -24,11 +24,11 @@ use monad_dataplane::udp::DEFAULT_SEGMENT_SIZE;
 use monad_raptor::ManagedDecoder;
 use monad_raptorcast::{
     packet::build_messages,
-    udp::{parse_message, MAX_REDUNDANCY, SIGNATURE_CACHE_SIZE},
+    udp::{parse_message, GroupId, MAX_REDUNDANCY, SIGNATURE_CACHE_SIZE},
     util::{BuildTarget, EpochValidators, Redundancy},
 };
 use monad_secp::{KeyPair, SecpSignature};
-use monad_types::{NodeId, Stake};
+use monad_types::{Epoch, NodeId, Stake};
 
 #[allow(clippy::useless_vec)]
 pub fn criterion_benchmark(c: &mut Criterion) {
@@ -71,8 +71,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 DEFAULT_SEGMENT_SIZE, // segment_size
                 message.clone(),
                 Redundancy::from_u8(2),
-                0, // epoch_no
-                0, // unix_ts_ms
+                GroupId::Primary(Epoch(0)), // epoch_no
+                0,                          // unix_ts_ms
                 BuildTarget::Raptorcast(epoch_validators),
                 &known_addresses,
             );
@@ -112,8 +112,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             DEFAULT_SEGMENT_SIZE, // segment_size
             message.clone(),
             Redundancy::from_u8(2),
-            0, // epoch_no
-            0, // unix_ts_ms
+            GroupId::Primary(Epoch(0)), // epoch_no
+            0,                          // unix_ts_ms
             BuildTarget::Raptorcast(epoch_validators),
             &known_addresses,
         )

--- a/monad-raptorcast/src/decoding.rs
+++ b/monad-raptorcast/src/decoding.rs
@@ -32,7 +32,7 @@ use monad_crypto::{
     hasher::{Hasher as _, HasherType},
 };
 use monad_raptor::{ManagedDecoder, SOURCE_SYMBOLS_MIN};
-use monad_types::{Epoch, NodeId, Stake};
+use monad_types::{NodeId, Stake};
 use rand::Rng as _;
 
 use crate::{
@@ -336,7 +336,6 @@ where
         let prune_config = PruneConfig {
             // TODO: sync with config.udp_message_max_age_ms
             max_unix_ts_ms_delta: Some(10 * 1000), // 10 seconds
-            max_epoch_delta: Some(2),              // 2 epochs
             pruning_min_ratio: 0.1,                // prune at least 10% of cache or enter cooldown
             pruning_cooldown: Duration::from_secs(10), // 10 seconds cooldown
         };
@@ -421,7 +420,6 @@ trait QuotaPolicy<PT: PubKey>: Send + Sync {
 #[derive(Clone, Copy)]
 pub struct PruneConfig {
     max_unix_ts_ms_delta: Option<u64>,
-    max_epoch_delta: Option<usize>,
 
     // if a full pruning sweep only reclaims less than this
     // fraction of the cache, we throttle further pruning for a
@@ -436,19 +434,13 @@ pub struct PruneConfig {
 pub struct DecodingContext<'a, PT: PubKey> {
     validator_set: Option<&'a ValidatorSet<PT>>,
     unix_ts_now: UnixTimestamp,
-    current_epoch: Epoch,
 }
 
 impl<'a, PT: PubKey> DecodingContext<'a, PT> {
-    pub fn new(
-        validator_set: Option<&'a ValidatorSet<PT>>,
-        unix_ts_now: UnixTimestamp,
-        current_epoch: Epoch,
-    ) -> Self {
+    pub fn new(validator_set: Option<&'a ValidatorSet<PT>>, unix_ts_now: UnixTimestamp) -> Self {
         Self {
             validator_set,
             unix_ts_now,
-            current_epoch,
         }
     }
 }
@@ -762,12 +754,7 @@ impl<PT: PubKey> AuthorIndex<PT> {
 
         let message_size = message.app_message_len as MessageSize;
 
-        index.insert(
-            cache_key.clone(),
-            message.unix_ts_ms,
-            Epoch(message.epoch),
-            message_size,
-        );
+        index.insert(cache_key.clone(), message.unix_ts_ms, message_size);
         self.used_size += message_size;
 
         if index.is_overquota() {
@@ -811,15 +798,11 @@ impl<PT: PubKey> AuthorIndex<PT> {
             .prune_config
             .max_unix_ts_ms_delta
             .and_then(|delta| context.unix_ts_now.checked_sub(delta));
-        let epoch_threshold: Option<Epoch> = self
-            .prune_config
-            .max_epoch_delta
-            .and_then(|delta| context.current_epoch.checked_sub(delta));
 
         let mut evicted_keys = PrunedKeys::empty();
 
         // we first try only pruning expired keys
-        let expired_keys = author_index.prune_expired(unix_ts_threshold, epoch_threshold);
+        let expired_keys = author_index.prune_expired(unix_ts_threshold);
         evicted_keys.extend(expired_keys);
 
         // if still over quota, compact the cache to fit under quota
@@ -852,10 +835,6 @@ impl<PT: PubKey> AuthorIndex<PT> {
             .prune_config
             .max_unix_ts_ms_delta
             .and_then(|delta| context.unix_ts_now.checked_sub(delta));
-        let epoch_threshold: Option<Epoch> = self
-            .prune_config
-            .max_epoch_delta
-            .and_then(|delta| context.current_epoch.checked_sub(delta));
 
         let mut authors_to_drop = vec![];
         let mut total_slots = 0;
@@ -863,7 +842,7 @@ impl<PT: PubKey> AuthorIndex<PT> {
         let mut pruned_keys = PrunedKeys::empty();
         for (author, author_index) in &mut self.per_author_index {
             total_slots += author_index.len();
-            pruned_keys.extend(author_index.prune_expired(unix_ts_threshold, epoch_threshold));
+            pruned_keys.extend(author_index.prune_expired(unix_ts_threshold));
 
             if author_index.is_empty() {
                 authors_to_drop.push(*author);
@@ -1000,8 +979,7 @@ struct PerAuthorIndex {
     quota: Quota,
     used_size: MessageSize,
     time_index: BTreeSet<(UnixTimestamp, CacheKey)>,
-    epoch_index: BTreeSet<(Epoch, CacheKey)>,
-    reverse_index: HashMap<CacheKey, (UnixTimestamp, Epoch, MessageSize)>,
+    reverse_index: HashMap<CacheKey, (UnixTimestamp, MessageSize)>,
 }
 
 impl PerAuthorIndex {
@@ -1010,7 +988,6 @@ impl PerAuthorIndex {
             quota,
             used_size: 0,
             time_index: BTreeSet::new(),
-            epoch_index: BTreeSet::new(),
             reverse_index: HashMap::new(),
         }
     }
@@ -1028,12 +1005,11 @@ impl PerAuthorIndex {
     }
 
     pub fn remove(&mut self, key: &CacheKey) -> PrunedKeys {
-        let Some((unix_ts_ms, epoch, size)) = self.reverse_index.remove(key) else {
+        let Some((unix_ts_ms, size)) = self.reverse_index.remove(key) else {
             return PrunedKeys::empty();
         };
 
         self.time_index.remove(&(unix_ts_ms, key.clone()));
-        self.epoch_index.remove(&(epoch, key.clone()));
         self.used_size -= size;
         PrunedKeys::singleton(key.clone(), size)
     }
@@ -1054,33 +1030,18 @@ impl PerAuthorIndex {
             .collect()
     }
 
-    pub fn insert(
-        &mut self,
-        cache_key: CacheKey,
-        unix_ts_ms: UnixTimestamp,
-        epoch: Epoch,
-        size: MessageSize,
-    ) {
+    pub fn insert(&mut self, cache_key: CacheKey, unix_ts_ms: UnixTimestamp, size: MessageSize) {
         self.time_index.insert((unix_ts_ms, cache_key.clone()));
-        self.epoch_index.insert((epoch, cache_key.clone()));
-        self.reverse_index
-            .insert(cache_key, (unix_ts_ms, epoch, size));
+        self.reverse_index.insert(cache_key, (unix_ts_ms, size));
         self.used_size += size;
     }
 
     // Remove expired entries.
-    pub fn prune_expired(
-        &mut self,
-        unix_ts_threshold: Option<UnixTimestamp>,
-        epoch_threshold: Option<Epoch>,
-    ) -> PrunedKeys {
+    pub fn prune_expired(&mut self, unix_ts_threshold: Option<UnixTimestamp>) -> PrunedKeys {
         let mut evicted_keys = PrunedKeys::empty();
         // first, we prune all expired keys
         if let Some(threshold) = unix_ts_threshold {
             evicted_keys.extend(self.prune_by_time(threshold));
-        }
-        if let Some(threshold) = epoch_threshold {
-            evicted_keys.extend(self.prune_by_epoch(threshold));
         }
         evicted_keys
     }
@@ -1115,17 +1076,6 @@ impl PerAuthorIndex {
         self.remove_many(&to_prune_keys)
     }
 
-    fn prune_by_epoch(&mut self, epoch_threshold: Epoch) -> PrunedKeys {
-        let mut to_prune_keys = vec![];
-        for (epoch, key) in &self.epoch_index {
-            if *epoch >= epoch_threshold {
-                break;
-            }
-            to_prune_keys.push(key.clone());
-        }
-        self.remove_many(&to_prune_keys)
-    }
-
     fn prune_by_slots(&mut self, target_len: usize) -> PrunedKeys {
         let slots_to_free_up = self.len().saturating_sub(target_len);
         if slots_to_free_up == 0 {
@@ -1150,20 +1100,14 @@ impl PerAuthorIndex {
     #[cfg(test)]
     fn consistency_breaches(&self, prefix: &str) -> Vec<String> {
         let mut breaches = vec![];
-        if self.epoch_index.len() != self.reverse_index.len() {
-            breaches.push(format!("{prefix}.epoch-index-size-mismatch"));
-        }
         if self.time_index.len() != self.reverse_index.len() {
             breaches.push(format!("{prefix}.time-index-size-mismatch"));
         }
 
         let mut used_size = self.used_size;
-        for (key, (unix_ts, epoch, _size)) in &self.reverse_index {
+        for (key, (unix_ts, _size)) in &self.reverse_index {
             if !self.time_index.contains(&(*unix_ts, key.clone())) {
                 breaches.push(format!("{prefix}.time-index-missing-key"));
-            }
-            if !self.epoch_index.contains(&(*epoch, key.clone())) {
-                breaches.push(format!("{prefix}.epoch-index-missing-key"));
             }
             used_size -= *_size;
         }
@@ -1587,7 +1531,7 @@ mod test {
     use rand::seq::SliceRandom as _;
 
     use super::*;
-    use crate::util::BroadcastMode;
+    use crate::{udp::GroupId, util::BroadcastMode};
     type PT = monad_crypto::NopPubKey;
 
     const EPOCH: Epoch = Epoch(1);
@@ -1656,7 +1600,7 @@ mod test {
                 // these fields are never touched in this module
                 recipient_hash: HexBytes([0; 20]),
                 message: Bytes::new(),
-                epoch: EPOCH.0,
+                group_id: GroupId::Primary(EPOCH),
                 unix_ts_ms,
             };
             messages.push(message);
@@ -1669,7 +1613,7 @@ mod test {
         let app_message = Bytes::from(vec![1u8; APP_MESSAGE_LEN]);
         let author = node_id(0);
         let symbols = make_symbols(&app_message, author, UNIX_TS_MS);
-        let context = DecodingContext::new(None, UNIX_TS_MS, EPOCH);
+        let context = DecodingContext::new(None, UNIX_TS_MS);
 
         for n in 0..MIN_DECODABLE_SYMBOLS {
             let mut cache = make_cache(10, 10, 10);
@@ -1746,7 +1690,7 @@ mod test {
         // single slot per tier is enough
         let mut cache = make_cache(1, 1, 1);
 
-        let context = DecodingContext::new(Some(&validator_set), UNIX_TS_MS, EPOCH);
+        let context = DecodingContext::new(Some(&validator_set), UNIX_TS_MS);
         let res = try_decode_all(&mut cache, &context, all_symbols.iter())
             .expect("Decoding should succeed");
 
@@ -1759,7 +1703,7 @@ mod test {
         let app_message = Bytes::from(vec![1u8; APP_MESSAGE_LEN]);
         let author = node_id(0);
         let symbols = make_symbols(&app_message, author, UNIX_TS_MS);
-        let context = DecodingContext::new(None, UNIX_TS_MS, EPOCH);
+        let context = DecodingContext::new(None, UNIX_TS_MS);
         let mut cache = make_cache(10, 10, 10);
 
         // Decode a message completely.
@@ -1782,7 +1726,7 @@ mod test {
         let app_message = Bytes::from(vec![1u8; APP_MESSAGE_LEN]);
         let author = node_id(0);
         let symbols = make_symbols(&app_message, author, old_ts);
-        let context = DecodingContext::new(None, old_ts, EPOCH);
+        let context = DecodingContext::new(None, old_ts);
 
         // Insert an old message.
         let _ = cache.try_decode(&symbols[0], &context);
@@ -1793,7 +1737,7 @@ mod test {
             let new_app_message = Bytes::from(vec![2u8; APP_MESSAGE_LEN]);
             let new_author = node_id(i);
             let new_symbols = make_symbols(&new_app_message, new_author, UNIX_TS_MS);
-            let new_context = DecodingContext::new(None, UNIX_TS_MS, EPOCH);
+            let new_context = DecodingContext::new(None, UNIX_TS_MS);
             let _ = cache.try_decode(&new_symbols[0], &new_context);
             assert!(cache.consistency_breaches().is_empty());
         }
@@ -1837,7 +1781,7 @@ mod test {
         config.validator_tier.min_slots_per_validator = Some(2);
 
         let mut cache = DecoderCache::new(config);
-        let context = DecodingContext::new(Some(&validator_set), UNIX_TS_MS, EPOCH);
+        let context = DecodingContext::new(Some(&validator_set), UNIX_TS_MS);
         let res = try_decode_all(&mut cache, &context, all_symbols_part_1.iter())
             .expect("Decoding should succeed");
         assert!(cache.consistency_breaches().is_empty());
@@ -1919,7 +1863,7 @@ mod test {
         }
 
         let mut cache = DecoderCache::new(config);
-        let context = DecodingContext::new(Some(&validator_set), UNIX_TS_MS, EPOCH);
+        let context = DecodingContext::new(Some(&validator_set), UNIX_TS_MS);
         let res = try_decode_all(&mut cache, &context, all_symbols_part_1.iter())
             .expect("Decoding should succeed");
         assert!(cache.consistency_breaches().is_empty());
@@ -1966,7 +1910,7 @@ mod test {
         config.p2p_tier.min_slots_per_author = 2; // each author gets at least 2 slots
 
         let mut cache = DecoderCache::new(config);
-        let context = DecodingContext::new(None, UNIX_TS_MS, EPOCH);
+        let context = DecodingContext::new(None, UNIX_TS_MS);
         let res = try_decode_all(&mut cache, &context, all_symbols_part_1.iter())
             .expect("Decoding should succeed");
         assert!(cache.consistency_breaches().is_empty());
@@ -2032,7 +1976,7 @@ mod test {
         }
 
         let mut cache = DecoderCache::new(config);
-        let context = DecodingContext::new(None, UNIX_TS_MS, EPOCH);
+        let context = DecodingContext::new(None, UNIX_TS_MS);
         let res = try_decode_all(&mut cache, &context, all_symbols_part_1.iter())
             .expect("Decoding should succeed");
         assert!(cache.consistency_breaches().is_empty());
@@ -2058,7 +2002,7 @@ mod test {
         let app_message = Bytes::from(vec![1u8; APP_MESSAGE_LEN]);
         let author = node_id(0);
         let symbols = make_symbols(&app_message, author, UNIX_TS_MS);
-        let context = DecodingContext::new(None, UNIX_TS_MS, EPOCH);
+        let context = DecodingContext::new(None, UNIX_TS_MS);
 
         // Insert a valid symbol first.
         let _ = cache.try_decode(&symbols[0], &context);
@@ -2092,7 +2036,7 @@ mod test {
         config.p2p_tier.min_slots_per_author = 2;
 
         let mut cache = DecoderCache::new(config);
-        let context = DecodingContext::new(None, UNIX_TS_MS, EPOCH);
+        let context = DecodingContext::new(None, UNIX_TS_MS);
 
         // Fill the cache.
         let app_message0 = Bytes::from(vec![0u8; APP_MESSAGE_LEN]);
@@ -2131,7 +2075,7 @@ mod test {
         config.p2p_tier.min_slots_per_author = 5;
 
         let mut cache = DecoderCache::new(config);
-        let context = DecodingContext::new(None, UNIX_TS_MS, EPOCH);
+        let context = DecodingContext::new(None, UNIX_TS_MS);
 
         // take a single symbol for a given message
         let partial_symbol = |msg: u8, ts: UnixTimestamp| {

--- a/monad-raptorcast/src/packet/assembler.rs
+++ b/monad-raptorcast/src/packet/assembler.rs
@@ -31,6 +31,7 @@ use super::{
     BuildError, Collector, PeerAddrLookup, Result, UdpMessage,
 };
 use crate::{
+    udp::GroupId,
     util::{compute_hash, Redundancy},
     SIGNATURE_SIZE,
 };
@@ -580,7 +581,7 @@ pub(crate) fn build_header(
     version: u16,
     broadcast_type: BroadcastType,
     merkle_tree_depth: u8,
-    epoch_no: u64,
+    group_id: GroupId,
     unix_ts_ms: u64,
     app_message_hash: &[u8; 20],
     app_message_len: usize,
@@ -590,7 +591,7 @@ pub(crate) fn build_header(
     //       Secondary broadcast bit,
     //       2 unused bits,
     //       4 bits for Merkle Tree Depth
-    // 8  // Epoch #
+    // 8  // Group id
     // 8  // Unix timestamp
     // 20 // AppMessage hash
     // 4  // AppMessage length
@@ -614,8 +615,9 @@ pub(crate) fn build_header(
     broadcast_byte |= merkle_tree_depth & 0b0000_1111;
     cursor_broadcast_merkle_depth[0] = broadcast_byte;
 
-    let (cursor_epoch_no, cursor) = cursor.split_at_mut_checked(8).expect("header too short");
-    cursor_epoch_no.copy_from_slice(&epoch_no.to_le_bytes());
+    let group_id: u64 = group_id.into();
+    let (cursor_group_id, cursor) = cursor.split_at_mut_checked(8).expect("header too short");
+    cursor_group_id.copy_from_slice(&group_id.to_le_bytes());
 
     let (cursor_unix_ts_ms, cursor) = cursor.split_at_mut_checked(8).expect("header too short");
     cursor_unix_ts_ms.copy_from_slice(&unix_ts_ms.to_le_bytes());

--- a/monad-raptorcast/src/packet/mod.rs
+++ b/monad-raptorcast/src/packet/mod.rs
@@ -30,7 +30,10 @@ pub(crate) use self::{
     assigner::ChunkAssigner,
     builder::MessageBuilder,
 };
-use crate::util::{BuildTarget, Redundancy};
+use crate::{
+    udp::GroupId,
+    util::{BuildTarget, Redundancy},
+};
 
 #[derive(Debug, Clone)]
 pub struct UdpMessage {
@@ -80,7 +83,7 @@ pub fn build_messages<ST>(
     segment_size: u16,
     app_message: Bytes,
     redundancy: Redundancy,
-    epoch_no: u64,
+    group_id: GroupId,
     unix_ts_ms: u64,
     build_target: BuildTarget<ST>,
     known_addresses: &HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddr>,
@@ -90,7 +93,7 @@ where
 {
     let builder = MessageBuilder::new(key, known_addresses)
         .segment_size(segment_size)
-        .epoch_no(epoch_no)
+        .group_id(group_id)
         .unix_ts_ms(unix_ts_ms)
         .redundancy(redundancy);
 

--- a/monad-raptorcast/tests/encoder_error.rs
+++ b/monad-raptorcast/tests/encoder_error.rs
@@ -21,11 +21,11 @@ use monad_crypto::hasher::{Hasher, HasherType};
 use monad_dataplane::udp::DEFAULT_SEGMENT_SIZE;
 use monad_raptor::SOURCE_SYMBOLS_MAX;
 use monad_raptorcast::{
-    udp::build_messages,
+    udp::{build_messages, GroupId},
     util::{BuildTarget, EpochValidators, Redundancy},
 };
 use monad_secp::{KeyPair, SecpSignature};
-use monad_types::{NodeId, Stake};
+use monad_types::{Epoch, NodeId, Stake};
 use tracing_subscriber::fmt::format::FmtSpan;
 
 // Try to encode a message that is too large to be encoded, to verify that the encoder
@@ -74,8 +74,8 @@ pub fn encoder_error() {
         DEFAULT_SEGMENT_SIZE,
         message,
         Redundancy::from_u8(1),
-        0, // epoch_no
-        0, // unix_ts_ms
+        GroupId::Primary(Epoch(0)), // epoch_no
+        0,                          // unix_ts_ms
         BuildTarget::Raptorcast(epoch_validators),
         &known_addresses,
     );

--- a/monad-raptorcast/tests/raptorcast_instance.rs
+++ b/monad-raptorcast/tests/raptorcast_instance.rs
@@ -37,7 +37,7 @@ use monad_raptorcast::{
     new_defaulted_raptorcast_for_tests,
     packet::build_messages,
     raptorcast_secondary::group_message::FullNodesGroupMessage,
-    udp::MAX_REDUNDANCY,
+    udp::{GroupId, MAX_REDUNDANCY},
     util::{BuildTarget, EpochValidators, Group, Redundancy},
     RaptorCast, RaptorCastEvent,
 };
@@ -95,8 +95,8 @@ pub fn different_symbol_sizes() {
             segment_size,
             message.clone(),
             Redundancy::from_u8(2),
-            0, // epoch_no
-            0, // unix_ts_ms
+            GroupId::Primary(Epoch(0)), // epoch_no
+            0,                          // unix_ts_ms
             BuildTarget::Raptorcast(epoch_validators),
             &known_addresses,
         );
@@ -155,8 +155,8 @@ pub fn buffer_count_overflow() {
         DEFAULT_SEGMENT_SIZE,
         message,
         Redundancy::from_u8(2),
-        0, // epoch_no
-        0, // unix_ts_ms
+        GroupId::Primary(Epoch(0)), // epoch_no
+        0,                          // unix_ts_ms
         BuildTarget::Raptorcast(epoch_validators),
         &known_addresses,
     );
@@ -234,9 +234,9 @@ pub fn valid_rebroadcast() {
         &tx_keypair,
         DEFAULT_SEGMENT_SIZE,
         message,
-        MAX_REDUNDANCY, // redundancy,
-        0,              // epoch_no
-        0,              // unix_ts_ms
+        MAX_REDUNDANCY,             // redundancy,
+        GroupId::Primary(Epoch(0)), // epoch_no
+        0,                          // unix_ts_ms
         BuildTarget::Raptorcast(epoch_validators),
         &known_addresses,
     );
@@ -550,6 +550,7 @@ async fn publish_to_full_nodes() {
     let message = MockMessage::new(42, 10000);
     let command = RouterCommand::PublishToFullNodes {
         epoch: Epoch(0),
+        round: Round(0),
         message,
     };
     validator_rc.exec(vec![command]);

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -315,9 +315,14 @@ where
                 RouterCommand::GetPeers => validator_cmds.push(cmd),
                 RouterCommand::UpdatePeers { .. } => validator_cmds.push(cmd),
 
-                RouterCommand::PublishToFullNodes { epoch, ref message } => {
+                RouterCommand::PublishToFullNodes {
+                    epoch,
+                    round,
+                    ref message,
+                } => {
                     let cmd_cpy = RouterCommand::PublishToFullNodes {
                         epoch,
+                        round,
                         message: message.clone(),
                     };
                     validator_cmds.push(cmd_cpy);

--- a/monad-state/src/consensus.rs
+++ b/monad-state/src/consensus.rs
@@ -233,6 +233,7 @@ where
                         match protocol_message {
                             ProtocolMessage::Proposal(msg) => {
                                 let proposal_epoch = msg.proposal_epoch;
+                                let proposal_round = msg.proposal_round;
                                 let mut proposal_cmds =
                                     consensus.handle_proposal_message(author, msg);
                                 // TODO:Maybe we could skip the below command if we could somehow determine that
@@ -241,6 +242,7 @@ where
                                 // send verified_message carrying author signature
                                 proposal_cmds.push(ConsensusCommand::PublishToFullNodes {
                                     epoch: proposal_epoch,
+                                    round: proposal_round,
                                     message: verified_message,
                                 });
                                 proposal_cmds
@@ -662,12 +664,15 @@ where
                     priority: monad_types::UdpPriority::High,
                 }))
             }
-            ConsensusCommand::PublishToFullNodes { epoch, message } => {
-                parent_cmds.push(Command::RouterCommand(RouterCommand::PublishToFullNodes {
-                    epoch,
-                    message: VerifiedMonadMessage::Consensus(message),
-                }))
-            }
+            ConsensusCommand::PublishToFullNodes {
+                epoch,
+                round,
+                message,
+            } => parent_cmds.push(Command::RouterCommand(RouterCommand::PublishToFullNodes {
+                epoch,
+                round,
+                message: VerifiedMonadMessage::Consensus(message),
+            })),
             ConsensusCommand::Schedule { round, duration } => {
                 parent_cmds.push(Command::TimerCommand(TimerCommand::Schedule {
                     duration,

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -222,13 +222,6 @@ impl Debug for Epoch {
         self.0.fmt(f)
     }
 }
-
-impl From<Epoch> for u64 {
-    fn from(epoch: Epoch) -> Self {
-        epoch.0
-    }
-}
-
 /// Block sequence number
 ///
 /// Consecutive blocks in the same branch have consecutive sequence numbers,


### PR DESCRIPTION
A full node may join new RaptorCast groups from the same validator while it's syncing or stuck. In such cases, it may rebroadcast to an expired group because its local round hasn't advanced, and expired groups are not garbage-collected. As a result, many full nodes end up receiving unsolicited Raptor chunks from groups they no longer belong to.

The root cause is that the node selects the rebroadcast group based on its local round. This PR resolves the issue by overloading the epoch field in the Raptor chunk header setting it to the round number for secondary raptorcast. This allows syncing or stuck full nodes to use the round number to identify and service the correct group