### PR TITLE
monad-wireauth: add global connect rate limit

### DIFF
--- a/monad-wireauth/README.md
+++ b/monad-wireauth/README.md
@@ -31,7 +31,7 @@ the filter operates in three modes based on load:
 | sessions >= `low_watermark_sessions` and cookie valid | apply per-ip rate limiting via lru cache |
 | sessions < `low_watermark_sessions` | no additional measures |
 
-defaults: `high_watermark_sessions`=100,000, `handshake_rate_limit`=2000/sec, `low_watermark_sessions`=10,000, `ip_rate_limit_window`=10s, `max_sessions_per_ip`=10, `ip_history_capacity`=1,000,000
+defaults: `high_watermark_sessions`=100,000, `handshake_rate_limit`=2000/sec, `connect_rate_limit`=1000/sec, `low_watermark_sessions`=10,000, `ip_rate_limit_window`=10s, `max_sessions_per_ip`=10, `ip_history_capacity`=1,000,000
 
 at 2000 handshakes/sec, approximately 400ms of cpu time per second is spent on handshake-related computation during such attack.
 
@@ -85,6 +85,7 @@ session_decrypt         time:   [166.11 ns 168.75 ns 171.20 ns]
 | `monad.wireauth.filter.pass` | handshake requests that passed all filters |
 | `monad.wireauth.filter.send_cookie` | cookie challenges sent (between low and high watermark) |
 | `monad.wireauth.filter.drop` | handshake requests rejected due to rate limits |
+| `monad.wireauth.rate_limit.connect` | outbound connect attempts rejected due to rate limits |
 
 ### api operations
 
@@ -152,6 +153,8 @@ session_decrypt         time:   [166.11 ns 168.75 ns 171.20 ns]
 | `max_session_duration` | Duration | 7h | absolute session lifetime regardless of activity (forces rekey) |
 | `handshake_rate_limit` | u64 | 2000 | max handshake requests processed per second (dos protection) |
 | `handshake_rate_reset_interval` | Duration | 1s | window for handshake rate limiting |
+| `connect_rate_limit` | u64 | 1000 | max outbound connect attempts per second (dos protection) |
+| `connect_rate_reset_interval` | Duration | 1s | window for outbound connect rate limiting |
 | `cookie_refresh_duration` | Duration | 120s | cookie validity period (responder rotates cookie key) |
 | `low_watermark_sessions` | usize | 10000 | below this threshold, accept all handshakes without cookie challenge |
 | `high_watermark_sessions` | usize | 100000 | at this threshold, drop all incoming handshake requests |

--- a/monad-wireauth/src/config/mod.rs
+++ b/monad-wireauth/src/config/mod.rs
@@ -40,6 +40,10 @@ pub struct Config {
     pub handshake_rate_limit: u64,
     /// window for handshake rate limiting
     pub handshake_rate_reset_interval: Duration,
+    /// max outbound connect attempts per second (dos protection)
+    pub connect_rate_limit: u64,
+    /// window for outbound connect rate limiting
+    pub connect_rate_reset_interval: Duration,
     /// cookie validity period (responder rotates cookie key)
     pub cookie_refresh_duration: Duration,
     /// below this threshold, accept all handshakes without cookie challenge
@@ -70,6 +74,8 @@ impl Default for Config {
             max_session_duration: Duration::from_secs(6 * 60 * 60 + 5 * 60),
             handshake_rate_limit: 2000,
             handshake_rate_reset_interval: Duration::from_secs(1),
+            connect_rate_limit: 1000,
+            connect_rate_reset_interval: Duration::from_secs(1),
             cookie_refresh_duration: Duration::from_secs(120),
             low_watermark_sessions: 10_000,
             high_watermark_sessions: 100_000,

--- a/monad-wireauth/src/error.rs
+++ b/monad-wireauth/src/error.rs
@@ -56,6 +56,12 @@ pub enum Error {
 
     #[error("session index not found: {index}")]
     SessionIndexNotFound { index: SessionIndex },
+
+    #[error("connect rate limited: limit={limit} interval={interval:?}")]
+    ConnectRateLimited {
+        limit: u64,
+        interval: std::time::Duration,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/monad-wireauth/src/metrics.rs
+++ b/monad-wireauth/src/metrics.rs
@@ -94,3 +94,4 @@ pub const GAUGE_WIREAUTH_ENQUEUED_COOKIE_REPLY: &str = "monad.wireauth.enqueued.
 pub const GAUGE_WIREAUTH_ENQUEUED_KEEPALIVE: &str = "monad.wireauth.enqueued.keepalive";
 
 pub const GAUGE_WIREAUTH_RATE_LIMIT_DROP: &str = "monad.wireauth.rate_limit.drop";
+pub const GAUGE_WIREAUTH_RATE_LIMIT_CONNECT: &str = "monad.wireauth.rate_limit.connect";


### PR DESCRIPTION
this is a defense in depth change to rate-limit outbound connect() attempts and reduce abuse potential