### PR TITLE
Remove ro db iouring sq poll thread

### DIFF
--- a/debian/usr/lib/systemd/system/monad-execution-genesis.service
+++ b/debian/usr/lib/systemd/system/monad-execution-genesis.service
@@ -9,8 +9,7 @@ ExecStart=/usr/local/bin/monad \
     --db /dev/triedb \
     --block_db /home/monad/monad-bft/ledger \
     --nblocks 0 \
-    --ro_sq_thread_cpu 1 \
-    --sq_thread_cpu 2 \
+    --sq_thread_cpu 1 \
     --log_level INFO
 EnvironmentFile=-/home/monad/.env
 User=monad

--- a/debian/usr/lib/systemd/system/monad-execution.service
+++ b/debian/usr/lib/systemd/system/monad-execution.service
@@ -9,8 +9,7 @@ ExecStart=/usr/local/bin/monad \
     --db /dev/triedb \
     --block_db /home/monad/monad-bft/ledger \
     --statesync /home/monad/monad-bft/statesync.sock \
-    --ro_sq_thread_cpu 1 \
-    --sq_thread_cpu 2 \
+    --sq_thread_cpu 1 \
     --log_level INFO
 EnvironmentFile=-/home/monad/.env
 Restart=no


### PR DESCRIPTION
We are currently oversubscribed with cores for monad-execution service, 7 threads are allocated but 9 are required. ro_sq_poll thread is used only during statesync currently. Since all threads are cpu bound, going over limit of cores creates context switches and degrades perfromance during statesync.

Remove ro sq poll thread to reduce impact of statesync on block execution. Any reduction in statesync performance can be addressed by increasing number of parallel server requests the client issues.