### PR TITLE
monad-wal: bound wal size with rotating chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5405,9 +5405,12 @@ dependencies = [
  "monad-consensus",
  "monad-consensus-types",
  "monad-crypto",
+ "monad-eth-types",
+ "monad-multi-sig",
  "monad-state-backend",
  "monad-types",
  "monad-validator",
+ "monad-wal",
  "serde",
  "serde_with",
 ]
@@ -6291,11 +6294,20 @@ dependencies = [
  "monad-secp",
  "monad-types",
  "monad-version",
+ "monad-wal-derive",
  "rayon",
  "serde_json",
  "tempfile",
  "test-case",
  "tracing",
+]
+
+[[package]]
+name = "monad-wal-derive"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6295,6 +6295,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "test-case",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ monad-updaters = { path = "./monad-updaters" }
 monad-validator = { path = "./monad-validator" }
 monad-version = { path = "./monad-version" }
 monad-wal = { path = "./monad-wal" }
+monad-wal-derive = { path = "./monad-wal-derive" }
 monad-wireauth = { path = "./monad-wireauth" }
 
 monad-cxx = { path = "./monad-execution/rust/crates/monad-cxx" }

--- a/monad-executor-glue/Cargo.toml
+++ b/monad-executor-glue/Cargo.toml
@@ -17,6 +17,7 @@ monad-crypto = { workspace = true }
 monad-state-backend = { workspace = true }
 monad-types = { workspace = true }
 monad-validator = { workspace = true }
+monad-wal = { workspace = true }
 
 alloy-rlp = { workspace = true }
 bincode = { workspace = true }
@@ -28,6 +29,8 @@ serde_with = { workspace = true, features = ["hex"] }
 
 [dev-dependencies]
 criterion = { workspace = true }
+monad-eth-types = { workspace = true }
+monad-multi-sig = { workspace = true }
 
 [[bench]]
 name = "rlp_bench"

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -795,24 +795,28 @@ where
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, monad_wal::WALLog)]
 pub enum ConsensusEvent<ST, SCT, EPT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
 {
+    #[wal(enable)]
     Message {
         sender: NodeId<SCT::NodeIdPubKey>,
         unverified_message: Unverified<ST, Unvalidated<ConsensusMessage<ST, SCT, EPT>>>,
     },
+    #[wal(enable)]
     Timeout(Round),
     /// a block that was previously requested
     /// this is an invariant
+    #[wal(enable)]
     BlockSync {
         block_range: BlockRange,
         full_blocks: Vec<ConsensusFullBlock<ST, SCT, EPT>>,
     },
+    #[wal(enable)]
     SendVote(Round),
 }
 
@@ -924,7 +928,7 @@ where
 }
 
 /// BlockSync related events
-#[derive(Clone, PartialEq, Eq, Serialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, monad_wal::WALLog)]
 pub enum BlockSyncEvent<ST, SCT, EPT>
 where
     ST: CertificateSignatureRecoverable,
@@ -932,29 +936,35 @@ where
     EPT: ExecutionProtocol,
 {
     /// A peer (not self) requesting for a missing block
+    #[wal(enable)]
     Request {
         sender: NodeId<SCT::NodeIdPubKey>,
         request: BlockSyncRequestMessage,
     },
     /// Outbound request timed out
+    #[wal(enable)]
     Timeout(BlockSyncRequestMessage),
     /// self requesting for a missing block
     /// this request must be retried if necessary
+    #[wal(enable)]
     SelfRequest {
         requester: BlockSyncSelfRequester,
         block_range: BlockRange,
     },
     /// cancel request for block
+    #[wal(enable)]
     SelfCancelRequest {
         requester: BlockSyncSelfRequester,
         block_range: BlockRange,
     },
     /// A peer (not self) sending us a block
+    #[wal(enable)]
     Response {
         sender: NodeId<SCT::NodeIdPubKey>,
         response: BlockSyncResponseMessage<ST, SCT, EPT>,
     },
     /// self sending us missing block (from ledger)
+    #[wal(enable)]
     SelfResponse {
         response: BlockSyncResponseMessage<ST, SCT, EPT>,
     },
@@ -1094,8 +1104,9 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, monad_wal::WALLog)]
 pub enum ValidatorEvent<SCT: SignatureCollection> {
+    #[wal(enable)]
     UpdateValidators(ValidatorSetDataWithEpoch<SCT>),
 }
 
@@ -1126,13 +1137,14 @@ impl<SCT: SignatureCollection> Decodable for ValidatorEvent<SCT> {
 }
 
 #[serde_as]
-#[derive(Clone, PartialEq, Eq, Serialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, monad_wal::WALLog)]
 pub enum MempoolEvent<ST, SCT, EPT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
 {
+    #[wal(enable)]
     Proposal {
         epoch: Epoch,
         round: Round,
@@ -1769,7 +1781,7 @@ impl Decodable for StateSyncNetworkMessage {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, monad_wal::WALLog)]
 pub enum StateSyncEvent<ST, SCT, EPT>
 where
     ST: CertificateSignatureRecoverable,
@@ -1784,15 +1796,18 @@ where
     ),
 
     /// Execution done syncing
+    #[wal(enable)]
     DoneSync(SeqNum),
 
     // Statesync-requested block
+    #[wal(enable)]
     BlockSync {
         block_range: BlockRange,
         full_blocks: Vec<ConsensusFullBlock<ST, SCT, EPT>>,
     },
 
     // Statesync re-sync request
+    #[wal(enable)]
     RequestSync {
         root: ConsensusBlockHeader<ST, SCT, EPT>,
         high_qc: QuorumCertificate<SCT>,
@@ -1876,7 +1891,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, monad_wal::WALLog)]
 pub enum ControlPanelEvent<ST>
 where
     ST: CertificateSignatureRecoverable,
@@ -1963,7 +1978,7 @@ where
     pub prioritized_full_nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, monad_wal::WALLog)]
 pub enum ConfigEvent<ST, SCT>
 where
     ST: CertificateSignatureRecoverable,
@@ -2020,7 +2035,7 @@ where
 }
 
 /// MonadEvent are inputs to MonadState
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, monad_wal::WALLog)]
 pub enum MonadEvent<ST, SCT, EPT>
 where
     ST: CertificateSignatureRecoverable,
