### PR TITLE
RaptorCast: Stream chunks into dataplane

### DIFF
--- a/monad-raptorcast/src/packet/assembler.rs
+++ b/monad-raptorcast/src/packet/assembler.rs
@@ -655,7 +655,7 @@ impl AssembleMode {
     pub fn expected_chunk_order(self) -> Option<ChunkOrder> {
         match self {
             AssembleMode::GsoFull => Some(ChunkOrder::GsoFriendly),
-            AssembleMode::GsoBestEffort => None,
+            AssembleMode::GsoBestEffort => Some(ChunkOrder::GsoFriendly),
             AssembleMode::RoundRobin => Some(ChunkOrder::RoundRobin),
         }
     }


### PR DESCRIPTION
In raptorcasting, a message is first raptor-coded into chunks, then batched into merkle trees (<=32 chunks per tree), signed, and assembled into UDP messages for delivery to the dataplane.

Although the merkle tree structure reduces the number of signing operations by up to 32x, signing each merkle batch remains the most time-consuming step in raptorcasting, often accounting for up to 90% of message build time. As a result, the dataplane can remain underutilized while waiting for the packet builder to generate all messages.

This PR improves dataplane utilization by streaming assembled UDP messages as soon as each merkle batch is constructed and signed. This reduces the latency for a raptorcasted message to reach the dataplane and distributes message delivery more evenly across the entire building operation.