### PR TITLE
Archive: make top-level args global in monad-archive-checker CLI

### DIFF
--- a/monad-archive/src/bin/monad-archive-checker/cli.rs
+++ b/monad-archive/src/bin/monad-archive-checker/cli.rs
@@ -52,16 +52,16 @@ pub struct Cli {
     pub bucket: String,
 
     /// AWS region
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub region: Option<String>,
 
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub otel_endpoint: Option<String>,
 
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub otel_replica_name_override: Option<String>,
 
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub max_compute_threads: Option<usize>,
 }
 
@@ -218,4 +218,41 @@ pub enum InspectorOutputFormat {
     GoodOnly,
     /// Show summary statistics only
     Summary,
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[test]
+    fn global_args_work_after_subcommand() {
+        let cli = Cli::try_parse_from([
+            "monad-archive-checker",
+            "--bucket",
+            "test-bucket",
+            "checker",
+            "--init-replicas",
+            "aws archive-1 20",
+            "--region",
+            "us-east-1",
+            "--otel-endpoint",
+            "http://localhost:4317",
+            "--otel-replica-name-override",
+            "test-replica",
+            "--max-compute-threads",
+            "4",
+        ])
+        .expect("should parse global args after subcommand");
+
+        assert_eq!(cli.bucket, "test-bucket");
+        assert_eq!(cli.region, Some("us-east-1".to_string()));
+        assert_eq!(cli.otel_endpoint, Some("http://localhost:4317".to_string()));
+        assert_eq!(
+            cli.otel_replica_name_override,
+            Some("test-replica".to_string())
+        );
+        assert_eq!(cli.max_compute_threads, Some(4));
+    }
 }


### PR DESCRIPTION
Allow region, otel_endpoint, otel_replica_name_override, and max_compute_threads to be specified after the subcommand.