### PR TITLE
Join blocks onto query_logs pages

### DIFF
--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
+    blocks::load_blocks_for_logs,
     error::{MonadChainDataError, Result},
     family::FinalizedBlock,
     ingest::{
@@ -161,10 +162,17 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
             ResolvedBlockWindow::resolve(&request, head, &self.limits, self.tables.blocks())
                 .await?;
 
-        if request.filter.has_indexed_clause() {
-            return execute_indexed_log_query(&self.tables, &request, window).await;
+        let mut response = if request.filter.has_indexed_clause() {
+            execute_indexed_log_query(&self.tables, &request, window).await?
+        } else {
+            execute_block_scan_query(&self.tables, &request, window).await?
+        };
+
+        if request.relations.blocks {
+            response.blocks =
+                Some(load_blocks_for_logs(self.tables.blocks(), &response.logs).await?);
         }
 
-        execute_block_scan_query(&self.tables, &request, window).await
+        Ok(response)
     }
 }

--- a/monad-chain-data/src/blocks.rs
+++ b/monad-chain-data/src/blocks.rs
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::BTreeSet;
+
+use crate::{
+    error::{MonadChainDataError, Result},
+    family::Hash32,
+    kernel::tables::BlockTables,
+    logs::LogEntry,
+    primitives::EvmBlockHeader,
+    store::MetaStore,
+};
+
+/// A block as returned by queries: the full header payload plus the block
+/// hash, which the header type itself does not carry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Block {
+    pub hash: Hash32,
+    pub header: EvmBlockHeader,
+}
+
+/// Loads the blocks referenced by `logs` in ascending block-number order,
+/// deduped. Used to fulfill the `blocks` relation on a logs query when the
+/// caller opts in.
+pub async fn load_blocks_for_logs<M: MetaStore>(
+    blocks: &BlockTables<M>,
+    logs: &[LogEntry],
+) -> Result<Vec<Block>> {
+    let distinct: BTreeSet<u64> = logs.iter().map(|l| l.block_number).collect();
+    let mut out = Vec::with_capacity(distinct.len());
+    for number in distinct {
+        out.push(load_block(blocks, number).await?);
+    }
+    Ok(out)
+}
+
+pub async fn load_block<M: MetaStore>(blocks: &BlockTables<M>, number: u64) -> Result<Block> {
+    let header = blocks
+        .load_header(number)
+        .await?
+        .ok_or(MonadChainDataError::MissingData("missing block header"))?;
+    let record = blocks
+        .load_record(number)
+        .await?
+        .ok_or(MonadChainDataError::MissingData("missing block record"))?;
+    Ok(Block {
+        hash: record.block_hash,
+        header,
+    })
+}

--- a/monad-chain-data/src/lib.rs
+++ b/monad-chain-data/src/lib.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pub mod api;
+pub mod blocks;
 pub mod error;
 pub mod family;
 pub mod ingest;
@@ -25,10 +26,11 @@ pub mod store;
 
 pub use alloy_primitives::{Address, Bytes, Log, LogData, B256};
 pub use api::{IngestOutcome, MonadChainDataService};
+pub use blocks::Block;
 pub use error::MonadChainDataError;
 pub use family::{FinalizedBlock, Hash32};
 pub use kernel::tables::Tables;
