### PR TITLE
dataplane: boost dataplane throughput with ringbuf implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5141,6 +5141,7 @@ name = "monad-dataplane"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "clap 4.5.47",
  "env_logger 0.10.2",
  "futures",
  "futures-util",
@@ -6479,8 +6480,7 @@ dependencies = [
 [[package]]
 name = "monoio"
 version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd0f8bcde87b1949f95338b547543fcab187bc7e7a5024247e359a5e828ba6a"
+source = "git+https://github.com/category-labs/monoio.git?tag=0.2.4-category#de97820bff58120407ced67b3b11e00550cd1598"
 dependencies = [
  "auto-const-array",
  "bytes",
@@ -6502,8 +6502,7 @@ dependencies = [
 [[package]]
 name = "monoio-macros"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176a5f5e69613d9e88337cf2a65e11135332b4efbcc628404a7c555e4452084c"
+source = "git+https://github.com/category-labs/monoio.git?tag=0.2.4-category#de97820bff58120407ced67b3b11e00550cd1598"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ libc = "0.2.153"
 lru = "0.12"
 lz4 = "1.28"
 mongodb = "3.2.1"
-monoio = { version = "0.2.4", features = ["sync"] }
+monoio = { git = "https://github.com/category-labs/monoio.git", tag = "0.2.4-category", features = ["sync", "iouring"] }
 notify = "6.1.1"
 ntest = "0.9"
 once_cell = "1.19.0"

--- a/monad-dataplane/Cargo.toml
+++ b/monad-dataplane/Cargo.toml
@@ -23,6 +23,7 @@ tracing = { workspace = true }
 zerocopy = { workspace = true }
 
 [dev-dependencies]
+clap = { workspace = true, features = ["derive"] }
 ntest = { workspace = true }
 rstest = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/monad-dataplane/examples/throughput.rs
+++ b/monad-dataplane/examples/throughput.rs
@@ -1,0 +1,414 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    net::{SocketAddr, UdpSocket},
+    os::unix::io::AsRawFd,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+use bytes::Bytes;
+use clap::{Parser, Subcommand};
+use futures::executor::block_on;
+use monad_dataplane::{DataplaneBuilder, UdpSocketConfig};
+use tracing::info;
+
+const UDP_SEGMENT: i32 = 103;
+const SOL_UDP: i32 = 17;
+
+extern "C" {
+    fn setsockopt(
+        socket: i32,
+        level: i32,
+        name: i32,
+        value: *const std::ffi::c_void,
+        option_len: u32,
+    ) -> i32;
+}
+
+#[derive(Parser)]
+#[command(name = "throughput")]
+#[command(about = "udp throughput test")]
+struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    #[command(alias = "w", about = "run gso-based udp writer")]
+    Writer {
+        #[arg(help = "target address to send packets to")]
+        target: String,
+
+        #[arg(
+            long,
+            default_value = "1",
+            help = "number of concurrent sender threads"
+        )]
+        writers: usize,
+
+        #[arg(
+            long,
+            default_value = "1472",
+            help = "packet size in bytes (max 1472 for standard MTU)"
+        )]
+        packet_size: usize,
+
+        #[arg(
+            long,
+            default_value = "44",
+            help = "burst size (number of packets per GSO send, max total 65536 bytes)"
+        )]
+        burst_size: usize,
+    },
+    #[command(alias = "nw", about = "run native dataplane writer")]
+    NativeWriter {
+        #[arg(help = "target address to send packets to")]
+        target: String,
+
+        #[arg(
+            long,
+            default_value = "1472",
+            help = "packet size in bytes (max 1472 for standard MTU)"
+        )]
+        packet_size: usize,
+
+        #[arg(
+            short = 'w',
+            long = "wb",
+            default_value = "1000",
+            help = "writer bandwidth in Mbps (megabits per second)"
+        )]
+        writer_bandwidth_mbps: u64,
+
+        #[arg(
+            short = 'd',
+            long = "db",
+            default_value = "10000",
+            help = "dataplane bandwidth limit in Mbps (should be >= writer bandwidth)"
+        )]
+        dataplane_bandwidth_mbps: u64,
+
+        #[arg(
+            long,
+            default_value = "128",
+            help = "number of messages to write before sleeping"
+        )]
+        batch_size: usize,
+    },
+    #[command(alias = "r", about = "run native udp reader")]
+    Reader {
+        #[arg(
+            long,
+            default_value = "0.0.0.0:19999",
+            help = "bind address for receiver"
+        )]
+        bind_addr: String,
+
+        #[arg(
+            short = 'm',
+            long,
+            default_value = "false",
+            help = "use multishot ringbuf receive"
+        )]
+        multishot: bool,
+    },
+}
+
+fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let args = Args::parse();
+
+    match args.command {
+        Command::Writer {
+            target,
+            writers,
+            packet_size,
+            burst_size,
+        } => {
+            let target_addr: SocketAddr = target.parse().expect("invalid target address");
+            run_writer(target_addr, writers, packet_size, burst_size);
+        }
+        Command::NativeWriter {
+            target,
+            packet_size,
+            writer_bandwidth_mbps,
+            dataplane_bandwidth_mbps,
+            batch_size,
+        } => {
+            let target_addr: SocketAddr = target.parse().expect("invalid target address");
+            run_native_writer(
+                target_addr,
+                packet_size,
+                writer_bandwidth_mbps,
+                dataplane_bandwidth_mbps,
+                batch_size,
+            );
+        }
+        Command::Reader {
+            bind_addr,
+            multishot,
+        } => {
+            let bind_addr: SocketAddr = bind_addr.parse().expect("invalid bind address");
+            run_native(bind_addr, multishot);
+        }
+    }
+}
+
+fn run_writer(target_addr: SocketAddr, num_writers: usize, packet_size: usize, burst_size: usize) {
+    assert!(
+        packet_size > 0 && packet_size <= 1472,
+        "packet_size must be between 1 and 1472 bytes"
+    );
+    assert!(burst_size > 0, "burst_size must be greater than 0");
+
+    let total_buffer_size = packet_size * burst_size;
+    assert!(
+        total_buffer_size < 65536,
+        "total buffer size (packet_size * burst_size = {}) must be less than 65536 bytes",
+        total_buffer_size
+    );
+    let msgs_sent = Arc::new(AtomicU64::new(0));
+
+    let mut writers = Vec::new();
+
+    for writer_id in 0..num_writers {
+        let msgs_sent_clone = msgs_sent.clone();
+
+        let writer = thread::spawn(move || {
+            let socket = UdpSocket::bind("0.0.0.0:0").expect("failed to bind writer socket");
+            socket.set_nonblocking(true).unwrap();
+
+            let send_buf_size = (total_buffer_size * 2).max(1024 * 1024);
+            unsafe {
+                let optval = send_buf_size as i32;
+                let ret = setsockopt(
+                    socket.as_raw_fd(),
+                    libc::SOL_SOCKET,
+                    libc::SO_SNDBUF,
+                    &optval as *const _ as *const std::ffi::c_void,
+                    std::mem::size_of_val(&optval) as u32,
+                );
+                if ret != 0 {
+                    eprintln!(
+                        "failed to set SO_SNDBUF: {}",
+                        std::io::Error::last_os_error()
+                    );
+                }
+            }
+
+            let gso_size = packet_size as u16;
+
+            unsafe {
+                let optval = gso_size as i32;
+                let ret = setsockopt(
+                    socket.as_raw_fd(),
+                    SOL_UDP,
+                    UDP_SEGMENT,
+                    &optval as *const _ as *const std::ffi::c_void,
+                    std::mem::size_of_val(&optval) as u32,
+                );
+                if ret != 0 {
+                    if writer_id == 0 {
+                        info!("gso not supported, falling back to regular sends");
+                    }
+                } else if writer_id == 0 {
+                    info!(
+                        packet_size = packet_size,
+                        burst_size = burst_size,
+                        total_buffer_size = total_buffer_size,
+                        gso_segment_size = gso_size,
+                        writers = num_writers,
+                        "gso enabled"
+                    );
+                }
+            }
+
+            let gso_buffer = vec![0u8; packet_size * burst_size];
+
+            let mut last_log = Instant::now();
+            let log_interval = Duration::from_secs(1);
+            let mut msgs_sent = 0u64;
+            let mut bytes_sent = 0u64;
+
+            loop {
+                match socket.send_to(&gso_buffer, target_addr) {
+                    Ok(_) => {
+                        msgs_sent_clone.fetch_add(burst_size as u64, Ordering::Relaxed);
+                        msgs_sent += burst_size as u64;
+                        bytes_sent += (packet_size * burst_size) as u64;
+
+                        let now = Instant::now();
+                        if now.duration_since(last_log) >= log_interval {
+                            let elapsed = now.duration_since(last_log).as_secs_f64();
+                            let msgs_per_sec = msgs_sent as f64 / elapsed;
+                            let mbps = (bytes_sent as f64 * 8.0) / elapsed / 1_000_000.0;
+
+                            info!(
+                                writer_id = writer_id,
+                                msgs_sent = msgs_sent,
+                                msgs_per_sec = format!("{:.0}", msgs_per_sec),
+                                mbps = format!("{:.2}", mbps),
+                                "writer throughput"
+                            );
+
+                            msgs_sent = 0;
+                            bytes_sent = 0;
+                            last_log = now;
+                        }
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::yield_now();
+                    }
+                    Err(e) => {
+                        eprintln!("writer {} send error: {}", writer_id, e);
+                        break;
+                    }
+                }
+            }
+        });
+
+        writers.push(writer);
+    }
+
+    for writer in writers {
+        writer.join().expect("writer thread panicked");
+    }
+}
+
+fn run_native_writer(
+    target_addr: SocketAddr,
+    packet_size: usize,
+    writer_bandwidth_mbps: u64,
+    dataplane_bandwidth_mbps: u64,
+    batch_size: usize,
+) {
+    assert!(
+        packet_size > 0 && packet_size <= 1472,
+        "packet_size must be between 1 and 1472 bytes"
+    );
+    assert!(
+        writer_bandwidth_mbps > 0,
+        "writer_bandwidth_mbps must be greater than 0"
+    );
+    assert!(
+        dataplane_bandwidth_mbps > 0,
+        "dataplane_bandwidth_mbps must be greater than 0"
+    );
+    assert!(batch_size > 0, "batch_size must be greater than 0");
+
+    let bind_addr: SocketAddr = "0.0.0.0:0".parse().unwrap();
+    info!(
+        bind_addr = %bind_addr,
+        target_addr = %target_addr,
+        packet_size = packet_size,
+        writer_bandwidth_mbps = writer_bandwidth_mbps,
+        dataplane_bandwidth_mbps = dataplane_bandwidth_mbps,
+        batch_size = batch_size,
+        "starting native dataplane writer"
+    );
+
+    let mut dataplane = DataplaneBuilder::new(&bind_addr, dataplane_bandwidth_mbps)
+        .extend_udp_sockets(vec![UdpSocketConfig {
+            socket_addr: bind_addr,
+            label: "writer".to_string(),
+        }])
+        .build();
+
+    dataplane
+        .block_until_ready(Duration::from_secs(5))
+        .then_some(())
+        .expect("dataplane not ready");
+
+    let udp_socket = dataplane
+        .take_udp_socket_handle("writer")
+        .expect("failed to get writer socket");
+
+    let writer = udp_socket.writer().clone();
+    let payload = Bytes::from(vec![0u8; packet_size]);
+
+    let sleep_duration_nanos =
+        (packet_size as u64 * batch_size as u64 * 8 * 1_000) / writer_bandwidth_mbps;
+    let sleep_duration = Duration::from_nanos(sleep_duration_nanos);
+
+    loop {
+        for _ in 0..batch_size {
+            writer.write(target_addr, payload.clone(), packet_size as u16);
+        }
+        thread::sleep(sleep_duration);
+    }
+}
+
+fn run_native(bind_addr: SocketAddr, multishot: bool) {
+    info!(addr = %bind_addr, multishot, "starting native dataplane reader");
+
+    let mut dataplane = DataplaneBuilder::new(&bind_addr, 10_000)
+        .with_udp_multishot(multishot)
+        .extend_udp_sockets(vec![UdpSocketConfig {
+            socket_addr: bind_addr,
+            label: "bench".to_string(),
+        }])
+        .build();
+
+    dataplane
+        .block_until_ready(Duration::from_secs(5))
+        .then_some(())
+        .expect("dataplane not ready");
+
+    let mut udp_socket = dataplane
+        .take_udp_socket_handle("bench")
+        .expect("failed to get bench socket");
+
+    let mut msgs_received = 0u64;
+    let mut bytes_received = 0u64;
+    let mut last_log = Instant::now();
+    let log_interval = Duration::from_secs(1);
+
+    loop {
+        let msg = block_on(udp_socket.recv());
+        msgs_received += 1;
+        bytes_received += msg.payload.len() as u64;
+
+        let now = Instant::now();
+        if now.duration_since(last_log) >= log_interval {
+            let elapsed = now.duration_since(last_log).as_secs_f64();
+            let msgs_per_sec = msgs_received as f64 / elapsed;
+            let mbps = (bytes_received as f64 * 8.0) / elapsed / 1_000_000.0;
+
+            info!(
+                msgs_received = msgs_received,
+                msgs_per_sec = format!("{:.0}", msgs_per_sec),
+                mbps = format!("{:.2}", mbps),
+                "native throughput stats"
+            );
+
+            msgs_received = 0;
+            bytes_received = 0;
+            last_log = now;
+        }
+    }
+}

