### PR TITLE
Archive: add require-traces archiver flag; indexer fallback source

### DIFF
--- a/monad-archive/src/bin/monad-archiver/cli.rs
+++ b/monad-archive/src/bin/monad-archiver/cli.rs
@@ -68,6 +68,10 @@ pub struct Cli {
     #[serde(default)]
     pub unsafe_skip_bad_blocks: bool,
 
+    #[serde(default)]
+    /// If set, archiver will require traces to be present for all blocks
+    pub require_traces: bool,
+
     /// Path to folder containing bft blocks
     /// If set, archiver will upload these files to blob store provided in archive_sink
     pub bft_block_path: Option<PathBuf>,
@@ -158,6 +162,7 @@ impl Cli {
             otel_endpoint,
             otel_replica_name_override,
             skip_connectivity_check,
+            require_traces,
         } = overrides;
 
         Ok(Self {
@@ -193,6 +198,7 @@ impl Cli {
             otel_endpoint,
             otel_replica_name_override,
             skip_connectivity_check: skip_connectivity_check.unwrap_or(false),
+            require_traces: require_traces.unwrap_or(false),
         })
     }
 
@@ -309,6 +315,10 @@ struct CliArgs {
     #[arg(long, action = ArgAction::SetTrue)]
     unsafe_skip_bad_blocks: bool,
 
+    /// If set, archiver will require traces to be present for all blocks
+    #[arg(long)]
+    require_traces: bool,
+
     /// Path to folder containing bft blocks
     /// If set, archiver will upload these files to blob store provided in archive_sink
     #[arg(long)]
@@ -392,6 +402,7 @@ impl CliArgs {
             otel_replica_name_override,
             skip_connectivity_check,
             unsafe_disable_normal_archiving,
+            require_traces,
         } = self;
 
         let overrides = CliOverrides {
@@ -417,6 +428,7 @@ impl CliArgs {
             otel_replica_name_override,
             skip_connectivity_check: bool_override(skip_connectivity_check),
             unsafe_disable_normal_archiving: bool_override(unsafe_disable_normal_archiving),
+            require_traces: bool_override(require_traces),
         };
 
         (config, overrides)
@@ -433,6 +445,7 @@ struct CliOverrides {
     start_block: Option<u64>,
     stop_block: Option<u64>,
     unsafe_skip_bad_blocks: Option<bool>,
+    require_traces: Option<bool>,
     bft_block_path: Option<PathBuf>,
     bft_block_poll_freq_secs: Option<u64>,
     bft_block_min_age_secs: Option<u64>,

--- a/monad-archive/src/bin/monad-indexer/cli.rs
+++ b/monad-archive/src/bin/monad-indexer/cli.rs
@@ -26,6 +26,10 @@ pub struct Cli {
     #[arg(long, value_parser = clap::value_parser!(BlockDataReaderArgs))]
     pub block_data_source: BlockDataReaderArgs,
 
+    /// If reading from --block-data-source fails, attempts to read from
+    /// this optional fallback
+    pub fallback_block_data_source: Option<BlockDataReaderArgs>,
+
     /// Where archive data is written to
     /// For aws: 'aws <bucket_name> <concurrent_requests>'
     #[arg(long, value_parser = clap::value_parser!(ArchiveArgs))]


### PR DESCRIPTION
Context:
Some archivers run on boxes where execution runs it `--trace_calls` and others without. This means that archiver does not fail and retry if it errored reading or pushing trace data and would silently allow a gap. This means some s3 buckets now have gaps in trace data

This change addresses two issues:
1. indexers can now have a fallback-block-data source just like archivers - if the primary source fails, it tries the secondary. This is useful for dealing with gaps in traces, and corrupt/missing data in general
2. Add `--require-traces` flag to archiver to indicate it should fail if archiving traces fails, just like blocks and receipts. This is important since network errors can be spurious even if traces are present in triedb