-pub use logs::{LogEntry, LogFilter, QueryLogsRequest, QueryLogsResponse};
+pub use logs::{LogEntry, LogFilter, LogsRelations, QueryLogsRequest, QueryLogsResponse};
 pub use primitives::{
     limits::{LimitExceededKind, QueryLimits},
     page::{QueryOrder, DEFAULT_QUERY_LIMIT},

--- a/monad-chain-data/src/logs/materialize.rs
+++ b/monad-chain-data/src/logs/materialize.rs
@@ -19,6 +19,7 @@ use alloy_primitives::{Address, Bytes, B256};
 
 use super::{LogBlockHeader, LogEntry, RawLogEntry};
 use crate::{
+    blocks::Block,
     error::{MonadChainDataError, Result},
     family::Hash32,
     kernel::{bitmap::sharded_stream_id, tables::Tables},
@@ -34,6 +35,17 @@ use crate::{
 pub struct LogFilter {
     pub address: Option<HashSet<Address>>,
     pub topics: [Option<HashSet<B256>>; 4],
+}
+
+/// Opt-in relations joined onto a logs query response. Each field is a
+/// hint to the service; disabled relations leave the corresponding vec
+/// empty in the response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct LogsRelations {
+    /// When true, `QueryLogsResponse::blocks` is populated with deduped
+    /// headers (sorted ascending by number) for the blocks that
+    /// contributed logs in this page.
+    pub blocks: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -55,6 +67,7 @@ pub struct QueryLogsRequest {
     /// [`DEFAULT_QUERY_LIMIT`].
     pub limit: usize,
     pub filter: LogFilter,
+    pub relations: LogsRelations,
 }
 
 impl Default for QueryLogsRequest {
@@ -65,6 +78,7 @@ impl Default for QueryLogsRequest {
             order: QueryOrder::default(),
             limit: DEFAULT_QUERY_LIMIT,
             filter: LogFilter::default(),
+            relations: LogsRelations::default(),
         }
     }
 }
@@ -75,6 +89,9 @@ impl Default for QueryLogsRequest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryLogsResponse {
     pub logs: Vec<LogEntry>,
+    /// Deduped blocks for the `logs` in this page, sorted ascending by
+    /// block number. `None` unless `QueryLogsRequest::relations.blocks`.
+    pub blocks: Option<Vec<Block>>,
     pub from_block: BlockRef,
     pub to_block: BlockRef,
     pub cursor_block: BlockRef,

--- a/monad-chain-data/src/logs/mod.rs
+++ b/monad-chain-data/src/logs/mod.rs
@@ -19,5 +19,5 @@ mod types;
 
 pub use ingest::LogIngestPlan;
 pub(crate) use materialize::{IndexedLogClause, LogMaterializer};
-pub use materialize::{LogFilter, QueryLogsRequest, QueryLogsResponse};
+pub use materialize::{LogFilter, LogsRelations, QueryLogsRequest, QueryLogsResponse};
 pub use types::{LogBlockHeader, LogEntry, RawLogEntry};

--- a/monad-chain-data/src/query/indexed.rs
+++ b/monad-chain-data/src/query/indexed.rs
@@ -37,6 +37,7 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
     let Some(log_window) = resolve_log_window(tables, &block_window).await? else {
         return Ok(QueryLogsResponse {
             logs: Vec::new(),
+            blocks: None,
             from_block: request_from,
             to_block: request_to,
             cursor_block: request_to,
@@ -76,6 +77,7 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
                     let cursor_block = materializer.load_block_ref(stop_block).await?;
                     return Ok(QueryLogsResponse {
                         logs,
+                        blocks: None,
                         from_block: request_from,
                         to_block: request_to,
                         cursor_block,
@@ -103,6 +105,7 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
 
     Ok(QueryLogsResponse {
         logs,
+        blocks: None,
         from_block: request_from,
         to_block: request_to,
         cursor_block: request_to,

--- a/monad-chain-data/src/query/runner.rs
+++ b/monad-chain-data/src/query/runner.rs
@@ -47,6 +47,7 @@ pub async fn execute_block_scan_query<M: MetaStore, B: BlobStore>(
 
     Ok(QueryLogsResponse {
         logs,
+        blocks: None,
         from_block: request_from,
         to_block: request_to,
         cursor_block,

--- a/monad-chain-data/tests/log_bitmap_pages.rs
+++ b/monad-chain-data/tests/log_bitmap_pages.rs
@@ -23,7 +23,7 @@ use monad_chain_data::{
     },
     store::MetaStore,
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData, LogFilter,
-    MonadChainDataService, QueryLimits, QueryLogsRequest, QueryOrder, Topic, B256,
+    LogsRelations, MonadChainDataService, QueryLimits, QueryLogsRequest, QueryOrder, Topic, B256,
 };
 
 mod common;
@@ -119,6 +119,7 @@ async fn ingest_compacts_sealed_pages_and_query_prefers_compacted_page_blobs() {
                 address: Some(HashSet::from([old_address])),
                 topics: [Some(HashSet::from([old_topic])), None, None, None],
             },
+            relations: LogsRelations::default(),
         })
         .await
         .expect("query compacted page");
@@ -137,6 +138,7 @@ async fn ingest_compacts_sealed_pages_and_query_prefers_compacted_page_blobs() {
                 address: Some(HashSet::from([frontier_address])),
                 topics: [Some(HashSet::from([frontier_topic])), None, None, None],
             },
+            relations: LogsRelations::default(),
         })
         .await
         .expect("query live frontier page");
@@ -195,6 +197,7 @@ async fn query_errors_when_compacted_page_meta_exists_but_blob_is_missing() {
                 address: Some(HashSet::from([address])),
                 topics: [Some(HashSet::from([topic])), None, None, None],
             },
+            relations: LogsRelations::default(),
         })
         .await
         .expect_err("missing page blob should error");

--- a/monad-chain-data/tests/query_logs_blocks_relation.rs
+++ b/monad-chain-data/tests/query_logs_blocks_relation.rs
@@ -1,0 +1,198 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+
+use monad_chain_data::{
+    Address, Bytes, EvmBlockHeader, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log,
+    LogData, LogFilter, LogsRelations, MonadChainDataService, QueryLimits, QueryLogsRequest,
+    QueryOrder, B256,
+};
+
+mod common;
+
+use common::{chain_header, test_header};
+
+#[tokio::test(flavor = "current_thread")]
+async fn include_blocks_false_omits_block_headers() {
+    let (service, _) = ingest_three_blocks().await;
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(1),
+            to_block: Some(3),
+            order: QueryOrder::Ascending,
+            limit: 100,
+            filter: LogFilter::default(),
+            relations: LogsRelations::default(),
+        })
+        .await
+        .expect("query");
+
+    assert!(page.blocks.is_none());
+    assert_eq!(page.logs.len(), 3);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn include_blocks_true_returns_deduped_headers_for_matched_blocks() {
+    // Block 2 has no matching logs (address differs); only blocks 1 and 3
+    // should appear in the relation.
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+    let matching = Address::repeat_byte(7);
+    let other = Address::repeat_byte(9);
+
+    let h1 = tagged_header(1, B256::ZERO);
+    let h2 = tagged_chain_header(2, &h1);
+    let h3 = tagged_chain_header(3, &h2);
+    let h1_hash = h1.hash_slow();
+    let h3_hash = h3.hash_slow();
+
+    ingest(&service, h1, vec![log(matching), log(matching)]).await;
+    ingest(&service, h2, vec![log(other)]).await;
+    ingest(&service, h3, vec![log(matching)]).await;
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(1),
+            to_block: Some(3),
+            order: QueryOrder::Ascending,
+            limit: 100,
+            filter: LogFilter {
+                address: Some(HashSet::from([matching])),
+                topics: [None, None, None, None],
+            },
+            relations: LogsRelations { blocks: true },
+        })
+        .await
+        .expect("query");
+
+    let blocks = page.blocks.expect("blocks relation");
+    assert_eq!(blocks.len(), 2);
+    assert_eq!(blocks[0].header.number, 1);
+    assert_eq!(blocks[1].header.number, 3);
+    assert_eq!(blocks[0].hash, h1_hash);
+    assert_eq!(blocks[1].hash, h3_hash);
+    assert_eq!(blocks[0].header.beneficiary, Address::repeat_byte(0x11));
+    assert_eq!(blocks[1].header.beneficiary, Address::repeat_byte(0x33));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn descending_query_still_returns_blocks_ascending() {
+    let (service, _) = ingest_three_blocks().await;
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(3),
+            to_block: Some(1),
+            order: QueryOrder::Descending,
+            limit: 100,
+            filter: LogFilter::default(),
+            relations: LogsRelations { blocks: true },
+        })
+        .await
+        .expect("query");
+
+    let blocks = page.blocks.expect("blocks relation");
+    let numbers: Vec<u64> = blocks.iter().map(|b| b.header.number).collect();
+    assert_eq!(numbers, vec![1, 2, 3]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn include_blocks_empty_result_returns_empty_blocks() {
+    let (service, _) = ingest_three_blocks().await;
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(1),
+            to_block: Some(3),
+            order: QueryOrder::Ascending,
+            limit: 100,
+            filter: LogFilter {
+                address: Some(HashSet::from([Address::repeat_byte(0xEE)])),
+                topics: [None, None, None, None],
+            },
+            relations: LogsRelations { blocks: true },
+        })
+        .await
+        .expect("query");
+
+    assert!(page.logs.is_empty());
+    let blocks = page.blocks.expect("blocks relation");
+    assert!(blocks.is_empty());
+}
+
+async fn ingest_three_blocks() -> (
+    MonadChainDataService<InMemoryMetaStore, InMemoryBlobStore>,
+    [B256; 3],
+) {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+    let addr = Address::repeat_byte(7);
+
+    let h1 = tagged_header(1, B256::ZERO);
+    let h2 = tagged_chain_header(2, &h1);
+    let h3 = tagged_chain_header(3, &h2);
+    let hashes = [h1.hash_slow(), h2.hash_slow(), h3.hash_slow()];
+
+    for header in [h1, h2, h3] {
+        ingest(&service, header, vec![log(addr)]).await;
+    }
+    (service, hashes)
+}
+
+async fn ingest(
+    service: &MonadChainDataService<InMemoryMetaStore, InMemoryBlobStore>,
+    header: EvmBlockHeader,
+    logs: Vec<Log>,
+) {
+    service
+        .ingest_block(FinalizedBlock {
+            header,
+            logs_by_tx: vec![logs],
+        })
+        .await
+        .expect("ingest");
+}
+
+fn tagged_header(number: u64, parent_hash: B256) -> EvmBlockHeader {
+    let mut header = test_header(number, parent_hash);
+    header.beneficiary = Address::repeat_byte(tag_byte(number));
+    header
+}
+
+fn tagged_chain_header(number: u64, parent: &EvmBlockHeader) -> EvmBlockHeader {
+    let mut header = chain_header(number, parent);
+    header.beneficiary = Address::repeat_byte(tag_byte(number));
+    header
+}
+
+fn tag_byte(n: u64) -> u8 {
+    // Distinct non-default byte per block so header.beneficiary asserts catch drift.
+    ((n << 4) | n) as u8
+}
+
+fn log(address: Address) -> Log {
+    Log {
+        address,
+        data: LogData::new_unchecked(vec![B256::repeat_byte(0xAA)], Bytes::from(vec![1, 2, 3])),
+    }
+}

--- a/monad-chain-data/tests/query_logs_indexed.rs
+++ b/monad-chain-data/tests/query_logs_indexed.rs
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 use monad_chain_data::{
     kernel::{bitmap::STREAM_PAGE_LOCAL_ID_SPAN, primary_dir::DIRECTORY_BUCKET_SIZE},
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData, LogFilter,
-    MonadChainDataService, QueryLimits, QueryLogsRequest, QueryOrder, Topic, B256,
+    LogsRelations, MonadChainDataService, QueryLimits, QueryLogsRequest, QueryOrder, Topic, B256,
 };
 
 mod common;
@@ -69,6 +69,7 @@ async fn indexed_query_logs_respects_and_or_filter_semantics() {
                     None,
                 ],
             },
+            relations: LogsRelations::default(),
         })
         .await
         .expect("query");
