### PR TITLE
Raptorcast: refactor publishing targets

### DIFF
--- a/monad-raptorcast/benches/raptor_bench.rs
+++ b/monad-raptorcast/benches/raptor_bench.rs
@@ -24,7 +24,7 @@ use monad_raptor::ManagedDecoder;
 use monad_raptorcast::{
     packet::build_messages,
     udp::{parse_message, ChunkSignatureVerifier, GroupId, MAX_REDUNDANCY, SIGNATURE_CACHE_SIZE},
-    util::{BuildTarget, EpochValidators, Redundancy},
+    util::{BuildTarget, Redundancy},
 };
 use monad_secp::{KeyPair, SecpSignature};
 use monad_types::{Epoch, NodeId, Stake};
@@ -51,9 +51,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             .iter()
             .map(|key| (NodeId::new(key.pubkey()), Stake::ONE))
             .collect();
-        let validators = EpochValidators {
-            validators: ValidatorSet::new_unchecked(valset),
-        };
+        let validators = ValidatorSet::new_unchecked(valset);
 
         let known_addresses = keys
             .iter()
@@ -66,7 +64,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             .collect();
 
         b.iter(|| {
-            let epoch_validators = validators.view_without(vec![&NodeId::new(keys[0].pubkey())]);
             let _ = build_messages::<SecpSignature>(
                 &keys[0],
                 DEFAULT_SEGMENT_SIZE, // segment_size
@@ -74,7 +71,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 Redundancy::from_u8(2),
                 GroupId::Primary(Epoch(0)), // epoch_no
                 0,                          // unix_ts_ms
-                BuildTarget::Raptorcast(epoch_validators),
+                BuildTarget::Raptorcast(&validators),
                 &known_addresses,
             );
         });
@@ -94,11 +91,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             .iter()
             .map(|key| (NodeId::new(key.pubkey()), Stake::ONE))
             .collect();
-        let validators = EpochValidators {
-            validators: ValidatorSet::new_unchecked(valset),
-        };
-
-        let epoch_validators = validators.view_without(vec![&NodeId::new(keys[0].pubkey())]);
+        let validators = ValidatorSet::new_unchecked(valset);
 
         let known_addresses = keys
             .iter()
@@ -117,7 +110,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             Redundancy::from_u8(2),
             GroupId::Primary(Epoch(0)), // epoch_no
             0,                          // unix_ts_ms
