### PR TITLE
ConfirmGroup message fix

### DIFF
--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -1370,6 +1370,7 @@ where
         }
         FullNodesGroupMessage::PrepareGroupResponse(msg) => &msg.node_id == sender,
         FullNodesGroupMessage::ConfirmGroup(msg) => &msg.prepare.validator_id == sender,
+        FullNodesGroupMessage::NoConfirm(msg) => &msg.prepare.validator_id == sender,
     }
 }
 

--- a/monad-raptorcast/src/raptorcast_secondary/client.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/client.rs
@@ -28,7 +28,10 @@ use super::{
     super::config::RaptorCastConfigSecondaryClient,
     group_message::{ConfirmGroup, PrepareGroup, PrepareGroupResponse},
 };
-use crate::util::{SecondaryGroup, SecondaryGroupAssignment};
+use crate::{
+    raptorcast_secondary::group_message::NoConfirm,
+    util::{SecondaryGroup, SecondaryGroupAssignment},
+};
 
 monad_executor::metric_consts! {
     pub CLIENT_NUM_CURRENT_GROUPS {
@@ -335,21 +338,23 @@ where
             return false;
         };
 
-        let maybe_entry = invites.get(&confirm_msg.prepare.validator_id);
-        let Some(old_invite) = maybe_entry else {
+        // TODO: discount validator reputation if it has sent an invalid
+        // ConfirmGroup
+        let Some(accepted_invite) = invites.get(&confirm_msg.prepare.validator_id) else {
             warn!(
+                ?confirm_msg,
                 "RaptorCastSecondary ignoring ConfirmGroup from \
-                            unrecognized validator id: {:?}",
-                confirm_msg
+                            unrecognized validator id"
             );
             return false;
         };
 
-        if old_invite != &confirm_msg.prepare {
+        if accepted_invite != &confirm_msg.prepare {
             warn!(
-                "RaptorCastSecondary ignoring ConfirmGroup that \
-                                doesn't match the original invite. Expected: {:?}, got: {:?}",
-                old_invite, confirm_msg.prepare
+                ?accepted_invite,
+                confirming_invite = ?confirm_msg.prepare,
+                "RaptorCastSecondary dropping ConfirmGroup that \
+                                doesn't match the original invite"
             );
             return false;
         }
@@ -357,21 +362,27 @@ where
         let confirm_group_size = confirm_msg.peers.len();
         if confirm_group_size > confirm_msg.prepare.max_group_size {
             warn!(
-                "RaptorCastSecondary ignoring ConfirmGroup that \
-                                is larger ({}) than the promised max_group_size ({}). \
-                                Message details: {:?}",
+                ?confirm_msg,
+                "RaptorCastSecondary dropping ConfirmGroup that \
+                                is larger ({}) than the promised max_group_size ({})",
                 confirm_msg.peers.len(),
                 confirm_msg.prepare.max_group_size,
-                confirm_msg
             );
             return false;
         }
 
         if !confirm_msg.peers.contains(&self.client_node_id) {
+            if confirm_msg.peers.len() == confirm_msg.prepare.max_group_size {
+                debug!(
+                    ?confirm_msg,
+                    "Group invite has reached max_group_size. Node participation is not confirmed"
+                );
+                return false;
+            }
             warn!(
-                "RaptorCastSecondary ignoring ConfirmGroup \
-                                with a group that does not contain our node_id: {:?}",
-                confirm_msg
+                ?confirm_msg,
+                "RaptorCastSecondary dropping ConfirmGroup \
+                                with a group that does not contain our node_id",
             );
             return false;
         }
@@ -390,7 +401,7 @@ where
         // round gaps, as they aren't receiving proposals and hence can't advance
         // (enter) rounds.
         if let Err(error) = self.group_sink_channel.send(group.clone()) {
-            tracing::error!(
+            error!(
                 "RaptorCastSecondary failed to send group to primary \
                                     Raptorcast instance: {}",
                 error
@@ -407,14 +418,52 @@ where
             confirm_group_size,
         );
 
+        // Remove the invite from pending_confirms and add the group to confirmed_groups
+        invites.remove(&confirm_msg.prepare.validator_id);
         self.confirmed_groups
             .force_insert(round_span.start..round_span.end, group);
-
-        invites.remove(&confirm_msg.prepare.validator_id);
-
         self.metrics[CLIENT_NUM_CURRENT_GROUPS] = self.get_current_group_count();
 
         true
+    }
+
+    pub fn handle_no_confirm_message(
+        &mut self,
+        no_confim_msg: NoConfirm<CertificateSignaturePubKey<ST>>,
+    ) {
+        let Some(invites) = self
+            .pending_confirms
+            .get_mut(&no_confim_msg.prepare.start_round)
+        else {
+            warn!(
+                ?no_confim_msg,
+                "RaptorCastSecondary ignoring no confirm message: unrecognized start round",
+            );
+            return;
+        };
+
+        let Some(accepted_invite) = invites.get(&no_confim_msg.prepare.validator_id) else {
+            warn!(
+                ?no_confim_msg,
+                "RaptorCastSecondary ignoring no confirm message: unrecognized validator id",
+            );
+            return;
+        };
+
+        if accepted_invite != &no_confim_msg.prepare {
+            warn!(
+                ?accepted_invite,
+                ?no_confim_msg,
+                "RaptorCastSecondary ignoring no confirm message: invite mismatch",
+            );
+            return;
+        };
+
+        invites.remove(&no_confim_msg.prepare.validator_id);
+        debug!(
+            ?no_confim_msg,
+            "RaptorCastSecondary received no confirm message. Releasing round to other invites",
+        );
     }
 
     fn get_current_group_count(&self) -> u64 {
@@ -462,6 +511,7 @@ mod tests {
                 config::RaptorCastConfigSecondaryClient,
                 util::{SecondaryGroup, SecondaryGroupAssignment},
             },
+            group_message::{NoConfirm, NoConfirmReason, PrepareGroup},
             Client,
         },
         *,
@@ -603,6 +653,54 @@ mod tests {
         // when we enter round 5, the group [1, 5) is expired
         clt.enter_round(Round(5));
         assert_eq!(clt.get_current_group_count(), 0);
+    }
+
+    #[test]
+    fn test_no_confirm_message() {
+        let (clt_tx, _clt_rx): RcToRcChannelGrp = unbounded_channel();
+        let self_id = nid(1);
+        let mut clt = Client::<ST>::new(
+            self_id,
+            clt_tx,
+            RaptorCastConfigSecondaryClient {
+                max_num_group: 5,
+                max_group_size: 3,
+                invite_future_dist_min: Round(1),
+                invite_future_dist_max: Round(100),
+                invite_accept_heartbeat: Duration::from_secs(10),
+            },
+        );
+
+        let validator_id = nid(2);
+        let prepare_invite = PrepareGroup {
+            max_group_size: 3,
+            validator_id,
+            start_round: Round(5),
+            end_round: Round(10),
+        };
+
+        // Set up client state: client has accepted an invite and is waiting for confirmation
+        clt.pending_confirms.insert(
+            Round(5),
+            BTreeMap::from([(validator_id, prepare_invite.clone())]),
+        );
+
+        // Test 1: Valid NoConfirm message - should be accepted and remove the invite
+        let valid_no_confirm = NoConfirm {
+            prepare: prepare_invite,
+            reason: NoConfirmReason::GroupFull,
+        };
+
+        clt.handle_no_confirm_message(valid_no_confirm);
+
+        // Verify the invite was removed from pending_confirms
+        assert!(
+            !clt.pending_confirms
+                .get(&Round(5))
+                .unwrap()
+                .contains_key(&validator_id),
+            "Valid NoConfirm should remove the invite from pending_confirms"
+        );
     }
 
     // Creates a node id that we can refer to just from its seed

--- a/monad-raptorcast/src/raptorcast_secondary/group_message.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/group_message.rs
@@ -47,17 +47,60 @@ pub struct ConfirmGroup<ST: CertificateSignatureRecoverable> {
     pub name_records: LimitedVec<MonadNameRecord<ST>, MAX_PEERS_IN_CONFIRM_GROUP>,
 }
 
+const NO_CONF_REASON_GROUP_FULL: u8 = 1;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum NoConfirmReason {
+    GroupFull,
+}
+
+impl Encodable for NoConfirmReason {
+    fn encode(&self, out: &mut dyn BufMut) {
+        match self {
+            Self::GroupFull => {
+                let enc: [&dyn Encodable; 1] = [&NO_CONF_REASON_GROUP_FULL];
+                encode_list::<_, dyn Encodable>(&enc, out);
+            }
+        }
+    }
+}
+
+impl Decodable for NoConfirmReason {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let mut payload = Header::decode_bytes(buf, true)?;
+        let reason = match u8::decode(&mut payload)? {
+            NO_CONF_REASON_GROUP_FULL => Self::GroupFull,
+            _ => {
+                return Err(alloy_rlp::Error::Custom(
+                    "Unknown NoConfirmReason enum variant",
+                ))
+            }
+        };
+        if !payload.is_empty() {
+            return Err(alloy_rlp::Error::Custom("Extra bytes in NoConfirmReason"));
+        }
+        Ok(reason)
+    }
+}
+#[derive(Debug, Clone, RlpEncodable, RlpDecodable, Eq, PartialEq)]
+pub struct NoConfirm<PT: PubKey> {
+    pub prepare: PrepareGroup<PT>,
+    pub reason: NoConfirmReason,
+}
+
 const GROUP_MSG_VERSION: u8 = 1;
 
 const MESSAGE_TYPE_PREP_REQ: u8 = 1;
 const MESSAGE_TYPE_PREP_RES: u8 = 2;
 const MESSAGE_TYPE_CONF_GRP: u8 = 3;
+const MESSAGE_TYPE_NO_CONF: u8 = 4;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FullNodesGroupMessage<ST: CertificateSignatureRecoverable> {
     PrepareGroup(PrepareGroup<CertificateSignaturePubKey<ST>>), // MESSAGE_TYPE_PREP_REQ
     PrepareGroupResponse(PrepareGroupResponse<CertificateSignaturePubKey<ST>>), // MESSAGE_TYPE_PREP_RES
     ConfirmGroup(ConfirmGroup<ST>), // MESSAGE_TYPE_CONF_GRP
+    NoConfirm(NoConfirm<CertificateSignaturePubKey<ST>>), // MESSAGE_TYPE_NO_CONF
 }
 
 impl<ST: CertificateSignatureRecoverable> Encodable for FullNodesGroupMessage<ST> {
@@ -74,6 +117,10 @@ impl<ST: CertificateSignatureRecoverable> Encodable for FullNodesGroupMessage<ST
             }
             Self::ConfirmGroup(inner_msg) => {
                 let enc: [&dyn Encodable; 3] = [&version, &MESSAGE_TYPE_CONF_GRP, inner_msg];
+                encode_list::<_, dyn Encodable>(&enc, out);
+            }
+            Self::NoConfirm(inner_msg) => {
+                let enc: [&dyn Encodable; 3] = [&version, &MESSAGE_TYPE_NO_CONF, inner_msg];
                 encode_list::<_, dyn Encodable>(&enc, out);
             }
         }
@@ -93,6 +140,7 @@ impl<ST: CertificateSignatureRecoverable> Decodable for FullNodesGroupMessage<ST
                 Self::PrepareGroupResponse(PrepareGroupResponse::decode(&mut payload)?)
             }
             MESSAGE_TYPE_CONF_GRP => Self::ConfirmGroup(ConfirmGroup::decode(&mut payload)?),
+            MESSAGE_TYPE_NO_CONF => Self::NoConfirm(NoConfirm::decode(&mut payload)?),
             _ => {
                 return Err(alloy_rlp::Error::Custom(
                     "Unknown FullNodesGroupMessage enum variant",
@@ -130,6 +178,7 @@ mod tests {
             FullNodesGroupMessage::PrepareGroup(_) => "PrepareGroup",
             FullNodesGroupMessage::PrepareGroupResponse(_) => "PrepareGroupResponse",
             FullNodesGroupMessage::ConfirmGroup(_) => "ConfirmGroup",
+            FullNodesGroupMessage::NoConfirm(_) => "NoConfirm",
         }
         .to_string()
     }
@@ -215,5 +264,37 @@ mod tests {
         let decoded_enum =
             FullNodesGroupMessage::<ST>::decode(&mut encoded_bytes.as_slice()).unwrap();
         assert_eq!(decoded_enum, org_enum);
+    }
+
+    #[test]
+    fn serialize_roundtrip_group_no_conf() {
+        let org_msg = NoConfirm {
+            prepare: make_prep_group(13),
+            reason: NoConfirmReason::GroupFull,
+        };
+        let org_enum = FullNodesGroupMessage::NoConfirm(org_msg);
+
+        let mut encoded_bytes = Vec::new();
+        org_enum.encode(&mut encoded_bytes); // 44 bytes
+
+        insta::assert_debug_snapshot!("no_conf_encoded", hex::encode(&encoded_bytes));
+
+        let decoded_enum =
+            FullNodesGroupMessage::<ST>::decode(&mut encoded_bytes.as_slice()).unwrap();
+        assert_eq!(decoded_enum, org_enum);
+    }
+
+    #[test]
+    fn no_confirm_reason_rejects_extra_bytes() {
+        // Encode NoConfirmReason::GroupFull normally: RLP list with single u8
+        // Valid encoding is [0xc1, 0x01] - a list of length 1 containing the byte 0x01
+        // We'll create a malformed encoding with extra bytes: [0xc2, 0x01, 0xff]
+        let malformed_encoding: &[u8] = &[0xc2, 0x01, 0xff];
+
+        let result = NoConfirmReason::decode(&mut &malformed_encoding[..]);
+        assert_eq!(
+            result.unwrap_err(),
+            alloy_rlp::Error::Custom("Extra bytes in NoConfirmReason")
+        );
     }
 }

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -425,7 +425,9 @@ where
 
         match &mut this.role {
             Role::Publisher(publisher) => {
-                publisher.on_candidate_response(inbound_grp_msg);
+                if let Some((msg, node_id)) = publisher.on_candidate_response(inbound_grp_msg) {
+                    this.send_single_msg(msg, node_id);
+                }
             }
 
             Role::Client(client) => {
@@ -487,13 +489,16 @@ where
                                     .into(),
                                 ));
                             } else if num_mappings > 0 {
-                                warn!( ?confirm_msg, num_peers =? confirm_msg.peers.len(), num_name_recs =? confirm_msg.name_records.len(),
+                                warn!(?confirm_msg, num_peers =? confirm_msg.peers.len(), num_name_recs =? confirm_msg.name_records.len(),
                                     "Number of peers does not match the number \
                                     of name records in ConfirmGroup message. \
                                     Skipping PeerDiscovery update"
                                 );
                             }
                         }
+                    }
+                    FullNodesGroupMessage::NoConfirm(no_confirm) => {
+                        client.handle_no_confirm_message(no_confirm);
                     }
                 }
             }

