### PR TITLE
monad-peer-discovery: add encrypted authenticated TCP port support to name records

### DIFF
--- a/monad-debug-node/src/main.rs
+++ b/monad-debug-node/src/main.rs
@@ -179,6 +179,7 @@ fn main() -> Result<(), Error> {
                         record_seq_num: peer.record_seq_num,
                         auth_port: peer.auth_port,
                         direct_udp_port: peer.direct_udp_port,
+                        tcp_auth_port: peer.tcp_auth_port,
                     })
                     .collect();
                 let bootstrap_config = NodeBootstrapConfig {

--- a/monad-debug-node/src/main.rs
+++ b/monad-debug-node/src/main.rs
@@ -179,6 +179,7 @@ fn main() -> Result<(), Error> {
                         record_seq_num: peer.record_seq_num,
                         auth_port: peer.auth_port,
                         direct_udp_port: peer.direct_udp_port,
+                        encrypted_tcp_port: peer.encrypted_tcp_port,
                     })
                     .collect();
                 let bootstrap_config = NodeBootstrapConfig {

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -298,6 +298,9 @@ pub struct PeerEntry<ST: CertificateSignatureRecoverable> {
         skip_serializing_if = "Option::is_none"
     )]
     pub direct_udp_port: Option<NonZeroU16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tcp_auth_port: Option<NonZeroU16>,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -376,17 +379,33 @@ impl<ST: CertificateSignatureRecoverable> Encodable for PeerEntry<ST> {
         let direct_udp_port = self.direct_udp_port.map_or(0, NonZeroU16::get);
         let tcp_port = self.tcp_port().get();
         let udp_port = self.udp_port().map_or(0, NonZeroU16::get);
-        let enc = [
-            &self.pubkey as &dyn Encodable,
-            &address as &dyn Encodable,
-            &self.signature as &dyn Encodable,
-            &self.record_seq_num as &dyn Encodable,
-            &auth_port as &dyn Encodable,
-            &direct_udp_port as &dyn Encodable,
-            &tcp_port as &dyn Encodable,
-            &udp_port as &dyn Encodable,
-        ];
-        encode_list::<_, dyn Encodable>(&enc, out);
+        if let Some(tcp_auth_port) = self.tcp_auth_port {
+            let tcp_auth_port = tcp_auth_port.get();
+            let enc = [
+                &self.pubkey as &dyn Encodable,
+                &address as &dyn Encodable,
+                &self.signature as &dyn Encodable,
+                &self.record_seq_num as &dyn Encodable,
+                &auth_port as &dyn Encodable,
+                &direct_udp_port as &dyn Encodable,
+                &tcp_port as &dyn Encodable,
+                &udp_port as &dyn Encodable,
+                &tcp_auth_port as &dyn Encodable,
+            ];
+            encode_list::<_, dyn Encodable>(&enc, out);
+        } else {
+            let enc = [
+                &self.pubkey as &dyn Encodable,
+                &address as &dyn Encodable,
+                &self.signature as &dyn Encodable,
+                &self.record_seq_num as &dyn Encodable,
+                &auth_port as &dyn Encodable,
+                &direct_udp_port as &dyn Encodable,
+                &tcp_port as &dyn Encodable,
+                &udp_port as &dyn Encodable,
+            ];
+            encode_list::<_, dyn Encodable>(&enc, out);
+        }
     }
 }
 
@@ -426,6 +445,12 @@ impl<ST: CertificateSignatureRecoverable> Decodable for PeerEntry<ST> {
             (tcp_port, udp_port)
         };
 
+        let tcp_auth_port = if payload.is_empty() {
+            None
+        } else {
+            decode_optional_non_zero_u16(&mut payload)?
+        };
+
         if !payload.is_empty() {
             return Err(alloy_rlp::Error::Custom("extra bytes in peer entry"));
         }
@@ -437,6 +462,7 @@ impl<ST: CertificateSignatureRecoverable> Decodable for PeerEntry<ST> {
             record_seq_num,
             auth_port,
             direct_udp_port,
+            tcp_auth_port,
         })
     }
 }
@@ -2732,6 +2758,7 @@ tcp_port = 8003"#,
             record_seq_num,
             auth_port: NonZeroU16::new(8000).unwrap(),
             direct_udp_port: None,
+            tcp_auth_port: None,
         };
         let encoded = alloy_rlp::encode(&entry);
         let decoded: PeerEntry<NopSignature> = alloy_rlp::decode_exact(&encoded).unwrap();
@@ -2754,6 +2781,7 @@ tcp_port = 8003"#,
             record_seq_num: 7,
             auth_port: NonZeroU16::new(9000).unwrap(),
             direct_udp_port: Some(NonZeroU16::new(9001).unwrap()),
+            tcp_auth_port: None,
         };
 
         let encoded = alloy_rlp::encode(&entry);
@@ -2775,6 +2803,31 @@ tcp_port = 8003"#,
             record_seq_num,
             auth_port: NonZeroU16::new(auth_port).unwrap(),
             direct_udp_port: None,
+            tcp_auth_port: None,
+        };
+
+        let encoded = alloy_rlp::encode(&entry);
+        let decoded: PeerEntry<NopSignature> = alloy_rlp::decode_exact(&encoded).unwrap();
+        assert_eq!(entry, decoded);
+    }
+
+    #[test]
+    fn peer_entry_rlp_encode_decode_with_tcp_auth() {
+        let pubkey = CertificateSignaturePubKey::<NopSignature>::from_bytes(&[4u8; 32]).unwrap();
+        let address: Ipv4Addr = "127.0.0.1".parse().unwrap();
+        let signature = NopSignature { pubkey, id: 77 };
+        let entry = PeerEntry {
+            pubkey,
+            address: PeerEntryAddress::new(
+                address,
+                NonZeroU16::new(8003).unwrap(),
+                Some(NonZeroU16::new(8003).unwrap()),
+            ),
+            signature,
+            record_seq_num: 12,
+            auth_port: NonZeroU16::new(9003).unwrap(),
+            direct_udp_port: None,
+            tcp_auth_port: Some(NonZeroU16::new(9004).unwrap()),
         };
 
         let encoded = alloy_rlp::encode(&entry);
@@ -2804,6 +2857,7 @@ tcp_port = 8003"#,
         assert_eq!(decoded.udp_port().map(NonZeroU16::get), Some(8006));
         assert_eq!(decoded.auth_port.get(), auth_port);
         assert_eq!(decoded.direct_udp_port, None);
+        assert_eq!(decoded.tcp_auth_port, None);
     }
 
     #[test]
@@ -2891,8 +2945,9 @@ tcp_port = 8003"#,
         let auth_port = 9003u16;
         let direct_udp_port = 9004u16;
         let tcp_port = 8003u16;
