### PR TITLE
docker/builder: adding libmagicenum-dev

### DIFF
--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -20,7 +20,8 @@ RUN apt update && apt install -y \
   libcrypto++-dev \
   libhugetlbfs0 \
   libhugetlbfs-bin \
-  libhugetlbfs-dev
+  libhugetlbfs-dev \
+  libmagicenum-dev
 
 RUN apt update && apt install -y \
   libboost1.83-dev \


### PR DESCRIPTION
adding libmagicenum-dev dependency for monad-execution build