### PR TITLE
Cover log query block-alignment and remove redundant indexed limit check

### DIFF
--- a/monad-chain-data/src/query/indexed.rs
+++ b/monad-chain-data/src/query/indexed.rs
@@ -91,10 +91,6 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
                 location.log_block_idx,
             );
 
-            if stop_after_block.is_none() && logs.len() >= request.limit {
-                stop_after_block = Some(location.block_number);
-            }
-
             logs.push(log);
 
             if stop_after_block.is_none() && logs.len() >= request.limit {

--- a/monad-chain-data/tests/query_logs_indexed.rs
+++ b/monad-chain-data/tests/query_logs_indexed.rs
@@ -269,6 +269,133 @@ async fn indexed_query_logs_scans_across_bucket_and_page_boundaries() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn indexed_query_completes_current_block_when_limit_reached_mid_block() {
+    let service =
+        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 1,
+            block_hash: B256::repeat_byte(1),
+            parent_hash: B256::ZERO,
+            logs_by_tx: vec![vec![log(
+                Address::repeat_byte(7),
+                vec![B256::repeat_byte(9)],
+            )]],
+        })
+        .await
+        .expect("ingest block 1");
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 2,
+            block_hash: B256::repeat_byte(2),
+            parent_hash: B256::repeat_byte(1),
+            logs_by_tx: vec![vec![
+                log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
+                log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
+                log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
+                log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
+                log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
+            ]],
+        })
+        .await
+        .expect("ingest block 2");
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 3,
+            block_hash: B256::repeat_byte(3),
+            parent_hash: B256::repeat_byte(2),
+            logs_by_tx: vec![vec![log(
+                Address::repeat_byte(7),
+                vec![B256::repeat_byte(9)],
+            )]],
+        })
+        .await
+        .expect("ingest block 3");
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(1),
+            to_block: Some(3),
+            order: QueryOrder::Ascending,
+            limit: 2,
+            filter: LogFilter {
+                address: Some(HashSet::from([Address::repeat_byte(7)])),
+                topics: [
+                    Some(HashSet::from([B256::repeat_byte(9)])),
+                    None,
+                    None,
+                    None,
+                ],
+            },
+        })
+        .await
+        .expect("query");
+
+    assert_eq!(page.logs.len(), 6);
+    assert!(page.logs.iter().take(1).all(|l| l.block_number == 1));
+    assert!(page.logs.iter().skip(1).all(|l| l.block_number == 2));
+    assert_eq!(page.cursor_block.number, 2);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn indexed_query_stops_at_block_when_limit_equals_block_match_count() {
+    let service =
+        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 1,
+            block_hash: B256::repeat_byte(1),
+            parent_hash: B256::ZERO,
+            logs_by_tx: vec![vec![
+                log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
+                log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
+            ]],
+        })
+        .await
+        .expect("ingest block 1");
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 2,
+            block_hash: B256::repeat_byte(2),
+            parent_hash: B256::repeat_byte(1),
+            logs_by_tx: vec![vec![log(
+                Address::repeat_byte(7),
+                vec![B256::repeat_byte(9)],
+            )]],
+        })
+        .await
+        .expect("ingest block 2");
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(1),
+            to_block: Some(2),
+            order: QueryOrder::Ascending,
+            limit: 2,
+            filter: LogFilter {
+                address: Some(HashSet::from([Address::repeat_byte(7)])),
+                topics: [
+                    Some(HashSet::from([B256::repeat_byte(9)])),
+                    None,
+                    None,
+                    None,
+                ],
+            },
+        })
+        .await
+        .expect("query");
+
+    assert_eq!(page.logs.len(), 2);
+    assert!(page.logs.iter().all(|l| l.block_number == 1));
+    assert_eq!(page.cursor_block.number, 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn unindexed_query_logs_still_uses_block_scan_fallback() {
     let service =
         MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());

--- a/monad-chain-data/tests/query_logs_scan.rs
+++ b/monad-chain-data/tests/query_logs_scan.rs
@@ -206,6 +206,51 @@ async fn ingest_assigns_contiguous_log_id_windows_across_empty_blocks() {
     assert_eq!(block_3.logs.count, 1);
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn block_scan_completes_current_block_when_limit_reached_mid_block() {
+    let service =
+        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 1,
+            block_hash: B256::repeat_byte(1),
+            parent_hash: B256::ZERO,
+            logs_by_tx: vec![vec![
+                log(Address::repeat_byte(5), B256::repeat_byte(8)),
+                log(Address::repeat_byte(5), B256::repeat_byte(8)),
+                log(Address::repeat_byte(5), B256::repeat_byte(8)),
+            ]],
+        })
+        .await
+        .expect("ingest block 1");
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 2,
+            block_hash: B256::repeat_byte(2),
+            parent_hash: B256::repeat_byte(1),
+            logs_by_tx: vec![vec![log(Address::repeat_byte(5), B256::repeat_byte(8))]],
+        })
+        .await
+        .expect("ingest block 2");
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(1),
+            to_block: Some(2),
+            order: QueryOrder::Ascending,
+            limit: 1,
+            filter: LogFilter::default(),
+        })
+        .await
+        .expect("query");
+
+    assert_eq!(page.logs.len(), 3);
+    assert!(page.logs.iter().all(|l| l.block_number == 1));
+    assert_eq!(page.cursor_block.number, 1);
+}
+
 fn log(address: Address, topic0: B256) -> Log {
     Log {
         address,


### PR DESCRIPTION
Pin the queryX spec invariant that the server always completes the current block before stopping, with three black-box tests covering both indexed and block-scan paths at exactly-limit and mid-block-limit boundaries.

The indexed query loop had two consecutive checks that both attempted to set stop_after_block when logs.len() crossed the limit. The pre-push check could never fire first: between iterations, stop_after_block remains None only if the previous iteration's post-push check did not fire, which means logs.len() < limit before the current push. The redundant check is removed.