--- a/monad-raptorcast/src/raptorcast_secondary/publisher.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/publisher.rs
@@ -31,7 +31,10 @@ use super::{
     super::config::{GroupSchedulingConfig, RaptorCastConfigSecondaryPublisher},
     group_message::{ConfirmGroup, FullNodesGroupMessage, PrepareGroup},
 };
-use crate::util::SecondaryGroup;
+use crate::{
+    raptorcast_secondary::group_message::{NoConfirm, NoConfirmReason, PrepareGroupResponse},
+    util::SecondaryGroup,
+};
 
 monad_executor::metric_consts! {
     pub PUBLISHER_CURRENT_GROUP_SIZE {
@@ -355,14 +358,21 @@ where
     // of our RaptorCast group scheduled for a future round.
     // We've received a response from the candidate but won't send any message
     // back right away, but when we have enough responses to form a group.
-    pub fn on_candidate_response(&mut self, msg: FullNodesGroupMessage<ST>) {
+    #[must_use]
+    pub fn on_candidate_response(
+        &mut self,
+        msg: FullNodesGroupMessage<ST>,
+    ) -> Option<(
+        FullNodesGroupMessage<ST>,
+        NodeId<CertificateSignaturePubKey<ST>>,
+    )> {
         trace!(?msg, "RaptorCastSecondary received candidate response");
         match msg {
             FullNodesGroupMessage::PrepareGroupResponse(response) => {
                 let candidate = response.node_id;
                 let start_round = response.req.start_round;
                 if let Some(group) = self.group_schedule.get_mut(&start_round) {
-                    group.on_candidate_response(candidate, response.accept);
+                    return group.on_candidate_response(candidate, response, &self.scheduling_cfg);
                 } else {
                     warn!(
                         ?candidate,
@@ -380,6 +390,7 @@ where
                 );
             }
         }
+        None
     }
 
     pub fn get_current_raptorcast_group(
@@ -429,8 +440,10 @@ struct GroupAsPublisher<ST>
 where
     ST: CertificateSignatureRecoverable,
 {
+    // TODO: register prepare invite data to verify response against
     full_nodes_accepted: FullNodesST<ST>,
     full_nodes_rejected: FullNodesST<ST>,
+    full_nodes_overflowed: FullNodesST<ST>,
 
     // Pre-randomized permutation of always_ask_full_nodes[] + peer_disc_full_nodes[]
     // Stays const once created.
@@ -478,6 +491,7 @@ where
         let mut new_group = Self {
             full_nodes_accepted: Vec::default(),
             full_nodes_rejected: Vec::default(),
+            full_nodes_overflowed: Vec::default(),
             full_nodes_candidates: always_ask_full_nodes.clone(),
             num_invites_sent: 0,
             start_round,
@@ -563,24 +577,29 @@ where
         Some((invite_msg, next_invitees))
     }
 
+    #[must_use]
     pub fn on_candidate_response(
         &mut self,
         candidate: NodeId<CertificateSignaturePubKey<ST>>,
-        accepted: bool,
-    ) {
+        response: PrepareGroupResponse<CertificateSignaturePubKey<ST>>,
+        cfg: &GroupSchedulingConfig,
+    ) -> Option<(
+        FullNodesGroupMessage<ST>,
+        NodeId<CertificateSignaturePubKey<ST>>,
+    )> {
         trace!(
             ?candidate,
-            ?accepted,
+            ?response,
             "RaptorCastSecondary Publisher on_candidate_response",
         );
         if self.is_locked() {
             // Already formed the group
             trace!(
                 ?candidate,
-                ?accepted,
+                ?response,
                 "RaptorCastSecondary Publisher on_candidate_response - Already formed the group"
             );
-            return;
+            return None;
         }
         let end = self.full_nodes_candidates.len().min(self.num_invites_sent);
         let invited = &self.full_nodes_candidates[..end];
@@ -591,7 +610,7 @@ where
                 "Ignoring response from FullNode who was \
                 never invited to RaptorCastSecondary group",
             );
-            return;
+            return None;
         }
         if self.full_nodes_accepted.contains(&candidate) {
             warn!(
@@ -600,7 +619,7 @@ where
                 "Ignoring duplicate response from FullNode \
                 who was already accepted into RaptorCastSecondary group",
             );
-            return;
+            return None;
         }
         if self.full_nodes_rejected.contains(&candidate) {
             warn!(
@@ -609,23 +628,47 @@ where
                 "Ignoring duplicate response from FullNode who \
                 has already rejected an invite from RaptorCastSecondary group",
             );
-            return;
+            return None;
         }
-        if accepted {
+        if self.full_nodes_overflowed.contains(&candidate) {
+            warn!(
+                ?candidate,
+                ?self,
+                "Ignoring duplicate response from FullNode. Group is full.",
+            );
+            return None;
+        }
+        if response.accept {
+            // Immediately respond with a NoConfirm message if the group is full
+            if self.full_nodes_accepted.len() >= cfg.max_group_size {
+                debug!(
+                    ?candidate,
+                    "RaptorCastSecondary group is full. Sending NoConfirm message to candidate",
+                );
+                self.full_nodes_overflowed.push(candidate);
+                return Some((
+                    FullNodesGroupMessage::NoConfirm(NoConfirm {
+                        prepare: response.req,
+                        reason: NoConfirmReason::GroupFull,
+                    }),
+                    candidate,
+                ));
+            }
             self.full_nodes_accepted.push(candidate);
             debug!(
                 ?candidate,
-                ?self,
-                "RaptorCastSecondary group invite accepted by, for group",
+                invite = ?response.req,
+                "RaptorCastSecondary group invite accepted by candidate",
             );
         } else {
             self.full_nodes_rejected.push(candidate);
             debug!(
                 ?candidate,
-                ?self,
-                "RaptorCastSecondary group invite rejected by, for group",
+                invite = ?response.req,
+                "RaptorCastSecondary group invite rejected by candidate",
             );
         }
+        None
     }
 
     pub fn to_finalized_group(&self) -> CurrentGroup<CertificateSignaturePubKey<ST>> {
@@ -1233,7 +1276,7 @@ mod tests {
         // 1st group accept (only nid_11)
         //----------------------------------------------------------------------
         let accept_msg = make_invite_response(nid(0), nid(11), true, Round(8), &sched_cfg);
-        v0_fsm.on_candidate_response(accept_msg);
+        let _ = v0_fsm.on_candidate_response(accept_msg);
 
         //-------------------------------------------------------------------[3]
         // 1st group invites t1
@@ -1286,7 +1329,7 @@ mod tests {
         // Received response from an odd note which wasn't invited for the round
         // The FSM should ignore this response.
         let accept_msg = make_invite_response(nid(0), nid(22), true, Round(8), &sched_cfg);
-        v0_fsm.on_candidate_response(accept_msg);
+        let _ = v0_fsm.on_candidate_response(accept_msg);
 
         //-------------------------------------------------------------------[5]
         // 1st group timeout
@@ -2056,7 +2099,7 @@ mod tests {
 
         // ACCEPT [3, 6)
         let accept_msg = make_invite_response(nid(0), nid(10), true, Round(3), &sched_cfg);
-        v0_fsm.on_candidate_response(accept_msg);
+        let _ = v0_fsm.on_candidate_response(accept_msg);
 
         // CONFIRM [3, 6)
         let (group_msg, _invitees) = v0_fsm
@@ -2094,7 +2137,7 @@ mod tests {
 
         // ACCEPT [6, 9)
         let accept_msg = make_invite_response(nid(0), nid(10), true, Round(6), &sched_cfg);
-        v0_fsm.on_candidate_response(accept_msg);
+        let _ = v0_fsm.on_candidate_response(accept_msg);
 
         // CONFIRM [6, 9)
         let (group_msg, _invitees) = v0_fsm
@@ -2132,7 +2175,7 @@ mod tests {
 
         // ACCEPT [9, 12)
         let accept_msg = make_invite_response(nid(0), nid(10), true, Round(9), &sched_cfg);
-        v0_fsm.on_candidate_response(accept_msg);
+        let _ = v0_fsm.on_candidate_response(accept_msg);
 
         // CONFIRM [9, 12)
         let (group_msg, _invitees) = v0_fsm
@@ -2307,14 +2350,14 @@ mod tests {
         //----------------------------------------------------------------------
 
         let response = make_invite_response(nid(0), nid(10), true, Round(8), &sched_cfg);
-        v0_fsm.on_candidate_response(response);
+        let _ = v0_fsm.on_candidate_response(response);
 
         let response = make_invite_response(nid(0), nid(11), true, Round(8), &sched_cfg);
-        v0_fsm.on_candidate_response(response);
+        let _ = v0_fsm.on_candidate_response(response);
 
         // A reject from node 12
         let response = make_invite_response(nid(0), nid(12), false, Round(8), &sched_cfg);
-        v0_fsm.on_candidate_response(response);
+        let _ = v0_fsm.on_candidate_response(response);
 
         //----------------------------------------------------------------------
         // 1st group invites t1
@@ -2356,7 +2399,7 @@ mod tests {
         // Node 12 now sends an accept after already have sent a reject
         //----------------------------------------------------------------------
         let bogus_response = make_invite_response(nid(0), nid(12), true, Round(8), &sched_cfg);
-        v0_fsm.on_candidate_response(bogus_response);
+        let _ = v0_fsm.on_candidate_response(bogus_response);
 
         // Verify that the publisher does not change accept/reject states
         if let Some(group) = v0_fsm.group_schedule.get(&Round(8)) {
@@ -2453,5 +2496,190 @@ mod tests {
             v0_fsm.curr_group.unwrap_active().1.start == Round(26),
             "Group [26, 31) should be present and set as current group"
         );
+    }
+
+    #[test]
+    fn no_confirm_when_group_full() {
+        let sched_cfg = GroupSchedulingConfig {
+            max_group_size: 3,
+            round_span: Round(5),
+            invite_lookahead: Round(8),
+            max_invite_wait: Round(2),
+            deadline_round_dist: Round(3),
+            init_empty_round_span: Round(7),
+        };
+
+        let v0_node_id = nid(0);
+
+        let mut v0_fsm: Publisher<ST> = Publisher::new(
+            v0_node_id,
+            RaptorCastConfigSecondaryPublisher {
+                full_nodes_prioritized: vec![nid(10), nid(11), nid(12)],
+                group_scheduling: sched_cfg,
+            },
+            ChaCha8Rng::seed_from_u64(42),
+        );
+
+        // Peer discovery gives us one more full-node beyond the prioritized list
+        v0_fsm.upsert_peer_disc_full_nodes(vec![nid(13)]);
+
+        //----------------------------------------------------------------------
+        // Initial invites for the first group
+        //----------------------------------------------------------------------
+        let (group_msg, invitees) = v0_fsm
+            .enter_round_and_step_until(Round(1))
+            .expect("FSM should have returned invites to be sent");
+
+        let reference_prepare_group = PrepareGroup {
+            start_round: Round(8),
+            end_round: Round(13),
+            max_group_size: 3,
+            validator_id: nid(0),
+        };
+
+        if let FullNodesGroupMessage::PrepareGroup(invite_msg) = group_msg {
+            assert_eq!(invite_msg, reference_prepare_group);
+            assert!(equal_node_vec(&invitees, &node_ids_vec![10, 11, 12]));
+        } else {
+            panic!(
+                "Expected FullNodesGroupMessage::PrepareGroup, got: {:?}\n\
+                publisher v0: {}",
+                group_msg,
+                dump_pub_sched(&v0_fsm)
+            );
+        };
+
+        //----------------------------------------------------------------------
+        // First two nodes accept quickly
+        //----------------------------------------------------------------------
+        let response = make_invite_response(nid(0), nid(10), true, Round(8), &sched_cfg);
+        let result = v0_fsm.on_candidate_response(response);
+        assert!(
+            result.is_none(),
+            "Still has capacity. No NoConfirm message should be sent"
+        );
+
+        let response = make_invite_response(nid(0), nid(11), true, Round(8), &sched_cfg);
+        let result = v0_fsm.on_candidate_response(response);
+        assert!(
+            result.is_none(),
+            "Still has capacity. No NoConfirm message should be sent"
+        );
+
+        //----------------------------------------------------------------------
+        // Publisher sends more invites since we only have 2 acceptances
+        //----------------------------------------------------------------------
+        let (group_msg, invitees) = v0_fsm
+            .enter_round_and_step_until(Round(3))
+            .expect("FSM should have returned invites to be sent");
+
+        if let FullNodesGroupMessage::PrepareGroup(invite_msg) = group_msg {
+            assert_eq!(invite_msg, reference_prepare_group);
+            // Should send more invites to reach max_group_size
+            assert!(!invitees.is_empty());
+        } else {
+            panic!(
+                "Expected FullNodesGroupMessage::PrepareGroup, got: {:?}\n\
+                publisher v0: {}",
+                group_msg,
+                dump_pub_sched(&v0_fsm)
+            );
+        }
+
+        //----------------------------------------------------------------------
+        // Third node accepts - now we have reached max_group_size
+        //----------------------------------------------------------------------
+        let response = make_invite_response(nid(0), nid(12), true, Round(8), &sched_cfg);
+        let result = v0_fsm.on_candidate_response(response);
+
+        // The third acceptance should be accepted without NoConfirm (returns None)
+        assert!(
+            result.is_none(),
+            "Third acceptance should not trigger NoConfirm"
+        );
+
+        // Verify we now have 3 accepted nodes
+        if let Some(group) = v0_fsm.group_schedule.get(&Round(8)) {
+            assert_eq!(group.full_nodes_accepted.len(), 3);
+            assert!(equal_node_vec(
+                &group.full_nodes_accepted,
+                &node_ids_vec![10, 11, 12]
+            ));
+        } else {
+            panic!("Expected a group to be scheduled for round 8");
+        }
+
+        //----------------------------------------------------------------------
+        // Fourth node tries to accept - should receive NoConfirm message
+        //----------------------------------------------------------------------
+        let response = make_invite_response(nid(0), nid(13), true, Round(8), &sched_cfg);
+        let (msg, recipient) = v0_fsm
+            .on_candidate_response(response)
+            .expect("Should return NoConfirm message when group is full");
+
+        assert_eq!(recipient, nid(13));
+        assert_eq!(
+            msg,
+            FullNodesGroupMessage::NoConfirm(NoConfirm {
+                prepare: reference_prepare_group.clone(),
+                reason: NoConfirmReason::GroupFull,
+            })
+        );
+
+        // Verify accepted list still has only 3 nodes
+        if let Some(group) = v0_fsm.group_schedule.get(&Round(8)) {
+            assert_eq!(group.full_nodes_accepted.len(), 3);
+            assert!(equal_node_vec(
+                &group.full_nodes_accepted,
+                &node_ids_vec![10, 11, 12]
+            ));
+        } else {
+            panic!("Expected a group to be scheduled for round 8");
+        }
+
+        //----------------------------------------------------------------------
+        // Fourth node tries to accept again - should be ignored (already overflowed)
+        //----------------------------------------------------------------------
+        let response = make_invite_response(nid(0), nid(13), true, Round(8), &sched_cfg);
+        let result = v0_fsm.on_candidate_response(response);
+        assert!(
+            result.is_none(),
+            "Should return None when receiving duplicate response"
+        );
+
+        // Final verification: still only 3 nodes in the group
+        if let Some(group) = v0_fsm.group_schedule.get(&Round(8)) {
+            assert_eq!(group.full_nodes_accepted.len(), 3);
+            assert!(equal_node_vec(
+                &group.full_nodes_accepted,
+                &node_ids_vec![10, 11, 12]
+            ));
+        } else {
+            panic!("Expected a group to be scheduled for round 8");
+        }
+
+        //----------------------------------------------------------------------
+        // Advance time to trigger group confirmation
+        //----------------------------------------------------------------------
+        let (group_msg, members) = v0_fsm
+            .enter_round_and_step_until(Round(5))
+            .expect("FSM should have returned group confirmation");
+
+        // Verify that the group is confirmed with exactly 3 members
+        if let FullNodesGroupMessage::ConfirmGroup(confirm_msg) = group_msg {
+            assert_eq!(confirm_msg.prepare, reference_prepare_group);
+            assert!(equal_node_vec(&members, &node_ids_vec![10, 11, 12]));
+            assert!(equal_node_vec(
+                &confirm_msg.peers,
+                &node_ids_vec![10, 11, 12]
+            ));
+        } else {
+            panic!(
+                "Expected FullNodesGroupMessage::ConfirmGroup, got: {:?}\n\
+                publisher v0: {}",
+                group_msg,
+                dump_pub_sched(&v0_fsm)
+            );
+        }
     }
 }

--- a/monad-raptorcast/src/raptorcast_secondary/snapshots/monad_raptorcast__raptorcast_secondary__group_message__tests__no_conf_encoded.snap
+++ b/monad-raptorcast/src/raptorcast_secondary/snapshots/monad_raptorcast__raptorcast_secondary__group_message__tests__no_conf_encoded.snap
@@ -1,0 +1,5 @@
+---
+source: monad-raptorcast/src/raptorcast_secondary/group_message.rs
+expression: "hex::encode(&encoded_bytes)"
+---
+"eb0104e8e5a102f0138192596eea59a45c319836046818239f702907ebc9478892ff3e950995a40e181ec101"


### PR DESCRIPTION
It was possible to create a ConfirmGroup message with peer list longer than max_group_size in the original invitation. This ConfirmGroup message will get rejected by full nodes. This PR introduces a NoConfirm message that's immediately sent to the client when group reaches max size. When client receives the NoConfirm message, it releases the round to other invites.

Regarding backwards compatibility, the NoConfirm message is a new addition. Older clients will simply ignore this message (fail to deserialize) and will not experience any negative effects.