### PR TITLE
monad-raptorcast: add signature verification rate limit with authenticated peer bypass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5831,6 +5831,7 @@ dependencies = [
  "fixed",
  "futures",
  "futures-util",
+ "governor",
  "hex",
  "humantime",
  "indexmap 2.12.0",

--- a/monad-node-config/src/network.rs
+++ b/monad-node-config/src/network.rs
@@ -48,6 +48,9 @@ pub struct NodeNetworkConfig {
 
     #[serde(default = "default_tcp_rate_limit_burst")]
     pub tcp_rate_limit_burst: u32,
+
+    #[serde(default = "default_signature_verifications_per_second")]
+    pub signature_verifications_per_second: u32,
 }
 
 fn default_mtu() -> u16 {
@@ -77,4 +80,8 @@ fn default_tcp_rate_limit_rps() -> u32 {
 
 fn default_tcp_rate_limit_burst() -> u32 {
     200
+}
+
+fn default_signature_verifications_per_second() -> u32 {
+    4_000
 }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -708,6 +708,7 @@ where
             shared_key,
             mtu: network_config.mtu,
             udp_message_max_age_ms: network_config.udp_message_max_age_ms,
+            sig_verification_rate_limit: network_config.signature_verifications_per_second,
             primary_instance: RaptorCastConfigPrimary {
                 raptor10_redundancy: 2.5f32,
                 fullnode_dedicated: full_nodes

--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -28,6 +28,7 @@ bitvec = { workspace = true }
 bytes = { workspace = true }
 fixed = { workspace = true}
 futures = { workspace = true }
+governor = { workspace = true }
 hex = { workspace = true }
 indexmap = { workspace = true }
 iset = { workspace = true }

--- a/monad-raptorcast/benches/raptor_bench.rs
+++ b/monad-raptorcast/benches/raptor_bench.rs
@@ -121,10 +121,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .map(|(_to, message)| message)
         .collect_vec();
 
-        let example_chunk = parse_message::<SecpSignature>(
+        let example_chunk = parse_message::<SecpSignature, _>(
             &mut LruCache::new(SIGNATURE_CACHE_SIZE),
             messages[0].clone().split_to(DEFAULT_SEGMENT_SIZE.into()),
             u64::MAX,
+            |_| Ok(()),
         )
         .expect("valid chunk");
 
@@ -145,10 +146,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 let mut decode_success = false;
                 for mut message in messages {
                     while !message.is_empty() {
-                        let parsed_message = parse_message::<SecpSignature>(
+                        let parsed_message = parse_message::<SecpSignature, _>(
                             &mut signature_cache,
                             message.split_to(DEFAULT_SEGMENT_SIZE.into()),
                             u64::MAX,
+                            |_| Ok(()),
                         )
                         .expect("valid message");
                         decoder.received_encoded_symbol(

--- a/monad-raptorcast/examples/latency.rs
+++ b/monad-raptorcast/examples/latency.rs
@@ -272,6 +272,7 @@ fn create_raptorcast_config(keypair: Arc<KeyPair>) -> RaptorCastConfig<Signature
         shared_key: keypair,
         mtu: monad_dataplane::udp::DEFAULT_MTU,
         udp_message_max_age_ms: 5000,
+        sig_verification_rate_limit: 4_000,
         primary_instance: RaptorCastConfigPrimary::default(),
         secondary_instance: FullNodeRaptorCastConfig {
             enable_publisher: false,

--- a/monad-raptorcast/src/auth/mod.rs
+++ b/monad-raptorcast/src/auth/mod.rs
@@ -24,4 +24,4 @@ pub use metrics::{
     GAUGE_RAPTORCAST_AUTH_NON_AUTHENTICATED_UDP_BYTES_WRITTEN,
 };
 pub use protocol::{AuthenticationProtocol, NoopAuthProtocol, NoopHeader, WireAuthProtocol};
-pub use socket::{AuthenticatedSocketHandle, DualSocketHandle};
+pub use socket::{AuthRecvMsg, AuthenticatedSocketHandle, DualSocketHandle};

--- a/monad-raptorcast/src/config.rs
+++ b/monad-raptorcast/src/config.rs
@@ -38,6 +38,9 @@ where
     // Maximum age of UDP messages in milliseconds. Messages older than this will be rejected.
     pub udp_message_max_age_ms: u64,
 
+    /// Rate limit for signature verifications performed by raptorcast
+    pub sig_verification_rate_limit: u32,
+
     // The primary instance owns the receive side of the UDP traffic used for
     // raptorcast and hence is mandatory in all configuration cases.
     pub primary_instance: RaptorCastConfigPrimary<ST>,
@@ -59,6 +62,7 @@ where
             shared_key: self.shared_key.clone(),
             mtu: self.mtu,
             udp_message_max_age_ms: self.udp_message_max_age_ms,
+            sig_verification_rate_limit: self.sig_verification_rate_limit,
             primary_instance: self.primary_instance.clone(),
             secondary_instance: self.secondary_instance.clone(),
         }

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -215,7 +215,11 @@ where
 
             current_epoch,
 
-            udp_state: udp::UdpState::new(self_id, config.udp_message_max_age_ms),
+            udp_state: udp::UdpState::new(
+                self_id,
+                config.udp_message_max_age_ms,
+                config.sig_verification_rate_limit,
+            ),
 
             tcp_reader,
             tcp_writer,
@@ -565,6 +569,7 @@ where
         shared_key,
         mtu: DEFAULT_MTU,
         udp_message_max_age_ms: u64::MAX, // No timestamp validation for tests
+        sig_verification_rate_limit: 10_000,
         primary_instance: Default::default(),
         secondary_instance: FullNodeRaptorCastConfig {
             enable_publisher: false,
@@ -641,6 +646,7 @@ where
         shared_key: shared_key.clone(),
         mtu: DEFAULT_MTU,
         udp_message_max_age_ms: u64::MAX,
+        sig_verification_rate_limit: 10_000,
         primary_instance: Default::default(),
         secondary_instance: FullNodeRaptorCastConfig {
             enable_publisher: false,

--- a/monad-raptorcast/src/metrics.rs
+++ b/monad-raptorcast/src/metrics.rs
@@ -23,6 +23,9 @@ pub const GAUGE_RAPTORCAST_TOTAL_MESSAGES_RECEIVED: &str =
     "monad.raptorcast.total_messages_received";
 pub const GAUGE_RAPTORCAST_TOTAL_RECV_ERRORS: &str = "monad.raptorcast.total_recv_errors";
 
+pub const GAUGE_RAPTORCAST_DECODING_CACHE_SIGNATURE_VERIFICATIONS_RATE_LIMITED: &str =
+    "monad.raptorcast.decoding_cache.signature_verifications_rate_limited";
+
 const HISTOGRAM_CLEAR_INTERVAL: Duration = Duration::from_secs(30);
 
 pub const PRIMARY_BROADCAST_LATENCY_P99_MS: &str =
@@ -112,6 +115,10 @@ impl UdpStateMetrics {
 
     pub fn executor_metrics(&self) -> &ExecutorMetrics {
         &self.executor_metrics
+    }
+
+    pub fn executor_metrics_mut(&mut self) -> &mut ExecutorMetrics {
+        &mut self.executor_metrics
     }
 }
 

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -335,6 +335,7 @@ where
                             shared_key,
                             mtu: DEFAULT_MTU,
                             udp_message_max_age_ms: u64::MAX,
+                            sig_verification_rate_limit: 10_000,
                             primary_instance: Default::default(),
                             secondary_instance: FullNodeRaptorCastConfig {
                                 enable_publisher: false,


### PR DESCRIPTION
we apply rate limiting of 4000 new sig verifications with a bypass for validator, based on auth information.
on stressnet normal rate is ~200 sigs/s, so 4000 is significantly higher than what we can expect.

verified that with this limit in place i can't starve raptorcast thread using my spam scripts, cpu usage peak around 50% and i am unable to prevent a node from participating in consensus.