### PR TITLE
Evict txs from txpool when limits exceeded

### DIFF
--- a/monad-eth-txpool/src/pool/tracked/priority.rs
+++ b/monad-eth-txpool/src/pool/tracked/priority.rs
@@ -1,0 +1,99 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    collections::{BTreeSet, HashMap},
+    time::Instant,
+};
+
+use alloy_primitives::Address;
+use tracing::error;
+
+use crate::{pool::tracked::TrackedTxList, EthTxPoolEventTracker};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) struct Priority {
+    pub nonce_gap: u64,
+    pub tips: [u64; 7],
+}
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct PriorityMap {
+    by_address: HashMap<Address, (Priority, Instant)>,
+    sorted: BTreeSet<(Priority, Instant, Address)>,
+}
+
+impl PriorityMap {
+    pub fn update_priority(
+        &mut self,
+        event_tracker: &EthTxPoolEventTracker<'_>,
+        address: Address,
+        tx_list: &TrackedTxList,
+    ) {
+        let time = if let Some((stale_priority, time)) = self.by_address.remove(&address) {
+            if !self.sorted.remove(&(stale_priority, time, address)) {
+                error!(
+                    ?address,
+                    "txpool priority map stale priority not in sorted priorities"
+                );
+            }
+
+            time
+        } else {
+            event_tracker.now
+        };
+
+        let priority = tx_list.compute_priority();
+
+        self.by_address.insert(address, (priority, time));
+        self.sorted.insert((priority, time, address));
+    }
+
+    pub fn pop_eviction_address(&mut self) -> Option<Address> {
+        let (_, _, eviction_address) = self.sorted.pop_last()?;
+
+        if self.by_address.remove(&eviction_address).is_none() {
+            error!(
+                ?eviction_address,
+                "txpool priority map eviction address not in by address map"
+            );
+        }
+
+        Some(eviction_address)
+    }
+
+    pub fn remove(&mut self, address: Address) {
+        let Some((priority, time)) = self.by_address.remove(&address) else {
+            error!(
+                ?address,
+                "txpool priority map remove address not in by address map"
+            );
+            return;
+        };
+
+        if !self.sorted.remove(&(priority, time, address)) {
+            error!(
+                ?address,
+                ?priority,
+                "txpool priority map remove address not in sorted priorities"
+            );
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.by_address.clear();
+        self.sorted.clear();
+    }
+}

--- a/monad-eth-txpool/tests/pool.rs
+++ b/monad-eth-txpool/tests/pool.rs
@@ -16,6 +16,7 @@
 use std::{
     collections::{BTreeMap, VecDeque},
     sync::Arc,
+    time::Duration,
 };
 
 use alloy_consensus::{
@@ -47,7 +48,7 @@ use monad_eth_txpool::{
 use monad_eth_txpool_types::EthTxPoolSnapshot;
 use monad_state_backend::{InMemoryBlockState, InMemoryState, InMemoryStateInner};
 use monad_testutil::signing::MockSignatures;
-use monad_types::{Balance, Epoch, NodeId, Round, SeqNum, GENESIS_SEQ_NUM};
+use monad_types::{Balance, Epoch, NodeId, Round, SeqNum, GENESIS_ROUND, GENESIS_SEQ_NUM};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use tracing_test::traced_test;
 
@@ -110,6 +111,13 @@ enum TxPoolTestEvent<'a> {
 }
 
 fn run_custom_iter<const N: usize>(
+    mut pool: EthTxPool<
+        SignatureType,
+        SignatureCollectionType,
+        StateBackendType,
+        MockChainConfig,
+        MockChainRevision,
+    >,
     mut eth_block_policy: EthBlockPolicy<
         SignatureType,
         SignatureCollectionType,
@@ -155,7 +163,6 @@ fn run_custom_iter<const N: usize>(
         )
     };
 
-    let mut pool = EthTxPool::default_testing();
     let metrics = EthTxPoolMetrics::default();
     let mut ipc_events = BTreeMap::default();
     let mut event_tracker = EthTxPoolEventTracker::new(&metrics, &mut ipc_events);
@@ -199,17 +206,24 @@ fn run_custom_iter<const N: usize>(
                         |inserted_tx| {
                             assert_eq!(&tx, inserted_tx.raw());
 
-                            if !should_insert {
-                                panic!("tx was inserted when it shouldn't have been!");
-                            }
-
                             was_inserted = true;
                         },
                     );
 
-                    if should_insert && !was_inserted {
-                        panic!("tx should have been inserted but was not! events: {ipc_events:?}",);
+                    if !should_insert && was_inserted {
+                        panic!(
+                            "tx was inserted when it shouldn't have been!\n{:#?}",
+                            ipc_events
+                        );
                     }
+
+                    if should_insert && !was_inserted {
+                        panic!(
+                            "tx should have been inserted but was not! events:\n{ipc_events:#?}",
+                        );
+                    }
+
+                    event_tracker.now += Duration::from_millis(1);
                 }
 
                 assert_eq!(
@@ -397,9 +411,18 @@ fn run_custom_iter<const N: usize>(
             TxPoolTestEvent::Block(f) => f(&mut pool),
         }
     }
+
+    event_tracker.now += Duration::from_millis(1);
 }
 
 fn run_custom<const N: usize>(
+    pool_generator: impl Fn() -> EthTxPool<
+        SignatureType,
+        SignatureCollectionType,
+        StateBackendType,
+        MockChainConfig,
+        MockChainRevision,
+    >,
     eth_block_policy_generator: impl Fn() -> EthBlockPolicy<
         SignatureType,
         SignatureCollectionType,
@@ -412,6 +435,7 @@ fn run_custom<const N: usize>(
 ) {
     for owned in [false, true] {
         run_custom_iter(
+            pool_generator(),
             eth_block_policy_generator(),
             max_account_balance,
             nonces_override.clone(),
@@ -422,7 +446,13 @@ fn run_custom<const N: usize>(
 }
 
 fn run_simple<const N: usize>(events: [TxPoolTestEvent<'_>; N]) {
-    run_custom(make_test_block_policy, Balance::MAX, None, events);
+    run_custom(
+        EthTxPool::default_testing,
+        make_test_block_policy,
+        Balance::MAX,
+        None,
+        events,
+    );
 }
 
 #[test]
@@ -832,6 +862,7 @@ fn test_nonce_exists_in_committed_block() {
         .collect();
 
     run_custom(
+        EthTxPool::default_testing,
         make_test_block_policy,
         Balance::MAX,
         Some(nonces),
@@ -858,6 +889,7 @@ fn test_insert_unknown_account() {
     let tx1 = make_legacy_tx(S1, BASE_FEE, GAS_LIMIT, 0, 10);
 
     run_custom(
+        EthTxPool::default_testing,
         make_test_block_policy,
         Balance::MAX,
         Some(BTreeMap::default()),
@@ -887,6 +919,7 @@ fn test_insert_low_balance() {
     let tx1 = make_legacy_tx(S1, BASE_FEE, GAS_LIMIT, 0, 10);
 
     run_custom(
+        EthTxPool::default_testing,
         make_test_block_policy,
         Balance::ZERO,
         None,
@@ -910,6 +943,7 @@ fn test_insert_low_balance() {
     );
 
     run_custom(
+        EthTxPool::default_testing,
         make_test_block_policy,
         (BASE_FEE_PER_GAS * tx1.gas_limit() - 1).try_into().unwrap(),
         None,
@@ -933,6 +967,7 @@ fn test_insert_low_balance() {
     );
 
     run_custom(
+        EthTxPool::default_testing,
         make_test_block_policy,
         (BASE_FEE_PER_GAS * tx1.gas_limit()).try_into().unwrap(),
         None,
@@ -1185,6 +1220,7 @@ fn test_tx_invalid_chain_id() {
     };
 
     run_custom(
+        EthTxPool::default_testing,
         || EthBlockPolicy::new(GENESIS_SEQ_NUM, 0),
         Balance::MAX,
         None,
@@ -1467,6 +1503,67 @@ fn test_proposal_tx_low_base_fee() {
 }
 
 #[test]
+fn test_eviction_policy() {
+    let tx_a = make_eip1559_tx(S1, (BASE_FEE_PER_GAS + 1).into(), 1, GAS_LIMIT, 0, 0);
+    let tx_b = make_eip1559_tx(S1, (BASE_FEE_PER_GAS + 1).into(), 2, GAS_LIMIT, 1, 0);
+    let tx_c = make_eip1559_tx(S2, (BASE_FEE_PER_GAS + 2).into(), 1, GAS_LIMIT, 0, 0);
+    let tx_d = make_eip1559_tx(S3, (BASE_FEE_PER_GAS + 3).into(), 3, GAS_LIMIT, 0, 0);
+
+    for txs in [&tx_a, &tx_b, &tx_c, &tx_d].iter().cloned().permutations(4) {
+        assert_eq!(txs.len(), 4);
+
+        let a_idx = txs.iter().position(|tx| *tx == &tx_a).unwrap();
+        let b_idx = txs.iter().position(|tx| *tx == &tx_b).unwrap();
+        let c_idx = txs.iter().position(|tx| *tx == &tx_c).unwrap();
+        let d_idx = txs.iter().position(|tx| *tx == &tx_d).unwrap();
+
+        let a_eviction_condition =
+            // tx_b will be evicted so tx_a will not have priority
+            a_idx == 3
+            // tx_a will be evicted to tx_b will not have priority
+            || (c_idx < a_idx && b_idx == 3);
+
+        run_custom(
+            || {
+                EthTxPool::new(
+                    Some(2),
+                    Some(3),
+                    None,
+                    Some(3),
+                    Duration::from_secs(60),
+                    Duration::from_secs(60),
+                    MockChainConfig::DEFAULT.chain_id(),
+                    MockChainConfig::DEFAULT.get_chain_revision(GENESIS_ROUND),
+                    MockChainConfig::DEFAULT.get_execution_chain_revision(GENESIS_TIMESTAMP as u64),
+                    true,
+                )
+            },
+            make_test_block_policy,
+            Balance::MAX,
+            None,
+            [
+                TxPoolTestEvent::InsertTxs {
+                    txs: txs.clone().into_iter().map(|tx| (tx, true)).collect_vec(),
+                    expected_pool_size_change: if a_eviction_condition { 2 } else { 3 },
+                },
+                TxPoolTestEvent::CreateProposal {
+                    base_fee: BASE_FEE_PER_GAS,
+                    tx_limit: usize::MAX,
+                    gas_limit: u64::MAX,
+                    byte_limit: u64::MAX,
+                    expected_txs: if a_eviction_condition {
+                        vec![&tx_d, &tx_c]
+                    } else {
+                        vec![&tx_d, &tx_a, &tx_b]
+                    },
+                    add_to_blocktree: true,
+                },
+            ],
+        );
+    }
+}
+
+#[test]
 fn test_eip7702_valid_authorization_changes_nonce() {
     let tx1 = make_eip7702_tx(
         S1,
@@ -1481,6 +1578,7 @@ fn test_eip7702_valid_authorization_changes_nonce() {
     let tx2 = make_legacy_tx(S2, BASE_FEE, GAS_LIMIT, 1, 0);
 
     run_custom(
+        EthTxPool::default_testing,
         make_test_block_policy,
         Balance::MAX,
         None,
@@ -1539,6 +1637,7 @@ fn test_eip7702_authorization_nonce_higher() {
     let tx2 = make_legacy_tx(S2, BASE_FEE, GAS_LIMIT, 0, 0);
 
     run_custom(
+        EthTxPool::default_testing,
         make_test_block_policy,
         Balance::MAX,
         None,
@@ -1614,6 +1713,7 @@ fn test_eip7702_authorization_nonce_lower() {
     let tx2 = make_legacy_tx(S2, BASE_FEE, GAS_LIMIT, 1, 0);
 
     run_custom(
+        EthTxPool::default_testing,
         make_test_block_policy,
         Balance::MAX,
         Some(BTreeMap::from_iter([


### PR DESCRIPTION
This change introduces an eviction policy for the txpool to mitigate DoS vectors when the pool hits its limits. When evicting, the pool selects the address with the lowest priority (highest value) and removes all the txs associated with that address.

The current eviction policy first looks at the size of the nonce gap to the first transaction (if any). After that, it prioritizes based on the max fee of the first 7 nonce-sequential transactions.