### PR TITLE
raptorcast: update timer after receiving control messages

### DIFF
--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -941,8 +941,6 @@ where
             return Poll::Ready(Some(event.into()));
         }
 
-        while let Poll::Ready(()) = pin!(this.dual_socket.timer()).poll_unpin(cx) {}
-
         loop {
             let message = {
                 let mut sock = pin!(this.dual_socket.recv());


### PR DESCRIPTION
in original code i was polling timer before receiving messages from socket, 
it could lead to premature termination of the idle session as timer may not be updated after session is established (after receiving messages), it could prevent it from sending keapalives on time, if raptorcast stream wasn't polled for other reasons.

in this change i polls timer again in select! after receiving messages

discovered that in simulation MAX was unreasonably high, thats because session had to be re-established sometimes in the middle of the benchmark

```
Overall Statistics Summary (g1 excluded):
================================================================================
                  Config  Count  Mean  Std   P50   p70   P90   P95   P99  P999   MAX
     AUTH DEBUG 2MB 20ms 43,861 260.7 30.9 261.5 279.5 299.6 306.3 321.8 391.1 508.9
AUTH FIXED LOOP 2MB 20ms 89,272 260.0 30.3 260.9 278.8 299.3 306.0 320.7 359.0 410.6
``` 