### PR TITLE
Switch to modular  packet builder

### DIFF
--- a/monad-dataplane/src/udp.rs
+++ b/monad-dataplane/src/udp.rs
@@ -76,7 +76,7 @@ pub const fn segment_size_for_mtu(mtu: u16) -> u16 {
 pub const DEFAULT_SEGMENT_SIZE: u16 = segment_size_for_mtu(DEFAULT_MTU);
 
 const ETHERNET_MTU: u16 = 1500;
-const ETHERNET_SEGMENT_SIZE: u16 = segment_size_for_mtu(ETHERNET_MTU);
+pub const ETHERNET_SEGMENT_SIZE: u16 = segment_size_for_mtu(ETHERNET_MTU);
 
 fn configure_socket(socket: &UdpSocket, buffer_size: Option<usize>) {
     if let Some(size) = buffer_size {

--- a/monad-raptor/tests/managed_decoder.rs
+++ b/monad-raptor/tests/managed_decoder.rs
@@ -15,7 +15,7 @@
 
 // Tests the managed Raptor decoder.
 
-use monad_raptor::{Encoder, ManagedDecoder};
+use monad_raptor::{Encoder, ManagedDecoder, SOURCE_SYMBOLS_MAX};
 use rand::{prelude::SliceRandom, thread_rng, Rng, RngCore};
 
 const SYMBOL_LEN: usize = 4;
@@ -87,4 +87,11 @@ fn test_invalid_symbol_len() {
     let buf = vec![0; SYMBOL_LEN + 1];
 
     decoder.received_encoded_symbol(buf.as_slice(), 0);
+}
+
+#[test]
+fn test_oversized_symbol() {
+    let num_symbols = SOURCE_SYMBOLS_MAX + 1;
+    let decoder = ManagedDecoder::new(num_symbols, num_symbols * 2, SYMBOL_LEN);
+    assert!(decoder.is_err());
 }

--- a/monad-raptorcast/benches/encode_bench.rs
+++ b/monad-raptorcast/benches/encode_bench.rs
@@ -21,7 +21,7 @@ use itertools::Itertools as _;
 use monad_crypto::certificate_signature::{CertificateSignature, CertificateSignaturePubKey};
 use monad_dataplane::udp::DEFAULT_SEGMENT_SIZE;
 use monad_raptorcast::{
-    packet, udp,
+    packet,
     util::{BuildTarget, EpochValidators, Redundancy},
 };
 use monad_secp::SecpSignature;
@@ -56,21 +56,6 @@ pub fn bench_build_messages(c: &mut Criterion, name: &str, message_size: usize, 
         _ => panic!("unsupported target"),
     };
 
-    group.bench_function("udp::build_messages", |b| {
-        b.iter(|| {
-            let _ = udp::build_messages(
-                &author,
-                DEFAULT_SEGMENT_SIZE, // segment_size
-                message.clone(),
-                Redundancy::from_u8(2),
-                0, // epoch_no
-                0, // unix_ts_ms
-                build_target.clone(),
-                &known_addrs,
-            );
-        });
-    });
-
     group.bench_function("packet::build_messages", |b| {
         b.iter(|| {
             let _ = packet::build_messages(
@@ -82,7 +67,6 @@ pub fn bench_build_messages(c: &mut Criterion, name: &str, message_size: usize, 
                 0, // unix_ts_ms
                 build_target.clone(),
                 &known_addrs,
-                &mut rand::thread_rng(),
             );
         });
     });

--- a/monad-raptorcast/benches/raptor_bench.rs
+++ b/monad-raptorcast/benches/raptor_bench.rs
@@ -23,8 +23,8 @@ use monad_crypto::hasher::{Hasher, HasherType};
 use monad_dataplane::udp::DEFAULT_SEGMENT_SIZE;
 use monad_raptor::ManagedDecoder;
 use monad_raptorcast::{
-    packet,
-    udp::{build_messages, parse_message, MAX_REDUNDANCY, SIGNATURE_CACHE_SIZE},
+    packet::build_messages,
+    udp::{parse_message, MAX_REDUNDANCY, SIGNATURE_CACHE_SIZE},
     util::{BuildTarget, EpochValidators, Redundancy},
 };
 use monad_secp::{KeyPair, SecpSignature};
@@ -75,49 +75,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 0, // unix_ts_ms
                 BuildTarget::Raptorcast(epoch_validators),
                 &known_addresses,
-            );
-        });
-    });
-
-    group.bench_function("Encoding (new)", |b| {
-        let keys = (0_u8..100_u8)
-            .map(|n| {
-                let mut hasher = HasherType::new();
-                hasher.update(n.to_le_bytes());
-                let mut hash = hasher.hash();
-                KeyPair::from_bytes(&mut hash.0).unwrap()
-            })
-            .collect_vec();
-
-        let validators = EpochValidators {
-            validators: keys
-                .iter()
-                .map(|key| (NodeId::new(key.pubkey()), Stake::ONE))
-                .collect(),
-        };
-
-        let known_addresses = keys
-            .iter()
-            .map(|key| {
-                (
-                    NodeId::new(key.pubkey()),
-                    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
-                )
-            })
-            .collect();
-
-        b.iter(|| {
-            let epoch_validators = validators.view_without(vec![&NodeId::new(keys[0].pubkey())]);
-            let _ = packet::build_messages::<SecpSignature>(
-                &keys[0],
-                DEFAULT_SEGMENT_SIZE, // segment_size
-                message.clone(),
-                Redundancy::from_u8(2),
-                0, // epoch_no
-                0, // unix_ts_ms
-                BuildTarget::Raptorcast(epoch_validators),
-                &known_addresses,
-                &mut rand::thread_rng(),
             );
         });
     });

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -40,7 +40,6 @@ use monad_crypto::{
 use monad_dataplane::{
     udp::{segment_size_for_mtu, DEFAULT_MTU},
     BroadcastMsg, DataplaneBuilder, DataplaneReader, DataplaneWriter, RecvTcpMsg, TcpMsg,
-    UnicastMsg,
 };
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{
@@ -59,9 +58,7 @@ use monad_validator::signature_collection::SignatureCollection;
 use raptorcast_secondary::{group_message::FullNodesGroupMessage, SecondaryRaptorCastModeConfig};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::{debug, debug_span, error, trace, warn};
-use util::{
-    unix_ts_ms_now, BuildTarget, EpochValidators, FullNodes, Group, ReBroadcastGroupMap, Redundancy,
-};
+use util::{BuildTarget, EpochValidators, FullNodes, Group, ReBroadcastGroupMap, Redundancy};
 
 pub mod config;
 pub mod decoding;
@@ -73,6 +70,9 @@ pub mod util;
 
 const SIGNATURE_SIZE: usize = 65;
 
+pub(crate) type OwnedMessageBuilder<ST, PD> =
+    packet::MessageBuilder<'static, ST, Arc<Mutex<PeerDiscoveryDriver<PD>>>>;
+
 pub struct RaptorCast<ST, M, OM, SE, PD>
 where
     ST: CertificateSignatureRecoverable,
@@ -81,7 +81,6 @@ where
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
 {
     signing_key: Arc<ST::KeyPairType>,
-    redundancy: Redundancy,
     is_dynamic_fullnode: bool,
 
     // Raptorcast group with stake information. For the send side (i.e., initiating proposals)
@@ -94,7 +93,7 @@ where
     current_epoch: Epoch,
 
     udp_state: udp::UdpState<ST>,
-    mtu: u16,
+    message_builder: OwnedMessageBuilder<ST, PD>,
 
     dataplane_reader: DataplaneReader,
     dataplane_writer: DataplaneWriter,
@@ -147,6 +146,15 @@ where
         debug!(
             ?is_dynamic_fullnode, ?self_id, ?config.mtu, "RaptorCast::new",
         );
+
+        let redundancy = Redundancy::from_f32(config.primary_instance.raptor10_redundancy)
+            .expect("primary raptor10_redundancy doesn't fit");
+        let message_builder =
+            OwnedMessageBuilder::new(config.shared_key.clone(), peer_discovery_driver.clone())
+                .segment_size(segment_size_for_mtu(config.mtu))
+                .epoch_no(current_epoch)
+                .redundancy(redundancy);
+
         Self {
             is_dynamic_fullnode,
             epoch_validators: Default::default(),
@@ -157,13 +165,11 @@ where
             peer_discovery_driver,
 
             signing_key: config.shared_key.clone(),
-            redundancy: Redundancy::from_f32(config.primary_instance.raptor10_redundancy)
-                .expect("primary raptor10_redundancy doesn't fit"),
+            message_builder,
 
             current_epoch,
 
             udp_state: udp::UdpState::new(self_id, config.udp_message_max_age_ms),
-            mtu: config.mtu,
 
             dataplane_reader,
             dataplane_writer,
@@ -258,38 +264,6 @@ where
         };
     }
 
-    // Prepares an app message (e.g. proposal) to be sent out via UDP, by signing
-    // it and then splitting into raptorcast chunks fitting MTU (depending on build_target)
-    fn udp_build(
-        epoch: &Epoch,
-        build_target: BuildTarget<ST>,
-        outbound_message: Bytes,
-        mtu: u16,
-        signing_key: &Arc<ST::KeyPairType>,
-        redundancy: Redundancy,
-        known_addresses: &HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddr>,
-    ) -> UnicastMsg {
-        let segment_size = segment_size_for_mtu(mtu);
-
-        let unix_ts_ms = unix_ts_ms_now();
-
-        let messages = udp::build_messages::<ST>(
-            signing_key,
-            segment_size,
-            outbound_message,
-            redundancy,
-            epoch.0,
-            unix_ts_ms,
-            build_target,
-            known_addresses,
-        );
-
-        UnicastMsg {
-            msgs: messages,
-            stride: segment_size,
-        }
-    }
-
     fn handle_publish(
         &mut self,
         target: RouterTarget<CertificateSignaturePubKey<ST>>,
@@ -301,12 +275,6 @@ where
         let _timer = DropTimer::start(Duration::from_millis(20), |elapsed| {
             warn!(?elapsed, "long time to publish message")
         });
-
-        let known_addresses = self
-            .peer_discovery_driver
-            .lock()
-            .unwrap()
-            .get_known_addresses();
 
         match target {
             RouterTarget::Broadcast(epoch) | RouterTarget::Raptorcast(epoch) => {
@@ -352,17 +320,15 @@ where
                             return;
                         }
                     };
-                let rc_chunks: UnicastMsg = Self::udp_build(
-                    &epoch,
-                    build_target,
-                    outbound_message,
-                    self.mtu,
-                    &self.signing_key,
-                    self.redundancy,
-                    &known_addresses,
-                );
-                self.dataplane_writer
-                    .udp_write_unicast_with_priority(rc_chunks, priority);
+                if let Some(rc_chunks) = self
+                    .message_builder
+                    .prepare()
+                    .epoch_no(epoch)
+                    .build_unicast_msg(&outbound_message, &build_target)
+                {
+                    self.dataplane_writer
+                        .udp_write_unicast_with_priority(rc_chunks, priority);
+                }
             }
 
             RouterTarget::PointToPoint(to) => {
@@ -385,17 +351,14 @@ where
                             return;
                         }
                     };
-                    let rc_chunks: UnicastMsg = Self::udp_build(
-                        &self.current_epoch,
-                        BuildTarget::<ST>::PointToPoint(&to),
-                        outbound_message,
-                        self.mtu,
-                        &self.signing_key,
-                        self.redundancy,
-                        &known_addresses,
-                    );
-                    self.dataplane_writer
-                        .udp_write_unicast_with_priority(rc_chunks, priority);
+                    let build_target = BuildTarget::<ST>::PointToPoint(&to);
+                    if let Some(rc_chunks) = self
+                        .message_builder
+                        .build_unicast_msg(&outbound_message, &build_target)
+                    {
+                        self.dataplane_writer
+                            .udp_write_unicast_with_priority(rc_chunks, priority);
+                    }
                 }
             }
 
