### PR TITLE
monad-wireauth: add message buffering during handshake with limits

### DIFF
--- a/monad-wireauth/README.md
+++ b/monad-wireauth/README.md
@@ -140,6 +140,13 @@ session_decrypt         time:   [166.11 ns 168.75 ns 171.20 ns]
 | `monad.wireauth.enqueued.cookie_reply` | cookie challenges added to outbound queue |
 | `monad.wireauth.enqueued.keepalive` | keepalive packets added to outbound queue |
 
+### initiator buffering
+
+| metric | description |
+|--------|-------------|
+| `monad.wireauth.initiator.buffered_messages` | messages buffered in initiator sessions during handshake |
+| `monad.wireauth.initiator.messages_sent_from_buffer` | buffered messages sent after session established |
+
 ## Configuration
 
 | parameter | type | default | description |
@@ -163,3 +170,5 @@ session_decrypt         time:   [166.11 ns 168.75 ns 171.20 ns]
 | `max_requests_per_ip` | usize | 10 | max handshake requests from single ip within rate limit window |
 | `ip_history_capacity` | usize | 1000000 | lru cache size for tracking handshake request timestamps per ip |
 | `psk` | [u8; 32] | zeros | optional pre-shared key mixed into handshake for additional auth |
+| `max_initiated_sessions` | usize | 1000 | max concurrent initiated sessions (handshakes in progress) |
+| `max_buffered_bytes_per_session` | usize | 131072 | max bytes of buffered messages per initiated session (128KB) |

--- a/monad-wireauth/src/api.rs
+++ b/monad-wireauth/src/api.rs
@@ -19,10 +19,11 @@ use std::{
     time::{Duration, Instant},
 };
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use monad_executor::{ExecutorMetrics, ExecutorMetricsChain};
 use monad_secp::PubKey;
 use tracing::{debug, error, instrument, trace, warn, Level};
+use zerocopy::IntoBytes;
 
 use crate::{
     config::Config,
@@ -280,6 +281,13 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         debug!(retry_attempts, "initiating connection");
 
         self.check_connect_rate_limit()?;
+        let initiated_count = self.state.initiated_sessions_count();
+        if initiated_count >= self.config.max_initiated_sessions {
+            self.metrics[self.metric_names.error_connect] += 1;
+            return Err(Error::TooManyInitiatedSessions {
+                limit: self.config.max_initiated_sessions,
+            });
+        }
 
         // Cookies are looked up from initiated sessions for simplicity.
         // In the future, this can be improved to look up from both initiated and accepted sessions.
@@ -612,6 +620,14 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
                     index: receiver_session_index,
                 }
             })?;
+        let expected_remote_addr = initiator.remote_addr;
+        if remote_addr != expected_remote_addr {
+            self.metrics[self.metric_names.error_handshake_response_validation] += 1;
+            return Err(Error::HandshakeResponseAddressMismatch {
+                expected: expected_remote_addr,
+                actual: remote_addr,
+            });
+        }
 
         let validated_response = initiator
             .validate_response(&self.config, self.local_static_key.as_ref(), response)
@@ -625,21 +641,47 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
             .remove_initiator(&receiver_session_index)
             .expect("initiator was accessed above");
 
+        let buffered_message_count = initiator.buffered_message_count();
         let duration_since_start = self.context.duration_since_start();
