### PR TITLE
 Add monad-chain-data crate to support queryX rpc methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4898,6 +4898,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-chain-data"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "auto_impl",
+ "bytes",
+ "futures",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "monad-compress"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,8 +4905,9 @@ dependencies = [
  "alloy-rlp",
  "auto_impl",
  "bytes",
- "futures",
+ "roaring",
  "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/monad-chain-data/Cargo.toml
+++ b/monad-chain-data/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "monad-chain-data"
+version = "0.1.0"
+edition = "2021"
+
+# this is necessary for criterion bench options
+# https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+[lib]
+bench = false
+
+[dependencies]
+alloy-primitives = { workspace = true, features = ["rlp"] }
+alloy-rlp = { workspace = true, features = ["derive"] }
+auto_impl = { workspace = true }
+bytes = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -14,11 +14,12 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-    error::Result,
+    error::{MonadChainDataError, Result},
     family::FinalizedBlock,
     kernel::tables::Tables,
-    logs::{QueryLogsRequest, QueryLogsResponse},
-    primitives::state::BlockRecord,
+    logs::{LogIngestPlan, QueryLogsRequest, QueryLogsResponse},
+    primitives::{range::ResolvedBlockWindow, state::BlockRecord},
+    query::runner::execute_block_scan_query,
     store::{BlobStore, MetaStore},
 };
 
@@ -44,13 +45,65 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
         &self.tables
     }
 
+    // TODO: Individual writes are idempotent, but a partial failure leaves the block
+    // incompletely written. Retry logic, logging, and metrics belong here once the
+    // overall pipeline shape stabilizes.
     pub async fn ingest_block(&self, block: FinalizedBlock) -> Result<IngestOutcome> {
-        let _ = block;
-        todo!("implement minimal logs-only ingest pipeline")
+        let current_head = self.tables.publication().load_published_head().await?;
+        self.tables
+            .blocks()
+            .validate_continuity(&block, current_head)
+            .await?;
+
+        let LogIngestPlan {
+            block_record,
+            block_log_header,
+            block_log_blob,
+            written_logs,
+        } = LogIngestPlan::build(&block)?;
+        self.tables
+            .logs()
+            .store_block_blob(block.block_number, block_log_blob)
+            .await?;
+        self.tables
+            .logs()
+            .store_block_header(block.block_number, &block_log_header)
+            .await?;
+        self.tables
+            .blocks()
+            .store_record(block.block_number, &block_record)
+            .await?;
+        self.tables
+            .publication()
+            .store_state(crate::primitives::state::PublicationState {
+                indexed_finalized_head: block.block_number,
+            })
+            .await?;
+
+        Ok(IngestOutcome {
+            indexed_finalized_head: block.block_number,
+            block_record,
+            written_logs,
+        })
     }
 
     pub async fn query_logs(&self, request: QueryLogsRequest) -> Result<QueryLogsResponse> {
-        let _ = request;
-        todo!("implement minimal block-scan query path")
+        if request.limit == 0 {
+            return Err(MonadChainDataError::InvalidRequest(
+                "limit must be at least 1",
+            ));
+        }
+
+        let head = self
+            .tables
+            .publication()
+            .load_published_head()
+            .await?
+            .ok_or(MonadChainDataError::MissingData("no published blocks"))?;
+        let window = ResolvedBlockWindow::resolve(&request, head, self.tables.blocks()).await?;
+
+        // First pass: all log queries use the fallback block-scan path.
+        // Indexed execution lands in later commits once log IDs and bitmap artifacts exist.
+        execute_block_scan_query(&self.tables, &request, window).await
     }
 }

--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -1,0 +1,56 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{
+    error::Result,
+    family::FinalizedBlock,
+    kernel::tables::Tables,
+    logs::{QueryLogsRequest, QueryLogsResponse},
+    primitives::state::BlockRecord,
+    store::{BlobStore, MetaStore},
+};
+
+pub struct MonadChainDataService<M: MetaStore, B: BlobStore> {
+    tables: Tables<M, B>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IngestOutcome {
+    pub indexed_finalized_head: u64,
+    pub block_record: BlockRecord,
+    pub written_logs: usize,
+}
+
+impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
+    pub fn new(meta_store: M, blob_store: B) -> Self {
+        Self {
+            tables: Tables::new(meta_store, blob_store),
+        }
+    }
+
+    pub fn tables(&self) -> &Tables<M, B> {
+        &self.tables
+    }
+
+    pub async fn ingest_block(&self, block: FinalizedBlock) -> Result<IngestOutcome> {
+        let _ = block;
+        todo!("implement minimal logs-only ingest pipeline")
+    }
+
+    pub async fn query_logs(&self, request: QueryLogsRequest) -> Result<QueryLogsResponse> {
+        let _ = request;
+        todo!("implement minimal block-scan query path")
+    }
+}

