### PR TITLE
Stricter balance check for eth_sendRawTransaction

### DIFF
--- a/monad-eth-txpool-executor/src/ipc/mod.rs
+++ b/monad-eth-txpool-executor/src/ipc/mod.rs
@@ -48,7 +48,7 @@ pub struct EthTxPoolIpcServer {
 
     connections: Vec<EthTxPoolIpcStream>,
 
-    batch: Vec<TxEnvelope>,
+    batch: Vec<(TxEnvelope, bool)>,
     #[pin]
     batch_timer: Sleep,
 }
@@ -105,7 +105,7 @@ impl EthTxPoolIpcServer {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         generate_snapshot: impl Fn() -> EthTxPoolSnapshot,
-    ) -> Poll<Vec<TxEnvelope>> {
+    ) -> Poll<Vec<(TxEnvelope, bool)>> {
         let EthTxPoolIpcServerProjected {
             listener,
 
@@ -139,11 +139,11 @@ impl EthTxPoolIpcServer {
                     break;
                 };
 
-                let Some(tx) = result else {
+                let Some(tx_with_flag) = result else {
                     return false;
                 };
 
-                batch.push(tx);
+                batch.push(tx_with_flag);
             }
 
             true

--- a/monad-eth-txpool-executor/tests/executor.rs
+++ b/monad-eth-txpool-executor/tests/executor.rs
@@ -120,21 +120,19 @@ async fn test_ipc_tx_forwarding_pacing() {
     const NUM_TXS: usize = 1024;
 
     for nonce in 0..NUM_TXS {
-        ipc_client
-            .feed(&make_legacy_tx(
-                S1,
-                MIN_BASE_FEE.into(),
-                30_000_000,
-                nonce as u64,
-                egress_max_size_bytes(
-                    MockChainConfig::DEFAULT
-                        .get_execution_chain_revision(0)
-                        .execution_chain_params(),
-                ) / 2
-                    - 256,
-            ))
-            .await
-            .unwrap();
+        let tx = make_legacy_tx(
+            S1,
+            MIN_BASE_FEE.into(),
+            30_000_000,
+            nonce as u64,
+            egress_max_size_bytes(
+                MockChainConfig::DEFAULT
+                    .get_execution_chain_revision(0)
+                    .execution_chain_params(),
+            ) / 2
+                - 256,
+        );
+        ipc_client.feed(&(tx, false)).await.unwrap();
     }
 
     ipc_client.flush().await.unwrap();

--- a/monad-eth-txpool-ipc/src/lib.rs
+++ b/monad-eth-txpool-ipc/src/lib.rs
@@ -21,12 +21,76 @@ use std::{
 };
 
 use alloy_consensus::TxEnvelope;
+use alloy_rlp::{Decodable, Encodable};
 use futures::{FutureExt, Sink, SinkExt, Stream, StreamExt};
 use monad_eth_txpool_types::{EthTxPoolEvent, EthTxPoolSnapshot};
 use tokio::{net::UnixStream, sync::mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
 use tracing::warn;
+
+/// Decode a transaction with backward-compatible RLP format.
+///
+/// - Old format (bypass=false): `RLP(TxEnvelope)` - standard transaction encoding
+/// - New format (bypass=true): `RLP([tx_bytes, bool_byte])` - 2-element RLP list wrapper
+///
+/// Returns `Ok((tx, bypass_flag))` on success, `Err(())` on failure.
+#[allow(clippy::result_unit_err)]
+pub fn decode_tx_with_flag(bytes: &[u8]) -> Result<(TxEnvelope, bool), ()> {
+    let mut buf = bytes;
+
+    // Try old format first: RLP(TxEnvelope)
+    if let Ok(tx) = TxEnvelope::decode(&mut buf) {
+        return Ok((tx, false));
+    }
+
+    // Try new format: RLP([tx_bytes, bool_byte])
+    let mut buf = bytes;
+
+    // Decode RLP header to check if it's a list
+    let header = alloy_rlp::Header::decode(&mut buf).map_err(|_| ())?;
+    if !header.list {
+        return Err(());
+    }
+
+    // It's a list, decode as [tx_bytes, bool_byte]
+    let tx_bytes = Vec::<u8>::decode(&mut buf).map_err(|_| ())?;
+    let bool_byte = u8::decode(&mut buf).map_err(|_| ())?;
+    let tx = TxEnvelope::decode(&mut tx_bytes.as_slice()).map_err(|_| ())?;
+
+    // bool_byte == 0x01 means bypass_transfer_balance_check = true
+    let bypass_flag = bool_byte == 0x01;
+
+    Ok((tx, bypass_flag))
+}
+
+/// Encode a transaction with backward-compatible RLP format.
+///
+/// - Old format (bypass=false): `RLP(TxEnvelope)` - standard transaction encoding
+/// - New format (bypass=true): `RLP([tx_bytes, bool_byte])` - 2-element RLP list wrapper
+pub fn encode_tx_with_flag(tx: &TxEnvelope, bypass_flag: bool) -> Vec<u8> {
+    if bypass_flag {
+        // New format: encode as 2-element RLP list [tx_bytes, 0x01]
+        let tx_bytes = alloy_rlp::encode(tx);
+        let bool_byte = 0x01u8;
+
+        // Manually encode as RLP list: [tx_bytes, bool_byte]
+        let mut out = Vec::new();
+        let payload_length = tx_bytes.length() + bool_byte.length();
+        alloy_rlp::Header {
+            list: true,
+            payload_length,
+        }
+        .encode(&mut out);
+        tx_bytes.encode(&mut out);
+        bool_byte.encode(&mut out);
+
+        out
+    } else {
+        // Old format: direct RLP encoding of transaction (backward compatible)
+        alloy_rlp::encode(tx)
+    }
+}
 
 pub struct EthTxPoolIpcStream {
     // It's really ugly to emulate Sink for a Framed<UnixStream, ...> in a sync
@@ -35,7 +99,7 @@ pub struct EthTxPoolIpcStream {
     // TODO(andr-dev): Remove tokio_util and write a custom sync framer/codec
     // implementation simlar to LengthDelimnitedCodec
     tx: mpsc::Sender<Vec<EthTxPoolEvent>>,
-    rx: ReceiverStream<TxEnvelope>,
+    rx: ReceiverStream<(TxEnvelope, bool)>,
 
     handle: tokio::task::JoinHandle<io::Result<()>>,
 }
@@ -56,7 +120,7 @@ impl EthTxPoolIpcStream {
     async fn run(
         stream: UnixStream,
         snapshot: EthTxPoolSnapshot,
-        tx_sender: mpsc::Sender<TxEnvelope>,
+        tx_sender: mpsc::Sender<(TxEnvelope, bool)>,
         mut event_rx: mpsc::Receiver<Vec<EthTxPoolEvent>>,
     ) -> io::Result<()> {
         let mut stream = Framed::new(stream, LengthDelimitedCodec::default());
@@ -72,14 +136,23 @@ impl EthTxPoolIpcStream {
                         break;
                     };
 
-                    let Ok(tx) = alloy_rlp::decode_exact::<TxEnvelope>(result?.as_ref()) else {
+                    let bytes = result?;
+                    if bytes.is_empty() {
                         return Err(io::Error::new(
                             ErrorKind::InvalidData,
-                            "EthTxPoolIpcStream received invalid tx serialized bytes!"
+                            "EthTxPoolIpcStream received empty data!"
                         ));
-                    };
+                    }
 
-                    let Err(error) = tx_sender.try_send(tx) else {
+                    // Decode transaction with backward-compatible RLP format
+                    let (tx, bypass_transfer_balance_check) = decode_tx_with_flag(&bytes).map_err(|_| {
+                        io::Error::new(
+                            ErrorKind::InvalidData,
+                            "EthTxPoolIpcStream received invalid tx serialized bytes!"
+                        )
+                    })?;
+
+                    let Err(error) = tx_sender.try_send((tx, bypass_transfer_balance_check)) else {
                         continue;
                     };
 
@@ -121,7 +194,7 @@ impl EthTxPoolIpcStream {
 }
 
 impl Stream for EthTxPoolIpcStream {
-    type Item = TxEnvelope;
+    type Item = (TxEnvelope, bool);
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         if let Poll::Ready(result) = self.handle.poll_unpin(cx) {
@@ -169,15 +242,18 @@ impl EthTxPoolIpcClient {
     }
 }
 
-impl<'a> Sink<&'a TxEnvelope> for EthTxPoolIpcClient {
+impl<'a> Sink<&'a (TxEnvelope, bool)> for EthTxPoolIpcClient {
     type Error = io::Error;
 
     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.stream.poll_ready_unpin(cx)
     }
 
-    fn start_send(mut self: Pin<&mut Self>, tx: &'a TxEnvelope) -> Result<(), Self::Error> {
-        let bytes = alloy_rlp::encode(tx);
+    fn start_send(
+        mut self: Pin<&mut Self>,
+        tx_with_flag: &'a (TxEnvelope, bool),
+    ) -> Result<(), Self::Error> {
+        let bytes = encode_tx_with_flag(&tx_with_flag.0, tx_with_flag.1);
         self.stream.start_send_unpin(bytes.into())
     }
 

--- a/monad-eth-txpool/benches/insert.rs
+++ b/monad-eth-txpool/benches/insert.rs
@@ -64,7 +64,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 &block_policy,
                 state_backend,
                 &MockChainConfig::DEFAULT,
-                txs.to_owned(),
+                txs.iter().map(|tx| (tx.clone(), false)).collect(),
                 true,
                 |_| {},
             );

--- a/monad-eth-txpool/src/pool/transaction.rs
+++ b/monad-eth-txpool/src/pool/transaction.rs
@@ -43,6 +43,7 @@ pub const fn max_eip2718_encoded_length(execution_params: &ExecutionChainParams)
 pub struct ValidEthTransaction {
     tx: Recovered<TxEnvelope>,
     owned: bool,
+    bypass_transfer_balance_check: bool,
     forward_last_seqnum: SeqNum,
     forward_retries: usize,
     max_value: Balance,
@@ -64,6 +65,7 @@ impl ValidEthTransaction {
         execution_params: &ExecutionChainParams,
         tx: Recovered<TxEnvelope>,
         owned: bool,
+        bypass_transfer_balance_check: bool,
     ) -> Result<Self, (Recovered<TxEnvelope>, EthTxPoolDropReason)>
     where
         ST: CertificateSignatureRecoverable,
@@ -154,6 +156,7 @@ impl ValidEthTransaction {
         Ok(Self {
             tx,
             owned,
+            bypass_transfer_balance_check,
             forward_last_seqnum: last_commit.seq_num,
             forward_retries: 0,
             max_value,
@@ -220,6 +223,10 @@ impl ValidEthTransaction {
         self.tx.gas_limit()
     }
 
+    pub fn value(&self) -> Balance {
+        self.tx.value()
+    }
+
     pub fn size(&self) -> u64 {
         self.tx.length() as u64
     }
@@ -234,6 +241,10 @@ impl ValidEthTransaction {
 
     pub(crate) fn is_owned(&self) -> bool {
         self.owned
+    }
+
+    pub fn bypass_transfer_balance_check(&self) -> bool {
+        self.bypass_transfer_balance_check
     }
 
     pub fn has_higher_priority(&self, other: &Self, _base_fee: u64) -> bool {

--- a/monad-eth-txpool/tests/forward.rs
+++ b/monad-eth-txpool/tests/forward.rs
@@ -94,7 +94,7 @@ fn with_txpool(
         &eth_block_policy,
         &state_backend,
         &MockChainConfig::DEFAULT,
-        vec![tx],
+        vec![(tx, false)],
         insert_tx_owned,
         |_| {},
     );

--- a/monad-eth-txpool/tests/performance.rs
+++ b/monad-eth-txpool/tests/performance.rs
@@ -75,8 +75,14 @@ fn txpool_create_proposal_lookups_bound_by_tx_limit() {
             &state_backend,
             &MockChainConfig::DEFAULT,
             vec![
-                recover_tx(make_legacy_tx(S1, MIN_BASE_FEE.into(), 100_000, 0, 0)),
-                recover_tx(make_legacy_tx(S2, MIN_BASE_FEE.into(), 100_000, 0, 0)),
+                (
+                    recover_tx(make_legacy_tx(S1, MIN_BASE_FEE.into(), 100_000, 0, 0)),
+                    false,
+                ),
+                (
+                    recover_tx(make_legacy_tx(S2, MIN_BASE_FEE.into(), 100_000, 0, 0)),
+                    false,
+                ),
             ],
             true,
             |_| {},
@@ -152,15 +158,18 @@ fn txpool_create_proposal_no_lookup_for_unknown_authorizations() {
             &eth_block_policy,
             &state_backend,
             &MockChainConfig::DEFAULT,
-            vec![recover_tx(make_eip7702_tx(
-                S1,
-                MIN_BASE_FEE.into(),
-                0,
-                1_000_000,
-                0,
-                vec![make_signed_authorization(S2, authorization_address, 0)],
-                0,
-            ))],
+            vec![(
+                recover_tx(make_eip7702_tx(
+                    S1,
+                    MIN_BASE_FEE.into(),
+                    0,
+                    1_000_000,
+                    0,
+                    vec![make_signed_authorization(S2, authorization_address, 0)],
+                    0,
+                )),
+                false,
+            )],
             true,
             |_| {},
         );

--- a/monad-eth-txpool/tests/pool.rs
+++ b/monad-eth-txpool/tests/pool.rs
@@ -194,7 +194,7 @@ fn run_custom_iter<const N: usize>(
                         &eth_block_policy,
                         &state_backend,
                         &MockChainConfig::DEFAULT,
-                        vec![tx.clone()],
+                        vec![(tx.clone(), false)],
                         owned,
                         |inserted_tx| {
                             assert_eq!(&tx, inserted_tx.raw());
@@ -233,6 +233,7 @@ fn run_custom_iter<const N: usize>(
                     txs.into_iter()
                         .map(ToOwned::to_owned)
                         .map(recover_tx)
+                        .map(|tx| (tx, false))
                         .collect(),
                     owned,
                     |_| {

--- a/monad-rpc/src/txpool/client.rs
+++ b/monad-rpc/src/txpool/client.rs
@@ -26,7 +26,7 @@ use super::{
 
 #[derive(Clone)]
 pub struct EthTxPoolBridgeClient {
-    tx_sender: Sender<(TxEnvelope, TxStatusSender)>,
+    tx_sender: Sender<(TxEnvelope, TxStatusSender, bool)>,
     tx_inflight: Arc<()>,
 
     state: EthTxPoolBridgeStateView,
@@ -34,7 +34,7 @@ pub struct EthTxPoolBridgeClient {
 
 impl EthTxPoolBridgeClient {
     pub(super) fn new(
-        tx_sender: Sender<(TxEnvelope, TxStatusSender)>,
+        tx_sender: Sender<(TxEnvelope, TxStatusSender, bool)>,
         state: EthTxPoolBridgeStateView,
     ) -> Self {
         Self {
@@ -53,8 +53,10 @@ impl EthTxPoolBridgeClient {
         &self,
         tx: TxEnvelope,
         tx_status_send: TxStatusSender,
-    ) -> Result<(), TrySendError<(TxEnvelope, TxStatusSender)>> {
-        self.tx_sender.try_send((tx, tx_status_send))
+        bypass_transfer_balance_check: bool,
+    ) -> Result<(), TrySendError<(TxEnvelope, TxStatusSender, bool)>> {
+        self.tx_sender
+            .try_send((tx, tx_status_send, bypass_transfer_balance_check))
     }
 
     pub fn get_status_by_hash(&self, hash: &TxHash) -> Option<TxStatus> {

--- a/monad-updaters/src/txpool.rs
+++ b/monad-updaters/src/txpool.rs
@@ -433,7 +433,7 @@ where
                             .filter_map(|raw_tx| {
                                 let tx = TxEnvelope::decode(&mut raw_tx.as_ref()).ok()?;
                                 let signer = tx.recover_signer().ok()?;
-                                Some(Recovered::new_unchecked(tx, signer))
+                                Some((Recovered::new_unchecked(tx, signer), false))
                             })
                             .collect(),
                         false,
@@ -576,7 +576,7 @@ where
             block_policy,
             state_backend,
             &MockChainConfig::DEFAULT,
-            vec![tx],
+            vec![(tx, false)],
             true,
             |tx| {
                 self.events.push_back(MempoolEvent::ForwardTxs(vec![


### PR DESCRIPTION
Closes https://github.com/category-labs/category-external/issues/121

Reserve balance allows a transaction with insufficient transfer balance to be included in the block, as long as the balance is sufficient to cover the gas cost of the transaction. However, in most cases, this is due to user error. This PR changes this by introducing a flag passed into txpool, where the default is for RPC (`eth_sendRawTransaction`) to reject such transaction where the transfer balance is insufficient. Since this is a RPC change and not a protocol change, the flag can be toggled to allow such transaction. 

Flexnet tests cover both with and without the flag.