### PR TITLE
Add support for hive rpc conformance suite

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@
 /docker/devnet/monad/wal
 /docker/devnet/monad/mempool.sock
 /docker/single-node/logs
+/docker/single-node/hive/logs
 
 **/.git
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *target
 /docker/single-node/.venv
 /docker/single-node/logs
+/docker/single-node/hive/logs
 /docker/devnet/monad/bft-ledger
 /docker/devnet/monad/block-payload
 /docker/devnet/monad/ledger

--- a/README.md
+++ b/README.md
@@ -77,10 +77,6 @@ nets/run.sh --toolchain gcc-avx512
 
 This will start a single node with chain ID of `20143` and RPC at `localhost:8080`. The known [Foundry/Anvil accounts](https://getfoundry.sh/anvil/overview/) have each been loaded with [large initial balances](https://github.com/category-labs/monad/blob/ce4101b11701bf4ef3a9cd996a6144883735187f/category/execution/monad/chain/monad_devnet_alloc.hpp#L22). The easiest way to fund transactions is to import the private key from one of those pre-allocated accounts.
 
-For replaying Hive-generated chains through the local RPC harness used by
-`category-labs/hive-runner`, see
-[docker/single-node/hive/README.md](docker/single-node/hive/README.md).
-
 > [!TIP]
 > To avoid a lengthy rebuild after shutting down the docker containers, you can call `nets/run.sh` with the `--cached-build <full path to build dir>` arg, e.g.
 >

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ nets/run.sh --toolchain gcc-avx512
 
 This will start a single node with chain ID of `20143` and RPC at `localhost:8080`. The known [Foundry/Anvil accounts](https://getfoundry.sh/anvil/overview/) have each been loaded with [large initial balances](https://github.com/category-labs/monad/blob/ce4101b11701bf4ef3a9cd996a6144883735187f/category/execution/monad/chain/monad_devnet_alloc.hpp#L22). The easiest way to fund transactions is to import the private key from one of those pre-allocated accounts.
 
+For replaying Hive-generated chains through the local RPC harness used by
+`category-labs/hive-runner`, see
+[docker/single-node/hive/README.md](docker/single-node/hive/README.md).
+
 > [!TIP]
 > To avoid a lengthy rebuild after shutting down the docker containers, you can call `nets/run.sh` with the `--cached-build <full path to build dir>` arg, e.g.
 >
@@ -107,7 +111,7 @@ Please consult the [official RPC docs](https://docs.monad.xyz/reference/) as the
 ### Using Cargo
 
 To run a Monad consensus client, follow instructions [here](monad-node/README.md).
- 
+
 To run a JsonRpc server, follow instructions [here](monad-rpc/README.md).
 
 #### Cargo targets that link Monad execution

--- a/docker/single-node/hive/README.md
+++ b/docker/single-node/hive/README.md
@@ -1,0 +1,43 @@
+# Hive RPC compatibility harness
+
+This directory contains the Monad setup helper used with the
+`category-labs/hive-runner` RPC compatibility tests. It imports the Hive test
+chain RLP into Monad execution, starts `monad-rpc` against the resulting state,
+and exposes JSON-RPC on `http://localhost:8080`.
+
+This is not a full upstream Ethereum Hive client wrapper. It does not start a
+consensus node or txpool, so write-path methods such as `eth_sendRawTransaction`
+are not expected to work through this harness.
+
+## Usage
+
+From this repository, run:
+
+```bash
+docker/single-node/hive/run.sh \
+  --chain-rlp /path/to/hive-runner/tests/chain.rlp \
+  --nblocks <block-count>
+```
+
+`--chain-rlp` must point at the Hive runner test chain RLP. `--nblocks` is
+passed to the execution import command and should match the number of blocks to
+import from that file.
+
+The helper writes its generated compose workspace under
+`docker/single-node/hive/logs/`, including the generated node config with Hive
+chain ID `3503995874084926` (`0xc72dd9d5e883e`).
+
+After `monad-rpc` is running, run the compatibility tests from the
+`category-labs/hive-runner` checkout:
+
+```bash
+RPC_URL=http://localhost:8080 ./rpc-compat
+```
+
+To verify the chain ID manually:
+
+```bash
+curl -s http://localhost:8080 \
+  -H 'Content-Type: application/json' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'
+```

--- a/docker/single-node/hive/compose.yaml
+++ b/docker/single-node/hive/compose.yaml
@@ -1,0 +1,74 @@
+services:
+  build_triedb:
+    image: monad-execution-builder:latest
+    command: monad-mpt --storage /monad/triedb/test.db --create --root-offsets-chunk-count=2
+    volumes:
+      - ./node:/monad
+    privileged: true
+    ulimits: &ulimits
+      nofile:
+        soft: 1048576
+        hard: 1048576
+      memlock:
+        soft: 16770785280
+        hard: 16770785280
+
+  build_genesis:
+    image: monad-execution-builder:latest
+    depends_on:
+      build_triedb:
+        condition: service_completed_successfully
+    volumes:
+      - ./node:/monad
+    privileged: true
+    command:
+      monad
+      --chain hive_net
+      --db /monad/triedb/test.db
+      --block_db /monad/ledger
+      --nblocks 0
+      --log_level ERROR
+    ulimits: *ulimits
+
+  monad_execution:
+    image: monad-execution-builder:latest
+    depends_on:
+      build_genesis:
+        condition: service_completed_successfully
+    volumes:
+      - ./node:/monad
+    privileged: true
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - >
+        monad
+        --chain hive_net
+        --db /monad/triedb/test.db
+        --block_db /monad/ledger
+        --log_level ERROR
+        --nblocks ${NBLOCKS}
+        --chain-rlp /monad/chain.rlp
+        --as-eth-blocks
+    ulimits: *ulimits
+
+  monad_rpc:
+    build:
+      context: ${MONAD_BFT_ROOT}
+      dockerfile: ${RPC_DIR}/Dockerfile
+      args:
+        GIT_TAG_VERSION: ${GIT_TAG_VERSION}
+    image: monad-rpc:latest
+    depends_on:
+      monad_execution:
+        condition: service_completed_successfully
+    volumes:
+      - ./node:/monad
+    privileged: true
+    ports:
+      - "8080:8080"
+    command: |
+      monad-rpc
+      --triedb-path /monad/triedb
+      --node-config /monad/config/node.toml
+    ulimits: *ulimits
+

--- a/docker/single-node/hive/compose.yaml
+++ b/docker/single-node/hive/compose.yaml
@@ -38,17 +38,15 @@ services:
     volumes:
       - ./node:/monad
     privileged: true
-    entrypoint: ["/bin/sh", "-c"]
-    command:
-      - >
-        monad
-        --chain hive_net
-        --db /monad/triedb/test.db
-        --block_db /monad/ledger
-        --log_level ERROR
-        --nblocks ${NBLOCKS}
-        --chain-rlp /monad/chain.rlp
-        --as-eth-blocks
+    command: |
+      monad
+      --chain hive_net
+      --db /monad/triedb/test.db
+      --block_db /monad/ledger
+      --log_level ERROR
+      --nblocks ${NBLOCKS:?NBLOCKS is required}
+      --chain-rlp /monad/chain.rlp
+      --as-eth-blocks
     ulimits: *ulimits
 
   monad_rpc:
@@ -71,4 +69,3 @@ services:
       --triedb-path /monad/triedb
       --node-config /monad/config/node.toml
     ulimits: *ulimits
-

--- a/docker/single-node/hive/run.sh
+++ b/docker/single-node/hive/run.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -ex
+
+CHAIN_RLP_PATH=""
+NBLOCKS=""
+
+usage() {
+    echo "Usage: $0 --chain-rlp /path/to/chain.rlp --nblocks <number>"
+    exit 1
+}
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --chain-rlp)
+            if [[ -z "$2" || "$2" == --* ]]; then
+                echo "Error: --chain-rlp requires a path argument." >&2
+                usage
+            fi
+            CHAIN_RLP_PATH="$2"
+            shift
+            ;;
+        --nblocks)
+            if [[ -z "$2" || "$2" == --* ]]; then
+                echo "Error: --nblocks requires a number argument." >&2
+                usage
+            fi
+            NBLOCKS="$2"
+            shift
+            ;;
+        *)
+            echo "Unknown parameter passed: $1"
+            usage
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$CHAIN_RLP_PATH" ]; then
+    echo "Error: --chain-rlp is required." >&2
+    usage
+fi
+if [ -z "$NBLOCKS" ]; then
+    echo "Error: --nblocks is required." >&2
+    usage
+fi
+if [ ! -f "$CHAIN_RLP_PATH" ]; then
+    echo "Error: Chain RLP file does not exist: $CHAIN_RLP_PATH" >&2
+    exit 1
+fi
+
+mkdir -p logs
+
+monad_bft_root="../.."
+rpc_dir="$monad_bft_root/docker/rpc"
+devnet_dir="$monad_bft_root/docker/devnet"
+hive_dir="$monad_bft_root/docker/single-node/hive"
+
+export MONAD_BFT_ROOT=$(realpath "$monad_bft_root")
+export RPC_DIR=$(realpath "$rpc_dir")
+export MONAD_EXECUTION_ROOT="${MONAD_BFT_ROOT}/monad-execution"
+export GIT_TAG_VERSION=$(git -C "$MONAD_BFT_ROOT" describe --always)
+
+rand_hex=$(od -vAn -N8 -tx1 /dev/urandom | tr -d " \n" | cut -c 1-16)
+vol_root="logs/$(date +%Y%m%d_%H%M%S)-$rand_hex"
+
+mkdir -p "$vol_root/node/ledger"
+touch "$vol_root/node/ledger/wal"
+cp -r "$hive_dir"/* "$vol_root"
+cp -r "$devnet_dir/monad/config" "$vol_root/node"
+sed -i'' -e 's/chain_id = 20143/chain_id = 3503995874084926/' "$vol_root/node/config/node.toml"
+
+mkdir -p "$vol_root/node/triedb"
+truncate -s 4GB "$vol_root/node/triedb/test.db"
+
+cp "$CHAIN_RLP_PATH" "$vol_root/node/chain.rlp"
+export NBLOCKS
+
+cd "$vol_root"
+
+set +e
+docker buildx inspect insecure &>/dev/null
+insecure_builder_no_exist=$?
+set -e
+if [ $insecure_builder_no_exist -ne 0 ]; then
+    docker buildx create --buildkitd-flags '--allow-insecure-entitlement security.insecure' --name insecure
+fi
+docker build --builder insecure --allow security.insecure \
+    -f "$MONAD_EXECUTION_ROOT/docker/Dockerfile" \
+    --load -t monad-execution-builder:latest "$MONAD_EXECUTION_ROOT" \
+    --build-arg GIT_COMMIT_HASH=$(git -C "$MONAD_EXECUTION_ROOT" rev-parse HEAD) \
+    --build-arg CC=gcc-15 \
+    --build-arg CXX=g++-15 \
+    --build-arg CMAKE_BUILD_TYPE=RelWithDebInfo \
+    --build-arg TOOLCHAIN=gcc-avx2
+
+docker compose up --build
+

--- a/docker/single-node/hive/run.sh
+++ b/docker/single-node/hive/run.sh
@@ -4,6 +4,7 @@ set -ex
 
 CHAIN_RLP_PATH=""
 NBLOCKS=""
+HIVE_CHAIN_ID="3503995874084926"
 
 usage() {
     echo "Usage: $0 --chain-rlp /path/to/chain.rlp --nblocks <number>"
@@ -13,7 +14,7 @@ usage() {
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --chain-rlp)
-            if [[ -z "$2" || "$2" == --* ]]; then
+            if [[ -z "${2:-}" || "$2" == --* ]]; then
                 echo "Error: --chain-rlp requires a path argument." >&2
                 usage
             fi
@@ -21,7 +22,7 @@ while [[ "$#" -gt 0 ]]; do
             shift
             ;;
         --nblocks)
-            if [[ -z "$2" || "$2" == --* ]]; then
+            if [[ -z "${2:-}" || "$2" == --* ]]; then
                 echo "Error: --nblocks requires a number argument." >&2
                 usage
             fi
@@ -44,17 +45,46 @@ if [ -z "$NBLOCKS" ]; then
     echo "Error: --nblocks is required." >&2
     usage
 fi
+if [[ ! "$NBLOCKS" =~ ^[0-9]+$ ]]; then
+    echo "Error: --nblocks must be a non-negative integer: $NBLOCKS" >&2
+    usage
+fi
 if [ ! -f "$CHAIN_RLP_PATH" ]; then
     echo "Error: Chain RLP file does not exist: $CHAIN_RLP_PATH" >&2
     exit 1
 fi
 
-mkdir -p logs
+replace_chain_id() {
+    local config_path="$1"
+    local tmp_path
 
-monad_bft_root="../.."
+    tmp_path="$(mktemp "${config_path}.XXXXXX")"
+    if ! awk -v chain_id="$HIVE_CHAIN_ID" '
+        /^[[:space:]]*chain_id[[:space:]]*=/ {
+            count++
+            sub(/=.*/, "= " chain_id)
+        }
+        { print }
+        END {
+            if (count != 1) {
+                printf("Error: expected exactly one chain_id in %s, found %d\n", FILENAME, count) > "/dev/stderr"
+                exit 1
+            }
+        }
+    ' "$config_path" > "$tmp_path"; then
+        rm -f "$tmp_path"
+        exit 1
+    fi
+    mv "$tmp_path" "$config_path"
+}
+
+CHAIN_RLP_PATH="$(realpath "$CHAIN_RLP_PATH")"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+
+monad_bft_root="$script_dir/../../.."
 rpc_dir="$monad_bft_root/docker/rpc"
 devnet_dir="$monad_bft_root/docker/devnet"
