### PR TITLE
Adopt queryX spec from/to semantics in log queries

### DIFF
--- a/monad-chain-data/src/logs/materialize.rs
+++ b/monad-chain-data/src/logs/materialize.rs
@@ -42,17 +42,17 @@ pub(crate) enum IndexedLogClause {
     Topic { position: usize, values: Vec<B256> },
 }
 
+/// Public log query in queryX spec semantics: `from_block`/`to_block` are
+/// the inclusive range start/end, with the lower/upper roles depending on
+/// `order`. Omitted bounds default to `"earliest"`/`"latest"` per order.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryLogsRequest {
     pub from_block: Option<u64>,
     pub to_block: Option<u64>,
     pub order: QueryOrder,
-    /// Target number of primary log objects to return.
-    ///
-    /// The server always completes the current block before stopping, so the
-    /// actual count may exceed this value. The server may also return fewer if
-    /// an internal constraint is reached. Defaults to
-    /// [`DEFAULT_QUERY_LIMIT`] (100).
+    /// Target log count. The server completes the current block before
+    /// stopping, so the actual count may exceed this. Defaults to
+    /// [`DEFAULT_QUERY_LIMIT`].
     pub limit: usize,
     pub filter: LogFilter,
 }
@@ -69,6 +69,9 @@ impl Default for QueryLogsRequest {
     }
 }
 
+/// `from_block`/`to_block` mirror the request's spec semantics. `cursor_block`
+/// is the last block scanned; pagination resumes from `cursor_block.number ± 1`
+/// per order.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryLogsResponse {
     pub logs: Vec<LogEntry>,

--- a/monad-chain-data/src/primitives/range.rs
+++ b/monad-chain-data/src/primitives/range.rs
@@ -17,7 +17,7 @@ use crate::{
     error::{MonadChainDataError, Result},
     kernel::tables::BlockTables,
     logs::QueryLogsRequest,
-    primitives::refs::BlockRef,
+    primitives::{page::QueryOrder, refs::BlockRef},
     store::MetaStore,
 };
 
