### PR TITLE
monad-raptorcast: use name record address for PingPongCommand

### DIFF
--- a/monad-peer-discovery/src/driver.rs
+++ b/monad-peer-discovery/src/driver.rs
@@ -309,6 +309,11 @@ impl<PD: PeerDiscoveryAlgo> PeerDiscoveryDriver<PD> {
         self.pd.get_name_records()
     }
 
+    #[doc(hidden)]
+    pub fn inner(&self) -> &PD {
+        &self.pd
+    }
+
     pub fn get_name_record(
         &self,
         id: &NodeId<CertificateSignaturePubKey<PD::SignatureType>>,


### PR DESCRIPTION
PingPongCommand strictly uses only the auth address specified in the name record. existing wireauth session is reused only if its address matches the one in the name record.

verified by a test that routes a ping message to the address in the name record when there is an existing session with the target identity at a different address.