### PR TITLE
Raptorcast: Remove peer lookup from packet builder

### DIFF
--- a/monad-raptor/src/r10/nonsystematic/encoder.rs
+++ b/monad-raptor/src/r10/nonsystematic/encoder.rs
@@ -55,7 +55,7 @@ pub struct Encoder<'a> {
 }
 
 impl Encoder<'_> {
-    pub fn new(src: &[u8], symbol_len: usize) -> Result<Encoder, Error> {
+    pub fn new(src: &[u8], symbol_len: usize) -> Result<Encoder<'_>, Error> {
         if symbol_len == 0 {
             return Err(Error::new(
                 ErrorKind::InvalidInput,

--- a/monad-raptorcast/src/auth/protocol.rs
+++ b/monad-raptorcast/src/auth/protocol.rs
@@ -75,7 +75,7 @@ pub trait AuthenticationProtocol {
 
     fn next_deadline(&self) -> Option<Instant>;
 
-    fn metrics(&self) -> ExecutorMetricsChain;
+    fn metrics(&self) -> ExecutorMetricsChain<'_>;
 }
 
 pub struct WireAuthProtocol {
@@ -185,7 +185,7 @@ impl AuthenticationProtocol for WireAuthProtocol {
         self.api.has_any_session_by_public_key(public_key)
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         self.api.metrics()
     }
 }
@@ -288,7 +288,7 @@ impl<P: PubKey> AuthenticationProtocol for NoopAuthProtocol<P> {
         false
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         ExecutorMetricsChain::default()
     }
 }

--- a/monad-raptorcast/src/auth/socket.rs
+++ b/monad-raptorcast/src/auth/socket.rs
@@ -209,7 +209,7 @@ where
         }
     }
 
-    pub fn metrics(&self) -> ExecutorMetricsChain {
+    pub fn metrics(&self) -> ExecutorMetricsChain<'_> {
         let mut chain = ExecutorMetricsChain::default().push(self.metrics.as_ref());
         if let Some(authenticated) = &self.authenticated {
             chain = chain.chain(authenticated.auth_protocol.metrics());

--- a/monad-raptorcast/src/decoding.rs
+++ b/monad-raptorcast/src/decoding.rs
@@ -330,7 +330,7 @@ where
         self.pending_messages.consistency_breaches()
     }
 
-    pub fn metrics(&self) -> ExecutorMetricsChain {
+    pub fn metrics(&self) -> ExecutorMetricsChain<'_> {
         ExecutorMetricsChain::default()
             .push(&self.metrics)
             .push(self.pending_messages.validator.metrics())

--- a/monad-raptorcast/src/packet/assigner.rs
+++ b/monad-raptorcast/src/packet/assigner.rs
@@ -334,7 +334,7 @@ pub(crate) trait ChunkAssigner<PT: PubKey> {
         &self,
         num_symbols: usize,
         preferred_order: Option<ChunkOrder>,
-    ) -> Result<ChunkAssignment<PT>>;
+    ) -> Result<ChunkAssignment<'_, PT>>;
 }
 
 impl<PT: PubKey> ChunkAssigner<PT> for Replicated<PT> {
@@ -342,7 +342,7 @@ impl<PT: PubKey> ChunkAssigner<PT> for Replicated<PT> {
         &self,
         num_symbols: usize,
         preferred_order: Option<ChunkOrder>,
-    ) -> Result<ChunkAssignment<PT>> {
+    ) -> Result<ChunkAssignment<'_, PT>> {
         if self.recipients.is_empty() {
             tracing::warn!("no recipients specified for chunk assigner");
             return Ok(ChunkAssignment::empty());
@@ -415,7 +415,7 @@ impl<PT: PubKey> Partitioned<PT> {
         }
     }
 
-    fn assign_gso(&self, num_symbols: usize) -> ChunkAssignment<PT> {
+    fn assign_gso(&self, num_symbols: usize) -> ChunkAssignment<'_, PT> {
         let num_nodes = self.weighted_nodes.len();
         let mut assignment = ChunkAssignment::with_capacity(num_nodes);
         assignment.hint_order(ChunkOrder::GsoFriendly);
@@ -439,7 +439,7 @@ impl<PT: PubKey> ChunkAssigner<PT> for Partitioned<PT> {
         &self,
         num_symbols: usize,
         _preferred_order: Option<ChunkOrder>,
-    ) -> Result<ChunkAssignment<PT>> {
+    ) -> Result<ChunkAssignment<'_, PT>> {
         if self.weighted_nodes.is_empty() {
             tracing::warn!("no nodes specified for partitioned chunk assigner");
             return Ok(ChunkAssignment::empty());
@@ -511,7 +511,7 @@ impl<PT: PubKey> ChunkAssigner<PT> for StakeBasedWithRC<PT> {
         &self,
         num_symbols: usize,
         _preferred_order: Option<ChunkOrder>,
-    ) -> Result<ChunkAssignment<PT>> {
+    ) -> Result<ChunkAssignment<'_, PT>> {
         if self.validator_set.is_empty() {
             tracing::warn!("no nodes specified for partitioned chunk assigner");
             return Ok(ChunkAssignment::empty());
@@ -625,7 +625,7 @@ mod tests {
             Self { slices }
         }
 
-        fn assign_chunks(&self) -> ChunkAssignment<PT> {
+        fn assign_chunks(&self) -> ChunkAssignment<'_, PT> {
             let mut assignment = ChunkAssignment::with_capacity(self.slices.len());
             for slice in &self.slices {
                 assignment.push(&slice.0, slice.1.clone());

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -383,7 +383,7 @@ where
         }
     }
 
-    fn metrics(&self) -> ExecutorMetricsChain {
+    fn metrics(&self) -> ExecutorMetricsChain<'_> {
         match &self.role {
             Role::Publisher(publisher) => publisher.metrics().into(),
             Role::Client(client) => client.metrics().into(),

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -1205,7 +1205,7 @@ mod tests {
         #[case] raptorcast: bool,
         #[case] should_succeed: bool,
     ) {
-        let (key, validators, known_addresses) = validator_set();
+        let (key, validators, _known_addresses) = validator_set();
         let epoch_validators = validators.view_without(vec![&NodeId::new(key.pubkey())]);
         let target = if raptorcast {
             BuildTarget::Raptorcast(epoch_validators)
@@ -1213,7 +1213,7 @@ mod tests {
             BuildTarget::Broadcast(epoch_validators.into())
         };
         let app_msg = vec![0; app_msg_len];
-        let messages = MessageBuilder::new(&key, known_addresses)
+        let messages = MessageBuilder::new(&key)
             .segment_size(DEFAULT_SEGMENT_SIZE as usize)
             .group_id(GroupId::Primary(EPOCH))
             .redundancy(Redundancy::from_u8(1))

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -130,7 +130,7 @@ impl<P: PubKey> FullNodes<P> {
         Self { list: nodes }
     }
 
-    pub fn view(&self) -> FullNodesView<P> {
+    pub fn view(&self) -> FullNodesView<'_, P> {
         FullNodesView(&self.list)
     }
 }
@@ -443,7 +443,7 @@ where
         &self.round_span
     }
 
-    fn empty_iterator(&self) -> GroupIterator<ST> {
+    fn empty_iterator(&self) -> GroupIterator<'_, ST> {
         GroupIterator {
             group: self,
             num_consumed: usize::MAX,
@@ -461,7 +461,7 @@ where
         &self,
         author_id: &NodeId<CertificateSignaturePubKey<ST>>,
         seed: usize,
-    ) -> GroupIterator<ST> {
+    ) -> GroupIterator<'_, ST> {
         // Hint for the index of author_id within self.sorted_other_peers.
         // We want to skip it when iterating the peers for broadcasting.
         let author_id_ix = if let Some(root_vid) = self.validator_id {
@@ -647,7 +647,7 @@ where
         &self,
         msg_group_id: GroupId,
         msg_author: &NodeId<CertificateSignaturePubKey<ST>>, // skipped when iterating RaptorCast group
-    ) -> Option<GroupIterator<ST>> {
+    ) -> Option<GroupIterator<'_, ST>> {
         let rebroadcast_group = match msg_group_id {
             GroupId::Primary(msg_epoch) => self.validator_map.get(&msg_epoch)?,
             GroupId::Secondary(msg_round) => {

--- a/monad-wireauth/src/api.rs
+++ b/monad-wireauth/src/api.rs
@@ -91,7 +91,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         }
     }
 
-    pub fn metrics(&self) -> ExecutorMetricsChain {
+    pub fn metrics(&self) -> ExecutorMetricsChain<'_> {
         ExecutorMetricsChain::default()
             .push(&self.metrics)
             .push(self.state.metrics())


### PR DESCRIPTION
This PR removes the dependency of peer lookup from raptorcast packet builder and postpone the lookup to actual message flushing phase. The change is meant to simplify the packet builder, and further makes it easier to build alternative protocols based on top of the packet builder.