### PR TITLE
fix(systemd): add explicit config path for monad-ledger-tail service

### DIFF
--- a/debian/usr/lib/systemd/system/monad-ledger-tail.service
+++ b/debian/usr/lib/systemd/system/monad-ledger-tail.service
@@ -4,7 +4,11 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/monad-ledger-tail 
+ExecStart=/usr/local/bin/monad-ledger-tail \
+    --ledger-path /home/monad/monad-bft/ledger \
+    --forkpoint-path /home/monad/monad-bft/config/forkpoint/forkpoint.toml \
+    --peers-path /home/monad/monad-bft/config/peers.toml \
+    --validators-path /home/monad/monad-bft/config/validators/validators.toml
 EnvironmentFile=-/home/monad/.env
 User=monad
 Restart=always


### PR DESCRIPTION
Replaces https://github.com/category-labs/monad-bft/pull/2916