### PR TITLE
tcp wireauth integration

### DIFF
--- a/monad-dataplane/src/lib.rs
+++ b/monad-dataplane/src/lib.rs
@@ -41,7 +41,7 @@ pub(crate) mod buffer_ext;
 pub mod tcp;
 pub mod udp;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum TcpSocketId {
     Raptorcast,
     AuthenticatedRaptorcast,
@@ -524,7 +524,7 @@ impl TcpSocketReader {
 pub struct TcpSocketWriter {
     socket_id: TcpSocketId,
     socket_addr: SocketAddr,
-    egress_tx: mpsc::Sender<(SocketAddr, TcpMsg)>,
+    egress_tx: mpsc::Sender<(TcpSocketId, SocketAddr, TcpMsg)>,
     msgs_dropped: Arc<AtomicUsize>,
 }
 
@@ -532,7 +532,7 @@ impl TcpSocketWriter {
     pub fn write(&self, addr: SocketAddr, msg: TcpMsg) {
         let msg_length = msg.msg.len();
 
-        match self.egress_tx.try_send((addr, msg)) {
+        match self.egress_tx.try_send((self.socket_id, addr, msg)) {
             Ok(()) => {}
             Err(TrySendError::Full(_)) => {
                 let total = self.msgs_dropped.fetch_add(1, Ordering::Relaxed);

--- a/monad-dataplane/src/tcp/mod.rs
+++ b/monad-dataplane/src/tcp/mod.rs
@@ -15,18 +15,24 @@
 
 use std::{
     collections::BTreeMap,
+    io::Error,
     net::{IpAddr, SocketAddr},
     num::NonZeroU32,
+    os::fd::{AsRawFd, RawFd},
     sync::{Arc, Mutex},
     time::Duration,
 };
 
 use monoio::{
-    net::{ListenerOpts, TcpListener},
+    io::{AsyncWriteRentExt, Splitable},
+    net::{
+        tcp::{TcpOwnedReadHalf, TcpOwnedWriteHalf},
+        ListenerOpts, TcpListener, TcpStream,
+    },
     spawn,
 };
-use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use tracing::trace;
+use tokio::sync::{mpsc, watch};
+use tracing::{trace, warn};
 use zerocopy::{
     byteorder::little_endian::{U32, U64},
     FromBytes, Immutable, IntoBytes,
@@ -61,15 +67,102 @@ impl TcpMsgHdr {
     }
 }
 
+pub(crate) type TcpReadHalf = TcpOwnedReadHalf;
+
+pub(crate) struct TcpWriteHalf {
+    inner: TcpOwnedWriteHalf,
+    raw_fd: RawFd,
+}
+
+impl TcpWriteHalf {
+    pub(crate) fn set_cork(&self, enabled: bool) {
+        let r = unsafe {
+            let cork_flag: libc::c_int = if enabled { 1 } else { 0 };
+            libc::setsockopt(
+                self.raw_fd,
+                libc::SOL_TCP,
+                libc::TCP_CORK,
+                &cork_flag as *const _ as _,
+                std::mem::size_of_val(&cork_flag) as _,
+            )
+        };
+        if r != 0 {
+            warn!(
+                "setsockopt(TCP_CORK) failed with: {}",
+                Error::last_os_error()
+            );
+        }
+    }
+
+    pub(crate) fn unacked_bytes(&self) -> usize {
+        let mut outq: libc::c_int = 0;
+        let r = unsafe { libc::ioctl(self.raw_fd, libc::TIOCOUTQ, &mut outq as *mut libc::c_int) };
+        if r == 0 {
+            outq as _
+        } else {
+            warn!("ioctl(TIOCOUTQ) failed with: {}", Error::last_os_error());
+            0
+        }
+    }
+
+    pub(crate) async fn write_all<T: monoio::buf::IoBuf>(
+        &mut self,
+        buf: T,
+    ) -> monoio::BufResult<usize, T> {
+        self.inner.write_all(buf).await
+    }
+}
+
+pub(crate) fn split_stream(stream: TcpStream) -> (TcpReadHalf, TcpWriteHalf) {
+    let raw_fd = stream.as_raw_fd();
+    let (read, write) = stream.into_split();
+    (
+        read,
+        TcpWriteHalf {
+            inner: write,
+            raw_fd,
+        },
+    )
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TcpConnection(watch::Sender<bool>);
+
+impl TcpConnection {
+    pub(crate) fn new() -> Self {
+        Self(watch::channel(false).0)
+    }
+
+    pub(crate) fn disconnect(&self) {
+        self.0.send_replace(true);
+    }
+
+    pub(crate) async fn disconnected(&self) {
+        let mut rx = self.0.subscribe();
+        let disconnected = *rx.borrow_and_update();
+        if !disconnected {
+            let _ = rx.changed().await;
+        }
+    }
+
+    #[cfg(test)]
+    fn is_disconnected(&self) -> bool {
+        *self.0.borrow()
+    }
+}
+
 pub(crate) fn spawn_tasks(
     cfg: TcpConfig,
     tcp_control_map: TcpControl,
     addrlist: Arc<Addrlist>,
     socket_configs: Vec<(TcpSocketId, SocketAddr, mpsc::Sender<RecvTcpMsg>)>,
-    tcp_egress_rx: mpsc::Receiver<(SocketAddr, TcpMsg)>,
+    tcp_egress_rx: mpsc::Receiver<(TcpSocketId, SocketAddr, TcpMsg)>,
     bound_addrs_tx: std::sync::mpsc::SyncSender<Vec<(TcpSocketId, SocketAddr)>>,
 ) {
     let mut bound_addrs = Vec::with_capacity(socket_configs.len());
+    let (write_half_tx, write_half_rx) = mpsc::unbounded_channel();
+
+    let mut read_half_txs = BTreeMap::new();
 
     let rx_state = rx::RxState::new(
         addrlist.clone(),
@@ -83,18 +176,32 @@ pub(crate) fn spawn_tasks(
         let actual_addr = tcp_listener.local_addr().unwrap();
         bound_addrs.push((socket_id, actual_addr));
 
+        let (read_half_tx, read_half_rx) = mpsc::unbounded_channel();
+        read_half_txs.insert(socket_id, read_half_tx);
+
         spawn(rx::task(
-            cfg.rate_limit,
-            tcp_control_map.clone(),
+            rx::RxContext {
+                socket_id,
+                rate_limit: cfg.rate_limit,
+                tcp_control_map: tcp_control_map.clone(),
+                tcp_ingress_tx: ingress_tx,
+                write_half_tx: write_half_tx.clone(),
+            },
             rx_state.clone(),
             tcp_listener,
-            ingress_tx,
+            read_half_rx,
         ));
         trace!(?socket_id, ?socket_addr, actual_addr = ?actual_addr, "created tcp listener");
     }
 
     bound_addrs_tx.send(bound_addrs).unwrap();
-    spawn(tx::task(cfg, addrlist, tcp_egress_rx));
+    spawn(tx::task(
+        cfg,
+        addrlist,
+        tcp_egress_rx,
+        write_half_rx,
+        read_half_txs,
+    ));
 }
 
 // Minimum message receive/transmit speed in bytes per second.  Messages that are
@@ -138,27 +245,18 @@ impl TcpRateLimit {
     }
 }
 
-#[derive(Debug, Clone)]
-pub(crate) enum TcpControlMsg {
-    Disconnect,
-}
-
 pub(crate) type TcpIdentifier = (IpAddr, u16, u64);
-pub(crate) type TcpControlSender = UnboundedSender<TcpControlMsg>;
-pub(crate) type TcpControlReceiver = UnboundedReceiver<TcpControlMsg>;
 
 #[derive(Debug, Clone)]
-pub(crate) struct TcpControl(Arc<Mutex<BTreeMap<TcpIdentifier, TcpControlSender>>>);
+pub(crate) struct TcpControl(Arc<Mutex<BTreeMap<TcpIdentifier, TcpConnection>>>);
 
 impl TcpControl {
     pub(crate) fn new() -> TcpControl {
         TcpControl(Arc::new(Mutex::new(BTreeMap::new())))
     }
 
-    pub(crate) fn register(&self, id: TcpIdentifier) -> TcpControlReceiver {
-        let (tx, rx) = mpsc::unbounded_channel();
-        self.0.lock().unwrap().insert(id, tx);
-        rx
+    pub(crate) fn register(&self, id: TcpIdentifier, connection: TcpConnection) {
+        self.0.lock().unwrap().insert(id, connection);
     }
 
     pub(crate) fn unregister(&self, id: &TcpIdentifier) {
@@ -166,18 +264,11 @@ impl TcpControl {
     }
 
     #[allow(unused)]
-    pub(crate) fn send_lossy(&self, id: &TcpIdentifier, msg: TcpControlMsg) {
-        if let Some(tx) = self.0.lock().unwrap().get(id) {
-            let _ = tx.send(msg);
-        }
-    }
-
-    #[allow(unused)]
     pub(crate) fn disconnect_ip(&self, ip: IpAddr) {
         let map = self.0.lock().unwrap();
         let mut count = 0;
-        for (id, tx) in map.range((ip, u16::MIN, u64::MIN)..(ip, u16::MAX, u64::MAX)) {
-            let _ = tx.send(TcpControlMsg::Disconnect);
+        for (id, connection) in map.range((ip, u16::MIN, u64::MIN)..(ip, u16::MAX, u64::MAX)) {
+            connection.disconnect();
             count += 1;
         }
         trace!(
@@ -191,8 +282,8 @@ impl TcpControl {
     pub(crate) fn disconnect_socket(&self, ip: IpAddr, port: u16) {
         let map = self.0.lock().unwrap();
         let mut count = 0;
-        for (_, tx) in map.range((ip, port, u64::MIN)..(ip, port, u64::MAX)) {
-            let _ = tx.send(TcpControlMsg::Disconnect);
+        for (_, connection) in map.range((ip, port, u64::MIN)..(ip, port, u64::MAX)) {
+            connection.disconnect();
             count += 1;
         }
         trace!(
@@ -208,12 +299,18 @@ impl TcpControl {
 mod tests {
     use std::{
         collections::HashMap,
+        io::ErrorKind,
         net::{IpAddr, Ipv4Addr},
+        num::NonZeroU32,
     };
 
+    use bytes::BytesMut;
+    use monoio::io::{AsyncReadRentExt, AsyncWriteRentExt, Splitable};
     use rstest::*;
+    use zerocopy::IntoBytes;
 
     use super::*;
+    use crate::{addrlist::Addrlist, TcpSocketId};
 
     #[fixture]
     fn tcp_control() -> TcpControl {
@@ -227,28 +324,23 @@ mod tests {
 
     #[rstest]
     fn test_register_and_unregister(tcp_control: TcpControl, tcp_id: TcpIdentifier) {
-        let _rx = tcp_control.register(tcp_id);
-        tcp_control.send_lossy(&tcp_id, TcpControlMsg::Disconnect);
+        let connection = TcpConnection::new();
+        tcp_control.register(tcp_id, connection.clone());
         tcp_control.unregister(&tcp_id);
-        tcp_control.send_lossy(&tcp_id, TcpControlMsg::Disconnect);
-    }
-
-    #[rstest]
-    fn test_send_lossy_existing_and_nonexistent(tcp_control: TcpControl, tcp_id: TcpIdentifier) {
-        tcp_control.send_lossy(&tcp_id, TcpControlMsg::Disconnect);
-
-        let mut rx = tcp_control.register(tcp_id);
-        tcp_control.send_lossy(&tcp_id, TcpControlMsg::Disconnect);
-        assert!(matches!(rx.try_recv().unwrap(), TcpControlMsg::Disconnect));
+        tcp_control.disconnect_socket(tcp_id.0, tcp_id.1);
+        assert!(!connection.is_disconnected());
     }
 
     #[rstest]
     fn test_multiple_registrations_same_id(tcp_control: TcpControl, tcp_id: TcpIdentifier) {
-        let _rx1 = tcp_control.register(tcp_id);
-        let mut rx2 = tcp_control.register(tcp_id);
+        let connection1 = TcpConnection::new();
+        let connection2 = TcpConnection::new();
+        tcp_control.register(tcp_id, connection1.clone());
+        tcp_control.register(tcp_id, connection2.clone());
 
-        tcp_control.send_lossy(&tcp_id, TcpControlMsg::Disconnect);
-        assert!(matches!(rx2.try_recv().unwrap(), TcpControlMsg::Disconnect));
+        tcp_control.disconnect_socket(tcp_id.0, tcp_id.1);
+        assert!(!connection1.is_disconnected());
+        assert!(connection2.is_disconnected());
     }
 
     #[rstest]
@@ -285,22 +377,21 @@ mod tests {
         #[case] disconnect_ip: IpAddr,
         #[case] expected_disconnected_indices: Vec<usize>,
     ) {
-        let mut socket_receivers = HashMap::new();
+        let mut connections = HashMap::new();
 
         for (i, &socket) in sockets.iter().enumerate() {
-            let rx = tcp_control.register(socket);
-            socket_receivers.insert(i, rx);
+            let connection = TcpConnection::new();
+            tcp_control.register(socket, connection.clone());
+            connections.insert(i, connection);
         }
 
         tcp_control.disconnect_ip(disconnect_ip);
 
-        for (i, mut rx) in socket_receivers {
-            let should_disconnect = expected_disconnected_indices.contains(&i);
-            if should_disconnect {
-                assert!(matches!(rx.try_recv().unwrap(), TcpControlMsg::Disconnect));
-            } else {
-                assert!(rx.try_recv().is_err());
-            }
+        for (i, connection) in connections {
+            assert_eq!(
+                connection.is_disconnected(),
+                expected_disconnected_indices.contains(&i)
+            );
         }
     }
 
@@ -343,22 +434,332 @@ mod tests {
         #[case] disconnect_port: u16,
         #[case] expected_disconnected_indices: Vec<usize>,
     ) {
-        let mut socket_receivers = HashMap::new();
+        let mut connections = HashMap::new();
 
         for (i, &socket) in sockets.iter().enumerate() {
-            let rx = tcp_control.register(socket);
-            socket_receivers.insert(i, rx);
+            let connection = TcpConnection::new();
+            tcp_control.register(socket, connection.clone());
+            connections.insert(i, connection);
         }
 
         tcp_control.disconnect_socket(disconnect_ip, disconnect_port);
 
-        for (i, mut rx) in socket_receivers {
-            let should_disconnect = expected_disconnected_indices.contains(&i);
-            if should_disconnect {
-                assert!(matches!(rx.try_recv().unwrap(), TcpControlMsg::Disconnect));
-            } else {
-                assert!(rx.try_recv().is_err());
-            }
+        for (i, connection) in connections {
+            assert_eq!(
+                connection.is_disconnected(),
+                expected_disconnected_indices.contains(&i)
+            );
         }
+    }
+
+    async fn write_tcp_message(
+        write_half: &mut monoio::net::tcp::TcpOwnedWriteHalf,
+        payload: &[u8],
+    ) {
+        let header = TcpMsgHdr::new(payload.len() as u64);
+        let (ret, _) = write_half
+            .write_all(Box::<[u8]>::from(header.as_bytes()))
+            .await;
+        ret.unwrap();
+        let (ret, _) = write_half.write_all(payload.to_vec()).await;
+        ret.unwrap();
+    }
+
+    async fn read_tcp_message(read_half: &mut monoio::net::tcp::TcpOwnedReadHalf) -> bytes::Bytes {
+        let header_buf = BytesMut::with_capacity(std::mem::size_of::<TcpMsgHdr>());
+        let (ret, header_buf) = read_half.read_exact(header_buf).await;
+        ret.unwrap();
+        let header = TcpMsgHdr::read_from_bytes(&header_buf[..]).unwrap();
+        assert_eq!(header.magic.get(), HEADER_MAGIC);
+        assert_eq!(header.version.get(), HEADER_VERSION);
+
+        let msg_len = header.length.get() as usize;
+        let msg_buf = BytesMut::with_capacity(msg_len);
+        let (ret, msg_buf) = read_half.read_exact(msg_buf).await;
+        ret.unwrap();
+        msg_buf.freeze()
+    }
+
+    fn spawn_test_sockets(
+        socket_ids: &[TcpSocketId],
+    ) -> (
+        mpsc::Sender<(TcpSocketId, SocketAddr, TcpMsg)>,
+        HashMap<TcpSocketId, mpsc::Receiver<RecvTcpMsg>>,
+        HashMap<TcpSocketId, SocketAddr>,
+        TcpControl,
+    ) {
+        let (tcp_egress_tx, tcp_egress_rx) = mpsc::channel(16);
+        let mut ingress_rxs = HashMap::new();
+        let socket_configs = socket_ids
+            .iter()
+            .map(|&socket_id| {
+                let (ingress_tx, ingress_rx) = mpsc::channel(16);
+                ingress_rxs.insert(socket_id, ingress_rx);
+                (socket_id, "127.0.0.1:0".parse().unwrap(), ingress_tx)
+            })
+            .collect();
+        let tcp_config = TcpConfig {
+            rate_limit: TcpRateLimit {
+                rps: NonZeroU32::new(1000).unwrap(),
+                rps_burst: NonZeroU32::new(100).unwrap(),
+            },
+            connections_limit: 100,
+            per_ip_connections_limit: 10,
+        };
+        let tcp_control = TcpControl::new();
+        let (bound_addrs_tx, bound_addrs_rx) = std::sync::mpsc::sync_channel(1);
+        spawn_tasks(
+            tcp_config,
+            tcp_control.clone(),
+            Arc::new(Addrlist::new()),
+            socket_configs,
+            tcp_egress_rx,
+            bound_addrs_tx,
+        );
+        (
+            tcp_egress_tx,
+            ingress_rxs,
+            bound_addrs_rx.recv().unwrap().into_iter().collect(),
+            tcp_control,
+        )
+    }
+
+    #[monoio::test(enable_timer = true)]
+    async fn test_outbound_connection_receives_messages() {
+        let server_listener = monoio::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let server_addr = server_listener.local_addr().unwrap();
+        let (tcp_egress_tx, mut ingress_rxs, _, _) = spawn_test_sockets(&[TcpSocketId::Raptorcast]);
+        let mut tcp_ingress_rx = ingress_rxs.remove(&TcpSocketId::Raptorcast).unwrap();
+
+        let test_payload = b"hello from client";
+        tcp_egress_tx
+            .send((
+                TcpSocketId::Raptorcast,
+                server_addr,
+                TcpMsg {
+                    msg: bytes::Bytes::from_static(test_payload),
+                    completion: None,
+                },
+            ))
+            .await
+            .unwrap();
+
+        let (server_stream, _client_addr) = server_listener.accept().await.unwrap();
+        let (mut server_read, mut server_write) = server_stream.into_split();
+
+        let received = read_tcp_message(&mut server_read).await;
+        assert_eq!(&received[..], test_payload);
+
+        let response_payload = b"hello from server";
+        write_tcp_message(&mut server_write, response_payload).await;
+
+        let recv_msg =
+            monoio::time::timeout(std::time::Duration::from_secs(5), tcp_ingress_rx.recv())
+                .await
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(&recv_msg.payload[..], response_payload);
+        assert_eq!(recv_msg.src_addr, server_addr);
+    }
+
+    #[monoio::test(enable_timer = true)]
+    async fn test_accepted_connection_can_send_messages() {
+        let (tcp_egress_tx, mut ingress_rxs, bound_addrs, tcp_control) =
+            spawn_test_sockets(&[TcpSocketId::Raptorcast]);
+        let mut tcp_ingress_rx = ingress_rxs.remove(&TcpSocketId::Raptorcast).unwrap();
+        let listen_addr = bound_addrs[&TcpSocketId::Raptorcast];
+
+        let client_stream = monoio::net::TcpStream::connect(listen_addr).await.unwrap();
+        let client_addr = client_stream.local_addr().unwrap();
+        let (mut client_read, mut client_write) = client_stream.into_split();
+
+        let test_payload = b"hello from raw client";
+        write_tcp_message(&mut client_write, test_payload).await;
+
+        let recv_msg =
+            monoio::time::timeout(std::time::Duration::from_secs(5), tcp_ingress_rx.recv())
+                .await
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(&recv_msg.payload[..], test_payload);
+        assert_eq!(recv_msg.src_addr, client_addr);
+
+        let response_payload = b"response to raw client";
+        tcp_egress_tx
+            .send((
+                TcpSocketId::Raptorcast,
+                client_addr,
+                TcpMsg {
+                    msg: bytes::Bytes::from_static(response_payload),
+                    completion: None,
+                },
+            ))
+            .await
+            .unwrap();
+
+        let received = monoio::time::timeout(
+            std::time::Duration::from_secs(5),
+            read_tcp_message(&mut client_read),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(&received[..], response_payload);
+
+        tcp_control.disconnect_socket(client_addr.ip(), client_addr.port());
+        let (result, _) = monoio::time::timeout(
+            Duration::from_secs(1),
+            client_read.read_exact(BytesMut::with_capacity(1)),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.unwrap_err().kind(), ErrorKind::UnexpectedEof);
+    }
+
+    #[monoio::test(enable_timer = true)]
+    async fn test_multi_socket_isolation() {
+        let socket_ids = [
+            TcpSocketId::Raptorcast,
+            TcpSocketId::AuthenticatedRaptorcast,
+        ];
+        let (tcp_egress_tx, mut ingress_rxs, bound_addrs, _) = spawn_test_sockets(&socket_ids);
+        let mut ingress_rx_a = ingress_rxs.remove(&socket_ids[0]).unwrap();
+        let mut ingress_rx_b = ingress_rxs.remove(&socket_ids[1]).unwrap();
+        let listen_addr_a = bound_addrs[&socket_ids[0]];
+        let listen_addr_b = bound_addrs[&socket_ids[1]];
+
+        let client_a = monoio::net::TcpStream::connect(listen_addr_a)
+            .await
+            .unwrap();
+        let client_a_addr = client_a.local_addr().unwrap();
+        let (mut read_a, mut write_a) = client_a.into_split();
+
+        let client_b = monoio::net::TcpStream::connect(listen_addr_b)
+            .await
+            .unwrap();
+        let client_b_addr = client_b.local_addr().unwrap();
+        let (mut read_b, mut write_b) = client_b.into_split();
+
+        write_tcp_message(&mut write_a, b"msg_a").await;
+        let recv = monoio::time::timeout(std::time::Duration::from_secs(2), ingress_rx_a.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(&recv.payload[..], b"msg_a");
+
+        write_tcp_message(&mut write_b, b"msg_b").await;
+        let recv = monoio::time::timeout(std::time::Duration::from_secs(2), ingress_rx_b.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(&recv.payload[..], b"msg_b");
+
+        tcp_egress_tx
+            .send((
+                TcpSocketId::Raptorcast,
+                client_a_addr,
+                TcpMsg {
+                    msg: bytes::Bytes::from_static(b"resp_a"),
+                    completion: None,
+                },
+            ))
+            .await
+            .unwrap();
+
+        tcp_egress_tx
+            .send((
+                TcpSocketId::AuthenticatedRaptorcast,
+                client_b_addr,
+                TcpMsg {
+                    msg: bytes::Bytes::from_static(b"resp_b"),
+                    completion: None,
+                },
+            ))
+            .await
+            .unwrap();
+
+        let recv_a = monoio::time::timeout(
+            std::time::Duration::from_secs(2),
+            read_tcp_message(&mut read_a),
+        )
+        .await
+        .unwrap();
+        assert_eq!(&recv_a[..], b"resp_a");
+
+        let recv_b = monoio::time::timeout(
+            std::time::Duration::from_secs(2),
+            read_tcp_message(&mut read_b),
+        )
+        .await
+        .unwrap();
+        assert_eq!(&recv_b[..], b"resp_b");
+    }
+
+    #[monoio::test(enable_timer = true)]
+    async fn test_same_peer_multiple_sockets() {
+        let server_a = monoio::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let server_b = monoio::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let server_a_addr = server_a.local_addr().unwrap();
+        let server_b_addr = server_b.local_addr().unwrap();
+
+        let socket_ids = [
+            TcpSocketId::Raptorcast,
+            TcpSocketId::AuthenticatedRaptorcast,
+        ];
+        let (tcp_egress_tx, mut ingress_rxs, _, _) = spawn_test_sockets(&socket_ids);
+        let mut ingress_rx_a = ingress_rxs.remove(&socket_ids[0]).unwrap();
+        let mut ingress_rx_b = ingress_rxs.remove(&socket_ids[1]).unwrap();
+
+        tcp_egress_tx
+            .send((
+                TcpSocketId::Raptorcast,
+                server_a_addr,
+                TcpMsg {
+                    msg: bytes::Bytes::from_static(b"via_socket_a"),
+                    completion: None,
+                },
+            ))
+            .await
+            .unwrap();
+
+        tcp_egress_tx
+            .send((
+                TcpSocketId::AuthenticatedRaptorcast,
+                server_b_addr,
+                TcpMsg {
+                    msg: bytes::Bytes::from_static(b"via_socket_b"),
+                    completion: None,
+                },
+            ))
+            .await
+            .unwrap();
+
+        let (stream_a, _) = server_a.accept().await.unwrap();
+        let (stream_b, _) = server_b.accept().await.unwrap();
+        let (mut read_a, mut write_a) = stream_a.into_split();
+        let (mut read_b, mut write_b) = stream_b.into_split();
+
+        let msg_a = read_tcp_message(&mut read_a).await;
+        assert_eq!(&msg_a[..], b"via_socket_a");
+
+        let msg_b = read_tcp_message(&mut read_b).await;
+        assert_eq!(&msg_b[..], b"via_socket_b");
+
+        write_tcp_message(&mut write_a, b"resp_from_a").await;
+        write_tcp_message(&mut write_b, b"resp_from_b").await;
+
+        let recv_a = monoio::time::timeout(std::time::Duration::from_secs(2), ingress_rx_a.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(&recv_a.payload[..], b"resp_from_a");
+
+        let recv_b = monoio::time::timeout(std::time::Duration::from_secs(2), ingress_rx_b.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(&recv_b.payload[..], b"resp_from_b");
     }
 }

--- a/monad-dataplane/src/tcp/rx.rs
+++ b/monad-dataplane/src/tcp/rx.rs
@@ -35,15 +35,29 @@ use tracing::{debug, enabled, trace, warn, Level};
 use zerocopy::FromBytes;
 
 use super::{
-    message_timeout, RecvTcpMsg, TcpControl, TcpControlMsg, TcpMsgHdr, TcpRateLimit, HEADER_MAGIC,
-    HEADER_VERSION, TCP_MESSAGE_LENGTH_LIMIT,
+    message_timeout, split_stream, RecvTcpMsg, TcpConnection, TcpControl, TcpMsgHdr, TcpRateLimit,
+    TcpReadHalf, TcpWriteHalf, HEADER_MAGIC, HEADER_VERSION, TCP_MESSAGE_LENGTH_LIMIT,
 };
 use crate::{
     addrlist::{Addrlist, Status},
-    tcp::RateLimiter,
+    TcpSocketId,
 };
 
+pub(crate) type WriteHalfSender =
+    mpsc::UnboundedSender<(TcpSocketId, SocketAddr, TcpWriteHalf, TcpConnection)>;
+pub(crate) type ReadHalfReceiver =
+    mpsc::UnboundedReceiver<(SocketAddr, TcpReadHalf, TcpConnection)>;
+
 const HEADER_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Clone)]
+pub(crate) struct RxContext {
+    pub(crate) socket_id: TcpSocketId,
+    pub(crate) rate_limit: TcpRateLimit,
+    pub(crate) tcp_control_map: TcpControl,
+    pub(crate) tcp_ingress_tx: mpsc::Sender<RecvTcpMsg>,
+    pub(crate) write_half_tx: WriteHalfSender,
+}
 
 #[derive(Clone)]
 pub(crate) struct RxState {
@@ -168,70 +182,107 @@ struct RxStateInner {
 }
 
 pub(crate) async fn task(
-    rate_limit: TcpRateLimit,
-    tcp_control_map: TcpControl,
+    context: RxContext,
     rx_state: RxState,
     tcp_listener: TcpListener,
-    tcp_ingress_tx: mpsc::Sender<RecvTcpMsg>,
+    mut read_half_rx: ReadHalfReceiver,
 ) {
     let mut conn_id: u64 = 0;
     loop {
-        match tcp_listener.accept().await {
-            Ok((tcp_stream, addr)) => match rx_state.apply_limits(addr.ip()) {
-                Ok(conn_state) => {
-                    spawn(task_connection(
-                        rate_limit.new_rate_limiter(),
-                        tcp_control_map.clone(),
-                        conn_state,
-                        conn_id,
-                        addr,
-                        tcp_stream,
-                        tcp_ingress_tx.clone(),
-                    ));
+        select! {
+            accepted = tcp_listener.accept() => {
+                match accepted {
+                    Ok((tcp_stream, addr)) => match rx_state.apply_limits(addr.ip()) {
+                        Ok(conn_state) => {
+                            spawn(task_connection(
+                                context.clone(),
+                                conn_state,
+                                conn_id,
+                                addr,
+                                tcp_stream,
+                            ));
+                        }
+                        Err(()) => {
+                            debug!(
+                                conn_id,
+                                ?addr,
+                                "connection limit reached, rejecting tcp connection"
+                            );
+                        }
+                    },
+                    Err(err) => {
+                        warn!(conn_id, ?err, "error accepting tcp connection");
+                    }
                 }
-                Err(()) => {
-                    debug!(
-                        conn_id,
-                        ?addr,
-                        "connection limit reached, rejecting tcp connection"
-                    );
-                }
-            },
-            Err(err) => {
-                warn!(conn_id, ?err, "error accepting tcp connection");
+                conn_id += 1;
+            }
+            read_half = read_half_rx.recv() => {
+                let Some((addr, read_half, connection)) = read_half else {
+                    break;
+                };
+                trace!(conn_id, ?addr, "received read half from tx");
+
+                spawn(task_read(
+                    context.clone(),
+                    None,
+                    conn_id,
+                    addr,
+                    read_half,
+                    connection,
+                ));
+                conn_id += 1;
             }
         }
-
-        conn_id += 1;
     }
 }
 
 async fn task_connection(
-    rate_limiter: RateLimiter,
-    tcp_control_map: TcpControl,
+    context: RxContext,
     _rx_state: ConnectionToken,
     conn_id: u64,
     addr: SocketAddr,
-    mut tcp_stream: TcpStream,
-    tcp_ingress_tx: mpsc::Sender<RecvTcpMsg>,
+    tcp_stream: TcpStream,
 ) {
-    let mut control_rx = tcp_control_map.register((addr.ip(), addr.port(), conn_id));
+    let (read_half, write_half) = split_stream(tcp_stream);
+    let connection = TcpConnection::new();
+
+    if let Err(err) =
+        context
+            .write_half_tx
+            .send((context.socket_id, addr, write_half, connection.clone()))
+    {
+        warn!(conn_id, ?addr, ?err, "failed to send write half to tx task");
+        return;
+    }
+
+    task_read(
+        context,
+        Some(_rx_state),
+        conn_id,
+        addr,
+        read_half,
+        connection,
+    )
+    .await;
+}
+
+async fn task_read(
+    context: RxContext,
+    _rx_state: Option<ConnectionToken>,
+    conn_id: u64,
+    addr: SocketAddr,
+    mut read_half: TcpReadHalf,
+    connection: TcpConnection,
+) {
+    let rate_limiter = context.rate_limit.new_rate_limiter();
+    let tcp_id = (addr.ip(), addr.port(), conn_id);
+    context.tcp_control_map.register(tcp_id, connection.clone());
     let mut message_id: u64 = 0;
     loop {
         select! {
             biased;
-            ctl = control_rx.recv() => {
-                match ctl {
-                    None => {
-                        break;
-                    }
-                    Some(TcpControlMsg::Disconnect) => {
-                        trace!(conn_id, ?addr, "received disconnect control message");
-                        break;
-                    }
-                }
-            },
-            msg = read_message(conn_id, addr, message_id, &mut tcp_stream) => {
+            _ = connection.disconnected() => break,
+            msg = read_message(conn_id, addr, message_id, &mut read_half) => {
                 if rate_limiter.check().is_err() {
                     warn!(conn_id, ?addr, "rate limit exceeded");
                     break;
@@ -243,7 +294,7 @@ async fn task_connection(
                     src_addr: addr,
                     payload: message,
                 };
-                if let Err(err) = tcp_ingress_tx.send(recv_msg).await {
+                if let Err(err) = context.tcp_ingress_tx.send(recv_msg).await {
                     warn!(
                         conn_id,
                         ?addr,
@@ -257,7 +308,8 @@ async fn task_connection(
             }
         }
     }
-    tcp_control_map.unregister(&(addr.ip(), addr.port(), conn_id));
+    connection.disconnect();
+    context.tcp_control_map.unregister(&tcp_id);
     trace!(
         conn_id,
         ?addr,
@@ -269,7 +321,7 @@ async fn read_message(
     conn_id: u64,
     addr: SocketAddr,
     message_id: u64,
-    tcp_stream: &mut TcpStream,
+    read_half: &mut TcpReadHalf,
 ) -> Option<Bytes> {
     let start_time = if enabled!(Level::DEBUG) {
         Some(Instant::now())
@@ -279,7 +331,7 @@ async fn read_message(
 
     let header_bytes = BytesMut::with_capacity(std::mem::size_of::<TcpMsgHdr>());
 
-    let header = match timeout(HEADER_TIMEOUT, tcp_stream.read_exact(header_bytes)).await {
+    let header = match timeout(HEADER_TIMEOUT, read_half.read_exact(header_bytes)).await {
         Ok((ret, header_bytes)) => match ret {
             Ok(_len) => TcpMsgHdr::read_from_bytes(&header_bytes[..]).unwrap(),
             Err(err) => {
@@ -360,7 +412,7 @@ async fn read_message(
 
     let message = match timeout(
         message_timeout(message_length),
-        tcp_stream.read_exact(message),
+        read_half.read_exact(message),
     )
     .await
     {

--- a/monad-dataplane/src/tcp/tx.rs
+++ b/monad-dataplane/src/tcp/tx.rs
@@ -18,7 +18,6 @@ use std::{
     collections::BTreeMap,
     io::{Error, ErrorKind},
     net::SocketAddr,
-    os::fd::{AsRawFd, RawFd},
     rc::Rc,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -28,9 +27,8 @@ use std::{
 };
 
 use monoio::{
-    io::AsyncWriteRentExt,
     net::TcpStream,
-    spawn,
+    select, spawn,
     time::{sleep, timeout},
 };
 use tokio::sync::mpsc::{
@@ -40,8 +38,19 @@ use tokio::sync::mpsc::{
 use tracing::{debug, enabled, trace, warn, Level};
 use zerocopy::IntoBytes;
 
-use super::{message_timeout, TcpConfig, TcpMsg, TcpMsgHdr, TCP_MESSAGE_LENGTH_LIMIT};
-use crate::addrlist::{Addrlist, Status};
+use super::{
+    message_timeout, split_stream, TcpConfig, TcpConnection, TcpMsg, TcpMsgHdr, TcpReadHalf,
+    TcpWriteHalf, TCP_MESSAGE_LENGTH_LIMIT,
+};
+use crate::{
+    addrlist::{Addrlist, Status},
+    TcpSocketId,
+};
+
+pub(crate) type WriteHalfReceiver =
+    mpsc::UnboundedReceiver<(TcpSocketId, SocketAddr, TcpWriteHalf, TcpConnection)>;
+pub(crate) type ReadHalfSenders =
+    BTreeMap<TcpSocketId, mpsc::UnboundedSender<(SocketAddr, TcpReadHalf, TcpConnection)>>;
 
 // These are per-peer limits.
 pub const QUEUED_MESSAGE_WARN_LIMIT: usize = 100;
@@ -49,7 +58,8 @@ pub const QUEUED_MESSAGE_WARN_LIMIT: usize = 100;
 pub const QUEUED_MESSAGE_LIMIT: usize = 150;
 pub const QUEUED_MESSAGE_BYTE_LIMIT: usize = 4 * 1024 * 1024;
 
-pub const MSG_WAIT_TIMEOUT: Duration = Duration::from_secs(1);
+// Must be higher than wireauth keepalive interval to avoid closing connections prematurely.
+pub const MSG_WAIT_TIMEOUT: Duration = Duration::from_secs(4);
 
 const TCP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const TCP_FAILURE_LINGER_WAIT: Duration = Duration::from_secs(1);
@@ -150,10 +160,17 @@ struct TxState {
     connections_limit: usize,
 }
 
+enum RegisterResult {
+    Rejected,
+    Existing,
+    New(BoundedQueueReceiver, TxStatePeerHandle),
+}
+
 impl TxState {
     fn new(addrlist: Arc<Addrlist>, connections_limit: usize) -> TxState {
         let inner = Rc::new(RefCell::new(TxStateInner {
             peer_channels: BTreeMap::new(),
+            outgoing_connections: 0,
         }));
 
         TxState {
@@ -163,46 +180,17 @@ impl TxState {
         }
     }
 
-    fn push(
-        &self,
-        addr: &SocketAddr,
-        msg: TcpMsg,
-    ) -> Option<(BoundedQueueReceiver, TxStatePeerHandle)> {
-        let mut ret = None;
+    fn try_send(&self, key: &(TcpSocketId, SocketAddr), msg: TcpMsg) -> Option<TcpMsg> {
+        let inner_ref = self.inner.borrow();
 
-        let mut inner_ref = self.inner.borrow_mut();
+        let Some(sender) = inner_ref.peer_channels.get(key) else {
+            return Some(msg);
+        };
 
-        let is_new_peer = !inner_ref.peer_channels.contains_key(addr);
-        if is_new_peer {
-            let is_trusted = self.addrlist.status(&addr.ip()) == Status::Trusted;
-            if !is_trusted && inner_ref.peer_channels.len() >= self.connections_limit {
-                warn!(
-                    ?addr,
-                    total_connections = inner_ref.peer_channels.len(),
-                    connections_limit = self.connections_limit,
-                    "outgoing connection limit reached, dropping message"
-                );
-                return None;
-            }
-        }
-
-        let msg_sender = inner_ref.peer_channels.entry(*addr).or_insert_with(|| {
-            let (sender, receiver) = bounded_queue();
-
-            ret = Some((
-                receiver,
-                TxStatePeerHandle {
-                    tx_state: self.clone(),
-                    addr: *addr,
-                },
-            ));
-
-            sender
-        });
-
-        match msg_sender.try_send(msg) {
+        let addr = key.1;
+        match sender.try_send(msg) {
             Ok(()) => {
-                let message_count = msg_sender.message_count();
+                let message_count = sender.message_count();
                 if message_count >= QUEUED_MESSAGE_WARN_LIMIT {
                     warn!(
                         ?addr,
@@ -213,7 +201,7 @@ impl TxState {
             Err(BoundedQueueError::ByteLimitExceeded) => {
                 warn!(
                     ?addr,
-                    queued_bytes = msg_sender.queued_bytes(),
+                    queued_bytes = sender.queued_bytes(),
                     byte_limit = QUEUED_MESSAGE_BYTE_LIMIT,
                     "peer byte limit reached, dropping message"
                 );
@@ -221,7 +209,7 @@ impl TxState {
             Err(BoundedQueueError::Full) => {
                 warn!(
                     ?addr,
-                    message_count = msg_sender.message_count(),
+                    message_count = sender.message_count(),
                     message_limit = QUEUED_MESSAGE_LIMIT,
                     "peer message limit reached, dropping message"
                 );
@@ -231,118 +219,257 @@ impl TxState {
             }
         }
 
-        ret
+        None
+    }
+
+    fn register(&self, key: (TcpSocketId, SocketAddr), outgoing: bool) -> RegisterResult {
+        let mut inner_ref = self.inner.borrow_mut();
+
+        if inner_ref.peer_channels.contains_key(&key) {
+            return RegisterResult::Existing;
+        }
+
+        let addr = key.1;
+        if outgoing {
+            let is_trusted = self.addrlist.status(&addr.ip()) == Status::Trusted;
+            if !is_trusted && inner_ref.outgoing_connections >= self.connections_limit {
+                warn!(
+                    ?addr,
+                    total_connections = inner_ref.outgoing_connections,
+                    connections_limit = self.connections_limit,
+                    "outgoing connection limit reached, dropping message"
+                );
+                return RegisterResult::Rejected;
+            }
+        }
+
+        let (sender, receiver) = bounded_queue();
+        inner_ref.peer_channels.insert(key, sender);
+        inner_ref.outgoing_connections += usize::from(outgoing);
+        RegisterResult::New(
+            receiver,
+            TxStatePeerHandle {
+                tx_state: self.clone(),
+                key,
+                outgoing,
+            },
+        )
     }
 }
 
 struct TxStatePeerHandle {
     tx_state: TxState,
-    addr: SocketAddr,
+    key: (TcpSocketId, SocketAddr),
+    outgoing: bool,
 }
 
 impl Drop for TxStatePeerHandle {
     fn drop(&mut self) {
-        self.tx_state
-            .inner
-            .borrow_mut()
-            .peer_channels
-            .remove(&self.addr);
-        trace!(?self.addr, "removed peer from tx channels map");
+        let mut inner = self.tx_state.inner.borrow_mut();
+        inner.peer_channels.remove(&self.key);
+        inner.outgoing_connections -= usize::from(self.outgoing);
+        let addr = self.key.1;
+        trace!(?addr, "removed peer from tx channels map");
     }
 }
 
 struct TxStateInner {
-    // There is a transmit connection task running for a given peer iff there is an
-    // entry for the peer address in this map.  Exiting the transmit connection task
-    // drops a TxStatePeerHandle which removes the entry from this map.
-    peer_channels: BTreeMap<SocketAddr, BoundedQueueSender>,
+    // There is a transmit connection task running for a given (socket_id, peer) iff
+    // there is an entry in this map. Exiting the transmit connection task drops a
+    // TxStatePeerHandle which removes the entry from this map.
+    peer_channels: BTreeMap<(TcpSocketId, SocketAddr), BoundedQueueSender>,
+    outgoing_connections: usize,
 }
 
 pub(crate) async fn task(
     cfg: TcpConfig,
     addrlist: Arc<Addrlist>,
-    mut tcp_egress_rx: mpsc::Receiver<(SocketAddr, TcpMsg)>,
+    mut tcp_egress_rx: mpsc::Receiver<(TcpSocketId, SocketAddr, TcpMsg)>,
+    mut write_half_rx: WriteHalfReceiver,
+    read_half_txs: ReadHalfSenders,
 ) {
     let tx_state = TxState::new(addrlist, cfg.connections_limit);
 
     let mut conn_id: u64 = 0;
 
-    while let Some((addr, msg)) = tcp_egress_rx.recv().await {
-        debug!(?addr, len = msg.msg.len(), "queueing up TCP message");
+    loop {
+        select! {
+            egress = tcp_egress_rx.recv() => {
+                let Some((socket_id, addr, msg)) = egress else {
+                    break;
+                };
+                debug!(?socket_id, ?addr, len = msg.msg.len(), "queueing up TCP message");
 
-        if let Some((msg_receiver, tx_state_peer_handle)) = tx_state.push(&addr, msg) {
-            let peer_count = tx_state.inner.borrow().peer_channels.len();
-            trace!(
-                conn_id,
-                ?addr,
-                total_tx_connections = peer_count,
-                "spawning tcp transmit connection task for peer"
-            );
+                let key = (socket_id, addr);
+                match tx_state.register(key, true) {
+                    RegisterResult::Rejected => continue,
+                    RegisterResult::Existing => {}
+                    RegisterResult::New(msg_receiver, tx_state_peer_handle) => {
+                        let peer_count = tx_state.inner.borrow().peer_channels.len();
+                        trace!(
+                            conn_id,
+                            ?socket_id,
+                            ?addr,
+                            total_tx_connections = peer_count,
+                            "spawning tcp connect and send task for peer"
+                        );
 
-            spawn(task_connection(
-                conn_id,
-                addr,
-                msg_receiver,
-                tx_state_peer_handle,
-            ));
+                        let read_half_tx = read_half_txs
+                            .get(&socket_id)
+                            .cloned()
+                            .expect("socket_id must exist in read_half_txs");
 
-            conn_id += 1;
+                        spawn(task_connect_and_send(
+                            conn_id,
+                            addr,
+                            msg_receiver,
+                            tx_state_peer_handle,
+                            read_half_tx,
+                        ));
+
+                        conn_id += 1;
+                    }
+                }
+
+                if tx_state.try_send(&key, msg).is_some() {
+                    warn!(?socket_id, ?addr, "failed to send message after register");
+                }
+            }
+            write_half = write_half_rx.recv() => {
+                let Some((socket_id, addr, write_half, connection)) = write_half else {
+                    break;
+                };
+                trace!(conn_id, ?socket_id, ?addr, "received write half from rx");
+
+                let key = (socket_id, addr);
+                if let RegisterResult::New(msg_receiver, tx_state_peer_handle) =
+                    tx_state.register(key, false)
+                {
+                    let peer_count = tx_state.inner.borrow().peer_channels.len();
+                    trace!(
+                        conn_id,
+                        ?socket_id,
+                        ?addr,
+                        total_tx_connections = peer_count,
+                        "spawning tcp send task for peer"
+                    );
+
+                    spawn(task_send(
+                        conn_id,
+                        addr,
+                        write_half,
+                        msg_receiver,
+                        tx_state_peer_handle,
+                        connection,
+                    ));
+
+                    conn_id += 1;
+                } else {
+                    connection.disconnect();
+                    warn!(?socket_id, ?addr, "received write half for already registered peer");
+                }
+            }
         }
     }
 }
 
-async fn task_connection(
+fn log_send_error(
+    conn_id: u64,
+    addr: SocketAddr,
+    err: Error,
+    msg_receiver: &mut BoundedQueueReceiver,
+) {
+    let mut dropped = 0;
+    while msg_receiver.try_recv().is_ok() {
+        dropped += 1;
+    }
+    warn!(
+        conn_id,
+        ?addr,
+        ?err,
+        additional_messages_dropped = dropped,
+        "error transmitting tcp message"
+    );
+}
+
+async fn task_send(
+    conn_id: u64,
+    addr: SocketAddr,
+    write_half: TcpWriteHalf,
+    mut msg_receiver: BoundedQueueReceiver,
+    _tx_state_peer_handle: TxStatePeerHandle,
+    connection: TcpConnection,
+) {
+    trace!(conn_id, ?addr, "starting tcp send task");
+    if let Err(err) = send_messages(conn_id, &addr, write_half, &mut msg_receiver, connection).await
+    {
+        log_send_error(conn_id, addr, err, &mut msg_receiver);
+    }
+    trace!(conn_id, ?addr, "exiting tcp send task");
+}
+
+async fn task_connect_and_send(
     conn_id: u64,
     addr: SocketAddr,
     mut msg_receiver: BoundedQueueReceiver,
     _tx_state_peer_handle: TxStatePeerHandle,
+    read_half_tx: mpsc::UnboundedSender<(SocketAddr, TcpReadHalf, TcpConnection)>,
 ) {
-    trace!(
-        conn_id,
-        ?addr,
-        "starting tcp transmit connection task for peer"
-    );
-
-    if let Err(err) = connect_and_send_messages(conn_id, &addr, &mut msg_receiver).await {
-        let mut additional_messages_dropped = 0;
-
-        // Throw away (and fail) all remaining queued messages immediately.
-        while msg_receiver.try_recv().is_ok() {
-            additional_messages_dropped += 1;
-        }
-
-        warn!(
-            conn_id,
-            ?addr,
-            ?err,
-            additional_messages_dropped,
-            "error transmitting tcp message"
-        );
-
-        // Sleep to avoid reconnecting too soon.
+    trace!(conn_id, ?addr, "starting tcp connect and send task");
+    if let Err(err) =
+        connect_and_send_messages(conn_id, &addr, &mut msg_receiver, read_half_tx).await
+    {
+        log_send_error(conn_id, addr, err, &mut msg_receiver);
         sleep(TCP_FAILURE_LINGER_WAIT).await;
     }
-
-    trace!(
-        conn_id,
-        ?addr,
-        "exiting tcp transmit connection task for peer"
-    );
+    trace!(conn_id, ?addr, "exiting tcp connect and send task");
 }
 
 async fn connect_and_send_messages(
     conn_id: u64,
     addr: &SocketAddr,
     msg_receiver: &mut BoundedQueueReceiver,
+    read_half_tx: mpsc::UnboundedSender<(SocketAddr, TcpReadHalf, TcpConnection)>,
 ) -> Result<(), Error> {
-    let mut stream = timeout(TCP_CONNECT_TIMEOUT, TcpStream::connect(addr))
+    let stream = timeout(TCP_CONNECT_TIMEOUT, TcpStream::connect(addr))
         .await
         .unwrap_or_else(|_| Err(Error::from(ErrorKind::TimedOut)))
         .map_err(|err| Error::other(format!("error connecting to remote host: {}", err)))?;
 
     trace!(conn_id, ?addr, "outbound tcp connection established");
 
-    conn_cork(stream.as_raw_fd(), true);
+    let (read_half, write_half) = split_stream(stream);
+    let connection = TcpConnection::new();
+
+    read_half_tx
+        .send((*addr, read_half, connection.clone()))
+        .map_err(|_| Error::other("failed to send read half to rx task"))?;
+
+    send_messages(conn_id, addr, write_half, msg_receiver, connection).await
+}
+
+async fn send_messages(
+    conn_id: u64,
+    addr: &SocketAddr,
+    mut write_half: TcpWriteHalf,
+    msg_receiver: &mut BoundedQueueReceiver,
+    connection: TcpConnection,
+) -> Result<(), Error> {
+    let result = select! {
+        result = send_messages_inner(conn_id, addr, &mut write_half, msg_receiver) => result,
+        _ = connection.disconnected() => Ok(()),
+    };
+    connection.disconnect();
+    result
+}
+
+async fn send_messages_inner(
+    conn_id: u64,
+    addr: &SocketAddr,
+    write_half: &mut TcpWriteHalf,
+    msg_receiver: &mut BoundedQueueReceiver,
+) -> Result<(), Error> {
+    write_half.set_cork(true);
 
     let mut message_id: u64 = 0;
 
@@ -351,12 +478,12 @@ async fn connect_and_send_messages(
             Ok(msg) => msg,
             Err(TryRecvError::Disconnected) => break,
             Err(TryRecvError::Empty) => {
-                conn_cork(stream.as_raw_fd(), false);
+                write_half.set_cork(false);
 
                 match timeout(MSG_WAIT_TIMEOUT, msg_receiver.recv()).await {
                     Ok(None) | Err(_) => break,
                     Ok(Some(msg)) => {
-                        conn_cork(stream.as_raw_fd(), true);
+                        write_half.set_cork(true);
                         msg
                     }
                 }
@@ -380,7 +507,7 @@ async fn connect_and_send_messages(
 
         timeout(
             message_timeout(len),
-            send_message(conn_id, addr, &mut stream, message_id, msg),
+            send_message(conn_id, addr, write_half, message_id, msg),
         )
         .await
         .unwrap_or_else(|_| Err(Error::from(ErrorKind::TimedOut)))
@@ -397,31 +524,10 @@ async fn connect_and_send_messages(
     Ok(())
 }
 
-fn conn_cork(raw_fd: RawFd, cork_flag: bool) {
-    let r = unsafe {
-        let cork_flag: libc::c_int = if cork_flag { 1 } else { 0 };
-
-        libc::setsockopt(
-            raw_fd,
-            libc::SOL_TCP,
-            libc::TCP_CORK,
-            &cork_flag as *const _ as _,
-            std::mem::size_of_val(&cork_flag) as _,
-        )
-    };
-
-    if r != 0 {
-        warn!(
-            "setsockopt(TCP_CORK) failed with: {}",
-            Error::last_os_error()
-        );
-    }
-}
-
 async fn send_message(
     conn_id: u64,
     addr: &SocketAddr,
-    stream: &mut TcpStream,
+    write_half: &mut TcpWriteHalf,
     message_id: u64,
     message: TcpMsg,
 ) -> Result<(), Error> {
@@ -434,7 +540,7 @@ async fn send_message(
     );
 
     let start = if enabled!(Level::DEBUG) {
-        Some((Instant::now(), num_unacked_bytes(stream.as_raw_fd())))
+        Some((Instant::now(), write_half.unacked_bytes()))
     } else {
         None
     };
@@ -443,14 +549,16 @@ async fn send_message(
 
     let header = TcpMsgHdr::new(message_len as u64);
 
-    let (ret, _header) = stream.write_all(Box::<[u8]>::from(header.as_bytes())).await;
+    let (ret, _header) = write_half
+        .write_all(Box::<[u8]>::from(header.as_bytes()))
+        .await;
     ret?;
 
-    let (ret, _message) = stream.write_all(message.msg).await;
+    let (ret, _message) = write_half.write_all(message.msg).await;
     ret?;
 
     if let Some((start_time, start_unacked_bytes)) = start {
-        let end_unacked_bytes = num_unacked_bytes(stream.as_raw_fd());
+        let end_unacked_bytes = write_half.unacked_bytes();
 
         let duration = Instant::now() - start_time;
 
@@ -494,19 +602,6 @@ async fn send_message(
     }
 
     Ok(())
-}
-
-fn num_unacked_bytes(raw_fd: RawFd) -> usize {
-    let mut outq: libc::c_int = 0;
-
-    let r = unsafe { libc::ioctl(raw_fd, libc::TIOCOUTQ, &mut outq as *mut libc::c_int) };
-
-    if r == 0 {
-        outq as _
-    } else {
-        warn!("ioctl(TIOCOUTQ) failed with: {}", Error::last_os_error());
-        0
-    }
 }
 
 #[cfg(test)]
@@ -554,6 +649,27 @@ mod tests {
         assert!(matches!(
             sender.try_send(make_msg(1)),
             Err(BoundedQueueError::Closed)
+        ));
+    }
+
+    #[test]
+    fn incoming_connections_do_not_use_outgoing_limit() {
+        let state = TxState::new(Arc::new(Addrlist::new()), 1);
+        let register = |addr: &str, outgoing| {
+            state.register((TcpSocketId::Raptorcast, addr.parse().unwrap()), outgoing)
+        };
+
+        let RegisterResult::New(_incoming_rx, _incoming_handle) = register("127.0.0.1:1000", false)
+        else {
+            panic!("incoming connection should be registered");
+        };
+        let RegisterResult::New(_outgoing_rx, _outgoing_handle) = register("127.0.0.1:2000", true)
+        else {
+            panic!("incoming connection should not consume outgoing capacity");
+        };
+        assert!(matches!(
+            register("127.0.0.1:3000", true),
+            RegisterResult::Rejected
         ));
     }
 }

--- a/monad-dataplane/tests/tests.rs
+++ b/monad-dataplane/tests/tests.rs
@@ -190,7 +190,7 @@ fn udp_direct_socket() {
 // This verifies that the TCP transmit task recovers from a peer transmit
 // task exiting after a timeout.
 #[test]
-#[timeout(10000)]
+#[timeout(20000)]
 fn tcp_very_slow() {
     once_setup();
 

--- a/monad-debug-node/src/main.rs
+++ b/monad-debug-node/src/main.rs
@@ -179,6 +179,7 @@ fn main() -> Result<(), Error> {
                         record_seq_num: peer.record_seq_num,
                         auth_port: peer.auth_port,
                         direct_udp_port: peer.direct_udp_port,
+                        tcp_auth_port: peer.tcp_auth_port,
                     })
                     .collect();
                 let bootstrap_config = NodeBootstrapConfig {

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -298,6 +298,9 @@ pub struct PeerEntry<ST: CertificateSignatureRecoverable> {
         skip_serializing_if = "Option::is_none"
     )]
     pub direct_udp_port: Option<NonZeroU16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tcp_auth_port: Option<NonZeroU16>,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -376,17 +379,33 @@ impl<ST: CertificateSignatureRecoverable> Encodable for PeerEntry<ST> {
         let direct_udp_port = self.direct_udp_port.map_or(0, NonZeroU16::get);
         let tcp_port = self.tcp_port().get();
         let udp_port = self.udp_port().map_or(0, NonZeroU16::get);
-        let enc = [
-            &self.pubkey as &dyn Encodable,
-            &address as &dyn Encodable,
-            &self.signature as &dyn Encodable,
-            &self.record_seq_num as &dyn Encodable,
-            &auth_port as &dyn Encodable,
-            &direct_udp_port as &dyn Encodable,
-            &tcp_port as &dyn Encodable,
-            &udp_port as &dyn Encodable,
-        ];
-        encode_list::<_, dyn Encodable>(&enc, out);
+        if let Some(tcp_auth_port) = self.tcp_auth_port {
+            let tcp_auth_port = tcp_auth_port.get();
+            let enc = [
+                &self.pubkey as &dyn Encodable,
+                &address as &dyn Encodable,
+                &self.signature as &dyn Encodable,
+                &self.record_seq_num as &dyn Encodable,
+                &auth_port as &dyn Encodable,
+                &direct_udp_port as &dyn Encodable,
+                &tcp_port as &dyn Encodable,
+                &udp_port as &dyn Encodable,
+                &tcp_auth_port as &dyn Encodable,
+            ];
+            encode_list::<_, dyn Encodable>(&enc, out);
+        } else {
+            let enc = [
+                &self.pubkey as &dyn Encodable,
+                &address as &dyn Encodable,
+                &self.signature as &dyn Encodable,
+                &self.record_seq_num as &dyn Encodable,
+                &auth_port as &dyn Encodable,
+                &direct_udp_port as &dyn Encodable,
+                &tcp_port as &dyn Encodable,
+                &udp_port as &dyn Encodable,
+            ];
+            encode_list::<_, dyn Encodable>(&enc, out);
+        }
     }
 }
 
@@ -426,6 +445,12 @@ impl<ST: CertificateSignatureRecoverable> Decodable for PeerEntry<ST> {
             (tcp_port, udp_port)
         };
 
+        let tcp_auth_port = if payload.is_empty() {
+            None
+        } else {
+            decode_optional_non_zero_u16(&mut payload)?
+        };
+
         if !payload.is_empty() {
             return Err(alloy_rlp::Error::Custom("extra bytes in peer entry"));
         }
@@ -437,6 +462,7 @@ impl<ST: CertificateSignatureRecoverable> Decodable for PeerEntry<ST> {
             record_seq_num,
             auth_port,
             direct_udp_port,
+            tcp_auth_port,
         })
     }
 }
@@ -2732,6 +2758,7 @@ tcp_port = 8003"#,
             record_seq_num,
             auth_port: NonZeroU16::new(8000).unwrap(),
             direct_udp_port: None,
+            tcp_auth_port: None,
         };
         let encoded = alloy_rlp::encode(&entry);
         let decoded: PeerEntry<NopSignature> = alloy_rlp::decode_exact(&encoded).unwrap();
@@ -2754,6 +2781,7 @@ tcp_port = 8003"#,
             record_seq_num: 7,
             auth_port: NonZeroU16::new(9000).unwrap(),
             direct_udp_port: Some(NonZeroU16::new(9001).unwrap()),
+            tcp_auth_port: None,
         };
 
         let encoded = alloy_rlp::encode(&entry);
@@ -2775,6 +2803,31 @@ tcp_port = 8003"#,
             record_seq_num,
             auth_port: NonZeroU16::new(auth_port).unwrap(),
             direct_udp_port: None,
+            tcp_auth_port: None,
+        };
+
+        let encoded = alloy_rlp::encode(&entry);
+        let decoded: PeerEntry<NopSignature> = alloy_rlp::decode_exact(&encoded).unwrap();
+        assert_eq!(entry, decoded);
+    }
+
+    #[test]
+    fn peer_entry_rlp_encode_decode_with_tcp_auth() {
+        let pubkey = CertificateSignaturePubKey::<NopSignature>::from_bytes(&[4u8; 32]).unwrap();
+        let address: Ipv4Addr = "127.0.0.1".parse().unwrap();
+        let signature = NopSignature { pubkey, id: 77 };
+        let entry = PeerEntry {
+            pubkey,
+            address: PeerEntryAddress::new(
+                address,
+                NonZeroU16::new(8003).unwrap(),
+                Some(NonZeroU16::new(8003).unwrap()),
+            ),
+            signature,
+            record_seq_num: 12,
+            auth_port: NonZeroU16::new(9003).unwrap(),
+            direct_udp_port: None,
+            tcp_auth_port: Some(NonZeroU16::new(9004).unwrap()),
         };
 
         let encoded = alloy_rlp::encode(&entry);
@@ -2804,6 +2857,7 @@ tcp_port = 8003"#,
         assert_eq!(decoded.udp_port().map(NonZeroU16::get), Some(8006));
         assert_eq!(decoded.auth_port.get(), auth_port);
         assert_eq!(decoded.direct_udp_port, None);
+        assert_eq!(decoded.tcp_auth_port, None);
     }
 
     #[test]
@@ -2891,8 +2945,9 @@ tcp_port = 8003"#,
         let auth_port = 9003u16;
         let direct_udp_port = 9004u16;
         let tcp_port = 8003u16;
-        let extra_port = 9005u16;
-        let enc: [&dyn Encodable; 9] = [
+        let tcp_auth_port = 9005u16;
+        let extra_port = 9006u16;
+        let enc: [&dyn Encodable; 10] = [
             &pubkey,
             &"127.0.0.1".to_string(),
             &signature,
@@ -2901,6 +2956,7 @@ tcp_port = 8003"#,
             &direct_udp_port,
             &tcp_port,
             &0u16,
+            &tcp_auth_port,
             &extra_port,
         ];
         let mut encoded = Vec::new();

--- a/monad-node-config/src/bootstrap.rs
+++ b/monad-node-config/src/bootstrap.rs
@@ -62,6 +62,9 @@ pub struct NodeBootstrapPeerConfig<ST: CertificateSignatureRecoverable> {
         skip_serializing_if = "Option::is_none"
     )]
     pub direct_udp_port: Option<NonZeroU16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tcp_auth_port: Option<NonZeroU16>,
 }
 
 fn deserialize_bootstrap_peers<'de, D, ST>(

--- a/monad-node-config/src/network.rs
+++ b/monad-node-config/src/network.rs
@@ -26,6 +26,7 @@ pub struct NodeNetworkConfig {
     pub bind_address_tcp_port: Option<u16>,
     pub authenticated_bind_address_port: u16,
     pub direct_udp_bind_address_port: Option<u16>,
+    pub authenticated_tcp_bind_address_port: Option<u16>,
 
     pub max_rtt_ms: u64,
     pub max_mbps: u16,

--- a/monad-node-config/src/peers.rs
+++ b/monad-node-config/src/peers.rs
@@ -35,6 +35,9 @@ pub struct PeerDiscoveryConfig<ST: CertificateSignatureRecoverable> {
     #[serde(alias = "self_direct_udp_auth_port")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub self_direct_udp_port: Option<NonZeroU16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub self_tcp_auth_port: Option<NonZeroU16>,
     pub self_record_seq_num: u64,
 
     pub self_name_record_sig: ST,

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -709,6 +709,9 @@ where
     let direct_udp_bind_address = network_config
         .direct_udp_bind_address_port
         .map(|port| SocketAddr::new(IpAddr::V4(network_config.bind_address_host), port));
+    let authenticated_tcp_bind_address = network_config
+        .authenticated_tcp_bind_address_port
+        .map(|port| SocketAddr::new(IpAddr::V4(network_config.bind_address_host), port));
     let self_id = NodeId::new(identity.pubkey());
     let self_tcp_port = peer_discovery_config.tcp_port();
     let name_record_address = if let Some(ip) = peer_discovery_config.ip() {
@@ -729,6 +732,7 @@ where
         ?non_authenticated_bind_address,
         ?authenticated_bind_address,
         ?direct_udp_bind_address,
+        ?authenticated_tcp_bind_address,
         ?name_record_address,
         "Monad-node starting, pid: {}",
         process::id()
@@ -759,9 +763,14 @@ where
     if let Some(direct_addr) = direct_udp_bind_address {
         udp_sockets.push((UdpSocketId::DirectUdp, direct_addr));
     }
+    let mut tcp_sockets: Vec<(TcpSocketId, SocketAddr)> =
+        vec![(TcpSocketId::Raptorcast, tcp_bind_address)];
+    if let Some(address) = authenticated_tcp_bind_address {
+        tcp_sockets.push((TcpSocketId::AuthenticatedRaptorcast, address));
+    }
     dp_builder = dp_builder
         .with_udp_sockets(udp_sockets)
-        .with_tcp_sockets([(TcpSocketId::Raptorcast, tcp_bind_address)]);
+        .with_tcp_sockets(tcp_sockets);
 
     assert_eq!(
         peer_discovery_config.self_direct_udp_port.is_some(),
@@ -880,6 +889,13 @@ where
             shared_key.clone(),
         )
     });
+    let tcp_auth_protocol = authenticated_tcp_bind_address.map(|_| {
+        WireAuthProtocol::new(
+            &monad_raptorcast::auth::metrics::TCP_METRICS,
+            wireauth_config.clone(),
+            shared_key.clone(),
+        )
+    });
 
     MultiRouter::new(
         self_id,
@@ -906,6 +922,7 @@ where
         direct_udp_auth_protocol,
         direct_udp_peer_score_reader,
         proposer_schedule,
+        tcp_auth_protocol,
     )
 }
 

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -767,6 +767,10 @@ where
         peer_discovery_config.self_direct_udp_port.is_some(),
         network_config.direct_udp_bind_address_port.is_some()
     );
+    assert_eq!(
+        peer_discovery_config.self_tcp_auth_port.is_some(),
+        network_config.authenticated_tcp_bind_address_port.is_some()
+    );
 
     let self_record = NameRecord::new_with_ports(
         *name_record_address.ip(),
@@ -775,6 +779,9 @@ where
         peer_discovery_config.self_auth_port.get(),
         peer_discovery_config
             .self_direct_udp_port
+            .map(NonZeroU16::get),
+        peer_discovery_config
+            .self_tcp_auth_port
             .map(NonZeroU16::get),
         peer_discovery_config.self_record_seq_num,
     );
@@ -950,6 +957,7 @@ fn bootstrap_peer_entry<ST: CertificateSignatureRecoverable>(
         record_seq_num: peer.record_seq_num,
         auth_port: peer.auth_port,
         direct_udp_port: peer.direct_udp_port,
+        tcp_auth_port: peer.tcp_auth_port,
     })
 }
 

--- a/monad-peer-discovery/examples/sign-name-record.rs
+++ b/monad-peer-discovery/examples/sign-name-record.rs
@@ -42,6 +42,9 @@ struct Args {
     #[arg(long, help = "Optional direct UDP port")]
     direct_udp_port: Option<NonZeroU16>,
 
+    #[arg(long, help = "Optional authenticated TCP port")]
+    authenticated_tcp_port: Option<NonZeroU16>,
+
     /// Sequence number for the name record
     #[arg(long)]
     self_record_seq_num: Option<u64>,
@@ -86,6 +89,7 @@ fn main() {
         args.udp_port.map(NonZeroU16::get),
         args.authenticated_udp_port.get(),
         args.direct_udp_port.map(NonZeroU16::get),
+        args.authenticated_tcp_port.map(NonZeroU16::get),
         self_record_seq_num,
     );
     let signed_name_record: MonadNameRecord<SecpSignature> =
@@ -99,7 +103,10 @@ fn main() {
     println!("self_record_seq_num = {}", self_record_seq_num);
     println!("self_auth_port = {}", args.authenticated_udp_port);
     if let Some(direct_udp_port) = args.direct_udp_port {
-        println!("self_direct_udp_auth_port = {}", direct_udp_port);
+        println!("self_direct_udp_port = {}", direct_udp_port);
+    }
+    if let Some(authenticated_tcp_port) = args.authenticated_tcp_port {
+        println!("self_tcp_auth_port = {}", authenticated_tcp_port);
     }
     println!(
         "self_name_record_sig = {:?}",

--- a/monad-peer-discovery/src/discovery.rs
+++ b/monad-peer-discovery/src/discovery.rs
@@ -3153,6 +3153,7 @@ mod tests {
                 Some(8000),
                 9100,
                 Some(9000),
+                None,
                 1,
             ),
             peer1,
@@ -3185,6 +3186,7 @@ mod tests {
                 Some(8001),
                 9101,
                 Some(9000),
+                None,
                 1,
             ),
             peer2,
@@ -3426,12 +3428,14 @@ mod tests {
         use monad_secp::SecpSignature;
         use monad_testutil::signing::create_keys as create_secp_keys;
 
-        let keys = create_secp_keys::<SecpSignature>(3);
+        let keys = create_secp_keys::<SecpSignature>(4);
         let peer0 = &keys[0];
         let peer1 = &keys[1];
         let peer1_pubkey = NodeId::new(peer1.pubkey());
         let peer2 = &keys[2];
         let peer2_pubkey = NodeId::new(peer2.pubkey());
+        let peer3 = &keys[3];
+        let peer3_pubkey = NodeId::new(peer3.pubkey());
 
         // peer1 has an authenticated UDP port
         let peer1_name_record = {
@@ -3454,6 +3458,7 @@ mod tests {
                 Some(8001),
                 9001,
                 Some(9002),
+                None,
                 2,
             );
             let mut encoded = Vec::new();
@@ -3465,7 +3470,26 @@ mod tests {
             }
         };
 
-        // initial state: peer1 in routing_info and peer2 in pending_queue
+        let peer3_name_record = {
+            let name_record = NameRecord::new_with_ports(
+                Ipv4Addr::new(8, 8, 2, 2),
+                8002,
+                Some(8002),
+                9003,
+                None,
+                Some(9004),
+                3,
+            );
+            let mut encoded = Vec::new();
+            name_record.encode(&mut encoded);
+            let signature = SecpSignature::sign::<signing_domain::NameRecord>(&encoded, peer3);
+            MonadNameRecord {
+                name_record,
+                signature,
+            }
+        };
+
+        // initial state: peer1 in routing_info and peer2, peer3 in pending_queue
         let mut routing_info = BTreeMap::new();
         routing_info.insert(peer1_pubkey, peer1_name_record);
         let mut pending_queue = BTreeMap::new();
@@ -3478,6 +3502,17 @@ mod tests {
                 },
                 unresponsive_pings: 0,
                 name_record: peer2_name_record,
+            },
+        );
+        pending_queue.insert(
+            peer3_pubkey,
+            ConnectionInfo {
+                last_ping: Ping {
+                    id: 0,
+                    local_name_record: peer3_name_record.clone(),
+                },
+                unresponsive_pings: 0,
+                name_record: peer3_name_record,
             },
         );
 
@@ -3542,10 +3577,12 @@ mod tests {
         // clean up any existing file
         let _ = std::fs::remove_file(&temp_file);
 
-        // verify initial state has peer1 in routing_info and peer2 in pending_queue
+        // verify initial state has peer1 in routing_info and peer2, peer3 in pending_queue
         assert!(state.routing_info.contains_key(&peer1_pubkey));
         assert!(!state.routing_info.contains_key(&peer2_pubkey));
+        assert!(!state.routing_info.contains_key(&peer3_pubkey));
         assert!(state.pending_queue.contains_key(&peer2_pubkey));
+        assert!(state.pending_queue.contains_key(&peer3_pubkey));
         assert!(!state.pending_queue.contains_key(&peer1_pubkey));
 
         // write peers to file
@@ -3570,9 +3607,10 @@ mod tests {
 
         state.read_peers_from_file();
 
-        // verify that peer1 and peer2 are restored from file and now in pending_queue
+        // verify that peer1, peer2, and peer3 are restored from file and now in pending_queue
         assert!(state.pending_queue.contains_key(&peer1_pubkey));
         assert!(state.pending_queue.contains_key(&peer2_pubkey));
+        assert!(state.pending_queue.contains_key(&peer3_pubkey));
         assert!(
             state.routing_info.is_empty(),
             "routing_info should still be empty before ping pong"
@@ -3609,6 +3647,29 @@ mod tests {
             loaded_peer2.name_record.direct_udp_port(),
             Some(9002),
             "peer2 direct UDP port should match"
+        );
+
+        let loaded_peer3 = &state.pending_queue.get(&peer3_pubkey).unwrap().name_record;
+        assert_eq!(
+            loaded_peer3.udp_address(),
+            Some(SocketAddrV4::new(Ipv4Addr::new(8, 8, 2, 2), 8002)),
+            "peer3 address should match"
+        );
+        assert_eq!(loaded_peer3.seq(), 3, "peer3 seq should match");
+        assert_eq!(
+            loaded_peer3.name_record.authenticated_udp_port(),
+            9003,
+            "peer3 auth port should match"
+        );
+        assert_eq!(
+            loaded_peer3.name_record.direct_udp_port(),
+            None,
+            "peer3 direct UDP port should be empty"
+        );
+        assert_eq!(
+            loaded_peer3.name_record.authenticated_tcp_port(),
+            Some(9004),
+            "peer3 tcp auth port should match"
         );
 
         let _ = std::fs::remove_file(&temp_file);

--- a/monad-peer-discovery/src/lib.rs
+++ b/monad-peer-discovery/src/lib.rs
@@ -55,6 +55,7 @@ pub enum PortTag {
     UDP = 1,
     AuthenticatedUDP = 2,
     DirectUDP = 3,
+    AuthenticatedTCP = 4,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -77,6 +78,7 @@ impl Port {
             1 => Some(PortTag::UDP),
             2 => Some(PortTag::AuthenticatedUDP),
             3 => Some(PortTag::DirectUDP),
+            4 => Some(PortTag::AuthenticatedTCP),
             _ => None,
         }
     }
@@ -181,6 +183,10 @@ impl<const N: usize> PortList<N> {
     fn direct_udp_port(&self) -> Option<NonZeroU16> {
         self.port_by_tag(PortTag::DirectUDP)
     }
+
+    fn authenticated_tcp_port(&self) -> Option<NonZeroU16> {
+        self.port_by_tag(PortTag::AuthenticatedTCP)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -226,8 +232,15 @@ impl NameRecord {
         capabilities: u64,
         seq: u64,
     ) -> Self {
-        let mut record =
-            Self::new_with_ports(ip, tcp_port, udp_port, authenticated_udp_port, None, seq);
+        let mut record = Self::new_with_ports(
+            ip,
+            tcp_port,
+            udp_port,
+            authenticated_udp_port,
+            None,
+            None,
+            seq,
+        );
         record.capabilities = capabilities;
         record
     }
@@ -238,6 +251,7 @@ impl NameRecord {
         udp_port: Option<u16>,
         authenticated_udp_port: u16,
         direct_udp_port: Option<u16>,
+        authenticated_tcp_port: Option<u16>,
         seq: u64,
     ) -> Self {
         let mut ports_vec = ArrayVec::new();
@@ -248,6 +262,9 @@ impl NameRecord {
         ports_vec.push(Port::new(PortTag::AuthenticatedUDP, authenticated_udp_port));
         if let Some(direct_udp_port) = direct_udp_port {
             ports_vec.push(Port::new(PortTag::DirectUDP, direct_udp_port));
+        }
+        if let Some(authenticated_tcp_port) = authenticated_tcp_port {
+            ports_vec.push(Port::new(PortTag::AuthenticatedTCP, authenticated_tcp_port));
         }
         Self {
             ip,
@@ -306,6 +323,15 @@ impl NameRecord {
 
     pub fn direct_udp_socket(&self) -> Option<SocketAddrV4> {
         self.direct_udp_port()
+            .map(|port| SocketAddrV4::new(self.ip(), port))
+    }
+
+    pub fn authenticated_tcp_port(&self) -> Option<u16> {
+        self.ports.authenticated_tcp_port().map(NonZeroU16::get)
+    }
+
+    pub fn authenticated_tcp_socket(&self) -> Option<SocketAddrV4> {
+        self.authenticated_tcp_port()
             .map(|port| SocketAddrV4::new(self.ip(), port))
     }
 
@@ -396,6 +422,10 @@ impl<ST: CertificateSignatureRecoverable> MonadNameRecord<ST> {
         self.name_record.direct_udp_socket()
     }
 
+    pub fn authenticated_tcp_address(&self) -> Option<SocketAddrV4> {
+        self.name_record.authenticated_tcp_socket()
+    }
+
     pub fn all_udp_sockets(&self) -> impl Iterator<Item = SocketAddrV4> + '_ {
         [
             self.udp_address(),
@@ -431,6 +461,7 @@ impl<ST: CertificateSignatureRecoverable> TryFrom<&PeerEntry<ST>> for MonadNameR
             peer.udp_port().map(NonZeroU16::get),
             peer.auth_port.get(),
             peer.direct_udp_port.map(NonZeroU16::get),
+            peer.tcp_auth_port.map(NonZeroU16::get),
             peer.record_seq_num,
         );
 
@@ -469,6 +500,9 @@ impl<ST: CertificateSignatureRecoverable> TryFrom<&MonadNameRecord<ST>> for Peer
             direct_udp_port: record.name_record.direct_udp_port().map(|port| {
                 NonZeroU16::new(port).expect("name record direct UDP port must be non-zero")
             }),
+            tcp_auth_port: record.name_record.authenticated_tcp_port().map(|port| {
+                NonZeroU16::new(port).expect("name record authenticated TCP port must be non-zero")
+            }),
         })
     }
 }
@@ -487,6 +521,7 @@ impl<ST: CertificateSignatureRecoverable> From<MonadNameRecordWithPubkey<'_, ST>
             record_seq_num: peer.record_seq_num,
             auth_port: peer.auth_port,
             direct_udp_port: peer.direct_udp_port,
+            tcp_auth_port: peer.tcp_auth_port,
         }
     }
 }
@@ -519,6 +554,7 @@ impl<ST: CertificateSignatureRecoverable> TryFrom<&NodeBootstrapPeerConfig<ST>>
             peer_config.udp_port().map(NonZeroU16::get),
             peer_config.auth_port.get(),
             peer_config.direct_udp_port.map(NonZeroU16::get),
+            peer_config.tcp_auth_port.map(NonZeroU16::get),
             peer_config.record_seq_num,
         );
 
@@ -574,6 +610,14 @@ impl<ST: CertificateSignatureRecoverable> From<MonadNameRecordWithPubkey<'_, ST>
                 .direct_udp_port()
                 .map(|port| {
                     NonZeroU16::new(port).expect("name record direct UDP port must be non-zero")
+                }),
+            tcp_auth_port: record_with_pubkey
+                .record
+                .name_record
+                .authenticated_tcp_port()
+                .map(|port| {
+                    NonZeroU16::new(port)
+                        .expect("name record authenticated TCP port must be non-zero")
                 }),
         }
     }
@@ -1043,6 +1087,7 @@ mod tests {
             Some(udp_port),
             authenticated_udp_port,
             Some(direct_udp_port),
+            None,
             seq,
         );
 
@@ -1081,6 +1126,7 @@ mod tests {
             Some(9201),
             9202,
             Some(9203),
+            None,
             102,
         ),
         vec![
@@ -1115,6 +1161,21 @@ mod tests {
         vec![
             SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 47), 9501),
             SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 47), 9501),
+        ],
+    )]
+    #[case::tcp_auth_does_not_add_udp_socket(
+        NameRecord::new_with_ports(
+            Ipv4Addr::new(10, 0, 0, 48),
+            9600,
+            Some(9601),
+            9602,
+            None,
+            Some(9603),
+            106,
+        ),
+        vec![
+            SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 48), 9601),
+            SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 48), 9602),
         ],
     )]
     fn test_monad_name_record_all_udp_sockets(
@@ -1153,6 +1214,7 @@ mod tests {
             record_seq_num: seq,
             auth_port: NonZeroU16::new(port).unwrap(),
             direct_udp_port: None,
+            tcp_auth_port: None,
         };
 
         let result = MonadNameRecord::<SecpSignature>::try_from(&peer_entry);
@@ -1196,8 +1258,15 @@ mod tests {
         let seq = 100u64;
 
         let keypair = KeyPair::from_ikm(b"test roundtrip direct udp").unwrap();
-        let name_record =
-            NameRecord::new_with_ports(ip, port, Some(port), auth_port, Some(direct_udp_port), seq);
+        let name_record = NameRecord::new_with_ports(
+            ip,
+            port,
+            Some(port),
+            auth_port,
+            Some(direct_udp_port),
+            None,
+            seq,
+        );
         let original_monad_record = MonadNameRecord::<SecpSignature>::new(name_record, &keypair);
 
         let pubkey = original_monad_record.recover_pubkey().unwrap().pubkey();
@@ -1283,5 +1352,46 @@ mod tests {
     #[should_panic(expected = "name record port must be non-zero")]
     fn test_name_record_new_rejects_zero_port() {
         let _ = NameRecord::new(Ipv4Addr::new(1, 1, 1, 1), 0, Some(9001), 9002, 0, 1);
+    }
+
+    #[test]
+    fn test_peer_entry_monad_name_record_roundtrip_with_tcp_auth() {
+        let ip = Ipv4Addr::from_str("172.31.0.103").unwrap();
+        let port = 8895u16;
+        let auth_port = 8896u16;
+        let tcp_auth_port = 8897u16;
+        let seq = 102u64;
+
+        let keypair = KeyPair::from_ikm(b"test roundtrip tcp auth").unwrap();
+        let name_record = NameRecord::new_with_ports(
+            ip,
+            port,
+            Some(port),
+            auth_port,
+            None,
+            Some(tcp_auth_port),
+            seq,
+        );
+        let original_monad_record = MonadNameRecord::<SecpSignature>::new(name_record, &keypair);
+
+        let pubkey = original_monad_record.recover_pubkey().unwrap().pubkey();
+        let peer_entry = PeerEntry::from(original_monad_record.with_pubkey(pubkey));
+        assert_eq!(peer_entry.auth_port.get(), auth_port);
+        assert_eq!(
+            peer_entry.tcp_auth_port.map(NonZeroU16::get),
+            Some(tcp_auth_port)
+        );
+
+        let converted_monad_record =
+            MonadNameRecord::<SecpSignature>::try_from(&peer_entry).unwrap();
+
+        assert_eq!(
+            converted_monad_record.name_record,
+            original_monad_record.name_record
+        );
+        assert_eq!(
+            converted_monad_record.name_record.authenticated_tcp_port(),
+            Some(tcp_auth_port)
+        );
     }
 }

--- a/monad-peer-discovery/src/snapshots/monad_peer_discovery__discovery__tests__persisted_peers_format.snap
+++ b/monad-peer-discovery/src/snapshots/monad_peer_discovery__discovery__tests__persisted_peers_format.snap
@@ -1,6 +1,6 @@
 ---
 source: monad-peer-discovery/src/discovery.rs
-assertion_line: 3344
+assertion_line: 3612
 expression: written_content
 ---
 [[peers]]
@@ -11,6 +11,16 @@ record_seq_num = 1
 secp256k1_pubkey = "0x0334944627833fe16cc7e21cd5e1442b42b3eb9bbd0cdd266e449a9dc026b45a39"
 name_record_sig = "0x22da25d0c0525eb01f8c37766439fc48f95b02eee0cba578cdbf03038114650c5ce59614af8c51f38f46e174edd7a1ebeb767f5d1d2b215998e95fac1615872f01"
 auth_port = 9000
+
+[[peers]]
+address = "8.8.2.2"
+tcp_port = 8002
+udp_port = 8002
+record_seq_num = 3
+secp256k1_pubkey = "0x02871061053f395ab80a6ba139fe2ed41d3d99c3df3f9d8b311ecac952f85af805"
+name_record_sig = "0x7d7a0988c907dc40c1a5f6daa4c11564dc6b3749f811bc555e7c8de0619c9b2c0e4f436aafa98e0991296d608360de557f10b37ccf55d040a9819a61357a13a800"
+auth_port = 9003
+tcp_auth_port = 9004
 
 [[peers]]
 address = "8.8.4.4"

--- a/monad-raptorcast/examples/latency.rs
+++ b/monad-raptorcast/examples/latency.rs
@@ -622,6 +622,7 @@ fn setup_node(
             ),
         ])
         .build();
+    assert!(dataplane.block_until_ready(Duration::from_secs(2)));
 
     let tcp_socket = dataplane
         .tcp_sockets
@@ -652,7 +653,7 @@ fn setup_node(
 
     let keypair_arc = Arc::new(keypair);
     let wireauth_config = monad_wireauth::Config::default();
-    let auth_protocol = monad_raptorcast::auth::WireAuthProtocol::new(
+    let udp_auth_protocol = monad_raptorcast::auth::WireAuthProtocol::new(
         &monad_raptorcast::auth::metrics::UDP_METRICS,
         wireauth_config,
         keypair_arc.clone(),
@@ -670,7 +671,8 @@ fn setup_node(
         create_raptorcast_config(keypair_arc),
         SecondaryRaptorCastModeConfig::None,
         tcp_socket,
-        (authenticated_socket, auth_protocol),
+        None,
+        (authenticated_socket, udp_auth_protocol),
         None,
         Some(non_authenticated_socket),
         dataplane_control,

--- a/monad-raptorcast/src/auth/common.rs
+++ b/monad-raptorcast/src/auth/common.rs
@@ -1,0 +1,115 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    future::Future,
+    net::SocketAddr,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Instant,
+};
+
+use bytes::{Bytes, BytesMut};
+use tokio::time::Sleep;
+use tracing::{trace, warn};
+use zerocopy::IntoBytes;
+
+use super::protocol::AuthenticationProtocol;
+
+pub struct AuthenticatedTimerFuture<'a, AP: AuthenticationProtocol> {
+    auth_protocol: &'a mut AP,
+    auth_timer: &'a mut Option<(Pin<Box<Sleep>>, Instant)>,
+}
+
+impl<'a, AP: AuthenticationProtocol> AuthenticatedTimerFuture<'a, AP> {
+    pub fn new(
+        auth_protocol: &'a mut AP,
+        auth_timer: &'a mut Option<(Pin<Box<Sleep>>, Instant)>,
+    ) -> Self {
+        Self {
+            auth_protocol,
+            auth_timer,
+        }
+    }
+}
+
+impl<AP: AuthenticationProtocol> Future for AuthenticatedTimerFuture<'_, AP> {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        trace!("polling wireauth timer");
+
+        loop {
+            let Some(deadline) = self.auth_protocol.next_deadline() else {
+                return Poll::Pending;
+            };
+
+            let now = Instant::now();
+            if deadline <= now {
+                if let Some(d) = now.checked_duration_since(deadline) {
+                    if d > std::time::Duration::from_millis(100) {
+                        warn!(delta_ms = d.as_millis(), "slow polling wireauth timer");
+                    }
+                }
+
+                self.auth_protocol.tick();
+                return Poll::Ready(());
+            }
+
+            let should_update_timer = self
+                .auth_timer
+                .as_ref()
+                .is_none_or(|(_, stored_deadline)| deadline < *stored_deadline);
+            if should_update_timer {
+                *self.auth_timer = Some((
+                    Box::pin(tokio::time::sleep_until(deadline.into())),
+                    deadline,
+                ));
+            }
+
+            let Some((sleep, _)) = self.auth_timer.as_mut() else {
+                return Poll::Pending;
+            };
+
+            match sleep.as_mut().poll(cx) {
+                Poll::Ready(()) => *self.auth_timer = None,
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+pub fn encrypt_packet<AP: AuthenticationProtocol>(
+    auth_protocol: &mut AP,
+    addr: &SocketAddr,
+    plaintext: Bytes,
+) -> Option<(SocketAddr, Bytes)> {
+    let header_size = AP::HEADER_SIZE as usize;
+    let mut packet = BytesMut::with_capacity(header_size + plaintext.len());
+    packet.resize(header_size, 0);
+    packet.extend_from_slice(&plaintext);
+
+    match auth_protocol.encrypt_by_socket(addr, &mut packet[header_size..]) {
+        Ok(header) => {
+            let header_bytes = header.as_bytes();
+            packet[..header_size].copy_from_slice(header_bytes);
+            Some((*addr, packet.freeze()))
+        }
+        Err(e) => {
+            warn!(addr=?addr, error=?e, "failed to encrypt message");
+            None
+        }
+    }
+}

--- a/monad-raptorcast/src/auth/metrics.rs
+++ b/monad-raptorcast/src/auth/metrics.rs
@@ -36,6 +36,26 @@ monad_executor::metric_consts! {
 
 monad_wireauth::define_metric_names!(UDP_METRICS, "udp");
 monad_wireauth::define_metric_names!(DIRECT_UDP_METRICS, "direct_udp");
+monad_wireauth::define_metric_names!(TCP_METRICS, "tcp");
+
+monad_executor::metric_consts! {
+    pub GAUGE_RAPTORCAST_AUTH_WIREAUTH_TCP_BYTES_WRITTEN {
+        name: "monad.raptorcast.auth.wireauth_tcp_bytes_written",
+        help: "Bytes written via wireauth TCP",
+    }
+    pub GAUGE_RAPTORCAST_AUTH_SIGAUTH_TCP_BYTES_WRITTEN {
+        name: "monad.raptorcast.auth.sigauth_tcp_bytes_written",
+        help: "Bytes written via signature-authenticated TCP",
+    }
+    pub GAUGE_RAPTORCAST_AUTH_WIREAUTH_TCP_BYTES_READ {
+        name: "monad.raptorcast.auth.wireauth_tcp_bytes_read",
+        help: "Bytes read via wireauth TCP",
+    }
+    pub GAUGE_RAPTORCAST_AUTH_SIGAUTH_TCP_BYTES_READ {
+        name: "monad.raptorcast.auth.sigauth_tcp_bytes_read",
+        help: "Bytes read via signature-authenticated TCP",
+    }
+}
 
 pub(crate) fn init_socket_executor_metrics() -> ExecutorMetrics {
     ExecutorMetrics::with_metric_defs(&[
@@ -43,5 +63,9 @@ pub(crate) fn init_socket_executor_metrics() -> ExecutorMetrics {
         GAUGE_RAPTORCAST_AUTH_NON_AUTHENTICATED_UDP_BYTES_WRITTEN,
         GAUGE_RAPTORCAST_AUTH_AUTHENTICATED_UDP_BYTES_READ,
         GAUGE_RAPTORCAST_AUTH_NON_AUTHENTICATED_UDP_BYTES_READ,
+        GAUGE_RAPTORCAST_AUTH_WIREAUTH_TCP_BYTES_WRITTEN,
+        GAUGE_RAPTORCAST_AUTH_SIGAUTH_TCP_BYTES_WRITTEN,
+        GAUGE_RAPTORCAST_AUTH_WIREAUTH_TCP_BYTES_READ,
+        GAUGE_RAPTORCAST_AUTH_SIGAUTH_TCP_BYTES_READ,
     ])
 }

--- a/monad-raptorcast/src/auth/mod.rs
+++ b/monad-raptorcast/src/auth/mod.rs
@@ -13,10 +13,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+mod common;
 pub mod framing;
 pub mod metrics;
 pub mod protocol;
 pub mod socket;
+pub mod tcp_socket;
+
+pub(crate) type DataplaneCompletion = Option<futures::channel::oneshot::Sender<()>>;
 
 pub use framing::{AuthPacketFramer, LeanUdpFramer, LeanUdpFramingError, NopScore};
 pub use metrics::{
@@ -24,9 +28,16 @@ pub use metrics::{
     GAUGE_RAPTORCAST_AUTH_AUTHENTICATED_UDP_BYTES_WRITTEN,
     GAUGE_RAPTORCAST_AUTH_NON_AUTHENTICATED_UDP_BYTES_READ,
     GAUGE_RAPTORCAST_AUTH_NON_AUTHENTICATED_UDP_BYTES_WRITTEN,
+    GAUGE_RAPTORCAST_AUTH_SIGAUTH_TCP_BYTES_READ, GAUGE_RAPTORCAST_AUTH_SIGAUTH_TCP_BYTES_WRITTEN,
+    GAUGE_RAPTORCAST_AUTH_WIREAUTH_TCP_BYTES_READ,
+    GAUGE_RAPTORCAST_AUTH_WIREAUTH_TCP_BYTES_WRITTEN, TCP_METRICS, UDP_METRICS,
 };
 pub use protocol::{AuthenticationProtocol, NoopAuthProtocol, NoopHeader, WireAuthProtocol};
 pub use socket::{
     AuthRecvMsg, AuthenticatedSocketHandle, DualSocketHandle, FramedAuthenticatedSocketHandle,
     FramedRecvError,
+};
+pub use tcp_socket::{
+    AuthRecvTcpMsg, AuthenticatedTcpSocketHandle, DualTcpRecvError, DualTcpSocketHandle,
+    SigAuthError, SigAuthTcpSocket,
 };

--- a/monad-raptorcast/src/auth/protocol.rs
+++ b/monad-raptorcast/src/auth/protocol.rs
@@ -21,6 +21,8 @@ use monad_executor::ExecutorMetricsChain;
 use monad_wireauth::messages::{DataPacketHeader, Packet};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
+use super::DataplaneCompletion;
+
 pub trait AuthenticationProtocol {
     type PublicKey: PubKey;
     type Error: std::fmt::Debug;
@@ -59,6 +61,7 @@ pub trait AuthenticationProtocol {
         &mut self,
         public_key: &Self::PublicKey,
         message: Bytes,
+        completion: DataplaneCompletion,
     ) -> Result<(), Self::Error>;
 
     fn is_connected_public_key(&self, public_key: &Self::PublicKey) -> bool;
@@ -83,7 +86,7 @@ pub trait AuthenticationProtocol {
         public_key: &Self::PublicKey,
     ) -> bool;
 
-    fn next_packet(&mut self) -> Option<(SocketAddr, Bytes)>;
+    fn next_packet(&mut self) -> Option<(SocketAddr, Bytes, DataplaneCompletion)>;
 
     fn tick(&mut self);
 
@@ -93,7 +96,11 @@ pub trait AuthenticationProtocol {
 }
 
 pub struct WireAuthProtocol {
-    api: monad_wireauth::API<monad_wireauth::StdContext, Arc<monad_secp::KeyPair>>,
+    api: monad_wireauth::API<
+        monad_wireauth::StdContext,
+        Arc<monad_secp::KeyPair>,
+        DataplaneCompletion,
+    >,
 }
 
 impl WireAuthProtocol {
@@ -104,7 +111,7 @@ impl WireAuthProtocol {
     ) -> Self {
         let context = monad_wireauth::StdContext::new();
         Self {
-            api: monad_wireauth::API::new(metric_names, config, signing_key, context),
+            api: monad_wireauth::API::new_with_metadata(metric_names, config, signing_key, context),
         }
     }
 }
@@ -170,12 +177,16 @@ impl AuthenticationProtocol for WireAuthProtocol {
         &mut self,
         public_key: &Self::PublicKey,
         message: Bytes,
+        completion: DataplaneCompletion,
     ) -> Result<(), Self::Error> {
-        self.api.buffer_message(public_key, message)
+        self.api
+            .buffer_message_with_metadata(public_key, message, completion)
     }
 
-    fn next_packet(&mut self) -> Option<(SocketAddr, Bytes)> {
-        self.api.next_packet()
+    fn next_packet(&mut self) -> Option<(SocketAddr, Bytes, DataplaneCompletion)> {
+        self.api
+            .next_packet_with_metadata()
+            .map(|(addr, packet, completion)| (addr, packet, completion.flatten()))
     }
 
     fn tick(&mut self) {
@@ -297,11 +308,12 @@ impl<P: PubKey> AuthenticationProtocol for NoopAuthProtocol<P> {
         &mut self,
         _public_key: &Self::PublicKey,
         _message: Bytes,
+        _completion: DataplaneCompletion,
     ) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn next_packet(&mut self) -> Option<(SocketAddr, Bytes)> {
+    fn next_packet(&mut self) -> Option<(SocketAddr, Bytes, DataplaneCompletion)> {
         None
     }
 

--- a/monad-raptorcast/src/auth/socket.rs
+++ b/monad-raptorcast/src/auth/socket.rs
@@ -13,13 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{
-    future::Future,
-    net::SocketAddr,
-    pin::Pin,
-    task::{Context, Poll},
-    time::Instant,
-};
+use std::{net::SocketAddr, pin::Pin, time::Instant};
 
 use bytes::{Bytes, BytesMut};
 use monad_crypto::certificate_signature::PubKey;
@@ -29,10 +23,11 @@ use monad_peer_discovery::NameRecord;
 use monad_types::{NodeId, UdpPriority};
 use thiserror::Error;
 use tokio::time::Sleep;
-use tracing::{debug, trace, warn};
+use tracing::{debug, warn};
 use zerocopy::IntoBytes;
 
 use super::{
+    common::{encrypt_packet, AuthenticatedTimerFuture},
     framing::AuthPacketFramer,
     metrics::{
         init_socket_executor_metrics, GAUGE_RAPTORCAST_AUTH_AUTHENTICATED_UDP_BYTES_READ,
@@ -320,10 +315,8 @@ where
 
     pub async fn recv(&mut self) -> Result<AuthRecvMsg<AP::PublicKey>, AP::Error> {
         loop {
-            let timer = AuthenticatedTimerFuture {
-                auth_protocol: &mut self.auth_protocol,
-                auth_timer: &mut self.auth_timer,
-            };
+            let timer =
+                AuthenticatedTimerFuture::new(&mut self.auth_protocol, &mut self.auth_timer);
 
             tokio::select! {
                 () = timer => {
@@ -445,7 +438,7 @@ where
                 continue;
             }
 
-            if let Err(err) = self.auth_protocol.buffer_message(public_key, piece) {
+            if let Err(err) = self.auth_protocol.buffer_message(public_key, piece, None) {
                 warn!(error=?err, "failed to buffer message");
                 return Err(());
             }
@@ -490,16 +483,13 @@ where
     }
 
     pub fn flush(&mut self) {
-        while let Some((addr, packet)) = self.auth_protocol.next_packet() {
+        while let Some((addr, packet, _completion)) = self.auth_protocol.next_packet() {
             self.write_auth_packet(addr, packet);
         }
     }
 
     pub fn timer(&mut self) -> AuthenticatedTimerFuture<'_, AP> {
-        AuthenticatedTimerFuture {
-            auth_protocol: &mut self.auth_protocol,
-            auth_timer: &mut self.auth_timer,
-        }
+        AuthenticatedTimerFuture::new(&mut self.auth_protocol, &mut self.auth_timer)
     }
 
     pub fn metrics(&self) -> ExecutorMetricsChain<'_> {
@@ -511,25 +501,7 @@ where
         addr: SocketAddr,
         plaintext: Bytes,
     ) -> Option<(SocketAddr, Bytes)> {
-        let header_size = AP::HEADER_SIZE as usize;
-        let mut packet = BytesMut::with_capacity(header_size + plaintext.len());
-        packet.resize(header_size, 0);
-        packet.extend_from_slice(&plaintext);
-
-        match self
-            .auth_protocol
-            .encrypt_by_socket(&addr, &mut packet[header_size..])
-        {
-            Ok(header) => {
-                let header_bytes = header.as_bytes();
-                packet[..header_size].copy_from_slice(header_bytes);
-                Some((addr, packet.freeze()))
-            }
-            Err(err) => {
-                warn!(addr=?addr, error=?err, "failed to encrypt message");
-                None
-            }
-        }
+        encrypt_packet(&mut self.auth_protocol, &addr, plaintext)
     }
 
     fn encrypt_packet_by_public_key(
@@ -718,59 +690,6 @@ where
     }
 }
 
-pub struct AuthenticatedTimerFuture<'a, AP: AuthenticationProtocol> {
-    auth_protocol: &'a mut AP,
-    auth_timer: &'a mut Option<(Pin<Box<Sleep>>, Instant)>,
-}
-
-impl<AP: AuthenticationProtocol> Future for AuthenticatedTimerFuture<'_, AP> {
-    type Output = ();
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        trace!("polling wireauth timer");
-
-        loop {
-            let Some(deadline) = self.auth_protocol.next_deadline() else {
-                return Poll::Pending;
-            };
-
-            let now = Instant::now();
-            if deadline <= now {
-                if let Some(d) = now.checked_duration_since(deadline) {
-                    if d > std::time::Duration::from_millis(100) {
-                        warn!(delta_ms = d.as_millis(), "slow polling wireauth timer");
-                    }
-                }
-
-                self.auth_protocol.tick();
-                return Poll::Ready(());
-            }
-
-            // wireauth internal timers are expected to be updated
-            // for example initially session with have long timer set to session_timeout
-            // after fully establishing session, keapalive_interval will be set to a shorter duration
-            let should_update_timer = self
-                .auth_timer
-                .as_ref()
-                .is_none_or(|(_, stored_deadline)| deadline < *stored_deadline);
-            if should_update_timer {
-                *self.auth_timer = Some((
-                    Box::pin(tokio::time::sleep_until(deadline.into())),
-                    deadline,
-                ));
-            }
-
-            match self.auth_timer.as_mut() {
-                Some((sleep, _)) => match sleep.as_mut().poll(cx) {
-                    Poll::Ready(()) => *self.auth_timer = None,
-                    Poll::Pending => return Poll::Pending,
-                },
-                None => return Poll::Pending,
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::{
@@ -797,7 +716,7 @@ mod tests {
     };
     use crate::auth::{
         framing::AuthPacketFramer,
-        metrics::GAUGE_RAPTORCAST_AUTH_AUTHENTICATED_UDP_BYTES_WRITTEN,
+        metrics::{GAUGE_RAPTORCAST_AUTH_AUTHENTICATED_UDP_BYTES_WRITTEN, UDP_METRICS},
         protocol::{NoopAuthProtocol, WireAuthProtocol},
     };
 
@@ -856,6 +775,7 @@ mod tests {
                 .with_udp_sockets(udp_sockets)
                 .build();
 
+            assert!(dp.block_until_ready(Duration::from_secs(1)));
             let tcp_socket = dp
                 .tcp_sockets
                 .take(monad_dataplane::TcpSocketId::Raptorcast)
@@ -877,11 +797,7 @@ mod tests {
             let keypair = keypair(seed);
             let public_key = keypair.pubkey();
             let config = Config::default();
-            let auth_protocol = WireAuthProtocol::new(
-                &crate::auth::metrics::UDP_METRICS,
-                config,
-                Arc::new(keypair),
-            );
+            let auth_protocol = WireAuthProtocol::new(&UDP_METRICS, config, Arc::new(keypair));
             let authenticated_handle =
                 AuthenticatedSocketHandle::new(authenticated_socket, auth_protocol);
             let socket = DualSocketHandle::new(authenticated_handle, non_authenticated_socket);
@@ -1102,15 +1018,17 @@ mod tests {
     async fn test_timer_deadline() {
         init_tracing();
 
-        let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let zero_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0));
 
         let mut dp = DataplaneBuilder::new(1000)
+            .with_tcp_sockets([(monad_dataplane::TcpSocketId::Raptorcast, zero_addr)])
             .with_udp_sockets([(
                 monad_dataplane::UdpSocketId::AuthenticatedRaptorcast,
-                bind_addr,
+                zero_addr,
             )])
             .build();
 
+        assert!(dp.block_until_ready(Duration::from_secs(1)));
         let authenticated_socket = dp
             .udp_sockets
             .take(monad_dataplane::UdpSocketId::AuthenticatedRaptorcast)
@@ -1124,11 +1042,7 @@ mod tests {
             ..Default::default()
         };
 
-        let auth_protocol = WireAuthProtocol::new(
-            &crate::auth::metrics::UDP_METRICS,
-            config,
-            Arc::new(local_keypair),
-        );
+        let auth_protocol = WireAuthProtocol::new(&UDP_METRICS, config, Arc::new(local_keypair));
         let mut handle = AuthenticatedSocketHandle::new(authenticated_socket, auth_protocol);
 
         assert_eq!(poll!(pin!(handle.timer())), Poll::Pending);
@@ -1138,9 +1052,8 @@ mod tests {
         assert_eq!(poll!(pin!(handle.timer())), Poll::Ready(()));
         assert_eq!(poll!(pin!(handle.timer())), Poll::Pending);
 
-        // this ensures that timer is updated with a shorter deadline
         let remote_keypair = keypair(2);
-        let remote_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 19004));
+        let remote_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 19999));
         handle
             .connect(&remote_keypair.pubkey(), remote_addr, 1)
             .expect("connect failed");

--- a/monad-raptorcast/src/auth/socket.rs
+++ b/monad-raptorcast/src/auth/socket.rs
@@ -1028,6 +1028,7 @@ mod tests {
             None,
             bob_auth_addr.port(),
             None,
+            None,
             1,
         );
         let payload = Bytes::from_static(b"authenticated path");
@@ -1071,6 +1072,7 @@ mod tests {
             bob_auth_addr.port(),
             None,
             bob_auth_addr.port(),
+            None,
             None,
             1,
         );

--- a/monad-raptorcast/src/auth/tcp_socket.rs
+++ b/monad-raptorcast/src/auth/tcp_socket.rs
@@ -1,0 +1,823 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    net::SocketAddr,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+
+use bytes::{Bytes, BytesMut};
+use monad_crypto::{
+    certificate_signature::{
+        CertificateSignature, CertificateSignaturePubKey, CertificateSignatureRecoverable,
+    },
+    signing_domain,
+};
+use monad_dataplane::{TcpMsg, TcpSocketReader, TcpSocketWriter};
+use monad_executor::{ExecutorMetrics, ExecutorMetricsChain};
+use monad_peer_discovery::{driver::PeerDiscoveryDriver, PeerDiscoveryAlgo};
+use monad_types::NodeId;
+use tokio::time::Sleep;
+use tracing::{debug, warn};
+
+use super::{
+    common::{encrypt_packet, AuthenticatedTimerFuture},
+    metrics::{
+        init_socket_executor_metrics, GAUGE_RAPTORCAST_AUTH_SIGAUTH_TCP_BYTES_READ,
+        GAUGE_RAPTORCAST_AUTH_SIGAUTH_TCP_BYTES_WRITTEN,
+        GAUGE_RAPTORCAST_AUTH_WIREAUTH_TCP_BYTES_READ,
+        GAUGE_RAPTORCAST_AUTH_WIREAUTH_TCP_BYTES_WRITTEN,
+    },
+    protocol::AuthenticationProtocol,
+    DataplaneCompletion,
+};
+use crate::SIGNATURE_SIZE;
+
+#[derive(Clone)]
+pub struct AuthRecvTcpMsg<P> {
+    pub src_addr: SocketAddr,
+    pub payload: Bytes,
+    pub from: P,
+}
+
+#[derive(Debug)]
+pub enum SigAuthError {
+    MessageTooShort,
+    InvalidSignature,
+    PubkeyRecoveryFailed,
+}
+
+#[derive(Debug)]
+pub enum DualTcpRecvError {
+    WireAuth(SocketAddr),
+    SigAuth(SocketAddr, SigAuthError),
+}
+
+impl DualTcpRecvError {
+    pub fn src_addr(&self) -> SocketAddr {
+        match self {
+            DualTcpRecvError::WireAuth(addr) => *addr,
+            DualTcpRecvError::SigAuth(addr, _) => *addr,
+        }
+    }
+}
+
+pub struct SigAuthTcpSocket<ST>
+where
+    ST: CertificateSignatureRecoverable,
+{
+    reader: TcpSocketReader,
+    writer: TcpSocketWriter,
+    signing_key: Arc<ST::KeyPairType>,
+}
+
+impl<ST> SigAuthTcpSocket<ST>
+where
+    ST: CertificateSignatureRecoverable,
+{
+    pub fn new(
+        reader: TcpSocketReader,
+        writer: TcpSocketWriter,
+        signing_key: Arc<ST::KeyPairType>,
+    ) -> Self {
+        Self {
+            reader,
+            writer,
+            signing_key,
+        }
+    }
+
+    pub fn write(&mut self, addr: SocketAddr, payload: Bytes, completion: DataplaneCompletion) {
+        let mut signed_message = BytesMut::zeroed(SIGNATURE_SIZE + payload.len());
+        let signature =
+            <ST as CertificateSignature>::serialize(&ST::sign::<
+                signing_domain::RaptorcastAppMessage,
+            >(&payload, &self.signing_key));
+        debug_assert_eq!(signature.len(), SIGNATURE_SIZE);
+        signed_message[..SIGNATURE_SIZE].copy_from_slice(&signature);
+        signed_message[SIGNATURE_SIZE..].copy_from_slice(&payload);
+
+        self.writer.write(
+            addr,
+            TcpMsg {
+                msg: signed_message.freeze(),
+                completion,
+            },
+        );
+    }
+
+    pub async fn recv(
+        &mut self,
+    ) -> Result<AuthRecvTcpMsg<CertificateSignaturePubKey<ST>>, (SocketAddr, SigAuthError)> {
+        let msg = self.reader.recv().await;
+        let payload = msg.payload;
+        let src_addr = msg.src_addr;
+
+        if payload.len() < SIGNATURE_SIZE {
+            return Err((src_addr, SigAuthError::MessageTooShort));
+        }
+
+        let signature_bytes = &payload[..SIGNATURE_SIZE];
+        let signature = <ST as CertificateSignature>::deserialize(signature_bytes)
+            .map_err(|_| (src_addr, SigAuthError::InvalidSignature))?;
+
+        let app_message_bytes = payload.slice(SIGNATURE_SIZE..);
+        let from = signature
+            .recover_pubkey::<signing_domain::RaptorcastAppMessage>(app_message_bytes.as_ref())
+            .map_err(|_| (src_addr, SigAuthError::PubkeyRecoveryFailed))?;
+
+        Ok(AuthRecvTcpMsg {
+            src_addr,
+            payload: app_message_bytes,
+            from,
+        })
+    }
+}
+
+pub struct DualTcpSocketHandle<ST, AP, PD>
+where
+    ST: CertificateSignatureRecoverable,
+    AP: AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
+    PD: PeerDiscoveryAlgo<SignatureType = ST>,
+{
+    authenticated: Option<AuthenticatedTcpSocketHandle<AP>>,
+    signature_based: SigAuthTcpSocket<ST>,
+    peer_discovery: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
+    metrics: ExecutorMetrics,
+}
+
+impl<ST, AP, PD> DualTcpSocketHandle<ST, AP, PD>
+where
+    ST: CertificateSignatureRecoverable,
+    AP: AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
+    PD: PeerDiscoveryAlgo<SignatureType = ST>,
+{
+    pub fn new(
+        authenticated: Option<AuthenticatedTcpSocketHandle<AP>>,
+        signature_based: SigAuthTcpSocket<ST>,
+        peer_discovery: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
+    ) -> Self {
+        Self {
+            authenticated,
+            signature_based,
+            peer_discovery,
+            metrics: init_socket_executor_metrics(),
+        }
+    }
+
+    pub fn write_to_peer(
+        &mut self,
+        peer_id: &NodeId<CertificateSignaturePubKey<ST>>,
+        payload: Bytes,
+        completion: DataplaneCompletion,
+    ) {
+        let (tcp_addr, wireauth_tcp_addr) = {
+            let pd_driver = self.peer_discovery.lock().unwrap();
+            let Some(name_record) = pd_driver.get_name_record(peer_id) else {
+                warn!(?peer_id, "tcp write_to_peer: name record unknown");
+                return;
+            };
+            let tcp_addr = SocketAddr::V4(name_record.name_record.tcp_socket());
+            let wireauth_addr = name_record
+                .name_record
+                .authenticated_tcp_socket()
+                .map(SocketAddr::V4);
+            (tcp_addr, wireauth_addr)
+        };
+
+        if let Some(wireauth_addr) = wireauth_tcp_addr {
+            let public_key = peer_id.pubkey();
+            let Some(authenticated) = &mut self.authenticated else {
+                warn!(
+                    ?peer_id,
+                    "tcp write_to_peer: authenticated tcp is not configured"
+                );
+                return;
+            };
+            let payload_len = payload.len() as u64;
+            let written = if let Some(session_addr) = authenticated
+                .auth_protocol
+                .get_socket_by_public_key(&public_key)
+            {
+                authenticated.write(session_addr, payload, completion)
+            } else {
+                authenticated.try_send_via_wireauth(&public_key, wireauth_addr, payload, completion)
+            };
+            if written {
+                self.metrics
+                    .gauge(GAUGE_RAPTORCAST_AUTH_WIREAUTH_TCP_BYTES_WRITTEN)
+                    .add(payload_len);
+            }
+            return;
+        }
+
+        self.metrics
+            .gauge(GAUGE_RAPTORCAST_AUTH_SIGAUTH_TCP_BYTES_WRITTEN)
+            .add(payload.len() as u64);
+        self.signature_based.write(tcp_addr, payload, completion);
+    }
+
+    pub async fn recv(&mut self) -> Result<AuthRecvTcpMsg<AP::PublicKey>, DualTcpRecvError> {
+        if let Some(authenticated) = &mut self.authenticated {
+            tokio::select! {
+                result = authenticated.recv() => {
+                    match result {
+                        Ok(msg) => {
+                            self.metrics
+                                .gauge(GAUGE_RAPTORCAST_AUTH_WIREAUTH_TCP_BYTES_READ)
+                                .add(msg.payload.len() as u64);
+                            Ok(msg)
+                        }
+                        Err(src_addr) => Err(DualTcpRecvError::WireAuth(src_addr)),
+                    }
+                },
+                result = self.signature_based.recv() => {
+                    match result {
+                        Ok(msg) => {
+                            self.metrics
+                                .gauge(GAUGE_RAPTORCAST_AUTH_SIGAUTH_TCP_BYTES_READ)
+                                .add(msg.payload.len() as u64);
+                            Ok(msg)
+                        }
+                        Err((src_addr, err)) => Err(DualTcpRecvError::SigAuth(src_addr, err)),
+                    }
+                },
+            }
+        } else {
+            match self.signature_based.recv().await {
+                Ok(msg) => {
+                    self.metrics
+                        .gauge(GAUGE_RAPTORCAST_AUTH_SIGAUTH_TCP_BYTES_READ)
+                        .add(msg.payload.len() as u64);
+                    Ok(msg)
+                }
+                Err((src_addr, err)) => Err(DualTcpRecvError::SigAuth(src_addr, err)),
+            }
+        }
+    }
+
+    pub fn metrics(&self) -> ExecutorMetricsChain<'_> {
+        let mut chain = ExecutorMetricsChain::default().push(self.metrics.as_ref());
+        if let Some(authenticated) = &self.authenticated {
+            chain = chain.chain(authenticated.auth_protocol.metrics());
+        }
+        chain
+    }
+}
+
+pub struct AuthenticatedTcpSocketHandle<AP>
+where
+    AP: AuthenticationProtocol,
+{
+    reader: TcpSocketReader,
+    writer: TcpSocketWriter,
+    pub(crate) auth_protocol: AP,
+    auth_timer: Option<(Pin<Box<Sleep>>, Instant)>,
+}
+
+impl<AP> AuthenticatedTcpSocketHandle<AP>
+where
+    AP: AuthenticationProtocol,
+    AP::PublicKey: Clone,
+{
+    pub fn new(reader: TcpSocketReader, writer: TcpSocketWriter, auth_protocol: AP) -> Self {
+        Self {
+            reader,
+            writer,
+            auth_protocol,
+            auth_timer: None,
+        }
+    }
+
+    pub async fn recv(&mut self) -> Result<AuthRecvTcpMsg<AP::PublicKey>, SocketAddr> {
+        loop {
+            let timer =
+                AuthenticatedTimerFuture::new(&mut self.auth_protocol, &mut self.auth_timer);
+
+            tokio::select! {
+                () = timer => {
+                    self.flush();
+                    continue;
+                }
+                message = self.reader.recv() => {
+                    let mut packet_buf = message.payload.to_vec();
+                    match self.auth_protocol.dispatch(&mut packet_buf, message.src_addr) {
+                        Ok(Some((plaintext, Some(from)))) => {
+                            return Ok(AuthRecvTcpMsg {
+                                src_addr: message.src_addr,
+                                payload: plaintext,
+                                from,
+                            })
+                        }
+                        Ok(Some((_, None))) => {
+                            warn!(addr=?message.src_addr, "received tcp data packet without public key");
+                            self.flush();
+                            continue;
+                        }
+                        Ok(None) => {
+                            self.flush();
+                            continue;
+                        }
+                        Err(e) => {
+                            debug!(addr=?message.src_addr, error=?e, "failed to decrypt tcp message");
+                            return Err(message.src_addr);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn write(
+        &mut self,
+        addr: SocketAddr,
+        payload: Bytes,
+        completion: DataplaneCompletion,
+    ) -> bool {
+        if let Some(encrypted) = self.encrypt_packet(addr, payload) {
+            self.writer.write(
+                encrypted.0,
+                TcpMsg {
+                    msg: encrypted.1,
+                    completion,
+                },
+            );
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn flush(&mut self) {
+        while let Some((addr, packet, completion)) = self.auth_protocol.next_packet() {
+            self.write_auth_packet(addr, packet, completion);
+        }
+    }
+
+    pub fn try_send_via_wireauth(
+        &mut self,
+        public_key: &AP::PublicKey,
+        wireauth_addr: SocketAddr,
+        payload: Bytes,
+        completion: DataplaneCompletion,
+    ) -> bool {
+        if !self
+            .auth_protocol
+            .has_initiator_session_by_public_key(public_key)
+        {
+            if let Err(err) = self.auth_protocol.connect(
+                public_key,
+                wireauth_addr,
+                monad_wireauth::DEFAULT_RETRY_ATTEMPTS,
+            ) {
+                warn!(?err, "failed to connect via wireauth");
+                return false;
+            }
+            self.flush();
+        }
+
+        if let Err(err) = self
+            .auth_protocol
+            .buffer_message(public_key, payload, completion)
+        {
+            warn!(?err, "failed to buffer tcp message");
+            return false;
+        }
+        true
+    }
+
+    fn encrypt_packet(
+        &mut self,
+        addr: SocketAddr,
+        plaintext: Bytes,
+    ) -> Option<(SocketAddr, Bytes)> {
+        encrypt_packet(&mut self.auth_protocol, &addr, plaintext)
+    }
+
+    fn write_auth_packet(&self, addr: SocketAddr, packet: Bytes, completion: DataplaneCompletion) {
+        self.writer.write(
+            addr,
+            TcpMsg {
+                msg: packet,
+                completion,
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        future::Future,
+        net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use bytes::Bytes;
+    use monad_crypto::certificate_signature::CertificateSignaturePubKey;
+    use monad_dataplane::{DataplaneBuilder, DataplaneControl, TcpSocketHandle, TcpSocketId};
+    use monad_peer_discovery::{
+        driver::PeerDiscoveryDriver,
+        mock::{NopDiscovery, NopDiscoveryBuilder},
+        MonadNameRecord, NameRecord,
+    };
+    use monad_secp::{KeyPair, SecpSignature};
+    use monad_types::NodeId;
+    use monad_wireauth::Config;
+    use tracing_subscriber::EnvFilter;
+
+    use super::{AuthenticatedTcpSocketHandle, DualTcpSocketHandle, SigAuthTcpSocket};
+    use crate::auth::{metrics::TCP_METRICS, protocol::WireAuthProtocol, DataplaneCompletion};
+
+    fn keypair(seed: u8) -> KeyPair {
+        KeyPair::from_bytes(&mut [seed; 32]).unwrap()
+    }
+
+    type PublicKey = CertificateSignaturePubKey<SecpSignature>;
+    type Discovery = NopDiscovery<SecpSignature>;
+    type DiscoveryDriver = Arc<Mutex<PeerDiscoveryDriver<Discovery>>>;
+    type TestSocket = DualTcpSocketHandle<SecpSignature, WireAuthProtocol, Discovery>;
+    type NameRecords = HashMap<NodeId<PublicKey>, MonadNameRecord<SecpSignature>>;
+
+    struct NodeInfo {
+        keypair: Arc<KeyPair>,
+        node_id: NodeId<PublicKey>,
+        sigauth_tcp_addr: SocketAddrV4,
+        wireauth_tcp_addr: SocketAddrV4,
+        sigauth_tcp: Option<TcpSocketHandle>,
+        wireauth_tcp: Option<TcpSocketHandle>,
+        control: Option<DataplaneControl>,
+    }
+
+    impl NodeInfo {
+        fn new(seed: u8) -> Self {
+            let kp = keypair(seed);
+            let node_id = NodeId::new(kp.pubkey());
+            let bind_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+            let mut dp = DataplaneBuilder::new(1000)
+                .with_tcp_sockets([
+                    (TcpSocketId::AuthenticatedRaptorcast, bind_addr),
+                    (TcpSocketId::Raptorcast, bind_addr),
+                ])
+                .build();
+            assert!(dp.block_until_ready(Duration::from_secs(1)));
+
+            let wireauth_tcp = dp
+                .tcp_sockets
+                .take(TcpSocketId::AuthenticatedRaptorcast)
+                .expect("wireauth tcp socket");
+            let sigauth_tcp = dp
+                .tcp_sockets
+                .take(TcpSocketId::Raptorcast)
+                .expect("sigauth tcp socket");
+            let SocketAddr::V4(wireauth_tcp_addr) = wireauth_tcp.local_addr() else {
+                panic!("expected IPv4 wireauth address");
+            };
+            let SocketAddr::V4(sigauth_tcp_addr) = sigauth_tcp.local_addr() else {
+                panic!("expected IPv4 sigauth address");
+            };
+
+            Self {
+                keypair: Arc::new(kp),
+                node_id,
+                sigauth_tcp_addr,
+                wireauth_tcp_addr,
+                sigauth_tcp: Some(sigauth_tcp),
+                wireauth_tcp: Some(wireauth_tcp),
+                control: Some(dp.control),
+            }
+        }
+
+        fn create_name_record(&self, with_wireauth_tcp: bool) -> MonadNameRecord<SecpSignature> {
+            self.create_name_record_with_tcp_port(with_wireauth_tcp, self.sigauth_tcp_addr.port())
+        }
+
+        fn create_name_record_with_tcp_port(
+            &self,
+            with_wireauth_tcp: bool,
+            tcp_port: u16,
+        ) -> MonadNameRecord<SecpSignature> {
+            let name_record = NameRecord::new_with_ports(
+                Ipv4Addr::LOCALHOST,
+                tcp_port,
+                Some(self.sigauth_tcp_addr.port()),
+                self.sigauth_tcp_addr.port(),
+                None,
+                if with_wireauth_tcp {
+                    Some(self.wireauth_tcp_addr.port())
+                } else {
+                    None
+                },
+                1,
+            );
+            MonadNameRecord::new(name_record, &*self.keypair)
+        }
+    }
+
+    fn create_dual_tcp_socket(
+        node: &mut NodeInfo,
+        peer_discovery: DiscoveryDriver,
+        config: Config,
+    ) -> (TestSocket, DataplaneControl) {
+        let wireauth_tcp = node.wireauth_tcp.take().expect("unused wireauth socket");
+        let sigauth_tcp = node.sigauth_tcp.take().expect("unused sigauth socket");
+
+        let (wireauth_reader, wireauth_writer) = wireauth_tcp.split();
+        let (sigauth_reader, sigauth_writer) = sigauth_tcp.split();
+
+        let auth_protocol = WireAuthProtocol::new(&TCP_METRICS, config, node.keypair.clone());
+        let authenticated_handle =
+            AuthenticatedTcpSocketHandle::new(wireauth_reader, wireauth_writer, auth_protocol);
+        let sig_auth = SigAuthTcpSocket::<SecpSignature>::new(
+            sigauth_reader,
+            sigauth_writer,
+            node.keypair.clone(),
+        );
+
+        let socket = DualTcpSocketHandle::new(Some(authenticated_handle), sig_auth, peer_discovery);
+        (
+            socket,
+            node.control.take().expect("unused dataplane control"),
+        )
+    }
+
+    fn create_peer_discovery(name_records: &NameRecords) -> DiscoveryDriver {
+        let builder = NopDiscoveryBuilder {
+            known_addresses: HashMap::new(),
+            name_records: name_records.clone(),
+            ..Default::default()
+        };
+        Arc::new(Mutex::new(PeerDiscoveryDriver::new(builder)))
+    }
+
+    struct TestPair {
+        sender_id: NodeId<PublicKey>,
+        receiver_id: NodeId<PublicKey>,
+        sender: TestSocket,
+        receiver: TestSocket,
+        _controls: [DataplaneControl; 2],
+    }
+
+    impl TestPair {
+        fn new(with_wireauth_tcp: bool) -> Self {
+            Self::with_options(with_wireauth_tcp, Config::default(), None)
+        }
+
+        fn with_options(
+            with_wireauth_tcp: bool,
+            sender_config: Config,
+            receiver_tcp_port: Option<u16>,
+        ) -> Self {
+            let mut sender = NodeInfo::new(1);
+            let mut receiver = NodeInfo::new(2);
+            let mut name_records =
+                HashMap::from([(sender.node_id, sender.create_name_record(with_wireauth_tcp))]);
+            let receiver_record = receiver_tcp_port.map_or_else(
+                || receiver.create_name_record(with_wireauth_tcp),
+                |port| receiver.create_name_record_with_tcp_port(with_wireauth_tcp, port),
+            );
+            name_records.insert(receiver.node_id, receiver_record);
+
+            let (sender_socket, sender_control) = create_dual_tcp_socket(
+                &mut sender,
+                create_peer_discovery(&name_records),
+                sender_config,
+            );
+            let (receiver_socket, receiver_control) = create_dual_tcp_socket(
+                &mut receiver,
+                create_peer_discovery(&name_records),
+                Config::default(),
+            );
+            Self {
+                sender_id: sender.node_id,
+                receiver_id: receiver.node_id,
+                sender: sender_socket,
+                receiver: receiver_socket,
+                _controls: [sender_control, receiver_control],
+            }
+        }
+    }
+
+    fn run_test(test: impl Future<Output = ()>) {
+        init_tracing();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        tokio::task::LocalSet::new().block_on(&runtime, test);
+    }
+
+    fn messages(prefix: &str, count: usize) -> Vec<Bytes> {
+        (0..count)
+            .map(|i| Bytes::from(format!("{prefix}_{i}")))
+            .collect()
+    }
+
+    async fn send_and_receive(
+        mut sender: TestSocket,
+        mut receiver: TestSocket,
+        receiver_id: NodeId<PublicKey>,
+        outbound: Vec<(Bytes, DataplaneCompletion)>,
+    ) -> Vec<Bytes> {
+        let message_count = outbound.len();
+        let drive_sender = async {
+            for (payload, completion) in outbound {
+                sender.write_to_peer(&receiver_id, payload, completion);
+            }
+            loop {
+                if let Err(err) = sender.recv().await {
+                    tracing::warn!(?err, "sender recv error");
+                }
+            }
+        };
+        let collect = async {
+            let mut received = Vec::with_capacity(message_count);
+            while received.len() < message_count {
+                match receiver.recv().await {
+                    Ok(message) => received.push(message.payload),
+                    Err(err) => tracing::warn!(?err, "receiver recv error"),
+                }
+            }
+            received
+        };
+
+        tokio::time::timeout(Duration::from_secs(10), async {
+            tokio::select! {
+                received = collect => received,
+                () = drive_sender => unreachable!("sender receive loop exited"),
+            }
+        })
+        .await
+        .expect("timed out receiving tcp messages")
+    }
+
+    fn init_tracing() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::from_default_env())
+            .try_init();
+    }
+
+    #[test]
+    fn test_dual_tcp_sigauth_only() {
+        const NUM_MESSAGES: usize = 10;
+        run_test(async {
+            let TestPair {
+                sender,
+                receiver,
+                receiver_id,
+                _controls,
+                ..
+            } = TestPair::new(false);
+            let expected = messages("sigauth_message", NUM_MESSAGES);
+            let outbound = expected
+                .iter()
+                .cloned()
+                .map(|message| (message, None))
+                .collect();
+
+            let received = send_and_receive(sender, receiver, receiver_id, outbound).await;
+            assert_eq!(received, expected);
+        });
+    }
+
+    #[test]
+    fn test_dual_tcp_wireauth_only() {
+        const NUM_MESSAGES: usize = 10;
+        run_test(async {
+            let TestPair {
+                sender,
+                receiver,
+                receiver_id,
+                _controls,
+                ..
+            } = TestPair::new(true);
+            let expected = messages("wireauth_message", NUM_MESSAGES);
+            let outbound = expected
+                .iter()
+                .cloned()
+                .map(|message| (message, None))
+                .collect();
+
+            let received = send_and_receive(sender, receiver, receiver_id, outbound).await;
+            assert_eq!(received, expected);
+        });
+    }
+
+    #[test]
+    fn test_dual_tcp_wireauth_bidirectional() {
+        run_test(async {
+            let TestPair {
+                sender_id: node_a_id,
+                receiver_id: node_b_id,
+                sender: mut socket_a,
+                receiver: mut socket_b,
+                _controls,
+            } = TestPair::new(true);
+            let exchange = async {
+                let node_a = async {
+                    socket_a.write_to_peer(&node_b_id, Bytes::from("init_from_a"), None);
+                    loop {
+                        match socket_a.recv().await {
+                            Ok(message) => break message.payload,
+                            Err(err) => tracing::warn!(?err, "node_a recv error"),
+                        }
+                    }
+                };
+                let node_b = async {
+                    loop {
+                        match socket_b.recv().await {
+                            Ok(message) => {
+                                socket_b.write_to_peer(
+                                    &node_a_id,
+                                    Bytes::from("reply_from_b"),
+                                    None,
+                                );
+                                break message.payload;
+                            }
+                            Err(err) => tracing::warn!(?err, "node_b recv error"),
+                        }
+                    }
+                };
+                tokio::join!(node_a, node_b)
+            };
+
+            let (received_by_a, received_by_b) =
+                tokio::time::timeout(Duration::from_secs(10), exchange)
+                    .await
+                    .expect("test timed out");
+            assert_eq!(received_by_a, Bytes::from_static(b"reply_from_b"));
+            assert_eq!(received_by_b, Bytes::from_static(b"init_from_a"));
+        });
+    }
+
+    #[test]
+    fn test_wireauth_preserves_completion() {
+        run_test(async {
+            let TestPair {
+                sender,
+                receiver,
+                receiver_id,
+                _controls,
+                ..
+            } = TestPair::with_options(true, Config::default(), Some(1));
+            let payload = Bytes::from_static(b"completion_message");
+            let (completion_tx, completion_rx) = futures::channel::oneshot::channel();
+
+            let received = send_and_receive(
+                sender,
+                receiver,
+                receiver_id,
+                vec![(payload.clone(), Some(completion_tx))],
+            )
+            .await;
+
+            assert_eq!(received, [payload]);
+            completion_rx.await.expect("tcp write should complete");
+        });
+    }
+
+    #[test]
+    fn test_wireauth_buffer_failure_does_not_fallback() {
+        run_test(async {
+            let sender_config = Config {
+                max_buffered_bytes_per_session: 0,
+                ..Config::default()
+            };
+            let TestPair {
+                sender: mut sender_socket,
+                receiver: mut receiver_socket,
+                receiver_id,
+                _controls,
+                ..
+            } = TestPair::with_options(true, sender_config, None);
+            let payload = Bytes::from_static(b"rejected_message");
+            let (completion_tx, completion_rx) = futures::channel::oneshot::channel();
+
+            sender_socket.write_to_peer(&receiver_id, payload, Some(completion_tx));
+
+            assert!(completion_rx.await.is_err());
+            assert!(
+                tokio::time::timeout(Duration::from_millis(100), receiver_socket.recv())
+                    .await
+                    .is_err(),
+                "buffer failure must not send via sigauth"
+            );
+        });
+    }
+}

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -26,21 +26,16 @@ use std::{
 };
 
 use alloy_rlp::{Decodable, Encodable};
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use futures::{channel::oneshot, FutureExt, Stream, StreamExt};
 use itertools::Itertools;
 use message::{InboundRouterMessage, OutboundRouterMessage};
-use monad_crypto::{
-    certificate_signature::{
-        CertificateKeyPair, CertificateSignature, CertificateSignaturePubKey,
-        CertificateSignatureRecoverable, PubKey,
-    },
-    signing_domain,
+use monad_crypto::certificate_signature::{
+    CertificateKeyPair, CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
 };
 use monad_dataplane::{
     udp::{segment_size_for_mtu, DEFAULT_MTU},
-    DataplaneBuilder, DataplaneControl, RecvTcpMsg, TcpMsg, TcpSocketHandle, TcpSocketId,
-    TcpSocketReader, TcpSocketWriter, UdpSocketHandle, UdpSocketId,
+    DataplaneBuilder, DataplaneControl, TcpSocketHandle, TcpSocketId, UdpSocketHandle, UdpSocketId,
 };
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{
@@ -97,7 +92,7 @@ pub mod udp;
 pub mod util;
 pub mod v1_rollout;
 
-const SIGNATURE_SIZE: usize = 65;
+pub(crate) const SIGNATURE_SIZE: usize = 65;
 const DEFAULT_RETRY_ATTEMPTS: u64 = 3;
 const TX_FORWARD_DIRECT_UDP_MAX_MESSAGE_SIZE_BYTES: usize = 512 * 1024;
 
@@ -118,7 +113,6 @@ where
     AP: auth::AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
     DS: IdentityScore<Identity = NodeId<CertificateSignaturePubKey<ST>>>,
 {
-    signing_key: Arc<ST::KeyPairType>,
     self_id: NodeId<CertificateSignaturePubKey<ST>>,
     is_dynamic_fullnode: bool,
 
@@ -136,8 +130,7 @@ where
     message_builder: OwnedMessageBuilder<ST>,
     secondary_message_builder: Option<OwnedMessageBuilder<ST>>,
 
-    tcp_reader: TcpSocketReader,
-    tcp_writer: TcpSocketWriter,
+    dual_tcp_socket: auth::DualTcpSocketHandle<ST, AP, PD>,
     dual_socket: auth::DualSocketHandle<AP>,
     direct_udp_transport: Option<DirectUdpTransport<ST, AP, DS>>,
     dataplane_control: DataplaneControl,
@@ -179,7 +172,8 @@ where
     pub fn new(
         config: config::RaptorCastConfig<ST>,
         secondary_mode: SecondaryRaptorCastModeConfig,
-        tcp_socket: TcpSocketHandle,
+        non_authenticated_tcp_socket: TcpSocketHandle,
+        authenticated_tcp: Option<(TcpSocketHandle, AP)>,
         authenticated: (UdpSocketHandle, AP),
         direct_udp: Option<(UdpSocketHandle, AP, DS)>,
         non_authenticated_socket: Option<UdpSocketHandle>,
@@ -188,7 +182,21 @@ where
         current_epoch: Epoch,
         proposer_schedule: BoxedProposerSchedule<CertificateSignaturePubKey<ST>>,
     ) -> Self {
-        let (tcp_reader, tcp_writer) = tcp_socket.split();
+        let (non_auth_tcp_reader, non_auth_tcp_writer) = non_authenticated_tcp_socket.split();
+        let sig_auth_tcp = auth::SigAuthTcpSocket::new(
+            non_auth_tcp_reader,
+            non_auth_tcp_writer,
+            config.shared_key.clone(),
+        );
+        let authenticated_tcp_handle = authenticated_tcp.map(|(socket, protocol)| {
+            let (reader, writer) = socket.split();
+            auth::AuthenticatedTcpSocketHandle::new(reader, writer, protocol)
+        });
+        let dual_tcp_socket = auth::DualTcpSocketHandle::new(
+            authenticated_tcp_handle,
+            sig_auth_tcp,
+            peer_discovery_driver.clone(),
+        );
 
         if config.primary_instance.raptor10_redundancy < 1f32 {
             panic!(
@@ -291,7 +299,6 @@ where
             dedicated_full_nodes: config.primary_instance.fullnode_dedicated.clone(),
             peer_discovery_driver,
 
-            signing_key: config.shared_key.clone(),
             message_builder,
             secondary_message_builder: Some(secondary_message_builder),
 
@@ -302,8 +309,7 @@ where
             udp_state,
             v1_rollout: config.deterministic_protocol_rollout,
 
-            tcp_reader,
-            tcp_writer,
+            dual_tcp_socket,
             dual_socket,
             direct_udp_transport,
             dataplane_control: control,
@@ -396,36 +402,9 @@ where
         make_app_message: impl FnOnce() -> Bytes,
         completion: Option<oneshot::Sender<()>>,
     ) {
-        match self.peer_discovery_driver.lock().unwrap().get_tcp_addr(to) {
-            None => {
-                warn!(
-                    ?to,
-                    "RaptorCastPrimary TcpPointToPoint not sending message, address unknown"
-                );
-            }
-            Some(address) => {
-                let app_message = make_app_message();
-                // TODO make this more sophisticated
-                // include timestamp, etc
-                let mut signed_message = BytesMut::zeroed(SIGNATURE_SIZE + app_message.len());
-                let signature = <ST as CertificateSignature>::serialize(&ST::sign::<
-                    signing_domain::RaptorcastAppMessage,
-                >(
-                    &app_message,
-                    &self.signing_key,
-                ));
-                assert_eq!(signature.len(), SIGNATURE_SIZE);
-                signed_message[..SIGNATURE_SIZE].copy_from_slice(&signature);
-                signed_message[SIGNATURE_SIZE..].copy_from_slice(&app_message);
-                self.tcp_writer.write(
-                    address,
-                    TcpMsg {
-                        msg: signed_message.freeze(),
-                        completion,
-                    },
-                );
-            }
-        };
+        let app_message = make_app_message();
+        self.dual_tcp_socket
+            .write_to_peer(to, app_message, completion);
     }
 
     fn handle_secondary_outbound_message(
@@ -708,6 +687,7 @@ where
 
 pub struct DataplaneHandles {
     pub tcp_socket: monad_dataplane::TcpSocketHandle,
+    pub authenticated_tcp_socket: Option<monad_dataplane::TcpSocketHandle>,
     pub authenticated_socket: UdpSocketHandle,
     pub direct_udp_socket: Option<UdpSocketHandle>,
     pub non_authenticated_socket: UdpSocketHandle,
@@ -775,6 +755,7 @@ pub fn create_dataplane_for_tests(with_direct_udp: bool) -> DataplaneHandles {
 
     DataplaneHandles {
         tcp_socket,
+        authenticated_tcp_socket: None,
         authenticated_socket,
         direct_udp_socket,
         non_authenticated_socket,
@@ -871,10 +852,14 @@ where
     };
     let pd = PeerDiscoveryDriver::new(peer_discovery_builder);
     let shared_pd = Arc::new(Mutex::new(pd));
+    let authenticated_tcp = dataplane
+        .authenticated_tcp_socket
+        .map(|socket| (socket, auth::NoopAuthProtocol::new()));
     RaptorCast::<ST, M, OM, SE, NopDiscovery<ST>, _, NopScore<NodeId<CertificateSignaturePubKey<ST>>>>::new(
         config,
         SecondaryRaptorCastModeConfig::None,
         dataplane.tcp_socket,
+        authenticated_tcp,
         (
             dataplane.authenticated_socket,
             auth::NoopAuthProtocol::new(),
@@ -938,10 +923,21 @@ where
     let pd = PeerDiscoveryDriver::new(peer_discovery_builder);
     let shared_pd = Arc::new(Mutex::new(pd));
     let wireauth_config = monad_wireauth::Config::default();
+    let authenticated_tcp = dataplane.authenticated_tcp_socket.map(|socket| {
+        (
+            socket,
+            auth::WireAuthProtocol::new(
+                &auth::metrics::TCP_METRICS,
+                wireauth_config.clone(),
+                shared_key.clone(),
+            ),
+        )
+    });
     RaptorCast::<ST, M, OM, SE, NopDiscovery<ST>, _, NopScore<NodeId<CertificateSignaturePubKey<ST>>>>::new(
         config,
         SecondaryRaptorCastModeConfig::None,
         dataplane.tcp_socket,
+        authenticated_tcp,
         (
             dataplane.authenticated_socket,
             auth::WireAuthProtocol::new(&auth::metrics::UDP_METRICS, wireauth_config, shared_key),
@@ -1179,7 +1175,8 @@ where
             .push(self.peer_discovery_metrics.as_ref())
             .push(self.udp_state.metrics().executor_metrics())
             .chain(self.udp_state.decoder_metrics())
-            .chain(self.dual_socket.metrics());
+            .chain(self.dual_socket.metrics())
+            .chain(self.dual_tcp_socket.metrics());
 
         if let Some(socket) = &self.direct_udp_transport {
             chain = chain.chain(socket.metrics());
@@ -1423,32 +1420,28 @@ where
 
         let mut poll_quota = TCP_POLL_QUOTA;
         loop {
-            let mut recv_fut = pin!(budgeted(this.tcp_reader.recv(), &mut poll_quota));
-            let Poll::Ready(msg) = recv_fut.poll_unpin(cx) else {
+            let mut recv_fut = pin!(budgeted(this.dual_tcp_socket.recv(), &mut poll_quota));
+            let Poll::Ready(result) = recv_fut.poll_unpin(cx) else {
                 break;
             };
-            let RecvTcpMsg { payload, src_addr } = msg;
-            // check message length to prevent panic during message slicing
-            if payload.len() < SIGNATURE_SIZE {
-                warn!(
-                    ?src_addr,
-                    "invalid message, message length less than signature size"
-                );
-                this.dataplane_control.disconnect(src_addr);
-                continue;
-            }
-            let signature_bytes = &payload[..SIGNATURE_SIZE];
-            let signature = match <ST as CertificateSignature>::deserialize(signature_bytes) {
-                Ok(signature) => signature,
+
+            let msg = match result {
+                Ok(msg) => msg,
                 Err(err) => {
-                    warn!(?err, ?src_addr, "invalid signature");
-                    this.dataplane_control.disconnect(src_addr);
+                    warn!(?err, "tcp error");
+                    this.dataplane_control.disconnect(err.src_addr());
                     continue;
                 }
             };
-            let app_message_bytes = payload.slice(SIGNATURE_SIZE..);
+
+            let auth::AuthRecvTcpMsg {
+                payload,
+                src_addr,
+                from,
+            } = msg;
+
             let deserialized_message =
-                match InboundRouterMessage::<M, ST>::try_deserialize(&app_message_bytes) {
+                match InboundRouterMessage::<M, ST>::try_deserialize(&payload) {
                     Ok(message) => message,
                     Err(err) => {
                         this.metrics
@@ -1459,16 +1452,6 @@ where
                         continue;
                     }
                 };
-            let from = match signature
-                .recover_pubkey::<signing_domain::RaptorcastAppMessage>(app_message_bytes.as_ref())
-            {
-                Ok(from) => from,
-                Err(err) => {
-                    warn!(?err, ?src_addr, "failed to recover pubkey");
-                    this.dataplane_control.disconnect(src_addr);
-                    continue;
-                }
-            };
 
             // Dispatch messages received via TCP
             match deserialized_message {

--- a/monad-raptorcast/tests/common/mod.rs
+++ b/monad-raptorcast/tests/common/mod.rs
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::net::{TcpListener, UdpSocket};
+
+/// Find a free UDP port by binding to an ephemeral port and returning it.
+pub fn find_udp_free_port() -> u16 {
+    let socket = UdpSocket::bind("127.0.0.1:0").expect("failed to bind");
+    socket.local_addr().expect("failed to get addr").port()
+}
+
+/// Find a free TCP port by binding to an ephemeral port and returning it.
+#[allow(dead_code)]
+pub fn find_tcp_free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind");
+    listener.local_addr().expect("failed to get addr").port()
+}

--- a/monad-raptorcast/tests/raptorcast_instance.rs
+++ b/monad-raptorcast/tests/raptorcast_instance.rs
@@ -409,6 +409,7 @@ fn test_name_record(keypair: &KeyPair, addr: SocketAddrV4) -> MonadNameRecord<Si
         Some(addr.port()),
         addr.port(),
         None,
+        None,
         1,
     );
     MonadNameRecord::new(name_record, keypair)

--- a/monad-raptorcast/tests/wireauth_raptorcast.rs
+++ b/monad-raptorcast/tests/wireauth_raptorcast.rs
@@ -251,6 +251,9 @@ fn spawn_noop_validator(
 
     tokio::task::spawn_local(async move {
         let config = create_raptorcast_config(keypair, DEFAULT_SIG_VERIFICATION_RATE_LIMIT);
+        let authenticated_tcp = dataplane
+            .authenticated_tcp_socket
+            .map(|socket| (socket, monad_raptorcast::auth::NoopAuthProtocol::new()));
 
         let mut validator_rc = monad_raptorcast::RaptorCast::<
             SecpSignature,
@@ -264,6 +267,7 @@ fn spawn_noop_validator(
             config,
             monad_raptorcast::raptorcast_secondary::SecondaryRaptorCastModeConfig::None,
             dataplane.tcp_socket,
+            authenticated_tcp,
             (
                 dataplane.authenticated_socket,
                 monad_raptorcast::auth::NoopAuthProtocol::new(),
@@ -345,6 +349,14 @@ fn spawn_wireauth_validator(
                 >::new(),
             )
         });
+        let authenticated_tcp = dataplane.authenticated_tcp_socket.map(|socket| {
+            let protocol = monad_raptorcast::auth::WireAuthProtocol::new(
+                &monad_raptorcast::auth::metrics::TCP_METRICS,
+                wireauth_config,
+                keypair.clone(),
+            );
+            (socket, protocol)
+        });
         let non_authenticated_socket = if with_non_authenticated_socket {
             Some(dataplane.non_authenticated_socket)
         } else {
@@ -363,6 +375,7 @@ fn spawn_wireauth_validator(
             config,
             monad_raptorcast::raptorcast_secondary::SecondaryRaptorCastModeConfig::None,
             dataplane.tcp_socket,
+            authenticated_tcp,
             authenticated,
             direct_udp,
             non_authenticated_socket,

--- a/monad-raptorcast/tests/wireauth_raptorcast.rs
+++ b/monad-raptorcast/tests/wireauth_raptorcast.rs
@@ -172,6 +172,7 @@ impl ValidatorInfo {
             non_auth_addr.map(|addr| addr.port()),
             auth_addr.port(),
             direct_udp_addr.map(|addr| addr.port()),
+            None,
             1,
         );
         MonadNameRecord::new(name_record, &*self.keypair)

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -99,6 +99,7 @@ where
         direct_udp_auth_protocol: Option<AP>,
         direct_udp_peer_score: DS,
         proposer_schedule: BoxedProposerSchedule<CertificateSignaturePubKey<ST>>,
+        tcp_auth_protocol: Option<AP>,
     ) -> Self
     where
         B: PeerDiscoveryAlgoBuilder<PeerDiscoveryAlgoType = PD>,
@@ -111,6 +112,14 @@ where
         assert!(dp.block_until_ready(Duration::from_secs(1)));
 
         let tcp_socket = dp.tcp_sockets.take(TcpSocketId::Raptorcast).unwrap();
+        let authenticated_tcp_socket = dp.tcp_sockets.take(TcpSocketId::AuthenticatedRaptorcast);
+        let authenticated_tcp = match (authenticated_tcp_socket, tcp_auth_protocol) {
+            (Some(socket), Some(protocol)) => Some((socket, protocol)),
+            (None, None) => None,
+            (Some(_), None) | (None, Some(_)) => {
+                panic!("authenticated tcp socket and auth protocol must be set or unset together");
+            }
+        };
         let authenticated_socket = dp
             .udp_sockets
             .take(UdpSocketId::AuthenticatedRaptorcast)
@@ -169,6 +178,7 @@ where
             cfg.clone(),
             secondary_mode,
             tcp_socket,
+            authenticated_tcp,
             (authenticated_socket, auth_protocol),
             direct_udp,
             non_authenticated_socket,

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -197,6 +197,7 @@ where
                     cfg,
                     SecondaryRaptorCastModeConfig::None,
                     tcp_socket,
+                    None,
                     authenticated,
                     None,
                     Some(non_authenticated_socket),

--- a/monad-updaters/src/config_loader.rs
+++ b/monad-updaters/src/config_loader.rs
@@ -239,6 +239,7 @@ where
                 record_seq_num: peer.record_seq_num,
                 auth_port: peer.auth_port,
                 direct_udp_port: peer.direct_udp_port,
+                tcp_auth_port: peer.tcp_auth_port,
             });
         }
         peer_entries

--- a/monad-wireauth/src/api.rs
+++ b/monad-wireauth/src/api.rs
@@ -41,10 +41,10 @@ use crate::{
     state::State,
 };
 
-pub struct API<C: Context, K: AsRef<monad_secp::KeyPair> = monad_secp::KeyPair> {
-    state: State,
+pub struct API<C: Context, K: AsRef<monad_secp::KeyPair> = monad_secp::KeyPair, M = ()> {
+    state: State<M>,
     timers: BTreeSet<(Duration, SessionIndex)>,
-    packet_queue: VecDeque<(SocketAddr, Bytes)>,
+    packet_queue: VecDeque<(SocketAddr, Bytes, Option<M>)>,
     config: Config,
     local_static_key: K,
     // Cached compressed public key to avoid recomputing when logging
@@ -59,9 +59,9 @@ pub struct API<C: Context, K: AsRef<monad_secp::KeyPair> = monad_secp::KeyPair> 
     connect_rate_last_reset: Duration,
 }
 
-impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
+impl<C: Context, K: AsRef<monad_secp::KeyPair>, M> API<C, K, M> {
     /// Creates a new API instance, it should be created for an individual socket.
-    pub fn new(
+    pub fn new_with_metadata(
         metric_names: &'static MetricNames,
         config: Config,
         local_static_key: K,
@@ -88,7 +88,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         let local_serialized_public = CompressedPublicKey::from(&local_static_public);
         debug!(local_public_key=?local_serialized_public, "initialized manager");
         Self {
-            state: State::new(metric_names),
+            state: State::new_with_metadata(metric_names),
             timers: BTreeSet::new(),
             packet_queue: VecDeque::new(),
             config,
@@ -117,7 +117,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
     /// Note: There are no limits for the internal queue, so it is better to use a separate
     /// queue for pacing.
     #[instrument(level = Level::TRACE, skip(self), fields(local_public_key = ?self.local_serialized_public))]
-    pub fn next_packet(&mut self) -> Option<(SocketAddr, Bytes)> {
+    pub fn next_packet_with_metadata(&mut self) -> Option<(SocketAddr, Bytes, Option<M>)> {
         self.metrics.gauge(self.metric_names.api_next_packet).inc();
         let result = self.packet_queue.pop_front();
         self.metrics
@@ -126,8 +126,8 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         result
     }
 
-    fn enqueue_packet(&mut self, addr: SocketAddr, pkt: impl Into<Bytes>) {
-        self.packet_queue.push_back((addr, pkt.into()));
+    fn enqueue_packet(&mut self, addr: SocketAddr, pkt: impl Into<Bytes>, metadata: Option<M>) {
+        self.packet_queue.push_back((addr, pkt.into(), metadata));
         self.metrics
             .gauge(self.metric_names.state_packet_queue_size)
             .set(self.packet_queue.len() as u64);
@@ -253,7 +253,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
                 self.metrics
                     .gauge(self.metric_names.enqueued_keepalive)
                     .inc();
-                self.enqueue_packet(message.remote_addr, message.header);
+                self.enqueue_packet(message.remote_addr, message.header, None);
             }
 
             if let Some(rekey) = rekey {
@@ -266,7 +266,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
                     self.metrics
                         .gauge(self.metric_names.enqueued_handshake_init)
                         .inc();
-                    self.enqueue_packet(rekey.remote_addr, message);
+                    self.enqueue_packet(rekey.remote_addr, message, None);
                     self.insert_timer(timer, new_session_index);
                 }
             }
@@ -331,7 +331,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         self.metrics
             .gauge(self.metric_names.enqueued_handshake_init)
             .inc();
-        self.enqueue_packet(remote_addr, message);
+        self.enqueue_packet(remote_addr, message, None);
         self.insert_timer(timer, local_index);
 
         Ok(())
@@ -429,7 +429,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
                 self.metrics
                     .gauge(self.metric_names.enqueued_cookie_reply)
                     .inc();
-                self.enqueue_packet(remote_addr, reply);
+                self.enqueue_packet(remote_addr, reply, None);
                 false
             }
             FilterAction::Drop => {
@@ -518,7 +518,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         self.metrics
             .gauge(self.metric_names.enqueued_handshake_response)
             .inc();
-        self.enqueue_packet(remote_addr, message);
+        self.enqueue_packet(remote_addr, message, None);
         self.insert_timer(timer, local_index);
 
         Ok(())
@@ -732,7 +732,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         self.state
             .insert_transport(receiver_session_index, transport);
 
-        for msg in messages {
+        for (msg, metadata) in messages {
             let mut packet = BytesMut::with_capacity(DataPacketHeader::SIZE + msg.len());
             packet.resize(DataPacketHeader::SIZE, 0);
             packet.extend_from_slice(&msg);
@@ -750,7 +750,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
             packet[..DataPacketHeader::SIZE].copy_from_slice(header.as_bytes());
 
             self.replace_timer(timer, receiver_session_index);
-            self.enqueue_packet(remote_addr, packet.freeze());
+            self.enqueue_packet(remote_addr, packet.freeze(), metadata);
             if is_buffered {
                 self.metrics
                     .gauge(self.metric_names.initiator_messages_sent_from_buffer)
@@ -829,11 +829,12 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
     /// Buffers a message for a peer that has an initiator session (handshake in progress).
     /// Returns Ok(()) if the message was buffered, or Err if no initiator session exists
     /// or the buffer limit would be exceeded.
-    #[instrument(level = Level::TRACE, skip(self, public_key, message), fields(local_public_key = ?self.local_serialized_public))]
-    pub fn buffer_message(
+    #[instrument(level = Level::TRACE, skip(self, public_key, message, metadata), fields(local_public_key = ?self.local_serialized_public))]
+    pub fn buffer_message_with_metadata(
         &mut self,
         public_key: &monad_secp::PubKey,
         message: Bytes,
+        metadata: M,
     ) -> Result<()> {
         let initiator = self
             .state
@@ -852,7 +853,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
                 limit: self.config.max_buffered_bytes_per_session,
             });
         }
-        initiator.buffer_message(message);
+        initiator.buffer_message(message, metadata);
         self.metrics
             .gauge(self.metric_names.initiator_buffered_messages)
             .inc();
@@ -916,6 +917,30 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
     /// Returns the socket address of the latest initiated session with the given public key.
     pub fn get_socket_by_public_key(&self, public_key: &monad_secp::PubKey) -> Option<SocketAddr> {
         self.state.get_socket_by_public_key(public_key)
+    }
+}
+
+impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
+    pub fn new(
+        metric_names: &'static MetricNames,
+        config: Config,
+        local_static_key: K,
+        context: C,
+    ) -> Self {
+        Self::new_with_metadata(metric_names, config, local_static_key, context)
+    }
+
+    pub fn next_packet(&mut self) -> Option<(SocketAddr, Bytes)> {
+        self.next_packet_with_metadata()
+            .map(|(addr, packet, _)| (addr, packet))
+    }
+
+    pub fn buffer_message(
+        &mut self,
+        public_key: &monad_secp::PubKey,
+        message: Bytes,
+    ) -> Result<()> {
+        self.buffer_message_with_metadata(public_key, message, ())
     }
 }
 

--- a/monad-wireauth/src/filter.rs
+++ b/monad-wireauth/src/filter.rs
@@ -116,9 +116,9 @@ impl Filter {
         self.last_reset + self.handshake_rate_reset_interval
     }
 
-    pub fn apply(
+    pub fn apply<M>(
         &mut self,
-        state: &State,
+        state: &State<M>,
         remote_addr: SocketAddr,
         duration_since_start: Duration,
         cookie_valid: bool,
@@ -235,7 +235,7 @@ impl Filter {
         }
     }
 
-    fn check_max_sessions_per_ip(&self, state: &State, ip: IpAddr) -> Option<FilterAction> {
+    fn check_max_sessions_per_ip<M>(&self, state: &State<M>, ip: IpAddr) -> Option<FilterAction> {
         (state.ip_session_count(&ip) >= self.max_sessions_per_ip).then(|| {
             debug!(
                 ip = %ip,

--- a/monad-wireauth/src/session/initiator.rs
+++ b/monad-wireauth/src/session/initiator.rs
@@ -41,14 +41,14 @@ pub struct ValidatedHandshakeResponse {
     remote_index: SessionIndex,
 }
 
-pub struct InitiatorState {
+pub struct InitiatorState<M = ()> {
     handshake_state: handshake::HandshakeState,
     common: SessionState,
-    buffered_messages: VecDeque<Bytes>,
+    buffered_messages: VecDeque<(Bytes, M)>,
     buffered_bytes: usize,
 }
 
-impl InitiatorState {
+impl<M> InitiatorState<M> {
     #[allow(clippy::too_many_arguments)]
     pub fn new<R: secp256k1::rand::Rng + secp256k1::rand::CryptoRng>(
         rng: &mut R,
@@ -138,7 +138,7 @@ impl InitiatorState {
         config: &Config,
         duration_since_start: Duration,
         validated_response: ValidatedHandshakeResponse,
-    ) -> (TransportState, MessagesToSend) {
+    ) -> (TransportState, MessagesToSend<M>) {
         self.common.reset_session_timeout(
             duration_since_start,
             add_jitter(rng, config.session_timeout, config.session_timeout_jitter),
@@ -185,9 +185,9 @@ impl InitiatorState {
         Some((timer, SessionTimeoutResult { terminated, rekey }))
     }
 
-    pub fn buffer_message(&mut self, message: Bytes) {
+    pub fn buffer_message(&mut self, message: Bytes, metadata: M) {
         self.buffered_bytes = self.buffered_bytes.saturating_add(message.len());
-        self.buffered_messages.push_back(message);
+        self.buffered_messages.push_back((message, metadata));
     }
 
     pub fn buffered_message_count(&self) -> usize {
@@ -199,17 +199,17 @@ impl InitiatorState {
     }
 }
 
-pub struct MessagesToSend {
-    inner: MessagesToSendInner,
+pub struct MessagesToSend<M> {
+    inner: MessagesToSendInner<M>,
 }
 
-enum MessagesToSendInner {
-    Buffered(vec_deque::IntoIter<Bytes>),
+enum MessagesToSendInner<M> {
+    Buffered(vec_deque::IntoIter<(Bytes, M)>),
     Keepalive(iter::Once<Bytes>),
 }
 
-impl MessagesToSend {
-    fn new(messages: VecDeque<Bytes>) -> Self {
+impl<M> MessagesToSend<M> {
+    fn new(messages: VecDeque<(Bytes, M)>) -> Self {
         let inner = if messages.is_empty() {
             MessagesToSendInner::Keepalive(iter::once(Bytes::new()))
         } else {
@@ -223,13 +223,15 @@ impl MessagesToSend {
     }
 }
 
-impl Iterator for MessagesToSend {
-    type Item = Bytes;
+impl<M> Iterator for MessagesToSend<M> {
+    type Item = (Bytes, Option<M>);
 
     fn next(&mut self) -> Option<Self::Item> {
         match &mut self.inner {
-            MessagesToSendInner::Buffered(iter) => iter.next(),
-            MessagesToSendInner::Keepalive(iter) => iter.next(),
+            MessagesToSendInner::Buffered(iter) => iter
+                .next()
+                .map(|(message, metadata)| (message, Some(metadata))),
+            MessagesToSendInner::Keepalive(iter) => iter.next().map(|message| (message, None)),
         }
     }
 
@@ -241,7 +243,7 @@ impl Iterator for MessagesToSend {
     }
 }
 
-impl ExactSizeIterator for MessagesToSend {
+impl<M> ExactSizeIterator for MessagesToSend<M> {
     fn len(&self) -> usize {
         match &self.inner {
             MessagesToSendInner::Buffered(iter) => iter.len(),
@@ -250,7 +252,7 @@ impl ExactSizeIterator for MessagesToSend {
     }
 }
 
-impl Deref for InitiatorState {
+impl<M> Deref for InitiatorState<M> {
     type Target = SessionState;
 
     fn deref(&self) -> &Self::Target {
@@ -258,7 +260,7 @@ impl Deref for InitiatorState {
     }
 }
 
-impl DerefMut for InitiatorState {
+impl<M> DerefMut for InitiatorState<M> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.common
     }

--- a/monad-wireauth/src/state.rs
+++ b/monad-wireauth/src/state.rs
@@ -91,12 +91,12 @@ impl EstablishedSessions {
     }
 }
 
-pub(crate) struct SessionIndexReservation<'a> {
-    state: &'a mut State,
+pub(crate) struct SessionIndexReservation<'a, M> {
+    state: &'a mut State<M>,
     index: SessionIndex,
 }
 
-impl<'a> SessionIndexReservation<'a> {
+impl<M> SessionIndexReservation<'_, M> {
     pub(crate) fn index(&self) -> SessionIndex {
         self.index
     }
@@ -112,8 +112,8 @@ impl<'a> SessionIndexReservation<'a> {
     }
 }
 
-pub struct State {
-    initiating_sessions: HashMap<SessionIndex, InitiatorState>,
+pub struct State<M = ()> {
+    initiating_sessions: HashMap<SessionIndex, InitiatorState<M>>,
     responding_sessions: HashMap<SessionIndex, ResponderState>,
     transport_sessions: HashMap<SessionIndex, TransportState>,
     last_established_session_by_public_key: HashMap<monad_secp::PubKey, EstablishedSessions>,
@@ -128,8 +128,8 @@ pub struct State {
     metric_names: &'static MetricNames,
 }
 
-impl State {
-    pub fn new(metric_names: &'static MetricNames) -> Self {
+impl<M> State<M> {
+    pub fn new_with_metadata(metric_names: &'static MetricNames) -> Self {
         Self {
             initiating_sessions: HashMap::new(),
             responding_sessions: HashMap::new(),
@@ -255,7 +255,7 @@ impl State {
         self.transport_sessions.get_mut(&session_id)
     }
 
-    pub(crate) fn reserve_session_index(&mut self) -> Option<SessionIndexReservation<'_>> {
+    pub(crate) fn reserve_session_index(&mut self) -> Option<SessionIndexReservation<'_, M>> {
         let start_index = self.next_session_index;
         let mut candidate = self.next_session_index;
 
@@ -451,21 +451,21 @@ impl State {
     }
 
     #[cfg(test)]
-    pub fn get_initiator(&self, session_index: &SessionIndex) -> Option<&InitiatorState> {
+    pub fn get_initiator(&self, session_index: &SessionIndex) -> Option<&InitiatorState<M>> {
         self.initiating_sessions.get(session_index)
     }
 
     pub fn get_initiator_mut(
         &mut self,
         session_index: &SessionIndex,
-    ) -> Option<&mut InitiatorState> {
+    ) -> Option<&mut InitiatorState<M>> {
         self.initiating_sessions.get_mut(session_index)
     }
 
     pub fn get_initiator_by_public_key_mut(
         &mut self,
         public_key: &monad_secp::PubKey,
-    ) -> Option<&mut InitiatorState> {
+    ) -> Option<&mut InitiatorState<M>> {
         let session_id = self.initiated_session_by_peer.get(public_key)?;
         self.initiating_sessions.get_mut(session_id)
     }
@@ -482,7 +482,7 @@ impl State {
         self.responding_sessions.get_mut(session_index)
     }
 
-    pub fn remove_initiator(&mut self, session_index: &SessionIndex) -> Option<InitiatorState> {
+    pub fn remove_initiator(&mut self, session_index: &SessionIndex) -> Option<InitiatorState<M>> {
         let session = self.initiating_sessions.remove(session_index)?;
         self.metrics
             .gauge(self.metric_names.state_initiating_sessions)
@@ -517,7 +517,7 @@ impl State {
     pub fn insert_initiator(
         &mut self,
         session_index: SessionIndex,
-        session: InitiatorState,
+        session: InitiatorState<M>,
         remote_key: monad_secp::PubKey,
     ) {
         let remote_addr = session.remote_addr;
@@ -681,6 +681,13 @@ impl State {
 
     pub fn initiated_sessions_count(&self) -> usize {
         self.initiating_sessions.len()
+    }
+}
+
+#[cfg(test)]
+impl State {
+    pub fn new(metric_names: &'static MetricNames) -> Self {
+        Self::new_with_metadata(metric_names)
     }
 }
 

--- a/monad-wireauth/tests/tests.rs
+++ b/monad-wireauth/tests/tests.rs
@@ -825,6 +825,44 @@ fn test_message_buffering_during_handshake() {
 }
 
 #[test]
+fn test_buffered_message_metadata() {
+    init_tracing();
+    let mut rng = rng();
+    let keypair = monad_secp::KeyPair::generate(&mut rng);
+    let mut peer1: API<TestContext, _, u8> = API::new_with_metadata(
+        DEFAULT_METRICS,
+        Config::default(),
+        keypair,
+        TestContext::new(),
+    );
+    let (mut peer2, peer2_pubkey, _, _) = create_manager();
+    let peer1_addr: SocketAddr = "127.0.0.1:8001".parse().unwrap();
+    let peer2_addr: SocketAddr = "127.0.0.1:8002".parse().unwrap();
+
+    peer1
+        .connect(peer2_pubkey, peer2_addr, DEFAULT_RETRY_ATTEMPTS)
+        .unwrap();
+    peer1
+        .buffer_message_with_metadata(&peer2_pubkey, bytes::Bytes::from_static(b"buffered"), 7)
+        .unwrap();
+
+    let (_, init, metadata) = peer1.next_packet_with_metadata().unwrap();
+    assert_eq!(metadata, None);
+    dispatch(&mut peer2, &init, peer1_addr);
+
+    let response = collect::<HandshakeResponse>(&mut peer2);
+    let mut response = response;
+    let Packet::Control(response) = Packet::try_from(response.as_mut_slice()).unwrap() else {
+        panic!("expected handshake response");
+    };
+    peer1.dispatch_control(response, peer2_addr).unwrap();
+
+    let (_, packet, metadata) = peer1.next_packet_with_metadata().unwrap();
+    assert_eq!(metadata, Some(7));
+    assert_eq!(decrypt(&mut peer2, &packet, peer1_addr), b"buffered");
+}
+
+#[test]
 fn test_handshake_response_address_mismatch_rejected() {
     init_tracing();
     let (mut peer1, _, _, _) = create_manager();


### PR DESCRIPTION
- replay protection for authenticated requests
- identity based rate limiting, currently it can be bypassed by using different keys over the same ip/connection
- faster than blake3 + signature (200us vs 600us per 3MB message)