-hive_dir="$monad_bft_root/docker/single-node/hive"
+hive_dir="$script_dir"
 
 export MONAD_BFT_ROOT=$(realpath "$monad_bft_root")
 export RPC_DIR=$(realpath "$rpc_dir")
@@ -62,13 +92,16 @@ export MONAD_EXECUTION_ROOT="${MONAD_BFT_ROOT}/monad-execution"
 export GIT_TAG_VERSION=$(git -C "$MONAD_BFT_ROOT" describe --always)
 
 rand_hex=$(od -vAn -N8 -tx1 /dev/urandom | tr -d " \n" | cut -c 1-16)
-vol_root="logs/$(date +%Y%m%d_%H%M%S)-$rand_hex"
+logs_dir="$hive_dir/logs"
+vol_root="$logs_dir/$(date +%Y%m%d_%H%M%S)-$rand_hex"
 
 mkdir -p "$vol_root/node/ledger"
 touch "$vol_root/node/ledger/wal"
-cp -r "$hive_dir"/* "$vol_root"
+cp "$hive_dir/compose.yaml" "$hive_dir/run.sh" "$vol_root"
 cp -r "$devnet_dir/monad/config" "$vol_root/node"
-sed -i'' -e 's/chain_id = 20143/chain_id = 3503995874084926/' "$vol_root/node/config/node.toml"
+# Hive uses the local single-node RPC config shape; only the chain ID must
+# match the execution-side hive_net chain.
+replace_chain_id "$vol_root/node/config/node.toml"
 
 mkdir -p "$vol_root/node/triedb"
 truncate -s 4GB "$vol_root/node/triedb/test.db"
@@ -94,5 +127,4 @@ docker build --builder insecure --allow security.insecure \
     --build-arg CMAKE_BUILD_TYPE=RelWithDebInfo \
     --build-arg TOOLCHAIN=gcc-avx2
 
-docker compose up --build
-
+docker compose up build_triedb build_genesis monad_execution monad_rpc --build

--- a/monad-chain-config/src/lib.rs
+++ b/monad-chain-config/src/lib.rs
@@ -35,6 +35,8 @@ pub const ETHEREUM_MAINNET_CHAIN_ID: u64 = 1;
 pub const MONAD_MAINNET_CHAIN_ID: u64 = 143;
 pub const MONAD_TESTNET_CHAIN_ID: u64 = 10143;
 pub const MONAD_DEVNET_CHAIN_ID: u64 = 20143;
+// Chain id used by hive: https://github.com/ethereum/execution-apis/blob/main/tests/genesis.json
+pub const HIVE_CHAIN_ID: u64 = 3503995874084926;
 
 pub trait ChainConfig<CR: ChainRevision>: Copy + Clone {
     fn chain_id(&self) -> u64;

--- a/monad-chain-config/src/lib.rs
+++ b/monad-chain-config/src/lib.rs
@@ -109,6 +109,11 @@ impl MonadChainConfig {
 
             info!("Using override devnet chain config");
             Ok(override_config)
+        } else if chain_id == HIVE_CHAIN_ID {
+            if devnet_override.is_some() {
+                warn!("Ignoring chain config from file in hive");
+            }
+            Ok(MONAD_HIVE_CHAIN_CONFIG)
         } else {
             Err(ChainConfigError::UnsupportedChainId(chain_id))
         }
@@ -182,6 +187,11 @@ const MONAD_DEVNET_CHAIN_CONFIG: MonadChainConfig = MonadChainConfig {
     execution_v_one_activation: 0,
     execution_v_two_activation: 0,
     execution_v_four_activation: 0,
+};
+
+const MONAD_HIVE_CHAIN_CONFIG: MonadChainConfig = MonadChainConfig {
+    chain_id: HIVE_CHAIN_ID,
+    ..MONAD_DEVNET_CHAIN_CONFIG
 };
 
 const MONAD_TESTNET_CHAIN_CONFIG: MonadChainConfig = MonadChainConfig {
@@ -291,5 +301,63 @@ impl ChainConfig<MockChainRevision> for MockChainConfig {
 
     fn get_execution_chain_revision(&self, _execution_timestamp_s: u64) -> MonadExecutionRevision {
         MonadExecutionRevision::LATEST
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ChainConfigError, MonadChainConfig, HIVE_CHAIN_ID, MONAD_DEVNET_CHAIN_CONFIG,
+        MONAD_DEVNET_CHAIN_ID, MONAD_MAINNET_CHAIN_ID, MONAD_TESTNET_CHAIN_ID,
+    };
+
+    #[test]
+    fn new_accepts_supported_chain_ids() {
+        assert_eq!(
+            MonadChainConfig::new(MONAD_MAINNET_CHAIN_ID, None)
+                .unwrap()
+                .chain_id,
+            MONAD_MAINNET_CHAIN_ID
+        );
+        assert_eq!(
+            MonadChainConfig::new(MONAD_TESTNET_CHAIN_ID, None)
+                .unwrap()
+                .chain_id,
+            MONAD_TESTNET_CHAIN_ID
+        );
+        assert_eq!(
+            MonadChainConfig::new(MONAD_DEVNET_CHAIN_ID, None)
+                .unwrap()
+                .chain_id,
+            MONAD_DEVNET_CHAIN_ID
+        );
+        assert_eq!(
+            MonadChainConfig::new(HIVE_CHAIN_ID, None).unwrap().chain_id,
+            HIVE_CHAIN_ID
+        );
+    }
+
+    #[test]
+    fn hive_uses_devnet_params_with_hive_chain_id() {
+        let hive = MonadChainConfig::new(HIVE_CHAIN_ID, None).unwrap();
+
+        assert_eq!(hive.chain_id, HIVE_CHAIN_ID);
+        assert_eq!(hive.epoch_length, MONAD_DEVNET_CHAIN_CONFIG.epoch_length);
+        assert_eq!(
+            hive.epoch_start_delay,
+            MONAD_DEVNET_CHAIN_CONFIG.epoch_start_delay
+        );
+        assert_eq!(
+            hive.staking_config,
+            MONAD_DEVNET_CHAIN_CONFIG.staking_config
+        );
+    }
+
+    #[test]
+    fn new_rejects_unsupported_chain_id() {
+        assert!(matches!(
+            MonadChainConfig::new(12345, None),
+            Err(ChainConfigError::UnsupportedChainId(12345))
+        ));
     }
 }

--- a/monad-rpc/src/handlers/mod.rs
+++ b/monad-rpc/src/handlers/mod.rs
@@ -82,7 +82,7 @@ pub mod resources;
 mod txpool;
 
 use monad_chain_config::{
-    ETHEREUM_MAINNET_CHAIN_ID, MONAD_DEVNET_CHAIN_ID, MONAD_MAINNET_CHAIN_ID,
+    ETHEREUM_MAINNET_CHAIN_ID, HIVE_CHAIN_ID, MONAD_DEVNET_CHAIN_ID, MONAD_MAINNET_CHAIN_ID,
     MONAD_TESTNET_CHAIN_ID,
 };
 use monad_ethcall::ChainId;
@@ -93,6 +93,7 @@ pub(crate) fn parse_ethcall_chain_id(chain_id: u64) -> JsonRpcResult<ChainId> {
         MONAD_MAINNET_CHAIN_ID => Ok(ChainId::MonadMainnet),
         MONAD_TESTNET_CHAIN_ID => Ok(ChainId::MonadTestnet),
         MONAD_DEVNET_CHAIN_ID => Ok(ChainId::MonadDevnet),
+        HIVE_CHAIN_ID => Ok(ChainId::HiveNet),
         other => Err(JsonRpcError::eth_call_error(
             "unsupported chain id".to_string(),
             Some(other.to_string()),
@@ -987,4 +988,44 @@ pub async fn rpc_select(
         .call(request_id, app_state, params)
         .instrument(span)
         .await
+}
+
+#[cfg(test)]
+mod tests {
+    use monad_chain_config::{
+        ETHEREUM_MAINNET_CHAIN_ID, HIVE_CHAIN_ID, MONAD_DEVNET_CHAIN_ID, MONAD_MAINNET_CHAIN_ID,
+        MONAD_TESTNET_CHAIN_ID,
+    };
+    use monad_ethcall::ChainId;
+
+    use super::parse_ethcall_chain_id;
+
+    #[test]
+    fn parse_ethcall_chain_id_maps_supported_chains() {
+        assert_eq!(
+            parse_ethcall_chain_id(ETHEREUM_MAINNET_CHAIN_ID).unwrap(),
+            ChainId::EthereumMainnet
+        );
+        assert_eq!(
+            parse_ethcall_chain_id(MONAD_MAINNET_CHAIN_ID).unwrap(),
+            ChainId::MonadMainnet
+        );
+        assert_eq!(
+            parse_ethcall_chain_id(MONAD_TESTNET_CHAIN_ID).unwrap(),
+            ChainId::MonadTestnet
+        );
+        assert_eq!(
+            parse_ethcall_chain_id(MONAD_DEVNET_CHAIN_ID).unwrap(),
+            ChainId::MonadDevnet
+        );
+        assert_eq!(
+            parse_ethcall_chain_id(HIVE_CHAIN_ID).unwrap(),
+            ChainId::HiveNet
+        );
+    }
+
+    #[test]
+    fn parse_ethcall_chain_id_rejects_unknown_chain() {
+        assert!(parse_ethcall_chain_id(42).is_err());
+    }
 }


### PR DESCRIPTION
The rust part of the https://github.com/category-labs/monad/pull/2103 PR.

I tried to keep the number of changes small and made a new docker compose config to run specifically in the needed configuration without bloating the main single-node run.sh or compose.yaml.