### PR TITLE
Chain Data: add logId resolution index

### DIFF
--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -16,6 +16,7 @@
 use crate::{
     error::{MonadChainDataError, Result},
     family::FinalizedBlock,
+    ingest::directory_compaction::compact_newly_sealed_log_directory_buckets,
     kernel::tables::Tables,
     logs::{LogIngestPlan, QueryLogsRequest, QueryLogsResponse},
     primitives::{
@@ -76,6 +77,7 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
             bitmap_fragments,
             written_logs,
         } = LogIngestPlan::build(&block, next_log_id)?;
+        let next_log_id_exclusive = block_record.logs.next_log_id()?;
         logs.store_block_blob(block.block_number, block_log_blob)
             .await?;
         logs.store_block_header(block.block_number, &block_log_header)
@@ -87,6 +89,12 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
                 block_record.logs.count,
             )
             .await?;
+        compact_newly_sealed_log_directory_buckets(
+            logs,
+            next_log_id.as_u64(),
+            next_log_id_exclusive.as_u64(),
+        )
+        .await?;
         for fragment in &bitmap_fragments {
             logs.store_bitmap_fragment(fragment, block.block_number)
                 .await?;

--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -51,6 +51,7 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
     // TODO: Individual writes are idempotent, but a partial failure leaves the block
     // incompletely written. Retry logic, logging, and metrics belong here once the
     // overall pipeline shape stabilizes.
+    /// Persists one finalized block and advances the published head on success.
     pub async fn ingest_block(&self, block: FinalizedBlock) -> Result<IngestOutcome> {
         let blocks = self.tables.blocks();
         let logs = self.tables.logs();
@@ -107,6 +108,7 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
         })
     }
 
