### PR TITLE
Raptorcast: Parameterize dataplane handles

### DIFF
--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -517,6 +517,7 @@ fn build_raptorcast_router<ST, SCT, M, OM>(
     MonadEvent<ST, SCT, ExecutionProtocolType>,
     PeerDiscovery<ST>,
     monad_raptorcast::auth::WireAuthProtocol,
+    monad_raptorcast::networking::Dataplane,
 >
 where
     ST: CertificateSignatureRecoverable<KeyPairType = monad_secp::KeyPair>,

--- a/monad-raptorcast/examples/latency.rs
+++ b/monad-raptorcast/examples/latency.rs
@@ -45,7 +45,9 @@ use monad_peer_discovery::{
     MonadNameRecord, NameRecord,
 };
 use monad_raptorcast::{
+    auth::WireAuthProtocol,
     config::{RaptorCastConfig, RaptorCastConfigPrimary},
+    networking::Dataplane,
     raptorcast_secondary::SecondaryRaptorCastModeConfig,
     RaptorCast, RaptorCastEvent, AUTHENTICATED_RAPTORCAST_SOCKET, RAPTORCAST_SOCKET,
 };
@@ -519,7 +521,8 @@ struct NodeSetup {
         MockMessage,
         <MockMessage as Message>::Event,
         NopDiscovery<SignatureType>,
-        monad_raptorcast::auth::WireAuthProtocol,
+        WireAuthProtocol,
+        Dataplane,
     >,
     node_id: NodeId<CertificateSignaturePubKey<SignatureType>>,
     tcp_addr: SocketAddrV4,
@@ -637,8 +640,7 @@ fn setup_node(
 
     let keypair_arc = Arc::new(keypair);
     let wireauth_config = monad_wireauth::Config::default();
-    let auth_protocol =
-        monad_raptorcast::auth::WireAuthProtocol::new(wireauth_config, keypair_arc.clone());
+    let auth_protocol = WireAuthProtocol::new(wireauth_config, keypair_arc.clone());
 
     let mut raptorcast = RaptorCast::<
         SignatureType,
@@ -646,7 +648,8 @@ fn setup_node(
         MockMessage,
         <MockMessage as Message>::Event,
         NopDiscovery<SignatureType>,
-        monad_raptorcast::auth::WireAuthProtocol,
+        WireAuthProtocol,
+        Dataplane,
     >::new(
         create_raptorcast_config(keypair_arc),
         SecondaryRaptorCastModeConfig::None,

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -39,8 +39,7 @@ use monad_crypto::{
 };
 use monad_dataplane::{
     udp::{DEFAULT_MTU, ETHERNET_SEGMENT_SIZE},
-    DataplaneBuilder, DataplaneControl, RecvTcpMsg, TcpMsg, TcpSocketReader, TcpSocketWriter,
-    UdpSocketHandle, UnicastMsg,
+    DataplaneBuilder, RecvTcpMsg, TcpMsg, UnicastMsg,
 };
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{
@@ -62,6 +61,7 @@ use util::{BuildTarget, EpochValidators, FullNodes, Group, ReBroadcastGroupMap, 
 
 use crate::{
     metrics::{GAUGE_RAPTORCAST_TOTAL_MESSAGES_RECEIVED, GAUGE_RAPTORCAST_TOTAL_RECV_ERRORS},
+    networking::{Control as _, DataplaneType, TcpMessageSink as _, TcpMessageSource as _},
     packet::RetrofitResult as _,
     raptorcast_secondary::{
         group_message::FullNodesGroupMessage, SecondaryOutboundMessage,
@@ -74,6 +74,7 @@ pub mod config;
 pub mod decoding;
 pub mod message;
 pub mod metrics;
+pub mod networking;
 pub mod packet;
 pub mod raptorcast_secondary;
 pub mod udp;
@@ -89,13 +90,14 @@ pub const AUTHENTICATED_RAPTORCAST_SOCKET: &str = "authenticated_raptorcast";
 pub(crate) type OwnedMessageBuilder<ST, PD> =
     packet::MessageBuilder<'static, ST, Arc<Mutex<PeerDiscoveryDriver<PD>>>>;
 
-pub struct RaptorCast<ST, M, OM, SE, PD, AP>
+pub struct RaptorCast<ST, M, OM, SE, PD, AP, DP>
 where
     ST: CertificateSignatureRecoverable,
     M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
     OM: Encodable + Into<M> + Clone,
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
     AP: auth::AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
+    DP: DataplaneType,
 {
     signing_key: Arc<ST::KeyPairType>,
     is_dynamic_fullnode: bool,
@@ -112,12 +114,12 @@ where
     message_builder: OwnedMessageBuilder<ST, PD>,
     secondary_message_builder: Option<OwnedMessageBuilder<ST, PD>>,
 
-    tcp_reader: TcpSocketReader,
-    tcp_writer: TcpSocketWriter,
-    dual_socket: auth::DualSocketHandle<AP>,
-    dataplane_control: DataplaneControl,
-    pending_events: VecDeque<RaptorCastEvent<M::Event, ST>>,
+    tcp_reader: DP::TcpMessageSource,
+    tcp_writer: DP::TcpMessageSink,
+    dual_socket: auth::DualSocketHandle<AP, DP::UdpMessageEndpoint>,
+    dataplane_control: DP::Control,
 
+    pending_events: VecDeque<RaptorCastEvent<M::Event, ST>>,
     channel_to_secondary: Option<UnboundedSender<FullNodesGroupMessage<ST>>>,
     channel_from_secondary: Option<UnboundedReceiver<Group<ST>>>,
     channel_from_secondary_outbound: Option<UnboundedReceiver<SecondaryOutboundMessage<ST>>>,
@@ -139,23 +141,24 @@ pub enum RaptorCastEvent<E, ST: CertificateSignatureRecoverable> {
     SecondaryRaptorcastPeersUpdate(Round, Vec<NodeId<CertificateSignaturePubKey<ST>>>),
 }
 
-impl<ST, M, OM, SE, PD, AP> RaptorCast<ST, M, OM, SE, PD, AP>
+impl<ST, M, OM, SE, PD, AP, DP> RaptorCast<ST, M, OM, SE, PD, AP, DP>
 where
     ST: CertificateSignatureRecoverable,
     M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
     OM: Encodable + Into<M> + Clone,
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
     AP: auth::AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
+    DP: DataplaneType,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: config::RaptorCastConfig<ST>,
         secondary_mode: SecondaryRaptorCastModeConfig,
-        tcp_reader: TcpSocketReader,
-        tcp_writer: TcpSocketWriter,
-        authenticated_socket: Option<UdpSocketHandle>,
-        non_authenticated_socket: UdpSocketHandle,
-        control: DataplaneControl,
+        tcp_reader: DP::TcpMessageSource,
+        tcp_writer: DP::TcpMessageSink,
+        authenticated_socket: Option<DP::UdpMessageEndpoint>,
+        non_authenticated_socket: DP::UdpMessageEndpoint,
+        control: DP::Control,
         peer_discovery_driver: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
         current_epoch: Epoch,
         auth_protocol: AP,
@@ -532,6 +535,7 @@ pub fn new_defaulted_raptorcast_for_tests<ST, M, OM, SE>(
     SE,
     NopDiscovery<ST>,
     auth::NoopAuthProtocol<CertificateSignaturePubKey<ST>>,
+    networking::Dataplane,
 >
 where
     ST: CertificateSignatureRecoverable,
@@ -591,7 +595,7 @@ where
     let pd = PeerDiscoveryDriver::new(peer_discovery_builder);
     let shared_pd = Arc::new(Mutex::new(pd));
     let auth_protocol = auth::NoopAuthProtocol::new();
-    RaptorCast::<ST, M, OM, SE, NopDiscovery<ST>, _>::new(
+    RaptorCast::<ST, M, OM, SE, NopDiscovery<ST>, _, _>::new(
         config,
         SecondaryRaptorCastModeConfig::None,
         tcp_reader,
@@ -609,7 +613,7 @@ pub fn new_wireauth_raptorcast_for_tests<ST, M, OM, SE>(
     local_addr: SocketAddr,
     known_addresses: HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddrV4>,
     shared_key: Arc<ST::KeyPairType>,
-) -> RaptorCast<ST, M, OM, SE, NopDiscovery<ST>, auth::WireAuthProtocol>
+) -> RaptorCast<ST, M, OM, SE, NopDiscovery<ST>, auth::WireAuthProtocol, networking::Dataplane>
 where
     ST: CertificateSignatureRecoverable<KeyPairType = monad_secp::KeyPair>,
     M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
@@ -669,7 +673,7 @@ where
     let shared_pd = Arc::new(Mutex::new(pd));
     let wireauth_config = monad_wireauth::Config::default();
     let auth_protocol = auth::WireAuthProtocol::new(wireauth_config, shared_key);
-    RaptorCast::<ST, M, OM, SE, NopDiscovery<ST>, _>::new(
+    RaptorCast::<ST, M, OM, SE, NopDiscovery<ST>, _, _>::new(
         config,
         SecondaryRaptorCastModeConfig::None,
         tcp_reader,
@@ -683,13 +687,14 @@ where
     )
 }
 
-impl<ST, M, OM, SE, PD, AP> Executor for RaptorCast<ST, M, OM, SE, PD, AP>
+impl<ST, M, OM, SE, PD, AP, DP> Executor for RaptorCast<ST, M, OM, SE, PD, AP, DP>
 where
     ST: CertificateSignatureRecoverable,
     M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
     OM: Encodable + Into<M> + Clone,
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
     AP: auth::AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
+    DP: DataplaneType,
 {
     type Command = RouterCommand<ST, OM>;
 
@@ -921,7 +926,7 @@ fn iter_ips<'a, ST: CertificateSignatureRecoverable, PD: PeerDiscoveryAlgo<Signa
         .map(|socket| socket.ip())
 }
 
-impl<ST, M, OM, E, PD, AP> Stream for RaptorCast<ST, M, OM, E, PD, AP>
+impl<ST, M, OM, E, PD, AP, DP> Stream for RaptorCast<ST, M, OM, E, PD, AP, DP>
 where
     ST: CertificateSignatureRecoverable,
     M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
@@ -929,6 +934,7 @@ where
     E: From<RaptorCastEvent<M::Event, ST>>,
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
     AP: auth::AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
+    DP: DataplaneType,
     PeerDiscoveryDriver<PD>: Unpin,
     Self: Unpin,
 {
@@ -1148,7 +1154,7 @@ where
 
         {
             let send_peer_disc_msg =
-                |this: &mut RaptorCast<ST, M, OM, E, PD, AP>,
+                |this: &mut RaptorCast<ST, M, OM, E, PD, AP, DP>,
                  target: NodeId<CertificateSignaturePubKey<ST>>,
                  target_name_record: Option<NameRecord>,
                  message: PeerDiscoveryMessage<ST>| {
@@ -1312,8 +1318,8 @@ where
     }
 }
 
-fn send<ST, PD, AP>(
-    dual_socket: &mut auth::DualSocketHandle<AP>,
+fn send<ST, PD, AP, UE>(
+    dual_socket: &mut auth::DualSocketHandle<AP, UE>,
     peer_discovery_driver: &Arc<Mutex<PeerDiscoveryDriver<PD>>>,
     message_builder: &mut OwnedMessageBuilder<ST, PD>,
     message: &Bytes,
@@ -1324,6 +1330,7 @@ fn send<ST, PD, AP>(
     ST: CertificateSignatureRecoverable,
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
     AP: auth::AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
+    UE: networking::UdpMessageEndpoint,
 {
     {
         let dual_socket_cell = std::cell::RefCell::new(&mut *dual_socket);
@@ -1343,8 +1350,8 @@ fn send<ST, PD, AP>(
     ensure_authenticated_sessions(dual_socket, peer_discovery_driver, build_target.iter());
 }
 
-fn send_with_record<ST, PD, AP>(
-    dual_socket: &mut auth::DualSocketHandle<AP>,
+fn send_with_record<ST, PD, AP, UE>(
+    dual_socket: &mut auth::DualSocketHandle<AP, UE>,
     peer_discovery_driver: &Arc<Mutex<PeerDiscoveryDriver<PD>>>,
     message_builder: &mut OwnedMessageBuilder<ST, PD>,
     message: &Bytes,
@@ -1355,13 +1362,14 @@ fn send_with_record<ST, PD, AP>(
     ST: CertificateSignatureRecoverable,
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
     AP: auth::AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
+    UE: networking::UdpMessageEndpoint,
 {
     let build_target: BuildTarget<'_, ST> = BuildTarget::PointToPoint(target);
     let should_authenticate = name_record.authenticated_udp_socket().is_some();
 
     {
         let dual_socket_cell = std::cell::RefCell::new(&mut *dual_socket);
-        let lookup = NameRecordLookup::<ST, AP> {
+        let lookup = NameRecordLookup::<ST, AP, UE> {
             target: *target,
             name_record,
             dual_socket: &dual_socket_cell,
@@ -1383,8 +1391,8 @@ fn send_with_record<ST, PD, AP>(
     }
 }
 
-fn rebroadcast_packet<ST, PD, AP>(
-    dual_socket: &mut auth::DualSocketHandle<AP>,
+fn rebroadcast_packet<ST, PD, AP, UE>(
+    dual_socket: &mut auth::DualSocketHandle<AP, UE>,
     peer_discovery_driver: &Arc<Mutex<PeerDiscoveryDriver<PD>>>,
     target: &NodeId<CertificateSignaturePubKey<ST>>,
     payload: Bytes,
@@ -1393,6 +1401,7 @@ fn rebroadcast_packet<ST, PD, AP>(
     ST: CertificateSignatureRecoverable,
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
     AP: auth::AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
+    UE: networking::UdpMessageEndpoint,
 {
     // if the packet was created by non-upgraded node we won't be able to fit auth header
     let fits_with_auth_header =
@@ -1431,14 +1440,15 @@ fn rebroadcast_packet<ST, PD, AP>(
     ensure_authenticated_sessions(dual_socket, peer_discovery_driver, std::iter::once(target));
 }
 
-fn ensure_authenticated_sessions<'a, ST, PD, AP>(
-    dual_socket: &mut auth::DualSocketHandle<AP>,
+fn ensure_authenticated_sessions<'a, ST, PD, AP, UE>(
+    dual_socket: &mut auth::DualSocketHandle<AP, UE>,
     peer_discovery_driver: &Arc<Mutex<PeerDiscoveryDriver<PD>>>,
     targets: impl Iterator<Item = &'a NodeId<CertificateSignaturePubKey<ST>>>,
 ) where
     ST: CertificateSignatureRecoverable,
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
     AP: auth::AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
+    UE: networking::UdpMessageEndpoint,
 {
     let pd_driver = peer_discovery_driver.lock().unwrap();
 
@@ -1471,15 +1481,16 @@ fn ensure_authenticated_sessions<'a, ST, PD, AP>(
     dual_socket.flush();
 }
 
-impl<ST, PD, AP> packet::PeerAddrLookup<CertificateSignaturePubKey<ST>>
+impl<ST, PD, AP, UE> packet::PeerAddrLookup<CertificateSignaturePubKey<ST>>
     for (
         &Arc<Mutex<PeerDiscoveryDriver<PD>>>,
-        &std::cell::RefCell<&mut auth::DualSocketHandle<AP>>,
+        &std::cell::RefCell<&mut auth::DualSocketHandle<AP, UE>>,
     )
 where
     ST: CertificateSignatureRecoverable,
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
     AP: auth::AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
+    UE: networking::UdpMessageEndpoint,
 {
     fn lookup(&self, node_id: &NodeId<CertificateSignaturePubKey<ST>>) -> Option<SocketAddr> {
         let (discovery, auth_socket) = self;
@@ -1495,20 +1506,23 @@ where
     }
 }
 
-struct NameRecordLookup<'a, ST, AP>
+struct NameRecordLookup<'a, ST, AP, UE>
 where
     ST: CertificateSignatureRecoverable,
     AP: auth::AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
+    UE: networking::UdpMessageEndpoint,
 {
     pub target: NodeId<CertificateSignaturePubKey<ST>>,
     pub name_record: &'a NameRecord,
-    pub dual_socket: &'a std::cell::RefCell<&'a mut auth::DualSocketHandle<AP>>,
+    pub dual_socket: &'a std::cell::RefCell<&'a mut auth::DualSocketHandle<AP, UE>>,
 }
 
-impl<ST, AP> packet::PeerAddrLookup<CertificateSignaturePubKey<ST>> for NameRecordLookup<'_, ST, AP>
+impl<ST, AP, UE> packet::PeerAddrLookup<CertificateSignaturePubKey<ST>>
+    for NameRecordLookup<'_, ST, AP, UE>
 where
     ST: CertificateSignatureRecoverable,
     AP: auth::AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
+    UE: networking::UdpMessageEndpoint,
 {
     fn lookup(&self, node_id: &NodeId<CertificateSignaturePubKey<ST>>) -> Option<SocketAddr> {
         if *node_id != self.target {

--- a/monad-raptorcast/src/networking.rs
+++ b/monad-raptorcast/src/networking.rs
@@ -1,0 +1,123 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::net::{IpAddr, SocketAddr};
+
+use bytes::Bytes;
+use monad_dataplane::{BroadcastMsg, RecvTcpMsg, RecvUdpMsg, TcpMsg, UnicastMsg};
+use monad_types::UdpPriority;
+
+pub use self::dp::Dataplane;
+
+pub trait TcpMessageSource {
+    #[allow(async_fn_in_trait)] // Send bound not used for now
+    async fn recv(&mut self) -> RecvTcpMsg;
+}
+
+pub trait TcpMessageSink {
+    fn write(&self, dest: SocketAddr, msg: TcpMsg);
+}
+
+pub trait UdpMessageEndpoint {
+    #[allow(async_fn_in_trait)] // Send bound not used for now
+    async fn recv(&mut self) -> RecvUdpMsg;
+
+    fn write(&self, dst: SocketAddr, payload: Bytes, stride: u16);
+    fn write_broadcast(&self, msg: BroadcastMsg);
+    fn write_broadcast_with_priority(&self, msg: BroadcastMsg, priority: UdpPriority);
+    fn write_unicast(&self, msg: UnicastMsg);
+    fn write_unicast_with_priority(&self, msg: UnicastMsg, priority: UdpPriority);
+}
+
+pub trait Control {
+    fn update_trusted(&self, added: Vec<IpAddr>, removed: Vec<IpAddr>);
+    fn disconnect(&self, addr: SocketAddr);
+}
+
+pub trait DataplaneType {
+    type TcpMessageSource: TcpMessageSource;
+    type TcpMessageSink: TcpMessageSink;
+    type UdpMessageEndpoint: UdpMessageEndpoint;
+    type Control: Control;
+}
+
+mod dp {
+    use std::net::{IpAddr, SocketAddr};
+
+    use bytes::Bytes;
+    use monad_dataplane::{
+        BroadcastMsg, DataplaneControl, RecvTcpMsg, RecvUdpMsg, TcpMsg, TcpSocketReader,
+        TcpSocketWriter, UdpSocketHandle, UnicastMsg,
+    };
+    use monad_types::UdpPriority;
+
+    use super::{Control, DataplaneType, TcpMessageSink, TcpMessageSource, UdpMessageEndpoint};
+
+    pub struct Dataplane;
+    impl DataplaneType for Dataplane {
+        type TcpMessageSource = TcpSocketReader;
+        type TcpMessageSink = TcpSocketWriter;
+        type UdpMessageEndpoint = UdpSocketHandle;
+        type Control = DataplaneControl;
+    }
+
+    impl TcpMessageSource for TcpSocketReader {
+        async fn recv(&mut self) -> RecvTcpMsg {
+            TcpSocketReader::recv(self).await
+        }
+    }
+
+    impl TcpMessageSink for TcpSocketWriter {
+        fn write(&self, dest: SocketAddr, msg: TcpMsg) {
+            TcpSocketWriter::write(self, dest, msg)
+        }
+    }
+
+    impl Control for DataplaneControl {
+        fn update_trusted(&self, added: Vec<IpAddr>, removed: Vec<IpAddr>) {
+            self.update_trusted(added, removed)
+        }
+
+        fn disconnect(&self, addr: SocketAddr) {
+            self.disconnect(addr)
+        }
+    }
+
+    impl UdpMessageEndpoint for UdpSocketHandle {
+        async fn recv(&mut self) -> RecvUdpMsg {
+            UdpSocketHandle::recv(self).await
+        }
+
+        fn write(&self, dst: SocketAddr, payload: Bytes, stride: u16) {
+            UdpSocketHandle::write(self, dst, payload, stride)
+        }
+
+        fn write_broadcast(&self, msg: BroadcastMsg) {
+            UdpSocketHandle::write_broadcast(self, msg)
+        }
+
+        fn write_broadcast_with_priority(&self, msg: BroadcastMsg, priority: UdpPriority) {
+            UdpSocketHandle::write_broadcast_with_priority(self, msg, priority)
+        }
+
+        fn write_unicast(&self, msg: UnicastMsg) {
+            UdpSocketHandle::write_unicast(self, msg)
+        }
+
+        fn write_unicast_with_priority(&self, msg: UnicastMsg, priority: UdpPriority) {
+            UdpSocketHandle::write_unicast_with_priority(self, msg, priority)
+        }
+    }
+}

--- a/monad-raptorcast/tests/raptorcast_instance.rs
+++ b/monad-raptorcast/tests/raptorcast_instance.rs
@@ -37,6 +37,8 @@ use monad_executor::Executor;
 use monad_executor_glue::{Message, RouterCommand};
 use monad_peer_discovery::mock::NopDiscovery;
 use monad_raptorcast::{
+    auth::NoopAuthProtocol,
+    networking::Dataplane,
     new_defaulted_raptorcast_for_tests,
     packet::build_messages,
     raptorcast_secondary::{group_message::FullNodesGroupMessage, SecondaryOutboundMessage},
@@ -466,7 +468,8 @@ fn setup_raptorcast_service(
     MockMessage,
     MockEvent<CertificateSignaturePubKey<SignatureType>>,
     NopDiscovery<SignatureType>,
-    monad_raptorcast::auth::NoopAuthProtocol<CertificateSignaturePubKey<SignatureType>>,
+    NoopAuthProtocol<CertificateSignaturePubKey<SignatureType>>,
+    Dataplane,
 > {
     new_defaulted_raptorcast_for_tests::<
         SignatureType,

--- a/monad-raptorcast/tests/wireauth_raptorcast.rs
+++ b/monad-raptorcast/tests/wireauth_raptorcast.rs
@@ -33,8 +33,10 @@ use monad_crypto::certificate_signature::{
 };
 use monad_executor::Executor;
 use monad_executor_glue::{Message, RouterCommand};
-use monad_peer_discovery::{MonadNameRecord, NameRecord};
-use monad_raptorcast::RaptorCastEvent;
+use monad_peer_discovery::{mock::NopDiscovery, MonadNameRecord, NameRecord};
+use monad_raptorcast::{
+    networking::Dataplane, raptorcast_secondary::SecondaryRaptorCastModeConfig, RaptorCastEvent,
+};
 use monad_secp::{KeyPair, SecpSignature};
 use monad_types::{Deserializable, Epoch, NodeId, Serializable, Stake};
 use rstest::rstest;
@@ -246,9 +248,7 @@ fn create_peer_discovery(
     >,
 ) -> Arc<
     std::sync::Mutex<
-        monad_peer_discovery::driver::PeerDiscoveryDriver<
-            monad_peer_discovery::mock::NopDiscovery<SecpSignature>,
-        >,
+        monad_peer_discovery::driver::PeerDiscoveryDriver<NopDiscovery<SecpSignature>>,
     >,
 > {
     let builder = monad_peer_discovery::mock::NopDiscoveryBuilder {
@@ -288,11 +288,12 @@ fn spawn_noop_validator(
             MockMessage,
             MockMessage,
             MockEvent<CertificateSignaturePubKey<SecpSignature>>,
-            monad_peer_discovery::mock::NopDiscovery<SecpSignature>,
+            NopDiscovery<SecpSignature>,
             _,
+            Dataplane,
         >::new(
             config,
-            monad_raptorcast::raptorcast_secondary::SecondaryRaptorCastModeConfig::None,
+            SecondaryRaptorCastModeConfig::None,
             tcp_reader,
             tcp_writer,
             None,
@@ -359,11 +360,12 @@ fn spawn_wireauth_validator(
             MockMessage,
             MockMessage,
             MockEvent<CertificateSignaturePubKey<SecpSignature>>,
-            monad_peer_discovery::mock::NopDiscovery<SecpSignature>,
+            NopDiscovery<SecpSignature>,
             _,
+            Dataplane,
         >::new(
             config,
-            monad_raptorcast::raptorcast_secondary::SecondaryRaptorCastModeConfig::None,
+            SecondaryRaptorCastModeConfig::None,
             tcp_reader,
             tcp_writer,
             Some(authenticated_socket),

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -39,7 +39,7 @@ use monad_peer_discovery::{
     mock::{NopDiscovery, NopDiscoveryBuilder},
 };
 use monad_raptorcast::{
-    auth::NoopAuthProtocol, config::RaptorCastConfig,
+    auth::NoopAuthProtocol, config::RaptorCastConfig, networking::Dataplane,
     raptorcast_secondary::SecondaryRaptorCastModeConfig, RaptorCast,
     AUTHENTICATED_RAPTORCAST_SOCKET, RAPTORCAST_SOCKET,
 };
@@ -191,6 +191,7 @@ where
                     MonadEvent<ST, SCT, MockExecutionProtocol>,
                     NopDiscovery<ST>,
                     NoopAuthProtocol<CertificateSignaturePubKey<ST>>,
+                    Dataplane,
                 >::new(
                     cfg,
                     SecondaryRaptorCastModeConfig::None,


### PR DESCRIPTION
Implements part of https://github.com/category-labs/category-internal/issues/2088.

Raptorcast's underlying networking I/O is handled by monad-dataplane. This PR extracts the set of behaviors expected of monad-dataplane. The behavior of dataplane is captured by the `DataplaneType` trait, which requires the following handles:

- TcpMessageSink, TcpMessageSource: handles for sending/receiving TCP messages
- UdpMessageEndpoint: the handle for sending/receiving UDP messages
- Control: the handle for controlling dataplane (e.g. `update_trusted`)

By isolating these types out and specifying the expected interfaces, we have a clear notion of dataplane's expected behavior. This would also help for testing raptorcast's core logic by mocking the networking layer.