### PR TITLE
Change eth call error code

### DIFF
--- a/monad-rpc/src/handlers/debug_replay.rs
+++ b/monad-rpc/src/handlers/debug_replay.rs
@@ -253,7 +253,7 @@ pub async fn monad_debug_trace_replay<T: Triedb>(
     let raw_payload = match call_result {
         CallResult::Success(monad_ethcall::SuccessCallResult { output_data, .. }) => output_data,
         CallResult::Failure(error) => {
-            return Err(JsonRpcError::eth_call_error(error.message, error.data));
+            return Err(error.into());
         }
         CallResult::Revert(result) => result.trace,
     };

--- a/monad-rpc/src/handlers/eth/call.rs
+++ b/monad-rpc/src/handlers/eth/call.rs
@@ -734,7 +734,7 @@ pub async fn monad_eth_call<T: Triedb + TriedbPath>(
         CallResult::Success(monad_ethcall::SuccessCallResult { output_data, .. }) => {
             Ok(ethhex::encode_bytes(&output_data))
         }
-        CallResult::Failure(error) => Err(JsonRpcError::eth_call_error(error.message, error.data)),
+        CallResult::Failure(error) => Err(error.into()),
         _ => Err(JsonRpcError::internal_error(
             "Unexpected CallResult type".into(),
         )),
@@ -774,9 +774,7 @@ pub async fn monad_debug_traceCall<T: Triedb + TriedbPath>(
     .await?;
     let raw_payload: Vec<u8> = match call_result {
         CallResult::Success(monad_ethcall::SuccessCallResult { output_data, .. }) => output_data,
-        CallResult::Failure(error) => {
-            return Err(JsonRpcError::eth_call_error(error.message, error.data))
-        }
+        CallResult::Failure(error) => return Err(error.into()),
         CallResult::Revert(result) => result.trace,
     };
 
@@ -892,7 +890,7 @@ fn access_list_from_trace_call_result(call_result: CallResult) -> Result<AccessL
         CallResult::Success(monad_ethcall::SuccessCallResult { output_data, .. }) => {
             decode_access_list_trace(&output_data)
         }
-        CallResult::Failure(error) => Err(JsonRpcError::eth_call_error(error.message, error.data)),
+        CallResult::Failure(error) => Err(error.into()),
         CallResult::Revert(result) => decode_access_list_trace(&result.trace),
     }
 }

--- a/monad-rpc/src/handlers/eth/gas.rs
+++ b/monad-rpc/src/handlers/eth/gas.rs
@@ -104,7 +104,7 @@ async fn estimate_gas_with_builder(
                     error.data,
                 ));
             }
-            _ => return Err(JsonRpcError::eth_call_error(error.message, error.data)),
+            _ => return Err(error.into()),
         },
         _ => {
             return Err(JsonRpcError::internal_error(

--- a/monad-rpc/src/types/jsonrpc.rs
+++ b/monad-rpc/src/types/jsonrpc.rs
@@ -477,6 +477,16 @@ impl JsonRpcError {
         }
     }
 
+    pub fn eth_call_execution_revert(message: String, data: Option<String>) -> Self {
+        Self {
+            code: 3,
+            message,
+            data: data.map(|data| {
+                serde_json::value::to_raw_value(&data).expect("RawValue can be built from String")
+            }),
+        }
+    }
+
     pub fn insufficient_funds() -> Self {
         Self {
             code: -32003,
@@ -537,6 +547,17 @@ impl From<monad_archive::prelude::Report> for JsonRpcError {
         // Log with debug to get more details, but return a generic error for response
         error!("Archive error: {e:?}");
         Self::internal_error(format!("Archive error: {}", e))
+    }
+}
+
+impl From<monad_ethcall::FailureCallResult> for JsonRpcError {
+    fn from(error: monad_ethcall::FailureCallResult) -> Self {
+        match error.error_code {
+            monad_ethcall::EthCallResult::ExecutionError => {
+                Self::eth_call_execution_revert(error.message, error.data)
+            }
+            _ => Self::eth_call_error(error.message, error.data),
+        }
     }
 }
 


### PR DESCRIPTION
Switch eth call execution revert error code from -32603 to 3, other error code remains the same

To be consistent with other ethereum clients https://www.quicknode.com/docs/ethereum/error-references