### PR TITLE
Start vote pacing timer on startup

### DIFF
--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1383,6 +1383,17 @@ where
         );
         self.consensus = ConsensusMode::Live(consensus);
         commands.push(Command::StateSyncCommand(StateSyncCommand::StartExecution));
+        // technically we should be waiting for the vote pacing timer
+        // to expire before we set scheduled_vote to TimerFired
+        //
+        // in practice, it won't make a difference, because f+1 nodes
+        // would need to restart at the exact same time and finish
+        // statesyncing/blocksyncing within the vote pacing window
+        commands.extend(
+            self.update(MonadEvent::ConsensusEvent(ConsensusEvent::SendVote(
+                current_round,
+            ))),
+        );
         commands.extend(
             self.update(MonadEvent::ConsensusEvent(ConsensusEvent::Timeout(
                 current_round,


### PR DESCRIPTION
The vote pacing timer would previously only start after a proposal carrying a TC was received. This changes the behavior to immediately fire the vote pacing timer on startup.

This is theoretically slightly inaccurate, as there's no guarantee that the vote pacing interval elapsed since the last time the node voted, but in practice this will not happen.