@@ -128,6 +129,7 @@ async fn indexed_query_logs_descending_returns_newest_first() {
                     None,
                 ],
             },
+            relations: LogsRelations::default(),
         })
         .await
         .expect("query");
@@ -188,6 +190,7 @@ async fn indexed_query_logs_paginates_at_block_boundaries() {
                     None,
                 ],
             },
+            relations: LogsRelations::default(),
         })
         .await
         .expect("first page");
@@ -210,6 +213,7 @@ async fn indexed_query_logs_paginates_at_block_boundaries() {
                     None,
                 ],
             },
+            relations: LogsRelations::default(),
         })
         .await
         .expect("second page");
@@ -269,6 +273,7 @@ async fn indexed_query_logs_scans_across_bucket_and_page_boundaries() {
                     None,
                 ],
             },
+            relations: LogsRelations::default(),
         })
         .await
         .expect("query");
@@ -344,6 +349,7 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block() {
                     None,
                 ],
             },
+            relations: LogsRelations::default(),
         })
         .await
         .expect("query");
@@ -417,6 +423,7 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block_desc
                     None,
                 ],
             },
+            relations: LogsRelations::default(),
         })
         .await
         .expect("query");
@@ -475,6 +482,7 @@ async fn indexed_query_stops_at_block_when_limit_equals_block_match_count() {
                     None,
                 ],
             },
