### PR TITLE
Use RawValue for RPC params

### DIFF
--- a/monad-rpc/src/handlers/eth/call.rs
+++ b/monad-rpc/src/handlers/eth/call.rs
@@ -88,10 +88,10 @@ pub struct EthCallStatsTracker {
 }
 
 impl EthCallStatsTracker {
-    pub async fn record_request_start(&self, request_id: &RequestId) {
+    pub async fn record_request_start(&self, request_id: RequestId) {
         let mut requests = self.active_requests.lock().await;
         requests.insert(
-            request_id.clone(),
+            request_id,
             EthCallRequestStats {
                 entry_time: Instant::now(),
             },

--- a/monad-rpc/src/timing.rs
+++ b/monad-rpc/src/timing.rs
@@ -46,7 +46,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct RequestId {
     id: u64,
 }
@@ -65,7 +65,7 @@ impl FromRequest for RequestId {
 
     fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
         match req.extensions().get::<RequestId>() {
-            Some(request_id) => ready(Ok(request_id.clone())),
+            Some(request_id) => ready(Ok(*request_id)),
             None => ready(Ok(RequestId::random())),
         }
     }


### PR DESCRIPTION
Previously, RPC deserialized incoming requests to a `serde_json::Value` which is an in-memory representation of a JSON object. This `Value` would then be passed to the corresponding RPC method which would try deserializing the `Value` to the actual method params type. This is inefficient for three main reasons:
1. Instead of deserializing directly to the Rust-native in-memory representation of the params, we perform two deserialization steps (`Bytes -> Value`, `Value -> T`)
2. Building a `Value` incurs a significant number of allocations for JSON arrays and objects.
3. Some RPC methods do not take any params and thus do not deserialize the `params` object passed to them which means building the `Value` is just wasting computation time.

This is especially problematic because attackers can control the RPC call input, which opens up several DOS vectors demonstrated in https://github.com/category-labs/monad-bft/pull/2453. On top of all of this, the in-memory `Value` in `rpc_handler` is cloned so it can be used when the `comparator` flag is enabled which doubles the number of wasteful allocations and exacerbates the DOS vector.

By using `serde_json::value::RawValue`, we can defer the deserialization of `params` to when the RPC method is called, which speeds up deserialization significantly on top of avoiding the `Bytes -> Value -> T` by going directly from `Bytes -> T`. This significantly decreases the effectiveness of the DOS vector because we no longer build the entire `Value` in-memory before attempting to deserialize to `T`, which is what makes the DOS vector effective.

Here are updated benchmarks showing a large performance increase for normal deserialization (eth_call, eth_call-batch) as well as a significant decrease in deserialization time for the aforementioned DOS attacks, rendering the payload attacks ineffective and the id attacks partially mitigated. The id attacks are further addressed in https://github.com/category-labs/monad-bft/pull/2455.
```
deserialize/eth_call    time:   [1.0637 µs 1.0642 µs 1.0648 µs]
                        thrpt:  [143.31 MiB/s 143.39 MiB/s 143.45 MiB/s]
                 change:
                        time:   [-54.819% -54.786% -54.755%] (p = 0.00 < 0.05)
                        thrpt:  [+121.02% +121.17% +121.33%]
                        Performance has improved.

deserialize/eth_call-batch
                        time:   [2.2649 µs 2.2657 µs 2.2667 µs]
                        thrpt:  [542.33 MiB/s 542.56 MiB/s 542.75 MiB/s]
                 change:
                        time:   [-79.186% -79.169% -79.155%] (p = 0.00 < 0.05)
                        thrpt:  [+379.72% +380.05% +380.44%]
                        Performance has improved.

deserialize/attack_large_id_array
                        time:   [51.708 ms 51.863 ms 52.022 ms]
                        thrpt:  [33.640 MiB/s 33.744 MiB/s 33.845 MiB/s]
                 change:
                        time:   [-59.380% -59.114% -58.847%] (p = 0.00 < 0.05)
                        thrpt:  [+143.00% +144.59% +146.18%]
                        Performance has improved.

deserialize/attack_large_id_dict
                        time:   [38.161 ms 38.791 ms 39.438 ms]
                        thrpt:  [47.544 MiB/s 48.338 MiB/s 49.135 MiB/s]
                 change:
                        time:   [-59.922% -59.202% -58.475%] (p = 0.00 < 0.05)
                        thrpt:  [+140.82% +145.11% +149.51%]
                        Performance has improved.

deserialize/attack_large_payload_array_without_params
                        time:   [4.1839 ms 4.1878 ms 4.1918 ms]
                        thrpt:  [417.50 MiB/s 417.90 MiB/s 418.29 MiB/s]
                 change:
                        time:   [-96.796% -96.781% -96.765%] (p = 0.00 < 0.05)
                        thrpt:  [+2991.4% +3006.2% +3021.0%]
                        Performance has improved.

deserialize/attack_large_payload_dict_without_params
                        time:   [4.9708 ms 4.9822 ms 4.9935 ms]
                        thrpt:  [375.50 MiB/s 376.35 MiB/s 377.21 MiB/s]
                 change:
                        time:   [-98.290% -98.268% -98.244%] (p = 0.00 < 0.05)
                        thrpt:  [+5594.3% +5672.2% +5749.2%]
                        Performance has improved.

deserialize/attack_large_payload_array_with_params
                        time:   [4.1875 ms 4.1894 ms 4.1915 ms]
                        thrpt:  [417.53 MiB/s 417.74 MiB/s 417.93 MiB/s]
                 change:
                        time:   [-96.493% -96.480% -96.466%] (p = 0.00 < 0.05)
                        thrpt:  [+2729.8% +2740.9% +2751.8%]
                        Performance has improved.

deserialize/attack_large_payload_dict_with_params
                        time:   [4.6527 ms 4.6569 ms 4.6611 ms]
                        thrpt:  [402.28 MiB/s 402.64 MiB/s 403.00 MiB/s]
                 change:
                        time:   [-98.666% -98.656% -98.646%] (p = 0.00 < 0.05)
                        thrpt:  [+7284.6% +7341.5% +7397.0%]
                        Performance has improved.
```

Resolves https://github.com/category-labs/monad-bft/issues/2331.