--- a/monad-dataplane/src/lib.rs
+++ b/monad-dataplane/src/lib.rs
@@ -54,6 +54,7 @@ pub struct DataplaneBuilder {
     tcp_config: TcpConfig,
     ban_duration: Duration,
     udp_sockets: Vec<UdpSocketConfig>,
+    udp_multishot: bool,
 }
 
 impl DataplaneBuilder {
@@ -73,6 +74,7 @@ impl DataplaneBuilder {
             },
             ban_duration: Duration::from_secs(5 * 60), // 5 minutes
             udp_sockets: vec![],
+            udp_multishot: true,
         }
     }
 
@@ -104,6 +106,11 @@ impl DataplaneBuilder {
         self
     }
 
+    pub fn with_udp_multishot(mut self, enabled: bool) -> Self {
+        self.udp_multishot = enabled;
+        self
+    }
+
     pub fn build(self) -> Dataplane {
         let DataplaneBuilder {
             local_addr,
@@ -113,6 +120,7 @@ impl DataplaneBuilder {
             tcp_config,
             ban_duration,
             udp_sockets,
+            udp_multishot,
         } = self;
 
         let mut seen_labels = std::collections::HashSet::new();
@@ -183,6 +191,7 @@ impl DataplaneBuilder {
                                 udp_egress_rx,
                                 up_bandwidth_mbps,
                                 udp_buffer_size,
+                                udp_multishot,
                             );
 
                             ready_clone.store(true, Ordering::Release);

--- a/monad-node-config/src/network.rs
+++ b/monad-node-config/src/network.rs
@@ -51,6 +51,9 @@ pub struct NodeNetworkConfig {
 
     #[serde(default = "default_signature_verifications_per_second")]
     pub signature_verifications_per_second: u32,
+
+    #[serde(default = "default_enable_udp_mutishot")]
+    pub enable_udp_multishot: bool,
 }
 
 fn default_mtu() -> u16 {
@@ -84,4 +87,8 @@ fn default_tcp_rate_limit_burst() -> u32 {
 
 fn default_signature_verifications_per_second() -> u32 {
     4_000
+}
+
+fn default_enable_udp_mutishot() -> bool {
+    true
 }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -557,7 +557,8 @@ where
 
     let network_config = node_config.network;
 
-    let mut dp_builder = DataplaneBuilder::new(&bind_address, network_config.max_mbps.into());
+    let mut dp_builder = DataplaneBuilder::new(&bind_address, network_config.max_mbps.into())
+        .with_udp_multishot(network_config.enable_udp_multishot);
     if let Some(buffer_size) = network_config.buffer_size {
         dp_builder = dp_builder.with_udp_buffer_size(buffer_size);
     }

--- a/monad-raptorcast/examples/latency.rs
+++ b/monad-raptorcast/examples/latency.rs
@@ -599,6 +599,7 @@ fn setup_node(
         SocketAddr::V4(SocketAddrV4::new(bind_ip, my_config.udp_addr.port()));
 
     let dataplane = DataplaneBuilder::new(&tcp_addr, UDP_BW)
+        .with_udp_multishot(true)
         .extend_udp_sockets(vec![
             monad_dataplane::UdpSocketConfig {
                 socket_addr: authenticated_udp_addr,


### PR DESCRIPTION
monoio is using this change https://github.com/category-labs/monoio/pull/1 from category labs fork

if there are any regressions `enable_udp_multishot = false` will revert to original udp method.
i use this to check for any perf related regressions `sum(monad_bft_raptorcast_udp_primary_broadcast_latency_p99_ms{network="stressnet"}) by (instance, service_version)` 

general improvement in broadcast latency for 2MB blocks in my simulations

```
Overall Statistics Summary (g1 excluded):
================================================================================
                  Config  Count  Mean  Std   P50   p70   P90   P95   P99  P999   MAX
AUTH FIXED LOOP 2MB 20ms 94,615 260.0 30.2 260.8 278.8 299.3 305.9 320.6 357.5 410.6
   AUTH RINGBUF 2MB 20ms 39,402 250.4 30.2 251.0 269.9 290.3 297.0 308.9 333.2 367.1
````

throughput for small packets is x3-x4 to the baseline.

```
dshulyak@waw-002:~/monad-bft$ ./target/release/examples/throughput reader -m
2025-11-26T15:20:12.797546Z  INFO throughput: starting native dataplane reader addr=0.0.0.0:19999 multishot=true
2025-11-26T15:20:19.527103Z  INFO throughput: native throughput stats msgs_received=985344 msgs_per_sec="985169" mbps="7.88"
2025-11-26T15:20:20.527282Z  INFO throughput: native throughput stats msgs_received=1056000 msgs_per_sec="1055812" mbps="8.45"
2025-11-26T15:20:21.527440Z  INFO throughput: native throughput stats msgs_received=1124608 msgs_per_sec="1124431" mbps="9.00"
2025-11-26T15:20:22.527594Z  INFO throughput: native throughput stats msgs_received=1118208 msgs_per_sec="1118036" mbps="8.94"
2025-11-26T15:20:23.527744Z  INFO throughput: native throughput stats msgs_received=1111040 msgs_per_sec="1110873" mbps="8.89"
2025-11-26T15:20:24.527743Z  INFO throughput: native throughput stats msgs_received=894165 msgs_per_sec="894165" mbps="7.15"
2025-11-26T15:20:25.527876Z  INFO throughput: native throughput stats msgs_received=1039147 msgs_per_sec="1039010" mbps="8.31"
2025-11-26T15:20:26.528031Z  INFO throughput: native throughput stats msgs_received=869376 msgs_per_sec="869240" mbps="6.95"
2025-11-26T15:20:27.528201Z  INFO throughput: native throughput stats msgs_received=1106688 msgs_per_sec="1106500" mbps="8.85"
^C
dshulyak@waw-002:~/monad-bft$ ./target/release/examples/throughput reader
2025-11-26T15:20:30.271954Z  INFO throughput: starting native dataplane reader addr=0.0.0.0:19999 multishot=false
2025-11-26T15:20:31.273079Z  INFO throughput: native throughput stats msgs_received=323467 msgs_per_sec="323467" mbps="2.59"
2025-11-26T15:20:32.273081Z  INFO throughput: native throughput stats msgs_received=325493 msgs_per_sec="325492" mbps="2.60"
2025-11-26T15:20:33.273082Z  INFO throughput: native throughput stats msgs_received=356736 msgs_per_sec="356735" mbps="2.85"
2025-11-26T15:20:34.273086Z  INFO throughput: native throughput stats msgs_received=356345 msgs_per_sec="356344" mbps="2.85"
2025-11-26T15:20:35.273087Z  INFO throughput: native throughput stats msgs_received=357920 msgs_per_sec="357919" mbps="2.86"
2025-11-26T15:20:36.273091Z  INFO throughput: native throughput stats msgs_received=308160 msgs_per_sec="308159" mbps="2.47"
2025-11-26T15:20:37.273097Z  INFO throughput: native throughput stats msgs_received=310165 msgs_per_sec="310163" mbps="2.48"
2025-11-26T15:20:38.273099Z  INFO throughput: native throughput stats msgs_received=357409 msgs_per_sec="357409" mbps="2.86"
2025-11-26T15:20:39.273103Z  INFO throughput: native throughput stats msgs_received=308428 msgs_per_sec="308427" mbps="2.47"
2025-11-26T15:20:40.273106Z  INFO throughput: native throughput stats msgs_received=283969 msgs_per_sec="283968" mbps="2.27"
```