+            relations: LogsRelations::default(),
         })
         .await
         .expect("query");
@@ -510,6 +518,7 @@ async fn unindexed_query_logs_still_uses_block_scan_fallback() {
             order: QueryOrder::Ascending,
             limit: 1,
             filter: LogFilter::default(),
+            relations: LogsRelations::default(),
         })
         .await
         .expect("query");

--- a/monad-chain-data/tests/query_logs_limits.rs
+++ b/monad-chain-data/tests/query_logs_limits.rs
@@ -15,8 +15,8 @@
 
 use monad_chain_data::{
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, LimitExceededKind, Log,
-    LogData, LogFilter, MonadChainDataError, MonadChainDataService, QueryLimits, QueryLogsRequest,
-    QueryOrder, B256,
+    LogData, LogFilter, LogsRelations, MonadChainDataError, MonadChainDataService, QueryLimits,
+    QueryLogsRequest, QueryOrder, B256,
 };
 
 mod common;
@@ -34,6 +34,7 @@ async fn limit_above_max_limit_returns_limit_exceeded() {
             order: QueryOrder::Ascending,
             limit: 10,
             filter: LogFilter::default(),
+            relations: LogsRelations::default(),
         })
         .await
         .expect_err("limit above max_limit should error");
@@ -63,6 +64,7 @@ async fn block_range_above_max_block_range_returns_limit_exceeded() {
             order: QueryOrder::Ascending,
             limit: 10,
             filter: LogFilter::default(),
+            relations: LogsRelations::default(),
         })
         .await
         .expect_err("block range above max_block_range should error");
