### PR TITLE
Add prioritized upstream to config

### DIFF
--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -86,6 +86,9 @@ pub enum RouterCommand<ST: CertificateSignatureRecoverable, OM> {
         dedicated_full_nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
         prioritized_full_nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
     },
+    UpdateUpstreamValidators {
+        prioritized_upstream: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
+    },
 }
 
 impl<ST: CertificateSignatureRecoverable, OM> Debug for RouterCommand<ST, OM> {
@@ -139,6 +142,12 @@ impl<ST: CertificateSignatureRecoverable, OM> Debug for RouterCommand<ST, OM> {
                 .debug_struct("UpdateFullNodes")
                 .field("dedicated_full_nodes", dedicated_full_nodes)
                 .field("prioritized_full_nodes", prioritized_full_nodes)
+                .finish(),
+            Self::UpdateUpstreamValidators {
+                prioritized_upstream,
+            } => f
+                .debug_struct("UpdateUpstreamValidators")
+                .field("prioritized_upstream", prioritized_upstream)
                 .finish(),
         }
     }
@@ -1926,6 +1935,7 @@ where
 {
     pub dedicated_full_nodes: Vec<NodeId<SCT::NodeIdPubKey>>,
     pub prioritized_full_nodes: Vec<NodeId<SCT::NodeIdPubKey>>,
+    pub prioritized_upstream: Vec<NodeId<SCT::NodeIdPubKey>>,
     pub blocksync_override_peers: Vec<NodeId<SCT::NodeIdPubKey>>,
 }
 

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -397,6 +397,9 @@ impl<S: SwarmRelation> Executor for MockExecutor<S> {
                 RouterCommand::UpdateFullNodes { .. } => {
                     // TODO
                 }
+                RouterCommand::UpdateUpstreamValidators { .. } => {
+                    // TODO
+                }
                 RouterCommand::PublishToFullNodes { .. } => {
                     // TODO
                 }

--- a/monad-node-config/src/fullnode_raptorcast.rs
+++ b/monad-node-config/src/fullnode_raptorcast.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use monad_crypto::certificate_signature::PubKey;
-use monad_types::Round;
+use monad_types::{NodeId, Round};
 use serde::{Deserialize, Serialize};
 
 use super::fullnode::FullNodeConfig;
@@ -44,4 +44,7 @@ pub struct FullNodeRaptorCastConfig<P: PubKey> {
     pub invite_future_dist_min: Round,
     pub invite_future_dist_max: Round,
     pub invite_accept_heartbeat_ms: u64,
+
+    #[serde(bound = "P:PubKey", default = "Vec::new")]
+    pub prioritized_upstream: Vec<NodeId<P>>,
 }

--- a/monad-peer-disc-swarm/src/lib.rs
+++ b/monad-peer-disc-swarm/src/lib.rs
@@ -159,6 +159,7 @@ impl<S: PeerDiscSwarmRelation> Executor for MockPeerDiscExecutor<S> {
                 RouterCommand::UpdatePeers { .. } => {}
                 RouterCommand::GetFullNodes => {}
                 RouterCommand::UpdateFullNodes { .. } => {}
+                RouterCommand::UpdateUpstreamValidators { .. } => {}
                 RouterCommand::PublishToFullNodes { .. } => {}
             }
         }

--- a/monad-raptorcast/src/config.rs
+++ b/monad-raptorcast/src/config.rs
@@ -130,12 +130,15 @@ where
     ST: CertificateSignatureRecoverable,
 {
     None, // Not participating in any raptor-casting to full-nodes.
-    Client(RaptorCastConfigSecondaryClient), // i.e. we are a full-node
+    Client(RaptorCastConfigSecondaryClient<ST>), // i.e. we are a full-node
     Publisher(RaptorCastConfigSecondaryPublisher<ST>), // we are a validator
 }
 
 #[derive(Clone)]
-pub struct RaptorCastConfigSecondaryClient {
+pub struct RaptorCastConfigSecondaryClient<ST>
+where
+    ST: CertificateSignatureRecoverable,
+{
     // Maximum number of groups a full node will join at a time
     pub max_num_group: usize,
     // Maximum number of full nodes in a group
@@ -146,16 +149,22 @@ pub struct RaptorCastConfigSecondaryClient {
     pub invite_future_dist_min: Round,
     pub invite_future_dist_max: Round,
     pub invite_accept_heartbeat: Duration,
+    // Prioritized upstream validators that this full node prefers to connect to
+    pub prioritized_upstream: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
 }
 
-impl Default for RaptorCastConfigSecondaryClient {
-    fn default() -> RaptorCastConfigSecondaryClient {
+impl<ST> Default for RaptorCastConfigSecondaryClient<ST>
+where
+    ST: CertificateSignatureRecoverable,
+{
+    fn default() -> RaptorCastConfigSecondaryClient<ST> {
         RaptorCastConfigSecondaryClient {
             max_num_group: 3,
             max_group_size: 50,
             invite_future_dist_min: Round(1),
             invite_future_dist_max: Round(600), // ~5 minutes into the future, with current round length of 500ms
             invite_accept_heartbeat: Duration::from_secs(10),
+            prioritized_upstream: Default::default(),
         }
     }
 }

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -422,6 +422,7 @@ where
             invite_future_dist_min: Round(1),
             invite_future_dist_max: Round(5),
             invite_accept_heartbeat_ms: 100,
+            prioritized_upstream: vec![],
         },
     };
     let pd = PeerDiscoveryDriver::new(peer_discovery_builder);
@@ -635,6 +636,10 @@ where
                     prioritized_full_nodes: _,
                 } => {
                     self.dedicated_full_nodes.list = dedicated_full_nodes;
+                }
+                RouterCommand::UpdateUpstreamValidators { .. } => {
+                    // Primary RaptorCast doesn't need upstream validators config
+                    // This command is consumed by secondary RaptorCast only
                 }
             }
         }

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -293,6 +293,22 @@ where
                         publisher.update_always_ask_full_nodes(prioritized_full_nodes);
                     }
                 },
