### PR TITLE
Raptorcast: refactor raptorcast chunk parser

### DIFF
--- a/monad-fuzz/Cargo.toml
+++ b/monad-fuzz/Cargo.toml
@@ -23,6 +23,10 @@ name = "fuzz_parse_message"
 path = "fuzz_targets/fuzz_parse_message.rs"
 
 [[bin]]
+name = "fuzz_parse_message_differential"
+path = "fuzz_targets/fuzz_parse_message_differential.rs"
+
+[[bin]]
 name = "fuzz_deserialize"
 path = "fuzz_targets/fuzz_deserialize.rs"
 

--- a/monad-fuzz/fuzz_targets/fuzz_parse_message_differential.rs
+++ b/monad-fuzz/fuzz_targets/fuzz_parse_message_differential.rs
@@ -1,0 +1,81 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Fuzz runner config:
+//
+// CORPUS_FILTER=*.parse_message.bin
+// TIMEOUT_QUICK=5m
+//
+// Environments:
+//
+// AFL_HANG_TMOUT=100
+// AFL_EXIT_ON_TIME=300000
+// AFL_INPUT_LEN_MAX=1500
+
+use bytes::Bytes;
+use monad_raptorcast::{
+    parser::legacy::{
+        parse_message as old_parse_message, ChunkSignatureVerifier as OldSigVerifier,
+    },
+    udp::{
+        parse_message as new_parse_message, ChunkSignatureVerifier as NewSigVerifier,
+        MessageValidationError,
+    },
+};
+use monad_secp::mock::MockSecpSignature;
+
+fn main() {
+    use MessageValidationError::*;
+
+    afl::fuzz!(|data: &[u8]| {
+        let payload = Bytes::copy_from_slice(data);
+
+        let mut old_sig_cache = OldSigVerifier::<MockSecpSignature>::new().with_cache(1);
+        let mut new_sig_cache = NewSigVerifier::<MockSecpSignature>::new().with_cache(1);
+
+        let old = old_parse_message::<MockSecpSignature, _>(
+            &mut old_sig_cache,
+            payload.clone(),
+            u64::MAX,
+            |_| true,
+        );
+
+        let new = new_parse_message::<MockSecpSignature, _>(
+            &mut new_sig_cache,
+            payload,
+            u64::MAX,
+            |_| true,
+        );
+
+        match (old, new) {
+            // known discrepancies due to different ordering of checks
+            (Err(InvalidSignature), Err(TooShort))
+            | (Err(InvalidSignature), Err(InvalidMerkleProof))
+            | (Err(InvalidSignature), Err(InvalidChunkId))
+            | (Err(InvalidTreeDepth), Err(TooShort))
+            | (Err(TooLong), Err(TooShort))
+            | (Err(InvalidMerkleProof), Err(InvalidChunkId))
+            | (Err(InvalidMerkleProof), Err(TooShort))
+            | (Err(InvalidBroadcastBits(_)), Err(TooShort))
+            | (Err(InvalidBroadcastBits(_)), Err(TooLong))
+            | (Err(InvalidBroadcastBits(_)), Err(InvalidTreeDepth)) => return,
+
+            (old, new) => {
+                // otherwise the two implementations should agree
+                assert_eq!(old, new);
+            }
+        }
+    });
+}

