### PR TITLE
Raptorcast: deterministic protocol

### DIFF
--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -1854,7 +1854,10 @@ where
                 );
 
                 cmds.push(ConsensusCommand::Publish {
-                    target: RouterTarget::Raptorcast(self.consensus.pacemaker.get_current_epoch()),
+                    target: RouterTarget::Raptorcast {
+                        round: self.consensus.pacemaker.get_current_round(),
+                        epoch: self.consensus.pacemaker.get_current_epoch(),
+                    },
                     message: ConsensusMessage {
                         version: self.version,
                         message: ProtocolMessage::Proposal(ProposalMessage {
@@ -2791,7 +2794,7 @@ mod test {
     {
         cmds.iter().find_map(|c| match c {
             ConsensusCommand::Publish {
-                target: RouterTarget::Raptorcast(_),
+                target: RouterTarget::Raptorcast { .. },
                 message,
             } => match &message.deref().deref().message {
                 ProtocolMessage::Proposal(p) => Some(p.clone()),

--- a/monad-node-config/src/lib.rs
+++ b/monad-node-config/src/lib.rs
@@ -37,6 +37,9 @@ mod peers;
 pub mod fullnode_raptorcast;
 pub use fullnode_raptorcast::FullNodeRaptorCastConfig;
 
+pub mod raptorcast;
+pub use raptorcast::DeterministicProtocolRolloutStage;
+
 mod sync_peers;
 
 #[derive(Debug, Deserialize, Clone)]
@@ -71,6 +74,9 @@ pub struct NodeConfig<ST: CertificateSignatureRecoverable> {
     pub txpool_peer_score: ema::ScoreConfig,
 
     pub fullnode_raptorcast: FullNodeRaptorCastConfig<CertificateSignaturePubKey<ST>>,
+
+    #[serde(default)]
+    pub deterministic_raptorcast_rollout: DeterministicProtocolRolloutStage,
 
     // TODO split network-wide configuration into separate file
     ////////////////////////////////

--- a/monad-node-config/src/raptorcast.rs
+++ b/monad-node-config/src/raptorcast.rs
@@ -1,0 +1,55 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+// Gradual rollout from v0 (regular) to v1 (deterministic) raptorcast.
+//
+// The rollout proceeds through four stages, bumped on release:
+//
+//                    AcceptBoth        AcceptBoth
+//   AlwaysV0         PublishV0         PublishV1          AlwaysV1
+//  -----------------+------------------+------------------+----------
+
+pub const CURRENT_STAGE: DeterministicProtocolRolloutStage =
+    DeterministicProtocolRolloutStage::AlwaysV0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeterministicProtocolRolloutStage {
+    AlwaysV0,
+    AcceptBothPublishV0,
+    AcceptBothPublishV1,
+    AlwaysV1,
+}
+
+impl Default for DeterministicProtocolRolloutStage {
+    fn default() -> Self {
+        CURRENT_STAGE
+    }
+}
+
+impl fmt::Display for DeterministicProtocolRolloutStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AlwaysV0 => write!(f, "always_v0"),
+            Self::AcceptBothPublishV0 => write!(f, "accept_both_publish_v0"),
+            Self::AcceptBothPublishV1 => write!(f, "accept_both_publish_v1"),
+            Self::AlwaysV1 => write!(f, "always_v1"),
+        }
+    }
+}

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -777,6 +777,7 @@ where
                     .collect(),
             },
             secondary_instance: node_config.fullnode_raptorcast,
+            deterministic_protocol_rollout: node_config.deterministic_raptorcast_rollout,
         },
         dp_builder,
         peer_discovery_builder,

--- a/monad-raptorcast/benches/encode_bench.rs
+++ b/monad-raptorcast/benches/encode_bench.rs
@@ -106,7 +106,7 @@ fn setup_raptorcast() -> (
     let author_id = Box::leak(Box::new(author_id));
     let group = PrimaryBroadcastGroup::of_epoch(Epoch(0), author_id, group_map).unwrap();
 
-    (author, BuildTarget::Raptorcast(group), known_addresses)
+    (author, BuildTarget::raptorcast(group), known_addresses)
 }
 
 fn setup_broadcast() -> (

--- a/monad-raptorcast/benches/raptor_bench.rs
+++ b/monad-raptorcast/benches/raptor_bench.rs
@@ -75,7 +75,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 message.clone(),
                 Redundancy::from_u8(2),
                 0, // unix_ts_ms
-                BuildTarget::Raptorcast(group),
+                BuildTarget::raptorcast(group),
                 &known_addresses,
             );
         });
@@ -118,7 +118,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             message.clone(),
             Redundancy::from_u8(2),
             0, // unix_ts_ms
-            BuildTarget::Raptorcast(group),
+            BuildTarget::raptorcast(group),
             &known_addresses,
         )
         .into_iter()

--- a/monad-raptorcast/examples/latency.rs
+++ b/monad-raptorcast/examples/latency.rs
@@ -51,7 +51,7 @@ use monad_raptorcast::{
     RaptorCast, RaptorCastEvent,
 };
 use monad_secp::{KeyPair, SecpSignature};
-use monad_types::{Deserializable, Epoch, NodeId, RouterTarget, Serializable, Stake};
+use monad_types::{Deserializable, Epoch, NodeId, Round, RouterTarget, Serializable, Stake};
 use opentelemetry::metrics::MeterProvider;
 use opentelemetry_otlp::{MetricExporter, WithExportConfig};
 use rand::{thread_rng, Rng};
@@ -291,6 +291,7 @@ fn create_raptorcast_config(keypair: Arc<KeyPair>) -> RaptorCastConfig<Signature
             invite_future_dist_max: monad_types::Round(5),
             invite_accept_heartbeat_ms: 100,
         },
+        deterministic_protocol_rollout: monad_raptorcast::v1_rollout::CURRENT_STAGE,
     }
 }
 