@@ -2028,18 +2043,24 @@ where
     EPT: ExecutionProtocol,
 {
     /// Events for consensus state
+    #[wal(enable(nested))]
     ConsensusEvent(ConsensusEvent<ST, SCT, EPT>),
     /// Events for block sync responder
+    #[wal(enable(nested))]
     BlockSyncEvent(BlockSyncEvent<ST, SCT, EPT>),
     /// Events to update validator set
+    #[wal(enable(nested))]
     ValidatorEvent(ValidatorEvent<SCT>),
     /// Events to mempool
+    #[wal(enable(nested))]
     MempoolEvent(MempoolEvent<ST, SCT, EPT>),
     /// Events for the debug control panel
     ControlPanelEvent(ControlPanelEvent<ST>),
     /// Events to update the block timestamper
+    #[wal(enable)]
     TimestampUpdateEvent(u128),
     /// Events to statesync
+    #[wal(enable(nested))]
     StateSyncEvent(StateSyncEvent<ST, SCT, EPT>),
     /// Config updates
     ConfigEvent(ConfigEvent<ST, SCT>),
@@ -2365,15 +2386,49 @@ mod tests {
     use std::{net::SocketAddrV4, num::NonZeroU16};
 
     use alloy_rlp::{encode_list, Encodable};
+    use monad_blocksync::messages::message::BlockSyncRequestMessage;
+    use monad_consensus_types::block::BlockRange;
     use monad_crypto::{
         certificate_signature::{CertificateSignaturePubKey, PubKey},
         NopSignature,
     };
+    use monad_eth_types::EthExecutionProtocol;
+    use monad_multi_sig::MultiSig;
+    use monad_types::{NodeId, SeqNum, GENESIS_BLOCK_ID};
+    use monad_wal::wal::WALLog;
 
     use crate::{
-        PeerEntry, StateSyncRequest, StateSyncResponse, StateSyncUpsertType, StateSyncUpsertV1,
-        StateSyncVersion, SELF_STATESYNC_VERSION, STATESYNC_VERSION_V0, STATESYNC_VERSION_V1,
+        BlockSyncEvent, MempoolEvent, MonadEvent, PeerEntry, StateSyncEvent,
+        StateSyncNetworkMessage, StateSyncRequest, StateSyncResponse, StateSyncUpsertType,
+        StateSyncUpsertV1, StateSyncVersion, SELF_STATESYNC_VERSION, STATESYNC_VERSION_V0,
+        STATESYNC_VERSION_V1,
     };
+
+    type TestSignature = NopSignature;
+    type TestSignatureCollection = MultiSig<TestSignature>;
+    type TestExecutionProtocol = EthExecutionProtocol;
+
+    #[derive(monad_wal::WALLog)]
+    enum VariantLoggedTestEvent {
+        #[wal(enable)]
+        Logged,
+        NotLogged,
+    }
+
+    #[derive(monad_wal::WALLog)]
+    enum UnannotatedLoggedTestEvent {
+        First,
+        Second,
+    }
+
+    #[derive(monad_wal::WALLog)]
+    enum NestedLoggedTestEvent {
+        #[wal(enable(nested))]
+        Nested(VariantLoggedTestEvent),
+        #[wal(enable)]
+        Scalar,
+        Hidden,
+    }
 
     #[test]
     fn statesync_version_is_compatible() {
@@ -2636,5 +2691,63 @@ mod tests {
 
         let decoded = alloy_rlp::decode_exact::<PeerEntry<NopSignature>>(&encoded);
         assert!(decoded.is_err());
+    }
+
+    #[test]
+    fn wal_logging_only_keeps_traceable_events() {
+        assert!(VariantLoggedTestEvent::Logged.is_wal_logged());
+        assert!(!VariantLoggedTestEvent::NotLogged.is_wal_logged());
+        assert!(!UnannotatedLoggedTestEvent::First.is_wal_logged());
+        assert!(!UnannotatedLoggedTestEvent::Second.is_wal_logged());
+        assert!(NestedLoggedTestEvent::Nested(VariantLoggedTestEvent::Logged).is_wal_logged());
+        assert!(!NestedLoggedTestEvent::Nested(VariantLoggedTestEvent::NotLogged).is_wal_logged());
+        assert!(NestedLoggedTestEvent::Scalar.is_wal_logged());
+        assert!(!NestedLoggedTestEvent::Hidden.is_wal_logged());
+
+        let logged_event = MonadEvent::<
+            TestSignature,
+            TestSignatureCollection,
+            TestExecutionProtocol,
+        >::BlockSyncEvent(BlockSyncEvent::Timeout(
+            BlockSyncRequestMessage::Headers(BlockRange {
+                last_block_id: GENESIS_BLOCK_ID,
+                num_blocks: SeqNum(1),
+            }),
+        ));
+        assert!(logged_event.is_wal_logged());
+
+        let mempool_event = MonadEvent::<
+            TestSignature,
+            TestSignatureCollection,
+            TestExecutionProtocol,
+        >::MempoolEvent(MempoolEvent::ForwardTxs(Vec::new()));
+        assert!(!mempool_event.is_wal_logged());
+
+        let timestamp_event = MonadEvent::<
+            TestSignature,
+            TestSignatureCollection,
+            TestExecutionProtocol,
+        >::TimestampUpdateEvent(7);
+        assert!(timestamp_event.is_wal_logged());
+
+        let state_sync_event = MonadEvent::<
+            TestSignature,
+            TestSignatureCollection,
+            TestExecutionProtocol,
+        >::StateSyncEvent(StateSyncEvent::DoneSync(SeqNum(2)));
+        assert!(state_sync_event.is_wal_logged());
+
+        let sender = NodeId::new(
+            CertificateSignaturePubKey::<TestSignature>::from_bytes(&[8u8; 32]).unwrap(),
+        );
+        let inbound_statesync = MonadEvent::<
+            TestSignature,
+            TestSignatureCollection,
+            TestExecutionProtocol,
+        >::StateSyncEvent(StateSyncEvent::Inbound(
+            sender,
+            StateSyncNetworkMessage::NotWhitelisted,
+        ));
+        assert!(!inbound_statesync.is_wal_logged());
     }
 }

--- a/monad-node/src/cli.rs
+++ b/monad-node/src/cli.rs
@@ -51,7 +51,7 @@ pub struct Cli {
     #[arg(long)]
     pub wal_path: PathBuf,
 
-    /// Set the maximum number of WAL chunks to retain
+    /// Set the maximum number of WAL chunks to retain. Set to 0 to disable WAL.
     #[arg(long, default_value_t = DEFAULT_WAL_CHUNKS)]
     pub wal_chunks: u64,
 

--- a/monad-node/src/cli.rs
+++ b/monad-node/src/cli.rs
@@ -17,6 +17,9 @@ use std::path::PathBuf;
 
 use clap::Parser;
 
+const DEFAULT_WAL_CHUNKS: u64 = 8;
+const DEFAULT_WAL_CHUNK_SIZE_BYTES: u64 = 1024 * 1024 * 1024;
+
 #[derive(Debug, Parser)]
 #[command(name = "monad-node", about, long_about = None, version = monad_version::version!())]
 pub struct Cli {
@@ -44,9 +47,17 @@ pub struct Cli {
     #[arg(long)]
     pub devnet_chain_config_override: Option<PathBuf>,
 
-    /// Set the path where the write-ahead log will be stored
+    /// Set the directory where WAL chunks will be stored
     #[arg(long)]
     pub wal_path: PathBuf,
+
+    /// Set the maximum number of WAL chunks to retain
+    #[arg(long, default_value_t = DEFAULT_WAL_CHUNKS)]
+    pub wal_chunks: u64,
+
+    /// Set the WAL chunk size in bytes
+    #[arg(long, default_value_t = DEFAULT_WAL_CHUNK_SIZE_BYTES)]
+    pub wal_chunk_size_bytes: u64,
 
     /// Set the path where consensus blocks will be stored
     #[arg(long)]

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -20,7 +20,7 @@ use std::{
     num::NonZeroU16,
     path::PathBuf,
     process,
-    sync::Arc,
+    sync::{mpsc::TrySendError, Arc},
     time::{Duration, Instant},
 };
 
@@ -98,6 +98,7 @@ const MONAD_NODE_VERSION: Option<&str> = option_env!("MONAD_VERSION");
 const STATESYNC_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 const EXECUTION_DELAY: u64 = 3;
+const WALTRACE_CHANNEL_CAPACITY: usize = 1024;
 
 fn main() {
     let mut cmd = Cli::command();
@@ -303,7 +304,7 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         config_loader: ConfigLoader::new(node_state.node_config_path),
     };
 
-    let mut wal = if node_state.wal_chunks == 0 {
+    let waltrace_tx = if node_state.wal_chunks == 0 {
         info!("wal is disabled");
         None
     } else {
@@ -315,18 +316,27 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         )
         .with_chunks(node_state.wal_chunks)
         .with_chunk_size(node_state.wal_chunk_size_bytes);
-        match logger_config.build() {
-            Ok(wal) => Some(wal),
-            Err(err) => {
-                event!(
-                    Level::ERROR,
-                    ?err,
-                    path = node_state.wal_path.as_path().display().to_string(),
-                    "failed to initialize wal",
-                );
-                return Err(());
-            }
-        }
+        let (waltrace_tx, waltrace_rx) = std::sync::mpsc::sync_channel(WALTRACE_CHANNEL_CAPACITY);
+        let _waltrace_thread = std::thread::Builder::new()
+            .name("monad_bft_waltrace".to_string())
+            .spawn(move || {
+                let mut wal = match logger_config.build() {
+                    Ok(wal) => wal,
+                    Err(err) => {
+                        error!(?err, "failed to initialize wal");
+                        return;
+                    }
+                };
+                while let Ok(event) = waltrace_rx.recv() {
+                    let _wal_event_span = tracing::trace_span!("wal_event_span").entered();
+                    if let Err(err) = wal.push(&event) {
+                        event!(Level::ERROR, ?err, "failed to push to wal");
+                        return;
+                    }
+                }
+            })
+            .expect("failed to spawn waltrace thread");
+        Some(waltrace_tx)
     };
 
     let block_sync_override_peers = node_state
@@ -466,21 +476,24 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
                     format!("{:?}", event)
                 };
 
-                let event = LogFriendlyMonadEvent {
-                    timestamp: Utc::now(),
-                    event,
-                };
-
                 {
                     let _ledger_span = ledger_span.enter();
-                    if let Some(wal) = wal.as_mut() {
-                        let _wal_event_span = tracing::trace_span!("wal_event_span").entered();
-                        if let Err(err) = wal.push(&event) {
-                            event!(Level::ERROR, ?err, "failed to push to wal",);
-                            return Err(());
+                    if let Some(waltrace_tx) = waltrace_tx.as_ref() {
+                        let wal_event = LogFriendlyMonadEvent {
+                            timestamp: Utc::now(),
+                            event: event.lossy_clone(),
+                        };
+                        match waltrace_tx.try_send(wal_event) {
+                            Ok(()) => {}
+                            Err(TrySendError::Full(_)) => {
+                                warn!("waltrace is lagging; dropping wal event");
+                            }
+                            Err(TrySendError::Disconnected(_)) => {
+                                event!(Level::ERROR, "waltrace thread stopped");
+                            }
                         }
                     }
-                };
+                }
 
                 let commands = {
                     let _timer = DropTimer::start(Duration::from_millis(50), |elapsed| {
@@ -491,9 +504,9 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
                         )
                     });
                     let _ledger_span = ledger_span.enter();
-                    let _event_span = tracing::trace_span!("event_span", ?event.event).entered();
+                    let _event_span = tracing::trace_span!("event_span", ?event).entered();
                     let start = Instant::now();
-                    let cmds = state.update(event.event);
+                    let cmds = state.update(event);
                     total_state_update_elapsed += start.elapsed();
                     cmds
                 };

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -303,17 +303,30 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         config_loader: ConfigLoader::new(node_state.node_config_path),
     };
 
-    let logger_config: WALoggerConfig<LogFriendlyMonadEvent<_, _, _>> = WALoggerConfig::new(
-        node_state.wal_path.clone(), // output wal path
-        false,                       // flush on every write
-    );
-    let Ok(mut wal) = logger_config.build() else {
-        event!(
-            Level::ERROR,
-            path = node_state.wal_path.as_path().display().to_string(),
-            "failed to initialize wal",
-        );
-        return Err(());
+    let mut wal = if node_state.wal_chunks == 0 {
+        info!("wal is disabled");
+        None
+    } else {
+        let logger_config: WALoggerConfig<
+            LogFriendlyMonadEvent<SignatureType, SignatureCollectionType, ExecutionProtocolType>,
+        > = WALoggerConfig::new(
+            node_state.wal_path.clone(), // output wal directory
+            false,                       // flush on every write
+        )
+        .with_chunks(node_state.wal_chunks)
+        .with_chunk_size(node_state.wal_chunk_size_bytes);
+        match logger_config.build() {
+            Ok(wal) => Some(wal),
+            Err(err) => {
+                event!(
+                    Level::ERROR,
+                    ?err,
+                    path = node_state.wal_path.as_path().display().to_string(),
+                    "failed to initialize wal",
+                );
+                return Err(());
+            }
+        }
     };
 
     let block_sync_override_peers = node_state
@@ -460,10 +473,12 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
 
                 {
                     let _ledger_span = ledger_span.enter();
-                    let _wal_event_span = tracing::trace_span!("wal_event_span").entered();
-                    if let Err(err) = wal.push(&event) {
-                        event!(Level::ERROR, ?err, "failed to push to wal",);
-                        return Err(());
+                    if let Some(wal) = wal.as_mut() {
+                        let _wal_event_span = tracing::trace_span!("wal_event_span").entered();
+                        if let Err(err) = wal.push(&event) {
+                            event!(Level::ERROR, ?err, "failed to push to wal",);
+                            return Err(());
+                        }
                     }
                 };
 

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -72,7 +72,7 @@ use monad_validator::{
     signature_collection::SignatureCollection, validator_set::ValidatorSetFactory,
     weighted_round_robin::WeightedRoundRobin,
 };
-use monad_wal::wal::WALoggerConfig;
+use monad_wal::wal::{WALLog, WALoggerConfig};
 use opentelemetry::metrics::MeterProvider;
 use opentelemetry_otlp::{MetricExporter, WithExportConfig};
 use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
@@ -478,18 +478,20 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
 
                 {
                     let _ledger_span = ledger_span.enter();
-                    if let Some(waltrace_tx) = waltrace_tx.as_ref() {
-                        let wal_event = LogFriendlyMonadEvent {
-                            timestamp: Utc::now(),
-                            event: event.lossy_clone(),
-                        };
-                        match waltrace_tx.try_send(wal_event) {
-                            Ok(()) => {}
-                            Err(TrySendError::Full(_)) => {
-                                warn!("waltrace is lagging; dropping wal event");
-                            }
-                            Err(TrySendError::Disconnected(_)) => {
-                                event!(Level::ERROR, "waltrace thread stopped");
+                    if event.is_wal_logged() {
+                        if let Some(waltrace_tx) = waltrace_tx.as_ref() {
+                            let wal_event = LogFriendlyMonadEvent {
+                                timestamp: Utc::now(),
+                                event: event.lossy_clone(),
+                            };
+                            match waltrace_tx.try_send(wal_event) {
+                                Ok(()) => {}
+                                Err(TrySendError::Full(_)) => {
+                                    warn!("waltrace is lagging; dropping wal event");
+                                }
+                                Err(TrySendError::Disconnected(_)) => {
+                                    event!(Level::ERROR, "waltrace thread stopped");
+                                }
                             }
                         }
                     }

--- a/monad-node/src/state.rs
+++ b/monad-node/src/state.rs
@@ -59,6 +59,8 @@ pub struct NodeState {
     pub forkpoint_path: PathBuf,
     pub validators_path: PathBuf,
     pub wal_path: PathBuf,
+    pub wal_chunks: u64,
+    pub wal_chunk_size_bytes: u64,
     pub ledger_path: PathBuf,
     pub mempool_ipc_path: PathBuf,
     pub control_panel_ipc_path: PathBuf,
@@ -85,6 +87,8 @@ impl NodeState {
             validators_path: validators_config_path,
             devnet_chain_config_override: maybe_devnet_chain_config_override_path,
             wal_path,
+            wal_chunks,
+            wal_chunk_size_bytes,
             ledger_path,
             mempool_ipc_path,
             triedb_path,
@@ -154,20 +158,6 @@ impl NodeState {
         let chain_config =
             MonadChainConfig::new(node_config.chain_id, devnet_chain_config_override)?;
 
-        let wal_path = wal_path.with_file_name(format!(
-            "{}_{}",
-            wal_path
-                .file_name()
-                .expect("no wal file name")
-                .to_owned()
-                .into_string()
-                .expect("invalid wal path"),
-            std::time::UNIX_EPOCH
-                .elapsed()
-                .expect("time went backwards")
-                .as_millis()
-        ));
-
         let otel_endpoint_interval = match (otel_endpoint, record_metrics_interval_seconds) {
             (Some(otel_endpoint), Some(record_metrics_interval_seconds)) => Some((
                 otel_endpoint,
@@ -191,6 +181,8 @@ impl NodeState {
             forkpoint_path: forkpoint_config_path,
             validators_path: validators_config_path,
             wal_path,
+            wal_chunks,
+            wal_chunk_size_bytes,
             ledger_path,
             triedb_path,
             mempool_ipc_path,

--- a/monad-wal-derive/Cargo.toml
+++ b/monad-wal-derive/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "monad-wal-derive"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = { workspace = true }
+syn = { workspace = true }

--- a/monad-wal-derive/src/lib.rs
+++ b/monad-wal-derive/src/lib.rs
@@ -1,0 +1,143 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput, Fields, Meta, NestedMeta};
+
+enum WALLogMode {
+    Disabled,
+    Enabled,
+    Nested,
+}
+
+#[proc_macro_derive(WALLog, attributes(wal))]
+pub fn derive_wal_log(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let ident = input.ident;
+    let generics = input.generics;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let Data::Enum(data) = input.data else {
+        return syn::Error::new_spanned(ident, "WALLog can only be derived on enums")
+            .to_compile_error()
+            .into();
+    };
+
+    let mut arms = Vec::new();
+    for variant in data.variants {
+        let ident = variant.ident;
+        let mode = match wal_log_mode(&variant.attrs) {
+            Ok(mode) => mode,
+            Err(err) => return err.to_compile_error().into(),
+        };
+        let fields = variant.fields;
+        let arm = match mode {
+            WALLogMode::Enabled => match fields {
+                Fields::Named(_) => quote!(Self::#ident { .. } => true),
+                Fields::Unnamed(_) => quote!(Self::#ident(..) => true),
+                Fields::Unit => quote!(Self::#ident => true),
+            },
+            WALLogMode::Nested => match fields {
+                Fields::Named(fields) if fields.named.len() == 1 => {
+                    let field_ident = fields.named.into_iter().next().unwrap().ident.unwrap();
+                    quote!(
+                        Self::#ident { #field_ident: wal_field } =>
+                            ::monad_wal::wal::WALLog::is_wal_logged(wal_field)
+                    )
+                }
+                Fields::Unnamed(fields) if fields.unnamed.len() == 1 => quote!(
+                    Self::#ident(wal_field) => ::monad_wal::wal::WALLog::is_wal_logged(wal_field)
+                ),
+                _ => {
+                    return syn::Error::new_spanned(
+                        ident,
+                        "#[wal(enable(nested))] requires exactly one field",
+                    )
+                    .to_compile_error()
+                    .into()
+                }
+            },
+            WALLogMode::Disabled => match fields {
+                Fields::Named(_) => quote!(Self::#ident { .. } => false),
+                Fields::Unnamed(_) => quote!(Self::#ident(..) => false),
+                Fields::Unit => quote!(Self::#ident => false),
+            },
+        };
+
+        arms.push(arm);
+    }
+
+    let is_wal_logged = quote! {
+        match self {
+            #( #arms, )*
+        }
+    };
+
+    quote! {
+        impl #impl_generics ::monad_wal::wal::WALLog for #ident #ty_generics #where_clause {
+            fn is_wal_logged(&self) -> bool {
+                #is_wal_logged
+            }
+        }
+    }
+    .into()
+}
+
+fn wal_log_mode(attrs: &[syn::Attribute]) -> syn::Result<WALLogMode> {
+    let mut mode = WALLogMode::Disabled;
+    for attr in attrs {
+        let Some(parsed_mode) = parse_wal_log_mode(attr)? else {
+            continue;
+        };
+        mode = parsed_mode;
+    }
+    Ok(mode)
+}
+
+fn parse_wal_log_mode(attr: &syn::Attribute) -> syn::Result<Option<WALLogMode>> {
+    if !attr.path.is_ident("wal") {
+        return Ok(None);
+    }
+
+    match attr.parse_meta()? {
+        Meta::List(list) if list.nested.len() == 1 => match list.nested.first().unwrap() {
+            NestedMeta::Meta(Meta::Path(path)) if path.is_ident("enable") => {
+                Ok(Some(WALLogMode::Enabled))
+            }
+            NestedMeta::Meta(Meta::List(list))
+                if list.path.is_ident("enable")
+                    && list.nested.len() == 1
+                    && matches!(
+                        list.nested.first(),
+                        Some(NestedMeta::Meta(Meta::Path(path))) if path.is_ident("nested")
+                    ) =>
+            {
+                Ok(Some(WALLogMode::Nested))
+            }
+            _ => Err(invalid_wal_attribute(attr)),
+        },
+        _ => Err(invalid_wal_attribute(attr)),
+    }
+}
+
+fn invalid_wal_attribute(attr: &syn::Attribute) -> syn::Error {
+    syn::Error::new_spanned(
+        attr,
+        "unrecognized #[wal(...)] attribute; expected #[wal(enable)] or #[wal(enable(nested))]",
+    )
+}

--- a/monad-wal/Cargo.toml
+++ b/monad-wal/Cargo.toml
@@ -10,6 +10,7 @@ bench = false
 
 [dependencies]
 monad-types = { workspace = true }
+monad-wal-derive = { workspace = true }
 
 bytes = { workspace = true }
 tracing = { workspace = true }

--- a/monad-wal/Cargo.toml
+++ b/monad-wal/Cargo.toml
@@ -12,6 +12,7 @@ bench = false
 monad-types = { workspace = true }
 
 bytes = { workspace = true }
+tracing = { workspace = true }
 
 [build-dependencies]
 monad-version = { workspace = true }

--- a/monad-wal/examples/wal2json.rs
+++ b/monad-wal/examples/wal2json.rs
@@ -28,7 +28,7 @@ use monad_eth_types::EthExecutionProtocol;
 use monad_executor_glue::LogFriendlyMonadEvent;
 use monad_secp::SecpSignature;
 use monad_types::Deserializable;
-use monad_wal::reader::{events_iter_in_range, events_iter_raw, WALReader, WALReaderConfig};
+use monad_wal::reader::{events_iter_in_range, events_iter_raw, WALReader};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 #[derive(Parser, Debug)]
@@ -88,8 +88,7 @@ fn main() {
 
     let raw_events_iter = events_iter_in_range(
         args.paths.into_iter().map(|path| {
-            let config = WALReaderConfig::new(path);
-            let reader: WALReader<WrappedEvent> = config.build().unwrap();
+            let reader: WALReader<WrappedEvent> = WALReader::new(path).unwrap();
             events_iter_raw(reader)
         }),
         |event| WrappedEvent::deserialize_timestamp(event),

--- a/monad-wal/src/lib.rs
+++ b/monad-wal/src/lib.rs
@@ -18,6 +18,10 @@ pub mod wal;
 
 use std::{error::Error, fmt::Debug, io};
 
+extern crate self as monad_wal;
+
+pub use monad_wal_derive::WALLog;
+
 #[derive(Debug)]
 pub enum WALError {
     IOError(io::Error),

--- a/monad-wal/src/reader.rs
+++ b/monad-wal/src/reader.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{
+    collections::VecDeque,
     fmt::Debug,
     fs::{File, OpenOptions},
     io::{BufReader, Read},
@@ -25,37 +26,59 @@ use std::{
 use monad_types::Deserializable;
 
 use crate::{
-    wal::{EventHeaderType, EVENT_HEADER_LEN},
+    wal::{discover_chunks, DiscoveredChunk, EventHeaderType, EVENT_HEADER_LEN},
     WALError,
 };
 
 const WAL_READ_BUFFER_SIZE: usize = 1024 * 1024; // 1MB
 
-/// Config for a write-ahead-log
-#[derive(Clone)]
-pub struct WALReaderConfig<M> {
-    file_path: PathBuf,
-
-    _marker: PhantomData<M>,
+#[derive(Debug)]
+struct ChunkReader {
+    reader: BufReader<File>,
+    exhausted: bool,
 }
 
-impl<M> WALReaderConfig<M>
-where
-    M: Deserializable<[u8]> + Debug,
-{
-    pub fn new(file_path: PathBuf) -> Self {
-        Self {
-            file_path,
-            _marker: PhantomData,
-        }
+impl ChunkReader {
+    fn is_exhausted(&self) -> bool {
+        self.exhausted
     }
 
-    pub fn build(self) -> Result<WALReader<M>, WALError> {
-        let file = OpenOptions::new().read(true).open(self.file_path)?;
+    fn load_one_raw(&mut self) -> Result<Option<Vec<u8>>, std::io::Error> {
+        if self.exhausted {
+            return Ok(None);
+        }
 
-        Ok(WALReader {
-            _marker: PhantomData,
+        let Some(len_buf) = self.read_header()? else {
+            self.exhausted = true;
+            return Ok(None);
+        };
+
+        let len = EventHeaderType::from_le_bytes(len_buf) as usize;
+        let mut buf = vec![0u8; len];
+        self.reader.read_exact(&mut buf)?;
+        Ok(Some(buf))
+    }
+
+    fn read_header(&mut self) -> Result<Option<[u8; EVENT_HEADER_LEN]>, std::io::Error> {
+        let mut len_buf = [0u8; EVENT_HEADER_LEN];
+        let bytes_read = self.reader.read(&mut len_buf)?;
+        if bytes_read == 0 {
+            return Ok(None);
+        }
+
+        self.reader.read_exact(&mut len_buf[bytes_read..])?;
+        Ok(Some(len_buf))
+    }
+}
+
+impl TryFrom<DiscoveredChunk> for ChunkReader {
+    type Error = WALError;
+
+    fn try_from(chunk: DiscoveredChunk) -> Result<Self, Self::Error> {
+        let file = OpenOptions::new().read(true).open(chunk.path)?;
+        Ok(Self {
             reader: BufReader::with_capacity(WAL_READ_BUFFER_SIZE, file),
+            exhausted: false,
         })
     }
 }
@@ -63,26 +86,54 @@ where
 #[derive(Debug)]
 pub struct WALReader<M> {
     _marker: PhantomData<M>,
-    reader: BufReader<File>,
+    readers: VecDeque<ChunkReader>,
 }
 
 impl<M> WALReader<M>
 where
     M: Deserializable<[u8]> + Debug,
 {
-    pub fn load_one_raw(&mut self) -> Result<Vec<u8>, std::io::Error> {
-        let mut len_buf = [0u8; EVENT_HEADER_LEN];
-        self.reader.read_exact(&mut len_buf)?;
-        let len = EventHeaderType::from_le_bytes(len_buf);
-        let mut buf = vec![0u8; len as usize];
-        self.reader.read_exact(&mut buf)?;
-        Ok(buf)
+    pub fn new(dir_path: PathBuf) -> Result<Self, WALError> {
+        let discovered = discover_chunks(&dir_path)?;
+        Self::from_discovered_chunks(discovered)
     }
 
-    pub fn load_one(&mut self) -> Result<M, WALError> {
-        let buf = self.load_one_raw()?;
-        let msg = M::deserialize(&buf).map_err(|e| WALError::DeserError(Box::new(e)))?;
-        Ok(msg)
+    pub fn from_discovered_chunks(chunks: Vec<DiscoveredChunk>) -> Result<Self, WALError> {
+        let readers = chunks
+            .into_iter()
+            .map(ChunkReader::try_from)
+            .collect::<Result<VecDeque<_>, _>>()?;
+
+        Ok(Self {
+            _marker: PhantomData,
+            readers,
+        })
+    }
+
+    pub fn load_one_raw(&mut self) -> Result<Option<Vec<u8>>, std::io::Error> {
+        loop {
+            let Some(reader) = self.readers.front_mut() else {
+                return Ok(None);
+            };
+            if reader.is_exhausted() {
+                self.readers.pop_front();
+                continue;
+            }
+
+            match reader.load_one_raw() {
+                Ok(Some(buf)) => return Ok(Some(buf)),
+                Ok(None) => {
+                    self.readers.pop_front();
+                }
+                Err(err) => return Err(err),
+            }
+        }
+    }
+
+    pub fn load_one(&mut self) -> Result<Option<M>, WALError> {
+        self.load_one_raw()?
+            .map(|buf| M::deserialize(&buf).map_err(|e| WALError::DeserError(Box::new(e))))
+            .transpose()
     }
 }
 
@@ -90,9 +141,8 @@ pub fn events_iter_raw<M>(mut reader: WALReader<M>) -> impl Iterator<Item = Vec<
 where
     M: Deserializable<[u8]> + Debug,
 {
-    std::iter::repeat(()).map_while(move |()| match reader.load_one_raw() {
-        Ok(event) => Some(event),
-        Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => None,
+    std::iter::from_fn(move || match reader.load_one_raw() {
+        Ok(event) => event,
         Err(err) => panic!("error reading WAL: {:?}", err),
     })
 }
@@ -101,9 +151,8 @@ pub fn events_iter<M>(mut reader: WALReader<M>) -> impl Iterator<Item = M>
 where
     M: Deserializable<[u8]> + Debug,
 {
-    std::iter::repeat(()).map_while(move |()| match reader.load_one() {
-        Ok(event) => Some(event),
-        Err(WALError::IOError(err)) if err.kind() == std::io::ErrorKind::UnexpectedEof => None,
+    std::iter::from_fn(move || match reader.load_one() {
+        Ok(event) => event,
         Err(err) => panic!("error reading WAL: {:?}", err),
     })
 }

--- a/monad-wal/src/wal.rs
+++ b/monad-wal/src/wal.rs
@@ -14,15 +14,18 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{
+    collections::VecDeque,
     fmt::Debug,
-    fs::{File, OpenOptions},
-    io::Write,
+    fs::{self, File, OpenOptions},
+    io::{self, Write},
     marker::PhantomData,
-    path::PathBuf,
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use bytes::Bytes;
 use monad_types::Serializable;
+use tracing::debug;
 
 use crate::WALError;
 
@@ -30,18 +33,30 @@ use crate::WALError;
 pub(crate) type EventHeaderType = u32;
 pub(crate) const EVENT_HEADER_LEN: usize = std::mem::size_of::<EventHeaderType>();
 
-/// Maximum file size. 1GB.
-pub(crate) const MAX_FILE_SIZE: usize = 1024 * 1024 * 1024;
+pub(crate) const DEFAULT_CHUNK_SIZE: u64 = 1024 * 1024 * 1024;
+pub(crate) const DEFAULT_CHUNKS: u64 = 8;
 
-/// Config for a write-ahead-log
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredChunk {
+    pub path: PathBuf,
+    pub timestamp: u64,
+    pub generation: u64,
+}
+
+#[derive(Debug)]
+struct ActiveChunkState {
+    path: PathBuf,
+    generation: u64,
+    size: u64,
+    handle: File,
+}
+
 #[derive(Clone)]
 pub struct WALoggerConfig<M> {
-    file_path: PathBuf,
-
-    /// option for fsync after write. There is a cost to doing
-    /// an fsync so its left configurable
+    dir_path: PathBuf,
     sync: bool,
-
+    chunks: u64,
+    chunk_size: u64,
     _marker: PhantomData<M>,
 }
 
@@ -49,50 +64,67 @@ impl<M> WALoggerConfig<M>
 where
     M: Serializable<Bytes> + Debug,
 {
-    pub fn new(file_path: PathBuf, sync: bool) -> Self {
+    pub fn new(dir_path: PathBuf, sync: bool) -> Self {
         Self {
-            file_path,
+            dir_path,
             sync,
+            chunks: DEFAULT_CHUNKS,
+            chunk_size: DEFAULT_CHUNK_SIZE,
             _marker: PhantomData,
         }
     }
 
-    // this definition of the build function means that we can only have one type of message in this WAL
-    // should enforce this in `push`/have WALogger parametrized by the message type
+    pub fn with_chunks(mut self, chunks: u64) -> Self {
+        self.chunks = chunks;
+        self
+    }
+
+    pub fn with_chunk_size(mut self, chunk_size: u64) -> Self {
+        self.chunk_size = chunk_size;
+        self
+    }
+
     pub fn build(self) -> Result<WALogger<M>, WALError> {
-        let curr_file_index = 0;
+        if self.chunks == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "wal chunks must be greater than zero",
+            )
+            .into());
+        }
 
-        let mut new_file_path = self.file_path.clone().into_os_string();
-        new_file_path.push(".");
-        new_file_path.push(curr_file_index.to_string());
+        fs::create_dir_all(&self.dir_path)?;
 
-        let curr_file_handle = OpenOptions::new()
-            .read(true)
-            .append(true)
-            .create(true)
-            .open(new_file_path)?;
+        let discovered = discover_chunks(&self.dir_path)?;
+        let (timestamp, current) = create_initial_chunk(&self.dir_path)?;
 
-        Ok(WALogger {
+        let mut wal = WALogger {
             _marker: PhantomData,
-            file_path: self.file_path,
-            curr_file_index,
-            curr_file_handle,
-            curr_file_offset: 0,
+            dir_path: self.dir_path,
+            timestamp,
+            generation: 0,
+            current,
+            rotated: discovered.into(),
+            chunks: self.chunks,
+            chunk_size: self.chunk_size,
             sync: self.sync,
-        })
+        };
+        wal.trim_oldest_chunks()?;
+
+        Ok(wal)
     }
 }
 
-/// Write-ahead-logger that Serializes Events to an append-only-file
 #[derive(Debug)]
 pub struct WALogger<M> {
     _marker: PhantomData<M>,
-    file_path: PathBuf,
-
-    curr_file_index: u64,
-    curr_file_handle: File,
-    curr_file_offset: u64,
-
+    dir_path: PathBuf,
+    timestamp: u64,
+    generation: u64,
+    current: ActiveChunkState,
+    rotated: VecDeque<DiscoveredChunk>,
+    chunks: u64,
+    chunk_size: u64,
     sync: bool,
 }
 
@@ -102,52 +134,187 @@ where
 {
     pub fn push(&mut self, message: &M) -> Result<(), WALError> {
         let msg_buf = message.serialize();
-        let buf = (msg_buf.len() as EventHeaderType).to_le_bytes().to_vec();
-        let msg_len = (EVENT_HEADER_LEN + msg_buf.len()) as u64;
-
-        // check file length before appending message
-        let next_offset = self.curr_file_offset + msg_len;
-        if next_offset > MAX_FILE_SIZE as u64 {
-            // open new file
-            // set length of current file and sync
-            self.curr_file_handle.set_len(self.curr_file_offset)?;
-            self.curr_file_handle.sync_all()?;
-
-            // update file index and open new file
-            self.curr_file_index += 1;
-            let mut new_file_path = self.file_path.clone().into_os_string();
-            new_file_path.push(".");
-            new_file_path.push(self.curr_file_index.to_string());
-
-            self.curr_file_handle = OpenOptions::new()
-                .read(true)
-                .append(true)
-                .create(true)
-                .open(new_file_path)?;
-            self.curr_file_offset = 0;
+        if msg_buf.len() > EventHeaderType::MAX as usize {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "serialized wal event exceeds u32 header size",
+            )
+            .into());
         }
 
-        self.curr_file_handle.write_all(&buf)?;
-        self.curr_file_handle.write_all(&msg_buf)?;
-        self.curr_file_offset += msg_len;
+        let msg_len = (EVENT_HEADER_LEN + msg_buf.len()) as u64;
+        if msg_len > self.chunk_size {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "serialized wal event exceeds chunk_size",
+            )
+            .into());
+        }
+
+        if self.current.size + msg_len > self.chunk_size {
+            self.rotate()?;
+        }
+
+        let len_buf = (msg_buf.len() as EventHeaderType).to_le_bytes();
+        self.current.handle.write_all(&len_buf)?;
+        self.current.handle.write_all(&msg_buf)?;
+        self.current.size += msg_len;
 
         if self.sync {
-            self.curr_file_handle.sync_all()?;
+            self.current.handle.sync_all()?;
+        }
+        Ok(())
+    }
+
+    fn rotate(&mut self) -> Result<(), WALError> {
+        self.generation += 1;
+        let previous = std::mem::replace(
+            &mut self.current,
+            create_chunk(&self.dir_path, self.timestamp, self.generation)?,
+        );
+        self.rotated.push_back(DiscoveredChunk {
+            path: previous.path,
+            timestamp: self.timestamp,
+            generation: previous.generation,
+        });
+        self.trim_oldest_chunks()?;
+        Ok(())
+    }
+
+    fn trim_oldest_chunks(&mut self) -> Result<(), WALError> {
+        while self.rotated.len() as u64 + 1 > self.chunks {
+            let Some(oldest) = self.rotated.pop_front() else {
+                break;
+            };
+            fs::remove_file(oldest.path)?;
         }
         Ok(())
     }
 }
 
+pub fn discover_chunks(dir_path: &Path) -> Result<Vec<DiscoveredChunk>, WALError> {
+    let mut chunks = discover_chunk_metadata(dir_path)?;
+    chunks.sort_by_key(|chunk| (chunk.timestamp, chunk.generation));
+    Ok(chunks)
+}
+
+fn discover_chunk_metadata(dir_path: &Path) -> Result<Vec<DiscoveredChunk>, WALError> {
+    let mut chunks = Vec::new();
+    let entries = match fs::read_dir(dir_path) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(chunks),
+        Err(err) => return Err(err.into()),
+    };
+
+    for entry in entries {
+        let entry = entry?;
+        if let Some(chunk) = discover_chunk(entry)? {
+            chunks.push(chunk);
+        }
+    }
+
+    Ok(chunks)
+}
+
+fn discover_chunk(entry: fs::DirEntry) -> Result<Option<DiscoveredChunk>, WALError> {
+    let path = entry.path();
+    let entry_type = entry.file_type()?;
+    if !entry_type.is_file() {
+        debug!(path = %path.display(), "skipping non-file wal entry");
+        return Ok(None);
+    }
+
+    let entry_name = entry.file_name();
+    let Some(entry_name) = entry_name.to_str() else {
+        debug!(path = %path.display(), "skipping wal entry with non-utf8 name");
+        return Ok(None);
+    };
+
+    let Some((timestamp, generation)) = entry_name
+        .strip_prefix("wal_")
+        .and_then(|suffix| suffix.split_once('.'))
+        .and_then(|(timestamp, generation)| {
+            Some((
+                timestamp.parse::<u64>().ok()?,
+                generation.parse::<u64>().ok()?,
+            ))
+        })
+    else {
+        debug!(path = %path.display(), "skipping non-wal directory entry");
+        return Ok(None);
+    };
+
+    Ok(Some(DiscoveredChunk {
+        path,
+        timestamp,
+        generation,
+    }))
+}
+
+pub(crate) fn chunk_path(dir_path: &Path, timestamp: u64, generation: u64) -> PathBuf {
+    dir_path.join(format!("wal_{timestamp}.{generation}"))
+}
+
+fn current_timestamp() -> Result<u64, WALError> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?
+        .as_millis()
+        .try_into()
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "wal timestamp overflow").into())
+}
+
+fn create_initial_chunk(dir_path: &Path) -> Result<(u64, ActiveChunkState), WALError> {
+    loop {
+        let timestamp = current_timestamp()?;
+        match create_chunk(dir_path, timestamp, 0) {
+            Ok(current) => return Ok((timestamp, current)),
+            Err(WALError::IOError(err)) if err.kind() == io::ErrorKind::AlreadyExists => {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+fn create_chunk(
+    dir_path: &Path,
+    timestamp: u64,
+    generation: u64,
+) -> Result<ActiveChunkState, WALError> {
+    let path = chunk_path(dir_path, timestamp, generation);
+    let handle = OpenOptions::new()
+        .read(true)
+        .append(true)
+        .create_new(true)
+        .open(&path)?;
+    Ok(ActiveChunkState {
+        path,
+        generation,
+        size: 0,
+        handle,
+    })
+}
+
 #[cfg(test)]
 mod test {
-    use std::array::TryFromSliceError;
+    use std::{
+        array::TryFromSliceError,
+        fs::{create_dir_all, write},
+        path::PathBuf,
+    };
 
     use bytes::Bytes;
     use monad_types::{Deserializable, Serializable};
+    use tempfile::tempdir;
 
     use crate::{
-        reader::{WALReader, WALReaderConfig},
-        wal::{WALogger, WALoggerConfig, EVENT_HEADER_LEN, MAX_FILE_SIZE},
+        reader::WALReader,
+        wal::{
+            chunk_path, discover_chunks, DiscoveredChunk, EventHeaderType, WALogger,
+            WALoggerConfig, EVENT_HEADER_LEN,
+        },
+        WALError,
     };
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -172,88 +339,181 @@ mod test {
         }
     }
 
-    #[derive(Debug, PartialEq, Eq, Default)]
-    struct VecState {
-        events: Vec<TestEvent>,
-    }
-
-    impl VecState {
-        fn update(&mut self, event: TestEvent) {
-            self.events.push(event);
+    fn write_chunk(dir_path: &PathBuf, timestamp: u64, generation: u64, events: &[TestEvent]) {
+        create_dir_all(dir_path).unwrap();
+        let mut buf = Vec::new();
+        for event in events {
+            let payload = Serializable::<Bytes>::serialize(event);
+            buf.extend_from_slice(&(payload.len() as EventHeaderType).to_le_bytes());
+            buf.extend_from_slice(&payload);
         }
+        write(chunk_path(dir_path, timestamp, generation), buf).unwrap();
     }
 
-    fn generate_test_events(num: u64) -> Vec<TestEvent> {
-        (0..num).map(|i| TestEvent { data: i }).collect()
+    fn decode_all(dir_path: PathBuf) -> Vec<u64> {
+        let mut reader: WALReader<TestEvent> = WALReader::new(dir_path).unwrap();
+        std::iter::from_fn(|| reader.load_one().unwrap())
+            .map(|event| event.data)
+            .collect()
     }
 
     #[test]
-    fn load_events() {
-        // setup
-        use std::fs::create_dir_all;
-
-        use tempfile::tempdir;
-
-        let input1 = generate_test_events(10);
-
+    fn reads_events_across_multiple_chunks() {
         let tmpdir = tempdir().unwrap();
-        create_dir_all(tmpdir.path()).unwrap();
-        let log1_path = tmpdir.path().join("wal");
-        let logger1_config = WALoggerConfig::new(
-            log1_path.clone(),
-            false, // sync
+        let wal_dir = tmpdir.path().join("wal");
+        let chunk_size = (EVENT_HEADER_LEN
+            + Serializable::<Bytes>::serialize(&TestEvent { data: 0 }).len())
+            as u64
+            * 2;
+
+        let mut logger: WALogger<TestEvent> = WALoggerConfig::new(wal_dir.clone(), false)
+            .with_chunks(4)
+            .with_chunk_size(chunk_size)
+            .build()
+            .unwrap();
+        for data in 0..6 {
+            logger.push(&TestEvent { data }).unwrap();
+        }
+        drop(logger);
+
+        assert_eq!(decode_all(wal_dir), (0..6).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn preserves_rotation_order_across_restarts() {
+        let tmpdir = tempdir().unwrap();
+        let wal_dir = tmpdir.path().join("wal");
+        let chunk_size = (EVENT_HEADER_LEN
+            + Serializable::<Bytes>::serialize(&TestEvent { data: 0 }).len())
+            as u64
+            * 2;
+
+        write_chunk(
+            &wal_dir,
+            1,
+            0,
+            &[TestEvent { data: 0 }, TestEvent { data: 1 }],
+        );
+        write_chunk(
+            &wal_dir,
+            1,
+            1,
+            &[TestEvent { data: 2 }, TestEvent { data: 3 }],
         );
 
-        let mut logger1: WALogger<TestEvent> = logger1_config.build().unwrap();
-        let mut state1 = VecState::default();
-
-        // driver loop (simulate executor by iterating events)
-        for event in input1.into_iter() {
-            logger1.push(&event).unwrap();
-
-            state1.update(event);
+        {
+            let mut logger: WALogger<TestEvent> = WALoggerConfig::new(wal_dir.clone(), false)
+                .with_chunks(4)
+                .with_chunk_size(chunk_size)
+                .build()
+                .unwrap();
+            for data in 4..8 {
+                logger.push(&TestEvent { data }).unwrap();
+            }
         }
 
-        // read events from the wal, assert equal
-        let mut log2_path = log1_path.into_os_string();
-        log2_path.push(".0");
-        let logger2_config = WALReaderConfig::new(log2_path.into());
-        let mut logger2: WALReader<TestEvent> = logger2_config.build().unwrap();
-        let mut state2 = VecState::default();
-        while let Ok(event) = logger2.load_one() {
-            state2.update(event);
-        }
-        assert_eq!(state1, state2);
+        let discovered = discover_chunks(&wal_dir).unwrap();
+        assert_eq!(discovered.len(), 4);
+        let chunks = discovered
+            .iter()
+            .map(|chunk| (chunk.timestamp, chunk.generation))
+            .collect::<Vec<_>>();
+        let current_timestamp = chunks[2].0;
+        assert_eq!(
+            chunks,
+            vec![
+                (1, 0),
+                (1, 1),
+                (current_timestamp, 0),
+                (current_timestamp, 1),
+            ]
+        );
+        assert_eq!(decode_all(wal_dir), (0..8).collect::<Vec<_>>());
     }
 
-    #[ignore = "too long for 1GB MAX_FILE_SIZE"]
     #[test]
-    fn rotate_wal() {
-        // setup
-        use std::fs::create_dir_all;
+    fn never_retains_more_chunks_than_configured() {
+        let tmpdir = tempdir().unwrap();
+        let wal_dir = tmpdir.path().join("wal");
+        let chunk_size = (EVENT_HEADER_LEN
+            + Serializable::<Bytes>::serialize(&TestEvent { data: 0 }).len())
+            as u64
+            * 2;
 
-        use tempfile::tempdir;
+        let mut logger: WALogger<TestEvent> = WALoggerConfig::new(wal_dir.clone(), false)
+            .with_chunks(2)
+            .with_chunk_size(chunk_size)
+            .build()
+            .unwrap();
+        for data in 0..10 {
+            logger.push(&TestEvent { data }).unwrap();
+            assert!(discover_chunks(&wal_dir).unwrap().len() <= 2);
+        }
+        drop(logger);
 
-        let num_files = 5;
+        assert_eq!(discover_chunks(&wal_dir).unwrap().len(), 2);
+        assert_eq!(decode_all(wal_dir), vec![6, 7, 8, 9]);
+    }
+
+    #[test]
+    fn reader_reports_incomplete_chunks() {
         let tmpdir = tempdir().unwrap();
         create_dir_all(tmpdir.path()).unwrap();
         let log_path = tmpdir.path().join("wal");
-        let logger_config = WALoggerConfig::new(
-            log_path, false, // sync
+
+        write_chunk(&log_path, 1, 0, &[TestEvent { data: 1 }]);
+        write(chunk_path(&log_path, 1, 1), 8_u32.to_le_bytes()).unwrap();
+        write_chunk(&log_path, 1, 2, &[TestEvent { data: 2 }]);
+
+        let mut reader: WALReader<TestEvent> = WALReader::new(log_path).unwrap();
+        assert_eq!(reader.load_one().unwrap(), Some(TestEvent { data: 1 }));
+        let err = reader.load_one().unwrap_err();
+        assert!(matches!(
+            err,
+            WALError::IOError(err) if err.kind() == std::io::ErrorKind::UnexpectedEof
+        ));
+    }
+
+    #[test]
+    fn reader_reports_partial_header() {
+        let tmpdir = tempdir().unwrap();
+        create_dir_all(tmpdir.path()).unwrap();
+        let log_path = tmpdir.path().join("wal");
+
+        write_chunk(&log_path, 1, 0, &[TestEvent { data: 1 }]);
+        write(chunk_path(&log_path, 1, 1), [0_u8; EVENT_HEADER_LEN - 1]).unwrap();
+        write_chunk(&log_path, 1, 2, &[TestEvent { data: 2 }]);
+
+        let mut reader: WALReader<TestEvent> = WALReader::new(log_path).unwrap();
+        assert_eq!(reader.load_one().unwrap(), Some(TestEvent { data: 1 }));
+        let err = reader.load_one().unwrap_err();
+        assert!(matches!(
+            err,
+            WALError::IOError(err) if err.kind() == std::io::ErrorKind::UnexpectedEof
+        ));
+    }
+
+    #[test]
+    fn discover_chunks_skips_non_matching_entries() {
+        let tmpdir = tempdir().unwrap();
+        create_dir_all(tmpdir.path()).unwrap();
+        let log_path = tmpdir.path().join("wal");
+        create_dir_all(&log_path).unwrap();
+
+        write(log_path.join("not_a_wal"), []).unwrap();
+        write(log_path.join("wal_abc.0"), []).unwrap();
+        write(log_path.join("wal_1.abc"), []).unwrap();
+        write(log_path.join("wal_1"), []).unwrap();
+        std::fs::create_dir(log_path.join("wal_1.0")).unwrap();
+        write(chunk_path(&log_path, 2, 3), []).unwrap();
+
+        assert_eq!(
+            discover_chunks(&log_path).unwrap(),
+            vec![DiscoveredChunk {
+                path: chunk_path(&log_path, 2, 3),
+                timestamp: 2,
+                generation: 3,
+            }]
         );
-
-        let payload_len = Serializable::<Bytes>::serialize(&TestEvent { data: 0 }).len();
-        let serialized_event_len = EVENT_HEADER_LEN + payload_len;
-        let num_events_per_file = MAX_FILE_SIZE / serialized_event_len;
-
-        let num_total_events = num_files * num_events_per_file;
-        let events = generate_test_events(num_total_events as u64);
-
-        let mut logger: WALogger<TestEvent> = logger_config.build().unwrap();
-
-        for (i, event) in events.into_iter().enumerate() {
-            logger.push(&event).unwrap();
-            assert!(logger.curr_file_index == (i / num_events_per_file) as u64)
-        }
     }
 }

--- a/monad-wal/src/wal.rs
+++ b/monad-wal/src/wal.rs
@@ -29,6 +29,10 @@ use tracing::debug;
 
 use crate::WALError;
 
+pub trait WALLog {
+    fn is_wal_logged(&self) -> bool;
+}
+
 /// Header prepended to each event in the log
 pub(crate) type EventHeaderType = u32;
 pub(crate) const EVENT_HEADER_LEN: usize = std::mem::size_of::<EventHeaderType>();


### PR DESCRIPTION
3 commits
- rotate wal chunks in the driver
- move wal writer to a separate thread not to interfere with consensus https://github.com/category-labs/monad-bft/pull/3022
- macro to exclude not needed events from writing to wal (for example forwarded txs) https://github.com/category-labs/monad-bft/pull/3024

also moves writer to a different thread so that wal writing doesn't delay proposal verification. mainly about proposal, as it is the only larger message in the protocol. in this case proposal was 400KB, larger size will take longer than 5ms

<img width="3350" height="1188" alt="image" src="https://github.com/user-attachments/assets/b6d24d12-440d-42ef-a07a-71ed6ce4d3e7" />

separate thread will be mostly idle and shed load on dos

<img width="3350" height="1188" alt="image" src="https://github.com/user-attachments/assets/06aa83c4-536b-48f9-b82f-f1e197033a4d" />

