### PR TITLE
Archive: remove --start-block from daemons, require imperative cli to set

### DIFF
--- a/monad-archive/src/bin/monad-block-writer/cli.rs
+++ b/monad-archive/src/bin/monad-block-writer/cli.rs
@@ -57,13 +57,29 @@ pub struct SharedArgs {
 pub enum Mode {
     WriteRange(WriteRangeArgs),
     Stream(StreamArgs),
+    /// Set the start block marker and exit.
+    /// Use this instead of --start-block to safely configure the starting point.
+    SetStartBlock {
+        /// Block number to set as the latest marker
+        #[arg(long)]
+        block: u64,
+
+        /// Destination path where the latest marker will be written
+        #[arg(long)]
+        dest_path: PathBuf,
+    },
 }
 
 impl Mode {
+    /// Returns the shared args for modes that have them.
+    /// Panics if called on SetStartBlock (handle that case separately before calling this).
     pub fn shared(&self) -> &SharedArgs {
         match self {
             Mode::WriteRange(args) => &args.shared_args,
             Mode::Stream(args) => &args.shared_args,
+            Mode::SetStartBlock { .. } => {
+                panic!("SetStartBlock does not have shared args - handle it separately")
+            }
         }
     }
 }
@@ -72,10 +88,6 @@ impl Mode {
 pub struct StreamArgs {
     #[command(flatten)]
     pub shared_args: SharedArgs,
-
-    /// Start block override
-    #[arg(long)]
-    pub start_block: Option<u64>,
 
     /// Sleep seconds between blocks
     #[arg(long, default_value = "1.0")]

--- a/monad-archive/src/bin/monad-indexer/cli.rs
+++ b/monad-archive/src/bin/monad-indexer/cli.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use clap::{Parser, Subcommand};
+use clap::{ArgAction, Parser, Subcommand};
 use monad_archive::cli::{ArchiveArgs, BlockDataReaderArgs};
 
 #[derive(Debug, Parser)]
@@ -51,10 +51,6 @@ pub struct Cli {
     #[arg(long, default_value_t = false)]
     pub reset_index: bool,
 
-    /// Override block number to start at
-    #[arg(long)]
-    pub start_block: Option<u64>,
-
     /// Override block number to stop at
     #[arg(long)]
     pub stop_block: Option<u64>,
@@ -83,7 +79,14 @@ pub struct Cli {
 #[derive(Debug, Subcommand)]
 pub enum Commands {
     /// Migrate logs index
-    MigrateLogs,
+    MigrateLogs {
+        /// Block number to start migration from (default: 0)
+        #[arg(long, default_value_t = 0)]
+        start_block: u64,
+        /// Block number to stop migration at (default: latest indexed)
+        #[arg(long)]
+        stop_block: Option<u64>,
+    },
     /// Migrate capped collection to uncapped
     MigrateCapped {
         /// Database name
@@ -98,5 +101,20 @@ pub enum Commands {
         /// Free space factor
         #[arg(long, default_value_t = 1.5)]
         free_factor: f64,
+    },
+    /// Set the start block marker in the archive and exit.
+    /// Use this instead of --start-block to safely configure the starting point.
+    SetStartBlock {
+        /// Block number to set as the latest indexed marker
+        #[arg(long)]
+        block: u64,
+
+        /// Archive sink to write the marker to
+        #[arg(long, value_parser = clap::value_parser!(ArchiveArgs))]
+        archive_sink: ArchiveArgs,
+
+        /// Set the async-backfill marker instead of the primary marker
+        #[arg(long, action = ArgAction::SetTrue)]
+        async_backfill: bool,
     },
 }

--- a/monad-archive/src/bin/monad-indexer/migrate_logs.rs
+++ b/monad-archive/src/bin/monad-indexer/migrate_logs.rs
@@ -16,7 +16,11 @@
 use futures::TryStreamExt;
 use monad_archive::{model::logs_index::LogsIndexArchiver, prelude::*};
 
-pub async fn run_migrate_logs(args: crate::cli::Cli) -> Result<()> {
+pub async fn run_migrate_logs(
+    args: crate::cli::Cli,
+    start_block: u64,
+    stop_block_override: Option<u64>,
+) -> Result<()> {
     let metrics = Metrics::none();
 
     let block_data_reader = args.block_data_source.build(&metrics).await?;
@@ -31,9 +35,8 @@ pub async fn run_migrate_logs(args: crate::cli::Cli) -> Result<()> {
             .await
             .wrap_err("Failed to create log index reader")?;
 
-    let start_block = args.start_block.unwrap_or(0);
     // If stop block not set, query block data reader for latest
-    let stop_block = if let Some(stop_block) = args.stop_block {
+    let stop_block = if let Some(stop_block) = stop_block_override {
         stop_block
     } else {
         block_data_reader


### PR DESCRIPTION
Operators leaving --start-block in their systemd overrides and forgetting to remove it has caused issues many times. When the service starts up the second time, the flag causes the daemon to overrite the 'latest' flag a second time and effectively loses a lot of progress.

This change instroduces a dedicated subcommand that operators imperatively set from their shell instead of modifying the daemon systemd overrides. This removes this class of operator error.