### PR TITLE
Archive: add exists(key) to kvstore

### DIFF
--- a/monad-archive/src/bin/monad-archiver/generic_folder_archiver.rs
+++ b/monad-archive/src/bin/monad-archiver/generic_folder_archiver.rs
@@ -310,7 +310,7 @@ async fn process_single_file(
     path: &PathBuf,
     metrics: &Metrics,
 ) -> Result<Option<String>> {
-    if s3_exists_key(&store, key).await? {
+    if store.exists(key).await? {
         metrics.inc_counter(MetricNames::GENERIC_ARCHIVE_FILES_ALREADY_IN_S3);
         return Ok(Some(key.to_string()));
     }
@@ -326,11 +326,6 @@ async fn process_single_file(
     info!(key, ?path, "Uploaded file to archive store");
     // Do NOT mark as known here; wait for next tick's exists check
     Ok(None)
-}
-
-async fn s3_exists_key(store: &impl KVStore, key: &str) -> Result<bool> {
-    let objs = store.scan_prefix(key).await?;
-    Ok(objs.iter().any(|k| k == key))
 }
 
 fn derive_prefix(base_prefix: &str, folder_path: &Path) -> Result<String> {

--- a/monad-archive/src/kvstore/fs.rs
+++ b/monad-archive/src/kvstore/fs.rs
@@ -113,6 +113,28 @@ impl KVReader for FsStorage {
                 .write_get_metrics_on_err(start.elapsed(), KVStoreType::FileSystem, &self.metrics),
         }
     }
+
+    async fn exists(&self, key: &str) -> Result<bool> {
+        let path = self.key_path(key)?;
+        let start = Instant::now();
+
+        match fs::try_exists(&path).await {
+            Ok(exists) => {
+                kvstore_get_metrics(
+                    start.elapsed(),
+                    true,
+                    KVStoreType::FileSystem,
+                    &self.metrics,
+                );
+                Ok(exists)
+            }
+            Err(err) => Err(err)
+                .wrap_err_with(|| {
+                    format!("Failed to check existence of key {key} at path {path:?}")
+                })
+                .write_get_metrics_on_err(start.elapsed(), KVStoreType::FileSystem, &self.metrics),
+        }
+    }
 }
 
 impl KVStore for FsStorage {

--- a/monad-archive/src/kvstore/memory.rs
+++ b/monad-archive/src/kvstore/memory.rs
@@ -53,6 +53,16 @@ impl KVReader for MemoryStorage {
 
         Ok(self.db.lock().await.get(key).map(ToOwned::to_owned))
     }
+
+    async fn exists(&self, key: &str) -> Result<bool> {
+        use std::sync::atomic::Ordering;
+
+        if self.should_fail.load(Ordering::SeqCst) {
+            return Err(eyre::eyre!("MemoryStorage simulated failure"));
+        }
+
+        Ok(self.db.lock().await.contains_key(key))
+    }
 }
 
 impl KVStore for MemoryStorage {

--- a/monad-archive/src/kvstore/mod.rs
+++ b/monad-archive/src/kvstore/mod.rs
@@ -147,6 +147,10 @@ pub trait KVStore: KVReader {
 #[enum_dispatch]
 pub trait KVReader: Clone {
     async fn get(&self, key: &str) -> Result<Option<Bytes>>;
+
+    /// Lightweight existence check; prefer this over `get` when you don't need payload bytes.
+    async fn exists(&self, key: &str) -> Result<bool>;
+
     async fn bulk_get(&self, keys: &[String]) -> Result<HashMap<String, Bytes>> {
         // Note: a stream based approach runs into lifetime generality errors for some reason here.
         // After a lot of variations I could not get it to work, so fell back on this join_all approach even


### PR DESCRIPTION
Replaces previous store.scan_prefix with exact match key. 
That impl was `O(log(N))` which works for quite a while, but eventually degrades after tens of millions of keys.