### PR TITLE
Fix coherency test harness

### DIFF
--- a/monad-eth-block-validator/tests/coherency_test.rs
+++ b/monad-eth-block-validator/tests/coherency_test.rs
@@ -450,25 +450,12 @@ fn check_txpool_coherency(
     state_backend: &NopStateBackend,
     root_info: RootInfo,
 ) {
-    let mut block_policy = TestBlockPolicy::new(GENESIS_SEQ_NUM, 3);
+    let block_policy = TestBlockPolicy::new(GENESIS_SEQ_NUM, 3);
 
     let mut txpool = create_test_txpool(chain_config);
     let metrics = EthTxPoolMetrics::default();
     let mut ipc_events = BTreeMap::default();
     let mut event_tracker = EthTxPoolEventTracker::new(&metrics, &mut ipc_events);
-
-    // insert extending blocks to txpool
-    for extending_block in extending_blocks.iter() {
-        txpool.update_committed_block(&mut event_tracker, chain_config, extending_block.clone());
-        <TestBlockPolicy as BlockPolicy<
-            NopSignature,
-            MockSignatures<NopSignature>,
-            EthExecutionProtocol,
-            NopStateBackend,
-            MonadChainConfig,
-            MonadChainRevision,
-        >>::update_committed_block(&mut block_policy, extending_block);
-    }
 
     // insert transactions of the incoming block into txpool
     let block_txs: Vec<Recovered<TxEnvelope>> = block_under_test


### PR DESCRIPTION
There's a bug with the test harness, which commits the blocks then later pass them as extending blocks again. Deleting the committed blocks.

Doesn't manifest because the test cases are to test reserve balance, and our reserve balance code explicitly handles it