-        debug!(local_session_id=?receiver_session_index, "initiator session established");
-        let (transport, timer, message) = initiator.establish(
+        debug!(
+            local_session_id=?receiver_session_index,
+            buffered_messages=buffered_message_count,
+            "initiator session established"
+        );
+        let (transport, messages) = initiator.establish(
             self.context.rng(),
             &self.config,
             duration_since_start,
             validated_response,
-            remote_addr,
         );
+        let is_buffered = messages.is_buffered();
 
         self.state
             .insert_transport(receiver_session_index, transport);
 
-        self.enqueue_packet(remote_addr, message);
-        self.replace_timer(timer, receiver_session_index);
+        for msg in messages {
+            let mut packet = BytesMut::with_capacity(DataPacketHeader::SIZE + msg.len());
+            packet.resize(DataPacketHeader::SIZE, 0);
+            packet.extend_from_slice(&msg);
+
+            let transport = self
+                .state
+                .get_transport_mut(&receiver_session_index)
+                .expect("transport was just inserted");
+            let (header, timer) = transport.encrypt(
+                self.context.rng(),
+                &self.config,
+                duration_since_start,
+                &mut packet[DataPacketHeader::SIZE..],
+            );
+            packet[..DataPacketHeader::SIZE].copy_from_slice(header.as_bytes());
+
+            self.replace_timer(timer, receiver_session_index);
+            self.enqueue_packet(remote_addr, packet.freeze());
+            if is_buffered {
+                self.metrics[self.metric_names.initiator_messages_sent_from_buffer] += 1;
+            }
+        }
 
         Ok(())
     }
@@ -697,6 +739,42 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         let session_id = transport.common.local_index;
         self.replace_timer(timer, session_id);
         Ok(header)
+    }
+
+    /// Buffers a message for a peer that has an initiator session (handshake in progress).
+    /// Returns Ok(()) if the message was buffered, or Err if no initiator session exists
+    /// or the buffer limit would be exceeded.
+    #[instrument(level = Level::TRACE, skip(self, public_key, message), fields(local_public_key = ?self.local_serialized_public))]
+    pub fn buffer_message(
+        &mut self,
+        public_key: &monad_secp::PubKey,
+        message: Bytes,
+    ) -> Result<()> {
+        let initiator = self
+            .state
+            .get_initiator_by_public_key_mut(public_key)
+            .ok_or(Error::SessionNotFound)?;
+        let new_size = initiator
+            .buffered_bytes()
+            .checked_add(message.len())
+            .ok_or(Error::BufferLimitExceeded {
+                size: usize::MAX,
+                limit: self.config.max_buffered_bytes_per_session,
+            })?;
+        if new_size > self.config.max_buffered_bytes_per_session {
+            return Err(Error::BufferLimitExceeded {
+                size: new_size,
+                limit: self.config.max_buffered_bytes_per_session,
+            });
+        }
+        initiator.buffer_message(message);
+        self.metrics[self.metric_names.initiator_buffered_messages] += 1;
+        trace!(
+            buffered_message_count = initiator.buffered_message_count(),
+            public_key = ?CompressedPublicKey::from(public_key),
+            "message buffered in initiator"
+        );
+        Ok(())
     }
 
     /// Disconnects and removes all sessions with the given public key.

--- a/monad-wireauth/src/config/mod.rs
+++ b/monad-wireauth/src/config/mod.rs
@@ -60,6 +60,10 @@ pub struct Config {
     pub ip_history_capacity: usize,
     /// optional pre-shared key mixed into handshake for additional auth
     pub psk: Zeroizing<[u8; 32]>,
+    /// max concurrent initiated sessions (handshakes in progress)
+    pub max_initiated_sessions: usize,
+    /// max bytes of buffered messages per initiated session
+    pub max_buffered_bytes_per_session: usize,
 }
 
 impl Default for Config {
@@ -84,6 +88,8 @@ impl Default for Config {
             max_requests_per_ip: 10,
             ip_history_capacity: 1_000_000,
             psk: Zeroizing::new([0u8; 32]),
+            max_initiated_sessions: 1000,
+            max_buffered_bytes_per_session: 128 * 1024,
         }
     }
 }

