### PR TITLE
Cleanup txpool bridge reconnection logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3389,18 +3389,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3499,15 +3487,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "funty"
@@ -4351,17 +4330,6 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
-dependencies = [
- "bitflags 1.3.2",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
@@ -4615,26 +4583,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kqueue"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
-]
-
-[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4667,17 +4615,6 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
-
-[[package]]
-name = "libredox"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
-dependencies = [
- "bitflags 2.10.0",
- "libc",
- "redox_syscall 0.7.0",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -5709,7 +5646,7 @@ dependencies = [
  "clap 4.5.54",
  "futures-util",
  "hex",
- "inotify 0.11.0",
+ "inotify",
  "lru",
  "monad-block-persist",
  "monad-bls",
@@ -5978,6 +5915,7 @@ dependencies = [
  "flume",
  "futures",
  "futures-util",
+ "inotify",
  "itertools 0.10.5",
  "monad-archive",
  "monad-chain-config",
@@ -5994,7 +5932,6 @@ dependencies = [
  "monad-triedb-utils",
  "monad-types",
  "monad-version",
- "notify",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -6006,6 +5943,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+ "tempfile",
  "test-case",
  "tikv-jemallocator",
  "tokio",
@@ -6680,25 +6618,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
-name = "notify"
-version = "6.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
-dependencies = [
- "bitflags 2.10.0",
- "crossbeam-channel",
- "filetime",
- "fsevent-sys",
- "inotify 0.9.6",
- "kqueue",
- "libc",
- "log",
- "mio 0.8.11",
- "walkdir",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ntest"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7089,7 +7008,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -7741,15 +7660,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.10.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags 2.10.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,6 @@ lru = "0.12"
 lz4 = "1.28"
 mongodb = "3.2.1"
 monoio = { git = "https://github.com/category-labs/monoio.git", tag = "0.2.4-category", features = ["sync", "iouring"] }
-notify = "6.1.1"
 ntest = "0.9"
 once_cell = "1.19.0"
 opentelemetry = "0.29"

--- a/monad-rpc/Cargo.toml
+++ b/monad-rpc/Cargo.toml
@@ -30,20 +30,20 @@ monad-ethcall = { workspace = true }
 monad-event-ring = { workspace = true }
 monad-exec-events = { workspace = true, features = ["alloy"] }
 monad-node-config = { workspace = true, features = ["crypto"] }
+monad-pprof = { workspace = true }
 monad-rpc-docs = { workspace = true }
 monad-tracing-timing = { workspace = true }
 monad-triedb-utils = { workspace = true }
 monad-types = { workspace = true }
-monad-pprof = { workspace = true }
 monad-version = { workspace = true }
 
 actix = { workspace = true }
-agent = { workspace = true }
 actix-http = { workspace = true }
 actix-rt = { workspace = true }
 actix-test = { workspace = true }
 actix-web = { workspace = true }
 actix-ws = { workspace = true }
+agent = { workspace = true }
 alloy-consensus = { workspace = true, features = ["k256"] }
 alloy-eips = { workspace = true }
 alloy-primitives = { workspace = true }
@@ -55,8 +55,8 @@ dashmap = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
+inotify = { workspace = true }
 itertools = { workspace = true }
-notify = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics", "trace"] }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio", "trace"] }
 opentelemetry-otlp = { workspace = true, features = ["metrics", "grpc-tonic"] }
@@ -68,17 +68,13 @@ schemars = { workspace = true, features = ["preserve_order", "raw_value"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_cbor = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
-tokio = { workspace = true, features = [
-    "net",
-    "macros",
-    "rt-multi-thread",
-    "fs",
-] }
+tokio = { workspace = true, features = ["net", "macros", "rt-multi-thread", "fs"] }
 toml = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
 tracing-actix-web = { workspace = true }
 tracing-manytrace = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
+
 [target.'cfg(not(target_env = "msvc"))'.dependencies.tikv-jemallocator]
 workspace = true
 features = [
@@ -104,6 +100,7 @@ arbitrary = { workspace = true }
 awc = { workspace = true }
 criterion = { workspace = true }
 reqwest = { workspace = true }
+tempfile = { workspace = true }
 test-case = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 

--- a/monad-rpc/src/txpool/mod.rs
+++ b/monad-rpc/src/txpool/mod.rs
@@ -16,26 +16,22 @@
 use std::{
     io,
     path::{Path, PathBuf},
-    pin::Pin,
-    task::Poll,
     time::Duration,
 };
 
 use alloy_consensus::TxEnvelope;
 use flume::Receiver;
-use futures::{ready, Future, Sink, SinkExt, Stream, StreamExt};
+use futures::{SinkExt, StreamExt};
 use monad_eth_txpool_ipc::{EthTxPoolIpcClient, EthTxPoolIpcTx};
-use monad_eth_txpool_types::{EthTxPoolEvent, EthTxPoolSnapshot};
-use pin_project::pin_project;
 use state::TxStatusReceiverSender;
-use tokio::pin;
-use tracing::warn;
+use tracing::{debug, error, info, warn};
 
 pub use self::{client::EthTxPoolBridgeClient, handle::EthTxPoolBridgeHandle, types::TxStatus};
 use self::{
     socket::SocketWatcher,
     state::{EthTxPoolBridgeEvictionQueue, EthTxPoolBridgeState},
 };
+use crate::txpool::socket::SocketWatcherEvent;
 
 mod client;
 mod handle;
@@ -45,21 +41,11 @@ mod types;
 
 pub const ETH_TXPOOL_BRIDGE_CHANNEL_SIZE: usize = 1024;
 
-#[pin_project(project = EthTxPoolBridgeIpcStateProjection)]
-enum EthTxPoolBridgeIpcState {
-    Ready,
-    Reconnect(
-        Pin<Box<dyn Future<Output = io::Result<(EthTxPoolIpcClient, EthTxPoolSnapshot)>> + Send>>,
-    ),
-    BrokenPipe(#[pin] SocketWatcher),
-}
-
-#[pin_project]
 pub struct EthTxPoolBridge {
-    socket_path: PathBuf,
-    ipc_client: EthTxPoolIpcClient,
-    #[pin]
-    ipc_state: EthTxPoolBridgeIpcState,
+    ipc_client: Option<EthTxPoolIpcClient>,
+
+    bind_path: PathBuf,
+    socket_watcher: SocketWatcher,
 
     state: EthTxPoolBridgeState,
     eviction_queue: EthTxPoolBridgeEvictionQueue,
@@ -72,9 +58,7 @@ impl EthTxPoolBridge {
     where
         P: AsRef<Path>,
     {
-        let socket_path = bind_path.as_ref().to_path_buf();
-
-        let (ipc_client, snapshot) = EthTxPoolIpcClient::new(bind_path).await?;
+        let (ipc_client, snapshot) = EthTxPoolIpcClient::new(&bind_path).await?;
 
         let mut eviction_queue = EthTxPoolBridgeEvictionQueue::default();
         let state: EthTxPoolBridgeState = EthTxPoolBridgeState::new(&mut eviction_queue, snapshot);
@@ -83,10 +67,13 @@ impl EthTxPoolBridge {
 
         let client = EthTxPoolBridgeClient::new(tx_sender, state.create_view());
 
+        let socket_watcher = SocketWatcher::try_new(&bind_path)?;
+
         let bridge = Self {
-            socket_path,
-            ipc_client,
-            ipc_state: EthTxPoolBridgeIpcState::Ready,
+            ipc_client: Some(ipc_client),
+
+            bind_path: bind_path.as_ref().to_path_buf(),
+            socket_watcher,
 
             state,
             eviction_queue,
@@ -103,11 +90,40 @@ impl EthTxPoolBridge {
         cleanup_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
         let err = loop {
+            let ipc_client = match self.ipc_client.as_mut() {
+                Some(ipc_client) => ipc_client,
+                None => match self.try_create_ipc_client().await {
+                    Err(err) => break err,
+                    Ok(()) => {
+                        tx_receiver.drain();
+                        continue;
+                    }
+                },
+            };
+
             tokio::select! {
+                biased;
+
+                result = ipc_client.next() => {
+                    if let Some(events) = result {
+                        self.state.handle_events(&mut self.eviction_queue, events);
+                    } else {
+                        error!("TxPoolBridge txpool ipc client died, trying to reconnect");
+
+                        if let Err(err) = self.try_reconnect().await {
+                            error!(?err, "TxPoolBridge txpool ipc client failed to reconnect, falling back to SocketWatcher");
+                            self.ipc_client = None;
+                        }
+                    }
+                }
+
                 result = tx_receiver.recv_async() => {
                     let tx_pair = match result {
                         Ok(tx_pair) => tx_pair,
-                        Err(e) => break e,
+                        Err(flume::RecvError::Disconnected) => {
+                            error!("TxPoolBridge tx receiver disconnected");
+                            break None;
+                        },
                     };
 
                     for (tx, tx_status_recv_send) in std::iter::once(tx_pair).chain(tx_receiver.drain()) {
@@ -115,25 +131,38 @@ impl EthTxPoolBridge {
                             continue;
                         }
 
-                        if let Err(e) = self.feed(tx).await {
-                            warn!("IPC feed failed, monad-bft likely crashed: {}", e);
+                        if let Err(e) = ipc_client.feed(EthTxPoolIpcTx::new_with_default_priority(
+                            tx,
+                            Vec::default(),
+                        )).await {
+                            warn!("TxPoolBridge IPC feed failed, monad-bft likely crashed: {}", e);
                         }
                     }
 
-                    if let Err(e) = self.flush().await {
-                        warn!("IPC flush failed, monad-bft likely crashed: {}", e);
+                    if let Err(e) = ipc_client.flush().await {
+                        error!("TxPoolBridge IPC flush failed, monad-bft likely crashed: {}", e);
                     }
                 }
 
-                result = self.next() => {
-                    let Some(events) = result else {
-                        continue;
+                result = self.socket_watcher.next() => {
+                    let Some(result) = result else {
+                        error!("TxPoolBridge SocketWatcher died while txpool ipc client alive");
+                        break None;
                     };
 
-                    self.state.handle_events(&mut self.eviction_queue, events);
+                    match result {
+                        Err(err) => {
+                            error!(?err, "TxPoolBridge SocketWatcher error while txpool ipc client alive");
+                            break Some(err);
+                        },
+                        Ok(event) => {
+                            warn!(?event, "TxPoolBridge SocketWatcher detected event while txpool ipc client alive");
+                        }
+                    }
                 }
 
                 now = cleanup_timer.tick() => {
+                    debug!("TxPoolBridge running state cleanup");
                     self.state.cleanup(&mut self.eviction_queue, now);
                 }
             }
@@ -141,88 +170,402 @@ impl EthTxPoolBridge {
 
         warn!(?err, "TxPoolBridge shutting down")
     }
-}
 
-impl Sink<TxEnvelope> for EthTxPoolBridge {
-    type Error = io::Error;
+    async fn try_create_ipc_client(&mut self) -> Result<(), Option<io::Error>> {
+        loop {
+            let Some(result) = self.socket_watcher.next().await else {
+                error!("TxPoolBridge SocketWatcher died while attempting to reconnect");
+                return Err(None);
+            };
 
-    fn poll_ready(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        self.ipc_client.poll_ready_unpin(cx)
-    }
+            let event = match result {
+                Err(err) => {
+                    error!(
+                        ?err,
+                        "TxPoolBridge SocketWatcher error while attempting to reconnect"
+                    );
+                    return Err(Some(err));
+                }
+                Ok(event) => event,
+            };
 
-    fn start_send(mut self: std::pin::Pin<&mut Self>, tx: TxEnvelope) -> Result<(), Self::Error> {
-        self.ipc_client
-            .start_send_unpin(EthTxPoolIpcTx::new_with_default_priority(
-                tx,
-                Vec::default(),
-            ))
-    }
-
-    fn poll_flush(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        let mut this = self.as_mut().project();
-        let mut ipc_state = this.ipc_state.as_mut();
-
-        match ipc_state.as_mut().project() {
-            EthTxPoolBridgeIpcStateProjection::Ready => {
-                let writer: Poll<Result<(), std::io::Error>> = this.ipc_client.poll_flush_unpin(cx);
-                match writer {
-                    Poll::Ready(Err(ref e)) if e.kind() == io::ErrorKind::BrokenPipe => {
-                        let sw = SocketWatcher::try_new(this.socket_path.clone())?;
-                        ipc_state.set(EthTxPoolBridgeIpcState::BrokenPipe(sw));
-                        cx.waker().wake_by_ref();
+            match event {
+                SocketWatcherEvent::Create(bind_path) => {
+                    if self.bind_path != bind_path {
+                        error!(
+                            expected_bind_path =? self.bind_path,
+                            socket_watcher_bind_path =? bind_path,
+                            "TxPoolBridge received different socket bind path from SocketWatcher"
+                        );
+                        return Err(None);
                     }
-                    Poll::Ready(Err(e)) => {
-                        return Poll::Ready(Err(e));
+
+                    match self.try_reconnect().await {
+                        Ok(()) => return Ok(()),
+                        Err(err) => {
+                            error!(?err, "TxPoolBridge failed to reconnect txpool ipc client");
+                        }
                     }
-                    v => return v,
+                }
+                SocketWatcherEvent::Delete => {
+                    info!(
+                        ?event,
+                        "TxPoolBridge detected socket delete event while trying to reconnect"
+                    );
                 }
             }
-            EthTxPoolBridgeIpcStateProjection::BrokenPipe(mut sw) => {
-                ready!(sw.as_mut().poll(cx))?;
-                ipc_state.set(EthTxPoolBridgeIpcState::Reconnect(Box::pin(
-                    EthTxPoolIpcClient::new(this.socket_path.to_path_buf()),
-                )));
-                cx.waker().wake_by_ref();
-            }
-            EthTxPoolBridgeIpcStateProjection::Reconnect(task) => {
-                match task.as_mut().poll(cx) {
-                    Poll::Ready(result) => {
-                        let (ipc_client, snapshot) = result?;
-                        this.state.apply_snapshot(this.eviction_queue, snapshot);
-
-                        *this.ipc_client = ipc_client;
-                        ipc_state.set(EthTxPoolBridgeIpcState::Ready);
-                        cx.waker().wake_by_ref();
-                    }
-                    Poll::Pending => return Poll::Pending,
-                };
-            }
         }
-
-        Poll::Pending
     }
 
-    fn poll_close(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        self.ipc_client.poll_close_unpin(cx)
+    async fn try_reconnect(&mut self) -> io::Result<()> {
+        info!(bind_path =? self.bind_path, "TxPoolBridge reconnecting txpool ipc client");
+
+        let (ipc_client, snapshot) = EthTxPoolIpcClient::new(&self.bind_path).await?;
+
+        info!("TxPoolBridge txpool ipc client reconnected");
+
+        self.ipc_client = Some(ipc_client);
+
+        self.state
+            .apply_snapshot(&mut self.eviction_queue, snapshot);
+
+        Ok(())
     }
 }
 
-impl Stream for EthTxPoolBridge {
-    type Item = Vec<EthTxPoolEvent>;
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashSet,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+    };
 
-    fn poll_next(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
-        self.ipc_client.poll_next_unpin(cx)
+    use flume::TrySendError;
+    use futures::StreamExt;
+    use itertools::Itertools;
+    use monad_eth_testutil::{make_legacy_tx, S1, S2};
+    use monad_eth_txpool_ipc::EthTxPoolIpcStream;
+    use monad_eth_txpool_types::EthTxPoolSnapshot;
+    use tempfile::TempDir;
+    use test_case::test_matrix;
+    use tokio::{net::UnixListener, time::Duration};
+
+    use super::{
+        client::EthTxPoolBridgeClient, handle::EthTxPoolBridgeHandle,
+        state::EthTxPoolBridgeStateView, EthTxPoolBridge, TxStatus,
+    };
+
+    const BASE_FEE_PER_GAS: u64 = 100_000_000_000;
+
+    #[test_matrix([1, 16, 64, 128, 1024])]
+    fn test_client_acquire_tx_inflight_guard_up_to_capacity(capacity: usize) {
+        let (tx_sender, _rx) = flume::bounded(capacity);
+
+        let state_view = EthTxPoolBridgeStateView::for_testing();
+        let client = EthTxPoolBridgeClient::new(tx_sender, state_view);
+
+        // We intentionally only allow up to capacity - 1
+        let guards = (0..(capacity - 1))
+            .map(|_| {
+                client
+                    .acquire_tx_inflight_guard()
+                    .expect("Can acquire up to capacity")
+            })
+            .collect_vec();
+
+        assert!(client.acquire_tx_inflight_guard().is_none());
+
+        drop(guards);
+    }
+
+    #[test]
+    fn test_client_try_send_disconnected() {
+        let (tx_sender, rx) = flume::bounded(1);
+        let state_view = EthTxPoolBridgeStateView::for_testing();
+        let client = EthTxPoolBridgeClient::new(tx_sender, state_view);
+
+        // Drop the receiver to disconnect
+        drop(rx);
+
+        let tx = make_legacy_tx(S1, BASE_FEE_PER_GAS.into(), 100_000, 0, 0);
+        let (status_sender, _status_recv) = tokio::sync::oneshot::channel();
+
+        let result = client.try_send(tx, status_sender);
+        assert!(matches!(result, Err(TrySendError::Disconnected(_))));
+    }
+
+    #[test]
+    fn test_client_try_send_success() {
+        let (tx_sender, rx) = flume::bounded(1);
+        let state_view = EthTxPoolBridgeStateView::for_testing();
+        let client = EthTxPoolBridgeClient::new(tx_sender, state_view);
+
+        let tx = make_legacy_tx(S1, BASE_FEE_PER_GAS.into(), 100_000, 0, 0);
+        let tx_hash = *tx.tx_hash();
+        let (status_sender, _status_recv) = tokio::sync::oneshot::channel();
+
+        let result = client.try_send(tx, status_sender);
+        assert!(result.is_ok());
+
+        let (received_tx, _) = rx.try_recv().unwrap();
+        assert_eq!(*received_tx.tx_hash(), tx_hash);
+    }
+
+    #[tokio::test]
+    async fn test_handle_awaits_task_completion() {
+        let completed = Arc::new(AtomicBool::new(false));
+        let completed_clone = completed.clone();
+
+        let handle = EthTxPoolBridgeHandle::new(tokio::task::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            completed_clone.store(true, Ordering::SeqCst);
+        }));
+
+        handle.await;
+
+        assert!(completed.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn test_bridge_reconnects_after_ipc_client_dies() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let socket_path = temp_dir.path().join("test.sock");
+
+        // Start persistent listener that will handle reconnections
+        let listener = UnixListener::bind(&socket_path).expect("Failed to bind socket");
+        let listener = Arc::new(listener);
+        let listener_clone = listener.clone();
+
+        // Spawn task to handle first connection
+        let first_connection = tokio::spawn(async move {
+            let (stream, _) = listener_clone.accept().await.expect("Failed to accept");
+            let ipc_stream = EthTxPoolIpcStream::new(
+                stream,
+                EthTxPoolSnapshot {
+                    txs: HashSet::default(),
+                },
+            );
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            drop(ipc_stream); // Simulate crash
+        });
+
+        let (client, _handle) = EthTxPoolBridge::start(&socket_path)
+            .await
+            .expect("Bridge should start");
+
+        // Wait for first connection to crash
+        first_connection
+            .await
+            .expect("First connection task failed");
+
+        // Bridge should attempt immediate reconnection (socket still exists)
+        let accept_result = tokio::time::timeout(Duration::from_secs(2), listener.accept()).await;
+
+        assert!(
+            accept_result.is_ok(),
+            "Bridge should attempt to reconnect after IPC client dies"
+        );
+
+        // Clean up
+        drop(client);
+    }
+
+    #[tokio::test]
+    async fn test_bridge_handles_rapid_reconnects() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let socket_path = temp_dir.path().join("test.sock");
+
+        let listener = UnixListener::bind(&socket_path).expect("Failed to bind socket");
+        let listener = Arc::new(listener);
+        let listener_clone = listener.clone();
+
+        let connections = tokio::spawn(async move {
+            // Simulate multiple rapid disconnects and reconnects
+            for _ in 0..3 {
+                let (stream, _) =
+                    tokio::time::timeout(Duration::from_secs(2), listener_clone.accept())
+                        .await
+                        .expect("Should accept connection")
+                        .expect("Failed to accept connection");
+
+                let ipc_stream = EthTxPoolIpcStream::new(
+                    stream,
+                    EthTxPoolSnapshot {
+                        txs: HashSet::default(),
+                    },
+                );
+
+                drop(ipc_stream);
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        });
+
+        let (client, handle) = EthTxPoolBridge::start(&socket_path)
+            .await
+            .expect("Bridge should start");
+
+        connections.await.unwrap();
+
+        // Final reconnection should still work
+        let accept_result = tokio::time::timeout(Duration::from_secs(2), listener.accept()).await;
+        assert!(
+            accept_result.is_ok(),
+            "Should reconnect after rapid disconnects"
+        );
+
+        drop(handle);
+        drop(client);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_bridge_handles_transactions_from_client() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let socket_path = temp_dir.path().join("test.sock");
+
+        let listener = UnixListener::bind(&socket_path).expect("Failed to bind socket");
+
+        let ipc_task = tokio::spawn(async move {
+            let (stream, _) = listener
+                .accept()
+                .await
+                .expect("Failed to accept connection");
+            let mut ipc_stream = EthTxPoolIpcStream::new(
+                stream,
+                EthTxPoolSnapshot {
+                    txs: HashSet::default(),
+                },
+            );
+
+            // The IPC stream should receive the transaction
+            let received_tx = tokio::time::timeout(Duration::from_millis(500), ipc_stream.next())
+                .await
+                .expect("Should receive transaction within timeout")
+                .expect("Stream should not be closed");
+
+            (received_tx, ipc_stream)
+        });
+
+        let (client, _handle) = EthTxPoolBridge::start(&socket_path)
+            .await
+            .expect("Bridge should start");
+
+        // Send a transaction through the client
+        let tx = make_legacy_tx(S1, BASE_FEE_PER_GAS.into(), 100_000, 0, 0);
+        let tx_hash = *tx.tx_hash();
+        let (status_sender, mut status_recv) = tokio::sync::oneshot::channel();
+
+        let result = client.try_send(tx.clone(), status_sender);
+        assert!(result.is_ok(), "Transaction should be sent successfully");
+
+        let (received_tx, ipc_stream) = ipc_task.await.expect("IPC task should complete");
+
+        assert_eq!(
+            *received_tx.tx.tx_hash(),
+            tx_hash,
+            "Received transaction should match sent transaction"
+        );
+
+        // Status should be available
+        let status_receiver = status_recv
+            .try_recv()
+            .expect("Status receiver should be available");
+        assert_eq!(
+            *status_receiver.borrow(),
+            TxStatus::Unknown,
+            "Initial status should be Unknown"
+        );
+
+        // Clean up
+        drop(ipc_stream);
+        drop(client);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_bridge_applies_snapshot_on_reconnect() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let socket_path = temp_dir.path().join("test.sock");
+
+        let tx1 = make_legacy_tx(S1, BASE_FEE_PER_GAS.into(), 100_000, 0, 0);
+        let tx2 = make_legacy_tx(S2, BASE_FEE_PER_GAS.into(), 100_000, 0, 0);
+        let tx1_hash = *tx1.tx_hash();
+        let tx2_hash = *tx2.tx_hash();
+
+        // Start with a snapshot containing tx1
+        let listener = UnixListener::bind(&socket_path).expect("Failed to bind socket");
+        let listener = Arc::new(listener);
+        let listener_clone = listener.clone();
+
+        // Spawn task to handle first connection with tx1 in snapshot
+        let ipc_task1 = tokio::spawn(async move {
+            let (stream1, _) = listener_clone
+                .accept()
+                .await
+                .expect("Failed to accept connection");
+            let ipc_stream1 = EthTxPoolIpcStream::new(
+                stream1,
+                EthTxPoolSnapshot {
+                    txs: HashSet::from_iter([tx1_hash]),
+                },
+            );
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            drop(ipc_stream1);
+        });
+
+        let (client, _handle) = EthTxPoolBridge::start(&socket_path)
+            .await
+            .expect("Bridge should start");
+
+        // Verify tx1 is tracked
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let tx1_status = client.get_status_by_hash(&tx1_hash);
+        assert_eq!(
+            tx1_status,
+            Some(TxStatus::Tracked),
+            "tx1 should be tracked initially"
+        );
+
+        // Wait for simulated crash
+        ipc_task1.await.expect("IPC task 1 should complete");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Spawn task to handle reconnection with new snapshot (tx2 instead of tx1)
+        let ipc_task2 = tokio::spawn(async move {
+            let (stream2, _) = tokio::time::timeout(Duration::from_secs(2), listener.accept())
+                .await
+                .expect("Should reconnect within timeout")
+                .expect("Failed to accept reconnection");
+
+            let ipc_stream2 = EthTxPoolIpcStream::new(
+                stream2,
+                EthTxPoolSnapshot {
+                    txs: HashSet::from_iter([tx2_hash]),
+                },
+            );
+
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            drop(ipc_stream2);
+        });
+
+        // Give time for snapshot to be applied
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // tx1 should be removed, tx2 should be tracked
+        let tx1_status = client.get_status_by_hash(&tx1_hash);
+        let tx2_status = client.get_status_by_hash(&tx2_hash);
+
+        assert_eq!(tx1_status, None, "tx1 should be removed after reconnect");
+        assert_eq!(
+            tx2_status,
+            Some(TxStatus::Tracked),
+            "tx2 should be tracked after reconnect"
+        );
+
+        // Clean up
+        ipc_task2.await.expect("IPC task 2 should complete");
+        drop(client);
     }
 }

--- a/monad-rpc/src/txpool/socket.rs
+++ b/monad-rpc/src/txpool/socket.rs
@@ -13,86 +13,348 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{ffi::OsStr, io, path::PathBuf, task::Poll};
+use std::{
+    ffi::OsString,
+    io,
+    path::{Path, PathBuf},
+    task::Poll,
+};
 
-use futures::{executor::block_on, Future};
-use notify::{Event, RecursiveMode, Watcher};
+use futures::{Stream, StreamExt};
+use inotify::{EventMask, EventStream, Inotify, WatchMask};
 use pin_project::pin_project;
-use tokio::{pin, sync::mpsc};
-use tracing::{debug, error};
-
-const MEMPOOL_TX_IPC_FILE: &str = "mempool.sock";
+use tracing::{debug, error, warn};
 
 #[pin_project]
 pub struct SocketWatcher {
-    socket_path: PathBuf,
-    #[pin]
-    watcher: notify::INotifyWatcher,
-    #[pin]
-    rx: mpsc::Receiver<notify::Result<notify::Event>>,
+    inotify: EventStream<[u8; 1024]>,
+    parent: PathBuf,
+    filename: OsString,
 }
 
 impl SocketWatcher {
-    pub fn try_new(socket_path: PathBuf) -> io::Result<Self> {
-        let (tx, rx) = mpsc::channel::<notify::Result<notify::Event>>(100);
-        let mut watcher = notify::INotifyWatcher::new(
-            move |res| {
-                block_on(async {
-                    if let Err(send) = tx.send(res).await {
-                        error!("cannot send on socket watcher channel: {:?}", send);
-                    };
-                })
-            },
-            notify::Config::default(),
-        )
-        .map_err(io::Error::other)?;
+    pub fn try_new<P>(socket_path: P) -> io::Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        let filename = socket_path
+            .as_ref()
+            .file_name()
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "Socket path does not have a filename",
+                )
+            })?
+            .to_os_string();
 
-        let dir_path = if let Some(parent_path) = socket_path.parent() {
-            parent_path
-        } else {
-            return Err(io::Error::new(
-                io::ErrorKind::NotFound,
-                "invalid socket path",
-            ));
-        };
+        let parent = socket_path
+            .as_ref()
+            .parent()
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotFound, "Socket path does not have parent")
+            })?
+            .to_path_buf();
 
-        watcher
-            .watch(dir_path.as_ref(), RecursiveMode::NonRecursive)
-            .map_err(io::Error::other)?;
+        let inotify = Inotify::init()?;
+
+        inotify.watches().add(
+            &parent,
+            WatchMask::CREATE | WatchMask::MOVED_FROM | WatchMask::DELETE | WatchMask::DELETE_SELF,
+        )?;
+
+        let inotify = inotify.into_event_stream([0; 1024])?;
 
         Ok(Self {
-            socket_path,
-            watcher,
-            rx,
+            inotify,
+            parent,
+            filename,
         })
     }
 }
 
-impl Future for SocketWatcher {
-    type Output = io::Result<()>;
+#[derive(Debug)]
+pub enum SocketWatcherEvent {
+    Create(PathBuf),
+    Delete,
+}
 
-    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
-        let mut this = self.project();
-        let event = this.rx.poll_recv(cx);
-        match event {
-            Poll::Ready(Some(Ok(Event { kind, paths, .. })))
-                if paths.first().is_some()
-                    && paths.first().unwrap().as_path().file_name()
-                        == Some(OsStr::new(MEMPOOL_TX_IPC_FILE)) =>
-            {
-                if let notify::EventKind::Create(_) = kind {
-                    debug!("new mempool socket created");
-                    Poll::Ready(Ok(()))
-                } else {
-                    cx.waker().wake_by_ref();
-                    Poll::Pending
-                }
+impl Stream for SocketWatcher {
+    type Item = io::Result<SocketWatcherEvent>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        loop {
+            let event = match self.as_mut().inotify.poll_next_unpin(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Ready(Some(Err(err))) => return Poll::Ready(Some(Err(err))),
+                Poll::Ready(Some(Ok(event))) => event,
+            };
+
+            debug!(mask =? event.mask, "socket watcher inotify event");
+
+            if event.mask.contains(EventMask::DELETE_SELF) {
+                error!("socket watcher parent directory deleted");
+                return Poll::Ready(None);
             }
-            Poll::Ready(_) => {
-                cx.waker().wake_by_ref();
-                Poll::Pending
+
+            let Some(name) = &event.name else {
+                error!("socket watcher event does not have a name");
+                continue;
+            };
+
+            if name != &self.filename {
+                continue;
             }
-            Poll::Pending => Poll::Pending,
+
+            if event.mask.contains(EventMask::CREATE) {
+                return Poll::Ready(Some(Ok(SocketWatcherEvent::Create(self.parent.join(name)))));
+            }
+
+            if event.mask.contains(EventMask::MOVED_FROM) {
+                error!("socket watcher detected socket file moved");
+                return Poll::Ready(None);
+            }
+
+            if event.mask.contains(EventMask::DELETE) {
+                return Poll::Ready(Some(Ok(SocketWatcherEvent::Delete)));
+            }
+
+            warn!(filename =? event.name, mask =? event.mask, "socket watcher inotify unknown event");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, time::Duration};
+
+    use futures::StreamExt;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    /// Helper function to create a temporary directory for testing
+    fn setup_test_dir() -> (TempDir, PathBuf) {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let socket_path = temp_dir.path().join("test.sock");
+        (temp_dir, socket_path)
+    }
+
+    #[tokio::test]
+    async fn test_try_new_valid_path() {
+        let (_temp_dir, socket_path) = setup_test_dir();
+
+        let watcher = SocketWatcher::try_new(&socket_path);
+        assert!(
+            watcher.is_ok(),
+            "SocketWatcher should successfully initialize with valid path"
+        );
+
+        let watcher = watcher.unwrap();
+        assert_eq!(
+            watcher.filename,
+            socket_path.file_name().unwrap(),
+            "Filename should match the socket path filename"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_try_new_no_filename() {
+        let result = SocketWatcher::try_new("/");
+
+        assert!(result.is_err(), "Should fail with path without filename");
+        let err = result.err().unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        assert_eq!(
+            err.to_string(),
+            "Socket path does not have a filename",
+            "Error message should indicate missing filename"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_try_new_nonexistent_parent() {
+        let result = SocketWatcher::try_new("/nonexistent/directory/socket.sock");
+
+        assert!(
+            result.is_err(),
+            "Should fail with non-existent parent directory"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_socket_create_event() {
+        let (_temp_dir, socket_path) = setup_test_dir();
+
+        let mut watcher = SocketWatcher::try_new(&socket_path).expect("Failed to create watcher");
+
+        fs::write(&socket_path, b"").expect("Failed to create socket file");
+
+        let result = tokio::time::timeout(Duration::from_secs(2), watcher.next()).await;
+
+        assert!(result.is_ok(), "Should receive event within timeout");
+        let event = result.unwrap();
+        assert!(event.is_some(), "Stream should not be closed");
+
+        let event = event.unwrap();
+        assert!(event.is_ok(), "Event should not be an error");
+
+        match event.unwrap() {
+            SocketWatcherEvent::Create(path) => {
+                assert_eq!(
+                    path, socket_path,
+                    "Created path should match socket filename"
+                );
+            }
+            SocketWatcherEvent::Delete => panic!("Expected Create event, got Delete"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_socket_delete_event() {
+        let (_temp_dir, socket_path) = setup_test_dir();
+
+        fs::write(&socket_path, b"").expect("Failed to create socket file");
+
+        let mut watcher = SocketWatcher::try_new(&socket_path).expect("Failed to create watcher");
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        fs::remove_file(&socket_path).expect("Failed to delete socket file");
+
+        let result = tokio::time::timeout(Duration::from_secs(2), watcher.next()).await;
+
+        assert!(result.is_ok(), "Should receive event within timeout");
+        let event = result.unwrap();
+        assert!(event.is_some(), "Stream should not be closed");
+
+        let event = event.unwrap();
+        assert!(event.is_ok(), "Event should not be an error");
+
+        match event.unwrap() {
+            SocketWatcherEvent::Delete => {}
+            SocketWatcherEvent::Create(_) => panic!("Expected Delete event, got Create"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_socket_moved_from_terminates_stream() {
+        let (_temp_dir, socket_path) = setup_test_dir();
+
+        fs::write(&socket_path, b"").expect("Failed to create socket file");
+
+        let mut watcher = SocketWatcher::try_new(&socket_path).expect("Failed to create watcher");
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let moved_path = socket_path.with_extension("moved");
+        fs::rename(&socket_path, &moved_path).expect("Failed to move socket file");
+
+        let result = tokio::time::timeout(Duration::from_secs(2), watcher.next()).await;
+
+        assert!(result.is_ok(), "Should receive event within timeout");
+        let event = result.unwrap();
+        assert!(
+            event.is_none(),
+            "Stream should terminate when socket is moved"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parent_directory_deletion_terminates_stream() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let nested_dir = temp_dir.path().join("nested");
+        fs::create_dir(&nested_dir).expect("Failed to create nested dir");
+
+        let socket_path = nested_dir.join("test.sock");
+        let mut watcher = SocketWatcher::try_new(&socket_path).expect("Failed to create watcher");
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        fs::remove_dir(&nested_dir).expect("Failed to remove nested dir");
+
+        let result = tokio::time::timeout(Duration::from_secs(2), watcher.next()).await;
+
+        assert!(result.is_ok(), "Should receive event within timeout");
+        let event = result.unwrap();
+        assert!(
+            event.is_none(),
+            "Stream should terminate when parent directory is deleted"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_unrelated_file_events_ignored() {
+        let (_temp_dir, socket_path) = setup_test_dir();
+
+        let mut watcher = SocketWatcher::try_new(&socket_path).expect("Failed to create watcher");
+
+        let other_file = socket_path.with_file_name("other.txt");
+        fs::write(&other_file, b"test").expect("Failed to create other file");
+
+        let result = tokio::time::timeout(Duration::from_millis(500), watcher.next()).await;
+
+        assert!(
+            result.is_err(),
+            "Should timeout because unrelated file events are ignored"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_similar_filename_ignored() {
+        let (_temp_dir, socket_path) = setup_test_dir();
+
+        let mut watcher = SocketWatcher::try_new(&socket_path).expect("Failed to create watcher");
+
+        let similar_file = socket_path.with_extension("sock.bak");
+        fs::write(&similar_file, b"test").expect("Failed to create similar file");
+
+        let result = tokio::time::timeout(Duration::from_millis(500), watcher.next()).await;
+
+        assert!(
+            result.is_err(),
+            "Should timeout because similar filename is ignored"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_multiple_events_sequence() {
+        let (_temp_dir, socket_path) = setup_test_dir();
+
+        let mut watcher = SocketWatcher::try_new(&socket_path).expect("Failed to create watcher");
+
+        fs::write(&socket_path, b"").expect("Failed to create socket file");
+
+        let result = tokio::time::timeout(Duration::from_secs(2), watcher.next()).await;
+        assert!(result.is_ok(), "Should receive create event");
+        let event = result.unwrap().unwrap().unwrap();
+        assert!(
+            matches!(event, SocketWatcherEvent::Create(_)),
+            "First event should be Create"
+        );
+
+        fs::remove_file(&socket_path).expect("Failed to delete socket file");
+
+        let result = tokio::time::timeout(Duration::from_secs(2), watcher.next()).await;
+        assert!(result.is_ok(), "Should receive delete event");
+        let event = result.unwrap().unwrap().unwrap();
+        assert!(
+            matches!(event, SocketWatcherEvent::Delete),
+            "Second event should be Delete"
+        );
+
+        fs::write(&socket_path, b"").expect("Failed to create socket file again");
+
+        let result = tokio::time::timeout(Duration::from_secs(2), watcher.next()).await;
+        assert!(result.is_ok(), "Should receive second create event");
+        let event = result.unwrap().unwrap().unwrap();
+        assert!(
+            matches!(event, SocketWatcherEvent::Create(_)),
+            "Third event should be Create"
+        );
     }
 }


### PR DESCRIPTION
The `EthTxPoolBridgeHandle` runtime code was grafted onto an existing socket watching approach that was convoluted and involved complex state across poll calls. This change simplifies the watching logic for new txpool sockets along with tests. Additionally, it removes the `notify` dependency which helps cut back on several other transient dependencies. Finally, this change also resolves https://github.com/category-labs/monad-bft/issues/1956.

### Testing

Added unit tests to the `SocketWatcher` utility and `EthTxPoolBridge` demonstrating various behaviors. The change was also tested on `devnet7` by manually restarting `monad-bft` several times and observing successful reconnections.