@@ -92,6 +94,7 @@ async fn block_range_at_max_block_range_succeeds() {
             order: QueryOrder::Ascending,
             limit: 10,
             filter: LogFilter::default(),
+            relations: LogsRelations::default(),
         })
         .await
         .expect("query at max should succeed");
@@ -113,6 +116,7 @@ async fn defaulted_block_range_is_bounded_by_max_block_range() {
             order: QueryOrder::Ascending,
             limit: 10,
             filter: LogFilter::default(),
+            relations: LogsRelations::default(),
         })
         .await
         .expect_err("defaulted full-chain range should be bounded");

--- a/monad-chain-data/tests/query_logs_range_resolution.rs
+++ b/monad-chain-data/tests/query_logs_range_resolution.rs
@@ -15,7 +15,8 @@
 
 use monad_chain_data::{
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData, LogFilter,
-    MonadChainDataError, MonadChainDataService, QueryLimits, QueryLogsRequest, QueryOrder, B256,
+    LogsRelations, MonadChainDataError, MonadChainDataService, QueryLimits, QueryLogsRequest,
+    QueryOrder, B256,
 };
 
 mod common;
@@ -33,6 +34,7 @@ async fn from_block_above_head_returns_invalid_request() {
             order: QueryOrder::Ascending,
             limit: 10,
             filter: LogFilter::default(),
+            relations: LogsRelations::default(),
         })
         .await
         .expect_err("from_block above head should not silently collapse");
@@ -54,6 +56,7 @@ async fn to_block_above_head_clips_to_head() {
             order: QueryOrder::Ascending,
             limit: 100,
             filter: LogFilter::default(),
+            relations: LogsRelations::default(),
         })
         .await
         .expect("query");