-        let extra_port = 9005u16;
-        let enc: [&dyn Encodable; 9] = [
+        let tcp_auth_port = 9005u16;
+        let extra_port = 9006u16;
+        let enc: [&dyn Encodable; 10] = [
             &pubkey,
             &"127.0.0.1".to_string(),
             &signature,
@@ -2901,6 +2956,7 @@ tcp_port = 8003"#,
             &direct_udp_port,
             &tcp_port,
             &0u16,
+            &tcp_auth_port,
             &extra_port,
         ];
         let mut encoded = Vec::new();

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -302,6 +302,9 @@ pub struct PeerEntry<ST: CertificateSignatureRecoverable> {
         skip_serializing_if = "Option::is_none"
     )]
     pub direct_udp_port: Option<NonZeroU16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encrypted_tcp_port: Option<NonZeroU16>,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -380,17 +383,33 @@ impl<ST: CertificateSignatureRecoverable> Encodable for PeerEntry<ST> {
         let direct_udp_port = self.direct_udp_port.map_or(0, NonZeroU16::get);
         let tcp_port = self.tcp_port().get();
         let udp_port = self.udp_port().map_or(0, NonZeroU16::get);
-        let enc = [
-            &self.pubkey as &dyn Encodable,
-            &address as &dyn Encodable,
-            &self.signature as &dyn Encodable,
-            &self.record_seq_num as &dyn Encodable,
-            &auth_port as &dyn Encodable,
-            &direct_udp_port as &dyn Encodable,
-            &tcp_port as &dyn Encodable,
-            &udp_port as &dyn Encodable,
-        ];
-        encode_list::<_, dyn Encodable>(&enc, out);
+        if let Some(encrypted_tcp_port) = self.encrypted_tcp_port {
+            let encrypted_tcp_port = encrypted_tcp_port.get();
+            let enc = [
+                &self.pubkey as &dyn Encodable,
+                &address as &dyn Encodable,
+                &self.signature as &dyn Encodable,
+                &self.record_seq_num as &dyn Encodable,
+                &auth_port as &dyn Encodable,
+                &direct_udp_port as &dyn Encodable,
+                &tcp_port as &dyn Encodable,
+                &udp_port as &dyn Encodable,
+                &encrypted_tcp_port as &dyn Encodable,
+            ];
+            encode_list::<_, dyn Encodable>(&enc, out);
+        } else {
+            let enc = [
+                &self.pubkey as &dyn Encodable,
+                &address as &dyn Encodable,
+                &self.signature as &dyn Encodable,
+                &self.record_seq_num as &dyn Encodable,
+                &auth_port as &dyn Encodable,
+                &direct_udp_port as &dyn Encodable,
+                &tcp_port as &dyn Encodable,
+                &udp_port as &dyn Encodable,
+            ];
+            encode_list::<_, dyn Encodable>(&enc, out);
+        }
     }
 }
 
@@ -430,6 +449,12 @@ impl<ST: CertificateSignatureRecoverable> Decodable for PeerEntry<ST> {
             (tcp_port, udp_port)
         };
 
+        let encrypted_tcp_port = if payload.is_empty() {
+            None
+        } else {
+            decode_optional_non_zero_u16(&mut payload)?
+        };
+
         if !payload.is_empty() {
             return Err(alloy_rlp::Error::Custom("extra bytes in peer entry"));
         }
@@ -441,6 +466,7 @@ impl<ST: CertificateSignatureRecoverable> Decodable for PeerEntry<ST> {
             record_seq_num,
             auth_port,
             direct_udp_port,
+            encrypted_tcp_port,
         })
     }
 }
@@ -2736,6 +2762,7 @@ tcp_port = 8003"#,
             record_seq_num,
             auth_port: NonZeroU16::new(8000).unwrap(),
             direct_udp_port: None,
+            encrypted_tcp_port: None,
         };
         let encoded = alloy_rlp::encode(&entry);
         let decoded: PeerEntry<NopSignature> = alloy_rlp::decode_exact(&encoded).unwrap();
@@ -2758,6 +2785,7 @@ tcp_port = 8003"#,
             record_seq_num: 7,
             auth_port: NonZeroU16::new(9000).unwrap(),
             direct_udp_port: Some(NonZeroU16::new(9001).unwrap()),
+            encrypted_tcp_port: None,
         };
 
         let encoded = alloy_rlp::encode(&entry);
@@ -2779,6 +2807,31 @@ tcp_port = 8003"#,
             record_seq_num,
             auth_port: NonZeroU16::new(auth_port).unwrap(),
             direct_udp_port: None,
+            encrypted_tcp_port: None,
+        };
+
+        let encoded = alloy_rlp::encode(&entry);
+        let decoded: PeerEntry<NopSignature> = alloy_rlp::decode_exact(&encoded).unwrap();
+        assert_eq!(entry, decoded);
+    }
+
+    #[test]
+    fn peer_entry_rlp_encode_decode_with_encrypted_tcp() {
+        let pubkey = CertificateSignaturePubKey::<NopSignature>::from_bytes(&[4u8; 32]).unwrap();
+        let address: Ipv4Addr = "127.0.0.1".parse().unwrap();
+        let signature = NopSignature { pubkey, id: 77 };
+        let entry = PeerEntry {
+            pubkey,
+            address: PeerEntryAddress::new(
+                address,
+                NonZeroU16::new(8003).unwrap(),
+                Some(NonZeroU16::new(8003).unwrap()),
+            ),
+            signature,
+            record_seq_num: 12,
+            auth_port: NonZeroU16::new(9003).unwrap(),
+            direct_udp_port: None,
+            encrypted_tcp_port: Some(NonZeroU16::new(9004).unwrap()),
         };
 
         let encoded = alloy_rlp::encode(&entry);
@@ -2808,6 +2861,7 @@ tcp_port = 8003"#,
         assert_eq!(decoded.udp_port().map(NonZeroU16::get), Some(8006));
         assert_eq!(decoded.auth_port.get(), auth_port);
         assert_eq!(decoded.direct_udp_port, None);
+        assert_eq!(decoded.encrypted_tcp_port, None);
     }
 
     #[test]
@@ -2895,8 +2949,9 @@ tcp_port = 8003"#,
         let auth_port = 9003u16;
         let direct_udp_port = 9004u16;
         let tcp_port = 8003u16;
-        let extra_port = 9005u16;
-        let enc: [&dyn Encodable; 9] = [
+        let encrypted_tcp_port = 9005u16;
+        let extra_port = 9006u16;
+        let enc: [&dyn Encodable; 10] = [
             &pubkey,
             &"127.0.0.1".to_string(),
             &signature,
@@ -2905,6 +2960,7 @@ tcp_port = 8003"#,
             &direct_udp_port,
             &tcp_port,
             &0u16,
+            &encrypted_tcp_port,
             &extra_port,
         ];
         let mut encoded = Vec::new();

--- a/monad-node-config/src/bootstrap.rs
+++ b/monad-node-config/src/bootstrap.rs
@@ -62,6 +62,9 @@ pub struct NodeBootstrapPeerConfig<ST: CertificateSignatureRecoverable> {
         skip_serializing_if = "Option::is_none"
     )]
     pub direct_udp_port: Option<NonZeroU16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tcp_auth_port: Option<NonZeroU16>,
 }
 
 fn deserialize_bootstrap_peers<'de, D, ST>(

--- a/monad-node-config/src/bootstrap.rs
+++ b/monad-node-config/src/bootstrap.rs
@@ -62,6 +62,9 @@ pub struct NodeBootstrapPeerConfig<ST: CertificateSignatureRecoverable> {
         skip_serializing_if = "Option::is_none"
     )]
     pub direct_udp_port: Option<NonZeroU16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encrypted_tcp_port: Option<NonZeroU16>,
 }
 
 fn deserialize_bootstrap_peers<'de, D, ST>(