--- a/monad-wireauth/src/error.rs
+++ b/monad-wireauth/src/error.rs
@@ -51,6 +51,12 @@ pub enum Error {
     #[error("invalid receiver index {index}")]
     InvalidReceiverIndex { index: SessionIndex },
 
+    #[error("handshake response source address mismatch: expected {expected}, got {actual}")]
+    HandshakeResponseAddressMismatch {
+        expected: SocketAddr,
+        actual: SocketAddr,
+    },
+
     #[error("timestamp replay detected: received timestamp is not newer than expected")]
     TimestampReplay,
 
@@ -62,6 +68,12 @@ pub enum Error {
         limit: u64,
         interval: std::time::Duration,
     },
+
+    #[error("too many initiated sessions: limit is {limit}")]
+    TooManyInitiatedSessions { limit: usize },
+
+    #[error("buffer limit exceeded: {size} bytes exceeds limit of {limit} bytes")]
+    BufferLimitExceeded { size: usize, limit: usize },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/monad-wireauth/src/metrics.rs
+++ b/monad-wireauth/src/metrics.rs
@@ -75,6 +75,9 @@ pub struct MetricNames {
 
     pub rate_limit_drop: &'static str,
     pub rate_limit_connect: &'static str,
+
+    pub initiator_buffered_messages: &'static str,
+    pub initiator_messages_sent_from_buffer: &'static str,
 }
 
 #[macro_export]
@@ -273,6 +276,17 @@ macro_rules! define_metric_names {
 
             rate_limit_drop: concat!("monad.wireauth.", $transport, ".rate_limit.drop"),
             rate_limit_connect: concat!("monad.wireauth.", $transport, ".rate_limit.connect"),
+
+            initiator_buffered_messages: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".initiator.buffered_messages"
+            ),
+            initiator_messages_sent_from_buffer: concat!(
+                "monad.wireauth.",
+                $transport,
+                ".initiator.messages_sent_from_buffer"
+            ),
         };
     };
 }

--- a/monad-wireauth/src/session/initiator.rs
+++ b/monad-wireauth/src/session/initiator.rs
@@ -14,13 +14,17 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{
+    collections::{vec_deque, VecDeque},
+    iter,
     net::SocketAddr,
     ops::{Deref, DerefMut},
     time::{Duration, SystemTime},
 };
 
