### PR TITLE
monad-leanudp: use fixed slots for reassembly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5669,6 +5669,7 @@ dependencies = [
  "monad-executor",
  "rand 0.8.5",
  "thiserror 1.0.69",
+ "tikv-jemallocator",
  "zerocopy",
 ]
 

--- a/monad-leanudp/Cargo.toml
+++ b/monad-leanudp/Cargo.toml
@@ -12,8 +12,16 @@ rand = { workspace = true }
 thiserror = { workspace = true }
 zerocopy = { workspace = true }
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies.tikv-jemallocator]
+workspace = true
+features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"]
+optional = true
+
 [dev-dependencies]
 criterion = { workspace = true }
+
+[features]
+jemallocator = ["tikv-jemallocator"]
 
 [[bench]]
 name = "decoder"

--- a/monad-leanudp/benches/decoder.rs
+++ b/monad-leanudp/benches/decoder.rs
@@ -24,6 +24,16 @@ use monad_leanudp::{
     Clock, Config, Decoder, Encoder, FragmentPolicy, IdentityScore, PacketHeader,
     MAX_CONCURRENT_MESSAGES_PER_IDENTITY,
 };
+use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+
+#[cfg(all(not(target_env = "msvc"), feature = "jemallocator"))]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+#[cfg(feature = "jemallocator")]
+#[allow(non_upper_case_globals)]
+#[export_name = "malloc_conf"]
+pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 
 #[derive(Clone, Copy)]
 struct FixedClock(Instant);
