### PR TITLE
Remove unmatched parenthesis in doc comments

### DIFF
--- a/monad-tfm/src/base_fee.rs
+++ b/monad-tfm/src/base_fee.rs
@@ -80,7 +80,7 @@ pub fn compute_base_fee(
 /// Computes an approximate `factor * e ** (numerator / denominator)` using
 /// taylor expansion
 ///
-/// based on https://eips.ethereum.org/EIPS/eip-4844#helpers) and modified to
+/// based on https://eips.ethereum.org/EIPS/eip-4844#helpers and modified to
 /// accept negative numerator
 ///
 /// # Parameters


### PR DESCRIPTION
small typo I noticed while reading through.

farming potential airdrops too.