### PR TITLE
monad-wireauth: split handshake rate limits by cookie validity

### DIFF
--- a/monad-wireauth/src/api.rs
+++ b/monad-wireauth/src/api.rs
@@ -75,7 +75,8 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
 
         let filter = Filter::new(
             metric_names,
-            config.handshake_rate_limit,
+            config.handshake_cookie_unverified_rate_limit,
+            config.handshake_cookie_verified_rate_limit,
             config.handshake_rate_reset_interval,
             config.ip_rate_limit_window,
             config.ip_history_capacity,

--- a/monad-wireauth/src/config/mod.rs
+++ b/monad-wireauth/src/config/mod.rs
@@ -36,8 +36,13 @@ pub struct Config {
     pub rekey_jitter: Duration,
     /// absolute session lifetime regardless of activity (forces rekey)
     pub max_session_duration: Duration,
-    /// max handshake requests processed per second (dos protection)
-    pub handshake_rate_limit: u64,
+    /// global rate limit (per reset interval) for handshake initiations without a valid cookie.
+    /// this budget is intended for "unproven" sources and prevents them from starving cookie-valid
+    /// handshakes.
+    pub handshake_cookie_unverified_rate_limit: u64,
+    /// global rate limit (per reset interval) for handshake initiations with a valid cookie.
+    /// this budget is intended for "proven" sources.
+    pub handshake_cookie_verified_rate_limit: u64,
     /// window for handshake rate limiting
     pub handshake_rate_reset_interval: Duration,
     /// max outbound connect attempts per second (dos protection)
@@ -54,8 +59,6 @@ pub struct Config {
     pub max_sessions_per_ip: usize,
     /// time window for counting handshake requests per ip
     pub ip_rate_limit_window: Duration,
-    /// max handshake requests from single ip within rate limit window
-    pub max_requests_per_ip: usize,
     /// lru cache size for tracking handshake request timestamps per ip
     pub ip_history_capacity: usize,
     /// optional pre-shared key mixed into handshake for additional auth
@@ -72,7 +75,8 @@ impl Default for Config {
             rekey_interval: Duration::from_secs(6 * 60 * 60),
             rekey_jitter: Duration::from_secs(60),
             max_session_duration: Duration::from_secs(6 * 60 * 60 + 5 * 60),
-            handshake_rate_limit: 2000,
+            handshake_cookie_unverified_rate_limit: 1000,
+            handshake_cookie_verified_rate_limit: 1000,
             handshake_rate_reset_interval: Duration::from_secs(1),
             connect_rate_limit: 1000,
             connect_rate_reset_interval: Duration::from_secs(1),
@@ -81,7 +85,6 @@ impl Default for Config {
             high_watermark_sessions: 100_000,
             max_sessions_per_ip: 10,
             ip_rate_limit_window: Duration::from_secs(10),
-            max_requests_per_ip: 10,
             ip_history_capacity: 1_000_000,
             psk: Zeroizing::new([0u8; 32]),
         }

--- a/monad-wireauth/tests/tests.rs
+++ b/monad-wireauth/tests/tests.rs
@@ -226,7 +226,8 @@ fn test_cookie_reply_on_init() {
     init_tracing();
     // 1. create managers with low_watermark_sessions=0 to trigger cookie immediate cookie reply under load
     let config = Config {
-        handshake_rate_limit: 10,
+        handshake_cookie_unverified_rate_limit: 10,
+        handshake_cookie_verified_rate_limit: 10,
         low_watermark_sessions: 0,
         session_timeout_jitter: Duration::ZERO, // to avoid randomness in tests
         ..Config::default()
@@ -429,7 +430,8 @@ fn test_filter_drop_rate_limit() {
     init_tracing();
     // 1. create manager with low handshake rate limit (3 per interval)
     let config = Config {
-        handshake_rate_limit: 3,
+        handshake_cookie_unverified_rate_limit: 3,
+        handshake_cookie_verified_rate_limit: 3,
         ..Config::default()
     };
 
@@ -465,12 +467,12 @@ fn test_filter_drop_rate_limit() {
         dispatch(&mut responder, &init, initiator_addr);
     }
 
-    // 3. verify only 2 responses (first consumed token, remaining 2 accepted)
+    // 3. verify 3 handshake responses + 1 cookie reply (4th init is challenged, not silently dropped)
     let mut pkts = vec![];
     while let Some(pkt) = responder.next_packet() {
         pkts.push(pkt);
     }
-    assert_eq!(pkts.len(), 2);
+    assert_eq!(pkts.len(), 4);
 }
 
 #[test]


### PR DESCRIPTION
right now the "cookie/ip validation" path only kicks in once
total_sessions >= low_watermark_sessions. an attacker can try to keep
total_sessions just below that threshold while still generating enough
handshake traffic to consume the global handshake budget, causing honest
peers new connections to get delayed or dropped without ever triggering
cookie-gated, per-ip controls.

split the handshake budget into two independent rate limits:
- handshake_cookie_unverified_rate_limit for cookie-invalid initiations
- handshake_cookie_verified_rate_limit for cookie-valid initiations

once the cookie-unverified budget is exhausted we send cookie replies
instead of dropping, so honest peers can obtain a cookie and retry into 
the protected verified lane. cookie replies are smaller than initiation/response, 
so even if we reply under attack we are not amplifying traffic

closes: https://github.com/category-labs/monad-bft/issues/2777