### PR TITLE
Persist EVM block header artifact per block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4901,6 +4901,7 @@ dependencies = [
 name = "monad-chain-data"
 version = "0.1.0"
 dependencies = [
+ "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "auto_impl",

--- a/monad-chain-data/Cargo.toml
+++ b/monad-chain-data/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 bench = false
 
 [dependencies]
+alloy-consensus = { workspace = true }
 alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-rlp = { workspace = true, features = ["derive"] }
 auto_impl = { workspace = true }

--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -59,9 +59,11 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
         &self.limits
     }
 
-    // TODO: Individual writes are idempotent, but a partial failure leaves the block
-    // incompletely written. Retry logic, logging, and metrics belong here once the
-    // overall pipeline shape stabilizes.
+    // The publication head is the commit boundary: every artifact written before
+    // `store_state` is pre-publication state and must not be treated as valid by
+    // readers until the head advances. Retry/recovery should derive the next block
+    // from the published head and may overwrite any matching pre-publication
+    // artifacts left by an interrupted ingest.
     /// Persists one finalized block and advances the published head on success.
     pub async fn ingest_block(&self, block: FinalizedBlock) -> Result<IngestOutcome> {
         let blocks = self.tables.blocks();
@@ -81,19 +83,22 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
             written_logs,
         } = LogIngestPlan::build(&block, next_log_id)?;
         let next_log_id_exclusive = block_record.logs.next_log_id()?;
-        logs.store_block_blob(block.block_number, block_log_blob)
+        blocks
+            .store_header(block.block_number(), &block.header)
             .await?;
-        logs.store_block_header(block.block_number, &block_log_header)
+        logs.store_block_blob(block.block_number(), block_log_blob)
+            .await?;
+        logs.store_block_header(block.block_number(), &block_log_header)
             .await?;
         logs.dir()
             .persist_block_fragment(
-                block.block_number,
+                block.block_number(),
                 block_record.logs.first_log_id.as_u64(),
                 block_record.logs.count,
             )
             .await?;
         for fragment in &bitmap_fragments {
-            logs.store_bitmap_fragment(fragment, block.block_number)
+            logs.store_bitmap_fragment(fragment, block.block_number())
                 .await?;
         }
         compact_newly_sealed_log_directory_buckets(
@@ -110,17 +115,17 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
         )
         .await?;
         blocks
-            .store_record(block.block_number, &block_record)
+            .store_record(block.block_number(), &block_record)
             .await?;
         self.tables
             .publication()
             .store_state(crate::primitives::state::PublicationState {
-                indexed_finalized_head: block.block_number,
+                indexed_finalized_head: block.block_number(),
             })
             .await?;
 
         Ok(IngestOutcome {
-            indexed_finalized_head: block.block_number,
+            indexed_finalized_head: block.block_number(),
             block_record,
             written_logs,
         })

--- a/monad-chain-data/src/kernel/tables.rs
+++ b/monad-chain-data/src/kernel/tables.rs
@@ -13,17 +13,21 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use alloy_rlp::Decodable;
 use bytes::Bytes;
 
 use crate::{
-    error::Result,
+    error::{MonadChainDataError, Result},
     family::FinalizedBlock,
     kernel::{
         bitmap::{BitmapFragmentWrite, BitmapPageMeta, BitmapTables},
         primary_dir::{PrimaryDirBucket, PrimaryDirFragment, PrimaryDirTables},
     },
     logs::LogBlockHeader,
-    primitives::state::{BlockRecord, PublicationState},
+    primitives::{
+        state::{BlockRecord, PublicationState},
+        EvmBlockHeader,
+    },
     store::{BlobStore, BlobTable, BlobTableId, KvTable, MetaStore, ScannableTableId, TableId},
 };
 
@@ -97,14 +101,17 @@ impl<M: MetaStore> PublicationTables<M> {
 
 pub struct BlockTables<M: MetaStore> {
     block_records: KvTable<M>,
+    block_headers: KvTable<M>,
 }
 
 impl<M: MetaStore> BlockTables<M> {
     pub const BLOCK_RECORD_TABLE: TableId = TableId::new("block_record");
+    pub const BLOCK_HEADER_TABLE: TableId = TableId::new("block_header");
 
     fn new(meta_store: M) -> Self {
         Self {
             block_records: meta_store.table(Self::BLOCK_RECORD_TABLE),
+            block_headers: meta_store.table(Self::BLOCK_HEADER_TABLE),
         }
     }
 
@@ -124,6 +131,24 @@ impl<M: MetaStore> BlockTables<M> {
         Ok(())
     }
 
+    pub async fn load_header(&self, block_number: u64) -> Result<Option<EvmBlockHeader>> {
+        let key = block_number_key(block_number);
+        let Some(record) = self.block_headers.get(&key).await? else {
+            return Ok(None);
+        };
+        let header = EvmBlockHeader::decode(&mut record.value.as_ref())
+            .map_err(|_| MonadChainDataError::Decode("invalid block header rlp"))?;
+        Ok(Some(header))
+    }
+
+    pub async fn store_header(&self, block_number: u64, header: &EvmBlockHeader) -> Result<()> {
+        let key = block_number_key(block_number);
+        self.block_headers
+            .put(&key, Bytes::from(alloy_rlp::encode(header)))
+            .await?;
+        Ok(())
+    }
+
     /// Validates that a new block extends the currently published chain.
     pub async fn validate_continuity(
         &self,
@@ -132,7 +157,7 @@ impl<M: MetaStore> BlockTables<M> {
     ) -> Result<Option<BlockRecord>> {
         match current_head {
             None => {
-                if block.block_number != 1 {
+                if block.block_number() != 1 {
                     return Err(crate::error::MonadChainDataError::InvalidRequest(
                         "first ingested block must be block 1 in the first pass",
                     ));
@@ -140,7 +165,7 @@ impl<M: MetaStore> BlockTables<M> {
                 Ok(None)
             }
             Some(head) => {
-                if block.block_number != head + 1 {
+                if block.block_number() != head + 1 {
                     return Err(crate::error::MonadChainDataError::InvalidRequest(
                         "block_number must extend the published head contiguously",
                     ));
@@ -149,7 +174,7 @@ impl<M: MetaStore> BlockTables<M> {
                 let previous = self.load_record(head).await?.ok_or(
                     crate::error::MonadChainDataError::MissingData("missing previous block record"),
                 )?;
-                if previous.block_hash != block.parent_hash {
+                if previous.block_hash != block.parent_hash() {
                     return Err(crate::error::MonadChainDataError::InvalidRequest(
                         "parent_hash must match the previous published block",
                     ));

--- a/monad-chain-data/src/lib.rs
+++ b/monad-chain-data/src/lib.rs
@@ -34,6 +34,7 @@ pub use primitives::{
     page::{QueryOrder, DEFAULT_QUERY_LIMIT},
     refs::BlockRef,
     state::{BlockRecord, FamilyWindowRecord, LogId},
+    EvmBlockHeader,
 };
 pub use store::{InMemoryBlobStore, InMemoryMetaStore};
 

--- a/monad-chain-data/src/logs/ingest.rs
+++ b/monad-chain-data/src/logs/ingest.rs
@@ -44,9 +44,9 @@ impl LogIngestPlan {
         let (block_log_header, block_log_blob) = Self::encode_block_logs(&logs)?;
         let bitmap_fragments = Self::collect_bitmap_fragments(&logs, first_log_id)?;
         let block_record = BlockRecord {
-            block_number: block.block_number,
-            block_hash: block.block_hash,
-            parent_hash: block.parent_hash,
+            block_number: block.block_number(),
+            block_hash: block.block_hash(),
+            parent_hash: block.parent_hash(),
             logs: FamilyWindowRecord {
                 first_log_id,
                 count: log_count,

--- a/monad-chain-data/src/primitives/mod.rs
+++ b/monad-chain-data/src/primitives/mod.rs
@@ -18,3 +18,5 @@ pub mod page;
 pub mod range;
 pub mod refs;
 pub mod state;
+
+pub use alloy_consensus::Header as EvmBlockHeader;

--- a/monad-chain-data/tests/block_header_artifact.rs
+++ b/monad-chain-data/tests/block_header_artifact.rs
@@ -1,0 +1,127 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use alloy_primitives::{aliases::B64, Address, Bloom, Bytes as AlloyBytes, U256};
+use monad_chain_data::{
+    EvmBlockHeader, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, MonadChainDataService,
+    QueryLimits, B256,
+};
+
+mod common;
+
+use common::test_header;
+
+#[tokio::test(flavor = "current_thread")]
+async fn ingest_persists_block_header() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let mut header = test_header(1, B256::ZERO);
+    header.beneficiary = Address::repeat_byte(0xAB);
+    header.gas_limit = 30_000_000;
+    header.gas_used = 21_000;
+    header.timestamp = 1_700_000_000;
+    header.extra_data = AlloyBytes::from_static(b"monad-test");
+
+    service
+        .ingest_block(FinalizedBlock {
+            header: header.clone(),
+            logs_by_tx: vec![vec![]],
+        })
+        .await
+        .expect("ingest block 1");
+
+    let loaded = service
+        .tables()
+        .blocks()
+        .load_header(1)
+        .await
+        .expect("load header")
+        .expect("header present");
+
+    assert_eq!(loaded, header);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn load_header_returns_none_for_missing_block() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let missing = service
+        .tables()
+        .blocks()
+        .load_header(42)
+        .await
+        .expect("load_header");
+
+    assert!(missing.is_none());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn block_header_roundtrips_with_all_optional_fields_populated() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let header = EvmBlockHeader {
+        parent_hash: B256::ZERO,
+        ommers_hash: B256::repeat_byte(2),
+        beneficiary: Address::repeat_byte(3),
+        state_root: B256::repeat_byte(4),
+        transactions_root: B256::repeat_byte(5),
+        receipts_root: B256::repeat_byte(6),
+        logs_bloom: Bloom::repeat_byte(7),
+        difficulty: U256::from(0x1234u64),
+        number: 1,
+        gas_limit: 30_000_000,
+        gas_used: 15_000_000,
+        timestamp: 1_700_000_000,
+        extra_data: AlloyBytes::from_static(&[1, 2, 3, 4]),
+        mix_hash: B256::repeat_byte(8),
+        nonce: B64::repeat_byte(9),
+        base_fee_per_gas: Some(7u64.pow(10)),
+        withdrawals_root: Some(B256::repeat_byte(10)),
+        blob_gas_used: Some(131_072),
+        excess_blob_gas: Some(262_144),
+        parent_beacon_block_root: Some(B256::repeat_byte(11)),
+        requests_hash: Some(B256::repeat_byte(12)),
+    };
+
+    service
+        .ingest_block(FinalizedBlock {
+            header: header.clone(),
+            logs_by_tx: vec![vec![]],
+        })
+        .await
+        .expect("ingest block 1");
+
+    let loaded = service
+        .tables()
+        .blocks()
+        .load_header(1)
+        .await
+        .expect("load header")
+        .expect("header present");
+
+    assert_eq!(loaded, header);
+}

--- a/monad-chain-data/tests/common/mod.rs
+++ b/monad-chain-data/tests/common/mod.rs
@@ -13,28 +13,18 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use alloy_primitives::{Log, B256};
+#![allow(dead_code)]
 
-use crate::primitives::EvmBlockHeader;
+use monad_chain_data::{EvmBlockHeader, B256};
 
-pub type Hash32 = B256;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FinalizedBlock {
-    pub header: EvmBlockHeader,
-    pub logs_by_tx: Vec<Vec<Log>>,
+pub fn test_header(number: u64, parent_hash: B256) -> EvmBlockHeader {
+    EvmBlockHeader {
+        number,
+        parent_hash,
+        ..EvmBlockHeader::default()
+    }
 }
 
-impl FinalizedBlock {
-    pub fn block_number(&self) -> u64 {
-        self.header.number
-    }
-
-    pub fn block_hash(&self) -> Hash32 {
-        self.header.hash_slow()
-    }
-
-    pub fn parent_hash(&self) -> Hash32 {
-        self.header.parent_hash
-    }
+pub fn chain_header(number: u64, parent: &EvmBlockHeader) -> EvmBlockHeader {
+    test_header(number, parent.hash_slow())
 }

--- a/monad-chain-data/tests/log_bitmap_fragments.rs
+++ b/monad-chain-data/tests/log_bitmap_fragments.rs
@@ -19,6 +19,10 @@ use monad_chain_data::{
     MonadChainDataService, QueryLimits, Topic, B256,
 };
 
+mod common;
+
+use common::{chain_header, test_header};
+
 #[tokio::test(flavor = "current_thread")]
 async fn ingest_persists_log_bitmap_fragments_for_address_and_topics() {
     let service = MonadChainDataService::new(
@@ -29,9 +33,7 @@ async fn ingest_persists_log_bitmap_fragments_for_address_and_topics() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: test_header(1, B256::ZERO),
             logs_by_tx: vec![vec![
                 log(
                     Address::repeat_byte(7),
@@ -91,11 +93,12 @@ async fn ingest_persists_log_bitmap_fragments_across_page_boundaries() {
         QueryLimits::UNLIMITED,
     );
 
+    let h1 = test_header(1, B256::ZERO);
+    let h2 = chain_header(2, &h1);
+
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: h1,
             logs_by_tx: vec![repeated_logs(
                 Address::repeat_byte(1),
                 vec![B256::repeat_byte(3)],
@@ -107,9 +110,7 @@ async fn ingest_persists_log_bitmap_fragments_across_page_boundaries() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 2,
-            block_hash: B256::repeat_byte(2),
-            parent_hash: B256::repeat_byte(1),
+            header: h2,
             logs_by_tx: vec![repeated_logs(
                 Address::repeat_byte(7),
                 vec![B256::repeat_byte(9)],
@@ -163,9 +164,7 @@ async fn ingest_empty_block_writes_no_log_bitmap_fragments() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: test_header(1, B256::ZERO),
             logs_by_tx: vec![vec![]],
         })
         .await

--- a/monad-chain-data/tests/log_bitmap_pages.rs
+++ b/monad-chain-data/tests/log_bitmap_pages.rs
@@ -26,6 +26,10 @@ use monad_chain_data::{
     MonadChainDataService, QueryLimits, QueryLogsRequest, QueryOrder, Topic, B256,
 };
 
+mod common;
+
+use common::{chain_header, test_header};
+
 // Fills a full bitmap page (~65k logs) to exercise the seal/compaction path;
 // the in-memory store makes that slow, so gate behind --ignored.
 #[tokio::test(flavor = "current_thread")]
@@ -36,13 +40,14 @@ async fn ingest_compacts_sealed_pages_and_query_prefers_compacted_page_blobs() {
     let service =
         MonadChainDataService::new(meta_store.clone(), blob_store, QueryLimits::UNLIMITED);
 
+    let h1 = test_header(1, B256::ZERO);
+    let h2 = chain_header(2, &h1);
+
     let old_address = Address::repeat_byte(7);
     let old_topic = B256::repeat_byte(9);
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: h1,
             logs_by_tx: vec![repeated_logs(
                 old_address,
                 vec![old_topic],
@@ -56,9 +61,7 @@ async fn ingest_compacts_sealed_pages_and_query_prefers_compacted_page_blobs() {
     let frontier_topic = B256::repeat_byte(10);
     service
         .ingest_block(FinalizedBlock {
-            block_number: 2,
-            block_hash: B256::repeat_byte(2),
-            parent_hash: B256::repeat_byte(1),
+            header: h2,
             logs_by_tx: vec![repeated_logs(frontier_address, vec![frontier_topic], 4)],
         })
         .await
@@ -150,11 +153,12 @@ async fn query_errors_when_compacted_page_meta_exists_but_blob_is_missing() {
 
     let address = Address::repeat_byte(7);
     let topic = B256::repeat_byte(9);
+    let h1 = test_header(1, B256::ZERO);
+    let h2 = chain_header(2, &h1);
+
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: h1,
             logs_by_tx: vec![repeated_logs(
                 address,
                 vec![topic],
@@ -165,9 +169,7 @@ async fn query_errors_when_compacted_page_meta_exists_but_blob_is_missing() {
         .expect("ingest block 1");
     service
         .ingest_block(FinalizedBlock {
-            block_number: 2,
-            block_hash: B256::repeat_byte(2),
-            parent_hash: B256::repeat_byte(1),
+            header: h2,
             logs_by_tx: vec![repeated_logs(
                 Address::repeat_byte(8),
                 vec![B256::repeat_byte(10)],

--- a/monad-chain-data/tests/log_dir_buckets.rs
+++ b/monad-chain-data/tests/log_dir_buckets.rs
@@ -19,6 +19,10 @@ use monad_chain_data::{
     MonadChainDataService, QueryLimits, B256,
 };
 
+mod common;
+
+use common::{chain_header, test_header};
+
 #[tokio::test(flavor = "current_thread")]
 async fn ingest_compacts_a_sealed_directory_bucket_when_crossing_the_boundary() {
     let service = MonadChainDataService::new(
@@ -27,11 +31,12 @@ async fn ingest_compacts_a_sealed_directory_bucket_when_crossing_the_boundary() 
         QueryLimits::UNLIMITED,
     );
 
+    let h1 = test_header(1, B256::ZERO);
+    let h2 = chain_header(2, &h1);
+
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: h1,
             logs_by_tx: vec![repeated_logs(
                 usize::try_from(DIRECTORY_BUCKET_SIZE - 2).expect("bucket size fits usize"),
             )],
@@ -41,9 +46,7 @@ async fn ingest_compacts_a_sealed_directory_bucket_when_crossing_the_boundary() 
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 2,
-            block_hash: B256::repeat_byte(2),
-            parent_hash: B256::repeat_byte(1),
+            header: h2,
             logs_by_tx: vec![repeated_logs(4)],
         })
         .await

--- a/monad-chain-data/tests/log_dir_fragments.rs
+++ b/monad-chain-data/tests/log_dir_fragments.rs
@@ -19,6 +19,10 @@ use monad_chain_data::{
     MonadChainDataService, QueryLimits, B256,
 };
 
+mod common;
+
+use common::{chain_header, test_header};
+
 #[tokio::test(flavor = "current_thread")]
 async fn ingest_persists_log_dir_fragment_for_single_bucket_block() {
     let service = MonadChainDataService::new(
@@ -29,9 +33,7 @@ async fn ingest_persists_log_dir_fragment_for_single_bucket_block() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: test_header(1, B256::ZERO),
             logs_by_tx: vec![vec![log(), log()]],
         })
         .await
@@ -64,9 +66,7 @@ async fn ingest_persists_zero_width_fragment_for_empty_block() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: test_header(1, B256::ZERO),
             logs_by_tx: vec![vec![]],
         })
         .await
@@ -97,11 +97,12 @@ async fn ingest_persists_spanning_fragment_in_each_covered_bucket() {
         QueryLimits::UNLIMITED,
     );
 
+    let h1 = test_header(1, B256::ZERO);
+    let h2 = chain_header(2, &h1);
+
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: h1,
             logs_by_tx: vec![repeated_logs(
                 usize::try_from(DIRECTORY_BUCKET_SIZE - 2).expect("bucket size fits usize"),
             )],
@@ -111,9 +112,7 @@ async fn ingest_persists_spanning_fragment_in_each_covered_bucket() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 2,
-            block_hash: B256::repeat_byte(2),
-            parent_hash: B256::repeat_byte(1),
+            header: h2,
             logs_by_tx: vec![repeated_logs(4)],
         })
         .await

--- a/monad-chain-data/tests/query_logs_indexed.rs
+++ b/monad-chain-data/tests/query_logs_indexed.rs
@@ -21,6 +21,10 @@ use monad_chain_data::{
     MonadChainDataService, QueryLimits, QueryLogsRequest, QueryOrder, Topic, B256,
 };
 
+mod common;
+
+use common::{chain_header, test_header};
+
 #[tokio::test(flavor = "current_thread")]
 async fn indexed_query_logs_respects_and_or_filter_semantics() {
     let service = MonadChainDataService::new(
@@ -31,9 +35,7 @@ async fn indexed_query_logs_respects_and_or_filter_semantics() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: test_header(1, B256::ZERO),
             logs_by_tx: vec![vec![
                 log(Address::repeat_byte(1), vec![B256::repeat_byte(9)]),
                 log(
@@ -84,11 +86,12 @@ async fn indexed_query_logs_descending_returns_newest_first() {
         QueryLimits::UNLIMITED,
     );
 
+    let h1 = test_header(1, B256::ZERO);
+    let h2 = chain_header(2, &h1);
+
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: h1,
             logs_by_tx: vec![vec![log(
                 Address::repeat_byte(7),
                 vec![B256::repeat_byte(9)],
@@ -99,9 +102,7 @@ async fn indexed_query_logs_descending_returns_newest_first() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 2,
-            block_hash: B256::repeat_byte(2),
-            parent_hash: B256::repeat_byte(1),
+            header: h2,
             logs_by_tx: vec![vec![
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
@@ -147,11 +148,12 @@ async fn indexed_query_logs_paginates_at_block_boundaries() {
         QueryLimits::UNLIMITED,
     );
 
+    let h1 = test_header(1, B256::ZERO);
+    let h2 = chain_header(2, &h1);
+
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: h1,
             logs_by_tx: vec![vec![
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
@@ -162,9 +164,7 @@ async fn indexed_query_logs_paginates_at_block_boundaries() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 2,
-            block_hash: B256::repeat_byte(2),
-            parent_hash: B256::repeat_byte(1),
+            header: h2,
             logs_by_tx: vec![vec![log(
                 Address::repeat_byte(7),
                 vec![B256::repeat_byte(9)],
@@ -226,11 +226,12 @@ async fn indexed_query_logs_scans_across_bucket_and_page_boundaries() {
         QueryLimits::UNLIMITED,
     );
 
+    let h1 = test_header(1, B256::ZERO);
+    let h2 = chain_header(2, &h1);
+
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: h1,
             logs_by_tx: vec![repeated_logs(
                 Address::repeat_byte(1),
                 vec![B256::repeat_byte(3)],
@@ -242,9 +243,7 @@ async fn indexed_query_logs_scans_across_bucket_and_page_boundaries() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 2,
-            block_hash: B256::repeat_byte(2),
-            parent_hash: B256::repeat_byte(1),
+            header: h2,
             logs_by_tx: vec![repeated_logs(
                 Address::repeat_byte(7),
                 vec![B256::repeat_byte(9)],
@@ -290,11 +289,13 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block() {
         QueryLimits::UNLIMITED,
     );
 
+    let h1 = test_header(1, B256::ZERO);
+    let h2 = chain_header(2, &h1);
+    let h3 = chain_header(3, &h2);
+
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: h1,
             logs_by_tx: vec![vec![log(
                 Address::repeat_byte(7),
                 vec![B256::repeat_byte(9)],
@@ -305,9 +306,7 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 2,
-            block_hash: B256::repeat_byte(2),
-            parent_hash: B256::repeat_byte(1),
+            header: h2,
             logs_by_tx: vec![vec![
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
@@ -321,9 +320,7 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 3,
-            block_hash: B256::repeat_byte(3),
-            parent_hash: B256::repeat_byte(2),
+            header: h3,
             logs_by_tx: vec![vec![log(
                 Address::repeat_byte(7),
                 vec![B256::repeat_byte(9)],
@@ -365,11 +362,13 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block_desc
         QueryLimits::UNLIMITED,
     );
 
+    let h1 = test_header(1, B256::ZERO);
+    let h2 = chain_header(2, &h1);
+    let h3 = chain_header(3, &h2);
+
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: h1,
             logs_by_tx: vec![vec![log(
                 Address::repeat_byte(7),
                 vec![B256::repeat_byte(9)],
@@ -380,9 +379,7 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block_desc
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 2,
-            block_hash: B256::repeat_byte(2),
-            parent_hash: B256::repeat_byte(1),
+            header: h2,
             logs_by_tx: vec![vec![
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
@@ -396,9 +393,7 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block_desc
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 3,
-            block_hash: B256::repeat_byte(3),
-            parent_hash: B256::repeat_byte(2),
+            header: h3,
             logs_by_tx: vec![vec![log(
                 Address::repeat_byte(7),
                 vec![B256::repeat_byte(9)],
@@ -440,11 +435,12 @@ async fn indexed_query_stops_at_block_when_limit_equals_block_match_count() {
         QueryLimits::UNLIMITED,
     );
 
+    let h1 = test_header(1, B256::ZERO);
+    let h2 = chain_header(2, &h1);
+
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: h1,
             logs_by_tx: vec![vec![
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
@@ -455,9 +451,7 @@ async fn indexed_query_stops_at_block_when_limit_equals_block_match_count() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 2,
-            block_hash: B256::repeat_byte(2),
-            parent_hash: B256::repeat_byte(1),
+            header: h2,
             logs_by_tx: vec![vec![log(
                 Address::repeat_byte(7),
                 vec![B256::repeat_byte(9)],
@@ -500,9 +494,7 @@ async fn unindexed_query_logs_still_uses_block_scan_fallback() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: test_header(1, B256::ZERO),
             logs_by_tx: vec![vec![
                 log(Address::repeat_byte(5), vec![B256::repeat_byte(8)]),
                 log(Address::repeat_byte(6), vec![B256::repeat_byte(9)]),

--- a/monad-chain-data/tests/query_logs_limits.rs
+++ b/monad-chain-data/tests/query_logs_limits.rs
@@ -19,6 +19,10 @@ use monad_chain_data::{
     QueryOrder, B256,
 };
 
+mod common;
+
+use common::{chain_header, test_header};
+
 #[tokio::test(flavor = "current_thread")]
 async fn limit_above_max_limit_returns_limit_exceeded() {
     let service = ingest_three_block_chain(QueryLimits::new(5, 1_000)).await;
@@ -134,16 +138,14 @@ async fn ingest_three_block_chain(
         limits,
     );
 
-    for (n, prev_hash) in [
-        (1u64, B256::ZERO),
-        (2, B256::repeat_byte(1)),
-        (3, B256::repeat_byte(2)),
-    ] {
+    let h1 = test_header(1, B256::ZERO);
+    let h2 = chain_header(2, &h1);
+    let h3 = chain_header(3, &h2);
+
+    for header in [h1, h2, h3] {
         service
             .ingest_block(FinalizedBlock {
-                block_number: n,
-                block_hash: B256::repeat_byte(n as u8),
-                parent_hash: prev_hash,
+                header,
                 logs_by_tx: vec![vec![log()]],
             })
             .await

--- a/monad-chain-data/tests/query_logs_range_resolution.rs
+++ b/monad-chain-data/tests/query_logs_range_resolution.rs
@@ -18,6 +18,10 @@ use monad_chain_data::{
     MonadChainDataError, MonadChainDataService, QueryLimits, QueryLogsRequest, QueryOrder, B256,
 };
 
+mod common;
+
+use common::{chain_header, test_header};
+
 #[tokio::test(flavor = "current_thread")]
 async fn from_block_above_head_returns_invalid_request() {
     let service = ingest_two_block_chain().await;
@@ -215,11 +219,12 @@ async fn ingest_two_block_chain() -> MonadChainDataService<InMemoryMetaStore, In
         QueryLimits::UNLIMITED,
     );
 
+    let h1 = test_header(1, B256::ZERO);
+    let h2 = chain_header(2, &h1);
+
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: h1,
             logs_by_tx: vec![vec![log(Address::repeat_byte(1), B256::repeat_byte(1))]],
         })
         .await
@@ -227,9 +232,7 @@ async fn ingest_two_block_chain() -> MonadChainDataService<InMemoryMetaStore, In
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 2,
-            block_hash: B256::repeat_byte(2),
-            parent_hash: B256::repeat_byte(1),
+            header: h2,
             logs_by_tx: vec![vec![log(Address::repeat_byte(2), B256::repeat_byte(2))]],
         })
         .await

--- a/monad-chain-data/tests/query_logs_scan.rs
+++ b/monad-chain-data/tests/query_logs_scan.rs
@@ -21,6 +21,10 @@ use monad_chain_data::{
     B256,
 };
 
+mod common;
+
+use common::{chain_header, test_header};
+
 #[tokio::test(flavor = "current_thread")]
 async fn query_logs_paginates_at_block_boundaries() {
     let service = MonadChainDataService::new(
@@ -29,11 +33,12 @@ async fn query_logs_paginates_at_block_boundaries() {
         QueryLimits::UNLIMITED,
     );
 
+    let h1 = test_header(1, B256::ZERO);
+    let h2 = chain_header(2, &h1);
+
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: h1,
             logs_by_tx: vec![vec![
                 log(Address::repeat_byte(7), B256::repeat_byte(9)),
                 log(Address::repeat_byte(7), B256::repeat_byte(9)),
@@ -44,9 +49,7 @@ async fn query_logs_paginates_at_block_boundaries() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 2,
-            block_hash: B256::repeat_byte(2),
-            parent_hash: B256::repeat_byte(1),
+            header: h2,
             logs_by_tx: vec![vec![log(Address::repeat_byte(7), B256::repeat_byte(9))]],
         })
         .await
@@ -110,9 +113,7 @@ async fn query_logs_descending_returns_newest_first() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: test_header(1, B256::ZERO),
             logs_by_tx: vec![vec![
                 log(Address::repeat_byte(5), B256::repeat_byte(8)),
                 log(Address::repeat_byte(5), B256::repeat_byte(8)),
@@ -155,9 +156,7 @@ async fn query_logs_rejects_from_block_above_published_head() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: test_header(1, B256::ZERO),
             logs_by_tx: vec![vec![log(Address::repeat_byte(5), B256::repeat_byte(8))]],
         })
         .await
@@ -186,11 +185,13 @@ async fn ingest_assigns_contiguous_log_id_windows_across_empty_blocks() {
         QueryLimits::UNLIMITED,
     );
 
+    let h1 = test_header(1, B256::ZERO);
+    let h2 = chain_header(2, &h1);
+    let h3 = chain_header(3, &h2);
+
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: h1,
             logs_by_tx: vec![vec![
                 log(Address::repeat_byte(3), B256::repeat_byte(4)),
                 log(Address::repeat_byte(3), B256::repeat_byte(4)),
@@ -201,9 +202,7 @@ async fn ingest_assigns_contiguous_log_id_windows_across_empty_blocks() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 2,
-            block_hash: B256::repeat_byte(2),
-            parent_hash: B256::repeat_byte(1),
+            header: h2,
             logs_by_tx: vec![vec![]],
         })
         .await
@@ -211,9 +210,7 @@ async fn ingest_assigns_contiguous_log_id_windows_across_empty_blocks() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 3,
-            block_hash: B256::repeat_byte(3),
-            parent_hash: B256::repeat_byte(2),
+            header: h3,
             logs_by_tx: vec![vec![log(Address::repeat_byte(3), B256::repeat_byte(4))]],
         })
         .await
@@ -257,11 +254,12 @@ async fn block_scan_completes_current_block_when_limit_reached_mid_block() {
         QueryLimits::UNLIMITED,
     );
 
+    let h1 = test_header(1, B256::ZERO);
+    let h2 = chain_header(2, &h1);
+
     service
         .ingest_block(FinalizedBlock {
-            block_number: 1,
-            block_hash: B256::repeat_byte(1),
-            parent_hash: B256::ZERO,
+            header: h1,
             logs_by_tx: vec![vec![
                 log(Address::repeat_byte(5), B256::repeat_byte(8)),
                 log(Address::repeat_byte(5), B256::repeat_byte(8)),
@@ -273,9 +271,7 @@ async fn block_scan_completes_current_block_when_limit_reached_mid_block() {
 
     service
         .ingest_block(FinalizedBlock {
-            block_number: 2,
-            block_hash: B256::repeat_byte(2),
-            parent_hash: B256::repeat_byte(1),
+            header: h2,
             logs_by_tx: vec![vec![log(Address::repeat_byte(5), B256::repeat_byte(8))]],
         })
         .await


### PR DESCRIPTION
Adds a new point-table `block_header` keyed by `<block_num>` that stores the full stored EVM header for each finalized block. This is the shared header artifact that upcoming surfaces (`block_header` relation on `query_logs`, `query_blocks`) depend on; today `BlockRecord` only carries `{number, hash, parent_hash, logs_window}`, so fields like `timestamp`,`gasLimit`, `gasUsed`, `stateRoot` are not addressable.

`FinalizedBlock` gains an owned `header: EvmBlockHeader`; `ingest_block` writes the header through `BlockTables::store_header` before any log family artifacts, matching the shared-first ordering in roaring-monad/docs/storage-model.md. Ingest also validates that `header.number == block_number` and `header.parent_hash == parent_hash`, rejecting malformed envelopes so readers can trust `header.number`.

`EvmBlockHeader` is a re-export of `alloy_consensus::Header`. Its handwritten RLP Encodable/Decodable impls are canonical and interop with external EVM tooling (`keccak256(rlp(header)) == block_hash`). Persistence uses `alloy_rlp::encode` for writes and `<alloy_consensus::Header as alloy_rlp::Decodable>::decode` for reads. `BlockRecord` remains the source of truth for block identity (block_hash, parent_hash); the header artifact carries the remaining EVM fields.