### PR TITLE
Add query limits to MonadChainDataService

### DIFF
--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -23,6 +23,7 @@ use crate::{
     kernel::tables::Tables,
     logs::{LogIngestPlan, QueryLogsRequest, QueryLogsResponse},
     primitives::{
+        limits::{LimitExceededKind, QueryLimits},
         range::ResolvedBlockWindow,
         state::{BlockRecord, LogId},
     },
@@ -32,6 +33,7 @@ use crate::{
 
 pub struct MonadChainDataService<M: MetaStore, B: BlobStore> {
     tables: Tables<M, B>,
+    limits: QueryLimits,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -42,14 +44,19 @@ pub struct IngestOutcome {
 }
 
 impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
-    pub fn new(meta_store: M, blob_store: B) -> Self {
+    pub fn new(meta_store: M, blob_store: B, limits: QueryLimits) -> Self {
         Self {
             tables: Tables::new(meta_store, blob_store),
+            limits,
         }
     }
 
     pub fn tables(&self) -> &Tables<M, B> {
         &self.tables
+    }
+
+    pub fn limits(&self) -> &QueryLimits {
+        &self.limits
     }
 
     // TODO: Individual writes are idempotent, but a partial failure leaves the block
@@ -120,11 +127,20 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
     }
 
     /// Executes a finalized logs query over the current published head.
+    /// The service's configured `QueryLimits` bound the request shape and
+    /// the resolved block-range span.
     pub async fn query_logs(&self, request: QueryLogsRequest) -> Result<QueryLogsResponse> {
         if request.limit == 0 {
             return Err(MonadChainDataError::InvalidRequest(
                 "limit must be at least 1",
             ));
+        }
+        if request.limit > self.limits.max_limit {
+            return Err(MonadChainDataError::LimitExceeded {
+                kind: LimitExceededKind::Limit,
+                max_limit: self.limits.max_limit,
+                max_block_range: self.limits.max_block_range,
+            });
         }
 
         let head = self
@@ -133,7 +149,9 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
             .load_published_head()
             .await?
             .ok_or(MonadChainDataError::MissingData("no published blocks"))?;
-        let window = ResolvedBlockWindow::resolve(&request, head, self.tables.blocks()).await?;
+        let window =
+            ResolvedBlockWindow::resolve(&request, head, &self.limits, self.tables.blocks())
+                .await?;
 
         if request.filter.has_indexed_clause() {
             return execute_indexed_log_query(&self.tables, &request, window).await;

--- a/monad-chain-data/src/error.rs
+++ b/monad-chain-data/src/error.rs
@@ -15,6 +15,8 @@
 
 use thiserror::Error;
 
+use crate::primitives::limits::LimitExceededKind;
+
 pub type Result<T> = std::result::Result<T, MonadChainDataError>;
 
 #[derive(Debug, Error)]
@@ -29,4 +31,10 @@ pub enum MonadChainDataError {
     InvalidRequest(&'static str),
     #[error("missing data: {0}")]
     MissingData(&'static str),
+    #[error("limit exceeded ({kind}): max_limit={max_limit}, max_block_range={max_block_range}")]
+    LimitExceeded {
+        kind: LimitExceededKind,
+        max_limit: usize,
+        max_block_range: u64,
+    },
 }

--- a/monad-chain-data/src/lib.rs
+++ b/monad-chain-data/src/lib.rs
@@ -30,6 +30,7 @@ pub use family::{FinalizedBlock, Hash32};
 pub use kernel::tables::Tables;
 pub use logs::{LogEntry, LogFilter, QueryLogsRequest, QueryLogsResponse};
 pub use primitives::{
+    limits::{LimitExceededKind, QueryLimits},
     page::{QueryOrder, DEFAULT_QUERY_LIMIT},
     refs::BlockRef,
     state::{BlockRecord, FamilyWindowRecord, LogId},

--- a/monad-chain-data/src/primitives/limits.rs
+++ b/monad-chain-data/src/primitives/limits.rs
@@ -1,0 +1,64 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+/// Per-deployment caps on accepted query shape. `max_limit` bounds the
+/// `request.limit` value the user may pass; `max_block_range` bounds the
+/// resolved range span. Breaches surface as
+/// [`crate::MonadChainDataError::LimitExceeded`], which the RPC layer maps
+/// to the queryX spec's `-32005 Limit exceeded` response. Neither cap
+/// constrains how many results a single block may return: the spec
+/// requires the server to complete the current block before stopping, so
+/// returned counts can exceed `max_limit` for a hot block.
+///
+/// `max_block_range` doubles as the worst-case scan budget for filters
+/// without an indexed clause: that path loads every block in the
+/// resolved window, so the bound on the window directly bounds the
+/// scan. A separate execution-time budget (e.g. wall-time for hot
+/// shards) is left for a future `ExecutionBudget` type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryLimits {
+    pub max_limit: usize,
+    pub max_block_range: u64,
+}
+
+impl QueryLimits {
+    /// Permissive limits for tests and trusted internal callers.
+    pub const UNLIMITED: Self = Self {
+        max_limit: usize::MAX,
+        max_block_range: u64::MAX,
+    };
+
+    pub const fn new(max_limit: usize, max_block_range: u64) -> Self {
+        Self {
+            max_limit,
+            max_block_range,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LimitExceededKind {
+    Limit,
+    BlockRange,
+}
+
+impl std::fmt::Display for LimitExceededKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Limit => f.write_str("limit"),
+            Self::BlockRange => f.write_str("block range"),
+        }
+    }
+}

--- a/monad-chain-data/src/primitives/mod.rs
+++ b/monad-chain-data/src/primitives/mod.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+pub mod limits;
 pub mod page;
 pub mod range;
 pub mod refs;

--- a/monad-chain-data/src/primitives/range.rs
+++ b/monad-chain-data/src/primitives/range.rs
@@ -17,7 +17,11 @@ use crate::{
     error::{MonadChainDataError, Result},
     kernel::tables::BlockTables,
     logs::QueryLogsRequest,
-    primitives::{page::QueryOrder, refs::BlockRef},
+    primitives::{
+        limits::{LimitExceededKind, QueryLimits},
+        page::QueryOrder,
+        refs::BlockRef,
+    },
     store::MetaStore,
 };
 
@@ -34,15 +38,25 @@ pub struct ResolvedBlockWindow {
 }
 
 impl ResolvedBlockWindow {
-    /// Resolves a query's inclusive block range against the published head.
-    /// Translates the spec's order-dependent `from_block`/`to_block` into
-    /// the internal order-independent `(low, high)` form.
+    /// Resolves a query's inclusive block range against the published head,
+    /// short-circuits if the resolved span exceeds `limits.max_block_range`,
+    /// then loads the per-bound block records.
     pub async fn resolve<M: MetaStore>(
         request: &QueryLogsRequest,
         published_head: u64,
+        limits: &QueryLimits,
         blocks: &BlockTables<M>,
     ) -> Result<Self> {
         let (low_number, high_number) = Self::resolve_block_numbers(request, published_head)?;
+
+        let span = high_number - low_number + 1;
+        if span > limits.max_block_range {
+            return Err(MonadChainDataError::LimitExceeded {
+                kind: LimitExceededKind::BlockRange,
+                max_limit: limits.max_limit,
+                max_block_range: limits.max_block_range,
+            });
+        }
 
         let low_record =
             blocks

--- a/monad-chain-data/tests/log_bitmap_fragments.rs
+++ b/monad-chain-data/tests/log_bitmap_fragments.rs
@@ -16,13 +16,16 @@
 use monad_chain_data::{
     kernel::bitmap::{decode_bitmap_blob, sharded_stream_id, STREAM_PAGE_LOCAL_ID_SPAN},
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData,
-    MonadChainDataService, Topic, B256,
+    MonadChainDataService, QueryLimits, Topic, B256,
 };
 
 #[tokio::test(flavor = "current_thread")]
 async fn ingest_persists_log_bitmap_fragments_for_address_and_topics() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {
@@ -82,8 +85,11 @@ async fn ingest_persists_log_bitmap_fragments_for_address_and_topics() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn ingest_persists_log_bitmap_fragments_across_page_boundaries() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {
@@ -149,8 +155,11 @@ async fn ingest_persists_log_bitmap_fragments_across_page_boundaries() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn ingest_empty_block_writes_no_log_bitmap_fragments() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {

--- a/monad-chain-data/tests/log_bitmap_pages.rs
+++ b/monad-chain-data/tests/log_bitmap_pages.rs
@@ -23,7 +23,7 @@ use monad_chain_data::{
     },
     store::MetaStore,
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData, LogFilter,
-    MonadChainDataService, QueryLogsRequest, QueryOrder, Topic, B256,
+    MonadChainDataService, QueryLimits, QueryLogsRequest, QueryOrder, Topic, B256,
 };
 
 // Fills a full bitmap page (~65k logs) to exercise the seal/compaction path;
@@ -33,7 +33,8 @@ use monad_chain_data::{
 async fn ingest_compacts_sealed_pages_and_query_prefers_compacted_page_blobs() {
     let meta_store = InMemoryMetaStore::default();
     let blob_store = InMemoryBlobStore::default();
-    let service = MonadChainDataService::new(meta_store.clone(), blob_store);
+    let service =
+        MonadChainDataService::new(meta_store.clone(), blob_store, QueryLimits::UNLIMITED);
 
     let old_address = Address::repeat_byte(7);
     let old_topic = B256::repeat_byte(9);
@@ -144,7 +145,8 @@ async fn ingest_compacts_sealed_pages_and_query_prefers_compacted_page_blobs() {
 async fn query_errors_when_compacted_page_meta_exists_but_blob_is_missing() {
     let meta_store = InMemoryMetaStore::default();
     let blob_store = InMemoryBlobStore::default();
-    let service = MonadChainDataService::new(meta_store.clone(), blob_store);
+    let service =
+        MonadChainDataService::new(meta_store.clone(), blob_store, QueryLimits::UNLIMITED);
 
     let address = Address::repeat_byte(7);
     let topic = B256::repeat_byte(9);

--- a/monad-chain-data/tests/log_dir_buckets.rs
+++ b/monad-chain-data/tests/log_dir_buckets.rs
@@ -16,13 +16,16 @@
 use monad_chain_data::{
     kernel::primary_dir::{PrimaryDirBucket, PrimaryDirFragment, DIRECTORY_BUCKET_SIZE},
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData,
-    MonadChainDataService, B256,
+    MonadChainDataService, QueryLimits, B256,
 };
 
 #[tokio::test(flavor = "current_thread")]
 async fn ingest_compacts_a_sealed_directory_bucket_when_crossing_the_boundary() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {

--- a/monad-chain-data/tests/log_dir_fragments.rs
+++ b/monad-chain-data/tests/log_dir_fragments.rs
@@ -16,13 +16,16 @@
 use monad_chain_data::{
     kernel::primary_dir::{PrimaryDirFragment, DIRECTORY_BUCKET_SIZE},
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData,
-    MonadChainDataService, B256,
+    MonadChainDataService, QueryLimits, B256,
 };
 
 #[tokio::test(flavor = "current_thread")]
 async fn ingest_persists_log_dir_fragment_for_single_bucket_block() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {
@@ -53,8 +56,11 @@ async fn ingest_persists_log_dir_fragment_for_single_bucket_block() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn ingest_persists_zero_width_fragment_for_empty_block() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {
@@ -85,8 +91,11 @@ async fn ingest_persists_zero_width_fragment_for_empty_block() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn ingest_persists_spanning_fragment_in_each_covered_bucket() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {

--- a/monad-chain-data/tests/query_logs_indexed.rs
+++ b/monad-chain-data/tests/query_logs_indexed.rs
@@ -18,13 +18,16 @@ use std::collections::HashSet;
 use monad_chain_data::{
     kernel::{bitmap::STREAM_PAGE_LOCAL_ID_SPAN, primary_dir::DIRECTORY_BUCKET_SIZE},
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData, LogFilter,
-    MonadChainDataService, QueryLogsRequest, QueryOrder, Topic, B256,
+    MonadChainDataService, QueryLimits, QueryLogsRequest, QueryOrder, Topic, B256,
 };
 
 #[tokio::test(flavor = "current_thread")]
 async fn indexed_query_logs_respects_and_or_filter_semantics() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {
@@ -75,8 +78,11 @@ async fn indexed_query_logs_respects_and_or_filter_semantics() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn indexed_query_logs_descending_returns_newest_first() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {
@@ -135,8 +141,11 @@ async fn indexed_query_logs_descending_returns_newest_first() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn indexed_query_logs_paginates_at_block_boundaries() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {
@@ -211,8 +220,11 @@ async fn indexed_query_logs_paginates_at_block_boundaries() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn indexed_query_logs_scans_across_bucket_and_page_boundaries() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {
@@ -272,8 +284,11 @@ async fn indexed_query_logs_scans_across_bucket_and_page_boundaries() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn indexed_query_completes_current_block_when_limit_reached_mid_block() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {
@@ -344,8 +359,11 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn indexed_query_completes_current_block_when_limit_reached_mid_block_descending() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {
@@ -416,8 +434,11 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block_desc
 
 #[tokio::test(flavor = "current_thread")]
 async fn indexed_query_stops_at_block_when_limit_equals_block_match_count() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {
@@ -471,8 +492,11 @@ async fn indexed_query_stops_at_block_when_limit_equals_block_match_count() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn unindexed_query_logs_still_uses_block_scan_fallback() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {

--- a/monad-chain-data/tests/query_logs_limits.rs
+++ b/monad-chain-data/tests/query_logs_limits.rs
@@ -1,0 +1,161 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use monad_chain_data::{
+    Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, LimitExceededKind, Log,
+    LogData, LogFilter, MonadChainDataError, MonadChainDataService, QueryLimits, QueryLogsRequest,
+    QueryOrder, B256,
+};
+
+#[tokio::test(flavor = "current_thread")]
+async fn limit_above_max_limit_returns_limit_exceeded() {
+    let service = ingest_three_block_chain(QueryLimits::new(5, 1_000)).await;
+
+    let err = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(1),
+            to_block: Some(3),
+            order: QueryOrder::Ascending,
+            limit: 10,
+            filter: LogFilter::default(),
+        })
+        .await
+        .expect_err("limit above max_limit should error");
+
+    match err {
+        MonadChainDataError::LimitExceeded {
+            kind,
+            max_limit,
+            max_block_range,
+        } => {
+            assert_eq!(kind, LimitExceededKind::Limit);
+            assert_eq!(max_limit, 5);
+            assert_eq!(max_block_range, 1_000);
+        }
+        other => panic!("expected LimitExceeded, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn block_range_above_max_block_range_returns_limit_exceeded() {
+    let service = ingest_three_block_chain(QueryLimits::new(100, 2)).await;
+
+    let err = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(1),
+            to_block: Some(3),
+            order: QueryOrder::Ascending,
+            limit: 10,
+            filter: LogFilter::default(),
+        })
+        .await
+        .expect_err("block range above max_block_range should error");
+
+    match err {
+        MonadChainDataError::LimitExceeded {
+            kind,
+            max_limit,
+            max_block_range,
+        } => {
+            assert_eq!(kind, LimitExceededKind::BlockRange);
+            assert_eq!(max_limit, 100);
+            assert_eq!(max_block_range, 2);
+        }
+        other => panic!("expected LimitExceeded, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn block_range_at_max_block_range_succeeds() {
+    let service = ingest_three_block_chain(QueryLimits::new(100, 3)).await;
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(1),
+            to_block: Some(3),
+            order: QueryOrder::Ascending,
+            limit: 10,
+            filter: LogFilter::default(),
+        })
+        .await
+        .expect("query at max should succeed");
+
+    assert_eq!(page.from_block.number, 1);
+    assert_eq!(page.to_block.number, 3);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn defaulted_block_range_is_bounded_by_max_block_range() {
+    // Limits allow a 2-block window; defaults expand to the full chain
+    // (3 blocks), which should still be bounded.
+    let service = ingest_three_block_chain(QueryLimits::new(100, 2)).await;
+
+    let err = service
+        .query_logs(QueryLogsRequest {
+            from_block: None,
+            to_block: None,
+            order: QueryOrder::Ascending,
+            limit: 10,
+            filter: LogFilter::default(),
+        })
+        .await
+        .expect_err("defaulted full-chain range should be bounded");
+
+    assert!(
+        matches!(
+            err,
+            MonadChainDataError::LimitExceeded {
+                kind: LimitExceededKind::BlockRange,
+                ..
+            }
+        ),
+        "expected BlockRange LimitExceeded, got {err:?}"
+    );
+}
+
+async fn ingest_three_block_chain(
+    limits: QueryLimits,
+) -> MonadChainDataService<InMemoryMetaStore, InMemoryBlobStore> {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        limits,
+    );
+
+    for (n, prev_hash) in [
+        (1u64, B256::ZERO),
+        (2, B256::repeat_byte(1)),
+        (3, B256::repeat_byte(2)),
+    ] {
+        service
+            .ingest_block(FinalizedBlock {
+                block_number: n,
+                block_hash: B256::repeat_byte(n as u8),
+                parent_hash: prev_hash,
+                logs_by_tx: vec![vec![log()]],
+            })
+            .await
+            .expect("ingest block");
+    }
+
+    service
+}
+
+fn log() -> Log {
+    Log {
+        address: Address::repeat_byte(1),
+        data: LogData::new_unchecked(vec![B256::repeat_byte(1)], Bytes::from(vec![1, 2, 3])),
+    }
+}

--- a/monad-chain-data/tests/query_logs_range_resolution.rs
+++ b/monad-chain-data/tests/query_logs_range_resolution.rs
@@ -15,7 +15,7 @@
 
 use monad_chain_data::{
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData, LogFilter,
-    MonadChainDataError, MonadChainDataService, QueryLogsRequest, QueryOrder, B256,
+    MonadChainDataError, MonadChainDataService, QueryLimits, QueryLogsRequest, QueryOrder, B256,
 };
 
 #[tokio::test(flavor = "current_thread")]
@@ -209,8 +209,11 @@ async fn defaulted_range_resolves_to_full_chain() {
 }
 
 async fn ingest_two_block_chain() -> MonadChainDataService<InMemoryMetaStore, InMemoryBlobStore> {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {

--- a/monad-chain-data/tests/query_logs_scan.rs
+++ b/monad-chain-data/tests/query_logs_scan.rs
@@ -16,15 +16,18 @@
 use std::collections::HashSet;
 
 use monad_chain_data::{
-    error::MonadChainDataError, Address, Bytes, FinalizedBlock, InMemoryBlobStore,
-    InMemoryMetaStore, Log, LogData, LogFilter, LogId, MonadChainDataService, QueryLogsRequest,
-    QueryOrder, B256,
+    Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData, LogFilter,
+    LogId, MonadChainDataError, MonadChainDataService, QueryLimits, QueryLogsRequest, QueryOrder,
+    B256,
 };
 
 #[tokio::test(flavor = "current_thread")]
 async fn query_logs_paginates_at_block_boundaries() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {
@@ -99,8 +102,11 @@ async fn query_logs_paginates_at_block_boundaries() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn query_logs_descending_returns_newest_first() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {
@@ -141,8 +147,11 @@ async fn query_logs_descending_returns_newest_first() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn query_logs_rejects_from_block_above_published_head() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {
@@ -171,8 +180,11 @@ async fn query_logs_rejects_from_block_above_published_head() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn ingest_assigns_contiguous_log_id_windows_across_empty_blocks() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {
@@ -239,8 +251,11 @@ async fn ingest_assigns_contiguous_log_id_windows_across_empty_blocks() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn block_scan_completes_current_block_when_limit_reached_mid_block() {
-    let service =
-        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
 
     service
         .ingest_block(FinalizedBlock {


### PR DESCRIPTION
Introduces QueryLimits as per-deployment caps on accepted query shape: max_limit bounds the request.limit value the user may pass, and max_block_range bounds the resolved range span. Limits are stored on the service alongside stores and tables and consulted by query_logs and ResolvedBlockWindow::resolve.

Breaches surface as MonadChainDataError::LimitExceeded, which carries both maxima so the RPC layer can populate the queryX spec's `-32005 Limit exceeded` payload regardless of which axis tripped. The block-range bound short-circuits on the numeric span before any block-record I/O.

QueryLimits is named for what it actually caps (the request shape), not for execution: the spec's block-completion invariant means a single hot block can return more items than max_limit. A future ExecutionBudget for wall-time will be a separate type.

QueryLimits is left exhaustive on purpose: when a future field lands, every construction site should fail to compile so the caller has to make a deliberate choice. The LimitExceeded error variant follows the same convention.