@@ -25,65 +25,104 @@ use crate::{
 /// chain to start at block 1, so block 0 has no record to load.
 const EARLIEST_QUERYABLE_BLOCK: u64 = 1;
 
-/// Inclusive block range clipped to the published head.
-///
-/// `from_block.number <= to_block.number` always holds, regardless of query
-/// order. Callers choose iteration direction based on `QueryOrder`.
+/// Inclusive block range in `(low, high)` form with `low.number <= high.number`.
+/// Iteration direction is the caller's choice via `QueryOrder`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResolvedBlockWindow {
-    pub from_block: BlockRef,
-    pub to_block: BlockRef,
+    pub low: BlockRef,
+    pub high: BlockRef,
 }
 
 impl ResolvedBlockWindow {
     /// Resolves a query's inclusive block range against the published head.
+    /// Translates the spec's order-dependent `from_block`/`to_block` into
+    /// the internal order-independent `(low, high)` form.
     pub async fn resolve<M: MetaStore>(
         request: &QueryLogsRequest,
         published_head: u64,
         blocks: &BlockTables<M>,
     ) -> Result<Self> {
-        let (from_number, to_number) = Self::resolve_query_block_numbers(request, published_head)?;
+        let (low_number, high_number) = Self::resolve_block_numbers(request, published_head)?;
 
-        let from_record =
+        let low_record =
             blocks
-                .load_record(from_number)
+                .load_record(low_number)
                 .await?
                 .ok_or(MonadChainDataError::MissingData(
-                    "missing from_block record",
+                    "missing block record at range low bound",
                 ))?;
-        let to_record = blocks
-            .load_record(to_number)
-            .await?
-            .ok_or(MonadChainDataError::MissingData("missing to_block record"))?;
+        let high_record =
+            blocks
+                .load_record(high_number)
+                .await?
+                .ok_or(MonadChainDataError::MissingData(
+                    "missing block record at range high bound",
+                ))?;
 
         Ok(Self {
-            from_block: BlockRef::from(&from_record),
-            to_block: BlockRef::from(&to_record),
+            low: BlockRef::from(&low_record),
+            high: BlockRef::from(&high_record),
         })
     }
 
-    fn resolve_query_block_numbers(
+    /// Maps internal `(low, high)` back to spec `(from, to)` for the given order.
+    pub fn request_endpoints(&self, order: QueryOrder) -> (BlockRef, BlockRef) {
+        match order {
+            QueryOrder::Ascending => (self.low, self.high),
+            QueryOrder::Descending => (self.high, self.low),
+        }
+    }
+
+    /// Maps the spec's order-dependent `(from_block, to_block)` to internal
+    /// `(low, high)` with `low <= high`. Errors if the inputs do not form a
+    /// valid range for `order`, or if the lower bound exceeds the published head.
+    fn resolve_block_numbers(
         request: &QueryLogsRequest,
         published_head: u64,
     ) -> Result<(u64, u64)> {
-        let from = request.from_block.unwrap_or(EARLIEST_QUERYABLE_BLOCK);
-        if from > published_head {
-            return Err(MonadChainDataError::InvalidRequest(
-                "from_block must be <= published head",
-            ));
+        // User-space inversion is checked before defaults so an unspecified
+        // bound (e.g. `from=None, to=N` with `N` above head) reports the
+        // genuine cause (above-head) rather than a defaulted-inversion artifact.
+        if let (Some(from), Some(to)) = (request.from_block, request.to_block) {
+            let inverted = match request.order {
+                QueryOrder::Ascending => from > to,
+                QueryOrder::Descending => from < to,
+            };
+            if inverted {
+                return Err(MonadChainDataError::InvalidRequest(
+                    "from_block and to_block do not form a valid range for the requested order",
+                ));
+            }
         }
-        // Floors an explicit `from_block = 0` to avoid loading a nonexistent record.
-        let from = from.max(EARLIEST_QUERYABLE_BLOCK);
-        let to = request
-            .to_block
-            .unwrap_or(published_head)
-            .min(published_head);
 
-        if from > to {
+        let (low, high) = match request.order {
+            QueryOrder::Ascending => (
+                request.from_block.unwrap_or(EARLIEST_QUERYABLE_BLOCK),
+                request.to_block.unwrap_or(published_head),
+            ),
+            QueryOrder::Descending => (
+                request.to_block.unwrap_or(EARLIEST_QUERYABLE_BLOCK),
+                request.from_block.unwrap_or(published_head),
+            ),
+        };
+
+        // The lower bound must be an ingested block — silently collapsing
+        // `low > head` to `[head, head]` would mask caller bugs and return
+        // empty pages. The upper bound is treated as "up to head" and clipped.
+        if low > published_head {
             return Err(MonadChainDataError::InvalidRequest(
-                "from_block must be <= to_block",
+                "block range starts above the published head",
             ));
         }
-        Ok((from, to))
+        let high = high.min(published_head);
+        // Floors an explicit `from_block = 0` to avoid loading a nonexistent record.
+        let low = low.max(EARLIEST_QUERYABLE_BLOCK);
+
+        if low > high {
+            return Err(MonadChainDataError::InvalidRequest(
+                "from_block and to_block do not form a valid range for the requested order",
+            ));
+        }
+        Ok((low, high))
     }
 }

--- a/monad-chain-data/src/query/indexed.rs
+++ b/monad-chain-data/src/query/indexed.rs
@@ -32,12 +32,14 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
     request: &QueryLogsRequest,
     block_window: ResolvedBlockWindow,
 ) -> Result<QueryLogsResponse> {
+    let (request_from, request_to) = block_window.request_endpoints(request.order);
+
     let Some(log_window) = resolve_log_window(tables, &block_window).await? else {
         return Ok(QueryLogsResponse {
             logs: Vec::new(),
-            from_block: block_window.from_block,
-            to_block: block_window.to_block,
-            cursor_block: block_window.to_block,
+            from_block: request_from,
+            to_block: request_to,
+            cursor_block: request_to,
         });
     };
 
@@ -74,8 +76,8 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
                     let cursor_block = materializer.load_block_ref(stop_block).await?;
                     return Ok(QueryLogsResponse {
                         logs,
-                        from_block: block_window.from_block,
-                        to_block: block_window.to_block,
+                        from_block: request_from,
+                        to_block: request_to,
                         cursor_block,
                     });
                 }
@@ -101,9 +103,9 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
 
     Ok(QueryLogsResponse {
         logs,
-        from_block: block_window.from_block,
-        to_block: block_window.to_block,
-        cursor_block: block_window.to_block,
+        from_block: request_from,
+        to_block: request_to,
+        cursor_block: request_to,
     })
 }
 

--- a/monad-chain-data/src/query/runner.rs
+++ b/monad-chain-data/src/query/runner.rs
@@ -30,8 +30,9 @@ pub async fn execute_block_scan_query<M: MetaStore, B: BlobStore>(
 ) -> Result<QueryLogsResponse> {
     let materializer = LogMaterializer::new(tables);
     let target_log_count = request.limit;
+    let (request_from, request_to) = window.request_endpoints(request.order);
     let mut logs = Vec::new();
-    let mut cursor_block = window.from_block;
+    let mut cursor_block = request_from;
 
     for block_number in block_range(window, request.order) {
         let (block_ref, block_logs) = materializer
@@ -46,14 +47,14 @@ pub async fn execute_block_scan_query<M: MetaStore, B: BlobStore>(
 
     Ok(QueryLogsResponse {
         logs,
-        from_block: window.from_block,
-        to_block: window.to_block,
+        from_block: request_from,
+        to_block: request_to,
         cursor_block,
     })
 }
 
 fn block_range(window: ResolvedBlockWindow, order: QueryOrder) -> impl Iterator<Item = u64> {
-    let range = window.from_block.number..=window.to_block.number;
+    let range = window.low.number..=window.high.number;
     let (fwd, rev) = match order {
         QueryOrder::Ascending => (Some(range), None),
         QueryOrder::Descending => (None, Some(range.rev())),

--- a/monad-chain-data/src/query/window.rs
+++ b/monad-chain-data/src/query/window.rs
@@ -62,14 +62,8 @@ pub(crate) async fn resolve_log_window<M: MetaStore, B: BlobStore>(
     tables: &Tables<M, B>,
     block_window: &ResolvedBlockWindow,
 ) -> Result<Option<ResolvedLogWindow>> {
-    let start_block = block_window
-        .from_block
-        .number
-        .min(block_window.to_block.number);
-    let end_block = block_window
-        .from_block
-        .number
-        .max(block_window.to_block.number);
+    let start_block = block_window.low.number;
+    let end_block = block_window.high.number;
 
     let Some(start) = first_log_id_in_range(tables, start_block, end_block).await? else {
         return Ok(None);

--- a/monad-chain-data/tests/query_logs_indexed.rs
+++ b/monad-chain-data/tests/query_logs_indexed.rs
@@ -106,8 +106,10 @@ async fn indexed_query_logs_descending_returns_newest_first() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(2),
+            // Spec semantics: in descending order from_block is the upper
+            // bound and to_block is the lower bound.
+            from_block: Some(2),
+            to_block: Some(1),
             order: QueryOrder::Descending,
             limit: 1,
             filter: LogFilter {
@@ -389,8 +391,8 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block_desc
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(3),
+            from_block: Some(3),
+            to_block: Some(1),
             order: QueryOrder::Descending,
             limit: 2,
             filter: LogFilter {

--- a/monad-chain-data/tests/query_logs_range_resolution.rs
+++ b/monad-chain-data/tests/query_logs_range_resolution.rs
@@ -81,6 +81,115 @@ async fn inverted_range_returns_invalid_request() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn descending_to_block_above_head_returns_invalid_request() {
+    let service = ingest_two_block_chain().await;
+
+    // In descending order to_block is the lower numeric bound, so
+    // to=50 against head=2 puts the lower bound above head. Leaving
+    // from_block unspecified isolates the lower-bound-above-head path
+    // from the inverted-range path.
+    let err = service
+        .query_logs(QueryLogsRequest {
+            from_block: None,
+            to_block: Some(50),
+            order: QueryOrder::Descending,
+            limit: 10,
+            filter: LogFilter::default(),
+        })
+        .await
+        .expect_err("to_block above head in desc should not silently collapse");
+
+    assert!(
+        matches!(err, MonadChainDataError::InvalidRequest(_)),
+        "expected InvalidRequest, got {err:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn descending_from_above_head_clips_to_head() {
+    let service = ingest_two_block_chain().await;
+
+    // In descending order from_block is the upper bound; values above
+    // the published head clip to head, mirroring the ascending
+    // to_block-above-head behavior.
+    let page = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(50),
+            to_block: Some(1),
+            order: QueryOrder::Descending,
+            limit: 100,
+            filter: LogFilter::default(),
+        })
+        .await
+        .expect("query");
+
+    assert_eq!(page.from_block.number, 2);
+    assert_eq!(page.to_block.number, 1);
+    assert_eq!(page.cursor_block.number, 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn from_block_zero_floors_to_earliest_queryable_block() {
+    let service = ingest_two_block_chain().await;
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(0),
+            to_block: Some(2),
+            order: QueryOrder::Ascending,
+            limit: 100,
+            filter: LogFilter::default(),
+        })
+        .await
+        .expect("query");
+
+    assert_eq!(page.from_block.number, 1);
+    assert_eq!(page.to_block.number, 2);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn descending_inverted_range_returns_invalid_request() {
+    let service = ingest_two_block_chain().await;
+
+    // In descending order from_block is the upper bound; from < to is
+    // the wrong shape.
+    let err = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(1),
+            to_block: Some(2),
+            order: QueryOrder::Descending,
+            limit: 10,
+            filter: LogFilter::default(),
+        })
+        .await
+        .expect_err("descending from < to should error");
+
+    assert!(
+        matches!(err, MonadChainDataError::InvalidRequest(_)),
+        "expected InvalidRequest, got {err:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn descending_defaulted_range_inverts_endpoints() {
+    let service = ingest_two_block_chain().await;
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            from_block: None,
+            to_block: None,
+            order: QueryOrder::Descending,
+            limit: 100,
+            filter: LogFilter::default(),
+        })
+        .await
+        .expect("query");
+
+    assert_eq!(page.from_block.number, 2);
+    assert_eq!(page.to_block.number, 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn defaulted_range_resolves_to_full_chain() {
     let service = ingest_two_block_chain().await;
 

--- a/monad-chain-data/tests/query_logs_scan.rs
+++ b/monad-chain-data/tests/query_logs_scan.rs
@@ -165,7 +165,7 @@ async fn query_logs_rejects_from_block_above_published_head() {
 
     assert!(matches!(
         err,
-        MonadChainDataError::InvalidRequest("from_block must be <= published head")
+        MonadChainDataError::InvalidRequest("block range starts above the published head")
     ));
 }
 


### PR DESCRIPTION
The public QueryLogsRequest/QueryLogsResponse now follow the queryX spec's order-dependent fromBlock/toBlock semantics: in ascending order from is the lower bound and to is the upper bound; in descending order the roles invert. Internally the substrate keeps its order-independent (low, high) form on ResolvedBlockWindow and translates back via request_endpoints when assembling responses.

This is a breaking API change for descending callers: requests that used to pass `from <= to` regardless of order now error in descending mode. Callers must flip to `from >= to` (high, low) or rely on the new order-aware defaults.