### PR TITLE
monad-peer-discovery: changes related to authentication

### DIFF
--- a/monad-debug-node/src/main.rs
+++ b/monad-debug-node/src/main.rs
@@ -176,6 +176,7 @@ fn main() -> Result<(), Error> {
                         secp256k1_pubkey: peer.pubkey,
                         name_record_sig: peer.signature,
                         record_seq_num: peer.record_seq_num,
+                        auth_port: peer.auth_port,
                     };
                     peer_configs.push(peer_config);
                 }

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -269,17 +269,31 @@ pub struct PeerEntry<ST: CertificateSignatureRecoverable> {
 
     pub signature: ST,
     pub record_seq_num: u64,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_port: Option<u16>,
 }
 
 impl<ST: CertificateSignatureRecoverable> Encodable for PeerEntry<ST> {
     fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
-        let enc: [&dyn Encodable; 4] = [
-            &self.pubkey,
-            &self.addr.to_string(),
-            &self.signature,
-            &self.record_seq_num,
-        ];
-        encode_list::<_, dyn Encodable>(&enc, out);
+        if let Some(auth_port) = self.auth_port {
+            let enc: [&dyn Encodable; 5] = [
+                &self.pubkey,
+                &self.addr.to_string(),
+                &self.signature,
+                &self.record_seq_num,
+                &auth_port,
+            ];
+            encode_list::<_, dyn Encodable>(&enc, out);
+        } else {
+            let enc: [&dyn Encodable; 4] = [
+                &self.pubkey,
+                &self.addr.to_string(),
+                &self.signature,
+                &self.record_seq_num,
+            ];
+            encode_list::<_, dyn Encodable>(&enc, out);
+        }
     }
 }
 
@@ -295,11 +309,18 @@ impl<ST: CertificateSignatureRecoverable> Decodable for PeerEntry<ST> {
         let signature = ST::decode(&mut payload)?;
         let record_seq_num = u64::decode(&mut payload)?;
 
+        let auth_port = if !payload.is_empty() {
+            Some(u16::decode(&mut payload)?)
+        } else {
+            None
+        };
+
         Ok(Self {
             pubkey,
             addr,
             signature,
             record_seq_num,
+            auth_port,
         })
     }
 }
@@ -2493,6 +2514,7 @@ mod tests {
             addr,
             signature,
             record_seq_num,
+            auth_port: None,
         };
         let encoded = alloy_rlp::encode(&entry);
         let decoded: PeerEntry<NopSignature> = alloy_rlp::decode_exact(&encoded).unwrap();

--- a/monad-node-config/src/bootstrap.rs
+++ b/monad-node-config/src/bootstrap.rs
@@ -40,4 +40,7 @@ pub struct NodeBootstrapPeerConfig<ST: CertificateSignatureRecoverable> {
 
     #[serde(bound = "ST: CertificateSignatureRecoverable")]
     pub name_record_sig: ST,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_port: Option<u16>,
 }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -30,11 +30,8 @@ use monad_chain_config::ChainConfig;
 use monad_consensus_state::ConsensusConfig;
 use monad_consensus_types::{metrics::Metrics, validator_data::ValidatorSetDataWithEpoch};
 use monad_control_panel::ipc::ControlPanelIpcReceiver;
-use monad_crypto::{
-    certificate_signature::{
-        CertificateKeyPair, CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
-    },
-    signing_domain,
+use monad_crypto::certificate_signature::{
+    CertificateKeyPair, CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
 };
 use monad_dataplane::DataplaneBuilder;
 use monad_eth_block_policy::EthBlockPolicy;
@@ -588,22 +585,17 @@ where
                     return None;
                 }
             };
-            let name_record = NameRecord::new(*address.ip(), address.port(), peer.record_seq_num);
 