--- a/monad-node-config/src/network.rs
+++ b/monad-node-config/src/network.rs
@@ -26,6 +26,7 @@ pub struct NodeNetworkConfig {
     pub bind_address_tcp_port: Option<u16>,
     pub authenticated_bind_address_port: u16,
     pub direct_udp_bind_address_port: Option<u16>,
+    pub authenticated_tcp_bind_address_port: Option<u16>,
 
     pub max_rtt_ms: u64,
     pub max_mbps: u16,

--- a/monad-node-config/src/network.rs
+++ b/monad-node-config/src/network.rs
@@ -26,6 +26,7 @@ pub struct NodeNetworkConfig {
     pub bind_address_tcp_port: Option<u16>,
     pub authenticated_bind_address_port: u16,
     pub direct_udp_bind_address_port: Option<u16>,
+    pub encrypted_tcp_bind_address_port: Option<u16>,
 
     pub max_rtt_ms: u64,
     pub max_mbps: u16,

--- a/monad-node-config/src/peers.rs
+++ b/monad-node-config/src/peers.rs
@@ -35,6 +35,9 @@ pub struct PeerDiscoveryConfig<ST: CertificateSignatureRecoverable> {
     #[serde(alias = "self_direct_udp_auth_port")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub self_direct_udp_port: Option<NonZeroU16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub self_tcp_auth_port: Option<NonZeroU16>,
     pub self_record_seq_num: u64,
 
     pub self_name_record_sig: ST,

--- a/monad-node-config/src/peers.rs
+++ b/monad-node-config/src/peers.rs
@@ -35,6 +35,9 @@ pub struct PeerDiscoveryConfig<ST: CertificateSignatureRecoverable> {
     #[serde(alias = "self_direct_udp_auth_port")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub self_direct_udp_port: Option<NonZeroU16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub self_encrypted_tcp_port: Option<NonZeroU16>,
     pub self_record_seq_num: u64,
 
     pub self_name_record_sig: ST,

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -767,6 +767,10 @@ where
         peer_discovery_config.self_direct_udp_port.is_some(),
         network_config.direct_udp_bind_address_port.is_some()
     );
+    assert_eq!(
+        peer_discovery_config.self_tcp_auth_port.is_some(),
+        network_config.authenticated_tcp_bind_address_port.is_some()
+    );
 
     let self_record = NameRecord::new_with_ports(
         *name_record_address.ip(),
@@ -775,6 +779,9 @@ where
         peer_discovery_config.self_auth_port.get(),
         peer_discovery_config
             .self_direct_udp_port
+            .map(NonZeroU16::get),
+        peer_discovery_config
+            .self_tcp_auth_port
             .map(NonZeroU16::get),
         peer_discovery_config.self_record_seq_num,
     );
@@ -950,6 +957,7 @@ fn bootstrap_peer_entry<ST: CertificateSignatureRecoverable>(
         record_seq_num: peer.record_seq_num,
         auth_port: peer.auth_port,
         direct_udp_port: peer.direct_udp_port,
+        tcp_auth_port: peer.tcp_auth_port,
     })
 }
 

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -794,6 +794,10 @@ where
         peer_discovery_config.self_direct_udp_port.is_some(),
         network_config.direct_udp_bind_address_port.is_some()
     );
+    assert_eq!(
+        peer_discovery_config.self_encrypted_tcp_port.is_some(),
+        network_config.encrypted_tcp_bind_address_port.is_some()
+    );
 
     let self_record = NameRecord::new_with_ports(
         *name_record_address.ip(),
@@ -802,6 +806,9 @@ where
         peer_discovery_config.self_auth_port.get(),
         peer_discovery_config
             .self_direct_udp_port
+            .map(NonZeroU16::get),
+        peer_discovery_config
+            .self_encrypted_tcp_port
             .map(NonZeroU16::get),
         peer_discovery_config.self_record_seq_num,
     );
@@ -977,6 +984,7 @@ fn bootstrap_peer_entry<ST: CertificateSignatureRecoverable>(
         record_seq_num: peer.record_seq_num,
         auth_port: peer.auth_port,
         direct_udp_port: peer.direct_udp_port,
+        encrypted_tcp_port: peer.encrypted_tcp_port,
     })
 }
 