--- a/monad-chain-data/src/error.rs
+++ b/monad-chain-data/src/error.rs
@@ -1,0 +1,32 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, MonadChainDataError>;
+
+#[derive(Debug, Error)]
+pub enum MonadChainDataError {
+    #[error("backend error: {0}")]
+    Backend(String),
+    #[error("decode error: {0}")]
+    Decode(&'static str),
+    #[error("not implemented: {0}")]
+    NotImplemented(&'static str),
+    #[error("invalid request: {0}")]
+    InvalidRequest(&'static str),
+    #[error("missing data: {0}")]
+    MissingData(&'static str),
+}

--- a/monad-chain-data/src/family.rs
+++ b/monad-chain-data/src/family.rs
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use alloy_primitives::{Log, B256};
+
+pub type Hash32 = B256;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FinalizedBlock {
+    pub block_number: u64,
+    pub block_hash: Hash32,
+    pub parent_hash: Hash32,
+    pub logs_by_tx: Vec<Vec<Log>>,
+}

--- a/monad-chain-data/src/kernel/mod.rs
+++ b/monad-chain-data/src/kernel/mod.rs
@@ -1,0 +1,16 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pub mod tables;

--- a/monad-chain-data/src/kernel/tables.rs
+++ b/monad-chain-data/src/kernel/tables.rs
@@ -1,0 +1,139 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{
+    error::Result,
+    logs::LogBlockHeader,
+    primitives::state::{BlockRecord, PublicationState},
+    store::{BlobStore, BlobTable, BlobTableId, KvTable, MetaStore, TableId},
+};
+
+pub struct Tables<M: MetaStore, B: BlobStore> {
+    publication: PublicationTables<M>,
+    blocks: BlockTables<M>,
+    logs: LogTables<M, B>,
+}
+
+impl<M: MetaStore, B: BlobStore> Tables<M, B> {
+    pub fn new(meta_store: M, blob_store: B) -> Self {
+        Self {
+            publication: PublicationTables::new(meta_store.clone()),
+            blocks: BlockTables::new(meta_store.clone()),
+            logs: LogTables::new(meta_store, blob_store),
+        }
+    }
+
+    pub fn publication(&self) -> &PublicationTables<M> {
+        &self.publication
+    }
+
+    pub fn blocks(&self) -> &BlockTables<M> {
+        &self.blocks
+    }
+
+    pub fn logs(&self) -> &LogTables<M, B> {
+        &self.logs
+    }
+}
+
+pub struct PublicationTables<M: MetaStore> {
+    publication_state: KvTable<M>,
+}
+
+impl<M: MetaStore> PublicationTables<M> {
+    pub const PUBLICATION_STATE_TABLE: TableId = TableId::new("publication_state");
+    pub const PUBLICATION_STATE_KEY: &[u8] = b"state";
+
+    fn new(meta_store: M) -> Self {
+        Self {
+            publication_state: meta_store.table(Self::PUBLICATION_STATE_TABLE),
+        }
+    }
+
+    pub async fn load_published_head(&self) -> Result<Option<u64>> {
+        let _ = &self.publication_state;
+        todo!("load publication-state metadata for the current head")
+    }
+
+    pub async fn store_state(&self, state: PublicationState) -> Result<()> {
+        let _ = (&self.publication_state, state);
+        todo!("store publication-state metadata")
+    }
+}
+
+pub struct BlockTables<M: MetaStore> {
+    block_records: KvTable<M>,
+}
+
+impl<M: MetaStore> BlockTables<M> {
+    pub const BLOCK_RECORD_TABLE: TableId = TableId::new("block_record");
+
+    fn new(meta_store: M) -> Self {
+        Self {
+            block_records: meta_store.table(Self::BLOCK_RECORD_TABLE),
+        }
+    }
+
+    pub async fn load_record(&self, block_number: u64) -> Result<Option<BlockRecord>> {
+        let _ = (&self.block_records, block_number);
+        todo!("load a shared block record by block number")
+    }
+
+    pub async fn store_record(&self, block_number: u64, block_record: &BlockRecord) -> Result<()> {
+        let _ = (&self.block_records, block_number, block_record);
+        todo!("store a shared block record by block number")
+    }
+}
+
+pub struct LogTables<M: MetaStore, B: BlobStore> {
+    block_headers: KvTable<M>,
+    block_blobs: BlobTable<B>,
+}
+
+impl<M: MetaStore, B: BlobStore> LogTables<M, B> {
+    pub const BLOCK_LOG_HEADER_TABLE: TableId = TableId::new("block_log_header");
+    pub const BLOCK_LOG_BLOB_TABLE: BlobTableId = BlobTableId::new("block_log_blob");
+
+    fn new(meta_store: M, blob_store: B) -> Self {
+        Self {
+            block_headers: meta_store.table(Self::BLOCK_LOG_HEADER_TABLE),
+            block_blobs: blob_store.table(Self::BLOCK_LOG_BLOB_TABLE),
+        }
+    }
+
+    pub async fn load_block_header(&self, block_number: u64) -> Result<Option<LogBlockHeader>> {
+        let _ = (&self.block_headers, block_number);
+        todo!("load a logs block header by block number")
+    }
+
+    pub async fn store_block_header(
+        &self,
+        block_number: u64,
+        block_log_header: &LogBlockHeader,
+    ) -> Result<()> {
+        let _ = (&self.block_headers, block_number, block_log_header);
+        todo!("store a logs block header by block number")
+    }
+
+    pub async fn load_block_blob(&self, block_number: u64) -> Result<Option<bytes::Bytes>> {
+        let _ = (&self.block_blobs, block_number);
+        todo!("load a logs block blob by block number")
+    }
+
+    pub async fn store_block_blob(&self, block_number: u64, block_log_blob: Vec<u8>) -> Result<()> {
+        let _ = (&self.block_blobs, block_number, block_log_blob);
+        todo!("store a logs block blob by block number")
+    }
+}

--- a/monad-chain-data/src/kernel/tables.rs
+++ b/monad-chain-data/src/kernel/tables.rs
@@ -13,8 +13,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use bytes::Bytes;
+
 use crate::{
     error::Result,
+    family::FinalizedBlock,
     logs::LogBlockHeader,
     primitives::state::{BlockRecord, PublicationState},
     store::{BlobStore, BlobTable, BlobTableId, KvTable, MetaStore, TableId},
@@ -48,6 +51,10 @@ impl<M: MetaStore, B: BlobStore> Tables<M, B> {
     }
 }
 
+fn block_number_key(block_number: u64) -> [u8; 8] {
+    block_number.to_be_bytes()
+}
+
 pub struct PublicationTables<M: MetaStore> {
     publication_state: KvTable<M>,
 }
@@ -63,13 +70,24 @@ impl<M: MetaStore> PublicationTables<M> {
     }
 
     pub async fn load_published_head(&self) -> Result<Option<u64>> {
-        let _ = &self.publication_state;
-        todo!("load publication-state metadata for the current head")
+        let Some(record) = self
+            .publication_state
+            .get(Self::PUBLICATION_STATE_KEY)
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(
+            PublicationState::decode(&record.value)?.indexed_finalized_head,
+        ))
     }
 
     pub async fn store_state(&self, state: PublicationState) -> Result<()> {
-        let _ = (&self.publication_state, state);
-        todo!("store publication-state metadata")
+        self.publication_state
+            .put(Self::PUBLICATION_STATE_KEY, Bytes::from(state.encode()))
+            .await?;
+        Ok(())
     }
 }
 
@@ -87,13 +105,53 @@ impl<M: MetaStore> BlockTables<M> {
     }
 
     pub async fn load_record(&self, block_number: u64) -> Result<Option<BlockRecord>> {
-        let _ = (&self.block_records, block_number);
-        todo!("load a shared block record by block number")
+        let key = block_number_key(block_number);
+        let Some(record) = self.block_records.get(&key).await? else {
+            return Ok(None);
+        };
+        Ok(Some(BlockRecord::decode(&record.value)?))
     }
 
     pub async fn store_record(&self, block_number: u64, block_record: &BlockRecord) -> Result<()> {
-        let _ = (&self.block_records, block_number, block_record);
-        todo!("store a shared block record by block number")
+        let key = block_number_key(block_number);
+        self.block_records
+            .put(&key, Bytes::from(block_record.encode()))
+            .await?;
+        Ok(())
+    }
+
+    pub async fn validate_continuity(
+        &self,
+        block: &FinalizedBlock,
+        current_head: Option<u64>,
+    ) -> Result<()> {
+        match current_head {
+            None => {
+                if block.block_number != 1 {
+                    return Err(crate::error::MonadChainDataError::InvalidRequest(
+                        "first ingested block must be block 1 in the first pass",
+                    ));
+                }
+            }
+            Some(head) => {
+                if block.block_number != head + 1 {
+                    return Err(crate::error::MonadChainDataError::InvalidRequest(
+                        "block_number must extend the published head contiguously",
+                    ));
+                }
+
+                let previous = self.load_record(head).await?.ok_or(
+                    crate::error::MonadChainDataError::MissingData("missing previous block record"),
+                )?;
+                if previous.block_hash != block.parent_hash {
+                    return Err(crate::error::MonadChainDataError::InvalidRequest(
+                        "parent_hash must match the previous published block",
+                    ));
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -114,8 +172,11 @@ impl<M: MetaStore, B: BlobStore> LogTables<M, B> {
     }
 
     pub async fn load_block_header(&self, block_number: u64) -> Result<Option<LogBlockHeader>> {
-        let _ = (&self.block_headers, block_number);
-        todo!("load a logs block header by block number")
+        let key = block_number_key(block_number);
+        let Some(record) = self.block_headers.get(&key).await? else {
+            return Ok(None);
+        };
+        Ok(Some(LogBlockHeader::decode(&record.value)?))
     }
 
     pub async fn store_block_header(
@@ -123,17 +184,26 @@ impl<M: MetaStore, B: BlobStore> LogTables<M, B> {
         block_number: u64,
         block_log_header: &LogBlockHeader,
     ) -> Result<()> {
-        let _ = (&self.block_headers, block_number, block_log_header);
-        todo!("store a logs block header by block number")
+        let key = block_number_key(block_number);
+        self.block_headers
+            .put(&key, Bytes::from(block_log_header.encode()))
+            .await?;
+        Ok(())
     }
 
-    pub async fn load_block_blob(&self, block_number: u64) -> Result<Option<bytes::Bytes>> {
-        let _ = (&self.block_blobs, block_number);
-        todo!("load a logs block blob by block number")
+    pub async fn load_block_blob(
+        &self,
+        block_number: u64,
+    ) -> Result<Option<alloy_primitives::Bytes>> {
+        let key = block_number_key(block_number);
+        Ok(self.block_blobs.get(&key).await?.map(Into::into))
     }
 
     pub async fn store_block_blob(&self, block_number: u64, block_log_blob: Vec<u8>) -> Result<()> {
-        let _ = (&self.block_blobs, block_number, block_log_blob);
-        todo!("store a logs block blob by block number")
+        let key = block_number_key(block_number);
+        self.block_blobs
+            .put(&key, Bytes::from(block_log_blob))
+            .await?;
+        Ok(())
     }
 }

--- a/monad-chain-data/src/lib.rs
+++ b/monad-chain-data/src/lib.rs
@@ -1,0 +1,33 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pub mod api;
+pub mod error;
+pub mod family;
+pub mod kernel;
+pub mod logs;
+pub mod primitives;
+pub mod query;
+pub mod store;
+
+pub use alloy_primitives::{Address, Bytes, Log, LogData, B256};
+pub use api::{IngestOutcome, MonadChainDataService};
+pub use family::{FinalizedBlock, Hash32};
+pub use kernel::tables::Tables;
+pub use logs::{LogEntry, LogFilter, QueryLogsRequest, QueryLogsResponse};
+pub use primitives::{page::QueryOrder, refs::BlockRef, state::BlockRecord};
+pub use store::{InMemoryBlobStore, InMemoryMetaStore};
+
+pub type Topic = B256;

--- a/monad-chain-data/src/lib.rs
+++ b/monad-chain-data/src/lib.rs
@@ -27,7 +27,11 @@ pub use api::{IngestOutcome, MonadChainDataService};
 pub use family::{FinalizedBlock, Hash32};
 pub use kernel::tables::Tables;
 pub use logs::{LogEntry, LogFilter, QueryLogsRequest, QueryLogsResponse};
-pub use primitives::{page::QueryOrder, refs::BlockRef, state::BlockRecord};
+pub use primitives::{
+    page::{QueryOrder, DEFAULT_QUERY_LIMIT},
+    refs::BlockRef,
+    state::BlockRecord,
+};
 pub use store::{InMemoryBlobStore, InMemoryMetaStore};
 
 pub type Topic = B256;

--- a/monad-chain-data/src/logs/ingest.rs
+++ b/monad-chain-data/src/logs/ingest.rs
@@ -13,14 +13,83 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{error::Result, family::FinalizedBlock, primitives::state::BlockRecord};
+use super::{LogBlockHeader, RawLogEntry};
+use crate::{
+    error::{MonadChainDataError, Result},
+    family::FinalizedBlock,
+    primitives::state::BlockRecord,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LogIngestPlan {
     pub block_record: BlockRecord,
+    pub block_log_header: LogBlockHeader,
+    pub block_log_blob: Vec<u8>,
     pub written_logs: usize,
 }
 
-pub fn plan_log_ingest(_block: &FinalizedBlock) -> Result<LogIngestPlan> {
-    todo!("implement logs-family ingest planning")
+impl LogIngestPlan {
+    pub fn build(block: &FinalizedBlock) -> Result<Self> {
+        // First pass writes only per-block payload/header artifacts plus the shared block record.
+        // Later commits add global log IDs, directory fragments, and bitmap index artifacts.
+        let logs = Self::flatten_logs(block)?;
+
+        let (block_log_header, block_log_blob) = Self::encode_block_logs(&logs)?;
+        let block_record = BlockRecord {
+            block_number: block.block_number,
+            block_hash: block.block_hash,
+            parent_hash: block.parent_hash,
+        };
+
+        Ok(Self {
+            block_record,
+            block_log_header,
+            block_log_blob,
+            written_logs: logs.len(),
+        })
+    }
+
+    fn flatten_logs(block: &FinalizedBlock) -> Result<Vec<RawLogEntry>> {
+        let total_logs: usize = block.logs_by_tx.iter().map(|tx| tx.len()).sum();
+        let mut logs = Vec::with_capacity(total_logs);
+
+        for (tx_index, tx_logs) in block.logs_by_tx.iter().enumerate() {
+            let tx_index = u32::try_from(tx_index)
+                .map_err(|_| MonadChainDataError::Decode("tx index overflow"))?;
+
+            for log in tx_logs {
+                let log_index = u32::try_from(logs.len())
+                    .map_err(|_| MonadChainDataError::Decode("log index overflow"))?;
+                logs.push(RawLogEntry {
+                    tx_index,
+                    log_index,
+                    address: log.address,
+                    topics: log.data.topics().to_vec(),
+                    data: log.data.data.clone(),
+                });
+            }
+        }
+
+        Ok(logs)
+    }
+
+    fn encode_block_logs(logs: &[RawLogEntry]) -> Result<(LogBlockHeader, Vec<u8>)> {
+        let mut offsets = Vec::with_capacity(logs.len() + 1);
+        let mut blob = Vec::new();
+
+        for log in logs {
+            offsets.push(
+                u32::try_from(blob.len())
+                    .map_err(|_| MonadChainDataError::Decode("block log blob too large"))?,
+            );
+            blob.extend_from_slice(&log.encode());
+        }
+
+        offsets.push(
+            u32::try_from(blob.len())
+                .map_err(|_| MonadChainDataError::Decode("block log blob too large"))?,
+        );
+
+        Ok((LogBlockHeader { offsets }, blob))
+    }
 }

--- a/monad-chain-data/src/logs/ingest.rs
+++ b/monad-chain-data/src/logs/ingest.rs
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{error::Result, family::FinalizedBlock, primitives::state::BlockRecord};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogIngestPlan {
+    pub block_record: BlockRecord,
+    pub written_logs: usize,
+}
+
+pub fn plan_log_ingest(_block: &FinalizedBlock) -> Result<LogIngestPlan> {
+    todo!("implement logs-family ingest planning")
+}

--- a/monad-chain-data/src/logs/materialize.rs
+++ b/monad-chain-data/src/logs/materialize.rs
@@ -13,15 +13,27 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use alloy_primitives::{Address, B256};
+use std::collections::HashSet;
 
-use super::LogEntry;
-use crate::primitives::{page::QueryOrder, refs::BlockRef};
+use alloy_primitives::{Address, Bytes, B256};
+
+use super::{LogBlockHeader, LogEntry, RawLogEntry};
+use crate::{
+    error::{MonadChainDataError, Result},
+    family::Hash32,
+    kernel::tables::Tables,
+    primitives::{
+        page::{QueryOrder, DEFAULT_QUERY_LIMIT},
+        refs::BlockRef,
+        state::BlockRecord,
+    },
+    store::{BlobStore, MetaStore},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct LogFilter {
-    pub address: Option<Vec<Address>>,
-    pub topics: [Option<Vec<B256>>; 4],
+    pub address: Option<HashSet<Address>>,
+    pub topics: [Option<HashSet<B256>>; 4],
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -29,8 +41,26 @@ pub struct QueryLogsRequest {
     pub from_block: Option<u64>,
     pub to_block: Option<u64>,
     pub order: QueryOrder,
+    /// Target number of primary log objects to return.
+    ///
+    /// The server always completes the current block before stopping, so the
+    /// actual count may exceed this value. The server may also return fewer if
+    /// an internal constraint is reached. Defaults to
+    /// [`DEFAULT_QUERY_LIMIT`] (100).
     pub limit: usize,
     pub filter: LogFilter,
+}
+
+impl Default for QueryLogsRequest {
+    fn default() -> Self {
+        Self {
+            from_block: None,
+            to_block: None,
+            order: QueryOrder::default(),
+            limit: DEFAULT_QUERY_LIMIT,
+            filter: LogFilter::default(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -39,4 +69,116 @@ pub struct QueryLogsResponse {
     pub from_block: BlockRef,
     pub to_block: BlockRef,
     pub cursor_block: BlockRef,
+}
+
+impl LogFilter {
+    pub fn matches(&self, log: &LogEntry) -> bool {
+        if let Some(addresses) = &self.address {
+            if !addresses.contains(&log.address) {
+                return false;
+            }
+        }
+
+        for (i, candidates) in self.topics.iter().enumerate() {
+            if let Some(candidates) = candidates {
+                match log.topics.get(i) {
+                    Some(actual) if candidates.contains(actual) => {}
+                    _ => return false,
+                }
+            }
+        }
+
+        true
+    }
+}
+
+pub struct LogMaterializer<'a, M: MetaStore, B: BlobStore> {
+    tables: &'a Tables<M, B>,
+}
+
+impl<'a, M: MetaStore, B: BlobStore> LogMaterializer<'a, M, B> {
+    pub fn new(tables: &'a Tables<M, B>) -> Self {
+        Self { tables }
+    }
+
+    pub async fn load_filtered_block_logs_for_block(
+        &self,
+        block_number: u64,
+        request: &QueryLogsRequest,
+    ) -> Result<(BlockRef, Vec<LogEntry>)> {
+        let block_record = self
+            .tables
+            .blocks()
+            .load_record(block_number)
+            .await?
+            .ok_or(MonadChainDataError::MissingData("missing block record"))?;
+        let block_ref = BlockRef::from(&block_record);
+
+        let header = self
+            .tables
+            .logs()
+            .load_block_header(block_number)
+            .await?
+            .ok_or(MonadChainDataError::MissingData("missing block log header"))?;
+        let blob = self
+            .tables
+            .logs()
+            .load_block_blob(block_number)
+            .await?
+            .ok_or(MonadChainDataError::MissingData("missing block log blob"))?;
+
+        let logs = load_filtered_block_logs(&header, &blob, &block_record, request)?;
+
+        Ok((block_ref, logs))
+    }
+}
+
+fn load_filtered_block_logs(
+    header: &LogBlockHeader,
+    blob: &Bytes,
+    block_record: &BlockRecord,
+    request: &QueryLogsRequest,
+) -> Result<Vec<LogEntry>> {
+    let count = header.log_count();
+    let indices: Box<dyn Iterator<Item = usize>> = match request.order {
+        QueryOrder::Ascending => Box::new(0..count),
+        QueryOrder::Descending => Box::new((0..count).rev()),
+    };
+
+    let mut logs = Vec::new();
+    for log_idx in indices {
+        let log = decode_log_at(
+            header,
+            blob.as_ref(),
+            log_idx,
+            block_record.block_number,
+            block_record.block_hash,
+        )?;
+        if request.filter.matches(&log) {
+            logs.push(log);
+        }
+    }
+
+    Ok(logs)
+}
+
+fn decode_log_at(
+    header: &LogBlockHeader,
+    blob: &[u8],
+    log_idx: usize,
+    block_number: u64,
+    block_hash: Hash32,
+) -> Result<LogEntry> {
+    if log_idx + 1 >= header.offsets.len() {
+        return Err(MonadChainDataError::Decode("log index out of range"));
+    }
+
+    let start = header.offsets[log_idx] as usize;
+    let end = header.offsets[log_idx + 1] as usize;
+    if start > end || end > blob.len() {
+        return Err(MonadChainDataError::Decode("invalid log range"));
+    }
+
+    let raw = RawLogEntry::decode(&blob[start..end])?;
+    Ok(raw.into_log_entry(block_number, block_hash))
 }

--- a/monad-chain-data/src/logs/materialize.rs
+++ b/monad-chain-data/src/logs/materialize.rs
@@ -1,0 +1,42 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use alloy_primitives::{Address, B256};
+
+use super::LogEntry;
+use crate::primitives::{page::QueryOrder, refs::BlockRef};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct LogFilter {
+    pub address: Option<Vec<Address>>,
+    pub topics: [Option<Vec<B256>>; 4],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryLogsRequest {
+    pub from_block: Option<u64>,
+    pub to_block: Option<u64>,
+    pub order: QueryOrder,
+    pub limit: usize,
+    pub filter: LogFilter,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryLogsResponse {
+    pub logs: Vec<LogEntry>,
+    pub from_block: BlockRef,
+    pub to_block: BlockRef,
+    pub cursor_block: BlockRef,
+}

--- a/monad-chain-data/src/logs/mod.rs
+++ b/monad-chain-data/src/logs/mod.rs
@@ -1,0 +1,22 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+mod ingest;
+mod materialize;
+mod types;
+
+pub use ingest::{plan_log_ingest, LogIngestPlan};
+pub use materialize::{LogFilter, QueryLogsRequest, QueryLogsResponse};
+pub use types::{LogBlockHeader, LogEntry};

--- a/monad-chain-data/src/logs/mod.rs
+++ b/monad-chain-data/src/logs/mod.rs
@@ -17,6 +17,7 @@ mod ingest;
 mod materialize;
 mod types;
 
-pub use ingest::{plan_log_ingest, LogIngestPlan};
+pub use ingest::LogIngestPlan;
+pub(crate) use materialize::LogMaterializer;
 pub use materialize::{LogFilter, QueryLogsRequest, QueryLogsResponse};
-pub use types::{LogBlockHeader, LogEntry};
+pub use types::{LogBlockHeader, LogEntry, RawLogEntry};

--- a/monad-chain-data/src/logs/types.rs
+++ b/monad-chain-data/src/logs/types.rs
@@ -14,8 +14,12 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use alloy_primitives::{Address, Bytes, B256};
+use alloy_rlp::{RlpDecodable, RlpEncodable};
 
-use crate::family::Hash32;
+use crate::{
+    error::{MonadChainDataError, Result},
+    family::Hash32,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LogEntry {
@@ -28,7 +32,56 @@ pub struct LogEntry {
     pub data: Bytes,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Per-log fields stored in the block blob. Block-level fields (block_number,
+/// block_hash) are reconstructed from the BlockRecord at read time.
+#[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+pub struct RawLogEntry {
+    pub tx_index: u32,
+    pub log_index: u32,
+    pub address: Address,
+    pub topics: Vec<B256>,
+    pub data: Bytes,
+}
+
+impl RawLogEntry {
+    pub fn encode(&self) -> Vec<u8> {
+        alloy_rlp::encode(self)
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        alloy_rlp::decode_exact(bytes)
+            .map_err(|_| MonadChainDataError::Decode("invalid log entry rlp"))
+    }
+
+    pub fn into_log_entry(self, block_number: u64, block_hash: Hash32) -> LogEntry {
+        LogEntry {
+            block_number,
+            block_hash,
+            tx_index: self.tx_index,
+            log_index: self.log_index,
+            address: self.address,
+            topics: self.topics,
+            data: self.data,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 pub struct LogBlockHeader {
     pub offsets: Vec<u32>,
+}
+
+impl LogBlockHeader {
+    pub fn log_count(&self) -> usize {
+        self.offsets.len().saturating_sub(1)
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        alloy_rlp::encode(self)
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        alloy_rlp::decode_exact(bytes)
+            .map_err(|_| MonadChainDataError::Decode("invalid log header rlp"))
+    }
 }

--- a/monad-chain-data/src/logs/types.rs
+++ b/monad-chain-data/src/logs/types.rs
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use alloy_primitives::{Address, Bytes, B256};
+
+use crate::family::Hash32;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogEntry {
+    pub block_number: u64,
+    pub block_hash: Hash32,
+    pub tx_index: u32,
+    pub log_index: u32,
+    pub address: Address,
+    pub topics: Vec<B256>,
+    pub data: Bytes,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogBlockHeader {
+    pub offsets: Vec<u32>,
+}

--- a/monad-chain-data/src/primitives/mod.rs
+++ b/monad-chain-data/src/primitives/mod.rs
@@ -1,0 +1,19 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pub mod page;
+pub mod range;
+pub mod refs;
+pub mod state;

--- a/monad-chain-data/src/primitives/page.rs
+++ b/monad-chain-data/src/primitives/page.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+pub const DEFAULT_QUERY_LIMIT: usize = 100;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum QueryOrder {
     #[default]

--- a/monad-chain-data/src/primitives/page.rs
+++ b/monad-chain-data/src/primitives/page.rs
@@ -1,0 +1,21 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum QueryOrder {
+    #[default]
+    Ascending,
+    Descending,
+}

--- a/monad-chain-data/src/primitives/range.rs
+++ b/monad-chain-data/src/primitives/range.rs
@@ -1,0 +1,30 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{error::Result, logs::QueryLogsRequest, primitives::refs::BlockRef};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedBlockWindow {
+    pub from_block: BlockRef,
+    pub to_block: BlockRef,
+}
+
+pub async fn resolve_block_window(
+    request: &QueryLogsRequest,
+    published_head: u64,
+) -> Result<ResolvedBlockWindow> {
+    let _ = (request, published_head);
+    todo!("resolve the published block window for the current query request")
+}

--- a/monad-chain-data/src/primitives/range.rs
+++ b/monad-chain-data/src/primitives/range.rs
@@ -13,18 +13,73 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{error::Result, logs::QueryLogsRequest, primitives::refs::BlockRef};
+use crate::{
+    error::{MonadChainDataError, Result},
+    kernel::tables::BlockTables,
+    logs::QueryLogsRequest,
+    primitives::refs::BlockRef,
+    store::MetaStore,
+};
 
+/// Inclusive block range clipped to the published head.
+///
+/// `from_block.number <= to_block.number` always holds, regardless of query
+/// order. Callers choose iteration direction based on `QueryOrder`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResolvedBlockWindow {
     pub from_block: BlockRef,
     pub to_block: BlockRef,
 }
 
-pub async fn resolve_block_window(
-    request: &QueryLogsRequest,
-    published_head: u64,
-) -> Result<ResolvedBlockWindow> {
-    let _ = (request, published_head);
-    todo!("resolve the published block window for the current query request")
+impl ResolvedBlockWindow {
+    pub async fn resolve<M: MetaStore>(
+        request: &QueryLogsRequest,
+        published_head: u64,
+        blocks: &BlockTables<M>,
+    ) -> Result<Self> {
+        let (from_number, to_number) = Self::resolve_query_block_numbers(request, published_head)?;
+
+        let from_record =
+            blocks
+                .load_record(from_number)
+                .await?
+                .ok_or(MonadChainDataError::MissingData(
+                    "missing from_block record",
+                ))?;
+        let to_record = blocks
+            .load_record(to_number)
+            .await?
+            .ok_or(MonadChainDataError::MissingData("missing to_block record"))?;
+
+        Ok(Self {
+            from_block: BlockRef::from(&from_record),
+            to_block: BlockRef::from(&to_record),
+        })
+    }
+
+    /// Resolves and validates the block range. Always returns (low, high) with
+    /// `low <= high`, independent of query order.
+    fn resolve_query_block_numbers(
+        request: &QueryLogsRequest,
+        published_head: u64,
+    ) -> Result<(u64, u64)> {
+        if request.from_block.is_some_and(|from| from > published_head) {
+            return Err(MonadChainDataError::InvalidRequest(
+                "from_block must be <= published head",
+            ));
+        }
+
+        let from = request.from_block.unwrap_or(1).max(1);
+        let to = request
+            .to_block
+            .unwrap_or(published_head)
+            .min(published_head);
+
+        if from > to {
+            return Err(MonadChainDataError::InvalidRequest(
+                "from_block must be <= to_block",
+            ));
+        }
+        Ok((from, to))
+    }
 }

--- a/monad-chain-data/src/primitives/refs.rs
+++ b/monad-chain-data/src/primitives/refs.rs
@@ -1,0 +1,23 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::family::Hash32;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockRef {
+    pub number: u64,
+    pub hash: Hash32,
+    pub parent_hash: Hash32,
+}

--- a/monad-chain-data/src/primitives/refs.rs
+++ b/monad-chain-data/src/primitives/refs.rs
@@ -13,11 +13,21 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::family::Hash32;
+use crate::{family::Hash32, primitives::state::BlockRecord};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BlockRef {
     pub number: u64,
     pub hash: Hash32,
     pub parent_hash: Hash32,
+}
+
+impl From<&BlockRecord> for BlockRef {
+    fn from(value: &BlockRecord) -> Self {
+        Self {
+            number: value.block_number,
+            hash: value.block_hash,
+            parent_hash: value.parent_hash,
+        }
+    }
 }

--- a/monad-chain-data/src/primitives/state.rs
+++ b/monad-chain-data/src/primitives/state.rs
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::family::Hash32;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockRecord {
+    pub block_number: u64,
+    pub block_hash: Hash32,
+    pub parent_hash: Hash32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PublicationState {
+    pub indexed_finalized_head: u64,
+}

--- a/monad-chain-data/src/primitives/state.rs
+++ b/monad-chain-data/src/primitives/state.rs
@@ -13,16 +13,43 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::family::Hash32;
+use alloy_rlp::{RlpDecodable, RlpEncodable};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+use crate::{
+    error::{MonadChainDataError, Result},
+    family::Hash32,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 pub struct BlockRecord {
     pub block_number: u64,
     pub block_hash: Hash32,
     pub parent_hash: Hash32,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+impl BlockRecord {
+    pub fn encode(&self) -> Vec<u8> {
+        alloy_rlp::encode(self)
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        alloy_rlp::decode_exact(bytes)
+            .map_err(|_| MonadChainDataError::Decode("invalid block record rlp"))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 pub struct PublicationState {
     pub indexed_finalized_head: u64,
+}
+
+impl PublicationState {
+    pub fn encode(self) -> Vec<u8> {
+        alloy_rlp::encode(self)
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        alloy_rlp::decode_exact(bytes)
+            .map_err(|_| MonadChainDataError::Decode("invalid publication state rlp"))
+    }
 }

--- a/monad-chain-data/src/query/mod.rs
+++ b/monad-chain-data/src/query/mod.rs
@@ -1,0 +1,16 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pub mod runner;

--- a/monad-chain-data/src/query/runner.rs
+++ b/monad-chain-data/src/query/runner.rs
@@ -16,9 +16,10 @@
 use crate::{
     error::Result,
     kernel::tables::Tables,
-    logs::{QueryLogsRequest, QueryLogsResponse},
+    logs::{LogMaterializer, QueryLogsRequest, QueryLogsResponse},
     primitives::range::ResolvedBlockWindow,
     store::{BlobStore, MetaStore},
+    QueryOrder,
 };
 
 pub async fn execute_block_scan_query<M: MetaStore, B: BlobStore>(
@@ -26,6 +27,35 @@ pub async fn execute_block_scan_query<M: MetaStore, B: BlobStore>(
     request: &QueryLogsRequest,
     window: ResolvedBlockWindow,
 ) -> Result<QueryLogsResponse> {
-    let _ = (tables, request, window);
-    todo!("execute the fallback block-scan query path")
+    let materializer = LogMaterializer::new(tables);
+    let target_log_count = request.limit;
+    let mut logs = Vec::new();
+    let mut cursor_block = window.from_block;
+
+    for block_number in block_range(window, request.order) {
+        let (block_ref, block_logs) = materializer
+            .load_filtered_block_logs_for_block(block_number, request)
+            .await?;
+        logs.extend(block_logs);
+        cursor_block = block_ref;
+        if logs.len() >= target_log_count {
+            break;
+        }
+    }
+
+    Ok(QueryLogsResponse {
+        logs,
+        from_block: window.from_block,
+        to_block: window.to_block,
+        cursor_block,
+    })
+}
+
+fn block_range(window: ResolvedBlockWindow, order: QueryOrder) -> impl Iterator<Item = u64> {
+    let range = window.from_block.number..=window.to_block.number;
+    let (fwd, rev) = match order {
+        QueryOrder::Ascending => (Some(range), None),
+        QueryOrder::Descending => (None, Some(range.rev())),
+    };
+    fwd.into_iter().flatten().chain(rev.into_iter().flatten())
 }

--- a/monad-chain-data/src/query/runner.rs
+++ b/monad-chain-data/src/query/runner.rs
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{
+    error::Result,
+    kernel::tables::Tables,
+    logs::{QueryLogsRequest, QueryLogsResponse},
+    primitives::range::ResolvedBlockWindow,
+    store::{BlobStore, MetaStore},
+};
+
+pub async fn execute_block_scan_query<M: MetaStore, B: BlobStore>(
+    tables: &Tables<M, B>,
+    request: &QueryLogsRequest,
+    window: ResolvedBlockWindow,
+) -> Result<QueryLogsResponse> {
+    let _ = (tables, request, window);
+    todo!("execute the fallback block-scan query path")
+}

--- a/monad-chain-data/src/store/blob/in_memory.rs
+++ b/monad-chain-data/src/store/blob/in_memory.rs
@@ -1,0 +1,65 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, RwLock},
+};
+
+use bytes::Bytes;
+
+use crate::{
+    error::Result,
+    store::blob::{BlobStore, BlobTableId},
+};
+
+/// Test-only blob fixture. Holds blobs in memory behind a sync `RwLock`.
+/// Not intended as a deployable backend.
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryBlobStore {
+    blobs: Arc<RwLock<BTreeMap<(BlobTableId, Vec<u8>), Bytes>>>,
+}
+
+impl InMemoryBlobStore {
+    pub fn len(&self) -> usize {
+        self.blobs
+            .read()
+            .map(|guard| guard.len())
+            .unwrap_or_default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl BlobStore for InMemoryBlobStore {
+    async fn put_blob(&self, table: BlobTableId, key: &[u8], value: Bytes) -> Result<()> {
+        let mut guard = self
+            .blobs
+            .write()
+            .map_err(|_| crate::error::MonadChainDataError::Backend("poisoned lock".to_string()))?;
+        guard.insert((table, key.to_vec()), value);
+        Ok(())
+    }
+
+    async fn get_blob(&self, table: BlobTableId, key: &[u8]) -> Result<Option<Bytes>> {
+        let guard = self
+            .blobs
+            .read()
+            .map_err(|_| crate::error::MonadChainDataError::Backend("poisoned lock".to_string()))?;
+        Ok(guard.get(&(table, key.to_vec())).cloned())
+    }
+}

--- a/monad-chain-data/src/store/blob/mod.rs
+++ b/monad-chain-data/src/store/blob/mod.rs
@@ -1,0 +1,116 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+mod in_memory;
+
+use bytes::Bytes;
+pub use in_memory::InMemoryBlobStore;
+
+use crate::error::{MonadChainDataError, Result};
+
+/// Logical identifier for a blob table.
+///
+/// Identifiers are opaque names. Backends are responsible for any
+/// prefixing or keyspacing required to map logical tables onto shared
+/// physical resources without collisions (e.g. distinct S3 buckets,
+/// per-deployment object-key prefixes). This type makes no namespacing
+/// guarantees on its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BlobTableId(&'static str);
+
+impl BlobTableId {
+    pub const fn new(name: &'static str) -> Self {
+        Self(name)
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        self.0
+    }
+}
+
+#[derive(Debug)]
+pub struct BlobTable<B> {
+    store: B,
+    pub table: BlobTableId,
+}
+
+impl<B> BlobTable<B> {
+    pub fn new(store: B, table: BlobTableId) -> Self {
+        Self { store, table }
+    }
+}
+
+impl<B: Clone> Clone for BlobTable<B> {
+    fn clone(&self) -> Self {
+        Self {
+            store: self.store.clone(),
+            table: self.table,
+        }
+    }
+}
+
+impl<B: BlobStore> BlobTable<B> {
+    pub async fn put(&self, key: &[u8], value: Bytes) -> Result<()> {
+        self.store.put_blob(self.table, key, value).await
+    }
+
+    pub async fn get(&self, key: &[u8]) -> Result<Option<Bytes>> {
+        self.store.get_blob(self.table, key).await
+    }
+
+    pub async fn read_range(
+        &self,
+        key: &[u8],
+        start: usize,
+        end_exclusive: usize,
+    ) -> Result<Option<Bytes>> {
+        self.store
+            .read_range(self.table, key, start, end_exclusive)
+            .await
+    }
+}
+
+/// Unversioned object storage with range-read support.
+///
+/// Implementations must be cheaply cloneable (e.g. via internal `Arc`).
+#[allow(async_fn_in_trait)]
+#[auto_impl::auto_impl(Arc)]
+pub trait BlobStore: Clone + Send + Sync {
+    #[auto_impl(keep_default_for(Arc))]
+    fn table(&self, table: BlobTableId) -> BlobTable<Self>
+    where
+        Self: Sized,
+    {
+        BlobTable::new(self.clone(), table)
+    }
+
+    async fn put_blob(&self, table: BlobTableId, key: &[u8], value: Bytes) -> Result<()>;
+    async fn get_blob(&self, table: BlobTableId, key: &[u8]) -> Result<Option<Bytes>>;
+    async fn read_range(
+        &self,
+        table: BlobTableId,
+        key: &[u8],
+        start: usize,
+        end_exclusive: usize,
+    ) -> Result<Option<Bytes>> {
+        let Some(blob) = self.get_blob(table, key).await? else {
+            return Ok(None);
+        };
+        if start > end_exclusive || start > blob.len() {
+            return Err(MonadChainDataError::Decode("invalid blob range"));
+        }
+        Ok(Some(blob.slice(start..end_exclusive.min(blob.len()))))
+    }
+}

--- a/monad-chain-data/src/store/common.rs
+++ b/monad-chain-data/src/store/common.rs
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#[derive(Debug, Clone)]
+pub struct Page {
+    pub keys: Vec<Vec<u8>>,
+    pub next_cursor: Option<Vec<u8>>,
+}

--- a/monad-chain-data/src/store/meta/in_memory.rs
+++ b/monad-chain-data/src/store/meta/in_memory.rs
@@ -1,0 +1,144 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, RwLock},
+};
+
+use bytes::Bytes;
+
+use crate::{
+    error::Result,
+    store::{
+        common::Page,
+        meta::{MetaStore, PutResult, Record, ScannableTableId, TableId},
+    },
+};
+
+/// Test-only meta-store fixture. Holds records in memory behind sync
+/// `RwLock`s. Not intended as a deployable backend.
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryMetaStore {
+    kv_records: Arc<RwLock<BTreeMap<(TableId, Vec<u8>), Record>>>,
+    scan_records: Arc<RwLock<BTreeMap<(ScannableTableId, Vec<u8>, Vec<u8>), Record>>>,
+}
+
+impl InMemoryMetaStore {
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn len(&self) -> usize {
+        self.kv_records
+            .read()
+            .map(|guard| guard.len())
+            .unwrap_or_default()
+            + self
+                .scan_records
+                .read()
+                .map(|guard| guard.len())
+                .unwrap_or_default()
+    }
+}
+
+impl MetaStore for InMemoryMetaStore {
+    async fn get(&self, table: TableId, key: &[u8]) -> Result<Option<Record>> {
+        let guard = self
+            .kv_records
+            .read()
+            .map_err(|_| crate::error::MonadChainDataError::Backend("poisoned lock".to_string()))?;
+        Ok(guard.get(&(table, key.to_vec())).cloned())
+    }
+
+    async fn scan_get(
+        &self,
+        table: ScannableTableId,
+        partition: &[u8],
+        clustering: &[u8],
+    ) -> Result<Option<Record>> {
+        let guard = self
+            .scan_records
+            .read()
+            .map_err(|_| crate::error::MonadChainDataError::Backend("poisoned lock".to_string()))?;
+        Ok(guard
+            .get(&(table, partition.to_vec(), clustering.to_vec()))
+            .cloned())
+    }
+
+    async fn put(&self, table: TableId, key: &[u8], value: Bytes) -> Result<PutResult> {
+        let mut guard = self
+            .kv_records
+            .write()
+            .map_err(|_| crate::error::MonadChainDataError::Backend("poisoned lock".to_string()))?;
+
+        let entry_key = (table, key.to_vec());
+        let current = guard.get(&entry_key).cloned();
+        let next_version = current.map_or(1, |record| record.version + 1);
+        guard.insert(
+            entry_key,
+            Record {
+                version: next_version,
+                value,
+            },
+        );
+
+        Ok(PutResult {
+            applied: true,
+            version: Some(next_version),
+        })
+    }
+
+    async fn scan_put(
+        &self,
+        table: ScannableTableId,
+        partition: &[u8],
+        clustering: &[u8],
+        value: Bytes,
+    ) -> Result<PutResult> {
+        let mut guard = self
+            .scan_records
+            .write()
+            .map_err(|_| crate::error::MonadChainDataError::Backend("poisoned lock".to_string()))?;
+
+        let entry_key = (table, partition.to_vec(), clustering.to_vec());
+        let current = guard.get(&entry_key).cloned();
+        let next_version = current.map_or(1, |record| record.version + 1);
+        guard.insert(
+            entry_key,
+            Record {
+                version: next_version,
+                value,
+            },
+        );
+
+        Ok(PutResult {
+            applied: true,
+            version: Some(next_version),
+        })
+    }
+
+    async fn scan_list(
+        &self,
+        table: ScannableTableId,
+        partition: &[u8],
+        prefix: &[u8],
+        cursor: Option<Vec<u8>>,
+        limit: usize,
+    ) -> Result<Page> {
+        let _ = (table, partition, prefix, cursor, limit);
+        todo!("list scannable metadata keys from the in-memory meta store")
+    }
+}

--- a/monad-chain-data/src/store/meta/mod.rs
+++ b/monad-chain-data/src/store/meta/mod.rs
@@ -1,0 +1,200 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+mod in_memory;
+
+use bytes::Bytes;
+pub use in_memory::InMemoryMetaStore;
+
+use crate::{error::Result, store::common::Page};
+
+/// Logical identifier for a key/value table.
+///
+/// Identifiers are opaque names. Backends are responsible for any
+/// prefixing or keyspacing required to map logical tables onto shared
+/// physical resources without collisions (e.g. distinct Scylla
+/// keyspaces, per-deployment table prefixes). This type makes no
+/// namespacing guarantees on its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TableId(&'static str);
+
+impl TableId {
+    pub const fn new(name: &'static str) -> Self {
+        Self(name)
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        self.0
+    }
+}
+
+/// Logical identifier for a scannable (partitioned + clustered) table.
+///
+/// Same namespacing model as [`TableId`]: backends own collision
+/// avoidance when these names map onto shared physical resources.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ScannableTableId(&'static str);
+
+impl ScannableTableId {
+    pub const fn new(name: &'static str) -> Self {
+        Self(name)
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Record {
+    pub version: u64,
+    pub value: Bytes,
+}
+
+#[derive(Debug, Clone)]
+pub struct PutResult {
+    pub applied: bool,
+    pub version: Option<u64>,
+}
+
+#[derive(Debug)]
+pub struct KvTable<M> {
+    store: M,
+    pub table: TableId,
+}
+
+impl<M> KvTable<M> {
+    pub fn new(store: M, table: TableId) -> Self {
+        Self { store, table }
+    }
+}
+
+impl<M: Clone> Clone for KvTable<M> {
+    fn clone(&self) -> Self {
+        Self {
+            store: self.store.clone(),
+            table: self.table,
+        }
+    }
+}
+
+impl<M: MetaStore> KvTable<M> {
+    pub async fn get(&self, key: &[u8]) -> Result<Option<Record>> {
+        self.store.get(self.table, key).await
+    }
+
+    pub async fn put(&self, key: &[u8], value: Bytes) -> Result<PutResult> {
+        self.store.put(self.table, key, value).await
+    }
+}
+
+#[derive(Debug)]
+pub struct ScannableKvTable<M> {
+    store: M,
+    pub table: ScannableTableId,
+}
+
+impl<M> ScannableKvTable<M> {
+    pub fn new(store: M, table: ScannableTableId) -> Self {
+        Self { store, table }
+    }
+}
+
+impl<M: Clone> Clone for ScannableKvTable<M> {
+    fn clone(&self) -> Self {
+        Self {
+            store: self.store.clone(),
+            table: self.table,
+        }
+    }
+}
+
+impl<M: MetaStore> ScannableKvTable<M> {
+    pub async fn get(&self, partition: &[u8], clustering: &[u8]) -> Result<Option<Record>> {
+        self.store.scan_get(self.table, partition, clustering).await
+    }
+
+    pub async fn put(
+        &self,
+        partition: &[u8],
+        clustering: &[u8],
+        value: Bytes,
+    ) -> Result<PutResult> {
+        self.store
+            .scan_put(self.table, partition, clustering, value)
+            .await
+    }
+
+    pub async fn list_prefix(
+        &self,
+        partition: &[u8],
+        prefix: &[u8],
+        cursor: Option<Vec<u8>>,
+        limit: usize,
+    ) -> Result<Page> {
+        self.store
+            .scan_list(self.table, partition, prefix, cursor, limit)
+            .await
+    }
+}
+
+/// Versioned key-value and scannable metadata storage.
+///
+/// Implementations must be cheaply cloneable (e.g. via internal `Arc`).
+#[allow(async_fn_in_trait)]
+#[auto_impl::auto_impl(Arc)]
+pub trait MetaStore: Clone + Send + Sync {
+    #[auto_impl(keep_default_for(Arc))]
+    fn table(&self, table: TableId) -> KvTable<Self>
+    where
+        Self: Sized,
+    {
+        KvTable::new(self.clone(), table)
+    }
+
+    #[auto_impl(keep_default_for(Arc))]
+    fn scannable_table(&self, table: ScannableTableId) -> ScannableKvTable<Self>
+    where
+        Self: Sized,
+    {
+        ScannableKvTable::new(self.clone(), table)
+    }
+
+    async fn get(&self, table: TableId, key: &[u8]) -> Result<Option<Record>>;
+    async fn scan_get(
+        &self,
+        table: ScannableTableId,
+        partition: &[u8],
+        clustering: &[u8],
+    ) -> Result<Option<Record>>;
+
+    async fn put(&self, table: TableId, key: &[u8], value: Bytes) -> Result<PutResult>;
+    async fn scan_put(
+        &self,
+        table: ScannableTableId,
+        partition: &[u8],
+        clustering: &[u8],
+        value: Bytes,
+    ) -> Result<PutResult>;
+
+    async fn scan_list(
+        &self,
+        table: ScannableTableId,
+        partition: &[u8],
+        prefix: &[u8],
+        cursor: Option<Vec<u8>>,
+        limit: usize,
+    ) -> Result<Page>;
+}

--- a/monad-chain-data/src/store/mod.rs
+++ b/monad-chain-data/src/store/mod.rs
@@ -1,0 +1,25 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pub mod blob;
+pub mod common;
+pub mod meta;
+
+pub use blob::{BlobStore, BlobTable, BlobTableId, InMemoryBlobStore};
+pub use common::Page;
+pub use meta::{
+    InMemoryMetaStore, KvTable, MetaStore, PutResult, Record, ScannableKvTable, ScannableTableId,
+    TableId,
+};

--- a/monad-chain-data/tests/blob_store.rs
+++ b/monad-chain-data/tests/blob_store.rs
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use bytes::Bytes;
+use monad_chain_data::{
+    store::{BlobStore, BlobTableId},
+    InMemoryBlobStore,
+};
+
+const TABLE: BlobTableId = BlobTableId::new("blob_store_test");
+const KEY: &[u8] = b"blob";
+
+#[tokio::test(flavor = "current_thread")]
+async fn read_range_clamps_overshooting_end() {
+    let store = InMemoryBlobStore::default();
+    store
+        .put_blob(TABLE, KEY, Bytes::from_static(b"abcdef"))
+        .await
+        .expect("put blob");
+
+    let tail = store
+        .read_range(TABLE, KEY, 2, 99)
+        .await
+        .expect("read range")
+        .expect("blob present");
+    assert_eq!(tail.as_ref(), b"cdef");
+
+    let empty_tail = store
+        .read_range(TABLE, KEY, 6, 99)
+        .await
+        .expect("read range")
+        .expect("blob present");
+    assert!(empty_tail.is_empty());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn read_range_rejects_invalid_start_bounds() {
+    let store = InMemoryBlobStore::default();
+    store
+        .put_blob(TABLE, KEY, Bytes::from_static(b"abcdef"))
+        .await
+        .expect("put blob");
+
+    let reversed = store
+        .read_range(TABLE, KEY, 4, 3)
+        .await
+        .expect_err("reversed range should error");
+    assert_eq!(reversed.to_string(), "decode error: invalid blob range");
+
+    let past_end = store
+        .read_range(TABLE, KEY, 7, 99)
+        .await
+        .expect_err("start past blob end should error");
+    assert_eq!(past_end.to_string(), "decode error: invalid blob range");
+}

--- a/monad-chain-data/tests/query_logs_scan.rs
+++ b/monad-chain-data/tests/query_logs_scan.rs
@@ -1,0 +1,177 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+
+use monad_chain_data::{
+    error::MonadChainDataError, Address, Bytes, FinalizedBlock, InMemoryBlobStore,
+    InMemoryMetaStore, Log, LogData, LogFilter, MonadChainDataService, QueryLogsRequest,
+    QueryOrder, B256,
+};
+
+#[tokio::test(flavor = "current_thread")]
+async fn query_logs_paginates_at_block_boundaries() {
+    let service =
+        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 1,
+            block_hash: B256::repeat_byte(1),
+            parent_hash: B256::ZERO,
+            logs_by_tx: vec![vec![
+                log(Address::repeat_byte(7), B256::repeat_byte(9)),
+                log(Address::repeat_byte(7), B256::repeat_byte(9)),
+            ]],
+        })
+        .await
+        .expect("ingest block 1");
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 2,
+            block_hash: B256::repeat_byte(2),
+            parent_hash: B256::repeat_byte(1),
+            logs_by_tx: vec![vec![log(Address::repeat_byte(7), B256::repeat_byte(9))]],
+        })
+        .await
+        .expect("ingest block 2");
+
+    let first_page = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(1),
+            to_block: Some(2),
+            order: QueryOrder::Ascending,
+            limit: 1,
+            filter: LogFilter {
+                address: Some(HashSet::from([Address::repeat_byte(7)])),
+                topics: [
+                    Some(HashSet::from([B256::repeat_byte(9)])),
+                    None,
+                    None,
+                    None,
+                ],
+            },
+        })
+        .await
+        .expect("first page");
+
+    assert_eq!(first_page.logs.len(), 2);
+    assert_eq!(first_page.cursor_block.number, 1);
+    assert_eq!(first_page.logs[0].block_number, 1);
+    assert_eq!(first_page.logs[1].block_number, 1);
+
+    let second_page = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(first_page.cursor_block.number + 1),
+            to_block: Some(2),
+            order: QueryOrder::Ascending,
+            limit: 1,
+            filter: LogFilter {
+                address: Some(HashSet::from([Address::repeat_byte(7)])),
+                topics: [
+                    Some(HashSet::from([B256::repeat_byte(9)])),
+                    None,
+                    None,
+                    None,
+                ],
+            },
+        })
+        .await
+        .expect("second page");
+
+    assert_eq!(second_page.logs.len(), 1);
+    assert_eq!(second_page.cursor_block.number, 2);
+    assert_eq!(second_page.logs[0].block_number, 2);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn query_logs_descending_returns_newest_first() {
+    let service =
+        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 1,
+            block_hash: B256::repeat_byte(1),
+            parent_hash: B256::ZERO,
+            logs_by_tx: vec![vec![
+                log(Address::repeat_byte(5), B256::repeat_byte(8)),
+                log(Address::repeat_byte(5), B256::repeat_byte(8)),
+            ]],
+        })
+        .await
+        .expect("ingest");
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(1),
+            to_block: Some(1),
+            order: QueryOrder::Descending,
+            limit: 1,
+            filter: LogFilter {
+                address: Some(HashSet::from([Address::repeat_byte(5)])),
+                topics: [
+                    Some(HashSet::from([B256::repeat_byte(8)])),
+                    None,
+                    None,
+                    None,
+                ],
+            },
+        })
+        .await
+        .expect("query");
+
+    assert_eq!(page.logs.len(), 2);
+    assert_eq!(page.logs[0].log_index, 1);
+    assert_eq!(page.logs[1].log_index, 0);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn query_logs_rejects_from_block_above_published_head() {
+    let service =
+        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 1,
+            block_hash: B256::repeat_byte(1),
+            parent_hash: B256::ZERO,
+            logs_by_tx: vec![vec![log(Address::repeat_byte(5), B256::repeat_byte(8))]],
+        })
+        .await
+        .expect("ingest");
+
+    let err = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(2),
+            to_block: None,
+            ..QueryLogsRequest::default()
+        })
+        .await
+        .expect_err("from_block above published head should error");
+
+    assert!(matches!(
+        err,
+        MonadChainDataError::InvalidRequest("from_block must be <= published head")
+    ));
+}
+
+fn log(address: Address, topic0: B256) -> Log {
+    Log {
+        address,
+        data: LogData::new_unchecked(vec![topic0], Bytes::from(vec![1, 2, 3])),
+    }
+}


### PR DESCRIPTION
[Intro Design Doc](https://www.notion.so/Bitmap-Indexed-History-Queries-32775b0ba84080a4bbb2ed1089a64a9d?source=copy_link)

These are the first 2 commits for upstreaming monad-chain-data. This crate will provide the backend for 
[QueryX](https://www.notion.so/RPC-Query-Methods-Draft-MIP-30b75b0ba840806186b9f6b2df4ccc7a?source=copy_link&utm_content=30b75b0b-a840-8061-86b9-f6b2df4ccc7a&utm_campaign=T081S0AP65N&n=slack&n=slack_link_unfurl&pvs=6)

Commits: 

1. inits crate dir and creates stub file scaffolds
2. creates naive log ingest and block-range scan query paths

The intention is to slowly build up to the completed codebase through vertical slices. 

Future slices will include:

- Accelerated queries using roaring-bitmaps and paged indexes (the main point of this crate)
- Integration into RPC and an ingest binary (eventually superseding monad-archive)
- Txs, Traces, Native Transfers, Blocks familes and query support
- Caching
- Production backends (Scylla + S3)
- Multi-writer support
- Zero-copy types