@@ -510,6 +473,8 @@ where
                         }
 
                         self.current_epoch = epoch;
+                        self.message_builder.set_epoch_no(epoch);
+
                         while let Some(entry) = self.epoch_validators.first_entry() {
                             if *entry.key() + Epoch(1) < self.current_epoch {
                                 entry.remove();
@@ -605,16 +570,14 @@ where
                         // TODO: optimize the build of copies of the
                         // same message to multiple recipients.
                         let build_target = BuildTarget::PointToPoint(node);
-                        let rc_chunks: UnicastMsg = Self::udp_build(
-                            &epoch,
-                            build_target,
-                            outbound_message.clone(),
-                            self.mtu,
-                            &self.signing_key,
-                            self.redundancy,
-                            &node_addrs,
-                        );
-                        self.dataplane_writer.udp_write_unicast(rc_chunks);
+                        if let Some(rc_chunks) = self
+                            .message_builder
+                            .prepare_with_peer_lookup(&node_addrs)
+                            .epoch_no(epoch)
+                            .build_unicast_msg(&outbound_message, &build_target)
+                        {
+                            self.dataplane_writer.udp_write_unicast(rc_chunks);
+                        };
                     }
                 }
                 RouterCommand::GetPeers => {
@@ -917,13 +880,11 @@ where
         }
 
         {
-            let mut pd_driver = this.peer_discovery_driver.lock().unwrap();
-
-            let send_peer_disc_msg = |target: NodeId<CertificateSignaturePubKey<ST>>,
+            let send_peer_disc_msg = |this: &RaptorCast<ST, M, OM, E, PD>,
+                                      target: NodeId<CertificateSignaturePubKey<ST>>,
                                       message: PeerDiscoveryMessage<ST>,
-                                      known_addresses: HashMap<
-                NodeId<CertificateSignaturePubKey<ST>>,
-                SocketAddr,
+                                      custom_known_addrs: Option<
+                HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddr>,
             >| {
                 let _span = debug_span!("publish discovery").entered();
                 let Ok(router_message) =
@@ -933,22 +894,34 @@ where
                     return;
                 };
 
-                let unicast_msg = Self::udp_build(
-                    &this.current_epoch,
-                    BuildTarget::<ST>::PointToPoint(&target),
-                    router_message,
-                    this.mtu,
-                    &this.signing_key,
-                    this.redundancy,
-                    &known_addresses,
-                );
-                this.dataplane_writer.udp_write_unicast(unicast_msg);
+                let build_target = BuildTarget::<ST>::PointToPoint(&target);
+
+                let rc_chunks = match custom_known_addrs {
+                    Some(addrs) => this
+                        .message_builder
+                        .prepare_with_peer_lookup(&addrs)
+                        .build_unicast_msg(&router_message, &build_target),
+                    None => this
+                        .message_builder
+                        .build_unicast_msg(&router_message, &build_target),
+                };
+
+                if let Some(rc_chunks) = rc_chunks {
+                    this.dataplane_writer.udp_write_unicast(rc_chunks);
+                };
             };
 
