### PR TITLE
Update router config when receiving UpdateFullNodes command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5683,6 +5683,7 @@ dependencies = [
  "monad-dataplane",
  "monad-executor",
  "monad-executor-glue",
+ "monad-node-config",
  "monad-peer-discovery",
  "monad-raptorcast",
  "monad-types",

--- a/monad-router-multi/Cargo.toml
+++ b/monad-router-multi/Cargo.toml
@@ -8,6 +8,7 @@ monad-crypto = { workspace = true }
 monad-dataplane = { workspace = true }
 monad-executor = { workspace = true }
 monad-executor-glue = { workspace = true }
+monad-node-config = { workspace = true }
 monad-peer-discovery = { workspace = true }
 monad-raptorcast = { workspace = true }
 monad-types = { workspace = true }

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -30,6 +30,7 @@ use monad_crypto::certificate_signature::{
 use monad_dataplane::{DataplaneBuilder, DataplaneWriter};
 use monad_executor::{Executor, ExecutorMetricsChain};
 use monad_executor_glue::{Message, RouterCommand};
+use monad_node_config::{FullNodeConfig, FullNodeIdentityConfig};
 use monad_peer_discovery::{
     driver::PeerDiscoveryDriver, PeerDiscoveryAlgo, PeerDiscoveryAlgoBuilder,
 };
@@ -327,6 +328,16 @@ where
                     ref dedicated_full_nodes,
                     ref prioritized_full_nodes,
                 } => {
+                    self.rc_config.primary_instance.fullnode_dedicated =
+                        dedicated_full_nodes.clone();
+                    self.rc_config.secondary_instance.full_nodes_prioritized = FullNodeConfig {
+                        identities: prioritized_full_nodes
+                            .iter()
+                            .map(|id| FullNodeIdentityConfig {
+                                secp256k1_pubkey: id.pubkey(),
+                            })
+                            .collect(),
+                    };
                     let cmd_cpy = RouterCommand::UpdateFullNodes {
                         dedicated_full_nodes: dedicated_full_nodes.clone(),
                         prioritized_full_nodes: prioritized_full_nodes.clone(),


### PR DESCRIPTION
We use `MultiRouter.rc_config` to reconstruct secondary state when node's role is updated. We need to apply config reloads on MultiRouter's copy of the config