### PR TITLE
Create proposal ahead

### DIFF
--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -71,8 +71,21 @@ where
     },
     /// Cancel scheduled (if exists) timeout event
     ScheduleReset,
-    /// Creates a proposal
-    CreateProposal {
+    CreateProposalAhead {
+        node_id: NodeId<CertificateSignaturePubKey<ST>>,
+        epoch: Epoch,
+        round: Round,
+        seq_num: SeqNum,
+
+        tx_limit: usize,
+        proposal_gas_limit: u64,
+        proposal_byte_limit: u64,
+        timestamp_ns: u128,
+
+        extending_blocks: Vec<BPT::ValidatedBlock>,
+    },
+    /// Fetches a proposal
+    FetchProposal {
         node_id: NodeId<CertificateSignaturePubKey<ST>>,
         epoch: Epoch,
         round: Round,

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -232,6 +232,8 @@ where
 
     pub timestamp_latency_estimate_ns: u128,
 
+    pub create_proposal_ahead: bool,
+
     pub _phantom: PhantomData<CRT>,
 }
 
@@ -533,6 +535,8 @@ where
         if proposal_round != pacemaker_round {
             debug!(?pacemaker_round, ?proposal_round, "out-of-order proposal");
             self.metrics.consensus_events.out_of_order_proposals += 1;
+        } else if self.config.create_proposal_ahead {
+            cmds.extend(self.try_create_proposal_ahead(block_id));
         }
 
         cmds
@@ -1666,6 +1670,99 @@ where
         cmds
     }
 
+    #[must_use]
+    fn try_create_proposal_ahead(
+        &mut self,
+        extending_block_id: BlockId,
+    ) -> Vec<ConsensusCommand<ST, SCT, EPT, BPT, SBT, CCT, CRT>> {
+        let mut cmds = Vec::new();
+
+        if !self
+            .consensus
+            .pending_block_tree
+            .is_coherent(&extending_block_id)
+        {
+            return cmds;
+        }
+
+        let current_round = self.consensus.get_current_round();
+        let next_round = current_round + Round(1);
+        let next_round_epoch = self
+            .epoch_manager
+            .get_epoch(next_round)
+            .expect("epoch of next round should be known");
+        let next_validator_set = self
+            .val_epoch_map
+            .get_val_set(&next_round_epoch)
+            .expect("validator set of next round should be available");
+        let next_leader = self
+            .election
+            .get_leader(next_round, next_validator_set.get_members());
+
+        // optimistically create next proposal if node is the leader of next round
+        if *self.nodeid == next_leader {
+            let extending_blocks = self
+                .consensus
+                .pending_block_tree
+                .get_blocks_on_path_from_root(&extending_block_id)
+                .expect("coherent block should have path to root");
+            let (next_seq_num, extending_block_id, next_timestamp_ns) =
+                if let Some(extending_block) = extending_blocks.last() {
+                    (
+                        extending_block.get_seq_num() + SeqNum(1),
+                        extending_block.get_id(),
+                        extending_block.get_timestamp() + 1,
+                    )
+                } else {
+                    let root = self.consensus.pending_block_tree.root();
+                    (
+                        root.seq_num + SeqNum(1),
+                        root.block_id,
+                        root.timestamp_ns + 1,
+                    )
+                };
+
+            debug!(
+                ?current_round,
+                ?next_round,
+                ?next_seq_num,
+                ?extending_block_id,
+                "consensus emitting creating proposal ahead for next round"
+            );
+            self.metrics.consensus_events.creating_proposal_ahead += 1;
+
+            cmds.push(ConsensusCommand::CreateProposalAhead {
+                node_id: *self.nodeid,
+                epoch: next_round_epoch,
+                round: next_round,
+                seq_num: next_seq_num,
+                tx_limit: self
+                    .config
+                    .chain_config
+                    .get_chain_revision(next_round)
+                    .chain_params()
+                    .tx_limit,
+                proposal_gas_limit: self
+                    .config
+                    .chain_config
+                    .get_chain_revision(next_round)
+                    .chain_params()
+                    .proposal_gas_limit,
+                proposal_byte_limit: self
+                    .config
+                    .chain_config
+                    .get_chain_revision(next_round)
+                    .chain_params()
+                    .proposal_byte_limit,
+                timestamp_ns: next_timestamp_ns,
+                // TODO remove clone. extending blocks are also cloned during FetchProposal
+                extending_blocks: extending_blocks.into_iter().cloned().collect(),
+            });
+        }
+
+        cmds
+    }
+
     /// This function is (and must be) idempotent
     #[must_use]
     fn try_propose(&mut self) -> Vec<ConsensusCommand<ST, SCT, EPT, BPT, SBT, CCT, CRT>> {
@@ -1872,10 +1969,11 @@ where
                     ?round,
                     ?qc,
                     ?try_propose_seq_num,
-                    "emitting create proposal command to txpool"
+                    "consensus emitting fetch proposal command to txpool"
                 );
+                self.metrics.consensus_events.fetching_proposal += 1;
 
