### PR TITLE
monad-dataplane: multi-socket TCP support

### DIFF
--- a/monad-dataplane/tests/address_family_mismatch.rs
+++ b/monad-dataplane/tests/address_family_mismatch.rs
@@ -15,13 +15,11 @@
 
 use std::{thread::sleep, time::Duration};
 
-use monad_dataplane::{udp::DEFAULT_SEGMENT_SIZE, BroadcastMsg, DataplaneBuilder};
+use monad_dataplane::{udp::DEFAULT_SEGMENT_SIZE, BroadcastMsg, DataplaneBuilder, UdpSocketId};
 use tracing::debug;
 
 /// 1_000 = 1 Gbps, 10_000 = 10 Gbps
 const UP_BANDWIDTH_MBPS: u64 = 1_000;
-
-const LEGACY_SOCKET: &str = "legacy";
 
 const BIND_ADDRS: [&str; 2] = ["0.0.0.0:0", "127.0.0.1:0"];
 
@@ -49,14 +47,11 @@ fn address_family_mismatch() {
 
     for addr in BIND_ADDRS {
         let bind_addr = addr.parse().unwrap();
-        let mut dataplane = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS)
-            .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
-                socket_addr: bind_addr,
-                label: LEGACY_SOCKET.to_string(),
-            }])
+        let mut dataplane = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+            .with_udp_sockets([(UdpSocketId::Raptorcast, bind_addr)])
             .build();
 
-        let socket = dataplane.take_udp_socket_handle(LEGACY_SOCKET).unwrap();
+        let socket = dataplane.udp_sockets.take(UdpSocketId::Raptorcast).unwrap();
         let local_addr = socket.local_addr();
 
         for tx_addr in [ipv4_target, ipv6_target] {

--- a/monad-dataplane/tests/tests.rs
+++ b/monad-dataplane/tests/tests.rs
@@ -26,7 +26,7 @@ use futures::{channel::oneshot, executor, FutureExt};
 use monad_dataplane::{
     tcp::tx::{MSG_WAIT_TIMEOUT, QUEUED_MESSAGE_LIMIT},
     udp::DEFAULT_SEGMENT_SIZE,
-    BroadcastMsg, DataplaneBuilder, RecvUdpMsg, TcpMsg, UnicastMsg,
+    BroadcastMsg, DataplaneBuilder, RecvUdpMsg, TcpMsg, TcpSocketId, UdpSocketId, UnicastMsg,
 };
 use monad_types::UdpPriority;
 use ntest::timeout;
@@ -35,9 +35,6 @@ use rstest::*;
 use tracing_subscriber::fmt::format::FmtSpan;
 
 const UP_BANDWIDTH_MBPS: u64 = 1_000;
-
-const LEGACY_SOCKET: &str = "legacy";
-const DIRECT_SOCKET: &str = "direct";
 
 static ONCE_SETUP: Once = Once::new();
 
@@ -58,25 +55,19 @@ fn udp_broadcast() {
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
     let num_msgs = 10;
 
-    let mut rx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS)
-        .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
-            socket_addr: bind_addr,
-            label: LEGACY_SOCKET.to_string(),
-        }])
+    let mut rx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_udp_sockets([(UdpSocketId::Raptorcast, bind_addr)])
         .build();
-    let mut tx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS)
-        .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
-            socket_addr: bind_addr,
-            label: LEGACY_SOCKET.to_string(),
-        }])
+    let mut tx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_udp_sockets([(UdpSocketId::Raptorcast, bind_addr)])
         .build();
 
     let payload: Vec<u8> = (0..DEFAULT_SEGMENT_SIZE)
         .map(|_| rand::thread_rng().gen_range(0..255))
         .collect();
 
-    let mut rx_socket = rx.take_udp_socket_handle(LEGACY_SOCKET).unwrap();
-    let tx_socket = tx.take_udp_socket_handle(LEGACY_SOCKET).unwrap();
+    let mut rx_socket = rx.udp_sockets.take(UdpSocketId::Raptorcast).unwrap();
+    let tx_socket = tx.udp_sockets.take(UdpSocketId::Raptorcast).unwrap();
 
     let rx_addr = rx_socket.local_addr();
     let tx_addr = tx_socket.local_addr();
@@ -103,25 +94,19 @@ fn udp_unicast() {
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
     let num_msgs = 10;
 
-    let mut rx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS)
-        .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
-            socket_addr: bind_addr,
-            label: LEGACY_SOCKET.to_string(),
-        }])
+    let mut rx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_udp_sockets([(UdpSocketId::Raptorcast, bind_addr)])
         .build();
-    let mut tx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS)
-        .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
-            socket_addr: bind_addr,
-            label: LEGACY_SOCKET.to_string(),
-        }])
+    let mut tx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_udp_sockets([(UdpSocketId::Raptorcast, bind_addr)])
         .build();
 
     let payload: Vec<u8> = (0..DEFAULT_SEGMENT_SIZE)
         .map(|_| rand::thread_rng().gen_range(0..255))
         .collect();
 
-    let mut rx_socket = rx.take_udp_socket_handle(LEGACY_SOCKET).unwrap();
-    let tx_socket = tx.take_udp_socket_handle(LEGACY_SOCKET).unwrap();
+    let mut rx_socket = rx.udp_sockets.take(UdpSocketId::Raptorcast).unwrap();
+    let tx_socket = tx.udp_sockets.take(UdpSocketId::Raptorcast).unwrap();
 
     let rx_addr = rx_socket.local_addr();
     let tx_addr = tx_socket.local_addr();
