### PR TITLE
Archive: async backfill; only traces archive

### DIFF
--- a/monad-archive/src/archive_reader.rs
+++ b/monad-archive/src/archive_reader.rs
@@ -30,6 +30,8 @@ use crate::{
 pub enum LatestKind {
     Uploaded,
     Indexed,
+    UploadedAsyncBackfill,
+    IndexedAsyncBackfill,
 }
 
 #[derive(Clone)]
@@ -204,9 +206,9 @@ impl ArchiveReader {
 }
 
 impl IndexReader for ArchiveReader {
-    async fn get_latest_indexed(&self) -> Result<Option<u64>> {
+    async fn get_latest_indexed(&self, async_backfill: bool) -> Result<Option<u64>> {
         self.index_executor
-            .execute(|idx| idx.get_latest_indexed())
+            .execute(|idx| idx.get_latest_indexed(async_backfill))
             .await
     }
 

--- a/monad-archive/src/bin/monad-archiver/main.rs
+++ b/monad-archive/src/bin/monad-archiver/main.rs
@@ -132,6 +132,8 @@ async fn main() -> Result<()> {
         stop_block: args.stop_block,
         unsafe_skip_bad_blocks: args.unsafe_skip_bad_blocks,
         require_traces: args.require_traces,
+        traces_only: args.traces_only,
+        async_backfill: args.async_backfill,
     };
 
     if !args.unsafe_disable_normal_archiving {

--- a/monad-archive/src/bin/monad-block-writer/main.rs
+++ b/monad-archive/src/bin/monad-block-writer/main.rs
@@ -141,11 +141,11 @@ async fn main() -> Result<()> {
         // Collect failed blocks for retry
         for result in results {
             match result {
-                Ok((block_num, Ok(()))) => {
+                Ok((_block_num, Ok(()))) => {
                     // Success - no retry needed
                 }
                 Ok((block_num, Err(e))) => {
-                    error!("Failed to process block {}: {:?}", block_num, e);
+                    error!("Failed to process block {block_num}: {e:?}");
                     if attempt < max_retries {
                         failed_blocks.push(block_num);
                     } else {

--- a/monad-archive/src/bin/monad-indexer/cli.rs
+++ b/monad-archive/src/bin/monad-indexer/cli.rs
@@ -35,6 +35,11 @@ pub struct Cli {
     #[arg(long, value_parser = clap::value_parser!(ArchiveArgs))]
     pub archive_sink: ArchiveArgs,
 
+    /// If set, indexer will perform an asynchronous backfill of the index
+    /// This allows a second indexer to backfill a range while the first indexer is running
+    #[arg(long, default_value_t = false)]
+    pub async_backfill: bool,
+
     #[arg(long, default_value_t = 50)]
     pub max_blocks_per_iteration: u64,
 

--- a/monad-archive/src/bin/monad-indexer/main.rs
+++ b/monad-archive/src/bin/monad-indexer/main.rs
@@ -86,7 +86,7 @@ async fn run_indexer(args: cli::Cli) -> Result<()> {
 
     // for testing
     if args.reset_index {
-        tx_index_archiver.update_latest_indexed(0).await?;
+        tx_index_archiver.update_latest_indexed(0, false).await?;
     }
 
     // tokio main should not await futures directly, so we spawn a worker
@@ -101,6 +101,7 @@ async fn run_indexer(args: cli::Cli) -> Result<()> {
         args.start_block,
         args.stop_block,
         Duration::from_millis(500),
+        args.async_backfill,
     ))
     .await
     .map_err(Into::into)

--- a/monad-archive/src/model/block_data_archive.rs
+++ b/monad-archive/src/model/block_data_archive.rs
@@ -49,6 +49,8 @@ pub struct BlockDataArchive {
 
     pub latest_uploaded_table_key: &'static str,
     pub latest_indexed_table_key: &'static str,
+    pub latest_uploaded_async_backfill_table_key: &'static str,
+    pub latest_indexed_async_backfill_table_key: &'static str,
     pub block_table_prefix: &'static str,
     pub block_hash_table_prefix: &'static str,
     pub receipts_table_prefix: &'static str,
@@ -64,6 +66,8 @@ impl BlockDataReader for BlockDataArchive {
         let key = match latest_kind {
             LatestKind::Uploaded => &self.latest_uploaded_table_key,
             LatestKind::Indexed => &self.latest_indexed_table_key,
+            LatestKind::UploadedAsyncBackfill => &self.latest_uploaded_async_backfill_table_key,
+            LatestKind::IndexedAsyncBackfill => &self.latest_indexed_async_backfill_table_key,
         };
 
         let value = match self
@@ -215,6 +219,8 @@ impl BlockDataArchive {
             traces_table_prefix: "traces",
             latest_uploaded_table_key: "latest",
             latest_indexed_table_key: "latest_indexed",
+            latest_uploaded_async_backfill_table_key: "latest_uploaded_async_backfill",
+            latest_indexed_async_backfill_table_key: "latest_indexed_async_backfill",
         }
     }
 
@@ -249,6 +255,8 @@ impl BlockDataArchive {
         let key = match latest_kind {
             LatestKind::Uploaded => &self.latest_uploaded_table_key,
             LatestKind::Indexed => &self.latest_indexed_table_key,
+            LatestKind::UploadedAsyncBackfill => &self.latest_uploaded_async_backfill_table_key,
+            LatestKind::IndexedAsyncBackfill => &self.latest_indexed_async_backfill_table_key,
         };
         let latest_value = format!("{:0width$}", block_num, width = BLOCK_PADDING_WIDTH);
         self.store.put(key, latest_value.as_bytes().to_vec()).await

--- a/monad-rpc/src/chainstate/mod.rs
+++ b/monad-rpc/src/chainstate/mod.rs
@@ -896,7 +896,7 @@ async fn get_logs_with_index(
         .wrap_err("Log index reader not present")?;
 
     let latest_indexed_tx = reader
-        .get_latest_indexed()
+        .get_latest_indexed(false)
         .await?
         .wrap_err("Latest indexed tx not found")?;
 


### PR DESCRIPTION
2 features related to backfilling traces quickly
1. `--traces-only` archiver flag allows skipping blocks and receipts and only uploading traces. This avoids clobbering correct blocks and receipts as well as speeding up the backfill process.
2. `--async-backfill` archiver and indexer flag allows a second process to backfill a given range while the first (main) process continues to process the chain tip. This is useful for RPC operators so that they do not have downtime

Copilot description arguably better:

> This PR adds two new features to the monad-archive system: asynchronous backfill capability and traces-only archiving mode. The async backfill feature allows a second archiver/indexer to backfill a historical range while the primary one continues processing new blocks, using separate tracking keys to avoid conflicts. The traces-only mode enables archiving block traces without storing blocks or receipts.
> 
> Key Changes
> Added async_backfill and traces_only configuration options with corresponding CLI flags
> Introduced new LatestKind enum variants (UploadedAsyncBackfill, IndexedAsyncBackfill) to track async backfill progress separately
> Updated archive and index workers to conditionally skip block/receipt operations when in traces-only mode