### PR TITLE
Remove Swatinem Rust cache from GH actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,6 @@ jobs:
         run: cargo shear
       - name: Format
         run: cargo +nightly-2025-12-09 fmt --all --check
-      - uses: Swatinem/rust-cache@v2
       - name: Lint
         run: cargo clippy --all-targets --all-features --
           -D clippy::suspicious

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -108,8 +108,6 @@ jobs:
       - name: Format
         run: cargo +nightly-2025-12-09 fmt --all --check
 
-      - uses: Swatinem/rust-cache@v2
-
       - name: Lint
         run: |
           cargo clippy --all-targets --all-features -- \


### PR DESCRIPTION
Due to the size of the cache we're achiving (~3.2G) compared to the maximum cache size allowed by Github (10G), we are spending a lot more time archiving the cache on each iteration of the GH action than we are saving by having the cache.