### PR TITLE
Rename pool tx datastructures

### DIFF
--- a/monad-eth-block-validator/tests/coherency_test.rs
+++ b/monad-eth-block-validator/tests/coherency_test.rs
@@ -40,7 +40,7 @@ use monad_eth_block_policy::{EthBlockPolicy, EthValidatedBlock};
 use monad_eth_block_validator::EthBlockValidator;
 use monad_eth_testutil::{recover_tx, secret_to_eth_address, S1, S2};
 use monad_eth_txpool::{
-    EthTxPool, EthTxPoolConfig, EthTxPoolEventTracker, EthTxPoolMetrics, PoolTransactionKind,
+    EthTxPool, EthTxPoolConfig, EthTxPoolEventTracker, EthTxPoolMetrics, PoolTxKind,
     TrackedTxLimitsConfig,
 };
 use monad_eth_types::{EthBlockBody, EthExecutionProtocol, EthHeader, ProposedEthHeader};
@@ -485,7 +485,7 @@ fn check_txpool_coherency(
             chain_config,
             block_txs
                 .into_iter()
-                .map(|tx| (tx, PoolTransactionKind::Forwarded))
+                .map(|tx| (tx, PoolTxKind::Forwarded))
                 .collect(),
             |_tx| {},
         );

--- a/monad-eth-txpool-executor/src/lib.rs
+++ b/monad-eth-txpool-executor/src/lib.rs
@@ -34,7 +34,7 @@ use monad_crypto::certificate_signature::{
 };
 use monad_eth_block_policy::EthBlockPolicy;
 use monad_eth_txpool::{
-    EthTxPool, EthTxPoolConfig, EthTxPoolEventTracker, PoolTransactionKind, TrackedTxLimitsConfig,
+    EthTxPool, EthTxPoolConfig, EthTxPoolEventTracker, PoolTxKind, TrackedTxLimitsConfig,
 };
 use monad_eth_txpool_types::{
     EthTxPoolDropReason, EthTxPoolEventType, EthTxPoolIpcTx, EthTxPoolTxInputStream,
@@ -553,7 +553,7 @@ where
                             match tx.secp256k1_recover() {
                                 Ok(signer) => rayon::iter::Either::Left((
                                     Recovered::new_unchecked(tx, signer),
-                                    PoolTransactionKind::Owned {
+                                    PoolTxKind::Owned {
                                         priority,
                                         extra_data,
                                     },
@@ -623,7 +623,7 @@ where
                         match tx.secp256k1_recover() {
                             Ok(signer) => rayon::iter::Either::Left((
                                 Recovered::new_unchecked(tx, signer),
-                                PoolTransactionKind::Forwarded,
+                                PoolTxKind::Forwarded,
                             )),
                             Err(_) => rayon::iter::Either::Right((
                                 *tx.tx_hash(),

--- a/monad-eth-txpool/benches/insert.rs
+++ b/monad-eth-txpool/benches/insert.rs
@@ -19,7 +19,7 @@ use common::SignatureType;
 use criterion::{criterion_group, criterion_main, Criterion};
 use monad_chain_config::{revision::MockChainRevision, MockChainConfig};
 use monad_eth_block_policy::EthBlockPolicy;
-use monad_eth_txpool::{EthTxPool, EthTxPoolEventTracker, EthTxPoolMetrics, PoolTransactionKind};
+use monad_eth_txpool::{EthTxPool, EthTxPoolEventTracker, EthTxPoolMetrics, PoolTxKind};
 use monad_types::GENESIS_SEQ_NUM;
 
 use self::common::{run_txpool_benches, BenchController, SignatureCollectionType, EXECUTION_DELAY};
@@ -65,7 +65,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 state_backend,
                 &MockChainConfig::DEFAULT,
                 txs.iter()
-                    .map(|tx| (tx.clone(), PoolTransactionKind::owned_default()))
+                    .map(|tx| (tx.clone(), PoolTxKind::owned_default()))
                     .collect(),
                 |_| {},
             );

--- a/monad-eth-txpool/src/lib.rs
+++ b/monad-eth-txpool/src/lib.rs
@@ -17,8 +17,7 @@ pub use self::{
     event_tracker::EthTxPoolEventTracker,
     metrics::EthTxPoolMetrics,
     pool::{
-        max_eip2718_encoded_length, EthTxPool, EthTxPoolConfig, PoolTransactionKind,
-        TrackedTxLimitsConfig,
+        max_eip2718_encoded_length, EthTxPool, EthTxPoolConfig, PoolTxKind, TrackedTxLimitsConfig,
     },
 };
 

--- a/monad-eth-txpool/src/pool/sequencer.rs
+++ b/monad-eth-txpool/src/pool/sequencer.rs
@@ -37,17 +37,17 @@ use tracing::{debug, error, trace};
 
 use crate::pool::{
     tracked::TrackedTxList,
-    transaction::{ValidEthRecoveredAuthorization, ValidEthTransaction},
+    transaction::{PoolTx, PoolTxRecoveredAuthorization},
 };
 
 #[derive(Debug, PartialEq, Eq)]
 struct OrderedTx<'a> {
-    tx: &'a ValidEthTransaction,
+    tx: &'a PoolTx,
     effective_tip_per_gas: u128,
 }
 
 impl<'a> OrderedTx<'a> {
-    fn new(tx: &'a ValidEthTransaction, base_fee: u64) -> Option<Self> {
+    fn new(tx: &'a PoolTx, base_fee: u64) -> Option<Self> {
         let effective_tip_per_gas = tx.raw().effective_tip_per_gas(base_fee)?;
 
         Some(Self {
@@ -237,7 +237,7 @@ impl<'a> ProposalSequencer<'a> {
                     self.push(address, next_tx, queued);
                 }
 
-                for ValidEthRecoveredAuthorization {
+                for PoolTxRecoveredAuthorization {
                     authority,
                     authorization,
                 } in tx.tx.iter_valid_recovered_authorizations()
@@ -272,7 +272,7 @@ impl<'a> ProposalSequencer<'a> {
         validator: &EthBlockPolicyBlockValidator<CRT>,
         proposal: &mut Proposal,
         address: &Address,
-        tx: &ValidEthTransaction,
+        tx: &PoolTx,
     ) -> bool {
         if proposal
             .total_gas

--- a/monad-eth-txpool/src/pool/tracked/limits.rs
+++ b/monad-eth-txpool/src/pool/tracked/limits.rs
@@ -19,7 +19,7 @@ use alloy_primitives::Address;
 use indexmap::IndexMap;
 use tracing::{error, info};
 
-use crate::pool::transaction::ValidEthTransaction;
+use crate::pool::transaction::PoolTx;
 
 // To produce 5k tx blocks, we need the tracked tx map to hold at least 15k addresses so that, after
 // pruning the txpool of up to 5k unique addresses in the last committed block update and up to 5k
@@ -110,12 +110,12 @@ impl TrackedTxLimits {
             || self.eip2718_bytes > self.config.max_eip2718_bytes
     }
 
-    pub fn add_tx(&mut self, tx: &ValidEthTransaction) {
+    pub fn add_tx(&mut self, tx: &PoolTx) {
         self.txs += 1;
         self.eip2718_bytes += tx.raw().eip2718_encoded_length() as u64;
     }
 
-    pub fn remove_tx(&mut self, tx: &ValidEthTransaction) {
+    pub fn remove_tx(&mut self, tx: &PoolTx) {
         self.txs = self.txs.checked_sub(1).unwrap_or_else(|| {
             error!("txpool txs limit underflowed, detected during remove_tx");
             0
@@ -130,7 +130,7 @@ impl TrackedTxLimits {
             });
     }
 
-    pub fn remove_txs<'a>(&mut self, txs: impl Iterator<Item = &'a ValidEthTransaction>) {
+    pub fn remove_txs<'a>(&mut self, txs: impl Iterator<Item = &'a PoolTx>) {
         for tx in txs {
             self.remove_tx(tx)
         }

--- a/monad-eth-txpool/src/pool/tracked/mod.rs
+++ b/monad-eth-txpool/src/pool/tracked/mod.rs
@@ -34,7 +34,7 @@ use tracing::error;
 use self::limits::TrackedTxLimits;
 pub use self::limits::TrackedTxLimitsConfig;
 pub(super) use self::list::TrackedTxList;
-use super::transaction::ValidEthTransaction;
+use super::transaction::PoolTx;
 use crate::{pool::tracked::priority::PriorityMap, EthTxPoolEventTracker};
 
 mod limits;
@@ -97,11 +97,11 @@ where
         self.txs.iter()
     }
 
-    pub fn iter_txs(&self) -> impl Iterator<Item = &ValidEthTransaction> {
+    pub fn iter_txs(&self) -> impl Iterator<Item = &PoolTx> {
         self.txs.values().flat_map(TrackedTxList::iter)
     }
 
-    pub fn iter_mut_txs(&mut self) -> impl Iterator<Item = &mut ValidEthTransaction> {
+    pub fn iter_mut_txs(&mut self) -> impl Iterator<Item = &mut PoolTx> {
         self.txs.values_mut().flat_map(TrackedTxList::iter_mut)
     }
 
@@ -123,9 +123,9 @@ where
         event_tracker: &mut EthTxPoolEventTracker<'_>,
         last_commit: &ConsensusBlockHeader<ST, SCT, EthExecutionProtocol>,
         address: Address,
-        txs: Vec<ValidEthTransaction>,
+        txs: Vec<PoolTx>,
         account_nonce: u64,
-        on_insert: &mut impl FnMut(&ValidEthTransaction),
+        on_insert: &mut impl FnMut(&PoolTx),
     ) {
         let mut inserted = false;
 

--- a/monad-eth-txpool/src/pool/transaction.rs
+++ b/monad-eth-txpool/src/pool/transaction.rs
@@ -41,12 +41,12 @@ pub const fn max_eip2718_encoded_length(execution_params: &ExecutionChainParams)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum PoolTransactionKind {
+pub enum PoolTxKind {
     Owned { priority: U256, extra_data: Vec<u8> },
     Forwarded,
 }
 
-impl PoolTransactionKind {
+impl PoolTxKind {
     pub fn owned_default() -> Self {
         Self::Owned {
             priority: DEFAULT_TX_PRIORITY,
@@ -56,30 +56,30 @@ impl PoolTransactionKind {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ValidEthTransaction {
+pub struct PoolTx {
     tx: Recovered<TxEnvelope>,
-    kind: PoolTransactionKind,
+    kind: PoolTxKind,
     forward_last_seqnum: SeqNum,
     forward_retries: usize,
     max_value: Balance,
     max_gas_cost: Balance,
-    valid_recovered_authorizations: Box<[ValidEthRecoveredAuthorization]>,
+    valid_recovered_authorizations: Box<[PoolTxRecoveredAuthorization]>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ValidEthRecoveredAuthorization {
+pub struct PoolTxRecoveredAuthorization {
     pub authority: Address,
     pub authorization: Authorization,
 }
 
-impl ValidEthTransaction {
+impl PoolTx {
     pub fn validate<ST, SCT>(
         last_commit: &ConsensusBlockHeader<ST, SCT, EthExecutionProtocol>,
         chain_id: u64,
         chain_params: &ChainParams,
         execution_params: &ExecutionChainParams,
         tx: Recovered<TxEnvelope>,
-        kind: PoolTransactionKind,
+        kind: PoolTxKind,
     ) -> Result<Self, (Recovered<TxEnvelope>, EthTxPoolDropReason)>
     where
         ST: CertificateSignatureRecoverable,
@@ -150,7 +150,7 @@ impl ValidEthTransaction {
                             return Some(Err(EthTxPoolDropReason::InvalidSignature));
                         }
 
-                        Some(Ok(ValidEthRecoveredAuthorization {
+                        Some(Ok(PoolTxRecoveredAuthorization {
                             authority,
                             authorization: signed_authorization.inner().clone(),
                         }))
@@ -249,25 +249,25 @@ impl ValidEthTransaction {
 
     pub fn tx_kind_priority(&self) -> U256 {
         match self.kind {
-            PoolTransactionKind::Owned { priority, .. } => priority,
-            PoolTransactionKind::Forwarded => DEFAULT_TX_PRIORITY,
+            PoolTxKind::Owned { priority, .. } => priority,
+            PoolTxKind::Forwarded => DEFAULT_TX_PRIORITY,
         }
     }
 
     pub fn is_owned(&self) -> bool {
         match self.kind {
-            PoolTransactionKind::Owned { .. } => true,
-            PoolTransactionKind::Forwarded => false,
+            PoolTxKind::Owned { .. } => true,
+            PoolTxKind::Forwarded => false,
         }
     }
 
     pub fn is_owned_and_forwardable(&self) -> bool {
         match &self.kind {
-            PoolTransactionKind::Owned {
+            PoolTxKind::Owned {
                 priority,
                 extra_data: _,
             } => priority <= &DEFAULT_TX_PRIORITY,
-            PoolTransactionKind::Forwarded => false,
+            PoolTxKind::Forwarded => false,
         }
     }
 
@@ -302,7 +302,7 @@ impl ValidEthTransaction {
 
     pub fn iter_valid_recovered_authorizations(
         &self,
-    ) -> impl Iterator<Item = &ValidEthRecoveredAuthorization> {
+    ) -> impl Iterator<Item = &PoolTxRecoveredAuthorization> {
         self.valid_recovered_authorizations.iter()
     }
 

--- a/monad-eth-txpool/tests/forward.rs
+++ b/monad-eth-txpool/tests/forward.rs
@@ -19,7 +19,7 @@ use monad_chain_config::{revision::MockChainRevision, MockChainConfig};
 use monad_crypto::NopSignature;
 use monad_eth_block_policy::EthBlockPolicy;
 use monad_eth_testutil::{generate_block_with_txs, make_legacy_tx, recover_tx, S1};
-use monad_eth_txpool::{EthTxPool, EthTxPoolEventTracker, EthTxPoolMetrics, PoolTransactionKind};
+use monad_eth_txpool::{EthTxPool, EthTxPoolEventTracker, EthTxPoolMetrics, PoolTxKind};
 use monad_state_backend::{InMemoryBlockState, InMemoryState, InMemoryStateInner};
 use monad_testutil::signing::MockSignatures;
 use monad_types::{Balance, Round, SeqNum, GENESIS_SEQ_NUM};
@@ -97,9 +97,9 @@ fn with_txpool(
         vec![(
             tx,
             if insert_tx_owned {
-                PoolTransactionKind::owned_default()
+                PoolTxKind::owned_default()
             } else {
-                PoolTransactionKind::Forwarded
+                PoolTxKind::Forwarded
             },
         )],
         |_| {},

--- a/monad-eth-txpool/tests/performance.rs
+++ b/monad-eth-txpool/tests/performance.rs
@@ -27,7 +27,7 @@ use monad_eth_testutil::{
     generate_block_with_txs, make_eip7702_tx, make_legacy_tx, make_signed_authorization,
     recover_tx, secret_to_eth_address, S1, S2,
 };
-use monad_eth_txpool::{EthTxPool, EthTxPoolEventTracker, EthTxPoolMetrics, PoolTransactionKind};
+use monad_eth_txpool::{EthTxPool, EthTxPoolEventTracker, EthTxPoolMetrics, PoolTxKind};
 use monad_state_backend::{InMemoryBlockState, InMemoryState, InMemoryStateInner, StateBackend};
 use monad_testutil::signing::MockSignatures;
 use monad_tfm::base_fee::MIN_BASE_FEE;
@@ -79,7 +79,7 @@ fn txpool_create_proposal_lookups_bound_by_tx_limit() {
                 recover_tx(make_legacy_tx(S2, MIN_BASE_FEE.into(), 100_000, 0, 0)),
             ]
             .into_iter()
-            .map(|tx| (tx, PoolTransactionKind::owned_default()))
+            .map(|tx| (tx, PoolTxKind::owned_default()))
             .collect(),
             |_| {},
         );
@@ -164,7 +164,7 @@ fn txpool_create_proposal_no_lookup_for_unknown_authorizations() {
                 0,
             ))]
             .into_iter()
-            .map(|tx| (tx, PoolTransactionKind::owned_default()))
+            .map(|tx| (tx, PoolTxKind::owned_default()))
             .collect(),
             |_| {},
         );

--- a/monad-eth-txpool/tests/pool.rs
+++ b/monad-eth-txpool/tests/pool.rs
@@ -45,7 +45,7 @@ use monad_eth_testutil::{
 };
 use monad_eth_txpool::{
     max_eip2718_encoded_length, EthTxPool, EthTxPoolConfig, EthTxPoolEventTracker,
-    EthTxPoolMetrics, PoolTransactionKind, TrackedTxLimitsConfig,
+    EthTxPoolMetrics, PoolTxKind, TrackedTxLimitsConfig,
 };
 use monad_eth_txpool_types::EthTxPoolSnapshot;
 use monad_state_backend::{InMemoryBlockState, InMemoryState, InMemoryStateInner};
@@ -206,9 +206,9 @@ fn run_custom_iter<const N: usize>(
                         vec![(
                             tx.clone(),
                             if owned {
-                                PoolTransactionKind::owned_default()
+                                PoolTxKind::owned_default()
                             } else {
-                                PoolTransactionKind::Forwarded
+                                PoolTxKind::Forwarded
                             },
                         )],
                         |inserted_tx| {
@@ -263,9 +263,9 @@ fn run_custom_iter<const N: usize>(
                             (
                                 tx,
                                 if owned {
-                                    PoolTransactionKind::owned_default()
+                                    PoolTxKind::owned_default()
                                 } else {
-                                    PoolTransactionKind::Forwarded
+                                    PoolTxKind::Forwarded
                                 },
                             )
                         })

--- a/monad-updaters/src/txpool.rs
+++ b/monad-updaters/src/txpool.rs
@@ -34,7 +34,7 @@ use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_eth_block_policy::EthBlockPolicy;
-use monad_eth_txpool::{EthTxPool, EthTxPoolEventTracker, EthTxPoolMetrics, PoolTransactionKind};
+use monad_eth_txpool::{EthTxPool, EthTxPoolEventTracker, EthTxPoolMetrics, PoolTxKind};
 use monad_eth_types::{EthExecutionProtocol, ExtractEthAddress};
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{MempoolEvent, MonadEvent, TxPoolCommand};
@@ -457,10 +457,7 @@ where
                             .filter_map(|raw_tx| {
                                 let tx = TxEnvelope::decode(&mut raw_tx.as_ref()).ok()?;
                                 let signer = tx.recover_signer().ok()?;
-                                Some((
-                                    Recovered::new_unchecked(tx, signer),
-                                    PoolTransactionKind::Forwarded,
-                                ))
+                                Some((Recovered::new_unchecked(tx, signer), PoolTxKind::Forwarded))
                             })
                             .collect(),
                         |_| {},
@@ -602,7 +599,7 @@ where
             block_policy,
             state_backend,
             &MockChainConfig::DEFAULT,
-            vec![(tx, PoolTransactionKind::owned_default())],
+            vec![(tx, PoolTxKind::owned_default())],
             |tx| {
                 self.events.push_back(MempoolEvent::ForwardTxs(vec![
                     alloy_rlp::encode(tx.raw()).into()


### PR DESCRIPTION
Unifies naming in `monad-eth-txpool/src/pool/transaction.rs`.