### PR TITLE
Lint: run clippy --fix

### DIFF
--- a/monad-blocksync/src/blocksync.rs
+++ b/monad-blocksync/src/blocksync.rs
@@ -1280,6 +1280,7 @@ mod test {
         fn wrapped_state(
             &mut self,
         ) -> BlockSyncWrapper<
+            '_,
             SignatureType,
             SignatureCollectionType,
             ExecutionProtocolType,

--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -920,7 +920,7 @@ mod test {
 
     #[test]
     fn duplicate_blocks() {
-        let mut metrics = Metrics::default();
+        let metrics = Metrics::default();
         let g = get_genesis_block();
         let b1 = get_next_block(&g, None, &[1]);
 
@@ -1793,7 +1793,7 @@ mod test {
         //    |
         //   b2
 
-        let mut metrics = Metrics::default();
+        let metrics = Metrics::default();
         let b1 = get_genesis_block();
         let b2 = get_next_block(&b1, None, &[1]);
 

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -2014,6 +2014,7 @@ mod test {
         fn wrapped_state(
             &mut self,
         ) -> ConsensusStateWrapper<
+            '_,
             ST,
             SCT,
             EthExecutionProtocol,

--- a/monad-control-panel/src/ipc.rs
+++ b/monad-control-panel/src/ipc.rs
@@ -275,7 +275,7 @@ where
         }
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         self.metrics.as_ref().into()
     }
 }

--- a/monad-cxx/src/lib.rs
+++ b/monad-cxx/src/lib.rs
@@ -34,10 +34,9 @@ type c_flush_fn = extern "C" fn(usize);
 // Called back by C++, sent to tracing framework via the event! macro
 extern "C" fn log_callback(plog: *const monad_log, _: usize) {
     let log = unsafe { &*plog };
-    let message = match unsafe { ffi::CStr::from_ptr(log.message) }.to_str() {
-        Ok(msg) => msg,
-        Err(_) => "UTF-8 decode error in log message",
-    };
+    let message = unsafe { ffi::CStr::from_ptr(log.message) }
+        .to_str()
+        .unwrap_or("UTF-8 decode error in log message");
     match log.syslog_level {
         0..=3 => event!(Level::ERROR, message),
         4 => event!(Level::WARN, message),

--- a/monad-eth-block-policy/src/validation.rs
+++ b/monad-eth-block-policy/src/validation.rs
@@ -276,7 +276,7 @@ fn compute_intrinsic_gas(tx: &TxEnvelope) -> u64 {
         intrinsic_gas += 32000;
         // EIP-3860: Limit and meter initcode
         // Init code stipend for bytecode analysis
-        intrinsic_gas += ((tx.input().len() as u64 + 31) / 32) * 2;
+        intrinsic_gas += (tx.input().len() as u64).div_ceil(32) * 2;
     }
 
     // EIP-2930

--- a/monad-eth-block-validator/tests/coherency_test.rs
+++ b/monad-eth-block-validator/tests/coherency_test.rs
@@ -869,7 +869,7 @@ fn sufficient_single_emptying_transaction_inputs() -> (
 ) {
     let signer = S1;
 
-    let max_fee_per_gas = (1 * ONE_ETHER) / 50_000;
+    let max_fee_per_gas = ONE_ETHER / 50_000;
 
     let tx1 = make_test_tx(signer, 50_000, max_fee_per_gas, 3 * ONE_ETHER, 0);
     let sender = tx1.signer();
@@ -954,7 +954,7 @@ fn sufficient_emptying_transaction_inputs() -> (
     let tx1 = make_test_tx(signer, 50_000, max_fee_per_gas, 2 * ONE_ETHER, 0);
     let sender = tx1.signer();
 
-    let max_fee_per_gas = (1 * ONE_ETHER) / 50_000;
+    let max_fee_per_gas = ONE_ETHER / 50_000;
     let tx2 = make_test_tx(signer, 50_000, max_fee_per_gas, ONE_ETHER, 1);
 
     let txs = BTreeMap::from([
@@ -1037,7 +1037,7 @@ fn emptying_transaction_different_blocks_sufficient_inputs() -> (
     let tx1 = make_test_tx(signer, 50_000, max_fee_per_gas, 2 * ONE_ETHER, 0);
     let sender = tx1.signer();
 
-    let max_fee_per_gas = (1 * ONE_ETHER) / 50_000;
+    let max_fee_per_gas = ONE_ETHER / 50_000;
     let tx2 = make_test_tx(signer, 50_000, max_fee_per_gas, ONE_ETHER, 1);
 
     let txs = BTreeMap::from([
@@ -1224,7 +1224,7 @@ fn delegation_non_emptying_same_block_sufficient_inputs() -> (
         make_eip7702_tx_with_value(S2, 0, 100_000_000_000, 0, 50_000, 0, vec![signed_auth], 0);
     let bundler = tx1.signer();
 
-    let max_fee_per_gas = (1 * ONE_ETHER) / 50_000;
+    let max_fee_per_gas = ONE_ETHER / 50_000;
     let tx2 = make_test_tx(signer, 50_000, max_fee_per_gas, 0, 1);
     let sender = tx2.signer();
 
@@ -1375,7 +1375,7 @@ fn delegation_non_emptying_different_blocks_sufficient_inputs() -> (
     let bundler = tx1.signer();
     let sender = signer;
 
-    let max_fee_per_gas = (1 * ONE_ETHER) / 50_000;
+    let max_fee_per_gas = ONE_ETHER / 50_000;
     let tx2 = make_test_tx(signer, 50_000, max_fee_per_gas, 0, 1);
 
     let txs = BTreeMap::from([
@@ -1568,7 +1568,7 @@ fn sufficient_balance_emptying_txn_with_value_and_delegation_same_block_inputs()
 ) {
     let signer = S1;
 
-    let max_fee_per_gas = (1 * ONE_ETHER) / 50_000;
+    let max_fee_per_gas = ONE_ETHER / 50_000;
     let tx1 = make_test_tx(signer, 50_000, max_fee_per_gas, 3 * ONE_ETHER, 0);
     let sender = tx1.signer();
 
@@ -1944,7 +1944,7 @@ fn emptying_and_delegation_preceding_blocks_sufficient_inputs() -> (
         make_eip7702_tx_with_value(S2, 0, 100_000_000_000, 0, 50_000, 0, vec![signed_auth], 0);
     let bundler = tx2.signer();
 
-    let max_fee_per_gas = (1 * ONE_ETHER) / 50_000;
+    let max_fee_per_gas = ONE_ETHER / 50_000;
     let tx3 = make_test_tx(signer, 50_000, max_fee_per_gas, 0, 2);
 
     let txs = BTreeMap::from([
@@ -2016,7 +2016,7 @@ fn multiple_non_emptying_same_block_sufficient_inputs() -> (
     let max_fee_per_gas = (5 * ONE_ETHER) / 50_000;
     let tx2 = make_test_tx(signer, 50_000, max_fee_per_gas, 0, 2);
 
-    let max_fee_per_gas = (1 * ONE_ETHER) / 50_000;
+    let max_fee_per_gas = ONE_ETHER / 50_000;
     let tx3 = make_test_tx(signer, 50_000, max_fee_per_gas, 0, 3);
 
     let txs = BTreeMap::from([
@@ -2054,7 +2054,7 @@ fn multiple_non_emptying_different_blocks_insufficient_inputs() -> (
     let max_fee_per_gas = (2 * ONE_ETHER) / 50_000;
     let tx3 = make_test_tx(signer, 50_000, max_fee_per_gas, 0, 3);
 
-    let max_fee_per_gas = (1 * ONE_ETHER) / 50_000;
+    let max_fee_per_gas = ONE_ETHER / 50_000;
     let tx4 = make_test_tx(signer, 50_000, max_fee_per_gas, 0, 4);
 
     let txs = BTreeMap::from([
@@ -2088,7 +2088,7 @@ fn multiple_non_emptying_different_blocks_sufficient_inputs() -> (
     let max_fee_per_gas = (3 * ONE_ETHER) / 50_000;
     let tx2 = make_test_tx(signer, 50_000, max_fee_per_gas, 0, 2);
 
-    let max_fee_per_gas = (1 * ONE_ETHER) / 50_000;
+    let max_fee_per_gas = ONE_ETHER / 50_000;
     let tx3 = make_test_tx(signer, 50_000, max_fee_per_gas, 0, 3);
 
     let tx4 = make_test_tx(signer, 50_000, max_fee_per_gas, 0, 4);

--- a/monad-eth-ledger/src/lib.rs
+++ b/monad-eth-ledger/src/lib.rs
@@ -182,7 +182,7 @@ where
         }
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         Default::default()
     }
 }

--- a/monad-eth-testutil/examples/rpc-request-generator/main.rs
+++ b/monad-eth-testutil/examples/rpc-request-generator/main.rs
@@ -340,7 +340,7 @@ impl RpcRequestGenerator {
                                 "eth_getTransactionByHash",
                                 &params,
                             )
-                            .map(|w| async move { w.await })
+                            .map(|w| w)
                             .unwrap()
                     })
                     .collect::<Vec<_>>();
@@ -384,7 +384,7 @@ impl RpcRequestGenerator {
                                 "eth_getTransactionReceipt",
                                 &params,
                             )
-                            .map(|w| async move { w.await })
+                            .map(|w| w)
                             .unwrap()
                     })
                     .collect::<Vec<_>>();
@@ -475,7 +475,7 @@ impl RpcRequestGenerator {
                         let params = (call_request, U64::from(block_number));
                         batch
                             .add_call::<_, Bytes>("eth_call", &params)
-                            .map(|w| async move { w.await })
+                            .map(|w| w)
                             .unwrap()
                     })
                     .collect::<Vec<_>>();
@@ -512,7 +512,7 @@ impl RpcRequestGenerator {
                         let params = (addr, U64::from(block_number));
                         batch
                             .add_call::<_, U256>("eth_getBalance", &params)
-                            .map(|w| async move { w.await })
+                            .map(|w| w)
                             .unwrap()
                     })
                     .collect::<Vec<_>>();
@@ -556,7 +556,7 @@ impl RpcRequestGenerator {
                         let params = (txn, config);
                         batch
                             .add_call::<_, GethTrace>("debug_traceTransaction", &params)
-                            .map(|w| async move { w.await })
+                            .map(|w| w)
                             .unwrap()
                     })
                     .collect::<Vec<_>>();

--- a/monad-eth-testutil/examples/txgen/config.rs
+++ b/monad-eth-testutil/examples/txgen/config.rs
@@ -474,16 +474,9 @@ pub enum RpcWorkflowConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
+#[derive(Default)]
 pub struct RpcRequestGeneratorConfig {
     pub workflows: Vec<RpcWorkflowConfig>,
-}
-
-impl Default for RpcRequestGeneratorConfig {
-    fn default() -> Self {
-        Self {
-            workflows: Vec::new(),
-        }
-    }
 }
 
 impl RpcRequestGeneratorConfig {

--- a/monad-eth-testutil/examples/txgen/workers/mod.rs
+++ b/monad-eth-testutil/examples/txgen/workers/mod.rs
@@ -73,14 +73,14 @@ impl From<Vec<SimpleAccount>> for Accounts {
 }
 
 impl Accounts {
-    pub fn iter_mut(&mut self) -> AccountsIterMut {
+    pub fn iter_mut(&mut self) -> AccountsIterMut<'_> {
         AccountsIterMut {
             slice: self.accts.iter_mut(),
             root: self.root.as_mut(),
             done: false,
         }
     }
-    pub fn iter(&self) -> AccountsIter {
+    pub fn iter(&self) -> AccountsIter<'_> {
         AccountsIter {
             slice: self.accts.iter(),
             root: &self.root,

--- a/monad-eth-testutil/examples/txgen/workers/rpc_request_gen.rs
+++ b/monad-eth-testutil/examples/txgen/workers/rpc_request_gen.rs
@@ -280,7 +280,7 @@ impl RpcRequestGenerator {
                         let params = (addr, U64::from(block_number));
                         batch
                             .add_call::<_, U256>("eth_getBalance", &params)
-                            .map(|w| async move { w.await })
+                            .map(|w| w)
                             .unwrap()
                     })
                     .collect::<Vec<_>>();
@@ -324,7 +324,7 @@ impl RpcRequestGenerator {
                         let params = (txn, config);
                         batch
                             .add_call::<_, GethTrace>("debug_traceTransaction", &params)
-                            .map(|w| async move { w.await })
+                            .map(|w| w)
                             .unwrap()
                     })
                     .collect::<Vec<_>>();

--- a/monad-eth-txpool-executor/src/client.rs
+++ b/monad-eth-txpool-executor/src/client.rs
@@ -227,7 +227,7 @@ where
         }
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         ExecutorMetricsChain::from(&self.metrics)
     }
 }

--- a/monad-eth-txpool-executor/src/lib.rs
+++ b/monad-eth-txpool-executor/src/lib.rs
@@ -461,7 +461,7 @@ where
         self.ipc.as_mut().broadcast_tx_events(ipc_events);
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         ExecutorMetricsChain::default().push(&self.executor_metrics)
     }
 }

--- a/monad-event-ring/src/ring/snapshot.rs
+++ b/monad-event-ring/src/ring/snapshot.rs
@@ -51,7 +51,7 @@ where
         let mut decompressed = Vec::new();
 
         zstd::stream::copy_decode(zstd_bytes, &mut decompressed)
-            .expect(format!("could not decompress `{}`", name.as_ref()).as_str());
+            .unwrap_or_else(|_| panic!("could not decompress `{}`", name.as_ref()));
 
         let n_write = unsafe {
             libc::write(

--- a/monad-exec-events/src/events/bytes.rs
+++ b/monad-exec-events/src/events/bytes.rs
@@ -30,7 +30,7 @@ fn split_ref_from_bytes<T>(bytes: &'_ [u8]) -> Result<(&'_ T, &'_ [u8]), String>
 
     let bytes_ptr = bytes.as_ptr();
 
-    if (bytes_ptr as usize) % align_of::<T>() != 0 {
+    if !(bytes_ptr as usize).is_multiple_of(align_of::<T>()) {
         return Err(format!(
             "Expected slice with alignment {} but slice has ptr {}",
             align_of::<T>(),

--- a/monad-ledger/src/lib.rs
+++ b/monad-ledger/src/lib.rs
@@ -306,7 +306,7 @@ where
         }
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         self.metrics.as_ref().into()
     }
 }

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -411,7 +411,7 @@ impl<S: SwarmRelation> Executor for MockExecutor<S> {
         }
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         // TODO do we want to see executor metrics in mock?
         Default::default()
     }
@@ -543,7 +543,7 @@ where
             }
         }
     }
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         Default::default()
     }
 }

--- a/monad-peer-disc-swarm/src/lib.rs
+++ b/monad-peer-disc-swarm/src/lib.rs
@@ -164,7 +164,7 @@ impl<S: PeerDiscSwarmRelation> Executor for MockPeerDiscExecutor<S> {
         }
     }
 
-    fn metrics(&self) -> monad_executor::ExecutorMetricsChain {
+    fn metrics(&self) -> monad_executor::ExecutorMetricsChain<'_> {
         Default::default()
     }
 }

--- a/monad-peer-discovery/src/lib.rs
+++ b/monad-peer-discovery/src/lib.rs
@@ -468,7 +468,7 @@ impl<ST: CertificateSignatureRecoverable> MonadNameRecord<ST> {
     pub fn with_pubkey(
         &self,
         pubkey: CertificateSignaturePubKey<ST>,
-    ) -> MonadNameRecordWithPubkey<ST> {
+    ) -> MonadNameRecordWithPubkey<'_, ST> {
         MonadNameRecordWithPubkey {
             record: self,
             pubkey,

--- a/monad-raptor/src/r10/nonsystematic/encoder.rs
+++ b/monad-raptor/src/r10/nonsystematic/encoder.rs
@@ -55,7 +55,7 @@ pub struct Encoder<'a> {
 }
 
 impl Encoder<'_> {
-    pub fn new(src: &[u8], symbol_len: usize) -> Result<Encoder, Error> {
+    pub fn new(src: &[u8], symbol_len: usize) -> Result<Encoder<'_>, Error> {
         if symbol_len == 0 {
             return Err(Error::new(
                 ErrorKind::InvalidInput,

--- a/monad-raptor/src/r10/parameters.rs
+++ b/monad-raptor/src/r10/parameters.rs
@@ -140,7 +140,7 @@ impl CodeParameters {
     fn determine_num_ldpc_symbols(num_source_symbols: u16, x: u8) -> Result<u16, String> {
         // "Let S be the smallest prime integer such that S >= ceil(0.01*K) + X"
         // where S = num_ldpc_symbols, K = num_source_symbols.
-        let num_ldpc_symbols_min = ((num_source_symbols + 99) / 100) + u16::from(x);
+        let num_ldpc_symbols_min = num_source_symbols.div_ceil(100) + u16::from(x);
 
         // For num_source_symbols = 4, X = 4, and so, num_ldpc_symbols >= 1 + 4 = 5.
         // For num_source_symbols = 8192, X = 129, and so, num_ldpc_symbols >= 82 + 129 = 211.
@@ -193,7 +193,7 @@ impl CodeParameters {
             smallest_integer_satisfying(Self::HALF_MIN, Self::HALF_MAX + 1, |pivot| {
                 let pivot = pivot.try_into().unwrap();
 
-                Self::choose(pivot, (pivot + 1) / 2) >= num_source_symbols + num_ldpc_symbols
+                Self::choose(pivot, pivot.div_ceil(2)) >= num_source_symbols + num_ldpc_symbols
             });
 
         match num_half_symbols {

--- a/monad-raptorcast/src/auth/protocol.rs
+++ b/monad-raptorcast/src/auth/protocol.rs
@@ -75,7 +75,7 @@ pub trait AuthenticationProtocol {
 
     fn next_deadline(&self) -> Option<Instant>;
 
-    fn metrics(&self) -> ExecutorMetricsChain;
+    fn metrics(&self) -> ExecutorMetricsChain<'_>;
 }
 
 pub struct WireAuthProtocol {
@@ -185,7 +185,7 @@ impl AuthenticationProtocol for WireAuthProtocol {
         self.api.has_any_session_by_public_key(public_key)
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         self.api.metrics()
     }
 }
@@ -288,7 +288,7 @@ impl<P: PubKey> AuthenticationProtocol for NoopAuthProtocol<P> {
         false
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         ExecutorMetricsChain::default()
     }
 }

--- a/monad-raptorcast/src/auth/socket.rs
+++ b/monad-raptorcast/src/auth/socket.rs
@@ -209,7 +209,7 @@ where
         }
     }
 
-    pub fn metrics(&self) -> ExecutorMetricsChain {
+    pub fn metrics(&self) -> ExecutorMetricsChain<'_> {
         let mut chain = ExecutorMetricsChain::default().push(self.metrics.as_ref());
         if let Some(authenticated) = &self.authenticated {
             chain = chain.chain(authenticated.auth_protocol.metrics());

--- a/monad-raptorcast/src/decoding.rs
+++ b/monad-raptorcast/src/decoding.rs
@@ -330,7 +330,7 @@ where
         self.pending_messages.consistency_breaches()
     }
 
-    pub fn metrics(&self) -> ExecutorMetricsChain {
+    pub fn metrics(&self) -> ExecutorMetricsChain<'_> {
         ExecutorMetricsChain::default()
             .push(&self.metrics)
             .push(self.pending_messages.validator.metrics())

--- a/monad-raptorcast/src/packet/assembler.rs
+++ b/monad-raptorcast/src/packet/assembler.rs
@@ -326,7 +326,7 @@ impl PacketLayout {
     pub const fn merkle_tree_depth(&self) -> u8 {
         let proof_len = self.chunk_header_start - HEADER_LEN;
         debug_assert!(proof_len < u8::MAX as usize * MERKLE_HASH_LEN);
-        debug_assert!(proof_len % MERKLE_HASH_LEN == 0);
+        debug_assert!(proof_len.is_multiple_of(MERKLE_HASH_LEN));
         (proof_len / MERKLE_HASH_LEN) as u8 + 1
     }
 
@@ -407,7 +407,7 @@ pub(super) struct MerkleBatch<'a, PT: PubKey> {
 pub(super) fn merkle_batches<PT: PubKey>(
     all_chunks: &mut [Chunk<PT>],
     layout: PacketLayout,
-) -> impl Iterator<Item = MerkleBatch<PT>> {
+) -> impl Iterator<Item = MerkleBatch<'_, PT>> {
     let batch_len = layout.merkle_batch_len();
     debug_assert!(batch_len > 0);
     all_chunks.chunks_mut(batch_len).map(MerkleBatch::from)

--- a/monad-raptorcast/src/packet/assigner.rs
+++ b/monad-raptorcast/src/packet/assigner.rs
@@ -334,7 +334,7 @@ pub(crate) trait ChunkAssigner<PT: PubKey> {
         &self,
         num_symbols: usize,
         preferred_order: Option<ChunkOrder>,
-    ) -> Result<ChunkAssignment<PT>>;
+    ) -> Result<ChunkAssignment<'_, PT>>;
 }
 
 impl<PT: PubKey> ChunkAssigner<PT> for Replicated<PT> {
@@ -342,7 +342,7 @@ impl<PT: PubKey> ChunkAssigner<PT> for Replicated<PT> {
         &self,
         num_symbols: usize,
         preferred_order: Option<ChunkOrder>,
-    ) -> Result<ChunkAssignment<PT>> {
+    ) -> Result<ChunkAssignment<'_, PT>> {
         if self.recipients.is_empty() {
             tracing::warn!("no recipients specified for chunk assigner");
             return Ok(ChunkAssignment::empty());
@@ -415,7 +415,7 @@ impl<PT: PubKey> Partitioned<PT> {
         }
     }
 
-    fn assign_gso(&self, num_symbols: usize) -> ChunkAssignment<PT> {
+    fn assign_gso(&self, num_symbols: usize) -> ChunkAssignment<'_, PT> {
         let num_nodes = self.weighted_nodes.len();
         let mut assignment = ChunkAssignment::with_capacity(num_nodes);
         assignment.hint_order(ChunkOrder::GsoFriendly);
@@ -439,7 +439,7 @@ impl<PT: PubKey> ChunkAssigner<PT> for Partitioned<PT> {
         &self,
         num_symbols: usize,
         _preferred_order: Option<ChunkOrder>,
-    ) -> Result<ChunkAssignment<PT>> {
+    ) -> Result<ChunkAssignment<'_, PT>> {
         if self.weighted_nodes.is_empty() {
             tracing::warn!("no nodes specified for partitioned chunk assigner");
             return Ok(ChunkAssignment::empty());
@@ -511,7 +511,7 @@ impl<PT: PubKey> ChunkAssigner<PT> for StakeBasedWithRC<PT> {
         &self,
         num_symbols: usize,
         _preferred_order: Option<ChunkOrder>,
-    ) -> Result<ChunkAssignment<PT>> {
+    ) -> Result<ChunkAssignment<'_, PT>> {
         if self.validator_set.is_empty() {
             tracing::warn!("no nodes specified for partitioned chunk assigner");
             return Ok(ChunkAssignment::empty());
@@ -625,7 +625,7 @@ mod tests {
             Self { slices }
         }
 
-        fn assign_chunks(&self) -> ChunkAssignment<PT> {
+        fn assign_chunks(&self) -> ChunkAssignment<'_, PT> {
             let mut assignment = ChunkAssignment::with_capacity(self.slices.len());
             for slice in &self.slices {
                 assignment.push(&slice.0, slice.1.clone());

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -383,7 +383,7 @@ where
         }
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         match &self.role {
             Role::Publisher(publisher) => publisher.metrics().into(),
             Role::Client(client) => client.metrics().into(),

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -130,7 +130,7 @@ impl<P: PubKey> FullNodes<P> {
         Self { list: nodes }
     }
 
-    pub fn view(&self) -> FullNodesView<P> {
+    pub fn view(&self) -> FullNodesView<'_, P> {
         FullNodesView(&self.list)
     }
 }
@@ -443,7 +443,7 @@ where
         &self.round_span
     }
 
-    fn empty_iterator(&self) -> GroupIterator<ST> {
+    fn empty_iterator(&self) -> GroupIterator<'_, ST> {
         GroupIterator {
             group: self,
             num_consumed: usize::MAX,
@@ -461,7 +461,7 @@ where
         &self,
         author_id: &NodeId<CertificateSignaturePubKey<ST>>,
         seed: usize,
-    ) -> GroupIterator<ST> {
+    ) -> GroupIterator<'_, ST> {
         // Hint for the index of author_id within self.sorted_other_peers.
         // We want to skip it when iterating the peers for broadcasting.
         let author_id_ix = if let Some(root_vid) = self.validator_id {
@@ -647,7 +647,7 @@ where
         &self,
         msg_group_id: GroupId,
         msg_author: &NodeId<CertificateSignaturePubKey<ST>>, // skipped when iterating RaptorCast group
-    ) -> Option<GroupIterator<ST>> {
+    ) -> Option<GroupIterator<'_, ST>> {
         let rebroadcast_group = match msg_group_id {
             GroupId::Primary(msg_epoch) => self.validator_map.get(&msg_epoch)?,
             GroupId::Secondary(msg_round) => {

--- a/monad-rpc/benches/serialize.rs
+++ b/monad-rpc/benches/serialize.rs
@@ -49,7 +49,7 @@ where
     T: Serialize,
     M: Measurement,
 {
-    g.throughput(Throughput::Bytes(serialize(value).as_bytes().len() as u64));
+    g.throughput(Throughput::Bytes(serialize(value).len() as u64));
     g.bench_function(name, |b| {
         b.iter(|| serialize(black_box(value)));
     });

--- a/monad-state/src/consensus.rs
+++ b/monad-state/src/consensus.rs
@@ -731,7 +731,7 @@ where
                     OptimisticPolicyCommit::Proposed(block) => {
                         let block_id = block.get_id();
                         let round = block.get_block_round();
-                        let seq_num = block.get_seq_num();
+                        let STATESYNC_BLOCK_THRESHOLD = block.get_seq_num();
                     }
                     OptimisticPolicyCommit::Finalized(block) => {
                         let finalized_seq_num = block.get_seq_num();

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1018,8 +1018,7 @@ where
 
                 if consensus_cmds
                     .iter()
-                    .find(|cmd| matches!(cmd.command, ConsensusCommand::EnterRound(_, _)))
-                    .is_some()
+                    .any(|cmd| matches!(cmd.command, ConsensusCommand::EnterRound(_, _)))
                 {
                     self.metrics.node_state.self_stake_bps = self.get_self_stake_bps();
                 }

--- a/monad-statesync/src/lib.rs
+++ b/monad-statesync/src/lib.rs
@@ -256,7 +256,7 @@ where
         self.update_syncing_metrics();
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         self.metrics.as_ref().into()
     }
 }

--- a/monad-triedb-utils/src/key.rs
+++ b/monad-triedb-utils/src/key.rs
@@ -153,7 +153,7 @@ pub fn create_triedb_key(version: Version, key: KeyInput) -> (Vec<u8>, u8) {
         }
     };
 
-    if num_nibbles % 2 != 0 {
+    if !num_nibbles.is_multiple_of(2) {
         key_nibbles.push(0);
     }
 
@@ -190,7 +190,7 @@ pub fn create_range_key(tx_index: u64) -> (Vec<u8>, u8) {
         }
     };
 
-    if num_nibbles % 2 != 0 {
+    if !num_nibbles.is_multiple_of(2) {
         key_nibbles.push(0);
     }
 

--- a/monad-triedb/src/lib.rs
+++ b/monad-triedb/src/lib.rs
@@ -188,7 +188,7 @@ impl TriedbHandle {
             error!("Key length nibbles exceeds maximum allowed value");
             return None;
         }
-        if (key_len_nibbles as usize + 1) / 2 > key.len() {
+        if (key_len_nibbles as usize).div_ceil(2) > key.len() {
             error!("Key length is insufficient for the given nibbles");
             return None;
         }
@@ -249,7 +249,7 @@ impl TriedbHandle {
             error!("Key length nibbles exceeds maximum allowed value");
             return;
         }
-        if (key_len_nibbles as usize + 1) / 2 > key.len() {
+        if (key_len_nibbles as usize).div_ceil(2) > key.len() {
             error!("Key length is insufficient for the given nibbles");
             return;
         }
@@ -300,7 +300,7 @@ impl TriedbHandle {
             error!("Key length nibbles exceeds maximum allowed value");
             return;
         }
-        if (key_len_nibbles as usize + 1) / 2 > key.len() {
+        if (key_len_nibbles as usize).div_ceil(2) > key.len() {
             error!("Key length is insufficient for the given nibbles");
             return;
         }
@@ -336,7 +336,7 @@ impl TriedbHandle {
             error!("Key length nibbles exceeds maximum allowed value");
             return;
         }
-        if (key_len_nibbles as usize + 1) / 2 > key.len() {
+        if (key_len_nibbles as usize).div_ceil(2) > key.len() {
             error!("Key length is insufficient for the given nibbles");
             return;
         }
@@ -378,7 +378,7 @@ impl TriedbHandle {
             error!("Min key length nibbles exceeds maximum allowed value");
             return;
         }
-        if (min_key_len_nibbles as usize + 1) / 2 > min_key.len() {
+        if (min_key_len_nibbles as usize).div_ceil(2) > min_key.len() {
             error!("Min key length is insufficient for the given nibbles");
             return;
         }
@@ -386,7 +386,7 @@ impl TriedbHandle {
             error!("Max key length nibbles exceeds maximum allowed value");
             return;
         }
-        if (max_key_len_nibbles as usize + 1) / 2 > max_key.len() {
+        if (max_key_len_nibbles as usize).div_ceil(2) > max_key.len() {
             error!("Max key length is insufficient for the given nibbles");
             return;
         }

--- a/monad-updaters/src/config_file.rs
+++ b/monad-updaters/src/config_file.rs
@@ -80,7 +80,7 @@ where
         }
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         self.metrics.as_ref().into()
     }
 }
@@ -246,7 +246,7 @@ where
         }
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         self.metrics.as_ref().into()
     }
 }

--- a/monad-updaters/src/config_loader.rs
+++ b/monad-updaters/src/config_loader.rs
@@ -68,7 +68,7 @@ where
 
     fn exec(&mut self, _commands: Vec<Self::Command>) {}
 
-    fn metrics(&self) -> monad_executor::ExecutorMetricsChain {
+    fn metrics(&self) -> monad_executor::ExecutorMetricsChain<'_> {
         Default::default()
     }
 }
@@ -261,7 +261,7 @@ where
         }
     }
 
-    fn metrics(&self) -> monad_executor::ExecutorMetricsChain {
+    fn metrics(&self) -> monad_executor::ExecutorMetricsChain<'_> {
         Default::default()
     }
 }

--- a/monad-updaters/src/ledger.rs
+++ b/monad-updaters/src/ledger.rs
@@ -225,7 +225,7 @@ where
             }
         }
     }
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         Default::default()
     }
 }

--- a/monad-updaters/src/local_router.rs
+++ b/monad-updaters/src/local_router.rs
@@ -200,7 +200,7 @@ where
         }
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         self.metrics.as_ref().into()
     }
 }

--- a/monad-updaters/src/loopback.rs
+++ b/monad-updaters/src/loopback.rs
@@ -63,7 +63,7 @@ impl<E> Executor for LoopbackExecutor<E> {
         }
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         self.metrics.as_ref().into()
     }
 }

--- a/monad-updaters/src/parent.rs
+++ b/monad-updaters/src/parent.rs
@@ -136,7 +136,7 @@ where
         self.config_loader.exec(config_reload_cmds);
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         ExecutorMetricsChain::default()
             .push(&self.metrics.0)
             .chain(self.router.metrics())

--- a/monad-updaters/src/statesync.rs
+++ b/monad-updaters/src/statesync.rs
@@ -197,7 +197,7 @@ where
         }
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         Default::default()
     }
 }

--- a/monad-updaters/src/timer.rs
+++ b/monad-updaters/src/timer.rs
@@ -89,7 +89,7 @@ where
         }
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         self.metrics.as_ref().into()
     }
 }

--- a/monad-updaters/src/tokio_timestamp.rs
+++ b/monad-updaters/src/tokio_timestamp.rs
@@ -62,7 +62,7 @@ impl<ST, SCT, EPT> Executor for TokioTimestamp<ST, SCT, EPT> {
             }
         }
     }
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         self.metrics.as_ref().into()
     }
 }

