### PR TITLE
[scripts] use $MONAD_RUN_DIR instead of /home/monad/monad-bft

### DIFF
--- a/debian/opt/monad/scripts/clear-old-artifacts.sh
+++ b/debian/opt/monad/scripts/clear-old-artifacts.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-TARGET_DIR="/home/monad/monad-bft/ledger/"
+source /home/monad/.env
+MONAD_RUN_DIR=${MONAD_RUN_DIR:-/home/monad/monad-bft}
+TARGET_DIR="$MONAD_RUN_DIR/ledger/"
 
 # Retention times in minutes
 RETENTION_FORKPOINT=${RETENTION_FORKPOINT:-300}      # 5 hours (forkpoint.rlp.* and forkpoint.toml.*)
@@ -13,12 +15,12 @@ echo "Cleanup script started: RETENTION_LEDGER=${RETENTION_LEDGER}min, RETENTION
 NEW_FILES=$(find "$TARGET_DIR" -type f -name "*" -mmin -20)
 if [ -n "$NEW_FILES" ]; then
     echo "New files detected in ledger, proceeding with cleanup"
-    find /home/monad/monad-bft/config/forkpoint/ -type f -name "forkpoint.rlp.*" -mmin +${RETENTION_FORKPOINT} -delete 2>/dev/null
-    find /home/monad/monad-bft/config/forkpoint/ -type f -name "forkpoint.toml.*" -mmin +${RETENTION_FORKPOINT} -delete 2>/dev/null
-    find /home/monad/monad-bft/config/validators/ -type f -name "validators.toml.*" -mmin +${RETENTION_VALIDATORS} -delete 2>/dev/null
-    find /home/monad/monad-bft/ledger/headers -type f -mmin +${RETENTION_LEDGER} -delete 2>/dev/null
-    find /home/monad/monad-bft/ledger/bodies -type f -mmin +${RETENTION_LEDGER} -delete 2>/dev/null
-    find /home/monad/monad-bft/ -type f -name "wal_*" -mmin +${RETENTION_WAL} -delete 2>/dev/null
+    find "$MONAD_RUN_DIR/config/forkpoint/" -type f -name "forkpoint.rlp.*" -mmin +${RETENTION_FORKPOINT} -delete 2>/dev/null
+    find "$MONAD_RUN_DIR/config/forkpoint/" -type f -name "forkpoint.toml.*" -mmin +${RETENTION_FORKPOINT} -delete 2>/dev/null
+    find "$MONAD_RUN_DIR/config/validators/" -type f -name "validators.toml.*" -mmin +${RETENTION_VALIDATORS} -delete 2>/dev/null
+    find "$MONAD_RUN_DIR/ledger/headers" -type f -mmin +${RETENTION_LEDGER} -delete 2>/dev/null
+    find "$MONAD_RUN_DIR/ledger/bodies" -type f -mmin +${RETENTION_LEDGER} -delete 2>/dev/null
+    find "$MONAD_RUN_DIR" -type f -name "wal_*" -mmin +${RETENTION_WAL} -delete 2>/dev/null
     echo "Cleanup completed successfully"
 else
     echo "No new files detected. Skipping deletion of ledger files."

--- a/debian/opt/monad/scripts/reset-workspace.sh
+++ b/debian/opt/monad/scripts/reset-workspace.sh
@@ -1,24 +1,30 @@
 #!/bin/bash
 
-set -ex
-systemctl stop monad-bft monad-execution monad-rpc monad-mpt monad-execution-genesis || true
-mkdir /home/monad/monad-bft/empty-dir
-rsync -r --delete /home/monad/monad-bft/empty-dir/ /home/monad/monad-bft/ledger/
-rsync -r --delete /home/monad/monad-bft/empty-dir/ /home/monad/monad-bft/config/forkpoint/
-rsync -r --delete /home/monad/monad-bft/empty-dir/ /home/monad/monad-bft/config/validators/
-touch /home/monad/monad-bft/ledger/wal
-rm -rf /home/monad/monad-bft/empty-dir
-rm -rf /home/monad/monad-bft/snapshots
-rm -f /home/monad/monad-bft/mempool.sock
-rm -f /home/monad/monad-bft/controlpanel.sock
-rm -f /home/monad/monad-bft/wal_*
-rm -f /home/monad/monad-bft/config/peers.toml
-rm -rf /home/monad/monad-bft/blockdb
 source /home/monad/.env
+MONAD_RUN_DIR=${MONAD_RUN_DIR:-/home/monad/monad-bft}
+
+set -ex
+
+if command -v systemctl &> /dev/null; then
+    systemctl stop monad-bft monad-execution monad-rpc monad-mpt monad-execution-genesis || true
+fi
+
+mkdir "$MONAD_RUN_DIR/empty-dir"
+rsync -r --delete "$MONAD_RUN_DIR/empty-dir/" "$MONAD_RUN_DIR/ledger/"
+rsync -r --delete "$MONAD_RUN_DIR/empty-dir/" "$MONAD_RUN_DIR/config/forkpoint/"
+rsync -r --delete "$MONAD_RUN_DIR/empty-dir/" "$MONAD_RUN_DIR/config/validators/"
+touch "$MONAD_RUN_DIR/ledger/wal"
+rm -rf "$MONAD_RUN_DIR/empty-dir"
+rm -rf "$MONAD_RUN_DIR/snapshots"
+rm -f "$MONAD_RUN_DIR/mempool.sock"
+rm -f "$MONAD_RUN_DIR/controlpanel.sock"
+rm -f "$MONAD_RUN_DIR/wal_"*
+rm -f "$MONAD_RUN_DIR/config/peers.toml"
+rm -rf "$MONAD_RUN_DIR/blockdb"
 monad-mpt --storage /dev/triedb --truncate --yes
 if [ -f "/home/monad/.config/forkpoint.genesis.toml" ]; then
-  yes | cp -rf /home/monad/.config/forkpoint.genesis.toml /home/monad/monad-bft/config/forkpoint/forkpoint.toml
+  yes | cp -rf /home/monad/.config/forkpoint.genesis.toml "$MONAD_RUN_DIR/config/forkpoint/forkpoint.toml"
 fi
 if [ -f "/home/monad/.config/validators.genesis.toml" ]; then
-  yes | cp -rf /home/monad/.config/validators.genesis.toml /home/monad/monad-bft/config/validators/validators.toml
+  yes | cp -rf /home/monad/.config/validators.genesis.toml "$MONAD_RUN_DIR/config/validators/validators.toml"
 fi


### PR DESCRIPTION
This is expected to come from the environment file (/home/monad/.env), and if it is not present it will default to /home/monad/monad-bft