### PR TITLE
monad-node-config: reuse default mtu from monad-dataplane

### DIFF
--- a/monad-dataplane/src/udp.rs
+++ b/monad-dataplane/src/udp.rs
@@ -98,7 +98,7 @@ impl PriorityQueues {
     }
 }
 
-pub const DEFAULT_MTU: u16 = ETHERNET_MTU;
+pub const DEFAULT_MTU: u16 = monad_types::DEFAULT_MTU;
 
 const IPV4_HDR_SIZE: u16 = 20;
 const UDP_HDR_SIZE: u16 = 8;
@@ -107,9 +107,7 @@ pub const fn segment_size_for_mtu(mtu: u16) -> u16 {
 }
 
 pub const DEFAULT_SEGMENT_SIZE: u16 = segment_size_for_mtu(DEFAULT_MTU);
-
-const ETHERNET_MTU: u16 = 1500;
-pub const ETHERNET_SEGMENT_SIZE: u16 = segment_size_for_mtu(ETHERNET_MTU);
+pub const ETHERNET_SEGMENT_SIZE: u16 = segment_size_for_mtu(monad_types::ETHERNET_MTU);
 
 fn configure_socket(socket: &UdpSocket, buffer_size: Option<usize>) {
     if let Some(size) = buffer_size {

--- a/monad-node-config/src/network.rs
+++ b/monad-node-config/src/network.rs
@@ -15,6 +15,7 @@
 
 use std::net::Ipv4Addr;
 
+use monad_types::DEFAULT_MTU;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
@@ -48,10 +49,8 @@ pub struct NodeNetworkConfig {
     pub tcp_rate_limit_burst: u32,
 }
 
-// When running in docker with vpnkit, the maximum safe MTU is 1480, as per:
-// https://github.com/moby/vpnkit/tree/v0.5.0/src/hostnet/slirp.ml#L17-L18
 fn default_mtu() -> u16 {
-    1480
+    DEFAULT_MTU
 }
 
 fn default_buffer_size() -> Option<usize> {

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -35,6 +35,9 @@ use zerocopy::IntoBytes;
 pub const GENESIS_SEQ_NUM: SeqNum = SeqNum(0);
 pub const GENESIS_ROUND: Round = Round(0);
 
+pub const ETHERNET_MTU: u16 = 1500;
+pub const DEFAULT_MTU: u16 = ETHERNET_MTU;
+
 const PROTOCOL_VERSION: u32 = 1;
 
 const CLIENT_MAJOR_VERSION: u16 = 0;


### PR DESCRIPTION
this doesn't backward compatibility, as long as configured mtu is not higher than ethernet mtu