### PR TITLE
Remove peers.toml on reset workspace

### DIFF
--- a/debian/opt/monad/scripts/reset-workspace.sh
+++ b/debian/opt/monad/scripts/reset-workspace.sh
@@ -12,6 +12,7 @@ rm -rf /home/monad/monad-bft/snapshots
 rm -f /home/monad/monad-bft/mempool.sock
 rm -f /home/monad/monad-bft/controlpanel.sock
 rm -f /home/monad/monad-bft/wal_*
+rm -f /home/monad/monad-bft/config/peers.toml
 rm -rf /home/monad/monad-bft/blockdb
 source /home/monad/.env
 monad-mpt --storage /dev/triedb --truncate --yes

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -601,6 +601,7 @@ where
         ),
     };
     let self_record = MonadNameRecord::new(self_record, &identity);
+    info!(?self_id, ?self_record, "self name record");
     assert!(
         self_record.signature == peer_discovery_config.self_name_record_sig,
         "self name record signature mismatch"


### PR DESCRIPTION
- Requested by MF to remove peers.toml on reset-workspace.sh since it's starting from scratch. 
- Add a log line for self node id and self name record on startup for debuggability. 