### PR TITLE
monad-wireauth: use Tai64N directly instead of SystemTime for timestamp comparison

### DIFF
--- a/monad-wireauth/src/api.rs
+++ b/monad-wireauth/src/api.rs
@@ -395,7 +395,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         if self
             .state
             .get_max_timestamp(&remote_key)
-            .is_some_and(|max| validated_init.system_time <= max)
+            .is_some_and(|max| validated_init.timestamp <= max)
         {
             self.metrics[GAUGE_WIREAUTH_ERROR_TIMESTAMP_REPLAY] += 1;
             debug!(?remote_addr, ?remote_key, "timestamp replay detected");

--- a/monad-wireauth/src/session/common.rs
+++ b/monad-wireauth/src/session/common.rs
@@ -13,11 +13,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{
-    net::SocketAddr,
-    time::{Duration, SystemTime},
-};
+use std::{net::SocketAddr, time::Duration};
 
+use tai64::Tai64N;
 use tracing::debug;
 
 use crate::{
@@ -83,7 +81,7 @@ pub struct SessionState {
     pub stored_cookie: Option<[u8; 16]>,
     pub last_handshake_mac1: Option<[u8; 16]>,
     pub retry_attempts: u64,
-    pub initiator_system_time: Option<SystemTime>,
+    pub initiator_timestamp: Option<Tai64N>,
     pub remote_addr: SocketAddr,
     pub remote_public_key: monad_secp::PubKey,
     pub local_index: SessionIndex,
@@ -98,7 +96,7 @@ impl SessionState {
         local_index: SessionIndex,
         created: Duration,
         retry_attempts: u64,
-        initiator_system_time: Option<SystemTime>,
+        initiator_timestamp: Option<Tai64N>,
         is_initiator: bool,
     ) -> Self {
         Self {
@@ -109,7 +107,7 @@ impl SessionState {
             stored_cookie: None,
             last_handshake_mac1: None,
             retry_attempts,
-            initiator_system_time,
+            initiator_timestamp,
             remote_addr,
             remote_public_key,
             local_index,
@@ -184,8 +182,8 @@ impl SessionState {
         self.stored_cookie
     }
 
-    pub fn initiator_system_time(&self) -> Option<SystemTime> {
-        self.initiator_system_time
+    pub fn initiator_timestamp(&self) -> Option<Tai64N> {
+        self.initiator_timestamp
     }
 
     pub fn handle_cookie(

--- a/monad-wireauth/src/session/responder.rs
+++ b/monad-wireauth/src/session/responder.rs
@@ -19,6 +19,8 @@ use std::{
     time::Duration,
 };
 
+use tai64::Tai64N;
+
 use super::{
     common::{add_jitter, RenewedTimer, SessionError, SessionState, SessionTimeoutResult},
     transport::TransportState,
@@ -35,7 +37,7 @@ use crate::{
 pub struct ValidatedHandshakeInit {
     pub(crate) handshake_state: crate::protocol::handshake::HandshakeState,
     pub(crate) remote_public_key: monad_secp::PubKey,
-    pub(crate) system_time: std::time::SystemTime,
+    pub(crate) timestamp: Tai64N,
 }
 
 pub struct ResponderState {
@@ -61,7 +63,7 @@ impl ResponderState {
         local_static_key: &monad_secp::KeyPair,
         handshake_packet: &mut HandshakeInitiation,
     ) -> Result<ValidatedHandshakeInit, SessionError> {
-        let (handshake_state, system_time) =
+        let (handshake_state, timestamp) =
             handshake::accept_handshake_init(local_static_key, handshake_packet)
                 .map_err(SessionError::HandshakeError)?;
 
@@ -72,7 +74,7 @@ impl ResponderState {
         Ok(ValidatedHandshakeInit {
             handshake_state,
             remote_public_key,
-            system_time,
+            timestamp,
         })
     }
 
@@ -102,7 +104,7 @@ impl ResponderState {
             local_session_index,
             duration_since_start,
             0,
-            Some(validated_init.system_time),
+            Some(validated_init.timestamp),
             false,
         );
         common.last_handshake_mac1 = Some(response_mac1);


### PR DESCRIPTION
we only need to know that next timestamp is newer to prevent replaying previously sent handshakes from honest nodes,
so to_system_time conversion is unnecessary and moreover is not safe