### PR TITLE
Raptorcast: clarify group types for primary/secondary raptorcast

### DIFF
--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -62,8 +62,8 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::{debug, debug_span, error, trace, warn};
 use udp::GroupId;
 use util::{
-    BuildTarget, Collector, Group, PeerAddrLookup, ReBroadcastGroupMap, Recipient, Redundancy,
-    UdpMessage,
+    BuildTarget, Collector, FullNodeGroupMap, PeerAddrLookup, Recipient, Redundancy,
+    SecondaryGroupAssignment, UdpMessage,
 };
 
 use crate::{
@@ -108,7 +108,7 @@ where
     is_dynamic_fullnode: bool,
 
     epoch_validators: BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
-    rebroadcast_map: ReBroadcastGroupMap<CertificateSignaturePubKey<ST>>,
+    full_node_groups: FullNodeGroupMap<CertificateSignaturePubKey<ST>>,
 
     dedicated_full_nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
     peer_discovery_driver: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
@@ -126,7 +126,8 @@ where
     pending_events: VecDeque<RaptorCastEvent<M::Event, ST>>,
 
     channel_to_secondary: Option<UnboundedSender<FullNodesGroupMessage<ST>>>,
-    channel_from_secondary: Option<UnboundedReceiver<Group<CertificateSignaturePubKey<ST>>>>,
+    channel_from_secondary:
+        Option<UnboundedReceiver<SecondaryGroupAssignment<CertificateSignaturePubKey<ST>>>>,
     channel_from_secondary_outbound:
         Option<UnboundedReceiver<SecondaryOutboundMessage<CertificateSignaturePubKey<ST>>>>,
 
@@ -210,7 +211,8 @@ where
         Self {
             is_dynamic_fullnode,
             epoch_validators: Default::default(),
-            rebroadcast_map: ReBroadcastGroupMap::new(self_id),
+            full_node_groups: Default::default(),
+
             dedicated_full_nodes: config.primary_instance.fullnode_dedicated.clone(),
             peer_discovery_driver,
 
@@ -255,7 +257,9 @@ where
         &mut self,
         role: SecondaryRaptorCastModeConfig,
         channel_to_secondary: UnboundedSender<FullNodesGroupMessage<ST>>,
-        channel_from_secondary: UnboundedReceiver<Group<CertificateSignaturePubKey<ST>>>,
+        channel_from_secondary: UnboundedReceiver<
+            SecondaryGroupAssignment<CertificateSignaturePubKey<ST>>,
+        >,
         channel_from_secondary_outbound: UnboundedReceiver<
             SecondaryOutboundMessage<CertificateSignaturePubKey<ST>>,
         >,
@@ -284,8 +288,9 @@ where
         self.dedicated_full_nodes = nodes;
     }
 
-    pub fn get_rebroadcast_groups(&self) -> &ReBroadcastGroupMap<CertificateSignaturePubKey<ST>> {
-        &self.rebroadcast_map
+    // Used only in tests
+    pub fn get_full_node_groups(&self) -> &FullNodeGroupMap<CertificateSignaturePubKey<ST>> {
+        &self.full_node_groups
     }
 
     pub fn is_connected_to(
@@ -747,15 +752,9 @@ where
                             secondary_mb.set_group_id(GroupId::Primary(epoch));
                         }
 
-                        while let Some(entry) = self.epoch_validators.first_entry() {
-                            if *entry.key() + Epoch(1) < self.current_epoch {
-                                entry.remove();
-                            } else {
-                                break;
-                            }
-                        }
+                        self.epoch_validators.retain(|e, _| *e + Epoch(1) >= epoch);
                     }
-                    self.rebroadcast_map.delete_expired_groups(epoch, round);
+                    self.full_node_groups.delete_expired(round);
                     self.peer_discovery_driver
                         .lock()
                         .unwrap()
@@ -766,8 +765,6 @@ where
                     validator_set,
                 } => {
                     trace!(?epoch, ?validator_set, "RaptorCast AddEpochValidatorSet");
-                    self.rebroadcast_map
-                        .push_group_validator_set(validator_set.clone(), epoch);
                     if let Some(epoch_validators) = self.epoch_validators.get(&epoch) {
                         assert_eq!(validator_set.len(), epoch_validators.len());
 
@@ -1004,8 +1001,8 @@ where
             let src_addr = message.src_addr;
             let decoded_app_messages = {
                 this.udp_state.handle_message(
-                    &this.rebroadcast_map,
                     &this.epoch_validators,
+                    &this.full_node_groups,
                     |targets, payload, bcast_stride| {
                         for target in targets {
                             rebroadcast_packet(
@@ -1262,7 +1259,16 @@ where
             loop {
                 match pin!(channel_from_secondary.recv()).poll(cx) {
                     Poll::Ready(Some(group)) => {
-                        this.rebroadcast_map.push_group_fullnodes(group);
+                        let round_span = *group.round_span(); // for logging only
+                        let publisher_id = *group.publisher_id();
+                        if this.full_node_groups.try_insert(group).is_none() {
+                            // TODO: convert to an assertion?
+                            error!(
+                                round_span =? round_span,
+                                publisher_id =? publisher_id,
+                                "Accepted group assignment contains overlaps"
+                            );
+                        };
                     }
                     Poll::Ready(None) => {
                         error!("RaptorCast secondary->primary channel disconnected.");

--- a/monad-raptorcast/src/raptorcast_secondary/client.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/client.rs
@@ -25,9 +25,10 @@ use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, error, warn};
 
 use super::{
-    super::{config::RaptorCastConfigSecondaryClient, util::Group},
+    super::config::RaptorCastConfigSecondaryClient,
     group_message::{ConfirmGroup, PrepareGroup, PrepareGroupResponse},
 };
+use crate::util::{SecondaryGroup, SecondaryGroupAssignment};
 
 monad_executor::metric_consts! {
     pub CLIENT_NUM_CURRENT_GROUPS {
@@ -44,8 +45,6 @@ monad_executor::metric_consts! {
     }
 }
 
-type GroupAsClient<PT> = Group<PT>;
-
 // This is for when the router is playing the role of a client
 // That is, we are a full-node receiving group invites from a validator
 pub struct Client<ST>
@@ -58,10 +57,10 @@ where
     // upload bandwidth to broadcast chunk to a large group.
     config: RaptorCastConfigSecondaryClient,
 
-    // [start_round, end_round) -> GroupAsClient
+    // [start_round, end_round) -> SecondaryGroupAssignment
     // Represents all raptorcast groups that we have accepted and haven't expired
     // yet. The groups may overlap.
-    confirmed_groups: IntervalMap<Round, GroupAsClient<CertificateSignaturePubKey<ST>>>,
+    confirmed_groups: IntervalMap<Round, SecondaryGroupAssignment<CertificateSignaturePubKey<ST>>>,
 
     // start_round -> validator_id -> group invite
     // Once we receive an invite, we remember how the invite looked like, so
@@ -75,7 +74,7 @@ where
     >,
 
     // Once a group is confirmed, it is sent to this channel
-    group_sink_channel: UnboundedSender<GroupAsClient<CertificateSignaturePubKey<ST>>>,
+    group_sink_channel: UnboundedSender<SecondaryGroupAssignment<CertificateSignaturePubKey<ST>>>,
 
     // For avoiding accepting invites/confirms for rounds we've already started
     curr_round: Round,
@@ -95,7 +94,9 @@ where
 {
     pub fn new(
         client_node_id: NodeId<CertificateSignaturePubKey<ST>>,
-        group_sink_channel: UnboundedSender<GroupAsClient<CertificateSignaturePubKey<ST>>>,
+        group_sink_channel: UnboundedSender<
+            SecondaryGroupAssignment<CertificateSignaturePubKey<ST>>,
+        >,
         config: RaptorCastConfigSecondaryClient,
     ) -> Self {
         assert!(
@@ -231,7 +232,7 @@ where
             // have [25, 35)->validator3
             // Note that we accept overlaps across different validators,
             // e.g. [30, 40)->validator3 + [25, 35)->validator4
-            if group.get_validator_id() == &invite_msg.validator_id {
+            if group.publisher_id() == &invite_msg.validator_id {
                 warn!(
                     "RaptorCastSecondary received self-overlapping \
                             invite for rounds [{:?}, {:?}) from validator {:?}",
@@ -375,11 +376,13 @@ where
             return false;
         }
 
-        let group = GroupAsClient::new_fullnode_group(
-            confirm_msg.peers.into_inner(),
-            &self.client_node_id,
+        let members = confirm_msg.peers.into_inner().into_iter().collect();
+        let group = SecondaryGroupAssignment::new(
             confirm_msg.prepare.validator_id,
             round_span,
+            // SAFETY: `members` includes self_id in a previous check,
+            // so it must not be empty.
+            SecondaryGroup::new_unchecked(members),
         );
 
         // Send the group to primary instance right away.
@@ -440,11 +443,6 @@ where
     }
 
     #[cfg(test)]
-    pub fn get_client_node_id(&self) -> NodeId<CertificateSignaturePubKey<ST>> {
-        self.client_node_id
-    }
-
-    #[cfg(test)]
     pub fn num_pending_confirms(&self) -> usize {
         self.pending_confirms.len()
     }
@@ -460,7 +458,10 @@ mod tests {
 
     use super::{
         super::{
-            super::{config::RaptorCastConfigSecondaryClient, util::Group},
+            super::{
+                config::RaptorCastConfigSecondaryClient,
+                util::{SecondaryGroup, SecondaryGroupAssignment},
+            },
             Client,
         },
         *,
@@ -469,8 +470,8 @@ mod tests {
     type ST = SecpSignature;
     type PubKeyType = CertificateSignaturePubKey<ST>;
     type RcToRcChannelGrp = (
-        UnboundedSender<Group<PubKeyType>>,
-        UnboundedReceiver<Group<PubKeyType>>,
+        UnboundedSender<SecondaryGroupAssignment<PubKeyType>>,
+        UnboundedReceiver<SecondaryGroupAssignment<PubKeyType>>,
     );
 
     #[test]
@@ -489,15 +490,14 @@ mod tests {
             },
         );
 
-        clt.confirmed_groups.insert(
-            Round(1)..Round(5),
-            GroupAsClient::new_fullnode_group(
-                vec![self_id, nid(3), nid(4), nid(5)],
-                &self_id,
-                nid(2),
-                RoundSpan::new(Round(1), Round(5)).unwrap(),
-            ),
+        let grp = SecondaryGroupAssignment::new(
+            nid(2),
+            RoundSpan::new(Round(1), Round(5)).unwrap(),
+            SecondaryGroup::new([self_id, nid(3), nid(4), nid(5)].into_iter().collect()).unwrap(),
         );
+        assert!(grp.is_member(&self_id));
+
+        clt.confirmed_groups.insert(Round(1)..Round(5), grp);
 
         let malformed_messages = [
             // group size overflow
@@ -539,15 +539,14 @@ mod tests {
             },
         );
 
-        clt.confirmed_groups.insert(
-            Round(1)..Round(5),
-            GroupAsClient::new_fullnode_group(
-                vec![self_id, nid(3), nid(4), nid(5)],
-                &self_id,
-                nid(2),
-                RoundSpan::new(Round(1), Round(5)).unwrap(),
-            ),
+        let grp = SecondaryGroupAssignment::new(
+            nid(2),
+            RoundSpan::new(Round(1), Round(5)).unwrap(),
+            SecondaryGroup::new([self_id, nid(3), nid(4), nid(5)].into_iter().collect()).unwrap(),
         );
+        assert!(grp.is_member(&self_id));
+
+        clt.confirmed_groups.insert(Round(1)..Round(5), grp);
 
         clt.pending_confirms.insert(
             Round(4),
@@ -589,15 +588,14 @@ mod tests {
         );
 
         clt.curr_round = Round(2);
-        clt.confirmed_groups.insert(
-            Round(1)..Round(5),
-            GroupAsClient::new_fullnode_group(
-                vec![self_id, nid(3), nid(4), nid(5)],
-                &self_id,
-                nid(2),
-                RoundSpan::new(Round(1), Round(5)).unwrap(),
-            ),
+        let grp = SecondaryGroupAssignment::new(
+            nid(2),
+            RoundSpan::new(Round(1), Round(5)).unwrap(),
+            SecondaryGroup::new([self_id, nid(3), nid(4), nid(5)].into_iter().collect()).unwrap(),
         );
+        assert!(grp.is_member(&self_id));
+
+        clt.confirmed_groups.insert(Round(1)..Round(5), grp);
 
         clt.enter_round(Round(3));
         assert_eq!(clt.get_current_group_count(), 1);

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -46,7 +46,7 @@ use crate::{
     config::{RaptorCastConfig, SecondaryRaptorCastMode},
     message::OutboundRouterMessage,
     udp::GroupId,
-    util::{Group, SecondaryGroup},
+    util::{SecondaryGroup, SecondaryGroupAssignment},
     RaptorCastEvent,
 };
 
@@ -117,7 +117,9 @@ where
         secondary_mode: SecondaryRaptorCastMode<CertificateSignaturePubKey<ST>>,
         peer_discovery_driver: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
         channel_from_primary: UnboundedReceiver<FullNodesGroupMessage<ST>>,
-        channel_to_primary: UnboundedSender<Group<CertificateSignaturePubKey<ST>>>,
+        channel_to_primary: UnboundedSender<
+            SecondaryGroupAssignment<CertificateSignaturePubKey<ST>>,
+        >,
         channel_to_primary_outbound: UnboundedSender<
             SecondaryOutboundMessage<CertificateSignaturePubKey<ST>>,
         >,

--- a/monad-raptorcast/src/raptorcast_secondary/publisher.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/publisher.rs
@@ -646,7 +646,7 @@ mod tests {
     use iset::{interval_map, IntervalMap};
     use monad_secp::SecpSignature;
     use monad_testutil::signing::get_key;
-    use monad_types::{Epoch, Round};
+    use monad_types::Round;
     use rand::SeedableRng;
     use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
     use tracing_subscriber::fmt::format::FmtSpan;
@@ -655,7 +655,7 @@ mod tests {
         super::{
             super::{
                 config::RaptorCastConfigSecondaryClient,
-                util::{Group, ReBroadcastGroupMap},
+                util::{FullNodeGroupMap, SecondaryGroupAssignment},
             },
             group_message::PrepareGroupResponse,
             Client,
@@ -666,8 +666,8 @@ mod tests {
     type ST = SecpSignature;
     type PubKeyType = CertificateSignaturePubKey<ST>;
     type RcToRcChannelGrp = (
-        UnboundedSender<Group<PubKeyType>>,
-        UnboundedReceiver<Group<PubKeyType>>,
+        UnboundedSender<SecondaryGroupAssignment<PubKeyType>>,
+        UnboundedReceiver<SecondaryGroupAssignment<PubKeyType>>,
     );
     type NodeIdST<ST> = NodeId<CertificateSignaturePubKey<ST>>;
 
@@ -1041,37 +1041,39 @@ mod tests {
     // This is a mock of how the primary raptorcast instance would represent
     // the rebroadcast group map.
     struct MockGroupMap {
-        rx_from_client: UnboundedReceiver<Group<PubKeyType>>,
-        group_map: ReBroadcastGroupMap<PubKeyType>,
+        rx_from_client: UnboundedReceiver<SecondaryGroupAssignment<PubKeyType>>,
+        group_map: FullNodeGroupMap<PubKeyType>,
     }
     impl MockGroupMap {
         fn new(
-            clt_node_id: NodeId<PubKeyType>,
-            rx_from_client: UnboundedReceiver<Group<PubKeyType>>,
+            _clt_node_id: NodeId<PubKeyType>,
+            rx_from_client: UnboundedReceiver<SecondaryGroupAssignment<PubKeyType>>,
         ) -> Self {
             Self {
-                group_map: ReBroadcastGroupMap::new(clt_node_id),
+                group_map: FullNodeGroupMap::default(),
                 rx_from_client,
             }
         }
 
         fn update(&mut self, clt: &Client<ST>) {
             let curr_round = clt.get_curr_round();
-            self.group_map.delete_expired_groups(Epoch(0), curr_round);
+            self.group_map.delete_expired(curr_round);
             while let Ok(group) = self.rx_from_client.try_recv() {
                 println!("Received group: {:?}", group);
                 println!(
-                    "   Other Peers: {:?}",
-                    nid_list_str(group.get_other_peers())
+                    "   Peers: {:?}",
+                    nid_list_str(&group.group().iter().cloned().collect())
                 );
-                self.group_map.push_group_fullnodes(group);
+                self.group_map
+                    .try_insert(group)
+                    .expect("non-overlapping round span");
             }
-            self.group_map.delete_expired_groups(Epoch(0), curr_round);
+            self.group_map.delete_expired(curr_round);
         }
 
         fn is_empty(&mut self, clt: &Client<ST>) -> bool {
             self.update(clt);
-            self.group_map.get_fullnode_map().is_empty()
+            self.group_map.is_empty()
         }
 
         fn get_rc_group_peers(
@@ -1080,13 +1082,14 @@ mod tests {
             validator_id: &NodeIdST<ST>,
         ) -> Vec<NodeIdST<ST>> {
             self.update(clt);
-            let fn_group_map = self.group_map.get_fullnode_map();
-            let Some(group) = fn_group_map.get(validator_id) else {
+            let Some(group_map) = self.group_map.get_group_map(validator_id) else {
                 return Vec::new();
             };
-            let mut group_incl_self = group.get_other_peers().clone();
-            group_incl_self.push(clt.get_client_node_id());
-            group_incl_self
+            let curr_round = clt.get_curr_round();
+            let Some(group) = group_map.get_current_or_next(curr_round) else {
+                return Vec::new();
+            };
+            group.iter().cloned().collect()
         }
     }
 

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -37,8 +37,8 @@ use crate::{
         signature_verifier::{SignatureVerifier, SignatureVerifierError},
     },
     util::{
-        compute_hash, unix_ts_ms_now, AppMessageHash, BroadcastMode, NodeIdHash,
-        ReBroadcastGroupMap, Redundancy,
+        compute_hash, unix_ts_ms_now, AppMessageHash, BroadcastGroup, BroadcastMode,
+        FullNodeGroupMap, NodeIdHash, Redundancy,
     },
 };
 
@@ -106,6 +106,7 @@ pub type ChunkSignatureVerifier<ST> =
 
 pub(crate) struct UdpState<ST: CertificateSignatureRecoverable> {
     self_id: NodeId<CertificateSignaturePubKey<ST>>,
+    self_id_hash: NodeIdHash,
     max_age_ms: u64,
 
     // TODO add a cap on max number of chunks that will be forwarded per message? so that a DOS
@@ -125,12 +126,14 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
         max_age_ms: u64,
         sig_verification_rate_limit: u32,
     ) -> Self {
+        let self_id_hash = compute_hash(&self_id);
         let signature_verifier = SignatureVerifier::new()
             .with_cache(SIGNATURE_CACHE_SIZE)
             .with_rate_limit(sig_verification_rate_limit);
 
         Self {
             self_id,
+            self_id_hash,
             max_age_ms,
 
             decoder_cache: DecoderCache::default(),
@@ -148,20 +151,152 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
         self.decoder_cache.metrics()
     }
 
+    pub fn handle_unicast(
+        &mut self,
+        epoch_validators: &BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
+        parsed_message: &ValidatedMessage<CertificateSignaturePubKey<ST>>,
+        _sender_pk: Option<&CertificateSignaturePubKey<ST>>,
+    ) -> Option<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
+        if parsed_message.recipient_hash != self.self_id_hash {
+            tracing::debug!(
+                ?self.self_id,
+                recipient_hash =? parsed_message.recipient_hash,
+                "dropping spoofed unicast message"
+            );
+            return None;
+        }
+
+        let validator_set = match parsed_message.group_id {
+            GroupId::Primary(epoch) => epoch_validators.get(&epoch),
+            GroupId::Secondary(_round) => None,
+        };
+
+        let decoding_context = DecodingContext::new(validator_set, unix_ts_ms_now());
+        self.try_decode(parsed_message, &decoding_context)?
+    }
+
+    pub fn handle_broadcast(
+        &mut self,
+        epoch_validators: &BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
+        full_node_group_map: &FullNodeGroupMap<CertificateSignaturePubKey<ST>>,
+        parsed_message: &ValidatedMessage<CertificateSignaturePubKey<ST>>,
+        rebroadcast_to: &mut impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
+        sender_pk: Option<&CertificateSignaturePubKey<ST>>,
+    ) -> Option<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
+        let self_id = self.self_id;
+        let Ok(group) = BroadcastGroup::from_group_id(
+            parsed_message.group_id,
+            &parsed_message.author,
+            epoch_validators,
+            full_node_group_map,
+        ) else {
+            tracing::debug!(
+                ?parsed_message.group_id,
+                author =? parsed_message.author,
+                "dropping message from unknown author/group"
+            );
+            return None;
+        };
+
+        if let Some(sender) = sender_pk {
+            let sender_id = NodeId::new(*sender);
+            if !group.is_sender_valid(&sender_id) {
+                tracing::debug!(
+                    ?parsed_message.group_id,
+                    author =? parsed_message.author,
+                    sender =? sender_id,
+                    "dropping message from invalid sender"
+                );
+                return None;
+            }
+        }
+
+        let validator_set = match parsed_message.group_id {
+            GroupId::Primary(epoch) => epoch_validators.get(&epoch),
+            GroupId::Secondary(_round) => None,
+        };
+
+        let decoding_context = DecodingContext::new(validator_set, unix_ts_ms_now());
+        let message = self.try_decode(parsed_message, &decoding_context)?;
+
+        let is_first_hop_recipient = parsed_message.recipient_hash == self.self_id_hash;
+        if let Some(ctx) = group.try_rebroadcast(&self_id, is_first_hop_recipient) {
+            // TODO: cap rebroadcast symbols based on some multiple of esis.
+            rebroadcast_to(ctx.peers().cloned().collect());
+        }
+
+        message
+    }
+
+    // Outer Option: whether the chunk was admitted
+    // Inner Option: the successfully decoded app message
+    fn try_decode(
+        &mut self,
+        parsed_message: &ValidatedMessage<CertificateSignaturePubKey<ST>>,
+        decoding_context: &DecodingContext<CertificateSignaturePubKey<ST>>,
+    ) -> Option<Option<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)>> {
+        match self
+            .decoder_cache
+            .try_decode(parsed_message, decoding_context)
+        {
+            Err(TryDecodeError::InvalidSymbol(err)) => {
+                err.log(parsed_message, &self.self_id);
+                None
+            }
+
+            Err(TryDecodeError::UnableToReconstructSourceData) => {
+                tracing::error!("failed to reconstruct source data");
+                None
+            }
+
+            Err(TryDecodeError::AppMessageHashMismatch { expected, actual }) => {
+                tracing::error!(
+                    author =? parsed_message.author,
+                    ?expected,
+                    ?actual,
+                    "mismatch message hash"
+                );
+                None
+            }
+
+            Ok(TryDecodeStatus::RejectedByCache) => {
+                tracing::warn!(
+                    author =? parsed_message.author,
+                    chunk_id = parsed_message.chunk_id,
+                    "message rejected by cache, author may be flooding messages",
+                );
+                None
+            }
+
+            Ok(TryDecodeStatus::RecentlyDecoded) | Ok(TryDecodeStatus::NeedsMoreSymbols) => {
+                Some(None)
+            }
+
+            Ok(TryDecodeStatus::Decoded {
+                author,
+                app_message,
+            }) => {
+                self.metrics.record_broadcast_latency(
+                    parsed_message.broadcast_mode,
+                    parsed_message.unix_ts_ms,
+                );
+
+                Some(Some((author, app_message)))
+            }
+        }
+    }
+
     /// Given a RecvUdpMsg, emits all decoded messages while rebroadcasting as necessary
     #[tracing::instrument(level = "debug", name = "udp_handle_message", skip_all)]
     pub fn handle_message(
         &mut self,
-        group_map: &ReBroadcastGroupMap<CertificateSignaturePubKey<ST>>,
         epoch_validators: &BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
+        full_node_group_map: &FullNodeGroupMap<CertificateSignaturePubKey<ST>>,
         rebroadcast: impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>, Bytes, u16),
         message: crate::auth::AuthRecvMsg<CertificateSignaturePubKey<ST>>,
     ) -> Vec<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
-        let self_id = self.self_id;
-        let self_hash = compute_hash(&self_id);
-
         let mut broadcast_batcher =
-            BroadcastBatcher::new(self_id, rebroadcast, &message.payload, message.stride);
+            BroadcastBatcher::new(self.self_id, rebroadcast, &message.payload, message.stride);
 
         let mut messages = Vec::new(); // The return result; decoded messages
 
@@ -175,20 +310,23 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
             let payload = message.payload.slice(payload_start_idx..payload_end_idx);
 
             // "message" here means a raptor-casted chunk (AKA r10 symbol), not the whole final message (proposal)
+            let bypass_rate_limiter = |epoch: Epoch| {
+                // validator senders are allowed to bypass signature
+                // verification rate limiting
+                message.auth_public_key.as_ref().is_some_and(|pk| {
+                    let node_id = NodeId::new(*pk);
+                    epoch_validators
+                        .get(&epoch)
+                        .iter()
+                        .any(|ev| ev.is_member(&node_id))
+                })
+            };
+
             let parsed_message = match parse_message(
                 &mut self.signature_verifier,
                 payload,
                 self.max_age_ms,
-                |epoch: Epoch| {
-                    // validator senders are allowed to bypass rate limiting
-                    message.auth_public_key.as_ref().is_some_and(|pk| {
-                        let node_id = NodeId::new(*pk);
-                        epoch_validators
-                            .get(&epoch)
-                            .iter()
-                            .any(|ev| ev.is_member(&node_id))
-                    })
-                },
+                bypass_rate_limiter,
             ) {
                 Ok(message) => message,
                 Err(MessageValidationError::RateLimited) => {
@@ -231,27 +369,6 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
                 continue;
             }
 
-            // Note: The check that parsed_message.author is valid is already
-            // done in iterate_rebroadcast_peers(), but we want to drop invalid
-            // chunks ASAP, before changing `recently_decoded_state`.
-            if !matches!(parsed_message.broadcast_mode, BroadcastMode::Unspecified) {
-                if !group_map.check_source(
-                    parsed_message.group_id,
-                    &parsed_message.author,
-                    &message.src_addr,
-                ) {
-                    continue;
-                }
-            } else if self_hash != parsed_message.recipient_hash {
-                tracing::debug!(
-                    src_addr = ?message.src_addr,
-                    ?self_hash,
-                    recipient_hash =? parsed_message.recipient_hash,
-                    "dropping spoofed message"
-                );
-                continue;
-            }
-
             tracing::trace!(
                 src_addr = ?message.src_addr,
                 app_message_len = ?parsed_message.app_message_len,
@@ -263,82 +380,30 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
                 "received encoded symbol"
             );
 
-            let mut try_rebroadcast_symbol = || {
-                // rebroadcast raptorcast chunks if broadcast mode is set and
-                // we're the assigned rebroadcaster
-                if !matches!(parsed_message.broadcast_mode, BroadcastMode::Unspecified)
-                    && self_hash == parsed_message.recipient_hash
-                {
-                    let maybe_targets = group_map
-                        .iterate_rebroadcast_peers(parsed_message.group_id, &parsed_message.author);
-                    if let Some(targets) = maybe_targets {
+            let maybe_decoded_message = match parsed_message.broadcast_mode {
+                BroadcastMode::Unspecified => self.handle_unicast(
+                    epoch_validators,
+                    &parsed_message,
+                    message.auth_public_key.as_ref(),
+                ),
+                BroadcastMode::Primary | BroadcastMode::Secondary => self.handle_broadcast(
+                    epoch_validators,
+                    full_node_group_map,
+                    &parsed_message,
+                    &mut |targets| {
                         batch_guard.queue_broadcast(
                             payload_start_idx,
                             payload_end_idx,
                             &parsed_message.author,
-                            || targets.cloned().collect(),
+                            || targets,
                         )
-                    }
-                }
+                    },
+                    message.auth_public_key.as_ref(),
+                ),
             };
 
-            let validator_set = match parsed_message.group_id {
-                GroupId::Primary(epoch) => epoch_validators.get(&epoch),
-                GroupId::Secondary(_round) => None,
-            };
-
-            let decoding_context = DecodingContext::new(validator_set, unix_ts_ms_now());
-
-            match self
-                .decoder_cache
-                .try_decode(&parsed_message, &decoding_context)
-            {
-                Err(TryDecodeError::InvalidSymbol(err)) => {
-                    err.log(&parsed_message, &self.self_id);
-                }
-
-                Err(TryDecodeError::UnableToReconstructSourceData) => {
-                    tracing::error!("failed to reconstruct source data");
-                }
-
-                Err(TryDecodeError::AppMessageHashMismatch { expected, actual }) => {
-                    tracing::error!(
-                        ?self_id,
-                        author =? parsed_message.author,
-                        ?expected,
-                        ?actual,
-                        "mismatch message hash"
-                    );
-                }
-
-                Ok(TryDecodeStatus::RejectedByCache) => {
-                    tracing::warn!(
-                        ?self_id,
-                        author =? parsed_message.author,
-                        chunk_id = parsed_message.chunk_id,
-                        "message rejected by cache, author may be flooding messages",
-                    );
-                }
-
-                Ok(TryDecodeStatus::RecentlyDecoded) | Ok(TryDecodeStatus::NeedsMoreSymbols) => {
-                    // TODO: cap rebroadcast symbols based on some multiple of esis.
-                    try_rebroadcast_symbol();
-                }
-
-                Ok(TryDecodeStatus::Decoded {
-                    author,
-                    app_message,
-                }) => {
-                    // TODO: cap rebroadcast symbols based on some multiple of esis.
-                    try_rebroadcast_symbol();
-
-                    self.metrics.record_broadcast_latency(
-                        parsed_message.broadcast_mode,
-                        parsed_message.unix_ts_ms,
-                    );
-
-                    messages.push((author, app_message));
-                }
+            if let Some((author, decoded_message)) = maybe_decoded_message {
+                messages.push((author, decoded_message))
             }
         }
 
@@ -614,7 +679,7 @@ mod tests {
         packet::{MessageBuilder, PacketLayout},
         parser::signature_verifier::SignatureVerifier,
         udp::{build_messages, parse_message, MAX_VALIDATOR_SET_SIZE, SIGNATURE_CACHE_SIZE},
-        util::{BroadcastMode, BuildTarget, ReBroadcastGroupMap, Redundancy, SecondaryGroup},
+        util::{BroadcastMode, BuildTarget, FullNodeGroupMap, Redundancy, SecondaryGroup},
     };
 
     type SignatureType = SecpSignature;
@@ -910,14 +975,8 @@ mod tests {
     fn test_handle_message_stride_slice() {
         let (key, validators, _known_addresses) = validator_set();
         let self_id = NodeId::new(key.pubkey());
-        let mut group_map = ReBroadcastGroupMap::new(self_id);
-        let node_stake_pairs: Vec<_> = validators
-            .get_members()
-            .iter()
-            .map(|(node_id, stake)| (*node_id, *stake))
-            .collect();
-        group_map.push_group_validator_set(node_stake_pairs, Epoch(1));
-        let validator_set = [(Epoch(1), validators)].into_iter().collect();
+        let epoch_validators = [(Epoch(1), validators)].into_iter().collect();
+        let full_node_groups = FullNodeGroupMap::default();
 
         let mut udp_state = UdpState::<SignatureType>::new(self_id, u64::MAX, 10_000);
 
@@ -931,8 +990,8 @@ mod tests {
         };
 
         udp_state.handle_message(
-            &group_map,
-            &validator_set,
+            &epoch_validators,
+            &full_node_groups,
             |_targets, _payload, _stride| {},
             recv_msg,
         );

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -15,54 +15,25 @@
 
 use std::{
     cell::OnceCell,
-    cmp::Ordering,
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
     fmt,
     net::SocketAddr,
     num::NonZero,
+    ops::Range,
     rc::Rc,
 };
 
 use bytes::Bytes;
 use fixed::{types::extra::U11, FixedU16};
-use itertools::Itertools;
+use iset::IntervalMap;
 use monad_crypto::{
     certificate_signature::{CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey},
     hasher::{Hasher, HasherType},
 };
-use monad_types::{Epoch, NodeId, Round, RoundSpan, Stake};
+use monad_types::{Epoch, NodeId, Round, RoundSpan};
 use monad_validator::validator_set::{ValidatorSet, ValidatorSetType as _};
-use tracing::{debug, warn};
 
 use crate::udp::GroupId;
-
-// Invariance: The group must be non-empty.
-#[derive(Debug, Clone)]
-pub struct SecondaryGroup<PT: PubKey> {
-    full_nodes: BTreeSet<NodeId<PT>>,
-}
-
-impl<PT: PubKey> SecondaryGroup<PT> {
-    // SAFETY: The caller must ensure that full_nodes set is non-empty.
-    pub fn new_unchecked(full_nodes: BTreeSet<NodeId<PT>>) -> Self {
-        Self { full_nodes }
-    }
-
-    pub fn new(full_nodes: BTreeSet<NodeId<PT>>) -> Option<Self> {
-        if full_nodes.is_empty() {
-            return None;
-        }
-        Some(Self { full_nodes })
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = &NodeId<PT>> + '_ {
-        self.full_nodes.iter()
-    }
-
-    pub fn len(&self) -> NonZero<usize> {
-        NonZero::new(self.full_nodes.len()).unwrap()
-    }
-}
 
 // Argument for raptorcast send
 #[derive(Debug, Clone, Copy)]
@@ -138,409 +109,349 @@ pub enum BroadcastMode {
     Unspecified,
 }
 
-// This represents a raptorcast group abstracted over the use cases below:
-// 1) Validator->Validator raptorcast recv & re-broadcast
-// 2) Validator->FullNode raptorcast recv & re-broadcast
-// 3) Validator->FullNode raptorcast send (when initiating proposals)
-// Validator->Validator send group is presented by EpochValidators instead, as
-// that contains stake info per validator.
-#[derive(Clone, PartialEq, Eq)] // For some reason Default doesn't work
-pub struct Group<PT: PubKey> {
-    // The node_id of the validator publishing to full-nodes.
-    validator_id: Option<NodeId<PT>>,
+// Invariance: The group must be non-empty.
+#[derive(Debug, Clone)]
+pub struct SecondaryGroup<PT: PubKey> {
+    full_nodes: BTreeSet<NodeId<PT>>,
+}
+
+impl<PT: PubKey> SecondaryGroup<PT> {
+    // SAFETY: The caller must ensure that full_nodes set is non-empty.
+    pub fn new_unchecked(full_nodes: BTreeSet<NodeId<PT>>) -> Self {
+        Self { full_nodes }
+    }
+
+    pub fn new(full_nodes: BTreeSet<NodeId<PT>>) -> Option<Self> {
+        if full_nodes.is_empty() {
+            return None;
+        }
+        Some(Self { full_nodes })
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &NodeId<PT>> + '_ {
+        self.full_nodes.iter()
+    }
+
+    pub fn len(&self) -> NonZero<usize> {
+        NonZero::new(self.full_nodes.len()).unwrap()
+    }
+
+    pub fn is_member(&self, node_id: &NodeId<PT>) -> bool {
+        self.full_nodes.contains(node_id)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SecondaryGroupAssignment<PT: PubKey> {
+    publisher_id: NodeId<PT>,
     round_span: RoundSpan,
-    sorted_other_peers: Vec<NodeId<PT>>, // Excludes self
+    group: SecondaryGroup<PT>,
 }
 
-// Keyed by starting round
-type GroupQueue<PT> = BTreeMap<Round, Group<PT>>;
-
-// Groups in a GroupQueue should be sorted by start round, earliest round first
-impl<PT: PubKey> Ord for Group<PT> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        // Compare fields other than round_span.start as well, to make the
-        // ordering more consistent and predictable
-        other
-            .round_span
-            .start
-            .cmp(&self.round_span.start)
-            .then_with(|| other.round_span.end.cmp(&self.round_span.end))
-            .then_with(|| other.validator_id.cmp(&self.validator_id))
-    }
-}
-
-impl<PT: PubKey> PartialOrd for Group<PT> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<PT: PubKey> fmt::Debug for Group<PT> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("Group")
-            .field("start", &self.round_span.start.0)
-            .field("end", &self.round_span.end.0)
-            .field("other_peers", &self.sorted_other_peers.len())
-            .finish()
-    }
-}
-
-impl<PT: PubKey> Group<PT> {
-    // For the use case where we re-raptorcast to validators
-    pub fn new_validator_group(all_peers: Vec<NodeId<PT>>, self_id: &NodeId<PT>) -> Self {
-        // We will call `check_author_node_id()` often, so sorting here will
-        // allow us to use binary search instead of linear search.
-        let sorted_other_peers: Vec<_> = all_peers
-            .into_iter()
-            .filter(|peer| peer != self_id)
-            .sorted()
-            .collect();
+impl<PT: PubKey> SecondaryGroupAssignment<PT> {
+    pub fn new(publisher_id: NodeId<PT>, round_span: RoundSpan, group: SecondaryGroup<PT>) -> Self {
         Self {
-            validator_id: None,
-            round_span: RoundSpan::empty(Round::MIN), // unused for validator group
-            sorted_other_peers,
-        }
-    }
-
-    // For the use case where we re-raptorcast to full-nodes
-    // Validators Raptorcasting to full-nodes should set `self_id` == `validator_id`
-    // Note that the user is responsible for checking that self_id exists in `all_peers`.
-    // This is specially important when a client receives a `ConfirmGroup`
-    // message over the network from a (rogue?) validator.
-    pub fn new_fullnode_group(
-        all_peers: Vec<NodeId<PT>>,
-        self_id: &NodeId<PT>,
-        validator_id: NodeId<PT>,
-        round_span: RoundSpan,
-    ) -> Self {
-        // We will call `check_author_node_id()` often, so sorting here will
-        // allow us to use binary search instead of linear search.
-        let mut sorted_other_peers = all_peers;
-        if self_id != &validator_id {
-            // The validator won't find its own nodeid among the peers
-            // Swap self_id in `all_peers` with the last element, then pop.
-            let self_index = sorted_other_peers
-                .iter()
-                .position(|peer| peer == self_id)
-                .expect(
-                    "Could not find own node id when instantiating a \
-                        Raptorcast group for full-nodes",
-                );
-            sorted_other_peers.swap_remove(self_index);
-        }
-        sorted_other_peers.sort(); // Groups recv over network are already sorted, though
-        Self {
-            validator_id: Some(validator_id),
+            publisher_id,
             round_span,
-            sorted_other_peers,
+            group,
         }
     }
 
-    // For bandwidth calculation and for calculating number of packets when
-    // originator segments app messages into raptorcast chunks.
-    pub fn size_excl_self(&self) -> usize {
-        self.sorted_other_peers.len()
+    pub fn group(&self) -> &SecondaryGroup<PT> {
+        &self.group
     }
 
-    pub fn get_validator_id(&self) -> &NodeId<PT> {
-        // Only set when re-raptorcasting to full-nodes
-        self.validator_id.as_ref().expect("Validator ID is not set")
+    pub fn is_member(&self, node_id: &NodeId<PT>) -> bool {
+        self.group.is_member(node_id)
     }
 
-    pub fn iter_peers(&self) -> impl Iterator<Item = &NodeId<PT>> + '_ {
-        self.sorted_other_peers.iter()
+    pub fn publisher_id(&self) -> &NodeId<PT> {
+        &self.publisher_id
     }
 
-    #[cfg(test)]
-    pub fn get_other_peers(&self) -> &Vec<NodeId<PT>> {
-        &self.sorted_other_peers
-    }
-
-    pub fn get_round_span(&self) -> &RoundSpan {
+    pub fn round_span(&self) -> &RoundSpan {
         &self.round_span
     }
+}
 
-    fn empty_iterator(&self) -> GroupIterator<'_, PT> {
-        GroupIterator {
-            group: self,
-            num_consumed: usize::MAX,
-            author_id_ix: usize::MAX,
-            start_ix: 0,
-        }
-    }
+// An interval map from RoundSpan to SecondaryGroup.
+//
+// Invariance: Each group's round span must be non-overlapping.
+pub struct SecondaryGroupMap<PT: PubKey> {
+    group_map: IntervalMap<Round, SecondaryGroup<PT>>,
+}
 
-    // Returns a safe iterator suitable for (re-) raptorcasting to full-nodes.
-    // Argument `seed` is used for avoiding always assigning chunks for small
-    // proposals to the same node.
-    // The iteration will start from index `seed % self.sorted_other_peers.len()`.
-    // Yields NodeIds.
-    pub fn iter_skip_self_and_author(
-        &self,
-        author_id: &NodeId<PT>,
-        seed: usize,
-    ) -> GroupIterator<'_, PT> {
-        // Hint for the index of author_id within self.sorted_other_peers.
-        // We want to skip it when iterating the peers for broadcasting.
-        let author_id_ix = if let Some(root_vid) = self.validator_id {
-            // Case for full-node raptorcasting. Lets check that the author_id
-            // (in the inbound message) is the same as expected for this group.
-            // Note that AuthorID is a validator and we will not find it among
-            // the full-node ids in the group.
-            if author_id != &root_vid {
-                warn!(
-                    "Author {} does not match raptorcast group validator id {}",
-                    author_id, root_vid
-                );
-                return self.empty_iterator();
-            }
-            usize::MAX
-        } else {
-            // Case for validator-to-validator raptorcasting.
-            // We are a validator and we are re-raptorcasting to full-nodes.
-            // We do a scan for author ID upfront because we don't want to yield
-            // any nodeID before we know for sure the author_id is among them.
-            let maybe_pos_author_id = self.sorted_other_peers.binary_search(author_id);
-            if maybe_pos_author_id.is_err() {
-                warn!("Author {} is not a member of raptorcast group", author_id);
-                return self.empty_iterator();
-            }
-            maybe_pos_author_id.unwrap()
-        };
-        // Avoid div by zero and also overflow when adding `num_consumed` later`
-        let start_ix = if self.sorted_other_peers.is_empty() {
-            0
-        } else {
-            seed % self.sorted_other_peers.len()
-        };
-        GroupIterator {
-            group: self,
-            num_consumed: 0,
-            author_id_ix,
-            start_ix,
-        }
-    }
-
-    // There are cases where we need to check that the source node is valid
-    // before we get to call iter_skip_self_and_author()
-    pub fn check_author_node_id(&self, author_id: &NodeId<PT>) -> bool {
-        if let Some(root_vid) = self.validator_id {
-            // Case for full-node raptorcasting
-            let good = &root_vid == author_id;
-            if !good {
-                debug!(?author_id, ?root_vid, "check_author_node_id (fn) failed");
-            }
-            good
-        } else {
-            // Case for validator-to-validator
-            let good = self.sorted_other_peers.binary_search(author_id).is_ok();
-            if !good {
-                debug!(?author_id, ?self.sorted_other_peers, "check_author_node_id (v2v) failed");
-            }
-            good
+impl<PT: PubKey> Default for SecondaryGroupMap<PT> {
+    fn default() -> Self {
+        Self {
+            group_map: IntervalMap::new(),
         }
     }
 }
 
-// The responsibility of this class is to simply skip self and author node_id
-// without copying or rebuilding vectors.
-// Intended to be used in the recv leg of re-raptorcasting to validators, or for
-// both the recv & send leg of (re-) raptorcasting to fullnodes, as these do
-// not need Stake information for each validator.
-pub struct GroupIterator<'a, PT: PubKey> {
-    group: &'a Group<PT>,
-    num_consumed: usize,
-    author_id_ix: usize,
-    start_ix: usize,
-}
+impl<PT: PubKey> SecondaryGroupMap<PT> {
+    pub fn get(&self, round: Round) -> Option<&SecondaryGroup<PT>> {
+        let mut iter = self.group_map.overlap(round);
+        let (_range, v) = iter.next()?;
+        Some(v)
+    }
 
-impl<'a, PT: PubKey> Iterator for GroupIterator<'a, PT> {
-    type Item = &'a NodeId<PT>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        while self.num_consumed < self.group.sorted_other_peers.len() {
-            let index = (self.num_consumed + self.start_ix) % self.group.sorted_other_peers.len();
-            self.num_consumed += 1;
-            if index != self.author_id_ix {
-                return Some(&self.group.sorted_other_peers[index]);
-            }
+    pub fn get_current_or_next(&self, round: Round) -> Option<&SecondaryGroup<PT>> {
+        if let Some(group) = self.get(round) {
+            return Some(group);
+        }
+        let (span, group) = self.group_map.smallest()?;
+        if round < span.start {
+            return Some(group);
         }
         None
     }
-}
 
-// This is an abstraction of a peer list that interfaces receive-side of RaptorCast
-// The send side, i.e. initiating a RaptorCast proposal, is represented with
-// struct `EpochValidators` instead.
-#[derive(Debug)]
-pub struct ReBroadcastGroupMap<PT: PubKey> {
-    // When iterating nodeIds in a raptorcast group, this node id is always skipped
-    our_node_id: NodeId<PT>,
-
-    // For Validator->validator re-raptorcasting
-    validator_map: BTreeMap<Epoch, Group<PT>>,
-
-    // For Validator->fullnode re-raptorcasting: each entry is keyed by
-    // validator NodeId. GroupQueue is a BTreeMap keyed by starting round
-    fullnode_map: BTreeMap<NodeId<PT>, GroupQueue<PT>>,
-}
-
-impl<PT: PubKey> ReBroadcastGroupMap<PT> {
-    pub fn new(our_node_id: NodeId<PT>) -> Self {
-        Self {
-            our_node_id,
-            validator_map: BTreeMap::new(),
-            fullnode_map: BTreeMap::new(),
-        }
-    }
-
-    // For UdpState::handle_message() so it can drop inbound messages early,
-    // before calling iterate_rebroadcast_peers().
-    pub fn check_source(
-        &self,
-        msg_group_id: GroupId,
-        author_node_id: &NodeId<PT>,
-        src_addr: &SocketAddr,
-    ) -> bool {
-        match msg_group_id {
-            GroupId::Primary(msg_epoch) => {
-                // validator to validator raptorcast
-                if let Some(group) = self.validator_map.get(&msg_epoch) {
-                    let author_found = group.check_author_node_id(author_node_id);
-                    if !author_found {
-                        debug!(?author_node_id, ?self.validator_map, ?src_addr,
-                            "Validator author for v2v group not found in validator_map");
-                    }
-                    author_found
-                } else {
-                    debug!(?msg_epoch, ?self.validator_map, "Epoch not found in validator_map");
-                    false
-                }
-            }
-            GroupId::Secondary(msg_round) => {
-                // Source node id (validator) is already the key to the map, so
-                // we don't need to look into the group itself.
-                if let Some(groups) = self.fullnode_map.get(author_node_id) {
-                    if let Some((_start_round, group)) = groups.range(..=msg_round).next_back() {
-                        if group.get_round_span().contains(msg_round) {
-                            return true;
-                        }
-                    }
-                    debug!(
-                        ?msg_round,
-                        ?author_node_id,
-                        ?self.fullnode_map,
-                        ?src_addr,
-                        "msg_round not found for validator's round span");
-                    // FIXME: returning true for backward compatibility,
-                    // to be removed after upgrade
-                    return true;
-                } else {
-                    debug!(?author_node_id, ?self.fullnode_map, ?src_addr,
-                        "Validator author for v2fn group not found in fullnode_map");
-                }
-                false
-            }
-        }
-    }
-
-    // Intended to be used by UdpState::handle_message()
-    // When receiving a raptorcast chunk, this method will help determine which
-    // peers (validators or full-nodes) to re-broadcast chunks to, given the
-    // inbound chunk's epoch field (for validator-to-validator raptorcasting)
-    // and author field (for validator-to-fullnodes raptorcasting)
-    pub fn iterate_rebroadcast_peers(
-        &self,
-        msg_group_id: GroupId,
-        msg_author: &NodeId<PT>, // skipped when iterating RaptorCast group
-    ) -> Option<GroupIterator<'_, PT>> {
-        let rebroadcast_group = match msg_group_id {
-            GroupId::Primary(msg_epoch) => self.validator_map.get(&msg_epoch)?,
-            GroupId::Secondary(msg_round) => {
-                let group_queue = self.fullnode_map.get(msg_author)?;
-
-                // FIXME: or_else defaults to the old behavior, which can be hit
-                // if full node is upgraded before the validator. It'll be
-                // removed after the upgrade
-                group_queue
-                    .range(..=msg_round)
-                    .next_back()
-                    .filter(|(_start_round, group)| group.get_round_span().contains(msg_round))
-                    .or_else(|| group_queue.first_key_value())
-                    .map(|(_key, group)| group)?
-            }
-        };
-
-        if rebroadcast_group.size_excl_self() == 0 {
-            // If there's no other peers in the group, then there's no one to broadcast to
+    #[must_use]
+    // the caller should check the return value to ensure the group is successfully inserted.
+    // returns None if there is an overlap with existing groups.
+    pub fn try_insert(&mut self, round_span: RoundSpan, group: SecondaryGroup<PT>) -> Option<()> {
+        let round_span: Range<_> = round_span.into();
+        if self.group_map.has_overlap(round_span.clone()) {
             return None;
         }
-
-        // this validates author
-        Some(rebroadcast_group.iter_skip_self_and_author(msg_author, 0))
+        self.group_map.insert(round_span, group);
+        Some(())
     }
 
-    // As Validator: When we get an AddEpochValidatorSet.
-    pub fn push_group_validator_set(
-        &mut self,
-        validator_set: Vec<(NodeId<PT>, Stake)>,
-        epoch: Epoch,
-    ) {
-        let (all_peers, _validator_stakes): (Vec<_>, Vec<_>) = validator_set.into_iter().unzip();
-        let new_group = Group::new_validator_group(all_peers, &self.our_node_id);
-        if let Some(existing_group) = self.validator_map.get(&epoch) {
-            assert_eq!(existing_group, &new_group);
-            warn!("duplicate validator set update (this is safe but unexpected)")
-        } else {
-            let replaced = self.validator_map.insert(epoch, new_group);
-            assert!(replaced.is_none());
-        }
-    }
-
-    // As Full-node: When secondary RaptorCast instance (Client) sends us a Group<>
-    pub fn push_group_fullnodes(&mut self, group: Group<PT>) {
-        let vid = *group.get_validator_id();
-        let prev_group_queue_from_vid = format!("{:?}", self.fullnode_map.get(&vid));
-        self.fullnode_map
-            .entry(vid)
-            .or_default()
-            .insert(group.round_span.start, group);
-        debug!(?vid, ?prev_group_queue_from_vid, "RaptorCast Group insert",);
-    }
-
-    pub fn delete_expired_groups(&mut self, curr_epoch: Epoch, curr_round: Round) {
-        // Keep current and future* groups.
-        // Note: normally the client will only send as groups that are
-        // currently active, but it is possible for the client to send us a
-        // group scheduled for the future when we (the non-dedicated full-node)
-        // aren't received proposals yet and hence do not know what the current
-        // round is.
-        for (_vid, group_queue) in self.fullnode_map.iter_mut() {
-            group_queue.retain(|_start_round, group| curr_round < group.round_span.end);
-        }
-        self.fullnode_map
-            .retain(|_vid, group_queue| !group_queue.is_empty());
-
-        // clear old validator map
-        self.validator_map
-            .retain(|key, _| *key + Epoch(1) >= curr_epoch);
-
-        debug!(
-            epoch=?curr_epoch,
-            round=?curr_round,
-            validator_map_len=?self.validator_map.len(),
-            fullnode_map_len=?self.fullnode_map.len(),
-            "RaptorCast delete_expired_groups",
-        );
-    }
-
-    pub fn get_fullnode_map(&self) -> BTreeMap<NodeId<PT>, Group<PT>> {
-        let mut res: BTreeMap<_, _> = BTreeMap::new();
-        for (vid, group_queue) in &self.fullnode_map {
-            if let Some((_start_round, group)) = group_queue.first_key_value() {
-                res.insert(*vid, group.clone());
+    // cull groups that ends before or at round_cap
+    pub fn delete_expired(&mut self, round_cap: Round) {
+        while let Some((range, _)) = self.group_map.smallest() {
+            if range.end <= round_cap {
+                self.group_map.remove(range);
+            } else {
+                break;
             }
         }
-        res
+    }
+
+    fn is_empty(&self) -> bool {
+        self.group_map.is_empty()
+    }
+}
+
+// The membership of a full node in multiple SecondaryGroupMaps, each
+// lead by a validator.
+pub struct FullNodeGroupMap<PT: PubKey> {
+    map: HashMap<NodeId<PT>, SecondaryGroupMap<PT>>,
+}
+
+impl<PT: PubKey> Default for FullNodeGroupMap<PT> {
+    fn default() -> Self {
+        Self {
+            map: Default::default(),
+        }
+    }
+}
+
+impl<PT: PubKey> FullNodeGroupMap<PT> {
+    pub fn get_group_map(&self, publisher_id: &NodeId<PT>) -> Option<&SecondaryGroupMap<PT>> {
+        self.map.get(publisher_id)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    #[must_use]
+    pub fn try_insert(&mut self, assignment: SecondaryGroupAssignment<PT>) -> Option<()> {
+        let group_map = self.map.entry(assignment.publisher_id).or_default();
+        group_map.try_insert(assignment.round_span, assignment.group)
+    }
+
+    // cull groups that ends before or at round_cap
+    pub fn delete_expired(&mut self, round_cap: Round) {
+        self.map.retain(|_publisher_id, group_map| {
+            group_map.delete_expired(round_cap);
+            !group_map.is_empty()
+        });
+    }
+}
+
+// This type is definitionally an alias of the epoch-validators
+// map. The semantic of ValidatorGroupMap restricted to the context a
+// usage as a group map.
+pub type ValidatorGroupMap<PT> = BTreeMap<Epoch, ValidatorSet<PT>>;
+
+#[derive(Debug)]
+pub enum BroadcastGroupError {
+    // The specified group_id does not correspond to any known group.
+    GroupNotFound,
+    // The author is not a member of the specified group.
+    InvalidAuthor,
+}
+
+pub struct PrimaryBroadcastGroup<'a, PT: PubKey> {
+    epoch: Epoch,
+    author: &'a NodeId<PT>,
+    group: &'a ValidatorSet<PT>,
+}
+
+impl<'a, PT: PubKey> PrimaryBroadcastGroup<'a, PT> {
+    pub fn of_epoch(
+        epoch: Epoch,
+        author: &'a NodeId<PT>,
+        validator_group_map: &'a ValidatorGroupMap<PT>,
+    ) -> Result<Self, BroadcastGroupError> {
+        let group = validator_group_map
+            .get(&epoch)
+            .ok_or(BroadcastGroupError::GroupNotFound)?;
+        if !group.is_member(author) {
+            return Err(BroadcastGroupError::InvalidAuthor);
+        }
+        Ok(Self {
+            epoch,
+            author,
+            group,
+        })
+    }
+
+    // For Primary RC, the sender can be any one of the validators.
+    pub fn is_sender_valid(&self, sender: &NodeId<PT>) -> bool {
+        self.group.is_member(sender)
+    }
+
+    pub fn try_rebroadcast(
+        &self,
+        self_id: &'a NodeId<PT>,
+        is_first_hop_recipient: bool,
+    ) -> Option<RebroadcastContext<'a, PT>> {
+        if !self.group.is_member(self_id) || !is_first_hop_recipient {
+            return None;
+        }
+        Some(RebroadcastContext {
+            members: Box::new(self.group.get_members().keys()),
+            excluded: [Some(self_id), Some(self.author)],
+        })
+    }
+}
+
+pub struct SecondaryBroadcastGroup<'a, PT: PubKey> {
+    round: Round,
+    publisher: &'a NodeId<PT>,
+    group: &'a SecondaryGroup<PT>,
+}
+
+impl<'a, PT: PubKey> SecondaryBroadcastGroup<'a, PT> {
+    pub fn of_round(
+        round: Round,
+        // The publisher is the author/signer of the raptorcast message.
+        publisher: &'a NodeId<PT>,
+        full_node_group_map: &'a FullNodeGroupMap<PT>,
+    ) -> Result<Self, BroadcastGroupError> {
+        let group = full_node_group_map
+            .get_group_map(publisher)
+            .ok_or(BroadcastGroupError::GroupNotFound)?
+            // FIXME: should use `get` method. `get_current_or_next`
+            // implements the old behavior, which can be hit if full node is
+            // upgraded before the validator. It'll be removed after the
+            // upgrade
+            .get_current_or_next(round)
+            .ok_or(BroadcastGroupError::GroupNotFound)?;
+        Ok(Self {
+            round,
+            publisher,
+            group,
+        })
+    }
+
+    // For Secondary RC, the sender must be either the
+    // publisher or someone in the group.
+    pub fn is_sender_valid(&self, sender: &NodeId<PT>) -> bool {
+        *sender == *self.publisher || self.group.is_member(sender)
+    }
+
+    pub fn try_rebroadcast(
+        &self,
+        self_id: &'a NodeId<PT>,
+        is_first_hop_recipient: bool,
+    ) -> Option<RebroadcastContext<'a, PT>> {
+        // Note: the publishing node is not expected to rebroadcast.
+        if !self.group.is_member(self_id) || !is_first_hop_recipient {
+            return None;
+        }
+        Some(RebroadcastContext {
+            members: Box::new(self.group.iter()),
+            excluded: [Some(self_id), None],
+        })
+    }
+}
+
+pub struct RebroadcastContext<'a, PT: PubKey> {
+    members: Box<dyn Iterator<Item = &'a NodeId<PT>> + 'a>,
+    excluded: [Option<&'a NodeId<PT>>; 2],
+}
+
+impl<'a, PT: PubKey> RebroadcastContext<'a, PT> {
+    pub fn peers(self) -> impl Iterator<Item = &'a NodeId<PT>> {
+        let excluded = self.excluded;
+        self.members
+            .filter(move |nid| !excluded.contains(&Some(*nid)))
+    }
+}
+
+pub enum BroadcastGroup<'a, PT: PubKey> {
+    Primary(PrimaryBroadcastGroup<'a, PT>),
+    Secondary(SecondaryBroadcastGroup<'a, PT>),
+}
+
+impl<'a, PT: PubKey> From<PrimaryBroadcastGroup<'a, PT>> for BroadcastGroup<'a, PT> {
+    fn from(group: PrimaryBroadcastGroup<'a, PT>) -> Self {
+        Self::Primary(group)
+    }
+}
+impl<'a, PT: PubKey> From<SecondaryBroadcastGroup<'a, PT>> for BroadcastGroup<'a, PT> {
+    fn from(group: SecondaryBroadcastGroup<'a, PT>) -> Self {
+        Self::Secondary(group)
+    }
+}
+
+impl<'a, PT: PubKey> BroadcastGroup<'a, PT> {
+    // Return a known valid group of the given group_id.
+    pub fn from_group_id(
+        group_id: GroupId,
+        // The signer of the raptorcast message, not necessarily the sender.
+        author: &'a NodeId<PT>,
+        validator_group_map: &'a ValidatorGroupMap<PT>,
+        full_node_group_map: &'a FullNodeGroupMap<PT>,
+    ) -> Result<Self, BroadcastGroupError> {
+        match group_id {
+            GroupId::Primary(epoch) => {
+                PrimaryBroadcastGroup::of_epoch(epoch, author, validator_group_map)
+                    .map(BroadcastGroup::Primary)
+            }
+            GroupId::Secondary(round) => {
+                SecondaryBroadcastGroup::of_round(round, author, full_node_group_map)
+                    .map(BroadcastGroup::Secondary)
+            }
+        }
+    }
+
+    pub fn is_sender_valid(&self, sender: &NodeId<PT>) -> bool {
+        match self {
+            BroadcastGroup::Primary(g) => g.is_sender_valid(sender),
+            BroadcastGroup::Secondary(g) => g.is_sender_valid(sender),
+        }
+    }
+
+    pub fn try_rebroadcast(
+        &self,
+        self_id: &'a NodeId<PT>,
+        is_first_hop_recipient: bool,
+    ) -> Option<RebroadcastContext<'a, PT>> {
+        match self {
+            BroadcastGroup::Primary(g) => g.try_rebroadcast(self_id, is_first_hop_recipient),
+            BroadcastGroup::Secondary(g) => g.try_rebroadcast(self_id, is_first_hop_recipient),
+        }
     }
 }
 
@@ -831,13 +742,14 @@ pub fn unix_ts_ms_now() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
     use monad_crypto::certificate_signature::CertificateSignaturePubKey;
     use monad_secp::SecpSignature;
     use monad_testutil::signing::get_key;
+    use monad_types::Stake;
+    use monad_validator::validator_set::ValidatorSet;
 
     use super::*;
+    use crate::udp::GroupId;
     type ST = SecpSignature;
     type PT = CertificateSignaturePubKey<ST>;
 
@@ -848,175 +760,10 @@ mod tests {
         NodeId::new(pub_key)
     }
 
-    #[test]
-    fn test_fullnode_iterator_self_on() {
-        let group = Group::<PT>::new_fullnode_group(
-            vec![nid(0), nid(1), nid(2)],
-            &nid(1), // self_id
-            nid(3),  // validator
-            RoundSpan::new(Round(3), Round(8)).unwrap(),
-        );
-        assert_eq!(group.size_excl_self(), 2);
-        assert_eq!(group.get_validator_id(), &nid(3));
-        assert_eq!(group.get_other_peers(), &vec![nid(0), nid(2)]);
-        assert_eq!(
-            group.get_round_span(),
-            &RoundSpan::new(Round(3), Round(8)).unwrap()
-        );
-        let empty_iter: Vec<_> = group.empty_iterator().collect();
-        assert!(empty_iter.is_empty());
-
-        let it: Vec<_> = group
-            .iter_skip_self_and_author(&nid(3), 0)
-            .cloned()
-            .collect();
-        assert_eq!(&it, &vec![nid(0), nid(2)]);
-
-        // Calling a second time should not change anything
-        let it: Vec<_> = group
-            .iter_skip_self_and_author(&nid(3), 0)
-            .cloned()
-            .collect();
-        assert_eq!(&it, &vec![nid(0), nid(2)]);
-
-        // Invalid author id: should return empty iterator
-        let it: Vec<_> = group
-            .iter_skip_self_and_author(&nid(5), 0)
-            .cloned()
-            .collect();
-        assert!(it.is_empty());
-    }
-
-    #[test]
-    fn test_fullnode_iterator_self_off() {
-        let group = Group::<PT>::new_fullnode_group(
-            vec![nid(0), nid(1), nid(2)],
-            &nid(3), // self_id
-            nid(3),  // validator id
-            RoundSpan::new(Round(3), Round(8)).unwrap(),
-        );
-        assert_eq!(group.size_excl_self(), 3);
-        assert_eq!(group.get_validator_id(), &nid(3));
-        assert_eq!(group.get_other_peers(), &vec![nid(0), nid(1), nid(2)]);
-        assert_eq!(
-            group.get_round_span(),
-            &RoundSpan::new(Round(3), Round(8)).unwrap()
-        );
-        let empty_iter: Vec<_> = group.empty_iterator().collect();
-        assert!(empty_iter.is_empty());
-
-        let it: Vec<_> = group
-            .iter_skip_self_and_author(&nid(3), 0)
-            .cloned()
-            .collect();
-        assert_eq!(&it, &vec![nid(0), nid(1), nid(2)]);
-
-        // Invalid author id: should return empty iterator
-        let it: Vec<_> = group
-            .iter_skip_self_and_author(&nid(5), 0)
-            .cloned()
-            .collect();
-        assert!(it.is_empty());
-    }
-
-    #[test]
-    fn test_fullnode_iterator_only_self() {
-        let group = Group::<PT>::new_fullnode_group(
-            vec![nid(1)],
-            &nid(1), // self_id
-            nid(3),  // validator id
-            RoundSpan::new(Round(3), Round(8)).unwrap(),
-        );
-        assert_eq!(group.size_excl_self(), 0);
-        assert_eq!(group.get_validator_id(), &nid(3));
-        assert_eq!(group.get_other_peers(), &vec![]);
-        assert_eq!(
-            group.get_round_span(),
-            &RoundSpan::new(Round(3), Round(8)).unwrap()
-        );
-        let empty_iter: Vec<_> = group.empty_iterator().collect();
-        assert!(empty_iter.is_empty());
-
-        let it: Vec<_> = group
-            .iter_skip_self_and_author(&nid(3), 0)
-            .cloned()
-            .collect();
-        assert!(it.is_empty());
-        // Invalid author id: should return empty iterator
-        let it: Vec<_> = group
-            .iter_skip_self_and_author(&nid(5), 0)
-            .cloned()
-            .collect();
-        assert!(it.is_empty());
-    }
-
-    #[test]
-    fn test_validator_iterator_self_on() {
-        let group = Group::<PT>::new_validator_group(
-            vec![nid(0), nid(1), nid(2)],
-            &nid(1), // self_id
-        );
-        assert_eq!(group.size_excl_self(), 2);
-        assert_eq!(group.get_other_peers(), &vec![nid(0), nid(2)]);
-        assert_eq!(group.get_round_span(), &RoundSpan::empty(Round::MIN));
-        let empty_iter: Vec<_> = group.empty_iterator().collect();
-        assert!(empty_iter.is_empty());
-
-        // Invalid author id: should return empty iterator
-        let it: Vec<_> = group
-            .iter_skip_self_and_author(&nid(5), 0)
-            .cloned()
-            .collect();
-        assert!(it.is_empty());
-
-        let it: Vec<_> = group
-            .iter_skip_self_and_author(&nid(2), 0)
-            .cloned()
-            .collect();
-        assert_eq!(&it, &vec![nid(0)]);
-    }
-
-    #[test]
-    fn test_iterator_rand() {
-        let group = Group::<PT>::new_fullnode_group(
-            vec![nid(0), nid(1), nid(2), nid(3), nid(4)],
-            &nid(0),  // self_id
-            nid(100), // validator id
-            RoundSpan::new(Round(3), Round(8)).unwrap(),
-        );
-
-        // Non-"randomized" iteration (but sorted)
-        let it: Vec<_> = group
-            .iter_skip_self_and_author(&nid(100), 0)
-            .cloned()
-            .collect();
-        let mut org_nodes = vec![nid(1), nid(2), nid(3), nid(4)];
-        org_nodes.sort();
-        assert_eq!(&it, &org_nodes);
-
-        // "Randomized" iterations
-        let mut permutations_seen = HashSet::<Vec<NodeId<PT>>>::new();
-        for seed in 1..10 {
-            let it: Vec<_> = group
-                .iter_skip_self_and_author(&nid(100), seed)
-                .cloned()
-                .collect();
-            permutations_seen.insert(it);
-        }
-
-        // Verify that we have seen a few permutations, ensuring that we won't
-        // always assign chunks for small proposals to the same node.
-        assert!(permutations_seen.len() >= 4);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_no_validator_id_in_validator_group() {
-        let group = Group::<PT>::new_validator_group(
-            vec![nid(0), nid(1), nid(2)],
-            &nid(1), // self_id
-        );
-        group.get_validator_id(); // should panic
+    fn make_validator_set(node_ids: &[NodeId<PT>]) -> ValidatorSet<PT> {
+        assert!(!node_ids.is_empty());
+        let members = node_ids.iter().map(|id| (*id, Stake::ONE)).collect();
+        ValidatorSet::new_unchecked(members)
     }
 
     #[test]
@@ -1084,5 +831,442 @@ mod tests {
 
         assert_eq!(lookup_fn.lookup(&node1), Some(addr));
         assert_eq!(lookup_fn.lookup(&node2), None);
+    }
+
+    #[test]
+    fn test_secondary_group() {
+        // membership check
+        let group = SecondaryGroup::new([nid(1), nid(2), nid(3)].into_iter().collect()).unwrap();
+        assert!(group.is_member(&nid(1)));
+        assert!(group.is_member(&nid(2)));
+        assert!(group.is_member(&nid(3)));
+        assert!(!group.is_member(&nid(4)));
+        assert_eq!(group.len().get(), 3);
+
+        // invariance
+        let group = SecondaryGroup::<PT>::new([].into_iter().collect());
+        assert!(group.is_none());
+    }
+
+    #[test]
+    fn test_secondary_group_assignment_accessors() {
+        let self_id = nid(1);
+        let publisher_id = nid(10);
+        let round_span = RoundSpan::new(Round(5), Round(10)).unwrap();
+        let group = SecondaryGroup::new([self_id, nid(2), nid(3)].into_iter().collect()).unwrap();
+        let assignment = SecondaryGroupAssignment::new(publisher_id, round_span, group);
+
+        assert_eq!(assignment.publisher_id(), &publisher_id);
+        assert_eq!(assignment.round_span(), &round_span);
+        assert!(assignment.is_member(&self_id));
+        assert!(assignment.is_member(&nid(2)));
+        assert!(!assignment.is_member(&nid(10))); // publisher not in group
+    }
+
+    #[test]
+    fn test_secondary_group_map_insert_and_get() {
+        let mut map = SecondaryGroupMap::<PT>::default();
+
+        let group1 = SecondaryGroup::new([nid(1), nid(2)].into_iter().collect()).unwrap();
+        let round_span1 = RoundSpan::new(Round(1), Round(5)).unwrap();
+
+        let group2 = SecondaryGroup::new([nid(3), nid(4)].into_iter().collect()).unwrap();
+        let round_span2 = RoundSpan::new(Round(10), Round(15)).unwrap();
+
+        assert!(map.try_insert(round_span1, group1).is_some());
+        assert!(map.try_insert(round_span2, group2).is_some());
+
+        // get group at round 3 (within [1, 5))
+        let grp = map.get(Round(3)).unwrap();
+        assert!(grp.is_member(&nid(1)));
+
+        // get group at round 12 (within [10, 15))
+        let grp = map.get(Round(12)).unwrap();
+        assert!(grp.is_member(&nid(3)));
+
+        // no group at round 7 (gap between groups)
+        assert!(map.get(Round(7)).is_none());
+    }
+
+    #[test]
+    fn test_secondary_group_map_overlap() {
+        let mut map = SecondaryGroupMap::<PT>::default();
+
+        let group1 = SecondaryGroup::new([nid(1), nid(2)].into_iter().collect()).unwrap();
+        let round_span1 = RoundSpan::new(Round(1), Round(10)).unwrap();
+
+        let group2 = SecondaryGroup::new([nid(3), nid(4)].into_iter().collect()).unwrap();
+        let round_span2 = RoundSpan::new(Round(5), Round(15)).unwrap(); // overlaps
+
+        assert!(map.try_insert(round_span1, group1).is_some());
+        assert!(map.try_insert(round_span2, group2).is_none()); // rejected
+    }
+
+    #[test]
+    fn test_secondary_group_map_delete_expired() {
+        let mut map = SecondaryGroupMap::<PT>::default();
+
+        let group1 = SecondaryGroup::new([nid(1)].into_iter().collect()).unwrap();
+        let round_span1 = RoundSpan::new(Round(1), Round(5)).unwrap();
+
+        let group2 = SecondaryGroup::new([nid(2)].into_iter().collect()).unwrap();
+        let round_span2 = RoundSpan::new(Round(5), Round(10)).unwrap();
+
+        let group3 = SecondaryGroup::new([nid(3)].into_iter().collect()).unwrap();
+        let round_span3 = RoundSpan::new(Round(10), Round(15)).unwrap();
+
+        assert!(map.try_insert(round_span1, group1).is_some());
+        assert!(map.try_insert(round_span2, group2).is_some());
+        assert!(map.try_insert(round_span3, group3).is_some());
+
+        // Delete groups ending at or before Round(5)
+        map.delete_expired(Round(5));
+
+        // group [1, 5) should be deleted
+        assert!(map.get(Round(3)).is_none());
+        // group [5, 10) should still exist
+        assert!(map.get(Round(7)).is_some());
+        // group [10, 15) should still exist
+        assert!(map.get(Round(12)).is_some());
+
+        // delete groups ending at or before Round(10)
+        map.delete_expired(Round(10));
+        assert!(map.get(Round(7)).is_none());
+        assert!(map.get(Round(12)).is_some());
+    }
+
+    #[test]
+    fn test_full_node_group_map_insert_and_get() {
+        let mut map = FullNodeGroupMap::<PT>::default();
+
+        let publisher1 = nid(100);
+        let publisher2 = nid(200);
+
+        let assignment1 = SecondaryGroupAssignment::new(
+            publisher1,
+            RoundSpan::new(Round(1), Round(5)).unwrap(),
+            SecondaryGroup::new([nid(1), nid(2)].into_iter().collect()).unwrap(),
+        );
+
+        let assignment2 = SecondaryGroupAssignment::new(
+            publisher2,
+            RoundSpan::new(Round(1), Round(5)).unwrap(),
+            SecondaryGroup::new([nid(3), nid(4)].into_iter().collect()).unwrap(),
+        );
+
+        assert!(map.try_insert(assignment1).is_some());
+        assert!(map.try_insert(assignment2).is_some());
+
+        assert_eq!(map.len(), 2);
+        assert!(!map.is_empty());
+
+        // get group map for publisher1
+        let group_map = map.get_group_map(&publisher1).unwrap();
+        let grp = group_map.get(Round(3)).unwrap();
+        assert!(grp.is_member(&nid(1)));
+
+        // get group map for publisher2
+        let group_map = map.get_group_map(&publisher2).unwrap();
+        let grp = group_map.get(Round(3)).unwrap();
+        assert!(grp.is_member(&nid(3)));
+
+        // unknown publisher returns None
+        assert!(map.get_group_map(&nid(999)).is_none());
+    }
+
+    #[test]
+    fn test_full_node_group_map_delete_expired() {
+        let mut map = FullNodeGroupMap::<PT>::default();
+
+        let publisher = nid(100);
+
+        let assignment1 = SecondaryGroupAssignment::new(
+            publisher,
+            RoundSpan::new(Round(1), Round(5)).unwrap(),
+            SecondaryGroup::new([nid(1)].into_iter().collect()).unwrap(),
+        );
+
+        let assignment2 = SecondaryGroupAssignment::new(
+            publisher,
+            RoundSpan::new(Round(10), Round(15)).unwrap(),
+            SecondaryGroup::new([nid(2)].into_iter().collect()).unwrap(),
+        );
+
+        assert!(map.try_insert(assignment1).is_some());
+        assert!(map.try_insert(assignment2).is_some());
+
+        // delete expired at Round(5)
+        map.delete_expired(Round(5));
+
+        let group_map = map.get_group_map(&publisher).unwrap();
+        assert!(group_map.get(Round(3)).is_none());
+        assert!(group_map.get(Round(12)).is_some());
+
+        // delete expired at Round(15) - remove entire publisher entry
+        map.delete_expired(Round(15));
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_broadcast_group_from_primary_group_id() {
+        let author = nid(2);
+        let validator_ids = [nid(1), nid(2), nid(3)];
+
+        let mut validator_group_map = ValidatorGroupMap::<PT>::new();
+        validator_group_map.insert(Epoch(1), make_validator_set(&validator_ids));
+        let full_node_group_map = FullNodeGroupMap::<PT>::default();
+
+        let group = BroadcastGroup::from_group_id(
+            GroupId::Primary(Epoch(1)),
+            &author,
+            &validator_group_map,
+            &full_node_group_map,
+        )
+        .unwrap();
+
+        assert!(matches!(group, BroadcastGroup::Primary(_)));
+    }
+
+    #[test]
+    fn test_broadcast_group_from_primary_group_not_found() {
+        let author = nid(2);
+
+        let validator_group_map = ValidatorGroupMap::<PT>::new();
+        let full_node_group_map = FullNodeGroupMap::<PT>::default();
+
+        // Epoch not found
+        let result = BroadcastGroup::from_group_id(
+            GroupId::Primary(Epoch(99)),
+            &author,
+            &validator_group_map,
+            &full_node_group_map,
+        );
+
+        assert!(matches!(result, Err(BroadcastGroupError::GroupNotFound)));
+    }
+
+    #[test]
+    fn test_broadcast_group_from_primary_invalid_author() {
+        let author = nid(99); // not in validator set
+        let validator_ids = [nid(1), nid(2), nid(3)];
+
+        let mut validator_group_map = ValidatorGroupMap::<PT>::new();
+        validator_group_map.insert(Epoch(1), make_validator_set(&validator_ids));
+
+        let full_node_group_map = FullNodeGroupMap::<PT>::default();
+
+        let result = BroadcastGroup::from_group_id(
+            GroupId::Primary(Epoch(1)),
+            &author,
+            &validator_group_map,
+            &full_node_group_map,
+        );
+
+        assert!(matches!(result, Err(BroadcastGroupError::InvalidAuthor)));
+    }
+
+    #[test]
+    fn test_broadcast_group_from_secondary_group_id() {
+        let self_id = nid(1);
+        let publisher = nid(100);
+
+        let validator_group_map = ValidatorGroupMap::<PT>::new();
+        let mut full_node_group_map = FullNodeGroupMap::<PT>::default();
+
+        let assignment = SecondaryGroupAssignment::new(
+            publisher,
+            RoundSpan::new(Round(1), Round(10)).unwrap(),
+            SecondaryGroup::new([self_id, nid(2), nid(3)].into_iter().collect()).unwrap(),
+        );
+        full_node_group_map
+            .try_insert(assignment)
+            .expect("no overlaps");
+
+        // Valid secondary group lookup
+        let group = BroadcastGroup::from_group_id(
+            GroupId::Secondary(Round(5)),
+            &publisher, // author is publisher for secondary
+            &validator_group_map,
+            &full_node_group_map,
+        )
+        .unwrap();
+
+        assert!(matches!(group, BroadcastGroup::Secondary(_)));
+    }
+
+    #[test]
+    fn test_broadcast_group_from_secondary_publisher_not_found() {
+        let unknown_publisher = nid(999);
+
+        let validator_group_map = ValidatorGroupMap::<PT>::new();
+        let full_node_group_map = FullNodeGroupMap::<PT>::default();
+
+        let result = BroadcastGroup::from_group_id(
+            GroupId::Secondary(Round(5)),
+            &unknown_publisher,
+            &validator_group_map,
+            &full_node_group_map,
+        );
+
+        assert!(matches!(result, Err(BroadcastGroupError::GroupNotFound)));
+    }
+
+    #[test]
+    fn test_broadcast_group_from_secondary_round_not_found() {
+        let self_id = nid(1);
+        let publisher = nid(100);
+
+        let validator_group_map = ValidatorGroupMap::<PT>::new();
+        let mut full_node_group_map = FullNodeGroupMap::<PT>::default();
+
+        let assignment = SecondaryGroupAssignment::new(
+            publisher,
+            RoundSpan::new(Round(1), Round(10)).unwrap(),
+            SecondaryGroup::new([self_id, nid(2)].into_iter().collect()).unwrap(),
+        );
+        full_node_group_map
+            .try_insert(assignment)
+            .expect("no overlaps");
+
+        // Round 50 is outside [1, 10)
+        let result = BroadcastGroup::from_group_id(
+            GroupId::Secondary(Round(50)),
+            &publisher,
+            &validator_group_map,
+            &full_node_group_map,
+        );
+
+        assert!(matches!(result, Err(BroadcastGroupError::GroupNotFound)));
+    }
+
+    #[test]
+    fn test_broadcast_group_is_sender_valid_validator() {
+        let author = nid(2);
+        let validator_ids = [nid(1), nid(2), nid(3)];
+
+        let mut validator_group_map = ValidatorGroupMap::<PT>::new();
+        validator_group_map.insert(Epoch(1), make_validator_set(&validator_ids));
+
+        let full_node_group_map = FullNodeGroupMap::<PT>::default();
+
+        let group = BroadcastGroup::from_group_id(
+            GroupId::Primary(Epoch(1)),
+            &author,
+            &validator_group_map,
+            &full_node_group_map,
+        )
+        .unwrap();
+
+        // Any validator is a valid sender
+        assert!(group.is_sender_valid(&nid(1)));
+        assert!(group.is_sender_valid(&nid(2)));
+        assert!(group.is_sender_valid(&nid(3)));
+        // Non-validator is not a valid sender
+        assert!(!group.is_sender_valid(&nid(99)));
+    }
+
+    #[test]
+    fn test_broadcast_group_is_sender_valid_fullnode() {
+        let self_id = nid(1);
+        let publisher = nid(100);
+
+        let validator_group_map = ValidatorGroupMap::<PT>::new();
+        let mut full_node_group_map = FullNodeGroupMap::<PT>::default();
+
+        let assignment = SecondaryGroupAssignment::new(
+            publisher,
+            RoundSpan::new(Round(1), Round(10)).unwrap(),
+            SecondaryGroup::new([self_id, nid(2), nid(3)].into_iter().collect()).unwrap(),
+        );
+        full_node_group_map
+            .try_insert(assignment)
+            .expect("no overlaps");
+
+        let group = BroadcastGroup::from_group_id(
+            GroupId::Secondary(Round(5)),
+            &publisher,
+            &validator_group_map,
+            &full_node_group_map,
+        )
+        .unwrap();
+
+        // Publisher is valid sender
+        assert!(group.is_sender_valid(&publisher));
+        // Group members are valid senders
+        assert!(group.is_sender_valid(&self_id));
+        assert!(group.is_sender_valid(&nid(2)));
+        assert!(group.is_sender_valid(&nid(3)));
+        // Non-member, non-publisher is not valid
+        assert!(!group.is_sender_valid(&nid(99)));
+    }
+
+    #[test]
+    fn test_try_rebroadcast_primary() {
+        let self_id = nid(1);
+        let author = nid(2);
+        let validator_ids = [nid(1), nid(2), nid(3), nid(4)];
+
+        let mut validator_group_map = ValidatorGroupMap::<PT>::new();
+        validator_group_map.insert(Epoch(1), make_validator_set(&validator_ids));
+
+        let full_node_group_map = FullNodeGroupMap::<PT>::default();
+
+        let group = BroadcastGroup::from_group_id(
+            GroupId::Primary(Epoch(1)),
+            &author,
+            &validator_group_map,
+            &full_node_group_map,
+        )
+        .unwrap();
+
+        // member + first hop -> rebroadcast
+        let ctx = group.try_rebroadcast(&self_id, true);
+        assert!(ctx.is_some());
+        let peers: Vec<_> = ctx.unwrap().peers().cloned().collect();
+        // Should exclude self_id (nid(1)) and author (nid(2))
+        assert_eq!(peers.len(), 2);
+        assert!(peers.contains(&nid(3)));
+        assert!(peers.contains(&nid(4)));
+
+        // member + not first hop -> no rebroadcast
+        assert!(group.try_rebroadcast(&self_id, false).is_none());
+
+        // non-member -> no rebroadcast
+        let non_member = nid(99);
+        assert!(group.try_rebroadcast(&non_member, true).is_none());
+    }
+
+    #[test]
+    fn test_try_rebroadcast_secondary() {
+        let self_id = nid(1);
+        let publisher = nid(100);
+
+        let validator_group_map = ValidatorGroupMap::<PT>::new();
+        let mut full_node_group_map = FullNodeGroupMap::<PT>::default();
+
+        let assignment = SecondaryGroupAssignment::new(
+            publisher,
+            RoundSpan::new(Round(1), Round(10)).unwrap(),
+            SecondaryGroup::new([self_id, nid(2), nid(3)].into_iter().collect()).unwrap(),
+        );
+        full_node_group_map
+            .try_insert(assignment)
+            .expect("no overlaps");
+
+        let group = BroadcastGroup::from_group_id(
+            GroupId::Secondary(Round(5)),
+            &publisher,
+            &validator_group_map,
+            &full_node_group_map,
+        )
+        .unwrap();
+
+        let ctx = group.try_rebroadcast(&self_id, true);
+        assert!(ctx.is_some());
+        let peers: Vec<_> = ctx.unwrap().peers().cloned().collect();
+        // Should exclude self_id (nid(1)), publisher is not in group
+        assert_eq!(peers.len(), 2);
+        assert!(peers.contains(&nid(2)));
+        assert!(peers.contains(&nid(3)));
     }
 }

--- a/monad-raptorcast/tests/raptorcast_instance.rs
+++ b/monad-raptorcast/tests/raptorcast_instance.rs
@@ -41,7 +41,7 @@ use monad_raptorcast::{
         SecondaryRaptorCastModeConfig,
     },
     udp::{GroupId, MAX_REDUNDANCY},
-    util::{BuildTarget, Group, Redundancy},
+    util::{BuildTarget, Redundancy, SecondaryGroup, SecondaryGroupAssignment},
     DataplaneHandles, RaptorCast, RaptorCastEvent,
 };
 use monad_secp::{KeyPair, SecpSignature};
@@ -576,7 +576,8 @@ async fn delete_expired_groups() {
 
     // setup
     let (send_group_messages, _) = unbounded_channel::<FullNodesGroupMessage<SignatureType>>();
-    let (send_group_infos, recv_group_infos) = unbounded_channel::<Group<PubKeyType>>();
+    let (send_group_infos, recv_group_infos) =
+        unbounded_channel::<SecondaryGroupAssignment<PubKeyType>>();
     let (_, recv_outbound_from_secondary) =
         unbounded_channel::<SecondaryOutboundMessage<PubKeyType>>();
     raptorcast.bind_channel_to_secondary_raptorcast(
@@ -587,16 +588,10 @@ async fn delete_expired_groups() {
     );
 
     // populate raptorcast group
-    let group = Group::new_fullnode_group(
-        vec![],
-        &node_id,
-        node_id,
-        RoundSpan {
-            start: Round(1),
-            end: Round(10),
-        },
-    );
-    send_group_infos.send(group).unwrap();
+    let round_span = RoundSpan::new(Round(1), Round(10)).unwrap();
+    let group = SecondaryGroup::new([node_id].into_iter().collect()).unwrap();
+    let assignment = SecondaryGroupAssignment::new(node_id, round_span, group);
+    send_group_infos.send(assignment).unwrap();
 
     loop {
         tokio::select! {
@@ -606,19 +601,22 @@ async fn delete_expired_groups() {
         }
     }
 
-    let rebroadcast_map = raptorcast.get_rebroadcast_groups().get_fullnode_map();
+    let full_node_groups = raptorcast.get_full_node_groups();
     assert_eq!(
-        rebroadcast_map.len(),
+        full_node_groups.len(),
         1,
-        "Expected one group in rebroadcast map"
+        "Expected one group in full node groups"
     );
 
     // round increment beyond group end round
     raptorcast.exec(vec![RouterCommand::UpdateCurrentRound(Epoch(1), Round(11))]);
-    let rebroadcast_map = raptorcast.get_rebroadcast_groups().get_fullnode_map();
+    let full_node_groups = raptorcast.get_full_node_groups();
 
     // expired group should be deleted
-    assert!(rebroadcast_map.is_empty(), "Expected empty rebroadcast map");
+    assert!(
+        full_node_groups.is_empty(),
+        "Expected empty full node groups"
+    );
 }
 
 #[tokio::test]

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -45,7 +45,7 @@ use monad_raptorcast::{
         group_message::FullNodesGroupMessage, RaptorCastSecondary, SecondaryOutboundMessage,
         SecondaryRaptorCastModeConfig,
     },
-    util::Group,
+    util::SecondaryGroupAssignment,
     RaptorCast, RaptorCastEvent,
 };
 use monad_types::{Epoch, NodeId};
@@ -119,7 +119,7 @@ where
             unbounded_channel::<FullNodesGroupMessage<ST>>();
         // Channel for secondary raptorcast to send group infos for primary raptorcast to update its broadcasting state
         let (send_group_infos, recv_group_infos) =
-            unbounded_channel::<Group<CertificateSignaturePubKey<ST>>>();
+            unbounded_channel::<SecondaryGroupAssignment<CertificateSignaturePubKey<ST>>>();
         // Channel for secondary raptorcast to send outbound messages since it does not have access to dataplane
         let (send_outbound_to_primary, recv_outbound_from_secondary) =
             unbounded_channel::<SecondaryOutboundMessage<CertificateSignaturePubKey<ST>>>();
@@ -214,7 +214,7 @@ where
         mode: SecondaryRaptorCastModeConfig,
         shared_pdd: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
         recv_group_messages: UnboundedReceiver<FullNodesGroupMessage<ST>>,
-        send_group_infos: UnboundedSender<Group<CertificateSignaturePubKey<ST>>>,
+        send_group_infos: UnboundedSender<SecondaryGroupAssignment<CertificateSignaturePubKey<ST>>>,
         channel_to_primary_outbound: UnboundedSender<
             SecondaryOutboundMessage<CertificateSignaturePubKey<ST>>,
         >,

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -134,19 +134,13 @@ impl FromStr for Round {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+// A non-empty span of rounds
 pub struct RoundSpan {
     pub start: Round, // inclusive
     pub end: Round,   // exclusive
 }
 
 impl RoundSpan {
-    // TODO: The empty RoundSpan is only used in the Group struct
-    // representing a validator set. Remove this exception after we
-    // refactor out the Group struct.
-    pub fn empty(at: Round) -> Self {
-        Self { start: at, end: at }
-    }
-
     pub fn new(start: Round, end: Round) -> Option<Self> {
         if start >= end {
             return None;
@@ -169,6 +163,12 @@ impl RoundSpan {
     }
     pub fn overlaps(&self, other: &RoundSpan) -> bool {
         self.start < other.end && other.start < self.end
+    }
+}
+
+impl From<RoundSpan> for std::ops::Range<Round> {
+    fn from(span: RoundSpan) -> Self {
+        span.start..span.end
     }
 }
 


### PR DESCRIPTION
This PR restructures the raptorcast group related types in order to make the types simpler and more explicit.

Major changes:

- Remove `Group`, split its usage into:
  + `SecondaryGroup` (newtype on `BTreeSet<Nodes>`, guaranteed non-empty)
  + `ValidatorSet`
  + `SecondaryGroupAssignment`, which bundles `publisher_id`, `round_span`, and a `SecondaryGroup` for the members
  + note in all above cases, self_id is not excluded from the member set, allowing these values unique universally (i.e. across nodes). If self_id is not desired, e.g. during rebroadcasting, the exclusion is delayed to that step.

- Remove `ReBroadcastGroupMap` type and the state in Raptorcast.
  + we already have `EpochValidators`, so we only add `FullNodeGroupMap` to the raptorcast state to track secondary groups
  + during the `handle_message`, we construct a `BroadcastGroup`, which is a borrowed view from group id and the groups. It's conceptually a raptorcast group of members related to the incoming raptorcast chunk, and implements relevant validation logic and utilities (i.e. group validity check, sender validity check, rebroadcasting peers).

Rationale:

The `Group` type was overloaded. It was used for both validator groups (primary raptorcast) and full node groups (secondary raptorcast). There are several downsides with this approach. First, it contains unnecessary data, e.g. round_span/validator_id for primary groups. Second, the condition that `other_peers` does not contains self is not applicable for secondary group where the self is a validator. The mixed semantics prevent `Group` type from representing an unambiguous, standalone concept.

The issue with `ReBroadcastGroupMap` is also from its overloaded meanings which makes its internal logic complex. In addition, the validator set per epoch is already stored independently in raptorcast state, duplicating the state in `ReBroadcastGroupMap` would be susceptible to desync if not managed correctly.

Please also see https://github.com/category-labs/monad-bft/pull/2843 for further refactory on these group types being used as part of build target.