### PR TITLE
integrate authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3382,6 +3382,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5634,6 +5644,7 @@ dependencies = [
  "monad-validator",
  "monad-version",
  "monad-wal",
+ "monad-wireauth",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -5793,17 +5804,24 @@ dependencies = [
  "monad-testutil",
  "monad-types",
  "monad-validator",
+ "monad-wireauth",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_distr",
  "rstest",
  "serde",
+ "serial_test",
  "thiserror 1.0.69",
  "tikv-jemallocator",
  "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",
+ "zerocopy",
 ]
 
 [[package]]
@@ -8198,6 +8216,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8281,6 +8308,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "seahash"
@@ -8516,6 +8549,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "fslock",
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,7 @@ rayon = "1.7"
 regex = "1.10.2"
 reqwest = { version = "0.11", features = ["json"] }
 rstest = "0.25.0"
+serial_test = { version = "3", features = ["file_locks"] }
 schemars = "0.8.21"
 scrypt = { version = "0.11", default-features = false }
 secp256k1 = "0.31"

--- a/monad-node-config/src/network.rs
+++ b/monad-node-config/src/network.rs
@@ -23,6 +23,7 @@ use serde::Deserialize;
 pub struct NodeNetworkConfig {
     pub bind_address_host: Ipv4Addr,
     pub bind_address_port: u16,
+    pub authenticated_bind_address_port: Option<u16>,
 
     pub max_rtt_ms: u64,
     pub max_mbps: u16,

--- a/monad-node/Cargo.toml
+++ b/monad-node/Cargo.toml
@@ -39,6 +39,7 @@ monad-updaters = { workspace = true, features = ["monad-triedb", "tokio"] }
 monad-validator = { workspace = true }
 monad-version = { workspace = true }
 monad-wal = { workspace = true }
+monad-wireauth = { workspace = true }
 
 agent = { workspace = true }
 alloy-rlp = { workspace = true }

--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -21,6 +21,7 @@ monad-raptor = { workspace = true }
 monad-secp = { workspace = true }
 monad-types = { workspace = true }
 monad-validator = { workspace = true }
+monad-wireauth = { workspace = true }
 
 alloy-rlp = { workspace = true }
 bitvec = { workspace = true }
@@ -36,7 +37,8 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
+zerocopy = { workspace = true }
 
 [dev-dependencies]
 monad-testutil = { workspace = true }
@@ -49,11 +51,16 @@ eyre = { workspace = true }
 futures-util = { workspace = true }
 humantime = { workspace = true }
 insta = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
+opentelemetry-otlp = { workspace = true, features = ["metrics", "grpc-tonic"] }
+opentelemetry-semantic-conventions = { workspace = true }
 rand_distr = { workspace = true }
 rstest = { workspace = true }
+serial_test = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tikv-jemallocator = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "test-util"] }
 toml = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 

--- a/monad-raptorcast/src/auth/metrics.rs
+++ b/monad-raptorcast/src/auth/metrics.rs
@@ -1,0 +1,23 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pub const GAUGE_RAPTORCAST_AUTH_AUTHENTICATED_UDP_BYTES_WRITTEN: &str =
+    "monad.raptorcast.auth.authenticated_udp_bytes_written";
+pub const GAUGE_RAPTORCAST_AUTH_NON_AUTHENTICATED_UDP_BYTES_WRITTEN: &str =
+    "monad.raptorcast.auth.non_authenticated_udp_bytes_written";
+pub const GAUGE_RAPTORCAST_AUTH_AUTHENTICATED_UDP_BYTES_READ: &str =
+    "monad.raptorcast.auth.authenticated_udp_bytes_read";
+pub const GAUGE_RAPTORCAST_AUTH_NON_AUTHENTICATED_UDP_BYTES_READ: &str =
+    "monad.raptorcast.auth.non_authenticated_udp_bytes_read";

--- a/monad-raptorcast/src/auth/mod.rs
+++ b/monad-raptorcast/src/auth/mod.rs
@@ -1,0 +1,27 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pub mod metrics;
+pub mod protocol;
+pub mod socket;
+
+pub use metrics::{
+    GAUGE_RAPTORCAST_AUTH_AUTHENTICATED_UDP_BYTES_READ,
+    GAUGE_RAPTORCAST_AUTH_AUTHENTICATED_UDP_BYTES_WRITTEN,
+    GAUGE_RAPTORCAST_AUTH_NON_AUTHENTICATED_UDP_BYTES_READ,
+    GAUGE_RAPTORCAST_AUTH_NON_AUTHENTICATED_UDP_BYTES_WRITTEN,
+};
+pub use protocol::{AuthenticationProtocol, NoopAuthProtocol, NoopHeader, WireAuthProtocol};
+pub use socket::{AuthenticatedSocketHandle, DualSocketHandle};

