### PR TITLE
Use RawValue for RPC id

### DIFF
--- a/monad-rpc/benches/deserialize.rs
+++ b/monad-rpc/benches/deserialize.rs
@@ -35,8 +35,8 @@ where
 
     match request {
         RequestWrapper::Single(json_request) => {
-            let request = serde_json::from_str::<Request>(json_request.get())
-                .map_err(|_| JsonRpcError::parse_error())?;
+            let request =
+                Request::from_raw_value(json_request).map_err(|_| JsonRpcError::parse_error())?;
 
             let id = request.id.clone();
 
@@ -57,7 +57,7 @@ where
             json_batch_request
                 .into_iter()
                 .map(|json_request| {
-                    let request = serde_json::from_str::<Request>(json_request.get()).unwrap();
+                    let request = Request::from_raw_value(json_request).unwrap();
 
                     black_box(request);
                 })

--- a/monad-rpc/src/handlers/mod.rs
+++ b/monad-rpc/src/handlers/mod.rs
@@ -91,7 +91,7 @@ pub async fn rpc_handler(
 
     let response = match request {
         RequestWrapper::Single(json_request) => {
-            let Ok(request) = serde_json::from_str::<Request>(json_request.get()) else {
+            let Ok(request) = Request::from_raw_value(json_request) else {
                 return HttpResponse::Ok().json(Response::from_error(JsonRpcError::parse_error()));
             };
             root_span.record("json_method", &request.method);
@@ -138,8 +138,7 @@ pub async fn rpc_handler(
                     let app_state = app_state.clone(); // cheap copy
 
                     async move {
-                        let Ok(request) = serde_json::from_str::<Request>(json_request.get())
-                        else {
+                        let Ok(request) = Request::from_raw_value(json_request) else {
                             return (
                                 crate::jsonrpc::RequestId::Null,
                                 Err(JsonRpcError::invalid_request()),


### PR DESCRIPTION
This change is a continuation of https://github.com/category-labs/monad-bft/pull/2454 to prevent building a `serde_json::Value` when deserializing the JSONRPC request `id`.

Originally, this was solved more cleanly using `#[serde(untagged)]`. Unfortunately, serde uses a custom deserializer for untagged enums which results in almost the same number of allocations when deserializing using `serde_json` as before, leading to a `15-20%` performance reduction for all of the `id` attacks. This change adds a `RequestRaw` type which internally uses a `RawValue` to manually parse the ID. This reduces this attack's effectiveness by over `90%`.

The following benchmark change shows that the effectiveness of both of the remaining DOS vectors (`attack_large_id_array` and `attack_large_id_dict`) are reduced by about `90%`. Interestingly, the `attack_large_payload_array_without_params` and `attack_large_payload_array_with_params` scenarios consistently perform better but these are all likely just noise, given the payload deserialization dominates those benchmark times and it did not change in this PR.

```
deserialize/eth_call    time:   [1.0844 µs 1.0848 µs 1.0852 µs]
                        thrpt:  [140.61 MiB/s 140.67 MiB/s 140.71 MiB/s]
                 change:
                        time:   [-3.0431% -2.9932% -2.9434%] (p = 0.00 < 0.05)
                        thrpt:  [+3.0326% +3.0855% +3.1386%]
                        Performance has improved.

deserialize/eth_call-batch
                        time:   [2.4239 µs 2.4248 µs 2.4260 µs]
                        thrpt:  [506.72 MiB/s 506.97 MiB/s 507.16 MiB/s]
                 change:
                        time:   [+3.0976% +3.1646% +3.2241%] (p = 0.00 < 0.05)
                        thrpt:  [-3.1234% -3.0675% -3.0046%]
                        Performance has regressed.

deserialize/attack_large_id_array
                        time:   [3.5572 ms 3.5618 ms 3.5663 ms]
                        thrpt:  [490.71 MiB/s 491.34 MiB/s 491.98 MiB/s]
                 change:
                        time:   [-93.290% -93.275% -93.261%] (p = 0.00 < 0.05)
                        thrpt:  [+1383.8% +1387.1% +1390.4%]
                        Performance has improved.

deserialize/attack_large_id_dict
                        time:   [4.6687 ms 4.6700 ms 4.6715 ms]
                        thrpt:  [401.38 MiB/s 401.51 MiB/s 401.62 MiB/s]
                 change:
                        time:   [-91.196% -91.049% -90.897%] (p = 0.00 < 0.05)
                        thrpt:  [+998.52% +1017.2% +1035.9%]
                        Performance has improved.

deserialize/attack_large_payload_array_without_params
                        time:   [3.3778 ms 3.3813 ms 3.3848 ms]
                        thrpt:  [517.04 MiB/s 517.58 MiB/s 518.11 MiB/s]
                 change:
                        time:   [-10.662% -10.471% -10.273%] (p = 0.00 < 0.05)
                        thrpt:  [+11.449% +11.696% +11.934%]
                        Performance has improved.

deserialize/attack_large_payload_dict_without_params
                        time:   [4.6606 ms 4.6623 ms 4.6641 ms]
                        thrpt:  [402.02 MiB/s 402.18 MiB/s 402.32 MiB/s]
                 change:
                        time:   [-12.206% -12.142% -12.076%] (p = 0.00 < 0.05)
                        thrpt:  [+13.735% +13.820% +13.903%]
                        Performance has improved.

deserialize/attack_large_payload_array_with_params
                        time:   [3.5465 ms 3.5526 ms 3.5586 ms]
                        thrpt:  [491.79 MiB/s 492.62 MiB/s 493.46 MiB/s]
                 change:
                        time:   [+0.8554% +1.0856% +1.3028%] (p = 0.00 < 0.05)
                        thrpt:  [-1.2860% -1.0739% -0.8481%]
                        Change within noise threshold.

deserialize/attack_large_payload_dict_with_params
                        time:   [4.7727 ms 4.7764 ms 4.7802 ms]
                        thrpt:  [392.26 MiB/s 392.57 MiB/s 392.87 MiB/s]
                 change:
                        time:   [-9.0041% -8.8944% -8.7824%] (p = 0.00 < 0.05)
                        thrpt:  [+9.6279% +9.7627% +9.8951%]
                        Performance has improved.
```