### PR TITLE
Update debug_getRawReceipts rlp response

### DIFF
--- a/monad-rpc/src/handlers/debug.rs
+++ b/monad-rpc/src/handlers/debug.rs
@@ -123,7 +123,7 @@ pub async fn monad_debug_getRawReceipts<T: Triedb>(
             .into_iter()
             .map(|r| {
                 let mut res = Vec::new();
-                r.encode(&mut res);
+                r.encode_2718(&mut res);
                 hex::encode(&res)
             })
             .collect();
@@ -736,9 +736,11 @@ async fn build_call_tree(
 
 #[cfg(test)]
 mod tests {
+    use alloy_consensus::ReceiptWithBloom;
+    use alloy_primitives::Bloom;
     use monad_triedb_utils::{
         mock_triedb,
-        triedb_env::{EthTxHash, TransactionLocation},
+        triedb_env::{EthTxHash, ReceiptWithLogIndex, TransactionLocation},
     };
 
     use super::*;
@@ -1066,5 +1068,39 @@ mod tests {
         assert_eq!(resp.input.0, *hex::decode("0xaabbccddee01").unwrap());
         assert_eq!(resp.output.0, *hex::decode("0x0102").unwrap());
         assert_eq!(resp.depth, 2);
+    }
+
+    #[tokio::test]
+    async fn debug_raw_receipts() {
+        let mut mock_triedb = mock_triedb::MockTriedb::default();
+        mock_triedb.set_latest_block(1);
+
+        let receipt = ReceiptWithBloom {
+            receipt: alloy_consensus::Receipt {
+                status: alloy_consensus::Eip658Value::Eip658(true),
+                cumulative_gas_used: 21000,
+                logs: vec![],
+            },
+            logs_bloom: Bloom::default(),
+        };
+
+        mock_triedb.set_receipts(vec![ReceiptWithLogIndex {
+            receipt: ReceiptEnvelope::Eip1559(receipt),
+            starting_log_index: 0,
+        }]);
+
+        let chain_state = ChainState::new(None, mock_triedb, None);
+        let result = monad_debug_getRawReceipts(
+            &chain_state,
+            DebugBlockParams {
+                block: BlockTags::Number(Quantity(1)),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.receipts.len(), 1);
+        let expected_receipt = "0x02f9010801825208b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0";
+        assert_eq!(result.receipts[0], expected_receipt);
     }
 }

--- a/monad-triedb-utils/src/mock_triedb.rs
+++ b/monad-triedb-utils/src/mock_triedb.rs
@@ -26,6 +26,8 @@ pub struct MockTriedb {
     tx_locations: HashMap<EthTxHash, TransactionLocation>,
     call_frames: HashMap<TransactionLocation, Vec<u8>>,
     code: String,
+    receipts: Vec<ReceiptWithLogIndex>,
+    transactions: Vec<TxEnvelopeWithSender>,
 }
 
 impl MockTriedb {
@@ -51,6 +53,14 @@ impl MockTriedb {
 
     pub fn set_code(&mut self, code: String) {
         self.code = code;
+    }
+
+    pub fn set_receipts(&mut self, receipts: Vec<ReceiptWithLogIndex>) {
+        self.receipts = receipts;
+    }
+
+    pub fn set_transactions(&mut self, transactions: Vec<TxEnvelopeWithSender>) {
+        self.transactions = transactions;
     }
 }
 
@@ -105,7 +115,7 @@ impl Triedb for MockTriedb {
         _block_key: BlockKey,
         _txn_index: u64,
     ) -> impl std::future::Future<Output = Result<Option<ReceiptWithLogIndex>, String>> + Send {
-        ready(Ok(None))
+        ready(Ok(self.receipts.get(_txn_index as usize).cloned()))
     }
 
     fn get_receipts(
@@ -113,7 +123,7 @@ impl Triedb for MockTriedb {
         _block_key: BlockKey,
     ) -> impl std::future::Future<Output = Result<Vec<ReceiptWithLogIndex>, String>> + Send + Sync
     {
-        ready(Ok(vec![]))
+        ready(Ok(self.receipts.clone()))
     }
 
     fn get_transaction(
@@ -122,7 +132,7 @@ impl Triedb for MockTriedb {
         _txn_index: u64,
     ) -> impl std::future::Future<Output = Result<Option<TxEnvelopeWithSender>, String>> + Send
     {
-        ready(Ok(None))
+        ready(Ok(self.transactions.get(_txn_index as usize).cloned()))
     }
 
     fn get_transactions(
@@ -130,7 +140,7 @@ impl Triedb for MockTriedb {
         _block_key: BlockKey,
     ) -> impl std::future::Future<Output = Result<Vec<TxEnvelopeWithSender>, String>> + Send + Sync
     {
-        ready(Ok(vec![]))
+        ready(Ok(self.transactions.clone()))
     }
 
     fn get_block_header(


### PR DESCRIPTION
Update response to be consistent with Ethereum rpc. `ReceiptEnvelope::encode` adds one more header in the rlp encoding, which is redundant. 