### PR TITLE
Use QC event for latest voted in RPC

### DIFF
--- a/monad-rpc/src/chainstate/mod.rs
+++ b/monad-rpc/src/chainstate/mod.rs
@@ -101,11 +101,11 @@ impl<T: Triedb> ChainState<T> {
     }
 
     pub fn get_latest_block_number(&self) -> u64 {
-        // Return triedb's latest block number.
-        // There is a race condition between buffer and triedb for common wallet workflows.
-        // For example, a wallet might call `eth_getBalance` after calling `eth_getBlockByNumber`
-        // and the balance might not be updated in triedb yet.
-        self.triedb_env.get_latest_voted_block_key().seq_num().0
+        if let Some(buffer) = &self.buffer {
+            buffer.get_latest_voted_block_num()
+        } else {
+            self.triedb_env.get_latest_voted_block_key().seq_num().0
+        }
     }
 
     pub async fn get_transaction_receipt(


### PR DESCRIPTION
Previously, the execution event for a QC was sent before the triedb voted metadata was updated, causing a race condition where RPC websockets would push a new head and subsequently querying something for triedb would fail.

After https://github.com/category-labs/monad/pull/1964 (which has been updated in `monad-bft` in a separate PR), we can go back to using the buffer (populated from execution events) for the latest block number. This will reduce user latency and put less pressure on triedb on top of the execution fix writing the QC before executing the proposal which should also further reduce latency.