### PR TITLE
Seed blocksync RNG from entropy

### DIFF
--- a/monad-blocksync/src/blocksync.rs
+++ b/monad-blocksync/src/blocksync.rs
@@ -196,6 +196,7 @@ where
     pub fn new(
         override_peers_inc_self: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
         self_node_id: NodeId<CertificateSignaturePubKey<ST>>,
+        maybe_rng_seed: Option<u64>,
     ) -> Self {
         let mut blocksync_instance = Self {
             headers_requests: Default::default(),
@@ -207,7 +208,7 @@ where
             self_request_mode: BlockSyncSelfRequester::StateSync,
             override_peers: Default::default(),
             self_node_id,
-            rng: ChaCha8Rng::seed_from_u64(123456),
+            rng: maybe_rng_seed.map_or(ChaCha8Rng::from_entropy(), ChaCha8Rng::seed_from_u64),
         };
         blocksync_instance.set_override_peers(override_peers_inc_self);
 
@@ -1563,7 +1564,7 @@ mod test {
         let peer_id = NodeId::new(keys[1].pubkey());
 
         BlockSyncContext {
-            block_sync: BlockSync::new(Default::default(), self_node_id),
+            block_sync: BlockSync::new(Default::default(), self_node_id, Some(123456)),
             blocktree,
             metrics: Metrics::default(),
             self_node_id,
@@ -1625,7 +1626,7 @@ mod test {
         let peer_id = NodeId::new(keys[1].pubkey());
 
         BlockSyncContext {
-            block_sync: BlockSync::new(Default::default(), self_node_id),
+            block_sync: BlockSync::new(Default::default(), self_node_id, Some(123456)),
             blocktree,
             metrics: Metrics::default(),
             self_node_id,

--- a/monad-mock-swarm/src/node.rs
+++ b/monad-mock-swarm/src/node.rs
@@ -139,6 +139,7 @@ impl<S: SwarmRelation> NodeBuilder<S> {
                 forkpoint: self.state_builder.forkpoint,
                 locked_epoch_validators: self.state_builder.locked_epoch_validators,
                 block_sync_override_peers: self.state_builder.block_sync_override_peers,
+                maybe_blocksync_rng_seed: Some(self.seed),
                 consensus_config: self.state_builder.consensus_config,
                 whitelisted_statesync_nodes: self.state_builder.whitelisted_statesync_nodes,
                 statesync_expand_to_group: self.state_builder.statesync_expand_to_group,

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -345,6 +345,7 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         forkpoint: node_state.forkpoint_config.into(),
         locked_epoch_validators,
         block_sync_override_peers,
+        maybe_blocksync_rng_seed: None,
         consensus_config: ConsensusConfig {
             execution_delay: SeqNum(EXECUTION_DELAY),
             delta: Duration::from_millis(100),

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -849,6 +849,7 @@ where
     pub certkey: SignatureCollectionKeyPairType<SCT>,
     pub beneficiary: [u8; 20],
     pub block_sync_override_peers: Vec<NodeId<SCT::NodeIdPubKey>>,
+    pub maybe_blocksync_rng_seed: Option<u64>,
     pub whitelisted_statesync_nodes: HashSet<NodeId<SCT::NodeIdPubKey>>,
     pub statesync_expand_to_group: bool,
 
@@ -928,7 +929,11 @@ where
                 self.locked_epoch_validators.clone(),
             ),
             certificate_cache: CertificateCache::default(),
-            block_sync: BlockSync::new(self.block_sync_override_peers, nodeid),
+            block_sync: BlockSync::new(
+                self.block_sync_override_peers,
+                nodeid,
+                self.maybe_blocksync_rng_seed,
+            ),
 
             leader_election: self.leader_election,
             epoch_manager,

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -307,6 +307,7 @@ where
         forkpoint,
         locked_epoch_validators,
         block_sync_override_peers: Default::default(),
+        maybe_blocksync_rng_seed: Some(123456),
         consensus_config: config.consensus_config,
         whitelisted_statesync_nodes: Default::default(),
         statesync_expand_to_group: true,

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -104,6 +104,7 @@ pub fn make_state_configs<S: SwarmRelation>(
 
             beneficiary: Default::default(),
             block_sync_override_peers: Default::default(),
+            maybe_blocksync_rng_seed: Some(123456),
 
             consensus_config: ConsensusConfig {
                 execution_delay,

--- a/monad-twins/utils/src/twin_reader.rs
+++ b/monad-twins/utils/src/twin_reader.rs
@@ -147,6 +147,7 @@ where
 
                 beneficiary: self.state_config.beneficiary,
                 block_sync_override_peers: self.state_config.block_sync_override_peers.clone(),
+                maybe_blocksync_rng_seed: self.state_config.maybe_blocksync_rng_seed,
 
                 consensus_config: self.state_config.consensus_config,
 
@@ -391,6 +392,7 @@ where
 
             beneficiary: Default::default(),
             block_sync_override_peers: Default::default(),
+            maybe_blocksync_rng_seed: Some(123456),
 
             consensus_config: ConsensusConfig {
                 execution_delay: SeqNum(TWINS_STATE_ROOT_DELAY),


### PR DESCRIPTION
closes: https://github.com/category-labs/category-internal/issues/1711