### PR TITLE
RPC: allow rpc to run without monad-bft

### DIFF
--- a/monad-rpc/src/cli.rs
+++ b/monad-rpc/src/cli.rs
@@ -21,8 +21,9 @@ use clap::Parser;
 #[command(name = "monad-rpc", about, long_about = None, version = monad_version::version!())]
 pub struct Cli {
     /// Set the mempool ipc path
+    /// If not set, the tx pool will be disabled.
     #[arg(long)]
-    pub ipc_path: PathBuf,
+    pub ipc_path: Option<PathBuf>,
 
     /// Set the monad triedb path
     #[arg(long)]

--- a/monad-rpc/src/handlers/mod.rs
+++ b/monad-rpc/src/handlers/mod.rs
@@ -411,9 +411,12 @@ async fn eth_sendRawTransaction(
     app_state: &MonadRpcResources,
     params: RequestParams<'_>,
 ) -> Result<Box<RawValue>, JsonRpcError> {
+    let Some(txpool_bridge_client) = &app_state.txpool_bridge_client else {
+        return Err(JsonRpcError::method_not_supported());
+    };
     let params = serde_json::from_str(params.get()).invalid_params()?;
     monad_eth_sendRawTransaction(
-        &app_state.txpool_bridge_client,
+        txpool_bridge_client,
         params,
         app_state.chain_id,
         app_state.allow_unprotected_txs,
@@ -428,12 +431,16 @@ async fn eth_sendRawTransactionSync(
     app_state: &MonadRpcResources,
     params: RequestParams<'_>,
 ) -> Result<Box<RawValue>, JsonRpcError> {
+    let Some(txpool_bridge_client) = &app_state.txpool_bridge_client else {
+        return Err(JsonRpcError::method_not_supported());
+    };
+
     // Require both chain_state and txpool_bridge_client
     let chain_state = app_state.chain_state.as_ref().method_not_supported()?;
     let params = serde_json::from_str(params.get()).invalid_params()?;
 
     monad_eth_sendRawTransactionSync(
-        &app_state.txpool_bridge_client,
+        txpool_bridge_client,
         chain_state,
         params,
         app_state.chain_id,
@@ -841,8 +848,11 @@ async fn txpool_statusByHash(
     app_state: &MonadRpcResources,
     params: RequestParams<'_>,
 ) -> Result<Box<RawValue>, JsonRpcError> {
+    let Some(txpool_bridge_client) = &app_state.txpool_bridge_client else {
+        return Err(JsonRpcError::method_not_supported());
+    };
     let params = serde_json::from_str(params.get()).invalid_params()?;
-    monad_txpool_statusByHash(&app_state.txpool_bridge_client, params)
+    monad_txpool_statusByHash(txpool_bridge_client, params)
         .await
         .map(serialize_result)?
 }
@@ -853,8 +863,11 @@ async fn txpool_statusByAddress(
     app_state: &MonadRpcResources,
     params: RequestParams<'_>,
 ) -> Result<Box<RawValue>, JsonRpcError> {
+    let Some(txpool_bridge_client) = &app_state.txpool_bridge_client else {
+        return Err(JsonRpcError::method_not_supported());
+    };
     let params = serde_json::from_str(params.get()).invalid_params()?;
-    monad_txpool_statusByAddress(&app_state.txpool_bridge_client, params)
+    monad_txpool_statusByAddress(txpool_bridge_client, params)
         .await
         .map(serialize_result)?
 }

--- a/monad-rpc/src/handlers/resources.rs
+++ b/monad-rpc/src/handlers/resources.rs
@@ -34,7 +34,7 @@ use crate::{
 
 #[derive(Clone)]
 pub struct MonadRpcResources {
-    pub txpool_bridge_client: EthTxPoolBridgeClient,
+    pub txpool_bridge_client: Option<EthTxPoolBridgeClient>,
     pub triedb_reader: Option<TriedbEnv>,
     pub eth_call_executor: Option<Arc<EthCallExecutor>>,
     pub eth_call_executor_fibers: usize,
@@ -62,7 +62,7 @@ pub struct MonadRpcResources {
 
 impl MonadRpcResources {
     pub fn new(
-        txpool_bridge_client: EthTxPoolBridgeClient,
+        txpool_bridge_client: Option<EthTxPoolBridgeClient>,
         triedb_reader: Option<TriedbEnv>,
         eth_call_executor: Option<Arc<EthCallExecutor>>,
         eth_call_executor_fibers: usize,

--- a/monad-rpc/src/websocket/handler.rs
+++ b/monad-rpc/src/websocket/handler.rs
@@ -674,7 +674,7 @@ mod tests {
             EventServer::start_for_testing_with_delay(snapshot, Duration::from_secs(1));
 
         let app_state = MonadRpcResources {
-            txpool_bridge_client: EthTxPoolBridgeClient::for_testing(),
+            txpool_bridge_client: Some(EthTxPoolBridgeClient::for_testing()),
             triedb_reader: None,
             eth_call_executor: None,
             eth_call_executor_fibers: 64,


### PR DESCRIPTION
This is useful for genesis replay boxes. The current solution involves spoofing the ipc path and sending a bincode serialized empty HashSet through before closing - this is clearly not ideal and should not be part of the instructions given to external operators.