-            BuildTarget::Raptorcast(epoch_validators),
+            BuildTarget::Raptorcast(&validators),
             &known_addresses,
         )
         .into_iter()

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -62,8 +62,8 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::{debug, debug_span, error, trace, warn};
 use udp::GroupId;
 use util::{
-    BuildTarget, Collector, EpochValidators, FullNodes, Group, PeerAddrLookup, ReBroadcastGroupMap,
-    Recipient, Redundancy, UdpMessage,
+    BuildTarget, Collector, Group, PeerAddrLookup, ReBroadcastGroupMap, Recipient, Redundancy,
+    UdpMessage,
 };
 
 use crate::{
@@ -107,10 +107,10 @@ where
     signing_key: Arc<ST::KeyPairType>,
     is_dynamic_fullnode: bool,
 
-    epoch_validators: BTreeMap<Epoch, EpochValidators<CertificateSignaturePubKey<ST>>>,
+    epoch_validators: BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
     rebroadcast_map: ReBroadcastGroupMap<CertificateSignaturePubKey<ST>>,
 
-    dedicated_full_nodes: FullNodes<CertificateSignaturePubKey<ST>>,
+    dedicated_full_nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
     peer_discovery_driver: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
 
     current_epoch: Epoch,
@@ -211,9 +211,7 @@ where
             is_dynamic_fullnode,
             epoch_validators: Default::default(),
             rebroadcast_map: ReBroadcastGroupMap::new(self_id),
-            dedicated_full_nodes: FullNodes::new(
-                config.primary_instance.fullnode_dedicated.clone(),
-            ),
+            dedicated_full_nodes: config.primary_instance.fullnode_dedicated.clone(),
             peer_discovery_driver,
 
             signing_key: config.shared_key.clone(),
@@ -283,7 +281,7 @@ where
     }
 
     pub fn set_dedicated_full_nodes(&mut self, nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>) {
-        self.dedicated_full_nodes = FullNodes::new(nodes);
+        self.dedicated_full_nodes = nodes;
     }
 
     pub fn get_rebroadcast_groups(&self) -> &ReBroadcastGroupMap<CertificateSignaturePubKey<ST>> {
@@ -384,14 +382,8 @@ where
                 group,
                 group_id,
             } => {
-                trace!(
-                    group_size = group.size_excl_self(),
-                    msg_len = msg_bytes.len(),
-                    "raptorcastprimary handling group message from secondary"
-                );
-                if group.size_excl_self() < 1 {
-                    return;
-                }
+                // Invariance: message from publisher, where the group
+                // of full nodes must not contain self as validator.
                 let build_target = BuildTarget::FullNodeRaptorCast(&group);
                 builder
                     .prepare()
@@ -416,7 +408,7 @@ where
 
         match target {
             RouterTarget::Broadcast(epoch) | RouterTarget::Raptorcast(epoch) => {
-                let Some(epoch_validators) = self.epoch_validators.get(&epoch) else {
+                let Some(valset) = self.epoch_validators.get(&epoch) else {
                     error!(
                         "don't have epoch validators populated for epoch: {:?}",
                         epoch
@@ -424,28 +416,24 @@ where
                     return;
                 };
 
-                if epoch_validators.validators.is_member(&self_id) {
+                if valset.is_member(&self_id) {
                     Self::enqueue_message_to_self(
                         message.clone(),
                         &mut self.pending_events,
                         &mut self.waker,
                         self_id,
                     );
-                }
-
-                let epoch_validators_without_self = epoch_validators.view_without(vec![&self_id]);
-
-                if epoch_validators_without_self.is_empty() {
-                    return;
+                } else {
+                    warn!(
+                        ?epoch,
+                        "attempt to publish to the whole validator set while self is not validator",
+                    );
+                    // TODO: early exit in this case
                 }
 
                 let build_target = match &target {
-                    RouterTarget::Broadcast(_) => {
-                        BuildTarget::Broadcast(epoch_validators_without_self.into())
-                    }
-                    RouterTarget::Raptorcast(_) => {
-                        BuildTarget::Raptorcast(epoch_validators_without_self)
-                    }
+                    RouterTarget::Broadcast(_) => BuildTarget::Broadcast(valset),
+                    RouterTarget::Raptorcast(_) => BuildTarget::Raptorcast(valset),
                     _ => unreachable!(),
                 };
                 let outbound_message =
@@ -475,47 +463,42 @@ where
                     .unwrap_log_on_error(&outbound_message, &build_target);
             }
 
+            RouterTarget::PointToPoint(to) if to == self_id => {
+                Self::enqueue_message_to_self(
+                    message,
+                    &mut self.pending_events,
+                    &mut self.waker,
+                    self_id,
+                );
+            }
+
             RouterTarget::PointToPoint(to) => {
-                if to == self_id {
-                    Self::enqueue_message_to_self(
-                        message,
-                        &mut self.pending_events,
-                        &mut self.waker,
-                        self_id,
-                    );
-                } else {
-                    let outbound_message = match OutboundRouterMessage::<OM, ST>::AppMessage(
-                        message,
-                    )
-                    .try_serialize()
-                    {
+                let outbound_message =
+                    match OutboundRouterMessage::<OM, ST>::AppMessage(message).try_serialize() {
                         Ok(msg) => msg,
                         Err(err) => {
                             error!(?err, "failed to serialize a message");
                             return;
                         }
                     };
-                    let build_target = BuildTarget::PointToPoint(&to);
+                let build_target = BuildTarget::PointToPoint(&to);
 
-                    let _timer = DropTimer::start(Duration::from_millis(10), |elapsed| {
-                        warn!(
-                            ?elapsed,
-                            app_msg_len = outbound_message.len(),
-                            "long time to build point-to-point message"
-                        )
-                    });
-
-                    let mut sink = DualUdpPacketSender::new(
-                        &mut self.dual_socket,
-                        &self.peer_discovery_driver,
+                let _timer = DropTimer::start(Duration::from_millis(10), |elapsed| {
+                    warn!(
+                        ?elapsed,
+                        app_msg_len = outbound_message.len(),
+                        "long time to build point-to-point message"
                     )
-                    .with_priority(priority);
-                    self.message_builder
-                        .prepare()
-                        .group_id(GroupId::Primary(self.current_epoch))
-                        .build_into(&outbound_message, &build_target, &mut sink)
-                        .unwrap_log_on_error(&outbound_message, &build_target);
-                }
+                });
+
+                let mut sink =
+                    DualUdpPacketSender::new(&mut self.dual_socket, &self.peer_discovery_driver)
+                        .with_priority(priority);
+                self.message_builder
+                    .prepare()
+                    .group_id(GroupId::Primary(self.current_epoch))
+                    .build_into(&outbound_message, &build_target, &mut sink)
+                    .unwrap_log_on_error(&outbound_message, &build_target);
             }
 
             RouterTarget::TcpPointToPoint { to, completion } => {
@@ -791,7 +774,8 @@ where
                         assert!(validator_set
                             .iter()
                             .all(|(validator_key, validator_stake)| {
-                                epoch_validators.get(validator_key) == Some(*validator_stake)
+                                epoch_validators.get_members().get(validator_key)
+                                    == Some(validator_stake)
                             }));
 
                         warn!("duplicate validator set update (this is safe but unexpected)")
@@ -802,9 +786,7 @@ where
                         let validators = ValidatorSet::new_unchecked(
                             validator_set.clone().into_iter().collect(),
                         );
-                        let removed = self
-                            .epoch_validators
-                            .insert(epoch, EpochValidators { validators });
+                        let removed = self.epoch_validators.insert(epoch, validators);
                         assert!(removed.is_none());
                     }
                     self.peer_discovery_driver.lock().unwrap().update(
@@ -829,17 +811,13 @@ where
                     round: _,
                     message,
                 } => {
-                    let full_nodes_view = self.dedicated_full_nodes.view();
                     if self.is_dynamic_fullnode {
                         debug!("self is dynamic full node, skipping publishing to full nodes");
                         continue;
                     }
 
-                    // self as a dedicated full node will have empty
-                    // full_nodes_view, so it won't attempt to
-                    // publish.
-                    if full_nodes_view.is_empty() {
-                        debug!("full_nodes view empty, skipping publishing to full nodes");
+                    if self.dedicated_full_nodes.is_empty() {
+                        debug!("dedicated_full_nodes empty, skipping publishing to full nodes");
                         continue;
                     }
 
@@ -867,7 +845,11 @@ where
                         )
                     });
 
-                    for node in full_nodes_view.iter() {
+                    for node in &self.dedicated_full_nodes {
+                        if self_id == *node {
+                            // No need to send to self. TODO: maybe loopback the message.
+                            continue;
+                        }
                         if !node_addrs.contains_key(node) {
                             continue;
                         }
@@ -922,7 +904,7 @@ where
                     );
                 }
                 RouterCommand::GetFullNodes => {
-                    let full_nodes = self.dedicated_full_nodes.list.clone();
+                    let full_nodes = self.dedicated_full_nodes.clone();
                     self.pending_events
                         .push_back(RaptorCastEvent::PeerManagerResponse(
                             PeerManagerResponse::FullNodes(full_nodes),
@@ -935,7 +917,7 @@ where
                     dedicated_full_nodes,
                     prioritized_full_nodes: _,
                 } => {
-                    self.dedicated_full_nodes.list = dedicated_full_nodes;
+                    self.dedicated_full_nodes = dedicated_full_nodes;
                 }
             }
         }
@@ -952,14 +934,13 @@ where
 }
 
 fn iter_ips<'a, ST: CertificateSignatureRecoverable, PD: PeerDiscoveryAlgo<SignatureType = ST>>(
-    validators: &'a EpochValidators<CertificateSignaturePubKey<ST>>,
+    validators: &'a ValidatorSet<CertificateSignaturePubKey<ST>>,
     peer_discovery: &'a PeerDiscoveryDriver<PD>,
 ) -> impl Iterator<Item = IpAddr> + 'a {
     validators
-        .validators
         .get_members()
-        .iter()
-        .filter_map(|(node_id, _)| peer_discovery.get_addr(node_id))
+        .keys()
+        .filter_map(|node_id| peer_discovery.get_addr(node_id))
         .map(|socket| socket.ip())
 }
 
@@ -1353,7 +1334,7 @@ where
 fn validate_group_message_sender<ST>(
     sender: &NodeId<CertificateSignaturePubKey<ST>>,
     group_message: &FullNodesGroupMessage<ST>,
-    epoch_validators: &EpochValidators<CertificateSignaturePubKey<ST>>,
+    validator_set: &ValidatorSet<CertificateSignaturePubKey<ST>>,
 ) -> bool
 where
     ST: CertificateSignatureRecoverable,
@@ -1361,7 +1342,7 @@ where
     match group_message {
         // Prepare group message should originate from a validator
         FullNodesGroupMessage::PrepareGroup(msg) => {
-            &msg.validator_id == sender && epoch_validators.validators.is_member(sender)
+            &msg.validator_id == sender && validator_set.is_member(sender)
         }
         FullNodesGroupMessage::PrepareGroupResponse(msg) => &msg.node_id == sender,
         FullNodesGroupMessage::ConfirmGroup(msg) => &msg.prepare.validator_id == sender,

--- a/monad-raptorcast/src/packet/assigner.rs
+++ b/monad-raptorcast/src/packet/assigner.rs
@@ -18,6 +18,7 @@ use std::{collections::HashMap, ops::Range};
 use bytes::BytesMut;
 use monad_crypto::certificate_signature::PubKey;
 use monad_types::{NodeId, Stake};
+use monad_validator::validator_set::{ValidatorSet, ValidatorSetType};
 use rand::{rngs::StdRng, seq::SliceRandom as _, SeedableRng as _};
 
 use super::{BuildError, Chunk, PacketLayout, Result};
@@ -315,13 +316,7 @@ pub(crate) struct Replicated<PT: PubKey> {
 }
 
 impl<PT: PubKey> Replicated<PT> {
-    pub fn from_unicast(node_id: NodeId<PT>) -> Self {
-        Self {
-            recipients: vec![Recipient::new(node_id)],
-        }
-    }
-
-    pub fn from_broadcast(recipients: Vec<NodeId<PT>>) -> Self {
+    pub fn from_broadcast(recipients: impl IntoIterator<Item = NodeId<PT>>) -> Self {
         Self {
             recipients: recipients.into_iter().map(Recipient::new).collect(),
         }
@@ -472,14 +467,16 @@ impl<PT: PubKey> StakeBasedWithRC<PT> {
     // for easy implementation in other languages, e.g., using Mt19937
     // and Fisher Yates shuffle.
     pub fn shuffle_validators(
-        view: &crate::util::ValidatorsView<PT>,
+        validator_set: &ValidatorSet<PT>,
+        self_id: &NodeId<PT>,
         seed: [u8; 32],
     ) -> Vec<(NodeId<PT>, Stake)> {
-        let mut validator_set = view
+        let mut validator_set = validator_set
+            .get_members()
             .iter()
-            .map(|(node_id, stake)| (*node_id, stake))
-            .collect::<std::collections::BinaryHeap<_>>()
-            .into_sorted_vec();
+            .filter(|(node_id, _stake)| *node_id != self_id)
+            .map(|(node_id, stake)| (*node_id, *stake))
+            .collect::<Vec<_>>();
         let mut rng = StdRng::from_seed(seed);
         validator_set.shuffle(&mut rng);
         validator_set

--- a/monad-raptorcast/src/parser/legacy.rs
+++ b/monad-raptorcast/src/parser/legacy.rs
@@ -287,7 +287,7 @@ mod tests {
     use crate::{
         packet::build_messages,
         udp::{GroupId, SIGNATURE_CACHE_SIZE},
-        util::{BuildTarget, EpochValidators, Redundancy},
+        util::{BuildTarget, Redundancy},
     };
 
     type SignatureType = SecpSignature;
@@ -297,7 +297,7 @@ mod tests {
 
     fn validator_set() -> (
         KeyPairType,
-        EpochValidators<CertificateSignaturePubKey<SignatureType>>,
+        ValidatorSet<CertificateSignaturePubKey<SignatureType>>,
         HashMap<NodeId<CertificateSignaturePubKey<SignatureType>>, SocketAddr>,
     ) {
         const NUM_KEYS: u8 = 100;
@@ -314,9 +314,7 @@ mod tests {
             .iter()
             .map(|key| (NodeId::new(key.pubkey()), Stake::ONE))
             .collect();
-        let validators = EpochValidators {
-            validators: ValidatorSet::new_unchecked(valset),
-        };
+        let validators = ValidatorSet::new_unchecked(valset);
 
         let known_addresses = HashMap::new();
         (keys.pop().unwrap(), validators, known_addresses)
@@ -328,7 +326,6 @@ mod tests {
     #[test]
     fn test_legacy_vs_new_parser_equivalence() {
         let (key, validators, known_addresses) = validator_set();
-        let epoch_validators = validators.view_without(vec![&NodeId::new(key.pubkey())]);
 
         let app_message: Bytes = vec![1_u8; 1024 * 64].into();
 
@@ -339,7 +336,7 @@ mod tests {
             Redundancy::from_u8(2),
             GroupId::Primary(EPOCH),
             UNIX_TS_MS,
-            BuildTarget::Raptorcast(epoch_validators),
+            BuildTarget::Raptorcast(&validators),
             &known_addresses,
         );
 

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -23,7 +23,7 @@ use monad_crypto::{
 use monad_dataplane::udp::{segment_size_for_mtu, ETHERNET_SEGMENT_SIZE};
 use monad_executor::ExecutorMetricsChain;
 use monad_types::{Epoch, NodeId, Round};
-use monad_validator::validator_set::ValidatorSetType as _;
+use monad_validator::validator_set::{ValidatorSet, ValidatorSetType as _};
 
 pub use crate::packet::build_messages;
 use crate::{
@@ -37,7 +37,7 @@ use crate::{
         signature_verifier::{SignatureVerifier, SignatureVerifierError},
     },
     util::{
-        compute_hash, unix_ts_ms_now, AppMessageHash, BroadcastMode, EpochValidators, NodeIdHash,
+        compute_hash, unix_ts_ms_now, AppMessageHash, BroadcastMode, NodeIdHash,
         ReBroadcastGroupMap, Redundancy,
     },
 };
@@ -151,7 +151,7 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
     pub fn handle_message(
         &mut self,
         group_map: &ReBroadcastGroupMap<CertificateSignaturePubKey<ST>>,
-        epoch_validators: &BTreeMap<Epoch, EpochValidators<CertificateSignaturePubKey<ST>>>,
+        epoch_validators: &BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
         rebroadcast: impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>, Bytes, u16),
         message: crate::auth::AuthRecvMsg<CertificateSignaturePubKey<ST>>,
     ) -> Vec<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
@@ -184,7 +184,7 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
                         epoch_validators
                             .get(&epoch)
                             .iter()
-                            .any(|ev| ev.validators.is_member(&node_id))
+                            .any(|ev| ev.is_member(&node_id))
                     })
                 },
             ) {
@@ -281,7 +281,7 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
             };
 
             let validator_set = match parsed_message.group_id {
-                GroupId::Primary(epoch) => epoch_validators.get(&epoch).map(|ev| &ev.validators),
+                GroupId::Primary(epoch) => epoch_validators.get(&epoch),
                 GroupId::Secondary(_round) => None,
             };
 
@@ -603,7 +603,7 @@ mod tests {
     };
     use monad_dataplane::udp::DEFAULT_SEGMENT_SIZE;
     use monad_secp::{KeyPair, SecpSignature};
-    use monad_types::{Epoch, NodeId, Round, RoundSpan, Stake};
+    use monad_types::{Epoch, NodeId, Stake};
     use monad_validator::validator_set::{ValidatorSet, ValidatorSetType as _};
     use rstest::*;
 
@@ -612,9 +612,7 @@ mod tests {
         packet::{MessageBuilder, PacketLayout},
         parser::signature_verifier::SignatureVerifier,
         udp::{build_messages, parse_message, MAX_VALIDATOR_SET_SIZE, SIGNATURE_CACHE_SIZE},
-        util::{
-            BroadcastMode, BuildTarget, EpochValidators, Group, ReBroadcastGroupMap, Redundancy,
-        },
+        util::{BroadcastMode, BuildTarget, ReBroadcastGroupMap, Redundancy, SecondaryGroup},
     };
 
     type SignatureType = SecpSignature;
@@ -627,7 +625,7 @@ mod tests {
 
     fn validator_set() -> (
         KeyPairType,
-        EpochValidators<CertificateSignaturePubKey<SignatureType>>,
+        ValidatorSet<CertificateSignaturePubKey<SignatureType>>,
         HashMap<NodeId<CertificateSignaturePubKey<SignatureType>>, SocketAddr>,
     ) {
         const NUM_KEYS: u8 = 100;
@@ -644,9 +642,7 @@ mod tests {
             .iter()
             .map(|key| (NodeId::new(key.pubkey()), Stake::ONE))
             .collect();
-        let validators = EpochValidators {
-            validators: ValidatorSet::new_unchecked(valset),
-        };
+        let validators = ValidatorSet::new_unchecked(valset);
 
         let known_addresses = keys
             .iter()
@@ -669,7 +665,6 @@ mod tests {
     #[test]
     fn test_roundtrip() {
         let (key, validators, known_addresses) = validator_set();
-        let epoch_validators = validators.view_without(vec![&NodeId::new(key.pubkey())]);
 
         let app_message: Bytes = vec![1_u8; 1024 * 1024].into();
         let app_message_hash = {
@@ -685,7 +680,7 @@ mod tests {
             Redundancy::from_u8(2),
             GroupId::Primary(EPOCH), // epoch_no
             UNIX_TS_MS,
-            BuildTarget::Raptorcast(epoch_validators),
+            BuildTarget::Raptorcast(&validators),
             &known_addresses,
         );
 
@@ -717,7 +712,6 @@ mod tests {
     #[test]
     fn test_bit_flip_parse_failure_slow() {
         let (key, validators, known_addresses) = validator_set();
-        let epoch_validators = validators.view_without(vec![&NodeId::new(key.pubkey())]);
 
         let app_message: Bytes = vec![1_u8; 1024 * 2].into();
 
@@ -728,7 +722,7 @@ mod tests {
             Redundancy::from_u8(2),
             GroupId::Primary(EPOCH), // epoch_no
             UNIX_TS_MS,
-            BuildTarget::Raptorcast(epoch_validators),
+            BuildTarget::Raptorcast(&validators),
             &known_addresses,
         );
 
@@ -768,7 +762,6 @@ mod tests {
     #[test]
     fn test_raptorcast_chunk_ids() {
         let (key, validators, known_addresses) = validator_set();
-        let epoch_validators = validators.view_without(vec![&NodeId::new(key.pubkey())]);
 
         let app_message: Bytes = vec![1_u8; 1024 * 1024].into();
 
@@ -779,7 +772,7 @@ mod tests {
             Redundancy::from_u8(2),
             GroupId::Primary(EPOCH), // epoch_no
             UNIX_TS_MS,
-            BuildTarget::Raptorcast(epoch_validators),
+            BuildTarget::Raptorcast(&validators),
             &known_addresses,
         );
 
@@ -807,17 +800,18 @@ mod tests {
     fn test_broadcast_bit() {
         let (key, validators, known_addresses) = validator_set();
         let self_id = NodeId::new(key.pubkey());
-        let epoch_validators = validators.view_without(vec![&self_id]);
-        let full_nodes = Group::new_fullnode_group(
-            epoch_validators.iter_nodes().cloned().collect(),
-            &self_id,
-            self_id,
-            RoundSpan::new(Round(1), Round(100)).unwrap(),
+        let full_nodes = SecondaryGroup::new_unchecked(
+            validators
+                .get_members()
+                .keys()
+                .filter(|&n| n != &self_id)
+                .cloned()
+                .collect(),
         );
 
         let app_message: Bytes = vec![1_u8; 1024 * 1024].into();
         let build_targets = vec![
-            BuildTarget::Raptorcast(epoch_validators),
+            BuildTarget::Raptorcast(&validators),
             BuildTarget::FullNodeRaptorCast(&full_nodes),
         ];
 
@@ -829,7 +823,7 @@ mod tests {
                 Redundancy::from_u8(2),
                 GroupId::Primary(EPOCH), // epoch_no
                 UNIX_TS_MS,
-                build_target.clone(),
+                build_target,
                 &known_addresses,
             );
 
@@ -869,7 +863,6 @@ mod tests {
     #[test]
     fn test_broadcast_chunk_ids() {
         let (key, validators, known_addresses) = validator_set();
-        let epoch_validators = validators.view_without(vec![&NodeId::new(key.pubkey())]);
 
         let app_message: Bytes = vec![1_u8; 1024 * 8].into();
 
@@ -880,7 +873,7 @@ mod tests {
             Redundancy::from_u8(2),
             GroupId::Primary(EPOCH), // epoch_no
             UNIX_TS_MS,
-            BuildTarget::Broadcast(epoch_validators.into()),
+            BuildTarget::Broadcast(&validators),
             &known_addresses,
         );
 
@@ -917,7 +910,6 @@ mod tests {
         let self_id = NodeId::new(key.pubkey());
         let mut group_map = ReBroadcastGroupMap::new(self_id);
         let node_stake_pairs: Vec<_> = validators
-            .validators
             .get_members()
             .iter()
             .map(|(node_id, stake)| (*node_id, *stake))
@@ -961,7 +953,6 @@ mod tests {
         #[case] should_succeed: bool,
     ) {
         let (key, validators, known_addresses) = validator_set();
-        let epoch_validators = validators.view_without(vec![&NodeId::new(key.pubkey())]);
         let mut signature_verifier = signature_verifier();
 
         let current_time = std::time::UNIX_EPOCH.elapsed().unwrap().as_millis() as u64;
@@ -975,7 +966,7 @@ mod tests {
             Redundancy::from_u8(1),
             GroupId::Primary(EPOCH),
             test_timestamp,
-            BuildTarget::Broadcast(epoch_validators.into()),
+            BuildTarget::Broadcast(&validators),
             &known_addresses,
         );
         let message = messages.into_iter().next().unwrap().1;
@@ -1016,11 +1007,10 @@ mod tests {
         #[case] should_succeed: bool,
     ) {
         let (key, validators, _known_addresses) = validator_set();
-        let epoch_validators = validators.view_without(vec![&NodeId::new(key.pubkey())]);
         let target = if raptorcast {
-            BuildTarget::Raptorcast(epoch_validators)
+            BuildTarget::Raptorcast(&validators)
         } else {
-            BuildTarget::Broadcast(epoch_validators.into())
+            BuildTarget::Broadcast(&validators)
         };
         let app_msg = vec![0; app_msg_len];
         let messages = MessageBuilder::<SignatureType>::new(&key)
@@ -1107,7 +1097,6 @@ mod tests {
     #[test]
     fn test_parse_message_signature_verifier() {
         let (key, validators, known_addresses) = validator_set();
-        let epoch_validators = validators.view_without(vec![&NodeId::new(key.pubkey())]);
 
         let app_message: Bytes = vec![1_u8; 1024].into();
 
@@ -1118,7 +1107,7 @@ mod tests {
             Redundancy::from_u8(1),
             GroupId::Primary(EPOCH),
             UNIX_TS_MS,
-            BuildTarget::Raptorcast(epoch_validators),
+            BuildTarget::Raptorcast(&validators),
             &known_addresses,
         );
 

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -16,9 +16,10 @@
 use std::{
     cell::OnceCell,
     cmp::Ordering,
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, BTreeSet},
     fmt,
     net::SocketAddr,
+    num::NonZero,
     rc::Rc,
 };
 
@@ -35,185 +36,57 @@ use tracing::{debug, warn};
 
 use crate::udp::GroupId;
 
-#[derive(Clone, Debug)]
-pub struct EpochValidators<PT: PubKey> {
-    pub validators: ValidatorSet<PT>,
-}
-
-impl<PT: PubKey> EpochValidators<PT> {
-    /// Returns a view of the validator set without a given node. On ValidatorsView being dropped,
-    /// the validator set is reverted back to normal.
-    pub fn view_without(&self, without: Vec<&NodeId<PT>>) -> ValidatorsView<'_, PT> {
-        ValidatorsView {
-            view: self.validators.get_members(),
-            without: without.into_iter().cloned().collect(),
-        }
-    }
-
-    pub fn get(&self, node_id: &NodeId<PT>) -> Option<Stake> {
-        self.validators.get_members().get(node_id).copied()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.validators.get_members().is_empty()
-    }
-
-    pub fn len(&self) -> usize {
-        self.validators.get_members().len()
-    }
-}
-
+// Invariance: The group must be non-empty.
 #[derive(Debug, Clone)]
-pub struct ValidatorsView<'a, PT: PubKey> {
-    view: &'a BTreeMap<NodeId<PT>, Stake>,
-    without: HashSet<NodeId<PT>>,
+pub struct SecondaryGroup<PT: PubKey> {
+    full_nodes: BTreeSet<NodeId<PT>>,
 }
 
-impl<PT: PubKey> ValidatorsView<'_, PT> {
-    pub fn iter(&self) -> impl Iterator<Item = (&NodeId<PT>, Stake)> + '_ {
-        self.view
-            .iter()
-            .filter(|(id, _)| !self.without.contains(id))
-            .map(|(id, stake)| (id, *stake))
+impl<PT: PubKey> SecondaryGroup<PT> {
+    // SAFETY: The caller must ensure that full_nodes set is non-empty.
+    pub fn new_unchecked(full_nodes: BTreeSet<NodeId<PT>>) -> Self {
+        Self { full_nodes }
     }
 
-    pub fn iter_nodes(&self) -> impl Iterator<Item = &NodeId<PT>> + '_ {
-        self.view
-            .keys()
-            .filter(move |id| !self.without.contains(id))
-    }
-
-    pub fn len(&self) -> usize {
-        if self.without.is_empty() {
-            return self.view.len();
+    pub fn new(full_nodes: BTreeSet<NodeId<PT>>) -> Option<Self> {
+        if full_nodes.is_empty() {
+            return None;
         }
-        self.iter().count()
+        Some(Self { full_nodes })
     }
 
-    pub fn total_stake(&self) -> Stake {
-        self.iter().map(|(_, stake)| stake).sum()
+    pub fn iter(&self) -> impl Iterator<Item = &NodeId<PT>> + '_ {
+        self.full_nodes.iter()
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.view.is_empty() || self.len() == 0
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct FullNodes<P: PubKey> {
-    pub list: Vec<NodeId<P>>,
-}
-
-impl<P: PubKey> Default for FullNodes<P> {
-    fn default() -> Self {
-        Self {
-            list: Default::default(),
-        }
-    }
-}
-
-impl<P: PubKey> FullNodes<P> {
-    pub fn new(nodes: Vec<NodeId<P>>) -> Self {
-        Self { list: nodes }
-    }
-
-    pub fn view(&self) -> FullNodesView<'_, P> {
-        FullNodesView(&self.list)
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct FullNodesView<'a, P: PubKey>(&'a Vec<NodeId<P>>);
-
-impl<P: PubKey> FullNodesView<'_, P> {
-    fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = &NodeId<P>> + '_ {
-        self.0.iter()
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum NodesView<'a, PT: PubKey> {
-    Validators(ValidatorsView<'a, PT>),
-    FullNodes(FullNodesView<'a, PT>),
-}
-
-impl<'a, PT: PubKey> From<ValidatorsView<'a, PT>> for NodesView<'a, PT> {
-    fn from(view: ValidatorsView<'a, PT>) -> Self {
-        NodesView::Validators(view)
-    }
-}
-
-impl<'a, PT: PubKey> From<FullNodesView<'a, PT>> for NodesView<'a, PT> {
-    fn from(view: FullNodesView<'a, PT>) -> Self {
-        NodesView::FullNodes(view)
-    }
-}
-
-impl<'a, PT: PubKey> NodesView<'a, PT> {
-    pub fn len(&self) -> usize {
-        match self {
-            NodesView::Validators(view) => view.len(),
-            NodesView::FullNodes(view) => view.len(),
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        match self {
-            NodesView::Validators(view) => view.is_empty(),
-            NodesView::FullNodes(view) => view.is_empty(),
-        }
-    }
-
-    pub fn iter(&self) -> Box<dyn Iterator<Item = &NodeId<PT>> + '_> {
-        match self {
-            NodesView::Validators(view) => Box::new(view.iter_nodes()),
-            NodesView::FullNodes(view) => Box::new(view.iter()),
-        }
+    pub fn len(&self) -> NonZero<usize> {
+        NonZero::new(self.full_nodes.len()).unwrap()
     }
 }
 
 // Argument for raptorcast send
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum BuildTarget<'a, PT: PubKey> {
-    // raptorcast to a set of nodes without stake-based distribution
-    // of chunks.
-    Broadcast(
-        // validator stakes for given epoch_no, not including self
-        // this MUST NOT BE EMPTY
-        NodesView<'a, PT>,
-    ),
-    // raptorcast to a set of validators, chunks distributed by their
+    // broadcast a message to the validators where each validator gets
+    // the full chunks of the raptor-coded message
+    Broadcast(&'a ValidatorSet<PT>),
+    // raptorcast to the validators, chunks distributed by their
     // proportion of stakes.
-    Raptorcast(
-        // validator stakes for given epoch_no, not including self
-        // this MUST NOT BE EMPTY
-        // Contains Stake information per validator node id
-        ValidatorsView<'a, PT>,
-    ),
-    // sharded raptor-aware broadcast
+    Raptorcast(&'a ValidatorSet<PT>),
+    // unicast message as raptor-coded chunks to a single recipient
     PointToPoint(&'a NodeId<PT>),
-    // Group should not be empty after excluding self node Id
-    FullNodeRaptorCast(&'a Group<PT>),
+    // raptorcast to a set of full nodes, assuming equal stake
+    // distribution
+    FullNodeRaptorCast(&'a SecondaryGroup<PT>),
 }
 
 impl<'a, PT: PubKey> BuildTarget<'a, PT> {
     pub fn iter(&self) -> Box<dyn Iterator<Item = &NodeId<PT>> + '_> {
         match self {
-            BuildTarget::Broadcast(nodes_view) => match nodes_view {
-                NodesView::Validators(validators_view) => Box::new(validators_view.iter_nodes()),
-                NodesView::FullNodes(fullnodes_view) => Box::new(fullnodes_view.iter()),
-            },
-            BuildTarget::Raptorcast(validators_view) => Box::new(validators_view.iter_nodes()),
+            BuildTarget::Broadcast(valset) => Box::new(valset.get_members().keys()),
+            BuildTarget::Raptorcast(valset) => Box::new(valset.get_members().keys()),
             BuildTarget::PointToPoint(node_id) => Box::new(std::iter::once(*node_id)),
-            BuildTarget::FullNodeRaptorCast(group) => Box::new(group.iter_peers()),
+            BuildTarget::FullNodeRaptorCast(group) => Box::new(group.iter()),
         }
     }
 }
@@ -312,17 +185,6 @@ impl<PT: PubKey> fmt::Debug for Group<PT> {
     }
 }
 
-// the trait `Default` is not implemented for `PT`
-impl<PT: PubKey> Default for Group<PT> {
-    fn default() -> Self {
-        Self {
-            validator_id: None,
-            round_span: RoundSpan::default(),
-            sorted_other_peers: Vec::new(),
-        }
-    }
-}
-
 impl<PT: PubKey> Group<PT> {
     // For the use case where we re-raptorcast to validators
     pub fn new_validator_group(all_peers: Vec<NodeId<PT>>, self_id: &NodeId<PT>) -> Self {
@@ -335,7 +197,7 @@ impl<PT: PubKey> Group<PT> {
             .collect();
         Self {
             validator_id: None,
-            round_span: RoundSpan::default(),
+            round_span: RoundSpan::empty(Round::MIN), // unused for validator group
             sorted_other_peers,
         }
     }
@@ -1096,7 +958,7 @@ mod tests {
         );
         assert_eq!(group.size_excl_self(), 2);
         assert_eq!(group.get_other_peers(), &vec![nid(0), nid(2)]);
-        assert_eq!(group.get_round_span(), &RoundSpan::default());
+        assert_eq!(group.get_round_span(), &RoundSpan::empty(Round::MIN));
         let empty_iter: Vec<_> = group.empty_iterator().collect();
         assert!(empty_iter.is_empty());
 

--- a/monad-raptorcast/tests/encoder_error.rs
+++ b/monad-raptorcast/tests/encoder_error.rs
@@ -22,7 +22,7 @@ use monad_dataplane::udp::DEFAULT_SEGMENT_SIZE;
 use monad_raptor::SOURCE_SYMBOLS_MAX;
 use monad_raptorcast::{
     udp::{build_messages, GroupId},
-    util::{BuildTarget, EpochValidators, Redundancy},
+    util::{BuildTarget, Redundancy},
 };
 use monad_secp::{KeyPair, SecpSignature};
 use monad_types::{Epoch, NodeId, Stake};
@@ -55,9 +55,7 @@ pub fn encoder_error() {
         .iter()
         .map(|key| (NodeId::new(key.pubkey()), Stake::ONE))
         .collect();
-    let validators = EpochValidators {
-        validators: ValidatorSet::new_unchecked(valset),
-    };
+    let validators = ValidatorSet::new_unchecked(valset);
 
     let known_addresses = keys
         .iter()
@@ -69,8 +67,6 @@ pub fn encoder_error() {
         })
         .collect();
 
-    let epoch_validators = validators.view_without(vec![&NodeId::new(keys[0].pubkey())]);
-
     let _ = build_messages::<SecpSignature>(
         &keys[0],
         DEFAULT_SEGMENT_SIZE,
@@ -78,7 +74,7 @@ pub fn encoder_error() {
         Redundancy::from_u8(1),
         GroupId::Primary(Epoch(0)), // epoch_no
         0,                          // unix_ts_ms
-        BuildTarget::Raptorcast(epoch_validators),
+        BuildTarget::Raptorcast(&validators),
         &known_addresses,
     );
 }

--- a/monad-raptorcast/tests/raptorcast_instance.rs
+++ b/monad-raptorcast/tests/raptorcast_instance.rs
@@ -41,7 +41,7 @@ use monad_raptorcast::{
         SecondaryRaptorCastModeConfig,
     },
     udp::{GroupId, MAX_REDUNDANCY},
-    util::{BuildTarget, EpochValidators, Group, Redundancy},
+    util::{BuildTarget, Group, Redundancy},
     DataplaneHandles, RaptorCast, RaptorCastEvent,
 };
 use monad_secp::{KeyPair, SecpSignature};
@@ -86,11 +86,7 @@ pub fn different_symbol_sizes() {
         };
 
         let valset = BTreeMap::from([(rx_nodeid, Stake::ONE), (tx_nodeid, Stake::ONE)]);
-        let validators = EpochValidators {
-            validators: ValidatorSet::new_unchecked(valset),
-        };
-
-        let epoch_validators = validators.view_without(vec![&tx_nodeid]);
+        let validators = ValidatorSet::new_unchecked(valset);
 
         let messages = build_messages::<SignatureType>(
             &tx_keypair,
@@ -99,7 +95,7 @@ pub fn different_symbol_sizes() {
             Redundancy::from_u8(2),
             GroupId::Primary(Epoch(0)), // epoch_no
             0,                          // unix_ts_ms
-            BuildTarget::Raptorcast(epoch_validators),
+            BuildTarget::Raptorcast(&validators),
             &known_addresses,
         );
 
@@ -144,11 +140,7 @@ pub fn buffer_count_overflow() {
     let tx_socket = UdpSocket::bind("127.0.0.1:0").unwrap();
 
     let valset = BTreeMap::from([(rx_nodeid, Stake::ONE), (tx_nodeid, Stake::ONE)]);
-    let validators = EpochValidators {
-        validators: ValidatorSet::new_unchecked(valset),
-    };
-
-    let epoch_validators = validators.view_without(vec![&tx_nodeid]);
+    let validators = ValidatorSet::new_unchecked(valset);
 
     let messages = build_messages::<SignatureType>(
         &tx_keypair,
@@ -157,7 +149,7 @@ pub fn buffer_count_overflow() {
         Redundancy::from_u8(2),
         GroupId::Primary(Epoch(0)), // epoch_no
         0,                          // unix_ts_ms
-        BuildTarget::Raptorcast(epoch_validators),
+        BuildTarget::Raptorcast(&validators),
         &known_addresses,
     );
 
@@ -218,11 +210,7 @@ pub fn valid_rebroadcast() {
         .unwrap();
 
     let valset = BTreeMap::from([(rx_nodeid, Stake::ONE), (tx_nodeid, Stake::ONE)]);
-    let validators = EpochValidators {
-        validators: ValidatorSet::new_unchecked(valset),
-    };
-
-    let epoch_validators = validators.view_without(vec![&tx_nodeid]);
+    let validators = ValidatorSet::new_unchecked(valset);
 
     let messages = build_messages::<SignatureType>(
         &tx_keypair,
@@ -231,7 +219,7 @@ pub fn valid_rebroadcast() {
         MAX_REDUNDANCY,             // redundancy,
         GroupId::Primary(Epoch(0)), // epoch_no
         0,                          // unix_ts_ms
-        BuildTarget::Raptorcast(epoch_validators),
+        BuildTarget::Raptorcast(&validators),
         &known_addresses,
     );
 

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -140,6 +140,13 @@ pub struct RoundSpan {
 }
 
 impl RoundSpan {
+    // TODO: The empty RoundSpan is only used in the Group struct
+    // representing a validator set. Remove this exception after we
+    // refactor out the Group struct.
+    pub fn empty(at: Round) -> Self {
+        Self { start: at, end: at }
+    }
+
     pub fn new(start: Round, end: Round) -> Option<Self> {
         if start >= end {
             return None;
@@ -162,15 +169,6 @@ impl RoundSpan {
     }
     pub fn overlaps(&self, other: &RoundSpan) -> bool {
         self.start < other.end && other.start < self.end
-    }
-}
-
-impl Default for RoundSpan {
-    fn default() -> Self {
-        Self {
-            start: Round::MIN,
-            end: Round::MIN,
-        }
     }
 }
 


### PR DESCRIPTION
This PR includes a bunch of changes around the `BuildTarget` group types used in message publishing:

- replace node view types like `FullNodesView`, `ValidatorsView` with simple reference of the owned group types
- simplify the use of `Group`/`FullNodes`/`EpochValidators` into explicit types like `ValidatorSet`, `SecondaryGroup`, and `Vec<NodeId>`
- delay the "`excl_self`" iterators to message builder step
- refactor Secondary Publisher usage of degenerate/invariance-violating `Group` type into `CurrentGroup` type that handles the cases explicitly

Rationale:

- the original types allow expressing invalid `BuildTarget` combinations:
  + Broadcast(NodesView) to non-validator nodes (should use individual point-to-point or use secondary)
  + FullNodeRaptorCast(Group) allows publishing to a validator group
- publishing to secondary group should never worry about "exclude self" because the publisher is never in the group.
- move all the "exclude self" logic to packet builder, which is closer to the actual protocols, other part of raptorcast can operate on the the full set
- unwrap unnecessary wrapper types:
  + `FullNodes` type doesn't require any invariances, or represent any extra semantic beyond `Vec<NodeId>` according to their uses.
  + similarly, `EpochValidators` is functionally and semantically identical to `ValidatorSet`
- enforce invariances on types, for example:
  + `SecondaryGroup` must be a non-empty set
  + `RoundSpan` must be an non-empty interval (e.g. `impl Default for {RoundSpan,Group}` are unsound)
