### PR TITLE
Fix known addresses when sending group invites

### DIFF
--- a/monad-peer-discovery/src/driver.rs
+++ b/monad-peer-discovery/src/driver.rs
@@ -291,14 +291,10 @@ impl<PD: PeerDiscoveryAlgo> PeerDiscoveryDriver<PD> {
             .collect()
     }
 
-    pub fn get_secondary_fullnode_addrs(
+    pub fn get_secondary_fullnodes(
         &self,
-    ) -> HashMap<NodeId<CertificateSignaturePubKey<PD::SignatureType>>, SocketAddr> {
-        self.pd
-            .get_secondary_fullnode_addrs()
-            .into_iter()
-            .map(|(k, v)| (k, SocketAddr::V4(v)))
-            .collect()
+    ) -> Vec<NodeId<CertificateSignaturePubKey<PD::SignatureType>>> {
+        self.pd.get_secondary_fullnodes()
     }
 
     pub fn get_name_records(

--- a/monad-peer-discovery/src/lib.rs
+++ b/monad-peer-discovery/src/lib.rs
@@ -330,9 +330,9 @@ pub trait PeerDiscoveryAlgo {
         &self,
     ) -> HashMap<NodeId<CertificateSignaturePubKey<Self::SignatureType>>, SocketAddrV4>;
 
-    fn get_secondary_fullnode_addrs(
+    fn get_secondary_fullnodes(
         &self,
-    ) -> HashMap<NodeId<CertificateSignaturePubKey<Self::SignatureType>>, SocketAddrV4>;
+    ) -> Vec<NodeId<CertificateSignaturePubKey<Self::SignatureType>>>;
 
     fn get_name_records(
         &self,

--- a/monad-peer-discovery/src/mock.rs
+++ b/monad-peer-discovery/src/mock.rs
@@ -265,10 +265,8 @@ where
         self.known_addresses.clone()
     }
 
-    fn get_secondary_fullnode_addrs(
-        &self,
-    ) -> HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddrV4> {
-        HashMap::new()
+    fn get_secondary_fullnodes(&self) -> Vec<NodeId<CertificateSignaturePubKey<ST>>> {
+        Vec::new()
     }
 
     fn get_name_records(

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -362,13 +362,12 @@ where
                             .peer_discovery_driver
                             .lock()
                             .unwrap()
-                            .get_secondary_fullnode_addrs();
-                        let full_nodes_vec: Vec<_> = full_nodes.keys().copied().collect();
+                            .get_secondary_fullnodes();
                         trace!(
                             "RaptorCastSecondary updating {} full nodes from PeerDiscovery",
-                            full_nodes_vec.len()
+                            full_nodes.len()
                         );
-                        publisher.upsert_peer_disc_full_nodes(FullNodes::new(full_nodes_vec));
+                        publisher.upsert_peer_disc_full_nodes(FullNodes::new(full_nodes));
 
                         if let Some((group_msg, full_nodes_set)) =
                             publisher.enter_round_and_step_until(round)
@@ -387,7 +386,12 @@ where
                                 );
                             }
 
-                            self.send_group_msg(group_msg, full_nodes_set, &full_nodes);
+                            let known_addresses = self
+                                .peer_discovery_driver
+                                .lock()
+                                .unwrap()
+                                .get_known_addresses();
+                            self.send_group_msg(group_msg, full_nodes_set, &known_addresses);
                         }
                     }
                 },


### PR DESCRIPTION
I notice that there is an inaccuracy at https://github.com/category-labs/monad-bft/blob/master/monad-raptorcast/src/raptorcast_secondary/mod.rs#L390 where the `known_addresses` passed in might not contain the addresses of the prioritized full nodes. We should use the full known addresses here. Tested on stressnet