### PR TITLE
Remove legacy do_local_insert

### DIFF
--- a/monad-eth-block-validator/tests/coherency_test.rs
+++ b/monad-eth-block-validator/tests/coherency_test.rs
@@ -436,7 +436,6 @@ fn create_test_txpool(chain_config: &MonadChainConfig) -> TestTxPool {
                 std::time::Duration::from_secs(60),
                 std::time::Duration::from_secs(60),
             ),
-            do_local_insert: true,
         },
         chain_config.chain_id(),
         chain_config.get_chain_revision(GENESIS_ROUND),

--- a/monad-eth-txpool-executor/src/lib.rs
+++ b/monad-eth-txpool-executor/src/lib.rs
@@ -110,7 +110,6 @@ where
         chain_config: CCT,
         round: Round,
         execution_timestamp_s: u64,
-        do_local_insert: bool,
     ) -> io::Result<EthTxPoolExecutorClient<ST, SCT, SBT, CCT, CRT>> {
         let ipc = Box::pin(EthTxPoolIpcServer::new(ipc_config)?);
 
@@ -136,7 +135,6 @@ where
                                 soft_tx_expiry,
                                 hard_tx_expiry,
                             ),
-                            do_local_insert,
                         },
                         chain_config.chain_id(),
                         chain_config.get_chain_revision(round),

--- a/monad-eth-txpool-executor/tests/executor.rs
+++ b/monad-eth-txpool-executor/tests/executor.rs
@@ -77,7 +77,6 @@ async fn setup_txpool_executor_with_client() -> (
         MockChainConfig::DEFAULT,
         GENESIS_ROUND,
         GENESIS_TIMESTAMP as u64,
-        true,
     )
     .unwrap();
 

--- a/monad-eth-txpool/src/pool/config.rs
+++ b/monad-eth-txpool/src/pool/config.rs
@@ -18,5 +18,4 @@ use super::TrackedTxLimitsConfig;
 #[derive(Clone, Debug)]
 pub struct EthTxPoolConfig {
     pub limits: TrackedTxLimitsConfig,
-    pub do_local_insert: bool,
 }

--- a/monad-eth-txpool/src/pool/mod.rs
+++ b/monad-eth-txpool/src/pool/mod.rs
@@ -75,8 +75,6 @@ where
     chain_id: u64,
     chain_revision: CRT,
     execution_revision: MonadExecutionRevision,
-
-    do_local_insert: bool,
 }
 
 impl<ST, SCT, SBT, CCT, CRT> EthTxPool<ST, SCT, SBT, CCT, CRT>
@@ -96,7 +94,6 @@ where
     ) -> Self {
         let EthTxPoolConfig {
             limits: config_limits,
-            do_local_insert,
         } = config;
 
         Self {
@@ -107,8 +104,6 @@ where
             chain_id,
             chain_revision,
             execution_revision,
-
-            do_local_insert,
         }
     }
 
@@ -133,14 +128,6 @@ where
         txs: Vec<(Recovered<TxEnvelope>, PoolTransactionKind)>,
         mut on_insert: impl FnMut(&ValidEthTransaction),
     ) {
-        if !self.do_local_insert {
-            event_tracker.drop_all(
-                txs.into_iter().map(|(tx, _)| tx),
-                EthTxPoolDropReason::PoolNotReady,
-            );
-            return;
-        }
-
         let Some(last_commit) = self.last_commit.as_ref() else {
             event_tracker.drop_all(
                 txs.into_iter().map(|(tx, _)| tx),
@@ -740,7 +727,6 @@ where
                     Duration::from_secs(60),
                     Duration::from_secs(60),
                 ),
-                do_local_insert: true,
             },
             MockChainConfig::DEFAULT.chain_id(),
             MockChainRevision::DEFAULT,

--- a/monad-eth-txpool/tests/pool.rs
+++ b/monad-eth-txpool/tests/pool.rs
@@ -1634,7 +1634,6 @@ fn test_eviction_policy() {
                             Duration::from_secs(60),
                             Duration::from_secs(60),
                         ),
-                        do_local_insert: true,
                     },
                     MockChainConfig::DEFAULT.chain_id(),
                     MockChainConfig::DEFAULT.get_chain_revision(GENESIS_ROUND),

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -261,7 +261,6 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
                 .get_round(),
             // TODO(andr-dev): Use timestamp from last commit in ledger
             0,
-            true,
         )
         .expect("txpool ipc succeeds"),
         control_panel: ControlPanelIpcReceiver::new(


### PR DESCRIPTION
do_local_insert is always hardcoded to true and has no impact on txpool insertion behavior