--- a/monad-raptorcast/src/parser/legacy.rs
+++ b/monad-raptorcast/src/parser/legacy.rs
@@ -1,0 +1,364 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Legacy packet parser implementation.
+
+use bytes::Bytes;
+use monad_crypto::{
+    certificate_signature::{
+        CertificateSignature, CertificateSignaturePubKey, CertificateSignatureRecoverable,
+    },
+    hasher::{Hasher, HasherType},
+    signing_domain,
+};
+use monad_merkle::{MerkleHash, MerkleProof};
+use monad_types::{Epoch, Round};
+
+use crate::{
+    message::MAX_MESSAGE_SIZE,
+    packet::assembler::HEADER_LEN,
+    parser::signature_verifier,
+    udp::{
+        GroupId, MessageValidationError, ValidatedMessage, MAX_MERKLE_TREE_DEPTH, MAX_REDUNDANCY,
+        MAX_VALIDATOR_SET_SIZE, MIN_MERKLE_TREE_DEPTH,
+    },
+    util::{BroadcastMode, HexBytes},
+    SIGNATURE_SIZE,
+};
+
+type SignatureCacheKey = [u8; HEADER_LEN + 20];
+pub type ChunkSignatureVerifier<ST> =
+    signature_verifier::SignatureVerifier<ST, SignatureCacheKey, signing_domain::RaptorcastChunk>;
+
+pub fn parse_message<ST, F>(
+    signature_verifier: &mut ChunkSignatureVerifier<ST>,
+    message: Bytes,
+    max_age_ms: u64,
+    bypass_rate_limiter: F,
+) -> Result<ValidatedMessage<CertificateSignaturePubKey<ST>>, MessageValidationError>
+where
+    ST: CertificateSignatureRecoverable,
+    F: FnOnce(Epoch) -> bool,
+{
+    let mut cursor: Bytes = message.clone();
+    let mut split_off = |mid| {
+        if mid > cursor.len() {
+            Err(MessageValidationError::TooShort)
+        } else {
+            Ok(cursor.split_to(mid))
+        }
+    };
+    let cursor_signature = split_off(SIGNATURE_SIZE)?;
+    let signature = <ST as CertificateSignature>::deserialize(&cursor_signature)
+        .map_err(|_| MessageValidationError::InvalidSignature)?;
+
+    let cursor_version = split_off(2)?;
+    let version = u16::from_le_bytes(cursor_version.as_ref().try_into().expect("u16 is 2 bytes"));
+    if version != 0 {
+        return Err(MessageValidationError::UnknownVersion(version));
+    }
+
+    let cursor_broadcast_tree_depth = split_off(1)?[0];
+    let broadcast = (cursor_broadcast_tree_depth & (1 << 7)) != 0;
+    let secondary_broadcast = (cursor_broadcast_tree_depth & (1 << 6)) != 0;
+    let tree_depth = cursor_broadcast_tree_depth & 0b0000_1111; // bottom 4 bits
+
+    let broadcast_mode = match (broadcast, secondary_broadcast) {
+        (true, false) => BroadcastMode::Primary,
+        (false, true) => BroadcastMode::Secondary,
+        (false, false) => BroadcastMode::Unspecified, // unicast or broadcast
+        (true, true) => {
+            return Err(MessageValidationError::InvalidBroadcastBits(0b11));
+        }
+    };
+
+    if !(MIN_MERKLE_TREE_DEPTH..=MAX_MERKLE_TREE_DEPTH).contains(&tree_depth) {
+        return Err(MessageValidationError::InvalidTreeDepth);
+    }
+
+    let cursor_group_id = split_off(8)?;
+    let group_id = u64::from_le_bytes(cursor_group_id.as_ref().try_into().expect("u64 is 8 bytes"));
+    let group_id = match broadcast_mode {
+        BroadcastMode::Primary | BroadcastMode::Unspecified => GroupId::Primary(Epoch(group_id)),
+        BroadcastMode::Secondary => GroupId::Secondary(Round(group_id)),
+    };
+
+    let cursor_unix_ts_ms = split_off(8)?;
+    let unix_ts_ms = u64::from_le_bytes(
+        cursor_unix_ts_ms
+            .as_ref()
+            .try_into()
+            .expect("u64 is 8 bytes"),
+    );
+
+    ensure_valid_timestamp(unix_ts_ms, max_age_ms)?;
+
+    let cursor_app_message_hash = split_off(20)?;
+    let app_message_hash: HexBytes<20> = HexBytes(
+        cursor_app_message_hash
+            .as_ref()
+            .try_into()
+            .expect("Hash is 20 bytes"),
+    );
+
+    let cursor_app_message_len = split_off(4)?;
+    let app_message_len = u32::from_le_bytes(
+        cursor_app_message_len
+            .as_ref()
+            .try_into()
+            .expect("u32 is 4 bytes"),
+    ) as usize;
+
+    if app_message_len > MAX_MESSAGE_SIZE {
+        return Err(MessageValidationError::TooLong);
+    };
+
+    let proof_size: u16 = 20 * (u16::from(tree_depth) - 1);
+
+    let mut merkle_proof = Vec::new();
+    for _ in 0..tree_depth - 1 {
+        let cursor_sibling = split_off(20)?;
+        let sibling =
+            MerkleHash::try_from(cursor_sibling.as_ref()).expect("MerkleHash is 20 bytes");
+        merkle_proof.push(sibling);
+    }
+
+    let cursor_recipient = split_off(20)?;
+    let recipient_hash: HexBytes<20> = HexBytes(
+        cursor_recipient
+            .as_ref()
+            .try_into()
+            .expect("Hash is 20 bytes"),
+    );
+
+    let cursor_merkle_idx = split_off(1)?[0];
+    let merkle_proof = MerkleProof::new_from_leaf_idx(merkle_proof, cursor_merkle_idx)
+        .ok_or(MessageValidationError::InvalidMerkleProof)?;
+
+    let _cursor_reserved = split_off(1)?;
+
+    let cursor_chunk_id = split_off(2)?;
+    let chunk_id = u16::from_le_bytes(cursor_chunk_id.as_ref().try_into().expect("u16 is 2 bytes"));
+
+    let cursor_payload = cursor;
+    let symbol_len = cursor_payload.len();
+    if symbol_len == 0 {
+        // handle the degenerate case
+        return Err(MessageValidationError::TooShort);
+    }
+
+    let chunk_id_range = match broadcast_mode {
+        BroadcastMode::Unspecified | BroadcastMode::Secondary => {
+            valid_chunk_id_range(app_message_len, symbol_len)?
+        }
+        BroadcastMode::Primary => {
+            // only perform a basic sanity check here. more precise
+            // check of chunk_id is in decoding.rs when the validator
+            // set is available.
+            valid_chunk_id_range_raptorcast(app_message_len, symbol_len, MAX_VALIDATOR_SET_SIZE)?
+        }
+    };
+    if !chunk_id_range.contains(&(chunk_id as usize)) {
+        return Err(MessageValidationError::InvalidChunkId);
+    }
+
+    let leaf_hash = {
+        let mut hasher = HasherType::new();
+        hasher.update(
+            &message[HEADER_LEN + proof_size as usize..
+                // HEADER_LEN as usize
+                //     + proof_size as usize
+                //     + CHUNK_HEADER_LEN as usize
+                //     + payload_len as usize
+            ],
+        );
+        hasher.hash()
+    };
+    let root = merkle_proof
+        .compute_root(&leaf_hash)
+        .ok_or(MessageValidationError::InvalidMerkleProof)?;
+    let mut signed_over: SignatureCacheKey = [0_u8; HEADER_LEN + 20];
+    // TODO can avoid this copy if necessary
+    signed_over[..HEADER_LEN].copy_from_slice(&message[..HEADER_LEN]);
+    signed_over[HEADER_LEN..].copy_from_slice(&root);
+
+    let author = if let Some(author) = signature_verifier.load_cached(&signed_over) {
+        author
+    } else {
+        let new_author = match group_id {
+            GroupId::Primary(epoch) if bypass_rate_limiter(epoch) => {
+                signature_verifier.verify_force(signature, &signed_over[SIGNATURE_SIZE..])?
+            }
+            _ => signature_verifier.verify(signature, &signed_over[SIGNATURE_SIZE..])?,
+        };
+        signature_verifier.save_cache(signed_over, new_author);
+        new_author
+    };
+
+    Ok(ValidatedMessage {
+        message,
+        author,
+        group_id,
+        unix_ts_ms,
+        app_message_hash,
+        app_message_len: app_message_len as u32,
+        broadcast_mode,
+        recipient_hash,
+        chunk_id,
+        chunk: cursor_payload,
+    })
+}
+
+fn ensure_valid_timestamp(unix_ts_ms: u64, max_age_ms: u64) -> Result<(), MessageValidationError> {
+    let current_time_ms = if let Ok(current_time_elapsed) = std::time::UNIX_EPOCH.elapsed() {
+        current_time_elapsed.as_millis() as u64
+    } else {
+        tracing::warn!("system time is before unix epoch, ignoring timestamp");
+        return Ok(());
+    };
+    let delta = (current_time_ms as i64).saturating_sub(unix_ts_ms as i64);
+    if delta.unsigned_abs() > max_age_ms {
+        Err(MessageValidationError::InvalidTimestamp {
+            timestamp: unix_ts_ms,
+            max: max_age_ms,
+            delta,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn valid_chunk_id_range_raptorcast(
+    app_message_len: usize,
+    symbol_len: usize,
+    num_validators: usize,
+) -> Result<std::ops::Range<usize>, MessageValidationError> {
+    if symbol_len == 0 {
+        return Err(MessageValidationError::TooShort);
+    }
+    let base_chunks = app_message_len.div_ceil(symbol_len);
+    let rounding_chunks = num_validators;
+    let num_chunks = MAX_REDUNDANCY
+        .scale(base_chunks)
+        .ok_or(MessageValidationError::TooLong)?
+        + rounding_chunks;
+    Ok(0..num_chunks)
+}
+
+fn valid_chunk_id_range(
+    app_message_len: usize,
+    symbol_len: usize,
+) -> Result<std::ops::Range<usize>, MessageValidationError> {
+    if symbol_len == 0 {
+        return Err(MessageValidationError::TooShort);
+    }
+    let base_chunks = app_message_len.div_ceil(symbol_len);
+    let num_chunks = MAX_REDUNDANCY
+        .scale(base_chunks)
+        .ok_or(MessageValidationError::TooLong)?;
+    Ok(0..num_chunks)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, net::SocketAddr};
+
+    use monad_crypto::{
+        certificate_signature::CertificateSignaturePubKey, hasher::Hasher as HasherTrait,
+    };
+    use monad_dataplane::udp::DEFAULT_SEGMENT_SIZE;
+    use monad_secp::{KeyPair, SecpSignature};
+    use monad_types::{NodeId, Stake};
+    use monad_validator::validator_set::ValidatorSet;
+
+    use super::*;
+    use crate::{
+        packet::build_messages,
+        udp::{GroupId, SIGNATURE_CACHE_SIZE},
+        util::{BuildTarget, EpochValidators, Redundancy},
+    };
+
+    type SignatureType = SecpSignature;
+    type KeyPairType = KeyPair;
+    type TestSignatureVerifier = crate::udp::ChunkSignatureVerifier<SignatureType>;
+    type LegacySignatureVerifier = super::ChunkSignatureVerifier<SignatureType>;
+
+    fn validator_set() -> (
+        KeyPairType,
+        EpochValidators<CertificateSignaturePubKey<SignatureType>>,
+        HashMap<NodeId<CertificateSignaturePubKey<SignatureType>>, SocketAddr>,
+    ) {
+        const NUM_KEYS: u8 = 100;
+        let mut keys = (0_u8..NUM_KEYS)
+            .map(|n| {
+                let mut hasher = HasherType::new();
+                hasher.update(n.to_le_bytes());
+                let mut hash = hasher.hash();
+                KeyPairType::from_bytes(&mut hash.0).unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        let valset = keys
+            .iter()
+            .map(|key| (NodeId::new(key.pubkey()), Stake::ONE))
+            .collect();
+        let validators = EpochValidators {
+            validators: ValidatorSet::new_unchecked(valset),
+        };
+
+        let known_addresses = HashMap::new();
+        (keys.pop().unwrap(), validators, known_addresses)
+    }
+
+    const EPOCH: Epoch = Epoch(5);
+    const UNIX_TS_MS: u64 = 5;
+
+    #[test]
+    fn test_legacy_vs_new_parser_equivalence() {
+        let (key, validators, known_addresses) = validator_set();
+        let epoch_validators = validators.view_without(vec![&NodeId::new(key.pubkey())]);
+
+        let app_message: Bytes = vec![1_u8; 1024 * 64].into();
+
+        let messages = build_messages::<SignatureType>(
+            &key,
+            DEFAULT_SEGMENT_SIZE,
+            app_message,
+            Redundancy::from_u8(2),
+            GroupId::Primary(EPOCH),
+            UNIX_TS_MS,
+            BuildTarget::Raptorcast(epoch_validators),
+            &known_addresses,
+        );
+
+        let mut legacy_verifier = LegacySignatureVerifier::new().with_cache(SIGNATURE_CACHE_SIZE);
+        let mut new_verifier = TestSignatureVerifier::new().with_cache(SIGNATURE_CACHE_SIZE);
+
+        for (_to, mut aggregate_message) in messages {
+            while !aggregate_message.is_empty() {
+                let message = aggregate_message.split_to(DEFAULT_SEGMENT_SIZE.into());
+                let legacy_result =
+                    super::parse_message(&mut legacy_verifier, message.clone(), u64::MAX, |_| true);
+                let new_result =
+                    crate::udp::parse_message(&mut new_verifier, message.clone(), u64::MAX, |_| {
+                        true
+                    });
+
+                assert!(new_result.is_ok() && legacy_result.is_ok());
+                assert_eq!(legacy_result, new_result);
+            }
+        }
+    }
+}

--- a/monad-raptorcast/src/parser/mod.rs
+++ b/monad-raptorcast/src/parser/mod.rs
@@ -13,4 +13,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+pub mod legacy;
+pub mod packet_parser;
 pub mod signature_verifier;

--- a/monad-raptorcast/src/parser/packet_parser.rs
+++ b/monad-raptorcast/src/parser/packet_parser.rs
@@ -1,0 +1,422 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use bytes::Bytes;
+use monad_crypto::{
+    certificate_signature::{
+        CertificateSignature, CertificateSignaturePubKey, CertificateSignatureRecoverable,
+    },
+    hasher::{Hasher as _, HasherType},
+};
+use monad_merkle::{MerkleHash, MerkleProof};
+use monad_types::{Epoch, Round};
+use tracing::warn;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Ref, LE, U16, U32, U64};
+
+use crate::{
+    message::MAX_MESSAGE_SIZE,
+    udp::{
+        ChunkSignatureVerifier, GroupId, MessageValidationError, SignatureCacheKey,
+        ValidatedMessage, MAX_MERKLE_TREE_DEPTH, MAX_REDUNDANCY, MAX_VALIDATOR_SET_SIZE,
+        MIN_MERKLE_TREE_DEPTH,
+    },
+    util::{BroadcastMode, HexBytes, Redundancy},
+    SIGNATURE_SIZE,
+};
+
+const MERKLE_HASH_SIZE: usize = 20;
+
+/// Raptorcast packet header (common to all versions):
+/// - 65 bytes => Signature of sender
+/// - 2 bytes => Version number
+#[repr(C, packed)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Clone, Copy)]
+pub struct RaptorcastHeader {
+    signature: [u8; SIGNATURE_SIZE],
+    version: U16<LE>,
+}
+
+impl RaptorcastHeader {
+    const SIZE: usize = SIGNATURE_SIZE + 2;
+}
+
+/// Raptorcast packet V0 versioned header layout (follows common header):
+/// - 1 bit => broadcast or not
+/// - 1 bit => secondary broadcast or not (full-node raptorcast)
+/// - 2 bits => unused
+/// - 4 bits => Merkle tree depth
+/// - 8 bytes (u64) => Epoch #
+/// - 8 bytes (u64) => Unix timestamp
+/// - 20 bytes => first 20 bytes of hash of AppMessage
+///   - this isn't technically necessary if payload_len is small enough to fit in 1 chunk, but keep
+///     for simplicity
+/// - 4 bytes (u32) => Serialized AppMessage length (bytes)
+#[repr(C, packed)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Clone, Copy)]
+pub struct RaptorcastHeaderV0 {
+    broadcast_tree_depth: u8,
+    group_id: U64<LE>,
+    unix_ts_ms: U64<LE>,
+    app_message_hash: [u8; MERKLE_HASH_SIZE],
+    app_message_len: U32<LE>,
+}
+
+impl RaptorcastHeaderV0 {
+    const SIZE: usize = 1 + 8 + 8 + MERKLE_HASH_SIZE + 4;
+
+    pub fn broadcast(&self) -> bool {
+        (self.broadcast_tree_depth & (1 << 7)) != 0
+    }
+
+    pub fn secondary_broadcast(&self) -> bool {
+        (self.broadcast_tree_depth & (1 << 6)) != 0
+    }
+
+    pub fn tree_depth(&self) -> u8 {
+        self.broadcast_tree_depth & 0b0000_1111
+    }
+
+    pub fn merkle_proof_size(&self) -> usize {
+        MERKLE_HASH_SIZE * (self.tree_depth() as usize - 1)
+    }
+
+    pub fn broadcast_mode(&self) -> Result<BroadcastMode, MessageValidationError> {
+        match (self.broadcast(), self.secondary_broadcast()) {
+            (true, false) => Ok(BroadcastMode::Primary),
+            (false, true) => Ok(BroadcastMode::Secondary),
+            (false, false) => Ok(BroadcastMode::Unspecified),
+            (true, true) => Err(MessageValidationError::InvalidBroadcastBits(0b11)),
+        }
+    }
+
+    pub fn group_id(&self) -> Result<GroupId, MessageValidationError> {
+        match self.broadcast_mode()? {
+            BroadcastMode::Primary | BroadcastMode::Unspecified => {
+                Ok(GroupId::Primary(Epoch(self.group_id.get())))
+            }
+            BroadcastMode::Secondary => Ok(GroupId::Secondary(Round(self.group_id.get()))),
+        }
+    }
+}
+
+/// Combined header size for V0 (common header + versioned header)
+const RAPTORCAST_HEADER_V0_SIZE: usize = RaptorcastHeader::SIZE + RaptorcastHeaderV0::SIZE;
+
+const _: () = assert!(
+    RAPTORCAST_HEADER_V0_SIZE == crate::packet::assembler::HEADER_LEN,
+    "RaptorcastHeader size must match HEADER_LEN"
+);
+
+/// Raptorcast V0 chunk header layout (follows header and merkle proof):
+/// - 20 bytes * (merkle_tree_depth - 1) => merkle proof (leaves include everything that follows,
+///   eg hash(chunk_recipient + chunk_byte_offset + symbol_len + payload))
+/// - 20 bytes => first 20 bytes of hash of chunk's first hop recipient
+///   - we set this even if broadcast bit is not set so that it's known if a message was intended
+///     to be sent to self
+/// - 1 byte => Chunk's merkle leaf idx
+/// - 1 byte => reserved
+/// - 2 bytes (u16) => This chunk's id
+/// - rest => data
+#[repr(C, packed)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Clone, Copy)]
+pub struct RaptorcastChunkHeaderV0 {
+    recipient_hash: [u8; MERKLE_HASH_SIZE],
+    merkle_leaf_idx: u8,
+    reserved: u8,
+    chunk_id: U16<LE>,
+}
+
+impl RaptorcastChunkHeaderV0 {
+    const SIZE: usize = MERKLE_HASH_SIZE + 1 + 1 + 2;
+}
+
+const _: () = assert!(
+    RaptorcastChunkHeaderV0::SIZE == crate::packet::assembler::CHUNK_HEADER_LEN,
+    "RaptorcastChunkHeader size must match CHUNK_HEADER_LEN"
+);
+
+/// header + merkle root, used as cache key for signatures
+#[repr(transparent)]
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct SignedOverDataV0([u8; RAPTORCAST_HEADER_V0_SIZE + MERKLE_HASH_SIZE]);
+
+impl SignedOverDataV0 {
+    pub fn new(
+        common_header: &Ref<&[u8], RaptorcastHeader>,
+        versioned_header: &Ref<&[u8], RaptorcastHeaderV0>,
+        merkle_root: &MerkleHash,
+    ) -> Self {
+        use zerocopy::IntoBytes;
+        let mut data = [0u8; RAPTORCAST_HEADER_V0_SIZE + MERKLE_HASH_SIZE];
+        data[..RaptorcastHeader::SIZE].copy_from_slice(common_header.as_bytes());
+        data[RaptorcastHeader::SIZE..RAPTORCAST_HEADER_V0_SIZE]
+            .copy_from_slice(versioned_header.as_bytes());
+        data[RAPTORCAST_HEADER_V0_SIZE..].copy_from_slice(merkle_root);
+        Self(data)
+    }
+
+    pub fn signed_message(&self) -> &[u8] {
+        &self.0[SIGNATURE_SIZE..]
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum SignedOverData {
+    V0(SignedOverDataV0),
+}
+
+impl SignedOverData {
+    pub fn signed_message(&self) -> &[u8] {
+        match self {
+            SignedOverData::V0(v0) => v0.signed_message(),
+        }
+    }
+}
+
+pub struct RaptorcastPacketV0<'a> {
+    pub header: Ref<&'a [u8], RaptorcastHeaderV0>,
+    pub merkle_proof: Ref<&'a [u8], [MerkleHash]>,
+    pub chunk_header: Ref<&'a [u8], RaptorcastChunkHeaderV0>,
+    pub chunk_header_and_payload: &'a [u8],
+    pub payload: &'a [u8],
+    pub payload_offset: usize,
+}
+
+impl<'a> RaptorcastPacketV0<'a> {
+    pub fn parse(rest: &'a [u8]) -> Result<Self, MessageValidationError> {
+        if rest.len() < RaptorcastHeaderV0::SIZE {
+            return Err(MessageValidationError::TooShort);
+        }
+        let (header_bytes, rest) = rest.split_at(RaptorcastHeaderV0::SIZE);
+        let header: Ref<&[u8], RaptorcastHeaderV0> =
+            Ref::from_bytes(header_bytes).map_err(|_| MessageValidationError::TooShort)?;
+
+        let tree_depth = header.tree_depth();
+        if !(MIN_MERKLE_TREE_DEPTH..=MAX_MERKLE_TREE_DEPTH).contains(&tree_depth) {
+            return Err(MessageValidationError::InvalidTreeDepth);
+        }
+
+        let merkle_proof_len = header.merkle_proof_size();
+        if rest.len() < merkle_proof_len {
+            return Err(MessageValidationError::TooShort);
+        }
+        let (merkle_proof_bytes, chunk_header_and_payload) = rest.split_at(merkle_proof_len);
+        let merkle_proof: Ref<&[u8], [MerkleHash]> =
+            Ref::from_bytes(merkle_proof_bytes).map_err(|_| MessageValidationError::TooShort)?;
+
+        if chunk_header_and_payload.len() < RaptorcastChunkHeaderV0::SIZE {
+            return Err(MessageValidationError::TooShort);
+        }
+        let (chunk_header_bytes, payload) =
+            chunk_header_and_payload.split_at(RaptorcastChunkHeaderV0::SIZE);
+        let chunk_header: Ref<&[u8], RaptorcastChunkHeaderV0> =
+            Ref::from_bytes(chunk_header_bytes).map_err(|_| MessageValidationError::TooShort)?;
+
+        if payload.is_empty() {
+            return Err(MessageValidationError::TooShort);
+        }
+
+        let payload_offset =
+            RAPTORCAST_HEADER_V0_SIZE + merkle_proof_len + RaptorcastChunkHeaderV0::SIZE;
+
+        Ok(Self {
+            header,
+            merkle_proof,
+            chunk_header,
+            chunk_header_and_payload,
+            payload,
+            payload_offset,
+        })
+    }
+
+    pub fn split_chunk(&self, message: &Bytes) -> Result<Bytes, MessageValidationError> {
+        if message.len() < self.payload_offset {
+            return Err(MessageValidationError::TooShort);
+        }
+        Ok(message.slice(self.payload_offset..))
+    }
+
+    pub fn payload(&self) -> &[u8] {
+        &self.chunk_header_and_payload[RaptorcastChunkHeaderV0::SIZE..]
+    }
+
+    pub fn compute_merkle_root(&self) -> Result<MerkleHash, MessageValidationError> {
+        let proof = MerkleProof::new_from_leaf_idx(
+            self.merkle_proof.to_vec(),
+            self.chunk_header.merkle_leaf_idx,
+        )
+        .ok_or(MessageValidationError::InvalidMerkleProof)?;
+
+        let mut hasher = HasherType::new();
+        hasher.update(self.chunk_header_and_payload);
+        let leaf_hash = hasher.hash();
+
+        proof
+            .compute_root(&leaf_hash)
+            .ok_or(MessageValidationError::InvalidMerkleProof)
+    }
+
+    pub fn signed_over_data(
+        &self,
+        common_header: &Ref<&[u8], RaptorcastHeader>,
+        merkle_root: &MerkleHash,
+    ) -> SignedOverData {
+        SignedOverData::V0(SignedOverDataV0::new(
+            common_header,
+            &self.header,
+            merkle_root,
+        ))
+    }
+}
+
+pub enum RaptorcastPacketVersioned<'a> {
+    V0(RaptorcastPacketV0<'a>),
+}
+
+pub type CommonRaptorcastHeader<'a> = Ref<&'a [u8], RaptorcastHeader>;
+
+pub struct RaptorcastPacket<'a> {
+    pub common_header: CommonRaptorcastHeader<'a>,
+    pub versioned: RaptorcastPacketVersioned<'a>,
+}
+
+impl<'a> RaptorcastPacket<'a> {
+    pub fn parse(data: &'a [u8]) -> Result<Self, MessageValidationError> {
+        if data.len() < RaptorcastHeader::SIZE {
+            return Err(MessageValidationError::TooShort);
+        }
+
+        let (header_bytes, rest) = data.split_at(RaptorcastHeader::SIZE);
+        let header: Ref<&[u8], RaptorcastHeader> =
+            Ref::from_bytes(header_bytes).map_err(|_| MessageValidationError::TooShort)?;
+
+        let versioned = match header.version.get() {
+            0 => RaptorcastPacketVersioned::V0(RaptorcastPacketV0::parse(rest)?),
+            v => return Err(MessageValidationError::UnknownVersion(v)),
+        };
+
+        Ok(Self {
+            common_header: header,
+            versioned,
+        })
+    }
+}
+
+pub fn validate_message_v0<ST, F>(
+    signature_verifier: &mut ChunkSignatureVerifier<ST>,
+    common_header: &Ref<&[u8], RaptorcastHeader>,
+    packet: &RaptorcastPacketV0,
+    message: &Bytes,
+    max_age_ms: u64,
+    bypass_rate_limiter: F,
+) -> Result<ValidatedMessage<CertificateSignaturePubKey<ST>>, MessageValidationError>
+where
+    ST: CertificateSignatureRecoverable,
+    F: FnOnce(Epoch) -> bool,
+{
+    let app_message_len = packet.header.app_message_len.get() as usize;
+    if app_message_len > MAX_MESSAGE_SIZE {
+        return Err(MessageValidationError::TooLong);
+    }
+
+    ensure_valid_timestamp(packet.header.unix_ts_ms.get(), max_age_ms)?;
+
+    let broadcast_mode = packet.header.broadcast_mode()?;
+    let group_id = packet.header.group_id()?;
+
+    match broadcast_mode {
+        BroadcastMode::Unspecified | BroadcastMode::Secondary => {
+            validate_chunk_id(packet, MAX_REDUNDANCY, 0)?
+        }
+        BroadcastMode::Primary => {
+            validate_chunk_id(packet, MAX_REDUNDANCY, MAX_VALIDATOR_SET_SIZE)?
+        }
+    };
+
+    let signature = <ST as CertificateSignature>::deserialize(&common_header.signature)
+        .map_err(|_| MessageValidationError::InvalidSignature)?;
+
+    let merkle_root = packet.compute_merkle_root()?;
+
+    let signed_over: SignatureCacheKey = packet.signed_over_data(common_header, &merkle_root);
+
+    let author = if let Some(author) = signature_verifier.load_cached(&signed_over) {
+        author
+    } else {
+        let new_author = match group_id {
+            GroupId::Primary(epoch) if bypass_rate_limiter(epoch) => {
+                signature_verifier.verify_force(signature, signed_over.signed_message())?
+            }
+            _ => signature_verifier.verify(signature, signed_over.signed_message())?,
+        };
+        signature_verifier.save_cache(signed_over, new_author);
+        new_author
+    };
+
+    Ok(ValidatedMessage {
+        message: message.clone(),
+        author,
+        group_id,
+        unix_ts_ms: packet.header.unix_ts_ms.get(),
+        app_message_hash: HexBytes(packet.header.app_message_hash),
+        app_message_len: packet.header.app_message_len.get(),
+        broadcast_mode,
+        recipient_hash: HexBytes(packet.chunk_header.recipient_hash),
+        chunk_id: packet.chunk_header.chunk_id.get(),
+        chunk: packet.split_chunk(message)?,
+    })
+}
+
+fn ensure_valid_timestamp(unix_ts_ms: u64, max_age_ms: u64) -> Result<(), MessageValidationError> {
+    let current_time_ms = if let Ok(current_time_elapsed) = std::time::UNIX_EPOCH.elapsed() {
+        current_time_elapsed.as_millis() as u64
+    } else {
+        warn!("system time is before unix epoch, ignoring timestamp");
+        return Ok(());
+    };
+    let delta = (current_time_ms as i64).saturating_sub(unix_ts_ms as i64);
+    if delta.unsigned_abs() > max_age_ms {
+        Err(MessageValidationError::InvalidTimestamp {
+            timestamp: unix_ts_ms,
+            max: max_age_ms,
+            delta,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+pub(crate) fn validate_chunk_id(
+    packet: &RaptorcastPacketV0,
+    max_redundancy: Redundancy,
+    max_rounding_chunks: usize,
+) -> Result<(), MessageValidationError> {
+    let symbol_len = packet.payload().len();
+    if symbol_len == 0 {
+        return Err(MessageValidationError::TooShort);
+    }
+    let base_chunks = (packet.header.app_message_len.get() as usize).div_ceil(symbol_len);
+    let num_chunks = max_redundancy
+        .scale(base_chunks)
+        .ok_or(MessageValidationError::TooLong)?
+        + max_rounding_chunks;
+
+    let chunk_id = packet.chunk_header.chunk_id.get() as usize;
+
+    if chunk_id >= num_chunks {
+        return Err(MessageValidationError::InvalidChunkId);
+    }
+    Ok(())
+}

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -13,37 +13,33 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{collections::BTreeMap, ops::Range};
+use std::collections::BTreeMap;
 
 use bytes::Bytes;
 use monad_crypto::{
-    certificate_signature::{
-        CertificateSignature, CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
-    },
-    hasher::{Hasher, HasherType},
+    certificate_signature::{CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey},
     signing_domain,
 };
 use monad_dataplane::udp::{segment_size_for_mtu, ETHERNET_SEGMENT_SIZE};
 use monad_executor::ExecutorMetricsChain;
-use monad_merkle::{MerkleHash, MerkleProof};
 use monad_types::{Epoch, NodeId, Round};
 use monad_validator::validator_set::ValidatorSetType as _;
-use tracing::warn;
 
 pub use crate::packet::build_messages;
 use crate::{
     decoding::{DecoderCache, DecodingContext, TryDecodeError, TryDecodeStatus},
-    message::MAX_MESSAGE_SIZE,
     metrics::{
         UdpStateMetrics, GAUGE_RAPTORCAST_DECODING_CACHE_SIGNATURE_VERIFICATIONS_RATE_LIMITED,
     },
-    packet::{assembler::HEADER_LEN, PacketLayout},
-    parser::signature_verifier::{SignatureVerifier, SignatureVerifierError},
-    util::{
-        compute_hash, unix_ts_ms_now, AppMessageHash, BroadcastMode, EpochValidators, HexBytes,
-        NodeIdHash, ReBroadcastGroupMap, Redundancy,
+    packet::PacketLayout,
+    parser::{
+        packet_parser::SignedOverData,
+        signature_verifier::{SignatureVerifier, SignatureVerifierError},
     },
-    SIGNATURE_SIZE,
+    util::{
+        compute_hash, unix_ts_ms_now, AppMessageHash, BroadcastMode, EpochValidators, NodeIdHash,
+        ReBroadcastGroupMap, Redundancy,
+    },
 };
 
 const _: () = assert!(
@@ -102,7 +98,7 @@ pub const MAX_SEGMENT_LENGTH: usize = ETHERNET_SEGMENT_SIZE as usize;
 pub const MAX_VALIDATOR_SET_SIZE: usize = 200;
 
 /// Cache key for signature verification: header + merkle root
-pub type SignatureCacheKey = [u8; HEADER_LEN + 20];
+pub type SignatureCacheKey = SignedOverData;
 pub type ChunkSignatureVerifier<ST> =
     SignatureVerifier<ST, SignatureCacheKey, signing_domain::RaptorcastChunk>;
 
@@ -348,7 +344,7 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum GroupId {
     Primary(Epoch),
     Secondary(Round),
@@ -363,7 +359,7 @@ impl From<GroupId> for u64 {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ValidatedMessage<PT>
 where
     PT: PubKey,
@@ -390,7 +386,7 @@ where
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum MessageValidationError {
-    UnknownVersion,
+    UnknownVersion(u16),
     TooShort,
     TooLong,
     InvalidSignature,
@@ -447,223 +443,22 @@ where
     ST: CertificateSignatureRecoverable,
     F: FnOnce(Epoch) -> bool,
 {
-    let mut cursor: Bytes = message.clone();
-    let mut split_off = |mid| {
-        if mid > cursor.len() {
-            Err(MessageValidationError::TooShort)
-        } else {
-            Ok(cursor.split_to(mid))
-        }
-    };
-    let cursor_signature = split_off(SIGNATURE_SIZE)?;
-    let signature = <ST as CertificateSignature>::deserialize(&cursor_signature)
-        .map_err(|_| MessageValidationError::InvalidSignature)?;
-
-    let cursor_version = split_off(2)?;
-    let version = u16::from_le_bytes(cursor_version.as_ref().try_into().expect("u16 is 2 bytes"));
-    if version != 0 {
-        return Err(MessageValidationError::UnknownVersion);
-    }
-
-    let cursor_broadcast_tree_depth = split_off(1)?[0];
-    let broadcast = (cursor_broadcast_tree_depth & (1 << 7)) != 0;
-    let secondary_broadcast = (cursor_broadcast_tree_depth & (1 << 6)) != 0;
-    let tree_depth = cursor_broadcast_tree_depth & 0b0000_1111; // bottom 4 bits
-
-    let broadcast_mode = match (broadcast, secondary_broadcast) {
-        (true, false) => BroadcastMode::Primary,
-        (false, true) => BroadcastMode::Secondary,
-        (false, false) => BroadcastMode::Unspecified, // unicast or broadcast
-        (true, true) => {
-            return Err(MessageValidationError::InvalidBroadcastBits(0b11));
-        }
+    use crate::parser::packet_parser::{
+        validate_message_v0, RaptorcastPacket, RaptorcastPacketVersioned,
     };
 
-    if !(MIN_MERKLE_TREE_DEPTH..=MAX_MERKLE_TREE_DEPTH).contains(&tree_depth) {
-        return Err(MessageValidationError::InvalidTreeDepth);
+    let packet = RaptorcastPacket::parse(&message)?;
+
+    match packet.versioned {
+        RaptorcastPacketVersioned::V0(ref v0_packet) => validate_message_v0(
+            signature_verifier,
+            &packet.common_header,
+            v0_packet,
+            &message,
+            max_age_ms,
+            bypass_rate_limiter,
+        ),
     }
-
-    let cursor_group_id = split_off(8)?;
-    let group_id = u64::from_le_bytes(cursor_group_id.as_ref().try_into().expect("u64 is 8 bytes"));
-    let group_id = match broadcast_mode {
-        BroadcastMode::Primary | BroadcastMode::Unspecified => GroupId::Primary(Epoch(group_id)),
-        BroadcastMode::Secondary => GroupId::Secondary(Round(group_id)),
-    };
-
-    let cursor_unix_ts_ms = split_off(8)?;
-    let unix_ts_ms = u64::from_le_bytes(
-        cursor_unix_ts_ms
-            .as_ref()
-            .try_into()
-            .expect("u64 is 8 bytes"),
-    );
-
-    ensure_valid_timestamp(unix_ts_ms, max_age_ms)?;
-
-    let cursor_app_message_hash = split_off(20)?;
-    let app_message_hash: AppMessageHash = HexBytes(
-        cursor_app_message_hash
-            .as_ref()
-            .try_into()
-            .expect("Hash is 20 bytes"),
-    );
-
-    let cursor_app_message_len = split_off(4)?;
-    let app_message_len = u32::from_le_bytes(
-        cursor_app_message_len
-            .as_ref()
-            .try_into()
-            .expect("u32 is 4 bytes"),
-    ) as usize;
-
-    if app_message_len > MAX_MESSAGE_SIZE {
-        return Err(MessageValidationError::TooLong);
-    };
-
-    let proof_size: u16 = 20 * (u16::from(tree_depth) - 1);
-
-    let mut merkle_proof = Vec::new();
-    for _ in 0..tree_depth - 1 {
-        let cursor_sibling = split_off(20)?;
-        let sibling =
-            MerkleHash::try_from(cursor_sibling.as_ref()).expect("MerkleHash is 20 bytes");
-        merkle_proof.push(sibling);
-    }
-
-    let cursor_recipient = split_off(20)?;
-    let recipient_hash: NodeIdHash = HexBytes(
-        cursor_recipient
-            .as_ref()
-            .try_into()
-            .expect("Hash is 20 bytes"),
-    );
-
-    let cursor_merkle_idx = split_off(1)?[0];
-    let merkle_proof = MerkleProof::new_from_leaf_idx(merkle_proof, cursor_merkle_idx)
-        .ok_or(MessageValidationError::InvalidMerkleProof)?;
-
-    let _cursor_reserved = split_off(1)?;
-
-    let cursor_chunk_id = split_off(2)?;
-    let chunk_id = u16::from_le_bytes(cursor_chunk_id.as_ref().try_into().expect("u16 is 2 bytes"));
-
-    let cursor_payload = cursor;
-    let symbol_len = cursor_payload.len();
-    if symbol_len == 0 {
-        // handle the degenerate case
-        return Err(MessageValidationError::TooShort);
-    }
-
-    let chunk_id_range = match broadcast_mode {
-        BroadcastMode::Unspecified | BroadcastMode::Secondary => {
-            valid_chunk_id_range(app_message_len, symbol_len)?
-        }
-        BroadcastMode::Primary => {
-            // only perform a basic sanity check here. more precise
-            // check of chunk_id is in decoding.rs when the validator
-            // set is available.
-            valid_chunk_id_range_raptorcast(app_message_len, symbol_len, MAX_VALIDATOR_SET_SIZE)?
-        }
-    };
-    if !chunk_id_range.contains(&(chunk_id as usize)) {
-        return Err(MessageValidationError::InvalidChunkId);
-    }
-
-    let leaf_hash = {
-        let mut hasher = HasherType::new();
-        hasher.update(
-            &message[HEADER_LEN + proof_size as usize..
-                // HEADER_LEN as usize
-                //     + proof_size as usize
-                //     + CHUNK_HEADER_LEN as usize
-                //     + payload_len as usize
-                ],
-        );
-        hasher.hash()
-    };
-    let root = merkle_proof
-        .compute_root(&leaf_hash)
-        .ok_or(MessageValidationError::InvalidMerkleProof)?;
-    let mut signed_over: SignatureCacheKey = [0_u8; HEADER_LEN + 20];
-    // TODO can avoid this copy if necessary
-    signed_over[..HEADER_LEN].copy_from_slice(&message[..HEADER_LEN]);
-    signed_over[HEADER_LEN..].copy_from_slice(&root);
-
-    let author = if let Some(author) = signature_verifier.load_cached(&signed_over) {
-        author
-    } else {
-        let new_author = match group_id {
-            GroupId::Primary(epoch) if bypass_rate_limiter(epoch) => {
-                signature_verifier.verify_force(signature, &signed_over[SIGNATURE_SIZE..])?
-            }
-            _ => signature_verifier.verify(signature, &signed_over[SIGNATURE_SIZE..])?,
-        };
-        signature_verifier.save_cache(signed_over, new_author);
-        new_author
-    };
-
-    Ok(ValidatedMessage {
-        message,
-        author,
-        group_id,
-        unix_ts_ms,
-        app_message_hash,
-        app_message_len: app_message_len as u32,
-        broadcast_mode,
-        recipient_hash,
-        chunk_id,
-        chunk: cursor_payload,
-    })
-}
-
-fn ensure_valid_timestamp(unix_ts_ms: u64, max_age_ms: u64) -> Result<(), MessageValidationError> {
-    let current_time_ms = if let Ok(current_time_elapsed) = std::time::UNIX_EPOCH.elapsed() {
-        current_time_elapsed.as_millis() as u64
-    } else {
-        warn!("system time is before unix epoch, ignoring timestamp");
-        return Ok(());
-    };
-    let delta = (current_time_ms as i64).saturating_sub(unix_ts_ms as i64);
-    if delta.unsigned_abs() > max_age_ms {
-        Err(MessageValidationError::InvalidTimestamp {
-            timestamp: unix_ts_ms,
-            max: max_age_ms,
-            delta,
-        })
-    } else {
-        Ok(())
-    }
-}
-
-fn valid_chunk_id_range_raptorcast(
-    app_message_len: usize,
-    symbol_len: usize,
-    num_validators: usize,
-) -> Result<Range<usize>, MessageValidationError> {
-    if symbol_len == 0 {
-        return Err(MessageValidationError::TooShort);
-    }
-    let base_chunks = app_message_len.div_ceil(symbol_len);
-    let rounding_chunks = num_validators;
-    let num_chunks = MAX_REDUNDANCY
-        .scale(base_chunks)
-        .ok_or(MessageValidationError::TooLong)?
-        + rounding_chunks;
-    Ok(0..num_chunks)
-}
-
-fn valid_chunk_id_range(
-    app_message_len: usize,
-    symbol_len: usize,
-) -> Result<Range<usize>, MessageValidationError> {
-    if symbol_len == 0 {
-        return Err(MessageValidationError::TooShort);
-    }
-    let base_chunks = app_message_len.div_ceil(symbol_len);
-    let num_chunks = MAX_REDUNDANCY
-        .scale(base_chunks)
-        .ok_or(MessageValidationError::TooLong)?;
-    Ok(0..num_chunks)
 }
 
 struct BroadcastBatch<PT: PubKey> {


### PR DESCRIPTION
This commit adapts the safe parser implemented in
https://github.com/category-labs/monad-bft/pull/2650 on top of the refactored `SignatureVerifier` type.