### PR TITLE
add signature verifier

### DIFF
--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -81,6 +81,7 @@ pub mod decoding;
 pub mod message;
 pub mod metrics;
 pub mod packet;
+pub mod parser;
 pub mod raptorcast_secondary;
 pub mod udp;
 pub mod util;

--- a/monad-raptorcast/src/parser/mod.rs
+++ b/monad-raptorcast/src/parser/mod.rs
@@ -1,0 +1,16 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pub mod signature_verifier;

--- a/monad-raptorcast/src/parser/signature_verifier.rs
+++ b/monad-raptorcast/src/parser/signature_verifier.rs
@@ -1,0 +1,262 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{hash::Hash, marker::PhantomData, num::NonZeroUsize};
+
+use governor::{DefaultDirectRateLimiter, Quota, RateLimiter};
+use lru::LruCache;
+use monad_crypto::certificate_signature::{
+    CertificateSignaturePubKey, CertificateSignatureRecoverable,
+};
+use monad_types::NodeId;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignatureVerifierError {
+    /// The verifier's rate limit was exceeded for this key or source.
+    RateLimited,
+    /// The provided signature could not be verified.
+    InvalidSignature,
+}
+
+pub struct SignatureVerifier<ST, CacheKey, SD>
+where
+    ST: CertificateSignatureRecoverable,
+{
+    signature_cache: Option<LruCache<CacheKey, NodeId<CertificateSignaturePubKey<ST>>>>,
+    rate_limiter: Option<DefaultDirectRateLimiter>,
+    _signing_domain: PhantomData<SD>,
+}
+
+impl<ST, CacheKey, SD> SignatureVerifier<ST, CacheKey, SD>
+where
+    ST: CertificateSignatureRecoverable,
+{
+    pub fn new() -> Self {
+        Self {
+            signature_cache: None,
+            rate_limiter: None,
+            _signing_domain: PhantomData,
+        }
+    }
+
+    pub fn with_cache(mut self, size: usize) -> Self
+    where
+        CacheKey: Eq + Hash,
+    {
+        let cache_size = NonZeroUsize::new(size).expect("cache size must be non-zero");
+        self.signature_cache = Some(LruCache::new(cache_size));
+        self
+    }
+
+    pub fn with_rate_limit(mut self, rate_per_second: u32) -> Self {
+        let quota = Quota::per_second(
+            std::num::NonZero::new(rate_per_second).expect("rate limit must be non-zero"),
+        );
+        self.rate_limiter = Some(RateLimiter::direct(quota));
+        self
+    }
+
+    /// Try to load author from cache only, without signature verification.
+    pub fn load_cached(
+        &mut self,
+        cache_key: &CacheKey,
+    ) -> Option<NodeId<CertificateSignaturePubKey<ST>>>
+    where
+        CacheKey: Eq + Hash,
+    {
+        self.signature_cache
+            .as_mut()
+            .and_then(|cache| cache.get(cache_key).copied())
+    }
+
+    pub fn verify(
+        &self,
+        signature: ST,
+        data: &[u8],
+    ) -> Result<NodeId<CertificateSignaturePubKey<ST>>, SignatureVerifierError>
+    where
+        SD: monad_crypto::signing_domain::SigningDomain,
+    {
+        // Check rate limit before expensive signature recovery
+        if !self.check_rate_limit() {
+            return Err(SignatureVerifierError::RateLimited);
+        }
+
+        self.verify_unchecked(signature, data)
+    }
+
+    // Verify signature, bypassing rate limit check
+    pub fn verify_force(
+        &self,
+        signature: ST,
+        data: &[u8],
+    ) -> Result<NodeId<CertificateSignaturePubKey<ST>>, SignatureVerifierError>
+    where
+        SD: monad_crypto::signing_domain::SigningDomain,
+    {
+        // We still register the verification in the rate limiter, but
+        // ignore the result.
+        let _ = self.check_rate_limit();
+        self.verify_unchecked(signature, data)
+    }
+
+    fn verify_unchecked(
+        &self,
+        signature: ST,
+        data: &[u8],
+    ) -> Result<NodeId<CertificateSignaturePubKey<ST>>, SignatureVerifierError>
+    where
+        SD: monad_crypto::signing_domain::SigningDomain,
+    {
+        let author_pubkey = signature
+            .recover_pubkey::<SD>(data)
+            .map_err(|_| SignatureVerifierError::InvalidSignature)?;
+        let author = NodeId::new(author_pubkey);
+
+        Ok(author)
+    }
+
+    pub fn save_cache(
+        &mut self,
+        cache_key: CacheKey,
+        author: NodeId<CertificateSignaturePubKey<ST>>,
+    ) where
+        CacheKey: Eq + Hash,
+    {
+        if let Some(cache) = &mut self.signature_cache {
+            cache.put(cache_key, author);
+        }
+    }
+
+    fn check_rate_limit(&self) -> bool {
+        self.rate_limiter
+            .as_ref()
+            .is_none_or(|rl| rl.check().is_ok())
+    }
+}
+
+impl<ST, CacheKey, SD> Default for SignatureVerifier<ST, CacheKey, SD>
+where
+    ST: CertificateSignatureRecoverable,
+{
+    fn default() -> Self {
+        Self {
+            signature_cache: None,
+            rate_limiter: None,
+            _signing_domain: PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use monad_crypto::{hasher::Hasher, signing_domain};
+    use monad_secp::{KeyPair, SecpSignature};
+
+    use super::*;
+    use crate::packet::assembler::HEADER_LEN;
+
+    type SignatureType = SecpSignature;
+    type CacheKey = [u8; HEADER_LEN + 20];
+    type TestSignatureVerifier =
+        SignatureVerifier<SignatureType, CacheKey, signing_domain::RaptorcastChunk>;
+
+    fn make_keypair(seed: u8) -> KeyPair {
+        let mut hasher = monad_crypto::hasher::HasherType::new();
+        hasher.update([seed]);
+        let mut hash = hasher.hash();
+        KeyPair::from_bytes(&mut hash.0).unwrap()
+    }
+
+    fn make_cache_key(seed: u8) -> CacheKey {
+        let mut data = [0; _];
+        data[0] = seed;
+        data
+    }
+
+    #[test]
+    fn test_cache() {
+        const CACHE_SIZE: usize = 3;
+        let mut verifier: TestSignatureVerifier = SignatureVerifier::new().with_cache(CACHE_SIZE);
+
+        let authors: Vec<_> = (0..4)
+            .map(|i| NodeId::new(make_keypair(i).pubkey()))
+            .collect();
+        let keys: Vec<_> = (0..4).map(make_cache_key).collect();
+
+        // Save and retrieve first 3 entries
+        for i in 0..CACHE_SIZE {
+            verifier.save_cache(keys[i], authors[i]);
+            assert_eq!(verifier.load_cached(&keys[i]), Some(authors[i]));
+        }
+        assert_eq!(verifier.load_cached(&keys[0]), Some(authors[0]));
+        assert_eq!(verifier.load_cached(&keys[1]), Some(authors[1]));
+        assert_eq!(verifier.load_cached(&keys[2]), Some(authors[2]));
+
+        // Adding 4th entry should evict the first
+        verifier.save_cache(keys[3], authors[3]);
+        assert!(
+            verifier.load_cached(&keys[0]).is_none(),
+            "key 0 should be evicted"
+        );
+        assert_eq!(verifier.load_cached(&keys[3]), Some(authors[3]));
+    }
+
+    #[test]
+    fn test_rate_limit() {
+        // Rate limit: 1 verification/sec
+        let verifier: TestSignatureVerifier = SignatureVerifier::new().with_rate_limit(1);
+        let key = make_keypair(1);
+
+        let data1 = b"message 1";
+        let sig1 = key.sign::<signing_domain::RaptorcastChunk>(data1);
+        let result1 = verifier.verify(sig1, data1);
+        assert!(result1.is_ok(), "first verify should succeed");
+
+        // Second verify should be rate limited
+        let data2 = b"message 2";
+        let sig2 = key.sign::<signing_domain::RaptorcastChunk>(data2);
+        let result2 = verifier.verify(sig2, data2);
+        assert!(
+            matches!(result2, Err(SignatureVerifierError::RateLimited)),
+            "second verify should be rate limited"
+        );
+
+        // With bypass, should succeed
+        let result3 = verifier.verify_force(sig2, data2);
+        assert!(result3.is_ok(), "verify with bypass should succeed");
+    }
+
+    #[test]
+    fn test_correctness() {
+        let verifier: TestSignatureVerifier = SignatureVerifier::new();
+        let key = make_keypair(42);
+
+        let data = b"foobar";
+        let signature = key.sign::<signing_domain::RaptorcastChunk>(data);
+
+        // Verify using SignatureVerifier
+        let verifier_result = verifier
+            .verify(signature, data)
+            .expect("should verify successfully");
+        assert_eq!(verifier_result.pubkey(), key.pubkey());
+
+        // Compare with direct recover_pubkey
+        let direct_pubkey = signature
+            .recover_pubkey::<signing_domain::RaptorcastChunk>(data)
+            .unwrap();
+        assert_eq!(verifier_result.pubkey(), direct_pubkey);
+    }
+}

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -13,11 +13,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{collections::BTreeMap, num::NonZero, ops::Range};
+use std::{collections::BTreeMap, ops::Range};
 
 use bytes::Bytes;
-use governor::{DefaultDirectRateLimiter, Quota, RateLimiter};
-use lru::LruCache;
 use monad_crypto::{
     certificate_signature::{
         CertificateSignature, CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
@@ -40,6 +38,7 @@ use crate::{
         UdpStateMetrics, GAUGE_RAPTORCAST_DECODING_CACHE_SIGNATURE_VERIFICATIONS_RATE_LIMITED,
     },
     packet::{assembler::HEADER_LEN, PacketLayout},
+    parser::signature_verifier::{SignatureVerifier, SignatureVerifierError},
     util::{
         compute_hash, unix_ts_ms_now, AppMessageHash, BroadcastMode, EpochValidators, HexBytes,
         NodeIdHash, ReBroadcastGroupMap, Redundancy,
@@ -57,7 +56,7 @@ const _: () = assert!(
     "MIN_SEGMENT_LENGTH should be the segment size for the IPv6 minimum MTU of 1280 bytes"
 );
 
-pub const SIGNATURE_CACHE_SIZE: NonZero<usize> = NonZero::new(10_000).unwrap();
+pub const SIGNATURE_CACHE_SIZE: usize = 10_000;
 
 // We assume an MTU of at least 1280 (the IPv6 minimum MTU), which for the maximum Merkle tree
 // depth of 9 gives a symbol size of 960 bytes, which we will use as the minimum chunk length for
@@ -102,6 +101,11 @@ pub const MAX_SEGMENT_LENGTH: usize = ETHERNET_SEGMENT_SIZE as usize;
 /// <execution>/monad/staking/util/constants.hpp.
 pub const MAX_VALIDATOR_SET_SIZE: usize = 200;
 
+/// Cache key for signature verification: header + merkle root
+pub type SignatureCacheKey = [u8; HEADER_LEN + 20];
+pub type ChunkSignatureVerifier<ST> =
+    SignatureVerifier<ST, SignatureCacheKey, signing_domain::RaptorcastChunk>;
+
 pub(crate) struct UdpState<ST: CertificateSignatureRecoverable> {
     self_id: NodeId<CertificateSignaturePubKey<ST>>,
     max_age_ms: u64,
@@ -112,9 +116,7 @@ pub(crate) struct UdpState<ST: CertificateSignatureRecoverable> {
     // generate a bunch of linearly dependent chunks and cause unbounded memory usage.
     decoder_cache: DecoderCache<CertificateSignaturePubKey<ST>>,
 
-    signature_cache: LruCache<[u8; HEADER_LEN + 20], NodeId<CertificateSignaturePubKey<ST>>>,
-
-    sig_verification_rate_limiter: DefaultDirectRateLimiter,
+    signature_verifier: ChunkSignatureVerifier<ST>,
 
     metrics: UdpStateMetrics,
 }
@@ -125,19 +127,16 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
         max_age_ms: u64,
         sig_verification_rate_limit: u32,
     ) -> Self {
-        let quota = Quota::per_second(
-            NonZero::new(sig_verification_rate_limit)
-                .expect("sig_verification_rate_limit must be non-zero"),
-        );
-        let sig_verification_rate_limiter = RateLimiter::direct(quota);
+        let signature_verifier = SignatureVerifier::new()
+            .with_cache(SIGNATURE_CACHE_SIZE)
+            .with_rate_limit(sig_verification_rate_limit);
 
         Self {
             self_id,
             max_age_ms,
 
             decoder_cache: DecoderCache::default(),
-            signature_cache: LruCache::new(SIGNATURE_CACHE_SIZE),
-            sig_verification_rate_limiter,
+            signature_verifier,
 
             metrics: UdpStateMetrics::new(),
         }
@@ -178,26 +177,19 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
             let payload = message.payload.slice(payload_start_idx..payload_end_idx);
 
             // "message" here means a raptor-casted chunk (AKA r10 symbol), not the whole final message (proposal)
-            let parsed_message = match parse_message::<ST, _>(
-                &mut self.signature_cache,
+            let parsed_message = match parse_message(
+                &mut self.signature_verifier,
                 payload,
                 self.max_age_ms,
-                |group_id| {
-                    let allowed = self.sig_verification_rate_limiter.check().is_ok();
-                    let is_validator = match (message.auth_public_key.as_ref(), group_id) {
-                        (Some(pk), GroupId::Primary(epoch)) => {
-                            let node_id = NodeId::new(*pk);
-                            epoch_validators
-                                .get(&epoch)
-                                .is_some_and(|ev| ev.validators.is_member(&node_id))
-                        }
-                        _ => false,
-                    };
-                    if allowed || is_validator {
-                        Ok(())
-                    } else {
-                        Err(MessageValidationError::RateLimited)
-                    }
+                |epoch: Epoch| {
+                    // validator senders are allowed to bypass rate limiting
+                    message.auth_public_key.as_ref().is_some_and(|pk| {
+                        let node_id = NodeId::new(*pk);
+                        epoch_validators
+                            .get(&epoch)
+                            .iter()
+                            .any(|ev| ev.validators.is_member(&node_id))
+                    })
                 },
             ) {
                 Ok(message) => message,
@@ -414,6 +406,15 @@ pub enum MessageValidationError {
     RateLimited,
 }
 
+impl From<SignatureVerifierError> for MessageValidationError {
+    fn from(err: SignatureVerifierError) -> Self {
+        match err {
+            SignatureVerifierError::RateLimited => MessageValidationError::RateLimited,
+            SignatureVerifierError::InvalidSignature => MessageValidationError::InvalidSignature,
+        }
+    }
+}
+
 /// - 65 bytes => Signature of sender over hash(rest of message up to merkle proof, concatenated with merkle root)
 /// - 2 bytes => Version: bumped on protocol updates
 /// - 1 bit => broadcast or not
@@ -437,14 +438,14 @@ pub enum MessageValidationError {
 /// - 2 bytes (u16) => This chunk's id
 /// - rest => data
 pub fn parse_message<ST, F>(
-    signature_cache: &mut LruCache<[u8; HEADER_LEN + 20], NodeId<CertificateSignaturePubKey<ST>>>,
+    signature_verifier: &mut ChunkSignatureVerifier<ST>,
     message: Bytes,
     max_age_ms: u64,
-    rate_limit_check: F,
+    bypass_rate_limiter: F,
 ) -> Result<ValidatedMessage<CertificateSignaturePubKey<ST>>, MessageValidationError>
 where
     ST: CertificateSignatureRecoverable,
-    F: Fn(GroupId) -> Result<(), MessageValidationError>,
+    F: FnOnce(Epoch) -> bool,
 {
     let mut cursor: Bytes = message.clone();
     let mut split_off = |mid| {
@@ -583,18 +584,23 @@ where
     let root = merkle_proof
         .compute_root(&leaf_hash)
         .ok_or(MessageValidationError::InvalidMerkleProof)?;
-    let mut signed_over = [0_u8; HEADER_LEN + 20];
+    let mut signed_over: SignatureCacheKey = [0_u8; HEADER_LEN + 20];
     // TODO can avoid this copy if necessary
     signed_over[..HEADER_LEN].copy_from_slice(&message[..HEADER_LEN]);
     signed_over[HEADER_LEN..].copy_from_slice(&root);
 
-    let author = *signature_cache.try_get_or_insert(signed_over, || {
-        rate_limit_check(group_id)?;
-        let author = signature
-            .recover_pubkey::<signing_domain::RaptorcastChunk>(&signed_over[SIGNATURE_SIZE..])
-            .map_err(|_| MessageValidationError::InvalidSignature)?;
-        Ok(NodeId::new(author))
-    })?;
+    let author = if let Some(author) = signature_verifier.load_cached(&signed_over) {
+        author
+    } else {
+        let new_author = match group_id {
+            GroupId::Primary(epoch) if bypass_rate_limiter(epoch) => {
+                signature_verifier.verify_force(signature, &signed_over[SIGNATURE_SIZE..])?
+            }
+            _ => signature_verifier.verify(signature, &signed_over[SIGNATURE_SIZE..])?,
+        };
+        signature_verifier.save_cache(signed_over, new_author);
+        new_author
+    };
 
     Ok(ValidatedMessage {
         message,
@@ -792,13 +798,10 @@ mod tests {
     use std::{
         collections::{HashMap, HashSet},
         net::{IpAddr, Ipv4Addr, SocketAddr},
-        num::NonZero,
     };
 
     use bytes::{Bytes, BytesMut};
-    use governor::{Quota, RateLimiter};
     use itertools::Itertools as _;
-    use lru::LruCache;
     use monad_crypto::{
         certificate_signature::CertificateSignaturePubKey,
         hasher::{Hasher, HasherType},
@@ -809,9 +812,10 @@ mod tests {
     use monad_validator::validator_set::{ValidatorSet, ValidatorSetType as _};
     use rstest::*;
 
-    use super::{GroupId, MessageValidationError, UdpState};
+    use super::{ChunkSignatureVerifier, GroupId, MessageValidationError, UdpState};
     use crate::{
         packet::{MessageBuilder, PacketLayout},
+        parser::signature_verifier::SignatureVerifier,
         udp::{build_messages, parse_message, MAX_VALIDATOR_SET_SIZE, SIGNATURE_CACHE_SIZE},
         util::{
             BroadcastMode, BuildTarget, EpochValidators, Group, ReBroadcastGroupMap, Redundancy,
@@ -820,6 +824,11 @@ mod tests {
 
     type SignatureType = SecpSignature;
     type KeyPairType = KeyPair;
+    type TestSignatureVerifier = ChunkSignatureVerifier<SignatureType>;
+
+    fn signature_verifier() -> TestSignatureVerifier {
+        SignatureVerifier::new().with_cache(SIGNATURE_CACHE_SIZE)
+    }
 
     fn validator_set() -> (
         KeyPairType,
@@ -885,16 +894,16 @@ mod tests {
             &known_addresses,
         );
 
-        let mut signature_cache = LruCache::new(SIGNATURE_CACHE_SIZE);
+        let mut signature_verifier = signature_verifier();
 
         for (_to, mut aggregate_message) in messages {
             while !aggregate_message.is_empty() {
                 let message = aggregate_message.split_to(DEFAULT_SEGMENT_SIZE.into());
-                let parsed_message = parse_message::<SignatureType, _>(
-                    &mut signature_cache,
+                let parsed_message = parse_message(
+                    &mut signature_verifier,
                     message.clone(),
                     u64::MAX,
-                    |_| Ok(()),
+                    |_| true, // bypass_rate_limiter
                 )
                 .expect("valid message");
                 assert_eq!(parsed_message.message, message);
@@ -928,7 +937,7 @@ mod tests {
             &known_addresses,
         );
 
-        let mut signature_cache = LruCache::new(SIGNATURE_CACHE_SIZE);
+        let mut signature_verifier = signature_verifier();
 
         for (_to, mut aggregate_message) in messages {
             while !aggregate_message.is_empty() {
@@ -941,11 +950,11 @@ mod tests {
                     let old_byte = message[bit_idx / 8];
                     // flip bit
                     message[bit_idx / 8] = old_byte ^ (1 << (bit_idx % 8));
-                    let maybe_parsed = parse_message::<SignatureType, _>(
-                        &mut signature_cache,
+                    let maybe_parsed = parse_message(
+                        &mut signature_verifier,
                         message.clone().into(),
                         u64::MAX,
-                        |_| Ok(()),
+                        |_| true, // bypass_rate_limiter
                     );
 
                     // check that decoding fails
@@ -979,18 +988,18 @@ mod tests {
             &known_addresses,
         );
 
-        let mut signature_cache = LruCache::new(SIGNATURE_CACHE_SIZE);
+        let mut signature_verifier = signature_verifier();
 
         let mut used_ids = HashSet::new();
 
         for (_to, mut aggregate_message) in messages {
             while !aggregate_message.is_empty() {
                 let message = aggregate_message.split_to(DEFAULT_SEGMENT_SIZE.into());
-                let parsed_message = parse_message::<SignatureType, _>(
-                    &mut signature_cache,
+                let parsed_message = parse_message(
+                    &mut signature_verifier,
                     message.clone(),
                     u64::MAX,
-                    |_| Ok(()),
+                    |_| true, // bypass_rate_limiter
                 )
                 .expect("valid message");
                 let newly_inserted = used_ids.insert(parsed_message.chunk_id);
@@ -1029,16 +1038,16 @@ mod tests {
                 &known_addresses,
             );
 
-            let mut signature_cache = LruCache::new(SIGNATURE_CACHE_SIZE);
+            let mut signature_verifier = signature_verifier();
 
             for (_to, mut aggregate_message) in messages {
                 while !aggregate_message.is_empty() {
                     let message = aggregate_message.split_to(DEFAULT_SEGMENT_SIZE.into());
-                    let parsed_message = parse_message::<SignatureType, _>(
-                        &mut signature_cache,
+                    let parsed_message = parse_message(
+                        &mut signature_verifier,
                         message.clone(),
                         u64::MAX,
-                        |_| Ok(()),
+                        |_| true, // bypass_rate_limiter
                     )
                     .expect("valid message");
 
@@ -1080,18 +1089,18 @@ mod tests {
             &known_addresses,
         );
 
-        let mut signature_cache = LruCache::new(SIGNATURE_CACHE_SIZE);
+        let mut signature_verifier = signature_verifier();
 
         let mut used_ids: HashMap<SocketAddr, HashSet<_>> = HashMap::new();
 
         for (to, mut aggregate_message) in messages {
             while !aggregate_message.is_empty() {
                 let message = aggregate_message.split_to(DEFAULT_SEGMENT_SIZE.into());
-                let parsed_message = parse_message::<SignatureType, _>(
-                    &mut signature_cache,
+                let parsed_message = parse_message(
+                    &mut signature_verifier,
                     message.clone(),
                     u64::MAX,
-                    |_| Ok(()),
+                    |_| true, // bypass_rate_limiter
                 )
                 .expect("valid message");
                 let newly_inserted = used_ids
@@ -1158,7 +1167,7 @@ mod tests {
     ) {
         let (key, validators, known_addresses) = validator_set();
         let epoch_validators = validators.view_without(vec![&NodeId::new(key.pubkey())]);
-        let mut signature_cache = LruCache::new(SIGNATURE_CACHE_SIZE);
+        let mut signature_verifier = signature_verifier();
 
         let current_time = std::time::UNIX_EPOCH.elapsed().unwrap().as_millis() as u64;
         let test_timestamp = (current_time as i64 + timestamp_offset_ms) as u64;
@@ -1175,11 +1184,11 @@ mod tests {
             &known_addresses,
         );
         let message = messages.into_iter().next().unwrap().1;
-        let result = parse_message::<SignatureType, _>(
-            &mut signature_cache,
+        let result = parse_message(
+            &mut signature_verifier,
             message,
             max_age_ms,
-            |_| Ok(()),
+            |_| true, // bypass_rate_limiter
         );
 
         if should_succeed {
@@ -1234,12 +1243,12 @@ mod tests {
         let chunk_id_buf: &mut [u8] = &mut chunk_header[22..24];
         chunk_id_buf.copy_from_slice(&chunk_id.to_le_bytes()); // override chunk id
 
-        let mut signature_cache = LruCache::new(SIGNATURE_CACHE_SIZE);
-        let result = parse_message::<SignatureType, _>(
-            &mut signature_cache,
+        let mut signature_verifier = signature_verifier();
+        let result = parse_message(
+            &mut signature_verifier,
             payload.freeze(),
             u64::MAX,
-            |_| Ok(()),
+            |_| true, // bypass_rate_limiter
         );
 
         if should_succeed {
@@ -1290,74 +1299,71 @@ mod tests {
 
             packet
         };
-        let mut signature_cache = LruCache::new(SIGNATURE_CACHE_SIZE);
-        let result = parse_message::<SignatureType, _>(
-            &mut signature_cache,
+        let mut signature_verifier = signature_verifier();
+        let result = parse_message(
+            &mut signature_verifier,
             payload.into(),
             u64::MAX,
-            |_| Ok(()),
+            |_| true, // bypass_rate_limiter
         );
         assert_eq!(result.err(), Some(MessageValidationError::TooShort))
     }
 
     #[test]
-    fn test_rate_limiting_per_signature() {
+    fn test_parse_message_signature_verifier() {
         let (key, validators, known_addresses) = validator_set();
         let epoch_validators = validators.view_without(vec![&NodeId::new(key.pubkey())]);
 
-        // 1 second is long enough for governor to be reliable
-        let quota = Quota::per_second(NonZero::new(10).unwrap());
-        let rate_limiter = RateLimiter::direct(quota);
-        let mut signature_cache = LruCache::new(SIGNATURE_CACHE_SIZE);
+        let app_message: Bytes = vec![1_u8; 1024].into();
 
-        const UNIX_TS_MS: u64 = 1000;
-        const EPOCH: Epoch = Epoch(1);
+        let messages = build_messages::<SignatureType>(
+            &key,
+            DEFAULT_SEGMENT_SIZE,
+            app_message,
+            Redundancy::from_u8(1),
+            GroupId::Primary(EPOCH),
+            UNIX_TS_MS,
+            BuildTarget::Raptorcast(epoch_validators),
+            &known_addresses,
+        );
 
-        // Create 11 different messages to force signature verification on each call
-        for i in 0..11 {
-            let message = format!("test message {}", i);
-            let app_message: Bytes = message.as_bytes().to_vec().into();
-            let messages = build_messages::<SignatureType>(
-                &key,
-                DEFAULT_SEGMENT_SIZE,
-                app_message,
-                Redundancy::from_u8(1),
-                GroupId::Primary(EPOCH),
-                UNIX_TS_MS,
-                BuildTarget::Broadcast(epoch_validators.clone().into()),
-                &known_addresses,
-            );
+        let message_a: Bytes = messages[0].1.slice(0..(DEFAULT_SEGMENT_SIZE as usize));
+        let message_b: Bytes = messages
+            .last()
+            .unwrap()
+            .1
+            .slice(0..(DEFAULT_SEGMENT_SIZE as usize));
 
-            let first_message = messages.into_iter().next().unwrap().1;
+        let mut signature_verifier: TestSignatureVerifier = SignatureVerifier::new()
+            .with_cache(SIGNATURE_CACHE_SIZE)
+            .with_rate_limit(1);
 
-            let result = parse_message::<SignatureType, _>(
-                &mut signature_cache,
-                first_message.clone(),
-                u64::MAX,
-                |_| {
-                    if rate_limiter.check().is_ok() {
-                        Ok(())
-                    } else {
-                        Err(MessageValidationError::RateLimited)
-                    }
-                },
-            );
+        // Case 1: cache miss, verify signature, cache saved
+        let bypass = |_| true;
+        let result1 = parse_message(&mut signature_verifier, message_a.clone(), u64::MAX, bypass);
+        let author = result1.expect("first parse should succeed").author;
+        assert_eq!(author, NodeId::new(key.pubkey()));
 
-            if i < 10 {
-                assert!(
-                    result.is_ok(),
-                    "parse_message #{} should succeed, got error: {:?}",
-                    i + 1,
-                    result.err()
-                );
-            } else {
-                // 11th call should fail due to rate limiting
-                assert!(
-                    matches!(result, Err(MessageValidationError::RateLimited)),
-                    "parse_message #11 should be rate limited, got: {:?}",
-                    result
-                );
-            }
-        }
+        // Case 2: parse with same message: cache hit, no rate limit consumed
+        let bypass = |_| false;
+        let result2 = parse_message(&mut signature_verifier, message_a, u64::MAX, bypass);
+        assert_eq!(
+            result2.expect("cache hit should succeed").author,
+            author,
+            "cache hit should return same author"
+        );
+
+        // Case 3: parse different message without bypass: rate limited
+        let bypass = |_| false;
+        let result3 = parse_message(&mut signature_verifier, message_b.clone(), u64::MAX, bypass);
+        assert!(
+            matches!(result3, Err(MessageValidationError::RateLimited)),
+            "new message without bypass should be rate limited"
+        );
+
+        // Case 4: Same message with bypass: succeeds
+        let bypass = |_| true;
+        let result4 = parse_message(&mut signature_verifier, message_b, u64::MAX, bypass);
+        assert!(result4.is_ok());
     }
 }


### PR DESCRIPTION
This commit combines the rate limiter and signature verifier into a unified type called `SignatureVerifier` and integrates it into the `udp::parse_message`.

The type captures the concept of a signature verification with optional caching and optional rate limiting.

The rate limiter bypassing mechanism is now reduced into a predicate. This can be further reduced to a single boolean value once the message parser is specialized to each protocol in follow up commits.