### PR TITLE
eth_createAccessList block tag as optional param

### DIFF
--- a/monad-rpc/src/handlers/eth/call.rs
+++ b/monad-rpc/src/handlers/eth/call.rs
@@ -593,6 +593,7 @@ pub struct MonadDebugTraceCallParams {
 #[derive(Debug, Deserialize, schemars::JsonSchema, Clone)]
 pub struct MonadCreateAccessListParams {
     pub transaction: CallRequest,
+    #[serde(default)]
     pub block: BlockTagOrHash,
 }
 


### PR DESCRIPTION
Block tag is an optional param according to geth
