### PR TITLE
Raptorcast: move utilities to util module

### DIFF
--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -61,7 +61,9 @@ use monad_validator::{
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::{debug, debug_span, error, trace, warn};
 use udp::GroupId;
-use util::{BuildTarget, EpochValidators, FullNodes, Group, ReBroadcastGroupMap, Redundancy};
+use util::{
+    BuildTarget, EpochValidators, FullNodes, Group, PeerAddrLookup, ReBroadcastGroupMap, Redundancy,
+};
 
 use crate::{
     metrics::{GAUGE_RAPTORCAST_TOTAL_MESSAGES_RECEIVED, GAUGE_RAPTORCAST_TOTAL_RECV_ERRORS},
@@ -1519,7 +1521,7 @@ fn ensure_authenticated_sessions<'a, ST, PD, AP>(
     dual_socket.flush();
 }
 
-impl<ST, PD, AP> packet::PeerAddrLookup<CertificateSignaturePubKey<ST>>
+impl<ST, PD, AP> PeerAddrLookup<CertificateSignaturePubKey<ST>>
     for (
         &Arc<Mutex<PeerDiscoveryDriver<PD>>>,
         &std::cell::RefCell<&mut auth::DualSocketHandle<AP>>,
@@ -1553,7 +1555,7 @@ where
     pub dual_socket: &'a std::cell::RefCell<&'a mut auth::DualSocketHandle<AP>>,
 }
 
-impl<ST, AP> packet::PeerAddrLookup<CertificateSignaturePubKey<ST>> for NameRecordLookup<'_, ST, AP>
+impl<ST, AP> PeerAddrLookup<CertificateSignaturePubKey<ST>> for NameRecordLookup<'_, ST, AP>
 where
     ST: CertificateSignatureRecoverable,
     AP: auth::AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,

--- a/monad-raptorcast/src/packet/assigner.rs
+++ b/monad-raptorcast/src/packet/assigner.rs
@@ -20,7 +20,8 @@ use monad_crypto::certificate_signature::PubKey;
 use monad_types::{NodeId, Stake};
 use rand::{rngs::StdRng, seq::SliceRandom as _, SeedableRng as _};
 
-use super::{BuildError, Chunk, PacketLayout, Recipient, Result};
+use super::{BuildError, Chunk, PacketLayout, Result};
+use crate::util::Recipient;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChunkOrder {
@@ -582,8 +583,8 @@ mod tests {
 
     use super::{ChunkAssignment, ChunkOrder, Partitioned, StakeBasedWithRC};
     use crate::{
-        packet::{assigner::Replicated, ChunkAssigner as _, PacketLayout, Recipient},
-        util::Redundancy,
+        packet::{assigner::Replicated, ChunkAssigner as _, PacketLayout},
+        util::{Recipient, Redundancy},
     };
 
     const DEFAULT_SEGMENT_LEN: usize = 1400;

--- a/monad-raptorcast/src/packet/builder.rs
+++ b/monad-raptorcast/src/packet/builder.rs
@@ -26,7 +26,7 @@ use rand::Rng;
 use super::{
     assembler::{self, build_header, AssembleMode, PacketLayout},
     assigner::{self, ChunkAssignment},
-    BuildError, ChunkAssigner, UdpMessage,
+    BuildError, ChunkAssigner,
 };
 use crate::{
     message::MAX_MESSAGE_SIZE,
@@ -34,7 +34,10 @@ use crate::{
         GroupId, MAX_MERKLE_TREE_DEPTH, MAX_NUM_PACKETS, MAX_REDUNDANCY, MAX_SEGMENT_LENGTH,
         MIN_CHUNK_LENGTH, MIN_MERKLE_TREE_DEPTH,
     },
-    util::{compute_app_message_hash, unix_ts_ms_now, BroadcastMode, BuildTarget, Redundancy},
+    util::{
+        compute_app_message_hash, unix_ts_ms_now, BroadcastMode, BuildTarget, Collector,
+        Redundancy, UdpMessage,
+    },
 };
 
 pub const DEFAULT_MERKLE_TREE_DEPTH: u8 = 6;
@@ -201,7 +204,7 @@ where
         collector: &mut C,
     ) -> Result<()>
     where
-        C: super::Collector<UdpMessage<CertificateSignaturePubKey<ST>>>,
+        C: Collector<UdpMessage<CertificateSignaturePubKey<ST>>>,
     {
         self.prepare()
             .build_into(app_message, build_target, collector)
@@ -394,7 +397,7 @@ where
         collector: &mut C,
     ) -> Result<()>
     where
-        C: super::Collector<super::UdpMessage<CertificateSignaturePubKey<ST>>>,
+        C: Collector<UdpMessage<CertificateSignaturePubKey<ST>>>,
     {
         // figure out the layout of the packet
         let segment_size = self.unwrap_segment_size()?;

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -14,16 +14,19 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{
+    cell::OnceCell,
     cmp::Ordering,
     collections::{BTreeMap, HashSet},
     fmt,
     net::SocketAddr,
+    rc::Rc,
 };
 
+use bytes::Bytes;
 use fixed::{types::extra::U11, FixedU16};
 use itertools::Itertools;
 use monad_crypto::{
-    certificate_signature::PubKey,
+    certificate_signature::{CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey},
     hasher::{Hasher, HasherType},
 };
 use monad_types::{Epoch, NodeId, Round, RoundSpan, Stake};
@@ -679,6 +682,223 @@ impl<PT: PubKey> ReBroadcastGroupMap<PT> {
     }
 }
 
+// Similar to std::iter::Extend trait but implemented for FnMut as
+// well.
+pub trait Collector<T> {
+    fn push(&mut self, item: T);
+    fn reserve(&mut self, _additional: usize) {}
+}
+
+impl<T> Collector<T> for Vec<T> {
+    fn push(&mut self, item: T) {
+        Vec::push(self, item)
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        Vec::reserve(self, additional)
+    }
+}
+
+impl<F, T> Collector<T> for F
+where
+    F: FnMut(T),
+{
+    fn push(&mut self, item: T) {
+        self(item)
+    }
+}
+
+// expect collecting no message.
+pub struct EmptyCollector;
+impl<T> Collector<T> for EmptyCollector {
+    fn push(&mut self, _item: T) {
+        tracing::debug!("Unexpected message collected in EmptyCollector");
+    }
+}
+
+// discards all collected messages.
+pub struct BlackholeCollector;
+impl<T> Collector<T> for BlackholeCollector {
+    fn push(&mut self, _item: T) {}
+}
+
+// a database of socket addresses for nodes.
+pub trait PeerAddrLookup<PT: PubKey> {
+    fn lookup(&self, node_id: &NodeId<PT>) -> Option<SocketAddr>;
+}
+
+impl<PT: PubKey> PeerAddrLookup<PT> for std::collections::HashMap<NodeId<PT>, SocketAddr> {
+    fn lookup(&self, node_id: &NodeId<PT>) -> Option<SocketAddr> {
+        self.get(node_id).copied()
+    }
+}
+
+// a specified socket address for a single node
+#[derive(Debug, Clone, Copy)]
+pub struct KnownSocketAddr<'a, PT: PubKey>(pub &'a NodeId<PT>, pub SocketAddr);
+
+impl<PT: PubKey> PeerAddrLookup<PT> for KnownSocketAddr<'_, PT> {
+    fn lookup(&self, node_id: &NodeId<PT>) -> Option<SocketAddr> {
+        if self.0 == node_id {
+            Some(self.1)
+        } else {
+            None
+        }
+    }
+}
+
+impl<PT: PubKey, F> PeerAddrLookup<PT> for F
+where
+    F: Fn(&NodeId<PT>) -> Option<SocketAddr>,
+{
+    fn lookup(&self, node_id: &NodeId<PT>) -> Option<SocketAddr> {
+        self(node_id)
+    }
+}
+
+impl<PT, T> PeerAddrLookup<PT> for std::sync::Arc<T>
+where
+    PT: PubKey,
+    T: PeerAddrLookup<PT>,
+{
+    fn lookup(&self, node_id: &NodeId<PT>) -> Option<SocketAddr> {
+        self.as_ref().lookup(node_id)
+    }
+}
+
+/// Used in RaptorCast instance to lookup peer addresses with the peer discovery driver.
+impl<ST: CertificateSignatureRecoverable, PD> PeerAddrLookup<CertificateSignaturePubKey<ST>>
+    for std::sync::Mutex<monad_peer_discovery::driver::PeerDiscoveryDriver<PD>>
+where
+    PD: monad_peer_discovery::PeerDiscoveryAlgo<SignatureType = ST>,
+{
+    fn lookup(&self, node_id: &NodeId<CertificateSignaturePubKey<ST>>) -> Option<SocketAddr> {
+        let guard = self.lock().ok()?;
+        guard.lookup(node_id)
+    }
+}
+
+impl<ST: CertificateSignatureRecoverable, PD> PeerAddrLookup<CertificateSignaturePubKey<ST>>
+    for monad_peer_discovery::driver::PeerDiscoveryDriver<PD>
+where
+    PD: monad_peer_discovery::PeerDiscoveryAlgo<SignatureType = ST>,
+{
+    fn lookup(&self, node_id: &NodeId<CertificateSignaturePubKey<ST>>) -> Option<SocketAddr> {
+        self.get_addr(node_id)
+    }
+}
+
+// A cheaply cloned wrapper around a node_id with lazily-calculated
+// hash and a lazily-lookedup socket address.
+//
+// Change to Arc if we need parallel processing.
+#[derive(Clone)]
+pub struct Recipient<PT: PubKey>(Rc<RecipientInner<PT>>);
+
+impl<PT: PubKey> std::hash::Hash for Recipient<PT> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.node_hash().hash(state);
+    }
+}
+
+impl<PT: PubKey> PartialEq for Recipient<PT> {
+    fn eq(&self, other: &Self) -> bool {
+        self.node_hash() == other.node_hash()
+    }
+}
+impl<PT: PubKey> Eq for Recipient<PT> {}
+
+impl<PT: PubKey> std::fmt::Debug for Recipient<PT> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<node-{}>", &hex::encode(&self.node_hash()[..6]))?;
+        if let Some(addr) = self.0.addr.get() {
+            if let Some(addr) = addr {
+                write!(f, "@{}", addr)?;
+            } else {
+                write!(f, "@<unknown>")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct RecipientInner<PT: PubKey> {
+    node_id: NodeId<PT>,
+    node_hash: OnceCell<[u8; 20]>,
+    addr: OnceCell<Option<SocketAddr>>,
+}
+
+impl Recipient<monad_crypto::NopPubKey> {
+    // only used for testing
+    #[cfg(test)]
+    pub fn dummy(addr: Option<SocketAddr>) -> Self {
+        let mut bytes = format!("{:?}", addr).into_bytes();
+        bytes.resize(32, 0u8);
+
+        let pubkey = monad_crypto::NopPubKey::from_bytes(&bytes).expect("pubkey");
+        let recipient = Self::new(NodeId::new(pubkey));
+        recipient.0.addr.set(addr).expect("addr not set");
+        recipient
+    }
+}
+
+impl<PT: PubKey> Recipient<PT> {
+    pub fn new(node_id: NodeId<PT>) -> Self {
+        let node_hash = OnceCell::new();
+        let addr = OnceCell::new();
+        let inner = RecipientInner {
+            node_id,
+            node_hash,
+            addr,
+        };
+        Self(Rc::new(inner))
+    }
+
+    pub fn node_id(&self) -> &NodeId<PT> {
+        &self.0.node_id
+    }
+
+    pub(crate) fn node_hash(&self) -> &[u8; 20] {
+        self.0
+            .node_hash
+            .get_or_init(|| compute_hash(&self.0.node_id).0)
+    }
+
+    // Expect `lookup` or `set_addr` performed earlier, otherwise panic.
+    #[allow(unused)]
+    pub(crate) fn get_addr(&self) -> Option<SocketAddr> {
+        *self.0.addr.get().expect("get addr called before lookup")
+    }
+
+    pub fn lookup(&self, handle: &(impl PeerAddrLookup<PT> + ?Sized)) -> &Option<SocketAddr> {
+        self.0.addr.get_or_init(|| {
+            let addr = handle.lookup(&self.0.node_id);
+            if addr.is_none() {
+                tracing::warn!("raptorcast: unknown address for node {}", self.0.node_id);
+            }
+            addr
+        })
+    }
+}
+
+#[cfg(test)]
+pub struct DummyPeerLookup;
+
+#[cfg(test)]
+impl PeerAddrLookup<monad_crypto::NopPubKey> for DummyPeerLookup {
+    fn lookup(&self, _node_id: &NodeId<monad_crypto::NopPubKey>) -> Option<SocketAddr> {
+        panic!("recipient addr should be self contained")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UdpMessage<PT: PubKey> {
+    pub recipient: Recipient<PT>,
+    pub payload: Bytes,
+    pub stride: usize,
+}
+
 // Represented as a fixed-point number with 11 fractional bits.
 // Range: 0 to ~31.9995, Increments: ~0.000488
 #[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
@@ -962,5 +1182,35 @@ mod tests {
         assert!((u16::MAX as usize)
             .checked_mul(Redundancy::MAX_MULTIPLIER + 1)
             .is_none());
+    }
+
+    #[test]
+    fn test_known_socket_addr() {
+        let node1 = nid(1);
+        let node2 = nid(2);
+        let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
+
+        let lookup = KnownSocketAddr(&node1, addr);
+
+        assert_eq!(lookup.lookup(&node1), Some(addr));
+        assert_eq!(lookup.lookup(&node2), None);
+    }
+
+    #[test]
+    fn test_peer_addr_lookup_closure() {
+        let node1 = nid(1);
+        let node2 = nid(2);
+        let addr: SocketAddr = "127.0.0.1:7000".parse().unwrap();
+
+        let lookup_fn = |node_id: &NodeId<PT>| {
+            if node_id == &node1 {
+                Some(addr)
+            } else {
+                None
+            }
+        };
+
+        assert_eq!(lookup_fn.lookup(&node1), Some(addr));
+        assert_eq!(lookup_fn.lookup(&node2), None);
     }
 }


### PR DESCRIPTION
In this PR:

- move `Collector`, `PeerAddrLookup`, `Recipient`, `UdpMessage` from the `packet` module into the `util` module.
- add helper types that implement the traits: `EmptyCollector`, `BlackholeCollector`, `KnownSocketAddr` that will be used later.
- add a few tests

These traits/types are expected to be useful beyond the packet builder module, so it makes better sense to put them in the shared `util.rs` file.