--- a/monad-raptorcast/src/auth/protocol.rs
+++ b/monad-raptorcast/src/auth/protocol.rs
@@ -1,0 +1,294 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{convert::TryFrom, net::SocketAddr, sync::Arc, time::Instant};
+
+use bytes::Bytes;
+use monad_crypto::certificate_signature::PubKey;
+use monad_executor::ExecutorMetricsChain;
+use monad_wireauth::messages::{DataPacketHeader, Packet};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+pub trait AuthenticationProtocol {
+    type PublicKey: PubKey;
+    type Error: std::fmt::Debug;
+    type Header: IntoBytes + Immutable;
+
+    const HEADER_SIZE: u16;
+
+    fn connect(
+        &mut self,
+        remote_public_key: &Self::PublicKey,
+        remote_addr: SocketAddr,
+        retry_attempts: u64,
+    ) -> Result<(), Self::Error>;
+
+    fn disconnect(&mut self, remote_public_key: &Self::PublicKey);
+
+    fn dispatch(
+        &mut self,
+        packet: &mut [u8],
+        remote_addr: SocketAddr,
+    ) -> Result<Option<(Bytes, Option<Self::PublicKey>)>, Self::Error>;
+
+    fn encrypt_by_public_key(
+        &mut self,
+        public_key: &Self::PublicKey,
+        plaintext: &mut [u8],
+    ) -> Result<Self::Header, Self::Error>;
+
+    fn encrypt_by_socket(
+        &mut self,
+        socket_addr: &SocketAddr,
+        plaintext: &mut [u8],
+    ) -> Result<Self::Header, Self::Error>;
+
+    fn is_connected_public_key(&self, public_key: &Self::PublicKey) -> bool;
+
+    fn is_connected_socket(&self, socket_addr: &SocketAddr) -> bool;
+
+    fn is_connected_socket_and_public_key(
+        &self,
+        socket_addr: &SocketAddr,
+        public_key: &Self::PublicKey,
+    ) -> bool;
+
+    fn get_socket_by_public_key(&self, public_key: &Self::PublicKey) -> Option<SocketAddr>;
+
+    fn has_any_session_by_public_key(&self, public_key: &Self::PublicKey) -> bool;
+
+    fn next_packet(&mut self) -> Option<(SocketAddr, Bytes)>;
+
+    fn tick(&mut self);
+
+    fn next_deadline(&self) -> Option<Instant>;
+
+    fn metrics(&self) -> ExecutorMetricsChain;
+}
+
+pub struct WireAuthProtocol {
+    api: monad_wireauth::API<monad_wireauth::StdContext, Arc<monad_secp::KeyPair>>,
+}
+
+impl WireAuthProtocol {
+    pub fn new(config: monad_wireauth::Config, signing_key: Arc<monad_secp::KeyPair>) -> Self {
+        let context = monad_wireauth::StdContext::new();
+        Self {
+            api: monad_wireauth::API::new(config, signing_key, context),
+        }
+    }
+}
+
+impl AuthenticationProtocol for WireAuthProtocol {
+    type PublicKey = monad_secp::PubKey;
+    type Error = monad_wireauth::Error;
+    type Header = monad_wireauth::messages::DataPacketHeader;
+
+    const HEADER_SIZE: u16 = DataPacketHeader::SIZE as u16;
+
+    fn connect(
+        &mut self,
+        remote_public_key: &Self::PublicKey,
+        remote_addr: SocketAddr,
+        retry_attempts: u64,
+    ) -> Result<(), Self::Error> {
+        self.api
+            .connect(*remote_public_key, remote_addr, retry_attempts)
+    }
+
+    fn disconnect(&mut self, remote_public_key: &Self::PublicKey) {
+        self.api.disconnect(remote_public_key)
+    }
+
+    fn dispatch(
+        &mut self,
+        packet: &mut [u8],
+        remote_addr: SocketAddr,
+    ) -> Result<Option<(Bytes, Option<Self::PublicKey>)>, Self::Error> {
+        match Packet::try_from(packet).map_err(monad_wireauth::Error::from)? {
+            Packet::Control(control_packet) => {
+                self.api.dispatch_control(control_packet, remote_addr)?;
+                Ok(None)
+            }
+            Packet::Data(data_packet) => {
+                let (plaintext, public_key) = self.api.decrypt(data_packet, remote_addr)?;
+                Ok(Some((
+                    Bytes::copy_from_slice(plaintext.as_ref()),
+                    Some(public_key),
+                )))
+            }
+        }
+    }
+
+    fn encrypt_by_public_key(
+        &mut self,
+        public_key: &Self::PublicKey,
+        plaintext: &mut [u8],
+    ) -> Result<Self::Header, Self::Error> {
+        self.api.encrypt_by_public_key(public_key, plaintext)
+    }
+
+    fn encrypt_by_socket(
+        &mut self,
+        socket_addr: &SocketAddr,
+        plaintext: &mut [u8],
+    ) -> Result<Self::Header, Self::Error> {
+        self.api.encrypt_by_socket(socket_addr, plaintext)
+    }
+
+    fn next_packet(&mut self) -> Option<(SocketAddr, Bytes)> {
+        self.api.next_packet()
+    }
+
+    fn tick(&mut self) {
+        self.api.tick();
+    }
+
+    fn next_deadline(&self) -> Option<Instant> {
+        self.api.next_deadline()
+    }
+
+    fn is_connected_public_key(&self, public_key: &Self::PublicKey) -> bool {
+        self.api.is_connected_public_key(public_key)
+    }
+
+    fn is_connected_socket(&self, socket_addr: &SocketAddr) -> bool {
+        self.api.is_connected_socket(socket_addr)
+    }
+
+    fn is_connected_socket_and_public_key(
+        &self,
+        socket_addr: &SocketAddr,
+        public_key: &Self::PublicKey,
+    ) -> bool {
+        self.api
+            .is_connected_socket_and_public_key(socket_addr, public_key)
+    }
+
+    fn get_socket_by_public_key(&self, public_key: &Self::PublicKey) -> Option<SocketAddr> {
+        self.api.get_socket_by_public_key(public_key)
+    }
+
+    fn has_any_session_by_public_key(&self, public_key: &Self::PublicKey) -> bool {
+        self.api.has_any_session_by_public_key(public_key)
+    }
+
+    fn metrics(&self) -> ExecutorMetricsChain {
+        self.api.metrics()
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct NoopHeader;
+
+pub struct NoopAuthProtocol<P: PubKey> {
+    _phantom: std::marker::PhantomData<P>,
+}
+
+impl<P: PubKey> NoopAuthProtocol<P> {
+    pub fn new() -> Self {
+        Self {
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<P: PubKey> Default for NoopAuthProtocol<P> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<P: PubKey> AuthenticationProtocol for NoopAuthProtocol<P> {
+    type PublicKey = P;
+    type Error = std::convert::Infallible;
+    type Header = NoopHeader;
+
+    const HEADER_SIZE: u16 = 0;
+
+    fn connect(
+        &mut self,
+        _remote_public_key: &Self::PublicKey,
+        _remote_addr: SocketAddr,
+        _retry_attempts: u64,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn disconnect(&mut self, _remote_public_key: &Self::PublicKey) {}
+
+    fn dispatch(
+        &mut self,
+        packet: &mut [u8],
+        _remote_addr: SocketAddr,
+    ) -> Result<Option<(Bytes, Option<Self::PublicKey>)>, Self::Error> {
+        Ok(Some((Bytes::copy_from_slice(packet), None)))
+    }
+
+    fn encrypt_by_public_key(
+        &mut self,
+        _public_key: &Self::PublicKey,
+        _plaintext: &mut [u8],
+    ) -> Result<Self::Header, Self::Error> {
+        Ok(NoopHeader)
+    }
+
+    fn encrypt_by_socket(
+        &mut self,
+        _socket_addr: &SocketAddr,
+        _plaintext: &mut [u8],
+    ) -> Result<Self::Header, Self::Error> {
+        Ok(NoopHeader)
+    }
+
+    fn next_packet(&mut self) -> Option<(SocketAddr, Bytes)> {
+        None
+    }
+
+    fn tick(&mut self) {}
+
+    fn next_deadline(&self) -> Option<Instant> {
+        None
+    }
+
+    fn is_connected_public_key(&self, _public_key: &Self::PublicKey) -> bool {
+        false
+    }
+
+    fn is_connected_socket(&self, _socket_addr: &SocketAddr) -> bool {
+        false
+    }
+
+    fn is_connected_socket_and_public_key(
+        &self,
+        _socket_addr: &SocketAddr,
+        _public_key: &Self::PublicKey,
+    ) -> bool {
+        false
+    }
+
+    fn get_socket_by_public_key(&self, _public_key: &Self::PublicKey) -> Option<SocketAddr> {
+        None
+    }
+
+    fn has_any_session_by_public_key(&self, _public_key: &Self::PublicKey) -> bool {
+        false
+    }
+
+    fn metrics(&self) -> ExecutorMetricsChain {
+        ExecutorMetricsChain::default()
+    }
+}

--- a/monad-raptorcast/src/auth/socket.rs
+++ b/monad-raptorcast/src/auth/socket.rs
@@ -1,0 +1,641 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    future::Future,
+    net::SocketAddr,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Instant,
+};
+
+use bytes::{Bytes, BytesMut};
+use monad_dataplane::{RecvUdpMsg, UdpSocketHandle, UnicastMsg};
+use monad_executor::{ExecutorMetrics, ExecutorMetricsChain};
+use monad_types::UdpPriority;
+use tokio::time::Sleep;
+use tracing::{trace, warn};
+use zerocopy::IntoBytes;
+
+use super::{
+    metrics::{
+        GAUGE_RAPTORCAST_AUTH_AUTHENTICATED_UDP_BYTES_READ,
+        GAUGE_RAPTORCAST_AUTH_AUTHENTICATED_UDP_BYTES_WRITTEN,
+        GAUGE_RAPTORCAST_AUTH_NON_AUTHENTICATED_UDP_BYTES_READ,
+        GAUGE_RAPTORCAST_AUTH_NON_AUTHENTICATED_UDP_BYTES_WRITTEN,
+    },
+    protocol::AuthenticationProtocol,
+};
+
+pub struct DualSocketHandle<AP>
+where
+    AP: AuthenticationProtocol,
+{
+    authenticated: Option<AuthenticatedSocketHandle<AP>>,
+    non_authenticated: UdpSocketHandle,
+    metrics: ExecutorMetrics,
+}
+
+impl<AP> DualSocketHandle<AP>
+where
+    AP: AuthenticationProtocol,
+{
+    pub fn new(
+        authenticated: Option<AuthenticatedSocketHandle<AP>>,
+        non_authenticated: UdpSocketHandle,
+    ) -> Self {
+        Self {
+            authenticated,
+            non_authenticated,
+            metrics: ExecutorMetrics::default(),
+        }
+    }
+
+    pub fn write_unicast_with_priority(&mut self, msg: UnicastMsg, priority: UdpPriority) {
+        let mut auth_msgs = Vec::new();
+        let mut non_auth_msgs = Vec::new();
+        let mut auth_bytes = 0u64;
+        let mut non_auth_bytes = 0u64;
+
+        for (addr, payload) in msg.msgs {
+            if let Some(authenticated) = &self.authenticated {
+                if authenticated.auth_protocol.is_connected_socket(&addr) {
+                    auth_bytes += payload.len() as u64;
+                    auth_msgs.push((addr, payload));
+                    continue;
+                }
+            }
+            non_auth_bytes += payload.len() as u64;
+            non_auth_msgs.push((addr, payload));
+        }
+
+        if !auth_msgs.is_empty() {
+            if let Some(authenticated) = &mut self.authenticated {
+                self.metrics[GAUGE_RAPTORCAST_AUTH_AUTHENTICATED_UDP_BYTES_WRITTEN] += auth_bytes;
+                authenticated.write_unicast_with_priority(
+                    UnicastMsg {
+                        msgs: auth_msgs,
+                        stride: msg.stride,
+                    },
+                    priority,
+                );
+            }
+        }
+
+        if !non_auth_msgs.is_empty() {
+            self.metrics[GAUGE_RAPTORCAST_AUTH_NON_AUTHENTICATED_UDP_BYTES_WRITTEN] +=
+                non_auth_bytes;
+            self.non_authenticated.write_unicast_with_priority(
+                UnicastMsg {
+                    msgs: non_auth_msgs,
+                    stride: msg.stride,
+                },
+                priority,
+            );
+        }
+    }
+
+    pub fn connect(
+        &mut self,
+        remote_public_key: &AP::PublicKey,
+        remote_addr: SocketAddr,
+        retry_attempts: u64,
+    ) -> Result<(), AP::Error> {
+        if let Some(authenticated) = &mut self.authenticated {
+            authenticated.connect(remote_public_key, remote_addr, retry_attempts)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn disconnect(&mut self, remote_public_key: &AP::PublicKey) {
+        if let Some(authenticated) = &mut self.authenticated {
+            authenticated.disconnect(remote_public_key);
+        }
+    }
+
+    pub fn flush(&mut self) {
+        if let Some(authenticated) = &mut self.authenticated {
+            authenticated.flush();
+        }
+    }
+
+    pub fn timer(&mut self) -> TimerFuture<'_, AP> {
+        TimerFuture { handle: self }
+    }
+
+    pub async fn recv(&mut self) -> Result<RecvUdpMsg, AP::Error> {
+        if let Some(authenticated) = &mut self.authenticated {
+            tokio::select! {
+                result = authenticated.recv() => {
+                    if let Ok(ref msg) = result {
+                        self.metrics[GAUGE_RAPTORCAST_AUTH_AUTHENTICATED_UDP_BYTES_READ] += msg.payload.len() as u64;
+                    }
+                    result
+                },
+                msg = self.non_authenticated.recv() => {
+                    self.metrics[GAUGE_RAPTORCAST_AUTH_NON_AUTHENTICATED_UDP_BYTES_READ] += msg.payload.len() as u64;
+                    Ok(msg)
+                },
+            }
+        } else {
+            let msg = self.non_authenticated.recv().await;
+            self.metrics[GAUGE_RAPTORCAST_AUTH_NON_AUTHENTICATED_UDP_BYTES_READ] +=
+                msg.payload.len() as u64;
+            Ok(msg)
+        }
+    }
+
+    pub fn is_connected_socket_and_public_key(
+        &self,
+        socket_addr: &SocketAddr,
+        public_key: &AP::PublicKey,
+    ) -> bool {
+        self.authenticated.as_ref().is_some_and(|authenticated| {
+            authenticated
+                .auth_protocol
+                .is_connected_socket_and_public_key(socket_addr, public_key)
+        })
+    }
+
+    pub fn get_socket_by_public_key(&self, public_key: &AP::PublicKey) -> Option<SocketAddr> {
+        self.authenticated.as_ref().and_then(|authenticated| {
+            authenticated
+                .auth_protocol
+                .get_socket_by_public_key(public_key)
+        })
+    }
+
+    pub fn has_any_session_by_public_key(&self, public_key: &AP::PublicKey) -> bool {
+        self.authenticated.as_ref().is_some_and(|authenticated| {
+            authenticated
+                .auth_protocol
+                .has_any_session_by_public_key(public_key)
+        })
+    }
+
+    pub(crate) fn non_auth_socket(&mut self) -> &mut UdpSocketHandle {
+        &mut self.non_authenticated
+    }
+
+    pub fn segment_size(&self, mtu: u16) -> u16 {
+        let base = monad_dataplane::udp::segment_size_for_mtu(mtu);
+        if self.authenticated.is_some() {
+            base - AP::HEADER_SIZE
+        } else {
+            base
+        }
+    }
+
+    pub fn metrics(&self) -> ExecutorMetricsChain {
+        let mut chain = ExecutorMetricsChain::default().push(self.metrics.as_ref());
+        if let Some(authenticated) = &self.authenticated {
+            chain = chain.chain(authenticated.auth_protocol.metrics());
+        }
+        chain
+    }
+}
+
+pub struct AuthenticatedSocketHandle<AP>
+where
+    AP: AuthenticationProtocol,
+{
+    socket: UdpSocketHandle,
+    auth_protocol: AP,
+    auth_timer: Option<(Pin<Box<Sleep>>, Instant)>,
+}
+
+impl<AP> AuthenticatedSocketHandle<AP>
+where
+    AP: AuthenticationProtocol,
+    AP::PublicKey: Clone,
+{
+    pub fn new(socket: UdpSocketHandle, auth_protocol: AP) -> Self {
+        Self {
+            socket,
+            auth_protocol,
+            auth_timer: None,
+        }
+    }
+
+    pub async fn recv(&mut self) -> Result<RecvUdpMsg, AP::Error> {
+        loop {
+            let message = self.socket.recv().await;
+
+            let mut packet_buf = message.payload.to_vec();
+            match self
+                .auth_protocol
+                .dispatch(&mut packet_buf, message.src_addr)
+            {
+                Ok(Some((plaintext, _public_key))) => {
+                    return Ok(RecvUdpMsg {
+                        src_addr: message.src_addr,
+                        payload: plaintext,
+                        stride: message.stride,
+                    })
+                }
+                Ok(None) => {
+                    self.flush();
+                    continue;
+                }
+                Err(e) => {
+                    trace!(addr=?message.src_addr, error=?e, "failed to decrypt message");
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    pub fn write_unicast_with_priority(&mut self, msg: UnicastMsg, priority: UdpPriority) {
+        let stride = msg.stride as usize;
+        for (addr, mut chunk) in msg.msgs {
+            while !chunk.is_empty() {
+                let piece = chunk.split_to(chunk.len().min(stride));
+                let piece_len = piece.len() as u16;
+                if let Some(encrypted) = self.encrypt_packet(addr, piece) {
+                    self.socket.write_unicast_with_priority(
+                        UnicastMsg {
+                            msgs: vec![encrypted],
+                            stride: piece_len + AP::HEADER_SIZE,
+                        },
+                        priority,
+                    );
+                }
+            }
+        }
+    }
+
+    pub fn connect(
+        &mut self,
+        remote_public_key: &AP::PublicKey,
+        remote_addr: SocketAddr,
+        retry_attempts: u64,
+    ) -> Result<(), AP::Error> {
+        self.auth_protocol
+            .connect(remote_public_key, remote_addr, retry_attempts)
+    }
+
+    pub fn disconnect(&mut self, remote_public_key: &AP::PublicKey) {
+        self.auth_protocol.disconnect(remote_public_key);
+    }
+
+    pub fn flush(&mut self) {
+        while let Some((addr, packet)) = self.auth_protocol.next_packet() {
+            self.write_auth_packet(addr, packet);
+        }
+    }
+
+    pub fn timer(&mut self) -> AuthenticatedTimerFuture<'_, AP> {
+        AuthenticatedTimerFuture { handle: self }
+    }
+
+    fn encrypt_packet(
+        &mut self,
+        addr: SocketAddr,
+        plaintext: Bytes,
+    ) -> Option<(SocketAddr, Bytes)> {
+        let header_size = AP::HEADER_SIZE as usize;
+        let mut packet = BytesMut::with_capacity(header_size + plaintext.len());
+        packet.resize(header_size, 0);
+        packet.extend_from_slice(&plaintext);
+
+        match self
+            .auth_protocol
+            .encrypt_by_socket(&addr, &mut packet[header_size..])
+        {
+            Ok(header) => {
+                let header_bytes = header.as_bytes();
+                packet[..header_size].copy_from_slice(header_bytes);
+                Some((addr, packet.freeze()))
+            }
+            Err(e) => {
+                warn!(addr=?addr, error=?e, "failed to encrypt message");
+                None
+            }
+        }
+    }
+
+    fn write_auth_packet(&self, addr: SocketAddr, packet: Bytes) {
+        let stride = packet.len() as u16;
+        self.socket.write_unicast_with_priority(
+            UnicastMsg {
+                msgs: vec![(addr, packet)],
+                stride,
+            },
+            UdpPriority::High,
+        );
+    }
+}
+
+pub struct AuthenticatedTimerFuture<'a, AP>
+where
+    AP: AuthenticationProtocol,
+{
+    handle: &'a mut AuthenticatedSocketHandle<AP>,
+}
+
+impl<'a, AP> Future for AuthenticatedTimerFuture<'a, AP>
+where
+    AP: AuthenticationProtocol,
+{
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        trace!("polling wireauth timer");
+
+        loop {
+            let Some(deadline) = self.handle.auth_protocol.next_deadline() else {
+                return Poll::Pending;
+            };
+
+            let now = Instant::now();
+            if deadline <= now {
+                if let Some(d) = now.checked_duration_since(deadline) {
+                    if d > std::time::Duration::from_millis(100) {
+                        warn!(delta_ms = d.as_millis(), "slow polling wireauth timer");
+                    }
+                }
+
+                self.handle.auth_protocol.tick();
+                self.handle.flush();
+
+                return Poll::Ready(());
+            }
+
+            // wireauth internal timers are expected to be updated
+            // for example initially session with have long timer set to session_timeout
+            // after fully establishing session, keapalive_interval will be set to a shorter duration
+            let should_update_timer = self
+                .handle
+                .auth_timer
+                .as_ref()
+                .is_none_or(|(_, stored_deadline)| deadline < *stored_deadline);
+            if should_update_timer {
+                self.handle.auth_timer = Some((
+                    Box::pin(tokio::time::sleep_until(deadline.into())),
+                    deadline,
+                ));
+            }
+
+            match self.handle.auth_timer.as_mut() {
+                Some((sleep, _)) => match sleep.as_mut().poll(cx) {
+                    Poll::Ready(()) => self.handle.auth_timer = None,
+                    Poll::Pending => return Poll::Pending,
+                },
+                None => return Poll::Pending,
+            }
+        }
+    }
+}
+
+pub struct TimerFuture<'a, AP>
+where
+    AP: AuthenticationProtocol,
+{
+    handle: &'a mut DualSocketHandle<AP>,
+}
+
+impl<'a, AP> Future for TimerFuture<'a, AP>
+where
+    AP: AuthenticationProtocol,
+{
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if let Some(authenticated) = &mut self.handle.authenticated {
+            Pin::new(&mut authenticated.timer()).poll(cx)
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+        pin::pin,
+        sync::Arc,
+        task::Poll,
+        time::Duration,
+    };
+
+    use bytes::Bytes;
+    use futures::poll;
+    use monad_dataplane::{DataplaneBuilder, UnicastMsg};
+    use monad_secp::KeyPair;
+    use monad_types::UdpPriority;
+    use monad_wireauth::{Config, DEFAULT_RETRY_ATTEMPTS};
+    use tracing_subscriber::EnvFilter;
+
+    use super::{AuthenticatedSocketHandle, DualSocketHandle};
+    use crate::auth::protocol::WireAuthProtocol;
+
+    const AUTHENTICATED_SOCKET: &str = "authenticated_socket";
+    const NON_AUTHENTICATED_SOCKET: &str = "non_authenticated_socket";
+
+    fn init_tracing() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::from_default_env())
+            .try_init();
+    }
+
+    fn keypair(seed: u8) -> KeyPair {
+        KeyPair::from_bytes(&mut [seed; 32]).unwrap()
+    }
+
+    struct PeerNode {
+        socket: DualSocketHandle<WireAuthProtocol>,
+        auth_addr: SocketAddr,
+        public_key: monad_secp::PubKey,
+        _tcp_socket: monad_dataplane::TcpSocketHandle,
+        _control: monad_dataplane::DataplaneControl,
+    }
+
+    impl PeerNode {
+        fn new(auth_port: u16, non_auth_port: u16, seed: u8) -> Self {
+            let auth_addr =
+                SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), auth_port));
+            let non_auth_addr = SocketAddr::V4(SocketAddrV4::new(
+                Ipv4Addr::new(127, 0, 0, 1),
+                non_auth_port,
+            ));
+
+            let dp = DataplaneBuilder::new(&auth_addr, 1000)
+                .extend_udp_sockets(vec![
+                    monad_dataplane::UdpSocketConfig {
+                        socket_addr: auth_addr,
+                        label: AUTHENTICATED_SOCKET.to_string(),
+                    },
+                    monad_dataplane::UdpSocketConfig {
+                        socket_addr: non_auth_addr,
+                        label: NON_AUTHENTICATED_SOCKET.to_string(),
+                    },
+                ])
+                .build();
+
+            assert!(dp.block_until_ready(Duration::from_secs(1)));
+            let (tcp_socket, mut udp_dataplane, control) = dp.split();
+
+            let authenticated_socket = udp_dataplane
+                .take_socket(AUTHENTICATED_SOCKET)
+                .expect("authenticated socket");
+            let non_authenticated_socket = udp_dataplane
+                .take_socket(NON_AUTHENTICATED_SOCKET)
+                .expect("non-authenticated socket");
+
+            let keypair = keypair(seed);
+            let public_key = keypair.pubkey();
+            let config = Config::default();
+            let auth_protocol = WireAuthProtocol::new(config, Arc::new(keypair));
+            let authenticated_handle =
+                AuthenticatedSocketHandle::new(authenticated_socket, auth_protocol);
+            let socket =
+                DualSocketHandle::new(Some(authenticated_handle), non_authenticated_socket);
+
+            Self {
+                socket,
+                auth_addr,
+                public_key,
+                _tcp_socket: tcp_socket,
+                _control: control,
+            }
+        }
+
+        fn connect(&mut self, peer_public: &monad_secp::PubKey, peer_addr: SocketAddr) {
+            self.socket
+                .connect(peer_public, peer_addr, DEFAULT_RETRY_ATTEMPTS)
+                .expect("connect failed");
+            self.socket.flush();
+        }
+
+        fn write_message(&mut self, dest: SocketAddr, message: &[u8]) {
+            self.socket.write_unicast_with_priority(
+                UnicastMsg {
+                    msgs: vec![(dest, Bytes::copy_from_slice(message))],
+                    stride: message.len() as u16,
+                },
+                UdpPriority::Regular,
+            );
+        }
+    }
+
+    async fn exchange_handshake(peer1: &mut PeerNode, peer2: &mut PeerNode) {
+        let timeout = Duration::from_secs(3);
+        let start = std::time::Instant::now();
+
+        while start.elapsed() < timeout {
+            tokio::select! {
+                result1 = tokio::time::timeout(Duration::from_millis(100), peer1.socket.recv()) => {
+                    if let Ok(Ok(msg)) = result1 {
+                        tracing::info!(src=?msg.src_addr, len=msg.payload.len(), "peer1 received");
+                    }
+                }
+                result2 = tokio::time::timeout(Duration::from_millis(100), peer2.socket.recv()) => {
+                    if let Ok(Ok(msg)) = result2 {
+                        tracing::info!(src=?msg.src_addr, len=msg.payload.len(), "peer2 received");
+                    }
+                }
+                _ = tokio::time::sleep(Duration::from_millis(100)) => {
+                    if peer1.socket.is_connected_socket_and_public_key(&peer2.auth_addr, &peer2.public_key) {
+                        tracing::info!("handshake complete");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_e2e_bidirectional() {
+        init_tracing();
+
+        let mut alice = PeerNode::new(18001, 19001, 1);
+        let mut bob = PeerNode::new(18002, 19002, 2);
+
+        let bob_addr = bob.auth_addr;
+        let alice_addr = alice.auth_addr;
+
+        alice.connect(&bob.public_key, bob_addr);
+
+        exchange_handshake(&mut alice, &mut bob).await;
+
+        alice.write_message(bob_addr, b"hello from alice");
+
+        let received_bob = tokio::time::timeout(Duration::from_secs(2), bob.socket.recv())
+            .await
+            .expect("timeout waiting for bob")
+            .expect("bob received");
+        assert_eq!(&received_bob.payload[..], b"hello from alice");
+        assert_eq!(received_bob.src_addr, alice_addr);
+
+        bob.write_message(alice_addr, b"hello from bob");
+
+        let received_alice = tokio::time::timeout(Duration::from_secs(2), alice.socket.recv())
+            .await
+            .expect("timeout waiting for alice")
+            .expect("alice received");
+        assert_eq!(&received_alice.payload[..], b"hello from bob");
+        assert_eq!(received_alice.src_addr, bob_addr);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_timer_deadline() {
+        init_tracing();
+
+        let auth_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 19003));
+
+        let dp = DataplaneBuilder::new(&auth_addr, 1000)
+            .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
+                socket_addr: auth_addr,
+                label: AUTHENTICATED_SOCKET.to_string(),
+            }])
+            .build();
+
+        assert!(dp.block_until_ready(Duration::from_secs(1)));
+        let (_tcp_socket, mut udp_dataplane, _control) = dp.split();
+
+        let authenticated_socket = udp_dataplane
+            .take_socket(AUTHENTICATED_SOCKET)
+            .expect("authenticated socket");
+
+        let local_keypair = keypair(1);
+        let config = Config {
+            handshake_rate_reset_interval: Duration::from_millis(10),
+            session_timeout: Duration::from_millis(4),
+            session_timeout_jitter: Duration::ZERO,
+            ..Default::default()
+        };
+
+        let auth_protocol = WireAuthProtocol::new(config, Arc::new(local_keypair));
+        let mut handle = AuthenticatedSocketHandle::new(authenticated_socket, auth_protocol);
+
+        assert_eq!(poll!(pin!(handle.timer())), Poll::Pending);
+
+        tokio::time::sleep(Duration::from_millis(11)).await;
+
+        assert_eq!(poll!(pin!(handle.timer())), Poll::Ready(()));
+        assert_eq!(poll!(pin!(handle.timer())), Poll::Pending);
+
+        // this ensures that timer is updated with a shorter deadline
+        let remote_keypair = keypair(2);
+        let remote_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 19004));
+        handle
+            .connect(&remote_keypair.pubkey(), remote_addr, 1)
+            .expect("connect failed");
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        assert_eq!(poll!(pin!(handle.timer())), Poll::Ready(()));
+    }
+}

--- a/monad-raptorcast/src/metrics.rs
+++ b/monad-raptorcast/src/metrics.rs
@@ -17,6 +17,10 @@ use monad_executor::{ExecutorMetrics, Histogram};
 
 use crate::util::unix_ts_ms_now;
 
+pub const GAUGE_RAPTORCAST_TOTAL_MESSAGES_RECEIVED: &str =
+    "monad.raptorcast.total_messages_received";
+pub const GAUGE_RAPTORCAST_TOTAL_RECV_ERRORS: &str = "monad.raptorcast.total_recv_errors";
+
 pub const PRIMARY_BROADCAST_LATENCY_P50_MS: &str =
     "monad.bft.raptorcast.udp.primary_broadcast_latency_p50_ms";
 pub const PRIMARY_BROADCAST_LATENCY_P90_MS: &str =

--- a/monad-raptorcast/src/raptorcast_secondary/publisher.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/publisher.rs
@@ -960,12 +960,12 @@ mod tests {
 
     fn enable_tracer() {
         TRACING_ONCE_SETUP.call_once(|| {
-            tracing_subscriber::fmt::fmt()
+            let _ = tracing_subscriber::fmt::fmt()
                 .with_max_level(tracing::Level::ERROR)
                 .with_writer(io::stdout)
                 .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
                 .with_span_events(FmtSpan::CLOSE)
-                .init();
+                .try_init();
         });
     }
 

--- a/monad-raptorcast/tests/common/mod.rs
+++ b/monad-raptorcast/tests/common/mod.rs
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::net::{TcpListener, UdpSocket};
+
+/// Find a free UDP port by binding to an ephemeral port and returning it.
+pub fn find_udp_free_port() -> u16 {
+    let socket = UdpSocket::bind("127.0.0.1:0").expect("failed to bind");
+    socket.local_addr().expect("failed to get addr").port()
+}
+
+/// Find a free TCP port by binding to an ephemeral port and returning it.
+#[allow(dead_code)]
+pub fn find_tcp_free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind");
+    listener.local_addr().expect("failed to get addr").port()
+}

--- a/monad-raptorcast/tests/wireauth_raptorcast.rs
+++ b/monad-raptorcast/tests/wireauth_raptorcast.rs
@@ -1,0 +1,609 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+mod common;
+
+use std::{
+    collections::HashMap,
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    num::ParseIntError,
+    sync::Arc,
+    time::Duration,
+};
+
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+use bytes::{Bytes, BytesMut};
+use common::{find_tcp_free_port, find_udp_free_port};
+use futures_util::StreamExt;
+use itertools::Itertools;
+use monad_crypto::certificate_signature::{
+    CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
+};
+use monad_executor::Executor;
+use monad_executor_glue::{Message, RouterCommand};
+use monad_peer_discovery::{MonadNameRecord, NameRecord};
+use monad_raptorcast::RaptorCastEvent;
+use monad_secp::{KeyPair, SecpSignature};
+use monad_types::{Deserializable, Epoch, NodeId, Serializable, Stake};
+use rstest::rstest;
+use tracing_subscriber::EnvFilter;
+
+const UP_BANDWIDTH_MBPS: u64 = 1_000;
+const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
+const MESSAGE_TIMEOUT: Duration = Duration::from_secs(10);
+const NUM_NODES: usize = 10;
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .try_init();
+}
+
+fn keypair(seed: u8) -> KeyPair {
+    KeyPair::from_bytes(&mut [seed; 32]).unwrap()
+}
+
+#[derive(Clone, Copy, RlpEncodable, RlpDecodable)]
+struct MockMessage {
+    id: u32,
+    message_len: usize,
+}
+
+impl MockMessage {
+    fn new(id: u32, message_len: usize) -> Self {
+        Self { id, message_len }
+    }
+}
+
+impl Message for MockMessage {
+    type NodeIdPubKey = CertificateSignaturePubKey<SecpSignature>;
+    type Event = MockEvent<Self::NodeIdPubKey>;
+
+    fn event(self, from: NodeId<Self::NodeIdPubKey>) -> Self::Event {
+        MockEvent((from, self.id))
+    }
+}
+
+impl Serializable<Bytes> for MockMessage {
+    fn serialize(&self) -> Bytes {
+        let mut message = BytesMut::zeroed(self.message_len);
+        let id_bytes = self.id.to_le_bytes();
+        message[0] = id_bytes[0];
+        message[1] = id_bytes[1];
+        message[2] = id_bytes[2];
+        message[3] = id_bytes[3];
+        message.into()
+    }
+}
+
+impl Deserializable<Bytes> for MockMessage {
+    type ReadError = ParseIntError;
+
+    fn deserialize(message: &Bytes) -> Result<Self, Self::ReadError> {
+        Ok(Self::new(
+            u32::from_le_bytes(message[..4].try_into().unwrap()),
+            message.len(),
+        ))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct MockEvent<P: PubKey>((NodeId<P>, u32));
+
+impl<ST> From<RaptorCastEvent<MockEvent<CertificateSignaturePubKey<ST>>, ST>>
+    for MockEvent<CertificateSignaturePubKey<ST>>
+where
+    ST: CertificateSignatureRecoverable,
+{
+    fn from(value: RaptorCastEvent<MockEvent<CertificateSignaturePubKey<ST>>, ST>) -> Self {
+        match value {
+            RaptorCastEvent::Message(event) => event,
+            RaptorCastEvent::PeerManagerResponse(_) => unimplemented!(),
+            RaptorCastEvent::SecondaryRaptorcastPeersUpdate { .. } => unimplemented!(),
+        }
+    }
+}
+
+struct ValidatorChannels {
+    cmd_tx: tokio::sync::mpsc::UnboundedSender<RouterCommand<SecpSignature, MockMessage>>,
+    event_rx:
+        tokio::sync::mpsc::UnboundedReceiver<MockEvent<CertificateSignaturePubKey<SecpSignature>>>,
+    ready_rx: tokio::sync::oneshot::Receiver<()>,
+}
+
+#[derive(Clone)]
+struct ValidatorInfo {
+    keypair: Arc<KeyPair>,
+    nodeid: NodeId<CertificateSignaturePubKey<SecpSignature>>,
+    pubkey: monad_secp::PubKey,
+    tcp_addr: SocketAddrV4,
+    auth_addr: SocketAddrV4,
+    non_auth_addr: SocketAddrV4,
+}
+
+impl ValidatorInfo {
+    fn new(seed: u8) -> Self {
+        let kp = keypair(seed);
+        let nodeid = NodeId::new(kp.pubkey());
+        let pubkey = kp.pubkey();
+        let tcp_addr = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), find_tcp_free_port());
+        let auth_addr = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), find_udp_free_port());
+        let non_auth_addr = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), find_udp_free_port());
+        Self {
+            keypair: Arc::new(kp),
+            nodeid,
+            pubkey,
+            tcp_addr,
+            auth_addr,
+            non_auth_addr,
+        }
+    }
+
+    fn create_name_record(&self, with_auth: bool) -> MonadNameRecord<SecpSignature> {
+        let name_record = if with_auth {
+            NameRecord::new_with_authentication(
+                Ipv4Addr::new(127, 0, 0, 1),
+                self.tcp_addr.port(),
+                self.non_auth_addr.port(),
+                self.auth_addr.port(),
+                1,
+            )
+        } else {
+            NameRecord::new(Ipv4Addr::new(127, 0, 0, 1), self.non_auth_addr.port(), 1)
+        };
+        MonadNameRecord::new(name_record, &*self.keypair)
+    }
+}
+
+fn create_raptorcast_config(
+    keypair: Arc<KeyPair>,
+) -> monad_raptorcast::config::RaptorCastConfig<SecpSignature> {
+    monad_raptorcast::config::RaptorCastConfig {
+        shared_key: keypair,
+        mtu: monad_dataplane::udp::DEFAULT_MTU,
+        udp_message_max_age_ms: u64::MAX,
+        primary_instance: Default::default(),
+        secondary_instance: monad_node_config::FullNodeRaptorCastConfig {
+            enable_publisher: false,
+            enable_client: false,
+            raptor10_fullnode_redundancy_factor: 2f32,
+            full_nodes_prioritized: monad_node_config::FullNodeConfig { identities: vec![] },
+            round_span: monad_types::Round(10),
+            invite_lookahead: monad_types::Round(5),
+            max_invite_wait: monad_types::Round(3),
+            deadline_round_dist: monad_types::Round(3),
+            init_empty_round_span: monad_types::Round(1),
+            max_group_size: 10,
+            max_num_group: 5,
+            invite_future_dist_min: monad_types::Round(1),
+            invite_future_dist_max: monad_types::Round(5),
+            invite_accept_heartbeat_ms: 100,
+        },
+    }
+}
+
+fn create_dataplane(
+    tcp_addr: SocketAddrV4,
+    auth_addr: SocketAddrV4,
+    non_auth_addr: SocketAddrV4,
+) -> (
+    monad_dataplane::TcpSocketHandle,
+    monad_dataplane::UdpSocketHandle,
+    monad_dataplane::UdpSocketHandle,
+    monad_dataplane::DataplaneControl,
+) {
+    let dp = monad_dataplane::DataplaneBuilder::new(&SocketAddr::V4(tcp_addr), UP_BANDWIDTH_MBPS)
+        .extend_udp_sockets(vec![
+            monad_dataplane::UdpSocketConfig {
+                socket_addr: SocketAddr::V4(auth_addr),
+                label: monad_raptorcast::AUTHENTICATED_RAPTORCAST_SOCKET.to_string(),
+            },
+            monad_dataplane::UdpSocketConfig {
+                socket_addr: SocketAddr::V4(non_auth_addr),
+                label: monad_raptorcast::RAPTORCAST_SOCKET.to_string(),
+            },
+        ])
+        .build();
+    assert!(dp.block_until_ready(Duration::from_secs(1)));
+
+    let (tcp_socket, mut udp_dataplane, control) = dp.split();
+    let authenticated_socket = udp_dataplane
+        .take_socket(monad_raptorcast::AUTHENTICATED_RAPTORCAST_SOCKET)
+        .expect("authenticated socket");
+    let non_authenticated_socket = udp_dataplane
+        .take_socket(monad_raptorcast::RAPTORCAST_SOCKET)
+        .expect("non-authenticated socket");
+
+    (
+        tcp_socket,
+        authenticated_socket,
+        non_authenticated_socket,
+        control,
+    )
+}
+
+fn create_peer_discovery(
+    known_addresses: HashMap<NodeId<CertificateSignaturePubKey<SecpSignature>>, SocketAddrV4>,
+    name_records: HashMap<
+        NodeId<CertificateSignaturePubKey<SecpSignature>>,
+        MonadNameRecord<SecpSignature>,
+    >,
+) -> Arc<
+    std::sync::Mutex<
+        monad_peer_discovery::driver::PeerDiscoveryDriver<
+            monad_peer_discovery::mock::NopDiscovery<SecpSignature>,
+        >,
+    >,
+> {
+    let builder = monad_peer_discovery::mock::NopDiscoveryBuilder {
+        known_addresses,
+        name_records,
+        ..Default::default()
+    };
+    let pd = monad_peer_discovery::driver::PeerDiscoveryDriver::new(builder);
+    Arc::new(std::sync::Mutex::new(pd))
+}
+
+fn spawn_noop_validator(
+    keypair: Arc<KeyPair>,
+    tcp_addr: SocketAddrV4,
+    auth_addr: SocketAddrV4,
+    non_auth_addr: SocketAddrV4,
+    known_addresses: HashMap<NodeId<CertificateSignaturePubKey<SecpSignature>>, SocketAddrV4>,
+    name_records: HashMap<
+        NodeId<CertificateSignaturePubKey<SecpSignature>>,
+        MonadNameRecord<SecpSignature>,
+    >,
+) -> ValidatorChannels {
+    let (cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+
+    tokio::task::spawn_local(async move {
+        let shared_pd = create_peer_discovery(known_addresses, name_records);
+        let (tcp_socket, _authenticated_socket, non_authenticated_socket, control) =
+            create_dataplane(tcp_addr, auth_addr, non_auth_addr);
+        let (tcp_reader, tcp_writer) = tcp_socket.split();
+        let config = create_raptorcast_config(keypair);
+        let auth_protocol = monad_raptorcast::auth::NoopAuthProtocol::new();
+
+        let mut validator_rc = monad_raptorcast::RaptorCast::<
+            SecpSignature,
+            MockMessage,
+            MockMessage,
+            MockEvent<CertificateSignaturePubKey<SecpSignature>>,
+            monad_peer_discovery::mock::NopDiscovery<SecpSignature>,
+            _,
+        >::new(
+            config,
+            monad_raptorcast::raptorcast_secondary::SecondaryRaptorCastModeConfig::None,
+            tcp_reader,
+            tcp_writer,
+            None,
+            non_authenticated_socket,
+            control,
+            shared_pd,
+            Epoch(0),
+            auth_protocol,
+        );
+
+        let mut cmd_rx = cmd_rx;
+        let _ = ready_tx.send(());
+
+        loop {
+            tokio::select! {
+                Some(cmd) = cmd_rx.recv() => {
+                    validator_rc.exec(vec![cmd]);
+                }
+                Some(event) = validator_rc.next() => {
+                    if event_tx.send(event).is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    ValidatorChannels {
+        cmd_tx,
+        event_rx,
+        ready_rx,
+    }
+}
+
+fn spawn_wireauth_validator(
+    keypair: Arc<KeyPair>,
+    tcp_addr: SocketAddrV4,
+    auth_addr: SocketAddrV4,
+    non_auth_addr: SocketAddrV4,
+    known_addresses: HashMap<NodeId<CertificateSignaturePubKey<SecpSignature>>, SocketAddrV4>,
+    name_records: HashMap<
+        NodeId<CertificateSignaturePubKey<SecpSignature>>,
+        MonadNameRecord<SecpSignature>,
+    >,
+    peers_to_check: Vec<(SocketAddrV4, monad_secp::PubKey)>,
+) -> ValidatorChannels {
+    let (cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+
+    tokio::task::spawn_local(async move {
+        let shared_pd = create_peer_discovery(known_addresses, name_records);
+        let (tcp_socket, authenticated_socket, non_authenticated_socket, control) =
+            create_dataplane(tcp_addr, auth_addr, non_auth_addr);
+        let (tcp_reader, tcp_writer) = tcp_socket.split();
+        let config = create_raptorcast_config(keypair.clone());
+        let wireauth_config = monad_wireauth::Config::default();
+        let auth_protocol =
+            monad_raptorcast::auth::WireAuthProtocol::new(wireauth_config, keypair.clone());
+
+        let mut validator_rc = monad_raptorcast::RaptorCast::<
+            SecpSignature,
+            MockMessage,
+            MockMessage,
+            MockEvent<CertificateSignaturePubKey<SecpSignature>>,
+            monad_peer_discovery::mock::NopDiscovery<SecpSignature>,
+            _,
+        >::new(
+            config,
+            monad_raptorcast::raptorcast_secondary::SecondaryRaptorCastModeConfig::None,
+            tcp_reader,
+            tcp_writer,
+            Some(authenticated_socket),
+            non_authenticated_socket,
+            control,
+            shared_pd,
+            Epoch(0),
+            auth_protocol,
+        );
+
+        let mut cmd_rx = cmd_rx;
+        let check_connections = !peers_to_check.is_empty();
+        let mut ready_tx = Some(ready_tx);
+        let mut check_interval = tokio::time::interval(Duration::from_millis(100));
+
+        loop {
+            tokio::select! {
+                Some(cmd) = cmd_rx.recv() => {
+                    validator_rc.exec(vec![cmd]);
+                }
+                Some(event) = validator_rc.next() => {
+                    if event_tx.send(event).is_err() {
+                        break;
+                    }
+                }
+                _ = check_interval.tick(), if check_connections => {
+                    if let Some(tx) = ready_tx.take() {
+                        let all_connected = peers_to_check.iter().all(|(addr, pubkey)| {
+                            validator_rc.is_connected_to(&SocketAddr::V4(*addr), pubkey)
+                        });
+
+                        if all_connected {
+                            let _ = tx.send(());
+                        } else {
+                            ready_tx = Some(tx);
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    ValidatorChannels {
+        cmd_tx,
+        event_rx,
+        ready_rx,
+    }
+}
+
+async fn establish_connections(
+    cmd_txs: &[&tokio::sync::mpsc::UnboundedSender<RouterCommand<SecpSignature, MockMessage>>],
+    ready_rxs: Vec<tokio::sync::oneshot::Receiver<()>>,
+    epoch: Epoch,
+    validator_set: Vec<(NodeId<CertificateSignaturePubKey<SecpSignature>>, Stake)>,
+    event_rxs: &mut [&mut tokio::sync::mpsc::UnboundedReceiver<
+        MockEvent<CertificateSignaturePubKey<SecpSignature>>,
+    >],
+) {
+    for cmd_tx in cmd_txs {
+        cmd_tx
+            .send(RouterCommand::AddEpochValidatorSet {
+                epoch,
+                validator_set: validator_set.clone(),
+            })
+            .unwrap();
+    }
+
+    let setup_message = MockMessage::new(1, 100);
+    for cmd_tx in cmd_txs {
+        cmd_tx
+            .send(RouterCommand::Publish {
+                target: monad_types::RouterTarget::Broadcast(epoch),
+                message: setup_message,
+            })
+            .unwrap();
+    }
+
+    for ready_rx in ready_rxs {
+        tokio::time::timeout(CONNECTION_TIMEOUT, ready_rx)
+            .await
+            .expect("connection timeout")
+            .expect("ready channel closed");
+    }
+
+    for event_rx in event_rxs {
+        while event_rx.try_recv().is_ok() {}
+    }
+}
+
+#[derive(Clone, Copy)]
+enum RoutingType {
+    PointToPoint,
+    Raptorcast,
+    Broadcast,
+}
+
+async fn run_test_scenario(num_auth_nodes: usize, routing_type: RoutingType, message_size: usize) {
+    let validator_infos: Vec<_> = (1..=NUM_NODES as u8).map(ValidatorInfo::new).collect();
+
+    let name_records: HashMap<_, _> = validator_infos
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (v.nodeid, v.create_name_record(i < num_auth_nodes)))
+        .collect();
+
+    let known_addresses: HashMap<_, _> = validator_infos
+        .iter()
+        .map(|v| (v.nodeid, v.non_auth_addr))
+        .collect();
+
+    let peers_for_check: Vec<_> = validator_infos
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i < num_auth_nodes)
+        .map(|(_, v)| (v.auth_addr, v.pubkey))
+        .collect();
+
+    let validators: Vec<_> = validator_infos
+        .iter()
+        .enumerate()
+        .map(|(i, v)| {
+            if i < num_auth_nodes {
+                let peers = peers_for_check
+                    .iter()
+                    .enumerate()
+                    .filter(|(j, _)| *j != i)
+                    .map(|(_, p)| *p)
+                    .collect();
+                spawn_wireauth_validator(
+                    v.keypair.clone(),
+                    v.tcp_addr,
+                    v.auth_addr,
+                    v.non_auth_addr,
+                    known_addresses.clone(),
+                    name_records.clone(),
+                    peers,
+                )
+            } else {
+                spawn_noop_validator(
+                    v.keypair.clone(),
+                    v.tcp_addr,
+                    v.auth_addr,
+                    v.non_auth_addr,
+                    known_addresses.clone(),
+                    name_records.clone(),
+                )
+            }
+        })
+        .collect();
+
+    let epoch = Epoch(0);
+    let validator_set: Vec<_> = validator_infos
+        .iter()
+        .map(|v| (v.nodeid, Stake::ONE))
+        .collect();
+
+    let (cmd_txs, ready_rxs, mut event_rxs): (Vec<_>, Vec<_>, Vec<_>) = validators
+        .into_iter()
+        .map(|v| (v.cmd_tx, v.ready_rx, v.event_rx))
+        .multiunzip();
+
+    let cmd_tx_refs: Vec<_> = cmd_txs.iter().collect();
+    let mut event_rx_refs: Vec<_> = event_rxs.iter_mut().collect();
+
+    establish_connections(
+        &cmd_tx_refs,
+        ready_rxs,
+        epoch,
+        validator_set,
+        &mut event_rx_refs,
+    )
+    .await;
+
+    let sender_idx = 0;
+    let sender_nodeid = validator_infos[sender_idx].nodeid;
+
+    match routing_type {
+        RoutingType::PointToPoint => {
+            for receiver_idx in 1..NUM_NODES {
+                let message = MockMessage::new(1000 + receiver_idx as u32, message_size);
+                cmd_txs[sender_idx]
+                    .send(RouterCommand::Publish {
+                        target: monad_types::RouterTarget::PointToPoint(
+                            validator_infos[receiver_idx].nodeid,
+                        ),
+                        message,
+                    })
+                    .unwrap();
+
+                let event = tokio::time::timeout(MESSAGE_TIMEOUT, event_rxs[receiver_idx].recv())
+                    .await
+                    .expect("timeout waiting for message")
+                    .expect("channel closed");
+
+                let MockEvent((from, msg_id)) = event;
+                assert_eq!(from, sender_nodeid);
+                assert_eq!(msg_id, 1000 + receiver_idx as u32);
+            }
+        }
+        RoutingType::Raptorcast | RoutingType::Broadcast => {
+            let message = MockMessage::new(1000, message_size);
+            let target = match routing_type {
+                RoutingType::Raptorcast => monad_types::RouterTarget::Raptorcast(epoch),
+                RoutingType::Broadcast => monad_types::RouterTarget::Broadcast(epoch),
+                _ => unreachable!(),
+            };
+
+            cmd_txs[sender_idx]
+                .send(RouterCommand::Publish { target, message })
+                .unwrap();
+
+            for event_rx in event_rxs.iter_mut().take(NUM_NODES) {
+                let event = tokio::time::timeout(MESSAGE_TIMEOUT, event_rx.recv())
+                    .await
+                    .expect("timeout waiting for message")
+                    .expect("channel closed");
+
+                let MockEvent((from, msg_id)) = event;
+                assert_eq!(from, sender_nodeid);
+                assert_eq!(msg_id, 1000);
+            }
+        }
+    }
+}
+
+#[rstest]
+#[case(10, RoutingType::Raptorcast, 2_000_000)]
+#[case(5, RoutingType::Raptorcast, 2_000_000)]
+#[case(0, RoutingType::Raptorcast, 2_000_000)]
+#[case(5, RoutingType::Broadcast, 10_000)]
+#[case(5, RoutingType::PointToPoint, 1_000)]
+#[serial_test::file_serial]
+#[tokio::test(flavor = "current_thread")]
+async fn test_wireauth_matrix(
+    #[case] num_auth_nodes: usize,
+    #[case] routing_type: RoutingType,
+    #[case] message_size: usize,
+) {
+    init_tracing();
+
+    tokio::task::LocalSet::new()
+        .run_until(run_test_scenario(
+            num_auth_nodes,
+            routing_type,
+            message_size,
+        ))
+        .await;
+}

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -27,7 +27,7 @@ use futures::{Stream, StreamExt};
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
-use monad_dataplane::{DataplaneBuilder, UdpSocketWriter};
+use monad_dataplane::DataplaneBuilder;
 use monad_executor::{Executor, ExecutorMetricsChain};
 use monad_executor_glue::{Message, RouterCommand};
 use monad_node_config::{FullNodeConfig, FullNodeIdentityConfig};
@@ -35,30 +35,33 @@ use monad_peer_discovery::{
     driver::PeerDiscoveryDriver, PeerDiscoveryAlgo, PeerDiscoveryAlgoBuilder,
 };
 use monad_raptorcast::{
+    auth::AuthenticationProtocol,
     config::{
         GroupSchedulingConfig, RaptorCastConfig, RaptorCastConfigSecondary,
         RaptorCastConfigSecondaryClient, RaptorCastConfigSecondaryPublisher,
         SecondaryRaptorCastMode,
     },
     raptorcast_secondary::{
-        group_message::FullNodesGroupMessage, RaptorCastSecondary, SecondaryRaptorCastModeConfig,
+        group_message::FullNodesGroupMessage, RaptorCastSecondary, SecondaryOutboundMessage,
+        SecondaryRaptorCastModeConfig,
     },
     util::Group,
-    RaptorCast, RaptorCastEvent, RAPTORCAST_SOCKET,
+    RaptorCast, RaptorCastEvent, AUTHENTICATED_RAPTORCAST_SOCKET, RAPTORCAST_SOCKET,
 };
 use monad_types::{Epoch, NodeId};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 pub use tracing::{debug, error, info, warn, Level};
 
 //==============================================================================
-pub struct MultiRouter<ST, M, OM, SE, PD>
+pub struct MultiRouter<ST, M, OM, SE, PD, AP>
 where
     ST: CertificateSignatureRecoverable,
     M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
     OM: Encodable + Into<M> + Clone,
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
+    AP: AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
 {
-    rc_primary: RaptorCast<ST, M, OM, SE, PD>,
+    rc_primary: RaptorCast<ST, M, OM, SE, PD, AP>,
     rc_secondary: Option<RaptorCastSecondary<ST, M, OM, SE, PD>>,
 
     // raptorcast config is stored for future role change
@@ -67,18 +70,18 @@ where
     current_epoch: Epoch,
     epoch_validators: BTreeMap<Epoch, BTreeSet<NodeId<CertificateSignaturePubKey<ST>>>>,
 
-    dp_writer: UdpSocketWriter,
     shared_pdd: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
 
     phantom: PhantomData<(OM, SE)>,
 }
 
-impl<ST, M, OM, SE, PD> MultiRouter<ST, M, OM, SE, PD>
+impl<ST, M, OM, SE, PD, AP> MultiRouter<ST, M, OM, SE, PD, AP>
 where
     ST: CertificateSignatureRecoverable,
     M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
     OM: Encodable + Into<M> + Clone,
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
+    AP: AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
 {
     pub fn new<B>(
         self_node_id: NodeId<CertificateSignaturePubKey<ST>>,
@@ -87,6 +90,7 @@ where
         peer_discovery_builder: B,
         current_epoch: Epoch,
         epoch_validators: BTreeMap<Epoch, BTreeSet<NodeId<CertificateSignaturePubKey<ST>>>>,
+        auth_protocol: AP,
     ) -> Self
     where
         B: PeerDiscoveryAlgoBuilder<PeerDiscoveryAlgoType = PD>,
@@ -99,19 +103,21 @@ where
         assert!(dp.block_until_ready(Duration::from_secs(1)));
 
         let (tcp_socket, mut udp_dataplane, control) = dp.split();
-        let udp_socket = udp_dataplane
+        let authenticated_socket = udp_dataplane.take_socket(AUTHENTICATED_RAPTORCAST_SOCKET);
+        let non_authenticated_socket = udp_dataplane
             .take_socket(RAPTORCAST_SOCKET)
             .expect("raptorcast socket");
-        let udp_writer_secondary = udp_socket.writer().clone();
 
         let (tcp_reader, tcp_writer) = tcp_socket.split();
 
-        // Create a channel between primary and secondary raptorcast instances.
+        // Create channels between primary and secondary raptorcast instances.
         // Fundamentally this is needed because, while both can send, only the
         // primary can receive data from the network.
         let (send_net_messages, recv_net_messages) =
             unbounded_channel::<FullNodesGroupMessage<ST>>();
         let (send_group_infos, recv_group_infos) = unbounded_channel::<Group<ST>>();
+        let (send_outbound_to_primary, recv_outbound_from_secondary) =
+            unbounded_channel::<SecondaryOutboundMessage<ST>>();
 
         // Determine initial secondary raptorcast role
         let is_current_epoch_validator = epoch_validators
@@ -130,10 +136,10 @@ where
         let rc_secondary = Self::build_secondary(
             cfg.clone(),
             secondary_mode,
-            udp_writer_secondary.clone(),
             shared_pdd.clone(),
             recv_net_messages,
             send_group_infos,
+            send_outbound_to_primary,
             current_epoch,
         );
 
@@ -142,12 +148,18 @@ where
             secondary_mode,
             tcp_reader,
             tcp_writer,
-            udp_socket,
+            authenticated_socket,
+            non_authenticated_socket,
             control,
             shared_pdd.clone(),
             current_epoch,
+            auth_protocol,
         );
-        rc_primary.bind_channel_to_secondary_raptorcast(send_net_messages, recv_group_infos);
+        rc_primary.bind_channel_to_secondary_raptorcast(
+            send_net_messages,
+            recv_group_infos,
+            recv_outbound_from_secondary,
+        );
 
         Self {
             rc_primary,
@@ -156,7 +168,6 @@ where
             current_epoch,
             epoch_validators,
             self_node_id,
-            dp_writer: udp_writer_secondary,
             shared_pdd,
             phantom: PhantomData,
         }
@@ -173,20 +184,25 @@ where
         let (send_net_messages, recv_net_messages) =
             unbounded_channel::<FullNodesGroupMessage<ST>>();
         let (send_group_infos, recv_group_infos) = unbounded_channel::<Group<ST>>();
+        let (send_outbound_to_primary, recv_outbound_from_secondary) =
+            unbounded_channel::<SecondaryOutboundMessage<ST>>();
 
         let is_dynamic = matches!(new_role, SecondaryRaptorCastModeConfig::Client);
         // we first need to update is_dynamic_full_node before binding the channels
         self.rc_primary.set_is_dynamic_full_node(is_dynamic);
-        self.rc_primary
-            .bind_channel_to_secondary_raptorcast(send_net_messages, recv_group_infos);
+        self.rc_primary.bind_channel_to_secondary_raptorcast(
+            send_net_messages,
+            recv_group_infos,
+            recv_outbound_from_secondary,
+        );
 
         let rc_secondary = Self::build_secondary(
             self.rc_config.clone(),
             new_role,
-            self.dp_writer.clone(),
             self.shared_pdd.clone(),
             recv_net_messages,
             send_group_infos,
+            send_outbound_to_primary,
             current_epoch,
         );
         self.rc_secondary = rc_secondary;
@@ -195,10 +211,10 @@ where
     fn build_secondary(
         cfg: RaptorCastConfig<ST>,
         mode: SecondaryRaptorCastModeConfig,
-        udp_writer: UdpSocketWriter,
         shared_pdd: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
         recv_net_messages: UnboundedReceiver<FullNodesGroupMessage<ST>>,
         send_group_infos: UnboundedSender<Group<ST>>,
+        channel_to_primary_outbound: UnboundedSender<SecondaryOutboundMessage<ST>>,
         current_epoch: Epoch,
     ) -> Option<RaptorCastSecondary<ST, M, OM, SE, PD>> {
         let secondary_instance: RaptorCastConfigSecondary<ST> = match mode {
@@ -253,10 +269,10 @@ where
             _ => Some(RaptorCastSecondary::new(
                 cfg,
                 secondary_instance.mode,
-                udp_writer,
                 shared_pdd,
                 recv_net_messages,
                 send_group_infos,
+                channel_to_primary_outbound,
                 current_epoch,
             )),
         }
@@ -264,13 +280,14 @@ where
 }
 
 //==============================================================================
-impl<ST, M, OM, SE, PD> Executor for MultiRouter<ST, M, OM, SE, PD>
+impl<ST, M, OM, SE, PD, AP> Executor for MultiRouter<ST, M, OM, SE, PD, AP>
 where
     ST: CertificateSignatureRecoverable,
     M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
     OM: Encodable + Into<M> + Clone,
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
-    RaptorCast<ST, M, OM, SE, PD>: Unpin,
+    AP: AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
+    RaptorCast<ST, M, OM, SE, PD, AP>: Unpin,
 {
     type Command = RouterCommand<ST, OM>;
 
@@ -425,14 +442,15 @@ where
 }
 
 //==============================================================================
-impl<ST, M, OM, E, PD> Stream for MultiRouter<ST, M, OM, E, PD>
+impl<ST, M, OM, E, PD, AP> Stream for MultiRouter<ST, M, OM, E, PD, AP>
 where
     ST: CertificateSignatureRecoverable,
     M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
     OM: Encodable + Into<M> + Clone,
     E: From<RaptorCastEvent<M::Event, ST>>,
     Self: Unpin,
-    RaptorCast<ST, M, OM, E, PD>: Unpin,
+    AP: AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
+    RaptorCast<ST, M, OM, E, PD, AP>: Unpin,
     RaptorCastSecondary<ST, M, OM, E, PD>: Unpin,
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
     PeerDiscoveryDriver<PD>: Unpin,

--- a/monad-secp/src/secp.rs
+++ b/monad-secp/src/secp.rs
@@ -152,6 +152,12 @@ impl KeyPair {
     }
 }
 
+impl AsRef<KeyPair> for KeyPair {
+    fn as_ref(&self) -> &KeyPair {
+        self
+    }
+}
+
 impl PubKey {
     /// Deserialize public key from bytes
     /// Can be compressed OR uncompressed pubkey


### PR DESCRIPTION
dependencies: https://github.com/category-labs/monad-bft/pull/2417 https://github.com/category-labs/monad-bft/pull/2458 https://github.com/category-labs/monad-bft/pull/2538

ci update to use auth https://github.com/category-labs/monad-integration/pull/384

### test plan

- [x] performance evaluation

auth overhead is 32 bytes per datagram and 200ns per encrypt/decrypt operation.
the expected latency degradation should be ~2%.

- [x] longevity testing with disruption (using chaos-mesh)

the goal is to verify that protocol doesn't enter broken state and can recover after
expected disruptions (one sided restarts/crashes, prolonged connectivity loss, packet loss)

i will use the same same workload as in the previous test and automate those disruptions with https://github.com/chaos-mesh/chaos-mesh

running this setup https://github.com/dshulyak/monad-testing/ , everything as expected so far

- [x] worst case dos attacks on authentication protocol

- handshake spamming should hit rate limits and not cause raptorcast thread starvation
- smallest (32bytes) unauthenticated messages with sub-1Gbps rate should not be able to cause raptorcast thread starvation

- [x] upgrades sanity testing on stressnet

it is possible to run auth/non-auth nodes at the same time, and should not cause any disruptions to normal operations.

#### performance evaluation

i am using [latency.rs](https://github.com/category-labs/monad-bft/blob/master/monad-raptorcast/examples/latency.rs) 100 nodes cluster with simulation toolkit on an aws c6a.48xlarge instance with 192vcpus.
for latency simulatation nodes are divided into 10 buckets, with 20ms incremental latency.
workload sends 2MB raptorcast payload every 1s, latency captures time for encoding, decoding and network propagation

```
Overall Statistics Summary (g1 excluded):
================================================================================
         Config  Count  Mean  Std   P50   p70   P90   P95   P99
  AUTH 2MB 20ms 28,631 261.2 31.8 261.8 279.8 300.2 307.8 326.2
NOAUTH 2MB 20ms 51,033 259.4 31.1 260.9 279.4 299.1 306.2 321.3
```

p99 is somewhat around 2% and in lower percentiles auth overhead is less noticeable.

<img width="2680" height="900" alt="image" src="https://github.com/user-attachments/assets/43ec289b-c5a0-464c-b4f4-70f7fc806235" />

#### dos attacks

i tested handshake spamming at 2000-3000-4000 handshakes per second and after 2000 they don't increase cpu/memory usage. the limits in place are affective, at the peak such spam utilizes 60% and can't starve raptorcast thread. 

cpu usage in raptorcast threads peak at ~20% with 60MB of working set size.

with 500mbps and 1000mbps dataplane thread gets completely starved, raptorcast peaks at 60%.