@@ -147,28 +132,16 @@ fn udp_direct_socket() {
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
     let num_msgs = 10;
 
-    let mut rx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS)
-        .extend_udp_sockets(vec![
-            monad_dataplane::UdpSocketConfig {
-                socket_addr: bind_addr,
-                label: LEGACY_SOCKET.to_string(),
-            },
-            monad_dataplane::UdpSocketConfig {
-                socket_addr: bind_addr,
-                label: DIRECT_SOCKET.to_string(),
-            },
+    let mut rx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_udp_sockets([
+            (UdpSocketId::Raptorcast, bind_addr),
+            (UdpSocketId::AuthenticatedRaptorcast, bind_addr),
         ])
         .build();
-    let mut tx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS)
-        .extend_udp_sockets(vec![
-            monad_dataplane::UdpSocketConfig {
-                socket_addr: bind_addr,
-                label: LEGACY_SOCKET.to_string(),
-            },
-            monad_dataplane::UdpSocketConfig {
-                socket_addr: bind_addr,
-                label: DIRECT_SOCKET.to_string(),
-            },
+    let mut tx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_udp_sockets([
+            (UdpSocketId::Raptorcast, bind_addr),
+            (UdpSocketId::AuthenticatedRaptorcast, bind_addr),
         ])
         .build();
 
@@ -176,10 +149,16 @@ fn udp_direct_socket() {
         .map(|_| rand::thread_rng().gen_range(0..255))
         .collect();
 
-    let mut rx_legacy_socket = rx.take_udp_socket_handle(LEGACY_SOCKET).unwrap();
-    let mut rx_direct_socket = rx.take_udp_socket_handle(DIRECT_SOCKET).unwrap();
-    let tx_legacy_socket = tx.take_udp_socket_handle(LEGACY_SOCKET).unwrap();
-    let tx_direct_socket = tx.take_udp_socket_handle(DIRECT_SOCKET).unwrap();
+    let mut rx_legacy_socket = rx.udp_sockets.take(UdpSocketId::Raptorcast).unwrap();
+    let mut rx_direct_socket = rx
+        .udp_sockets
+        .take(UdpSocketId::AuthenticatedRaptorcast)
+        .unwrap();
+    let tx_legacy_socket = tx.udp_sockets.take(UdpSocketId::Raptorcast).unwrap();
+    let tx_direct_socket = tx
+        .udp_sockets
+        .take(UdpSocketId::AuthenticatedRaptorcast)
+        .unwrap();
 
     let rx_legacy_addr = rx_legacy_socket.local_addr();
     let rx_direct_addr = rx_direct_socket.local_addr();
@@ -218,18 +197,25 @@ fn tcp_very_slow() {
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
     let num_msgs = 2;
 
-    let mut rx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
-    let rx_addr = rx.tcp_local_addr();
-    let tx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
+    let mut rx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
+    let mut tx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
+
+    let mut rx_socket = rx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    let rx_addr = rx_socket.local_addr();
 
     let payload: Vec<u8> = (0..DEFAULT_SEGMENT_SIZE)
         .map(|_| rand::thread_rng().gen_range(0..255))
         .collect();
 
+    let tcp_socket = tx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
     for _ in 0..num_msgs {
         let (sender, receiver) = oneshot::channel::<()>();
 
-        tx.tcp_write(
+        tcp_socket.write(
             rx_addr,
             TcpMsg {
                 msg: payload.clone().into(),
@@ -243,7 +229,7 @@ fn tcp_very_slow() {
     }
 
     for _ in 0..num_msgs {
-        let recv_msg = executor::block_on(rx.tcp_read());
+        let recv_msg = executor::block_on(rx_socket.recv());
 
         assert_eq!(recv_msg.payload, payload);
     }
@@ -258,18 +244,25 @@ fn tcp_slow() {
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
     let num_msgs = 10;
 
-    let mut rx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
-    let rx_addr = rx.tcp_local_addr();
-    let tx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
+    let mut rx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
+    let mut tx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
+
+    let mut rx_socket = rx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    let rx_addr = rx_socket.local_addr();
 
     let payload: Vec<u8> = (0..DEFAULT_SEGMENT_SIZE)
         .map(|_| rand::thread_rng().gen_range(0..255))
         .collect();
 
+    let tcp_socket = tx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
     for _ in 0..num_msgs {
         let (sender, receiver) = oneshot::channel::<()>();
 
-        tx.tcp_write(
+        tcp_socket.write(
             rx_addr,
             TcpMsg {
                 msg: payload.clone().into(),
@@ -281,7 +274,7 @@ fn tcp_slow() {
     }
 
     for _ in 0..num_msgs {
-        let recv_msg = executor::block_on(rx.tcp_read());
+        let recv_msg = executor::block_on(rx_socket.recv());
 
         assert_eq!(recv_msg.payload, payload);
     }
@@ -295,9 +288,15 @@ fn tcp_rapid() {
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
     let num_msgs = 1024;
 
-    let mut rx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
-    let rx_addr = rx.tcp_local_addr();
-    let tx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
+    let mut rx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
+    let mut tx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
+
+    let mut rx_socket = rx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    let rx_addr = rx_socket.local_addr();
 
     let payload: Vec<u8> = (0..DEFAULT_SEGMENT_SIZE)
         .map(|_| rand::thread_rng().gen_range(0..255))
@@ -305,10 +304,11 @@ fn tcp_rapid() {
 
     let mut completions = VecDeque::with_capacity(QUEUED_MESSAGE_LIMIT);
 
+    let tcp_socket = tx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
     for _ in 0..num_msgs {
         let (sender, receiver) = oneshot::channel::<()>();
 
-        tx.tcp_write(
+        tcp_socket.write(
             rx_addr,
             TcpMsg {
                 msg: payload.clone().into(),
@@ -328,7 +328,7 @@ fn tcp_rapid() {
     }
 
     for _ in 0..num_msgs {
-        let recv_msg = executor::block_on(rx.tcp_read());
+        let recv_msg = executor::block_on(rx_socket.recv());
 
         assert_eq!(recv_msg.payload, payload);
     }
@@ -347,7 +347,9 @@ fn tcp_connect_fail() {
         .local_addr()
         .unwrap();
 
-    let tx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
+    let mut tx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
 
     let payload: Vec<u8> = (0..DEFAULT_SEGMENT_SIZE)
         .map(|_| rand::thread_rng().gen_range(0..255))
@@ -355,7 +357,8 @@ fn tcp_connect_fail() {
 
     let (sender, receiver) = oneshot::channel::<()>();
 
-    tx.tcp_write(
+    let tcp_socket = tx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    tcp_socket.write(
         rx_addr,
         TcpMsg {
             msg: payload.into(),
@@ -374,9 +377,15 @@ fn tcp_exceed_queue_limits() {
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
     let num_msgs = 100 * QUEUED_MESSAGE_LIMIT;
 
-    let mut rx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
-    let rx_addr = rx.tcp_local_addr();
-    let tx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
+    let mut rx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
+    let mut tx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
+
+    let mut rx_socket = rx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    let rx_addr = rx_socket.local_addr();
 
     let payload: Vec<u8> = (0..DEFAULT_SEGMENT_SIZE)
         .map(|_| rand::thread_rng().gen_range(0..255))
@@ -384,10 +393,11 @@ fn tcp_exceed_queue_limits() {
 
     let mut completions = Vec::with_capacity(num_msgs);
 
+    let tcp_socket = tx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
     for _ in 0..num_msgs {
         let (sender, receiver) = oneshot::channel::<()>();
 
-        tx.tcp_write(
+        tcp_socket.write(
             rx_addr,
             TcpMsg {
                 msg: payload.clone().into(),
@@ -400,7 +410,7 @@ fn tcp_exceed_queue_limits() {
 
     // At least QUEUED_MESSAGE_LIMIT messages should be delivered successfully.
     for _ in 0..QUEUED_MESSAGE_LIMIT {
-        let recv_msg = executor::block_on(rx.tcp_read());
+        let recv_msg = executor::block_on(rx_socket.recv());
 
         assert_eq!(recv_msg.payload, payload);
     }
@@ -429,13 +439,20 @@ fn tcp_reject_oversized_message() {
 
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
 
-    let mut rx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
-    let rx_addr = rx.tcp_local_addr();
-    let tx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
+    let mut rx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
+    let mut tx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
+
+    let mut rx_socket = rx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    let rx_addr = rx_socket.local_addr();
 
     let oversized_payload = vec![0u8; 3 * 1024 * 1024 + 1];
 
-    tx.tcp_write(
+    let tcp_socket = tx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    tcp_socket.write(
         rx_addr,
         TcpMsg {
             msg: oversized_payload.into(),
@@ -445,7 +462,7 @@ fn tcp_reject_oversized_message() {
 
     let start = std::time::Instant::now();
     while start.elapsed() < Duration::from_millis(100) {
-        if rx.tcp_read().now_or_never().is_some() {
+        if rx_socket.recv().now_or_never().is_some() {
             panic!("expected no message but received one");
         }
     }
@@ -458,15 +475,22 @@ fn tcp_accept_max_size_message() {
 
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
 
-    let mut rx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
-    let rx_addr = rx.tcp_local_addr();
-    let tx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
+    let mut rx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
+    let mut tx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
+
+    let mut rx_socket = rx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    let rx_addr = rx_socket.local_addr();
 
     let max_size_payload = vec![0u8; 3 * 1024 * 1024];
 
     let (sender, receiver) = oneshot::channel::<()>();
 
-    tx.tcp_write(
+    let tcp_socket = tx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    tcp_socket.write(
         rx_addr,
         TcpMsg {
             msg: max_size_payload.clone().into(),
@@ -476,7 +500,7 @@ fn tcp_accept_max_size_message() {
 
     assert!(executor::block_on(receiver).is_ok());
 
-    let recv_msg = executor::block_on(rx.tcp_read());
+    let recv_msg = executor::block_on(rx_socket.recv());
     assert_eq!(recv_msg.payload, max_size_payload);
 }
 
@@ -487,8 +511,12 @@ fn tcp_rx_reject_oversized_header() {
 
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
 
-    let mut rx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
-    let rx_addr = rx.tcp_local_addr();
+    let mut rx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
+
+    let mut rx_tcp_socket = rx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    let rx_addr = rx_tcp_socket.local_addr();
 
     let mut tcp_stream = TcpStream::connect(rx_addr).unwrap();
 
@@ -502,10 +530,9 @@ fn tcp_rx_reject_oversized_header() {
         .write_all(&oversized_length.to_le_bytes())
         .unwrap();
     tcp_stream.flush().unwrap();
-
     let start = std::time::Instant::now();
     while start.elapsed() < Duration::from_millis(100) {
-        if rx.tcp_read().now_or_never().is_some() {
+        if rx_tcp_socket.recv().now_or_never().is_some() {
             panic!("Expected no message but received one");
         }
         sleep(Duration::from_millis(10));
@@ -519,18 +546,12 @@ fn broadcast_all_strides() {
 
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
 
-    let mut rx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS)
+    let mut rx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
         .with_udp_buffer_size(400 << 10)
-        .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
-            socket_addr: bind_addr,
-            label: LEGACY_SOCKET.to_string(),
-        }])
+        .with_udp_sockets([(UdpSocketId::Raptorcast, bind_addr)])
         .build();
-    let mut tx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS)
-        .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
-            socket_addr: bind_addr,
-            label: LEGACY_SOCKET.to_string(),
-        }])
+    let mut tx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_udp_sockets([(UdpSocketId::Raptorcast, bind_addr)])
         .build();
 
     let total_length: usize = 100000;
@@ -539,8 +560,8 @@ fn broadcast_all_strides() {
         .map(|_| rand::thread_rng().gen_range(0..255))
         .collect();
 
-    let mut rx_socket = rx.take_udp_socket_handle(LEGACY_SOCKET).unwrap();
-    let tx_socket = tx.take_udp_socket_handle(LEGACY_SOCKET).unwrap();
+    let mut rx_socket = rx.udp_sockets.take(UdpSocketId::Raptorcast).unwrap();
+    let tx_socket = tx.udp_sockets.take(UdpSocketId::Raptorcast).unwrap();
 
     let rx_addr = rx_socket.local_addr();
     let tx_addr = tx_socket.local_addr();
@@ -575,18 +596,12 @@ fn unicast_all_strides() {
 
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
 
-    let mut rx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS)
+    let mut rx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
         .with_udp_buffer_size(400 << 10)
-        .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
-            socket_addr: bind_addr,
-            label: LEGACY_SOCKET.to_string(),
-        }])
+        .with_udp_sockets([(UdpSocketId::Raptorcast, bind_addr)])
         .build();
-    let mut tx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS)
-        .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
-            socket_addr: bind_addr,
-            label: LEGACY_SOCKET.to_string(),
-        }])
+    let mut tx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_udp_sockets([(UdpSocketId::Raptorcast, bind_addr)])
         .build();
 
     let total_length: usize = 100000;
@@ -595,8 +610,8 @@ fn unicast_all_strides() {
         .map(|_| rand::thread_rng().gen_range(0..255))
         .collect();
 
-    let mut rx_socket = rx.take_udp_socket_handle(LEGACY_SOCKET).unwrap();
-    let tx_socket = tx.take_udp_socket_handle(LEGACY_SOCKET).unwrap();
+    let mut rx_socket = rx.udp_sockets.take(UdpSocketId::Raptorcast).unwrap();
+    let tx_socket = tx.udp_sockets.take(UdpSocketId::Raptorcast).unwrap();
 
     let rx_addr = rx_socket.local_addr();
     let tx_addr = tx_socket.local_addr();
@@ -635,17 +650,28 @@ async fn test_tcp_limits_are_applied(
 
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
 
-    let mut rx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS)
+    let mut rx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
         .with_tcp_connections_limit(tcp_connection_limit, tcp_per_ip_connection_limit)
         .build();
-    let rx_addr = rx.tcp_local_addr();
 
-    let tx1 = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
-    let tx2 = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
+    let mut tx1 = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
+    let mut tx2 = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
+
+    let rx_addr = rx
+        .tcp_sockets
+        .get(TcpSocketId::Raptorcast)
+        .unwrap()
+        .local_addr();
 
     let payload1: Vec<u8> = "first message".into();
 
-    tx1.tcp_write(
+    let tx1_socket = tx1.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    tx1_socket.write(
         rx_addr,
         TcpMsg {
             msg: payload1.clone().into(),
@@ -653,11 +679,13 @@ async fn test_tcp_limits_are_applied(
         },
     );
 
-    let recv_msg = rx.tcp_read().await;
+    let mut rx_tcp_socket = rx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    let recv_msg = rx_tcp_socket.recv().await;
     assert_eq!(recv_msg.payload, payload1);
 
     let payload2: Vec<u8> = "second message".into();
-    tx2.tcp_write(
+    let tx2_socket = tx2.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    tx2_socket.write(
         rx_addr,
         TcpMsg {
             msg: payload2.clone().into(),
@@ -666,7 +694,7 @@ async fn test_tcp_limits_are_applied(
     );
 
     let result = async {
-        monoio::time::timeout(Duration::from_millis(50), rx.tcp_read())
+        monoio::time::timeout(Duration::from_millis(50), rx_tcp_socket.recv())
             .await
             .ok()
     }
@@ -682,17 +710,25 @@ async fn test_tcp_rps_limits() {
 
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
 
-    let mut rx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS)
+    let mut rx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
         .with_tcp_rps_burst(10, 2)
         .build();
-    let rx_addr = rx.tcp_local_addr();
+    let rx_addr = rx
+        .tcp_sockets
+        .get(TcpSocketId::Raptorcast)
+        .unwrap()
+        .local_addr();
 
-    let tx1 = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
+    let mut tx1 = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
 
     let num_messages = 2;
+    let tx1_socket = tx1.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
     for i in 0..num_messages {
         let payload = format!("message {}", i).into_bytes();
-        tx1.tcp_write(
+        tx1_socket.write(
             rx_addr,
             TcpMsg {
                 msg: payload.into(),
@@ -701,14 +737,15 @@ async fn test_tcp_rps_limits() {
         );
     }
 
+    let mut rx_tcp_socket = rx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
     for i in 0..2 {
-        let recv_msg = rx.tcp_read().await;
+        let recv_msg = rx_tcp_socket.recv().await;
         let expected = format!("message {}", i).into_bytes();
         assert_eq!(recv_msg.payload, expected);
     }
 
     let result = async {
-        monoio::time::timeout(Duration::from_millis(50), rx.tcp_read())
+        monoio::time::timeout(Duration::from_millis(50), rx_tcp_socket.recv())
             .await
             .ok()
     }
@@ -728,18 +765,28 @@ async fn test_tcp_limits_ignored_for_trusted(
 
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
 
-    let mut rx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS)
+    let mut rx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
         .with_tcp_connections_limit(tcp_connection_limit, tcp_per_ip_connection_limit)
         .build();
-    let rx_addr = rx.tcp_local_addr();
+    let rx_addr = rx
+        .tcp_sockets
+        .get(TcpSocketId::Raptorcast)
+        .unwrap()
+        .local_addr();
     rx.add_trusted("127.0.0.1".parse().unwrap());
 
-    let tx1 = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
-    let tx2 = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
+    let mut tx1 = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
+    let mut tx2 = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
 
     let payload1: Vec<u8> = "first message".into();
 
-    tx1.tcp_write(
+    let tx1_socket = tx1.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    tx1_socket.write(
         rx_addr,
         TcpMsg {
             msg: payload1.clone().into(),
@@ -747,11 +794,13 @@ async fn test_tcp_limits_ignored_for_trusted(
         },
     );
 
-    let recv_msg = rx.tcp_read().await;
+    let mut rx_tcp_socket = rx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    let recv_msg = rx_tcp_socket.recv().await;
     assert_eq!(recv_msg.payload, payload1);
 
     let payload2: Vec<u8> = "second message".into();
-    tx2.tcp_write(
+    let tx2_socket = tx2.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    tx2_socket.write(
         rx_addr,
         TcpMsg {
             msg: payload2.clone().into(),
@@ -759,7 +808,7 @@ async fn test_tcp_limits_ignored_for_trusted(
         },
     );
 
-    let recv_msg = rx.tcp_read().await;
+    let recv_msg = rx_tcp_socket.recv().await;
     assert_eq!(recv_msg.payload, payload2);
 }
 
@@ -769,26 +818,35 @@ async fn test_tcp_banned() {
 
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
 
-    let mut rx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
-    let rx_addr = rx.tcp_local_addr();
-    let tx1 = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS).build();
+    let mut rx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
+    let rx_addr = rx
+        .tcp_sockets
+        .get(TcpSocketId::Raptorcast)
+        .unwrap()
+        .local_addr();
+    let mut tx1 = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .build();
 
     let payload1: Vec<u8> = "first message".into();
-    tx1.tcp_write(
+    let tx1_socket = tx1.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    tx1_socket.write(
         rx_addr,
         TcpMsg {
             msg: payload1.clone().into(),
             completion: None,
         },
     );
-    let recv_msg = rx.tcp_read().await;
+    let mut rx_tcp_socket = rx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    let recv_msg = rx_tcp_socket.recv().await;
     assert_eq!(recv_msg.payload, payload1);
 
-    // once banned all further message will be dropped for next 5 minutes
     rx.ban("127.0.0.1".parse().unwrap());
 
     let payload2: Vec<u8> = "second message".into();
-    tx1.tcp_write(
+    tx1_socket.write(
         rx_addr,
         TcpMsg {
             msg: payload2.clone().into(),
@@ -796,7 +854,7 @@ async fn test_tcp_banned() {
         },
     );
     let result = async {
-        monoio::time::timeout(Duration::from_millis(50), rx.tcp_read())
+        monoio::time::timeout(Duration::from_millis(50), rx_tcp_socket.recv())
             .await
             .ok()
     }
@@ -817,18 +875,15 @@ fn udp_large_stride() {
         .unwrap();
     let rx_addr = rx_socket.local_addr().unwrap();
 
-    let mut tx = DataplaneBuilder::new(&bind_addr, UP_BANDWIDTH_MBPS)
-        .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
-            socket_addr: bind_addr,
-            label: LEGACY_SOCKET.to_string(),
-        }])
+    let mut tx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_udp_sockets([(UdpSocketId::Raptorcast, bind_addr)])
         .build();
 
     let payload: Vec<u8> = (0..65536)
         .map(|_| rand::thread_rng().gen_range(0..255))
         .collect();
 
-    let tx_socket = tx.take_udp_socket_handle(LEGACY_SOCKET).unwrap();
+    let tx_socket = tx.udp_sockets.take(UdpSocketId::Raptorcast).unwrap();
 
     tx_socket.write_broadcast(BroadcastMsg {
         targets: vec![rx_addr],
@@ -862,17 +917,11 @@ fn udp_priority_delivery() {
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
 
     let low_bandwidth_mbps = 10;
-    let mut rx = DataplaneBuilder::new(&bind_addr, low_bandwidth_mbps)
-        .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
-            socket_addr: bind_addr,
-            label: LEGACY_SOCKET.to_string(),
-        }])
+    let mut rx = DataplaneBuilder::new(low_bandwidth_mbps)
+        .with_udp_sockets([(UdpSocketId::Raptorcast, bind_addr)])
         .build();
-    let mut tx = DataplaneBuilder::new(&bind_addr, low_bandwidth_mbps)
-        .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
-            socket_addr: bind_addr,
-            label: LEGACY_SOCKET.to_string(),
-        }])
+    let mut tx = DataplaneBuilder::new(low_bandwidth_mbps)
+        .with_udp_sockets([(UdpSocketId::Raptorcast, bind_addr)])
         .build();
 
     let message_size = 1024 * 1024; // 1MB
@@ -882,7 +931,7 @@ fn udp_priority_delivery() {
     let expected_total_msgs = 2 * message_size.div_ceil(DEFAULT_SEGMENT_SIZE as usize);
     let (msg_tx, msg_rx) = mpsc::channel();
 
-    let mut rx_socket = rx.take_udp_socket_handle(LEGACY_SOCKET).unwrap();
+    let mut rx_socket = rx.udp_sockets.take(UdpSocketId::Raptorcast).unwrap();
     let rx_addr = rx_socket.local_addr();
     let rx_handle = thread::spawn(move || {
         let mut messages = Vec::new();
@@ -896,9 +945,8 @@ fn udp_priority_delivery() {
         }
     });
 
-    let tx_socket = tx.take_udp_socket_handle(LEGACY_SOCKET).unwrap();
+    let tx_socket = tx.udp_sockets.take(UdpSocketId::Raptorcast).unwrap();
     let tx_addr = tx_socket.local_addr();
-
     tx_socket.write_unicast_with_priority(
         UnicastMsg {
             msgs: vec![(rx_addr, high_priority_data.into())],
@@ -962,17 +1010,11 @@ fn udp_priority_with_regular_then_high_traffic() {
     let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
     let low_bandwidth_mbps = 10;
 
-    let mut rx = DataplaneBuilder::new(&bind_addr, low_bandwidth_mbps)
-        .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
-            socket_addr: bind_addr,
-            label: LEGACY_SOCKET.to_string(),
-        }])
+    let mut rx = DataplaneBuilder::new(low_bandwidth_mbps)
+        .with_udp_sockets([(UdpSocketId::Raptorcast, bind_addr)])
         .build();
-    let mut tx = DataplaneBuilder::new(&bind_addr, low_bandwidth_mbps)
-        .extend_udp_sockets(vec![monad_dataplane::UdpSocketConfig {
-            socket_addr: bind_addr,
-            label: LEGACY_SOCKET.to_string(),
-        }])
+    let mut tx = DataplaneBuilder::new(low_bandwidth_mbps)
+        .with_udp_sockets([(UdpSocketId::Raptorcast, bind_addr)])
         .build();
 
     let message_size = 1024 * 1024; // 1MB
@@ -983,7 +1025,7 @@ fn udp_priority_with_regular_then_high_traffic() {
     let expected_total_msgs = 2 * num_msgs_per_mb;
 
     let (msg_tx, msg_rx) = mpsc::channel();
-    let mut rx_socket = rx.take_udp_socket_handle(LEGACY_SOCKET).unwrap();
+    let mut rx_socket = rx.udp_sockets.take(UdpSocketId::Raptorcast).unwrap();
     let rx_addr = rx_socket.local_addr();
     let rx_handle = thread::spawn(move || {
         let mut messages = Vec::new();
@@ -997,9 +1039,8 @@ fn udp_priority_with_regular_then_high_traffic() {
         }
     });
 
-    let tx_socket = tx.take_udp_socket_handle(LEGACY_SOCKET).unwrap();
+    let tx_socket = tx.udp_sockets.take(UdpSocketId::Raptorcast).unwrap();
     let tx_addr = tx_socket.local_addr();
-
     tx_socket.write_unicast_with_priority(
         UnicastMsg {
             msgs: vec![(rx_addr, regular_priority_data.into())],
@@ -1059,4 +1100,72 @@ fn udp_priority_with_regular_then_high_traffic() {
         "should process only small amount of regular traffic before high traffic. Got {} regular messages before high priority",
         regular_before_high
     );
+}
+
+#[test]
+#[timeout(3000)]
+fn tcp_multi_socket() {
+    once_setup();
+
+    let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let num_msgs = 5;
+
+    let mut rx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([
+            (TcpSocketId::Raptorcast, bind_addr),
+            (TcpSocketId::AuthenticatedRaptorcast, bind_addr),
+        ])
+        .build();
+    let mut tx = DataplaneBuilder::new(UP_BANDWIDTH_MBPS)
+        .with_tcp_sockets([
+            (TcpSocketId::Raptorcast, bind_addr),
+            (TcpSocketId::AuthenticatedRaptorcast, bind_addr),
+        ])
+        .build();
+
+    let mut rx_tcp_socket = rx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    let mut rx_tcp_socket_2 = rx
+        .tcp_sockets
+        .take(TcpSocketId::AuthenticatedRaptorcast)
+        .unwrap();
+    let rx_addr = rx_tcp_socket.local_addr();
+    let rx_addr_2 = rx_tcp_socket_2.local_addr();
+
+    let payload1: Vec<u8> = (0..DEFAULT_SEGMENT_SIZE)
+        .map(|_| rand::thread_rng().gen_range(0..255))
+        .collect();
+    let payload2: Vec<u8> = (0..DEFAULT_SEGMENT_SIZE)
+        .map(|_| rand::thread_rng().gen_range(0..255))
+        .collect();
+
+    let tcp_socket = tx.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    let tcp_socket_2 = tx
+        .tcp_sockets
+        .take(TcpSocketId::AuthenticatedRaptorcast)
+        .unwrap();
+
+    for _ in 0..num_msgs {
+        tcp_socket.write(
+            rx_addr,
+            TcpMsg {
+                msg: payload1.clone().into(),
+                completion: None,
+            },
+        );
+        tcp_socket_2.write(
+            rx_addr_2,
+            TcpMsg {
+                msg: payload2.clone().into(),
+                completion: None,
+            },
+        );
+    }
+
+    for _ in 0..num_msgs {
+        let recv_msg = executor::block_on(rx_tcp_socket.recv());
+        assert_eq!(recv_msg.payload, payload1);
+
+        let recv_msg_2 = executor::block_on(rx_tcp_socket_2.recv());
+        assert_eq!(recv_msg_2.payload, payload2);
+    }
 }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -34,7 +34,7 @@ use monad_control_panel::ipc::ControlPanelIpcReceiver;
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
 };
-use monad_dataplane::DataplaneBuilder;
+use monad_dataplane::{DataplaneBuilder, TcpSocketId, UdpSocketId};
 use monad_eth_block_policy::EthBlockPolicy;
 use monad_eth_block_validator::EthBlockValidator;
 use monad_eth_txpool_executor::{EthTxPoolExecutor, EthTxPoolIpcConfig};
@@ -50,10 +50,7 @@ use monad_peer_discovery::{
     MonadNameRecord, NameRecord,
 };
 use monad_pprof::start_pprof_server;
-use monad_raptorcast::{
-    config::{RaptorCastConfig, RaptorCastConfigPrimary},
-    AUTHENTICATED_RAPTORCAST_SOCKET, RAPTORCAST_SOCKET,
-};
+use monad_raptorcast::config::{RaptorCastConfig, RaptorCastConfigPrimary};
 use monad_router_multi::MultiRouter;
 use monad_state::{MonadMessage, MonadStateBuilder, VerifiedMonadMessage};
 use monad_state_backend::StateBackendThreadClient;
@@ -557,7 +554,7 @@ where
 
     let network_config = node_config.network;
 
-    let mut dp_builder = DataplaneBuilder::new(&bind_address, network_config.max_mbps.into())
+    let mut dp_builder = DataplaneBuilder::new(network_config.max_mbps.into())
         .with_udp_multishot(network_config.enable_udp_multishot);
     if let Some(buffer_size) = network_config.buffer_size {
         dp_builder = dp_builder.with_udp_buffer_size(buffer_size);
@@ -572,17 +569,14 @@ where
             network_config.tcp_rate_limit_burst,
         );
 
-    let mut udp_sockets = vec![monad_dataplane::UdpSocketConfig {
-        socket_addr: bind_address,
-        label: RAPTORCAST_SOCKET.to_string(),
-    }];
+    let mut udp_sockets: Vec<(UdpSocketId, std::net::SocketAddr)> =
+        vec![(UdpSocketId::Raptorcast, bind_address)];
     if let Some(auth_addr) = authenticated_bind_address {
-        udp_sockets.push(monad_dataplane::UdpSocketConfig {
-            socket_addr: auth_addr,
-            label: AUTHENTICATED_RAPTORCAST_SOCKET.to_string(),
-        });
+        udp_sockets.push((UdpSocketId::AuthenticatedRaptorcast, auth_addr));
     }
-    dp_builder = dp_builder.extend_udp_sockets(udp_sockets);
+    dp_builder = dp_builder
+        .with_udp_sockets(udp_sockets)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_address)]);
 
     // auth port in peer discovery config and network config should be set and unset simultaneously
     assert_eq!(

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -39,8 +39,8 @@ use monad_crypto::{
 };
 use monad_dataplane::{
     udp::{DEFAULT_MTU, ETHERNET_SEGMENT_SIZE},
-    DataplaneBuilder, DataplaneControl, RecvTcpMsg, TcpMsg, TcpSocketReader, TcpSocketWriter,
-    UdpSocketHandle, UnicastMsg,
+    DataplaneBuilder, DataplaneControl, RecvTcpMsg, TcpMsg, TcpSocketHandle, TcpSocketId,
+    TcpSocketReader, TcpSocketWriter, UdpSocketHandle, UdpSocketId, UnicastMsg,
 };
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{
@@ -83,8 +83,6 @@ const SIGNATURE_SIZE: usize = 65;
 const DEFAULT_RETRY_ATTEMPTS: u64 = 3;
 
 pub const UNICAST_MSG_BATCH_SIZE: usize = 32;
-pub const RAPTORCAST_SOCKET: &str = "raptorcast";
-pub const AUTHENTICATED_RAPTORCAST_SOCKET: &str = "authenticated_raptorcast";
 
 pub(crate) type OwnedMessageBuilder<ST, PD> =
     packet::MessageBuilder<'static, ST, Arc<Mutex<PeerDiscoveryDriver<PD>>>>;
@@ -151,8 +149,7 @@ where
     pub fn new(
         config: config::RaptorCastConfig<ST>,
         secondary_mode: SecondaryRaptorCastModeConfig,
-        tcp_reader: TcpSocketReader,
-        tcp_writer: TcpSocketWriter,
+        tcp_socket: TcpSocketHandle,
         authenticated_socket: Option<UdpSocketHandle>,
         non_authenticated_socket: UdpSocketHandle,
         control: DataplaneControl,
@@ -160,6 +157,8 @@ where
         current_epoch: Epoch,
         auth_protocol: AP,
     ) -> Self {
+        let (tcp_reader, tcp_writer) = tcp_socket.split();
+
         if config.primary_instance.raptor10_redundancy < 1f32 {
             panic!(
                 "Configuration value raptor10_redundancy must be equal or greater than 1, \
@@ -535,35 +534,28 @@ pub fn create_dataplane_for_tests(with_auth: bool) -> DataplaneHandles {
     let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
     let up_bandwidth_mbps = 1_000;
 
-    let mut udp_sockets = vec![monad_dataplane::UdpSocketConfig {
-        socket_addr: bind_addr,
-        label: RAPTORCAST_SOCKET.to_string(),
-    }];
+    let mut udp_sockets: Vec<(UdpSocketId, SocketAddr)> =
+        vec![(UdpSocketId::Raptorcast, bind_addr)];
 
     if with_auth {
-        udp_sockets.insert(
-            0,
-            monad_dataplane::UdpSocketConfig {
-                socket_addr: bind_addr,
-                label: AUTHENTICATED_RAPTORCAST_SOCKET.to_string(),
-            },
-        );
+        udp_sockets.insert(0, (UdpSocketId::AuthenticatedRaptorcast, bind_addr));
     }
 
-    let dp = DataplaneBuilder::new(&bind_addr, up_bandwidth_mbps)
-        .extend_udp_sockets(udp_sockets)
+    let mut dp = DataplaneBuilder::new(up_bandwidth_mbps)
+        .with_tcp_sockets([(TcpSocketId::Raptorcast, bind_addr)])
+        .with_udp_sockets(udp_sockets)
         .build();
 
-    let tcp_addr = match dp.tcp_local_addr() {
+    let tcp_socket = dp.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+    let tcp_addr = match tcp_socket.local_addr() {
         SocketAddr::V4(addr) => addr,
         _ => panic!("expected v4 address"),
     };
 
-    let (tcp_socket, mut udp_dataplane, control) = dp.split();
-
     let (authenticated_socket, auth_addr) = if with_auth {
-        let socket = udp_dataplane
-            .take_socket(AUTHENTICATED_RAPTORCAST_SOCKET)
+        let socket = dp
+            .udp_sockets
+            .take(UdpSocketId::AuthenticatedRaptorcast)
             .expect("authenticated socket");
         let addr = match socket.local_addr() {
             SocketAddr::V4(addr) => addr,
@@ -574,8 +566,9 @@ pub fn create_dataplane_for_tests(with_auth: bool) -> DataplaneHandles {
         (None, None)
     };
 
-    let non_authenticated_socket = udp_dataplane
-        .take_socket(RAPTORCAST_SOCKET)
+    let non_authenticated_socket = dp
+        .udp_sockets
+        .take(UdpSocketId::Raptorcast)
         .expect("non-authenticated socket");
     let non_auth_addr = match non_authenticated_socket.local_addr() {
         SocketAddr::V4(addr) => addr,
@@ -586,7 +579,7 @@ pub fn create_dataplane_for_tests(with_auth: bool) -> DataplaneHandles {
         tcp_socket,
         authenticated_socket,
         non_authenticated_socket,
-        control,
+        control: dp.control,
         tcp_addr,
         auth_addr,
         non_auth_addr,
@@ -614,7 +607,6 @@ where
         known_addresses,
         ..Default::default()
     };
-    let (tcp_reader, tcp_writer) = dataplane.tcp_socket.split();
     let config = config::RaptorCastConfig {
         shared_key,
         mtu: DEFAULT_MTU,
@@ -644,8 +636,7 @@ where
     RaptorCast::<ST, M, OM, SE, NopDiscovery<ST>, _>::new(
         config,
         SecondaryRaptorCastModeConfig::None,
-        tcp_reader,
-        tcp_writer,
+        dataplane.tcp_socket,
         dataplane.authenticated_socket,
         dataplane.non_authenticated_socket,
         dataplane.control,
@@ -669,7 +660,6 @@ where
         known_addresses,
         ..Default::default()
     };
-    let (tcp_reader, tcp_writer) = dataplane.tcp_socket.split();
     let config = config::RaptorCastConfig {
         shared_key: shared_key.clone(),
         mtu: DEFAULT_MTU,
@@ -700,8 +690,7 @@ where
     RaptorCast::<ST, M, OM, SE, NopDiscovery<ST>, _>::new(
         config,
         SecondaryRaptorCastModeConfig::None,
-        tcp_reader,
-        tcp_writer,
+        dataplane.tcp_socket,
         dataplane.authenticated_socket,
         dataplane.non_authenticated_socket,
         dataplane.control,

--- a/monad-raptorcast/tests/wireauth_raptorcast.rs
+++ b/monad-raptorcast/tests/wireauth_raptorcast.rs
@@ -228,7 +228,6 @@ fn spawn_noop_validator(
 
     tokio::task::spawn_local(async move {
         let shared_pd = create_peer_discovery(known_addresses, name_records);
-        let (tcp_reader, tcp_writer) = dataplane.tcp_socket.split();
         let config = create_raptorcast_config(keypair, DEFAULT_SIG_VERIFICATION_RATE_LIMIT);
         let auth_protocol = monad_raptorcast::auth::NoopAuthProtocol::new();
 
@@ -242,8 +241,7 @@ fn spawn_noop_validator(
         >::new(
             config,
             monad_raptorcast::raptorcast_secondary::SecondaryRaptorCastModeConfig::None,
-            tcp_reader,
-            tcp_writer,
+            dataplane.tcp_socket,
             None,
             dataplane.non_authenticated_socket,
             dataplane.control,
@@ -293,7 +291,6 @@ fn spawn_wireauth_validator(
 
     tokio::task::spawn_local(async move {
         let shared_pd = create_peer_discovery(known_addresses, name_records);
-        let (tcp_reader, tcp_writer) = dataplane.tcp_socket.split();
         let config = create_raptorcast_config(keypair.clone(), sig_verification_rate_limit);
         let wireauth_config = monad_wireauth::Config::default();
         let auth_protocol =
@@ -309,8 +306,7 @@ fn spawn_wireauth_validator(
         >::new(
             config,
             monad_raptorcast::raptorcast_secondary::SecondaryRaptorCastModeConfig::None,
-            tcp_reader,
-            tcp_writer,
+            dataplane.tcp_socket,
             dataplane.authenticated_socket,
             dataplane.non_authenticated_socket,
             dataplane.control,

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -27,7 +27,7 @@ use futures::{Stream, StreamExt};
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
-use monad_dataplane::DataplaneBuilder;
+use monad_dataplane::{DataplaneBuilder, TcpSocketId, UdpSocketId};
 use monad_executor::{Executor, ExecutorMetricsChain};
 use monad_executor_glue::{Message, RouterCommand};
 use monad_node_config::{FullNodeConfig, FullNodeIdentityConfig};
@@ -46,7 +46,7 @@ use monad_raptorcast::{
         SecondaryRaptorCastModeConfig,
     },
     util::Group,
-    RaptorCast, RaptorCastEvent, AUTHENTICATED_RAPTORCAST_SOCKET, RAPTORCAST_SOCKET,
+    RaptorCast, RaptorCastEvent,
 };
 use monad_types::{Epoch, NodeId};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
@@ -99,16 +99,16 @@ where
         let pdd = PeerDiscoveryDriver::new(peer_discovery_builder);
         let shared_pdd = Arc::new(Mutex::new(pdd));
 
-        let dp = dataplane_builder.build();
+        let mut dp = dataplane_builder.build();
         assert!(dp.block_until_ready(Duration::from_secs(1)));
 
-        let (tcp_socket, mut udp_dataplane, control) = dp.split();
-        let authenticated_socket = udp_dataplane.take_socket(AUTHENTICATED_RAPTORCAST_SOCKET);
-        let non_authenticated_socket = udp_dataplane
-            .take_socket(RAPTORCAST_SOCKET)
+        let tcp_socket = dp.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+        let authenticated_socket = dp.udp_sockets.take(UdpSocketId::AuthenticatedRaptorcast);
+        let non_authenticated_socket = dp
+            .udp_sockets
+            .take(UdpSocketId::Raptorcast)
             .expect("raptorcast socket");
-
-        let (tcp_reader, tcp_writer) = tcp_socket.split();
+        let control = dp.control;
 
         // Create channels between primary and secondary raptorcast instances.
         // Fundamentally this is needed because, while both can send, only the
@@ -146,8 +146,7 @@ where
         let mut rc_primary = RaptorCast::new(
             cfg.clone(),
             secondary_mode,
-            tcp_reader,
-            tcp_writer,
+            tcp_socket,
             authenticated_socket,
             non_authenticated_socket,
             control,


### PR DESCRIPTION
adds support for registering tcp sockets similarly to udp, additionally switches both udp and tcp to use enums that are defined once in dataplane