### PR TITLE
monad-version: added crate for git version info and used in the selected binaries

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -66,9 +66,13 @@ jobs:
             type=ref,event=branch
             type=sha,prefix=
 
-      - name: Set Git Tag Version
-        if: ${{ matrix.dockerfile.name == 'monad-bft' || matrix.dockerfile.name == 'monad-rpc' }}
-        run: echo "GIT_TAG_VERSION=$(git describe --tags --always)" >> $GITHUB_ENV
+      - name: Set Git Version Info
+        run: |
+          echo "GIT_TAG_VERSION=$(git describe --tags --always)" >> $GITHUB_ENV
+          echo "GIT_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "GIT_BRANCH=$(git branch --show-current)" >> $GITHUB_ENV
+          echo "GIT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || echo '')" >> $GITHUB_ENV
+          echo "GIT_MODIFIED=false" >> $GITHUB_ENV
 
       - name: Setup Docker Buildx
         id: setup-buildx
@@ -100,6 +104,10 @@ jobs:
           build-args: |
             GIT_COMMIT_HASH=${{ env.GIT_COMMIT_HASH }}
             GIT_TAG_VERSION=${{ env.GIT_TAG_VERSION }}
+            GIT_COMMIT=${{ env.GIT_COMMIT }}
+            GIT_BRANCH=${{ env.GIT_BRANCH }}
+            GIT_TAG=${{ env.GIT_TAG }}
+            GIT_MODIFIED=${{ env.GIT_MODIFIED }}
             CC=gcc-15
             CXX=g++-15
             CMAKE_BUILD_TYPE=RelWithDebInfo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5237,6 +5237,7 @@ dependencies = [
  "monad-tfm",
  "monad-types",
  "monad-validator",
+ "monad-version",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -5457,6 +5458,7 @@ dependencies = [
  "monad-bls",
  "monad-crypto",
  "monad-secp",
+ "monad-version",
  "pbkdf2 0.12.2",
  "rand 0.8.5",
  "rstest",
@@ -5596,6 +5598,7 @@ dependencies = [
  "monad-types",
  "monad-updaters",
  "monad-validator",
+ "monad-version",
  "monad-wal",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5840,6 +5843,7 @@ dependencies = [
  "monad-tracing-timing",
  "monad-triedb-utils",
  "monad-types",
+ "monad-version",
  "notify",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -6239,6 +6243,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-version"
+version = "0.1.0"
+
+[[package]]
 name = "monad-wal"
 version = "0.1.0"
 dependencies = [
@@ -6253,6 +6261,7 @@ dependencies = [
  "monad-executor-glue",
  "monad-secp",
  "monad-types",
+ "monad-version",
  "rayon",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ monad-twins-utils = { path = "./monad-twins/utils" }
 monad-types = { path = "./monad-types" }
 monad-updaters = { path = "./monad-updaters" }
 monad-validator = { path = "./monad-validator" }
+monad-version = { path = "./monad-version" }
 monad-wal = { path = "./monad-wal" }
 
 actix = "0.13"

--- a/docker/archive/Dockerfile
+++ b/docker/archive/Dockerfile
@@ -70,6 +70,16 @@ ENV PATH="${CARGO_ROOT}/bin:$PATH"
 RUN rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu
 ARG TRIEDB_TARGET=triedb_driver
 
+ARG GIT_COMMIT=""
+ARG GIT_BRANCH=""
+ARG GIT_TAG=""
+ARG GIT_MODIFIED="false"
+
+ENV GIT_COMMIT=$GIT_COMMIT
+ENV GIT_BRANCH=$GIT_BRANCH
+ENV GIT_TAG=$GIT_TAG
+ENV GIT_MODIFIED=$GIT_MODIFIED
+
 # Builder
 COPY . .
 RUN ASMFLAGS="-march=haswell" CFLAGS="-march=haswell" CXXFLAGS="-march=haswell" \

--- a/docker/devnet/Dockerfile
+++ b/docker/devnet/Dockerfile
@@ -74,6 +74,16 @@ ARG GIT_TAG_VERSION
 RUN test -n "$GIT_TAG_VERSION"
 ENV MONAD_VERSION=$GIT_TAG_VERSION
 
+ARG GIT_COMMIT=""
+ARG GIT_BRANCH=""
+ARG GIT_TAG=""
+ARG GIT_MODIFIED="false"
+
+ENV GIT_COMMIT=$GIT_COMMIT
+ENV GIT_BRANCH=$GIT_BRANCH
+ENV GIT_TAG=$GIT_TAG
+ENV GIT_MODIFIED=$GIT_MODIFIED
+
 # Builder
 COPY . .
 RUN ASMFLAGS="-march=haswell" CFLAGS="-march=haswell -fno-omit-frame-pointer" CXXFLAGS="-march=haswell -fno-omit-frame-pointer" \

--- a/docker/gossip-testground/Dockerfile
+++ b/docker/gossip-testground/Dockerfile
@@ -4,6 +4,16 @@ WORKDIR /usr/src/monad-bft
 RUN apt update
 RUN apt install -y python3 clang
 
+ARG GIT_COMMIT=""
+ARG GIT_BRANCH=""
+ARG GIT_TAG=""
+ARG GIT_MODIFIED="false"
+
+ENV GIT_COMMIT=$GIT_COMMIT
+ENV GIT_BRANCH=$GIT_BRANCH
+ENV GIT_TAG=$GIT_TAG
+ENV GIT_MODIFIED=$GIT_MODIFIED
+
 # Builder
 COPY . .
 RUN cargo build --release --example service && \

--- a/docker/rpc-request-gen/Dockerfile
+++ b/docker/rpc-request-gen/Dockerfile
@@ -72,6 +72,16 @@ RUN rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu
 
 WORKDIR /usr/src/monad-bft
 
+ARG GIT_COMMIT=""
+ARG GIT_BRANCH=""
+ARG GIT_TAG=""
+ARG GIT_MODIFIED="false"
+
+ENV GIT_COMMIT=$GIT_COMMIT
+ENV GIT_BRANCH=$GIT_BRANCH
+ENV GIT_TAG=$GIT_TAG
+ENV GIT_MODIFIED=$GIT_MODIFIED
+
 # Builder
 COPY . .
 RUN cargo build --release --example rpc-request-generator && \

--- a/docker/rpc/Dockerfile
+++ b/docker/rpc/Dockerfile
@@ -73,6 +73,16 @@ ARG GIT_TAG_VERSION
 RUN test -n "$GIT_TAG_VERSION"
 ENV MONAD_VERSION=$GIT_TAG_VERSION
 
+ARG GIT_COMMIT=""
+ARG GIT_BRANCH=""
+ARG GIT_TAG=""
+ARG GIT_MODIFIED="false"
+
+ENV GIT_COMMIT=$GIT_COMMIT
+ENV GIT_BRANCH=$GIT_BRANCH
+ENV GIT_TAG=$GIT_TAG
+ENV GIT_MODIFIED=$GIT_MODIFIED
+
 # Builder
 COPY . .
 RUN ASMFLAGS="-march=haswell" CFLAGS="-march=haswell -fno-omit-frame-pointer" CXXFLAGS="-march=haswell -fno-omit-frame-pointer" \

--- a/docker/testground/Dockerfile
+++ b/docker/testground/Dockerfile
@@ -4,6 +4,16 @@ WORKDIR /usr/src/monad-bft
 RUN apt update
 RUN apt install -y python3 clang
 
+ARG GIT_COMMIT=""
+ARG GIT_BRANCH=""
+ARG GIT_TAG=""
+ARG GIT_MODIFIED="false"
+
+ENV GIT_COMMIT=$GIT_COMMIT
+ENV GIT_BRANCH=$GIT_BRANCH
+ENV GIT_TAG=$GIT_TAG
+ENV GIT_MODIFIED=$GIT_MODIFIED
+
 # Builder
 COPY . .
 RUN cargo build --release --bin monad-testground && \

--- a/docker/txgen/Dockerfile
+++ b/docker/txgen/Dockerfile
@@ -72,6 +72,16 @@ RUN rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu
 
 WORKDIR /usr/src/monad-bft
 
+ARG GIT_COMMIT=""
+ARG GIT_BRANCH=""
+ARG GIT_TAG=""
+ARG GIT_MODIFIED="false"
+
+ENV GIT_COMMIT=$GIT_COMMIT
+ENV GIT_BRANCH=$GIT_BRANCH
+ENV GIT_TAG=$GIT_TAG
+ENV GIT_MODIFIED=$GIT_MODIFIED
+
 # Builder
 COPY . .
 RUN cargo build --release --example txgen && \

--- a/monad-eth-testutil/Cargo.toml
+++ b/monad-eth-testutil/Cargo.toml
@@ -27,6 +27,9 @@ alloy-signer = { workspace = true }
 alloy-signer-local = { workspace = true }
 rand = { workspace = true }
 
+[build-dependencies]
+monad-version = { workspace = true }
+
 [dev-dependencies]
 alloy-json-rpc = { workspace = true }
 alloy-network = { workspace = true }
@@ -64,3 +67,4 @@ tracing-subscriber = { workspace = true, features = [
     "std",
 ] }
 url = { workspace = true }
+monad-version = { workspace = true }

--- a/monad-eth-testutil/build.rs
+++ b/monad-eth-testutil/build.rs
@@ -1,0 +1,25 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{env, path::Path};
+
+fn main() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let repo_root = Path::new(&manifest_dir)
+        .parent()
+        .expect("no parent directory");
+
+    monad_version::auto(repo_root);
+}

--- a/monad-eth-testutil/examples/txgen/cli.rs
+++ b/monad-eth-testutil/examples/txgen/cli.rs
@@ -33,7 +33,7 @@ fn parse_priority_fee_range(range_str: &str) -> Option<(u128, u128)> {
 }
 
 #[derive(Debug, Parser, Clone)]
-#[command(name = "monad-node", about, long_about = None)]
+#[command(name = "txgen", about, long_about = None, version = monad_version::version!())]
 pub struct CliConfig {
     /// Path to the config file to use instead of the cli args
     #[arg(long, global = true)]

--- a/monad-keystore/Cargo.toml
+++ b/monad-keystore/Cargo.toml
@@ -16,6 +16,7 @@ bench = false
 monad-bls = { workspace = true }
 monad-crypto = { workspace = true }
 monad-secp = { workspace = true }
+monad-version = { workspace = true }
 
 aes = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
@@ -29,6 +30,9 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 unicode-normalization = { workspace = true }
 zeroize = { workspace = true }
+
+[build-dependencies]
+monad-version = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/monad-keystore/build.rs
+++ b/monad-keystore/build.rs
@@ -1,0 +1,25 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{env, path::Path};
+
+fn main() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let repo_root = Path::new(&manifest_dir)
+        .parent()
+        .expect("no parent directory");
+
+    monad_version::auto(repo_root);
+}

--- a/monad-keystore/src/main.rs
+++ b/monad-keystore/src/main.rs
@@ -31,7 +31,7 @@ pub mod kdf_module;
 pub mod keystore;
 
 #[derive(Parser)]
-#[command(name = "monad-keystore", about, long_about = None)]
+#[command(name = "monad-keystore", about, long_about = None, version = monad_version::version!())]
 struct Args {
     #[command(subcommand)]
     mode: Commands,

--- a/monad-node/Cargo.toml
+++ b/monad-node/Cargo.toml
@@ -37,6 +37,7 @@ monad-triedb-utils = { workspace = true }
 monad-types = { workspace = true }
 monad-updaters = { workspace = true, features = ["monad-triedb", "tokio"] }
 monad-validator = { workspace = true }
+monad-version = { workspace = true }
 monad-wal = { workspace = true }
 
 agent = { workspace = true }
@@ -62,6 +63,9 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 workspace = true
 features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"]
 optional = true
+
+[build-dependencies]
+monad-version = { workspace = true }
 
 [dev-dependencies]
 monad-block-persist = { workspace = true }

--- a/monad-node/build.rs
+++ b/monad-node/build.rs
@@ -1,0 +1,25 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{env, path::Path};
+
+fn main() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let repo_root = Path::new(&manifest_dir)
+        .parent()
+        .expect("no parent directory");
+
+    monad_version::auto(repo_root);
+}

--- a/monad-node/src/cli.rs
+++ b/monad-node/src/cli.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 use clap::Parser;
 
 #[derive(Debug, Parser)]
-#[command(name = "monad-node", about, long_about = None)]
+#[command(name = "monad-node", about, long_about = None, version = monad_version::version!())]
 pub struct Cli {
     /// Set the bls12_381 secret key path
     #[arg(long)]

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -35,6 +35,7 @@ monad-tracing-timing = { workspace = true }
 monad-triedb-utils = { workspace = true }
 monad-types = { workspace = true }
 monad-pprof = { workspace = true }
+monad-version = { workspace = true }
 
 actix = { workspace = true }
 agent = { workspace = true }
@@ -87,6 +88,9 @@ features = [
     "background_threads",
 ]
 optional = true
+
+[build-dependencies]
+monad-version = { workspace = true }
 
 [dev-dependencies]
 monad-eth-testutil = { workspace = true }

--- a/monad-rpc/build.rs
+++ b/monad-rpc/build.rs
@@ -1,0 +1,25 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{env, path::Path};
+
+fn main() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let repo_root = Path::new(&manifest_dir)
+        .parent()
+        .expect("no parent directory");
+
+    monad_version::auto(repo_root);
+}

--- a/monad-rpc/src/cli.rs
+++ b/monad-rpc/src/cli.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 use clap::Parser;
 
 #[derive(Debug, Parser)]
-#[command(name = "monad-node", about, long_about = None)]
+#[command(name = "monad-rpc", about, long_about = None, version = monad_version::version!())]
 pub struct Cli {
     /// Set the mempool ipc path
     #[arg(long)]

--- a/monad-version/Cargo.toml
+++ b/monad-version/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "monad-version"
+description = "Git version information for Monad binaries"
+version = "0.1.0"
+edition = "2021"
+license = "GPL-3.0-or-later"
+
+[dependencies]

--- a/monad-version/src/lib.rs
+++ b/monad-version/src/lib.rs
@@ -1,0 +1,133 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    ffi::OsStr,
+    io,
+    path::Path,
+    process::{Command, Output},
+};
+
+fn git_command<D, I, S>(work_tree: D, args: I) -> io::Result<Output>
+where
+    D: AsRef<Path>,
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let work_tree = work_tree.as_ref();
+    Command::new("git")
+        .arg("-C")
+        .arg(work_tree)
+        .args(args)
+        .output()
+}
+
+fn git_output<D, I, S>(work_tree: D, args: I) -> Option<String>
+where
+    D: AsRef<Path>,
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let output = git_command(work_tree, args).ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+pub fn print_rerun_if_changed<D>(work_tree: D)
+where
+    D: AsRef<Path>,
+{
+    let work_tree = work_tree.as_ref();
+
+    [".git/HEAD", ".git/index", ".git/refs"]
+        .iter()
+        .for_each(|path| {
+            println!("cargo:rerun-if-changed={}", work_tree.join(path).display());
+        });
+}
+
+pub fn commit<D>(work_tree: D) -> String
+where
+    D: AsRef<Path>,
+{
+    git_output(work_tree, ["rev-parse", "HEAD"])
+        .or_else(|| std::env::var("GIT_COMMIT").ok())
+        .unwrap_or_default()
+}
+
+pub fn branch<D>(work_tree: D) -> String
+where
+    D: AsRef<Path>,
+{
+    git_output(work_tree, ["branch", "--show-current"])
+        .or_else(|| std::env::var("GIT_BRANCH").ok())
+        .unwrap_or_default()
+}
+
+pub fn tag<D>(work_tree: D) -> String
+where
+    D: AsRef<Path>,
+{
+    git_output(work_tree, ["describe", "--tags", "--exact-match", "HEAD"])
+        .or_else(|| std::env::var("GIT_TAG").ok())
+        .unwrap_or_default()
+}
+
+pub fn modified<D>(work_tree: D) -> bool
+where
+    D: AsRef<Path>,
+{
+    git_output(work_tree, ["status", "--porcelain"])
+        .map(|output| !output.is_empty())
+        .or_else(|| {
+            std::env::var("GIT_MODIFIED")
+                .ok()
+                .and_then(|v| v.parse().ok())
+        })
+        .unwrap_or(false)
+}
+
+pub fn auto<D>(work_tree: D)
+where
+    D: AsRef<Path>,
+{
+    let work_tree = work_tree.as_ref();
+
+    print_rerun_if_changed(work_tree);
+
+    let commit_hash = commit(work_tree);
+    let branch_name = branch(work_tree);
+    let tag_name = tag(work_tree);
+    let is_modified = modified(work_tree);
+
+    let version_json = format!(
+        r#"{{"commit":"{}","tag":"{}","branch":"{}","modified":{}}}"#,
+        commit_hash, tag_name, branch_name, is_modified
+    );
+
+    println!("cargo:rustc-env=MONAD_CLI_VERSION={}", version_json);
+}
+
+#[macro_export]
+macro_rules! version {
+    () => {
+        env!("MONAD_CLI_VERSION")
+    };
+}

--- a/monad-wal/Cargo.toml
+++ b/monad-wal/Cargo.toml
@@ -13,6 +13,9 @@ monad-types = { workspace = true }
 
 bytes = { workspace = true }
 
+[build-dependencies]
+monad-version = { workspace = true }
+
 [dev-dependencies]
 monad-bls = { workspace = true }
 monad-crypto = { workspace = true }
@@ -20,6 +23,7 @@ monad-eth-types = { workspace = true }
 monad-executor-glue = { workspace = true }
 monad-secp = { workspace = true }
 monad-types = { workspace = true }
+monad-version = { workspace = true }
 
 clap = { workspace = true, features = ["derive"] }
 criterion = { workspace = true }

--- a/monad-wal/build.rs
+++ b/monad-wal/build.rs
@@ -1,0 +1,25 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{env, path::Path};
+
+fn main() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let repo_root = Path::new(&manifest_dir)
+        .parent()
+        .expect("no parent directory");
+
+    monad_version::auto(repo_root);
+}

--- a/monad-wal/examples/wal2json.rs
+++ b/monad-wal/examples/wal2json.rs
@@ -32,7 +32,7 @@ use monad_wal::reader::{events_iter_in_range, events_iter_raw, WALReader, WALRea
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 #[derive(Parser, Debug)]
-#[command(long_about = "\
+#[command(name = "wal2json", version = monad_version::version!(), long_about = "\
 Selected timestamp formats
   excerpt from https://docs.rs/dateparser/latest/dateparser/index.html#accepted-date-formats
 


### PR DESCRIPTION
```
./target/debug/monad-keystore --version

monad-keystore {"commit":"0f2db414bbad61e5a3d8a4845e5e82c7c20bf3b8","tag":"test-again","branch":"dmitry/monad-node-version","modified":false}
```

i would remove binary name from the output, but this is done by clap and i can't overwrite that
and just using clap macro seems cleaner

fields (git command with env var fallback):
- commit: git rev-parse HEAD (or GIT_COMMIT env)
- tag: git describe --tags --exact-match HEAD (or GIT_TAG env)
- branch: git branch --show-current (or GIT_BRANCH env)
- modified: git status --porcelain (or GIT_MODIFIED env)

rebuild triggers if any of the following changes: .git/HEAD, .git/index, .git/refs

binaries updated: monad-node, monad-rpc, monad-keystore, wal2json, txgen

Edit: this PR closes https://github.com/category-labs/category-internal/issues/2052