### PR TITLE
wal2json: add multi-file support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,6 +2835,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "dateparser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ef451feee09ae5ecd8a02e738bd9adee9266b8fa9b44e22d3ce968d8694238"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6226,6 +6238,8 @@ dependencies = [
  "bytes",
  "clap 4.5.47",
  "criterion",
+ "dateparser",
+ "itertools 0.10.5",
  "monad-bls",
  "monad-crypto",
  "monad-eth-types",
@@ -6235,6 +6249,7 @@ dependencies = [
  "rayon",
  "serde_json",
  "tempfile",
+ "test-case",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ cmake = "0.1"
 codespan-reporting = "0.11.1"
 console_error_panic_hook = "0.1"
 criterion = { version = "0.4", features = ["html_reports"] }
+dateparser = "0.2"
 insta = "1.42"
 ctr = "0.9.2"
 dashmap = "6.1.0"

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -2239,6 +2239,24 @@ where
     pub event: MonadEvent<ST, SCT, EPT>,
 }
 
+impl<ST, SCT, EPT> LogFriendlyMonadEvent<ST, SCT, EPT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    EPT: ExecutionProtocol,
+{
+    pub fn deserialize_timestamp(data: &[u8]) -> DateTime<Utc> {
+        // TODO consolidate with the similar code in deserialize impl
+        let mut offset = 0;
+        let header: [u8; 4] = data[0..EVENT_HEADER_LEN].try_into().unwrap();
+        let ts_size = EventHeaderType::from_le_bytes(header) as usize;
+        offset += EVENT_HEADER_LEN;
+
+        let ts: DateTime<Utc> = bincode::deserialize(&data[offset..offset + ts_size]).unwrap();
+        ts
+    }
+}
+
 type EventHeaderType = u32;
 const EVENT_HEADER_LEN: usize = std::mem::size_of::<EventHeaderType>();
 

--- a/monad-wal/Cargo.toml
+++ b/monad-wal/Cargo.toml
@@ -23,9 +23,12 @@ monad-types = { workspace = true }
 
 clap = { workspace = true, features = ["derive"] }
 criterion = { workspace = true }
+dateparser = { workspace = true }
+itertools = { workspace = true }
 rayon = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
+test-case = { workspace = true }
 
 [[bench]]
 name = "raw_bench"

--- a/monad-wal/examples/wal2json.rs
+++ b/monad-wal/examples/wal2json.rs
@@ -13,28 +13,54 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{io::Write, path::PathBuf};
+use std::{
+    fmt::Debug,
+    io::{ErrorKind, Write},
+    path::PathBuf,
+};
 
 use clap::Parser;
+use dateparser::DateTimeUtc;
+use itertools::Itertools;
 use monad_bls::BlsSignatureCollection;
 use monad_crypto::certificate_signature::CertificateSignaturePubKey;
 use monad_eth_types::EthExecutionProtocol;
 use monad_executor_glue::LogFriendlyMonadEvent;
 use monad_secp::SecpSignature;
 use monad_types::Deserializable;
-use monad_wal::{
-    reader::{WALReader, WALReaderConfig},
-    WALError,
-};
+use monad_wal::reader::{events_iter_in_range, events_iter_raw, WALReader, WALReaderConfig};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 #[derive(Parser, Debug)]
-struct Args {
-    #[arg(long)]
-    wal_path: PathBuf,
+#[command(long_about = "\
+Selected timestamp formats
+  excerpt from https://docs.rs/dateparser/latest/dateparser/index.html#accepted-date-formats
 
+unix timestamp:
+  1511648546
+  1620021848429
+rfc3339:
+  2021-05-01T01:17:02.604456Z
+  2017-11-25T22:34:50Z
+yyyy-mm-dd:
+  2021-02-21
+hh:mm:ss:
+  01:06:06
+  4:00pm
+hh:mm:ss z:
+  01:06:06 PST")]
+struct Args {
     #[arg(short, default_value_t = 1)]
     jobs: usize,
+
+    #[arg(short, default_value = "2000-01-01")]
+    after: DateTimeUtc,
+
+    #[arg(short, default_value = "2100-01-01")]
+    before: DateTimeUtc,
+
+    #[arg(value_delimiter = ' ')]
+    paths: Vec<PathBuf>,
 }
 
 type SigType = SecpSignature;
@@ -42,8 +68,14 @@ type SigColType = BlsSignatureCollection<CertificateSignaturePubKey<SigType>>;
 type ExecutionProtocolType = EthExecutionProtocol;
 type WrappedEvent = LogFriendlyMonadEvent<SigType, SigColType, ExecutionProtocolType>;
 
+const EVENTS_SERIALIZE_BATCH_SIZE: usize = 10_000;
+
 fn main() {
     let args = Args::parse();
+    if args.paths.is_empty() {
+        eprintln!("error: no wal paths specified");
+        std::process::exit(1);
+    }
 
     let start = std::time::Instant::now();
 
@@ -52,38 +84,61 @@ fn main() {
         .build_global()
         .unwrap();
 
-    let config = WALReaderConfig::new(args.wal_path);
-    let mut reader: WALReader<WrappedEvent> = config.build().unwrap();
+    let timestamp_range = args.after.0..=args.before.0;
 
-    // this loads everything into memory at once
-    // this is not ideal, but each file is capped at 1GB currently anyways
-    let raw_events: Vec<_> = std::iter::repeat(())
-        .map_while(move |()| match reader.load_one_raw() {
-            Ok(raw) => Some(raw),
-            Err(WALError::IOError(err)) if err.kind() == std::io::ErrorKind::UnexpectedEof => None,
-            Err(err) => panic!("error reading WAL: {:?}", err),
-        })
-        .collect();
+    let raw_events_iter = events_iter_in_range(
+        args.paths.into_iter().map(|path| {
+            let config = WALReaderConfig::new(path);
+            let reader: WALReader<WrappedEvent> = config.build().unwrap();
+            events_iter_raw(reader)
+        }),
+        |event| WrappedEvent::deserialize_timestamp(event),
+        timestamp_range,
+    );
 
-    eprintln!("done read from disk in {:?}", start.elapsed());
-
-    // build output strings in memory
-    let events = raw_events
-        .into_par_iter()
-        .map(|raw| {
-            let event = WrappedEvent::deserialize(&raw).expect("failed to deserialize WAL event");
-            serde_json::to_string(&event).unwrap()
-        })
-        .collect_vec_list();
-
-    eprintln!("done serializing events in {:?}", start.elapsed());
-
+    let mut num_events = 0usize;
     let mut stdout = std::io::stdout().lock();
     let mut buffered_stdout = std::io::BufWriter::new(&mut stdout);
-    for event in events.iter().flatten() {
-        writeln!(buffered_stdout, "{}", event).unwrap();
-    }
-    buffered_stdout.flush().unwrap();
 
-    eprintln!("done flushing in {:?}", start.elapsed());
+    for raw_events_batch in raw_events_iter
+        .chunks(EVENTS_SERIALIZE_BATCH_SIZE)
+        .into_iter()
+    {
+        let raw_events_batch = raw_events_batch.collect_vec();
+        num_events += raw_events_batch.len();
+        eprintln!("read {} events in {:?}", num_events, start.elapsed());
+
+        // build output strings in memory
+        let serialized_events = raw_events_batch
+            .into_par_iter()
+            .map(|raw| {
+                let event =
+                    WrappedEvent::deserialize(&raw).expect("failed to deserialize WAL event");
+                serde_json::to_string(&event).unwrap()
+            })
+            .collect_vec_list();
+        eprintln!("serialized {} events in {:?}", num_events, start.elapsed());
+
+        for serialized_event in serialized_events.iter().flatten() {
+            match writeln!(buffered_stdout, "{}", serialized_event) {
+                Ok(()) => {}
+                Err(e) if e.kind() == ErrorKind::BrokenPipe => {
+                    // pipe broken, exit early
+                    std::process::exit(0);
+                }
+                Err(e) => {
+                    eprintln!("error writing to stdout: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
+
+        eprintln!(
+            "wrote {} events to stdout in {:?}",
+            num_events,
+            start.elapsed()
+        );
+    }
+
+    buffered_stdout.flush().unwrap();
 }

--- a/monad-wal/src/reader.rs
+++ b/monad-wal/src/reader.rs
@@ -18,10 +18,10 @@ use std::{
     fs::{File, OpenOptions},
     io::{BufReader, Read},
     marker::PhantomData,
+    ops::RangeInclusive,
     path::PathBuf,
 };
 
-use bytes::Bytes;
 use monad_types::Deserializable;
 
 use crate::{
@@ -70,18 +70,158 @@ impl<M> WALReader<M>
 where
     M: Deserializable<[u8]> + Debug,
 {
-    pub fn load_one_raw(&mut self) -> Result<Bytes, WALError> {
+    pub fn load_one_raw(&mut self) -> Result<Vec<u8>, std::io::Error> {
         let mut len_buf = [0u8; EVENT_HEADER_LEN];
         self.reader.read_exact(&mut len_buf)?;
         let len = EventHeaderType::from_le_bytes(len_buf);
         let mut buf = vec![0u8; len as usize];
         self.reader.read_exact(&mut buf)?;
-        Ok(buf.into())
+        Ok(buf)
     }
 
     pub fn load_one(&mut self) -> Result<M, WALError> {
         let buf = self.load_one_raw()?;
         let msg = M::deserialize(&buf).map_err(|e| WALError::DeserError(Box::new(e)))?;
         Ok(msg)
+    }
+}
+
+pub fn events_iter_raw<M>(mut reader: WALReader<M>) -> impl Iterator<Item = Vec<u8>>
+where
+    M: Deserializable<[u8]> + Debug,
+{
+    std::iter::repeat(()).map_while(move |()| match reader.load_one_raw() {
+        Ok(event) => Some(event),
+        Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => None,
+        Err(err) => panic!("error reading WAL: {:?}", err),
+    })
+}
+
+pub fn events_iter<M>(mut reader: WALReader<M>) -> impl Iterator<Item = M>
+where
+    M: Deserializable<[u8]> + Debug,
+{
+    std::iter::repeat(()).map_while(move |()| match reader.load_one() {
+        Ok(event) => Some(event),
+        Err(WALError::IOError(err)) if err.kind() == std::io::ErrorKind::UnexpectedEof => None,
+        Err(err) => panic!("error reading WAL: {:?}", err),
+    })
+}
+
+pub fn events_iter_in_range<E, Ts>(
+    events_iters: impl Iterator<Item = impl Iterator<Item = E>>,
+    event_to_ts: impl Fn(&E) -> Ts + Copy,
+    range: RangeInclusive<Ts>,
+) -> impl Iterator<Item = E>
+where
+    Ts: Copy + Ord + 'static,
+{
+    let end = *range.end();
+    let mut fused_events = events_iters
+        .map(|events_iter| events_iter.peekable())
+        // we can immediately drop any logs that only contain events past the end time
+        // equivalently, we only keep logs that contain events before the end time
+        .filter_map(|mut events_iter| {
+            let first_event = events_iter.peek()?;
+            let first_event_ts = event_to_ts(first_event);
+            if first_event_ts <= end {
+                Some((first_event_ts, events_iter))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // sort logs by first event timestamp
+    fused_events.sort_by_key(|(first_event_ts, _)| *first_event_ts);
+
+    let start = *range.start();
+    let truncate_before = fused_events
+        .iter()
+        // find the last log that has its first event timestamp <= start time
+        // the significance of this is that we can drop all logs before it
+        .rposition(|(first_event_ts, _)| *first_event_ts <= start)
+        // if all logs have first event timestamp > start time, we can't drop any
+        .unwrap_or(0);
+    if truncate_before > 0 {
+        // drop all logs before that log
+        fused_events.drain(0..truncate_before);
+    }
+
+    fused_events
+        .into_iter()
+        .map(|(_, events)| events)
+        .flatten()
+        .skip_while(move |event| event_to_ts(event) < start)
+        .take_while(move |event| event_to_ts(event) <= end)
+}
+
+#[cfg(test)]
+mod test {
+    use std::ops::RangeInclusive;
+
+    use test_case::test_case;
+
+    use crate::reader::events_iter_in_range;
+
+    #[test_case(
+        vec![
+            vec![1, 2, 3],
+            vec![4, 5, 6],
+            vec![7, 8, 9],
+            vec![10, 11, 12],
+        ];
+        "events 1"
+    )]
+    #[test_case(
+        vec![
+            vec![],
+            vec![1, 2, 3],
+            vec![10, 11, 12],
+            vec![4, 5, 6],
+        ];
+        "events 2"
+    )]
+    fn test_events_iter_all(logs: Vec<Vec<usize>>) {
+        let ranges = {
+            let sorted_timestamps = {
+                let mut timestamps = logs.iter().flatten().copied().collect::<Vec<_>>();
+                timestamps.push(usize::MIN);
+                timestamps.push(usize::MAX);
+                timestamps.sort();
+                timestamps
+            };
+            let mut ranges = Vec::new();
+            for &start in &sorted_timestamps {
+                for &end in &sorted_timestamps {
+                    if start > end {
+                        continue;
+                    }
+                    ranges.push(start..=end);
+                }
+            }
+            ranges
+        };
+
+        for range in ranges {
+            assert_events_iter_range(logs.clone(), range);
+        }
+    }
+
+    fn assert_events_iter_range(logs: Vec<Vec<usize>>, range: RangeInclusive<usize>) {
+        let mut expected_events: Vec<_> = logs
+            .iter()
+            .flatten()
+            .copied()
+            .filter(|i| range.contains(i))
+            .collect();
+        expected_events.sort();
+        let events: Vec<_> = events_iter_in_range(
+            logs.into_iter().map(|log| log.into_iter()),
+            |i| *i,
+            range.clone(),
+        )
+        .collect();
+        assert_eq!(expected_events, events, "failed for range {:?}", range);
     }
 }


### PR DESCRIPTION
Also adds fast timestamp seeking/filtering across the multiple files.

Example usage:
`wal2json -a"3:30pm EDT" -b"4:00pm EDT" wal*`