-            while let Poll::Ready(Some(peer_disc_emit)) = pd_driver.poll_next_unpin(cx) {
+            loop {
+                let mut pd_driver = this.peer_discovery_driver.lock().unwrap();
+                let Poll::Ready(Some(peer_disc_emit)) = pd_driver.poll_next_unpin(cx) else {
+                    break;
+                };
+                // unlock pd driver so it can be used for lookup peers in `send_peer_disc_msg`.
+                drop(pd_driver);
+
                 match peer_disc_emit {
                     PeerDiscoveryEmit::RouterCommand { target, message } => {
-                        send_peer_disc_msg(target, message, pd_driver.get_known_addresses());
+                        send_peer_disc_msg(this, target, message, None);
                     }
                     PeerDiscoveryEmit::PingPongCommand {
                         target,
@@ -956,7 +929,7 @@ where
                         message,
                     } => {
                         let addrs = HashMap::from_iter([(target, SocketAddr::V4(socket_address))]);
-                        send_peer_disc_msg(target, message, addrs);
+                        send_peer_disc_msg(this, target, message, Some(addrs));
                     }
                     PeerDiscoveryEmit::MetricsCommand(executor_metrics) => {
                         this.peer_discovery_metrics = executor_metrics;

--- a/monad-raptorcast/src/packet/builder.rs
+++ b/monad-raptorcast/src/packet/builder.rs
@@ -1,0 +1,523 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use monad_crypto::certificate_signature::{
+    CertificateKeyPair as _, CertificateSignaturePubKey, CertificateSignatureRecoverable,
+};
+use monad_dataplane::udp::DEFAULT_SEGMENT_SIZE;
+use monad_types::NodeId;
+use rand::{seq::SliceRandom as _, Rng};
+
+use super::{
+    assembler::{self, build_header, AssembleMode, BroadcastType, PacketLayout},
+    assigner::{self, ChunkAssignment},
+    BuildError, ChunkAssigner, PeerAddrLookup, RetrofitResult as _, UdpMessage,
+};
+use crate::{
+    message::MAX_MESSAGE_SIZE,
+    udp::{
+        MAX_MERKLE_TREE_DEPTH, MAX_NUM_PACKETS, MAX_REDUNDANCY, MAX_SEGMENT_LENGTH,
+        MIN_CHUNK_LENGTH, MIN_MERKLE_TREE_DEPTH,
+    },
+    util::{self, BuildTarget, Redundancy},
+};
+
+pub const DEFAULT_MERKLE_TREE_DEPTH: u8 = 6;
+
+type Result<T, E = BuildError> = std::result::Result<T, E>;
+
+enum MaybeArc<'a, T> {
+    Ref(&'a T),
+    Arc(Arc<T>),
+}
+
+impl<T> From<Arc<T>> for MaybeArc<'_, T> {
+    fn from(arc: Arc<T>) -> Self {
+        MaybeArc::Arc(arc)
+    }
+}
+
+impl<'a, T> From<&'a T> for MaybeArc<'a, T> {
+    fn from(r: &'a T) -> Self {
+        MaybeArc::Ref(r)
+    }
+}
+
+impl<T> Clone for MaybeArc<'_, T> {
+    fn clone(&self) -> Self {
+        match self {
+            MaybeArc::Ref(r) => MaybeArc::Ref(r),
+            MaybeArc::Arc(a) => MaybeArc::Arc(a.clone()),
+        }
+    }
+}
+
+impl<'a, T> AsRef<T> for MaybeArc<'a, T> {
+    fn as_ref(&self) -> &T {
+        match self {
+            MaybeArc::Ref(r) => r,
+            MaybeArc::Arc(a) => a.as_ref(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum TimestampMode {
+    Fixed(u64),
+    RealTime,
+}
+
+pub struct MessageBuilder<'key, ST, PL>
+where
+    ST: CertificateSignatureRecoverable,
+    PL: PeerAddrLookup<CertificateSignaturePubKey<ST>>,
+{
+    // support both owned or borrowed keys
+    key: MaybeArc<'key, ST::KeyPairType>,
+    peer_lookup: PL,
+
+    // required fields
+    epoch_no: Option<u64>,
+    redundancy: Option<Redundancy>,
+
+    // optional fields
+    unix_ts_ms: TimestampMode,
+    segment_size: usize,
+    merkle_tree_depth: u8,
+    assemble_mode: AssembleMode,
+}
+
+impl<'key, ST, PL> Clone for MessageBuilder<'key, ST, PL>
+where
+    ST: CertificateSignatureRecoverable,
+    PL: PeerAddrLookup<CertificateSignaturePubKey<ST>> + Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            key: self.key.clone(),
+            peer_lookup: self.peer_lookup.clone(),
+            epoch_no: self.epoch_no,
+            redundancy: self.redundancy,
+            unix_ts_ms: self.unix_ts_ms,
+            segment_size: self.segment_size,
+            merkle_tree_depth: self.merkle_tree_depth,
+            assemble_mode: self.assemble_mode,
+        }
+    }
+}
+
+impl<'key, ST, PL> MessageBuilder<'key, ST, PL>
+where
+    ST: CertificateSignatureRecoverable,
+    PL: PeerAddrLookup<CertificateSignaturePubKey<ST>>,
+{
+    #[allow(private_bounds)]
+    pub fn new<K>(key: K, peer_lookup: PL) -> Self
+    where
+        K: Into<MaybeArc<'key, ST::KeyPairType>>,
+    {
+        let segment_size = DEFAULT_SEGMENT_SIZE as usize;
+        let merkle_tree_depth = DEFAULT_MERKLE_TREE_DEPTH;
+        let key = key.into();
+
+        Self {
+            key,
+            peer_lookup,
+
+            // default fields
+            redundancy: None,
+            epoch_no: None,
+            unix_ts_ms: TimestampMode::RealTime,
+
+            // optional fields
+            assemble_mode: AssembleMode::default(),
+            segment_size,
+            merkle_tree_depth,
+        }
+    }
+
+    // ----- Field filling methods -----
+    pub fn segment_size(mut self, size: impl Into<usize>) -> Self {
+        self.segment_size = size.into();
+        self
+    }
+
+    pub fn redundancy(mut self, redundancy: Redundancy) -> Self {
+        self.redundancy = Some(redundancy);
+        self
+    }
+
+    pub fn epoch_no(mut self, epoch_no: impl Into<u64>) -> Self {
+        self.epoch_no = Some(epoch_no.into());
+        self
+    }
+
+    pub fn unix_ts_ms(mut self, unix_ts_ms: impl Into<u64>) -> Self {
+        self.unix_ts_ms = TimestampMode::Fixed(unix_ts_ms.into());
+        self
+    }
+
+    // we currently don't use non-standard merkle_tree_depth
+    #[expect(unused)]
+    pub fn merkle_tree_depth(mut self, depth: u8) -> Result<Self> {
+        self.merkle_tree_depth = depth;
+        Ok(self)
+    }
+
+    // we currently don't use any non-standard assemble mode.
+    #[expect(unused)]
+    pub fn assemble_mode(mut self, mode: AssembleMode) -> Result<Self> {
+        self.assemble_mode = mode;
+        Ok(self)
+    }
+
+    // ----- Convenience methods for modifying the builder -----
+    pub fn set_epoch_no(&mut self, epoch_no: impl Into<u64>) {
+        self.epoch_no = Some(epoch_no.into());
+    }
+
+    // ----- Prepare override builder -----
+    pub fn prepare(&self) -> PreparedMessageBuilder<'_, 'key, ST, PL, PL> {
+        PreparedMessageBuilder {
+            base: self,
+            peer_lookup: None,
+            epoch_no: None,
+        }
+    }
+
+    pub fn prepare_with_peer_lookup<PL2>(
+        &self,
+        peer_lookup: PL2,
+    ) -> PreparedMessageBuilder<'_, 'key, ST, PL, PL2>
+    where
+        PL2: PeerAddrLookup<CertificateSignaturePubKey<ST>>,
+    {
+        PreparedMessageBuilder {
+            base: self,
+            peer_lookup: Some(peer_lookup),
+            epoch_no: None,
+        }
+    }
+
+    // ----- Delegated build methods -----
+    #[expect(unused)]
+    pub fn build_into<C>(
+        &self,
+        app_message: &[u8],
+        build_target: &BuildTarget<ST>,
+        collector: &mut C,
+    ) -> Result<()>
+    where
+        C: super::Collector<super::UdpMessage>,
+    {
+        self.prepare()
+            .build_into(app_message, build_target, collector)
+    }
+
+    pub fn build_vec(
+        &self,
+        app_message: &[u8],
+        build_target: &BuildTarget<ST>,
+    ) -> Result<Vec<UdpMessage>> {
+        self.prepare().build_vec(app_message, build_target)
+    }
+
+    pub fn build_unicast_msg(
+        &self,
+        app_message: &[u8],
+        build_target: &BuildTarget<ST>,
+    ) -> Option<monad_dataplane::UnicastMsg> {
+        self.prepare().build_unicast_msg(app_message, build_target)
+    }
+}
+
+pub struct PreparedMessageBuilder<'base, 'key, ST, PL, PL2>
+where
+    ST: CertificateSignatureRecoverable,
+    PL: PeerAddrLookup<CertificateSignaturePubKey<ST>>,
+    PL2: PeerAddrLookup<CertificateSignaturePubKey<ST>>,
+{
+    base: &'base MessageBuilder<'key, ST, PL>,
+
+    // Add extra override fields as needed
+    peer_lookup: Option<PL2>,
+    epoch_no: Option<u64>,
+}
+
+impl<'base, 'key, ST, PL, PL2> PreparedMessageBuilder<'base, 'key, ST, PL, PL2>
+where
+    ST: CertificateSignatureRecoverable,
+    PL: PeerAddrLookup<CertificateSignaturePubKey<ST>>,
+    PL2: PeerAddrLookup<CertificateSignaturePubKey<ST>>,
+{
+    // ----- Setters for overrides -----
+    pub fn epoch_no(mut self, epoch_no: impl Into<u64>) -> Self {
+        self.epoch_no = Some(epoch_no.into());
+        self
+    }
+
+    // ----- Parameter validation methods -----
+    fn unwrap_epoch_no(&self) -> Result<u64> {
+        if let Some(epoch_no) = self.epoch_no {
+            return Ok(epoch_no);
+        }
+        let epoch_no = self
+            .base
+            .epoch_no
+            .expect("epoch_no must be set before building");
+        Ok(epoch_no)
+    }
+    fn unwrap_unix_ts_ms(&self) -> Result<u64> {
+        let unix_ts_ms = match self.base.unix_ts_ms {
+            TimestampMode::Fixed(ts) => ts,
+            TimestampMode::RealTime => util::unix_ts_ms_now(),
+        };
+        Ok(unix_ts_ms)
+    }
+    fn unwrap_redundancy(&self) -> Result<Redundancy> {
+        let redundancy = self
+            .base
+            .redundancy
+            .expect("redundancy must be set before building");
+
+        if redundancy > MAX_REDUNDANCY {
+            return Err(BuildError::RedundancyTooHigh);
+        }
+        Ok(redundancy)
+    }
+
+    fn unwrap_merkle_tree_depth(&self) -> Result<u8> {
+        let depth = self.base.merkle_tree_depth;
+        if depth < MIN_MERKLE_TREE_DEPTH {
+            return Err(BuildError::MerkleTreeTooShallow);
+        } else if depth > MAX_MERKLE_TREE_DEPTH {
+            return Err(BuildError::MerkleTreeTooDeep);
+        }
+
+        Ok(depth)
+    }
+
+    fn unwrap_segment_size(&self) -> Result<usize> {
+        let segment_size = self.base.segment_size;
+        debug_assert!(segment_size <= MAX_SEGMENT_LENGTH);
+        let min_segment_size_for_depth =
+            PacketLayout::calc_segment_len(MIN_CHUNK_LENGTH, self.base.merkle_tree_depth);
+        debug_assert!(segment_size >= min_segment_size_for_depth);
+
+        Ok(segment_size)
+    }
+
+    fn checked_message_len(&self, len: usize) -> Result<usize> {
+        if len > MAX_MESSAGE_SIZE {
+            return Err(BuildError::AppMessageTooLarge);
+        }
+        Ok(len)
+    }
+
+    fn check_assignment(
+        &self,
+        assignment: &ChunkAssignment<CertificateSignaturePubKey<ST>>,
+        app_msg_len: usize, // only used for logging
+    ) -> Result<()> {
+        if assignment.is_empty() {
+            tracing::warn!(?app_msg_len, "no chunk generated");
+            return Ok(());
+        }
+
+        if assignment.total_chunks() > MAX_NUM_PACKETS {
+            return Err(BuildError::TooManyChunks);
+        }
+
+        Ok(())
+    }
+
+    // ----- Helper methods -----
+    fn calc_num_symbols(&self, layout: PacketLayout, app_message_len: usize) -> Result<usize> {
+        let redundancy = self.unwrap_redundancy()?;
+        let num_symbols = layout
+            .calc_num_symbols(app_message_len, redundancy)
+            .ok_or(BuildError::TooManyChunks)?;
+        if num_symbols > MAX_NUM_PACKETS {
+            return Err(BuildError::TooManyChunks);
+        }
+
+        Ok(num_symbols)
+    }
+
+    fn build_header(
+        &self,
+        merkle_tree_depth: u8,
+        layout: PacketLayout,
+        broadcast_type: BroadcastType,
+        app_message: &[u8],
+    ) -> Result<Bytes> {
+        let epoch_no = self.unwrap_epoch_no()?;
+        let unix_ts_ms = self.unwrap_unix_ts_ms()?;
+
+        let header_buf = build_header(
+            0, // version
+            broadcast_type,
+            merkle_tree_depth,
+            epoch_no,
+            unix_ts_ms,
+            app_message,
+        )?;
+
+        debug_assert_eq!(header_buf.len(), layout.header_sans_signature_range().len());
+
+        Ok(header_buf)
+    }
+
+    fn choose_assigner(
+        build_target: &BuildTarget<ST>,
+        self_node_id: &NodeId<CertificateSignaturePubKey<ST>>,
+        rng: &mut impl Rng,
+    ) -> Box<dyn ChunkAssigner<CertificateSignaturePubKey<ST>>>
+    where
+        ST: CertificateSignatureRecoverable,
+    {
+        match build_target {
+            BuildTarget::PointToPoint(to) => Box::new(assigner::Replicated::from_unicast(**to)),
+            BuildTarget::Broadcast(nodes) => Box::new(assigner::Replicated::from_broadcast(
+                nodes.iter().copied().collect(),
+            )),
+            BuildTarget::Raptorcast(validators) => {
+                let mut validator_set: Vec<_> = validators
+                    .iter()
+                    .map(|(node_id, stake)| (*node_id, stake))
+                    .collect();
+                validator_set.shuffle(rng);
+                Box::new(assigner::Partitioned::from_validator_set(validator_set))
+            }
+            BuildTarget::FullNodeRaptorCast(group) => {
+                let seed = rng.gen::<usize>();
+                let nodes = group
+                    .iter_skip_self_and_author(self_node_id, seed)
+                    .copied()
+                    .collect();
+                Box::new(assigner::Partitioned::from_homogeneous_peers(nodes))
+            }
+        }
+    }
+
+    // ----- Build methods -----
+    pub fn build_into<C>(
+        &self,
+        app_message: &[u8],
+        build_target: &BuildTarget<ST>,
+        collector: &mut C,
+    ) -> Result<()>
+    where
+        C: super::Collector<super::UdpMessage>,
+    {
+        // figure out the layout of the packet
+        let segment_size = self.unwrap_segment_size()?;
+        let depth = self.unwrap_merkle_tree_depth()?;
+        let layout = PacketLayout::new(segment_size, depth);
+
+        // select chunk assignment algorithm based on build target
+        let rng = &mut rand::thread_rng();
+        let self_node_id = NodeId::new(self.base.key.as_ref().pubkey());
+        let assigner = Self::choose_assigner(build_target, &self_node_id, rng);
+
+        // calculate the number of symbols needed for assignment
+        let app_message_len = self.checked_message_len(app_message.len())?;
+        let num_symbols = self.calc_num_symbols(layout, app_message_len)?;
+
+        // assign the chunks to recipients
+        let assemble_mode = self.base.assemble_mode;
+        let order = assemble_mode.expected_chunk_order();
+        let mut assignment = assigner.assign_chunks(num_symbols, order)?;
+        assignment.ensure_order(order);
+        self.check_assignment(&assignment, app_message_len)?;
+
+        // build the shared header
+        let header = self.build_header(
+            depth,
+            layout,
+            broadcast_type_from_build_target(build_target),
+            app_message,
+        )?;
+
+        // assemble the chunks's headers and content
+        let peer_lookup: &dyn PeerAddrLookup<_> = match &self.peer_lookup {
+            Some(pl) => pl,
+            None => &self.base.peer_lookup,
+        };
+        assembler::assemble::<ST, _>(
+            self.base.key.as_ref(),
+            layout,
+            app_message,
+            &header,
+            assignment,
+            assemble_mode,
+            peer_lookup,
+            collector,
+        )?;
+
+        Ok(())
+    }
+
+    pub fn build_vec(
+        &self,
+        app_message: &[u8],
+        build_target: &BuildTarget<ST>,
+    ) -> Result<Vec<UdpMessage>> {
+        let mut packets = Vec::new();
+        self.build_into(app_message, build_target, &mut packets)?;
+        Ok(packets)
+    }
+
+    pub fn build_unicast_msg(
+        &self,
+        app_message: &[u8],
+        build_target: &BuildTarget<ST>,
+    ) -> Option<monad_dataplane::UnicastMsg> {
+        use std::time::Duration;
+
+        use monad_types::DropTimer;
+
+        let _timer = DropTimer::start(Duration::from_millis(10), |elapsed| {
+            tracing::warn!(
+                ?elapsed,
+                app_message_len = app_message.len(),
+                "long time to build_unicast_msg"
+            )
+        });
+
+        let messages = self
+            .build_vec(app_message, build_target)
+            .unwrap_log_on_error(app_message, build_target);
+
+        let stride = messages.first()?.stride as u16;
+        let msgs = messages.into_iter().map(|m| (m.dest, m.payload)).collect();
+
+        Some(monad_dataplane::UnicastMsg { msgs, stride })
+    }
+}
+
+fn broadcast_type_from_build_target<ST>(build_target: &BuildTarget<'_, ST>) -> BroadcastType
+where
+    ST: CertificateSignatureRecoverable,
+{
+    match build_target {
+        BuildTarget::Raptorcast { .. } => BroadcastType::Primary,
+        BuildTarget::FullNodeRaptorCast { .. } => BroadcastType::Secondary,
+        _ => BroadcastType::Unspecified,
+    }
+}

--- a/monad-raptorcast/src/packet/mod.rs
+++ b/monad-raptorcast/src/packet/mod.rs
@@ -13,22 +13,22 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-mod assembler;
-mod assigner;
+pub(crate) mod assembler;
+pub(crate) mod assigner;
+mod builder;
 
 use std::{collections::HashMap, net::SocketAddr};
 
-use assembler::AssembleMode;
 use bytes::Bytes;
 use monad_crypto::certificate_signature::{
-    CertificateKeyPair as _, CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
+    CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
 };
 use monad_types::NodeId;
-use rand::seq::SliceRandom as _;
 
 pub(crate) use self::{
-    assembler::{assemble, BroadcastType, Chunk, PacketLayout, Recipient},
+    assembler::{Chunk, PacketLayout, Recipient},
     assigner::ChunkAssigner,
+    builder::MessageBuilder,
 };
 use crate::util::{BuildTarget, Redundancy};
 
@@ -41,12 +41,16 @@ pub struct UdpMessage {
 
 #[derive(Debug)]
 pub enum BuildError {
-    // merkle tree depth does not fit in u4
+    // merkle tree depth is 0
+    MerkleTreeTooShallow,
+    // merkle tree depth is larger than the allowed maximum
     MerkleTreeTooDeep,
     // chunk id does not fit in u16
     ChunkIdOverflow,
     // failed to create encoder
     EncoderCreationFailed,
+    // chunk length smaller than the allowed minimum
+    ChunkLengthTooSmall,
     // too many chunks
     TooManyChunks,
     // app message is too large
@@ -70,8 +74,6 @@ pub(crate) trait Collector<T> {
 
 type Result<A, E = BuildError> = std::result::Result<A, E>;
 
-// A compatible interface to crate::udp::build_messages that uses
-// packet::assemble underneath.
 #[allow(clippy::too_many_arguments)]
 pub fn build_messages<ST>(
     key: &ST::KeyPairType,
@@ -82,88 +84,19 @@ pub fn build_messages<ST>(
     unix_ts_ms: u64,
     build_target: BuildTarget<ST>,
     known_addresses: &HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddr>,
-    rng: &mut impl rand::Rng,
 ) -> Vec<(SocketAddr, Bytes)>
 where
     ST: CertificateSignatureRecoverable,
 {
-    use self::assigner::{Partitioned, Replicated};
+    let builder = MessageBuilder::new(key, known_addresses)
+        .segment_size(segment_size)
+        .epoch_no(epoch_no)
+        .unix_ts_ms(unix_ts_ms)
+        .redundancy(redundancy);
 
-    let broadcast_type = match build_target {
-        BuildTarget::Raptorcast { .. } => BroadcastType::Primary,
-        BuildTarget::FullNodeRaptorCast { .. } => BroadcastType::Secondary,
-        _ => BroadcastType::Unspecified,
-    };
-    let peer_lookup = known_addresses;
-
-    let assigner: Box<dyn ChunkAssigner<_>> = match build_target {
-        BuildTarget::PointToPoint(to) => Box::new(Replicated::from_unicast(*to)),
-        BuildTarget::Broadcast(ref nodes_view) => Box::new(Replicated::from_broadcast(
-            nodes_view.iter().copied().collect(),
-        )),
-        BuildTarget::Raptorcast(ref validators_view) => {
-            let mut validator_set: Vec<_> = validators_view
-                .iter()
-                .map(|(node_id, stake)| (*node_id, stake))
-                .collect();
-            validator_set.shuffle(rng);
-            Box::new(Partitioned::from_validator_set(validator_set))
-        }
-        BuildTarget::FullNodeRaptorCast(group) => {
-            let self_id = NodeId::new(key.pubkey());
-            let seed = rng.gen::<usize>();
-            let nodes = group
-                .iter_skip_self_and_author(&self_id, seed)
-                .copied()
-                .collect();
-            Box::new(Partitioned::from_homogeneous_peers(nodes))
-        }
-    };
-
-    let app_message_len = app_message.len();
-    let mut packets = Vec::new();
-    let result = assemble::<ST, _, _>(
-        key,
-        segment_size as usize,
-        app_message,
-        redundancy,
-        epoch_no,
-        unix_ts_ms,
-        broadcast_type,
-        AssembleMode::GsoFull,
-        peer_lookup,
-        &*assigner,
-        &mut packets,
-    );
-
-    let packets = match result {
-        Ok(()) => packets,
-        Err(BuildError::TooManyChunks) => {
-            tracing::error!(
-                ?app_message_len,
-                ?redundancy,
-                ?build_target,
-                "Too many chunks generated."
-            );
-            return vec![];
-        }
-        Err(BuildError::AppMessageTooLarge) => {
-            tracing::error!(?app_message_len, "App message too large");
-            return vec![];
-        }
-        Err(BuildError::ZeroTotalStake) => {
-            tracing::error!(?build_target, "Total stake is zero");
-            return vec![];
-        }
-        Err(BuildError::RedundancyTooHigh) => {
-            tracing::error!(?redundancy, ?build_target, "Redundancy too high");
-            return vec![];
-        }
-        Err(e) => {
-            tracing::error!("Failed to build packets: {:?}", e);
-            return vec![];
-        }
-    };
+    let packets = builder
+        .build_vec(&app_message, &build_target)
+        .unwrap_log_on_error(&app_message, &build_target);
 
     packets
         .into_iter()
@@ -171,9 +104,91 @@ where
         .collect()
 }
 
+// retrofit original error handling
+pub trait RetrofitResult<T> {
+    fn unwrap_log_on_error<ST>(self, ctx_app_msg: &[u8], ctx_build_target: &BuildTarget<ST>) -> T
+    where
+        ST: CertificateSignatureRecoverable;
+}
+
+impl<T> RetrofitResult<Vec<T>> for Result<Vec<T>> {
+    fn unwrap_log_on_error<ST>(
+        self,
+        ctx_app_msg: &[u8],
+        ctx_build_target: &BuildTarget<ST>,
+    ) -> Vec<T>
+    where
+        ST: CertificateSignatureRecoverable,
+    {
+        let app_message_len = ctx_app_msg.len();
+        let build_target = ctx_build_target;
+
+        match self {
+            Ok(packets) => packets,
+
+            // retrofit original error handling
+            Err(BuildError::TooManyChunks) => {
+                tracing::error!(
+                    ?app_message_len,
+                    ?build_target,
+                    "Too many chunks generated."
+                );
+                vec![]
+            }
+            Err(BuildError::AppMessageTooLarge) => {
+                tracing::error!(?app_message_len, "App message too large");
+                vec![]
+            }
+            Err(BuildError::ZeroTotalStake) => {
+                tracing::error!(?build_target, "Total stake is zero");
+                vec![]
+            }
+            Err(BuildError::RedundancyTooHigh) => {
+                tracing::error!(?build_target, "Redundancy too high");
+                vec![]
+            }
+            Err(e) => {
+                tracing::error!("Failed to build packets: {:?}", e);
+                vec![]
+            }
+        }
+    }
+}
+
 impl<PT: PubKey> PeerAddrLookup<PT> for HashMap<NodeId<PT>, SocketAddr> {
     fn lookup(&self, node_id: &NodeId<PT>) -> Option<SocketAddr> {
         self.get(node_id).copied()
+    }
+}
+
+/// Used in RaptorCast instance to lookup peer addresses with the peer discovery driver.
+impl<ST: CertificateSignatureRecoverable, PD> PeerAddrLookup<CertificateSignaturePubKey<ST>>
+    for std::sync::Mutex<monad_peer_discovery::driver::PeerDiscoveryDriver<PD>>
+where
+    PD: monad_peer_discovery::PeerDiscoveryAlgo<SignatureType = ST>,
+{
+    fn lookup(&self, node_id: &NodeId<CertificateSignaturePubKey<ST>>) -> Option<SocketAddr> {
+        let guard = self.lock().ok()?;
+        guard.get_addr(node_id)
+    }
+}
+
+impl<PT, T> PeerAddrLookup<PT> for &T
+where
+    PT: PubKey,
+    T: PeerAddrLookup<PT>,
+{
+    fn lookup(&self, node_id: &NodeId<PT>) -> Option<SocketAddr> {
+        (*self).lookup(node_id)
+    }
+}
+impl<PT, T> PeerAddrLookup<PT> for std::sync::Arc<T>
+where
+    PT: PubKey,
+    T: PeerAddrLookup<PT>,
+{
+    fn lookup(&self, node_id: &NodeId<PT>) -> Option<SocketAddr> {
+        self.as_ref().lookup(node_id)
     }
 }
 
@@ -193,225 +208,5 @@ where
 {
     fn push(&mut self, item: T) {
         self(item)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::BTreeSet;
-
-    use bytes::{Bytes, BytesMut};
-    use monad_crypto::certificate_signature::CertificateSignature;
-    use monad_secp::SecpSignature;
-    use monad_testutil::signing::get_key;
-    use monad_types::{Round, RoundSpan, Stake};
-    use rand::{rngs::StdRng, seq::IteratorRandom as _, Rng as _, RngCore as _, SeedableRng as _};
-
-    use super::{
-        assembler::{CHUNK_HEADER_LEN, HEADER_LEN},
-        build_messages as build_new, *,
-    };
-    use crate::{
-        udp::build_messages_with_rng as build_old,
-        util::{EpochValidators, Group},
-        SIGNATURE_SIZE,
-    };
-
-    const DEFAULT_SEGMENT_LEN: usize = 1400;
-    const DEFAULT_PROOF_LEN: usize = 100; // 5 * 20
-    const DEFAULT_DATA_LEN: usize =
-        DEFAULT_SEGMENT_LEN - HEADER_LEN - CHUNK_HEADER_LEN - DEFAULT_PROOF_LEN;
-
-    const EPOCH: u64 = 5;
-    const UNIX_TS_MS: u64 = 5;
-
-    type ST = SecpSignature;
-    type PT = CertificateSignaturePubKey<ST>;
-
-    fn key_pair(seed: u64) -> <ST as CertificateSignature>::KeyPairType {
-        get_key::<ST>(seed)
-    }
-
-    fn node_id(seed: u64) -> NodeId<PT> {
-        let key_pair = get_key::<ST>(seed);
-        NodeId::new(key_pair.pubkey())
-    }
-
-    #[test]
-    fn test_compatibility() {
-        let rng = &mut rand::thread_rng();
-
-        let node_addr = |i: u64| {
-            SocketAddr::from((
-                ((i & 0xffffffff0000 >> 16) as u32).to_le_bytes(),
-                (i & 0xffff) as u16,
-            ))
-        };
-        let rand_stake = || Stake::from(rand::thread_rng().gen_range(1..1000000u64));
-        let rand_validators = |n: usize| EpochValidators {
-            validators: (1..n).map(|i| (node_id(i as u64), rand_stake())).collect(),
-        };
-        let known_addresses = (1..5).map(|i| (node_id(i), node_addr(i))).collect();
-
-        for num_pkts in [0, 1, 100, 2000] {
-            let mut trail_lens = (2..(DEFAULT_SEGMENT_LEN - 1)).choose_multiple(rng, 10);
-            // always test for these boundary cases.
-            trail_lens.push(0);
-            trail_lens.push(1);
-            trail_lens.push(DEFAULT_DATA_LEN - 1);
-            trail_lens.push(DEFAULT_DATA_LEN);
-            trail_lens.push(DEFAULT_DATA_LEN + 1);
-            trail_lens.push(DEFAULT_SEGMENT_LEN - 1);
-            trail_lens.push(DEFAULT_SEGMENT_LEN);
-            trail_lens.push(DEFAULT_SEGMENT_LEN + 1);
-
-            for trail_len in trail_lens {
-                for redundancy in [1.0, 1.3, 3.0, 7.0] {
-                    let app_msg_len = DEFAULT_SEGMENT_LEN * num_pkts + trail_len;
-                    let mut app_msg = BytesMut::zeroed(app_msg_len);
-                    rng.fill_bytes(&mut app_msg);
-                    let app_msg = app_msg.freeze();
-
-                    // validator #5 and up will have no known addresses
-                    let num_validators = rng.gen_range(2..8);
-                    let validators = rand_validators(num_validators);
-                    let self_id = (1..(num_validators + 1)).choose(rng).unwrap() as u64;
-                    let self_node_id = node_id(self_id);
-                    let self_key = key_pair(self_id);
-
-                    let assert_compatible = |target| {
-                        assert_build_compatible(
-                            &self_key,
-                            &app_msg,
-                            redundancy,
-                            &target,
-                            &known_addresses,
-                        )
-                    };
-
-                    {
-                        let epoch_validators = validators.view_without(vec![&self_node_id]);
-                        let build_target = BuildTarget::Raptorcast(epoch_validators);
-                        assert_compatible(build_target);
-                    }
-
-                    // skip broadcast cases that are too slow to test on ci
-                    if num_pkts < 30 && redundancy < 3.0 {
-                        let epoch_validators = validators.view_without(vec![&self_node_id]);
-                        let build_target = BuildTarget::Broadcast(epoch_validators.into());
-                        assert_compatible(build_target);
-                    }
-
-                    for node in validators.validators.keys() {
-                        let build_target = BuildTarget::PointToPoint(node);
-                        assert_compatible(build_target);
-                    }
-
-                    {
-                        // we pretend the validators form a fullnode group
-                        let group = Group::new_fullnode_group(
-                            validators.validators.keys().cloned().collect(),
-                            &self_node_id,
-                            self_node_id,
-                            RoundSpan::single(Round(1)).unwrap(),
-                        );
-                        let build_target = BuildTarget::FullNodeRaptorCast(&group);
-                        assert_compatible(build_target);
-                    }
-                }
-            }
-        }
-    }
-
-    fn assert_build_compatible(
-        key: &<ST as CertificateSignature>::KeyPairType,
-        app_msg: &Bytes,
-        redundancy: f32,
-        build_target: &BuildTarget<ST>,
-        known_addresses: &HashMap<NodeId<PT>, SocketAddr>,
-    ) {
-        let make_rng = || StdRng::seed_from_u64(42);
-        let redundancy = Redundancy::from_f32(redundancy).expect("bad redundancy");
-
-        let new = build_new(
-            key,
-            DEFAULT_SEGMENT_LEN as u16,
-            app_msg.clone(),
-            redundancy,
-            EPOCH,
-            UNIX_TS_MS,
-            build_target.clone(),
-            known_addresses,
-            &mut make_rng(),
-        );
-
-        let old = build_old(
-            key,
-            DEFAULT_SEGMENT_LEN as u16,
-            app_msg.clone(),
-            redundancy,
-            EPOCH,
-            UNIX_TS_MS,
-            build_target.clone(),
-            known_addresses,
-            &mut make_rng(),
-        );
-
-        assert_compatible_eq(&old, &new);
-    }
-
-    type Packets = Vec<(SocketAddr, Bytes)>;
-
-    // We loosen up two constraints for comparing the output from old
-    // and new implementations:
-    //
-    // 1. we allow the packets to be reordered (new implementation
-    // uses a HashMap when assembling packets, which scrambles the
-    // order.)
-    //
-    // 2. we allow the signature to differ because the signature is
-    // non-deterministic.
-    fn normalize(packets: &Packets) -> Packets {
-        let mut normalized_packets = BTreeSet::new();
-        for (addr, payload) in packets {
-            let payload_without_signature = payload.slice(SIGNATURE_SIZE..);
-            normalized_packets.insert((*addr, payload_without_signature));
-        }
-
-        normalized_packets.into_iter().collect()
-    }
-
-    #[allow(unreachable_code)]
-    fn assert_compatible_eq(expected: &Packets, actual: &Packets) {
-        assert_eq!(expected.len(), actual.len());
-
-        // Set the environment variable to show detailed difference in
-        // packet bytes.
-        let (expected, actual) = (normalize(expected), normalize(actual));
-        if option_env!("SCRUTINIZE_PACKET") != Some("1") {
-            assert_eq!(expected, actual);
-            return;
-        }
-
-        for ((e_addr, e_payload), (a_addr, a_payload)) in expected.iter().zip(actual.iter()) {
-            // The recipient's socket address is the same.
-            if e_addr != a_addr {
-                println!("{:?} {:?}", e_addr, a_addr);
-                println!("{:?}\n-----\n{:?}", e_payload, a_payload);
-                assert_eq!(e_addr, a_addr);
-            }
-
-            // The signatures are different even when signing the same
-            // message with the same key.
-            assert_eq!(e_payload.len(), a_payload.len());
-
-            for (i, (be, ba)) in e_payload.iter().zip(a_payload.iter()).enumerate() {
-                assert_eq!(
-                    be, ba,
-                    "payloads differ at byte {}: 0x{:02x} != 0x{:02x}",
-                    i, be, ba
-                );
-            }
-        }
     }
 }

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -223,6 +223,12 @@ impl Debug for Epoch {
     }
 }
 
+impl From<Epoch> for u64 {
+    fn from(epoch: Epoch) -> Self {
+        epoch.0
+    }
+}
+
 /// Block sequence number
 ///
 /// Consecutive blocks in the same branch have consecutive sequence numbers,


### PR DESCRIPTION
This PR replaces `udp::build_messages` with `packet::build_messages`.

This PR adds a new builder-style API for building udp messages, intended for reusing parameters. I replaced the `RaptorCast{,Secondary}::udp_build` method with this new API.

Note on testing:

- I removed the regression test for oversized message because it relies on building invalid udp message with unusual length, which is non-trivial to do with the new builder. This test is no longer relevant because the current decoder cache [will not panic](https://github.com/category-labs/monad-bft/blob/e35648e5f6b39b4117bdecc437aa1fc17bcfa74e/monad-raptorcast/src/decoding.rs#L1417-L1418) on failed decoder initialization, as long as the decoder creation itself does not panic, which is covered by [a new test](https://github.com/category-labs/monad-bft/pull/2469/files#diff-26e9efe2d911d609a77921fe02741b938fd804059721df614a564bea3d925aa4R93).
- The compatibility test is removed since the original version is removed. The correctness of the builder is covered by the numerous tests of the original `udp::build_messages`.
- The correctness of the new builder API is covered transitively through those original tests.