@@ -90,6 +100,68 @@ fn encode_packets(encoder: &mut Encoder, size: usize) -> Vec<Bytes> {
         .unwrap()
         .map(|(header, data)| make_packet(&header, &data))
         .collect()
+}
+
+#[derive(Clone, Copy)]
+enum Order {
+    InOrder,
+    Shuffled,
+}
+
+impl Order {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::InOrder => "in_order",
+            Self::Shuffled => "shuffled",
+        }
+    }
+}
+
+struct WorstCaseBenchCase {
+    name: &'static str,
+    payload_size: usize,
+    max_fragment_payload: usize,
+}
+
+fn worst_case_bench_config(case: &WorstCaseBenchCase) -> Config {
+    Config {
+        max_message_size: case.payload_size,
+        max_priority_messages: 8,
+        max_regular_messages: 8,
+        max_messages_per_identity: MAX_CONCURRENT_MESSAGES_PER_IDENTITY,
+        message_timeout: Duration::from_secs(60),
+        max_fragment_payload: case.max_fragment_payload,
+    }
+}
+
+fn make_worst_case_bench_packets(case: &WorstCaseBenchCase, order: Order) -> Vec<Bytes> {
+    let config = worst_case_bench_config(case);
+    let clock = FixedClock(Instant::now());
+    let (mut encoder, _decoder) = config.build_with_clock(AllRegular, clock);
+    let mut packets = encode_packets(&mut encoder, case.payload_size);
+    if matches!(order, Order::Shuffled) {
+        let mut rng = StdRng::seed_from_u64(7);
+        packets.shuffle(&mut rng);
+    }
+    packets
+}
+
+fn bench_worst_case_case(
+    b: &mut criterion::Bencher<'_>,
+    packets: &[Bytes],
+    case: &WorstCaseBenchCase,
+) {
+    let config = worst_case_bench_config(case);
+    let clock = FixedClock(Instant::now());
+    let (_encoder, mut decoder) = config.build_with_clock(AllRegular, clock);
+    let mut identity = 0u64;
+
+    b.iter(|| {
+        for packet in packets {
+            let _ = black_box(decoder.decode(identity, packet.clone()));
+        }
+        identity += 1;
+    });
 }
 
 fn bench_decode(c: &mut Criterion) {
@@ -164,5 +236,44 @@ fn bench_encode(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_decode, bench_encode);
+fn bench_worst_case_bench(c: &mut Criterion) {
+    let cases = [
+        WorstCaseBenchCase {
+            name: "512frags_1byte",
+            payload_size: 512,
+            max_fragment_payload: PacketHeader::SIZE + 1,
+        },
+        WorstCaseBenchCase {
+            name: "366frags_default",
+            payload_size: 512 * 1024,
+            max_fragment_payload: 1440,
+        },
+        WorstCaseBenchCase {
+            name: "512frags_worst",
+            payload_size: 512 * 1024,
+            max_fragment_payload: 1030,
+        },
+    ];
+
+    for order in [Order::InOrder, Order::Shuffled] {
+        let mut group = c.benchmark_group(format!("worst_case_bench/{}", order.as_str()));
+        group.sample_size(30);
+        group.measurement_time(Duration::from_secs(8));
+
+        for case in &cases {
+            let packets = make_worst_case_bench_packets(case, order);
+            group.throughput(Throughput::Bytes(case.payload_size as u64));
+
+            group.bench_with_input(
+                BenchmarkId::new(case.name, packets.len()),
+                &packets,
+                |b, packets| bench_worst_case_case(b, packets, case),
+            );
+        }
+
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_decode, bench_encode, bench_worst_case_bench);
 criterion_main!(benches);

--- a/monad-leanudp/src/pool.rs
+++ b/monad-leanudp/src/pool.rs
@@ -54,7 +54,8 @@ pub(crate) struct FragmentInput<I> {
 }
 
 struct MessageState {
-    fragments: BTreeMap<u16, Bytes>,
+    fragments: Box<[Option<Bytes>; MAX_FRAGMENTS]>,
+    fragment_count: u16,
     total_size: usize,
     total_frags: Option<u16>,
     eviction_deadline: Instant,
@@ -63,7 +64,8 @@ struct MessageState {
 impl MessageState {
     fn new(eviction_deadline: Instant) -> Self {
         Self {
-            fragments: BTreeMap::new(),
+            fragments: Box::new(std::array::from_fn(|_| None)),
+            fragment_count: 0,
             total_size: 0,
             total_frags: None,
             eviction_deadline,
@@ -72,7 +74,10 @@ impl MessageState {
 
     fn extract(self) -> Bytes {
         let mut buf = BytesMut::with_capacity(self.total_size);
-        for frag in self.fragments.into_values() {
+        let total_frags =
+            self.total_frags
+                .expect("complete message must have declared fragment count") as usize;
+        for frag in self.fragments.into_iter().take(total_frags).flatten() {
             buf.extend_from_slice(&frag);
         }
         buf.freeze()
@@ -349,7 +354,7 @@ impl<I: Eq + Hash + Clone + Ord, R: CryptoRng + RngCore> MessagePool<I, R> {
             // NOTE(dshulyak): duplicate fragments should only happen when a sender is buggy
             // or malicious and resends the same chunk.
             ensure!(
-                !state.fragments.contains_key(&seq_num),
+                state.fragments[seq_num as usize].is_none(),
                 DecodeError::DuplicateFragment { msg_id, seq_num }
             );
 
@@ -393,9 +398,10 @@ impl<I: Eq + Hash + Clone + Ord, R: CryptoRng + RngCore> MessagePool<I, R> {
                 }
             );
             state.total_size = total_size.expect("total_size validated above");
-            state.fragments.insert(seq_num, data);
+            state.fragments[seq_num as usize] = Some(data);
+            state.fragment_count += 1;
 
-            state.total_frags == Some(state.fragments.len() as u16)
+            state.total_frags == Some(state.fragment_count)
         };
         if !is_complete {
             return Ok(DecodeOutcome::Pending);


### PR DESCRIPTION
use a fixed MAX_FRAGMENTS slot table for decoder reassembly and keep the worst-case decoder benchmark in benches/decoder.rs with a jemallocator feature matching the monad-node allocator setup.

criterion output for the 512-fragment cases with --features jemallocator:

worst_case_bench/in_order/512frags_1byte/512
time:   [95.478 us 95.531 us 95.605 us]
thrpt:  [5.1073 MiB/s 5.1112 MiB/s 5.1141 MiB/s]
change:
time:   [-15.130% -14.270% -13.543%] (p = 0.00 < 0.05)
thrpt:  [+15.665% +16.645% +17.828%]
performance has improved.
found 2 outliers among 30 measurements (6.67%)
2 (6.67%) high severe

worst_case_bench/in_order/512frags_worst/512
time:   [110.34 us 110.41 us 110.45 us]
thrpt:  [4.4207 GiB/s 4.4226 GiB/s 4.4251 GiB/s]
change:
time:   [-14.093% -13.980% -13.865%] (p = 0.00 < 0.05)
thrpt:  [+16.097% +16.252% +16.405%]
performance has improved.
found 1 outliers among 30 measurements (3.33%)
1 (3.33%) high severe

worst_case_bench/shuffled/512frags_1byte/512
time:   [95.231 us 95.282 us 95.357 us]
thrpt:  [5.1206 MiB/s 5.1246 MiB/s 5.1273 MiB/s]
change:
time:   [-13.592% -13.480% -13.356%] (p = 0.00 < 0.05)
thrpt:  [+15.414% +15.580% +15.730%]
performance has improved.
found 2 outliers among 30 measurements (6.67%)
2 (6.67%) high severe

worst_case_bench/shuffled/512frags_worst/512
time:   [109.97 us 110.02 us 110.06 us]
thrpt:  [4.4364 GiB/s 4.4382 GiB/s 4.4399 GiB/s]
change:
time:   [-13.094% -12.997% -12.900%] (p = 0.00 < 0.05)
thrpt:  [+14.811% +14.938% +15.067%]
performance has improved.
found 3 outliers among 30 measurements (10.00%)
1 (3.33%) low mild
1 (3.33%) high mild
1 (3.33%) high severe

Change-Id: Ic88be73d135fd4f41f7447f96b7da8d24de5f065