### PR TITLE
Index block_hash to block_number on ingest

### DIFF
--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -115,6 +115,9 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
         )
         .await?;
         blocks
+            .store_hash_index(&block.block_hash(), block.block_number())
+            .await?;
+        blocks
             .store_record(block.block_number(), &block_record)
             .await?;
         self.tables

--- a/monad-chain-data/src/kernel/tables.rs
+++ b/monad-chain-data/src/kernel/tables.rs
@@ -18,7 +18,7 @@ use bytes::Bytes;
 
 use crate::{
     error::{MonadChainDataError, Result},
-    family::FinalizedBlock,
+    family::{FinalizedBlock, Hash32},
     kernel::{
         bitmap::{BitmapFragmentWrite, BitmapPageMeta, BitmapTables},
         primary_dir::{PrimaryDirBucket, PrimaryDirFragment, PrimaryDirTables},
@@ -102,16 +102,20 @@ impl<M: MetaStore> PublicationTables<M> {
 pub struct BlockTables<M: MetaStore> {
     block_records: KvTable<M>,
     block_headers: KvTable<M>,
+    block_hash_to_number_index: KvTable<M>,
 }
 
 impl<M: MetaStore> BlockTables<M> {
     pub const BLOCK_RECORD_TABLE: TableId = TableId::new("block_record");
     pub const BLOCK_HEADER_TABLE: TableId = TableId::new("block_header");
+    pub const BLOCK_HASH_TO_NUMBER_INDEX_TABLE: TableId =
+        TableId::new("block_hash_to_number_index");
 
     fn new(meta_store: M) -> Self {
         Self {
             block_records: meta_store.table(Self::BLOCK_RECORD_TABLE),
             block_headers: meta_store.table(Self::BLOCK_HEADER_TABLE),
+            block_hash_to_number_index: meta_store.table(Self::BLOCK_HASH_TO_NUMBER_INDEX_TABLE),
         }
     }
 
@@ -145,6 +149,38 @@ impl<M: MetaStore> BlockTables<M> {
         let key = block_number_key(block_number);
         self.block_headers
             .put(&key, Bytes::from(alloy_rlp::encode(header)))
+            .await?;
+        Ok(())
+    }
+
+    /// Resolves a block hash to its block number via the hash-to-number index.
+    /// A returned `Some(n)` is not by itself a guarantee that block `n` is
+    /// fully published — the index entry is written before the publication
+    /// head advances, so a hash hit may name a block whose record/header is
+    /// not yet visible. Callers that turn the number into a record/header
+    /// load should expect `MissingData` if `n > published_head` or if the
+    /// follow-up loads fail.
+    pub async fn block_number_by_hash(&self, block_hash: &Hash32) -> Result<Option<u64>> {
+        let Some(record) = self
+            .block_hash_to_number_index
+            .get(block_hash.as_slice())
+            .await?
+        else {
+            return Ok(None);
+        };
+        let bytes: [u8; 8] =
+            record.value.as_ref().try_into().map_err(|_| {
+                MonadChainDataError::Decode("invalid block_hash_to_number_index value")
+            })?;
+        Ok(Some(u64::from_be_bytes(bytes)))
+    }
+
+    pub async fn store_hash_index(&self, block_hash: &Hash32, block_number: u64) -> Result<()> {
+        self.block_hash_to_number_index
+            .put(
+                block_hash.as_slice(),
+                Bytes::copy_from_slice(&block_number.to_be_bytes()),
+            )
             .await?;
         Ok(())
     }

--- a/monad-chain-data/tests/block_hash_index.rs
+++ b/monad-chain-data/tests/block_hash_index.rs
@@ -1,0 +1,101 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use monad_chain_data::{
+    FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, MonadChainDataService, QueryLimits, B256,
+};
+
+mod common;
+
+use common::{chain_header, test_header};
+
+#[tokio::test(flavor = "current_thread")]
+async fn ingest_persists_block_hash_index_entry() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let header = test_header(1, B256::ZERO);
+    let block_hash = header.hash_slow();
+
+    service
+        .ingest_block(FinalizedBlock {
+            header,
+            logs_by_tx: vec![vec![]],
+        })
+        .await
+        .expect("ingest block 1");
+
+    let resolved = service
+        .tables()
+        .blocks()
+        .block_number_by_hash(&block_hash)
+        .await
+        .expect("lookup");
+
+    assert_eq!(resolved, Some(1));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn lookup_returns_none_for_unknown_hash() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let missing = service
+        .tables()
+        .blocks()
+        .block_number_by_hash(&B256::repeat_byte(0xFF))
+        .await
+        .expect("lookup");
+
+    assert!(missing.is_none());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multi_block_chain_indexes_each_hash_distinctly() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let h1 = test_header(1, B256::ZERO);
+    let h2 = chain_header(2, &h1);
+    let h3 = chain_header(3, &h2);
+
+    let hash_1 = h1.hash_slow();
+    let hash_2 = h2.hash_slow();
+    let hash_3 = h3.hash_slow();
+
+    for header in [h1, h2, h3] {
+        service
+            .ingest_block(FinalizedBlock {
+                header,
+                logs_by_tx: vec![vec![]],
+            })
+            .await
+            .expect("ingest");
+    }
+
+    let blocks = service.tables().blocks();
+    assert_eq!(blocks.block_number_by_hash(&hash_1).await.unwrap(), Some(1));
+    assert_eq!(blocks.block_number_by_hash(&hash_2).await.unwrap(), Some(2));
+    assert_eq!(blocks.block_number_by_hash(&hash_3).await.unwrap(), Some(3));
+}


### PR DESCRIPTION
Adds a point-lookup table keyed by block hash so callers can resolve a hash to its block number without scanning. Wired into BlockTables and written from ingest_block alongside the block record. Unblocks hash-based request bounds and point block-by-hash reads.