@@ -74,6 +77,7 @@ async fn inverted_range_returns_invalid_request() {
             order: QueryOrder::Ascending,
             limit: 10,
             filter: LogFilter::default(),
+            relations: LogsRelations::default(),
         })
         .await
         .expect_err("from > to should error");
@@ -99,6 +103,7 @@ async fn descending_to_block_above_head_returns_invalid_request() {
             order: QueryOrder::Descending,
             limit: 10,
             filter: LogFilter::default(),
+            relations: LogsRelations::default(),
         })
         .await
         .expect_err("to_block above head in desc should not silently collapse");
@@ -123,6 +128,7 @@ async fn descending_from_above_head_clips_to_head() {
             order: QueryOrder::Descending,
             limit: 100,
             filter: LogFilter::default(),
+            relations: LogsRelations::default(),
         })
         .await
         .expect("query");
@@ -143,6 +149,7 @@ async fn from_block_zero_floors_to_earliest_queryable_block() {
             order: QueryOrder::Ascending,
             limit: 100,
             filter: LogFilter::default(),
+            relations: LogsRelations::default(),
         })
         .await
         .expect("query");
@@ -164,6 +171,7 @@ async fn descending_inverted_range_returns_invalid_request() {
             order: QueryOrder::Descending,
             limit: 10,
             filter: LogFilter::default(),
+            relations: LogsRelations::default(),
         })
         .await
         .expect_err("descending from < to should error");
@@ -185,6 +193,7 @@ async fn descending_defaulted_range_inverts_endpoints() {
             order: QueryOrder::Descending,
             limit: 100,
             filter: LogFilter::default(),
+            relations: LogsRelations::default(),
         })
         .await
         .expect("query");
@@ -204,6 +213,7 @@ async fn defaulted_range_resolves_to_full_chain() {
             order: QueryOrder::Ascending,
             limit: 100,
             filter: LogFilter::default(),
+            relations: LogsRelations::default(),
         })
         .await
         .expect("query");

--- a/monad-chain-data/tests/query_logs_scan.rs
+++ b/monad-chain-data/tests/query_logs_scan.rs
@@ -17,8 +17,8 @@ use std::collections::HashSet;
 
 use monad_chain_data::{
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData, LogFilter,
-    LogId, MonadChainDataError, MonadChainDataService, QueryLimits, QueryLogsRequest, QueryOrder,
-    B256,
+    LogId, LogsRelations, MonadChainDataError, MonadChainDataService, QueryLimits,
+    QueryLogsRequest, QueryOrder, B256,
 };
 
 mod common;
@@ -70,6 +70,7 @@ async fn query_logs_paginates_at_block_boundaries() {
                     None,
                 ],
             },
+            relations: LogsRelations::default(),
         })
         .await
         .expect("first page");
@@ -94,6 +95,7 @@ async fn query_logs_paginates_at_block_boundaries() {
                     None,
                 ],
             },
+            relations: LogsRelations::default(),
         })
         .await
         .expect("second page");
@@ -137,6 +139,7 @@ async fn query_logs_descending_returns_newest_first() {
                     None,
                 ],
             },
+            relations: LogsRelations::default(),
         })
         .await
         .expect("query");
@@ -284,6 +287,7 @@ async fn block_scan_completes_current_block_when_limit_reached_mid_block() {
             order: QueryOrder::Ascending,
             limit: 1,
             filter: LogFilter::default(),
+            relations: LogsRelations::default(),
         })
         .await
         .expect("query");


### PR DESCRIPTION
Adds the blocks relation to query_logs: when the caller sets relations.blocks on the request, the response carries a deduped, ascending-by-number vec of `Block { hash, header }` entries for the blocks that contributed logs in this page. Hash comes from the BlockRecord since `alloy_consensus::Header` does not carry the hash.

Relations are packaged in a dedicated `LogsRelations` struct so adding the next relation (transactions, traces) extends the shape without churning the request envelope. Block-side types and helpers live in a new `src/blocks.rs` module — the natural home for cross-family block-query machinery.