+    /// Executes a finalized logs query over the current published head.
     pub async fn query_logs(&self, request: QueryLogsRequest) -> Result<QueryLogsResponse> {
         if request.limit == 0 {
             return Err(MonadChainDataError::InvalidRequest(

--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -16,6 +16,7 @@
 use crate::{
     error::{MonadChainDataError, Result},
     family::FinalizedBlock,
+    ingest::directory_compaction::compact_newly_sealed_log_directory_buckets,
     kernel::tables::Tables,
     logs::{LogIngestPlan, QueryLogsRequest, QueryLogsResponse},
     primitives::{
@@ -69,6 +70,7 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
             bitmap_fragments,
             written_logs,
         } = LogIngestPlan::build(&block, next_log_id)?;
+        let next_log_id_exclusive = block_record.logs.next_log_id()?;
         logs.store_block_blob(block.block_number, block_log_blob)
             .await?;
         logs.store_block_header(block.block_number, &block_log_header)
@@ -80,6 +82,12 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
                 block_record.logs.count,
             )
             .await?;
+        compact_newly_sealed_log_directory_buckets(
+            logs,
+            next_log_id.as_u64(),
+            next_log_id_exclusive.as_u64(),
+        )
+        .await?;
         for fragment in &bitmap_fragments {
             logs.store_bitmap_fragment(fragment, block.block_number)
                 .await?;

--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -51,6 +51,7 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
     // TODO: Individual writes are idempotent, but a partial failure leaves the block
     // incompletely written. Retry logic, logging, and metrics belong here once the
     // overall pipeline shape stabilizes.
+    /// Persists one finalized block and advances the published head on success.
     pub async fn ingest_block(&self, block: FinalizedBlock) -> Result<IngestOutcome> {
         let blocks = self.tables.blocks();
         let logs = self.tables.logs();
@@ -100,6 +101,7 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
         })
     }
 
+    /// Executes a finalized logs query over the current published head.
     pub async fn query_logs(&self, request: QueryLogsRequest) -> Result<QueryLogsResponse> {
         if request.limit == 0 {
             return Err(MonadChainDataError::InvalidRequest(

--- a/monad-chain-data/src/ingest/directory_compaction.rs
+++ b/monad-chain-data/src/ingest/directory_compaction.rs
@@ -1,0 +1,190 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{
+    error::{MonadChainDataError, Result},
+    kernel::{
+        primary_dir::{
+            bucket_start, PrimaryDirBucket, PrimaryDirFragment, PrimaryDirTables,
+            DIRECTORY_BUCKET_SIZE,
+        },
+        tables::LogTables,
+    },
+    store::{BlobStore, MetaStore},
+};
+
+/// Compacts every directory bucket sealed by the given ingest transition.
+pub(crate) async fn compact_newly_sealed_log_directory_buckets<M: MetaStore, B: BlobStore>(
+    logs: &LogTables<M, B>,
+    from_next_primary_id: u64,
+    next_primary_id: u64,
+) -> Result<()> {
+    compact_newly_sealed_buckets(logs.dir(), from_next_primary_id, next_primary_id).await
+}
+
+async fn compact_newly_sealed_buckets<M: MetaStore>(
+    dir: &PrimaryDirTables<M>,
+    from_next_primary_id: u64,
+    next_primary_id: u64,
+) -> Result<()> {
+    for sealed_bucket_start in sealed_ranges(from_next_primary_id, next_primary_id) {
+        let bucket =
+            compact_bucket_from_fragments(&dir.load_bucket_fragments(sealed_bucket_start).await?)?;
+        // Sealed fragments are intentionally retained after the compacted bucket
+        // is written. Reads prefer the bucket via `load_bucket`, so the fragments
+        // are unreferenced but kept available for replay/recovery. Eager deletion
+        // is deferred to a backend that exposes safe delete semantics.
+        dir.put_bucket(sealed_bucket_start, &bucket).await?;
+    }
+
+    Ok(())
+}
+
+fn compact_bucket_from_fragments(fragments: &[PrimaryDirFragment]) -> Result<PrimaryDirBucket> {
+    let Some(first_fragment) = fragments.first() else {
+        return Err(MonadChainDataError::MissingData(
+            "missing sealed primary directory bucket fragments",
+        ));
+    };
+    let last_fragment = fragments.last().expect("fragments.first() returned Some");
+    validate_fragment(first_fragment)?;
+
+    let start_block = first_fragment.block_number;
+    let mut first_primary_ids = Vec::with_capacity(fragments.len() + 1);
+    first_primary_ids.push(first_fragment.first_primary_id);
+
+    for window in fragments.windows(2) {
+        let [previous, fragment] = window else {
+            unreachable!("windows(2) yields slices of length 2");
+        };
+        validate_fragment(fragment)?;
+
+        if fragment.block_number != previous.block_number.saturating_add(1) {
+            return Err(MonadChainDataError::Decode(
+                "inconsistent primary directory bucket block sequence",
+            ));
+        }
+        if previous.end_primary_id_exclusive != fragment.first_primary_id {
+            return Err(MonadChainDataError::Decode(
+                "inconsistent primary directory bucket primary-id sequence",
+            ));
+        }
+
+        first_primary_ids.push(fragment.first_primary_id);
+    }
+
+    first_primary_ids.push(last_fragment.end_primary_id_exclusive);
+
+    PrimaryDirBucket::new(start_block, first_primary_ids)
+}
+
+fn sealed_ranges(from_next_primary_id: u64, next_primary_id: u64) -> Vec<u64> {
+    if next_primary_id <= from_next_primary_id {
+        return Vec::new();
+    }
+
+    let mut current_bucket_start = bucket_start(from_next_primary_id);
+    let mut out = Vec::new();
+    loop {
+        let bucket_end = current_bucket_start.saturating_add(DIRECTORY_BUCKET_SIZE);
+        if bucket_end > next_primary_id {
+            break;
+        }
+        if bucket_end > from_next_primary_id {
+            out.push(current_bucket_start);
+        }
+        current_bucket_start = current_bucket_start.saturating_add(DIRECTORY_BUCKET_SIZE);
+    }
+
+    out
+}
+
+fn validate_fragment(fragment: &PrimaryDirFragment) -> Result<()> {
+    if fragment.first_primary_id > fragment.end_primary_id_exclusive {
+        return Err(MonadChainDataError::Decode(
+            "primary directory fragment range inverted",
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        compact_bucket_from_fragments, sealed_ranges, PrimaryDirBucket, PrimaryDirFragment,
+        DIRECTORY_BUCKET_SIZE,
+    };
+
+    #[test]
+    fn compact_bucket_from_fragments_builds_summary_with_sentinel() {
+        let bucket = compact_bucket_from_fragments(&[
+            PrimaryDirFragment {
+                block_number: 7,
+                first_primary_id: 100,
+                end_primary_id_exclusive: 103,
+            },
+            PrimaryDirFragment {
+                block_number: 8,
+                first_primary_id: 103,
+                end_primary_id_exclusive: 103,
+            },
+            PrimaryDirFragment {
+                block_number: 9,
+                first_primary_id: 103,
+                end_primary_id_exclusive: 108,
+            },
+        ])
+        .expect("compact bucket");
+
+        assert_eq!(
+            bucket,
+            PrimaryDirBucket {
+                start_block: 7,
+                first_primary_ids: vec![100, 103, 103, 108],
+            }
+        );
+    }
+
+    #[test]
+    fn compact_bucket_from_fragments_rejects_noncontiguous_blocks() {
+        let error = compact_bucket_from_fragments(&[
+            PrimaryDirFragment {
+                block_number: 7,
+                first_primary_id: 100,
+                end_primary_id_exclusive: 103,
+            },
+            PrimaryDirFragment {
+                block_number: 9,
+                first_primary_id: 103,
+                end_primary_id_exclusive: 108,
+            },
+        ])
+        .expect_err("detect gap");
+
+        assert_eq!(
+            error.to_string(),
+            "decode error: inconsistent primary directory bucket block sequence"
+        );
+    }
+
+    #[test]
+    fn sealed_ranges_reports_each_crossed_bucket_boundary() {
+        assert_eq!(
+            sealed_ranges(DIRECTORY_BUCKET_SIZE - 2, DIRECTORY_BUCKET_SIZE * 2 + 3),
+            vec![0, DIRECTORY_BUCKET_SIZE]
+        );
+    }
+}

--- a/monad-chain-data/src/ingest/directory_compaction.rs
+++ b/monad-chain-data/src/ingest/directory_compaction.rs
@@ -1,0 +1,214 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{
+    error::{MonadChainDataError, Result},
+    kernel::{
+        primary_dir::{
+            bucket_start, PrimaryDirBucket, PrimaryDirFragment, PrimaryDirTables,
+            DIRECTORY_BUCKET_SIZE,
+        },
+        tables::LogTables,
+    },
+    store::{BlobStore, MetaStore},
+};
+
+/// Compacts every directory bucket sealed by the given ingest transition.
+pub(crate) async fn compact_newly_sealed_log_directory_buckets<M: MetaStore, B: BlobStore>(
+    logs: &LogTables<M, B>,
+    from_next_primary_id: u64,
+    next_primary_id: u64,
+) -> Result<()> {
+    compact_newly_sealed_buckets(logs.dir(), from_next_primary_id, next_primary_id).await
+}
+
+async fn compact_newly_sealed_buckets<M: MetaStore>(
+    dir: &PrimaryDirTables<M>,
+    from_next_primary_id: u64,
+    next_primary_id: u64,
+) -> Result<()> {
+    for sealed_bucket_start in sealed_ranges(from_next_primary_id, next_primary_id) {
+        let bucket =
+            compact_bucket_from_fragments(&dir.load_bucket_fragments(sealed_bucket_start).await?)?;
+        dir.put_bucket(sealed_bucket_start, &bucket).await?;
+    }
+
+    Ok(())
+}
+
+fn compact_bucket_from_fragments(fragments: &[PrimaryDirFragment]) -> Result<PrimaryDirBucket> {
+    let Some(first_fragment) = fragments.first() else {
+        return Err(MonadChainDataError::MissingData(
+            "missing sealed primary directory bucket fragments",
+        ));
+    };
+    validate_fragment(first_fragment)?;
+
+    let start_block = first_fragment.block_number;
+    let mut first_primary_ids = Vec::with_capacity(fragments.len() + 1);
+    first_primary_ids.push(first_fragment.first_primary_id);
+
+    for (index, fragment) in fragments.iter().enumerate().skip(1) {
+        validate_fragment(fragment)?;
+
+        let previous = &fragments[index - 1];
+        if fragment.block_number != previous.block_number.saturating_add(1) {
+            return Err(MonadChainDataError::Decode(
+                "inconsistent primary directory bucket block sequence",
+            ));
+        }
+        if previous.end_primary_id_exclusive != fragment.first_primary_id {
+            return Err(MonadChainDataError::Decode(
+                "inconsistent primary directory bucket primary-id sequence",
+            ));
+        }
+
+        first_primary_ids.push(fragment.first_primary_id);
+    }
+
+    first_primary_ids.push(
+        fragments
+            .last()
+            .map(|fragment| fragment.end_primary_id_exclusive)
+            .ok_or(MonadChainDataError::MissingData(
+                "missing sealed primary directory bucket fragments",
+            ))?,
+    );
+
+    let bucket = PrimaryDirBucket {
+        start_block,
+        first_primary_ids,
+    };
+    validate_bucket(&bucket)?;
+    Ok(bucket)
+}
+
+fn sealed_ranges(from_next_primary_id: u64, next_primary_id: u64) -> Vec<u64> {
+    if next_primary_id <= from_next_primary_id {
+        return Vec::new();
+    }
+
+    let mut current_bucket_start = bucket_start(from_next_primary_id);
+    let mut out = Vec::new();
+    loop {
+        let bucket_end = current_bucket_start.saturating_add(DIRECTORY_BUCKET_SIZE);
+        if bucket_end > next_primary_id {
+            break;
+        }
+        if bucket_end > from_next_primary_id {
+            out.push(current_bucket_start);
+        }
+        current_bucket_start = current_bucket_start.saturating_add(DIRECTORY_BUCKET_SIZE);
+    }
+
+    out
+}
+
+fn validate_bucket(bucket: &PrimaryDirBucket) -> Result<()> {
+    if bucket.first_primary_ids.len() < 2 {
+        return Err(MonadChainDataError::Decode(
+            "primary directory bucket missing sentinel",
+        ));
+    }
+    if bucket
+        .first_primary_ids
+        .windows(2)
+        .any(|window| window[0] > window[1])
+    {
+        return Err(MonadChainDataError::Decode(
+            "primary directory bucket ids must be nondecreasing",
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_fragment(fragment: &PrimaryDirFragment) -> Result<()> {
+    if fragment.first_primary_id > fragment.end_primary_id_exclusive {
+        return Err(MonadChainDataError::Decode(
+            "primary directory fragment range inverted",
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        compact_bucket_from_fragments, sealed_ranges, PrimaryDirBucket, PrimaryDirFragment,
+        DIRECTORY_BUCKET_SIZE,
+    };
+
+    #[test]
+    fn compact_bucket_from_fragments_builds_summary_with_sentinel() {
+        let bucket = compact_bucket_from_fragments(&[
+            PrimaryDirFragment {
+                block_number: 7,
+                first_primary_id: 100,
+                end_primary_id_exclusive: 103,
+            },
+            PrimaryDirFragment {
+                block_number: 8,
+                first_primary_id: 103,
+                end_primary_id_exclusive: 103,
+            },
+            PrimaryDirFragment {
+                block_number: 9,
+                first_primary_id: 103,
+                end_primary_id_exclusive: 108,
+            },
+        ])
+        .expect("compact bucket");
+
+        assert_eq!(
+            bucket,
+            PrimaryDirBucket {
+                start_block: 7,
+                first_primary_ids: vec![100, 103, 103, 108],
+            }
+        );
+    }
+
+    #[test]
+    fn compact_bucket_from_fragments_rejects_noncontiguous_blocks() {
+        let error = compact_bucket_from_fragments(&[
+            PrimaryDirFragment {
+                block_number: 7,
+                first_primary_id: 100,
+                end_primary_id_exclusive: 103,
+            },
+            PrimaryDirFragment {
+                block_number: 9,
+                first_primary_id: 103,
+                end_primary_id_exclusive: 108,
+            },
+        ])
+        .expect_err("detect gap");
+
+        assert_eq!(
+            error.to_string(),
+            "decode error: inconsistent primary directory bucket block sequence"
+        );
+    }
+
+    #[test]
+    fn sealed_ranges_reports_each_crossed_bucket_boundary() {
+        assert_eq!(
+            sealed_ranges(DIRECTORY_BUCKET_SIZE - 2, DIRECTORY_BUCKET_SIZE * 2 + 3),
+            vec![0, DIRECTORY_BUCKET_SIZE]
+        );
+    }
+}

--- a/monad-chain-data/src/ingest/mod.rs
+++ b/monad-chain-data/src/ingest/mod.rs
@@ -13,26 +13,4 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pub mod api;
-pub mod error;
-pub mod family;
-pub mod ingest;
-pub mod kernel;
-pub mod logs;
-pub mod primitives;
-pub mod query;
-pub mod store;
-
-pub use alloy_primitives::{Address, Bytes, Log, LogData, B256};
-pub use api::{IngestOutcome, MonadChainDataService};
-pub use family::{FinalizedBlock, Hash32};
-pub use kernel::tables::Tables;
-pub use logs::{LogEntry, LogFilter, QueryLogsRequest, QueryLogsResponse};
-pub use primitives::{
-    page::{QueryOrder, DEFAULT_QUERY_LIMIT},
-    refs::BlockRef,
-    state::{BlockRecord, FamilyWindowRecord, LogId},
-};
-pub use store::{InMemoryBlobStore, InMemoryMetaStore};
-
-pub type Topic = B256;
+pub(crate) mod directory_compaction;

--- a/monad-chain-data/src/kernel/bitmap.rs
+++ b/monad-chain-data/src/kernel/bitmap.rs
@@ -43,6 +43,7 @@ pub struct BitmapFragmentWrite {
     pub bitmap_blob: Bytes,
 }
 
+/// Encodes one bitmap blob into the stored fragment/page format.
 pub fn encode_bitmap_blob(blob: &BitmapBlob) -> Result<Bytes> {
     let mut payload = Vec::new();
     blob.bitmap
@@ -58,6 +59,7 @@ pub fn encode_bitmap_blob(blob: &BitmapBlob) -> Result<Bytes> {
     Ok(Bytes::from(out))
 }
 
+/// Decodes one stored bitmap blob and validates its framing header.
 pub fn decode_bitmap_blob(bytes: &[u8]) -> Result<BitmapBlob> {
     let header = bytes
         .get(..BITMAP_BLOB_HEADER_LEN)
@@ -153,6 +155,7 @@ pub fn stream_page_key(stream_id: &str, page_start_local: u32) -> Vec<u8> {
     key
 }
 
+/// Expands one log into the indexed stream entries written at ingest time.
 pub fn stream_entries_for_log(
     address: &[u8],
     topics: &[alloy_primitives::B256],

--- a/monad-chain-data/src/kernel/bitmap.rs
+++ b/monad-chain-data/src/kernel/bitmap.rs
@@ -42,6 +42,7 @@ pub struct BitmapFragmentWrite {
     pub bitmap_blob: Bytes,
 }
 
+/// Encodes one bitmap blob into the stored fragment/page format.
 pub fn encode_bitmap_blob(blob: &BitmapBlob) -> Result<Bytes> {
     let mut payload = Vec::new();
     blob.bitmap
@@ -57,6 +58,7 @@ pub fn encode_bitmap_blob(blob: &BitmapBlob) -> Result<Bytes> {
     Ok(Bytes::from(out))
 }
 
+/// Decodes one stored bitmap blob and validates its framing header.
 pub fn decode_bitmap_blob(bytes: &[u8]) -> Result<BitmapBlob> {
     let header = bytes
         .get(..BITMAP_BLOB_HEADER_LEN)
@@ -152,6 +154,7 @@ pub fn stream_page_key(stream_id: &str, page_start_local: u32) -> Vec<u8> {
     key
 }
 
+/// Expands one log into the indexed stream entries written at ingest time.
 pub fn stream_entries_for_log(
     address: &[u8],
     topics: &[alloy_primitives::B256],

--- a/monad-chain-data/src/kernel/primary_dir.rs
+++ b/monad-chain-data/src/kernel/primary_dir.rs
@@ -16,11 +16,53 @@
 use bytes::Bytes;
 
 use crate::{
-    error::Result,
-    store::{MetaStore, ScannableKvTable},
+    error::{MonadChainDataError, Result},
+    store::{KvTable, MetaStore, ScannableKvTable},
 };
 
 pub const DIRECTORY_BUCKET_SIZE: u64 = 10_000;
+
+#[derive(Debug, Clone, PartialEq, Eq, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
+pub struct PrimaryDirBucket {
+    pub start_block: u64,
+    pub first_primary_ids: Vec<u64>,
+}
+
+impl PrimaryDirBucket {
+    /// Constructs a bucket after enforcing the sentinel and nondecreasing
+    /// invariants. All bucket producers — RLP decode and ingest-side
+    /// compaction — funnel through here so the type's invariants live in
+    /// one place.
+    pub(crate) fn new(start_block: u64, first_primary_ids: Vec<u64>) -> Result<Self> {
+        if first_primary_ids.len() < 2 {
+            return Err(MonadChainDataError::Decode(
+                "primary directory bucket missing sentinel",
+            ));
+        }
+        if first_primary_ids
+            .windows(2)
+            .any(|window| window[0] > window[1])
+        {
+            return Err(MonadChainDataError::Decode(
+                "primary directory bucket ids must be nondecreasing",
+            ));
+        }
+        Ok(Self {
+            start_block,
+            first_primary_ids,
+        })
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        alloy_rlp::encode(self)
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        let raw: Self = alloy_rlp::decode_exact(bytes)
+            .map_err(|_| MonadChainDataError::Decode("invalid primary directory bucket rlp"))?;
+        Self::new(raw.start_block, raw.first_primary_ids)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
 pub struct PrimaryDirFragment {
@@ -43,11 +85,12 @@ impl PrimaryDirFragment {
 
 pub struct PrimaryDirTables<M: MetaStore> {
     fragments: ScannableKvTable<M>,
+    buckets: KvTable<M>,
 }
 
 impl<M: MetaStore> PrimaryDirTables<M> {
-    pub fn new(fragments: ScannableKvTable<M>) -> Self {
-        Self { fragments }
+    pub fn new(fragments: ScannableKvTable<M>, buckets: KvTable<M>) -> Self {
+        Self { fragments, buckets }
     }
 
     /// Writes a directory fragment for the given block into every 10k bucket
@@ -85,6 +128,17 @@ impl<M: MetaStore> PrimaryDirTables<M> {
         Ok(())
     }
 
+    /// Loads the compacted summary for one sealed 10k bucket.
+    pub async fn load_bucket(&self, bucket_start: u64) -> Result<Option<PrimaryDirBucket>> {
+        let key = u64_key(bucket_start);
+        let Some(record) = self.buckets.get(&key).await? else {
+            return Ok(None);
+        };
+
+        Ok(Some(PrimaryDirBucket::decode(&record.value)?))
+    }
+
+    /// Loads all retained fragments for one 10k bucket.
     pub async fn load_bucket_fragments(
         &self,
         bucket_start: u64,
@@ -106,6 +160,12 @@ impl<M: MetaStore> PrimaryDirTables<M> {
         }
 
         Ok(fragments)
+    }
+
+    pub async fn put_bucket(&self, bucket_start: u64, bucket: &PrimaryDirBucket) -> Result<()> {
+        let key = u64_key(bucket_start);
+        self.buckets.put(&key, Bytes::from(bucket.encode())).await?;
+        Ok(())
     }
 
     async fn put_fragment(

--- a/monad-chain-data/src/kernel/primary_dir.rs
+++ b/monad-chain-data/src/kernel/primary_dir.rs
@@ -16,11 +16,30 @@
 use bytes::Bytes;
 
 use crate::{
-    error::Result,
-    store::{MetaStore, ScannableKvTable},
+    error::{MonadChainDataError, Result},
+    store::{KvTable, MetaStore, ScannableKvTable},
 };
 
 pub const DIRECTORY_BUCKET_SIZE: u64 = 10_000;
+
+#[derive(Debug, Clone, PartialEq, Eq, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
+pub struct PrimaryDirBucket {
+    pub start_block: u64,
+    pub first_primary_ids: Vec<u64>,
+}
+
+impl PrimaryDirBucket {
+    pub fn encode(&self) -> Vec<u8> {
+        alloy_rlp::encode(self)
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        let bucket = alloy_rlp::decode_exact(bytes)
+            .map_err(|_| MonadChainDataError::Decode("invalid primary directory bucket rlp"))?;
+        validate_bucket(&bucket)?;
+        Ok(bucket)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
 pub struct PrimaryDirFragment {
@@ -43,11 +62,12 @@ impl PrimaryDirFragment {
 
 pub struct PrimaryDirTables<M: MetaStore> {
     fragments: ScannableKvTable<M>,
+    buckets: KvTable<M>,
 }
 
 impl<M: MetaStore> PrimaryDirTables<M> {
-    pub fn new(fragments: ScannableKvTable<M>) -> Self {
-        Self { fragments }
+    pub fn new(fragments: ScannableKvTable<M>, buckets: KvTable<M>) -> Self {
+        Self { fragments, buckets }
     }
 
     /// Writes a directory fragment for the given block into every 10k bucket
@@ -85,6 +105,17 @@ impl<M: MetaStore> PrimaryDirTables<M> {
         Ok(())
     }
 
+    /// Loads the compacted summary for one sealed 10k bucket.
+    pub async fn load_bucket(&self, bucket_start: u64) -> Result<Option<PrimaryDirBucket>> {
+        let key = u64_key(bucket_start);
+        let Some(record) = self.buckets.get(&key).await? else {
+            return Ok(None);
+        };
+
+        Ok(Some(PrimaryDirBucket::decode(&record.value)?))
+    }
+
+    /// Loads all retained fragments for one 10k bucket.
     pub async fn load_bucket_fragments(
         &self,
         bucket_start: u64,
@@ -108,6 +139,12 @@ impl<M: MetaStore> PrimaryDirTables<M> {
         Ok(fragments)
     }
 
+    pub async fn put_bucket(&self, bucket_start: u64, bucket: &PrimaryDirBucket) -> Result<()> {
+        let key = u64_key(bucket_start);
+        self.buckets.put(&key, Bytes::from(bucket.encode())).await?;
+        Ok(())
+    }
+
     async fn put_fragment(
         &self,
         bucket_start: u64,
@@ -125,6 +162,25 @@ impl<M: MetaStore> PrimaryDirTables<M> {
 
 pub fn bucket_start(primary_id: u64) -> u64 {
     aligned_u64_start(primary_id, DIRECTORY_BUCKET_SIZE)
+}
+
+fn validate_bucket(bucket: &PrimaryDirBucket) -> Result<()> {
+    if bucket.first_primary_ids.len() < 2 {
+        return Err(MonadChainDataError::Decode(
+            "primary directory bucket missing sentinel",
+        ));
+    }
+    if bucket
+        .first_primary_ids
+        .windows(2)
+        .any(|window| window[0] > window[1])
+    {
+        return Err(MonadChainDataError::Decode(
+            "primary directory bucket ids must be nondecreasing",
+        ));
+    }
+
+    Ok(())
 }
 
 fn aligned_u64_start(value: u64, alignment: u64) -> u64 {

--- a/monad-chain-data/src/kernel/primary_dir.rs
+++ b/monad-chain-data/src/kernel/primary_dir.rs
@@ -20,7 +20,7 @@ use crate::{
     store::{MetaStore, ScannableKvTable},
 };
 
-pub const DIRECTORY_SUB_BUCKET_SIZE: u64 = 10_000;
+pub const DIRECTORY_BUCKET_SIZE: u64 = 10_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
 pub struct PrimaryDirFragment {
@@ -50,10 +50,10 @@ impl<M: MetaStore> PrimaryDirTables<M> {
         Self { fragments }
     }
 
-    /// Writes a directory fragment for the given block into every sub-bucket
-    /// its log-ID window overlaps. A single block can span multiple sub-buckets
+    /// Writes a directory fragment for the given block into every 10k bucket
+    /// its log-ID window overlaps. A single block can span multiple buckets
     /// when its ID range crosses a 10k boundary, so the same fragment is stored
-    /// in each one to allow readers to locate it from any covered sub-bucket.
+    /// in each one to allow readers to locate it from any covered bucket.
     pub async fn persist_block_fragment(
         &self,
         block_number: u64,
@@ -66,31 +66,30 @@ impl<M: MetaStore> PrimaryDirTables<M> {
             end_primary_id_exclusive: first_primary_id.saturating_add(u64::from(count)),
         };
 
-        let mut current_sub_bucket_start = sub_bucket_start(first_primary_id);
-        let last_sub_bucket_start = if count == 0 {
-            current_sub_bucket_start
+        let mut current_bucket_start = bucket_start(first_primary_id);
+        let last_bucket_start = if count == 0 {
+            current_bucket_start
         } else {
-            sub_bucket_start(fragment.end_primary_id_exclusive.saturating_sub(1))
+            bucket_start(fragment.end_primary_id_exclusive.saturating_sub(1))
         };
 
         loop {
-            self.put_fragment(current_sub_bucket_start, block_number, &fragment)
+            self.put_fragment(current_bucket_start, block_number, &fragment)
                 .await?;
-            if current_sub_bucket_start == last_sub_bucket_start {
+            if current_bucket_start == last_bucket_start {
                 break;
             }
-            current_sub_bucket_start =
-                current_sub_bucket_start.saturating_add(DIRECTORY_SUB_BUCKET_SIZE);
+            current_bucket_start = current_bucket_start.saturating_add(DIRECTORY_BUCKET_SIZE);
         }
 
         Ok(())
     }
 
-    pub async fn load_sub_bucket_fragments(
+    pub async fn load_bucket_fragments(
         &self,
-        sub_bucket_start: u64,
+        bucket_start: u64,
     ) -> Result<Vec<PrimaryDirFragment>> {
-        let partition = u64_key(sub_bucket_start);
+        let partition = u64_key(bucket_start);
         let page = self
             .fragments
             .list_prefix(&partition, &[], None, usize::MAX)
@@ -111,11 +110,11 @@ impl<M: MetaStore> PrimaryDirTables<M> {
 
     async fn put_fragment(
         &self,
-        sub_bucket_start: u64,
+        bucket_start: u64,
         block_number: u64,
         fragment: &PrimaryDirFragment,
     ) -> Result<()> {
-        let partition = u64_key(sub_bucket_start);
+        let partition = u64_key(bucket_start);
         let clustering = u64_key(block_number);
         self.fragments
             .put(&partition, &clustering, Bytes::from(fragment.encode()))
@@ -124,8 +123,8 @@ impl<M: MetaStore> PrimaryDirTables<M> {
     }
 }
 
-pub fn sub_bucket_start(primary_id: u64) -> u64 {
-    aligned_u64_start(primary_id, DIRECTORY_SUB_BUCKET_SIZE)
+pub fn bucket_start(primary_id: u64) -> u64 {
+    aligned_u64_start(primary_id, DIRECTORY_BUCKET_SIZE)
 }
 
 fn aligned_u64_start(value: u64, alignment: u64) -> u64 {

--- a/monad-chain-data/src/kernel/tables.rs
+++ b/monad-chain-data/src/kernel/tables.rs
@@ -127,6 +127,7 @@ impl<M: MetaStore> BlockTables<M> {
         Ok(())
     }
 
+    /// Validates that a new block extends the currently published chain.
     pub async fn validate_continuity(
         &self,
         block: &FinalizedBlock,
@@ -237,11 +238,11 @@ impl<M: MetaStore, B: BlobStore> LogTables<M, B> {
         Ok(())
     }
 
-    pub async fn load_sub_bucket_fragments(
+    pub async fn load_bucket_fragments(
         &self,
-        sub_bucket_start: u64,
+        bucket_start: u64,
     ) -> Result<Vec<PrimaryDirFragment>> {
-        self.dir.load_sub_bucket_fragments(sub_bucket_start).await
+        self.dir.load_bucket_fragments(bucket_start).await
     }
 
     pub async fn store_bitmap_fragment(

--- a/monad-chain-data/src/kernel/tables.rs
+++ b/monad-chain-data/src/kernel/tables.rs
@@ -20,7 +20,7 @@ use crate::{
     family::FinalizedBlock,
     kernel::{
         bitmap::{stream_page_key, BitmapFragmentWrite},
-        primary_dir::{PrimaryDirFragment, PrimaryDirTables},
+        primary_dir::{PrimaryDirBucket, PrimaryDirFragment, PrimaryDirTables},
     },
     logs::LogBlockHeader,
     primitives::state::{BlockRecord, PublicationState},
@@ -173,6 +173,7 @@ pub struct LogTables<M: MetaStore, B: BlobStore> {
 impl<M: MetaStore, B: BlobStore> LogTables<M, B> {
     pub const BLOCK_LOG_HEADER_TABLE: TableId = TableId::new("block_log_header");
     pub const BLOCK_LOG_BLOB_TABLE: BlobTableId = BlobTableId::new("block_log_blob");
+    pub const LOG_DIR_BUCKET_TABLE: TableId = TableId::new("log_dir_bucket");
     pub const LOG_DIR_BY_BLOCK_TABLE: ScannableTableId = ScannableTableId::new("log_dir_by_block");
     pub const LOG_BITMAP_BY_BLOCK_TABLE: ScannableTableId =
         ScannableTableId::new("log_bitmap_by_block");
@@ -181,7 +182,10 @@ impl<M: MetaStore, B: BlobStore> LogTables<M, B> {
         Self {
             block_headers: meta_store.table(Self::BLOCK_LOG_HEADER_TABLE),
             block_blobs: blob_store.table(Self::BLOCK_LOG_BLOB_TABLE),
-            dir: PrimaryDirTables::new(meta_store.scannable_table(Self::LOG_DIR_BY_BLOCK_TABLE)),
+            dir: PrimaryDirTables::new(
+                meta_store.scannable_table(Self::LOG_DIR_BY_BLOCK_TABLE),
+                meta_store.table(Self::LOG_DIR_BUCKET_TABLE),
+            ),
             bitmap_fragments: meta_store.scannable_table(Self::LOG_BITMAP_BY_BLOCK_TABLE),
         }
     }
@@ -243,6 +247,10 @@ impl<M: MetaStore, B: BlobStore> LogTables<M, B> {
         bucket_start: u64,
     ) -> Result<Vec<PrimaryDirFragment>> {
         self.dir.load_bucket_fragments(bucket_start).await
+    }
+
+    pub async fn load_bucket(&self, bucket_start: u64) -> Result<Option<PrimaryDirBucket>> {
+        self.dir.load_bucket(bucket_start).await
     }
 
     pub async fn store_bitmap_fragment(

--- a/monad-chain-data/src/logs/ingest.rs
+++ b/monad-chain-data/src/logs/ingest.rs
@@ -33,6 +33,7 @@ pub struct LogIngestPlan {
 }
 
 impl LogIngestPlan {
+    /// Derives the per-block log artifacts and index fragments for one finalized block.
     pub fn build(block: &FinalizedBlock, first_log_id: LogId) -> Result<Self> {
         // First pass writes only per-block payload/header artifacts plus the shared block record.
         // Later commits add global log IDs, directory fragments, and bitmap index artifacts.

--- a/monad-chain-data/src/logs/materialize.rs
+++ b/monad-chain-data/src/logs/materialize.rs
@@ -167,6 +167,7 @@ impl<'a, M: MetaStore, B: BlobStore> LogMaterializer<'a, M, B> {
         Ok(BlockRef::from(&block_record))
     }
 
+    /// Resolves and materializes one log by block number and block-local ordinal.
     pub async fn load_log_at(&self, block_number: u64, log_idx: usize) -> Result<LogEntry> {
         let block_record = self
             .tables
@@ -198,6 +199,7 @@ impl<'a, M: MetaStore, B: BlobStore> LogMaterializer<'a, M, B> {
         Ok(raw.into_log_entry(block_record.block_number, block_record.block_hash))
     }
 
+    /// Loads and filters all logs for one block in the requested output order.
     pub async fn load_filtered_block_logs_for_block(
         &self,
         block_number: u64,

--- a/monad-chain-data/src/primitives/range.rs
+++ b/monad-chain-data/src/primitives/range.rs
@@ -32,6 +32,7 @@ pub struct ResolvedBlockWindow {
 }
 
 impl ResolvedBlockWindow {
+    /// Resolves a query's inclusive block range against the published head.
     pub async fn resolve<M: MetaStore>(
         request: &QueryLogsRequest,
         published_head: u64,

--- a/monad-chain-data/src/query/directory_resolver.rs
+++ b/monad-chain-data/src/query/directory_resolver.rs
@@ -1,0 +1,72 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::{hash_map::Entry, HashMap};
+
+use crate::{
+    error::Result,
+    kernel::{
+        primary_dir::{bucket_start, PrimaryDirFragment},
+        tables::Tables,
+    },
+    primitives::state::LogId,
+    store::{BlobStore, MetaStore},
+};
+
+/// Resolves a global log ID to its block number and position within that block.
+///
+/// Caches directory bucket fragments to avoid redundant lookups when
+/// resolving many IDs from the same region.
+pub(super) struct LogIdResolver<'a, M: MetaStore, B: BlobStore> {
+    tables: &'a Tables<M, B>,
+    fragment_cache: HashMap<u64, Vec<PrimaryDirFragment>>,
+}
+
+impl<'a, M: MetaStore, B: BlobStore> LogIdResolver<'a, M, B> {
+    pub(super) fn new(tables: &'a Tables<M, B>) -> Self {
+        Self {
+            tables,
+            fragment_cache: HashMap::new(),
+        }
+    }
+
+    pub(super) async fn resolve(&mut self, log_id: LogId) -> Result<Option<ResolvedLogLocation>> {
+        let bucket = bucket_start(log_id.as_u64());
+        if let Entry::Vacant(entry) = self.fragment_cache.entry(bucket) {
+            entry.insert(self.tables.logs().load_bucket_fragments(bucket).await?);
+        }
+
+        let Some(fragments) = self.fragment_cache.get(&bucket) else {
+            return Ok(None);
+        };
+        let Some(fragment) = fragments.iter().find(|fragment| {
+            log_id.as_u64() >= fragment.first_primary_id
+                && log_id.as_u64() < fragment.end_primary_id_exclusive
+        }) else {
+            return Ok(None);
+        };
+
+        Ok(Some(ResolvedLogLocation {
+            block_number: fragment.block_number,
+            log_block_idx: log_id.idx_in_block(LogId::new(fragment.first_primary_id))?,
+        }))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ResolvedLogLocation {
+    pub(super) block_number: u64,
+    pub(super) log_block_idx: usize,
+}

--- a/monad-chain-data/src/query/directory_resolver.rs
+++ b/monad-chain-data/src/query/directory_resolver.rs
@@ -18,7 +18,7 @@ use std::collections::{hash_map::Entry, HashMap};
 use crate::{
     error::{MonadChainDataError, Result},
     kernel::{
-        primary_dir::{bucket_start, PrimaryDirFragment},
+        primary_dir::{bucket_start, PrimaryDirBucket, PrimaryDirFragment},
         tables::Tables,
     },
     primitives::state::LogId,
@@ -27,42 +27,39 @@ use crate::{
 
 /// Resolves a global log ID to its block number and position within that block.
 ///
-/// Caches directory bucket fragments to avoid redundant lookups when
-/// resolving many IDs from the same region.
+/// Caches the chosen directory source for each 10k bucket so repeated log-id
+/// lookups do not re-read summaries or fragments.
 pub(super) struct LogIdResolver<'a, M: MetaStore, B: BlobStore> {
     tables: &'a Tables<M, B>,
-    fragment_cache: HashMap<u64, Vec<PrimaryDirFragment>>,
+    bucket_cache: HashMap<u64, CachedBucket>,
 }
 
 impl<'a, M: MetaStore, B: BlobStore> LogIdResolver<'a, M, B> {
     pub(super) fn new(tables: &'a Tables<M, B>) -> Self {
         Self {
             tables,
-            fragment_cache: HashMap::new(),
+            bucket_cache: HashMap::new(),
         }
     }
 
     pub(super) async fn resolve(&mut self, log_id: LogId) -> Result<Option<ResolvedLogLocation>> {
         let bucket = bucket_start(log_id.as_u64());
-        if let Entry::Vacant(entry) = self.fragment_cache.entry(bucket) {
-            entry.insert(self.tables.logs().load_bucket_fragments(bucket).await?);
+        if let Entry::Vacant(entry) = self.bucket_cache.entry(bucket) {
+            let cached = if let Some(summary) = self.tables.logs().load_bucket(bucket).await? {
+                CachedBucket::Summary(summary)
+            } else {
+                CachedBucket::Fragments(self.tables.logs().load_bucket_fragments(bucket).await?)
+            };
+            entry.insert(cached);
         }
 
-        let Some(fragments) = self.fragment_cache.get(&bucket) else {
-            return Ok(None);
-        };
-        let Some(fragment) = fragments.iter().find(|fragment| {
-            log_id.as_u64() >= fragment.first_primary_id
-                && log_id.as_u64() < fragment.end_primary_id_exclusive
-        }) else {
-            return Ok(None);
-        };
-
-        Ok(Some(ResolvedLogLocation {
-            block_number: fragment.block_number,
-            log_block_idx: usize::try_from(log_id.as_u64() - fragment.first_primary_id)
-                .map_err(|_| MonadChainDataError::Decode("log block index overflow"))?,
-        }))
+        let cached = self
+            .bucket_cache
+            .get(&bucket)
+            .ok_or(MonadChainDataError::Decode(
+                "missing cached log directory bucket",
+            ))?;
+        cached.resolve(log_id)
     }
 }
 
@@ -70,4 +67,127 @@ impl<'a, M: MetaStore, B: BlobStore> LogIdResolver<'a, M, B> {
 pub(super) struct ResolvedLogLocation {
     pub(super) block_number: u64,
     pub(super) log_block_idx: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CachedBucket {
+    Summary(PrimaryDirBucket),
+    Fragments(Vec<PrimaryDirFragment>),
+}
+
+impl CachedBucket {
+    fn resolve(&self, log_id: LogId) -> Result<Option<ResolvedLogLocation>> {
+        match self {
+            Self::Summary(bucket) => resolved_location_from_bucket(bucket, log_id)?
+                .ok_or(MonadChainDataError::Decode(
+                    "compacted primary directory bucket missing queried log id",
+                ))
+                .map(Some),
+            Self::Fragments(fragments) => resolved_location_from_fragments(fragments, log_id)?
+                .ok_or(MonadChainDataError::Decode(
+                    "primary directory fragments missing queried log id",
+                ))
+                .map(Some),
+        }
+    }
+}
+
+fn resolved_location_from_bucket(
+    bucket: &PrimaryDirBucket,
+    log_id: LogId,
+) -> Result<Option<ResolvedLogLocation>> {
+    let Some(entry_index) = containing_bucket_entry(bucket, log_id.as_u64()) else {
+        return Ok(None);
+    };
+
+    Ok(Some(ResolvedLogLocation {
+        block_number: bucket.start_block + entry_index as u64,
+        log_block_idx: usize::try_from(log_id.as_u64() - bucket.first_primary_ids[entry_index])
+            .map_err(|_| MonadChainDataError::Decode("log block index overflow"))?,
+    }))
+}
+
+fn containing_bucket_entry(bucket: &PrimaryDirBucket, log_id: u64) -> Option<usize> {
+    if bucket.first_primary_ids.len() < 2 {
+        return None;
+    }
+
+    let upper = bucket
+        .first_primary_ids
+        .partition_point(|first_primary_id| *first_primary_id <= log_id);
+    if upper == 0 || upper >= bucket.first_primary_ids.len() {
+        return None;
+    }
+
+    let entry_index = upper - 1;
+    let end = bucket.first_primary_ids[upper];
+    (log_id < end).then_some(entry_index)
+}
+
+fn resolved_location_from_fragments(
+    fragments: &[PrimaryDirFragment],
+    log_id: LogId,
+) -> Result<Option<ResolvedLogLocation>> {
+    let Some(fragment) = fragments.iter().find(|fragment| {
+        log_id.as_u64() >= fragment.first_primary_id
+            && log_id.as_u64() < fragment.end_primary_id_exclusive
+    }) else {
+        return Ok(None);
+    };
+
+    Ok(Some(ResolvedLogLocation {
+        block_number: fragment.block_number,
+        log_block_idx: usize::try_from(log_id.as_u64() - fragment.first_primary_id)
+            .map_err(|_| MonadChainDataError::Decode("log block index overflow"))?,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        containing_bucket_entry, resolved_location_from_bucket, CachedBucket, PrimaryDirFragment,
+    };
+    use crate::{kernel::primary_dir::PrimaryDirBucket, primitives::state::LogId};
+
+    #[test]
+    fn bucket_lookup_uses_last_duplicate_boundary() {
+        let bucket = PrimaryDirBucket {
+            start_block: 50,
+            first_primary_ids: vec![1000, 1003, 1003, 1008],
+        };
+
+        assert_eq!(containing_bucket_entry(&bucket, 1006), Some(2));
+
+        let location =
+            resolved_location_from_bucket(&bucket, LogId::new(1006)).expect("resolve bucket");
+        let location = location.expect("contained");
+        assert_eq!(location.block_number, 52);
+        assert_eq!(location.log_block_idx, 3);
+    }
+
+    #[test]
+    fn bucket_lookup_rejects_ids_past_the_sentinel() {
+        let bucket = PrimaryDirBucket {
+            start_block: 50,
+            first_primary_ids: vec![1000, 1003, 1003, 1008],
+        };
+
+        assert_eq!(containing_bucket_entry(&bucket, 1008), None);
+    }
+
+    #[test]
+    fn fragment_lookup_errors_when_candidate_id_is_missing() {
+        let error = CachedBucket::Fragments(vec![PrimaryDirFragment {
+            block_number: 7,
+            first_primary_id: 100,
+            end_primary_id_exclusive: 103,
+        }])
+        .resolve(LogId::new(104))
+        .expect_err("missing fragment candidate should fail loud");
+
+        assert_eq!(
+            error.to_string(),
+            "decode error: primary directory fragments missing queried log id"
+        );
+    }
 }

--- a/monad-chain-data/src/query/directory_resolver.rs
+++ b/monad-chain-data/src/query/directory_resolver.rs
@@ -16,9 +16,9 @@
 use std::collections::{hash_map::Entry, HashMap};
 
 use crate::{
-    error::Result,
+    error::{MonadChainDataError, Result},
     kernel::{
-        primary_dir::{bucket_start, PrimaryDirFragment},
+        primary_dir::{bucket_start, PrimaryDirBucket, PrimaryDirFragment},
         tables::Tables,
     },
     primitives::state::LogId,
@@ -27,41 +27,39 @@ use crate::{
 
 /// Resolves a global log ID to its block number and position within that block.
 ///
-/// Caches directory bucket fragments to avoid redundant lookups when
-/// resolving many IDs from the same region.
+/// Caches the chosen directory source for each 10k bucket so repeated log-id
+/// lookups do not re-read summaries or fragments.
 pub(super) struct LogIdResolver<'a, M: MetaStore, B: BlobStore> {
     tables: &'a Tables<M, B>,
-    fragment_cache: HashMap<u64, Vec<PrimaryDirFragment>>,
+    bucket_cache: HashMap<u64, CachedBucket>,
 }
 
 impl<'a, M: MetaStore, B: BlobStore> LogIdResolver<'a, M, B> {
     pub(super) fn new(tables: &'a Tables<M, B>) -> Self {
         Self {
             tables,
-            fragment_cache: HashMap::new(),
+            bucket_cache: HashMap::new(),
         }
     }
 
     pub(super) async fn resolve(&mut self, log_id: LogId) -> Result<Option<ResolvedLogLocation>> {
         let bucket = bucket_start(log_id.as_u64());
-        if let Entry::Vacant(entry) = self.fragment_cache.entry(bucket) {
-            entry.insert(self.tables.logs().load_bucket_fragments(bucket).await?);
+        if let Entry::Vacant(entry) = self.bucket_cache.entry(bucket) {
+            let cached = if let Some(summary) = self.tables.logs().load_bucket(bucket).await? {
+                CachedBucket::Summary(summary)
+            } else {
+                CachedBucket::Fragments(self.tables.logs().load_bucket_fragments(bucket).await?)
+            };
+            entry.insert(cached);
         }
 
-        let Some(fragments) = self.fragment_cache.get(&bucket) else {
-            return Ok(None);
-        };
-        let Some(fragment) = fragments.iter().find(|fragment| {
-            log_id.as_u64() >= fragment.first_primary_id
-                && log_id.as_u64() < fragment.end_primary_id_exclusive
-        }) else {
-            return Ok(None);
-        };
-
-        Ok(Some(ResolvedLogLocation {
-            block_number: fragment.block_number,
-            log_block_idx: log_id.idx_in_block(LogId::new(fragment.first_primary_id))?,
-        }))
+        let cached = self
+            .bucket_cache
+            .get(&bucket)
+            .ok_or(MonadChainDataError::Decode(
+                "missing cached log directory bucket",
+            ))?;
+        cached.resolve(log_id)
     }
 }
 
@@ -69,4 +67,125 @@ impl<'a, M: MetaStore, B: BlobStore> LogIdResolver<'a, M, B> {
 pub(super) struct ResolvedLogLocation {
     pub(super) block_number: u64,
     pub(super) log_block_idx: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CachedBucket {
+    Summary(PrimaryDirBucket),
+    Fragments(Vec<PrimaryDirFragment>),
+}
+
+impl CachedBucket {
+    fn resolve(&self, log_id: LogId) -> Result<Option<ResolvedLogLocation>> {
+        match self {
+            Self::Summary(bucket) => resolved_location_from_bucket(bucket, log_id)?
+                .ok_or(MonadChainDataError::Decode(
+                    "compacted primary directory bucket missing queried log id",
+                ))
+                .map(Some),
+            Self::Fragments(fragments) => resolved_location_from_fragments(fragments, log_id)?
+                .ok_or(MonadChainDataError::Decode(
+                    "primary directory fragments missing queried log id",
+                ))
+                .map(Some),
+        }
+    }
+}
+
+fn resolved_location_from_bucket(
+    bucket: &PrimaryDirBucket,
+    log_id: LogId,
+) -> Result<Option<ResolvedLogLocation>> {
+    let Some(entry_index) = containing_bucket_entry(bucket, log_id.as_u64()) else {
+        return Ok(None);
+    };
+
+    Ok(Some(ResolvedLogLocation {
+        block_number: bucket.start_block.saturating_add(entry_index as u64),
+        log_block_idx: log_id.idx_in_block(LogId::new(bucket.first_primary_ids[entry_index]))?,
+    }))
+}
+
+fn containing_bucket_entry(bucket: &PrimaryDirBucket, log_id: u64) -> Option<usize> {
+    if bucket.first_primary_ids.len() < 2 {
+        return None;
+    }
+
+    let upper = bucket
+        .first_primary_ids
+        .partition_point(|first_primary_id| *first_primary_id <= log_id);
+    if upper == 0 || upper >= bucket.first_primary_ids.len() {
+        return None;
+    }
+
+    let entry_index = upper - 1;
+    let end = bucket.first_primary_ids[upper];
+    (log_id < end).then_some(entry_index)
+}
+
+fn resolved_location_from_fragments(
+    fragments: &[PrimaryDirFragment],
+    log_id: LogId,
+) -> Result<Option<ResolvedLogLocation>> {
+    let Some(fragment) = fragments.iter().find(|fragment| {
+        log_id.as_u64() >= fragment.first_primary_id
+            && log_id.as_u64() < fragment.end_primary_id_exclusive
+    }) else {
+        return Ok(None);
+    };
+
+    Ok(Some(ResolvedLogLocation {
+        block_number: fragment.block_number,
+        log_block_idx: log_id.idx_in_block(LogId::new(fragment.first_primary_id))?,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        containing_bucket_entry, resolved_location_from_bucket, CachedBucket, PrimaryDirFragment,
+    };
+    use crate::{kernel::primary_dir::PrimaryDirBucket, primitives::state::LogId};
+
+    #[test]
+    fn bucket_lookup_uses_last_duplicate_boundary() {
+        let bucket = PrimaryDirBucket {
+            start_block: 50,
+            first_primary_ids: vec![1000, 1003, 1003, 1008],
+        };
+
+        assert_eq!(containing_bucket_entry(&bucket, 1006), Some(2));
+
+        let location =
+            resolved_location_from_bucket(&bucket, LogId::new(1006)).expect("resolve bucket");
+        let location = location.expect("contained");
+        assert_eq!(location.block_number, 52);
+        assert_eq!(location.log_block_idx, 3);
+    }
+
+    #[test]
+    fn bucket_lookup_rejects_ids_past_the_sentinel() {
+        let bucket = PrimaryDirBucket {
+            start_block: 50,
+            first_primary_ids: vec![1000, 1003, 1003, 1008],
+        };
+
+        assert_eq!(containing_bucket_entry(&bucket, 1008), None);
+    }
+
+    #[test]
+    fn fragment_lookup_errors_when_candidate_id_is_missing() {
+        let error = CachedBucket::Fragments(vec![PrimaryDirFragment {
+            block_number: 7,
+            first_primary_id: 100,
+            end_primary_id_exclusive: 103,
+        }])
+        .resolve(LogId::new(104))
+        .expect_err("missing fragment candidate should fail loud");
+
+        assert_eq!(
+            error.to_string(),
+            "decode error: primary directory fragments missing queried log id"
+        );
+    }
 }

--- a/monad-chain-data/src/query/directory_resolver.rs
+++ b/monad-chain-data/src/query/directory_resolver.rs
@@ -1,0 +1,73 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::{hash_map::Entry, HashMap};
+
+use crate::{
+    error::{MonadChainDataError, Result},
+    kernel::{
+        primary_dir::{bucket_start, PrimaryDirFragment},
+        tables::Tables,
+    },
+    primitives::state::LogId,
+    store::{BlobStore, MetaStore},
+};
+
+/// Resolves a global log ID to its block number and position within that block.
+///
+/// Caches directory bucket fragments to avoid redundant lookups when
+/// resolving many IDs from the same region.
+pub(super) struct LogIdResolver<'a, M: MetaStore, B: BlobStore> {
+    tables: &'a Tables<M, B>,
+    fragment_cache: HashMap<u64, Vec<PrimaryDirFragment>>,
+}
+
+impl<'a, M: MetaStore, B: BlobStore> LogIdResolver<'a, M, B> {
+    pub(super) fn new(tables: &'a Tables<M, B>) -> Self {
+        Self {
+            tables,
+            fragment_cache: HashMap::new(),
+        }
+    }
+
+    pub(super) async fn resolve(&mut self, log_id: LogId) -> Result<Option<ResolvedLogLocation>> {
+        let bucket = bucket_start(log_id.as_u64());
+        if let Entry::Vacant(entry) = self.fragment_cache.entry(bucket) {
+            entry.insert(self.tables.logs().load_bucket_fragments(bucket).await?);
+        }
+
+        let Some(fragments) = self.fragment_cache.get(&bucket) else {
+            return Ok(None);
+        };
+        let Some(fragment) = fragments.iter().find(|fragment| {
+            log_id.as_u64() >= fragment.first_primary_id
+                && log_id.as_u64() < fragment.end_primary_id_exclusive
+        }) else {
+            return Ok(None);
+        };
+
+        Ok(Some(ResolvedLogLocation {
+            block_number: fragment.block_number,
+            log_block_idx: usize::try_from(log_id.as_u64() - fragment.first_primary_id)
+                .map_err(|_| MonadChainDataError::Decode("log block index overflow"))?,
+        }))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ResolvedLogLocation {
+    pub(super) block_number: u64,
+    pub(super) log_block_idx: usize,
+}

--- a/monad-chain-data/src/query/indexed.rs
+++ b/monad-chain-data/src/query/indexed.rs
@@ -13,67 +13,20 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{hash_map::Entry, HashMap};
-
 use roaring::RoaringBitmap;
 
-use super::{bitmap::load_clause_bitmap_for_shard, window::resolve_log_window};
+use super::{
+    bitmap::load_clause_bitmap_for_shard,
+    directory_resolver::LogIdResolver,
+    window::resolve_log_window,
+};
 use crate::{
     error::{MonadChainDataError, Result},
-    kernel::{
-        primary_dir::{sub_bucket_start, PrimaryDirFragment},
-        tables::Tables,
-    },
+    kernel::tables::Tables,
     logs::{LogMaterializer, QueryLogsRequest, QueryLogsResponse},
     primitives::{page::QueryOrder, range::ResolvedBlockWindow, state::LogId},
     store::{BlobStore, MetaStore},
 };
-
-/// Resolves a global log ID to its block number and position within that block.
-///
-/// Caches directory sub-bucket fragments to avoid redundant lookups when
-/// resolving many IDs from the same region.
-struct LogIdResolver<'a, M: MetaStore, B: BlobStore> {
-    tables: &'a Tables<M, B>,
-    fragment_cache: HashMap<u64, Vec<PrimaryDirFragment>>,
-}
-
-impl<'a, M: MetaStore, B: BlobStore> LogIdResolver<'a, M, B> {
-    fn new(tables: &'a Tables<M, B>) -> Self {
-        Self {
-            tables,
-            fragment_cache: HashMap::new(),
-        }
-    }
-
-    async fn resolve(&mut self, log_id: LogId) -> Result<Option<ResolvedLogLocation>> {
-        let bucket = sub_bucket_start(log_id.as_u64());
-        if let Entry::Vacant(entry) = self.fragment_cache.entry(bucket) {
-            entry.insert(self.tables.logs().load_sub_bucket_fragments(bucket).await?);
-        }
-
-        let Some(fragments) = self.fragment_cache.get(&bucket) else {
-            return Ok(None);
-        };
-        let Some(fragment) = fragments.iter().find(|f| {
-            log_id.as_u64() >= f.first_primary_id && log_id.as_u64() < f.end_primary_id_exclusive
-        }) else {
-            return Ok(None);
-        };
-
-        Ok(Some(ResolvedLogLocation {
-            block_number: fragment.block_number,
-            log_block_idx: usize::try_from(log_id.as_u64() - fragment.first_primary_id)
-                .map_err(|_| MonadChainDataError::Decode("log block index overflow"))?,
-        }))
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ResolvedLogLocation {
-    block_number: u64,
-    log_block_idx: usize,
-}
 
 pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
     tables: &Tables<M, B>,

--- a/monad-chain-data/src/query/indexed.rs
+++ b/monad-chain-data/src/query/indexed.rs
@@ -13,66 +13,19 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{hash_map::Entry, HashMap};
-
 use roaring::RoaringBitmap;
 
-use super::{bitmap::load_clause_bitmap_for_shard, window::resolve_log_window};
+use super::{
+    bitmap::load_clause_bitmap_for_shard, directory_resolver::LogIdResolver,
+    window::resolve_log_window,
+};
 use crate::{
     error::{MonadChainDataError, Result},
-    kernel::{
-        primary_dir::{sub_bucket_start, PrimaryDirFragment},
-        tables::Tables,
-    },
+    kernel::tables::Tables,
     logs::{LogMaterializer, QueryLogsRequest, QueryLogsResponse},
     primitives::{page::QueryOrder, range::ResolvedBlockWindow, state::LogId},
     store::{BlobStore, MetaStore},
 };
-
-/// Resolves a global log ID to its block number and position within that block.
-///
-/// Caches directory sub-bucket fragments to avoid redundant lookups when
-/// resolving many IDs from the same region.
-struct LogIdResolver<'a, M: MetaStore, B: BlobStore> {
-    tables: &'a Tables<M, B>,
-    fragment_cache: HashMap<u64, Vec<PrimaryDirFragment>>,
-}
-
-impl<'a, M: MetaStore, B: BlobStore> LogIdResolver<'a, M, B> {
-    fn new(tables: &'a Tables<M, B>) -> Self {
-        Self {
-            tables,
-            fragment_cache: HashMap::new(),
-        }
-    }
-
-    async fn resolve(&mut self, log_id: LogId) -> Result<Option<ResolvedLogLocation>> {
-        let bucket = sub_bucket_start(log_id.as_u64());
-        if let Entry::Vacant(entry) = self.fragment_cache.entry(bucket) {
-            entry.insert(self.tables.logs().load_sub_bucket_fragments(bucket).await?);
-        }
-
-        let Some(fragments) = self.fragment_cache.get(&bucket) else {
-            return Ok(None);
-        };
-        let Some(fragment) = fragments.iter().find(|f| {
-            log_id.as_u64() >= f.first_primary_id && log_id.as_u64() < f.end_primary_id_exclusive
-        }) else {
-            return Ok(None);
-        };
-
-        Ok(Some(ResolvedLogLocation {
-            block_number: fragment.block_number,
-            log_block_idx: log_id.idx_in_block(LogId::new(fragment.first_primary_id))?,
-        }))
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ResolvedLogLocation {
-    block_number: u64,
-    log_block_idx: usize,
-}
 
 pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
     tables: &Tables<M, B>,

--- a/monad-chain-data/src/query/indexed.rs
+++ b/monad-chain-data/src/query/indexed.rs
@@ -16,8 +16,7 @@
 use roaring::RoaringBitmap;
 
 use super::{
-    bitmap::load_clause_bitmap_for_shard,
-    directory_resolver::LogIdResolver,
+    bitmap::load_clause_bitmap_for_shard, directory_resolver::LogIdResolver,
     window::resolve_log_window,
 };
 use crate::{

--- a/monad-chain-data/src/query/mod.rs
+++ b/monad-chain-data/src/query/mod.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pub(crate) mod bitmap;
+pub(crate) mod directory_resolver;
 pub(crate) mod indexed;
 pub mod runner;
 pub(crate) mod window;

--- a/monad-chain-data/src/query/runner.rs
+++ b/monad-chain-data/src/query/runner.rs
@@ -22,6 +22,7 @@ use crate::{
     QueryOrder,
 };
 
+/// Executes the block-scan fallback path for unindexed log queries.
 pub async fn execute_unfiltered_block_query<M: MetaStore, B: BlobStore>(
     tables: &Tables<M, B>,
     request: &QueryLogsRequest,

--- a/monad-chain-data/src/query/runner.rs
+++ b/monad-chain-data/src/query/runner.rs
@@ -22,6 +22,7 @@ use crate::{
     QueryOrder,
 };
 
+/// Executes the block-scan fallback path for unindexed log queries.
 pub async fn execute_block_scan_query<M: MetaStore, B: BlobStore>(
     tables: &Tables<M, B>,
     request: &QueryLogsRequest,

--- a/monad-chain-data/tests/log_dir_buckets.rs
+++ b/monad-chain-data/tests/log_dir_buckets.rs
@@ -1,0 +1,107 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use monad_chain_data::{
+    kernel::primary_dir::{PrimaryDirBucket, PrimaryDirFragment, DIRECTORY_BUCKET_SIZE},
+    Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData,
+    MonadChainDataService, B256,
+};
+
+#[tokio::test(flavor = "current_thread")]
+async fn ingest_compacts_a_sealed_directory_bucket_when_crossing_the_boundary() {
+    let service =
+        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 1,
+            block_hash: B256::repeat_byte(1),
+            parent_hash: B256::ZERO,
+            logs_by_tx: vec![repeated_logs(
+                usize::try_from(DIRECTORY_BUCKET_SIZE - 2).expect("bucket size fits usize"),
+            )],
+        })
+        .await
+        .expect("ingest block 1");
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 2,
+            block_hash: B256::repeat_byte(2),
+            parent_hash: B256::repeat_byte(1),
+            logs_by_tx: vec![repeated_logs(4)],
+        })
+        .await
+        .expect("ingest block 2");
+
+    let bucket = service
+        .tables()
+        .logs()
+        .load_bucket(0)
+        .await
+        .expect("load compacted bucket")
+        .expect("bucket should be compacted");
+    assert_eq!(
+        bucket,
+        PrimaryDirBucket {
+            start_block: 1,
+            first_primary_ids: vec![0, DIRECTORY_BUCKET_SIZE - 2, DIRECTORY_BUCKET_SIZE + 2],
+        }
+    );
+
+    let fragments = service
+        .tables()
+        .logs()
+        .load_bucket_fragments(0)
+        .await
+        .expect("load fragments");
+    assert_eq!(
+        fragments,
+        vec![
+            PrimaryDirFragment {
+                block_number: 1,
+                first_primary_id: 0,
+                end_primary_id_exclusive: DIRECTORY_BUCKET_SIZE - 2,
+            },
+            PrimaryDirFragment {
+                block_number: 2,
+                first_primary_id: DIRECTORY_BUCKET_SIZE - 2,
+                end_primary_id_exclusive: DIRECTORY_BUCKET_SIZE + 2,
+            },
+        ]
+    );
+
+    assert!(
+        service
+            .tables()
+            .logs()
+            .load_bucket(DIRECTORY_BUCKET_SIZE)
+            .await
+            .expect("load frontier bucket")
+            .is_none(),
+        "frontier bucket should still resolve from fragments",
+    );
+}
+
+fn repeated_logs(count: usize) -> Vec<Log> {
+    std::iter::repeat_with(log).take(count).collect()
+}
+
+fn log() -> Log {
+    Log {
+        address: Address::repeat_byte(7),
+        data: LogData::new_unchecked(vec![B256::repeat_byte(9)], Bytes::from(vec![1, 2, 3])),
+    }
+}

--- a/monad-chain-data/tests/log_dir_fragments.rs
+++ b/monad-chain-data/tests/log_dir_fragments.rs
@@ -14,13 +14,13 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use monad_chain_data::{
-    kernel::primary_dir::{PrimaryDirFragment, DIRECTORY_SUB_BUCKET_SIZE},
+    kernel::primary_dir::{PrimaryDirFragment, DIRECTORY_BUCKET_SIZE},
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData,
     MonadChainDataService, B256,
 };
 
 #[tokio::test(flavor = "current_thread")]
-async fn ingest_persists_log_dir_fragment_for_single_sub_bucket_block() {
+async fn ingest_persists_log_dir_fragment_for_single_bucket_block() {
     let service =
         MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
 
@@ -37,7 +37,7 @@ async fn ingest_persists_log_dir_fragment_for_single_sub_bucket_block() {
     let fragments = service
         .tables()
         .logs()
-        .load_sub_bucket_fragments(0)
+        .load_bucket_fragments(0)
         .await
         .expect("load fragments");
 
@@ -69,7 +69,7 @@ async fn ingest_persists_zero_width_fragment_for_empty_block() {
     let fragments = service
         .tables()
         .logs()
-        .load_sub_bucket_fragments(0)
+        .load_bucket_fragments(0)
         .await
         .expect("load fragments");
 
@@ -84,7 +84,7 @@ async fn ingest_persists_zero_width_fragment_for_empty_block() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn ingest_persists_spanning_fragment_in_each_covered_sub_bucket() {
+async fn ingest_persists_spanning_fragment_in_each_covered_bucket() {
     let service =
         MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
 
@@ -94,7 +94,7 @@ async fn ingest_persists_spanning_fragment_in_each_covered_sub_bucket() {
             block_hash: B256::repeat_byte(1),
             parent_hash: B256::ZERO,
             logs_by_tx: vec![repeated_logs(
-                usize::try_from(DIRECTORY_SUB_BUCKET_SIZE - 2).expect("bucket size fits usize"),
+                usize::try_from(DIRECTORY_BUCKET_SIZE - 2).expect("bucket size fits usize"),
             )],
         })
         .await
@@ -113,20 +113,20 @@ async fn ingest_persists_spanning_fragment_in_each_covered_sub_bucket() {
     let first_partition = service
         .tables()
         .logs()
-        .load_sub_bucket_fragments(0)
+        .load_bucket_fragments(0)
         .await
         .expect("load first partition");
     let second_partition = service
         .tables()
         .logs()
-        .load_sub_bucket_fragments(DIRECTORY_SUB_BUCKET_SIZE)
+        .load_bucket_fragments(DIRECTORY_BUCKET_SIZE)
         .await
         .expect("load second partition");
 
     let expected = PrimaryDirFragment {
         block_number: 2,
-        first_primary_id: DIRECTORY_SUB_BUCKET_SIZE - 2,
-        end_primary_id_exclusive: DIRECTORY_SUB_BUCKET_SIZE + 2,
+        first_primary_id: DIRECTORY_BUCKET_SIZE - 2,
+        end_primary_id_exclusive: DIRECTORY_BUCKET_SIZE + 2,
     };
 
     assert!(first_partition.contains(&expected));

--- a/monad-chain-data/tests/query_logs_indexed.rs
+++ b/monad-chain-data/tests/query_logs_indexed.rs
@@ -16,7 +16,7 @@
 use std::collections::HashSet;
 
 use monad_chain_data::{
-    kernel::{bitmap::STREAM_PAGE_LOCAL_ID_SPAN, primary_dir::DIRECTORY_SUB_BUCKET_SIZE},
+    kernel::{bitmap::STREAM_PAGE_LOCAL_ID_SPAN, primary_dir::DIRECTORY_BUCKET_SIZE},
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData, LogFilter,
     MonadChainDataService, QueryLogsRequest, QueryOrder, Topic, B256,
 };
@@ -208,7 +208,7 @@ async fn indexed_query_logs_paginates_at_block_boundaries() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn indexed_query_logs_scans_across_sub_bucket_and_page_boundaries() {
+async fn indexed_query_logs_scans_across_bucket_and_page_boundaries() {
     let service =
         MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
 
@@ -234,7 +234,7 @@ async fn indexed_query_logs_scans_across_sub_bucket_and_page_boundaries() {
             logs_by_tx: vec![repeated_logs(
                 Address::repeat_byte(7),
                 vec![B256::repeat_byte(9)],
-                usize::try_from(DIRECTORY_SUB_BUCKET_SIZE + 4)
+                usize::try_from(DIRECTORY_BUCKET_SIZE + 4)
                     .expect("directory bucket size fits usize"),
             )],
         })
@@ -262,7 +262,7 @@ async fn indexed_query_logs_scans_across_sub_bucket_and_page_boundaries() {
 
     assert_eq!(
         page.logs.len(),
-        usize::try_from(DIRECTORY_SUB_BUCKET_SIZE + 4).expect("directory bucket size fits usize")
+        usize::try_from(DIRECTORY_BUCKET_SIZE + 4).expect("directory bucket size fits usize")
     );
     assert!(page.logs.iter().all(|log| log.block_number == 2));
     assert_eq!(page.cursor_block.number, 2);


### PR DESCRIPTION
Adds a logId -> block number index to improve log materialization.

This index is created every 10k logIds currently.