### PR TITLE
Tighten log query range resolution

### DIFF
--- a/monad-chain-data/src/lib.rs
+++ b/monad-chain-data/src/lib.rs
@@ -25,6 +25,7 @@ pub mod store;
 
 pub use alloy_primitives::{Address, Bytes, Log, LogData, B256};
 pub use api::{IngestOutcome, MonadChainDataService};
+pub use error::MonadChainDataError;
 pub use family::{FinalizedBlock, Hash32};
 pub use kernel::tables::Tables;
 pub use logs::{LogEntry, LogFilter, QueryLogsRequest, QueryLogsResponse};

--- a/monad-chain-data/src/primitives/range.rs
+++ b/monad-chain-data/src/primitives/range.rs
@@ -21,6 +21,10 @@ use crate::{
     store::MetaStore,
 };
 
+/// Floor for the lower numeric bound. The current ingest path requires the
+/// chain to start at block 1, so block 0 has no record to load.
+const EARLIEST_QUERYABLE_BLOCK: u64 = 1;
+
 /// Inclusive block range clipped to the published head.
 ///
 /// `from_block.number <= to_block.number` always holds, regardless of query
@@ -58,19 +62,18 @@ impl ResolvedBlockWindow {
         })
     }
 
-    /// Resolves and validates the block range. Always returns (low, high) with
-    /// `low <= high`, independent of query order.
     fn resolve_query_block_numbers(
         request: &QueryLogsRequest,
         published_head: u64,
     ) -> Result<(u64, u64)> {
-        if request.from_block.is_some_and(|from| from > published_head) {
+        let from = request.from_block.unwrap_or(EARLIEST_QUERYABLE_BLOCK);
+        if from > published_head {
             return Err(MonadChainDataError::InvalidRequest(
                 "from_block must be <= published head",
             ));
         }
-
-        let from = request.from_block.unwrap_or(1).max(1);
+        // Floors an explicit `from_block = 0` to avoid loading a nonexistent record.
+        let from = from.max(EARLIEST_QUERYABLE_BLOCK);
         let to = request
             .to_block
             .unwrap_or(published_head)

--- a/monad-chain-data/tests/query_logs_range_resolution.rs
+++ b/monad-chain-data/tests/query_logs_range_resolution.rs
@@ -1,0 +1,134 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use monad_chain_data::{
+    Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData, LogFilter,
+    MonadChainDataError, MonadChainDataService, QueryLogsRequest, QueryOrder, B256,
+};
+
+#[tokio::test(flavor = "current_thread")]
+async fn from_block_above_head_returns_invalid_request() {
+    let service = ingest_two_block_chain().await;
+
+    let err = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(50),
+            to_block: Some(60),
+            order: QueryOrder::Ascending,
+            limit: 10,
+            filter: LogFilter::default(),
+        })
+        .await
+        .expect_err("from_block above head should not silently collapse");
+
+    assert!(
+        matches!(err, MonadChainDataError::InvalidRequest(_)),
+        "expected InvalidRequest, got {err:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn to_block_above_head_clips_to_head() {
+    let service = ingest_two_block_chain().await;
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(1),
+            to_block: Some(50),
+            order: QueryOrder::Ascending,
+            limit: 100,
+            filter: LogFilter::default(),
+        })
+        .await
+        .expect("query");
+
+    assert_eq!(page.from_block.number, 1);
+    assert_eq!(page.to_block.number, 2);
+    assert_eq!(page.cursor_block.number, 2);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn inverted_range_returns_invalid_request() {
+    let service = ingest_two_block_chain().await;
+
+    let err = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(2),
+            to_block: Some(1),
+            order: QueryOrder::Ascending,
+            limit: 10,
+            filter: LogFilter::default(),
+        })
+        .await
+        .expect_err("from > to should error");
+
+    assert!(
+        matches!(err, MonadChainDataError::InvalidRequest(_)),
+        "expected InvalidRequest, got {err:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn defaulted_range_resolves_to_full_chain() {
+    let service = ingest_two_block_chain().await;
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            from_block: None,
+            to_block: None,
+            order: QueryOrder::Ascending,
+            limit: 100,
+            filter: LogFilter::default(),
+        })
+        .await
+        .expect("query");
+
+    assert_eq!(page.from_block.number, 1);
+    assert_eq!(page.to_block.number, 2);
+}
+
+async fn ingest_two_block_chain() -> MonadChainDataService<InMemoryMetaStore, InMemoryBlobStore> {
+    let service =
+        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 1,
+            block_hash: B256::repeat_byte(1),
+            parent_hash: B256::ZERO,
+            logs_by_tx: vec![vec![log(Address::repeat_byte(1), B256::repeat_byte(1))]],
+        })
+        .await
+        .expect("ingest block 1");
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 2,
+            block_hash: B256::repeat_byte(2),
+            parent_hash: B256::repeat_byte(1),
+            logs_by_tx: vec![vec![log(Address::repeat_byte(2), B256::repeat_byte(2))]],
+        })
+        .await
+        .expect("ingest block 2");
+
+    service
+}
+
+fn log(address: Address, topic0: B256) -> Log {
+    Log {
+        address,
+        data: LogData::new_unchecked(vec![topic0], Bytes::from(vec![1, 2, 3])),
+    }
+}


### PR DESCRIPTION
Replaces the silent from_block.min(published_head) clip with an explicit InvalidRequest error: a request whose lower bound is above the published head should not collapse to [head, head]. Adds an EARLIEST_QUERYABLE_BLOCK constant and floors an explicit from_block = 0 against it so the resolver does not try to load a nonexistent record on a chain that started at block 1.

Re-exports MonadChainDataError so integration tests can match on it.