--- a/monad-peer-discovery/examples/sign-name-record.rs
+++ b/monad-peer-discovery/examples/sign-name-record.rs
@@ -42,6 +42,9 @@ struct Args {
     #[arg(long, help = "Optional direct UDP port")]
     direct_udp_port: Option<NonZeroU16>,
 
+    #[arg(long, help = "Optional authenticated TCP port")]
+    authenticated_tcp_port: Option<NonZeroU16>,
+
     /// Sequence number for the name record
     #[arg(long)]
     self_record_seq_num: Option<u64>,
@@ -86,6 +89,7 @@ fn main() {
         args.udp_port.map(NonZeroU16::get),
         args.authenticated_udp_port.get(),
         args.direct_udp_port.map(NonZeroU16::get),
+        args.authenticated_tcp_port.map(NonZeroU16::get),
         self_record_seq_num,
     );
     let signed_name_record: MonadNameRecord<SecpSignature> =
@@ -99,7 +103,10 @@ fn main() {
     println!("self_record_seq_num = {}", self_record_seq_num);
     println!("self_auth_port = {}", args.authenticated_udp_port);
     if let Some(direct_udp_port) = args.direct_udp_port {
-        println!("self_direct_udp_auth_port = {}", direct_udp_port);
+        println!("self_direct_udp_port = {}", direct_udp_port);
+    }
+    if let Some(authenticated_tcp_port) = args.authenticated_tcp_port {
+        println!("self_tcp_auth_port = {}", authenticated_tcp_port);
     }
     println!(
         "self_name_record_sig = {:?}",

--- a/monad-peer-discovery/examples/sign-name-record.rs
+++ b/monad-peer-discovery/examples/sign-name-record.rs
@@ -56,6 +56,9 @@ struct Args {
     #[arg(long, help = "Optional direct UDP port")]
     direct_udp_port: Option<NonZeroU16>,
 
+    #[arg(long, help = "Optional encrypted TCP port")]
+    encrypted_tcp_port: Option<NonZeroU16>,
+
     /// Sequence number for the name record
     #[arg(long)]
     self_record_seq_num: Option<u64>,
@@ -159,6 +162,7 @@ fn main() {
         udp_port,
         args.authenticated_udp_port.get(),
         args.direct_udp_port.map(NonZeroU16::get),
+        args.encrypted_tcp_port.map(NonZeroU16::get),
         self_record_seq_num,
     );
     let signed_name_record: MonadNameRecord<SecpSignature> =
@@ -169,6 +173,9 @@ fn main() {
     println!("self_auth_port = {}", args.authenticated_udp_port);
     if let Some(direct_udp_port) = args.direct_udp_port {
         println!("self_direct_udp_auth_port = {}", direct_udp_port);
+    }
+    if let Some(encrypted_tcp_port) = args.encrypted_tcp_port {
+        println!("self_encrypted_tcp_port = {}", encrypted_tcp_port);
     }
     println!(
         "self_name_record_sig = {:?}",

--- a/monad-peer-discovery/src/discovery.rs
+++ b/monad-peer-discovery/src/discovery.rs
@@ -3153,6 +3153,7 @@ mod tests {
                 Some(8000),
                 9100,
                 Some(9000),
+                None,
                 1,
             ),
             peer1,
@@ -3185,6 +3186,7 @@ mod tests {
                 Some(8001),
                 9101,
                 Some(9000),
+                None,
                 1,
             ),
             peer2,
@@ -3426,12 +3428,14 @@ mod tests {
         use monad_secp::SecpSignature;
         use monad_testutil::signing::create_keys as create_secp_keys;
 
-        let keys = create_secp_keys::<SecpSignature>(3);
+        let keys = create_secp_keys::<SecpSignature>(4);
         let peer0 = &keys[0];
         let peer1 = &keys[1];
         let peer1_pubkey = NodeId::new(peer1.pubkey());
         let peer2 = &keys[2];
         let peer2_pubkey = NodeId::new(peer2.pubkey());
+        let peer3 = &keys[3];
+        let peer3_pubkey = NodeId::new(peer3.pubkey());
 
         // peer1 has an authenticated UDP port
         let peer1_name_record = {
@@ -3454,6 +3458,7 @@ mod tests {
                 Some(8001),
                 9001,
                 Some(9002),
+                None,
                 2,
             );
             let mut encoded = Vec::new();
@@ -3465,7 +3470,26 @@ mod tests {
             }
         };
 
-        // initial state: peer1 in routing_info and peer2 in pending_queue
+        let peer3_name_record = {
+            let name_record = NameRecord::new_with_ports(
+                Ipv4Addr::new(8, 8, 2, 2),
+                8002,
+                Some(8002),
+                9003,
+                None,
+                Some(9004),
+                3,
+            );
+            let mut encoded = Vec::new();
+            name_record.encode(&mut encoded);
+            let signature = SecpSignature::sign::<signing_domain::NameRecord>(&encoded, peer3);
+            MonadNameRecord {
+                name_record,
+                signature,
+            }
+        };
+
+        // initial state: peer1 in routing_info and peer2, peer3 in pending_queue
         let mut routing_info = BTreeMap::new();
         routing_info.insert(peer1_pubkey, peer1_name_record);
         let mut pending_queue = BTreeMap::new();
@@ -3478,6 +3502,17 @@ mod tests {
                 },
                 unresponsive_pings: 0,
                 name_record: peer2_name_record,
+            },
+        );
+        pending_queue.insert(
+            peer3_pubkey,
+            ConnectionInfo {
+                last_ping: Ping {
+                    id: 0,
+                    local_name_record: peer3_name_record.clone(),
+                },
+                unresponsive_pings: 0,
+                name_record: peer3_name_record,
             },
         );
 
@@ -3542,10 +3577,12 @@ mod tests {
         // clean up any existing file
         let _ = std::fs::remove_file(&temp_file);
 
-        // verify initial state has peer1 in routing_info and peer2 in pending_queue
+        // verify initial state has peer1 in routing_info and peer2, peer3 in pending_queue
         assert!(state.routing_info.contains_key(&peer1_pubkey));
         assert!(!state.routing_info.contains_key(&peer2_pubkey));
+        assert!(!state.routing_info.contains_key(&peer3_pubkey));
         assert!(state.pending_queue.contains_key(&peer2_pubkey));
+        assert!(state.pending_queue.contains_key(&peer3_pubkey));
         assert!(!state.pending_queue.contains_key(&peer1_pubkey));
 
         // write peers to file
@@ -3570,9 +3607,10 @@ mod tests {
 
         state.read_peers_from_file();
 
-        // verify that peer1 and peer2 are restored from file and now in pending_queue
+        // verify that peer1, peer2, and peer3 are restored from file and now in pending_queue
         assert!(state.pending_queue.contains_key(&peer1_pubkey));
         assert!(state.pending_queue.contains_key(&peer2_pubkey));
+        assert!(state.pending_queue.contains_key(&peer3_pubkey));
         assert!(
             state.routing_info.is_empty(),
             "routing_info should still be empty before ping pong"
@@ -3609,6 +3647,29 @@ mod tests {
             loaded_peer2.name_record.direct_udp_port(),
             Some(9002),
             "peer2 direct UDP port should match"
+        );
+
+        let loaded_peer3 = &state.pending_queue.get(&peer3_pubkey).unwrap().name_record;
+        assert_eq!(
+            loaded_peer3.udp_address(),
+            Some(SocketAddrV4::new(Ipv4Addr::new(8, 8, 2, 2), 8002)),
+            "peer3 address should match"
+        );
+        assert_eq!(loaded_peer3.seq(), 3, "peer3 seq should match");
+        assert_eq!(
+            loaded_peer3.name_record.authenticated_udp_port(),
+            9003,
+            "peer3 auth port should match"
+        );
+        assert_eq!(
+            loaded_peer3.name_record.direct_udp_port(),
+            None,
+            "peer3 direct UDP port should be empty"
+        );
+        assert_eq!(
+            loaded_peer3.name_record.authenticated_tcp_port(),
+            Some(9004),
+            "peer3 tcp auth port should match"
         );
 
         let _ = std::fs::remove_file(&temp_file);

--- a/monad-peer-discovery/src/discovery.rs
+++ b/monad-peer-discovery/src/discovery.rs
@@ -3153,6 +3153,7 @@ mod tests {
                 Some(8000),
                 9100,
                 Some(9000),
+                None,
                 1,
             ),
             peer1,
@@ -3185,6 +3186,7 @@ mod tests {
                 Some(8001),
                 9101,
                 Some(9000),
+                None,
                 1,
             ),
             peer2,
@@ -3426,12 +3428,14 @@ mod tests {
         use monad_secp::SecpSignature;
         use monad_testutil::signing::create_keys as create_secp_keys;
 
-        let keys = create_secp_keys::<SecpSignature>(3);
+        let keys = create_secp_keys::<SecpSignature>(4);
         let peer0 = &keys[0];
         let peer1 = &keys[1];
         let peer1_pubkey = NodeId::new(peer1.pubkey());
         let peer2 = &keys[2];
         let peer2_pubkey = NodeId::new(peer2.pubkey());
+        let peer3 = &keys[3];
+        let peer3_pubkey = NodeId::new(peer3.pubkey());
 
         // peer1 has an authenticated UDP port
         let peer1_name_record = {
@@ -3454,6 +3458,7 @@ mod tests {
                 Some(8001),
                 9001,
                 Some(9002),
+                None,
                 2,
             );
             let mut encoded = Vec::new();
@@ -3465,7 +3470,26 @@ mod tests {
             }
         };
 
-        // initial state: peer1 in routing_info and peer2 in pending_queue
+        let peer3_name_record = {
+            let name_record = NameRecord::new_with_ports(
+                Ipv4Addr::new(8, 8, 2, 2),
+                8002,
+                Some(8002),
+                9003,
+                None,
+                Some(9004),
+                3,
+            );
+            let mut encoded = Vec::new();
+            name_record.encode(&mut encoded);
+            let signature = SecpSignature::sign::<signing_domain::NameRecord>(&encoded, peer3);
+            MonadNameRecord {
+                name_record,
+                signature,
+            }
+        };
+
+        // initial state: peer1 in routing_info and peer2, peer3 in pending_queue
         let mut routing_info = BTreeMap::new();
         routing_info.insert(peer1_pubkey, peer1_name_record);
         let mut pending_queue = BTreeMap::new();
@@ -3478,6 +3502,17 @@ mod tests {
                 },
                 unresponsive_pings: 0,
                 name_record: peer2_name_record,
+            },
+        );
+        pending_queue.insert(
+            peer3_pubkey,
+            ConnectionInfo {
+                last_ping: Ping {
+                    id: 0,
+                    local_name_record: peer3_name_record.clone(),
+                },
+                unresponsive_pings: 0,
+                name_record: peer3_name_record,
             },
         );
 
@@ -3542,10 +3577,12 @@ mod tests {
         // clean up any existing file
         let _ = std::fs::remove_file(&temp_file);
 
-        // verify initial state has peer1 in routing_info and peer2 in pending_queue
+        // verify initial state has peer1 in routing_info and peer2, peer3 in pending_queue
         assert!(state.routing_info.contains_key(&peer1_pubkey));
         assert!(!state.routing_info.contains_key(&peer2_pubkey));
+        assert!(!state.routing_info.contains_key(&peer3_pubkey));
         assert!(state.pending_queue.contains_key(&peer2_pubkey));
+        assert!(state.pending_queue.contains_key(&peer3_pubkey));
         assert!(!state.pending_queue.contains_key(&peer1_pubkey));
 
         // write peers to file
@@ -3570,9 +3607,10 @@ mod tests {
 
         state.read_peers_from_file();
 
-        // verify that peer1 and peer2 are restored from file and now in pending_queue
+        // verify that peer1, peer2, and peer3 are restored from file and now in pending_queue
         assert!(state.pending_queue.contains_key(&peer1_pubkey));
         assert!(state.pending_queue.contains_key(&peer2_pubkey));
+        assert!(state.pending_queue.contains_key(&peer3_pubkey));
         assert!(
             state.routing_info.is_empty(),
             "routing_info should still be empty before ping pong"
@@ -3609,6 +3647,29 @@ mod tests {
             loaded_peer2.name_record.direct_udp_port(),
             Some(9002),
             "peer2 direct UDP port should match"
+        );
+
+        let loaded_peer3 = &state.pending_queue.get(&peer3_pubkey).unwrap().name_record;
+        assert_eq!(
+            loaded_peer3.udp_address(),
+            Some(SocketAddrV4::new(Ipv4Addr::new(8, 8, 2, 2), 8002)),
+            "peer3 address should match"
+        );
+        assert_eq!(loaded_peer3.seq(), 3, "peer3 seq should match");
+        assert_eq!(
+            loaded_peer3.name_record.authenticated_udp_port(),
+            9003,
+            "peer3 auth port should match"
+        );
+        assert_eq!(
+            loaded_peer3.name_record.direct_udp_port(),
+            None,
+            "peer3 direct UDP port should be empty"
+        );
+        assert_eq!(
+            loaded_peer3.name_record.encrypted_tcp_port(),
+            Some(9004),
+            "peer3 encrypted TCP port should match"
         );
 
         let _ = std::fs::remove_file(&temp_file);

--- a/monad-peer-discovery/src/lib.rs
+++ b/monad-peer-discovery/src/lib.rs
@@ -55,6 +55,7 @@ pub enum PortTag {
     UDP = 1,
     AuthenticatedUDP = 2,
     DirectUDP = 3,
+    AuthenticatedTCP = 4,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -77,6 +78,7 @@ impl Port {
             1 => Some(PortTag::UDP),
             2 => Some(PortTag::AuthenticatedUDP),
             3 => Some(PortTag::DirectUDP),
+            4 => Some(PortTag::AuthenticatedTCP),
             _ => None,
         }
     }
@@ -181,6 +183,10 @@ impl<const N: usize> PortList<N> {
     fn direct_udp_port(&self) -> Option<NonZeroU16> {
         self.port_by_tag(PortTag::DirectUDP)
     }
+
+    fn authenticated_tcp_port(&self) -> Option<NonZeroU16> {
+        self.port_by_tag(PortTag::AuthenticatedTCP)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -226,8 +232,15 @@ impl NameRecord {
         capabilities: u64,
         seq: u64,
     ) -> Self {
-        let mut record =
-            Self::new_with_ports(ip, tcp_port, udp_port, authenticated_udp_port, None, seq);
+        let mut record = Self::new_with_ports(
+            ip,
+            tcp_port,
+            udp_port,
+            authenticated_udp_port,
+            None,
+            None,
+            seq,
+        );
         record.capabilities = capabilities;
         record
     }
@@ -238,6 +251,7 @@ impl NameRecord {
         udp_port: Option<u16>,
         authenticated_udp_port: u16,
         direct_udp_port: Option<u16>,
+        authenticated_tcp_port: Option<u16>,
         seq: u64,
     ) -> Self {
         let mut ports_vec = ArrayVec::new();
@@ -248,6 +262,9 @@ impl NameRecord {
         ports_vec.push(Port::new(PortTag::AuthenticatedUDP, authenticated_udp_port));
         if let Some(direct_udp_port) = direct_udp_port {
             ports_vec.push(Port::new(PortTag::DirectUDP, direct_udp_port));
+        }
+        if let Some(authenticated_tcp_port) = authenticated_tcp_port {
+            ports_vec.push(Port::new(PortTag::AuthenticatedTCP, authenticated_tcp_port));
         }
         Self {
             ip,
@@ -306,6 +323,15 @@ impl NameRecord {
 
     pub fn direct_udp_socket(&self) -> Option<SocketAddrV4> {
         self.direct_udp_port()
+            .map(|port| SocketAddrV4::new(self.ip(), port))
+    }
+
+    pub fn authenticated_tcp_port(&self) -> Option<u16> {
+        self.ports.authenticated_tcp_port().map(NonZeroU16::get)
+    }
+
+    pub fn authenticated_tcp_socket(&self) -> Option<SocketAddrV4> {
+        self.authenticated_tcp_port()
             .map(|port| SocketAddrV4::new(self.ip(), port))
     }
 
@@ -396,6 +422,10 @@ impl<ST: CertificateSignatureRecoverable> MonadNameRecord<ST> {
         self.name_record.direct_udp_socket()
     }
 
+    pub fn authenticated_tcp_address(&self) -> Option<SocketAddrV4> {
+        self.name_record.authenticated_tcp_socket()
+    }
+
     pub fn all_udp_sockets(&self) -> impl Iterator<Item = SocketAddrV4> + '_ {
         [
             self.udp_address(),
@@ -431,6 +461,7 @@ impl<ST: CertificateSignatureRecoverable> TryFrom<&PeerEntry<ST>> for MonadNameR
             peer.udp_port().map(NonZeroU16::get),
             peer.auth_port.get(),
             peer.direct_udp_port.map(NonZeroU16::get),
+            peer.tcp_auth_port.map(NonZeroU16::get),
             peer.record_seq_num,
         );
 
@@ -469,6 +500,9 @@ impl<ST: CertificateSignatureRecoverable> TryFrom<&MonadNameRecord<ST>> for Peer
             direct_udp_port: record.name_record.direct_udp_port().map(|port| {
                 NonZeroU16::new(port).expect("name record direct UDP port must be non-zero")
             }),
+            tcp_auth_port: record.name_record.authenticated_tcp_port().map(|port| {
+                NonZeroU16::new(port).expect("name record authenticated TCP port must be non-zero")
+            }),
         })
     }
 }
@@ -487,6 +521,7 @@ impl<ST: CertificateSignatureRecoverable> From<MonadNameRecordWithPubkey<'_, ST>
             record_seq_num: peer.record_seq_num,
             auth_port: peer.auth_port,
             direct_udp_port: peer.direct_udp_port,
+            tcp_auth_port: peer.tcp_auth_port,
         }
     }
 }
@@ -519,6 +554,7 @@ impl<ST: CertificateSignatureRecoverable> TryFrom<&NodeBootstrapPeerConfig<ST>>
             peer_config.udp_port().map(NonZeroU16::get),
             peer_config.auth_port.get(),
             peer_config.direct_udp_port.map(NonZeroU16::get),
+            peer_config.tcp_auth_port.map(NonZeroU16::get),
             peer_config.record_seq_num,
         );
 
@@ -574,6 +610,14 @@ impl<ST: CertificateSignatureRecoverable> From<MonadNameRecordWithPubkey<'_, ST>
                 .direct_udp_port()
                 .map(|port| {
                     NonZeroU16::new(port).expect("name record direct UDP port must be non-zero")
+                }),
+            tcp_auth_port: record_with_pubkey
+                .record
+                .name_record
+                .authenticated_tcp_port()
+                .map(|port| {
+                    NonZeroU16::new(port)
+                        .expect("name record authenticated TCP port must be non-zero")
                 }),
         }
     }
@@ -1043,6 +1087,7 @@ mod tests {
             Some(udp_port),
             authenticated_udp_port,
             Some(direct_udp_port),
+            None,
             seq,
         );
 
@@ -1081,6 +1126,7 @@ mod tests {
             Some(9201),
             9202,
             Some(9203),
+            None,
             102,
         ),
         vec![
@@ -1115,6 +1161,21 @@ mod tests {
         vec![
             SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 47), 9501),
             SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 47), 9501),
+        ],
+    )]
+    #[case::tcp_auth_does_not_add_udp_socket(
+        NameRecord::new_with_ports(
+            Ipv4Addr::new(10, 0, 0, 48),
+            9600,
+            Some(9601),
+            9602,
+            None,
+            Some(9603),
+            106,
+        ),
+        vec![
+            SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 48), 9601),
+            SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 48), 9602),
         ],
     )]
     fn test_monad_name_record_all_udp_sockets(
@@ -1153,6 +1214,7 @@ mod tests {
             record_seq_num: seq,
             auth_port: NonZeroU16::new(port).unwrap(),
             direct_udp_port: None,
+            tcp_auth_port: None,
         };
 
         let result = MonadNameRecord::<SecpSignature>::try_from(&peer_entry);
@@ -1196,8 +1258,15 @@ mod tests {
         let seq = 100u64;
 
         let keypair = KeyPair::from_ikm(b"test roundtrip direct udp").unwrap();
-        let name_record =
-            NameRecord::new_with_ports(ip, port, Some(port), auth_port, Some(direct_udp_port), seq);
+        let name_record = NameRecord::new_with_ports(
+            ip,
+            port,
+            Some(port),
+            auth_port,
+            Some(direct_udp_port),
+            None,
+            seq,
+        );
         let original_monad_record = MonadNameRecord::<SecpSignature>::new(name_record, &keypair);
 
         let pubkey = original_monad_record.recover_pubkey().unwrap().pubkey();
@@ -1283,5 +1352,46 @@ mod tests {
     #[should_panic(expected = "name record port must be non-zero")]
     fn test_name_record_new_rejects_zero_port() {
         let _ = NameRecord::new(Ipv4Addr::new(1, 1, 1, 1), 0, Some(9001), 9002, 0, 1);
+    }
+
+    #[test]
+    fn test_peer_entry_monad_name_record_roundtrip_with_tcp_auth() {
+        let ip = Ipv4Addr::from_str("172.31.0.103").unwrap();
+        let port = 8895u16;
+        let auth_port = 8896u16;
+        let tcp_auth_port = 8897u16;
+        let seq = 102u64;
+
+        let keypair = KeyPair::from_ikm(b"test roundtrip tcp auth").unwrap();
+        let name_record = NameRecord::new_with_ports(
+            ip,
+            port,
+            Some(port),
+            auth_port,
+            None,
+            Some(tcp_auth_port),
+            seq,
+        );
+        let original_monad_record = MonadNameRecord::<SecpSignature>::new(name_record, &keypair);
+
+        let pubkey = original_monad_record.recover_pubkey().unwrap().pubkey();
+        let peer_entry = PeerEntry::from(original_monad_record.with_pubkey(pubkey));
+        assert_eq!(peer_entry.auth_port.get(), auth_port);
+        assert_eq!(
+            peer_entry.tcp_auth_port.map(NonZeroU16::get),
+            Some(tcp_auth_port)
+        );
+
+        let converted_monad_record =
+            MonadNameRecord::<SecpSignature>::try_from(&peer_entry).unwrap();
+
+        assert_eq!(
+            converted_monad_record.name_record,
+            original_monad_record.name_record
+        );
+        assert_eq!(
+            converted_monad_record.name_record.authenticated_tcp_port(),
+            Some(tcp_auth_port)
+        );
     }
 }

--- a/monad-peer-discovery/src/lib.rs
+++ b/monad-peer-discovery/src/lib.rs
@@ -55,6 +55,7 @@ pub enum PortTag {
     UDP = 1,
     AuthenticatedUDP = 2,
     DirectUDP = 3,
+    EncryptedTCP = 4,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -77,6 +78,7 @@ impl Port {
             1 => Some(PortTag::UDP),
             2 => Some(PortTag::AuthenticatedUDP),
             3 => Some(PortTag::DirectUDP),
+            4 => Some(PortTag::EncryptedTCP),
             _ => None,
         }
     }
@@ -181,6 +183,10 @@ impl<const N: usize> PortList<N> {
     fn direct_udp_port(&self) -> Option<NonZeroU16> {
         self.port_by_tag(PortTag::DirectUDP)
     }
+
+    fn encrypted_tcp_port(&self) -> Option<NonZeroU16> {
+        self.port_by_tag(PortTag::EncryptedTCP)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -226,8 +232,15 @@ impl NameRecord {
         capabilities: u64,
         seq: u64,
     ) -> Self {
-        let mut record =
-            Self::new_with_ports(ip, tcp_port, udp_port, authenticated_udp_port, None, seq);
+        let mut record = Self::new_with_ports(
+            ip,
+            tcp_port,
+            udp_port,
+            authenticated_udp_port,
+            None,
+            None,
+            seq,
+        );
         record.capabilities = capabilities;
         record
     }
@@ -238,6 +251,7 @@ impl NameRecord {
         udp_port: Option<u16>,
         authenticated_udp_port: u16,
         direct_udp_port: Option<u16>,
+        encrypted_tcp_port: Option<u16>,
         seq: u64,
     ) -> Self {
         let mut ports_vec = ArrayVec::new();
@@ -248,6 +262,9 @@ impl NameRecord {
         ports_vec.push(Port::new(PortTag::AuthenticatedUDP, authenticated_udp_port));
         if let Some(direct_udp_port) = direct_udp_port {
             ports_vec.push(Port::new(PortTag::DirectUDP, direct_udp_port));
+        }
+        if let Some(encrypted_tcp_port) = encrypted_tcp_port {
+            ports_vec.push(Port::new(PortTag::EncryptedTCP, encrypted_tcp_port));
         }
         Self {
             ip,
@@ -306,6 +323,15 @@ impl NameRecord {
 
     pub fn direct_udp_socket(&self) -> Option<SocketAddrV4> {
         self.direct_udp_port()
+            .map(|port| SocketAddrV4::new(self.ip(), port))
+    }
+
+    pub fn encrypted_tcp_port(&self) -> Option<u16> {
+        self.ports.encrypted_tcp_port().map(NonZeroU16::get)
+    }
+
+    pub fn encrypted_tcp_socket(&self) -> Option<SocketAddrV4> {
+        self.encrypted_tcp_port()
             .map(|port| SocketAddrV4::new(self.ip(), port))
     }
 
@@ -396,6 +422,10 @@ impl<ST: CertificateSignatureRecoverable> MonadNameRecord<ST> {
         self.name_record.direct_udp_socket()
     }
 
+    pub fn encrypted_tcp_address(&self) -> Option<SocketAddrV4> {
+        self.name_record.encrypted_tcp_socket()
+    }
+
     pub fn all_udp_sockets(&self) -> impl Iterator<Item = SocketAddrV4> + '_ {
         [
             self.udp_address(),
@@ -431,6 +461,7 @@ impl<ST: CertificateSignatureRecoverable> TryFrom<&PeerEntry<ST>> for MonadNameR
             peer.udp_port().map(NonZeroU16::get),
             peer.auth_port.get(),
             peer.direct_udp_port.map(NonZeroU16::get),
+            peer.encrypted_tcp_port.map(NonZeroU16::get),
             peer.record_seq_num,
         );
 
@@ -469,6 +500,9 @@ impl<ST: CertificateSignatureRecoverable> TryFrom<&MonadNameRecord<ST>> for Peer
             direct_udp_port: record.name_record.direct_udp_port().map(|port| {
                 NonZeroU16::new(port).expect("name record direct UDP port must be non-zero")
             }),
+            encrypted_tcp_port: record.name_record.encrypted_tcp_port().map(|port| {
+                NonZeroU16::new(port).expect("name record encrypted TCP port must be non-zero")
+            }),
         })
     }
 }
@@ -487,6 +521,7 @@ impl<ST: CertificateSignatureRecoverable> From<MonadNameRecordWithPubkey<'_, ST>
             record_seq_num: peer.record_seq_num,
             auth_port: peer.auth_port,
             direct_udp_port: peer.direct_udp_port,
+            encrypted_tcp_port: peer.encrypted_tcp_port,
         }
     }
 }
@@ -519,6 +554,7 @@ impl<ST: CertificateSignatureRecoverable> TryFrom<&NodeBootstrapPeerConfig<ST>>
             peer_config.udp_port().map(NonZeroU16::get),
             peer_config.auth_port.get(),
             peer_config.direct_udp_port.map(NonZeroU16::get),
+            peer_config.encrypted_tcp_port.map(NonZeroU16::get),
             peer_config.record_seq_num,
         );
 
