### PR TITLE
read delegated status of eoa from the account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5457,6 +5457,7 @@ dependencies = [
  "serde",
  "serde_with",
  "toml",
+ "tracing",
 ]
 
 [[package]]
@@ -5944,6 +5945,7 @@ dependencies = [
  "monad-eth-testutil",
  "monad-eth-txpool-ipc",
  "monad-eth-txpool-types",
+ "monad-eth-types",
  "monad-ethcall",
  "monad-event-ring",
  "monad-exec-events",

--- a/monad-eth-types/Cargo.toml
+++ b/monad-eth-types/Cargo.toml
@@ -16,6 +16,7 @@ alloy-consensus = { workspace = true, features = ["serde"] }
 alloy-eips = { workspace = true }
 alloy-primitives = { workspace = true, features = ["serde"] }
 alloy-rlp = { workspace = true, features = ["derive"] }
+tracing = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true, features = ["hex"] }
 

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -25,6 +25,7 @@ jemallocator = ["tikv-jemallocator", "monad-pprof/jemallocator"]
 monad-archive = { workspace = true }
 monad-chain-config = { workspace = true }
 monad-eth-txpool-ipc = { workspace = true }
+monad-eth-types = { workspace = true }
 monad-eth-txpool-types = { workspace = true }
 monad-ethcall = { workspace = true }
 monad-event-ring = { workspace = true }

--- a/monad-rpc/src/handlers/eth/gas.rs
+++ b/monad-rpc/src/handlers/eth/gas.rs
@@ -23,6 +23,7 @@ use alloy_primitives::{Address, TxKind, U256, U64};
 use alloy_rpc_types::{FeeHistory, TransactionReceipt};
 use futures::stream::StreamExt;
 use itertools::Itertools;
+use monad_eth_types::AccountCodeOrHash;
 use monad_ethcall::{CallResult, EthCallExecutor, MonadTracer, StateOverrideSet};
 use monad_rpc_docs::rpc;
 use monad_triedb_utils::triedb_env::{BlockKey, FinalizedBlockKey, ProposedBlockKey, Triedb};
@@ -323,7 +324,7 @@ pub async fn monad_eth_estimateGas<T: Triedb>(
         let to = txn.to().unwrap();
         if let Ok(acct) = triedb_env.get_account(block_key, to.into()).await {
             // If the account has no code, then execute the call with gas limit 21000
-            if acct.code_hash == [0; 32]
+            if matches!(acct.code_or_hash, AccountCodeOrHash::IsEmpty)
                 && matches!(
                     eth_call_provider
                         .eth_call(txn.clone(), Some(eth_call_executor.clone()))

--- a/monad-state-backend/src/in_memory.rs
+++ b/monad-state-backend/src/in_memory.rs
@@ -293,7 +293,7 @@ where
                 Some(EthAccount {
                     nonce: *nonce,
                     balance: self.max_account_balance,
-                    code_hash: None,
+                    code_or_hash: Default::default(),
                     is_delegated: false,
                 })
             })

--- a/monad-state-backend/src/mock.rs
+++ b/monad-state-backend/src/mock.rs
@@ -49,7 +49,7 @@ where
                 Some(EthAccount {
                     balance: self.balances.get(address).cloned().unwrap_or_default(),
                     nonce: self.nonces.get(address).cloned().unwrap_or_default(),
-                    code_hash: None,
+                    code_or_hash: Default::default(),
                     is_delegated: false,
                 })
             })

--- a/monad-triedb-utils/src/decode.rs
+++ b/monad-triedb-utils/src/decode.rs
@@ -13,9 +13,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use alloy_primitives::{B256, U256};
+use alloy_primitives::U256;
 use alloy_rlp::Decodable;
-use monad_eth_types::EthAccount;
+use monad_eth_types::{AccountCodeOrHash, EthAccount};
 use tracing::warn;
 
 pub fn rlp_decode_account(account_rlp: Vec<u8>) -> Option<EthAccount> {
@@ -47,24 +47,18 @@ pub fn rlp_decode_account(account_rlp: Vec<u8>) -> Option<EthAccount> {
         return None;
     };
 
-    let is_delegated = false;
-    let code_hash = if buf.is_empty() {
-        None
-    } else {
-        match <[u8; 32]>::decode(&mut buf) {
-            Ok(x) => Some(x),
-            Err(e) => {
-                warn!("rlp code_hash decode failed: {:?}", e);
-                return None;
-            }
+    let code_or_hash = match AccountCodeOrHash::decode(&mut buf) {
+        Ok(v) => v,
+        Err(_e) => {
+            return None;
         }
     };
 
     Some(EthAccount {
         nonce,
         balance,
-        code_hash: code_hash.map(B256::from),
-        is_delegated,
+        code_or_hash,
+        is_delegated: false,
     })
 }
 

--- a/monad-triedb-utils/src/mock_triedb.rs
+++ b/monad-triedb-utils/src/mock_triedb.rs
@@ -103,7 +103,7 @@ impl Triedb for MockTriedb {
         ready(Ok("0x0".to_string()))
     }
 
-    fn get_code(
+    fn get_code_db(
         &self,
         _block_key: BlockKey,
         _code_hash: EthCodeHash,


### PR DESCRIPTION
Changes:

Adds ability to read delegation status from EOA accounts using the inline delegated account format in vicky/account-delegated.

Performance Testing:
Created flexnet tests with 1k, 3k, and 10k delegated accounts sending transactions to force BFT delegation status reads. Tests ran on  16 cores and 192 cores with 1 and 4 node topologies comparing legacy vs inline reads.
Results (average read time in ns):
1-node topology: nproc = 16
┌──────────┬─────────────┬─────────────┬─────────────┐
│ Accounts │ Legacy (ns) │ Inline (ns) │ Improvement │
├──────────┼─────────────┼─────────────┼─────────────┤
│ 1k              │ 8,748          │ 6,254        │ 29% faster  │
│ 3k             │ 8,193          │ 4,685         │ 43% faster  │
│ 10k           │ 6,455          │ 2,555         │ 60% faster  │
└──────────┴─────────────┴─────────────┴─────────────┘
1-node topology: nproc = 192
┌──────────┬─────────────┬─────────────┬─────────────┐
│ Accounts │ Legacy (ns) │ Inline (ns) │ Improvement │
├──────────┼─────────────┼─────────────┼─────────────┤
│ 1k              │ 30,340       │ 19,077        │ 37% faster  │
│ 3k             │ 30,457         │ 18,060      │ 41% faster  │
│ 10k           │ 28,484         │ 17,821       │ 37% faster  │
└──────────┴─────────────┴─────────────┴─────────────┘
4-node topology: nproc = 192
┌──────────┬─────────────┬─────────────┬─────────────┐
│ Accounts │ Legacy (ns) │ Inline (ns) │ Improvement │
├──────────┼─────────────┼─────────────┼─────────────┤
│ 1k             │ ~40,000     │ ~28,000     │ 30% faster  │
│ 3k            │ ~39,000     │ ~27,000      │ 31% faster  │
│ 10k           │ ~38,000     │ ~25,000     │ 34% faster  │
└──────────┴─────────────┴─────────────┴─────────────┘
Conclusion: Inline reads consistently outperform legacy reads across all test configurations (29-60% improvement).


Dependent on https://github.com/category-labs/monad/pull/1612