### PR TITLE
dataplane: refactor to use socket handles

### DIFF
--- a/monad-dataplane/src/lib.rs
+++ b/monad-dataplane/src/lib.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{
+    fmt::Debug,
     net::{IpAddr, SocketAddr},
     num::NonZeroU32,
     sync::{
@@ -39,7 +40,10 @@ pub(crate) mod buffer_ext;
 pub mod tcp;
 pub mod udp;
 
-pub(crate) use udp::UdpMessageType;
+pub struct UdpSocketConfig {
+    pub socket_addr: SocketAddr,
+    pub label: String,
+}
 
 pub struct DataplaneBuilder {
     local_addr: SocketAddr,
@@ -49,7 +53,7 @@ pub struct DataplaneBuilder {
     udp_buffer_size: Option<usize>,
     tcp_config: TcpConfig,
     ban_duration: Duration,
-    direct_socket_port: Option<u16>,
+    udp_sockets: Vec<UdpSocketConfig>,
 }
 
 impl DataplaneBuilder {
@@ -68,26 +72,21 @@ impl DataplaneBuilder {
                 per_ip_connections_limit: 100,
             },
             ban_duration: Duration::from_secs(5 * 60), // 5 minutes
-            direct_socket_port: None,
+            udp_sockets: vec![],
         }
     }
 
-    /// with_udp_buffer_size sets the buffer size for udp socket that is managed by dataplane
-    /// to a requested value.
     pub fn with_udp_buffer_size(mut self, buffer_size: usize) -> Self {
         self.udp_buffer_size = Some(buffer_size);
         self
     }
 
-    /// with_tcp_connections_limit sets total and per_ip connection limit. if per_ip is zero it will be
-    /// equal to total.
     pub fn with_tcp_connections_limit(mut self, total: usize, per_ip: usize) -> Self {
         self.tcp_config.connections_limit = total;
         self.tcp_config.per_ip_connections_limit = if per_ip == 0 { total } else { per_ip };
         self
     }
 
-    /// with_tcp_rps_burst sets the rate limit and burst for tcp connections.
     pub fn with_tcp_rps_burst(mut self, rps: u32, burst: u32) -> Self {
         self.tcp_config.rate_limit.rps = NonZeroU32::new(rps).expect("rps must be non-zero");
         self.tcp_config.rate_limit.rps_burst =
@@ -95,15 +94,13 @@ impl DataplaneBuilder {
         self
     }
 
-    /// with trusted_ips sets the list of trusted ip addresses.
     pub fn with_trusted_ips(mut self, ips: Vec<IpAddr>) -> Self {
         self.trusted_addresses = ips;
         self
     }
 
-    /// with_direct_socket configures an additional UDP socket for direct peer communication
-    pub fn with_direct_socket(mut self, port: u16) -> Self {
-        self.direct_socket_port = Some(port);
+    pub fn extend_udp_sockets(mut self, sockets: Vec<UdpSocketConfig>) -> Self {
+        self.udp_sockets.extend(sockets);
         self
     }
 
@@ -115,15 +112,40 @@ impl DataplaneBuilder {
             trusted_addresses: trusted,
             tcp_config,
             ban_duration,
-            direct_socket_port,
+            udp_sockets,
         } = self;
+
+        let mut seen_labels = std::collections::HashSet::new();
+        let mut seen_ports = std::collections::HashSet::new();
+        for socket in &udp_sockets {
+            assert!(
+                seen_labels.insert(socket.label.clone()),
+                "duplicate udp socket label: {}",
+                socket.label
+            );
+            assert!(
+                seen_ports.insert(socket.socket_addr.port()),
+                "duplicate udp socket port: {}",
+                socket.socket_addr.port()
+            );
+        }
 
         let (tcp_ingress_tx, tcp_ingress_rx) = mpsc::channel(TCP_INGRESS_CHANNEL_SIZE);
         let (tcp_egress_tx, tcp_egress_rx) = mpsc::channel(TCP_EGRESS_CHANNEL_SIZE);
-        let (udp_ingress_tx, udp_ingress_rx) = mpsc::channel(UDP_INGRESS_CHANNEL_SIZE);
-        let (udp_direct_ingress_tx, udp_direct_ingress_rx) =
-            mpsc::channel(UDP_INGRESS_CHANNEL_SIZE);
+
         let (udp_egress_tx, udp_egress_rx) = mpsc::channel(UDP_EGRESS_CHANNEL_SIZE);
+
+        let mut udp_socket_handles = Vec::new();
+        let mut socket_configs = Vec::new();
+
+        for (socket_id, UdpSocketConfig { socket_addr, label }) in
+            udp_sockets.into_iter().enumerate()
+        {
+            let (handle, config) =
+                create_socket_handle(socket_id, socket_addr, label, udp_egress_tx.clone());
+            udp_socket_handles.push(handle);
+            socket_configs.push(config);
+        }
 
         let ready = Arc::new(AtomicBool::new(false));
         let ready_clone = ready.clone();
@@ -157,10 +179,7 @@ impl DataplaneBuilder {
                                 tcp_egress_rx,
                             );
                             udp::spawn_tasks(
-                                local_addr,
-                                direct_socket_port,
-                                udp_ingress_tx,
-                                udp_direct_ingress_tx,
+                                socket_configs,
                                 udp_egress_rx,
                                 up_bandwidth_mbps,
                                 udp_buffer_size,
@@ -174,421 +193,317 @@ impl DataplaneBuilder {
             })
             .expect("failed to spawn dataplane thread");
 
-        let writer = DataplaneWriter::new(
-            tcp_egress_tx,
-            udp_egress_tx,
-            tcp_control_map,
-            banned_ips_tx,
-            addrlist,
-        );
-        let reader = DataplaneReader::new(tcp_ingress_rx, udp_ingress_rx, udp_direct_ingress_rx);
+        let control = DataplaneControl::new(tcp_control_map, banned_ips_tx, addrlist);
+
+        let tcp_reader = TcpSocketReader {
+            ingress_rx: tcp_ingress_rx,
+        };
+        let tcp_writer = TcpSocketWriter {
+            egress_tx: tcp_egress_tx,
+            msgs_dropped: Arc::new(AtomicUsize::new(0)),
+        };
+        let tcp_socket = TcpSocketHandle {
+            reader: tcp_reader,
+            writer: tcp_writer,
+        };
 
         Dataplane {
-            writer,
-            reader,
+            tcp_socket: Some(tcp_socket),
+            udp_socket_handles,
+            control,
             ready,
         }
     }
 }
 
 pub struct Dataplane {
-    writer: DataplaneWriter,
-    reader: DataplaneReader,
+    tcp_socket: Option<TcpSocketHandle>,
+    udp_socket_handles: Vec<UdpSocketHandle>,
+    control: DataplaneControl,
     ready: Arc<AtomicBool>,
 }
 
-pub struct DataplaneReader {
-    tcp_ingress_rx: mpsc::Receiver<RecvTcpMsg>,
-    udp_ingress_rx: mpsc::Receiver<RecvUdpMsg>,
-    udp_direct_ingress_rx: mpsc::Receiver<RecvUdpMsg>,
+pub struct UdpSocketReader {
+    socket_id: usize,
+    label: String,
+    ingress_rx: mpsc::Receiver<RecvUdpMsg>,
 }
 
-#[derive(Clone)]
-pub struct DataplaneWriter {
-    inner: Arc<DataplaneWriterInner>,
-}
-
-struct DataplaneWriterInner {
-    tcp_egress_tx: mpsc::Sender<(SocketAddr, TcpMsg)>,
-    udp_egress_tx: mpsc::Sender<UdpMsg>,
-
-    tcp_control_map: TcpControl,
-    notify_ban_expiry: mpsc::UnboundedSender<(IpAddr, Instant)>,
-    addrlist: Arc<Addrlist>,
-
-    tcp_msgs_dropped: AtomicUsize,
-    udp_msgs_dropped: AtomicUsize,
-}
-
-#[derive(Clone)]
-pub struct BroadcastMsg {
-    pub targets: Vec<SocketAddr>,
-    pub payload: Bytes,
-    pub stride: u16,
-}
-
-impl BroadcastMsg {
-    fn msg_count(&self) -> usize {
-        self.targets.len()
-    }
-
-    fn into_iter_with_priority(self, priority: UdpPriority) -> impl Iterator<Item = UdpMsg> {
-        let Self {
-            targets,
-            payload,
-            stride,
-        } = self;
-        targets.into_iter().map(move |dst| UdpMsg {
-            dst,
-            payload: payload.clone(),
-            stride,
-            msg_type: UdpMessageType::Broadcast,
-            priority,
+impl UdpSocketReader {
+    pub async fn recv(&mut self) -> RecvUdpMsg {
+        self.ingress_rx.recv().await.unwrap_or_else(|| {
+            panic!(
+                "socket {} ({}) ingress channel closed",
+                self.socket_id, self.label
+            )
         })
     }
 }
 
 #[derive(Clone)]
-pub struct UnicastMsg {
-    pub msgs: Vec<(SocketAddr, Bytes)>,
-    pub stride: u16,
+pub struct UdpSocketWriter {
+    socket_id: usize,
+    socket_addr: SocketAddr,
+    label: String,
+    egress_tx: mpsc::Sender<UdpMsg>,
+    msgs_dropped: Arc<AtomicUsize>,
 }
 
-impl UnicastMsg {
-    fn msg_count(&self) -> usize {
-        self.msgs.len()
-    }
-
-    fn into_iter_with_priority(self, priority: UdpPriority) -> impl Iterator<Item = UdpMsg> {
-        let Self { msgs, stride } = self;
-        msgs.into_iter().map(move |(dst, payload)| UdpMsg {
-            dst,
-            payload,
-            stride,
-            msg_type: UdpMessageType::Broadcast,
-            priority,
-        })
-    }
+pub struct UdpSocketHandle {
+    reader: UdpSocketReader,
+    writer: UdpSocketWriter,
 }
 
-#[derive(Clone)]
-pub struct RecvUdpMsg {
-    pub src_addr: SocketAddr,
-    pub payload: Bytes,
-    pub stride: u16,
-}
-
-#[derive(Clone)]
-pub struct RecvTcpMsg {
-    pub src_addr: SocketAddr,
-    pub payload: Bytes,
-}
-
-pub struct TcpMsg {
-    pub msg: Bytes,
-    pub completion: Option<oneshot::Sender<()>>,
-}
-
-pub(crate) struct UdpMsg {
-    pub(crate) dst: SocketAddr,
-    pub(crate) payload: Bytes,
-    pub(crate) stride: u16,
-    pub(crate) msg_type: UdpMessageType,
-    pub(crate) priority: UdpPriority,
-}
-
-const TCP_INGRESS_CHANNEL_SIZE: usize = 1024;
-const TCP_EGRESS_CHANNEL_SIZE: usize = 1024;
-const UDP_INGRESS_CHANNEL_SIZE: usize = 12_800;
-const UDP_EGRESS_CHANNEL_SIZE: usize = 12_800;
-
-impl Dataplane {
-    pub fn split(self) -> (DataplaneReader, DataplaneWriter) {
+impl UdpSocketHandle {
+    pub fn split(self) -> (UdpSocketReader, UdpSocketWriter) {
         (self.reader, self.writer)
     }
 
-    /// add_trusted marks ip address as trusted.
-    /// connections limits are not applied to trusted ips.
-    pub fn add_trusted(&self, addr: IpAddr) {
-        self.writer.add_trusted(addr);
+    pub async fn recv(&mut self) -> RecvUdpMsg {
+        self.reader.recv().await
     }
 
-    /// remove_trusted removes ip address from trusted list.
-    pub fn remove_trusted(&self, addr: IpAddr) {
-        self.writer.remove_trusted(addr);
+    pub fn write(&self, dst: SocketAddr, payload: Bytes, stride: u16) {
+        self.writer.write(dst, payload, stride)
     }
 
-    pub fn update_trusted(&self, added: Vec<IpAddr>, removed: Vec<IpAddr>) {
-        self.writer.update_trusted(added, removed);
+    pub fn write_broadcast(&self, msg: BroadcastMsg) {
+        self.writer.write_broadcast(msg)
     }
 
-    /// ban ip address. ban duration is specified in dataplane config.
-    pub fn ban(&self, ip: IpAddr) {
-        self.writer.ban(ip);
+    pub fn write_broadcast_with_priority(&self, msg: BroadcastMsg, priority: UdpPriority) {
+        self.writer.write_broadcast_with_priority(msg, priority)
     }
 
-    /// disconnect all connections from specified ip address.
-    pub fn disconnect_ip(&self, ip: IpAddr) {
-        self.writer.disconnect_ip(ip);
+    pub fn write_unicast(&self, msg: UnicastMsg) {
+        self.writer.write_unicast(msg)
     }
 
-    /// disconnect single connection.
-    pub fn disconnect(&self, addr: SocketAddr) {
-        self.writer.disconnect(addr);
+    pub fn write_unicast_with_priority(&self, msg: UnicastMsg, priority: UdpPriority) {
+        self.writer.write_unicast_with_priority(msg, priority)
     }
 
-    pub async fn tcp_read(&mut self) -> RecvTcpMsg {
-        self.reader.tcp_read().await
+    pub fn writer(&self) -> &UdpSocketWriter {
+        &self.writer
     }
 
-    pub fn tcp_write(&self, addr: SocketAddr, msg: TcpMsg) {
-        self.writer.tcp_write(addr, msg)
+    pub fn label(&self) -> &str {
+        &self.writer.label
     }
+}
 
-    pub async fn udp_read(&mut self) -> RecvUdpMsg {
-        self.reader.udp_read().await
-    }
+impl UdpSocketWriter {
+    pub fn write(&self, dst: SocketAddr, payload: Bytes, stride: u16) {
+        let msg_length = payload.len();
+        let result = self.egress_tx.try_send(UdpMsg {
+            socket_id: self.socket_id,
+            dst,
+            payload,
+            stride,
+            priority: UdpPriority::Regular,
+        });
 
-    pub async fn udp_direct_read(&mut self) -> RecvUdpMsg {
-        self.reader.udp_direct_read().await
-    }
-
-    pub fn udp_write_broadcast(&self, msg: BroadcastMsg) {
-        self.writer.udp_write_broadcast(msg);
-    }
-
-    pub fn udp_write_broadcast_with_priority(&self, msg: BroadcastMsg, priority: UdpPriority) {
-        self.writer.udp_write_broadcast_with_priority(msg, priority);
-    }
-
-    pub fn udp_write_unicast(&self, msg: UnicastMsg) {
-        self.writer.udp_write_unicast(msg);
-    }
-
-    pub fn udp_write_direct(&self, dst: SocketAddr, payload: Bytes, stride: u16) {
-        self.writer.udp_write_direct(dst, payload, stride);
-    }
-
-    pub fn udp_write_unicast_with_priority(&self, msg: UnicastMsg, priority: UdpPriority) {
-        self.writer.udp_write_unicast_with_priority(msg, priority);
-    }
-
-    pub fn ready(&self) -> bool {
-        self.ready.load(Ordering::Acquire)
-    }
-
-    pub fn block_until_ready(&self, timeout: Duration) -> bool {
-        let start = std::time::Instant::now();
-        while !self.ready() {
-            if start.elapsed() >= timeout {
-                return false;
+        match result {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                let total = self.msgs_dropped.fetch_add(1, Ordering::Relaxed);
+                warn!(
+                    socket_id = self.socket_id,
+                    label = %self.label,
+                    ?dst,
+                    msg_length,
+                    total_msgs_dropped = total,
+                    "udp egress channel full, dropping message"
+                );
             }
-            std::thread::sleep(Duration::from_millis(1));
+            Err(TrySendError::Closed(_)) => {
+                panic!(
+                    "socket {} ({}) egress channel closed",
+                    self.socket_id, self.label
+                )
+            }
         }
-        true
+    }
+
+    pub fn write_broadcast(&self, msg: BroadcastMsg) {
+        self.write_broadcast_with_priority(msg, UdpPriority::Regular);
+    }
+
+    pub fn write_broadcast_with_priority(&self, msg: BroadcastMsg, priority: UdpPriority) {
+        let msg_len = msg.payload.len();
+        let mut pending_count = msg.msg_count();
+
+        for udp_msg in msg.into_iter_with_priority(self.socket_id, priority) {
+            match self.egress_tx.try_send(udp_msg) {
+                Ok(()) => pending_count -= 1,
+                Err(TrySendError::Full(_)) => break,
+                Err(TrySendError::Closed(_)) => {
+                    panic!(
+                        "socket {} ({}) egress channel closed",
+                        self.socket_id, self.label
+                    )
+                }
+            }
+        }
+
+        if pending_count > 0 {
+            let total = self
+                .msgs_dropped
+                .fetch_add(pending_count, Ordering::Relaxed);
+            warn!(
+                socket_id = self.socket_id,
+                label = %self.label,
+                num_msgs_dropped = pending_count,
+                total_msgs_dropped = total,
+                msg_length = msg_len,
+                ?priority,
+                "udp egress channel full, dropping broadcast messages"
+            );
+        }
+    }
+
+    pub fn write_unicast(&self, msg: UnicastMsg) {
+        self.write_unicast_with_priority(msg, UdpPriority::Regular);
+    }
+
+    pub fn write_unicast_with_priority(&self, msg: UnicastMsg, priority: UdpPriority) {
+        let mut pending_count = msg.msg_count();
+
+        for udp_msg in msg.into_iter_with_priority(self.socket_id, priority) {
+            match self.egress_tx.try_send(udp_msg) {
+                Ok(()) => pending_count -= 1,
+                Err(TrySendError::Full(_)) => break,
+                Err(TrySendError::Closed(_)) => {
+                    panic!(
+                        "socket {} ({}) egress channel closed",
+                        self.socket_id, self.label
+                    )
+                }
+            }
+        }
+
+        if pending_count > 0 {
+            let total = self
+                .msgs_dropped
+                .fetch_add(pending_count, Ordering::Relaxed);
+            warn!(
+                socket_id = self.socket_id,
+                label = %self.label,
+                num_msgs_dropped = pending_count,
+                total_msgs_dropped = total,
+                ?priority,
+                "udp egress channel full, dropping unicast messages"
+            );
+        }
     }
 }
 
-impl DataplaneReader {
+impl Debug for UdpSocketHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UdpSocketHandle")
+            .field("socket_id", &self.writer.socket_id)
+            .field("label", &self.writer.label)
+            .field("socket_addr", &self.writer.socket_addr)
+            .finish()
+    }
+}
+
+pub struct UdpDataplane {
+    socket_handles: Vec<UdpSocketHandle>,
+}
+
+impl UdpDataplane {
+    pub fn take_socket(&mut self, label: &str) -> Option<UdpSocketHandle> {
+        self.socket_handles
+            .iter()
+            .position(|h| h.label() == label)
+            .map(|idx| self.socket_handles.swap_remove(idx))
+    }
+}
+
+pub struct TcpSocketReader {
+    ingress_rx: mpsc::Receiver<RecvTcpMsg>,
+}
+
+impl TcpSocketReader {
+    pub async fn recv(&mut self) -> RecvTcpMsg {
+        self.ingress_rx
+            .recv()
+            .await
+            .unwrap_or_else(|| panic!("tcp ingress channel closed"))
+    }
+}
+
+#[derive(Clone)]
+pub struct TcpSocketWriter {
+    egress_tx: mpsc::Sender<(SocketAddr, TcpMsg)>,
+    msgs_dropped: Arc<AtomicUsize>,
+}
+
+impl TcpSocketWriter {
+    pub fn write(&self, addr: SocketAddr, msg: TcpMsg) {
+        let msg_length = msg.msg.len();
+
+        match self.egress_tx.try_send((addr, msg)) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                let total = self.msgs_dropped.fetch_add(1, Ordering::Relaxed);
+                warn!(
+                    ?addr,
+                    msg_length,
+                    total_msgs_dropped = total,
+                    "tcp egress channel full, dropping message"
+                );
+            }
+            Err(TrySendError::Closed(_)) => panic!("tcp egress channel closed"),
+        }
+    }
+}
+
+pub struct TcpSocketHandle {
+    reader: TcpSocketReader,
+    writer: TcpSocketWriter,
+}
+
+impl TcpSocketHandle {
+    pub fn split(self) -> (TcpSocketReader, TcpSocketWriter) {
+        (self.reader, self.writer)
+    }
+
+    pub async fn recv(&mut self) -> RecvTcpMsg {
+        self.reader.recv().await
+    }
+
+    pub fn write(&self, addr: SocketAddr, msg: TcpMsg) {
+        self.writer.write(addr, msg)
+    }
+}
+
+#[derive(Clone)]
+pub struct DataplaneControl {
+    inner: Arc<DataplaneControlInner>,
+}
+
+struct DataplaneControlInner {
+    tcp_control_map: TcpControl,
+    notify_ban_expiry: mpsc::UnboundedSender<(IpAddr, Instant)>,
+    addrlist: Arc<Addrlist>,
+}
+
+impl DataplaneControl {
     fn new(
-        tcp_ingress_rx: mpsc::Receiver<RecvTcpMsg>,
-        udp_ingress_rx: mpsc::Receiver<RecvUdpMsg>,
-        udp_direct_ingress_rx: mpsc::Receiver<RecvUdpMsg>,
-    ) -> Self {
-        Self {
-            tcp_ingress_rx,
-            udp_ingress_rx,
-            udp_direct_ingress_rx,
-        }
-    }
-
-    pub async fn tcp_read(&mut self) -> RecvTcpMsg {
-        match self.tcp_ingress_rx.recv().await {
-            Some(msg) => msg,
-            None => panic!("tcp_ingress_rx channel closed"),
-        }
-    }
-
-    pub async fn udp_read(&mut self) -> RecvUdpMsg {
-        match self.udp_ingress_rx.recv().await {
-            Some(msg) => msg,
-            None => panic!("udp_ingress_rx channel closed"),
-        }
-    }
-
-    pub async fn udp_direct_read(&mut self) -> RecvUdpMsg {
-        match self.udp_direct_ingress_rx.recv().await {
-            Some(msg) => msg,
-            None => panic!("udp_direct_ingress_rx channel closed"),
-        }
-    }
-
-    pub fn split(self) -> (TcpReader, UdpReader) {
-        (
-            TcpReader(self.tcp_ingress_rx),
-            UdpReader {
-                udp_ingress_rx: self.udp_ingress_rx,
-                udp_direct_ingress_rx: self.udp_direct_ingress_rx,
-            },
-        )
-    }
-}
-
-pub struct TcpReader(mpsc::Receiver<RecvTcpMsg>);
-pub struct UdpReader {
-    udp_ingress_rx: mpsc::Receiver<RecvUdpMsg>,
-    udp_direct_ingress_rx: mpsc::Receiver<RecvUdpMsg>,
-}
-
-impl TcpReader {
-    pub async fn read(&mut self) -> RecvTcpMsg {
-        match self.0.recv().await {
-            Some(msg) => msg,
-            None => panic!("tcp_ingress_rx channel closed"),
-        }
-    }
-}
-
-impl UdpReader {
-    pub async fn read(&mut self) -> RecvUdpMsg {
-        match self.udp_ingress_rx.recv().await {
-            Some(msg) => msg,
-            None => panic!("udp_ingress_rx channel closed"),
-        }
-    }
-
-    pub async fn direct_read(&mut self) -> RecvUdpMsg {
-        match self.udp_direct_ingress_rx.recv().await {
-            Some(msg) => msg,
-            None => panic!("udp_direct_ingress_rx channel closed"),
-        }
-    }
-}
-
-impl DataplaneWriter {
-    fn new(
-        tcp_egress_tx: mpsc::Sender<(SocketAddr, TcpMsg)>,
-        udp_egress_tx: mpsc::Sender<UdpMsg>,
         tcp_control_map: TcpControl,
         notify_ban_expiry: mpsc::UnboundedSender<(IpAddr, Instant)>,
         addrlist: Arc<Addrlist>,
     ) -> Self {
-        let inner = DataplaneWriterInner {
-            tcp_egress_tx,
-            udp_egress_tx,
+        let inner = DataplaneControlInner {
             tcp_control_map,
             notify_ban_expiry,
             addrlist,
-            tcp_msgs_dropped: AtomicUsize::new(0),
-            udp_msgs_dropped: AtomicUsize::new(0),
         };
         Self {
             inner: Arc::new(inner),
         }
-    }
-
-    pub fn tcp_write(&self, addr: SocketAddr, msg: TcpMsg) {
-        let msg_length = msg.msg.len();
-
-        match self.inner.tcp_egress_tx.try_send((addr, msg)) {
-            Ok(()) => {}
-            Err(TrySendError::Full(_)) => {
-                let tcp_msgs_dropped = self.inner.tcp_msgs_dropped.fetch_add(1, Ordering::Relaxed);
-
-                warn!(
-                    num_msgs_dropped = 1,
-                    total_tcp_msgs_dropped = tcp_msgs_dropped,
-                    ?addr,
-                    msg_length,
-                    "tcp_egress_tx channel full, dropping message"
-                );
-            }
-            Err(TrySendError::Closed(_)) => panic!("tcp_egress_tx channel closed"),
-        }
-    }
-
-    pub fn udp_write_broadcast(&self, msg: BroadcastMsg) {
-        self.udp_write_broadcast_with_priority(msg, UdpPriority::Regular);
-    }
-
-    pub fn udp_write_unicast(&self, msg: UnicastMsg) {
-        self.udp_write_unicast_with_priority(msg, UdpPriority::Regular);
-    }
-
-    #[tracing::instrument(
-        level="trace",
-        skip_all,
-        fields(len = msg.payload.len(), targets = msg.targets.len(), priority = ?priority)
-    )]
-    pub fn udp_write_broadcast_with_priority(&self, msg: BroadcastMsg, priority: UdpPriority) {
-        let mut pending_count = msg.msg_count();
-        let msg_len = msg.payload.len();
-
-        for udp_msg in msg.into_iter_with_priority(priority) {
-            match self.inner.udp_egress_tx.try_send(udp_msg) {
-                Ok(()) => {
-                    pending_count -= 1;
-                }
-                Err(TrySendError::Full(_)) => {
-                    break;
-                }
-                Err(TrySendError::Closed(_)) => panic!("udp_egress_tx channel closed"),
-            }
-        }
-
-        if pending_count == 0 {
-            return;
-        }
-
-        let udp_msgs_dropped = self
-            .inner
-            .udp_msgs_dropped
-            .fetch_add(pending_count, Ordering::Relaxed);
-
-        warn!(
-            num_msgs_dropped = pending_count,
-            total_udp_msgs_dropped = udp_msgs_dropped,
-            msg_length = msg_len,
-            ?priority,
-            "udp_egress_tx channel full, dropping message"
-        );
-    }
-
-    #[tracing::instrument(
-        level="trace",
-        skip_all,
-        fields(msgs = msg.msgs.len(), priority = ?priority)
-    )]
-    pub fn udp_write_unicast_with_priority(&self, msg: UnicastMsg, priority: UdpPriority) {
-        let mut pending_count = msg.msg_count();
-
-        for udp_msg in msg.into_iter_with_priority(priority) {
-            match self.inner.udp_egress_tx.try_send(udp_msg) {
-                Ok(()) => {
-                    pending_count -= 1;
-                }
-                Err(TrySendError::Full(_)) => {
-                    break;
-                }
-                Err(TrySendError::Closed(_)) => panic!("udp_egress_tx channel closed"),
-            }
-        }
-
-        if pending_count == 0 {
-            return;
-        }
-
-        let udp_msgs_dropped = self
-            .inner
-            .udp_msgs_dropped
-            .fetch_add(pending_count, Ordering::Relaxed);
-
-        warn!(
-            num_msgs_dropped = pending_count,
-            total_udp_msgs_dropped = udp_msgs_dropped,
-            ?priority,
-            "udp_egress_tx channel full, dropping message"
-        );
     }
 
     /// add_trusted marks ip address as trusted.
@@ -630,31 +545,204 @@ impl DataplaneWriter {
             .tcp_control_map
             .disconnect_socket(addr.ip(), addr.port());
     }
+}
 
-    pub fn udp_write_direct(&self, dst: SocketAddr, payload: Bytes, stride: u16) {
-        let msg_length = payload.len();
-        let udp_msg = UdpMsg {
+#[derive(Clone)]
+pub struct BroadcastMsg {
+    pub targets: Vec<SocketAddr>,
+    pub payload: Bytes,
+    pub stride: u16,
+}
+
+impl BroadcastMsg {
+    fn msg_count(&self) -> usize {
+        self.targets.len()
+    }
+
+    fn into_iter_with_priority(
+        self,
+        socket_id: usize,
+        priority: UdpPriority,
+    ) -> impl Iterator<Item = UdpMsg> {
+        let Self {
+            targets,
+            payload,
+            stride,
+        } = self;
+        targets.into_iter().map(move |dst| UdpMsg {
+            socket_id,
+            dst,
+            payload: payload.clone(),
+            stride,
+            priority,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct UnicastMsg {
+    pub msgs: Vec<(SocketAddr, Bytes)>,
+    pub stride: u16,
+}
+
+impl UnicastMsg {
+    fn msg_count(&self) -> usize {
+        self.msgs.len()
+    }
+
+    fn into_iter_with_priority(
+        self,
+        socket_id: usize,
+        priority: UdpPriority,
+    ) -> impl Iterator<Item = UdpMsg> {
+        let Self { msgs, stride } = self;
+        msgs.into_iter().map(move |(dst, payload)| UdpMsg {
+            socket_id,
             dst,
             payload,
             stride,
-            msg_type: UdpMessageType::Direct,
-            priority: UdpPriority::Regular,
+            priority,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct RecvUdpMsg {
+    pub src_addr: SocketAddr,
+    pub payload: Bytes,
+    pub stride: u16,
+}
+
+#[derive(Clone)]
+pub struct RecvTcpMsg {
+    pub src_addr: SocketAddr,
+    pub payload: Bytes,
+}
+
+pub struct TcpMsg {
+    pub msg: Bytes,
+    pub completion: Option<oneshot::Sender<()>>,
+}
+
+pub(crate) struct UdpMsg {
+    pub(crate) socket_id: usize,
+    pub(crate) dst: SocketAddr,
+    pub(crate) payload: Bytes,
+    pub(crate) stride: u16,
+    pub(crate) priority: UdpPriority,
+}
+
+const TCP_INGRESS_CHANNEL_SIZE: usize = 1024;
+const TCP_EGRESS_CHANNEL_SIZE: usize = 1024;
+const UDP_INGRESS_CHANNEL_SIZE: usize = 12_800;
+const UDP_EGRESS_CHANNEL_SIZE: usize = 12_800;
+
+fn create_socket_handle(
+    socket_id: usize,
+    socket_addr: SocketAddr,
+    label: String,
+    egress_tx: mpsc::Sender<UdpMsg>,
+) -> (
+    UdpSocketHandle,
+    (usize, SocketAddr, String, mpsc::Sender<RecvUdpMsg>),
+) {
+    let (ingress_tx, ingress_rx) = mpsc::channel(UDP_INGRESS_CHANNEL_SIZE);
+    let msgs_dropped = Arc::new(AtomicUsize::new(0));
+
+    let reader = UdpSocketReader {
+        socket_id,
+        label: label.clone(),
+        ingress_rx,
+    };
+
+    let writer = UdpSocketWriter {
+        socket_id,
+        socket_addr,
+        label: label.clone(),
+        egress_tx,
+        msgs_dropped,
+    };
+
+    let handle = UdpSocketHandle { reader, writer };
+    let config = (socket_id, socket_addr, label, ingress_tx);
+    (handle, config)
+}
+
+impl Dataplane {
+    pub fn split(self) -> (TcpSocketHandle, UdpDataplane, DataplaneControl) {
+        let tcp_socket = self.tcp_socket.expect("tcp socket already taken");
+        let udp = UdpDataplane {
+            socket_handles: self.udp_socket_handles,
         };
+        (tcp_socket, udp, self.control)
+    }
 
-        match self.inner.udp_egress_tx.try_send(udp_msg) {
-            Ok(()) => {}
-            Err(TrySendError::Full(_)) => {
-                let udp_msgs_dropped = self.inner.udp_msgs_dropped.fetch_add(1, Ordering::Relaxed);
+    pub fn take_tcp_socket(&mut self) -> Option<TcpSocketHandle> {
+        self.tcp_socket.take()
+    }
 
-                warn!(
-                    num_msgs_dropped = 1,
-                    total_udp_msgs_dropped = udp_msgs_dropped,
-                    ?dst,
-                    msg_length,
-                    "udp_egress_tx channel full, dropping direct message"
-                );
+    pub fn udp_socket_handles(&mut self) -> &mut [UdpSocketHandle] {
+        &mut self.udp_socket_handles
+    }
+
+    pub fn take_udp_socket_handle(&mut self, label: &str) -> Option<UdpSocketHandle> {
+        self.udp_socket_handles
+            .iter()
+            .position(|h| h.label() == label)
+            .map(|idx| self.udp_socket_handles.swap_remove(idx))
+    }
+
+    pub fn add_trusted(&self, addr: IpAddr) {
+        self.control.add_trusted(addr);
+    }
+
+    pub fn remove_trusted(&self, addr: IpAddr) {
+        self.control.remove_trusted(addr);
+    }
+
+    pub fn update_trusted(&self, added: Vec<IpAddr>, removed: Vec<IpAddr>) {
+        self.control.update_trusted(added, removed);
+    }
+
+    pub fn ban(&self, ip: IpAddr) {
+        self.control.ban(ip);
+    }
+
+    pub fn disconnect_ip(&self, ip: IpAddr) {
+        self.control.disconnect_ip(ip);
+    }
+
+    pub fn disconnect(&self, addr: SocketAddr) {
+        self.control.disconnect(addr);
+    }
+
+    pub async fn tcp_read(&mut self) -> RecvTcpMsg {
+        self.tcp_socket
+            .as_mut()
+            .expect("tcp socket already taken")
+            .recv()
+            .await
+    }
+
+    pub fn tcp_write(&self, addr: SocketAddr, msg: TcpMsg) {
+        self.tcp_socket
+            .as_ref()
+            .expect("tcp socket already taken")
+            .write(addr, msg);
+    }
+
+    pub fn ready(&self) -> bool {
+        self.ready.load(Ordering::Acquire)
+    }
+
+    pub fn block_until_ready(&self, timeout: Duration) -> bool {
+        let start = std::time::Instant::now();
+        while !self.ready() {
+            if start.elapsed() >= timeout {
+                return false;
             }
-            Err(TrySendError::Closed(_)) => panic!("udp_egress_tx channel closed"),
+            std::thread::sleep(Duration::from_millis(1));
         }
+        true
     }
 }

--- a/monad-dataplane/src/udp.rs
+++ b/monad-dataplane/src/udp.rs
@@ -32,12 +32,6 @@ use tracing::{debug, error, trace, warn};
 use super::{RecvUdpMsg, UdpMsg};
 use crate::buffer_ext::SocketBufferExt;
 
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum UdpMessageType {
-    Broadcast,
-    Direct,
-}
-
 const PRIORITY_QUEUE_BYTES_CAPACITY: usize = 100 * 1024 * 1024;
 
 #[derive(Error, Debug)]
@@ -165,36 +159,21 @@ fn set_mtu_discovery(socket: &UdpSocket) {
 }
 
 pub(crate) fn spawn_tasks(
-    local_addr: SocketAddr,
-    direct_socket_port: Option<u16>,
-    udp_ingress_tx: mpsc::Sender<RecvUdpMsg>,
-    udp_direct_ingress_tx: mpsc::Sender<RecvUdpMsg>,
+    socket_configs: Vec<(usize, SocketAddr, String, mpsc::Sender<RecvUdpMsg>)>,
     udp_egress_rx: mpsc::Receiver<UdpMsg>,
     up_bandwidth_mbps: u64,
     buffer_size: Option<usize>,
 ) {
-    let (udp_socket_rx, udp_socket_tx) = create_socket_pair(local_addr, buffer_size);
-    let (direct_socket_rx, direct_socket_tx) = direct_socket_port
-        .map(|port| {
-            let mut direct_addr = local_addr;
-            direct_addr.set_port(port);
-            let (rx, tx) = create_socket_pair(direct_addr, buffer_size);
-            (Some(rx), Some(tx))
-        })
-        .unwrap_or((None, None));
+    let mut tx_sockets = Vec::new();
 
-    spawn(rx(
-        udp_socket_rx,
-        direct_socket_rx,
-        udp_ingress_tx,
-        udp_direct_ingress_tx,
-    ));
-    spawn(tx(
-        udp_socket_tx,
-        direct_socket_tx,
-        udp_egress_rx,
-        up_bandwidth_mbps,
-    ));
+    for (socket_id, socket_addr, label, ingress_tx) in socket_configs {
+        let (rx, tx) = create_socket_pair(socket_addr, buffer_size);
+        spawn(rx_single_socket(rx, ingress_tx));
+        trace!(socket_id, label = %label, ?socket_addr, "created socket");
+        tx_sockets.push(tx);
+    }
+
+    spawn(tx(tx_sockets, udp_egress_rx, up_bandwidth_mbps));
 }
 
 fn create_socket_pair(addr: SocketAddr, buffer_size: Option<usize>) -> (UdpSocket, UdpSocket) {
@@ -203,23 +182,6 @@ fn create_socket_pair(addr: SocketAddr, buffer_size: Option<usize>) -> (UdpSocke
     let tx =
         UdpSocket::from_std(unsafe { std::net::UdpSocket::from_raw_fd(rx.as_raw_fd()) }).unwrap();
     (rx, tx)
-}
-
-async fn rx(
-    udp_socket_rx: UdpSocket,
-    direct_socket_rx: Option<UdpSocket>,
-    udp_ingress_tx: mpsc::Sender<RecvUdpMsg>,
-    udp_direct_ingress_tx: mpsc::Sender<RecvUdpMsg>,
-) {
-    match direct_socket_rx {
-        Some(direct_socket) => {
-            spawn(rx_single_socket(udp_socket_rx, udp_ingress_tx));
-            spawn(rx_single_socket(direct_socket, udp_direct_ingress_tx));
-        }
-        None => {
-            rx_single_socket(udp_socket_rx, udp_ingress_tx).await;
-        }
-    }
 }
 
 async fn rx_single_socket(socket: UdpSocket, udp_ingress_tx: mpsc::Sender<RecvUdpMsg>) {
@@ -251,8 +213,7 @@ async fn rx_single_socket(socket: UdpSocket, udp_ingress_tx: mpsc::Sender<RecvUd
 const PACING_SLEEP_OVERSHOOT_DETECTION_WINDOW: Duration = Duration::from_millis(100);
 
 async fn tx(
-    socket_tx: UdpSocket,
-    direct_socket_tx: Option<UdpSocket>,
+    tx_sockets: Vec<UdpSocket>,
     mut udp_egress_rx: mpsc::Receiver<UdpMsg>,
     up_bandwidth_mbps: u64,
 ) {
@@ -312,13 +273,10 @@ async fn tx(
             let chunk = msg.payload.split_to(chunk_size);
             total_bytes += chunk.len();
 
-            let socket = match (&msg.msg_type, &direct_socket_tx) {
-                (UdpMessageType::Direct, Some(direct_socket)) => direct_socket,
-                _ => &socket_tx,
-            };
-
+            let socket_id = msg.socket_id;
             let dst = msg.dst;
-            let msg_type = msg.msg_type;
+
+            let socket = tx_sockets.get(socket_id).expect("valid socket_id");
 
             if !msg.payload.is_empty() {
                 if let Err(err) = priority_queues.try_push(msg) {
@@ -327,9 +285,9 @@ async fn tx(
             }
 
             trace!(
+                socket_id,
                 dst_addr = ?dst,
                 chunk_len = chunk.len(),
-                msg_type = ?msg_type,
                 "preparing udp send"
             );
 
@@ -420,11 +378,11 @@ mod tests {
 
     fn create_test_msg(priority: UdpPriority, payload_size: usize) -> UdpMsg {
         UdpMsg {
+            socket_id: 0,
             dst: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080),
             payload: Bytes::from(vec![0u8; payload_size]),
             stride: 1024,
             priority,
-            msg_type: UdpMessageType::Broadcast,
         }
     }
 

--- a/monad-dataplane/tests/address_family_mismatch.rs
+++ b/monad-dataplane/tests/address_family_mismatch.rs
@@ -21,6 +21,8 @@ use tracing::debug;
 /// 1_000 = 1 Gbps, 10_000 = 10 Gbps
 const UP_BANDWIDTH_MBPS: u64 = 1_000;
 
+const LEGACY_SOCKET: &str = "legacy";
+
 const BIND_ADDRS: [&str; 2] = ["0.0.0.0:19100", "127.0.0.1:19101"];
 
 const TX_ADDRS: [&str; 2] = ["127.0.0.1:19200", "[::1]:19201"];
@@ -40,22 +42,28 @@ fn address_family_mismatch() {
     }));
 
     for addr in BIND_ADDRS {
-        let dataplane = DataplaneBuilder::new(&addr.parse().unwrap(), UP_BANDWIDTH_MBPS).build();
+        let bind_addr = addr.parse().unwrap();
+        let mut dataplane = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS)
+            .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
+                socket_addr: bind_addr,
+                label: LEGACY_SOCKET.to_string(),
+            }])
+            .build();
 
-        // Allow Dataplane thread to set itself up.
         assert!(dataplane.block_until_ready(Duration::from_secs(1)));
+
+        let socket = dataplane.take_udp_socket_handle(LEGACY_SOCKET).unwrap();
 
         for tx_addr in TX_ADDRS {
             debug!("sending to {} from {}", tx_addr, addr);
 
-            dataplane.udp_write_broadcast(BroadcastMsg {
+            socket.write_broadcast(BroadcastMsg {
                 targets: vec![tx_addr.parse().unwrap(); 1],
                 payload: vec![0; DEFAULT_SEGMENT_SIZE.into()].into(),
                 stride: DEFAULT_SEGMENT_SIZE,
             });
         }
 
-        // Allow Dataplane thread to catch up.
         sleep(Duration::from_millis(10));
     }
 }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -52,7 +52,10 @@ use monad_peer_discovery::{
     MonadNameRecord, NameRecord,
 };
 use monad_pprof::start_pprof_server;
-use monad_raptorcast::config::{RaptorCastConfig, RaptorCastConfigPrimary};
+use monad_raptorcast::{
+    config::{RaptorCastConfig, RaptorCastConfigPrimary},
+    RAPTORCAST_SOCKET,
+};
 use monad_router_multi::MultiRouter;
 use monad_state::{MonadMessage, MonadStateBuilder, VerifiedMonadMessage};
 use monad_state_backend::StateBackendThreadClient;
@@ -554,7 +557,11 @@ where
         .with_tcp_rps_burst(
             network_config.tcp_rate_limit_rps,
             network_config.tcp_rate_limit_burst,
-        );
+        )
+        .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
+            socket_addr: bind_address,
+            label: RAPTORCAST_SOCKET.to_string(),
+        }]);
 
     let self_id = NodeId::new(identity.pubkey());
     let self_record = NameRecord::new(

--- a/monad-raptorcast/examples/latency.rs
+++ b/monad-raptorcast/examples/latency.rs
@@ -43,7 +43,7 @@ use monad_peer_discovery::{
 use monad_raptorcast::{
     config::{RaptorCastConfig, RaptorCastConfigPrimary},
     raptorcast_secondary::SecondaryRaptorCastModeConfig,
-    RaptorCast, RaptorCastEvent,
+    RaptorCast, RaptorCastEvent, RAPTORCAST_SOCKET,
 };
 use monad_secp::{KeyPair, SecpSignature};
 use monad_types::{Deserializable, Epoch, NodeId, RouterTarget, Serializable, Stake};
@@ -408,10 +408,19 @@ fn setup_node(
 
     let udp_addr = SocketAddr::V4(my_config.udp_addr);
 
-    let dataplane = DataplaneBuilder::new(&udp_addr, UDP_BW).build();
+    let dataplane = DataplaneBuilder::new(&udp_addr, UDP_BW)
+        .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
+            socket_addr: udp_addr,
+            label: RAPTORCAST_SOCKET.to_string(),
+        }])
+        .build();
     assert!(dataplane.block_until_ready(Duration::from_secs(2)));
 
-    let (dataplane_reader, dataplane_writer) = dataplane.split();
+    let (tcp_socket, mut udp_dataplane, dataplane_control) = dataplane.split();
+    let (tcp_reader, tcp_writer) = tcp_socket.split();
+    let udp_socket = udp_dataplane
+        .take_socket(RAPTORCAST_SOCKET)
+        .expect("raptorcast socket not found");
 
     let mut known_addresses = std::collections::HashMap::new();
     for (node_id, record) in &routing_info {
@@ -436,8 +445,10 @@ fn setup_node(
     >::new(
         create_raptorcast_config(keypair_arc),
         SecondaryRaptorCastModeConfig::None,
-        dataplane_reader,
-        dataplane_writer,
+        tcp_reader,
+        tcp_writer,
+        udp_socket,
+        dataplane_control,
         Arc::new(std::sync::Mutex::new(pd)),
         Epoch(0),
     );

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -39,7 +39,8 @@ use monad_crypto::{
 };
 use monad_dataplane::{
     udp::{segment_size_for_mtu, DEFAULT_MTU},
-    BroadcastMsg, DataplaneBuilder, DataplaneReader, DataplaneWriter, RecvTcpMsg, TcpMsg,
+    BroadcastMsg, DataplaneBuilder, DataplaneControl, RecvTcpMsg, TcpMsg, TcpSocketReader,
+    TcpSocketWriter, UdpSocketHandle,
 };
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{
@@ -74,9 +75,8 @@ pub mod util;
 
 const SIGNATURE_SIZE: usize = 65;
 
-// Number of chunks to aggregate into udp messages before sending to
-// the dataplane.
 pub const UNICAST_MSG_BATCH_SIZE: usize = 32;
+pub const RAPTORCAST_SOCKET: &str = "raptorcast";
 
 pub(crate) type OwnedMessageBuilder<ST, PD> =
     packet::MessageBuilder<'static, ST, Arc<Mutex<PeerDiscoveryDriver<PD>>>>;
@@ -91,7 +91,6 @@ where
     signing_key: Arc<ST::KeyPairType>,
     is_dynamic_fullnode: bool,
 
-    // Raptorcast group with stake information. For the send side (i.e., initiating proposals)
     epoch_validators: BTreeMap<Epoch, EpochValidators<ST>>,
     rebroadcast_map: ReBroadcastGroupMap<ST>,
 
@@ -103,8 +102,10 @@ where
     udp_state: udp::UdpState<ST>,
     message_builder: OwnedMessageBuilder<ST, PD>,
 
-    dataplane_reader: DataplaneReader,
-    dataplane_writer: DataplaneWriter,
+    tcp_reader: TcpSocketReader,
+    tcp_writer: TcpSocketWriter,
+    udp_socket: UdpSocketHandle,
+    dataplane_control: DataplaneControl,
     pending_events: VecDeque<RaptorCastEvent<M::Event, ST>>,
 
     channel_to_secondary: Option<UnboundedSender<FullNodesGroupMessage<ST>>>,
@@ -137,8 +138,10 @@ where
     pub fn new(
         config: config::RaptorCastConfig<ST>,
         secondary_mode: SecondaryRaptorCastModeConfig,
-        dataplane_reader: DataplaneReader,
-        dataplane_writer: DataplaneWriter,
+        tcp_reader: TcpSocketReader,
+        tcp_writer: TcpSocketWriter,
+        udp_socket: UdpSocketHandle,
+        control: DataplaneControl,
         peer_discovery_driver: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
         current_epoch: Epoch,
     ) -> Self {
@@ -179,8 +182,10 @@ where
 
             udp_state: udp::UdpState::new(self_id, config.udp_message_max_age_ms),
 
-            dataplane_reader,
-            dataplane_writer,
+            tcp_reader,
+            tcp_writer,
+            udp_socket,
+            dataplane_control: control,
             pending_events: Default::default(),
             channel_to_secondary: None,
             channel_from_secondary: None,
@@ -261,7 +266,7 @@ where
                 assert_eq!(signature.len(), SIGNATURE_SIZE);
                 signed_message[..SIGNATURE_SIZE].copy_from_slice(&signature);
                 signed_message[SIGNATURE_SIZE..].copy_from_slice(&app_message);
-                self.dataplane_writer.tcp_write(
+                self.tcp_writer.write(
                     address,
                     TcpMsg {
                         msg: signed_message.freeze(),
@@ -337,8 +342,8 @@ where
                     )
                 });
                 let mut sink = UdpMessageBatcher::new(UNICAST_MSG_BATCH_SIZE, |rc_chunks| {
-                    self.dataplane_writer
-                        .udp_write_unicast_with_priority(rc_chunks, priority);
+                    self.udp_socket
+                        .write_unicast_with_priority(rc_chunks, priority);
                 });
 
                 self.message_builder
@@ -378,8 +383,8 @@ where
                         )
                     });
                     let mut sink = UdpMessageBatcher::new(UNICAST_MSG_BATCH_SIZE, |rc_chunks| {
-                        self.dataplane_writer
-                            .udp_write_unicast_with_priority(rc_chunks, priority);
+                        self.udp_socket
+                            .write_unicast_with_priority(rc_chunks, priority);
                     });
 
                     self.message_builder
@@ -425,9 +430,18 @@ where
         ..Default::default()
     };
     let up_bandwidth_mbps = 1_000;
-    let dp = DataplaneBuilder::new(&local_addr, up_bandwidth_mbps).build();
+    let dp = DataplaneBuilder::new(&local_addr, up_bandwidth_mbps)
+        .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
+            socket_addr: local_addr,
+            label: RAPTORCAST_SOCKET.to_string(),
+        }])
+        .build();
     assert!(dp.block_until_ready(Duration::from_secs(1)));
-    let (dp_reader, dp_writer) = dp.split();
+    let (tcp_socket, mut udp_dataplane, control) = dp.split();
+    let udp_socket = udp_dataplane
+        .take_socket(RAPTORCAST_SOCKET)
+        .expect("raptorcast socket");
+    let (tcp_reader, tcp_writer) = tcp_socket.split();
     let config = config::RaptorCastConfig {
         shared_key,
         mtu: DEFAULT_MTU,
@@ -455,8 +469,10 @@ where
     RaptorCast::<ST, M, OM, SE, NopDiscovery<ST>>::new(
         config,
         SecondaryRaptorCastModeConfig::None,
-        dp_reader,
-        dp_writer,
+        tcp_reader,
+        tcp_writer,
+        udp_socket,
+        control,
         shared_pd,
         Epoch(0),
     )
@@ -495,7 +511,7 @@ where
                                 .flat_map(|val| iter_ips(val, &*pd_driver))
                                 .collect();
                             drop(pd_driver);
-                            self.dataplane_writer.update_trusted(added, removed);
+                            self.dataplane_control.update_trusted(added, removed);
                         }
 
                         self.current_epoch = epoch;
@@ -601,7 +617,7 @@ where
                         )
                     });
                     let mut sink = UdpMessageBatcher::new(UNICAST_MSG_BATCH_SIZE, |rc_chunks| {
-                        self.dataplane_writer.udp_write_unicast(rc_chunks);
+                        self.udp_socket.write_unicast(rc_chunks);
                     });
 
                     for node in full_nodes_view.iter() {
@@ -609,8 +625,6 @@ where
                             continue;
                         }
 
-                        // TODO: optimize the build of copies of the
-                        // same message to multiple recipients.
                         let build_target = BuildTarget::PointToPoint(node);
                         self.message_builder
                             .prepare_with_peer_lookup(&node_addrs)
@@ -724,8 +738,7 @@ where
         }
 
         loop {
-            let dataplane = &mut this.dataplane_reader;
-            let Poll::Ready(message) = pin!(dataplane.udp_read()).poll_unpin(cx) else {
+            let Poll::Ready(message) = pin!(this.udp_socket.recv()).poll_unpin(cx) else {
                 break;
             };
 
@@ -755,14 +768,11 @@ where
                             })
                             .collect();
 
-                        this.dataplane_writer.udp_write_broadcast_with_priority(
-                            BroadcastMsg {
-                                targets: target_addrs,
-                                payload,
-                                stride: bcast_stride,
-                            },
-                            UdpPriority::High,
-                        );
+                        this.udp_socket.write_broadcast(BroadcastMsg {
+                            targets: target_addrs,
+                            payload,
+                            stride: bcast_stride,
+                        });
                     },
                     message,
                 )
@@ -850,8 +860,7 @@ where
         }
 
         loop {
-            let dataplane = &mut this.dataplane_reader;
-            let Poll::Ready(msg) = pin!(dataplane.tcp_read()).poll_unpin(cx) else {
+            let Poll::Ready(msg) = pin!(this.tcp_reader.recv()).poll_unpin(cx) else {
                 break;
             };
             let RecvTcpMsg { payload, src_addr } = msg;
@@ -861,7 +870,7 @@ where
                     ?src_addr,
                     "invalid message, message length less than signature size"
                 );
-                this.dataplane_writer.disconnect(src_addr);
+                this.dataplane_control.disconnect(src_addr);
                 continue;
             }
             let signature_bytes = &payload[..SIGNATURE_SIZE];
@@ -869,7 +878,7 @@ where
                 Ok(signature) => signature,
                 Err(err) => {
                     warn!(?err, ?src_addr, "invalid signature");
-                    this.dataplane_writer.disconnect(src_addr);
+                    this.dataplane_control.disconnect(src_addr);
                     continue;
                 }
             };
@@ -879,7 +888,7 @@ where
                     Ok(message) => message,
                     Err(err) => {
                         warn!(?err, ?src_addr, "failed to deserialize message");
-                        this.dataplane_writer.disconnect(src_addr);
+                        this.dataplane_control.disconnect(src_addr);
                         continue;
                     }
                 };
@@ -889,7 +898,7 @@ where
                 Ok(from) => from,
                 Err(err) => {
                     warn!(?err, ?src_addr, "failed to recover pubkey");
-                    this.dataplane_writer.disconnect(src_addr);
+                    this.dataplane_control.disconnect(src_addr);
                     continue;
                 }
             };
@@ -907,13 +916,12 @@ where
                         ?message,
                         "dropping peer discovery message, should come through udp channel"
                     );
-                    this.dataplane_writer.disconnect(src_addr);
+                    this.dataplane_control.disconnect(src_addr);
                     continue;
                 }
                 InboundRouterMessage::FullNodesGroup(_group_message) => {
-                    // pass TCP message to MultiRouter
                     warn!("FullNodesGroup protocol via TCP not implemented");
-                    this.dataplane_writer.disconnect(src_addr);
+                    this.dataplane_control.disconnect(src_addr);
                     continue;
                 }
             }
@@ -944,7 +952,7 @@ where
                     )
                 });
                 let mut sink = UdpMessageBatcher::new(UNICAST_MSG_BATCH_SIZE, |rc_chunks| {
-                    this.dataplane_writer.udp_write_unicast(rc_chunks);
+                    this.udp_socket.write_unicast(rc_chunks);
                 });
 
                 match custom_known_addrs {


### PR DESCRIPTION
 this pr makes dataplane api to be based around socket handles, rather than writer/reader. caller will be able to setup multiple udp sockets and interact with them through distinct handles. specifically this is meant to simplify integration of the following changes:

- authentication protocol will be listening on a distinct socket, and at least during rolling upgrade both sockets will coexist
- point to point traffic (specifically tx ingestion) will be eventually moved to a different socket, that will allow using different framing instead of raptorcast and applying independent firewall rules for it