### PR TITLE
Serialize forkpoints as rlp

### DIFF
--- a/debian/opt/monad/scripts/clear-old-artifacts.sh
+++ b/debian/opt/monad/scripts/clear-old-artifacts.sh
@@ -4,6 +4,7 @@ TARGET_DIR="/home/monad/monad-bft/ledger/"
 
 NEW_FILES=$(find "$TARGET_DIR" -type f -name "*" -mmin -20)
 if [ -n "$NEW_FILES" ]; then
+    find /home/monad/monad-bft/config/forkpoint/ -type f -name "forkpoint.rlp.*" -mmin +300 -delete 2>/dev/null
     find /home/monad/monad-bft/config/forkpoint/ -type f -name "forkpoint.toml.*" -mmin +300 -delete 2>/dev/null
     find /home/monad/monad-bft/config/validators/ -type f -name "validators.toml.*" -mtime +30 -delete 2>/dev/null
     find /home/monad/monad-bft/ledger/headers -type f -mmin +600 -delete 2>/dev/null

--- a/monad-consensus-types/src/validator_data.rs
+++ b/monad-consensus-types/src/validator_data.rs
@@ -74,6 +74,24 @@ pub struct ValidatorsConfigFile<SCT: SignatureCollection> {
     pub validator_sets: Vec<ValidatorSetDataWithEpoch<SCT>>,
 }
 
+impl<SCT> From<&ValidatorsConfig<SCT>> for ValidatorsConfigFile<SCT>
+where
+    SCT: SignatureCollection,
+{
+    fn from(config: &ValidatorsConfig<SCT>) -> Self {
+        Self {
+            validator_sets: config
+                .validators
+                .iter()
+                .map(|(&epoch, vset)| ValidatorSetDataWithEpoch {
+                    epoch,
+                    validators: vset.clone(),
+                })
+                .collect(),
+        }
+    }
+}
+
 impl<SCT: SignatureCollection> ValidatorsConfig<SCT> {
     pub fn read_from_path(validators_path: impl AsRef<Path>) -> Result<Self, Box<dyn Error>> {
         let contents = std::fs::read_to_string(validators_path)?;

--- a/monad-node/examples/ledger-tail.rs
+++ b/monad-node/examples/ledger-tail.rs
@@ -293,8 +293,11 @@ pub fn latest_tip_stream(
     inotify_events.filter_map(move |maybe_event| {
         let result = (|| match maybe_event {
             Ok(_event) => {
-                let forkpoint_config: ForkpointConfig =
-                    toml::from_str(&std::fs::read_to_string(&forkpoint_path).ok()?).ok()?;
+                let forkpoint_config = ForkpointConfig::try_parse_bytes(
+                    &forkpoint_path.to_string_lossy(),
+                    &std::fs::read(&forkpoint_path).ok()?,
+                )
+                .ok()?;
                 let proposed_head = block_persist.read_proposed_head_bft_header().ok()?;
                 Some((forkpoint_config.high_certificate, proposed_head))
             }


### PR DESCRIPTION
Previously, forkpoints were only serialized as toml. If the toml serialization failed, the node would panic.

Now, forkpoints are serialized as both toml and rlp. The rlp serialization is considered the source of truth. If the toml serialization fails, the node will no longer panic. To maintain operational backwards compatibility, a node can be started up from either the toml or rlp formats.