--- a/monad-updaters/src/triedb_val_set.rs
+++ b/monad-updaters/src/triedb_val_set.rs
@@ -215,7 +215,7 @@ impl Executor for ValSetUpdater<SecpSignature, BlsSignatureCollection<PubKey>> {
         }
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         self.metrics.as_ref().into()
     }
 }

--- a/monad-updaters/src/txpool.rs
+++ b/monad-updaters/src/txpool.rs
@@ -266,7 +266,7 @@ where
         }
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         ExecutorMetricsChain::default()
     }
 }
@@ -449,7 +449,7 @@ where
         self.metrics.update(&mut self.executor_metrics);
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         ExecutorMetricsChain::default().push(&self.executor_metrics)
     }
 }

--- a/monad-updaters/src/val_set.rs
+++ b/monad-updaters/src/val_set.rs
@@ -165,7 +165,7 @@ where
         }
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         self.metrics.as_ref().into()
     }
 }
@@ -260,7 +260,7 @@ where
             }
             let locked_epoch = seq_num.get_locked_epoch(self.epoch_length);
             assert_eq!(locked_epoch, seq_num.to_epoch(self.epoch_length) + Epoch(1));
-            self.next_val_data = if locked_epoch.0 % 2 == 0 {
+            self.next_val_data = if locked_epoch.0.is_multiple_of(2) {
                 Some(ValidatorSetDataWithEpoch {
                     epoch: locked_epoch,
                     validators: self.val_data_1.clone(),
@@ -302,7 +302,7 @@ where
         // at the end of Epoch(even), next validator set is val_data_1
         // odd epoch number <> val_data_1
         // even epoch number <> val_data_2
-        if epoch.0 % 2 == 0 {
+        if epoch.0.is_multiple_of(2) {
             self.val_data_2.clone()
         } else {
             self.val_data_1.clone()
@@ -336,7 +336,7 @@ where
         }
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         self.metrics.as_ref().into()
     }
 }

--- a/monad-wal/src/reader.rs
+++ b/monad-wal/src/reader.rs
@@ -150,8 +150,7 @@ where
 
     fused_events
         .into_iter()
-        .map(|(_, events)| events)
-        .flatten()
+        .flat_map(|(_, events)| events)
         .skip_while(move |event| event_to_ts(event) < start)
         .take_while(move |event| event_to_ts(event) <= end)
 }

--- a/monad-wireauth/src/api.rs
+++ b/monad-wireauth/src/api.rs
@@ -91,7 +91,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         }
     }
 
-    pub fn metrics(&self) -> ExecutorMetricsChain {
+    pub fn metrics(&self) -> ExecutorMetricsChain<'_> {
         ExecutorMetricsChain::default()
             .push(&self.metrics)
             .push(self.state.metrics())


### PR DESCRIPTION
I disagree with `hiding a lifetime that's elided elsewhere is confusing`, but otherwise seems fine and reduces clippy noise. 

Example:
```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> monad-raptorcast/src/packet/assigner.rs:628:26
    |
628 |         fn assign_chunks(&self) -> ChunkAssignment<PT> {
    |                          ^^^^^     ^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |                          |
    |                          the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
628 |         fn assign_chunks(&self) -> ChunkAssignment<'_, PT> {
    |
```