### PR TITLE
monad-dataplane: add per-peer byte limit for TCP egress queue

### DIFF
--- a/monad-dataplane/src/lib.rs
+++ b/monad-dataplane/src/lib.rs
@@ -745,7 +745,7 @@ pub(crate) struct UdpMsg {
 }
 
 const TCP_INGRESS_CHANNEL_SIZE: usize = 1024;
-const TCP_EGRESS_CHANNEL_SIZE: usize = 1024;
+const TCP_EGRESS_CHANNEL_SIZE: usize = 256;
 const UDP_INGRESS_CHANNEL_SIZE: usize = 12_800;
 const UDP_EGRESS_CHANNEL_SIZE: usize = 12_800;
 

--- a/monad-dataplane/src/tcp/mod.rs
+++ b/monad-dataplane/src/tcp/mod.rs
@@ -72,7 +72,7 @@ pub(crate) fn spawn_tasks(
     let mut bound_addrs = Vec::with_capacity(socket_configs.len());
 
     let rx_state = rx::RxState::new(
-        addrlist,
+        addrlist.clone(),
         cfg.connections_limit,
         cfg.per_ip_connections_limit,
     );
@@ -94,7 +94,7 @@ pub(crate) fn spawn_tasks(
     }
 
     bound_addrs_tx.send(bound_addrs).unwrap();
-    spawn(tx::task(tcp_egress_rx));
+    spawn(tx::task(cfg, addrlist, tcp_egress_rx));
 }
 
 // Minimum message receive/transmit speed in bytes per second.  Messages that are


### PR DESCRIPTION
closes: https://github.com/category-labs/category-internal/issues/1557

in addition to 150 message limit per connection we enforce 4MB byte limit, thats 2 max block sizes and slightly more than 2 max statesync responses. we set upper bound for outoging connections, in addition to incoming, just as a safety measure. and reduce the size of the global response queue from 1024 to 256, to reduce potential memory pressure there, that queue is relevant only if we do a burst of responses larger than the queue