### PR TITLE
Make Triedb::get_block_key stricter

### DIFF
--- a/monad-rpc/src/handlers/eth/block.rs
+++ b/monad-rpc/src/handlers/eth/block.rs
@@ -36,14 +36,18 @@ pub async fn get_block_key_from_tag_or_hash<T: Triedb>(
     block_reference: BlockTagOrHash,
 ) -> JsonRpcResult<BlockKey> {
     match block_reference {
-        BlockTagOrHash::BlockTags(tag) => Ok(get_block_key_from_tag(triedb_env, tag)),
+        BlockTagOrHash::BlockTags(tag) => {
+            get_block_key_from_tag(triedb_env, tag).ok_or(JsonRpcError::block_not_found())
+        }
         BlockTagOrHash::Hash(block_hash) => {
             let num = triedb_env
                 .get_block_number_by_hash(triedb_env.get_latest_voted_block_key(), block_hash.0)
                 .await
                 .map_err(|_| JsonRpcError::block_not_found())?
                 .ok_or(JsonRpcError::block_not_found())?;
-            Ok(triedb_env.get_block_key(SeqNum(num)))
+            triedb_env
+                .get_block_key(SeqNum(num))
+                .ok_or(JsonRpcError::block_not_found())
         }
     }
 }

--- a/monad-rpc/src/handlers/eth/call.rs
+++ b/monad-rpc/src/handlers/eth/call.rs
@@ -646,13 +646,6 @@ async fn prepare_eth_call<T: Triedb + TriedbPath>(
     // TODO: check duplicate address, duplicate storage key, etc.
 
     let block_key = get_block_key_from_tag_or_hash(triedb_env, params.block()).await?;
-    let version_exist = triedb_env
-        .get_state_availability(block_key)
-        .await
-        .map_err(JsonRpcError::internal_error)?;
-    if !version_exist {
-        return Err(JsonRpcError::block_not_found());
-    }
 
     let mut header = match triedb_env
         .get_block_header(block_key)
@@ -660,11 +653,7 @@ async fn prepare_eth_call<T: Triedb + TriedbPath>(
         .map_err(JsonRpcError::internal_error)?
     {
         Some(header) => header,
-        None => {
-            return Err(JsonRpcError::internal_error(
-                "error getting block header".into(),
-            ))
-        }
+        None => return Err(JsonRpcError::block_not_found()),
     };
 
     let state_overrides = params.state_overrides().clone();

--- a/monad-rpc/src/handlers/eth/gas.rs
+++ b/monad-rpc/src/handlers/eth/gas.rs
@@ -257,14 +257,8 @@ pub async fn monad_eth_estimateGas<T: Triedb>(
         ));
     }
 
-    let block_key = get_block_key_from_tag(triedb_env, params.block);
-    let version_exist = triedb_env
-        .get_state_availability(block_key)
-        .await
-        .map_err(JsonRpcError::internal_error)?;
-    if !version_exist {
-        return Err(JsonRpcError::block_not_found());
-    }
+    let block_key =
+        get_block_key_from_tag(triedb_env, params.block).ok_or(JsonRpcError::block_not_found())?;
 
     let mut header = match triedb_env
         .get_block_header(block_key)
@@ -272,11 +266,7 @@ pub async fn monad_eth_estimateGas<T: Triedb>(
         .map_err(JsonRpcError::internal_error)?
     {
         Some(header) => header,
-        None => {
-            return Err(JsonRpcError::internal_error(
-                "error getting block header".into(),
-            ))
-        }
+        None => return Err(JsonRpcError::block_not_found()),
     };
 
     let gas_specified = params.tx.gas.is_some();

--- a/monad-triedb-utils/src/mock_triedb.rs
+++ b/monad-triedb-utils/src/mock_triedb.rs
@@ -61,8 +61,8 @@ impl Triedb for MockTriedb {
     fn get_latest_voted_block_key(&self) -> BlockKey {
         BlockKey::Finalized(self.get_latest_finalized_block_key())
     }
-    fn get_block_key(&self, block_num: SeqNum) -> BlockKey {
-        BlockKey::Finalized(FinalizedBlockKey(block_num))
+    fn get_block_key(&self, block_num: SeqNum) -> Option<BlockKey> {
+        Some(BlockKey::Finalized(FinalizedBlockKey(block_num)))
     }
 
     fn get_state_availability(


### PR DESCRIPTION
Previously, when looking up a block with a given sequence number, Triedb::get_block_key would silently default the block to the Finalized nibble. This is not incorrect per se, but would require the caller to also check for state_availability every time the caller wanted to operate on this block key.

Instead, we can make Triedb::get_block_key stricter so that an unfinalized block is never upcasted to a Finalized one.


Concretely, before this change, this was the safe way of using the api:
1. get_block_key(block_num)
    - if None, return Err
2. get_state_availability(block_num)
    - if None, return Err
3. get_account(block_num)
4. get_state_availability(block_num)
   - if None, return Err

After this change, the following usage of the api is safe:
1. get_block_key(block_num)
    - if None, return Err
2. get_account(block_num)
3. get_state_availability(block_num)
   - if None, return Err

The intuition here is that get_block_key will only return block keys that were at one point valid, which is an implicit get_state_availability check.