@@ -769,7 +770,7 @@ async fn run_producer(
             _ = interval_timer.tick() => {
                 let message = MockMessage::new_with_timestamp(size);
                 raptorcast.exec(vec![RouterCommand::Publish {
-                    target: RouterTarget::Raptorcast(Epoch(0)),
+                    target: RouterTarget::Raptorcast { round: Round(0), epoch: Epoch(0) },
                     message,
                 }]);
 

--- a/monad-raptorcast/examples/service.rs
+++ b/monad-raptorcast/examples/service.rs
@@ -33,7 +33,7 @@ use monad_executor::Executor;
 use monad_executor_glue::{Message, RouterCommand};
 use monad_raptorcast::{new_defaulted_raptorcast_for_tests, RaptorCastEvent};
 use monad_secp::SecpSignature;
-use monad_types::{Deserializable, Epoch, NodeId, RouterTarget, Serializable, Stake};
+use monad_types::{Deserializable, Epoch, NodeId, Round, RouterTarget, Serializable, Stake};
 use tracing_subscriber::fmt::format::FmtSpan;
 
 #[derive(Parser, Debug)]
@@ -168,7 +168,10 @@ fn service(
     for broadcast_id in 0..num_broadcast {
         let message = MockMessage::new(broadcast_id, message_len);
         let command = RouterCommand::Publish {
-            target: RouterTarget::Raptorcast(Epoch(0)),
+            target: RouterTarget::Raptorcast {
+                round: Round(0),
+                epoch: Epoch(0),
+            },
             message,
         };
         tx_router

--- a/monad-raptorcast/src/config.rs
+++ b/monad-raptorcast/src/config.rs
@@ -21,6 +21,8 @@ use monad_crypto::certificate_signature::{
 use monad_node_config::FullNodeRaptorCastConfig;
 use monad_types::{NodeId, Round};
 
+use crate::v1_rollout::DeterministicProtocolRolloutStage;
+
 pub struct RaptorCastConfig<ST>
 where
     ST: CertificateSignatureRecoverable,
@@ -51,6 +53,8 @@ where
     // Validators and full-nodes who do not want to participate in validator-
     // to-full-node raptor-casting may opt out of this.
     pub secondary_instance: FullNodeRaptorCastConfig<CertificateSignaturePubKey<ST>>,
+
+    pub deterministic_protocol_rollout: DeterministicProtocolRolloutStage,
 }
 
 impl<ST> Clone for RaptorCastConfig<ST>
@@ -65,6 +69,7 @@ where
             sig_verification_rate_limit: self.sig_verification_rate_limit,
             primary_instance: self.primary_instance.clone(),
             secondary_instance: self.secondary_instance.clone(),
+            deterministic_protocol_rollout: self.deterministic_protocol_rollout,
         }
     }
 }

--- a/monad-raptorcast/src/decoding.rs
+++ b/monad-raptorcast/src/decoding.rs
@@ -1775,6 +1775,7 @@ mod test {
                 broadcast_mode: BroadcastMode::Unspecified,
                 chunk: chunk.freeze(),
                 // these fields are never touched in this module
+                signature: Bytes::new(),
                 recipient_hash: None,
                 message: Bytes::new(),
                 group_id: GroupId::Primary(EPOCH),

--- a/monad-raptorcast/src/decoding.rs
+++ b/monad-raptorcast/src/decoding.rs
@@ -16,7 +16,7 @@
 #![allow(clippy::manual_range_contains)]
 #![allow(clippy::identity_op)]
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     hash::Hash,
     num::NonZero,
     sync::Arc,
@@ -1516,7 +1516,6 @@ impl InvalidSymbol {
 
 struct DecoderState {
     decoder: ManagedDecoder,
-    recipient_chunks: BTreeMap<NodeIdHash, usize>,
     app_message_len: usize,
     seen_esis: BitVec<usize, Lsb0>,
 }
@@ -1538,7 +1537,6 @@ impl DecoderState {
 
         let mut decoder_state = DecoderState {
             decoder,
-            recipient_chunks: BTreeMap::new(),
             app_message_len,
             seen_esis: bitvec![usize, Lsb0; 0; encoded_symbol_capacity],
         };
@@ -1558,10 +1556,6 @@ impl DecoderState {
         self.seen_esis.set(symbol_id, true);
         self.decoder
             .received_encoded_symbol(&message.chunk, symbol_id);
-        *self
-            .recipient_chunks
-            .entry(message.recipient_hash)
-            .or_insert(0) += 1;
 
         Ok(())
     }
@@ -1704,6 +1698,8 @@ fn quota_policy_from_config<PT: PubKey>(config: &SoftQuotaCacheConfig) -> Box<dy
 
 #[cfg(test)]
 mod test {
+    use std::collections::BTreeMap;
+
     use bytes::BytesMut;
     use itertools::Itertools;
     use monad_types::{Epoch, Stake};
@@ -1779,7 +1775,7 @@ mod test {
                 broadcast_mode: BroadcastMode::Unspecified,
                 chunk: chunk.freeze(),
                 // these fields are never touched in this module
-                recipient_hash: HexBytes([0; 20]),
+                recipient_hash: None,
                 message: Bytes::new(),
                 group_id: GroupId::Primary(EPOCH),
                 unix_ts_ms,

--- a/monad-raptorcast/src/decoding.rs
+++ b/monad-raptorcast/src/decoding.rs
@@ -36,13 +36,8 @@ use rand::Rng as _;
 
 use crate::{
     udp::ValidatedChunk,
-    util::{compute_hash, AppMessageHash, BroadcastMode, NodeIdHash},
+    util::{compute_hash, AppMessageHash, BroadcastMode, GlobalMerkleRoot, NodeIdHash},
 };
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-enum MessageIdentifier {
-    AppMessageHash(AppMessageHash),
-}
 
 pub const DECODING_CACHE_METRIC_PREFIX: &str = "monad.raptorcast.decoding_cache";
 monad_executor::metric_consts! {
@@ -101,6 +96,12 @@ pub const MAX_TOTAL_SIZE_LIMIT: usize = 20 * 1024 * 1024 * 1024; // 20 GB
 //
 // Required properties: (Copy, Add, Sub, Eq, Ord)
 type MessageSize = usize;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+enum MessageIdentifier {
+    AppMessageHash(AppMessageHash),
+    GlobalMerkleRoot(GlobalMerkleRoot),
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct DecoderCacheConfig {
@@ -436,9 +437,19 @@ struct CacheKey {
 
 impl CacheKey {
     fn from_message<PT: PubKey>(message: &ValidatedChunk<PT>) -> Self {
+        let message_id = if let Some(root) = message.global_merkle_root() {
+            MessageIdentifier::GlobalMerkleRoot(*root)
+        } else {
+            MessageIdentifier::AppMessageHash(
+                message
+                    .app_message_hash()
+                    .copied()
+                    .expect("V0 chunks must have app_message_hash"),
+            )
+        };
         let inner = CacheKeyInner {
             author_hash: compute_hash(&message.author),
-            message_id: MessageIdentifier::AppMessageHash(message.app_message_hash),
+            message_id,
             unix_ts_ms: message.unix_ts_ms,
         };
         Self {
@@ -1522,7 +1533,6 @@ impl DecoderState {
             .expect("usize smaller than u32");
         let num_source_symbols = message.num_source_symbols;
         let encoded_symbol_capacity = message.encoded_symbol_capacity;
-
         let decoder = ManagedDecoder::new(num_source_symbols, encoded_symbol_capacity, symbol_len)
             .map_err(InvalidSymbol::InvalidDecoderParameter)?;
 
@@ -1702,7 +1712,7 @@ mod test {
     use super::*;
     use crate::{
         udp::GroupId,
-        util::{compute_app_message_hash, BroadcastMode, HexBytes},
+        util::{compute_app_message_hash, BroadcastMode, EncodingScheme, HexBytes},
     };
     type PT = monad_crypto::NopPubKey;
 
@@ -1762,8 +1772,10 @@ mod test {
             let chunk = ValidatedChunk {
                 chunk_id: symbol_id as u16,
                 author,
-                app_message_hash,
+                app_message_hash: Some(app_message_hash),
+                merkle_root: HexBytes([0; 20]),
                 app_message_len: app_message.len() as u32,
+                encoding_scheme: EncodingScheme::Unspecified,
                 broadcast_mode: BroadcastMode::Unspecified,
                 chunk: chunk.freeze(),
                 // these fields are never touched in this module
@@ -2440,7 +2452,7 @@ mod test {
 
         let wrong_hash = HexBytes([0xAA; 20]);
         for symbol in &mut symbols {
-            symbol.app_message_hash = wrong_hash;
+            symbol.app_message_hash = Some(wrong_hash);
         }
 
         let context = DecodingContext::new(None, UNIX_TS_MS);

--- a/monad-raptorcast/src/decoding.rs
+++ b/monad-raptorcast/src/decoding.rs
@@ -1707,7 +1707,7 @@ mod test {
 
     use super::*;
     use crate::{
-        udp::GroupId,
+        udp::{ChunkVersion, GroupId},
         util::{compute_app_message_hash, BroadcastMode, EncodingScheme, HexBytes},
     };
     type PT = monad_crypto::NopPubKey;
@@ -1771,6 +1771,7 @@ mod test {
                 app_message_hash: Some(app_message_hash),
                 merkle_root: HexBytes([0; 20]),
                 app_message_len: app_message.len() as u32,
+                version: ChunkVersion::V0,
                 encoding_scheme: EncodingScheme::Unspecified,
                 broadcast_mode: BroadcastMode::Unspecified,
                 chunk: chunk.freeze(),

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -91,6 +91,7 @@ pub mod metrics;
 pub mod packet;
 pub mod parser;
 pub mod raptorcast_secondary;
+mod round_info;
 pub mod udp;
 pub mod util;
 
@@ -915,6 +916,7 @@ where
 
                         self.epoch_validators.retain(|e, _| *e + Epoch(1) >= epoch);
                     }
+                    self.udp_state.update_current_round(round);
                     self.full_node_groups.delete_expired(round);
                     self.peer_discovery_driver
                         .lock()

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -61,7 +61,7 @@ use monad_validator::{
 };
 use packet::regular;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use tracing::{debug, debug_span, error, trace, warn};
+use tracing::{debug, debug_span, error, info, trace, warn};
 use util::{
     AutoRebroadcast, BroadcastGroup, BroadcastGroupError, BuildTarget, Collector, FullNodeGroupMap,
     PeerAddrLookup, PrimaryBroadcastGroup, Recipient, Redundancy, SecondaryBroadcastGroup,
@@ -94,6 +94,7 @@ pub mod raptorcast_secondary;
 mod round_info;
 pub mod udp;
 pub mod util;
+pub mod v1_rollout;
 
 const SIGNATURE_SIZE: usize = 65;
 const DEFAULT_RETRY_ATTEMPTS: u64 = 3;
@@ -129,6 +130,7 @@ where
     current_epoch: Epoch,
 
     udp_state: udp::UdpState<ST>,
+    v1_rollout: v1_rollout::DeterministicProtocolRolloutStage,
     message_builder: OwnedMessageBuilder<ST>,
     secondary_message_builder: Option<OwnedMessageBuilder<ST>>,
 
@@ -213,6 +215,10 @@ where
         debug!(
             ?is_dynamic_fullnode, ?self_id, ?config.mtu, "RaptorCast::new",
         );
+        info!(
+            stage = %config.deterministic_protocol_rollout,
+            "deterministic raptorcast rollout",
+        );
 
         let dual_socket = auth::DualSocketHandle::new(
             auth::AuthenticatedSocketHandle::new(authenticated.0, authenticated.1),
@@ -250,6 +256,13 @@ where
             .segment_size(segment_size)
             .redundancy(secondary_redundancy);
 
+        let mut udp_state = udp::UdpState::new(
+            self_id,
+            config.udp_message_max_age_ms,
+            config.sig_verification_rate_limit,
+        );
+        udp_state.set_v1_rollout(config.deterministic_protocol_rollout);
+
         Self {
             self_id,
             is_dynamic_fullnode,
@@ -263,13 +276,13 @@ where
             message_builder,
             secondary_message_builder: Some(secondary_message_builder),
 
+            // TODO: call UpdateCurrentRound instead of pass in
+            // current_{epoch,round} as argument to allow downstream
+            // components to initialize appropriately.
             current_epoch,
 
-            udp_state: udp::UdpState::new(
-                self_id,
-                config.udp_message_max_age_ms,
-                config.sig_verification_rate_limit,
-            ),
+            udp_state,
+            v1_rollout: config.deterministic_protocol_rollout,
 
             tcp_reader,
             tcp_writer,
@@ -455,7 +468,7 @@ where
         });
 
         match target {
-            RouterTarget::Broadcast(epoch) | RouterTarget::Raptorcast(epoch) => {
+            RouterTarget::Broadcast(epoch) | RouterTarget::Raptorcast { epoch, .. } => {
                 let group = match PrimaryBroadcastGroup::of_epoch(
                     epoch,
                     &self_id, // author
@@ -488,7 +501,9 @@ where
 
                 let build_target = match &target {
                     RouterTarget::Broadcast(_) => BuildTarget::Broadcast(group),
-                    RouterTarget::Raptorcast(_) => BuildTarget::raptorcast(group),
+                    RouterTarget::Raptorcast { round, .. } => {
+                        v1_rollout::build_target(self.v1_rollout, *round, group)
+                    }
                     _ => unreachable!(),
                 };
                 let outbound_message =
@@ -791,6 +806,7 @@ where
             invite_future_dist_max: Round(5),
             invite_accept_heartbeat_ms: 100,
         },
+        deterministic_protocol_rollout: v1_rollout::CURRENT_STAGE,
     };
     let pd = PeerDiscoveryDriver::new(peer_discovery_builder);
     let shared_pd = Arc::new(Mutex::new(pd));
@@ -854,6 +870,7 @@ where
             invite_future_dist_max: Round(5),
             invite_accept_heartbeat_ms: 100,
         },
+        deterministic_protocol_rollout: v1_rollout::CURRENT_STAGE,
     };
     let pd = PeerDiscoveryDriver::new(peer_discovery_builder);
     let shared_pd = Arc::new(Mutex::new(pd));
@@ -916,6 +933,7 @@ where
 
                         self.epoch_validators.retain(|e, _| *e + Epoch(1) >= epoch);
                     }
+
                     self.udp_state.update_current_round(round);
                     self.full_node_groups.delete_expired(round);
                     self.peer_discovery_driver

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -487,7 +487,7 @@ where
 
                 let build_target = match &target {
                     RouterTarget::Broadcast(_) => BuildTarget::Broadcast(group),
-                    RouterTarget::Raptorcast(_) => BuildTarget::Raptorcast(group),
+                    RouterTarget::Raptorcast(_) => BuildTarget::raptorcast(group),
                     _ => unreachable!(),
                 };
                 let outbound_message =

--- a/monad-raptorcast/src/metrics.rs
+++ b/monad-raptorcast/src/metrics.rs
@@ -48,6 +48,22 @@ monad_executor::metric_consts! {
         name: "monad.raptorcast.direct_udp.forward_oversize",
         help: "Direct UDP forwards rejected due to oversize payload",
     }
+    pub COUNTER_RAPTORCAST_CHUNKS_DROPPED_INCOMPATIBLE_VERSION {
+        name: "monad.raptorcast.chunks_dropped_incompatible_version",
+        help: "Chunks dropped due to incompatible raptorcast version",
+    }
+    pub COUNTER_RAPTORCAST_V0_PRIMARY_CHUNKS_ACCEPTED {
+        name: "monad.raptorcast.v0_primary_chunks_accepted",
+        help: "V0 (regular) primary raptorcast chunks accepted",
+    }
+    pub COUNTER_RAPTORCAST_V1_PRIMARY_CHUNKS_ACCEPTED {
+        name: "monad.raptorcast.v1_primary_chunks_accepted",
+        help: "V1 (deterministic) primary raptorcast chunks accepted",
+    }
+    pub GAUGE_RAPTORCAST_DETERMINISTIC_ROLLOUT_STAGE {
+        name: "monad.raptorcast.deterministic_rollout_stage",
+        help: "Current deterministic raptorcast rollout stage (0=always_v0, 1=accept_both_publish_v0, 2=accept_both_publish_v1, 3=always_v1)",
+    }
     pub PRIMARY_BROADCAST_LATENCY_P99_MS {
         name: "monad.bft.raptorcast.udp.primary_broadcast_latency_p99_ms",
         help: "P99 primary UDP broadcast latency in ms (30s rolling window)",

--- a/monad-raptorcast/src/packet/assigner.rs
+++ b/monad-raptorcast/src/packet/assigner.rs
@@ -19,7 +19,8 @@ use bytes::BytesMut;
 use monad_crypto::certificate_signature::PubKey;
 use monad_raptor::r10::lt::MAX_TRIPLES;
 use monad_types::{NodeId, Stake};
-use rand::{rngs::StdRng, seq::SliceRandom as _, SeedableRng as _};
+use rand::{seq::SliceRandom as _, SeedableRng as _};
+use rand_chacha::ChaCha20Rng;
 
 use super::{BuildError, Chunk, Result};
 use crate::util::{ensure, PrimaryBroadcastGroup, Recipient, Redundancy, SecondaryBroadcastGroup};
@@ -51,7 +52,7 @@ where
     PT: PubKey,
 {
     fn get(&self, index: NodeIndex) -> Option<&NodeId<PT>>;
-    // [u8; 32] == <StdRng as SeedableRng>::Seed
+    // [u8; 32] == <ChaCha20Rng as SeedableRng>::Seed
     fn shuffle(&mut self, seed: [u8; 32]);
     fn len(&self) -> usize;
 }
@@ -267,7 +268,7 @@ where
     }
 
     fn shuffle(&mut self, seed: [u8; 32]) {
-        let mut rng = StdRng::from_seed(seed);
+        let mut rng = ChaCha20Rng::from_seed(seed);
         self.nodes.shuffle(&mut rng);
     }
 
@@ -320,7 +321,7 @@ impl<PT: PubKey> OrderedNodes<PT> for StakePartition<PT> {
     // validators compute the shuffling using the same seed and
     // algorithm for deterministic raptorcast.
     fn shuffle(&mut self, seed: [u8; 32]) {
-        let mut rng = StdRng::from_seed(seed);
+        let mut rng = ChaCha20Rng::from_seed(seed);
         self.validators.shuffle(&mut rng);
     }
 

--- a/monad-raptorcast/src/packet/assigner.rs
+++ b/monad-raptorcast/src/packet/assigner.rs
@@ -146,7 +146,6 @@ impl ChunkAssignment {
     //
     // The provided nodes must be the same OrderedNodes instance that
     // produced this assignment.
-    #[cfg_attr(not(test), expect(unused))]
     pub fn resolve_chunk_id<'a, PT, N>(
         &'a self,
         chunk_id: usize,
@@ -219,12 +218,10 @@ pub struct ChunkRouting<'a, PT: PubKey, N> {
 }
 
 impl<'a, PT: PubKey, N: OrderedNodes<PT>> ChunkRouting<'a, PT, N> {
-    #[cfg_attr(not(test), expect(unused))]
     pub fn recipient(&self) -> &NodeId<PT> {
         self.recipient
     }
 
-    #[cfg_attr(not(test), expect(unused))]
     pub fn rebroadcast_targets(&self) -> Vec<NodeId<PT>> {
         let recipient_idx = self.target.node_index;
         match &self.target.rebroadcast_targets {

--- a/monad-raptorcast/src/packet/builder.rs
+++ b/monad-raptorcast/src/packet/builder.rs
@@ -20,10 +20,13 @@ use monad_crypto::certificate_signature::{
 };
 use monad_dataplane::udp::DEFAULT_SEGMENT_SIZE;
 
-use super::{regular, BuildError};
+use super::{deterministic, regular, BuildError};
 use crate::{
     message::MAX_MESSAGE_SIZE,
-    util::{unix_ts_ms_now, BuildTarget, Collector, Redundancy, UdpMessage},
+    util::{
+        unix_ts_ms_now, BuildTarget, Collector, EncodingScheme, RaptorcastMode, Redundancy,
+        UdpMessage,
+    },
 };
 
 pub const DEFAULT_MERKLE_TREE_DEPTH: u8 = 6;
@@ -193,13 +196,6 @@ where
         Ok(segment_size)
     }
 
-    fn checked_message_len(&self, len: usize) -> Result<usize> {
-        if len > MAX_MESSAGE_SIZE {
-            return Err(BuildError::AppMessageTooLarge);
-        }
-        Ok(len)
-    }
-
     // ----- Build methods -----
     pub fn build_into<C>(
         &self,
@@ -210,12 +206,33 @@ where
     where
         C: Collector<UdpMessage<CertificateSignaturePubKey<ST>>>,
     {
+        if let BuildTarget::Raptorcast {
+            group,
+            mode: RaptorcastMode::Deterministic { round },
+        } = build_target
+        {
+            let unix_ts_ms = self.unwrap_unix_ts_ms()?;
+            return deterministic::build::<ST, C>(
+                self.key.as_ref(),
+                unix_ts_ms,
+                app_message,
+                group,
+                EncodingScheme::Deterministic25(*round),
+                collector,
+            );
+        }
+
+        if app_message.is_empty() {
+            return Err(BuildError::AppMessageEmpty);
+        }
+        if app_message.len() > MAX_MESSAGE_SIZE {
+            return Err(BuildError::AppMessageTooLarge);
+        }
+
         let segment_size = self.unwrap_segment_size()?;
         let depth = self.unwrap_merkle_tree_depth()?;
         let redundancy = self.unwrap_redundancy()?;
         let unix_ts_ms = self.unwrap_unix_ts_ms()?;
-        self.checked_message_len(app_message.len())?;
-
         let layout = regular::PacketLayout::new(segment_size, depth);
 
         regular::build_into::<ST, C>(

--- a/monad-raptorcast/src/packet/deterministic.rs
+++ b/monad-raptorcast/src/packet/deterministic.rs
@@ -85,7 +85,6 @@ impl PacketLayout {
         + 4; // App message length
 
     pub const CHUNK_HEADER_LEN: usize = 0
-        + 20 // Chunk recipient hash
         + 2  // Reserved
         + 2; // Chunk idx
 
@@ -171,7 +170,6 @@ impl PacketLayout {
     }
 
     pub fn write_chunk_header<PT: PubKey>(&self, chunk: &mut Chunk<PT>) -> Result<(), BuildError> {
-        let recipient_hash = *chunk.recipient().node_hash();
         let chunk_id: [u8; 2] = u16::try_from(chunk.chunk_id())
             .map_err(|_| BuildError::ChunkIdOverflow)?
             .to_le_bytes();
@@ -179,10 +177,9 @@ impl PacketLayout {
         let buffer = &mut chunk.payload_mut()[self.chunk_header_range()];
         debug_assert_eq!(buffer.len(), Self::CHUNK_HEADER_LEN);
 
-        buffer[0..20].copy_from_slice(&recipient_hash); // node_id hash
-        buffer[20] = 0; // reserved
-        buffer[21] = 0; // reserved
-        buffer[22..24].copy_from_slice(&chunk_id);
+        buffer[0] = 0; // reserved
+        buffer[1] = 0; // reserved
+        buffer[2..4].copy_from_slice(&chunk_id);
 
         Ok(())
     }
@@ -413,7 +410,6 @@ impl<PT: PubKey> PrimaryEncoding<PT> {
         Ok(assignment)
     }
 
-    #[expect(unused)]
     pub fn partition(&self) -> &StakePartition<PT> {
         &self.partition
     }
@@ -625,8 +621,8 @@ mod tests {
         DEFAULT_SEGMENT_LEN == 1440,
         "DEFAULT_SEGMENT_LEN must be set to 1440"
     );
-    const _: () = assert!(MIN_SYMBOL_LEN == 1019);
-    const _: () = assert!(MAX_SYMBOL_LEN == 1259);
+    const _: () = assert!(MIN_SYMBOL_LEN == 1039);
+    const _: () = assert!(MAX_SYMBOL_LEN == 1279);
 
     fn validate_d25_layout(app_msg_len: usize, val_set_size: usize) {
         let depth = calc_tree_depth(

--- a/monad-raptorcast/src/packet/deterministic.rs
+++ b/monad-raptorcast/src/packet/deterministic.rs
@@ -1,0 +1,680 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use bytes::{Bytes, BytesMut};
+use monad_crypto::{
+    certificate_signature::{
+        CertificateSignature, CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
+    },
+    hasher::Hasher as _,
+    signing_domain,
+};
+use monad_dataplane::udp::segment_size_for_mtu;
+use monad_merkle::{MerkleHash, MerkleTree};
+use monad_raptor::Encoder;
+use monad_types::{NodeId, Round, ETHERNET_MTU};
+use monad_wireauth::messages::DataPacketHeader;
+
+use super::{
+    assigner::{stake_partition_num_chunks_hint, ChunkAssignment, StakePartition},
+    Chunk,
+};
+use crate::{
+    message::MAX_MESSAGE_SIZE,
+    packet::{assigner::OrderedNodes, BuildError},
+    udp::GroupId,
+    util::{
+        ensure, BroadcastMode, Collector, EncodingScheme, PrimaryBroadcastGroup, Redundancy,
+        UdpMessage,
+    },
+    SIGNATURE_SIZE,
+};
+
+// Deterministic RaptorCast requires the parameters (segment_len,
+// redundancy) to be fixed for all nodes in order to provide
+// deterministic encoding guarantee.
+
+const VERSION: u16 = 0x1;
+
+// default parameter for Deterministic25 encoding scheme
+pub const DEFAULT_REDUNDANCY: Redundancy = Redundancy::from_fract(2, 50);
+pub const DEFAULT_SEGMENT_LEN: usize =
+    segment_size_for_mtu(ETHERNET_MTU - DataPacketHeader::SIZE as u16) as usize;
+
+// The smallest message requires 4 chunks (from redundancy=2.5 +
+// min_validator_set_size=1), which is accommodated by a merkle tree
+// of depth 3 with 4 leaves.
+pub const MIN_MERKLE_TREE_DEPTH: u8 = 3;
+pub const MAX_MERKLE_TREE_DEPTH: u8 = 15;
+
+pub const MIN_SEGMENT_LEN: usize = DEFAULT_SEGMENT_LEN;
+pub const MAX_SEGMENT_LEN: usize = DEFAULT_SEGMENT_LEN;
+
+pub const MIN_SYMBOL_LEN: usize = DEFAULT_SEGMENT_LEN - PacketLayout::MAX_HEADER_LEN;
+pub const MAX_SYMBOL_LEN: usize = DEFAULT_SEGMENT_LEN - PacketLayout::MIN_HEADER_LEN;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PacketLayout {
+    segment_len: usize,
+    merkle_tree_depth: u8,
+}
+
+#[allow(clippy::identity_op)]
+impl PacketLayout {
+    pub const HEADER_LEN: usize = 0
+        + SIGNATURE_SIZE // Sender signature (65 bytes)
+        + 2  // Version
+        + 1  // 2 bits for Broadcast Mode, 2 bits reserved, 4 bits for Merkle Tree Depth
+        + 1  // Encoding scheme variant
+        + 8  // Round #
+        + 8  // Epoch #
+        + 8  // Unix timestamp
+        + 20 // Global merkle root
+        + 4; // App message length
+
+    pub const CHUNK_HEADER_LEN: usize = 0
+        + 20 // Chunk recipient hash
+        + 2  // Reserved
+        + 2; // Chunk idx
+
+    // the size of individual merkle hash
+    pub const MERKLE_HASH_LEN: usize = 20;
+
+    pub const MAX_HEADER_LEN: usize = PacketLayout::HEADER_LEN
+        + PacketLayout::CHUNK_HEADER_LEN
+        + PacketLayout::MERKLE_HASH_LEN * (MAX_MERKLE_TREE_DEPTH as usize - 1);
+    pub const MIN_HEADER_LEN: usize = PacketLayout::HEADER_LEN
+        + PacketLayout::CHUNK_HEADER_LEN
+        + PacketLayout::MERKLE_HASH_LEN * (MIN_MERKLE_TREE_DEPTH as usize - 1);
+
+    pub fn new(segment_len: usize, merkle_tree_depth: u8) -> Self {
+        let header_len = Self::HEADER_LEN + Self::CHUNK_HEADER_LEN;
+        let proof_len = Self::MERKLE_HASH_LEN * (merkle_tree_depth as usize - 1);
+        let symbol_len = segment_len.saturating_sub(header_len + proof_len);
+        assert!(symbol_len > 0);
+
+        Self {
+            segment_len,
+            merkle_tree_depth,
+        }
+    }
+
+    pub fn segment_len(&self) -> usize {
+        self.segment_len
+    }
+
+    pub const fn symbol_len(&self) -> usize {
+        self.segment_len - Self::HEADER_LEN - self.merkle_proof_len() - Self::CHUNK_HEADER_LEN
+    }
+
+    pub const fn num_base_symbols(&self, app_message_len: usize) -> usize {
+        app_message_len.div_ceil(self.symbol_len())
+    }
+
+    pub const fn merkle_proof_len(&self) -> usize {
+        Self::MERKLE_HASH_LEN * (self.merkle_tree_depth as usize - 1)
+    }
+
+    pub const fn header_len(&self) -> usize {
+        Self::HEADER_LEN
+    }
+
+    const fn symbol_offset(&self) -> usize {
+        Self::HEADER_LEN + self.merkle_proof_len() + Self::CHUNK_HEADER_LEN
+    }
+
+    pub fn merkle_tree_depth(&self) -> u8 {
+        self.merkle_tree_depth
+    }
+
+    pub fn merkle_proof_range(&self) -> std::ops::Range<usize> {
+        Self::HEADER_LEN..(Self::HEADER_LEN + self.merkle_proof_len())
+    }
+
+    pub fn chunk_header_range(&self) -> std::ops::Range<usize> {
+        let start = Self::HEADER_LEN + self.merkle_proof_len();
+        start..(start + Self::CHUNK_HEADER_LEN)
+    }
+
+    pub fn merkle_hashed_range(&self) -> std::ops::Range<usize> {
+        // chunk header + symbol
+        let start = Self::HEADER_LEN + self.merkle_proof_len();
+        start..self.segment_len
+    }
+
+    pub fn symbol_range(&self) -> std::ops::Range<usize> {
+        self.symbol_offset()..self.segment_len
+    }
+
+    pub fn symbol_mut<'a, PT: PubKey>(&self, chunk: &'a mut Chunk<PT>) -> &'a mut [u8] {
+        &mut chunk.payload_mut()[self.symbol_range()]
+    }
+
+    pub fn write_header<PT: PubKey>(
+        &self,
+        chunk: &mut Chunk<PT>,
+        header: &[u8], // including signature
+    ) {
+        chunk.payload_mut()[..self.header_len()].copy_from_slice(header);
+    }
+
+    pub fn write_chunk_header<PT: PubKey>(&self, chunk: &mut Chunk<PT>) -> Result<(), BuildError> {
+        let recipient_hash = *chunk.recipient().node_hash();
+        let chunk_id: [u8; 2] = u16::try_from(chunk.chunk_id())
+            .map_err(|_| BuildError::ChunkIdOverflow)?
+            .to_le_bytes();
+
+        let buffer = &mut chunk.payload_mut()[self.chunk_header_range()];
+        debug_assert_eq!(buffer.len(), Self::CHUNK_HEADER_LEN);
+
+        buffer[0..20].copy_from_slice(&recipient_hash); // node_id hash
+        buffer[20] = 0; // reserved
+        buffer[21] = 0; // reserved
+        buffer[22..24].copy_from_slice(&chunk_id);
+
+        Ok(())
+    }
+
+    pub fn write_merkle_proof<PT: PubKey>(&self, chunk: &mut Chunk<PT>, proof: &[MerkleHash]) {
+        let buffer = &mut chunk.payload_mut()[self.merkle_proof_range()];
+        debug_assert_eq!(buffer.len() % Self::MERKLE_HASH_LEN, 0);
+
+        for (idx, hash) in proof.iter().enumerate() {
+            let start = idx * Self::MERKLE_HASH_LEN;
+            let end = (idx + 1) * Self::MERKLE_HASH_LEN;
+            buffer[start..end].copy_from_slice(hash);
+        }
+    }
+
+    pub fn chunk_hash<PT: PubKey>(&self, chunk: &Chunk<PT>) -> monad_crypto::hasher::Hash {
+        let mut hasher = monad_crypto::hasher::HasherType::new();
+        hasher.update(&chunk.payload()[self.merkle_hashed_range()]);
+        monad_crypto::hasher::Hasher::hash(hasher)
+    }
+}
+
+fn build_header<ST>(
+    key: &ST::KeyPairType,
+    broadcast_mode: BroadcastMode,
+    encoding_scheme: EncodingScheme,
+    merkle_tree_depth: u8,
+    group_id: GroupId,
+    unix_ts_ms: u64,
+    global_merkle_root: &MerkleHash,
+    app_message_len: usize,
+) -> Result<Bytes, BuildError>
+where
+    ST: CertificateSignatureRecoverable,
+{
+    // 65 // Signature
+    // 2  // Version
+    // 1  // Broadcast mode bits (2 bits)
+    //       2 unused bits,
+    //       4 bits for Merkle tree depth
+    // 1  // Encoding scheme variant
+    // 8  // Round
+    // 8  // Epoch
+    // 8  // Unix timestamp
+    // 20 // Global merkle root
+    // 4  // App message length
+    let mut buffer = BytesMut::zeroed(PacketLayout::HEADER_LEN);
+    let cursor = &mut buffer[SIGNATURE_SIZE..];
+
+    let (cursor_version, cursor) = cursor.split_at_mut_checked(2).expect("header too short");
+    cursor_version.copy_from_slice(&VERSION.to_le_bytes());
+
+    let (cursor_broadcast_merkle_depth, cursor) =
+        cursor.split_at_mut_checked(1).expect("header too short");
+
+    let broadcast_bits: u8 = match broadcast_mode {
+        BroadcastMode::Primary => 0b10 << 6,
+        _ => return Err(BuildError::InvalidBroadcastMode(broadcast_mode)),
+    };
+    if (merkle_tree_depth & 0b1111_0000) != 0 {
+        return Err(BuildError::MerkleTreeTooDeep);
+    }
+    cursor_broadcast_merkle_depth[0] = broadcast_bits | (merkle_tree_depth & 0b0000_1111);
+
+    let (cursor_encoding_scheme, cursor) =
+        cursor.split_at_mut_checked(1).expect("header too short");
+    let EncodingScheme::Deterministic25(round) = encoding_scheme else {
+        return Err(BuildError::InvalidEncodingScheme);
+    };
+    cursor_encoding_scheme[0] = 0x1; // Deterministic25
+
+    let GroupId::Primary(epoch) = group_id else {
+        return Err(BuildError::InvalidGroupId(group_id));
+    };
+    let (cursor_round, cursor) = cursor.split_at_mut_checked(8).expect("header too short");
+    cursor_round.copy_from_slice(&round.0.to_le_bytes());
+
+    let (cursor_epoch, cursor) = cursor.split_at_mut_checked(8).expect("header too short");
+    cursor_epoch.copy_from_slice(&epoch.0.to_le_bytes());
+
+    let (cursor_unix_ts_ms, cursor) = cursor.split_at_mut_checked(8).expect("header too short");
+    cursor_unix_ts_ms.copy_from_slice(&unix_ts_ms.to_le_bytes());
+
+    let (cursor_global_merkle_root, cursor) =
+        cursor.split_at_mut_checked(20).expect("header too short");
+    cursor_global_merkle_root.copy_from_slice(global_merkle_root);
+
+    let (cursor_app_message_len, cursor) =
+        cursor.split_at_mut_checked(4).expect("header too short");
+    let app_message_len: u32 = app_message_len
+        .try_into()
+        .map_err(|_| BuildError::AppMessageTooLarge)?;
+    cursor_app_message_len.copy_from_slice(&app_message_len.to_le_bytes());
+
+    // should have consumed the whole buffer
+    debug_assert_eq!(cursor.len(), 0);
+
+    let signed_over = &buffer[SIGNATURE_SIZE..];
+    let signature = <ST as CertificateSignature>::serialize(&ST::sign::<
+        signing_domain::RaptorcastChunk,
+    >(signed_over, key));
+    debug_assert_eq!(signature.len(), SIGNATURE_SIZE);
+
+    buffer[..SIGNATURE_SIZE].copy_from_slice(&signature);
+
+    Ok(buffer.freeze())
+}
+
+pub(super) struct GlobalMerkleTree<'a, PT: PubKey> {
+    chunks: &'a mut [Chunk<PT>],
+    tree: MerkleTree,
+    layout: PacketLayout,
+}
+
+impl<'a, PT: PubKey> GlobalMerkleTree<'a, PT> {
+    fn build(chunks: &'a mut [Chunk<PT>], layout: PacketLayout) -> Result<Self, BuildError> {
+        chunks.sort_by_key(|c| c.chunk_id());
+
+        let mut hashes = Vec::with_capacity(chunks.len());
+        let depth = layout.merkle_tree_depth();
+        debug_assert!(chunks.len() <= 2usize.pow((depth - 1) as u32));
+
+        for (leaf_index, chunk) in chunks.iter_mut().enumerate() {
+            if chunk.chunk_id() != leaf_index {
+                return Err(BuildError::NonContiguousChunkIds);
+            }
+
+            layout.write_chunk_header(chunk)?;
+            let hash = layout.chunk_hash(chunk);
+            hashes.push(hash);
+        }
+
+        let tree = MerkleTree::new_with_depth(&hashes, depth);
+        Ok(Self {
+            chunks,
+            tree,
+            layout,
+        })
+    }
+
+    fn write_header_and_proofs(&mut self, header: &[u8]) -> Result<(), BuildError> {
+        for (leaf_idx, chunk) in self.chunks.iter_mut().enumerate() {
+            // for deterministic rc, leaf_idx === chunk_id
+            debug_assert_eq!(leaf_idx, chunk.chunk_id());
+
+            // write header
+            self.layout.write_header(chunk, header);
+
+            // write merkle proof
+            let leaf_idx: u16 = leaf_idx
+                .try_into()
+                .map_err(|_| BuildError::ChunkIdOverflow)?;
+            let proof = self.tree.proof(leaf_idx);
+            self.layout.write_merkle_proof(chunk, proof.siblings());
+        }
+        Ok(())
+    }
+
+    fn root(&self) -> &MerkleHash {
+        self.tree.root()
+    }
+}
+
+pub(crate) struct PrimaryEncoding<PT: PubKey> {
+    layout: PacketLayout,
+    redundancy: Redundancy,
+    app_message_len: usize,
+    partition: StakePartition<PT>,
+}
+
+impl<PT: PubKey> PrimaryEncoding<PT> {
+    pub fn new<'a>(
+        encoding_scheme: EncodingScheme,
+        group: &'a PrimaryBroadcastGroup<'a, PT>,
+        app_message_len: usize,
+        unix_ts_ms: u64,
+    ) -> Result<Self, BuildError> {
+        let EncodingScheme::Deterministic25(round) = encoding_scheme else {
+            return Err(BuildError::InvalidEncodingScheme);
+        };
+
+        ensure!(app_message_len > 0, BuildError::AppMessageEmpty);
+        ensure!(
+            app_message_len <= MAX_MESSAGE_SIZE,
+            BuildError::AppMessageTooLarge
+        );
+
+        // Encoding scheme for Deterministic25
+        let mut partition = StakePartition::from_group(group);
+        let redundancy = DEFAULT_REDUNDANCY;
+        let segment_len = DEFAULT_SEGMENT_LEN;
+
+        // Search for optimal tree depth.
+        let depth = optimal_merkle_tree_depth(|d| {
+            let layout = PacketLayout::new(segment_len, d);
+            let num_base_symbols = layout.num_base_symbols(app_message_len);
+            partition.num_chunks_hint(num_base_symbols, redundancy)
+        })
+        .ok_or(BuildError::MerkleTreeTooDeep)?;
+        let layout = PacketLayout::new(segment_len, depth);
+
+        // Shuffle the validator set
+        let author = group.author();
+        let seed = derive_seed(author, round, unix_ts_ms);
+        partition.shuffle(seed);
+
+        Ok(Self {
+            redundancy,
+            layout,
+            app_message_len,
+            partition,
+        })
+    }
+
+    pub fn layout(&self) -> PacketLayout {
+        self.layout
+    }
+
+    pub fn make_chunks(&self) -> Result<Vec<Chunk<PT>>, BuildError> {
+        let assignment = self.make_assignment()?;
+        let chunks = assignment.materialize(self.layout.segment_len(), &self.partition)?;
+        Ok(chunks)
+    }
+
+    pub fn make_assignment(&self) -> Result<ChunkAssignment, BuildError> {
+        let num_base_symbols = self.layout.num_base_symbols(self.app_message_len);
+        let assignment = self.partition.assign(num_base_symbols, self.redundancy)?;
+        Ok(assignment)
+    }
+
+    #[expect(unused)]
+    pub fn partition(&self) -> &StakePartition<PT> {
+        &self.partition
+    }
+}
+
+pub fn calc_tree_depth(
+    encoding_scheme: EncodingScheme,
+    app_message_len: usize,
+    validator_set_size: usize,
+) -> Option<u8> {
+    let EncodingScheme::Deterministic25(_) = encoding_scheme else {
+        // we only support Deterministic25 for now.
+        return None;
+    };
+
+    let redundancy = DEFAULT_REDUNDANCY;
+    let segment_len = DEFAULT_SEGMENT_LEN;
+
+    let depth = optimal_merkle_tree_depth(|d| {
+        let layout = PacketLayout::new(segment_len, d);
+        let num_base_symbols = layout.num_base_symbols(app_message_len);
+        stake_partition_num_chunks_hint(num_base_symbols, redundancy, validator_set_size)
+    })?;
+
+    Some(depth)
+}
+
+#[cfg(test)]
+pub(crate) fn build_with_given_header<PT, C>(
+    header: &[u8],
+    app_message: &[u8],
+    group: &PrimaryBroadcastGroup<'_, PT>,
+    encoding_scheme: EncodingScheme,
+    unix_ts_ms: u64,
+    collector: &mut C,
+) -> Result<(), BuildError>
+where
+    PT: PubKey,
+    C: Collector<UdpMessage<PT>>,
+{
+    // step 1: chunk assignment
+    let encoding = PrimaryEncoding::new(encoding_scheme, group, app_message.len(), unix_ts_ms)?;
+    let layout = encoding.layout();
+    let mut chunks = encoding.make_chunks()?;
+
+    // step 2: write the encoded symbols into chunk's payload
+    encode_unique_symbols(app_message, &mut chunks, layout)?;
+
+    // step 3: build merkle tree & write chunk header
+    let mut merkle_tree = GlobalMerkleTree::build(&mut chunks[..], layout)?;
+    merkle_tree.write_header_and_proofs(header)?;
+
+    // step 4: send out the chunks
+    collector.reserve(chunks.len());
+    for chunk in chunks.into_iter() {
+        collector.push(chunk.into());
+    }
+
+    Ok(())
+}
+
+pub(crate) fn build<ST, C>(
+    key: &ST::KeyPairType,
+    unix_ts_ms: u64,
+    app_message: &[u8],
+    group: &PrimaryBroadcastGroup<'_, CertificateSignaturePubKey<ST>>,
+    encoding_scheme: EncodingScheme,
+    collector: &mut C,
+) -> Result<(), BuildError>
+where
+    ST: CertificateSignatureRecoverable,
+    C: Collector<UdpMessage<CertificateSignaturePubKey<ST>>>,
+{
+    // step 1: chunk assignment
+    let encoding = PrimaryEncoding::new(encoding_scheme, group, app_message.len(), unix_ts_ms)?;
+    let layout = encoding.layout();
+    let mut chunks = encoding.make_chunks()?;
+
+    // step 2: write the encoded symbols into chunk's payload
+    encode_unique_symbols(app_message, &mut chunks, layout)?;
+
+    // step 3: build merkle tree & write chunk header
+    let mut merkle_tree = GlobalMerkleTree::build(&mut chunks[..], layout)?;
+
+    // step 4: write header
+    let group_id = group.group_id();
+    let header = build_header::<ST>(
+        key,
+        BroadcastMode::Primary,
+        encoding_scheme,
+        layout.merkle_tree_depth(),
+        group_id,
+        unix_ts_ms,
+        merkle_tree.root(),
+        app_message.len(),
+    )?;
+    merkle_tree.write_header_and_proofs(&header)?;
+
+    // step 5: send out the chunks
+    collector.reserve(chunks.len());
+    for chunk in chunks.into_iter() {
+        collector.push(chunk.into());
+    }
+
+    Ok(())
+}
+
+// Calculate the deterministic global merkle root of a given app
+// message without actually building the packets.
+pub(crate) fn calc_global_merkle_root<PT: PubKey>(
+    app_message: &[u8],
+    group: &PrimaryBroadcastGroup<'_, PT>,
+    encoding_scheme: EncodingScheme,
+    unix_ts_ms: u64,
+) -> Result<MerkleHash, BuildError> {
+    // step 1: chunk assignment
+    let encoding = PrimaryEncoding::new(encoding_scheme, group, app_message.len(), unix_ts_ms)?;
+    let layout = encoding.layout();
+    let mut chunks = encoding.make_chunks()?;
+
+    // step 2: write the encoded symbols into chunk's payload
+    encode_unique_symbols(app_message, &mut chunks, layout)?;
+
+    // step 3: write the chunk header & build a global merkle tree
+    let merkle_tree = GlobalMerkleTree::build(&mut chunks[..], layout)?;
+
+    // step 4: find the merkle root
+    Ok(*merkle_tree.root())
+}
+
+fn encode_unique_symbols<PT: PubKey>(
+    app_message: &[u8],
+    chunks: &mut [Chunk<PT>],
+    layout: PacketLayout,
+) -> Result<(), BuildError> {
+    let symbol_len = layout.symbol_len();
+    let encoder =
+        Encoder::new(app_message, symbol_len).map_err(|_| BuildError::EncoderCreationFailed)?;
+    for chunk in chunks.iter_mut() {
+        let chunk_id = chunk.chunk_id();
+        let symbol_buffer = layout.symbol_mut(chunk);
+        encoder.encode_symbol(symbol_buffer, chunk_id);
+    }
+    Ok(())
+}
+
+// Derive the seed used to shuffling validator set for deterministic raptorcast.
+// Layout: round (8) || floor(unix_ts_ms / 2048) (8) || author_pk[1..17] (16) = 32 bytes
+pub fn derive_seed<PT: PubKey>(author: &NodeId<PT>, round: Round, unix_ts_ms: u64) -> [u8; 32] {
+    let author_bytes = author.pubkey().bytes();
+    let coarse_ts = unix_ts_ms / 2048; // ~2s resolution
+    let mut seed = [0u8; 32];
+    seed[..8].copy_from_slice(&round.0.to_le_bytes());
+    seed[8..16].copy_from_slice(&coarse_ts.to_le_bytes());
+    // skipping first byte (tag) of the pubkey with low entropy
+    seed[16..].copy_from_slice(&author_bytes[1..17]);
+    seed
+}
+
+fn optimal_merkle_tree_depth(calc_total_symbols: impl Fn(u8) -> Option<usize>) -> Option<u8> {
+    for depth in MIN_MERKLE_TREE_DEPTH..=MAX_MERKLE_TREE_DEPTH {
+        let leaf_count = 2usize.pow((depth - 1) as u32);
+        let Some(total_symbols) = calc_total_symbols(depth) else {
+            continue;
+        };
+        if total_symbols <= leaf_count {
+            return Some(depth);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use monad_merkle::MerkleTree;
+    use monad_raptor::r10::lt::MAX_TRIPLES;
+    use monad_validator::validator_set::MAX_VALIDATOR_SET_SIZE;
+
+    use super::{
+        calc_tree_depth, PacketLayout, DEFAULT_REDUNDANCY, DEFAULT_SEGMENT_LEN,
+        MAX_MERKLE_TREE_DEPTH, MAX_SYMBOL_LEN, MIN_MERKLE_TREE_DEPTH, MIN_SYMBOL_LEN,
+    };
+    use crate::{
+        message::MAX_MESSAGE_SIZE, packet::assigner::stake_partition_num_chunks_hint,
+        udp::MAX_NUM_PACKETS,
+    };
+
+    // Statically asserted properties
+    const _: () = assert!(
+        super::MAX_MERKLE_TREE_DEPTH <= 0b1111,
+        "MAX_MERKLE_TREE_DEPTH must fit in 4 bits"
+    );
+    const _: () = assert!(
+        MIN_MERKLE_TREE_DEPTH <= MAX_MERKLE_TREE_DEPTH,
+        "MIN_MERKLE_TREE_DEPTH must be less than MAX_MERKLE_TREE_DEPTH"
+    );
+    const _: () = assert!(
+        MIN_SYMBOL_LEN >= crate::packet::regular::MIN_CHUNK_LENGTH,
+        "MIN_SYMBOL_LEN must be no smaller than regular MIN_CHUNK_LENGTH"
+    );
+
+    // Statically asserted fixed value for constants
+    //   1500 (ethernet mtu)
+    // - 20   (ip header)
+    // - 8    (udp header)
+    // - 32   (wireauth header)
+    // = 1440
+    const _: () = assert!(
+        DEFAULT_SEGMENT_LEN == 1440,
+        "DEFAULT_SEGMENT_LEN must be set to 1440"
+    );
+    const _: () = assert!(MIN_SYMBOL_LEN == 1019);
+    const _: () = assert!(MAX_SYMBOL_LEN == 1259);
+
+    fn validate_d25_layout(app_msg_len: usize, val_set_size: usize) {
+        let depth = calc_tree_depth(
+            super::EncodingScheme::Deterministic25(super::Round(0)),
+            app_msg_len,
+            val_set_size,
+        )
+        .expect("should find a valid tree depth");
+
+        assert!((MIN_MERKLE_TREE_DEPTH..=MAX_MERKLE_TREE_DEPTH).contains(&depth));
+
+        let segment_len = DEFAULT_SEGMENT_LEN;
+        let redundancy = DEFAULT_REDUNDANCY;
+
+        let layout = PacketLayout::new(segment_len, depth);
+        let num_chunks_hint = stake_partition_num_chunks_hint(
+            layout.num_base_symbols(app_msg_len),
+            redundancy,
+            val_set_size,
+        )
+        .expect("should yield valid total chunks");
+
+        // within valid ranges
+        assert!((1..=MerkleTree::MAX_NUM_LEAVES).contains(&num_chunks_hint));
+        assert!((1..=MAX_NUM_PACKETS).contains(&num_chunks_hint));
+        assert!((1..=MAX_TRIPLES).contains(&num_chunks_hint));
+
+        // depth optimal
+        assert!(2usize.pow((depth - 1) as u32) >= num_chunks_hint);
+        assert!(2usize.pow((depth - 2) as u32) < num_chunks_hint);
+    }
+
+    #[test]
+    fn test_no_panic_on_valid_ranges() {
+        for app_msg_len in 1..=MAX_MESSAGE_SIZE {
+            for val_set_size in [1, 100, MAX_VALIDATOR_SET_SIZE] {
+                validate_d25_layout(app_msg_len, val_set_size);
+            }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn test_no_panic_on_valid_ranges_slow() {
+        for app_msg_len in 1..=MAX_MESSAGE_SIZE {
+            for val_set_size in 1..=MAX_VALIDATOR_SET_SIZE {
+                validate_d25_layout(app_msg_len, val_set_size);
+            }
+        }
+    }
+}

--- a/monad-raptorcast/src/packet/mod.rs
+++ b/monad-raptorcast/src/packet/mod.rs
@@ -16,6 +16,7 @@
 pub(crate) mod assigner;
 mod builder;
 mod chunk;
+pub mod deterministic;
 pub mod regular;
 
 use std::{collections::HashMap, net::SocketAddr};
@@ -27,7 +28,10 @@ use monad_crypto::certificate_signature::{
 use monad_types::NodeId;
 
 pub(crate) use self::{builder::MessageBuilder, chunk::Chunk};
-use crate::util::{BuildTarget, Redundancy};
+use crate::{
+    udp::GroupId,
+    util::{BroadcastMode, BuildTarget, Redundancy},
+};
 
 #[derive(Debug)]
 pub enum BuildError {
@@ -45,10 +49,21 @@ pub enum BuildError {
     TooManyChunks,
     // app message is too large
     AppMessageTooLarge,
+    // app message is empty
+    AppMessageEmpty,
     // total stake is zero
     ZeroTotalStake,
     // redundancy is too high
     RedundancyTooHigh,
+    // group id not supported with the broadcast mode
+    InvalidGroupId(GroupId),
+    // broadcast mode not supported
+    InvalidBroadcastMode(BroadcastMode),
+    // encoding scheme not supported
+    InvalidEncodingScheme,
+    // chunk ids are not contiguous starting from 0, as required by
+    // deterministic RC
+    NonContiguousChunkIds,
 }
 
 type Result<A, E = BuildError> = std::result::Result<A, E>;

--- a/monad-raptorcast/src/packet/regular.rs
+++ b/monad-raptorcast/src/packet/regular.rs
@@ -633,7 +633,10 @@ fn generate_chunks<PT: PubKey>(
             chunks
         }
 
-        BuildTarget::Raptorcast(primary_group) => {
+        BuildTarget::Raptorcast {
+            group: primary_group,
+            ..
+        } => {
             let mut partition = StakePartition::from_group(primary_group);
             partition.shuffle(derive_seed(app_message_hash));
             let assignment = partition.assign(num_base_symbols, redundancy)?;

--- a/monad-raptorcast/src/parser/packet_parser.rs
+++ b/monad-raptorcast/src/parser/packet_parser.rs
@@ -29,7 +29,7 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Ref, LE, U16, U32, 
 use crate::{
     message::MAX_MESSAGE_SIZE,
     packet::{assigner::stake_partition_num_chunks_hint, deterministic, regular},
-    udp::{ChunkSignatureVerifier, GroupId, InvalidChunk, ValidatedChunk},
+    udp::{ChunkSignatureVerifier, ChunkVersion, GroupId, InvalidChunk, ValidatedChunk},
     util::{ensure, BroadcastMode, EncodingScheme, HexBytes},
     SIGNATURE_SIZE,
 };
@@ -749,9 +749,9 @@ impl<'a> RaptorcastPacket<'a> {
     {
         let meta = self.validate_chunk_meta(env.max_age_ms)?;
         let author = verify_signature(env.signature_verifier, &meta, env.bypass_rate_limiter)?;
-        let chunk = match &self.versioned {
-            RaptorcastPacketVersioned::V0(v0) => v0.split_chunk(message)?,
-            RaptorcastPacketVersioned::V1(v1) => v1.split_chunk(message)?,
+        let (chunk, version) = match &self.versioned {
+            RaptorcastPacketVersioned::V0(v0) => (v0.split_chunk(message)?, ChunkVersion::V0),
+            RaptorcastPacketVersioned::V1(v1) => (v1.split_chunk(message)?, ChunkVersion::V1),
         };
 
         ensure!(author != *env.self_id, InvalidChunk::Loopback);
@@ -761,6 +761,7 @@ impl<'a> RaptorcastPacket<'a> {
             message: message.clone(),
             signature: message.slice(..SIGNATURE_SIZE),
             author,
+            version,
             group_id: meta.group_id,
             unix_ts_ms: meta.timestamp,
             app_message_hash: meta.app_message_hash,

--- a/monad-raptorcast/src/parser/packet_parser.rs
+++ b/monad-raptorcast/src/parser/packet_parser.rs
@@ -759,6 +759,7 @@ impl<'a> RaptorcastPacket<'a> {
         Ok(ValidatedChunk {
             chunk,
             message: message.clone(),
+            signature: message.slice(..SIGNATURE_SIZE),
             author,
             group_id: meta.group_id,
             unix_ts_ms: meta.timestamp,

--- a/monad-raptorcast/src/parser/packet_parser.rs
+++ b/monad-raptorcast/src/parser/packet_parser.rs
@@ -45,7 +45,7 @@ struct ChunkMeta {
     group_id: GroupId,
     app_message_hash: Option<HexBytes<HASH_SIZE>>,
     merkle_root: HexBytes<MERKLE_HASH_SIZE>,
-    recipient_hash: HexBytes<HASH_SIZE>,
+    recipient_hash: Option<HexBytes<HASH_SIZE>>,
     signed_over_data: SignedOverData,
 }
 
@@ -263,23 +263,19 @@ impl RaptorcastHeaderV1 {
 
 /// Raptorcast V1 chunk header layout (follows header and merkle proof):
 /// - 20 bytes * (merkle_tree_depth - 1) => merkle proof (leaves include everything that follows,
-///   eg hash(chunk_recipient + chunk_byte_offset + symbol_len + payload))
-/// - 20 bytes => first 20 bytes of hash of chunk's first hop recipient
-///   - we set this even if broadcast bit is not set so that it's known if a message was intended
-///     to be sent to self
+///   eg hash(reserved + chunk_id + payload))
 /// - 2 bytes => reserved
 /// - 2 bytes (u16) => This chunk's id, also used as the merkle leaf index
 /// - rest => data
 #[repr(C, packed)]
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Clone, Copy)]
 pub struct RaptorcastChunkHeaderV1 {
-    recipient_hash: [u8; MERKLE_HASH_SIZE],
     reserved: U16<LE>,
     chunk_id: U16<LE>,
 }
 
 impl RaptorcastChunkHeaderV1 {
-    const SIZE: usize = MERKLE_HASH_SIZE + 2 + 2;
+    const SIZE: usize = 2 + 2;
 
     fn merkle_leaf_index(&self) -> u16 {
         self.chunk_id.get()
@@ -490,7 +486,7 @@ impl<'a> RaptorcastPacketV0<'a> {
         let group_id = self.header.group_id()?;
         let signed_over_data = self.signed_over_data(common_header, &merkle_root);
         let app_message_hash = Some(HexBytes(self.header.app_message_hash));
-        let recipient_hash = HexBytes(self.chunk_header.recipient_hash);
+        let recipient_hash = Some(HexBytes(self.chunk_header.recipient_hash));
 
         Ok(ChunkMeta {
             app_message_len,
@@ -637,7 +633,6 @@ impl<'a> RaptorcastPacketV1<'a> {
         let group_id = self.header.group_id()?;
         let signed_over_data = self.signed_over_data(common_header);
         let merkle_root = self.validate_merkle_root()?;
-        let recipient_hash = HexBytes(self.chunk_header.recipient_hash);
 
         Ok(ChunkMeta {
             app_message_len,
@@ -650,7 +645,7 @@ impl<'a> RaptorcastPacketV1<'a> {
             group_id,
             app_message_hash: None,
             merkle_root: HexBytes(merkle_root),
-            recipient_hash,
+            recipient_hash: None,
             signed_over_data,
         })
     }

--- a/monad-raptorcast/src/parser/packet_parser.rs
+++ b/monad-raptorcast/src/parser/packet_parser.rs
@@ -28,9 +28,9 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Ref, LE, U16, U32, 
 
 use crate::{
     message::MAX_MESSAGE_SIZE,
-    packet::regular,
+    packet::{assigner::stake_partition_num_chunks_hint, deterministic, regular},
     udp::{ChunkSignatureVerifier, GroupId, InvalidChunk, ValidatedChunk},
-    util::{ensure, BroadcastMode, HexBytes},
+    util::{ensure, BroadcastMode, EncodingScheme, HexBytes},
     SIGNATURE_SIZE,
 };
 
@@ -41,11 +41,14 @@ struct ChunkMeta {
     encoded_symbol_capacity: usize,
     timestamp: u64,
     broadcast_mode: BroadcastMode,
+    encoding_scheme: EncodingScheme,
     group_id: GroupId,
-    app_message_hash: HexBytes<HASH_SIZE>,
+    app_message_hash: Option<HexBytes<HASH_SIZE>>,
+    merkle_root: HexBytes<MERKLE_HASH_SIZE>,
     recipient_hash: HexBytes<HASH_SIZE>,
     signed_over_data: SignedOverData,
 }
+
 impl ChunkMeta {
     fn get_epoch(&self) -> Option<Epoch> {
         match self.group_id {
@@ -64,6 +67,7 @@ pub enum MalformedPacket {
     TooLong,
     InvalidTreeDepth(u8),
     InvalidBroadcastBits(u8),
+    InvalidEncodingScheme(u8),
     UnknownVersion(u16),
 }
 
@@ -159,6 +163,16 @@ const _: () = assert!(
     "RaptorcastChunkHeader size must match CHUNK_HEADER_LEN"
 );
 
+const _: () = assert!(
+    RAPTORCAST_HEADER_V1_SIZE == crate::packet::deterministic::PacketLayout::HEADER_LEN,
+    "RaptorcastHeader size must match HEADER_LEN"
+);
+
+const _: () = assert!(
+    RaptorcastChunkHeaderV1::SIZE == crate::packet::deterministic::PacketLayout::CHUNK_HEADER_LEN,
+    "RaptorcastChunkHeader size must match CHUNK_HEADER_LEN"
+);
+
 /// Raptorcast V0 chunk header layout (follows header and merkle proof):
 /// - 20 bytes * (merkle_tree_depth - 1) => merkle proof (leaves include everything that follows,
 ///   eg hash(chunk_recipient + chunk_byte_offset + symbol_len + payload))
@@ -180,6 +194,96 @@ pub struct RaptorcastChunkHeaderV0 {
 
 impl RaptorcastChunkHeaderV0 {
     const SIZE: usize = MERKLE_HASH_SIZE + 1 + 1 + 2;
+}
+
+/// Raptorcast packet V1 versioned header layout (follows common header):
+/// - 2 bits => broadcast mode
+/// - 2 bits => unused
+/// - 4 bits => Merkle tree depth
+/// - 1 byte (u8) => encoding scheme variant
+/// - 8 bytes (u64) => Round #
+/// - 8 bytes (u64) => Epoch #
+/// - 8 bytes (u64) => Unix timestamp
+/// - 20 bytes => global merkle tree root for the full message
+/// - 4 bytes (u32) => Serialized AppMessage length (bytes)
+#[repr(C, packed)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Clone, Copy)]
+pub struct RaptorcastHeaderV1 {
+    broadcast_tree_depth: u8,
+    encoding_scheme_variant: u8,
+    round: U64<LE>,
+    epoch: U64<LE>,
+    unix_ts_ms: U64<LE>,
+    global_merkle_root: [u8; MERKLE_HASH_SIZE],
+    app_message_len: U32<LE>,
+}
+
+/// Combined header size for V1 (common header + versioned header)
+const RAPTORCAST_HEADER_V1_SIZE: usize = RaptorcastHeader::SIZE + RaptorcastHeaderV1::SIZE;
+
+impl RaptorcastHeaderV1 {
+    const SIZE: usize = 1 + 1 + 8 + 8 + 8 + MERKLE_HASH_SIZE + 4;
+
+    pub fn broadcast_mode(&self) -> Result<BroadcastMode, MalformedPacket> {
+        match (self.broadcast_tree_depth & 0b1100_0000) >> 6 {
+            0b10 => Ok(BroadcastMode::Primary),
+            bits => Err(MalformedPacket::InvalidBroadcastBits(bits)),
+        }
+    }
+
+    pub fn encoding_scheme(&self) -> Result<EncodingScheme, MalformedPacket> {
+        let round = Round(self.round.get());
+        match self.encoding_scheme_variant {
+            0x1 => Ok(EncodingScheme::Deterministic25(round)),
+            v => Err(MalformedPacket::InvalidEncodingScheme(v)),
+        }
+    }
+
+    #[allow(clippy::manual_range_contains)]
+    pub fn tree_depth(&self) -> Result<u8, MalformedPacket> {
+        let depth = self.broadcast_tree_depth & 0b0000_1111;
+        ensure!(
+            (deterministic::MIN_MERKLE_TREE_DEPTH..=deterministic::MAX_MERKLE_TREE_DEPTH)
+                .contains(&depth),
+            MalformedPacket::InvalidTreeDepth(depth)
+        );
+
+        Ok(depth)
+    }
+
+    pub fn group_id(&self) -> Result<GroupId, MalformedPacket> {
+        let epoch = Epoch(self.epoch.get());
+        match self.broadcast_mode()? {
+            BroadcastMode::Primary => Ok(GroupId::Primary(epoch)),
+            // broadcast_mode() only returns Primary for v1
+            _broadcast_mode => unreachable!(),
+        }
+    }
+}
+
+/// Raptorcast V1 chunk header layout (follows header and merkle proof):
+/// - 20 bytes * (merkle_tree_depth - 1) => merkle proof (leaves include everything that follows,
+///   eg hash(chunk_recipient + chunk_byte_offset + symbol_len + payload))
+/// - 20 bytes => first 20 bytes of hash of chunk's first hop recipient
+///   - we set this even if broadcast bit is not set so that it's known if a message was intended
+///     to be sent to self
+/// - 2 bytes => reserved
+/// - 2 bytes (u16) => This chunk's id, also used as the merkle leaf index
+/// - rest => data
+#[repr(C, packed)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Clone, Copy)]
+pub struct RaptorcastChunkHeaderV1 {
+    recipient_hash: [u8; MERKLE_HASH_SIZE],
+    reserved: U16<LE>,
+    chunk_id: U16<LE>,
+}
+
+impl RaptorcastChunkHeaderV1 {
+    const SIZE: usize = MERKLE_HASH_SIZE + 2 + 2;
+
+    fn merkle_leaf_index(&self) -> u16 {
+        self.chunk_id.get()
+    }
 }
 
 /// header + merkle root, used as cache key for signatures
@@ -212,20 +316,47 @@ impl SignedOverDataV0 {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SignedOverDataV1([u8; RAPTORCAST_HEADER_V1_SIZE]);
+
+impl SignedOverDataV1 {
+    pub fn new(
+        common_header: &Ref<&[u8], RaptorcastHeader>,
+        versioned_header: &Ref<&[u8], RaptorcastHeaderV1>,
+    ) -> Self {
+        use zerocopy::IntoBytes;
+        let mut data = [0u8; RAPTORCAST_HEADER_V1_SIZE];
+        data[..RaptorcastHeader::SIZE].copy_from_slice(common_header.as_bytes());
+        data[RaptorcastHeader::SIZE..].copy_from_slice(versioned_header.as_bytes());
+        Self(data)
+    }
+
+    pub fn signed_message(&self) -> &[u8] {
+        &self.0[SIGNATURE_SIZE..]
+    }
+
+    fn signature(&self) -> &[u8] {
+        &self.0[..SIGNATURE_SIZE]
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SignedOverData {
     V0(SignedOverDataV0),
+    V1(SignedOverDataV1),
 }
 
 impl SignedOverData {
     pub fn signature(&self) -> &[u8] {
         match self {
             SignedOverData::V0(v0) => v0.signature(),
+            SignedOverData::V1(v1) => v1.signature(),
         }
     }
 
     pub fn signed_message(&self) -> &[u8] {
         match self {
             SignedOverData::V0(v0) => v0.signed_message(),
+            SignedOverData::V1(v1) => v1.signed_message(),
         }
     }
 }
@@ -352,12 +483,13 @@ impl<'a> RaptorcastPacketV0<'a> {
             // TODO: use more accurate estimation for number of rounding chunks
             chunk_id_cap = chunk_id_cap.saturating_add(MAX_VALIDATOR_SET_SIZE);
         }
+
         let chunk_id = self.chunk_header.chunk_id.get() as usize;
         ensure!(chunk_id < chunk_id_cap, InvalidChunk::InvalidChunkId);
 
         let group_id = self.header.group_id()?;
         let signed_over_data = self.signed_over_data(common_header, &merkle_root);
-        let app_message_hash = HexBytes(self.header.app_message_hash);
+        let app_message_hash = Some(HexBytes(self.header.app_message_hash));
         let recipient_hash = HexBytes(self.chunk_header.recipient_hash);
 
         Ok(ChunkMeta {
@@ -367,8 +499,10 @@ impl<'a> RaptorcastPacketV0<'a> {
             encoded_symbol_capacity: chunk_id_cap,
             timestamp,
             broadcast_mode,
+            encoding_scheme: EncodingScheme::Unspecified,
             group_id,
             app_message_hash,
+            merkle_root: HexBytes(merkle_root),
             recipient_hash,
             signed_over_data,
         })
@@ -387,8 +521,175 @@ impl<'a> RaptorcastPacketV0<'a> {
     }
 }
 
+pub struct RaptorcastPacketV1<'a> {
+    pub header: Ref<&'a [u8], RaptorcastHeaderV1>,
+    pub merkle_proof: Ref<&'a [u8], [MerkleHash]>,
+    pub chunk_header: Ref<&'a [u8], RaptorcastChunkHeaderV1>,
+    pub chunk_header_and_payload: &'a [u8],
+    pub payload: &'a [u8],
+    pub payload_offset: usize,
+}
+
+impl<'a> RaptorcastPacketV1<'a> {
+    pub fn parse(rest: &'a [u8]) -> Result<Self, MalformedPacket> {
+        // Deterministic raptorcast uses a globally fixed segment size.
+        let expected_min_len = deterministic::MIN_SEGMENT_LEN - RaptorcastHeader::SIZE;
+        let expected_max_len = deterministic::MAX_SEGMENT_LEN - RaptorcastHeader::SIZE;
+        ensure!(rest.len() >= expected_min_len, MalformedPacket::TooShort);
+        ensure!(rest.len() <= expected_max_len, MalformedPacket::TooLong);
+
+        // Defensive: Should be unreachable given the asserted segment size.
+        ensure!(
+            rest.len() >= RaptorcastChunkHeaderV1::SIZE,
+            MalformedPacket::TooShort
+        );
+
+        let (header_bytes, rest) = rest.split_at(RaptorcastHeaderV1::SIZE);
+        let header: Ref<&[u8], RaptorcastHeaderV1> =
+            Ref::from_bytes(header_bytes).map_err(|_| MalformedPacket::TooShort)?;
+
+        let tree_depth = header.tree_depth()?;
+        let merkle_proof_len = MERKLE_HASH_SIZE * (tree_depth - 1) as usize;
+        ensure!(rest.len() > merkle_proof_len, MalformedPacket::TooShort);
+
+        let (merkle_proof_bytes, chunk_header_and_payload) = rest.split_at(merkle_proof_len);
+        let merkle_proof: Ref<&[u8], [MerkleHash]> =
+            Ref::from_bytes(merkle_proof_bytes).map_err(|_| MalformedPacket::TooShort)?;
+
+        ensure!(
+            chunk_header_and_payload.len() >= RaptorcastChunkHeaderV1::SIZE,
+            MalformedPacket::TooShort
+        );
+        let (chunk_header_bytes, payload) =
+            chunk_header_and_payload.split_at(RaptorcastChunkHeaderV1::SIZE);
+        let chunk_header: Ref<&[u8], RaptorcastChunkHeaderV1> =
+            Ref::from_bytes(chunk_header_bytes).map_err(|_| MalformedPacket::TooShort)?;
+
+        ensure!(!payload.is_empty(), MalformedPacket::TooShort);
+
+        let payload_offset =
+            RAPTORCAST_HEADER_V1_SIZE + merkle_proof_len + RaptorcastChunkHeaderV1::SIZE;
+
+        Ok(Self {
+            header,
+            merkle_proof,
+            chunk_header,
+            chunk_header_and_payload,
+            payload,
+            payload_offset,
+        })
+    }
+
+    pub fn split_chunk(&self, message: &Bytes) -> Result<Bytes, MalformedPacket> {
+        ensure!(
+            message.len() >= self.payload_offset,
+            MalformedPacket::TooShort
+        );
+        Ok(message.slice(self.payload_offset..))
+    }
+
+    pub fn payload(&self) -> &[u8] {
+        &self.chunk_header_and_payload[RaptorcastChunkHeaderV1::SIZE..]
+    }
+
+    pub fn signed_over_data(&self, common_header: &Ref<&[u8], RaptorcastHeader>) -> SignedOverData {
+        SignedOverData::V1(SignedOverDataV1::new(common_header, &self.header))
+    }
+
+    // Validates all the header fields to be consistent and within
+    // expected bounds. Does not check the signature yet.
+    fn validate_chunk_meta(
+        &self,
+        common_header: &Ref<&'a [u8], RaptorcastHeader>,
+        max_age_ms: u64,
+    ) -> Result<ChunkMeta, InvalidChunk> {
+        let encoding_scheme = self.header.encoding_scheme()?;
+        // ensure encoding scheme is recognized before any other validation
+
+        let app_message_len = self.ensure_app_message_length()?;
+        let timestamp = self.header.unix_ts_ms.get();
+        ensure_valid_timestamp(timestamp, max_age_ms)?;
+
+        let symbol_len = self.payload().len();
+        ensure!(
+            // should hold unconditionally for packet passing `parse()`. kept defensively.
+            (deterministic::MIN_SYMBOL_LEN..=deterministic::MAX_SYMBOL_LEN).contains(&symbol_len),
+            InvalidChunk::InvalidChunkLen
+        );
+
+        let num_source_symbols = app_message_len.div_ceil(symbol_len);
+        ensure!(
+            (monad_raptor::SOURCE_SYMBOLS_MIN..=monad_raptor::SOURCE_SYMBOLS_MAX)
+                .contains(&num_source_symbols),
+            InvalidChunk::InvalidAppMessageLen(app_message_len)
+        );
+
+        let broadcast_mode = self.header.broadcast_mode()?;
+        let chunk_id_cap = stake_partition_num_chunks_hint(
+            num_source_symbols,
+            deterministic::DEFAULT_REDUNDANCY,
+            MAX_VALIDATOR_SET_SIZE,
+        )
+        .ok_or(InvalidChunk::InvalidChunkId)?;
+        let chunk_id = self.chunk_header.chunk_id.get() as usize;
+        ensure!(chunk_id < chunk_id_cap, InvalidChunk::InvalidChunkId);
+
+        let group_id = self.header.group_id()?;
+        let signed_over_data = self.signed_over_data(common_header);
+        let merkle_root = self.validate_merkle_root()?;
+        let recipient_hash = HexBytes(self.chunk_header.recipient_hash);
+
+        Ok(ChunkMeta {
+            app_message_len,
+            chunk_id,
+            num_source_symbols,
+            encoded_symbol_capacity: chunk_id_cap,
+            timestamp,
+            broadcast_mode,
+            encoding_scheme,
+            group_id,
+            app_message_hash: None,
+            merkle_root: HexBytes(merkle_root),
+            recipient_hash,
+            signed_over_data,
+        })
+    }
+
+    fn ensure_app_message_length(&self) -> Result<usize, InvalidChunk> {
+        let app_message_len = self.header.app_message_len.get() as usize;
+        ensure!(
+            app_message_len > 0 && app_message_len <= MAX_MESSAGE_SIZE,
+            InvalidChunk::InvalidAppMessageLen(app_message_len)
+        );
+        Ok(app_message_len)
+    }
+
+    fn validate_merkle_root(&self) -> Result<MerkleHash, InvalidChunk> {
+        let proof = MerkleProof::new_from_leaf_idx(
+            self.merkle_proof.to_vec(),
+            self.chunk_header.merkle_leaf_index(),
+        )
+        .ok_or(InvalidChunk::InvalidMerkleProof)?;
+
+        let mut hasher = HasherType::new();
+        hasher.update(self.chunk_header_and_payload);
+        let leaf_hash = hasher.hash();
+
+        let root = proof
+            .compute_root(&leaf_hash)
+            .ok_or(InvalidChunk::InvalidMerkleProof)?;
+
+        if root != self.header.global_merkle_root {
+            return Err(InvalidChunk::InvalidMerkleProof);
+        }
+
+        Ok(root)
+    }
+}
+
 pub enum RaptorcastPacketVersioned<'a> {
     V0(RaptorcastPacketV0<'a>),
+    V1(RaptorcastPacketV1<'a>),
 }
 
 pub type CommonRaptorcastHeader<'a> = Ref<&'a [u8], RaptorcastHeader>;
@@ -421,6 +722,7 @@ impl<'a> RaptorcastPacket<'a> {
 
         let versioned = match header.version.get() {
             0 => RaptorcastPacketVersioned::V0(RaptorcastPacketV0::parse(rest)?),
+            1 => RaptorcastPacketVersioned::V1(RaptorcastPacketV1::parse(rest)?),
             v => return Err(MalformedPacket::UnknownVersion(v)),
         };
 
@@ -434,6 +736,9 @@ impl<'a> RaptorcastPacket<'a> {
         match &self.versioned {
             RaptorcastPacketVersioned::V0(v0) => {
                 v0.validate_chunk_meta(&self.common_header, max_age_ms)
+            }
+            RaptorcastPacketVersioned::V1(v1) => {
+                v1.validate_chunk_meta(&self.common_header, max_age_ms)
             }
         }
     }
@@ -451,6 +756,7 @@ impl<'a> RaptorcastPacket<'a> {
         let author = verify_signature(env.signature_verifier, &meta, env.bypass_rate_limiter)?;
         let chunk = match &self.versioned {
             RaptorcastPacketVersioned::V0(v0) => v0.split_chunk(message)?,
+            RaptorcastPacketVersioned::V1(v1) => v1.split_chunk(message)?,
         };
 
         ensure!(author != *env.self_id, InvalidChunk::Loopback);
@@ -462,7 +768,9 @@ impl<'a> RaptorcastPacket<'a> {
             group_id: meta.group_id,
             unix_ts_ms: meta.timestamp,
             app_message_hash: meta.app_message_hash,
+            merkle_root: meta.merkle_root,
             app_message_len: meta.app_message_len as u32,
+            encoding_scheme: meta.encoding_scheme,
             broadcast_mode: meta.broadcast_mode,
             recipient_hash: meta.recipient_hash,
             chunk_id: meta.chunk_id as u16,

--- a/monad-raptorcast/src/round_info.rs
+++ b/monad-raptorcast/src/round_info.rs
@@ -1,0 +1,218 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::BTreeMap;
+
+use monad_crypto::certificate_signature::PubKey;
+use monad_types::Round;
+
+use crate::{
+    packet::{
+        assigner::{ChunkAssignment, ChunkRouting, StakePartition},
+        deterministic,
+    },
+    udp::ValidatedChunk,
+    util::PrimaryBroadcastGroup,
+};
+
+const CACHE_MAX_FUTURE_ROUNDS: Round = Round(100);
+const CACHE_MAX_PAST_ROUNDS: Round = Round(100);
+
+// Stores information related to the current round.
+pub struct RoundInfoCache<PT: PubKey> {
+    current_round: Option<Round>,
+    primary: BTreeMap<Round, PrimaryRoundInfo<PT>>,
+}
+
+impl<PT: PubKey> RoundInfoCache<PT> {
+    pub fn new() -> Self {
+        Self {
+            current_round: None,
+            primary: BTreeMap::new(),
+        }
+    }
+
+    pub fn update_current_round(&mut self, round: Round) {
+        if let Some(current) = self.current_round {
+            assert!(
+                round > current,
+                "Cannot enter a past round: current {}, new {}",
+                current,
+                round
+            );
+        }
+
+        self.current_round = Some(round);
+
+        // Evict rounds from the cache
+        if let Some(cutoff_future) = round.checked_add(CACHE_MAX_FUTURE_ROUNDS) {
+            drop(self.primary.split_off(&cutoff_future));
+        };
+        if let Some(cutoff_past) = round.checked_sub(CACHE_MAX_PAST_ROUNDS) {
+            let mut active = self.primary.split_off(&cutoff_past);
+            std::mem::swap(&mut self.primary, &mut active);
+        }
+    }
+
+    // Returns None on out-of-window round
+    pub fn get_or_insert_primary(&mut self, round: Round) -> Option<&mut PrimaryRoundInfo<PT>> {
+        if !self.primary.contains_key(&round) {
+            self.check_round(round)?;
+            self.primary.insert(round, Default::default());
+        }
+        self.primary.get_mut(&round)
+    }
+
+    #[cfg(test)]
+    fn get_primary(&self, round: Round) -> Option<&PrimaryRoundInfo<PT>> {
+        self.primary.get(&round)
+    }
+
+    fn check_round(&self, round: Round) -> Option<()> {
+        if let Some(current) = self.current_round {
+            let max_round = current
+                .checked_add(CACHE_MAX_FUTURE_ROUNDS)
+                .unwrap_or(Round::MAX);
+            let min_round = current
+                .checked_sub(CACHE_MAX_PAST_ROUNDS)
+                .unwrap_or(Round::MIN);
+
+            if round > max_round || round < min_round {
+                return None;
+            }
+        }
+
+        Some(())
+    }
+}
+
+pub struct PrimaryRoundInfo<PT: PubKey> {
+    encoding: Option<(deterministic::PrimaryEncoding<PT>, ChunkAssignment)>,
+    // more info:
+    //
+    // - commitment
+    // - cache chunks for pulling
+}
+
+impl<PT: PubKey> Default for PrimaryRoundInfo<PT> {
+    fn default() -> Self {
+        Self { encoding: None }
+    }
+}
+
+impl<PT: PubKey> PrimaryRoundInfo<PT> {
+    pub fn chunk_routing(
+        &mut self,
+        group: &PrimaryBroadcastGroup<'_, PT>,
+        chunk: &ValidatedChunk<PT>,
+    ) -> Option<ChunkRouting<'_, PT, StakePartition<PT>>> {
+        // The construction of encoding and assignment should never
+        // return None on a validated chunk where the app_message_len
+        // is checked to be within valid range. The try operators
+        // are defensive.
+        if self.encoding.is_none() {
+            let encoding = deterministic::PrimaryEncoding::new(
+                chunk.encoding_scheme,
+                group,
+                chunk.app_message_len as usize,
+                chunk.unix_ts_ms,
+            )
+            .ok()?;
+            let assignment = encoding.make_assignment().ok()?;
+            self.encoding = Some((encoding, assignment));
+        }
+
+        if let Some((encoding, assignment)) = &self.encoding {
+            return assignment.resolve_chunk_id(chunk.chunk_id as usize, encoding.partition());
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use monad_crypto::NopPubKey;
+
+    use super::*;
+
+    type Cache = RoundInfoCache<NopPubKey>;
+
+    // -- RoundInfoCache tests --
+    #[test]
+    fn get_or_insert() {
+        let mut cache = Cache::new();
+
+        // Any round accepted before first update_current_round.
+        assert!(cache.get_or_insert_primary(Round(0)).is_some());
+        assert!(cache.get_or_insert_primary(Round(200)).is_some());
+        assert!(cache.get_or_insert_primary(Round(500)).is_some());
+
+        // update_current_round evicts out-of-window entries.
+        cache.update_current_round(Round(200));
+        assert!(cache.get_primary(Round(0)).is_none());
+        assert!(cache.get_primary(Round(200)).is_some());
+        assert!(cache.get_primary(Round(500)).is_none());
+
+        // Repeated insert returns existing entry.
+        assert!(cache.get_or_insert_primary(Round(200)).is_some());
+    }
+
+    #[test]
+    fn round_window_bounds() {
+        let mut cache = Cache::new();
+        cache.update_current_round(Round(200));
+
+        // Exactly at future boundary: 200 + 100 = 300, accepted.
+        assert!(cache.get_or_insert_primary(Round(300)).is_some());
+        // One past: rejected.
+        assert!(cache.get_or_insert_primary(Round(301)).is_none());
+
+        // Exactly at past boundary: 200 - 100 = 100, accepted.
+        assert!(cache.get_or_insert_primary(Round(100)).is_some());
+        // One past: rejected.
+        assert!(cache.get_or_insert_primary(Round(99)).is_none());
+    }
+
+    #[test]
+    fn eviction() {
+        let mut cache = Cache::new();
+        cache.get_or_insert_primary(Round(10));
+        cache.get_or_insert_primary(Round(11));
+        cache.get_or_insert_primary(Round(199));
+        cache.get_or_insert_primary(Round(200));
+
+        // Future eviction: cutoff = 100 + 100 = 200, entries >= 200 are dropped.
+        cache.update_current_round(Round(100));
+        assert!(cache.get_primary(Round(199)).is_some());
+        assert!(cache.get_primary(Round(200)).is_none());
+
+        // Past eviction: advance to 111, cutoff = 111 - 100 = 11, entries < 11 are dropped.
+        cache.update_current_round(Round(111));
+        assert!(cache.get_primary(Round(10)).is_none());
+        assert!(cache.get_primary(Round(11)).is_some());
+
+        // In-window entries survive across rounds.
+        let mut cache = Cache::new();
+        cache.update_current_round(Round(100));
+        for r in 50..=150 {
+            cache.get_or_insert_primary(Round(r));
+        }
+        cache.update_current_round(Round(110));
+        for r in 50..=150 {
+            assert!(cache.get_primary(Round(r)).is_some());
+        }
+    }
+}

--- a/monad-raptorcast/src/round_info.rs
+++ b/monad-raptorcast/src/round_info.rs
@@ -24,7 +24,8 @@ use crate::{
         deterministic,
     },
     udp::ValidatedChunk,
-    util::PrimaryBroadcastGroup,
+    util::{EncodingScheme, GlobalMerkleRoot, PrimaryBroadcastGroup},
+    SIGNATURE_SIZE,
 };
 
 const CACHE_MAX_FUTURE_ROUNDS: Round = Round(100);
@@ -100,15 +101,18 @@ impl<PT: PubKey> RoundInfoCache<PT> {
 
 pub struct PrimaryRoundInfo<PT: PubKey> {
     encoding: Option<(deterministic::PrimaryEncoding<PT>, ChunkAssignment)>,
+    commitment: Option<EncodingCommitment>,
     // more info:
     //
-    // - commitment
     // - cache chunks for pulling
 }
 
 impl<PT: PubKey> Default for PrimaryRoundInfo<PT> {
     fn default() -> Self {
-        Self { encoding: None }
+        Self {
+            encoding: None,
+            commitment: None,
+        }
     }
 }
 
@@ -140,15 +144,152 @@ impl<PT: PubKey> PrimaryRoundInfo<PT> {
 
         None
     }
+
+    // Returns None if there is a conflicting commitment suggesting
+    // publisher equivocation.
+    #[must_use]
+    pub fn try_commit(&mut self, chunk: &ValidatedChunk<PT>) -> Option<()> {
+        let Ok(claim) = ChunkCommitmentClaim::try_from(chunk) else {
+            // not applicable, so we ignore this chunk for commitment.
+            return Some(());
+        };
+
+        let Some(commitment) = &mut self.commitment else {
+            // no commitment for this round yet, so we will commit to
+            // the first claim we see.
+            self.commitment = Some(EncodingCommitment::from(claim));
+            return Some(());
+        };
+        if commitment.is_compatible_with(claim) {
+            return Some(());
+        }
+
+        // log conflicting commitment once
+        if !commitment.conflict_logged {
+            tracing::error!(
+                author = ?chunk.author,
+                round = ?claim.round,
+                chunk_merkle_root = ?claim.global_merkle_root,
+                commit_merkle_root = ?commitment.global_merkle_root,
+                chunk_signature = ?claim.signature,
+                commit_signature = ?commitment.signature,
+                "Conflicting commitment"
+            );
+            commitment.conflict_logged = true;
+        }
+        None
+    }
+}
+
+type Signature = [u8; SIGNATURE_SIZE];
+
+#[derive(Clone, Copy)]
+struct ChunkCommitmentClaim<'a> {
+    round: Round,
+    signature: &'a Signature,
+    global_merkle_root: &'a GlobalMerkleRoot,
+}
+
+impl<'a, PT> TryFrom<&'a ValidatedChunk<PT>> for ChunkCommitmentClaim<'a>
+where
+    PT: PubKey,
+{
+    type Error = ();
+
+    fn try_from(chunk: &'a ValidatedChunk<PT>) -> Result<Self, ()> {
+        let round = match chunk.encoding_scheme {
+            EncodingScheme::Deterministic25(round) => round,
+            EncodingScheme::Unspecified => return Err(()), // not applicable
+        };
+        let global_merkle_root = chunk
+            .global_merkle_root()
+            .expect("deterministic rc must have global merkle root");
+        let signature = <&[u8; SIGNATURE_SIZE]>::try_from(chunk.signature.as_ref())
+            .expect("signature of validated chunk must have correct length");
+
+        Ok(Self {
+            signature,
+            global_merkle_root,
+            round,
+        })
+    }
+}
+
+struct EncodingCommitment {
+    signature: Signature,
+    global_merkle_root: GlobalMerkleRoot,
+
+    // Remember whether this commitment has been logged as conflicting
+    // with another commitment, set to avoid log spam.
+    conflict_logged: bool,
+}
+
+impl From<ChunkCommitmentClaim<'_>> for EncodingCommitment {
+    fn from(claim: ChunkCommitmentClaim<'_>) -> Self {
+        Self {
+            signature: *claim.signature,
+            global_merkle_root: *claim.global_merkle_root,
+            conflict_logged: false,
+        }
+    }
+}
+
+impl EncodingCommitment {
+    fn is_compatible_with(&self, claim: ChunkCommitmentClaim<'_>) -> bool {
+        if self.global_merkle_root != *claim.global_merkle_root
+            || self.signature != *claim.signature
+        {
+            return false;
+        }
+
+        true
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use monad_crypto::NopPubKey;
+    use bytes::Bytes;
+    use monad_crypto::{certificate_signature::PubKey as _, NopPubKey};
+    use monad_types::NodeId;
 
     use super::*;
+    use crate::{
+        udp::GroupId,
+        util::{BroadcastMode, HexBytes, MerkleRoot},
+    };
 
     type Cache = RoundInfoCache<NopPubKey>;
+
+    const SIG_A: [u8; SIGNATURE_SIZE] = [0xAA; SIGNATURE_SIZE];
+    const SIG_B: [u8; SIGNATURE_SIZE] = [0xBB; SIGNATURE_SIZE];
+    const MERKLE_A: MerkleRoot = HexBytes([1; 20]);
+    const MERKLE_B: MerkleRoot = HexBytes([2; 20]);
+
+    fn dummy_chunk(
+        round: u64,
+        sig: &[u8; SIGNATURE_SIZE],
+        merkle: &MerkleRoot,
+    ) -> ValidatedChunk<NopPubKey> {
+        ValidatedChunk {
+            chunk: Bytes::new(),
+            message: Bytes::new(),
+            signature: Bytes::copy_from_slice(sig),
+            author: NodeId::new(NopPubKey::from_bytes(&[0; 32]).unwrap()),
+            group_id: GroupId::Primary(monad_types::Epoch(0)),
+            unix_ts_ms: 0,
+            app_message_hash: None,
+            app_message_len: 0,
+            recipient_hash: None,
+            chunk_id: 0,
+            num_source_symbols: 0,
+            encoded_symbol_capacity: 0,
+            encoding_scheme: EncodingScheme::Deterministic25(Round(round)),
+            broadcast_mode: BroadcastMode::Primary,
+            merkle_root: *merkle,
+        }
+    }
+
+    // -- RoundInfoCache tests --
 
     // -- RoundInfoCache tests --
     #[test]
@@ -214,5 +355,46 @@ mod tests {
         for r in 50..=150 {
             assert!(cache.get_primary(Round(r)).is_some());
         }
+    }
+
+    #[test]
+    fn only_accept_compatible_claim() {
+        let mut info = PrimaryRoundInfo::<NopPubKey>::default();
+        assert!(info
+            .try_commit(&dummy_chunk(10, &SIG_A, &MERKLE_A))
+            .is_some());
+
+        // Conflicting signature.
+        assert!(info
+            .try_commit(&dummy_chunk(10, &SIG_B, &MERKLE_A))
+            .is_none());
+        // Conflicting merkle root.
+        assert!(info
+            .try_commit(&dummy_chunk(10, &SIG_A, &MERKLE_B))
+            .is_none());
+        // Compatible.
+        assert!(info
+            .try_commit(&dummy_chunk(10, &SIG_A, &MERKLE_A))
+            .is_some());
+    }
+
+    #[test]
+    fn independent_rounds_have_independent_commitments() {
+        let mut info_10 = PrimaryRoundInfo::<NopPubKey>::default();
+        let mut info_11 = PrimaryRoundInfo::<NopPubKey>::default();
+        assert!(info_10
+            .try_commit(&dummy_chunk(10, &SIG_A, &MERKLE_A))
+            .is_some());
+        assert!(info_11
+            .try_commit(&dummy_chunk(11, &SIG_B, &MERKLE_B))
+            .is_some());
+
+        // Each round has its own commitment.
+        assert!(info_10
+            .try_commit(&dummy_chunk(10, &SIG_B, &MERKLE_B))
+            .is_none());
+        assert!(info_11
+            .try_commit(&dummy_chunk(11, &SIG_A, &MERKLE_A))
+            .is_none());
     }
 }

--- a/monad-raptorcast/src/round_info.rs
+++ b/monad-raptorcast/src/round_info.rs
@@ -254,7 +254,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        udp::GroupId,
+        udp::{ChunkVersion, GroupId},
         util::{BroadcastMode, HexBytes, MerkleRoot},
     };
 
@@ -281,6 +281,7 @@ mod tests {
             app_message_len: 0,
             recipient_hash: None,
             chunk_id: 0,
+            version: ChunkVersion::V1,
             num_source_symbols: 0,
             encoded_symbol_capacity: 0,
             encoding_scheme: EncodingScheme::Deterministic25(Round(round)),
@@ -288,8 +289,6 @@ mod tests {
             merkle_root: *merkle,
         }
     }
-
-    // -- RoundInfoCache tests --
 
     // -- RoundInfoCache tests --
     #[test]

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -30,13 +30,15 @@ use crate::{
     metrics::{
         UdpStateMetrics, GAUGE_RAPTORCAST_DECODING_CACHE_SIGNATURE_VERIFICATIONS_RATE_LIMITED,
     },
+    packet::deterministic,
     parser::{
         packet_parser::{ChunkValidationEnv, MalformedPacket, RaptorcastPacket, SignedOverData},
         signature_verifier::{SignatureVerifier, SignatureVerifierError},
     },
     util::{
-        compute_app_message_hash, compute_hash, unix_ts_ms_now, AppMessageHash, BroadcastGroup,
-        BroadcastMode, FullNodeGroupMap, NodeIdHash,
+        compute_app_message_hash, compute_hash, unix_ts_ms_now, AppMessageHash, BroadcastMode,
+        EncodingScheme, FullNodeGroupMap, GlobalMerkleRoot, MerkleRoot, NodeIdHash,
+        PrimaryBroadcastGroup, SecondaryBroadcastGroup,
     },
 };
 
@@ -46,6 +48,7 @@ pub const SIGNATURE_CACHE_SIZE: usize = 10_000;
 // to be transmitted.  This can happen in Broadcast mode when the message is large or
 // if we have many peers to transmit the message to.
 pub const MAX_NUM_PACKETS: usize = 65535;
+pub const MIN_VALIDATOR_SET_SIZE: usize = 1;
 
 /// Cache key for signature verification: header + merkle root
 pub type SignatureCacheKey = SignedOverData;
@@ -138,20 +141,20 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
         message
     }
 
-    pub fn handle_broadcast(
+    pub fn handle_primary_raptorcast(
         &mut self,
         epoch_validators: &BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
-        full_node_group_map: &FullNodeGroupMap<CertificateSignaturePubKey<ST>>,
         chunk: &ValidatedChunk<CertificateSignaturePubKey<ST>>,
         rebroadcast_to: &mut impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
         sender: Option<&NodeId<CertificateSignaturePubKey<ST>>>,
     ) -> Option<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
-        let Ok(group) = BroadcastGroup::from_group_id(
-            chunk.group_id,
-            &chunk.author,
-            epoch_validators,
-            full_node_group_map,
-        ) else {
+        let epoch = match chunk.group_id {
+            GroupId::Primary(epoch) => epoch,
+            GroupId::Secondary(_round) => unreachable!(),
+        };
+
+        let Ok(group) = PrimaryBroadcastGroup::of_epoch(epoch, &chunk.author, epoch_validators)
+        else {
             tracing::debug!(
                 ?chunk.group_id,
                 author =? chunk.author,
@@ -165,7 +168,81 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
                 tracing::debug!(
                     ?chunk.group_id,
                     author =? chunk.author,
-                    sender =? sender,
+                    ?sender,
+                    "dropping message from invalid sender"
+                );
+                return None;
+            }
+
+            // Future: check if author (proposer) is valid for round.
+        }
+
+        let validator_set = epoch_validators.get(&epoch);
+        let decoding_context = DecodingContext::new(validator_set, unix_ts_ms_now());
+        let message = self.try_decode(chunk, &decoding_context)?;
+
+        if let Some((_author, message)) = &message {
+            if let Some(encoding_valid) = chunk.check_deterministic_encoding(message, &group) {
+                if !encoding_valid {
+                    self.decoder_cache.mark_tainted(chunk);
+                    tracing::warn!(
+                        author =? chunk.author,
+                        "message failed deterministic encoding validation"
+                    );
+                    return None;
+                }
+            }
+
+            if let Some(hash_valid) = chunk.check_message_hash(message) {
+                if !hash_valid {
+                    self.decoder_cache.mark_tainted(chunk);
+                    tracing::warn!(
+                        author =? chunk.author,
+                        "message failed hash validation"
+                    );
+                    return None;
+                }
+            }
+        }
+
+        let is_first_hop_recipient = chunk.recipient_hash == self.self_id_hash;
+        if let Some(ctx) = group.try_rebroadcast(&self.self_id, is_first_hop_recipient) {
+            // TODO: cap rebroadcast symbols based on some multiple of esis.
+            rebroadcast_to(ctx.peers().cloned().collect());
+        }
+
+        message
+    }
+
+    pub fn handle_secondary_raptorcast(
+        &mut self,
+        epoch_validators: &BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
+        full_node_group_map: &FullNodeGroupMap<CertificateSignaturePubKey<ST>>,
+        chunk: &ValidatedChunk<CertificateSignaturePubKey<ST>>,
+        rebroadcast_to: &mut impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
+        sender: Option<&NodeId<CertificateSignaturePubKey<ST>>>,
+    ) -> Option<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
+        let round = match chunk.group_id {
+            GroupId::Secondary(round) => round,
+            _ => unreachable!(),
+        };
+        let Ok(group) =
+            SecondaryBroadcastGroup::of_round(round, &chunk.author, full_node_group_map)
+        else {
+            tracing::debug!(
+                ?chunk.group_id,
+                author =? chunk.author,
+                "dropping message from unknown author/group"
+            );
+            return None;
+        };
+
+        if let Some(sender) = sender {
+            if !group.is_sender_valid(sender) {
+                tracing::debug!(
+                    ?chunk.group_id,
+                    author =? chunk.author,
+                    ?sender,
                     "dropping message from invalid sender"
                 );
                 return None;
@@ -331,22 +408,31 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
                 "received encoded symbol"
             );
 
+            let rebroadcast_to = &mut |targets| {
+                batch_guard.queue_broadcast(
+                    payload_start_idx,
+                    payload_end_idx,
+                    &chunk.author,
+                    || targets,
+                )
+            };
+
             let maybe_decoded_message = match chunk.broadcast_mode {
                 BroadcastMode::Unspecified => {
                     self.handle_unicast(epoch_validators, &chunk, message.sender.as_ref())
                 }
-                BroadcastMode::Primary | BroadcastMode::Secondary => self.handle_broadcast(
+                BroadcastMode::Primary => self.handle_primary_raptorcast(
+                    epoch_validators,
+                    &chunk,
+                    rebroadcast_to,
+                    message.sender.as_ref(),
+                ),
+
+                BroadcastMode::Secondary => self.handle_secondary_raptorcast(
                     epoch_validators,
                     full_node_group_map,
                     &chunk,
-                    &mut |targets| {
-                        batch_guard.queue_broadcast(
-                            payload_start_idx,
-                            payload_end_idx,
-                            &chunk.author,
-                            || targets,
-                        )
-                    },
+                    rebroadcast_to,
                     message.sender.as_ref(),
                 ),
             };
@@ -389,8 +475,10 @@ where
     // - round number for validator-to-fullnode raptorcast
     pub group_id: GroupId,
     pub unix_ts_ms: u64,
-    pub app_message_hash: AppMessageHash,
+    pub app_message_hash: Option<AppMessageHash>,
+    pub merkle_root: MerkleRoot,
     pub app_message_len: u32,
+    pub encoding_scheme: EncodingScheme,
     pub broadcast_mode: BroadcastMode,
     pub recipient_hash: NodeIdHash, // if this matches our node_id, then we need to re-broadcast RaptorCast chunks
     pub chunk_id: u16,
@@ -399,8 +487,38 @@ where
 }
 
 impl<PT: PubKey> ValidatedChunk<PT> {
+    // Return None if chunk is not applicable for app message hash
+    // check (e.g. deterministic raptorcast)
     pub fn app_message_hash(&self) -> Option<&AppMessageHash> {
-        Some(&self.app_message_hash)
+        self.app_message_hash.as_ref()
+    }
+
+    pub fn global_merkle_root(&self) -> Option<&GlobalMerkleRoot> {
+        match self.encoding_scheme {
+            EncodingScheme::Deterministic25(_) => Some(&self.merkle_root),
+            _ => None,
+        }
+    }
+
+    // Return None if chunk is not encoded using deterministic raptorcast
+    pub fn check_deterministic_encoding(
+        &self,
+        app_message: &[u8],
+        group: &PrimaryBroadcastGroup<'_, PT>,
+    ) -> Option<bool> {
+        if !matches!(self.encoding_scheme, EncodingScheme::Deterministic25(_)) {
+            return None;
+        }
+
+        match deterministic::calc_global_merkle_root(
+            app_message,
+            group,
+            self.encoding_scheme,
+            self.unix_ts_ms,
+        ) {
+            Ok(expected_root) => Some(expected_root == self.merkle_root.0),
+            Err(_err) => Some(false),
+        }
     }
 
     // Return None if chunk is not applicable for app message hash
@@ -424,6 +542,7 @@ pub enum InvalidChunk {
     InvalidAppMessageLen(usize),
     InvalidChunkLen,
     InvalidChunkId,
+    InvalidMerkleTreeDepth,
     InvalidTimestamp {
         packet_ts_ms: u64,
         current_ts_ms: u64,
@@ -727,7 +846,7 @@ mod tests {
             app_message.clone(),
             Redundancy::from_u8(2),
             UNIX_TS_MS,
-            BuildTarget::Raptorcast(group),
+            BuildTarget::raptorcast(group),
             &known_addresses,
         );
 
@@ -737,7 +856,7 @@ mod tests {
                 let message = aggregate_message.split_to(DEFAULT_SEGMENT_SIZE.into());
                 let chunk = parser.parse(&message).expect("valid message");
                 assert_eq!(chunk.message, message);
-                assert_eq!(chunk.app_message_hash, app_message_hash);
+                assert_eq!(chunk.app_message_hash, Some(app_message_hash));
                 assert_eq!(chunk.unix_ts_ms, UNIX_TS_MS);
                 assert!(matches!(chunk.broadcast_mode, BroadcastMode::Primary));
                 assert_eq!(chunk.app_message_len, app_message.len() as u32);
@@ -761,7 +880,7 @@ mod tests {
             app_message,
             Redundancy::from_u8(2),
             UNIX_TS_MS,
-            BuildTarget::Raptorcast(group),
+            BuildTarget::raptorcast(group),
             &known_addresses,
         );
 
@@ -808,7 +927,7 @@ mod tests {
             app_message,
             Redundancy::from_u8(2),
             UNIX_TS_MS,
-            BuildTarget::Raptorcast(group),
+            BuildTarget::raptorcast(group),
             &known_addresses,
         );
 
@@ -847,7 +966,7 @@ mod tests {
 
         let app_message: Bytes = vec![1_u8; 1024 * 1024].into();
         let build_targets = vec![
-            BuildTarget::Raptorcast(primary_group),
+            BuildTarget::raptorcast(primary_group),
             BuildTarget::FullNodeRaptorCast(secondary_group),
         ];
 
@@ -869,7 +988,7 @@ mod tests {
                     let chunk = parser.parse(&message).expect("valid message");
 
                     match build_target {
-                        BuildTarget::Raptorcast(_) => {
+                        BuildTarget::Raptorcast { .. } => {
                             assert!(matches!(chunk.broadcast_mode, BroadcastMode::Primary));
                         }
                         BuildTarget::FullNodeRaptorCast(_) => {
@@ -1016,7 +1135,7 @@ mod tests {
         let group_map = make_group_map(&validators);
         let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &self_id, &group_map).unwrap();
         let target = if raptorcast {
-            BuildTarget::Raptorcast(group)
+            BuildTarget::raptorcast(group)
         } else {
             BuildTarget::Broadcast(group)
         };
@@ -1102,7 +1221,7 @@ mod tests {
             app_message,
             Redundancy::from_u8(1),
             UNIX_TS_MS,
-            BuildTarget::Raptorcast(group),
+            BuildTarget::raptorcast(group),
             &known_addresses,
         );
 
@@ -1138,5 +1257,656 @@ mod tests {
         // Case 4: Same message with bypass: succeeds
         let result4 = parser.parse(&message_b);
         assert!(result4.is_ok());
+    }
+}
+
+#[cfg(test)]
+mod tests_deterministic {
+    use std::{
+        collections::{BTreeMap, HashMap, HashSet},
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+    };
+
+    use bytes::{Bytes, BytesMut};
+    use itertools::Itertools as _;
+    use monad_crypto::{
+        certificate_signature::CertificateSignaturePubKey,
+        hasher::{Hasher, HasherType},
+    };
+    use monad_secp::{KeyPair, SecpSignature};
+    use monad_types::{Epoch, NodeId, Round, Stake};
+    use monad_validator::validator_set::{ValidatorSet, ValidatorSetType as _};
+    use rstest::*;
+
+    use super::{ChunkSignatureVerifier, InvalidChunk, UdpState, ValidatedChunk};
+    use crate::{
+        auth::AuthRecvMsg,
+        packet::{
+            deterministic::{self, build_with_given_header},
+            MessageBuilder,
+        },
+        parser::{
+            packet_parser::{ChunkValidationEnv, RaptorcastPacket},
+            signature_verifier::SignatureVerifier,
+        },
+        udp::SIGNATURE_CACHE_SIZE,
+        util::{
+            compute_hash, BroadcastMode, BuildTarget, EncodingScheme, FullNodeGroupMap,
+            PrimaryBroadcastGroup, UdpMessage, ValidatorGroupMap,
+        },
+    };
+
+    type SignatureType = SecpSignature;
+    type PubKeyType = CertificateSignaturePubKey<SignatureType>;
+    type KeyPairType = KeyPair;
+    type TestSignatureVerifier = ChunkSignatureVerifier<SignatureType>;
+
+    fn signature_verifier() -> TestSignatureVerifier {
+        SignatureVerifier::new().with_cache(SIGNATURE_CACHE_SIZE)
+    }
+
+    struct ChunkParser {
+        self_id: NodeId<PubKeyType>,
+        max_age_ms: u64,
+        signature_verifier: ChunkSignatureVerifier<SecpSignature>,
+    }
+
+    impl ChunkParser {
+        fn new() -> Self {
+            Self {
+                self_id: NodeId::new(make_key_pair(0xff).pubkey()),
+                max_age_ms: u64::MAX,
+                signature_verifier: signature_verifier(),
+            }
+        }
+
+        fn with_max_age_ms(mut self, max_age_ms: u64) -> Self {
+            self.max_age_ms = max_age_ms;
+            self
+        }
+
+        fn with_rate_limit(mut self, rate_limit: u32) -> Self {
+            self.signature_verifier = SignatureVerifier::new()
+                .with_cache(SIGNATURE_CACHE_SIZE)
+                .with_rate_limit(rate_limit);
+            self
+        }
+
+        fn parse(&mut self, message: &Bytes) -> Result<ValidatedChunk<PubKeyType>, InvalidChunk> {
+            self.parse_with(message, |_| true)
+        }
+
+        fn parse_with(
+            &mut self,
+            message: &Bytes,
+            bypass_rate_limiter: impl FnOnce(Epoch) -> bool,
+        ) -> Result<ValidatedChunk<PubKeyType>, InvalidChunk> {
+            let packet = RaptorcastPacket::parse(message)?;
+            packet.validate_chunk(
+                message,
+                ChunkValidationEnv {
+                    signature_verifier: &mut self.signature_verifier,
+                    max_age_ms: self.max_age_ms,
+                    bypass_rate_limiter,
+                    self_id: &self.self_id,
+                },
+            )
+        }
+    }
+
+    fn make_key_pair(n: u8) -> KeyPairType {
+        let mut hasher = HasherType::new();
+        hasher.update(n.to_le_bytes());
+        let mut hash = hasher.hash();
+        KeyPairType::from_bytes(&mut hash.0).unwrap()
+    }
+
+    fn validator_set() -> (
+        KeyPairType,
+        ValidatorSet<PubKeyType>,
+        HashMap<NodeId<PubKeyType>, SocketAddr>,
+    ) {
+        const NUM_KEYS: u8 = 100;
+        let mut keys = (0_u8..NUM_KEYS).map(make_key_pair).collect_vec();
+
+        let valset = keys
+            .iter()
+            .map(|key| (NodeId::new(key.pubkey()), Stake::ONE))
+            .collect();
+        let validators = ValidatorSet::new_unchecked(valset);
+
+        let known_addresses = keys
+            .iter()
+            .skip(NUM_KEYS as usize / 10) // test some missing known_addresses
+            .enumerate()
+            .map(|(idx, key)| {
+                (
+                    NodeId::new(key.pubkey()),
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), idx as u16),
+                )
+            })
+            .collect();
+
+        (keys.pop().unwrap(), validators, known_addresses)
+    }
+
+    const EPOCH: Epoch = Epoch(5);
+    const UNIX_TS_MS: u64 = 5;
+    const ROUND: Round = Round(42);
+
+    fn make_group_map(validators: &ValidatorSet<PubKeyType>) -> ValidatorGroupMap<PubKeyType> {
+        [(EPOCH, validators.clone())].into()
+    }
+
+    fn build_packets(
+        key: &KeyPairType,
+        app_message: &[u8],
+        group: PrimaryBroadcastGroup<'_, PubKeyType>,
+    ) -> Vec<UdpMessage<PubKeyType>> {
+        MessageBuilder::<SignatureType>::new(key)
+            .unix_ts_ms(UNIX_TS_MS)
+            .build_vec(
+                app_message,
+                &BuildTarget::deterministic_raptorcast(group, ROUND),
+            )
+            .expect("build should succeed")
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let (key, validators, _known_addresses) = validator_set();
+        let self_id = NodeId::new(key.pubkey());
+        let group_map = make_group_map(&validators);
+        let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &self_id, &group_map).unwrap();
+
+        let app_message: Bytes = vec![0x1_u8; 1024 * 1024].into();
+        let packets = build_packets(&key, &app_message, group);
+
+        assert!(!packets.is_empty());
+        assert!(packets
+            .iter()
+            .all(|msg| msg.payload.len() == deterministic::DEFAULT_SEGMENT_LEN));
+
+        let mut parser = ChunkParser::new();
+        let mut global_root: Option<_> = None;
+
+        for msg in &packets {
+            let message = msg.payload.clone();
+            let parsed = parser.parse(&message).expect("valid message");
+
+            assert_eq!(parsed.message, message);
+            assert_eq!(parsed.unix_ts_ms, UNIX_TS_MS);
+            assert_eq!(parsed.app_message_len, app_message.len() as u32);
+            assert_eq!(parsed.author, NodeId::new(key.pubkey()));
+            assert_eq!(parsed.broadcast_mode, BroadcastMode::Primary);
+            assert_eq!(
+                parsed.encoding_scheme,
+                EncodingScheme::Deterministic25(ROUND)
+            );
+            let root = parsed
+                .global_merkle_root()
+                .expect("deterministic chunks must have global_merkle_root");
+
+            match &global_root {
+                None => global_root = Some(*root),
+                Some(first) => assert_eq!(
+                    root, first,
+                    "all chunks must share the same global merkle root"
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn test_bit_flip_parse_failure_slow() {
+        let (key, validators, _known_addresses) = validator_set();
+        let self_id = NodeId::new(key.pubkey());
+        let group_map = make_group_map(&validators);
+        let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &self_id, &group_map).unwrap();
+
+        let app_message: Bytes = vec![1_u8; 1024 * 2].into();
+        let packets = build_packets(&key, &app_message, group);
+
+        let mut parser = ChunkParser::new();
+
+        for msg in &packets {
+            let mut payload: BytesMut = msg.payload.as_ref().into();
+            // try flipping each bit
+            for bit_idx in 0..payload.len() * 8 {
+                let old_byte = payload[bit_idx / 8];
+                // flip bit
+                payload[bit_idx / 8] = old_byte ^ (1 << (bit_idx % 8));
+                let flipped: Bytes = payload.clone().into();
+                let maybe_parsed = parser.parse(&flipped);
+
+                // check that decoding fails
+                assert!(
+                    maybe_parsed.is_err()
+                        || maybe_parsed.unwrap().author != NodeId::new(key.pubkey())
+                );
+
+                // reset bit
+                payload[bit_idx / 8] = old_byte;
+            }
+        }
+    }
+
+    #[test]
+    fn test_raptorcast_chunk_ids() {
+        let (key, validators, _known_addresses) = validator_set();
+        let self_id = NodeId::new(key.pubkey());
+        let group_map = make_group_map(&validators);
+        let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &self_id, &group_map).unwrap();
+
+        let app_message: Bytes = vec![1_u8; 1024 * 1024].into();
+        let packets = build_packets(&key, &app_message, group);
+
+        let mut parser = ChunkParser::new();
+        let mut used_ids = HashSet::new();
+
+        for msg in &packets {
+            let parsed = parser.parse(&msg.payload).expect("valid message");
+            let newly_inserted = used_ids.insert(parsed.chunk_id);
+            assert!(newly_inserted);
+        }
+    }
+
+    #[test]
+    fn test_handle_message_stride_slice() {
+        let (key, validators, _known_addresses) = validator_set();
+        let self_id = NodeId::new(key.pubkey());
+        let epoch_validators = [(Epoch(1), validators)].into_iter().collect();
+        let full_node_groups = FullNodeGroupMap::default();
+
+        let mut udp_state = UdpState::<SignatureType>::new(self_id, u64::MAX, 10_000);
+
+        // payload will fail to parse but shouldn't panic on index error
+        let stride = deterministic::DEFAULT_SEGMENT_LEN;
+        let payload: Bytes = vec![1_u8; stride * 8 + 1].into();
+        let recv_msg = AuthRecvMsg {
+            src_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8000),
+            payload,
+            stride: stride as u16,
+            sender: None,
+        };
+
+        udp_state.handle_message(
+            &epoch_validators,
+            &full_node_groups,
+            |_targets, _payload, _stride| {},
+            recv_msg,
+        );
+    }
+
+    #[rstest]
+    #[case(-2 * 60 * 60 * 1000, u64::MAX, true)]
+    #[case(2 * 60 * 60 * 1000, u64::MAX, true)]
+    #[case(-2 * 60 * 60 * 1000, 0, false)]
+    #[case(2 * 60 * 60 * 1000, 0, false)]
+    #[case(-30_000, 60_000, true)]
+    #[case(-120_000, 60_000, false)]
+    #[case(120_000, 60_000, false)]
+    #[case(30_000, 60_000, true)]
+    #[case(-90_000, 60_000, false)]
+    #[case(90_000, 60_000, false)]
+    fn test_timestamp_validation(
+        #[case] timestamp_offset_ms: i64,
+        #[case] max_age_ms: u64,
+        #[case] should_succeed: bool,
+    ) {
+        let (key, validators, _known_addresses) = validator_set();
+
+        let current_time = std::time::UNIX_EPOCH.elapsed().unwrap().as_millis() as u64;
+        let test_timestamp = (current_time as i64 + timestamp_offset_ms) as u64;
+
+        let self_id = NodeId::new(key.pubkey());
+        let group_map = make_group_map(&validators);
+        let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &self_id, &group_map).unwrap();
+
+        let app_message = Bytes::from_static(b"test message");
+        let packets = MessageBuilder::<SignatureType>::new(&key)
+            .unix_ts_ms(test_timestamp)
+            .build_vec(
+                &app_message,
+                &BuildTarget::deterministic_raptorcast(group, ROUND),
+            )
+            .expect("build should succeed");
+
+        let message = packets.into_iter().next().unwrap().payload;
+        let mut parser = ChunkParser::new().with_max_age_ms(max_age_ms);
+        let result = parser.parse(&message);
+
+        if should_succeed {
+            assert!(result.is_ok(), "unexpected success: {:?}", result.err());
+        } else {
+            assert!(result.is_err());
+            match result.err().unwrap() {
+                InvalidChunk::InvalidTimestamp { .. } => {}
+                other => panic!("unexpected error {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn test_zero_len_chunk() {
+        let (key, validators, _known_addresses) = validator_set();
+        let self_id = NodeId::new(key.pubkey());
+        let group_map = make_group_map(&validators);
+        let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &self_id, &group_map).unwrap();
+        let app_message: Bytes = vec![1_u8; 1024 * 1024].into();
+        let encoding = deterministic::PrimaryEncoding::new(
+            EncodingScheme::Deterministic25(ROUND),
+            &group,
+            app_message.len(),
+            UNIX_TS_MS,
+        )
+        .unwrap();
+        let layout = encoding.layout();
+        let mut packet = build_packets(&key, &app_message, group).pop().unwrap();
+        packet.payload.truncate(layout.symbol_range().start);
+        assert_eq!(
+            packet.payload.len(),
+            layout.segment_len() - layout.symbol_len()
+        );
+
+        let mut parser = ChunkParser::new();
+        let result = parser.parse(&packet.payload);
+        // should error instead of panicking
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_message_signature_verifier() {
+        let (key, validators, _known_addresses) = validator_set();
+        let self_id = NodeId::new(key.pubkey());
+        let group_map = make_group_map(&validators);
+        let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &self_id, &group_map).unwrap();
+
+        // Two different app messages to get distinct global merkle roots (= distinct
+        // signed_over_data cache keys), required to exercise the rate-limiter path.
+        let app_message_a: Bytes = vec![1_u8; 1024].into();
+        let app_message_b: Bytes = vec![2_u8; 1024].into();
+
+        let packets_a = build_packets(&key, &app_message_a, group);
+        let packets_b = build_packets(&key, &app_message_b, group);
+
+        let message_a: Bytes = packets_a[0].payload.clone();
+        let message_b: Bytes = packets_b[0].payload.clone();
+
+        let mut parser = ChunkParser::new().with_rate_limit(1);
+
+        // Case 1: cache miss, verify signature, cache saved
+        let result1 = parser.parse(&message_a);
+        let author = result1.expect("first parse should succeed").author;
+        assert_eq!(author, NodeId::new(key.pubkey()));
+
+        // Case 2: parse with same message: cache hit, no rate limit consumed
+        let result2 = parser.parse_with(&message_a, |_| false);
+        assert_eq!(
+            result2.expect("cache hit should succeed").author,
+            author,
+            "cache hit should return same author"
+        );
+
+        // Case 3: parse different message without bypass: rate limited
+        let result3 = parser.parse_with(&message_b, |_| false);
+        assert!(
+            matches!(result3, Err(InvalidChunk::RateLimited)),
+            "new message without bypass should be rate limited"
+        );
+
+        // Case 4: Same message with bypass: succeeds
+        let result4 = parser.parse(&message_b);
+        assert!(result4.is_ok());
+    }
+
+    #[test]
+    fn test_deterministic_end_to_end_decode_and_rebroadcast() {
+        let (sender_key, validators, _) = validator_set();
+        let sender_id = NodeId::new(sender_key.pubkey());
+        let group_map = make_group_map(&validators);
+        let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &sender_id, &group_map).unwrap();
+
+        let app_message: Bytes = vec![0xAB_u8; 64 * 1024].into();
+        let packets = build_packets(&sender_key, &app_message, group);
+        assert!(!packets.is_empty());
+
+        // Pick a receiver that is in the validator set but not the sender
+        let receiver_id = validators
+            .get_members()
+            .keys()
+            .find(|id| **id != sender_id)
+            .copied()
+            .unwrap();
+        let receiver_id_hash = compute_hash(&receiver_id);
+
+        let epoch_validators: BTreeMap<_, _> = [(EPOCH, validators)].into();
+        let full_node_groups = FullNodeGroupMap::default();
+        let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
+
+        let stride = deterministic::DEFAULT_SEGMENT_LEN;
+        let mut all_decoded = Vec::new();
+        let mut rebroadcast_count = 0usize;
+
+        for packet in &packets {
+            let recv_msg = AuthRecvMsg {
+                src_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8000),
+                payload: packet.payload.clone(),
+                stride: stride as u16,
+                sender: None,
+            };
+            let decoded = udp_state.handle_message(
+                &epoch_validators,
+                &full_node_groups,
+                |_targets, _payload, _stride| rebroadcast_count += 1,
+                recv_msg,
+            );
+            all_decoded.extend(decoded);
+        }
+
+        assert_eq!(all_decoded.len(), 1, "should decode exactly one message");
+        let (author, decoded) = &all_decoded[0];
+        assert_eq!(*author, sender_id);
+        assert_eq!(*decoded, app_message);
+
+        // Chunks addressed to receiver should trigger rebroadcast
+        let mut parser = ChunkParser::new();
+        let addressed_to_receiver = packets
+            .iter()
+            .filter(|p| {
+                let parsed = parser.parse(&p.payload).unwrap();
+                parsed.recipient_hash == receiver_id_hash
+            })
+            .count();
+        assert_eq!(rebroadcast_count, addressed_to_receiver);
+        assert!(
+            rebroadcast_count > 0,
+            "receiver should be assigned some chunks"
+        );
+    }
+
+    #[rstest]
+    #[case::tiny(1)]
+    #[case::one_symbol(900)]
+    #[case::medium(64 * 1024)]
+    #[case::large(1024 * 1024)]
+    #[case::max(crate::message::MAX_MESSAGE_SIZE)]
+    fn test_deterministic_roundtrip_various_sizes(#[case] msg_size: usize) {
+        let (key, validators, _) = validator_set();
+        let self_id = NodeId::new(key.pubkey());
+        let group_map = make_group_map(&validators);
+        let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &self_id, &group_map).unwrap();
+
+        let app_message: Bytes = vec![0x42_u8; msg_size].into();
+        let packets = build_packets(&key, &app_message, group);
+
+        assert!(!packets.is_empty());
+        assert!(
+            packets
+                .iter()
+                .all(|msg| msg.payload.len() == deterministic::DEFAULT_SEGMENT_LEN),
+            "all packets must be exactly SEGMENT_LEN"
+        );
+
+        let mut parser = ChunkParser::new();
+        let mut seen_ids = HashSet::new();
+        let mut global_root = None;
+
+        for msg in &packets {
+            let parsed = parser.parse(&msg.payload).expect("valid message");
+
+            assert_eq!(parsed.app_message_len, msg_size as u32);
+            assert!(seen_ids.insert(parsed.chunk_id), "duplicate chunk_id");
+
+            let root = parsed
+                .global_merkle_root()
+                .expect("deterministic chunks must have global_merkle_root");
+            match &global_root {
+                None => global_root = Some(*root),
+                Some(first) => assert_eq!(root, first),
+            }
+        }
+    }
+
+    // The v1 builder must generate enough encoding symbols
+    // >= redundancy * num_source_symbols for the raptor10 decoder to
+    // reconstruct.
+    #[test]
+    fn test_deterministic_decode_with_partial_chunks() {
+        let (sender_key, validators, _) = validator_set();
+        let sender_id = NodeId::new(sender_key.pubkey());
+        let group_map = make_group_map(&validators);
+        let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &sender_id, &group_map).unwrap();
+
+        let app_message: Bytes = vec![0xAB_u8; 200 * 1024].into();
+
+        // With 3x redundancy we should have >> num_source_symbols chunks.
+        let encoding = deterministic::PrimaryEncoding::new(
+            EncodingScheme::Deterministic25(ROUND),
+            &group,
+            app_message.len(),
+            UNIX_TS_MS,
+        )
+        .unwrap();
+        let num_source = app_message
+            .len()
+            .div_ceil(encoding.layout().symbol_len())
+            .max(1);
+        let packets = build_packets(&sender_key, &app_message, group);
+        assert!(
+            packets.len() > num_source * 2,
+            "expected > 2K chunks from 3x redundancy, got {} chunks for {} source symbols",
+            packets.len(),
+            num_source,
+        );
+
+        // Feed only 2/3 of the chunks to a receiver. This should be
+        // enough for reconstruction under 3x redundancy.
+        let receiver_id = validators
+            .get_members()
+            .keys()
+            .find(|id| **id != sender_id)
+            .copied()
+            .unwrap();
+        let epoch_validators: BTreeMap<_, _> = [(EPOCH, validators)].into();
+        let full_node_groups = FullNodeGroupMap::default();
+        let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
+
+        let subset_len = packets.len() * 2 / 3;
+        let stride = deterministic::DEFAULT_SEGMENT_LEN;
+        let mut decoded = Vec::new();
+
+        for packet in packets.iter().take(subset_len) {
+            let recv_msg = AuthRecvMsg {
+                src_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8000),
+                payload: packet.payload.clone(),
+                stride: stride as u16,
+                sender: None,
+            };
+            decoded.extend(udp_state.handle_message(
+                &epoch_validators,
+                &full_node_groups,
+                |_, _, _| {},
+                recv_msg,
+            ));
+        }
+
+        assert_eq!(decoded.len(), 1, "should decode from 2/3 of chunks");
+        assert_eq!(decoded[0].0, sender_id);
+        assert_eq!(decoded[0].1, app_message);
+    }
+
+    #[test]
+    fn test_deterministic_reproducibility() {
+        let (proposer_key, validators, _) = validator_set();
+        let proposer_id = NodeId::new(proposer_key.pubkey());
+
+        // Validator: a different member of the validator set
+        let validator_key = {
+            let mut hasher = HasherType::new();
+            hasher.update(0_u8.to_le_bytes());
+            let mut hash = hasher.hash();
+            KeyPairType::from_bytes(&mut hash.0).unwrap()
+        };
+        let validator_id = NodeId::new(validator_key.pubkey());
+        assert_ne!(proposer_id, validator_id);
+        assert!(validators.is_member(&validator_id));
+
+        let group_map = make_group_map(&validators);
+        let app_message: Bytes = vec![0xFF_u8; 64 * 1024].into();
+        let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &proposer_id, &group_map).unwrap();
+
+        // Step 1: Proposer builds packets
+        let proposer_packets = build_packets(&proposer_key, &app_message, group);
+
+        // Step 2: Validator receives and decodes
+        let epoch_validators: BTreeMap<_, _> = [(EPOCH, validators)].into();
+        let full_node_groups = FullNodeGroupMap::default();
+        let mut udp_state = UdpState::<SignatureType>::new(validator_id, u64::MAX, 10_000);
+        let stride = deterministic::DEFAULT_SEGMENT_LEN;
+
+        let mut decoded_msg = None;
+        for packet in &proposer_packets {
+            let recv_msg = AuthRecvMsg {
+                src_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8000),
+                payload: packet.payload.clone(),
+                stride: stride as u16,
+                sender: None,
+            };
+            for (_, msg) in udp_state.handle_message(
+                &epoch_validators,
+                &full_node_groups,
+                |_, _, _| {},
+                recv_msg,
+            ) {
+                decoded_msg = Some(msg);
+            }
+        }
+        let decoded_msg = decoded_msg.expect("should decode");
+        assert_eq!(decoded_msg, app_message);
+
+        // Step 3: Validator rebuilds the packets from the decoded
+        // message using the same parameters (validator set & header).
+        let header = proposer_packets[0]
+            .payload
+            .slice(0..deterministic::PacketLayout::HEADER_LEN);
+        let mut validator_packets = vec![];
+        build_with_given_header(
+            &header,
+            &app_message,
+            &group,
+            EncodingScheme::Deterministic25(ROUND),
+            UNIX_TS_MS,
+            &mut validator_packets,
+        )
+        .expect("should build successfully");
+        assert_eq!(proposer_packets.len(), validator_packets.len());
+
+        // Step 4: For each rebuilt chunk, write proposer's signature
+        // then it should be bit-identical to proposer's original
+        // chunk.
+        for (pp, vp) in proposer_packets.iter().zip(validator_packets.iter()) {
+            assert_eq!(pp.payload, vp.payload);
+        }
     }
 }

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -28,7 +28,11 @@ pub use crate::packet::build_messages;
 use crate::{
     decoding::{DecoderCache, DecodingContext, TryDecodeError, TryDecodeStatus},
     metrics::{
-        UdpStateMetrics, GAUGE_RAPTORCAST_DECODING_CACHE_SIGNATURE_VERIFICATIONS_RATE_LIMITED,
+        UdpStateMetrics, COUNTER_RAPTORCAST_CHUNKS_DROPPED_INCOMPATIBLE_VERSION,
+        COUNTER_RAPTORCAST_V0_PRIMARY_CHUNKS_ACCEPTED,
+        COUNTER_RAPTORCAST_V1_PRIMARY_CHUNKS_ACCEPTED,
+        GAUGE_RAPTORCAST_DECODING_CACHE_SIGNATURE_VERIFICATIONS_RATE_LIMITED,
+        GAUGE_RAPTORCAST_DETERMINISTIC_ROLLOUT_STAGE,
     },
     packet::deterministic,
     parser::{
@@ -41,6 +45,7 @@ use crate::{
         EncodingScheme, FullNodeGroupMap, GlobalMerkleRoot, MerkleRoot, NodeIdHash,
         PrimaryBroadcastGroup, SecondaryBroadcastGroup,
     },
+    v1_rollout::{self, DeterministicProtocolRolloutStage},
 };
 
 pub const SIGNATURE_CACHE_SIZE: usize = 10_000;
@@ -70,6 +75,7 @@ pub(crate) struct UdpState<ST: CertificateSignatureRecoverable> {
     round_info_cache: RoundInfoCache<CertificateSignaturePubKey<ST>>,
 
     signature_verifier: ChunkSignatureVerifier<ST>,
+    v1_rollout: DeterministicProtocolRolloutStage,
 
     metrics: UdpStateMetrics,
 }
@@ -93,9 +99,16 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
             decoder_cache: DecoderCache::default(),
             signature_verifier,
             round_info_cache: RoundInfoCache::new(),
+            v1_rollout: v1_rollout::CURRENT_STAGE,
 
             metrics: UdpStateMetrics::new(),
         }
+    }
+
+    pub fn set_v1_rollout(&mut self, stage: DeterministicProtocolRolloutStage) {
+        self.v1_rollout = stage;
+        self.metrics.executor_metrics_mut()[GAUGE_RAPTORCAST_DETERMINISTIC_ROLLOUT_STAGE] =
+            stage as u64;
     }
 
     pub fn metrics(&self) -> &UdpStateMetrics {
@@ -493,12 +506,24 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
                 BroadcastMode::Unspecified => {
                     self.handle_unicast(epoch_validators, &chunk, message.sender.as_ref())
                 }
-                BroadcastMode::Primary => self.handle_primary_raptorcast(
-                    epoch_validators,
-                    &chunk,
-                    rebroadcast_to,
-                    message.sender.as_ref(),
-                ),
+                BroadcastMode::Primary => {
+                    if !v1_rollout::should_accept(self.v1_rollout, &chunk) {
+                        self.metrics.executor_metrics_mut()
+                            [COUNTER_RAPTORCAST_CHUNKS_DROPPED_INCOMPATIBLE_VERSION] += 1;
+                        continue;
+                    }
+                    let accepted_metric = match chunk.version {
+                        ChunkVersion::V0 => COUNTER_RAPTORCAST_V0_PRIMARY_CHUNKS_ACCEPTED,
+                        ChunkVersion::V1 => COUNTER_RAPTORCAST_V1_PRIMARY_CHUNKS_ACCEPTED,
+                    };
+                    self.metrics.executor_metrics_mut()[accepted_metric] += 1;
+                    self.handle_primary_raptorcast(
+                        epoch_validators,
+                        &chunk,
+                        rebroadcast_to,
+                        message.sender.as_ref(),
+                    )
+                }
 
                 BroadcastMode::Secondary => self.handle_secondary_raptorcast(
                     epoch_validators,
@@ -533,6 +558,12 @@ impl From<GroupId> for u64 {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChunkVersion {
+    V0, // raptor-coded message for broadcast/point-to-point
+    V1, // primary raptorcast with deterministic encoding
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ValidatedChunk<PT>
 where
@@ -551,6 +582,7 @@ where
     pub app_message_hash: Option<AppMessageHash>,
     pub merkle_root: MerkleRoot,
     pub app_message_len: u32,
+    pub version: ChunkVersion,
     pub encoding_scheme: EncodingScheme,
     pub broadcast_mode: BroadcastMode,
     pub recipient_hash: Option<NodeIdHash>, // V0: hash of first-hop recipient; V1 (deterministic): None
@@ -1367,6 +1399,7 @@ mod tests_deterministic {
             BroadcastMode, BuildTarget, EncodingScheme, FullNodeGroupMap, PrimaryBroadcastGroup,
             UdpMessage, ValidatorGroupMap,
         },
+        v1_rollout::DeterministicProtocolRolloutStage,
     };
 
     type SignatureType = SecpSignature;
@@ -1592,6 +1625,7 @@ mod tests_deterministic {
         let full_node_groups = FullNodeGroupMap::default();
 
         let mut udp_state = UdpState::<SignatureType>::new(self_id, u64::MAX, 10_000);
+        udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
 
         // payload will fail to parse but shouldn't panic on index error
         let stride = deterministic::DEFAULT_SEGMENT_LEN;
@@ -1754,6 +1788,7 @@ mod tests_deterministic {
         let epoch_validators: BTreeMap<_, _> = [(EPOCH, validators)].into();
         let full_node_groups = FullNodeGroupMap::default();
         let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
+        udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
 
         let stride = deterministic::DEFAULT_SEGMENT_LEN;
         let mut all_decoded = Vec::new();
@@ -1888,6 +1923,7 @@ mod tests_deterministic {
         let epoch_validators: BTreeMap<_, _> = [(EPOCH, validators)].into();
         let full_node_groups = FullNodeGroupMap::default();
         let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
+        udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
 
         let subset_len = packets.len() * 2 / 3;
         let stride = deterministic::DEFAULT_SEGMENT_LEN;
@@ -1940,6 +1976,8 @@ mod tests_deterministic {
         let epoch_validators: BTreeMap<_, _> = [(EPOCH, validators)].into();
         let full_node_groups = FullNodeGroupMap::default();
         let mut udp_state = UdpState::<SignatureType>::new(validator_id, u64::MAX, 10_000);
+        udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
+
         let stride = deterministic::DEFAULT_SEGMENT_LEN;
 
         let mut decoded_msg = None;

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -215,6 +215,9 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
             return None;
         };
 
+        // already logged the equivocation in try_commit.
+        round_info.try_commit(chunk)?;
+
         let Some(routing) = round_info.chunk_routing(group, chunk) else {
             tracing::debug!(
                 ?chunk.group_id,
@@ -537,6 +540,7 @@ where
 {
     pub chunk: Bytes, // raptor-coded portion
     pub message: Bytes,
+    pub signature: Bytes,
 
     pub author: NodeId<PT>,
     // group_id is set to

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -35,6 +35,7 @@ use crate::{
         packet_parser::{ChunkValidationEnv, MalformedPacket, RaptorcastPacket, SignedOverData},
         signature_verifier::{SignatureVerifier, SignatureVerifierError},
     },
+    round_info::RoundInfoCache,
     util::{
         compute_app_message_hash, compute_hash, unix_ts_ms_now, AppMessageHash, BroadcastMode,
         EncodingScheme, FullNodeGroupMap, GlobalMerkleRoot, MerkleRoot, NodeIdHash,
@@ -66,6 +67,8 @@ pub(crate) struct UdpState<ST: CertificateSignatureRecoverable> {
     // generate a bunch of linearly dependent chunks and cause unbounded memory usage.
     decoder_cache: DecoderCache<CertificateSignaturePubKey<ST>>,
 
+    round_info_cache: RoundInfoCache<CertificateSignaturePubKey<ST>>,
+
     signature_verifier: ChunkSignatureVerifier<ST>,
 
     metrics: UdpStateMetrics,
@@ -89,6 +92,7 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
 
             decoder_cache: DecoderCache::default(),
             signature_verifier,
+            round_info_cache: RoundInfoCache::new(),
 
             metrics: UdpStateMetrics::new(),
         }
@@ -102,13 +106,17 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
         self.decoder_cache.metrics()
     }
 
+    pub fn update_current_round(&mut self, round: Round) {
+        self.round_info_cache.update_current_round(round);
+    }
+
     pub fn handle_unicast(
         &mut self,
         epoch_validators: &BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
         chunk: &ValidatedChunk<CertificateSignaturePubKey<ST>>,
         _sender: Option<&NodeId<CertificateSignaturePubKey<ST>>>,
     ) -> Option<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
-        if chunk.recipient_hash != self.self_id_hash {
+        if chunk.recipient_hash != Some(self.self_id_hash) {
             tracing::debug!(
                 ?self.self_id,
                 recipient_hash =? chunk.recipient_hash,
@@ -152,7 +160,6 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
             GroupId::Primary(epoch) => epoch,
             GroupId::Secondary(_round) => unreachable!(),
         };
-
         let Ok(group) = PrimaryBroadcastGroup::of_epoch(epoch, &chunk.author, epoch_validators)
         else {
             tracing::debug!(
@@ -173,16 +180,61 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
                 );
                 return None;
             }
-
-            // Future: check if author (proposer) is valid for round.
         }
 
-        let validator_set = epoch_validators.get(&epoch);
-        let decoding_context = DecodingContext::new(validator_set, unix_ts_ms_now());
-        let message = self.try_decode(chunk, &decoding_context)?;
+        let validator_set = group.validator_set();
+        let decoding_context = DecodingContext::new(Some(validator_set), unix_ts_ms_now());
 
+        match chunk.encoding_scheme {
+            EncodingScheme::Deterministic25(round) => self.handle_deterministic_primary(
+                &group,
+                round,
+                chunk,
+                &decoding_context,
+                rebroadcast_to,
+            ),
+            _ => self.handle_regular_primary(&group, chunk, &decoding_context, rebroadcast_to),
+        }
+    }
+
+    fn handle_deterministic_primary(
+        &mut self,
+        group: &PrimaryBroadcastGroup<'_, CertificateSignaturePubKey<ST>>,
+        round: Round,
+        chunk: &ValidatedChunk<CertificateSignaturePubKey<ST>>,
+        decoding_context: &DecodingContext<CertificateSignaturePubKey<ST>>,
+        rebroadcast_to: &mut impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
+    ) -> Option<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
+        let Some(round_info) = self.round_info_cache.get_or_insert_primary(round) else {
+            tracing::debug!(
+                ?chunk.group_id,
+                ?chunk.chunk_id,
+                author =? chunk.author,
+                "dropping primary chunk for round that is too far in the past or future"
+            );
+            return None;
+        };
+
+        let Some(routing) = round_info.chunk_routing(group, chunk) else {
+            tracing::debug!(
+                ?chunk.group_id,
+                ?chunk.chunk_id,
+                author =? chunk.author,
+                "dropping chunk that is not routed to self or any peers"
+            );
+            return None;
+        };
+
+        let is_recipient = *routing.recipient() == self.self_id;
+        let rebroadcast_targets = if is_recipient {
+            Some(routing.rebroadcast_targets())
+        } else {
+            None
+        };
+
+        let message = self.try_decode(chunk, decoding_context)?;
         if let Some((_author, message)) = &message {
-            if let Some(encoding_valid) = chunk.check_deterministic_encoding(message, &group) {
+            if let Some(encoding_valid) = chunk.check_deterministic_encoding(message, group) {
                 if !encoding_valid {
                     self.decoder_cache.mark_tainted(chunk);
                     tracing::warn!(
@@ -192,7 +244,25 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
                     return None;
                 }
             }
+        }
 
+        if let Some(targets) = rebroadcast_targets {
+            rebroadcast_to(targets);
+        }
+
+        message
+    }
+
+    fn handle_regular_primary(
+        &mut self,
+        group: &PrimaryBroadcastGroup<'_, CertificateSignaturePubKey<ST>>,
+        chunk: &ValidatedChunk<CertificateSignaturePubKey<ST>>,
+        decoding_context: &DecodingContext<CertificateSignaturePubKey<ST>>,
+        rebroadcast_to: &mut impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
+    ) -> Option<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
+        let message = self.try_decode(chunk, decoding_context)?;
+
+        if let Some((_author, message)) = &message {
             if let Some(hash_valid) = chunk.check_message_hash(message) {
                 if !hash_valid {
                     self.decoder_cache.mark_tainted(chunk);
@@ -205,9 +275,8 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
             }
         }
 
-        let is_first_hop_recipient = chunk.recipient_hash == self.self_id_hash;
+        let is_first_hop_recipient = chunk.recipient_hash == Some(self.self_id_hash);
         if let Some(ctx) = group.try_rebroadcast(&self.self_id, is_first_hop_recipient) {
-            // TODO: cap rebroadcast symbols based on some multiple of esis.
             rebroadcast_to(ctx.peers().cloned().collect());
         }
 
@@ -270,7 +339,7 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
             }
         }
 
-        let is_first_hop_recipient = chunk.recipient_hash == self.self_id_hash;
+        let is_first_hop_recipient = chunk.recipient_hash == Some(self.self_id_hash);
         if let Some(ctx) = group.try_rebroadcast(&self.self_id, is_first_hop_recipient) {
             // TODO: cap rebroadcast symbols based on some multiple of esis.
             rebroadcast_to(ctx.peers().cloned().collect());
@@ -480,7 +549,7 @@ where
     pub app_message_len: u32,
     pub encoding_scheme: EncodingScheme,
     pub broadcast_mode: BroadcastMode,
-    pub recipient_hash: NodeIdHash, // if this matches our node_id, then we need to re-broadcast RaptorCast chunks
+    pub recipient_hash: Option<NodeIdHash>, // V0: hash of first-hop recipient; V1 (deterministic): None
     pub chunk_id: u16,
     pub num_source_symbols: usize,
     pub encoded_symbol_capacity: usize,
@@ -1291,8 +1360,8 @@ mod tests_deterministic {
         },
         udp::SIGNATURE_CACHE_SIZE,
         util::{
-            compute_hash, BroadcastMode, BuildTarget, EncodingScheme, FullNodeGroupMap,
-            PrimaryBroadcastGroup, UdpMessage, ValidatorGroupMap,
+            BroadcastMode, BuildTarget, EncodingScheme, FullNodeGroupMap, PrimaryBroadcastGroup,
+            UdpMessage, ValidatorGroupMap,
         },
     };
 
@@ -1678,8 +1747,6 @@ mod tests_deterministic {
             .find(|id| **id != sender_id)
             .copied()
             .unwrap();
-        let receiver_id_hash = compute_hash(&receiver_id);
-
         let epoch_validators: BTreeMap<_, _> = [(EPOCH, validators)].into();
         let full_node_groups = FullNodeGroupMap::default();
         let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
@@ -1709,14 +1776,20 @@ mod tests_deterministic {
         assert_eq!(*author, sender_id);
         assert_eq!(*decoded, app_message);
 
-        // Chunks addressed to receiver should trigger rebroadcast
-        let mut parser = ChunkParser::new();
-        let addressed_to_receiver = packets
+        // Reconstruct chunk assignment to count chunks addressed to receiver
+        let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &sender_id, &epoch_validators).unwrap();
+        let encoding_scheme = EncodingScheme::Deterministic25(ROUND);
+        let encoding = deterministic::PrimaryEncoding::new(
+            encoding_scheme,
+            &group,
+            app_message.len(),
+            UNIX_TS_MS,
+        )
+        .unwrap();
+        let chunks = encoding.make_chunks().unwrap();
+        let addressed_to_receiver = chunks
             .iter()
-            .filter(|p| {
-                let parsed = parser.parse(&p.payload).unwrap();
-                parsed.recipient_hash == receiver_id_hash
-            })
+            .filter(|c| *c.recipient().node_id() == receiver_id)
             .count();
         assert_eq!(rebroadcast_count, addressed_to_receiver);
         assert!(

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -20,7 +20,6 @@ macro_rules! ensure {
         }
     };
 }
-pub(crate) use ensure; // export the macro for use in other modules
 use std::{
     cell::OnceCell,
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -32,6 +31,7 @@ use std::{
 };
 
 use bytes::Bytes;
+pub(crate) use ensure; // export the macro for use in other modules
 use fixed::{types::extra::U11, FixedU16};
 use iset::IntervalMap;
 use monad_crypto::{
@@ -423,6 +423,10 @@ impl<'a, PT: PubKey> PrimaryBroadcastGroup<'a, PT> {
             members: Box::new(self.group.get_members().keys()),
             excluded: [Some(self_id), Some(self.author)],
         })
+    }
+
+    pub fn validator_set(&self) -> &ValidatorSet<PT> {
+        self.group
     }
 
     pub fn group_id(&self) -> GroupId {

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -20,7 +20,7 @@ macro_rules! ensure {
         }
     };
 }
-
+pub(crate) use ensure; // export the macro for use in other modules
 use std::{
     cell::OnceCell,
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -32,7 +32,6 @@ use std::{
 };
 
 use bytes::Bytes;
-pub(crate) use ensure; // export the macro for use in other modules
 use fixed::{types::extra::U11, FixedU16};
 use iset::IntervalMap;
 use monad_crypto::{
@@ -44,6 +43,12 @@ use monad_validator::validator_set::{ValidatorSet, ValidatorSetType as _};
 
 use crate::udp::GroupId;
 
+#[derive(Debug, Clone, Copy)]
+pub enum RaptorcastMode {
+    Regular,
+    Deterministic { round: Round },
+}
+
 // Argument for raptorcast send
 #[derive(Debug, Clone, Copy)]
 pub enum BuildTarget<'a, PT: PubKey> {
@@ -52,7 +57,10 @@ pub enum BuildTarget<'a, PT: PubKey> {
     Broadcast(PrimaryBroadcastGroup<'a, PT>),
     // raptorcast to the validators, chunks distributed by their
     // proportion of stakes.
-    Raptorcast(PrimaryBroadcastGroup<'a, PT>),
+    Raptorcast {
+        group: PrimaryBroadcastGroup<'a, PT>,
+        mode: RaptorcastMode,
+    },
     // unicast message as raptor-coded chunks to a single recipient
     PointToPoint {
         group_id: GroupId,
@@ -64,6 +72,20 @@ pub enum BuildTarget<'a, PT: PubKey> {
 }
 
 impl<'a, PT: PubKey> BuildTarget<'a, PT> {
+    pub fn raptorcast(group: PrimaryBroadcastGroup<'a, PT>) -> Self {
+        BuildTarget::Raptorcast {
+            group,
+            mode: RaptorcastMode::Regular,
+        }
+    }
+
+    pub fn deterministic_raptorcast(group: PrimaryBroadcastGroup<'a, PT>, round: Round) -> Self {
+        BuildTarget::Raptorcast {
+            group,
+            mode: RaptorcastMode::Deterministic { round },
+        }
+    }
+
     pub fn point_to_point(epoch: Epoch, recipient: &'a NodeId<PT>) -> Self {
         BuildTarget::PointToPoint {
             group_id: GroupId::Primary(epoch),
@@ -73,7 +95,7 @@ impl<'a, PT: PubKey> BuildTarget<'a, PT> {
 
     pub fn iter(&self) -> Box<dyn Iterator<Item = &NodeId<PT>> + '_> {
         match self {
-            BuildTarget::Broadcast(group) | BuildTarget::Raptorcast(group) => {
+            BuildTarget::Broadcast(group) | BuildTarget::Raptorcast { group, .. } => {
                 Box::new(group.iter().map(|(n, _)| n))
             }
             BuildTarget::PointToPoint { recipient, .. } => Box::new(std::iter::once(*recipient)),
@@ -83,7 +105,9 @@ impl<'a, PT: PubKey> BuildTarget<'a, PT> {
 
     pub fn group_id(&self) -> GroupId {
         match self {
-            BuildTarget::Broadcast(group) | BuildTarget::Raptorcast(group) => group.group_id(),
+            BuildTarget::Broadcast(group) | BuildTarget::Raptorcast { group, .. } => {
+                group.group_id()
+            }
             BuildTarget::FullNodeRaptorCast(group) => group.group_id(),
             BuildTarget::PointToPoint { group_id, .. } => *group_id,
         }
@@ -129,6 +153,19 @@ impl<const N: usize> HexBytes<N> {
 
 pub type NodeIdHash = HexBytes<20>;
 pub type AppMessageHash = HexBytes<20>;
+pub type MerkleRoot = HexBytes<20>;
+pub type GlobalMerkleRoot = MerkleRoot;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EncodingScheme {
+    Unspecified,
+
+    // Deterministic RaptorCast (encoding_scheme_variant=0x1)
+    // - redundancy: 2.5
+    // - seed: (round, unix_ts_ms//2048, author_pk[1:17])
+    // - assignment: round-robin
+    Deterministic25(Round),
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BroadcastMode {
@@ -350,16 +387,16 @@ impl<'a, PT: PubKey> PrimaryBroadcastGroup<'a, PT> {
         })
     }
 
+    pub fn author(&self) -> &NodeId<PT> {
+        self.author
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = (&NodeId<PT>, &Stake)> + '_ {
         self.group.get_members().iter()
     }
 
     pub fn is_member(&self, node_id: &NodeId<PT>) -> bool {
         self.group.is_member(node_id)
-    }
-
-    pub fn author(&self) -> &NodeId<PT> {
-        self.author
     }
 
     pub fn len(&self) -> NonZero<usize> {
@@ -843,6 +880,18 @@ impl Redundancy {
     pub const fn from_u8(num: u8) -> Self {
         assert!((num as u16) <= u16::MAX >> Self::FRAC_BITS);
         Redundancy(FixedU16::from_bits((num as u16) << Self::FRAC_BITS))
+    }
+
+    pub const fn from_fract(
+        int_part: u8,
+        fract_part_hundredth: u8, // out of 100
+    ) -> Self {
+        assert!((int_part as u16) < u16::MAX >> Self::FRAC_BITS);
+        assert!(fract_part_hundredth < 100);
+
+        let int_bits = (int_part as u16) << Self::FRAC_BITS;
+        let decimal_bits = ((fract_part_hundredth as u32) << Self::FRAC_BITS) / 100;
+        Redundancy(FixedU16::from_bits(int_bits + decimal_bits as u16))
     }
 
     // may round to the nearest representable number when needed

--- a/monad-raptorcast/src/v1_rollout.rs
+++ b/monad-raptorcast/src/v1_rollout.rs
@@ -1,0 +1,190 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use monad_crypto::certificate_signature::PubKey;
+pub use monad_node_config::raptorcast::{DeterministicProtocolRolloutStage, CURRENT_STAGE};
+use monad_types::Round;
+
+use crate::{
+    udp::{ChunkVersion, ValidatedChunk},
+    util::{BuildTarget, PrimaryBroadcastGroup},
+};
+
+// should only be called on receiving a v0 or v1 primary raptorcast chunk
+pub(crate) fn should_accept<PT: PubKey>(
+    stage: DeterministicProtocolRolloutStage,
+    chunk: &ValidatedChunk<PT>,
+) -> bool {
+    match chunk.version {
+        ChunkVersion::V1 => should_accept_v1(stage),
+        ChunkVersion::V0 => should_accept_v0(stage),
+    }
+}
+
+// should only be called when building primary raptorcast message
+pub(crate) fn build_target<'a, PT: PubKey>(
+    stage: DeterministicProtocolRolloutStage,
+    message_round: Round,
+    group: PrimaryBroadcastGroup<'a, PT>,
+) -> BuildTarget<'a, PT> {
+    if should_publish_v1(stage) {
+        BuildTarget::deterministic_raptorcast(group, message_round)
+    } else {
+        BuildTarget::raptorcast(group)
+    }
+}
+
+fn should_accept_v0(stage: DeterministicProtocolRolloutStage) -> bool {
+    !matches!(stage, DeterministicProtocolRolloutStage::AlwaysV1)
+}
+
+fn should_accept_v1(stage: DeterministicProtocolRolloutStage) -> bool {
+    !matches!(stage, DeterministicProtocolRolloutStage::AlwaysV0)
+}
+
+fn should_publish_v1(stage: DeterministicProtocolRolloutStage) -> bool {
+    matches!(
+        stage,
+        DeterministicProtocolRolloutStage::AcceptBothPublishV1
+            | DeterministicProtocolRolloutStage::AlwaysV1
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use bytes::Bytes;
+    use itertools::Itertools as _;
+    use monad_crypto::{
+        certificate_signature::CertificateSignaturePubKey,
+        hasher::{Hasher, HasherType},
+    };
+    use monad_secp::{KeyPair, SecpSignature};
+    use monad_types::{Epoch, NodeId, Round, Stake};
+    use monad_validator::validator_set::{ValidatorSet, ValidatorSetType as _};
+
+    use super::{build_target, DeterministicProtocolRolloutStage};
+    use crate::{
+        auth::AuthRecvMsg,
+        packet::MessageBuilder,
+        udp::UdpState,
+        util::{FullNodeGroupMap, PrimaryBroadcastGroup, Redundancy},
+    };
+
+    type SignatureType = SecpSignature;
+    type PubKeyType = CertificateSignaturePubKey<SignatureType>;
+
+    const EPOCH: Epoch = Epoch(5);
+    const ROUND: Round = Round(42);
+
+    fn make_key_pair(n: u8) -> KeyPair {
+        let mut hasher = HasherType::new();
+        hasher.update(n.to_le_bytes());
+        let mut hash = hasher.hash();
+        KeyPair::from_bytes(&mut hash.0).unwrap()
+    }
+
+    fn validator_set() -> (KeyPair, ValidatorSet<PubKeyType>) {
+        let mut keys = (0_u8..100).map(make_key_pair).collect_vec();
+        let valset = keys
+            .iter()
+            .map(|key| (NodeId::new(key.pubkey()), Stake::ONE))
+            .collect();
+        let validators = ValidatorSet::new_unchecked(valset);
+        (keys.pop().unwrap(), validators)
+    }
+
+    // returns the number of successfully decoded messages.
+    fn rollout_publish_and_receive(
+        publisher_stage: DeterministicProtocolRolloutStage,
+        receiver_stage: DeterministicProtocolRolloutStage,
+    ) -> usize {
+        let (sender_key, validators) = validator_set();
+        let sender_id = NodeId::new(sender_key.pubkey());
+        let group_map = [(EPOCH, validators.clone())].into();
+        let fn_group_map = FullNodeGroupMap::default();
+        let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &sender_id, &group_map).unwrap();
+
+        let app_message: Bytes = vec![0xAB_u8; 64 * 1024].into();
+
+        // Build packets using the publisher's rollout stage
+        let build_target = build_target(publisher_stage, ROUND, group);
+        let packets = MessageBuilder::<SignatureType>::new(&sender_key)
+            .redundancy(Redundancy::from_u8(2))
+            .build_vec(&app_message, &build_target)
+            .expect("build should succeed");
+        assert!(!packets.is_empty());
+
+        // Set up receiver
+        let receiver_id = validators
+            .get_members()
+            .keys()
+            .find(|id| **id != sender_id)
+            .copied()
+            .unwrap();
+
+        let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
+        udp_state.set_v1_rollout(receiver_stage);
+
+        // Feed all packets into the receiver
+        let mut decoded_count = 0;
+        for packet in &packets {
+            let recv_msg = AuthRecvMsg {
+                src_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8000),
+                payload: packet.payload.clone(),
+                stride: packet.stride as u16,
+                sender: None,
+            };
+            let decoded =
+                udp_state.handle_message(&group_map, &fn_group_map, |_, _, _| {}, recv_msg);
+            decoded_count += decoded.len();
+        }
+
+        decoded_count
+    }
+
+    #[test]
+    fn test_rollout_adjacent_stages_compatible() {
+        use DeterministicProtocolRolloutStage::*;
+        let stages = [AlwaysV0, AcceptBothPublishV0, AcceptBothPublishV1, AlwaysV1];
+
+        for window in stages.windows(2) {
+            let (a, b) = (window[0], window[1]);
+            let count = rollout_publish_and_receive(a, b);
+            assert_eq!(count, 1);
+
+            let count = rollout_publish_and_receive(b, a);
+            assert_eq!(count, 1);
+        }
+    }
+
+    #[test]
+    fn test_rollout_non_adjacent_stages_incompatible() {
+        use DeterministicProtocolRolloutStage::{self as Stage, *};
+
+        const NON_ADJACENT_PAIRS: &[(Stage, Stage)] = &[
+            (AlwaysV0, AcceptBothPublishV1),
+            (AcceptBothPublishV0, AlwaysV1),
+            (AlwaysV0, AlwaysV1),
+        ];
+
+        for (a, b) in NON_ADJACENT_PAIRS {
+            let count1 = rollout_publish_and_receive(*a, *b);
+            let count2 = rollout_publish_and_receive(*b, *a);
+            assert!(count1 == 0 || count2 == 0);
+        }
+    }
+}

--- a/monad-raptorcast/tests/encoder_error.rs
+++ b/monad-raptorcast/tests/encoder_error.rs
@@ -77,7 +77,7 @@ pub fn encoder_error() {
         message,
         Redundancy::from_u8(1),
         0, // unix_ts_ms
-        BuildTarget::Raptorcast(group),
+        BuildTarget::raptorcast(group),
         &known_addresses,
     );
 }

--- a/monad-raptorcast/tests/raptorcast_instance.rs
+++ b/monad-raptorcast/tests/raptorcast_instance.rs
@@ -98,7 +98,7 @@ pub fn different_symbol_sizes() {
             message.clone(),
             Redundancy::from_u8(2),
             0, // unix_ts_ms
-            BuildTarget::Raptorcast(group),
+            BuildTarget::raptorcast(group),
             &known_addresses,
         );
 
@@ -153,7 +153,7 @@ pub fn buffer_count_overflow() {
         message,
         Redundancy::from_u8(2),
         0, // unix_ts_ms
-        BuildTarget::Raptorcast(group),
+        BuildTarget::raptorcast(group),
         &known_addresses,
     );
 
@@ -224,7 +224,7 @@ pub fn valid_rebroadcast() {
         message,
         regular::MAX_REDUNDANCY, // redundancy,
         0,                       // unix_ts_ms
-        BuildTarget::Raptorcast(group),
+        BuildTarget::raptorcast(group),
         &known_addresses,
     );
 

--- a/monad-raptorcast/tests/wireauth_raptorcast.rs
+++ b/monad-raptorcast/tests/wireauth_raptorcast.rs
@@ -36,7 +36,7 @@ use monad_peer_discovery::{
 };
 use monad_raptorcast::{create_dataplane_for_tests, DataplaneHandles, RaptorCastEvent};
 use monad_secp::{KeyPair, SecpSignature};
-use monad_types::{Deserializable, Epoch, NodeId, Serializable, Stake};
+use monad_types::{Deserializable, Epoch, NodeId, Round, Serializable, Stake};
 use rstest::rstest;
 use tracing_subscriber::EnvFilter;
 
@@ -191,6 +191,7 @@ fn create_raptorcast_config(
             invite_future_dist_max: monad_types::Round(5),
             invite_accept_heartbeat_ms: 100,
         },
+        deterministic_protocol_rollout: monad_raptorcast::v1_rollout::CURRENT_STAGE,
     }
 }
 
@@ -515,6 +516,7 @@ async fn run_test_scenario(num_auth_nodes: usize, routing_type: RoutingType, mes
         .collect();
 
     let epoch = Epoch(0);
+    let round = Round(0);
     let validator_set: Vec<_> = validator_infos
         .iter()
         .map(|v| (v.nodeid, Stake::ONE))
@@ -575,7 +577,7 @@ async fn run_test_scenario(num_auth_nodes: usize, routing_type: RoutingType, mes
         RoutingType::Raptorcast | RoutingType::Broadcast => {
             let message = MockMessage::new(1000, message_size);
             let target = match routing_type {
-                RoutingType::Raptorcast => monad_types::RouterTarget::Raptorcast(epoch),
+                RoutingType::Raptorcast => monad_types::RouterTarget::Raptorcast { round, epoch },
                 RoutingType::Broadcast => monad_types::RouterTarget::Broadcast(epoch),
                 _ => unreachable!(),
             };

--- a/monad-router-scheduler/src/lib.rs
+++ b/monad-router-scheduler/src/lib.rs
@@ -143,7 +143,7 @@ where
                 .unwrap_or(Duration::ZERO)
         );
         match to {
-            RouterTarget::Broadcast(_) | RouterTarget::Raptorcast(_) => {
+            RouterTarget::Broadcast(_) | RouterTarget::Raptorcast { .. } => {
                 self.events.extend(
                     self.all_peers
                         .iter()
@@ -260,7 +260,7 @@ where
         );
         let message = message.serialize();
         match to {
-            RouterTarget::Broadcast(_) | RouterTarget::Raptorcast(_) => {
+            RouterTarget::Broadcast(_) | RouterTarget::Raptorcast { .. } => {
                 self.events.extend(
                     self.all_peers
                         .iter()

--- a/monad-state/src/consensus.rs
+++ b/monad-state/src/consensus.rs
@@ -422,7 +422,7 @@ where
                 .sign(self.keypair);
 
                 vec![Command::RouterCommand(RouterCommand::Publish {
-                    target: RouterTarget::Raptorcast(epoch),
+                    target: RouterTarget::Raptorcast { round, epoch },
                     message: VerifiedMonadMessage::Consensus(msg),
                 })]
             }

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -353,6 +353,8 @@ where
                                 invite_future_dist_max: Round(5),
                                 invite_accept_heartbeat_ms: 100,
                             },
+                            deterministic_protocol_rollout:
+                                monad_raptorcast::v1_rollout::CURRENT_STAGE,
                         }),
                     },
 

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -690,7 +690,10 @@ impl<S: Clone> Deserializable<S> for S {
 #[derive(Debug)]
 pub enum RouterTarget<P: PubKey> {
     Broadcast(Epoch),
-    Raptorcast(Epoch), // sharded raptor-aware broadcast
+    Raptorcast {
+        round: Round,
+        epoch: Epoch,
+    },
     PointToPoint(NodeId<P>),
     DirectPointToPoint(NodeId<P>),
     TcpPointToPoint {

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -78,6 +78,14 @@ impl Round {
             .checked_add(1)
             .is_some_and(|next_round| next_round == self.as_u64())
     }
+
+    pub fn checked_sub(self, count: Round) -> Option<Self> {
+        self.0.checked_sub(count.0).map(Round)
+    }
+
+    pub fn checked_add(self, count: Round) -> Option<Self> {
+        self.0.checked_add(count.0).map(Round)
+    }
 }
 
 pub type Balance = U256;

--- a/monad-updaters/src/local_router.rs
+++ b/monad-updaters/src/local_router.rs
@@ -139,7 +139,7 @@ where
                 RouterCommand::UpdateCurrentRound(_, _) => {}
                 RouterCommand::PublishToFullNodes { .. } => {}
                 RouterCommand::Publish { target, message } => match target {
-                    RouterTarget::Broadcast(_) | RouterTarget::Raptorcast(_) => {
+                    RouterTarget::Broadcast(_) | RouterTarget::Raptorcast { .. } => {
                         let message = message.into();
                         for tx in self.txs.values() {
                             tx.send((now, self.me, message.clone())).unwrap();
@@ -168,7 +168,7 @@ where
                     message,
                     priority: _,
                 } => match target {
-                    RouterTarget::Broadcast(_) | RouterTarget::Raptorcast(_) => {
+                    RouterTarget::Broadcast(_) | RouterTarget::Raptorcast { .. } => {
                         let message = message.into();
                         for tx in self.txs.values() {
                             tx.send((now, self.me, message.clone())).unwrap();


### PR DESCRIPTION
This PR implements the deterministic raptorcast protocol ([MIP-10](https://github.com/monad-crypto/MIPs/blob/main/MIPS/MIP-10.md)) as an alternative to regular raptorcast protocol specifically designed for proposal dissemination.

The implementation is divided into commits. It's recommended to review each individually:

- the packet building & parsing capability
  + implements building & parsing & validation for v1 packets
  + this commit should look almost identical to v0 packet building
  + verify canonical encoding after decoding the message
- rebroadcast using deterministic assignment (also read https://github.com/category-labs/monad-bft/pull/2978)
  + removes recipient_hash field from chunk header because the assignment is fully deterministic
  + the chunk_id validation is now exact, and rebroadcasting targets source directly from the assignment
- the encoding commitment logic
  + adds commitment logic to a single encoding per round, this precludes encoding-level equivocation
- the rollout logic
  + implements a 4-stage gradual rollout plan

(Some tests are generated using Claude Opus 4.6)
