### PR TITLE
monad-wireauth: parametrize metrics

### DIFF
--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -696,8 +696,11 @@ where
 
     let shared_key = Arc::new(identity);
     let wireauth_config = monad_wireauth::Config::default();
-    let auth_protocol =
-        monad_raptorcast::auth::WireAuthProtocol::new(wireauth_config, shared_key.clone());
+    let auth_protocol = monad_raptorcast::auth::WireAuthProtocol::new(
+        &monad_raptorcast::auth::metrics::UDP_METRICS,
+        wireauth_config,
+        shared_key.clone(),
+    );
 
     MultiRouter::new(
         self_id,

--- a/monad-raptorcast/examples/latency.rs
+++ b/monad-raptorcast/examples/latency.rs
@@ -642,8 +642,11 @@ fn setup_node(
 
     let keypair_arc = Arc::new(keypair);
     let wireauth_config = monad_wireauth::Config::default();
-    let auth_protocol =
-        monad_raptorcast::auth::WireAuthProtocol::new(wireauth_config, keypair_arc.clone());
+    let auth_protocol = monad_raptorcast::auth::WireAuthProtocol::new(
+        &monad_raptorcast::auth::metrics::UDP_METRICS,
+        wireauth_config,
+        keypair_arc.clone(),
+    );
 
     let mut raptorcast = RaptorCast::<
         SignatureType,

--- a/monad-raptorcast/src/auth/metrics.rs
+++ b/monad-raptorcast/src/auth/metrics.rs
@@ -21,3 +21,5 @@ pub const GAUGE_RAPTORCAST_AUTH_AUTHENTICATED_UDP_BYTES_READ: &str =
     "monad.raptorcast.auth.authenticated_udp_bytes_read";
 pub const GAUGE_RAPTORCAST_AUTH_NON_AUTHENTICATED_UDP_BYTES_READ: &str =
     "monad.raptorcast.auth.non_authenticated_udp_bytes_read";
+
+monad_wireauth::define_metric_names!(UDP_METRICS, "udp");

--- a/monad-raptorcast/src/auth/protocol.rs
+++ b/monad-raptorcast/src/auth/protocol.rs
@@ -83,10 +83,14 @@ pub struct WireAuthProtocol {
 }
 
 impl WireAuthProtocol {
-    pub fn new(config: monad_wireauth::Config, signing_key: Arc<monad_secp::KeyPair>) -> Self {
+    pub fn new(
+        metric_names: &'static monad_wireauth::MetricNames,
+        config: monad_wireauth::Config,
+        signing_key: Arc<monad_secp::KeyPair>,
+    ) -> Self {
         let context = monad_wireauth::StdContext::new();
         Self {
-            api: monad_wireauth::API::new(config, signing_key, context),
+            api: monad_wireauth::API::new(metric_names, config, signing_key, context),
         }
     }
 }

--- a/monad-raptorcast/src/auth/socket.rs
+++ b/monad-raptorcast/src/auth/socket.rs
@@ -487,7 +487,11 @@ mod tests {
             let keypair = keypair(seed);
             let public_key = keypair.pubkey();
             let config = Config::default();
-            let auth_protocol = WireAuthProtocol::new(config, Arc::new(keypair));
+            let auth_protocol = WireAuthProtocol::new(
+                &crate::auth::metrics::UDP_METRICS,
+                config,
+                Arc::new(keypair),
+            );
             let authenticated_handle =
                 AuthenticatedSocketHandle::new(authenticated_socket, auth_protocol);
             let socket =
@@ -605,7 +609,11 @@ mod tests {
             ..Default::default()
         };
 
-        let auth_protocol = WireAuthProtocol::new(config, Arc::new(local_keypair));
+        let auth_protocol = WireAuthProtocol::new(
+            &crate::auth::metrics::UDP_METRICS,
+            config,
+            Arc::new(local_keypair),
+        );
         let mut handle = AuthenticatedSocketHandle::new(authenticated_socket, auth_protocol);
 
         assert_eq!(poll!(pin!(handle.timer())), Poll::Pending);

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -690,7 +690,8 @@ where
     let pd = PeerDiscoveryDriver::new(peer_discovery_builder);
     let shared_pd = Arc::new(Mutex::new(pd));
     let wireauth_config = monad_wireauth::Config::default();
-    let auth_protocol = auth::WireAuthProtocol::new(wireauth_config, shared_key);
+    let auth_protocol =
+        auth::WireAuthProtocol::new(&auth::metrics::UDP_METRICS, wireauth_config, shared_key);
     RaptorCast::<ST, M, OM, SE, NopDiscovery<ST>, _>::new(
         config,
         SecondaryRaptorCastModeConfig::None,

--- a/monad-raptorcast/tests/wireauth_raptorcast.rs
+++ b/monad-raptorcast/tests/wireauth_raptorcast.rs
@@ -304,8 +304,11 @@ fn spawn_wireauth_validator(
     tokio::task::spawn_local(async move {
         let config = create_raptorcast_config(keypair.clone(), sig_verification_rate_limit);
         let wireauth_config = monad_wireauth::Config::default();
-        let auth_protocol =
-            monad_raptorcast::auth::WireAuthProtocol::new(wireauth_config, keypair.clone());
+        let auth_protocol = monad_raptorcast::auth::WireAuthProtocol::new(
+            &monad_raptorcast::auth::metrics::UDP_METRICS,
+            wireauth_config,
+            keypair.clone(),
+        );
 
         let mut validator_rc = monad_raptorcast::RaptorCast::<
             SecpSignature,

--- a/monad-wireauth/benches/manager_bench.rs
+++ b/monad-wireauth/benches/manager_bench.rs
@@ -16,7 +16,7 @@
 use std::net::SocketAddr;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use monad_wireauth::{messages::Packet, Config, TestContext, API};
+use monad_wireauth::{messages::Packet, Config, TestContext, API, DEFAULT_METRICS};
 use secp256k1::rand::rng;
 use zerocopy::IntoBytes;
 
@@ -31,7 +31,7 @@ fn create_test_manager() -> (API<TestContext>, monad_secp::PubKey, TestContext) 
     let context = TestContext::new();
     let context_clone = context.clone();
 
-    let manager = API::new(config, keypair, context);
+    let manager = API::new(DEFAULT_METRICS, config, keypair, context);
     (manager, public_key, context_clone)
 }
 

--- a/monad-wireauth/examples/demo.rs
+++ b/monad-wireauth/examples/demo.rs
@@ -22,7 +22,9 @@ use std::{
 };
 
 use clap::Parser;
-use monad_wireauth::{messages::Packet, Config, PublicKey, StdContext, API, RETRY_ALWAYS};
+use monad_wireauth::{
+    messages::Packet, Config, PublicKey, StdContext, API, DEFAULT_METRICS, RETRY_ALWAYS,
+};
 use monoio::{net::udp::UdpSocket, time::sleep_until};
 use secp256k1::rand::{rngs::StdRng, SeedableRng};
 use tracing::{debug, info, warn};
@@ -63,7 +65,7 @@ impl PeerNode {
         };
 
         let context = StdContext::new();
-        let manager = API::new(config, keypair, context);
+        let manager = API::new(DEFAULT_METRICS, config, keypair, context);
         let socket = UdpSocket::bind(addr)?;
 
         Ok(Self {

--- a/monad-wireauth/src/api.rs
+++ b/monad-wireauth/src/api.rs
@@ -31,7 +31,7 @@ use crate::{
     error::{Error, Result},
     filter::{Filter, FilterAction},
     messages::MacMessage,
-    metrics::*,
+    metrics::MetricNames,
     protocol::messages::{
         ControlPacket, CookieReply, DataPacket, DataPacketHeader, HandshakeInitiation,
         HandshakeResponse, Plaintext,
@@ -52,6 +52,7 @@ pub struct API<C: Context, K: AsRef<monad_secp::KeyPair> = monad_secp::KeyPair> 
     filter: Filter,
     context: C,
     metrics: ExecutorMetrics,
+    metric_names: &'static MetricNames,
     last_tick: Option<Duration>,
     connect_rate_counter: u64,
     connect_rate_last_reset: Duration,
@@ -59,7 +60,12 @@ pub struct API<C: Context, K: AsRef<monad_secp::KeyPair> = monad_secp::KeyPair> 
 
 impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
     /// Creates a new API instance, it should be created for an individual socket.
-    pub fn new(config: Config, local_static_key: K, mut context: C) -> Self {
+    pub fn new(
+        metric_names: &'static MetricNames,
+        config: Config,
+        local_static_key: K,
+        mut context: C,
+    ) -> Self {
         let local_static_public = local_static_key.as_ref().pubkey();
         let cookies = Cookies::new(
             context.rng(),
@@ -68,6 +74,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         );
 
         let filter = Filter::new(
+            metric_names,
             config.handshake_rate_limit,
             config.handshake_rate_reset_interval,
             config.ip_rate_limit_window,
@@ -79,7 +86,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         let local_serialized_public = CompressedPublicKey::from(&local_static_public);
         debug!(local_public_key=?local_serialized_public, "initialized manager");
         Self {
-            state: State::new(),
+            state: State::new(metric_names),
             timers: BTreeSet::new(),
             packet_queue: VecDeque::new(),
             config,
@@ -89,6 +96,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
             filter,
             context,
             metrics: ExecutorMetrics::default(),
+            metric_names,
             last_tick: None,
             connect_rate_counter: 0,
             connect_rate_last_reset: Duration::ZERO,
@@ -108,15 +116,15 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
     /// queue for pacing.
     #[instrument(level = Level::TRACE, skip(self), fields(local_public_key = ?self.local_serialized_public))]
     pub fn next_packet(&mut self) -> Option<(SocketAddr, Bytes)> {
-        self.metrics[GAUGE_WIREAUTH_API_NEXT_PACKET] += 1;
+        self.metrics[self.metric_names.api_next_packet] += 1;
         let result = self.packet_queue.pop_front();
-        self.metrics[GAUGE_WIREAUTH_STATE_PACKET_QUEUE_SIZE] = self.packet_queue.len() as u64;
+        self.metrics[self.metric_names.state_packet_queue_size] = self.packet_queue.len() as u64;
         result
     }
 
     fn enqueue_packet(&mut self, addr: SocketAddr, pkt: impl Into<Bytes>) {
         self.packet_queue.push_back((addr, pkt.into()));
-        self.metrics[GAUGE_WIREAUTH_STATE_PACKET_QUEUE_SIZE] = self.packet_queue.len() as u64;
+        self.metrics[self.metric_names.state_packet_queue_size] = self.packet_queue.len() as u64;
     }
 
     /// Returns the next deadline.
@@ -139,7 +147,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
 
     fn insert_timer(&mut self, timer: Duration, session_id: SessionIndex) {
         self.timers.insert((timer, session_id));
-        self.metrics[GAUGE_WIREAUTH_STATE_TIMERS_SIZE] = self.timers.len() as u64;
+        self.metrics[self.metric_names.state_timers_size] = self.timers.len() as u64;
     }
 
     fn replace_timer(&mut self, timer: RenewedTimer, session_index: SessionIndex) {
@@ -147,12 +155,12 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
             self.timers.remove(&(previous, session_index));
         }
         self.timers.insert((timer.current, session_index));
-        self.metrics[GAUGE_WIREAUTH_STATE_TIMERS_SIZE] = self.timers.len() as u64;
+        self.metrics[self.metric_names.state_timers_size] = self.timers.len() as u64;
     }
 
     #[instrument(level = Level::TRACE, skip(self), fields(local_public_key = ?self.local_serialized_public))]
     pub fn tick(&mut self) {
-        self.metrics[GAUGE_WIREAUTH_API_TICK] += 1;
+        self.metrics[self.metric_names.api_tick] += 1;
         let duration_since_start = self.context.duration_since_start();
 
         self.filter.tick(duration_since_start);
@@ -176,7 +184,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
 
         for (duration, session_id) in expired_timers {
             self.timers.remove(&(duration, session_id));
-            self.metrics[GAUGE_WIREAUTH_STATE_TIMERS_SIZE] = self.timers.len() as u64;
+            self.metrics[self.metric_names.state_timers_size] = self.timers.len() as u64;
 
             if let Some(elapsed) = duration_since_start.checked_sub(duration) {
                 let elapsed_ms = elapsed.as_millis();
@@ -218,7 +226,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
             };
 
             if let Some(message) = message {
-                self.metrics[GAUGE_WIREAUTH_ENQUEUED_KEEPALIVE] += 1;
+                self.metrics[self.metric_names.enqueued_keepalive] += 1;
                 self.enqueue_packet(message.remote_addr, message.header);
             }
 
@@ -229,7 +237,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
                     rekey.stored_cookie,
                     rekey.retry_attempts,
                 ) {
-                    self.metrics[GAUGE_WIREAUTH_ENQUEUED_HANDSHAKE_INIT] += 1;
+                    self.metrics[self.metric_names.enqueued_handshake_init] += 1;
                     self.enqueue_packet(rekey.remote_addr, message);
                     self.insert_timer(timer, new_session_index);
                 }
@@ -268,7 +276,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         remote_addr: SocketAddr,
         retry_attempts: u64,
     ) -> Result<()> {
-        self.metrics[GAUGE_WIREAUTH_API_CONNECT] += 1;
+        self.metrics[self.metric_names.api_connect] += 1;
         debug!(retry_attempts, "initiating connection");
 
         self.check_connect_rate_limit()?;
@@ -282,10 +290,10 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         let (local_index, timer, message) = self
             .init_session_with_cookie(remote_static_key, remote_addr, cookie, retry_attempts)
             .inspect_err(|_| {
-                self.metrics[GAUGE_WIREAUTH_ERROR_CONNECT] += 1;
+                self.metrics[self.metric_names.error_connect] += 1;
             })?;
 
-        self.metrics[GAUGE_WIREAUTH_ENQUEUED_HANDSHAKE_INIT] += 1;
+        self.metrics[self.metric_names.enqueued_handshake_init] += 1;
         self.enqueue_packet(remote_addr, message);
         self.insert_timer(timer, local_index);
 
@@ -301,8 +309,8 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         }
 
         if self.connect_rate_counter >= self.config.connect_rate_limit {
-            self.metrics[GAUGE_WIREAUTH_RATE_LIMIT_CONNECT] += 1;
-            self.metrics[GAUGE_WIREAUTH_ERROR_CONNECT] += 1;
+            self.metrics[self.metric_names.rate_limit_connect] += 1;
+            self.metrics[self.metric_names.error_connect] += 1;
             return Err(Error::ConnectRateLimited {
                 limit: self.config.connect_rate_limit,
                 interval: self.config.connect_rate_reset_interval,
@@ -324,7 +332,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
 
         // reservation should be committed when code is no longer fallible
         let reservation = self.state.reserve_session_index().ok_or_else(|| {
-            self.metrics[GAUGE_WIREAUTH_ERROR_SESSION_EXHAUSTED] += 1;
+            self.metrics[self.metric_names.error_session_exhausted] += 1;
             Error::SessionIndexExhausted
         })?;
         trace!(local_session_id=?reservation.index(), "allocating session index for new connection");
@@ -377,12 +385,12 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
                     message,
                     duration_since_start,
                 );
-                self.metrics[GAUGE_WIREAUTH_ENQUEUED_COOKIE_REPLY] += 1;
+                self.metrics[self.metric_names.enqueued_cookie_reply] += 1;
                 self.enqueue_packet(remote_addr, reply);
                 false
             }
             FilterAction::Drop => {
-                self.metrics[GAUGE_WIREAUTH_RATE_LIMIT_DROP] += 1;
+                self.metrics[self.metric_names.rate_limit_drop] += 1;
                 false
             }
         }
@@ -398,7 +406,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
             &self.local_static_key.as_ref().pubkey(),
         )
         .inspect_err(|_| {
-            self.metrics[GAUGE_WIREAUTH_ERROR_MAC1_VERIFICATION_FAILED] += 1;
+            self.metrics[self.metric_names.error_mac1_verification_failed] += 1;
         })?;
 
         if !self.is_under_load(
@@ -415,7 +423,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         let validated_init =
             ResponderState::validate_init(self.local_static_key.as_ref(), handshake_packet)
                 .inspect_err(|_| {
-                    self.metrics[GAUGE_WIREAUTH_ERROR_HANDSHAKE_INIT_VALIDATION] += 1;
+                    self.metrics[self.metric_names.error_handshake_init_validation] += 1;
                 })?;
 
         let remote_key = validated_init.remote_public_key;
@@ -424,7 +432,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
             .get_max_timestamp(&remote_key)
             .is_some_and(|max| validated_init.timestamp <= max)
         {
-            self.metrics[GAUGE_WIREAUTH_ERROR_TIMESTAMP_REPLAY] += 1;
+            self.metrics[self.metric_names.error_timestamp_replay] += 1;
             debug!(?remote_addr, ?remote_key, "timestamp replay detected");
             return Err(Error::TimestampReplay);
         }
@@ -437,7 +445,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         // Reservation should be committed only when code is no longer fallible
         // TODO(dshulyak): Get rid of reservation; code was refactored to be non-fallible when index is allocated
         let reservation = self.state.reserve_session_index().ok_or_else(|| {
-            self.metrics[GAUGE_WIREAUTH_ERROR_SESSION_EXHAUSTED] += 1;
+            self.metrics[self.metric_names.error_session_exhausted] += 1;
             Error::SessionIndexExhausted
         })?;
         let local_index = reservation.index();
@@ -456,7 +464,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         self.state
             .insert_responder(local_index, session, remote_key);
 
-        self.metrics[GAUGE_WIREAUTH_ENQUEUED_HANDSHAKE_RESPONSE] += 1;
+        self.metrics[self.metric_names.enqueued_handshake_response] += 1;
         self.enqueue_packet(remote_addr, message);
         self.insert_timer(timer, local_index);
 
@@ -468,11 +476,11 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
 
         if let Some(session) = self.state.get_initiator_mut(&receiver_session_index) {
             session.handle_cookie(cookie_reply).inspect_err(|_| {
-                self.metrics[GAUGE_WIREAUTH_ERROR_COOKIE_REPLY] += 1;
+                self.metrics[self.metric_names.error_cookie_reply] += 1;
             })?;
         } else if let Some(session) = self.state.get_responder_mut(&receiver_session_index) {
             session.handle_cookie(cookie_reply).inspect_err(|_| {
-                self.metrics[GAUGE_WIREAUTH_ERROR_COOKIE_REPLY] += 1;
+                self.metrics[self.metric_names.error_cookie_reply] += 1;
             })?;
         }
         Ok(())
@@ -488,32 +496,32 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         control: ControlPacket,
         remote_addr: SocketAddr,
     ) -> Result<()> {
-        self.metrics[GAUGE_WIREAUTH_API_DISPATCH_CONTROL] += 1;
+        self.metrics[self.metric_names.api_dispatch_control] += 1;
         let result = match control {
             ControlPacket::HandshakeInitiation(handshake) => {
                 debug!("processing handshake initiation");
-                self.metrics[GAUGE_WIREAUTH_DISPATCH_HANDSHAKE_INIT] += 1;
+                self.metrics[self.metric_names.dispatch_handshake_init] += 1;
                 self.accept_handshake_init(handshake, remote_addr)
             }
             ControlPacket::HandshakeResponse(response) => {
                 debug!("processing handshake response");
-                self.metrics[GAUGE_WIREAUTH_DISPATCH_HANDSHAKE_RESPONSE] += 1;
+                self.metrics[self.metric_names.dispatch_handshake_response] += 1;
                 self.complete_handshake(response, remote_addr)
             }
             ControlPacket::CookieReply(cookie_reply) => {
                 debug!("processing cookie reply");
-                self.metrics[GAUGE_WIREAUTH_DISPATCH_COOKIE_REPLY] += 1;
+                self.metrics[self.metric_names.dispatch_cookie_reply] += 1;
                 self.accept_cookie(cookie_reply)
             }
             ControlPacket::Keepalive(data_packet) => {
                 trace!("processing keepalive packet");
-                self.metrics[GAUGE_WIREAUTH_DISPATCH_KEEPALIVE] += 1;
+                self.metrics[self.metric_names.dispatch_keepalive] += 1;
                 self.decrypt(data_packet, remote_addr)?;
                 Ok(())
             }
         };
         if result.is_err() {
-            self.metrics[GAUGE_WIREAUTH_ERROR_DISPATCH_CONTROL] += 1;
+            self.metrics[self.metric_names.error_dispatch_control] += 1;
         }
         result
     }
@@ -525,7 +533,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         data_packet: DataPacket<'a>,
         remote_addr: SocketAddr,
     ) -> Result<(Plaintext<'a>, PubKey)> {
-        self.metrics[GAUGE_WIREAUTH_API_DECRYPT] += 1;
+        self.metrics[self.metric_names.api_decrypt] += 1;
         let receiver_index = data_packet.header().receiver_index.into();
         let nonce: u64 = data_packet.header().nonce.into();
         trace!(local_session_id=?receiver_index, nonce, "decrypting data packet");
@@ -537,7 +545,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
             let (timer, plaintext) = transport
                 .decrypt(&self.config, duration_since_start, data_packet)
                 .inspect_err(|e| {
-                    track_decrypt_error_metrics(&mut self.metrics, e);
+                    track_decrypt_error_metrics(&mut self.metrics, self.metric_names, e);
                 })?;
             let remote_public_key = transport.remote_public_key;
             self.replace_timer(timer, receiver_index);
@@ -557,17 +565,17 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
                     debug!(local_session_id=?receiver_index, "responder session established");
                     self.state.insert_transport(receiver_index, transport);
                     self.timers.insert((establish_timer, receiver_index));
-                    self.metrics[GAUGE_WIREAUTH_STATE_TIMERS_SIZE] = self.timers.len() as u64;
+                    self.metrics[self.metric_names.state_timers_size] = self.timers.len() as u64;
                     (remote_public_key, plaintext)
                 }
                 Err(e) => {
-                    track_decrypt_error_metrics(&mut self.metrics, &e);
+                    track_decrypt_error_metrics(&mut self.metrics, self.metric_names, &e);
                     return Err(e.into());
                 }
             }
         } else {
-            self.metrics[GAUGE_WIREAUTH_ERROR_DECRYPT] += 1;
-            self.metrics[GAUGE_WIREAUTH_ERROR_SESSION_INDEX_NOT_FOUND] += 1;
+            self.metrics[self.metric_names.error_decrypt] += 1;
+            self.metrics[self.metric_names.error_session_index_not_found] += 1;
             return Err(Error::SessionIndexNotFound {
                 index: receiver_index,
             });
@@ -585,7 +593,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         // All validators and other fallible actions must be done before removing the initiator from state.
         crate::protocol::crypto::verify_mac1(response, &self.local_static_key.as_ref().pubkey())
             .inspect_err(|_| {
-                self.metrics[GAUGE_WIREAUTH_ERROR_MAC1_VERIFICATION_FAILED] += 1;
+                self.metrics[self.metric_names.error_mac1_verification_failed] += 1;
             })?;
 
         if !self.is_under_load(remote_addr, response.sender_index.get(), response) {
@@ -599,7 +607,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
             .state
             .get_initiator_mut(&receiver_session_index)
             .ok_or_else(|| {
-                self.metrics[GAUGE_WIREAUTH_ERROR_SESSION_INDEX_NOT_FOUND] += 1;
+                self.metrics[self.metric_names.error_session_index_not_found] += 1;
                 Error::InvalidReceiverIndex {
                     index: receiver_session_index,
                 }
@@ -608,7 +616,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         let validated_response = initiator
             .validate_response(&self.config, self.local_static_key.as_ref(), response)
             .inspect_err(|_| {
-                self.metrics[GAUGE_WIREAUTH_ERROR_HANDSHAKE_RESPONSE_VALIDATION] += 1;
+                self.metrics[self.metric_names.error_handshake_response_validation] += 1;
             })?;
 
         // Code should not be fallible after this point
@@ -643,13 +651,13 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         public_key: &monad_secp::PubKey,
         plaintext: &mut [u8],
     ) -> Result<DataPacketHeader> {
-        self.metrics[GAUGE_WIREAUTH_API_ENCRYPT_BY_PUBLIC_KEY] += 1;
+        self.metrics[self.metric_names.api_encrypt_by_public_key] += 1;
         let transport = self
             .state
             .get_transport_by_public_key(public_key)
             .ok_or_else(|| {
-                self.metrics[GAUGE_WIREAUTH_ERROR_ENCRYPT_BY_PUBLIC_KEY] += 1;
-                self.metrics[GAUGE_WIREAUTH_ERROR_SESSION_NOT_FOUND] += 1;
+                self.metrics[self.metric_names.error_encrypt_by_public_key] += 1;
+                self.metrics[self.metric_names.error_session_not_found] += 1;
                 Error::SessionNotFound
             })?;
         let duration_since_start = self.context.duration_since_start();
@@ -671,12 +679,12 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         socket_addr: &SocketAddr,
         plaintext: &mut [u8],
     ) -> Result<DataPacketHeader> {
-        self.metrics[GAUGE_WIREAUTH_API_ENCRYPT_BY_SOCKET] += 1;
+        self.metrics[self.metric_names.api_encrypt_by_socket] += 1;
         let transport = self
             .state
             .get_transport_by_socket(socket_addr)
             .ok_or_else(|| {
-                self.metrics[GAUGE_WIREAUTH_ERROR_ENCRYPT_BY_SOCKET] += 1;
+                self.metrics[self.metric_names.error_encrypt_by_socket] += 1;
                 Error::SessionNotEstablishedForAddress { addr: *socket_addr }
             })?;
         let duration_since_start = self.context.duration_since_start();
@@ -694,7 +702,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
     /// Disconnects and removes all sessions with the given public key.
     #[instrument(level = Level::TRACE, skip(self, public_key), fields(local_public_key = ?self.local_serialized_public))]
     pub fn disconnect(&mut self, public_key: &monad_secp::PubKey) {
-        self.metrics[GAUGE_WIREAUTH_API_DISCONNECT] += 1;
+        self.metrics[self.metric_names.api_disconnect] += 1;
         self.state.terminate_by_public_key(public_key);
     }
 
@@ -750,17 +758,21 @@ impl std::fmt::Debug for CompressedPublicKey {
     }
 }
 
-fn track_decrypt_error_metrics(metrics: &mut ExecutorMetrics, e: &SessionError) {
-    metrics[GAUGE_WIREAUTH_ERROR_DECRYPT] += 1;
+fn track_decrypt_error_metrics(
+    metrics: &mut ExecutorMetrics,
+    metric_names: &'static MetricNames,
+    e: &SessionError,
+) {
+    metrics[metric_names.error_decrypt] += 1;
     match e {
         SessionError::NonceOutsideWindow { .. } => {
-            metrics[GAUGE_WIREAUTH_ERROR_DECRYPT_NONCE_OUTSIDE_WINDOW] += 1;
+            metrics[metric_names.error_decrypt_nonce_outside_window] += 1;
         }
         SessionError::NonceDuplicate { .. } => {
-            metrics[GAUGE_WIREAUTH_ERROR_DECRYPT_NONCE_DUPLICATE] += 1;
+            metrics[metric_names.error_decrypt_nonce_duplicate] += 1;
         }
         SessionError::InvalidMac(_) => {
-            metrics[GAUGE_WIREAUTH_ERROR_DECRYPT_MAC] += 1;
+            metrics[metric_names.error_decrypt_mac] += 1;
         }
         _ => {
             warn!(error=?e, "unexpected decrypt error variant");

--- a/monad-wireauth/src/filter.rs
+++ b/monad-wireauth/src/filter.rs
@@ -23,7 +23,7 @@ use lru::LruCache;
 use monad_executor::ExecutorMetrics;
 use tracing::{debug, trace, warn};
 
-use crate::{metrics::*, state::State};
+use crate::{metrics::MetricNames, state::State};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FilterAction {
@@ -44,10 +44,12 @@ pub struct Filter {
     low_watermark_sessions: usize,
     high_watermark_sessions: usize,
     metrics: ExecutorMetrics,
+    metric_names: &'static MetricNames,
 }
 
 impl Filter {
     pub fn new(
+        metric_names: &'static MetricNames,
         handshake_rate_limit: u64,
         handshake_rate_reset_interval: Duration,
         ip_rate_limit_window: Duration,
@@ -67,6 +69,7 @@ impl Filter {
             low_watermark_sessions,
             high_watermark_sessions,
             metrics: ExecutorMetrics::default(),
+            metric_names,
         }
     }
 
@@ -179,7 +182,7 @@ impl Filter {
             }
             None => {
                 self.ip_request_history.put(ip, duration_since_start);
-                self.metrics[GAUGE_WIREAUTH_FILTER_IP_REQUEST_HISTORY_SIZE] =
+                self.metrics[self.metric_names.filter_ip_request_history_size] =
                     self.ip_request_history.len() as u64;
                 None
             }
@@ -199,9 +202,9 @@ impl Filter {
 
     fn record_metric(&mut self, action: FilterAction) {
         let metric = match action {
-            FilterAction::Pass => GAUGE_WIREAUTH_FILTER_PASS,
-            FilterAction::SendCookie => GAUGE_WIREAUTH_FILTER_SEND_COOKIE,
-            FilterAction::Drop => GAUGE_WIREAUTH_FILTER_DROP,
+            FilterAction::Pass => self.metric_names.filter_pass,
+            FilterAction::SendCookie => self.metric_names.filter_send_cookie,
+            FilterAction::Drop => self.metric_names.filter_drop,
         };
         self.metrics[metric] += 1;
     }
@@ -210,10 +213,11 @@ impl Filter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::insert_test_initiator_session;
+    use crate::{metrics::DEFAULT_METRICS, state::insert_test_initiator_session};
 
     fn default_filter() -> Filter {
         Filter::new(
+            DEFAULT_METRICS,
             100,
             Duration::from_secs(60),
             Duration::from_secs(60),
@@ -227,7 +231,7 @@ mod tests {
     #[test]
     fn test_basic_pass_no_limits() {
         let mut filter = default_filter();
-        let state = State::new();
+        let state = State::new(DEFAULT_METRICS);
         let addr = "127.0.0.1:8080".parse().unwrap();
         let action = filter.apply(&state, addr, Duration::from_secs(1), false);
         assert_eq!(action, FilterAction::Pass);
@@ -237,6 +241,7 @@ mod tests {
     fn test_high_watermark_drops() {
         let high_watermark = 10;
         let mut filter = Filter::new(
+            DEFAULT_METRICS,
             100,
             Duration::from_secs(60),
             Duration::from_secs(60),
@@ -245,7 +250,7 @@ mod tests {
             5,
             high_watermark,
         );
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         for i in 0..high_watermark {
             let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
             insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
@@ -259,6 +264,7 @@ mod tests {
     fn test_between_watermarks_requires_cookie() {
         let low_watermark = 5;
         let mut filter = Filter::new(
+            DEFAULT_METRICS,
             100,
             Duration::from_secs(60),
             Duration::from_secs(60),
@@ -267,7 +273,7 @@ mod tests {
             low_watermark,
             10,
         );
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         for i in 0..low_watermark {
             let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
             insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
@@ -281,6 +287,7 @@ mod tests {
     fn test_between_watermarks_passes_with_cookie() {
         let low_watermark = 5;
         let mut filter = Filter::new(
+            DEFAULT_METRICS,
             100,
             Duration::from_secs(60),
             Duration::from_secs(60),
@@ -289,7 +296,7 @@ mod tests {
             low_watermark,
             10,
         );
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         for i in 0..low_watermark {
             let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
             insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
@@ -303,6 +310,7 @@ mod tests {
     fn test_handshake_rate_limit_drops() {
         let handshake_rate_limit = 5;
         let mut filter = Filter::new(
+            DEFAULT_METRICS,
             handshake_rate_limit,
             Duration::from_secs(60),
             Duration::from_secs(60),
@@ -311,7 +319,7 @@ mod tests {
             50,
             100,
         );
-        let state = State::new();
+        let state = State::new(DEFAULT_METRICS);
         let addr = "127.0.0.1:8080".parse().unwrap();
         for _ in 0..handshake_rate_limit {
             filter.apply(&state, addr, Duration::from_secs(1), false);
@@ -324,6 +332,7 @@ mod tests {
     fn test_handshake_rate_limit_drops_with_cookie() {
         let handshake_rate_limit = 5;
         let mut filter = Filter::new(
+            DEFAULT_METRICS,
             handshake_rate_limit,
             Duration::from_secs(60),
             Duration::from_secs(60),
@@ -332,7 +341,7 @@ mod tests {
             50,
             100,
         );
-        let state = State::new();
+        let state = State::new(DEFAULT_METRICS);
         let addr = "127.0.0.1:8080".parse().unwrap();
         for _ in 0..handshake_rate_limit {
             filter.apply(&state, addr, Duration::from_secs(1), false);
@@ -345,6 +354,7 @@ mod tests {
     fn test_tick_resets_counter() {
         let handshake_rate_limit = 5;
         let mut filter = Filter::new(
+            DEFAULT_METRICS,
             handshake_rate_limit,
             Duration::from_secs(1),
             Duration::from_secs(60),
@@ -353,7 +363,7 @@ mod tests {
             50,
             100,
         );
-        let state = State::new();
+        let state = State::new(DEFAULT_METRICS);
         let addr = "127.0.0.1:8080".parse().unwrap();
         for _ in 0..handshake_rate_limit {
             filter.apply(&state, addr, Duration::from_secs(0), false);
@@ -367,6 +377,7 @@ mod tests {
     fn test_tick_does_not_reset_before_interval() {
         let handshake_rate_limit = 5;
         let mut filter = Filter::new(
+            DEFAULT_METRICS,
             handshake_rate_limit,
             Duration::from_secs(10),
             Duration::from_secs(60),
@@ -375,7 +386,7 @@ mod tests {
             50,
             100,
         );
-        let state = State::new();
+        let state = State::new(DEFAULT_METRICS);
         let addr = "127.0.0.1:8080".parse().unwrap();
         for _ in 0..handshake_rate_limit {
             filter.apply(&state, addr, Duration::from_secs(0), false);
@@ -389,6 +400,7 @@ mod tests {
     fn test_ip_rate_limit_within_window() {
         let low_watermark = 5;
         let mut filter = Filter::new(
+            DEFAULT_METRICS,
             100,
             Duration::from_secs(60),
             Duration::from_secs(5),
@@ -397,7 +409,7 @@ mod tests {
             low_watermark,
             10,
         );
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         for i in 0..low_watermark {
             let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
             insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
@@ -412,6 +424,7 @@ mod tests {
     fn test_ip_rate_limit_after_window() {
         let low_watermark = 5;
         let mut filter = Filter::new(
+            DEFAULT_METRICS,
             100,
             Duration::from_secs(60),
             Duration::from_secs(5),
@@ -420,7 +433,7 @@ mod tests {
             low_watermark,
             10,
         );
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         for i in 0..low_watermark {
             let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
             insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
@@ -436,6 +449,7 @@ mod tests {
         let low_watermark = 5;
         let max_sessions_per_ip = 2;
         let mut filter = Filter::new(
+            DEFAULT_METRICS,
             100,
             Duration::from_secs(60),
             Duration::from_secs(60),
@@ -444,7 +458,7 @@ mod tests {
             low_watermark,
             10,
         );
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         for i in 0..low_watermark {
             let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
             insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
@@ -463,6 +477,7 @@ mod tests {
         let low_watermark = 5;
         let max_sessions_per_ip = 2;
         let mut filter = Filter::new(
+            DEFAULT_METRICS,
             100,
             Duration::from_secs(60),
             Duration::from_secs(60),
@@ -471,7 +486,7 @@ mod tests {
             low_watermark,
             10,
         );
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         for i in 0..low_watermark {
             let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
             insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
@@ -488,6 +503,7 @@ mod tests {
         let handshake_rate_limit = 5;
         let low_watermark = 5;
         let mut filter = Filter::new(
+            DEFAULT_METRICS,
             handshake_rate_limit,
             Duration::from_secs(60),
             Duration::from_secs(60),
@@ -496,7 +512,7 @@ mod tests {
             low_watermark,
             10,
         );
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         for i in 0..low_watermark {
             let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
             insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
@@ -513,6 +529,7 @@ mod tests {
     fn test_lru_cache_eviction() {
         let low_watermark = 5;
         let mut filter = Filter::new(
+            DEFAULT_METRICS,
             100,
             Duration::from_secs(60),
             Duration::from_secs(5),
@@ -521,7 +538,7 @@ mod tests {
             low_watermark,
             10,
         );
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         for i in 0..low_watermark {
             let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
             insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));

--- a/monad-wireauth/src/lib.rs
+++ b/monad-wireauth/src/lib.rs
@@ -13,7 +13,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pub(crate) mod metrics;
 pub(crate) mod protocol;
 pub(crate) mod session;
 
@@ -23,11 +22,13 @@ mod context;
 mod cookie;
 mod error;
 mod filter;
+mod metrics;
 mod state;
 
 pub use api::API;
 pub use config::{Config, DEFAULT_RETRY_ATTEMPTS, RETRY_ALWAYS};
 pub use context::{Context, StdContext, TestContext};
 pub use error::{Error, Result};
+pub use metrics::{MetricNames, DEFAULT_METRICS};
 pub use monad_secp::PubKey as PublicKey;
 pub use protocol::{crypto, messages};

--- a/monad-wireauth/src/metrics.rs
+++ b/monad-wireauth/src/metrics.rs
@@ -13,85 +13,272 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pub const GAUGE_WIREAUTH_STATE_INITIATING_SESSIONS: &str =
-    "monad.wireauth.state.initiating_sessions";
-pub const GAUGE_WIREAUTH_STATE_RESPONDING_SESSIONS: &str =
-    "monad.wireauth.state.responding_sessions";
-pub const GAUGE_WIREAUTH_STATE_TRANSPORT_SESSIONS: &str = "monad.wireauth.state.transport_sessions";
-pub const GAUGE_WIREAUTH_STATE_TOTAL_SESSIONS: &str = "monad.wireauth.state.total_sessions";
-pub const GAUGE_WIREAUTH_STATE_ALLOCATED_INDICES: &str = "monad.wireauth.state.allocated_indices";
-pub const GAUGE_WIREAUTH_STATE_SESSIONS_BY_PUBLIC_KEY: &str =
-    "monad.wireauth.state.sessions_by_public_key";
-pub const GAUGE_WIREAUTH_STATE_SESSIONS_BY_SOCKET: &str = "monad.wireauth.state.sessions_by_socket";
-pub const GAUGE_WIREAUTH_STATE_SESSION_INDEX_ALLOCATED: &str =
-    "monad.wireauth.state.session_index_allocated";
-pub const GAUGE_WIREAUTH_STATE_SESSION_ESTABLISHED_INITIATOR: &str =
-    "monad.wireauth.state.session_established_initiator";
-pub const GAUGE_WIREAUTH_STATE_SESSION_ESTABLISHED_RESPONDER: &str =
-    "monad.wireauth.state.session_established_responder";
-pub const GAUGE_WIREAUTH_STATE_SESSION_TERMINATED: &str = "monad.wireauth.state.session_terminated";
-pub const GAUGE_WIREAUTH_STATE_TIMERS_SIZE: &str = "monad.wireauth.state.timers_size";
-pub const GAUGE_WIREAUTH_STATE_PACKET_QUEUE_SIZE: &str = "monad.wireauth.state.packet_queue_size";
-pub const GAUGE_WIREAUTH_STATE_INITIATED_SESSION_BY_PEER_SIZE: &str =
-    "monad.wireauth.state.initiated_session_by_peer_size";
-pub const GAUGE_WIREAUTH_STATE_ACCEPTED_SESSIONS_BY_PEER_SIZE: &str =
-    "monad.wireauth.state.accepted_sessions_by_peer_size";
-pub const GAUGE_WIREAUTH_STATE_IP_SESSION_COUNTS_SIZE: &str =
-    "monad.wireauth.state.ip_session_counts_size";
-pub const GAUGE_WIREAUTH_FILTER_IP_REQUEST_HISTORY_SIZE: &str =
-    "monad.wireauth.filter.ip_request_history_size";
+pub struct MetricNames {
+    pub state_initiating_sessions: &'static str,
+    pub state_responding_sessions: &'static str,
+    pub state_transport_sessions: &'static str,
+    pub state_total_sessions: &'static str,
+    pub state_allocated_indices: &'static str,
+    pub state_sessions_by_public_key: &'static str,
+    pub state_sessions_by_socket: &'static str,
+    pub state_session_index_allocated: &'static str,
+    pub state_session_established_initiator: &'static str,
+    pub state_session_established_responder: &'static str,
+    pub state_session_terminated: &'static str,
+    pub state_timers_size: &'static str,
+    pub state_packet_queue_size: &'static str,
+    pub state_initiated_session_by_peer_size: &'static str,
+    pub state_accepted_sessions_by_peer_size: &'static str,
+    pub state_ip_session_counts_size: &'static str,
 
-pub const GAUGE_WIREAUTH_FILTER_PASS: &str = "monad.wireauth.filter.pass";
-pub const GAUGE_WIREAUTH_FILTER_SEND_COOKIE: &str = "monad.wireauth.filter.send_cookie";
-pub const GAUGE_WIREAUTH_FILTER_DROP: &str = "monad.wireauth.filter.drop";
+    pub filter_pass: &'static str,
+    pub filter_send_cookie: &'static str,
+    pub filter_drop: &'static str,
+    pub filter_ip_request_history_size: &'static str,
 
-pub const GAUGE_WIREAUTH_API_CONNECT: &str = "monad.wireauth.api.connect";
-pub const GAUGE_WIREAUTH_API_DECRYPT: &str = "monad.wireauth.api.decrypt";
-pub const GAUGE_WIREAUTH_API_ENCRYPT_BY_PUBLIC_KEY: &str =
-    "monad.wireauth.api.encrypt_by_public_key";
-pub const GAUGE_WIREAUTH_API_ENCRYPT_BY_SOCKET: &str = "monad.wireauth.api.encrypt_by_socket";
-pub const GAUGE_WIREAUTH_API_DISCONNECT: &str = "monad.wireauth.api.disconnect";
-pub const GAUGE_WIREAUTH_API_DISPATCH_CONTROL: &str = "monad.wireauth.api.dispatch_control";
-pub const GAUGE_WIREAUTH_API_NEXT_PACKET: &str = "monad.wireauth.api.next_packet";
-pub const GAUGE_WIREAUTH_API_TICK: &str = "monad.wireauth.api.tick";
+    pub api_connect: &'static str,
+    pub api_decrypt: &'static str,
+    pub api_encrypt_by_public_key: &'static str,
+    pub api_encrypt_by_socket: &'static str,
+    pub api_disconnect: &'static str,
+    pub api_dispatch_control: &'static str,
+    pub api_next_packet: &'static str,
+    pub api_tick: &'static str,
 
-pub const GAUGE_WIREAUTH_DISPATCH_HANDSHAKE_INIT: &str =
-    "monad.wireauth.dispatch.handshake_initiation";
-pub const GAUGE_WIREAUTH_DISPATCH_HANDSHAKE_RESPONSE: &str =
-    "monad.wireauth.dispatch.handshake_response";
-pub const GAUGE_WIREAUTH_DISPATCH_COOKIE_REPLY: &str = "monad.wireauth.dispatch.cookie_reply";
-pub const GAUGE_WIREAUTH_DISPATCH_KEEPALIVE: &str = "monad.wireauth.dispatch.keepalive";
+    pub dispatch_handshake_init: &'static str,
+    pub dispatch_handshake_response: &'static str,
+    pub dispatch_cookie_reply: &'static str,
+    pub dispatch_keepalive: &'static str,
 
-pub const GAUGE_WIREAUTH_ERROR_CONNECT: &str = "monad.wireauth.error.connect";
-pub const GAUGE_WIREAUTH_ERROR_DECRYPT: &str = "monad.wireauth.error.decrypt";
-pub const GAUGE_WIREAUTH_ERROR_DECRYPT_NONCE_OUTSIDE_WINDOW: &str =
-    "monad.wireauth.error.decrypt.nonce_outside_window";
-pub const GAUGE_WIREAUTH_ERROR_DECRYPT_NONCE_DUPLICATE: &str =
-    "monad.wireauth.error.decrypt.nonce_duplicate";
-pub const GAUGE_WIREAUTH_ERROR_DECRYPT_MAC: &str = "monad.wireauth.error.decrypt.mac";
-pub const GAUGE_WIREAUTH_ERROR_ENCRYPT_BY_PUBLIC_KEY: &str =
-    "monad.wireauth.error.encrypt_by_public_key";
-pub const GAUGE_WIREAUTH_ERROR_ENCRYPT_BY_SOCKET: &str = "monad.wireauth.error.encrypt_by_socket";
-pub const GAUGE_WIREAUTH_ERROR_DISPATCH_CONTROL: &str = "monad.wireauth.error.dispatch_control";
+    pub error_connect: &'static str,
+    pub error_decrypt: &'static str,
+    pub error_decrypt_nonce_outside_window: &'static str,
+    pub error_decrypt_nonce_duplicate: &'static str,
+    pub error_decrypt_mac: &'static str,
+    pub error_encrypt_by_public_key: &'static str,
+    pub error_encrypt_by_socket: &'static str,
+    pub error_dispatch_control: &'static str,
 
-pub const GAUGE_WIREAUTH_ERROR_SESSION_EXHAUSTED: &str = "monad.wireauth.error.session_exhausted";
-pub const GAUGE_WIREAUTH_ERROR_MAC1_VERIFICATION_FAILED: &str =
-    "monad.wireauth.error.mac1_verification_failed";
-pub const GAUGE_WIREAUTH_ERROR_TIMESTAMP_REPLAY: &str = "monad.wireauth.error.timestamp_replay";
-pub const GAUGE_WIREAUTH_ERROR_SESSION_NOT_FOUND: &str = "monad.wireauth.error.session_not_found";
-pub const GAUGE_WIREAUTH_ERROR_SESSION_INDEX_NOT_FOUND: &str =
-    "monad.wireauth.error.session_index_not_found";
-pub const GAUGE_WIREAUTH_ERROR_HANDSHAKE_INIT_VALIDATION: &str =
-    "monad.wireauth.error.handshake_init_validation";
-pub const GAUGE_WIREAUTH_ERROR_COOKIE_REPLY: &str = "monad.wireauth.error.cookie_reply";
-pub const GAUGE_WIREAUTH_ERROR_HANDSHAKE_RESPONSE_VALIDATION: &str =
-    "monad.wireauth.error.handshake_response_validation";
+    pub error_session_exhausted: &'static str,
+    pub error_mac1_verification_failed: &'static str,
+    pub error_timestamp_replay: &'static str,
+    pub error_session_not_found: &'static str,
+    pub error_session_index_not_found: &'static str,
+    pub error_handshake_init_validation: &'static str,
+    pub error_cookie_reply: &'static str,
+    pub error_handshake_response_validation: &'static str,
 
-pub const GAUGE_WIREAUTH_ENQUEUED_HANDSHAKE_INIT: &str = "monad.wireauth.enqueued.handshake_init";
-pub const GAUGE_WIREAUTH_ENQUEUED_HANDSHAKE_RESPONSE: &str =
-    "monad.wireauth.enqueued.handshake_response";
-pub const GAUGE_WIREAUTH_ENQUEUED_COOKIE_REPLY: &str = "monad.wireauth.enqueued.cookie_reply";
-pub const GAUGE_WIREAUTH_ENQUEUED_KEEPALIVE: &str = "monad.wireauth.enqueued.keepalive";
+    pub enqueued_handshake_init: &'static str,
+    pub enqueued_handshake_response: &'static str,
+    pub enqueued_cookie_reply: &'static str,
+    pub enqueued_keepalive: &'static str,
 
-pub const GAUGE_WIREAUTH_RATE_LIMIT_DROP: &str = "monad.wireauth.rate_limit.drop";
-pub const GAUGE_WIREAUTH_RATE_LIMIT_CONNECT: &str = "monad.wireauth.rate_limit.connect";
+    pub rate_limit_drop: &'static str,
+    pub rate_limit_connect: &'static str,
+}
+
+#[macro_export]
+macro_rules! define_metric_names {
+    ($name:ident, $transport:literal) => {
+        $crate::define_metric_names!(pub $name, $transport);
+    };
+    ($vis:vis $name:ident, $transport:literal) => {
+        $vis static $name: $crate::MetricNames = $crate::MetricNames {
+            state_initiating_sessions: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".state.initiating_sessions"
+            ),
+            state_responding_sessions: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".state.responding_sessions"
+            ),
+            state_transport_sessions: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".state.transport_sessions"
+            ),
+            state_total_sessions: concat!("monad.wireauth.", $transport, ".state.total_sessions"),
+            state_allocated_indices: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".state.allocated_indices"
+            ),
+            state_sessions_by_public_key: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".state.sessions_by_public_key"
+            ),
+            state_sessions_by_socket: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".state.sessions_by_socket"
+            ),
+            state_session_index_allocated: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".state.session_index_allocated"
+            ),
+            state_session_established_initiator: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".state.session_established_initiator"
+            ),
+            state_session_established_responder: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".state.session_established_responder"
+            ),
+            state_session_terminated: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".state.session_terminated"
+            ),
+            state_timers_size: concat!("monad.wireauth.", $transport, ".state.timers_size"),
+            state_packet_queue_size: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".state.packet_queue_size"
+            ),
+            state_initiated_session_by_peer_size: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".state.initiated_session_by_peer_size"
+            ),
+            state_accepted_sessions_by_peer_size: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".state.accepted_sessions_by_peer_size"
+            ),
+            state_ip_session_counts_size: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".state.ip_session_counts_size"
+            ),
+
+            filter_pass: concat!("monad.wireauth.", $transport, ".filter.pass"),
+            filter_send_cookie: concat!("monad.wireauth.", $transport, ".filter.send_cookie"),
+            filter_drop: concat!("monad.wireauth.", $transport, ".filter.drop"),
+            filter_ip_request_history_size: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".filter.ip_request_history_size"
+            ),
+
+            api_connect: concat!("monad.wireauth.", $transport, ".api.connect"),
+            api_decrypt: concat!("monad.wireauth.", $transport, ".api.decrypt"),
+            api_encrypt_by_public_key: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".api.encrypt_by_public_key"
+            ),
+            api_encrypt_by_socket: concat!("monad.wireauth.", $transport, ".api.encrypt_by_socket"),
+            api_disconnect: concat!("monad.wireauth.", $transport, ".api.disconnect"),
+            api_dispatch_control: concat!("monad.wireauth.", $transport, ".api.dispatch_control"),
+            api_next_packet: concat!("monad.wireauth.", $transport, ".api.next_packet"),
+            api_tick: concat!("monad.wireauth.", $transport, ".api.tick"),
+
+            dispatch_handshake_init: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".dispatch.handshake_initiation"
+            ),
+            dispatch_handshake_response: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".dispatch.handshake_response"
+            ),
+            dispatch_cookie_reply: concat!("monad.wireauth.", $transport, ".dispatch.cookie_reply"),
+            dispatch_keepalive: concat!("monad.wireauth.", $transport, ".dispatch.keepalive"),
+
+            error_connect: concat!("monad.wireauth.", $transport, ".error.connect"),
+            error_decrypt: concat!("monad.wireauth.", $transport, ".error.decrypt"),
+            error_decrypt_nonce_outside_window: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".error.decrypt.nonce_outside_window"
+            ),
+            error_decrypt_nonce_duplicate: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".error.decrypt.nonce_duplicate"
+            ),
+            error_decrypt_mac: concat!("monad.wireauth.", $transport, ".error.decrypt.mac"),
+            error_encrypt_by_public_key: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".error.encrypt_by_public_key"
+            ),
+            error_encrypt_by_socket: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".error.encrypt_by_socket"
+            ),
+            error_dispatch_control: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".error.dispatch_control"
+            ),
+
+            error_session_exhausted: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".error.session_exhausted"
+            ),
+            error_mac1_verification_failed: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".error.mac1_verification_failed"
+            ),
+            error_timestamp_replay: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".error.timestamp_replay"
+            ),
+            error_session_not_found: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".error.session_not_found"
+            ),
+            error_session_index_not_found: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".error.session_index_not_found"
+            ),
+            error_handshake_init_validation: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".error.handshake_init_validation"
+            ),
+            error_cookie_reply: concat!("monad.wireauth.", $transport, ".error.cookie_reply"),
+            error_handshake_response_validation: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".error.handshake_response_validation"
+            ),
+
+            enqueued_handshake_init: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".enqueued.handshake_init"
+            ),
+            enqueued_handshake_response: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".enqueued.handshake_response"
+            ),
+            enqueued_cookie_reply: concat!("monad.wireauth.", $transport, ".enqueued.cookie_reply"),
+            enqueued_keepalive: concat!("monad.wireauth.", $transport, ".enqueued.keepalive"),
+
+            rate_limit_drop: concat!("monad.wireauth.", $transport, ".rate_limit.drop"),
+            rate_limit_connect: concat!("monad.wireauth.", $transport, ".rate_limit.connect"),
+        };
+    };
+}
+
+// `MetricNames` instances are intended to be defined by integration crates (e.g. raptorcast),
+// but keep a `DEFAULT_METRICS` for wireauth's own examples/tests.
+define_metric_names!(pub(crate) DEFAULT_METRIC_NAMES, "udp");
+
+pub static DEFAULT_METRICS: &MetricNames = &DEFAULT_METRIC_NAMES;

--- a/monad-wireauth/src/state.rs
+++ b/monad-wireauth/src/state.rs
@@ -22,7 +22,7 @@ use std::{
 use monad_executor::ExecutorMetrics;
 
 use crate::{
-    metrics::*,
+    metrics::MetricNames,
     protocol::tai64::Tai64N,
     session::{InitiatorState, ResponderState, SessionIndex, TransportState},
 };
@@ -105,7 +105,7 @@ impl<'a> SessionIndexReservation<'a> {
         self.state.next_session_index = self.index;
         self.state.next_session_index.increment();
         self.state.allocated_indices.insert(self.index);
-        self.state.metrics[GAUGE_WIREAUTH_STATE_ALLOCATED_INDICES] =
+        self.state.metrics[self.state.metric_names.state_allocated_indices] =
             self.state.allocated_indices.len() as u64;
     }
 }
@@ -123,10 +123,11 @@ pub struct State {
     ip_session_counts: HashMap<IpAddr, usize>,
     total_sessions: usize,
     metrics: ExecutorMetrics,
+    metric_names: &'static MetricNames,
 }
 
 impl State {
-    pub fn new() -> Self {
+    pub fn new(metric_names: &'static MetricNames) -> Self {
         Self {
             initiating_sessions: HashMap::new(),
             responding_sessions: HashMap::new(),
@@ -140,6 +141,7 @@ impl State {
             ip_session_counts: HashMap::new(),
             total_sessions: 0,
             metrics: ExecutorMetrics::default(),
+            metric_names,
         }
     }
 
@@ -261,14 +263,14 @@ impl State {
         let is_initiator = transport.is_initiator;
 
         if is_initiator {
-            self.metrics[GAUGE_WIREAUTH_STATE_SESSION_ESTABLISHED_INITIATOR] += 1;
+            self.metrics[self.metric_names.state_session_established_initiator] += 1;
             self.initiating_sessions.remove(&session_id);
-            self.metrics[GAUGE_WIREAUTH_STATE_INITIATING_SESSIONS] =
+            self.metrics[self.metric_names.state_initiating_sessions] =
                 self.initiating_sessions.len() as u64;
         } else {
-            self.metrics[GAUGE_WIREAUTH_STATE_SESSION_ESTABLISHED_RESPONDER] += 1;
+            self.metrics[self.metric_names.state_session_established_responder] += 1;
             self.responding_sessions.remove(&session_id);
-            self.metrics[GAUGE_WIREAUTH_STATE_RESPONDING_SESSIONS] =
+            self.metrics[self.metric_names.state_responding_sessions] =
                 self.responding_sessions.len() as u64;
         }
 
@@ -287,7 +289,7 @@ impl State {
         if let Some(evicted_id) = evicted {
             evicted_sessions.push(evicted_id);
         }
-        self.metrics[GAUGE_WIREAUTH_STATE_SESSIONS_BY_PUBLIC_KEY] =
+        self.metrics[self.metric_names.state_sessions_by_public_key] =
             self.last_established_session_by_public_key.len() as u64;
 
         let sessions = self
@@ -305,7 +307,7 @@ impl State {
                 evicted_sessions.push(evicted_id);
             }
         }
-        self.metrics[GAUGE_WIREAUTH_STATE_SESSIONS_BY_SOCKET] =
+        self.metrics[self.metric_names.state_sessions_by_socket] =
             self.last_established_session_by_socket.len() as u64;
 
         for evicted_session_id in evicted_sessions {
@@ -321,7 +323,7 @@ impl State {
         }
 
         self.transport_sessions.insert(session_id, transport);
-        self.metrics[GAUGE_WIREAUTH_STATE_TRANSPORT_SESSIONS] =
+        self.metrics[self.metric_names.state_transport_sessions] =
             self.transport_sessions.len() as u64;
     }
 
@@ -331,30 +333,31 @@ impl State {
         remote_public_key: &monad_secp::PubKey,
         remote_addr: SocketAddr,
     ) {
-        self.metrics[GAUGE_WIREAUTH_STATE_SESSION_TERMINATED] += 1;
+        self.metrics[self.metric_names.state_session_terminated] += 1;
 
         if let Some(count) = self.ip_session_counts.get_mut(&remote_addr.ip()) {
             *count = count.saturating_sub(1);
             if *count == 0 {
                 self.ip_session_counts.remove(&remote_addr.ip());
-                self.metrics[GAUGE_WIREAUTH_STATE_IP_SESSION_COUNTS_SIZE] =
+                self.metrics[self.metric_names.state_ip_session_counts_size] =
                     self.ip_session_counts.len() as u64;
             }
         }
         self.total_sessions = self.total_sessions.saturating_sub(1);
-        self.metrics[GAUGE_WIREAUTH_STATE_TOTAL_SESSIONS] = self.total_sessions as u64;
+        self.metrics[self.metric_names.state_total_sessions] = self.total_sessions as u64;
 
         let transport = self.transport_sessions.remove(&session_id);
-        self.metrics[GAUGE_WIREAUTH_STATE_TRANSPORT_SESSIONS] =
+        self.metrics[self.metric_names.state_transport_sessions] =
             self.transport_sessions.len() as u64;
         self.initiating_sessions.remove(&session_id);
-        self.metrics[GAUGE_WIREAUTH_STATE_INITIATING_SESSIONS] =
+        self.metrics[self.metric_names.state_initiating_sessions] =
             self.initiating_sessions.len() as u64;
         self.responding_sessions.remove(&session_id);
-        self.metrics[GAUGE_WIREAUTH_STATE_RESPONDING_SESSIONS] =
+        self.metrics[self.metric_names.state_responding_sessions] =
             self.responding_sessions.len() as u64;
         self.allocated_indices.remove(&session_id);
-        self.metrics[GAUGE_WIREAUTH_STATE_ALLOCATED_INDICES] = self.allocated_indices.len() as u64;
+        self.metrics[self.metric_names.state_allocated_indices] =
+            self.allocated_indices.len() as u64;
 
         if let Some(transport) = transport {
             if let Some(sessions) = self
@@ -369,7 +372,7 @@ impl State {
 
                 if sessions.is_empty() {
                     self.last_established_session_by_socket.remove(&remote_addr);
-                    self.metrics[GAUGE_WIREAUTH_STATE_SESSIONS_BY_SOCKET] =
+                    self.metrics[self.metric_names.state_sessions_by_socket] =
                         self.last_established_session_by_socket.len() as u64;
                 }
             }
@@ -387,7 +390,7 @@ impl State {
                 if sessions.is_empty() {
                     self.last_established_session_by_public_key
                         .remove(remote_public_key);
-                    self.metrics[GAUGE_WIREAUTH_STATE_SESSIONS_BY_PUBLIC_KEY] =
+                    self.metrics[self.metric_names.state_sessions_by_public_key] =
                         self.last_established_session_by_public_key.len() as u64;
                 }
             }
@@ -396,14 +399,14 @@ impl State {
         if let Some(&initiated_id) = self.initiated_session_by_peer.get(remote_public_key) {
             if initiated_id == session_id {
                 self.initiated_session_by_peer.remove(remote_public_key);
-                self.metrics[GAUGE_WIREAUTH_STATE_INITIATED_SESSION_BY_PEER_SIZE] =
+                self.metrics[self.metric_names.state_initiated_session_by_peer_size] =
                     self.initiated_session_by_peer.len() as u64;
             }
         }
 
         self.accepted_sessions_by_peer
             .remove(&(*remote_public_key, session_id));
-        self.metrics[GAUGE_WIREAUTH_STATE_ACCEPTED_SESSIONS_BY_PEER_SIZE] =
+        self.metrics[self.metric_names.state_accepted_sessions_by_peer_size] =
             self.accepted_sessions_by_peer.len() as u64;
     }
 
@@ -433,14 +436,14 @@ impl State {
 
     pub fn remove_initiator(&mut self, session_index: &SessionIndex) -> Option<InitiatorState> {
         let session = self.initiating_sessions.remove(session_index)?;
-        self.metrics[GAUGE_WIREAUTH_STATE_INITIATING_SESSIONS] =
+        self.metrics[self.metric_names.state_initiating_sessions] =
             self.initiating_sessions.len() as u64;
         let remote_public_key = session.remote_public_key;
         if let Some(&stored_session_index) = self.initiated_session_by_peer.get(&remote_public_key)
         {
             if stored_session_index == *session_index {
                 self.initiated_session_by_peer.remove(&remote_public_key);
-                self.metrics[GAUGE_WIREAUTH_STATE_INITIATED_SESSION_BY_PEER_SIZE] =
+                self.metrics[self.metric_names.state_initiated_session_by_peer_size] =
                     self.initiated_session_by_peer.len() as u64;
             }
         }
@@ -449,12 +452,12 @@ impl State {
 
     pub fn remove_responder(&mut self, session_index: &SessionIndex) -> Option<ResponderState> {
         let session = self.responding_sessions.remove(session_index)?;
-        self.metrics[GAUGE_WIREAUTH_STATE_RESPONDING_SESSIONS] =
+        self.metrics[self.metric_names.state_responding_sessions] =
             self.responding_sessions.len() as u64;
         let remote_public_key = session.remote_public_key;
         self.accepted_sessions_by_peer
             .remove(&(remote_public_key, *session_index));
-        self.metrics[GAUGE_WIREAUTH_STATE_ACCEPTED_SESSIONS_BY_PEER_SIZE] =
+        self.metrics[self.metric_names.state_accepted_sessions_by_peer_size] =
             self.accepted_sessions_by_peer.len() as u64;
         Some(session)
     }
@@ -467,18 +470,18 @@ impl State {
     ) {
         let remote_addr = session.remote_addr;
         self.initiating_sessions.insert(session_index, session);
-        self.metrics[GAUGE_WIREAUTH_STATE_INITIATING_SESSIONS] =
+        self.metrics[self.metric_names.state_initiating_sessions] =
             self.initiating_sessions.len() as u64;
         self.initiated_session_by_peer
             .insert(remote_key, session_index);
-        self.metrics[GAUGE_WIREAUTH_STATE_INITIATED_SESSION_BY_PEER_SIZE] =
+        self.metrics[self.metric_names.state_initiated_session_by_peer_size] =
             self.initiated_session_by_peer.len() as u64;
         *self.ip_session_counts.entry(remote_addr.ip()).or_insert(0) += 1;
-        self.metrics[GAUGE_WIREAUTH_STATE_IP_SESSION_COUNTS_SIZE] =
+        self.metrics[self.metric_names.state_ip_session_counts_size] =
             self.ip_session_counts.len() as u64;
         self.total_sessions += 1;
-        self.metrics[GAUGE_WIREAUTH_STATE_TOTAL_SESSIONS] = self.total_sessions as u64;
-        self.metrics[GAUGE_WIREAUTH_STATE_SESSION_INDEX_ALLOCATED] += 1;
+        self.metrics[self.metric_names.state_total_sessions] = self.total_sessions as u64;
+        self.metrics[self.metric_names.state_session_index_allocated] += 1;
     }
 
     pub fn insert_responder(
@@ -489,17 +492,17 @@ impl State {
     ) {
         let remote_addr = session.remote_addr;
         self.responding_sessions.insert(session_index, session);
-        self.metrics[GAUGE_WIREAUTH_STATE_RESPONDING_SESSIONS] =
+        self.metrics[self.metric_names.state_responding_sessions] =
             self.responding_sessions.len() as u64;
         self.accepted_sessions_by_peer
             .insert((remote_key, session_index));
-        self.metrics[GAUGE_WIREAUTH_STATE_ACCEPTED_SESSIONS_BY_PEER_SIZE] =
+        self.metrics[self.metric_names.state_accepted_sessions_by_peer_size] =
             self.accepted_sessions_by_peer.len() as u64;
         *self.ip_session_counts.entry(remote_addr.ip()).or_insert(0) += 1;
-        self.metrics[GAUGE_WIREAUTH_STATE_IP_SESSION_COUNTS_SIZE] =
+        self.metrics[self.metric_names.state_ip_session_counts_size] =
             self.ip_session_counts.len() as u64;
         self.total_sessions += 1;
-        self.metrics[GAUGE_WIREAUTH_STATE_TOTAL_SESSIONS] = self.total_sessions as u64;
+        self.metrics[self.metric_names.state_total_sessions] = self.total_sessions as u64;
     }
 
     pub fn lookup_cookie_from_initiated_sessions(
@@ -653,7 +656,7 @@ mod tests {
     use secp256k1::rand::rng;
 
     use super::*;
-    use crate::config::Config;
+    use crate::{config::Config, metrics::DEFAULT_METRICS};
 
     fn create_dummy_hash_output() -> crate::protocol::common::HashOutput {
         crate::protocol::common::HashOutput([0u8; 32])
@@ -761,7 +764,7 @@ mod tests {
 
     #[test]
     fn test_allocate_session_index() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
 
         let reservation0 = state.reserve_session_index().unwrap();
         let idx0 = reservation0.index();
@@ -785,7 +788,7 @@ mod tests {
 
     #[test]
     fn test_allocate_session_index_skips_allocated() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
 
         let reservation0 = state.reserve_session_index().unwrap();
         let idx0 = reservation0.index();
@@ -803,7 +806,7 @@ mod tests {
 
     #[test]
     fn test_get_transport_mut() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -819,7 +822,7 @@ mod tests {
 
     #[test]
     fn test_get_transport() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -835,7 +838,7 @@ mod tests {
 
     #[test]
     fn test_get_transport_by_public_key_empty() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -844,7 +847,7 @@ mod tests {
 
     #[test]
     fn test_get_transport_by_public_key_single_initiator() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -859,7 +862,7 @@ mod tests {
 
     #[test]
     fn test_get_transport_by_public_key_single_responder() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -874,7 +877,7 @@ mod tests {
 
     #[test]
     fn test_get_transport_by_public_key_both_newer_initiator() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -898,7 +901,7 @@ mod tests {
 
     #[test]
     fn test_get_transport_by_public_key_both_newer_responder() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -922,14 +925,14 @@ mod tests {
 
     #[test]
     fn test_get_transport_by_socket_empty() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 51820);
         assert!(state.get_transport_by_socket(&addr).is_none());
     }
 
     #[test]
     fn test_get_transport_by_socket_single() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -944,7 +947,7 @@ mod tests {
 
     #[test]
     fn test_get_transport_by_socket_both_newer_initiator() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -966,7 +969,7 @@ mod tests {
 
     #[test]
     fn test_insert_and_get_initiator() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -989,7 +992,7 @@ mod tests {
 
     #[test]
     fn test_insert_and_get_responder() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1013,7 +1016,7 @@ mod tests {
 
     #[test]
     fn test_get_initiator_mut() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1027,7 +1030,7 @@ mod tests {
 
     #[test]
     fn test_get_responder_mut() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1041,7 +1044,7 @@ mod tests {
 
     #[test]
     fn test_remove_initiator() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1056,7 +1059,7 @@ mod tests {
 
     #[test]
     fn test_remove_responder() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1071,7 +1074,7 @@ mod tests {
 
     #[test]
     fn test_insert_transport_initiator() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1094,7 +1097,7 @@ mod tests {
 
     #[test]
     fn test_insert_transport_keeps_previous_initiator() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1127,7 +1130,7 @@ mod tests {
 
     #[test]
     fn test_insert_transport_responder() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1143,7 +1146,7 @@ mod tests {
 
     #[test]
     fn test_insert_transport_both_initiator_and_responder() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1172,7 +1175,7 @@ mod tests {
 
     #[test]
     fn test_handle_terminate_removes_transport() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1194,7 +1197,7 @@ mod tests {
 
     #[test]
     fn test_handle_terminate_cleans_up_by_public_key() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1214,7 +1217,7 @@ mod tests {
 
     #[test]
     fn test_handle_terminate_preserves_other_slot() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1245,7 +1248,7 @@ mod tests {
 
     #[test]
     fn test_handle_terminate_cleans_up_by_socket() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1265,7 +1268,7 @@ mod tests {
 
     #[test]
     fn test_handle_terminate_removes_initiator() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1289,7 +1292,7 @@ mod tests {
 
     #[test]
     fn test_handle_terminate_removes_responder() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1316,7 +1319,7 @@ mod tests {
 
     #[test]
     fn test_handle_terminate_removes_initiated_session_by_peer() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1334,7 +1337,7 @@ mod tests {
 
     #[test]
     fn test_lookup_cookie_from_initiated_sessions_none() {
-        let state = State::new();
+        let state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1346,7 +1349,7 @@ mod tests {
 
     #[test]
     fn test_lookup_cookie_from_accepted_sessions_none() {
-        let state = State::new();
+        let state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1358,7 +1361,7 @@ mod tests {
 
     #[test]
     fn test_get_max_timestamp_empty() {
-        let state = State::new();
+        let state = State::new(DEFAULT_METRICS);
         let mut rng = rng();
         let keypair = monad_secp::KeyPair::generate(&mut rng);
         let public_key = keypair.pubkey();
@@ -1368,7 +1371,7 @@ mod tests {
 
     #[test]
     fn test_reserve_success_and_commit() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
 
         let index = {
             let reservation = state.reserve_session_index().unwrap();
@@ -1393,7 +1396,7 @@ mod tests {
 
     #[test]
     fn test_reserve_drop_without_commit() {
-        let mut state = State::new();
+        let mut state = State::new(DEFAULT_METRICS);
 
         {
             let _reservation = state.reserve_session_index().unwrap();

--- a/monad-wireauth/tests/e2e.rs
+++ b/monad-wireauth/tests/e2e.rs
@@ -16,7 +16,9 @@
 use std::{convert::TryFrom, rc::Rc, time::Duration};
 
 use bytes::Bytes;
-use monad_wireauth::{messages::Packet, Config, StdContext, API, DEFAULT_RETRY_ATTEMPTS};
+use monad_wireauth::{
+    messages::Packet, Config, StdContext, API, DEFAULT_METRICS, DEFAULT_RETRY_ATTEMPTS,
+};
 use monoio::net::udp::UdpSocket;
 use secp256k1::rand::{rngs::StdRng, SeedableRng};
 use zerocopy::IntoBytes;
@@ -44,7 +46,7 @@ impl PeerNode {
         };
 
         let context = StdContext::new();
-        let manager = API::new(config, keypair, context);
+        let manager = API::new(DEFAULT_METRICS, config, keypair, context);
 
         let addr = format!("127.0.0.1:{}", port);
         let socket = UdpSocket::bind(addr)?;

--- a/monad-wireauth/tests/tests.rs
+++ b/monad-wireauth/tests/tests.rs
@@ -17,7 +17,7 @@ use std::{convert::TryFrom, net::SocketAddr, time::Duration};
 
 use monad_wireauth::{
     messages::{CookieReply, DataPacketHeader, HandshakeInitiation, HandshakeResponse, Packet},
-    Config, Context, TestContext, API, DEFAULT_RETRY_ATTEMPTS,
+    Config, Context, TestContext, API, DEFAULT_METRICS, DEFAULT_RETRY_ATTEMPTS,
 };
 use secp256k1::rand::rng;
 use tracing_subscriber::EnvFilter;
@@ -36,7 +36,7 @@ fn create_manager() -> (API<TestContext>, monad_secp::PubKey, TestContext, Confi
     let config = Config::default();
     let context = TestContext::new();
     let context_clone = context.clone();
-    let manager = API::new(config.clone(), keypair, context);
+    let manager = API::new(DEFAULT_METRICS, config.clone(), keypair, context);
     (manager, public_key, context_clone, config)
 }
 
@@ -236,12 +236,12 @@ fn test_cookie_reply_on_init() {
     let mut rng = rng();
     let keypair1 = monad_secp::KeyPair::generate(&mut rng);
     let context1 = TestContext::new();
-    let mut peer1 = API::new(config.clone(), keypair1, context1.clone());
+    let mut peer1 = API::new(DEFAULT_METRICS, config.clone(), keypair1, context1.clone());
 
     let keypair2 = monad_secp::KeyPair::generate(&mut rng);
     let public_key2 = keypair2.pubkey();
     let context2 = TestContext::new();
-    let mut peer2 = API::new(config, keypair2, context2);
+    let mut peer2 = API::new(DEFAULT_METRICS, config, keypair2, context2);
 
     let peer1_addr: SocketAddr = "192.0.0.1:8001".parse().unwrap();
     let peer2_addr: SocketAddr = "192.0.0.2:8002".parse().unwrap();
@@ -316,7 +316,7 @@ fn test_connect_rate_limit() {
 
     let context = TestContext::new();
     let context_clone = context.clone();
-    let mut peer1 = API::new(config, keypair1, context);
+    let mut peer1 = API::new(DEFAULT_METRICS, config, keypair1, context);
 
     peer1
         .connect(peer2_pubkey, peer2_addr, DEFAULT_RETRY_ATTEMPTS)
@@ -376,14 +376,24 @@ fn test_too_many_accepted_sessions() {
     let responder_keypair = monad_secp::KeyPair::generate(&mut rng);
     let responder_public = responder_keypair.pubkey();
     let responder_ctx = TestContext::new();
-    let mut responder = API::new(config.clone(), responder_keypair, responder_ctx);
+    let mut responder = API::new(
+        DEFAULT_METRICS,
+        config.clone(),
+        responder_keypair,
+        responder_ctx,
+    );
     let responder_addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
 
     // 2. 10 initiators each send init to responder
     for i in 0..10 {
         let initiator_ctx = TestContext::new();
         let initiator_keypair = monad_secp::KeyPair::generate(&mut rng);
-        let mut initiator = API::new(config.clone(), initiator_keypair, initiator_ctx);
+        let mut initiator = API::new(
+            DEFAULT_METRICS,
+            config.clone(),
+            initiator_keypair,
+            initiator_ctx,
+        );
         let initiator_addr: SocketAddr = format!("127.0.0.1:800{}", i).parse().unwrap();
 
         initiator
@@ -427,14 +437,24 @@ fn test_filter_drop_rate_limit() {
     let responder_keypair = monad_secp::KeyPair::generate(&mut rng);
     let responder_public = responder_keypair.pubkey();
     let responder_ctx = TestContext::new();
-    let mut responder = API::new(config.clone(), responder_keypair, responder_ctx);
+    let mut responder = API::new(
+        DEFAULT_METRICS,
+        config.clone(),
+        responder_keypair,
+        responder_ctx,
+    );
     let responder_addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
 
     // 2. exceed rate limit with 4 inits (limit is 3)
     for i in 0..4 {
         let initiator_keypair = monad_secp::KeyPair::generate(&mut rng);
         let initiator_ctx = TestContext::new();
-        let mut initiator = API::new(config.clone(), initiator_keypair, initiator_ctx);
+        let mut initiator = API::new(
+            DEFAULT_METRICS,
+            config.clone(),
+            initiator_keypair,
+            initiator_ctx,
+        );
         let initiator_addr: SocketAddr = format!("127.0.0.1:800{}", i).parse().unwrap();
 
         initiator
@@ -508,7 +528,7 @@ fn test_next_deadline_includes_filter_reset() {
 
     let peer_keypair = monad_secp::KeyPair::generate(&mut rng);
     let peer_ctx = TestContext::new();
-    let peer = API::new(config, peer_keypair, peer_ctx.clone());
+    let peer = API::new(DEFAULT_METRICS, config, peer_keypair, peer_ctx.clone());
 
     // 2. verify next_deadline returns filter reset deadline
     let deadline = peer.next_deadline();
@@ -527,12 +547,17 @@ fn test_next_deadline_returns_minimum_of_session_and_filter() {
 
     let peer1_keypair = monad_secp::KeyPair::generate(&mut rng);
     let peer1_ctx = TestContext::new();
-    let mut peer1 = API::new(config.clone(), peer1_keypair, peer1_ctx.clone());
+    let mut peer1 = API::new(
+        DEFAULT_METRICS,
+        config.clone(),
+        peer1_keypair,
+        peer1_ctx.clone(),
+    );
 
     let peer2_keypair = monad_secp::KeyPair::generate(&mut rng);
     let peer2_public = peer2_keypair.pubkey();
     let peer2_ctx = TestContext::new();
-    let mut peer2 = API::new(config, peer2_keypair, peer2_ctx);
+    let mut peer2 = API::new(DEFAULT_METRICS, config, peer2_keypair, peer2_ctx);
 
     let peer2_addr: SocketAddr = "127.0.0.1:8002".parse().unwrap();
     let peer1_addr: SocketAddr = "127.0.0.1:8001".parse().unwrap();
@@ -693,12 +718,12 @@ fn test_keepalive_reset_on_encrypt() {
     let mut rng = rng();
     let keypair1 = monad_secp::KeyPair::generate(&mut rng);
     let context1 = TestContext::new();
-    let mut peer1 = API::new(config.clone(), keypair1, context1.clone());
+    let mut peer1 = API::new(DEFAULT_METRICS, config.clone(), keypair1, context1.clone());
 
     let keypair2 = monad_secp::KeyPair::generate(&mut rng);
     let peer2_pubkey = keypair2.pubkey();
     let context2 = TestContext::new();
-    let mut peer2 = API::new(config, keypair2, context2);
+    let mut peer2 = API::new(DEFAULT_METRICS, config, keypair2, context2);
 
     let peer1_addr: SocketAddr = "127.0.0.1:8001".parse().unwrap();
     let peer2_addr: SocketAddr = "127.0.0.1:8002".parse().unwrap();

--- a/monad-wireauth/tests/two_peer_model.rs
+++ b/monad-wireauth/tests/two_peer_model.rs
@@ -21,7 +21,7 @@ mod tests {
         time::Duration,
     };
 
-    use monad_wireauth::{messages::Packet, Config, TestContext, API};
+    use monad_wireauth::{messages::Packet, Config, TestContext, API, DEFAULT_METRICS};
     use proptest::prelude::*;
     use secp256k1::rand::{rng, Rng};
     use tracing_subscriber::EnvFilter;
@@ -67,7 +67,7 @@ mod tests {
             let public_key = keypair.pubkey();
             let context = TestContext::new();
             let config = test_config();
-            let manager = API::new(config, keypair, context.clone());
+            let manager = API::new(DEFAULT_METRICS, config, keypair, context.clone());
             let addr = SocketAddr::new(
                 IpAddr::V4(Ipv4Addr::new(10, 0, 0, peer_id)),
                 30000 + peer_id as u16,
@@ -284,7 +284,8 @@ mod tests {
                     let mut key_bytes = self.peers[peer_idx].private_key_bytes;
                     let keypair = monad_secp::KeyPair::from_bytes(&mut key_bytes).unwrap();
 
-                    self.peers[peer_idx].manager = API::new(config, keypair, context.clone());
+                    self.peers[peer_idx].manager =
+                        API::new(DEFAULT_METRICS, config, keypair, context.clone());
                     self.peers[peer_idx].context = context;
 
                     self.connected_for = Duration::ZERO;
@@ -301,7 +302,8 @@ mod tests {
                     let mut key_bytes = self.peers[peer_idx].private_key_bytes;
                     let keypair = monad_secp::KeyPair::from_bytes(&mut key_bytes).unwrap();
 
-                    self.peers[peer_idx].manager = API::new(config, keypair, context.clone());
+                    self.peers[peer_idx].manager =
+                        API::new(DEFAULT_METRICS, config, keypair, context.clone());
                     self.peers[peer_idx].context = context;
 
                     self.connected_for = Duration::ZERO;


### PR DESCRIPTION
wireauth will be used for both TCP, UDP (raptorcast and separate point to point) and we need separate
metrics , and since we don't support labels we just generate different instances of metrics