### PR TITLE
monad-wireauth: drop tai64 dependency, implement tai64n in-place

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6399,7 +6399,6 @@ dependencies = [
  "rstest",
  "secp256k1",
  "serde",
- "tai64",
  "thiserror 1.0.69",
  "tikv-jemallocator",
  "tracing",
@@ -8979,12 +8978,6 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
-
-[[package]]
-name = "tai64"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "014639506e4f425c78e823eabf56e71c093f940ae55b43e58f682e7bc2f5887a"
 
 [[package]]
 name = "take_mut"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,6 @@ sorted_vector_map = "0.2.0"
 sorted-vec = "0.8.3"
 strum = "0.26.3"
 syn = { version = "1.0.0", features = ["full"] }
-tai64 = "4.0"
 tempfile = "3.5"
 test-case = "3.0"
 thiserror = "1.0"

--- a/monad-wireauth/Cargo.toml
+++ b/monad-wireauth/Cargo.toml
@@ -17,7 +17,6 @@ hex.workspace = true
 lru.workspace = true
 blake3.workspace = true
 aegis.workspace = true
-tai64.workspace = true
 zeroize = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/monad-wireauth/src/protocol/errors.rs
+++ b/monad-wireauth/src/protocol/errors.rs
@@ -23,8 +23,8 @@ pub enum HandshakeError {
     #[error("timestamp decryption failed: {0}")]
     TimestampDecryptionFailed(#[source] CryptoError),
 
-    #[error("invalid timestamp format: unable to parse TAI64N from {size} bytes")]
-    InvalidTimestamp { size: usize },
+    #[error("invalid timestamp: {0}")]
+    InvalidTimestamp(#[from] super::tai64::Tai64NError),
 
     #[error("empty message decryption failed: {0}")]
     EmptyMessageDecryptionFailed(#[source] CryptoError),

--- a/monad-wireauth/src/protocol/mod.rs
+++ b/monad-wireauth/src/protocol/mod.rs
@@ -19,5 +19,6 @@ pub mod crypto;
 pub mod errors;
 pub mod handshake;
 pub mod messages;
+pub mod tai64;
 
 pub use common::SessionIndex;

--- a/monad-wireauth/src/protocol/tai64.rs
+++ b/monad-wireauth/src/protocol/tai64.rs
@@ -1,0 +1,124 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use zerocopy::{BigEndian, FromBytes, Immutable, IntoBytes, KnownLayout, U32, U64};
+
+// TAI64 offset from Unix epoch: 2^62 (1970-01-01 00:00:00 TAI) + 37 (leap seconds from UTC to TAI)
+const TAI64_UNIX_EPOCH: u64 = 37 + (1u64 << 62);
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    FromBytes,
+    IntoBytes,
+    Immutable,
+    KnownLayout,
+)]
+#[repr(C, packed)]
+pub struct Tai64N {
+    seconds: U64<BigEndian>,
+    nanoseconds: U32<BigEndian>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum Tai64NError {
+    #[error("nanoseconds {0} exceed 1 second")]
+    NanosOverflow(u32),
+}
+
+impl From<Tai64N> for [u8; 12] {
+    fn from(tai: Tai64N) -> Self {
+        zerocopy::transmute!(tai)
+    }
+}
+
+impl TryFrom<[u8; 12]> for Tai64N {
+    type Error = Tai64NError;
+
+    fn try_from(bytes: [u8; 12]) -> Result<Self, Self::Error> {
+        let tai: Self = zerocopy::transmute!(bytes);
+        let nanos = tai.nanoseconds.get();
+        if nanos >= 1_000_000_000 {
+            return Err(Tai64NError::NanosOverflow(nanos));
+        }
+        Ok(tai)
+    }
+}
+
+impl From<SystemTime> for Tai64N {
+    fn from(t: SystemTime) -> Self {
+        let duration = t.duration_since(UNIX_EPOCH).unwrap_or_default();
+        Self {
+            seconds: U64::new(duration.as_secs().wrapping_add(TAI64_UNIX_EPOCH)),
+            nanoseconds: U32::new(duration.subsec_nanos()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let now: Tai64N = SystemTime::now().into();
+        let bytes: [u8; 12] = now.into();
+        let decoded = Tai64N::try_from(bytes).unwrap();
+        assert_eq!(now, decoded);
+    }
+
+    #[test]
+    fn from_system_time() {
+        let t: Tai64N = SystemTime::now().into();
+        let bytes: [u8; 12] = t.into();
+        assert_eq!(bytes.len(), 12);
+        let seconds = u64::from_be_bytes(bytes[..8].try_into().unwrap());
+        assert!(seconds > TAI64_UNIX_EPOCH);
+    }
+
+    #[test]
+    fn ordering() {
+        let a = Tai64N {
+            seconds: U64::new(100),
+            nanoseconds: U32::new(0),
+        };
+        let b = Tai64N {
+            seconds: U64::new(100),
+            nanoseconds: U32::new(1),
+        };
+        let c = Tai64N {
+            seconds: U64::new(101),
+            nanoseconds: U32::new(0),
+        };
+        assert!(a < b);
+        assert!(b < c);
+        assert_eq!(a.max(b), b);
+    }
+
+    #[test]
+    fn invalid_nanos() {
+        let mut bytes = [0u8; 12];
+        bytes[8..].copy_from_slice(&1_000_000_000u32.to_be_bytes());
+        assert!(Tai64N::try_from(bytes).is_err());
+    }
+}

--- a/monad-wireauth/src/session/common.rs
+++ b/monad-wireauth/src/session/common.rs
@@ -15,12 +15,11 @@
 
 use std::{net::SocketAddr, time::Duration};
 
-use tai64::Tai64N;
 use tracing::debug;
 
 use crate::{
     config::RETRY_ALWAYS,
-    protocol::{common::*, cookies},
+    protocol::{common::*, cookies, tai64::Tai64N},
 };
 
 #[derive(Debug, Clone)]

--- a/monad-wireauth/src/session/responder.rs
+++ b/monad-wireauth/src/session/responder.rs
@@ -19,8 +19,6 @@ use std::{
     time::Duration,
 };
 
-use tai64::Tai64N;
-
 use super::{
     common::{add_jitter, RenewedTimer, SessionError, SessionState, SessionTimeoutResult},
     transport::TransportState,
@@ -31,6 +29,7 @@ use crate::{
         common::*,
         handshake::{self},
         messages::{DataPacket, HandshakeInitiation, HandshakeResponse, Plaintext},
+        tai64::Tai64N,
     },
 };
 

--- a/monad-wireauth/src/state.rs
+++ b/monad-wireauth/src/state.rs
@@ -20,10 +20,10 @@ use std::{
 };
 
 use monad_executor::ExecutorMetrics;
-use tai64::Tai64N;
 
 use crate::{
     metrics::*,
+    protocol::tai64::Tai64N,
     session::{InitiatorState, ResponderState, SessionIndex, TransportState},
 };
 
@@ -740,7 +740,7 @@ mod tests {
         let validated_init = crate::session::responder::ValidatedHandshakeInit {
             handshake_state,
             remote_public_key: *remote_public_key,
-            timestamp: Tai64N::now(),
+            timestamp: SystemTime::now().into(),
         };
 
         let config = Config::default();


### PR DESCRIPTION
trivial zerocopy-based implementation preserving full compatibility