@@ -574,6 +610,13 @@ impl<ST: CertificateSignatureRecoverable> From<MonadNameRecordWithPubkey<'_, ST>
                 .direct_udp_port()
                 .map(|port| {
                     NonZeroU16::new(port).expect("name record direct UDP port must be non-zero")
+                }),
+            encrypted_tcp_port: record_with_pubkey
+                .record
+                .name_record
+                .encrypted_tcp_port()
+                .map(|port| {
+                    NonZeroU16::new(port).expect("name record encrypted TCP port must be non-zero")
                 }),
         }
     }
@@ -1043,6 +1086,7 @@ mod tests {
             Some(udp_port),
             authenticated_udp_port,
             Some(direct_udp_port),
+            None,
             seq,
         );
 
@@ -1081,6 +1125,7 @@ mod tests {
             Some(9201),
             9202,
             Some(9203),
+            None,
             102,
         ),
         vec![
@@ -1115,6 +1160,21 @@ mod tests {
         vec![
             SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 47), 9501),
             SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 47), 9501),
+        ],
+    )]
+    #[case::encrypted_tcp_does_not_add_udp_socket(
+        NameRecord::new_with_ports(
+            Ipv4Addr::new(10, 0, 0, 48),
+            9600,
+            Some(9601),
+            9602,
+            None,
+            Some(9603),
+            106,
+        ),
+        vec![
+            SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 48), 9601),
+            SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 48), 9602),
         ],
     )]
     fn test_monad_name_record_all_udp_sockets(
@@ -1153,6 +1213,7 @@ mod tests {
             record_seq_num: seq,
             auth_port: NonZeroU16::new(port).unwrap(),
             direct_udp_port: None,
+            encrypted_tcp_port: None,
         };
 
         let result = MonadNameRecord::<SecpSignature>::try_from(&peer_entry);
@@ -1196,8 +1257,15 @@ mod tests {
         let seq = 100u64;
 
         let keypair = KeyPair::from_ikm(b"test roundtrip direct udp").unwrap();
-        let name_record =
-            NameRecord::new_with_ports(ip, port, Some(port), auth_port, Some(direct_udp_port), seq);
+        let name_record = NameRecord::new_with_ports(
+            ip,
+            port,
+            Some(port),
+            auth_port,
+            Some(direct_udp_port),
+            None,
+            seq,
+        );
         let original_monad_record = MonadNameRecord::<SecpSignature>::new(name_record, &keypair);
 
         let pubkey = original_monad_record.recover_pubkey().unwrap().pubkey();
@@ -1283,5 +1351,46 @@ mod tests {
     #[should_panic(expected = "name record port must be non-zero")]
     fn test_name_record_new_rejects_zero_port() {
         let _ = NameRecord::new(Ipv4Addr::new(1, 1, 1, 1), 0, Some(9001), 9002, 0, 1);
+    }
+
+    #[test]
+    fn test_peer_entry_monad_name_record_roundtrip_with_encrypted_tcp() {
+        let ip = Ipv4Addr::from_str("172.31.0.103").unwrap();
+        let port = 8895u16;
+        let auth_port = 8896u16;
+        let encrypted_tcp_port = 8897u16;
+        let seq = 102u64;
+
+        let keypair = KeyPair::from_ikm(b"test roundtrip encrypted tcp").unwrap();
+        let name_record = NameRecord::new_with_ports(
+            ip,
+            port,
+            Some(port),
+            auth_port,
+            None,
+            Some(encrypted_tcp_port),
+            seq,
+        );
+        let original_monad_record = MonadNameRecord::<SecpSignature>::new(name_record, &keypair);
+
+        let pubkey = original_monad_record.recover_pubkey().unwrap().pubkey();
+        let peer_entry = PeerEntry::from(original_monad_record.with_pubkey(pubkey));
+        assert_eq!(peer_entry.auth_port.get(), auth_port);
+        assert_eq!(
+            peer_entry.encrypted_tcp_port.map(NonZeroU16::get),
+            Some(encrypted_tcp_port)
+        );
+
+        let converted_monad_record =
+            MonadNameRecord::<SecpSignature>::try_from(&peer_entry).unwrap();
+
+        assert_eq!(
+            converted_monad_record.name_record,
+            original_monad_record.name_record
+        );
+        assert_eq!(
+            converted_monad_record.name_record.encrypted_tcp_port(),
+            Some(encrypted_tcp_port)
+        );
     }
 }

--- a/monad-peer-discovery/src/snapshots/monad_peer_discovery__discovery__tests__persisted_peers_format.snap
+++ b/monad-peer-discovery/src/snapshots/monad_peer_discovery__discovery__tests__persisted_peers_format.snap
@@ -1,6 +1,6 @@
 ---
 source: monad-peer-discovery/src/discovery.rs
-assertion_line: 3344
+assertion_line: 3612
 expression: written_content
 ---
 [[peers]]
@@ -11,6 +11,16 @@ record_seq_num = 1
 secp256k1_pubkey = "0x0334944627833fe16cc7e21cd5e1442b42b3eb9bbd0cdd266e449a9dc026b45a39"
 name_record_sig = "0x22da25d0c0525eb01f8c37766439fc48f95b02eee0cba578cdbf03038114650c5ce59614af8c51f38f46e174edd7a1ebeb767f5d1d2b215998e95fac1615872f01"
 auth_port = 9000
+
+[[peers]]
+address = "8.8.2.2"
+tcp_port = 8002
+udp_port = 8002
+record_seq_num = 3
+secp256k1_pubkey = "0x02871061053f395ab80a6ba139fe2ed41d3d99c3df3f9d8b311ecac952f85af805"
+name_record_sig = "0x7d7a0988c907dc40c1a5f6daa4c11564dc6b3749f811bc555e7c8de0619c9b2c0e4f436aafa98e0991296d608360de557f10b37ccf55d040a9819a61357a13a800"
+auth_port = 9003
+tcp_auth_port = 9004
 
 [[peers]]
 address = "8.8.4.4"

--- a/monad-peer-discovery/src/snapshots/monad_peer_discovery__discovery__tests__persisted_peers_format.snap
+++ b/monad-peer-discovery/src/snapshots/monad_peer_discovery__discovery__tests__persisted_peers_format.snap
@@ -1,6 +1,6 @@
 ---
 source: monad-peer-discovery/src/discovery.rs
-assertion_line: 3344
+assertion_line: 3612
 expression: written_content
 ---
 [[peers]]
@@ -11,6 +11,16 @@ record_seq_num = 1
 secp256k1_pubkey = "0x0334944627833fe16cc7e21cd5e1442b42b3eb9bbd0cdd266e449a9dc026b45a39"
 name_record_sig = "0x22da25d0c0525eb01f8c37766439fc48f95b02eee0cba578cdbf03038114650c5ce59614af8c51f38f46e174edd7a1ebeb767f5d1d2b215998e95fac1615872f01"
 auth_port = 9000
+
+[[peers]]
+address = "8.8.2.2"
+tcp_port = 8002
+udp_port = 8002
+record_seq_num = 3
+secp256k1_pubkey = "0x02871061053f395ab80a6ba139fe2ed41d3d99c3df3f9d8b311ecac952f85af805"
+name_record_sig = "0x7d7a0988c907dc40c1a5f6daa4c11564dc6b3749f811bc555e7c8de0619c9b2c0e4f436aafa98e0991296d608360de557f10b37ccf55d040a9819a61357a13a800"
+auth_port = 9003
+encrypted_tcp_port = 9004
 
 [[peers]]
 address = "8.8.4.4"

--- a/monad-raptorcast/src/auth/socket.rs
+++ b/monad-raptorcast/src/auth/socket.rs
@@ -1028,6 +1028,7 @@ mod tests {
             None,
             bob_auth_addr.port(),
             None,
+            None,
             1,
         );
         let payload = Bytes::from_static(b"authenticated path");
@@ -1071,6 +1072,7 @@ mod tests {
             bob_auth_addr.port(),
             None,
             bob_auth_addr.port(),
+            None,
             None,
             1,
         );

--- a/monad-raptorcast/src/auth/socket.rs
+++ b/monad-raptorcast/src/auth/socket.rs
@@ -1042,6 +1042,7 @@ mod tests {
             None,
             bob_auth_addr.port(),
             None,
+            None,
             1,
         );
         let payload = Bytes::from_static(b"authenticated path");
@@ -1085,6 +1086,7 @@ mod tests {
             bob_auth_addr.port(),
             None,
             bob_auth_addr.port(),
+            None,
             None,
             1,
         );

--- a/monad-raptorcast/tests/epoch_boundary.rs
+++ b/monad-raptorcast/tests/epoch_boundary.rs
@@ -156,6 +156,7 @@ impl ValidatorInfo {
             Some(dp.non_auth_addr.port()),
             dp.auth_addr.port(),
             None,
+            None,
             1,
         );
         MonadNameRecord::new(name_record, &*self.keypair)

--- a/monad-raptorcast/tests/raptorcast_instance.rs
+++ b/monad-raptorcast/tests/raptorcast_instance.rs
@@ -409,6 +409,7 @@ fn test_name_record(keypair: &KeyPair, addr: SocketAddrV4) -> MonadNameRecord<Si
         Some(addr.port()),
         addr.port(),
         None,
+        None,
         1,
     );
     MonadNameRecord::new(name_record, keypair)

--- a/monad-raptorcast/tests/wireauth_raptorcast.rs
+++ b/monad-raptorcast/tests/wireauth_raptorcast.rs
@@ -172,6 +172,7 @@ impl ValidatorInfo {
             non_auth_addr.map(|addr| addr.port()),
             auth_addr.port(),
             direct_udp_addr.map(|addr| addr.port()),
+            None,
             1,
         );
         MonadNameRecord::new(name_record, &*self.keypair)

--- a/monad-updaters/src/config_loader.rs
+++ b/monad-updaters/src/config_loader.rs
@@ -239,6 +239,7 @@ where
                 record_seq_num: peer.record_seq_num,
                 auth_port: peer.auth_port,
                 direct_udp_port: peer.direct_udp_port,
+                tcp_auth_port: peer.tcp_auth_port,
             });
         }
         peer_entries

--- a/monad-updaters/src/config_loader.rs
+++ b/monad-updaters/src/config_loader.rs
@@ -239,6 +239,7 @@ where
                 record_seq_num: peer.record_seq_num,
                 auth_port: peer.auth_port,
                 direct_udp_port: peer.direct_udp_port,
+                encrypted_tcp_port: peer.encrypted_tcp_port,
             });
         }
         peer_entries


### PR DESCRIPTION
extends name record with new recognized encrypted tcp port, and related data structures that are used for configuration

this protocol will be used in place of existing tcp. for some new features we will want to send data encrypted and i plan to use tcp for that, and beside that authenticated using wireauth will be faster then the existing blake3 + secp approach.