### PR TITLE
fix cargo-shear 1.6.5 failures on unrelated prs

### DIFF
--- a/monad-dataplane/Cargo.toml
+++ b/monad-dataplane/Cargo.toml
@@ -12,13 +12,10 @@ bench = false
 monad-types = { workspace = true }
 
 bytes = { workspace = true }
-env_logger = { workspace = true }
 futures = { workspace = true }
-futures-util = { workspace = true }
 governor = { workspace = true }
 libc = { workspace = true }
 monoio = { workspace = true }
-rand = { workspace = true }
 socket2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
@@ -29,3 +26,6 @@ zerocopy = { workspace = true }
 ntest = { workspace = true }
 rstest = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+env_logger = { workspace = true }
+rand = { workspace = true }
+futures-util = { workspace = true }

--- a/monad-eth-testutil/Cargo.toml
+++ b/monad-eth-testutil/Cargo.toml
@@ -26,7 +26,6 @@ alloy-primitives = { workspace = true }
 alloy-signer = { workspace = true }
 alloy-signer-local = { workspace = true }
 rand = { workspace = true }
-tokio-tungstenite = { workspace = true, features = ["native-tls"]}
 
 [build-dependencies]
 monad-version = { workspace = true }
@@ -69,3 +68,4 @@ tracing-subscriber = { workspace = true, features = [
 ] }
 url = { workspace = true }
 monad-version = { workspace = true }
+tokio-tungstenite = { workspace = true, features = ["native-tls"]}

--- a/monad-mock-swarm/Cargo.toml
+++ b/monad-mock-swarm/Cargo.toml
@@ -14,7 +14,6 @@ monad-chain-config = { workspace = true }
 monad-consensus = { workspace = true }
 monad-consensus-types = { workspace = true }
 monad-crypto = { workspace = true }
-monad-eth-types = { workspace = true }
 monad-executor = { workspace = true }
 monad-executor-glue = { workspace = true }
 monad-multi-sig = { workspace = true }
@@ -53,6 +52,7 @@ serde_json = { workspace = true }
 test-case = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+monad-eth-types = { workspace = true }
 
 [[bench]]
 name = "two_node_benchmark"

--- a/monad-peer-disc-swarm/Cargo.toml
+++ b/monad-peer-disc-swarm/Cargo.toml
@@ -11,8 +11,6 @@ monad-peer-discovery = { workspace = true }
 monad-router-scheduler = { workspace = true }
 monad-transformer = { workspace = true }
 monad-types = { workspace = true }
-
-alloy-rlp = { workspace = true }
 itertools = { workspace = true }
 priority-queue = { workspace = true }
 rand = { workspace = true }
@@ -22,3 +20,4 @@ tracing = { workspace = true }
 [dev-dependencies]
 monad-testutil = { workspace = true }
 tracing-test = { workspace = true, features = ["no-env-filter"] }
+alloy-rlp = { workspace = true }


### PR DESCRIPTION
move test-only dependencies to dev-dependencies to pass cargo-shear 1.6.5 checks

example https://github.com/category-labs/monad-bft/actions/runs/19636028246/job/56226838375?pr=2602