### PR TITLE
monad-wireauth: add gc idle timer for sessions without useful data

### DIFF
--- a/monad-wireauth/README.md
+++ b/monad-wireauth/README.md
@@ -174,3 +174,5 @@ session_decrypt         time:   [166.11 ns 168.75 ns 171.20 ns]
 | `psk` | [u8; 32] | zeros | optional pre-shared key mixed into handshake for additional auth |
 | `max_initiated_sessions` | usize | 1000 | max concurrent initiated sessions (handshakes in progress) |
 | `max_buffered_bytes_per_session` | usize | 131072 | max bytes of buffered messages per initiated session (128KB) |
+| `gc_idle_timeout` | Duration | 120s | idle time without useful data before session is garbage collected (keepalives don't reset) |
+| `max_expired_timers_per_tick` | usize | 10000 | cap expired timers processed per `API::tick` |

--- a/monad-wireauth/src/api.rs
+++ b/monad-wireauth/src/api.rs
@@ -166,27 +166,39 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         let duration_since_start = self.context.duration_since_start();
 
         self.filter.tick(duration_since_start);
+        let max_expired_timers_per_tick = self.config.max_expired_timers_per_tick;
 
-        let expired_timers: Vec<(Duration, SessionIndex)> = self
+        let has_expired_timer = self
             .timers
-            .range(..=(duration_since_start, SessionIndex::MAX))
-            .copied()
-            .collect();
-
+            .first()
+            .is_some_and(|&(deadline, _)| deadline <= duration_since_start);
         if let Some(last_tick) = self.last_tick {
             let checked_duration = duration_since_start.saturating_sub(last_tick);
             trace!(
                 checked_duration_ms = checked_duration.as_millis(),
-                expired_timers = expired_timers.len(),
+                has_expired_timer,
+                timers_size = self.timers.len(),
                 "tick"
             );
         } else {
-            trace!(expired_timers = expired_timers.len(), "tick");
+            trace!(has_expired_timer, timers_size = self.timers.len(), "tick");
         }
 
-        for (duration, session_id) in expired_timers {
-            self.timers.remove(&(duration, session_id));
+        let mut processed_timers = 0usize;
+
+        while processed_timers < max_expired_timers_per_tick {
+            let Some((deadline, _)) = self.timers.first().copied() else {
+                break;
+            };
+            if deadline > duration_since_start {
+                break;
+            }
+            let (duration, session_id) = self
+                .timers
+                .pop_first()
+                .expect("timer disappeared after checking it exists");
             self.metrics[self.metric_names.state_timers_size] = self.timers.len() as u64;
+            processed_timers += 1;
 
             if let Some(elapsed) = duration_since_start.checked_sub(duration) {
                 let elapsed_ms = elapsed.as_millis();

--- a/monad-wireauth/src/config/mod.rs
+++ b/monad-wireauth/src/config/mod.rs
@@ -67,6 +67,10 @@ pub struct Config {
     pub max_initiated_sessions: usize,
     /// max bytes of buffered messages per initiated session
     pub max_buffered_bytes_per_session: usize,
+    /// idle time (without useful data) before session is garbage collected
+    pub gc_idle_timeout: Duration,
+    /// cap how many expired timers are processed per tick (dos protection)
+    pub max_expired_timers_per_tick: usize,
 }
 
 impl Default for Config {
@@ -93,6 +97,8 @@ impl Default for Config {
             psk: Zeroizing::new([0u8; 32]),
             max_initiated_sessions: 1000,
             max_buffered_bytes_per_session: 128 * 1024,
+            gc_idle_timeout: Duration::from_secs(120),
+            max_expired_timers_per_tick: 10_000,
         }
     }
 }

--- a/monad-wireauth/src/filter.rs
+++ b/monad-wireauth/src/filter.rs
@@ -50,6 +50,9 @@ pub struct Filter {
 }
 
 impl Filter {
+    // This is essentially a "configuration constructor" for `Filter`.
+    // Keeping it as a single constructor avoids proliferating ad-hoc config structs
+    // across call sites. Clippy's default threshold is 7 args; we intentionally exceed it.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         metric_names: &'static MetricNames,

--- a/monad-wireauth/src/session/common.rs
+++ b/monad-wireauth/src/session/common.rs
@@ -77,6 +77,7 @@ pub struct SessionState {
     pub rekey_deadline: Option<Duration>,
     pub session_timeout_deadline: Option<Duration>,
     pub max_session_duration_deadline: Option<Duration>,
+    pub gc_deadline: Option<Duration>,
     pub stored_cookie: Option<[u8; 16]>,
     pub last_handshake_mac1: Option<[u8; 16]>,
     pub retry_attempts: u64,
@@ -103,6 +104,7 @@ impl SessionState {
             rekey_deadline: None,
             session_timeout_deadline: None,
             max_session_duration_deadline: None,
+            gc_deadline: None,
             stored_cookie: None,
             last_handshake_mac1: None,
             retry_attempts,
@@ -165,12 +167,21 @@ impl SessionState {
         self.max_session_duration_deadline = None;
     }
 
+    pub fn reset_gc_deadline(&mut self, duration_since_start: Duration, timer_duration: Duration) {
+        self.gc_deadline = Some(duration_since_start + timer_duration);
+    }
+
+    pub fn clear_gc_deadline(&mut self) {
+        self.gc_deadline = None;
+    }
+
     pub fn get_next_deadline(&self) -> Option<Duration> {
         [
             self.keepalive_deadline,
             self.rekey_deadline,
             self.session_timeout_deadline,
             self.max_session_duration_deadline,
+            self.gc_deadline,
         ]
         .iter()
         .filter_map(|&timer| timer)

--- a/monad-wireauth/src/session/initiator.rs
+++ b/monad-wireauth/src/session/initiator.rs
@@ -142,6 +142,8 @@ impl InitiatorState {
         );
         self.common
             .set_max_session_duration(duration_since_start, config.max_session_duration);
+        self.common
+            .reset_gc_deadline(duration_since_start, config.gc_idle_timeout);
 
         let transport = TransportState::new(
             validated_response.remote_index,

--- a/monad-wireauth/src/session/responder.rs
+++ b/monad-wireauth/src/session/responder.rs
@@ -151,6 +151,9 @@ impl ResponderState {
         self.transport
             .common
             .set_max_session_duration(duration_since_start, config.max_session_duration);
+        self.transport
+            .common
+            .reset_gc_deadline(duration_since_start, config.gc_idle_timeout);
 
         let timer = self
             .transport

--- a/monad-wireauth/tests/tests.rs
+++ b/monad-wireauth/tests/tests.rs
@@ -951,3 +951,139 @@ fn test_buffer_message_session_not_found() {
     let err = result.unwrap_err();
     assert!(matches!(err, monad_wireauth::Error::SessionNotFound));
 }
+
+#[test]
+fn test_gc_timer_reset_on_useful_data() {
+    init_tracing();
+    let config = Config {
+        gc_idle_timeout: Duration::from_secs(10),
+        session_timeout: Duration::from_secs(1000),
+        session_timeout_jitter: Duration::ZERO,
+        keepalive_interval: Duration::from_secs(3),
+        keepalive_jitter: Duration::ZERO,
+        ..Config::default()
+    };
+
+    let mut rng = rng();
+    let keypair1 = monad_secp::KeyPair::generate(&mut rng);
+    let peer1_pubkey = keypair1.pubkey();
+    let context1 = TestContext::new();
+    let mut peer1 = API::new(DEFAULT_METRICS, config.clone(), keypair1, context1.clone());
+
+    let keypair2 = monad_secp::KeyPair::generate(&mut rng);
+    let peer2_pubkey = keypair2.pubkey();
+    let context2 = TestContext::new();
+    let mut peer2 = API::new(DEFAULT_METRICS, config, keypair2, context2.clone());
+
+    let peer1_addr: SocketAddr = "127.0.0.1:8001".parse().unwrap();
+    let peer2_addr: SocketAddr = "127.0.0.1:8002".parse().unwrap();
+
+    peer1
+        .connect(peer2_pubkey, peer2_addr, DEFAULT_RETRY_ATTEMPTS)
+        .unwrap();
+    let init = collect::<HandshakeInitiation>(&mut peer1);
+    dispatch(&mut peer2, &init, peer1_addr);
+    let resp = collect::<HandshakeResponse>(&mut peer2);
+    dispatch(&mut peer1, &resp, peer2_addr);
+    let confirm = collect::<DataPacketHeader>(&mut peer1);
+    dispatch(&mut peer2, &confirm, peer1_addr);
+
+    // advance close to gc timeout, peer1 sends (resets peer1 gc), peer2 receives (resets peer2 gc)
+    context1.advance_time(Duration::from_secs(8));
+    context2.advance_time(Duration::from_secs(8));
+    peer1.tick();
+    peer2.tick();
+    let mut plaintext1 = b"from peer1".to_vec();
+    let packet1 = encrypt(&mut peer1, &peer2_pubkey, &mut plaintext1);
+    assert_eq!(decrypt(&mut peer2, &packet1, peer1_addr), b"from peer1");
+
+    // advance again, peer2 sends (resets peer2 gc), peer1 receives (resets peer1 gc)
+    context1.advance_time(Duration::from_secs(8));
+    context2.advance_time(Duration::from_secs(8));
+    peer1.tick();
+    peer2.tick();
+    let mut plaintext2 = b"from peer2".to_vec();
+    let packet2 = encrypt(&mut peer2, &peer1_pubkey, &mut plaintext2);
+    assert_eq!(decrypt(&mut peer1, &packet2, peer2_addr), b"from peer2");
+
+    // both sessions still alive after useful data exchange
+    assert!(peer1.is_connected_public_key(&peer2_pubkey));
+    assert!(peer2.is_connected_public_key(&peer1_pubkey));
+
+    // send keepalives multiple times - they should NOT reset gc timer
+    for _ in 0..3 {
+        context1.advance_time(Duration::from_secs(4));
+        context2.advance_time(Duration::from_secs(4));
+        peer1.tick();
+        peer2.tick();
+
+        // keepalives are triggered and exchanged
+        if let Some((addr, keepalive)) = peer1.next_packet() {
+            assert_eq!(addr, peer2_addr);
+            dispatch(&mut peer2, &keepalive, peer1_addr);
+        }
+        if let Some((addr, keepalive)) = peer2.next_packet() {
+            assert_eq!(addr, peer1_addr);
+            dispatch(&mut peer1, &keepalive, peer2_addr);
+        }
+    }
+
+    // sessions terminated by gc despite keepalives being exchanged
+    assert!(!peer1.is_connected_public_key(&peer2_pubkey));
+    assert!(!peer2.is_connected_public_key(&peer1_pubkey));
+}
+
+#[test]
+fn test_gc_terminate_has_no_side_effects() {
+    init_tracing();
+    let config = Config {
+        gc_idle_timeout: Duration::from_secs(5),
+        session_timeout: Duration::from_secs(1000),
+        session_timeout_jitter: Duration::ZERO,
+        keepalive_interval: Duration::from_secs(1),
+        keepalive_jitter: Duration::ZERO,
+        ..Config::default()
+    };
+
+    let mut rng = rng();
+    let keypair1 = monad_secp::KeyPair::generate(&mut rng);
+    let peer1_pubkey = keypair1.pubkey();
+    let context1 = TestContext::new();
+    let mut peer1 = API::new(DEFAULT_METRICS, config.clone(), keypair1, context1.clone());
+
+    let keypair2 = monad_secp::KeyPair::generate(&mut rng);
+    let peer2_pubkey = keypair2.pubkey();
+    let context2 = TestContext::new();
+    let mut peer2 = API::new(DEFAULT_METRICS, config, keypair2, context2.clone());
+
+    let peer1_addr: SocketAddr = "127.0.0.1:8001".parse().unwrap();
+    let peer2_addr: SocketAddr = "127.0.0.1:8002".parse().unwrap();
+
+    // Establish session without exchanging any useful data.
+    peer1
+        .connect(peer2_pubkey, peer2_addr, DEFAULT_RETRY_ATTEMPTS)
+        .unwrap();
+    let init = collect::<HandshakeInitiation>(&mut peer1);
+    dispatch(&mut peer2, &init, peer1_addr);
+    let resp = collect::<HandshakeResponse>(&mut peer2);
+    dispatch(&mut peer1, &resp, peer2_addr);
+    let confirm = collect::<DataPacketHeader>(&mut peer1);
+    dispatch(&mut peer2, &confirm, peer1_addr);
+
+    // Drain any leftover packets from handshake.
+    while peer1.next_packet().is_some() {}
+    while peer2.next_packet().is_some() {}
+
+    // Jump past GC and keepalive deadline; the tick should terminate sessions without
+    // enqueueing a keepalive (or other actions) in the same tick.
+    context1.advance_time(Duration::from_secs(6));
+    context2.advance_time(Duration::from_secs(6));
+    peer1.tick();
+    peer2.tick();
+
+    assert!(peer1.next_packet().is_none());
+    assert!(peer2.next_packet().is_none());
+
+    assert!(!peer1.is_connected_public_key(&peer2_pubkey));
+    assert!(!peer2.is_connected_public_key(&peer1_pubkey));
+}


### PR DESCRIPTION
cleanup sessions that didn't transmit useful data for 2 minutes (useful data is anything beside keapalives