### PR TITLE
Make full-node blocksync peer set more strict

### DIFF
--- a/monad-consensus-types/src/metrics.rs
+++ b/monad-consensus-types/src/metrics.rs
@@ -161,6 +161,7 @@ metrics!(
             self_payload_response_successful,
             self_payload_response_failed,
             request_timeout,
+            request_failed_no_peers,
             peer_headers_request,
             peer_headers_request_successful,
             peer_headers_request_failed,


### PR DESCRIPTION
Previously, full-nodes would default to blocksync to the validator set if they had no blocksync_overrides or secondary raptorcast peers. This commit changes the default full-node behavior to not try to blocksync from the validator set.

- Validator behavior is unchanged
- Dedicated full-nodes must specify their upstream as a blocksync override
- Prioritized/public full-nodes will not be able to blocksync until they join a secondary raptorcast group. After joining a secondary raptorcast group, behavior is unchanged.