### PR TITLE
Use txpool bridge channel size for ratelimiting

### DIFF
--- a/monad-rpc/src/txpool/mod.rs
+++ b/monad-rpc/src/txpool/mod.rs
@@ -43,6 +43,8 @@ mod socket;
 mod state;
 mod types;
 
+pub const ETH_TXPOOL_BRIDGE_CHANNEL_SIZE: usize = 1024;
+
 #[pin_project(project = EthTxPoolBridgeIpcStateProjection)]
 enum EthTxPoolBridgeIpcState {
     Ready,
@@ -77,7 +79,7 @@ impl EthTxPoolBridge {
         let mut eviction_queue = EthTxPoolBridgeEvictionQueue::default();
         let state: EthTxPoolBridgeState = EthTxPoolBridgeState::new(&mut eviction_queue, snapshot);
 
-        let (tx_sender, tx_receiver) = flume::bounded(1024);
+        let (tx_sender, tx_receiver) = flume::bounded(ETH_TXPOOL_BRIDGE_CHANNEL_SIZE);
 
         let client = EthTxPoolBridgeClient::new(tx_sender, state.create_view());
 


### PR DESCRIPTION
Previously, we used a const in the eth txn handler file when ratelimiting `eth_sendRawTransaction`. Instead, we can use the capacity of the `EthTxPoolBridgeClient` channel since at most that many transactions can be sent to the bridge at a time. This prevents the `try_send` method from ever failing.