-                cmds.push(ConsensusCommand::CreateProposal {
+                cmds.push(ConsensusCommand::FetchProposal {
                     node_id: *self.nodeid,
                     epoch,
                     round,
@@ -1907,6 +2005,7 @@ where
                     beneficiary: *self.beneficiary,
                     timestamp_ns,
 
+                    // TODO remove clone. extending blocks are also cloned during CreateProposalAhead
                     extending_blocks: pending_blocktree_blocks.into_iter().cloned().collect(),
                     delayed_execution_results,
                 });
@@ -2455,6 +2554,7 @@ mod test {
                     start_execution_threshold: SeqNum(300),
                     chain_config: MockChainConfig::new(&CHAIN_PARAMS),
                     timestamp_latency_estimate_ns: 1,
+                    create_proposal_ahead: true,
                     _phantom: Default::default(),
                 };
                 let genesis_qc = QuorumCertificate::genesis_qc();
@@ -2656,7 +2756,21 @@ mod test {
             .collect::<Vec<_>>()
     }
 
-    fn extract_create_proposal_command_round<ST, SCT, BPT, SBT>(
+    fn find_create_proposal_ahead<ST, SCT, EPT, BPT, SBT>(
+        cmds: &[ConsensusCommand<ST, SCT, EPT, BPT, SBT, MockChainConfig, MockChainRevision>],
+    ) -> Option<&ConsensusCommand<ST, SCT, EPT, BPT, SBT, MockChainConfig, MockChainRevision>>
+    where
+        ST: CertificateSignatureRecoverable,
+        SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+        EPT: ExecutionProtocol,
+        BPT: BlockPolicy<ST, SCT, EPT, SBT, MockChainConfig, MockChainRevision>,
+        SBT: StateBackend<ST, SCT>,
+    {
+        cmds.iter()
+            .find(|c| matches!(c, ConsensusCommand::CreateProposalAhead { .. }))
+    }
+
+    fn extract_fetch_proposal_command_round<ST, SCT, BPT, SBT>(
         cmds: Vec<
             ConsensusCommand<
                 ST,
@@ -2678,7 +2792,7 @@ mod test {
     {
         cmds.iter()
             .find_map(|c| match c {
-                ConsensusCommand::CreateProposal { round, .. } => Some(*round),
+                ConsensusCommand::FetchProposal { round, .. } => Some(*round),
                 _ => None,
             })
             .unwrap_or_else(|| panic!("couldn't extract proposal: {:?}", cmds))
@@ -4123,7 +4237,7 @@ mod test {
             leader.consensus_state.pacemaker.get_current_round(),
             Round(missing_round + 1)
         );
-        let round = extract_create_proposal_command_round(cmds);
+        let round = extract_fetch_proposal_command_round(cmds);
         assert_eq!(Round(missing_round + 1), round);
     }
 
@@ -5481,8 +5595,6 @@ mod test {
         assert!(block_3_blocktree_entry.is_coherent);
     }
 
-    const EXPECTED_FUTURE_LEADER_IDXS: &[usize] = &[2, 3, 1];
-
     #[test]
     fn test_iter_upcoming_self_leader_rounds() {
         let num_states = 4;
@@ -5955,5 +6067,62 @@ mod test {
 
         assert_eq!(node0.consensus_state.get_current_round(), round + Round(1));
         assert_eq!(node1.consensus_state.get_current_round(), round + Round(1));
+    }
+
+    #[test]
+    fn test_create_proposal_ahead() {
+        let num_states = 2;
+        let execution_delay = SeqNum(4);
+        let (mut env, ctx) = setup::<
+            SignatureType,
+            SignatureCollectionType,
+            BlockPolicyType,
+            StateBackendType,
+            BlockValidatorType,
+            _,
+            _,
+        >(
+            num_states as u32,
+            ValidatorSetFactory::default(),
+            SimpleRoundRobin::default(),
+            || EthBlockPolicy::new(GENESIS_SEQ_NUM, execution_delay.0),
+            || InMemoryStateInner::genesis(Balance::MAX, execution_delay),
+            EthBlockValidator::default,
+            execution_delay,
+        );
+
+        let p1 = env.next_proposal_empty();
+        let (author, _, verified_message) = p1.destructure();
+        let proposal_round = verified_message.proposal_round;
+        let proposal_seq_num = verified_message.tip.block_header.seq_num;
+
+        let next_round = proposal_round + Round(1);
+        let next_epoch = env
+            .epoch_manager
+            .get_epoch(next_round)
+            .expect("epoch exists");
+        let next_leader = env.election.get_leader(
+            next_round,
+            env.val_epoch_map
+                .get_val_set(&next_epoch)
+                .unwrap()
+                .get_members(),
+        );
+        let next_seq_num = proposal_seq_num + SeqNum(1);
+
+        for mut node in ctx {
+            let cmds = node.handle_proposal_message(author, verified_message.clone());
+            let create_proposal_ahead_cmd = find_create_proposal_ahead(&cmds);
+            if node.nodeid == next_leader {
+                assert!(create_proposal_ahead_cmd.is_some_and(|cmd| match cmd {
+                    ConsensusCommand::CreateProposalAhead { round, seq_num, .. } => {
+                        *round == next_round && *seq_num == next_seq_num
+                    }
+                    _ => panic!("expected CreateProposalAhead command"),
+                }));
+            } else {
+                assert!(create_proposal_ahead_cmd.is_none());
+            }
+        }
     }
 }

--- a/monad-consensus-types/src/metrics.rs
+++ b/monad-consensus-types/src/metrics.rs
@@ -117,10 +117,9 @@ metrics!(
             process_qc,
             process_old_tc,
             process_tc,
-            // TODO(andr-dev, PR): Add metric to differentiate emitting
-            // TxPoolCommand::CreateProposal vs consensus state creating + broadcasting finalized
-            // proposal
-            creating_proposal,
+            creating_proposal_ahead,
+            fetching_proposal,
+            broadcasting_proposal,
             rx_execution_lagging,
             rx_bad_state_root,
             rx_base_fee_error,

--- a/monad-eth-block-validator/tests/coherency_test.rs
+++ b/monad-eth-block-validator/tests/coherency_test.rs
@@ -500,7 +500,7 @@ fn check_txpool_coherency(
         .into();
     let seq_num = block_under_test.header().seq_num;
     let round = block_under_test.header().block_round;
-    let proposal = txpool
+    let transactions = txpool
         .create_proposal(
             &mut event_tracker,
             block_under_test.header().epoch,
@@ -510,11 +510,9 @@ fn check_txpool_coherency(
             5000,
             200_000_000,
             2_000_000,
-            beneficiary,
             timestamp_ns,
             block_under_test.header().author,
-            block_under_test.header().round_signature.clone(),
-            extending_blocks.to_vec(),
+            extending_blocks,
             &block_policy,
             state_backend,
             chain_config,
@@ -523,13 +521,11 @@ fn check_txpool_coherency(
 
     info!(
         "Txpool created proposal with {} txs for seq_num {:?}",
-        proposal.body.transactions.len(),
+        transactions.len(),
         block_under_test.header().seq_num
     );
 
-    let txs = proposal
-        .body
-        .transactions
+    let txs = transactions
         .iter()
         .cloned()
         .map(recover_tx)

--- a/monad-eth-txpool-executor/src/lib.rs
+++ b/monad-eth-txpool-executor/src/lib.rs
@@ -23,28 +23,30 @@ use std::{
     time::Duration,
 };
 
-use alloy_consensus::{transaction::Recovered, TxEnvelope};
+use alloy_consensus::{
+    constants::EMPTY_WITHDRAWALS, transaction::Recovered, TxEnvelope, EMPTY_OMMER_ROOT_HASH,
+};
 use alloy_primitives::Address;
 use alloy_rlp::Decodable;
 use futures::Stream;
 use monad_chain_config::{revision::ChainRevision, ChainConfig};
-use monad_consensus_types::block::BlockPolicy;
+use monad_consensus_types::block::{BlockPolicy, ProposedExecutionInputs};
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
-use monad_eth_block_policy::EthBlockPolicy;
+use monad_eth_block_policy::{timestamp_ns_to_secs, EthBlockPolicy, EthValidatedBlock};
 use monad_eth_txpool::{
     EthTxPool, EthTxPoolConfig, EthTxPoolEventTracker, PoolTxKind, TrackedTxLimitsConfig,
 };
 use monad_eth_txpool_types::{
     EthTxPoolDropReason, EthTxPoolEventType, EthTxPoolIpcTx, EthTxPoolTxInputStream,
 };
-use monad_eth_types::{EthExecutionProtocol, ExtractEthAddress};
+use monad_eth_types::{EthBlockBody, EthExecutionProtocol, ExtractEthAddress, ProposedEthHeader};
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{MempoolEvent, MonadEvent, TxPoolCommand};
 use monad_secp::RecoverableAddress;
 use monad_state_backend::StateBackend;
-use monad_types::{DropTimer, Round};
+use monad_types::{DropTimer, Round, SeqNum};
 use monad_validator::signature_collection::SignatureCollection;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use tokio::{sync::mpsc, time::Instant};
@@ -64,6 +66,16 @@ mod metrics;
 mod preload;
 mod reset;
 
+#[derive(Clone, Debug)]
+struct ReadyProposal<ST, SCT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+{
+    pub transactions: Vec<TxEnvelope>,
+    pub extending_blocks: Vec<EthValidatedBlock<ST, SCT>>,
+}
+
 pub struct EthTxPoolExecutor<ST, SCT, SBT, CCT, CRT, TIS>
 where
     ST: CertificateSignatureRecoverable,
@@ -74,6 +86,7 @@ where
     TIS: EthTxPoolTxInputStream,
 {
     pool: EthTxPool<ST, SCT, SBT, CCT, CRT>,
+    ready_proposals: BTreeMap<SeqNum, ReadyProposal<ST, SCT>>,
     tx_input_stream: Pin<Box<TIS>>,
 
     reset: EthTxPoolResetTrigger,
@@ -145,6 +158,7 @@ where
 
                     Self {
                         pool,
+                        ready_proposals: BTreeMap::new(),
                         tx_input_stream: ipc,
                         block_policy,
                         reset: EthTxPoolResetTrigger::default(),
@@ -329,7 +343,78 @@ where
                         .project()
                         .schedule_egress_txs(&mut self.pool);
                 }
-                TxPoolCommand::CreateProposal {
+                TxPoolCommand::CreateProposalAhead {
+                    node_id,
+                    epoch,
+                    round,
+                    seq_num,
+                    tx_limit,
+                    proposal_gas_limit,
+                    proposal_byte_limit,
+                    timestamp_ns,
+                    extending_blocks,
+                } => {
+                    let _span =
+                        debug_span!("create proposal ahead", seq_num = seq_num.as_u64(),).entered();
+                    self.preload_manager.update_on_create_proposal(seq_num);
+
+                    if let Some(ready_proposal) = self.ready_proposals.get(&seq_num) {
+                        if ready_proposal.extending_blocks == extending_blocks {
+                            info!(
+                                ?seq_num,
+                                "txpool executor received duplicate create proposal ahead call"
+                            );
+                            continue;
+                        }
+                    };
+
+                    let (base_fee, _, _) = self
+                        .block_policy
+                        .compute_base_fee(&extending_blocks, &self.chain_config);
+
+                    let create_proposal_start = Instant::now();
+                    match self.pool.create_proposal(
+                        &mut event_tracker,
+                        epoch,
+                        round,
+                        seq_num,
+                        base_fee,
+                        tx_limit,
+                        proposal_gas_limit,
+                        proposal_byte_limit,
+                        timestamp_ns,
+                        node_id,
+                        extending_blocks.as_slice(),
+                        &self.block_policy,
+                        &self.state_backend,
+                        &self.chain_config,
+                    ) {
+                        Ok(transactions) => {
+                            let elapsed = create_proposal_start.elapsed();
+
+                            self.metrics.create_proposal.fetch_add(1, Ordering::SeqCst);
+                            self.metrics
+                                .create_proposal_elapsed_ns
+                                .fetch_add(elapsed.as_nanos() as u64, Ordering::SeqCst);
+
+                            info!(
+                                ?seq_num,
+                                "txpool executor created proposal for round {}", round.0,
+                            );
+                            self.ready_proposals.insert(
+                                seq_num,
+                                ReadyProposal {
+                                    transactions,
+                                    extending_blocks,
+                                },
+                            );
+                        }
+                        Err(err) => {
+                            info!(?err, "txpool executor create proposal ahead error");
+                        }
+                    }
+                }
+                TxPoolCommand::FetchProposal {
                     node_id,
                     epoch,
                     round,
@@ -349,63 +434,126 @@ where
                     delayed_execution_results,
                 } => {
                     let _span =
-                        debug_span!("create proposal", seq_num = seq_num.as_u64(),).entered();
-                    self.preload_manager.update_on_create_proposal(seq_num);
+                        debug_span!("fetch proposal", seq_num = seq_num.as_u64(),).entered();
 
-                    let create_proposal_start = Instant::now();
+                    let maybe_ready_proposal = self.ready_proposals.remove(&seq_num);
+
+                    let is_proposal_ready =
+                        maybe_ready_proposal.as_ref().is_some_and(|ready_proposal| {
+                            ready_proposal.extending_blocks == extending_blocks
+                        });
 
                     let (base_fee, base_fee_trend, base_fee_moment) = self
                         .block_policy
                         .compute_base_fee(&extending_blocks, &self.chain_config);
 
-                    match self.pool.create_proposal(
-                        &mut event_tracker,
-                        epoch,
-                        round,
-                        seq_num,
-                        base_fee,
-                        tx_limit,
-                        proposal_gas_limit,
-                        proposal_byte_limit,
-                        beneficiary,
-                        timestamp_ns,
-                        node_id,
-                        round_signature.clone(),
-                        extending_blocks,
-                        &self.block_policy,
-                        &self.state_backend,
-                        &self.chain_config,
-                    ) {
-                        Ok(proposed_execution_inputs) => {
-                            let elapsed = create_proposal_start.elapsed();
+                    let transactions = if is_proposal_ready {
+                        info!(?round, ?seq_num, "txpool fetching ready proposal");
 
-                            self.metrics.create_proposal.fetch_add(1, Ordering::SeqCst);
-                            self.metrics
-                                .create_proposal_elapsed_ns
-                                .fetch_add(elapsed.as_nanos() as u64, Ordering::SeqCst);
+                        maybe_ready_proposal.unwrap().transactions
+                    } else {
+                        self.preload_manager.update_on_create_proposal(seq_num);
 
-                            self.events_tx
-                                .send(MempoolEvent::Proposal {
-                                    epoch,
-                                    round,
-                                    seq_num,
-                                    high_qc,
-                                    timestamp_ns,
-                                    round_signature,
-                                    base_fee,
-                                    base_fee_trend,
-                                    base_fee_moment,
-                                    delayed_execution_results,
-                                    proposed_execution_inputs,
-                                    last_round_tc,
-                                    fresh_proposal_certificate,
-                                })
-                                .expect("events never dropped");
+                        let create_proposal_start = Instant::now();
+                        match self.pool.create_proposal(
+                            &mut event_tracker,
+                            epoch,
+                            round,
+                            seq_num,
+                            base_fee,
+                            tx_limit,
+                            proposal_gas_limit,
+                            proposal_byte_limit,
+                            timestamp_ns,
+                            node_id,
+                            extending_blocks.as_slice(),
+                            &self.block_policy,
+                            &self.state_backend,
+                            &self.chain_config,
+                        ) {
+                            Ok(transactions) => {
+                                let elapsed = create_proposal_start.elapsed();
+
+                                self.metrics.create_proposal.fetch_add(1, Ordering::SeqCst);
+                                self.metrics
+                                    .create_proposal_elapsed_ns
+                                    .fetch_add(elapsed.as_nanos() as u64, Ordering::SeqCst);
+
+                                transactions
+                            }
+                            Err(err) => {
+                                error!(?err, "txpool executor failed to create proposal");
+                                continue;
+                            }
                         }
-                        Err(err) => {
-                            error!(?err, "txpool executor failed to create proposal");
-                        }
-                    }
+                    };
+
+                    let body = EthBlockBody {
+                        transactions,
+                        ommers: Vec::new(),
+                        withdrawals: Vec::new(),
+                    };
+
+                    // Monad does not use request hashes yet
+                    // It is hardcoded to zero hash for prague compatibility
+                    let maybe_request_hash = if self
+                        .chain_config
+                        .get_execution_chain_revision(timestamp_ns_to_secs(timestamp_ns))
+                        .execution_chain_params()
+                        .prague_enabled
+                    {
+                        Some([0_u8; 32])
+                    } else {
+                        None
+                    };
+
+                    let header = ProposedEthHeader {
+                        transactions_root: *alloy_consensus::proofs::calculate_transaction_root(
+                            &body.transactions,
+                        ),
+                        ommers_hash: {
+                            assert_eq!(body.ommers.len(), 0);
+                            *EMPTY_OMMER_ROOT_HASH
+                        },
+                        withdrawals_root: {
+                            assert_eq!(body.withdrawals.len(), 0);
+                            *EMPTY_WITHDRAWALS
+                        },
+
+                        beneficiary: beneficiary.into(),
+                        difficulty: 0,
+                        number: seq_num.0,
+                        gas_limit: proposal_gas_limit,
+                        timestamp: timestamp_ns_to_secs(timestamp_ns),
+                        mix_hash: round_signature.get_hash().0,
+                        nonce: [0_u8; 8],
+                        extra_data: [0_u8; 32],
+                        base_fee_per_gas: base_fee,
+                        blob_gas_used: 0,
+                        excess_blob_gas: 0,
+                        parent_beacon_block_root: [0_u8; 32],
+                        requests_hash: maybe_request_hash,
+                    };
+
+                    let proposed_execution_inputs = ProposedExecutionInputs { header, body };
+
+                    self.events_tx
+                        .send(MempoolEvent::Proposal {
+                            epoch,
+                            round,
+                            seq_num,
+                            high_qc,
+                            timestamp_ns,
+                            round_signature,
+                            base_fee,
+                            base_fee_trend,
+                            base_fee_moment,
+                            delayed_execution_results,
+                            proposed_execution_inputs,
+                            last_round_tc,
+                            fresh_proposal_certificate,
+                        })
+                        .expect("events never dropped");
                 }
                 TxPoolCommand::InsertForwardedTxs { sender, txs } => {
                     // This will never happen because we separate out these commands in `EthTxPoolExecutorClient`.
@@ -486,6 +634,7 @@ where
 
         let Self {
             pool,
+            ready_proposals: _,
             tx_input_stream,
 
             reset,

--- a/monad-eth-txpool-executor/src/preload.rs
+++ b/monad-eth-txpool-executor/src/preload.rs
@@ -128,7 +128,7 @@ impl EthTxPoolPreloadManager {
                 .entry(next_round_predicted_proposal_seqnum)
                 .and_modify(|entry| {
                     // We enable preload for the next round, which remains enabled until we receive a
-                    // CreateProposal event for that seqnum and it gets disabled or the entry is
+                    // FetchProposal event for that seqnum and it gets disabled or the entry is
                     // removed.
                     entry.preload = true;
                 })

--- a/monad-eth-txpool/benches/create_proposal.rs
+++ b/monad-eth-txpool/benches/create_proposal.rs
@@ -17,11 +17,8 @@ use std::collections::BTreeMap;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use monad_chain_config::MockChainConfig;
-use monad_consensus_types::{block::GENESIS_TIMESTAMP, payload::RoundSignature};
-use monad_crypto::{
-    certificate_signature::{CertificateKeyPair, PubKey},
-    NopKeyPair, NopPubKey,
-};
+use monad_consensus_types::block::GENESIS_TIMESTAMP;
+use monad_crypto::{certificate_signature::PubKey, NopPubKey};
 use monad_eth_block_policy::EthBlockPolicy;
 use monad_eth_txpool::EthTxPoolEventTracker;
 use monad_types::{Epoch, NodeId, Round, SeqNum, GENESIS_SEQ_NUM};
@@ -37,7 +34,6 @@ fn criterion_benchmark(c: &mut Criterion) {
     // policy state we want to benchmark
     let block_policy = EthBlockPolicy::new(GENESIS_SEQ_NUM, EXECUTION_DELAY);
 
-    let mock_keypair = NopKeyPair::from_bytes(&mut [5_u8; 32]).unwrap();
     run_txpool_benches(
         c,
         "create_proposal",
@@ -62,13 +58,11 @@ fn criterion_benchmark(c: &mut Criterion) {
                 *proposal_tx_limit,
                 *proposal_gas_limit,
                 *proposal_byte_limit,
-                [0_u8; 20],
                 GENESIS_TIMESTAMP
                     + block_policy.get_last_commit().0 as u128
                     + pending_blocks.len() as u128,
                 NodeId::new(NopPubKey::from_bytes(&[0_u8; 32]).unwrap()),
-                RoundSignature::new(Round(0), &mock_keypair),
-                pending_blocks.to_owned(),
+                pending_blocks,
                 block_policy,
                 state_backend,
                 &MockChainConfig::DEFAULT,

--- a/monad-eth-txpool/src/pool/mod.rs
+++ b/monad-eth-txpool/src/pool/mod.rs
@@ -15,9 +15,7 @@
 
 use std::time::Duration;
 
-use alloy_consensus::{
-    constants::EMPTY_WITHDRAWALS, transaction::Recovered, TxEnvelope, EMPTY_OMMER_ROOT_HASH,
-};
+use alloy_consensus::{transaction::Recovered, TxEnvelope};
 use alloy_primitives::Address;
 use alloy_rlp::Encodable;
 use itertools::{Either, Itertools};
@@ -26,10 +24,7 @@ use monad_chain_config::{
     revision::{ChainRevision, MockChainRevision},
     ChainConfig, MockChainConfig,
 };
-use monad_consensus_types::{
-    block::{BlockPolicyError, ConsensusBlockHeader, ProposedExecutionInputs},
-    payload::RoundSignature,
-};
+use monad_consensus_types::block::{BlockPolicyError, ConsensusBlockHeader};
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
@@ -38,7 +33,7 @@ use monad_eth_block_policy::{
     EthValidatedBlock,
 };
 use monad_eth_txpool_types::{EthTxPoolDropReason, EthTxPoolInternalDropReason, EthTxPoolSnapshot};
-use monad_eth_types::{EthBlockBody, EthExecutionProtocol, ExtractEthAddress, ProposedEthHeader};
+use monad_eth_types::{EthExecutionProtocol, ExtractEthAddress};
 use monad_state_backend::{StateBackend, StateBackendError};
 use monad_system_calls::{SystemTransactionGenerator, SYSTEM_SENDER_ETH_ADDRESS};
 use monad_types::{DropTimer, Epoch, NodeId, Round, SeqNum};
@@ -117,6 +112,46 @@ where
 
     pub fn current_revision(&self) -> (&CRT, &MonadExecutionRevision) {
         (&self.chain_revision, &self.execution_revision)
+    }
+
+    fn update_chain_params(
+        &mut self,
+        event_tracker: &mut EthTxPoolEventTracker<'_>,
+        round: Round,
+        timestamp_ns: u128,
+        chain_config: &CCT,
+    ) -> bool {
+        let timestamp_seconds = timestamp_ns_to_secs(timestamp_ns);
+        let chain_id = chain_config.chain_id();
+
+        if self.chain_id != chain_id {
+            panic!(
+                "txpool chain id changed from {} to {} in create_proposal",
+                self.chain_id, chain_id
+            );
+        }
+
+        let chain_revision = chain_config.get_chain_revision(round);
+        let execution_revision = chain_config.get_execution_chain_revision(timestamp_seconds);
+
+        if chain_revision.chain_params() != self.chain_revision.chain_params()
+            || self.execution_revision != execution_revision
+        {
+            self.chain_revision = chain_revision;
+            self.execution_revision = execution_revision;
+
+            info!(
+                chain_params =? chain_revision.chain_params(),
+                execution_revision =? execution_revision,
+                "updating chain params and execution revision"
+            );
+
+            self.static_validate_all_txs(event_tracker);
+
+            return true;
+        }
+
+        false
     }
 
     pub fn insert_txs(
@@ -259,16 +294,14 @@ where
         tx_limit: usize,
         proposal_gas_limit: u64,
         proposal_byte_limit: u64,
-        beneficiary: [u8; 20],
         timestamp_ns: u128,
         node_id: NodeId<CertificateSignaturePubKey<ST>>,
-        round_signature: RoundSignature<SCT::SignatureType>,
-        extending_blocks: Vec<EthValidatedBlock<ST, SCT>>,
+        extending_blocks: &[EthValidatedBlock<ST, SCT>],
 
         block_policy: &EthBlockPolicy<ST, SCT, CCT, CRT>,
         state_backend: &SBT,
         chain_config: &CCT,
-    ) -> Result<ProposedExecutionInputs<EthExecutionProtocol>, BlockPolicyError> {
+    ) -> Result<Vec<TxEnvelope>, BlockPolicyError> {
         info!(
             ?proposed_seq_num,
             ?tx_limit,
@@ -279,118 +312,26 @@ where
 
         self.tracked.evict_expired_txs(event_tracker);
 
-        let timestamp_seconds = timestamp_ns_to_secs(timestamp_ns);
+        self.update_chain_params(event_tracker, round, timestamp_ns, chain_config);
 
-        {
-            let chain_id = chain_config.chain_id();
-
-            if self.chain_id != chain_id {
-                panic!(
-                    "txpool chain id changed from {} to {} in create_proposal",
-                    self.chain_id, chain_id
-                );
-            }
-
-            let chain_revision = chain_config.get_chain_revision(round);
-            let execution_revision = chain_config.get_execution_chain_revision(timestamp_seconds);
-
-            if chain_revision.chain_params() != self.chain_revision.chain_params()
-                || self.execution_revision != execution_revision
-            {
-                self.chain_revision = chain_revision;
-                self.execution_revision = execution_revision;
-
-                info!(
-                    chain_params =? chain_revision.chain_params(),
-                    execution_revision =? execution_revision,
-                    "updating chain params and execution revision in create_proposal"
-                );
-
-                self.static_validate_all_txs(event_tracker);
-            }
-        }
-
-        let self_eth_address = node_id.pubkey().get_eth_address();
-        let system_transactions = self.get_system_transactions(
+        let transactions = self.sequence_transactions(
+            event_tracker,
             epoch,
             proposed_seq_num,
-            self_eth_address,
-            &extending_blocks.iter().collect(),
-            block_policy,
-            state_backend,
-            chain_config,
-        )?;
-        let system_txs_size: u64 = system_transactions
-            .iter()
-            .map(|tx| tx.length() as u64)
-            .sum();
-
-        let user_transactions = self.sequence_user_transactions(
-            event_tracker,
-            proposed_seq_num,
             base_fee,
-            tx_limit - system_transactions.len(),
+            tx_limit,
             proposal_gas_limit,
-            proposal_byte_limit - system_txs_size,
-            extending_blocks.iter().collect(),
+            proposal_byte_limit,
+            node_id,
+            extending_blocks,
             block_policy,
             state_backend,
             chain_config,
         )?;
-
-        let body = EthBlockBody {
-            transactions: system_transactions
-                .into_iter()
-                .chain(user_transactions)
-                .map(|tx| tx.into_inner())
-                .collect(),
-            ommers: Vec::new(),
-            withdrawals: Vec::new(),
-        };
-
-        // Monad does not use request hashes yet
-        // It is hardcoded to zero hash for prague compatibility
-        let maybe_request_hash = if self
-            .execution_revision
-            .execution_chain_params()
-            .prague_enabled
-        {
-            Some([0_u8; 32])
-        } else {
-            None
-        };
-
-        let header = ProposedEthHeader {
-            transactions_root: *alloy_consensus::proofs::calculate_transaction_root(
-                &body.transactions,
-            ),
-            ommers_hash: {
-                assert_eq!(body.ommers.len(), 0);
-                *EMPTY_OMMER_ROOT_HASH
-            },
-            withdrawals_root: {
-                assert_eq!(body.withdrawals.len(), 0);
-                *EMPTY_WITHDRAWALS
-            },
-
-            beneficiary: beneficiary.into(),
-            difficulty: 0,
-            number: proposed_seq_num.0,
-            gas_limit: proposal_gas_limit,
-            timestamp: timestamp_seconds,
-            mix_hash: round_signature.get_hash().0,
-            nonce: [0_u8; 8],
-            extra_data: [0_u8; 32],
-            base_fee_per_gas: base_fee,
-            blob_gas_used: 0,
-            excess_blob_gas: 0,
-            parent_beacon_block_root: [0_u8; 32],
-            requests_hash: maybe_request_hash,
-        };
 
         self.update_aggregate_metrics(event_tracker);
 
-        Ok(ProposedExecutionInputs { header, body })
+        Ok(transactions.into_iter().map(|tx| tx.into_inner()).collect())
     }
 
     pub fn enter_round(
@@ -582,6 +523,56 @@ where
             .into_iter()
             .map(|sys_txn| sys_txn.into())
             .collect_vec())
+    }
+
+    pub fn sequence_transactions(
+        &mut self,
+        event_tracker: &mut EthTxPoolEventTracker<'_>,
+        epoch: Epoch,
+        proposed_seq_num: SeqNum,
+        base_fee: u64,
+        tx_limit: usize,
+        proposal_gas_limit: u64,
+        proposal_byte_limit: u64,
+        node_id: NodeId<CertificateSignaturePubKey<ST>>,
+        extending_blocks: &[EthValidatedBlock<ST, SCT>],
+
+        block_policy: &EthBlockPolicy<ST, SCT, CCT, CRT>,
+        state_backend: &SBT,
+        chain_config: &CCT,
+    ) -> Result<Vec<Recovered<TxEnvelope>>, BlockPolicyError> {
+        let self_eth_address = node_id.pubkey().get_eth_address();
+        let system_transactions = self.get_system_transactions(
+            epoch,
+            proposed_seq_num,
+            self_eth_address,
+            &extending_blocks.iter().collect(),
+            block_policy,
+            state_backend,
+            chain_config,
+        )?;
+        let system_txs_size: u64 = system_transactions
+            .iter()
+            .map(|tx| tx.length() as u64)
+            .sum();
+
+        let user_transactions = self.sequence_user_transactions(
+            event_tracker,
+            proposed_seq_num,
+            base_fee,
+            tx_limit - system_transactions.len(),
+            proposal_gas_limit,
+            proposal_byte_limit - system_txs_size,
+            extending_blocks.iter().collect(),
+            block_policy,
+            state_backend,
+            chain_config,
+        )?;
+
+        Ok(system_transactions
+            .into_iter()
+            .chain(user_transactions)
+            .collect())
     }
 
     pub fn sequence_user_transactions(

--- a/monad-eth-txpool/src/pool/sequencer.rs
+++ b/monad-eth-txpool/src/pool/sequencer.rs
@@ -338,7 +338,7 @@ impl<'a> ProposalSequencer<'a> {
     }
 }
 
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub(super) struct Proposal {
     pub txs: Vec<Recovered<TxEnvelope>>,
     pub total_gas: u64,

--- a/monad-eth-txpool/tests/performance.rs
+++ b/monad-eth-txpool/tests/performance.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 
 use alloy_primitives::FixedBytes;
 use monad_chain_config::MockChainConfig;
-use monad_consensus_types::{block::GENESIS_TIMESTAMP, payload::RoundSignature};
+use monad_consensus_types::block::GENESIS_TIMESTAMP;
 use monad_crypto::{
     certificate_signature::{CertificateKeyPair, PubKey},
     NopKeyPair, NopPubKey, NopSignature,
@@ -86,8 +86,6 @@ fn txpool_create_proposal_lookups_bound_by_tx_limit() {
 
         assert_eq!(pool.num_txs(), 2);
 
-        let mock_keypair = NopKeyPair::from_bytes(&mut [5_u8; 32]).unwrap();
-
         let _ = pool
             .create_proposal(
                 &mut event_tracker,
@@ -98,11 +96,9 @@ fn txpool_create_proposal_lookups_bound_by_tx_limit() {
                 tx_limit,
                 1_000_000,
                 1024 * 1024,
-                [0_u8; 20],
                 GENESIS_TIMESTAMP,
                 NodeId::new(NopPubKey::from_bytes(&[0_u8; 32]).unwrap()),
-                RoundSignature::new(Round(0), &mock_keypair),
-                vec![],
+                &[],
                 &eth_block_policy,
                 &state_backend,
                 &MockChainConfig::DEFAULT,
@@ -183,11 +179,9 @@ fn txpool_create_proposal_no_lookup_for_unknown_authorizations() {
                 usize::MAX,
                 1_000_000,
                 1024 * 1024,
-                [0_u8; 20],
                 GENESIS_TIMESTAMP,
                 NodeId::new(NopPubKey::from_bytes(&[0_u8; 32]).unwrap()),
-                RoundSignature::new(Round(0), &mock_keypair),
-                vec![],
+                &[],
                 &eth_block_policy,
                 &state_backend,
                 &MockChainConfig::DEFAULT,

--- a/monad-eth-txpool/tests/pool.rs
+++ b/monad-eth-txpool/tests/pool.rs
@@ -32,12 +32,8 @@ use monad_consensus_types::{
     block::{BlockPolicy, GENESIS_TIMESTAMP},
     block_validator::BlockValidator,
     metrics::Metrics,
-    payload::RoundSignature,
 };
-use monad_crypto::{
-    certificate_signature::{CertificateKeyPair, PubKey},
-    NopKeyPair, NopPubKey, NopSignature,
-};
+use monad_crypto::{certificate_signature::PubKey, NopPubKey, NopSignature};
 use monad_eth_block_policy::{validation::TFM_MAX_GAS_LIMIT, EthBlockPolicy};
 use monad_eth_block_validator::EthBlockValidator;
 use monad_eth_testutil::{
@@ -82,7 +78,7 @@ enum TxPoolTestEvent<'a> {
         txs: Vec<&'a TxEnvelope>,
         should_insert: bool,
     },
-    CreateProposal {
+    FetchProposal {
         base_fee: u64,
         tx_limit: usize,
         gas_limit: u64,
@@ -290,7 +286,7 @@ fn run_custom_iter<const N: usize>(
                     "pool size tx insertion count mismatch"
                 );
             }
-            TxPoolTestEvent::CreateProposal {
+            TxPoolTestEvent::FetchProposal {
                 base_fee,
                 tx_limit,
                 gas_limit,
@@ -298,8 +294,7 @@ fn run_custom_iter<const N: usize>(
                 expected_txs,
                 add_to_blocktree,
             } => {
-                let mock_keypair = NopKeyPair::from_bytes(&mut [5_u8; 32]).unwrap();
-                let encoded_txns = pool
+                let decoded_txns = pool
                     .create_proposal(
                         &mut event_tracker,
                         Epoch(1),
@@ -309,18 +304,14 @@ fn run_custom_iter<const N: usize>(
                         tx_limit,
                         gas_limit,
                         byte_limit,
-                        [0_u8; 20],
                         GENESIS_TIMESTAMP + current_seq_num as u128,
                         NodeId::new(NopPubKey::from_bytes(&[0_u8; 32]).unwrap()),
-                        RoundSignature::new(Round(0), &mock_keypair),
-                        pending_blocks.iter().cloned().collect_vec(),
+                        pending_blocks.iter().cloned().collect_vec().as_slice(),
                         &eth_block_policy,
                         &state_backend,
                         &MockChainConfig::DEFAULT,
                     )
                     .expect("create proposal succeeds");
-
-                let decoded_txns = encoded_txns.body.transactions;
 
                 let expected_txs = expected_txs.into_iter().cloned().collect_vec();
 
@@ -487,7 +478,7 @@ fn test_insert_tx_exceeds_gas_limit() {
             txs: vec![(&tx, false)],
             expected_pool_size_change: 0,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 1,
             gas_limit: PROPOSAL_GAS_LIMIT,
@@ -508,7 +499,7 @@ fn test_create_proposal_with_insufficient_tx_limit() {
             txs: vec![(&tx, true)],
             expected_pool_size_change: 1,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 0,
             gas_limit: GAS_LIMIT,
@@ -534,7 +525,7 @@ fn test_create_partial_proposal_with_insufficient_gas_limit() {
             txs: vec![(&tx1, true), (&tx2, true), (&tx3, true)],
             expected_pool_size_change: 3,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 3,
             gas_limit: 200_000,
@@ -559,7 +550,7 @@ fn test_basic_price_priority() {
             txs: vec![(&tx1, true), (&tx2, true)],
             expected_pool_size_change: 2,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 2,
             gas_limit: GAS_LIMIT * 3,
@@ -584,7 +575,7 @@ fn test_resubmit_with_same_price() {
             txs: vec![(&tx1, true), (&tx2, false)],
             expected_pool_size_change: 1,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 2,
             gas_limit: GAS_LIMIT * 2,
@@ -606,7 +597,7 @@ fn test_resubmit_with_better_price() {
             txs: vec![(&tx1, true), (&tx2, true)],
             expected_pool_size_change: 1,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 2,
             gas_limit: GAS_LIMIT * 3,
@@ -638,7 +629,7 @@ fn nontrivial_example() {
                 .collect_vec(),
             expected_pool_size_change: 9,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 1024 * GAS_LIMIT,
@@ -667,7 +658,7 @@ fn another_non_trivial_example() {
                 .collect_vec(),
             expected_pool_size_change: 6,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 1024 * GAS_LIMIT,
@@ -704,7 +695,7 @@ fn attacker_tries_to_include_transaction_with_large_gas_limit_to_exit_proposal_c
             .collect_vec(),
             expected_pool_size_change: 10,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 10 * GAS_LIMIT,
@@ -744,7 +735,7 @@ fn suboptimal_block() {
                 txs: txs.into_iter().map(|tx| (tx, true)).collect_vec(),
                 expected_pool_size_change: 11,
             },
-            TxPoolTestEvent::CreateProposal {
+            TxPoolTestEvent::FetchProposal {
                 base_fee: BASE_FEE_PER_GAS,
                 tx_limit: 11,
                 gas_limit: TFM_MAX_GAS_LIMIT,
@@ -789,7 +780,7 @@ fn insertion_order() {
                 .collect_vec(),
             expected_pool_size_change: 10,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 10,
             gas_limit: 10 * GAS_LIMIT,
@@ -812,7 +803,7 @@ fn test_zero_nonce_included_in_block() {
             txs: vec![(&tx1, true)],
             expected_pool_size_change: 1,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 10 * GAS_LIMIT,
@@ -835,7 +826,7 @@ fn test_nonce_gap() {
             txs: vec![(&tx1, true)],
             expected_pool_size_change: 1,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 10 * GAS_LIMIT,
@@ -860,7 +851,7 @@ fn test_intermediary_nonce_gap() {
             txs: vec![(&tx1, true), (&tx2, true), (&tx3, true)],
             expected_pool_size_change: 3,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 10 * GAS_LIMIT,
@@ -893,7 +884,7 @@ fn test_nonce_exists_in_committed_block() {
                 txs: vec![(&tx1, false), (&tx2, true)],
                 expected_pool_size_change: 1,
             },
-            TxPoolTestEvent::CreateProposal {
+            TxPoolTestEvent::FetchProposal {
                 base_fee: BASE_FEE_PER_GAS,
                 tx_limit: 128,
                 gas_limit: 10 * GAS_LIMIT,
@@ -923,7 +914,7 @@ fn test_insert_unknown_account() {
             TxPoolTestEvent::Block(Arc::new(|pool| {
                 assert!(pool.is_empty());
             })),
-            TxPoolTestEvent::CreateProposal {
+            TxPoolTestEvent::FetchProposal {
                 base_fee: BASE_FEE_PER_GAS,
                 tx_limit: 1,
                 gas_limit: GAS_LIMIT,
@@ -953,7 +944,7 @@ fn test_insert_legacy_low_balance() {
             TxPoolTestEvent::Block(Arc::new(|pool| {
                 assert!(pool.is_empty());
             })),
-            TxPoolTestEvent::CreateProposal {
+            TxPoolTestEvent::FetchProposal {
                 base_fee: BASE_FEE_PER_GAS,
                 tx_limit: 1,
                 gas_limit: GAS_LIMIT,
@@ -977,7 +968,7 @@ fn test_insert_legacy_low_balance() {
             TxPoolTestEvent::Block(Arc::new(|pool| {
                 assert!(pool.is_empty());
             })),
-            TxPoolTestEvent::CreateProposal {
+            TxPoolTestEvent::FetchProposal {
                 base_fee: BASE_FEE_PER_GAS,
                 tx_limit: 1,
                 gas_limit: GAS_LIMIT,
@@ -998,7 +989,7 @@ fn test_insert_legacy_low_balance() {
                 txs: vec![(&tx, true)],
                 expected_pool_size_change: 1,
             },
-            TxPoolTestEvent::CreateProposal {
+            TxPoolTestEvent::FetchProposal {
                 base_fee: BASE_FEE_PER_GAS,
                 tx_limit: 1,
                 gas_limit: GAS_LIMIT,
@@ -1028,7 +1019,7 @@ fn test_insert_1559_low_balance() {
             TxPoolTestEvent::Block(Arc::new(|pool| {
                 assert!(pool.is_empty());
             })),
-            TxPoolTestEvent::CreateProposal {
+            TxPoolTestEvent::FetchProposal {
                 base_fee: BASE_FEE_PER_GAS,
                 tx_limit: 1,
                 gas_limit: GAS_LIMIT,
@@ -1052,7 +1043,7 @@ fn test_insert_1559_low_balance() {
             TxPoolTestEvent::Block(Arc::new(|pool| {
                 assert!(pool.is_empty());
             })),
-            TxPoolTestEvent::CreateProposal {
+            TxPoolTestEvent::FetchProposal {
                 base_fee: BASE_FEE_PER_GAS,
                 tx_limit: 1,
                 gas_limit: GAS_LIMIT,
@@ -1075,7 +1066,7 @@ fn test_insert_1559_low_balance() {
                 txs: vec![(&tx, true)],
                 expected_pool_size_change: 1,
             },
-            TxPoolTestEvent::CreateProposal {
+            TxPoolTestEvent::FetchProposal {
                 base_fee: BASE_FEE_PER_GAS,
                 tx_limit: 1,
                 gas_limit: GAS_LIMIT,
@@ -1103,7 +1094,7 @@ fn test_nonce_exists_in_pending_block() {
             txs: vec![(&tx1, true)],
             expected_pool_size_change: 1,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 1,
             gas_limit: GAS_LIMIT,
@@ -1115,7 +1106,7 @@ fn test_nonce_exists_in_pending_block() {
             txs: vec![(&tx2, true), (&tx3, true)],
             expected_pool_size_change: 1,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 10 * GAS_LIMIT,
@@ -1140,7 +1131,7 @@ fn test_combine_nonces_of_blocks() {
             txs: vec![(&tx1, true)],
             expected_pool_size_change: 1,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 10 * GAS_LIMIT,
@@ -1156,7 +1147,7 @@ fn test_combine_nonces_of_blocks() {
             txs: vec![(&tx2, true)],
             expected_pool_size_change: 1,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 10 * GAS_LIMIT,
@@ -1168,7 +1159,7 @@ fn test_combine_nonces_of_blocks() {
             txs: vec![(&tx3, true)],
             expected_pool_size_change: 1,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 10 * GAS_LIMIT,
@@ -1192,7 +1183,7 @@ fn test_nonce_gap_maintained_across_proposals() {
             txs: vec![(&tx1, true), (&tx2, true), (&tx4, true)],
             expected_pool_size_change: 3,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 10 * GAS_LIMIT,
@@ -1200,7 +1191,7 @@ fn test_nonce_gap_maintained_across_proposals() {
             expected_txs: vec![&tx1, &tx2],
             add_to_blocktree: false,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 10 * GAS_LIMIT,
@@ -1213,7 +1204,7 @@ fn test_nonce_gap_maintained_across_proposals() {
             expected_pool_size_change: 1,
         },
         // Even though proposals have been created, the txpool should still contain tx4!
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 10 * GAS_LIMIT,
@@ -1221,7 +1212,7 @@ fn test_nonce_gap_maintained_across_proposals() {
             expected_txs: vec![&tx1, &tx2, &tx3, &tx4],
             add_to_blocktree: true,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 10 * GAS_LIMIT,
@@ -1245,7 +1236,7 @@ fn test_nonce_gap_maintained_across_commit() {
             txs: vec![(&tx1, true), (&tx2, true), (&tx4, true)],
             expected_pool_size_change: 3,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 10 * GAS_LIMIT,
@@ -1262,7 +1253,7 @@ fn test_nonce_gap_maintained_across_commit() {
             expected_pool_size_change: 1,
         },
         // Even though block has been committed, the txpool should still contain tx4!
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 10 * GAS_LIMIT,
@@ -1270,7 +1261,7 @@ fn test_nonce_gap_maintained_across_commit() {
             expected_txs: vec![&tx3, &tx4],
             add_to_blocktree: false,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 10 * GAS_LIMIT,
@@ -1278,7 +1269,7 @@ fn test_nonce_gap_maintained_across_commit() {
             expected_txs: vec![&tx3, &tx4],
             add_to_blocktree: true,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 128,
             gas_limit: 10 * GAS_LIMIT,
@@ -1343,7 +1334,7 @@ fn test_same_account_priority_fee_ordering() {
                 txs: vec![(tx1, true), (tx2, false), (tx3, tx1 == &tx_a), (tx4, true)],
                 expected_pool_size_change: 1,
             },
-            TxPoolTestEvent::CreateProposal {
+            TxPoolTestEvent::FetchProposal {
                 base_fee: BASE_FEE_PER_GAS,
                 tx_limit: 4,
                 gas_limit: GAS_LIMIT * 4,
@@ -1367,7 +1358,7 @@ fn test_different_account_priority_fee_ordering() {
                     txs: vec![(tx1, true), (tx2, true)],
                     expected_pool_size_change: 2,
                 },
-                TxPoolTestEvent::CreateProposal {
+                TxPoolTestEvent::FetchProposal {
                     base_fee: BASE_FEE_PER_GAS,
                     tx_limit: 2,
                     gas_limit: GAS_LIMIT * 2,
@@ -1391,7 +1382,7 @@ fn test_eip1559_proposal_base_fee() {
                 txs: vec![(txa, true), (txb, true)],
                 expected_pool_size_change: 2,
             },
-            TxPoolTestEvent::CreateProposal {
+            TxPoolTestEvent::FetchProposal {
                 base_fee: BASE_FEE_PER_GAS,
                 tx_limit: 2,
                 gas_limit: 2 * GAS_LIMIT,
@@ -1399,7 +1390,7 @@ fn test_eip1559_proposal_base_fee() {
                 expected_txs: vec![&tx1, &tx2],
                 add_to_blocktree: false,
             },
-            TxPoolTestEvent::CreateProposal {
+            TxPoolTestEvent::FetchProposal {
                 base_fee: BASE_FEE_PER_GAS + 10,
                 tx_limit: 2,
                 gas_limit: 2 * GAS_LIMIT,
@@ -1435,7 +1426,7 @@ fn test_missing_chain_id() {
             txs: vec![(&tx, true)],
             expected_pool_size_change: 1,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 1,
             gas_limit: GAS_LIMIT,
@@ -1500,7 +1491,7 @@ fn test_exceed_proposal_byte_limit() {
             txs: vec![(&tx1, true), (&tx2, true)],
             expected_pool_size_change: 2,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 2,
             gas_limit: PROPOSAL_GAS_LIMIT,
@@ -1508,7 +1499,7 @@ fn test_exceed_proposal_byte_limit() {
             expected_txs: vec![],
             add_to_blocktree: true,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 2,
             gas_limit: PROPOSAL_GAS_LIMIT,
@@ -1516,7 +1507,7 @@ fn test_exceed_proposal_byte_limit() {
             expected_txs: vec![&tx1],
             add_to_blocktree: true,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 2,
             gas_limit: PROPOSAL_GAS_LIMIT,
@@ -1582,7 +1573,7 @@ fn test_proposal_tx_low_base_fee() {
             txs: vec![(&tx1, true)],
             expected_pool_size_change: 1,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS + 1,
             tx_limit: 1,
             gas_limit: GAS_LIMIT,
@@ -1590,7 +1581,7 @@ fn test_proposal_tx_low_base_fee() {
             expected_txs: vec![],
             add_to_blocktree: false,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 1,
             gas_limit: GAS_LIMIT,
@@ -1648,7 +1639,7 @@ fn test_eviction_policy() {
                     txs: txs.clone().into_iter().map(|tx| (tx, true)).collect_vec(),
                     expected_pool_size_change: if a_eviction_condition { 2 } else { 3 },
                 },
-                TxPoolTestEvent::CreateProposal {
+                TxPoolTestEvent::FetchProposal {
                     base_fee: BASE_FEE_PER_GAS,
                     tx_limit: usize::MAX,
                     gas_limit: u64::MAX,
@@ -1689,7 +1680,7 @@ fn test_eip7702_valid_authorization_changes_nonce() {
                 txs: vec![(&tx1, true), (&tx2, true)],
                 expected_pool_size_change: 2,
             },
-            TxPoolTestEvent::CreateProposal {
+            TxPoolTestEvent::FetchProposal {
                 base_fee: BASE_FEE_PER_GAS,
                 tx_limit: 2,
                 gas_limit: 2 * GAS_LIMIT,
@@ -1708,7 +1699,7 @@ fn test_eip7702_valid_authorization_changes_nonce() {
                 address: secret_to_eth_address(S2),
                 nonce: 1,
             },
-            TxPoolTestEvent::CreateProposal {
+            TxPoolTestEvent::FetchProposal {
                 base_fee: BASE_FEE_PER_GAS,
                 tx_limit: 2,
                 gas_limit: 2 * GAS_LIMIT,
@@ -1748,7 +1739,7 @@ fn test_eip7702_authorization_nonce_higher() {
                 txs: vec![(&tx1, true), (&tx2, true)],
                 expected_pool_size_change: 2,
             },
-            TxPoolTestEvent::CreateProposal {
+            TxPoolTestEvent::FetchProposal {
                 base_fee: BASE_FEE_PER_GAS,
                 tx_limit: 2,
                 gas_limit: 2 * GAS_LIMIT_EIP_7702,
@@ -1786,7 +1777,7 @@ fn test_eip7702_authorization_nonce_equal() {
             txs: vec![(&tx1, true), (&tx2, true)],
             expected_pool_size_change: 2,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 2,
             gas_limit: GAS_LIMIT + GAS_LIMIT_EIP_7702,
@@ -1827,7 +1818,7 @@ fn test_eip7702_authorization_nonce_lower() {
                 txs: vec![(&tx1, true), (&tx2, true)],
                 expected_pool_size_change: 2,
             },
-            TxPoolTestEvent::CreateProposal {
+            TxPoolTestEvent::FetchProposal {
                 base_fee: BASE_FEE_PER_GAS,
                 tx_limit: 3,
                 gas_limit: 3 * GAS_LIMIT,
@@ -1873,7 +1864,7 @@ fn test_eip7702_authorizations_with_conflicting_txs() {
             txs: vec![(&tx0, true), (&tx1, true), (&tx2, true)],
             expected_pool_size_change: 3,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 3,
             gas_limit: GAS_LIMIT_EIP_7702 * 100,
@@ -1889,7 +1880,7 @@ fn test_eip7702_authorizations_with_conflicting_txs() {
             address: secret_to_eth_address(S2),
             nonce: 4,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 3,
             gas_limit: GAS_LIMIT_EIP_7702 * 100,
@@ -1972,7 +1963,7 @@ fn test_eip_7702_sponsor_with_1559() {
             txs: insert_txs,
             expected_pool_size_change: 20,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 20,
             gas_limit: PROPOSAL_GAS_LIMIT,
@@ -1980,7 +1971,7 @@ fn test_eip_7702_sponsor_with_1559() {
             expected_txs: txs.iter().step_by(2).collect(),
             add_to_blocktree: true,
         },
-        TxPoolTestEvent::CreateProposal {
+        TxPoolTestEvent::FetchProposal {
             base_fee: BASE_FEE_PER_GAS,
             tx_limit: 20,
             gas_limit: PROPOSAL_GAS_LIMIT,

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -530,7 +530,20 @@ where
     /// Used to update the nonces of tracked txs
     BlockCommit(Vec<BPT::ValidatedBlock>),
 
-    CreateProposal {
+    CreateProposalAhead {
+        node_id: NodeId<CertificateSignaturePubKey<ST>>,
+        epoch: Epoch,
+        round: Round,
+        seq_num: SeqNum,
+
+        tx_limit: usize,
+        proposal_gas_limit: u64,
+        proposal_byte_limit: u64,
+        timestamp_ns: u128,
+
+        extending_blocks: Vec<BPT::ValidatedBlock>,
+    },
+    FetchProposal {
         node_id: NodeId<CertificateSignaturePubKey<ST>>,
         epoch: Epoch,
         round: Round,
@@ -580,7 +593,29 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::BlockCommit(arg0) => f.debug_tuple("BlockCommit").field(arg0).finish(),
-            Self::CreateProposal {
+            Self::CreateProposalAhead {
+                node_id,
+                epoch,
+                round,
+                seq_num,
+                tx_limit,
+                proposal_gas_limit,
+                proposal_byte_limit,
+                timestamp_ns,
+                extending_blocks,
+            } => f
+                .debug_struct("CreateProposalAhead")
+                .field("node_id", node_id)
+                .field("epoch", epoch)
+                .field("round", round)
+                .field("seq_num", seq_num)
+                .field("tx_limit", tx_limit)
+                .field("proposal_gas_limit", proposal_gas_limit)
+                .field("proposal_byte_limit", proposal_byte_limit)
+                .field("timestamp_ns", timestamp_ns)
+                .field("extending_blocks", extending_blocks)
+                .finish(),
+            Self::FetchProposal {
                 node_id,
                 epoch,
                 round,

--- a/monad-mock-swarm/src/verifier.rs
+++ b/monad-mock-swarm/src/verifier.rs
@@ -318,10 +318,10 @@ impl<S: SwarmRelation> MockSwarmVerifier<S> {
                 fetch_metric!(consensus_events.process_old_qc),
                 num_blocks_authored,
             );
-            // should create proposals for all blocks authored in ledger
+            // should broadcast proposals for all blocks authored in ledger
             self.metric_minimum(
                 &vec![*node_id],
-                fetch_metric!(consensus_events.creating_proposal),
+                fetch_metric!(consensus_events.broadcasting_proposal),
                 num_blocks_authored,
             );
         }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -353,6 +353,8 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
             start_execution_threshold: SeqNum(statesync_threshold as u64 / 2),
             chain_config: node_state.chain_config,
             timestamp_latency_estimate_ns: 20_000_000,
+            // TODO: make this configurable
+            create_proposal_ahead: true,
             _phantom: Default::default(),
         },
         whitelisted_statesync_nodes,

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -380,6 +380,7 @@ where
                         start_execution_threshold: SeqNum(300),
                         chain_config: MockChainConfig::new(&CHAIN_PARAMS),
                         timestamp_latency_estimate_ns: 10_000_000,
+                        create_proposal_ahead: false,
                         _phantom: Default::default(),
                     },
                 },

--- a/monad-testutil/src/swarm.rs
+++ b/monad-testutil/src/swarm.rs
@@ -117,6 +117,7 @@ pub fn make_state_configs<S: SwarmRelation>(
                 start_execution_threshold: SeqNum(statesync_threshold.0 / 2),
                 chain_config,
                 timestamp_latency_estimate_ns: 10_000_000,
+                create_proposal_ahead: false,
 
                 _phantom: PhantomData,
             },

--- a/monad-twins/utils/src/twin_reader.rs
+++ b/monad-twins/utils/src/twin_reader.rs
@@ -402,6 +402,7 @@ where
                 start_execution_threshold: SeqNum(300),
                 chain_config: MockChainConfig::new(&CHAIN_PARAMS),
                 timestamp_latency_estimate_ns: 10_000_000,
+                create_proposal_ahead: false,
                 _phantom: PhantomData,
             },
 

--- a/monad-updaters/src/txpool.rs
+++ b/monad-updaters/src/txpool.rs
@@ -19,8 +19,9 @@ use std::{
 };
 
 use alloy_consensus::{
+    constants::EMPTY_WITHDRAWALS,
     transaction::{Recovered, SignerRecoverable},
-    TxEnvelope,
+    TxEnvelope, EMPTY_OMMER_ROOT_HASH,
 };
 use alloy_rlp::Decodable;
 use bytes::Bytes;
@@ -36,14 +37,15 @@ use monad_consensus_types::block::{
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
-use monad_eth_block_policy::EthBlockPolicy;
+use monad_eth_block_policy::{timestamp_ns_to_secs, EthBlockPolicy};
 use monad_eth_txpool::{EthTxPool, EthTxPoolEventTracker, EthTxPoolMetrics, PoolTxKind};
-use monad_eth_types::{EthExecutionProtocol, ExtractEthAddress};
+use monad_eth_types::{EthBlockBody, EthExecutionProtocol, ExtractEthAddress, ProposedEthHeader};
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{MempoolEvent, MonadEvent, TxPoolCommand};
 use monad_state_backend::StateBackend;
 use monad_types::{ExecutionProtocol, SeqNum};
 use monad_validator::signature_collection::SignatureCollection;
+use tracing::info;
 
 pub trait MockableTxPool:
     Executor<
@@ -231,7 +233,8 @@ where
     fn exec(&mut self, commands: Vec<Self::Command>) {
         for command in commands {
             match command {
-                TxPoolCommand::CreateProposal {
+                TxPoolCommand::CreateProposalAhead { .. } => {}
+                TxPoolCommand::FetchProposal {
                     node_id: _,
                     epoch,
                     round,
@@ -326,7 +329,47 @@ where
 
         for command in commands {
             match command {
-                TxPoolCommand::CreateProposal {
+                TxPoolCommand::CreateProposalAhead {
+                    node_id,
+                    epoch,
+                    round,
+                    seq_num,
+                    tx_limit,
+                    proposal_gas_limit,
+                    proposal_byte_limit,
+                    timestamp_ns,
+                    extending_blocks,
+                } => {
+                    let (base_fee, _, _) =
+                        block_policy.compute_base_fee(&extending_blocks, &self.chain_config);
+
+                    match pool.create_proposal(
+                        &mut event_tracker,
+                        epoch,
+                        round,
+                        seq_num,
+                        base_fee,
+                        tx_limit,
+                        proposal_gas_limit,
+                        proposal_byte_limit,
+                        timestamp_ns,
+                        node_id,
+                        extending_blocks.as_slice(),
+                        block_policy,
+                        state_backend,
+                        &self.chain_config,
+                    ) {
+                        Ok(_) => {}
+                        Err(block_policy_err) => {
+                            info!(
+                                ?seq_num,
+                                ?block_policy_err,
+                                "failed to create proposal ahead"
+                            );
+                        }
+                    }
+                }
+                TxPoolCommand::FetchProposal {
                     node_id,
                     epoch,
                     round,
@@ -346,7 +389,7 @@ where
                     let (base_fee, base_fee_trend, base_fee_moment) =
                         block_policy.compute_base_fee(&extending_blocks, &self.chain_config);
 
-                    let proposed_execution_inputs = pool
+                    let transactions = pool
                         .create_proposal(
                             &mut event_tracker,
                             epoch,
@@ -356,11 +399,9 @@ where
                             tx_limit,
                             proposal_gas_limit,
                             proposal_byte_limit,
-                            beneficiary,
                             timestamp_ns,
                             node_id,
-                            round_signature.clone(),
-                            extending_blocks,
+                            extending_blocks.as_slice(),
                             block_policy,
                             state_backend,
                             &self.chain_config,
@@ -372,6 +413,55 @@ where
                     } else {
                         seq_num
                     };
+
+                    let body = EthBlockBody {
+                        transactions,
+                        ommers: Vec::new(),
+                        withdrawals: Vec::new(),
+                    };
+
+                    // Monad does not use request hashes yet
+                    // It is hardcoded to zero hash for prague compatibility
+                    let maybe_request_hash = if self
+                        .chain_config
+                        .get_execution_chain_revision(timestamp_ns_to_secs(timestamp_ns))
+                        .execution_chain_params()
+                        .prague_enabled
+                    {
+                        Some([0_u8; 32])
+                    } else {
+                        None
+                    };
+
+                    let header = ProposedEthHeader {
+                        transactions_root: *alloy_consensus::proofs::calculate_transaction_root(
+                            &body.transactions,
+                        ),
+                        ommers_hash: {
+                            assert_eq!(body.ommers.len(), 0);
+                            *EMPTY_OMMER_ROOT_HASH
+                        },
+                        withdrawals_root: {
+                            assert_eq!(body.withdrawals.len(), 0);
+                            *EMPTY_WITHDRAWALS
+                        },
+
+                        beneficiary: beneficiary.into(),
+                        difficulty: 0,
+                        number: seq_num.0,
+                        gas_limit: proposal_gas_limit,
+                        timestamp: timestamp_ns_to_secs(timestamp_ns),
+                        mix_hash: round_signature.get_hash().0,
+                        nonce: [0_u8; 8],
+                        extra_data: [0_u8; 32],
+                        base_fee_per_gas: base_fee,
+                        blob_gas_used: 0,
+                        excess_blob_gas: 0,
+                        parent_beacon_block_root: [0_u8; 32],
+                        requests_hash: maybe_request_hash,
+                    };
+
+                    let proposed_execution_inputs = ProposedExecutionInputs { header, body };
 
                     self.events.push_back(MempoolEvent::Proposal {
                         epoch,


### PR DESCRIPTION
Txpool optimistically creates a proposal for `Round(N)` assuming a QC will be formed for the block proposed in `Round(N-1)`. On formation of QC, consensus fetches the created proposal and broadcasts it immediately.

In the event that there's a timeout or consensus decides to extend a different block in `Round(N)`, txpool defaults back to creating the proposal when `Round(N)` begins