+use bytes::Bytes;
+
 use super::{
-    common::{add_jitter, RenewedTimer, SessionError, SessionState, SessionTimeoutResult},
+    common::{add_jitter, SessionError, SessionState, SessionTimeoutResult},
     transport::TransportState,
 };
 use crate::{
@@ -28,7 +32,7 @@ use crate::{
     protocol::{
         common::*,
         handshake::{self},
-        messages::{CookieReply, DataPacketHeader, HandshakeInitiation, HandshakeResponse},
+        messages::{CookieReply, HandshakeInitiation, HandshakeResponse},
     },
 };
 
@@ -40,6 +44,8 @@ pub struct ValidatedHandshakeResponse {
 pub struct InitiatorState {
     handshake_state: handshake::HandshakeState,
     common: SessionState,
+    buffered_messages: VecDeque<Bytes>,
+    buffered_bytes: usize,
 }
 
 impl InitiatorState {
@@ -81,6 +87,8 @@ impl InitiatorState {
         let mut session = InitiatorState {
             handshake_state,
             common,
+            buffered_messages: VecDeque::new(),
+            buffered_bytes: 0,
         };
 
         let timeout_with_jitter =
@@ -123,8 +131,7 @@ impl InitiatorState {
         config: &Config,
         duration_since_start: Duration,
         validated_response: ValidatedHandshakeResponse,
-        _remote_addr: SocketAddr,
-    ) -> (TransportState, RenewedTimer, DataPacketHeader) {
+    ) -> (TransportState, MessagesToSend) {
         self.common.reset_session_timeout(
             duration_since_start,
             add_jitter(rng, config.session_timeout, config.session_timeout_jitter),
@@ -136,14 +143,14 @@ impl InitiatorState {
         self.common
             .set_max_session_duration(duration_since_start, config.max_session_duration);
 
-        let mut transport = TransportState::new(
+        let transport = TransportState::new(
             validated_response.remote_index,
             validated_response.transport_keys.send_key,
             validated_response.transport_keys.recv_key,
             self.common,
         );
-        let (header, timer) = transport.encrypt(rng, config, duration_since_start, &mut []);
-        (transport, timer, header)
+        let messages = MessagesToSend::new(self.buffered_messages);
+        (transport, messages)
     }
 
     pub fn handle_cookie(&mut self, cookie_reply: &mut CookieReply) -> Result<(), SessionError> {
@@ -167,6 +174,70 @@ impl InitiatorState {
         let (terminated, rekey) = self.handle_session_timeout();
         let timer = self.common.get_next_deadline();
         Some((timer, SessionTimeoutResult { terminated, rekey }))
+    }
+
+    pub fn buffer_message(&mut self, message: Bytes) {
+        self.buffered_bytes = self.buffered_bytes.saturating_add(message.len());
+        self.buffered_messages.push_back(message);
+    }
+
+    pub fn buffered_message_count(&self) -> usize {
+        self.buffered_messages.len()
+    }
+
+    pub fn buffered_bytes(&self) -> usize {
+        self.buffered_bytes
+    }
+}
+
+pub struct MessagesToSend {
+    inner: MessagesToSendInner,
+}
+
+enum MessagesToSendInner {
+    Buffered(vec_deque::IntoIter<Bytes>),
+    Keepalive(iter::Once<Bytes>),
+}
+
+impl MessagesToSend {
+    fn new(messages: VecDeque<Bytes>) -> Self {
+        let inner = if messages.is_empty() {
+            MessagesToSendInner::Keepalive(iter::once(Bytes::new()))
+        } else {
+            MessagesToSendInner::Buffered(messages.into_iter())
+        };
+        Self { inner }
+    }
+
+    pub fn is_buffered(&self) -> bool {
+        matches!(self.inner, MessagesToSendInner::Buffered(_))
+    }
+}
+
+impl Iterator for MessagesToSend {
+    type Item = Bytes;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.inner {
+            MessagesToSendInner::Buffered(iter) => iter.next(),
+            MessagesToSendInner::Keepalive(iter) => iter.next(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match &self.inner {
+            MessagesToSendInner::Buffered(iter) => iter.size_hint(),
+            MessagesToSendInner::Keepalive(iter) => iter.size_hint(),
+        }
+    }
+}
+
+impl ExactSizeIterator for MessagesToSend {
+    fn len(&self) -> usize {
+        match &self.inner {
+            MessagesToSendInner::Buffered(iter) => iter.len(),
+            MessagesToSendInner::Keepalive(iter) => iter.len(),
+        }
     }
 }
 

--- a/monad-wireauth/src/state.rs
+++ b/monad-wireauth/src/state.rs
@@ -422,6 +422,14 @@ impl State {
         self.initiating_sessions.get_mut(session_index)
     }
 
+    pub fn get_initiator_by_public_key_mut(
+        &mut self,
+        public_key: &monad_secp::PubKey,
+    ) -> Option<&mut InitiatorState> {
+        let session_id = self.initiated_session_by_peer.get(public_key)?;
+        self.initiating_sessions.get_mut(session_id)
+    }
+
     #[cfg(test)]
     pub fn get_responder(&self, session_index: &SessionIndex) -> Option<&ResponderState> {
         self.responding_sessions.get(session_index)
@@ -613,6 +621,10 @@ impl State {
 
     pub fn ip_session_count(&self, ip: &IpAddr) -> usize {
         self.ip_session_counts.get(ip).copied().unwrap_or(0)
+    }
+
+    pub fn initiated_sessions_count(&self) -> usize {
+        self.initiating_sessions.len()
     }
 }
 

--- a/monad-wireauth/tests/tests.rs
+++ b/monad-wireauth/tests/tests.rs
@@ -778,3 +778,174 @@ fn test_keepalive_reset_on_encrypt() {
         unexpected_packet
     );
 }
+
+#[test]
+fn test_message_buffering_during_handshake() {
+    init_tracing();
+    let (mut peer1, _, _, _) = create_manager();
+    let (mut peer2, peer2_pubkey, _, _) = create_manager();
+    let peer1_addr: SocketAddr = "127.0.0.1:8001".parse().unwrap();
+    let peer2_addr: SocketAddr = "127.0.0.1:8002".parse().unwrap();
+
+    peer1
+        .connect(peer2_pubkey, peer2_addr, DEFAULT_RETRY_ATTEMPTS)
+        .unwrap();
+
+    peer1
+        .buffer_message(&peer2_pubkey, bytes::Bytes::from_static(b"buffered1"))
+        .unwrap();
+    peer1
+        .buffer_message(&peer2_pubkey, bytes::Bytes::from_static(b"buffered2"))
+        .unwrap();
+    peer1
+        .buffer_message(&peer2_pubkey, bytes::Bytes::from_static(b"buffered3"))
+        .unwrap();
+
+    let init = collect::<HandshakeInitiation>(&mut peer1);
+    dispatch(&mut peer2, &init, peer1_addr);
+
+    let response = collect::<HandshakeResponse>(&mut peer2);
+    dispatch(&mut peer1, &response, peer2_addr);
+
+    let packet1 = peer1.next_packet().unwrap();
+    let decrypted1 = decrypt(&mut peer2, &packet1.1, peer1_addr);
+    assert_eq!(decrypted1, b"buffered1");
+
+    let packet2 = peer1.next_packet().unwrap();
+    let decrypted2 = decrypt(&mut peer2, &packet2.1, peer1_addr);
+    assert_eq!(decrypted2, b"buffered2");
+
+    let packet3 = peer1.next_packet().unwrap();
+    let decrypted3 = decrypt(&mut peer2, &packet3.1, peer1_addr);
+    assert_eq!(decrypted3, b"buffered3");
+
+    assert!(peer1.next_packet().is_none());
+}
+
+#[test]
+fn test_handshake_response_address_mismatch_rejected() {
+    init_tracing();
+    let (mut peer1, _, _, _) = create_manager();
+    let (mut peer2, peer2_pubkey, _, _) = create_manager();
+    let peer1_addr: SocketAddr = "127.0.0.1:8001".parse().unwrap();
+    let peer2_addr: SocketAddr = "127.0.0.1:8002".parse().unwrap();
+    let spoofed_addr: SocketAddr = "127.0.0.1:9009".parse().unwrap();
+
+    peer1
+        .connect(peer2_pubkey, peer2_addr, DEFAULT_RETRY_ATTEMPTS)
+        .unwrap();
+
+    let init = collect::<HandshakeInitiation>(&mut peer1);
+    dispatch(&mut peer2, &init, peer1_addr);
+
+    let response = collect::<HandshakeResponse>(&mut peer2);
+    let mut response_packet = response.clone();
+    let parsed_packet = Packet::try_from(&mut response_packet[..]).unwrap();
+    let err = match parsed_packet {
+        Packet::Control(control) => peer1.dispatch_control(control, spoofed_addr).unwrap_err(),
+        Packet::Data(_) => panic!("expected control packet"),
+    };
+    assert!(matches!(
+        err,
+        monad_wireauth::Error::HandshakeResponseAddressMismatch { expected, actual }
+        if expected == peer2_addr && actual == spoofed_addr
+    ));
+
+    // Same response succeeds from the expected source address.
+    let mut response_packet = response;
+    let parsed_packet = Packet::try_from(&mut response_packet[..]).unwrap();
+    match parsed_packet {
+        Packet::Control(control) => peer1.dispatch_control(control, peer2_addr).unwrap(),
+        Packet::Data(_) => panic!("expected control packet"),
+    }
+
+    let mut plaintext = b"hello after address check".to_vec();
+    let packet = encrypt(&mut peer1, &peer2_pubkey, &mut plaintext);
+    let decrypted = decrypt(&mut peer2, &packet, peer1_addr);
+    assert_eq!(decrypted, b"hello after address check");
+}
+
+#[test]
+fn test_max_initiated_sessions_limit() {
+    init_tracing();
+    let config = Config {
+        max_initiated_sessions: 3,
+        ..Config::default()
+    };
+
+    let mut rng = rng();
+    let keypair = monad_secp::KeyPair::generate(&mut rng);
+    let context = TestContext::new();
+    let mut peer = API::new(DEFAULT_METRICS, config, keypair, context);
+
+    for i in 0..3 {
+        let remote_keypair = monad_secp::KeyPair::generate(&mut rng);
+        let remote_pubkey = remote_keypair.pubkey();
+        let remote_addr: SocketAddr = format!("127.0.0.1:800{}", i).parse().unwrap();
+        peer.connect(remote_pubkey, remote_addr, DEFAULT_RETRY_ATTEMPTS)
+            .unwrap();
+    }
+
+    let extra_keypair = monad_secp::KeyPair::generate(&mut rng);
+    let extra_pubkey = extra_keypair.pubkey();
+    let extra_addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
+    let result = peer.connect(extra_pubkey, extra_addr, DEFAULT_RETRY_ATTEMPTS);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(
+        err,
+        monad_wireauth::Error::TooManyInitiatedSessions { limit: 3 }
+    ));
+}
+
+#[test]
+fn test_buffer_limit_per_session() {
+    init_tracing();
+    let config = Config {
+        max_buffered_bytes_per_session: 100,
+        ..Config::default()
+    };
+
+    let mut rng = rng();
+    let keypair = monad_secp::KeyPair::generate(&mut rng);
+    let context = TestContext::new();
+    let mut peer = API::new(DEFAULT_METRICS, config, keypair, context);
+
+    let remote_keypair = monad_secp::KeyPair::generate(&mut rng);
+    let remote_pubkey = remote_keypair.pubkey();
+    let remote_addr: SocketAddr = "127.0.0.1:8001".parse().unwrap();
+    peer.connect(remote_pubkey, remote_addr, DEFAULT_RETRY_ATTEMPTS)
+        .unwrap();
+
+    peer.buffer_message(&remote_pubkey, bytes::Bytes::from(vec![0u8; 50]))
+        .unwrap();
+
+    peer.buffer_message(&remote_pubkey, bytes::Bytes::from(vec![0u8; 40]))
+        .unwrap();
+
+    let result = peer.buffer_message(&remote_pubkey, bytes::Bytes::from(vec![0u8; 20]));
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(
+        err,
+        monad_wireauth::Error::BufferLimitExceeded {
+            size: 110,
+            limit: 100
+        }
+    ));
+}
+
+#[test]
+fn test_buffer_message_session_not_found() {
+    init_tracing();
+    let (mut peer, _, _, _) = create_manager();
+
+    let mut rng = rng();
+    let remote_keypair = monad_secp::KeyPair::generate(&mut rng);
+    let remote_pubkey = remote_keypair.pubkey();
+
+    let result = peer.buffer_message(&remote_pubkey, bytes::Bytes::from_static(b"test"));
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(err, monad_wireauth::Error::SessionNotFound));
+}


### PR DESCRIPTION
for tcp workload we need to buffer message instead of falling back to original tcp protocol.
so if session is not established, we initiate a session and buffer message, once session completes
buffered messages are sent to a peer immediately

for safety we enforce that there are atmost 1000 concurrent initiated sessions and each session can buffer atmost 128KB of data

this functionality will be also useful for some udp workloads when we disable unauthenticated udp,
for example discovery ping/pong will have to be buffered, instead of dropping the message