### PR TITLE
Dynamically expand statesync upstream peers

### DIFF
--- a/docker/devnet/monad/config/node.toml
+++ b/docker/devnet/monad/config/node.toml
@@ -57,8 +57,9 @@ peers = []
 # secp256k1_pubkey = "..."
 
 [statesync]
-peers = []
-# [[statesync.peers]]
+expand_to_group = true
+init_peers = []
+# [[statesync.init_peers]]
 # secp256k1_pubkey = "..."
 
 [fullnode_raptorcast]

--- a/monad-consensus-types/src/validator_data.rs
+++ b/monad-consensus-types/src/validator_data.rs
@@ -216,6 +216,19 @@ impl<SCT: SignatureCollection> ValidatorSetData<SCT> {
             )
             .collect()
     }
+
+    pub fn get_pubkeys(&self) -> Vec<NodeId<SCT::NodeIdPubKey>> {
+        self.0
+            .iter()
+            .map(
+                |ValidatorData {
+                     node_id,
+                     stake: _,
+                     cert_pubkey: _,
+                 }| *node_id,
+            )
+            .collect()
+    }
 }
 
 pub fn serialize_nodeid<S, SCT>(

--- a/monad-debugger/src/lib.rs
+++ b/monad-debugger/src/lib.rs
@@ -85,18 +85,10 @@ pub fn simulation_make() -> *mut Simulation {
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
                         NoSerRouterConfig::new(all_peers.clone()).build(),
-                        MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
+                        MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
                         MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                         MockLedger::new(state_backend.clone()),
-                        MockStateSyncExecutor::new(
-                            state_backend,
-                            validators
-                                .validators
-                                .0
-                                .into_iter()
-                                .map(|v| v.node_id)
-                                .collect(),
-                        ),
+                        MockStateSyncExecutor::new(state_backend),
                         vec![
                             GenericTransformer::Latency(LatencyTransformer::new(
                                 Duration::from_millis(25),

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -475,6 +475,8 @@ where
         ),
     ),
     StartExecution,
+    /// Expand the set of peers the statesync client can sync from
+    ExpandUpstreamPeers(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
 }
 
 #[derive(Debug)]

--- a/monad-mock-swarm/benches/two_node_benchmark.rs
+++ b/monad-mock-swarm/benches/two_node_benchmark.rs
@@ -81,18 +81,10 @@ fn two_nodes() {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
                     MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                     MockLedger::new(state_backend.clone()),
-                    MockStateSyncExecutor::new(
-                        state_backend,
-                        validators
-                            .validators
-                            .0
-                            .into_iter()
-                            .map(|v| v.node_id)
-                            .collect(),
-                    ),
+                    MockStateSyncExecutor::new(state_backend),
                     vec![GenericTransformer::Latency(LatencyTransformer::new(
                         Duration::from_millis(1),
                     ))],

--- a/monad-mock-swarm/src/node.rs
+++ b/monad-mock-swarm/src/node.rs
@@ -139,7 +139,8 @@ impl<S: SwarmRelation> NodeBuilder<S> {
                 locked_epoch_validators: self.state_builder.locked_epoch_validators,
                 block_sync_override_peers: self.state_builder.block_sync_override_peers,
                 consensus_config: self.state_builder.consensus_config,
-                whitelisted_statesync_nodes: Default::default(),
+                whitelisted_statesync_nodes: self.state_builder.whitelisted_statesync_nodes,
+                statesync_expand_to_group: self.state_builder.statesync_expand_to_group,
 
                 _phantom: PhantomData,
             },

--- a/monad-mock-swarm/tests/block_sync.rs
+++ b/monad-mock-swarm/tests/block_sync.rs
@@ -107,18 +107,10 @@ mod test {
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
                         NoSerRouterConfig::new(all_peers.clone()).build(),
-                        MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
+                        MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
                         MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                         MockLedger::new(state_backend.clone()),
-                        MockStateSyncExecutor::new(
-                            state_backend,
-                            validators
-                                .validators
-                                .0
-                                .into_iter()
-                                .map(|v| v.node_id)
-                                .collect(),
-                        ),
+                        MockStateSyncExecutor::new(state_backend),
                         outbound_pipeline.clone(),
                         vec![],
                         TimestamperConfig::default(),
@@ -222,18 +214,10 @@ mod test {
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
                         NoSerRouterConfig::new(all_peers.clone()).build(),
-                        MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
+                        MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
                         MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                         MockLedger::new(state_backend.clone()),
-                        MockStateSyncExecutor::new(
-                            state_backend,
-                            validators
-                                .validators
-                                .0
-                                .into_iter()
-                                .map(|v| v.node_id)
-                                .collect(),
-                        ),
+                        MockStateSyncExecutor::new(state_backend),
                         vec![
                             GenericTransformer::Latency(LatencyTransformer::new(delta)),
                             GenericTransformer::Partition(PartitionTransformer(
@@ -305,18 +289,10 @@ mod test {
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
                         NoSerRouterConfig::new(all_peers.clone()).build(),
-                        MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
+                        MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
                         MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                         MockLedger::new(state_backend.clone()),
-                        MockStateSyncExecutor::new(
-                            state_backend,
-                            validators
-                                .validators
-                                .0
-                                .into_iter()
-                                .map(|v| v.node_id)
-                                .collect(),
-                        ),
+                        MockStateSyncExecutor::new(state_backend),
                         vec![
                             GenericTransformer::Latency(LatencyTransformer::new(delta)),
                             GenericTransformer::Partition(PartitionTransformer(
@@ -445,18 +421,10 @@ mod test {
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
                         NoSerRouterConfig::new(all_peers.clone()).build(),
-                        MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
+                        MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
                         MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                         MockLedger::new(state_backend.clone()),
-                        MockStateSyncExecutor::new(
-                            state_backend,
-                            validators
-                                .validators
-                                .0
-                                .into_iter()
-                                .map(|v| v.node_id)
-                                .collect(),
-                        ),
+                        MockStateSyncExecutor::new(state_backend),
                         vec![
                             GenericTransformer::Latency(LatencyTransformer::new(delta)),
                             GenericTransformer::Partition(PartitionTransformer(

--- a/monad-mock-swarm/tests/epoch.rs
+++ b/monad-mock-swarm/tests/epoch.rs
@@ -244,18 +244,10 @@ mod test {
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
                         NoSerRouterConfig::new(all_peers.clone()).build(),
-                        MockValSetUpdaterNop::new(validators.validators.clone(), epoch_length),
+                        MockValSetUpdaterNop::new(validators.validators, epoch_length),
                         MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                         MockLedger::new(state_backend.clone()),
-                        MockStateSyncExecutor::new(
-                            state_backend,
-                            validators
-                                .validators
-                                .0
-                                .into_iter()
-                                .map(|v| v.node_id)
-                                .collect(),
-                        ),
+                        MockStateSyncExecutor::new(state_backend),
                         vec![GenericTransformer::Latency(LatencyTransformer::new(delta))],
                         vec![],
                         TimestamperConfig::default(),
@@ -344,18 +336,10 @@ mod test {
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
                         NoSerRouterConfig::new(all_peers.clone()).build(),
-                        MockValSetUpdaterNop::new(validators.validators.clone(), epoch_length),
+                        MockValSetUpdaterNop::new(validators.validators, epoch_length),
                         MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                         MockLedger::new(state_backend.clone()),
-                        MockStateSyncExecutor::new(
-                            state_backend,
-                            validators
-                                .validators
-                                .0
-                                .into_iter()
-                                .map(|v| v.node_id)
-                                .collect(),
-                        ),
+                        MockStateSyncExecutor::new(state_backend),
                         regular_pipeline.clone(),
                         vec![],
                         TimestamperConfig::default(),
@@ -530,18 +514,10 @@ mod test {
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
                         NoSerRouterConfig::new(all_peers.clone()).build(),
-                        MockValSetUpdaterSwap::new(validators.validators.clone(), epoch_length),
+                        MockValSetUpdaterSwap::new(validators.validators, epoch_length),
                         MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                         MockLedger::new(state_backend.clone()),
-                        MockStateSyncExecutor::new(
-                            state_backend,
-                            validators
-                                .validators
-                                .0
-                                .into_iter()
-                                .map(|v| v.node_id)
-                                .collect(),
-                        ),
+                        MockStateSyncExecutor::new(state_backend),
                         regular_pipeline.clone(),
                         vec![],
                         TimestamperConfig::default(),
@@ -728,18 +704,10 @@ mod test {
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
                         NoSerRouterConfig::new(all_peers.clone()).build(),
-                        MockValSetUpdaterSwap::new(validators.validators.clone(), epoch_length),
+                        MockValSetUpdaterSwap::new(validators.validators, epoch_length),
                         MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                         MockLedger::new(state_backend.clone()),
-                        MockStateSyncExecutor::new(
-                            state_backend,
-                            validators
-                                .validators
-                                .0
-                                .into_iter()
-                                .map(|v| v.node_id)
-                                .collect(),
-                        ),
+                        MockStateSyncExecutor::new(state_backend),
                         vec![GenericTransformer::Latency(LatencyTransformer::new(delta))],
                         vec![],
                         TimestamperConfig::default(),

--- a/monad-mock-swarm/tests/forkpoint.rs
+++ b/monad-mock-swarm/tests/forkpoint.rs
@@ -396,15 +396,8 @@ fn forkpoint_restart_one(
                             .with_chain_params(&CHAIN_PARAMS),
                         MockLedger::new(state_backend.clone())
                             .with_finalization_delay(finalization_delay),
-                        MockStateSyncExecutor::new(
-                            state_backend,
-                            validators
-                                .0
-                                .iter()
-                                .map(|validator| validator.node_id)
-                                .collect(),
-                        )
-                        .with_max_service_window(statesync_service_window),
+                        MockStateSyncExecutor::new(state_backend)
+                            .with_max_service_window(statesync_service_window),
                         vec![GenericTransformer::Latency(LatencyTransformer::new(delta))],
                         vec![],
                         TimestamperConfig::default(),
@@ -500,14 +493,7 @@ fn forkpoint_restart_one(
             MockLedger::new(restart_builder_state_backend.clone())
                 .with_finalization_delay(finalization_delay)
                 .with_blocks(failed_node.executor.ledger()),
-            MockStateSyncExecutor::new(
-                restart_builder_state_backend,
-                validators
-                    .0
-                    .iter()
-                    .map(|validator| validator.node_id)
-                    .collect(),
-            ),
+            MockStateSyncExecutor::new(restart_builder_state_backend),
             vec![GenericTransformer::Latency(LatencyTransformer::new(delta))],
             vec![],
             TimestamperConfig::default(),
@@ -723,14 +709,7 @@ fn forkpoint_restart_below_all(
                         MockValSetUpdaterNop::new(validators.clone(), epoch_length),
                         MockTxPoolExecutor::new(create_block_policy(), state_backend.clone()),
                         MockLedger::new(state_backend.clone()),
-                        MockStateSyncExecutor::new(
-                            state_backend,
-                            validators
-                                .0
-                                .iter()
-                                .map(|validator| validator.node_id)
-                                .collect(),
-                        ),
+                        MockStateSyncExecutor::new(state_backend),
                         vec![GenericTransformer::Latency(LatencyTransformer::new(delta))],
                         vec![],
                         TimestamperConfig::default(),
@@ -834,14 +813,7 @@ fn forkpoint_restart_below_all(
                 MockValSetUpdaterNop::new(validators.clone(), epoch_length),
                 MockTxPoolExecutor::new(create_block_policy(), state_backend.clone()),
                 MockLedger::new(state_backend.clone()),
-                MockStateSyncExecutor::new(
-                    state_backend,
-                    validators
-                        .0
-                        .iter()
-                        .map(|validator| validator.node_id)
-                        .collect(),
-                ),
+                MockStateSyncExecutor::new(state_backend),
                 vec![GenericTransformer::Latency(LatencyTransformer::new(delta))],
                 vec![],
                 TimestamperConfig::default(),

--- a/monad-mock-swarm/tests/many_nodes.rs
+++ b/monad-mock-swarm/tests/many_nodes.rs
@@ -78,18 +78,10 @@ fn many_nodes_noser() {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
                     MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                     MockLedger::new(state_backend.clone()),
-                    MockStateSyncExecutor::new(
-                        state_backend,
-                        validators
-                            .validators
-                            .0
-                            .into_iter()
-                            .map(|v| v.node_id)
-                            .collect(),
-                    ),
+                    MockStateSyncExecutor::new(state_backend),
                     vec![GenericTransformer::Latency(LatencyTransformer::new(delta))],
                     vec![],
                     TimestamperConfig::default(),
@@ -143,18 +135,10 @@ fn many_nodes_noser_one_offline() {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
                     MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                     MockLedger::new(state_backend.clone()),
-                    MockStateSyncExecutor::new(
-                        state_backend,
-                        validators
-                            .validators
-                            .0
-                            .into_iter()
-                            .map(|v| v.node_id)
-                            .collect(),
-                    ),
+                    MockStateSyncExecutor::new(state_backend),
                     vec![
                         GenericTransformer::Latency(LatencyTransformer::new(
                             Duration::from_millis(1),

--- a/monad-mock-swarm/tests/msg_delays.rs
+++ b/monad-mock-swarm/tests/msg_delays.rs
@@ -78,18 +78,10 @@ fn two_nodes() {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
                     MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                     MockLedger::new(state_backend.clone()),
-                    MockStateSyncExecutor::new(
-                        state_backend,
-                        validators
-                            .validators
-                            .0
-                            .into_iter()
-                            .map(|v| v.node_id)
-                            .collect(),
-                    ),
+                    MockStateSyncExecutor::new(state_backend),
                     vec![GenericTransformer::XorLatency(XorLatencyTransformer::new(
                         delta,
                     ))],

--- a/monad-mock-swarm/tests/nonces.rs
+++ b/monad-mock-swarm/tests/nonces.rs
@@ -190,19 +190,11 @@ mod test {
                         ID::new(NodeId::new(state_builder.key.pubkey())),
                         state_builder,
                         NoSerRouterConfig::new(all_peers.clone()).build(),
-                        MockValSetUpdaterNop::new(validators.validators.clone(), epoch_length),
+                        MockValSetUpdaterNop::new(validators.validators, epoch_length),
                         MockTxPoolExecutor::new(create_block_policy(), state_backend.clone())
                             .with_chain_params(&CHAIN_PARAMS),
                         MockEthLedger::new(state_backend.clone()),
-                        MockStateSyncExecutor::new(
-                            state_backend,
-                            validators
-                                .validators
-                                .0
-                                .into_iter()
-                                .map(|v| v.node_id)
-                                .collect(),
-                        ),
+                        MockStateSyncExecutor::new(state_backend),
                         vec![GenericTransformer::Latency(LatencyTransformer::new(
                             CONSENSUS_DELTA,
                         ))],

--- a/monad-mock-swarm/tests/order.rs
+++ b/monad-mock-swarm/tests/order.rs
@@ -137,18 +137,10 @@ fn all_messages_delayed(direction: TransformerReplayOrder) -> Result<(), String>
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
                     MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                     MockLedger::new(state_backend.clone()),
-                    MockStateSyncExecutor::new(
-                        state_backend,
-                        validators
-                            .validators
-                            .0
-                            .into_iter()
-                            .map(|v| v.node_id)
-                            .collect(),
-                    ),
+                    MockStateSyncExecutor::new(state_backend),
                     vec![GenericTransformer::Latency(LatencyTransformer::new(delta))],
                     vec![
                         GenericTransformer::Partition(PartitionTransformer(filter_peers.clone())),

--- a/monad-mock-swarm/tests/rand_lat.rs
+++ b/monad-mock-swarm/tests/rand_lat.rs
@@ -141,18 +141,10 @@ fn nodes_with_random_latency(latency_seed: u64) -> Result<(), String> {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(3000)),
+                    MockValSetUpdaterNop::new(validators.validators, SeqNum(3000)),
                     MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                     MockLedger::new(state_backend.clone()),
-                    MockStateSyncExecutor::new(
-                        state_backend,
-                        validators
-                            .validators
-                            .0
-                            .into_iter()
-                            .map(|v| v.node_id)
-                            .collect(),
-                    ),
+                    MockStateSyncExecutor::new(state_backend),
                     vec![GenericTransformer::RandLatency(
                         RandLatencyTransformer::new(latency_seed, delta),
                     )],

--- a/monad-mock-swarm/tests/timestamp_drift.rs
+++ b/monad-mock-swarm/tests/timestamp_drift.rs
@@ -91,18 +91,10 @@ fn drift_one_node() {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
                     MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                     MockLedger::new(state_backend.clone()),
-                    MockStateSyncExecutor::new(
-                        state_backend,
-                        validators
-                            .validators
-                            .0
-                            .into_iter()
-                            .map(|v| v.node_id)
-                            .collect(),
-                    ),
+                    MockStateSyncExecutor::new(state_backend),
                     vec![GenericTransformer::Latency(LatencyTransformer::new(
                         latency,
                     ))],

--- a/monad-mock-swarm/tests/two_nodes.rs
+++ b/monad-mock-swarm/tests/two_nodes.rs
@@ -76,18 +76,10 @@ fn two_nodes_noser() {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
                     MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                     MockLedger::new(state_backend.clone()),
-                    MockStateSyncExecutor::new(
-                        state_backend,
-                        validators
-                            .validators
-                            .0
-                            .into_iter()
-                            .map(|v| v.node_id)
-                            .collect(),
-                    ),
+                    MockStateSyncExecutor::new(state_backend),
                     vec![GenericTransformer::Latency(LatencyTransformer::new(delta))],
                     vec![],
                     TimestamperConfig::default(),

--- a/monad-mock-swarm/tests/two_nodes_bls.rs
+++ b/monad-mock-swarm/tests/two_nodes_bls.rs
@@ -152,18 +152,10 @@ fn two_nodes_bls() {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
                     MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                     MockLedger::new(state_backend.clone()),
-                    MockStateSyncExecutor::new(
-                        state_backend,
-                        validators
-                            .validators
-                            .0
-                            .into_iter()
-                            .map(|v| v.node_id)
-                            .collect(),
-                    ),
+                    MockStateSyncExecutor::new(state_backend),
                     vec![GenericTransformer::Latency(LatencyTransformer::new(delta))],
                     vec![],
                     TimestamperConfig::default(),

--- a/monad-node-config/src/sync_peers.rs
+++ b/monad-node-config/src/sync_peers.rs
@@ -27,8 +27,9 @@ pub struct BlockSyncPeersConfig<P: PubKey> {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct StateSyncPeersConfig<P: PubKey> {
+    pub expand_to_group: bool,
     #[serde(bound = "P:PubKey")]
-    pub peers: Vec<SyncPeerIdentityConfig<P>>,
+    pub init_peers: Vec<SyncPeerIdentityConfig<P>>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -197,18 +197,13 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         bootstrap_nodes.push(peer_id);
     }
 
-    // default statesync peers to bootstrap nodes if none is specified
-    let state_sync_peers = if node_state.node_config.statesync.peers.is_empty() {
-        bootstrap_nodes
-    } else {
-        node_state
-            .node_config
-            .statesync
-            .peers
-            .into_iter()
-            .map(|p| NodeId::new(p.secp256k1_pubkey))
-            .collect()
-    };
+    let state_sync_init_peers = node_state
+        .node_config
+        .statesync
+        .init_peers
+        .into_iter()
+        .map(|p| NodeId::new(p.secp256k1_pubkey))
+        .collect();
 
     // TODO: use PassThruBlockPolicy and NopStateBackend for consensus only mode
     let create_block_policy = || {
@@ -280,7 +275,7 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         state_sync: StateSync::<SignatureType, SignatureCollectionType>::new(
             vec![statesync_triedb_path.to_string_lossy().to_string()],
             node_state.statesync_sq_thread_cpu,
-            state_sync_peers,
+            state_sync_init_peers,
             node_state
                 .node_config
                 .statesync_max_concurrent_requests
@@ -362,6 +357,7 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
             _phantom: Default::default(),
         },
         whitelisted_statesync_nodes,
+        statesync_expand_to_group: node_state.node_config.statesync.expand_to_group,
         _phantom: PhantomData,
     };
 

--- a/monad-randomized-tests/src/testcases/tests.rs
+++ b/monad-randomized-tests/src/testcases/tests.rs
@@ -77,18 +77,10 @@ fn random_latency_test(latency_seed: u64) {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
                     MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                     MockLedger::new(state_backend.clone()),
-                    MockStateSyncExecutor::new(
-                        state_backend,
-                        validators
-                            .validators
-                            .0
-                            .into_iter()
-                            .map(|v| v.node_id)
-                            .collect(),
-                    ),
+                    MockStateSyncExecutor::new(state_backend),
                     vec![GenericTransformer::RandLatency(
                         RandLatencyTransformer::new(latency_seed, Duration::from_millis(330)),
                     )],
@@ -149,18 +141,10 @@ fn delayed_message_test(latency_seed: u64) {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockValSetUpdaterNop::new(validators.validators.clone(), SeqNum(2000)),
+                    MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
                     MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                     MockLedger::new(state_backend.clone()),
-                    MockStateSyncExecutor::new(
-                        state_backend,
-                        validators
-                            .validators
-                            .0
-                            .into_iter()
-                            .map(|v| v.node_id)
-                            .collect(),
-                    ),
+                    MockStateSyncExecutor::new(state_backend),
                     vec![
                         GenericTransformer::Latency(LatencyTransformer::new(
                             Duration::from_millis(1),

--- a/monad-statesync/src/ffi.rs
+++ b/monad-statesync/src/ffi.rs
@@ -155,7 +155,7 @@ impl<PT: PubKey> StateSync<PT> {
     pub fn start(
         db_paths: &[String],
         sq_thread_cpu: Option<u32>,
-        state_sync_peers: &[NodeId<PT>],
+        state_sync_init_peers: &[NodeId<PT>],
         max_parallel_requests: usize,
         request_timeout: Duration,
     ) -> Self {
@@ -338,7 +338,7 @@ impl<PT: PubKey> StateSync<PT> {
             outbound_requests: OutboundRequests::new(
                 max_parallel_requests,
                 request_timeout,
-                state_sync_peers,
+                state_sync_init_peers,
             ),
             current_target: None,
 
@@ -411,6 +411,10 @@ impl<PT: PubKey> StateSync<PT> {
         }
 
         self.outbound_requests.handle_not_whitelisted(from);
+    }
+
+    pub fn expand_upstream_peers(&mut self, new_peers: &[NodeId<PT>]) {
+        self.outbound_requests.expand_upstream_peers(new_peers);
     }
 
     /// An estimate of current sync progress in `Target` units

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -197,11 +197,7 @@ where
         )
         .expect("uds bind failed"),
         loopback: LoopbackExecutor::default(),
-        state_sync: MockStateSyncExecutor::new(
-            state_backend,
-            // TODO do we test statesync in testground?
-            Vec::new(),
-        ),
+        state_sync: MockStateSyncExecutor::new(state_backend),
         config_loader: MockConfigLoader::default(),
     }
 }
@@ -281,6 +277,7 @@ where
         block_sync_override_peers: Default::default(),
         consensus_config: config.consensus_config,
         whitelisted_statesync_nodes: Default::default(),
+        statesync_expand_to_group: true,
 
         _phantom: PhantomData,
     }

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -121,6 +121,7 @@ pub fn make_state_configs<S: SwarmRelation>(
             },
 
             whitelisted_statesync_nodes: Default::default(),
+            statesync_expand_to_group: true,
 
             _phantom: PhantomData,
         })

--- a/monad-twins/utils/src/lib.rs
+++ b/monad-twins/utils/src/lib.rs
@@ -110,20 +110,12 @@ where
             )
             .build(),
             MockValSetUpdaterNop::new(
-                validators.validators.clone(),
+                validators.validators,
                 SeqNum(TWINS_STATE_ROOT_DELAY), // ?? val_set_interval?
             ),
             S::TxPoolExecutor::default(),
             MockLedger::new(state_backend.clone()),
-            MockStateSyncExecutor::new(
-                state_backend,
-                validators
-                    .validators
-                    .0
-                    .into_iter()
-                    .map(|v| v.node_id)
-                    .collect(),
-            ),
+            MockStateSyncExecutor::new(state_backend),
             outbound_pipeline,
             vec![],
             TimestamperConfig::default(),

--- a/monad-twins/utils/src/twin_reader.rs
+++ b/monad-twins/utils/src/twin_reader.rs
@@ -151,6 +151,7 @@ where
                 consensus_config: self.state_config.consensus_config,
 
                 whitelisted_statesync_nodes: Default::default(),
+                statesync_expand_to_group: true,
 
                 _phantom: PhantomData,
             },
@@ -403,6 +404,7 @@ where
             },
 
             whitelisted_statesync_nodes: Default::default(),
+            statesync_expand_to_group: true,
 
             _phantom: PhantomData,
         })


### PR DESCRIPTION
1. Always initialize statesync_peers to statesync.init_peers, and no longer default to bootstrap peers
2. If expand_to_group and is_validator, then expand statesync_peers to validator set
3. if expand_to_group, then expand statesync_peers to secondary raptorcast peers


on top of #2536 and #2537