-            // verify signature of name record
-            let mut encoded = Vec::new();
-            name_record.encode(&mut encoded);
-            match peer
-                .name_record_sig
-                .verify::<signing_domain::NameRecord>(&encoded, &peer.secp256k1_pubkey)
-            {
-                Ok(_) => Some((
-                    node_id,
-                    MonadNameRecord {
-                        name_record,
-                        signature: peer.name_record_sig,
-                    },
-                )),
+            let peer_entry = monad_executor_glue::PeerEntry {
+                pubkey: peer.secp256k1_pubkey,
+                addr: address,
+                signature: peer.name_record_sig,
+                record_seq_num: peer.record_seq_num,
+                auth_port: peer.auth_port,
+            };
+
+            match MonadNameRecord::try_from(&peer_entry) {
+                Ok(monad_name_record) => Some((node_id, monad_name_record)),
                 Err(_) => {
                     warn!(?node_id, "invalid name record signature in config file");
                     None

--- a/monad-peer-disc-swarm/src/driver.rs
+++ b/monad-peer-disc-swarm/src/driver.rs
@@ -145,9 +145,9 @@ where
         let cmds = match event {
             PeerDiscoveryEvent::SendPing {
                 to,
-                socket_address,
+                name_record,
                 ping,
-            } => self.algo.send_ping(to, socket_address, ping),
+            } => self.algo.send_ping(to, name_record, ping),
             PeerDiscoveryEvent::PingRequest { from, ping } => self.algo.handle_ping(from, ping),
             PeerDiscoveryEvent::PongResponse { from, pong } => self.algo.handle_pong(from, pong),
             PeerDiscoveryEvent::PingTimeout { to, ping_id } => {
@@ -215,7 +215,7 @@ where
                 PeerDiscoveryCommand::RouterCommand { target, message }
                 | PeerDiscoveryCommand::PingPongCommand {
                     target,
-                    socket_address: _,
+                    name_record: _,
                     message,
                 } => router_cmds.push(RouterCommand::Publish {
                     target: RouterTarget::PointToPoint(target),

--- a/monad-peer-discovery/src/mock.rs
+++ b/monad-peer-discovery/src/mock.rs
@@ -34,12 +34,14 @@ use crate::{
 
 pub struct NopDiscovery<ST: CertificateSignatureRecoverable> {
     known_addresses: HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddrV4>,
+    name_records: HashMap<NodeId<CertificateSignaturePubKey<ST>>, MonadNameRecord<ST>>,
     metrics: ExecutorMetrics,
     pd: PhantomData<ST>,
 }
 
 pub struct NopDiscoveryBuilder<ST: CertificateSignatureRecoverable> {
     pub known_addresses: HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddrV4>,
+    pub name_records: HashMap<NodeId<CertificateSignaturePubKey<ST>>, MonadNameRecord<ST>>,
     pub pd: PhantomData<ST>,
 }
 
@@ -47,6 +49,7 @@ impl<ST: CertificateSignatureRecoverable> Default for NopDiscoveryBuilder<ST> {
     fn default() -> Self {
         Self {
             known_addresses: HashMap::new(),
+            name_records: HashMap::new(),
             pd: PhantomData,
         }
     }
@@ -65,6 +68,7 @@ impl<ST: CertificateSignatureRecoverable> PeerDiscoveryAlgoBuilder for NopDiscov
     ) {
         let state = NopDiscovery {
             known_addresses: self.known_addresses,
+            name_records: self.name_records,
             metrics: ExecutorMetrics::default(),
             pd: PhantomData,
         };
@@ -83,7 +87,7 @@ where
     fn send_ping(
         &mut self,
         target: NodeId<CertificateSignaturePubKey<ST>>,
-        _socket_address: SocketAddrV4,
+        _name_record: crate::NameRecord,
         _ping: Ping<ST>,
     ) -> Vec<PeerDiscoveryCommand<ST>> {
         debug!(?target, "handle send ping");
@@ -277,6 +281,13 @@ where
     fn get_name_records(
         &self,
     ) -> HashMap<NodeId<CertificateSignaturePubKey<ST>>, MonadNameRecord<ST>> {
-        HashMap::new()
+        self.name_records.clone()
+    }
+
+    fn get_name_record(
+        &self,
+        id: &NodeId<CertificateSignaturePubKey<ST>>,
+    ) -> Option<&MonadNameRecord<ST>> {
+        self.name_records.get(id)
     }
 }

--- a/monad-peer-discovery/src/snapshots/monad_peer_discovery__tests__auth_encoded.snap
+++ b/monad-peer-discovery/src/snapshots/monad_peer_discovery__tests__auth_encoded.snap
@@ -1,0 +1,5 @@
+---
+source: monad-peer-discovery/src/lib.rs
+expression: "hex::encode(&encoded)"
+---
+"d7840a00002acfc480822328c401822329c40282232a8064"

--- a/monad-raptorcast/examples/latency.rs
+++ b/monad-raptorcast/examples/latency.rs
@@ -420,6 +420,7 @@ fn setup_node(
 
     let noop_builder = NopDiscoveryBuilder {
         known_addresses,
+        name_records: routing_info.clone().into_iter().collect(),
         pd: std::marker::PhantomData,
     };
 

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -628,11 +628,8 @@ where
                         .get_name_records();
                     let peer_list = name_records
                         .iter()
-                        .map(|(node_id, name_record)| PeerEntry {
-                            pubkey: node_id.pubkey(),
-                            addr: name_record.udp_address(),
-                            signature: name_record.signature,
-                            record_seq_num: name_record.seq(),
+                        .map(|(node_id, name_record)| {
+                            name_record.with_pubkey(node_id.pubkey()).into()
                         })
                         .collect::<Vec<_>>();
                     self.pending_events
@@ -975,10 +972,13 @@ where
                     }
                     PeerDiscoveryEmit::PingPongCommand {
                         target,
-                        socket_address,
+                        name_record,
                         message,
                     } => {
-                        let addrs = HashMap::from_iter([(target, SocketAddr::V4(socket_address))]);
+                        let addrs = HashMap::from_iter([(
+                            target,
+                            SocketAddr::V4(name_record.udp_socket()),
+                        )]);
                         send_peer_disc_msg(this, target, message, Some(addrs));
                     }
                     PeerDiscoveryEmit::MetricsCommand(executor_metrics) => {

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -479,13 +479,7 @@ where
                         // FIXME: bind name records with peers and ask peer discovery to verify
                         for ii in 0..num_mappings {
                             let rec = &confirm_msg.name_records[ii];
-                            let peer_entry = PeerEntry {
-                                pubkey: confirm_msg.peers[ii].pubkey(),
-                                addr: rec.udp_address(),
-                                signature: rec.signature,
-                                record_seq_num: rec.name_record.seq(),
-                            };
-                            peers.push(peer_entry);
+                            peers.push(rec.with_pubkey(confirm_msg.peers[ii].pubkey()).into());
                         }
                         this.peer_discovery_driver
                             .lock()

--- a/monad-updaters/src/config_loader.rs
+++ b/monad-updaters/src/config_loader.rs
@@ -217,6 +217,7 @@ where
                 addr,
                 signature: peer.name_record_sig,
                 record_seq_num: peer.record_seq_num,
+                auth_port: peer.auth_port,
             });
         }
         peer_entries


### PR DESCRIPTION
- new_with_authentication initializer for MonadNameRecord
- optional auth udp port for PeerEntry and added TryFrom<&PeerEntry<ST>> for MonadNameRecord<ST> for less error prone conversion
- name_records to NoopDiscovery for additional testing in raptorcast and get_name_record on the trait