+                Self::Command::UpdateUpstreamValidators {
+                    prioritized_upstream,
+                } => match &mut self.role {
+                    Role::Client(client) => {
+                        debug!(
+                            ?prioritized_upstream,
+                            "RaptorCastSecondary Client updating prioritized_upstream validators"
+                        );
+                        client.update_prioritized_upstream(prioritized_upstream);
+                    }
+                    Role::Publisher(_) => {
+                        debug!(
+                            "RaptorCastSecondary Publisher ignoring UpdateUpstreamValidators command"
+                        );
+                    }
+                },
 
                 Self::Command::UpdateCurrentRound(epoch, round) => match &mut self.role {
                     Role::Client(client) => {

--- a/monad-raptorcast/src/raptorcast_secondary/publisher.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/publisher.rs
@@ -1496,6 +1496,7 @@ mod tests {
                 invite_future_dist_min: Round(1),
                 invite_future_dist_max: Round(100),
                 invite_accept_heartbeat: Duration::from_secs(10),
+                prioritized_upstream: vec![],
             },
         );
         let mut group_map = MockGroupMap::new(nid(10), clt_rx);
@@ -1625,6 +1626,7 @@ mod tests {
                 invite_future_dist_min: Round(1),
                 invite_future_dist_max: Round(100),
                 invite_accept_heartbeat: Duration::from_secs(10),
+                prioritized_upstream: vec![],
             },
         );
         let mut group_map = MockGroupMap::new(nid(10), clt_rx);
@@ -1768,6 +1770,7 @@ mod tests {
                 invite_future_dist_min: Round(1),
                 invite_future_dist_max: Round(100),
                 invite_accept_heartbeat: Duration::from_secs(10),
+                prioritized_upstream: vec![],
             },
         );
         let mut group_map = MockGroupMap::new(nid(me), clt_rx);

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -208,6 +208,7 @@ where
                         invite_accept_heartbeat: Duration::from_millis(
                             cfg.secondary_instance.invite_accept_heartbeat_ms,
                         ),
+                        prioritized_upstream: cfg.secondary_instance.prioritized_upstream.clone(),
                     }),
                 }
             }
@@ -343,6 +344,14 @@ where
                         prioritized_full_nodes: prioritized_full_nodes.clone(),
                     };
                     validator_cmds.push(cmd_cpy);
+                    fullnodes_cmds.push(cmd);
+                }
+                RouterCommand::UpdateUpstreamValidators {
+                    ref prioritized_upstream,
+                } => {
+                    // This command is only relevant for full-nodes
+                    self.rc_config.secondary_instance.prioritized_upstream =
+                        prioritized_upstream.clone();
                     fullnodes_cmds.push(cmd);
                 }
                 RouterCommand::UpdateCurrentRound(epoch, round) => {

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1143,6 +1143,12 @@ where
                         prioritized_full_nodes: config_update.prioritized_full_nodes,
                     }));
 
+                    cmds.push(Command::RouterCommand(
+                        RouterCommand::UpdateUpstreamValidators {
+                            prioritized_upstream: config_update.prioritized_upstream,
+                        },
+                    ));
+
                     cmds.push(Command::ControlPanelCommand(ControlPanelCommand::Write(
                         WriteCommand::ReloadConfig(ReloadConfig::Response("Success".to_string())),
                     )));

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -351,6 +351,7 @@ where
                                 invite_future_dist_min: Round(1),
                                 invite_future_dist_max: Round(5),
                                 invite_accept_heartbeat_ms: 100,
+                                prioritized_upstream: vec![],
                             },
                         }),
                     },

--- a/monad-updaters/src/config_loader.rs
+++ b/monad-updaters/src/config_loader.rs
@@ -177,6 +177,7 @@ where
         ConfigEvent::ConfigUpdate(ConfigUpdate {
             dedicated_full_nodes,
             prioritized_full_nodes,
+            prioritized_upstream: node_config.fullnode_raptorcast.prioritized_upstream,
             blocksync_override_peers,
         })
     }

--- a/monad-updaters/src/local_router.rs
+++ b/monad-updaters/src/local_router.rs
@@ -196,6 +196,7 @@ where
                 RouterCommand::UpdatePeers { .. } => {}
                 RouterCommand::GetFullNodes => {}
                 RouterCommand::UpdateFullNodes { .. } => {}
+                RouterCommand::UpdateUpstreamValidators { .. } => {}
             }
         }
     }


### PR DESCRIPTION
Add an optional configuration option for a fullnode to specify prioritized validator upstream. Invites from prioritized upstreams bypass the `max_num_group` check, which may increase the number of connections above the limit temporarily. The hard max is `max_num_group + prioritized_upstream.len()`

It's recommended to set `prioritized_upstream.len()` lower than `max_num_group`. Otherwise node might experience a gap when transitioning from other upstreams to prioritized upstreams.