### PR TITLE
wireauth: increase replay window to size and debugability qol

### DIFF
--- a/monad-raptorcast/src/auth/socket.rs
+++ b/monad-raptorcast/src/auth/socket.rs
@@ -26,7 +26,7 @@ use monad_dataplane::{RecvUdpMsg, UdpSocketHandle, UnicastMsg};
 use monad_executor::{ExecutorMetrics, ExecutorMetricsChain};
 use monad_types::UdpPriority;
 use tokio::time::Sleep;
-use tracing::{trace, warn};
+use tracing::{debug, trace, warn};
 use zerocopy::IntoBytes;
 
 use super::{
@@ -251,7 +251,7 @@ where
                     continue;
                 }
                 Err(e) => {
-                    trace!(addr=?message.src_addr, error=?e, "failed to decrypt message");
+                    debug!(addr=?message.src_addr, error=?e, "failed to decrypt message");
                     return Err(e);
                 }
             }

--- a/monad-wireauth/README.md
+++ b/monad-wireauth/README.md
@@ -113,7 +113,10 @@ session_decrypt         time:   [166.11 ns 168.75 ns 171.20 ns]
 | metric | description |
 |--------|-------------|
 | `monad.wireauth.error.connect` | failed connection attempts (no memory, duplicate, etc) |
-| `monad.wireauth.error.decrypt` | decryption failures (bad auth tag, replay, no session) |
+| `monad.wireauth.error.decrypt` | total decryption failures (includes all decrypt error subtypes) |
+| `monad.wireauth.error.decrypt.nonce_outside_window` | packet counter outside replay window (too old) |
+| `monad.wireauth.error.decrypt.nonce_duplicate` | duplicate packet counter detected (replay attack) |
+| `monad.wireauth.error.decrypt.mac` | chacha20poly1305 mac authentication tag verification failed |
 | `monad.wireauth.error.encrypt_by_public_key` | encryption failures when looking up by public key |
 | `monad.wireauth.error.encrypt_by_socket` | encryption failures when looking up by socket address |
 | `monad.wireauth.error.dispatch_control` | control message processing failures |

--- a/monad-wireauth/src/metrics.rs
+++ b/monad-wireauth/src/metrics.rs
@@ -64,6 +64,11 @@ pub const GAUGE_WIREAUTH_DISPATCH_KEEPALIVE: &str = "monad.wireauth.dispatch.kee
 
 pub const GAUGE_WIREAUTH_ERROR_CONNECT: &str = "monad.wireauth.error.connect";
 pub const GAUGE_WIREAUTH_ERROR_DECRYPT: &str = "monad.wireauth.error.decrypt";
+pub const GAUGE_WIREAUTH_ERROR_DECRYPT_NONCE_OUTSIDE_WINDOW: &str =
+    "monad.wireauth.error.decrypt.nonce_outside_window";
+pub const GAUGE_WIREAUTH_ERROR_DECRYPT_NONCE_DUPLICATE: &str =
+    "monad.wireauth.error.decrypt.nonce_duplicate";
+pub const GAUGE_WIREAUTH_ERROR_DECRYPT_MAC: &str = "monad.wireauth.error.decrypt.mac";
 pub const GAUGE_WIREAUTH_ERROR_ENCRYPT_BY_PUBLIC_KEY: &str =
     "monad.wireauth.error.encrypt_by_public_key";
 pub const GAUGE_WIREAUTH_ERROR_ENCRYPT_BY_SOCKET: &str = "monad.wireauth.error.encrypt_by_socket";

--- a/monad-wireauth/src/session/common.rs
+++ b/monad-wireauth/src/session/common.rs
@@ -69,8 +69,10 @@ pub enum SessionError {
     InvalidMac(#[source] crate::protocol::errors::CryptoError),
     #[error("cookie validation failed: {0}")]
     InvalidCookie(#[source] crate::protocol::errors::CookieError),
-    #[error("replay detected: packet counter {counter} already seen")]
-    NonceReplay { counter: u64 },
+    #[error("counter {counter} is outside replay window (next={next})")]
+    NonceOutsideWindow { counter: u64, next: u64 },
+    #[error("duplicate counter {counter} detected")]
+    NonceDuplicate { counter: u64 },
 }
 
 pub struct SessionState {


### PR DESCRIPTION
increased tolerated reordering up to 8192 packets, the downside is memory per session, but it is still bounded to 1GB with 100_000 session limit.

beside that some log level were increased and added more metrics to differentiate different decrypt failures