### PR TITLE
Refactor StateSync task and simplify read/apply ops

### DIFF
--- a/monad-statesync/src/outbound_requests.rs
+++ b/monad-statesync/src/outbound_requests.rs
@@ -150,21 +150,13 @@ impl<PT: PubKey> InFlightRequest<PT> {
         }
 
         if response.response_index == self.response_index {
-            let curr_index = self.response_index;
             self.response_index += 1;
             let mut responses = vec![response];
 
             // Remove consecutive responses from out-of-order queue
-            for index in self.responses.keys() {
-                if *index == self.response_index {
-                    self.response_index += 1;
-                } else {
-                    break;
-                }
-            }
-            for index in curr_index + 1..self.response_index {
-                let response = self.responses.remove(&index).expect("missing response");
+            while let Some(response) = self.responses.remove(&self.response_index) {
                 responses.push(response);
+                self.response_index += 1;
             }
             return responses;
         }


### PR DESCRIPTION
1. Moved task to a separate function to reduce inlining and indentation
2. Update expect comments to specify what was expected instead of what went wrong
3. Split out duplicated code into `read_sync_upsert` helper
4. Simplified complex double for loop