### PR TITLE
Hoist shared query envelope primitives

### DIFF
--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -24,7 +24,7 @@ use crate::{
     kernel::tables::Tables,
     logs::{LogIngestPlan, QueryLogsRequest, QueryLogsResponse},
     primitives::{
-        limits::{LimitExceededKind, QueryLimits},
+        limits::QueryLimits,
         range::ResolvedBlockWindow,
         state::{BlockRecord, LogId},
     },
@@ -139,28 +139,16 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
     /// The service's configured `QueryLimits` bound the request shape and
     /// the resolved block-range span.
     pub async fn query_logs(&self, request: QueryLogsRequest) -> Result<QueryLogsResponse> {
-        if request.limit == 0 {
-            return Err(MonadChainDataError::InvalidRequest(
-                "limit must be at least 1",
-            ));
-        }
-        if request.limit > self.limits.max_limit {
-            return Err(MonadChainDataError::LimitExceeded {
-                kind: LimitExceededKind::Limit,
-                max_limit: self.limits.max_limit,
-                max_block_range: self.limits.max_block_range,
-            });
-        }
+        self.limits.check_limit(request.envelope.limit)?;
 
-        let head = self
-            .tables
-            .publication()
-            .load_published_head()
-            .await?
-            .ok_or(MonadChainDataError::MissingData("no published blocks"))?;
-        let window =
-            ResolvedBlockWindow::resolve(&request, head, &self.limits, self.tables.blocks())
-                .await?;
+        let head = self.load_published_head().await?;
+        let window = ResolvedBlockWindow::resolve(
+            &request.envelope,
+            head,
+            &self.limits,
+            self.tables.blocks(),
+        )
+        .await?;
 
         let mut response = if request.filter.has_indexed_clause() {
             execute_indexed_log_query(&self.tables, &request, window).await?
@@ -174,5 +162,13 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
         }
 
         Ok(response)
+    }
+
+    async fn load_published_head(&self) -> Result<u64> {
+        self.tables
+            .publication()
+            .load_published_head()
+            .await?
+            .ok_or(MonadChainDataError::MissingData("no published blocks"))
     }
 }

--- a/monad-chain-data/src/lib.rs
+++ b/monad-chain-data/src/lib.rs
@@ -32,9 +32,9 @@ pub use family::{FinalizedBlock, Hash32};
 pub use kernel::tables::Tables;
 pub use logs::{LogEntry, LogFilter, LogsRelations, QueryLogsRequest, QueryLogsResponse};
 pub use primitives::{
-    limits::{LimitExceededKind, QueryLimits},
+    limits::{LimitExceededKind, QueryEnvelope, QueryLimits},
     page::{QueryOrder, DEFAULT_QUERY_LIMIT},
-    refs::BlockRef,
+    refs::{BlockRef, BlockSpan},
     state::{BlockRecord, FamilyWindowRecord, LogId},
     EvmBlockHeader,
 };

--- a/monad-chain-data/src/logs/materialize.rs
+++ b/monad-chain-data/src/logs/materialize.rs
@@ -24,8 +24,9 @@ use crate::{
     family::Hash32,
     kernel::{bitmap::sharded_stream_id, tables::Tables},
     primitives::{
-        page::{QueryOrder, DEFAULT_QUERY_LIMIT},
-        refs::BlockRef,
+        limits::QueryEnvelope,
+        page::QueryOrder,
+        refs::{BlockRef, BlockSpan},
         state::BlockRecord,
     },
     store::{BlobStore, MetaStore},
@@ -57,44 +58,23 @@ pub(crate) enum IndexedLogClause {
 /// Public log query in queryX spec semantics: `from_block`/`to_block` are
 /// the inclusive range start/end, with the lower/upper roles depending on
 /// `order`. Omitted bounds default to `"earliest"`/`"latest"` per order.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct QueryLogsRequest {
-    pub from_block: Option<u64>,
-    pub to_block: Option<u64>,
-    pub order: QueryOrder,
-    /// Target log count. The server completes the current block before
-    /// stopping, so the actual count may exceed this. Defaults to
-    /// [`DEFAULT_QUERY_LIMIT`].
-    pub limit: usize,
+    pub envelope: QueryEnvelope,
     pub filter: LogFilter,
     pub relations: LogsRelations,
 }
 
-impl Default for QueryLogsRequest {
-    fn default() -> Self {
-        Self {
-            from_block: None,
-            to_block: None,
-            order: QueryOrder::default(),
-            limit: DEFAULT_QUERY_LIMIT,
-            filter: LogFilter::default(),
-            relations: LogsRelations::default(),
-        }
-    }
-}
-
-/// `from_block`/`to_block` mirror the request's spec semantics. `cursor_block`
-/// is the last block scanned; pagination resumes from `cursor_block.number ± 1`
-/// per order.
+/// The span mirrors the resolved request bounds and records the last
+/// block scanned. When `logs` is empty there is no next page; callers
+/// should treat the response as terminal rather than advance the cursor.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryLogsResponse {
     pub logs: Vec<LogEntry>,
     /// Deduped blocks for the `logs` in this page, sorted ascending by
     /// block number. `None` unless `QueryLogsRequest::relations.blocks`.
     pub blocks: Option<Vec<Block>>,
-    pub from_block: BlockRef,
-    pub to_block: BlockRef,
-    pub cursor_block: BlockRef,
+    pub span: BlockSpan,
 }
 
 impl LogFilter {
@@ -259,7 +239,7 @@ fn load_filtered_block_logs(
     request: &QueryLogsRequest,
 ) -> Result<Vec<LogEntry>> {
     let count = header.log_count();
-    let indices: Box<dyn Iterator<Item = usize>> = match request.order {
+    let indices: Box<dyn Iterator<Item = usize>> = match request.envelope.order {
         QueryOrder::Ascending => Box::new(0..count),
         QueryOrder::Descending => Box::new((0..count).rev()),
     };

--- a/monad-chain-data/src/primitives/limits.rs
+++ b/monad-chain-data/src/primitives/limits.rs
@@ -13,6 +13,33 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use super::page::{QueryOrder, DEFAULT_QUERY_LIMIT};
+
+/// Common request envelope shared by query families. `from_block`/`to_block`
+/// are interpreted in queryX spec semantics, with lower/upper roles depending
+/// on `order`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryEnvelope {
+    pub from_block: Option<u64>,
+    pub to_block: Option<u64>,
+    pub order: QueryOrder,
+    /// Target result count. The server completes the current block before
+    /// stopping, so the actual count may exceed this. Defaults to
+    /// [`DEFAULT_QUERY_LIMIT`].
+    pub limit: usize,
+}
+
+impl Default for QueryEnvelope {
+    fn default() -> Self {
+        Self {
+            from_block: None,
+            to_block: None,
+            order: QueryOrder::default(),
+            limit: DEFAULT_QUERY_LIMIT,
+        }
+    }
+}
+
 /// Per-deployment caps on accepted query shape. `max_limit` bounds the
 /// `request.limit` value the user may pass; `max_block_range` bounds the
 /// resolved range span. Breaches surface as
@@ -46,6 +73,22 @@ impl QueryLimits {
             max_block_range,
         }
     }
+
+    pub fn check_limit(&self, limit: usize) -> crate::error::Result<()> {
+        if limit == 0 {
+            return Err(crate::error::MonadChainDataError::InvalidRequest(
+                "limit must be at least 1",
+            ));
+        }
+        if limit > self.max_limit {
+            return Err(crate::error::MonadChainDataError::LimitExceeded {
+                kind: LimitExceededKind::Limit,
+                max_limit: self.max_limit,
+                max_block_range: self.max_block_range,
+            });
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -60,5 +103,33 @@ impl std::fmt::Display for LimitExceededKind {
             Self::Limit => f.write_str("limit"),
             Self::BlockRange => f.write_str("block range"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::QueryLimits;
+    use crate::{LimitExceededKind, MonadChainDataError};
+
+    #[test]
+    fn check_limit_accepts_and_rejects_boundary_values() {
+        let limits = QueryLimits::new(5, 1_000);
+
+        assert!(matches!(
+            limits.check_limit(0),
+            Err(MonadChainDataError::InvalidRequest(
+                "limit must be at least 1",
+            ))
+        ));
+        assert!(limits.check_limit(1).is_ok());
+        assert!(limits.check_limit(5).is_ok());
+        assert!(matches!(
+            limits.check_limit(6),
+            Err(MonadChainDataError::LimitExceeded {
+                kind: LimitExceededKind::Limit,
+                max_limit: 5,
+                max_block_range: 1_000,
+            })
+        ));
     }
 }

--- a/monad-chain-data/src/primitives/range.rs
+++ b/monad-chain-data/src/primitives/range.rs
@@ -16,9 +16,8 @@
 use crate::{
     error::{MonadChainDataError, Result},
     kernel::tables::BlockTables,
-    logs::QueryLogsRequest,
     primitives::{
-        limits::{LimitExceededKind, QueryLimits},
+        limits::{LimitExceededKind, QueryEnvelope, QueryLimits},
         page::QueryOrder,
         refs::BlockRef,
     },
@@ -42,12 +41,17 @@ impl ResolvedBlockWindow {
     /// short-circuits if the resolved span exceeds `limits.max_block_range`,
     /// then loads the per-bound block records.
     pub async fn resolve<M: MetaStore>(
-        request: &QueryLogsRequest,
+        envelope: &QueryEnvelope,
         published_head: u64,
         limits: &QueryLimits,
         blocks: &BlockTables<M>,
     ) -> Result<Self> {
-        let (low_number, high_number) = Self::resolve_block_numbers(request, published_head)?;
+        let (low_number, high_number) = Self::resolve_block_numbers(
+            envelope.from_block,
+            envelope.to_block,
+            envelope.order,
+            published_head,
+        )?;
 
         let span = high_number - low_number + 1;
         if span > limits.max_block_range {
@@ -87,18 +91,30 @@ impl ResolvedBlockWindow {
         }
     }
 
+    /// Iterates `low..=high` in the requested traversal direction.
+    pub fn iter(&self, order: QueryOrder) -> impl Iterator<Item = u64> {
+        let range = self.low.number..=self.high.number;
+        let (fwd, rev) = match order {
+            QueryOrder::Ascending => (Some(range), None),
+            QueryOrder::Descending => (None, Some(range.rev())),
+        };
+        fwd.into_iter().flatten().chain(rev.into_iter().flatten())
+    }
+
     /// Maps the spec's order-dependent `(from_block, to_block)` to internal
     /// `(low, high)` with `low <= high`. Errors if the inputs do not form a
     /// valid range for `order`, or if the lower bound exceeds the published head.
     fn resolve_block_numbers(
-        request: &QueryLogsRequest,
+        from_block: Option<u64>,
+        to_block: Option<u64>,
+        order: QueryOrder,
         published_head: u64,
     ) -> Result<(u64, u64)> {
         // User-space inversion is checked before defaults so an unspecified
         // bound (e.g. `from=None, to=N` with `N` above head) reports the
         // genuine cause (above-head) rather than a defaulted-inversion artifact.
-        if let (Some(from), Some(to)) = (request.from_block, request.to_block) {
-            let inverted = match request.order {
+        if let (Some(from), Some(to)) = (from_block, to_block) {
+            let inverted = match order {
                 QueryOrder::Ascending => from > to,
                 QueryOrder::Descending => from < to,
             };
@@ -109,14 +125,14 @@ impl ResolvedBlockWindow {
             }
         }
 
-        let (low, high) = match request.order {
+        let (low, high) = match order {
             QueryOrder::Ascending => (
-                request.from_block.unwrap_or(EARLIEST_QUERYABLE_BLOCK),
-                request.to_block.unwrap_or(published_head),
+                from_block.unwrap_or(EARLIEST_QUERYABLE_BLOCK),
+                to_block.unwrap_or(published_head),
             ),
             QueryOrder::Descending => (
-                request.to_block.unwrap_or(EARLIEST_QUERYABLE_BLOCK),
-                request.from_block.unwrap_or(published_head),
+                to_block.unwrap_or(EARLIEST_QUERYABLE_BLOCK),
+                from_block.unwrap_or(published_head),
             ),
         };
 

--- a/monad-chain-data/src/primitives/refs.rs
+++ b/monad-chain-data/src/primitives/refs.rs
@@ -22,6 +22,13 @@ pub struct BlockRef {
     pub parent_hash: Hash32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockSpan {
+    pub from_block: BlockRef,
+    pub to_block: BlockRef,
+    pub cursor_block: BlockRef,
+}
+
 impl From<&BlockRecord> for BlockRef {
     fn from(value: &BlockRecord) -> Self {
         Self {

--- a/monad-chain-data/src/query/indexed.rs
+++ b/monad-chain-data/src/query/indexed.rs
@@ -23,7 +23,7 @@ use crate::{
     error::{MonadChainDataError, Result},
     kernel::tables::Tables,
     logs::{LogMaterializer, QueryLogsRequest, QueryLogsResponse},
-    primitives::{page::QueryOrder, range::ResolvedBlockWindow, state::LogId},
+    primitives::{page::QueryOrder, range::ResolvedBlockWindow, refs::BlockSpan, state::LogId},
     store::{BlobStore, MetaStore},
 };
 
@@ -32,15 +32,17 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
     request: &QueryLogsRequest,
     block_window: ResolvedBlockWindow,
 ) -> Result<QueryLogsResponse> {
-    let (request_from, request_to) = block_window.request_endpoints(request.order);
+    let (request_from, request_to) = block_window.request_endpoints(request.envelope.order);
 
     let Some(log_window) = resolve_log_window(tables, &block_window).await? else {
         return Ok(QueryLogsResponse {
             logs: Vec::new(),
             blocks: None,
-            from_block: request_from,
-            to_block: request_to,
-            cursor_block: request_to,
+            span: BlockSpan {
+                from_block: request_from,
+                to_block: request_to,
+                cursor_block: request_to,
+            },
         });
     };
 
@@ -56,7 +58,7 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
     let mut logs = Vec::new();
     let mut stop_after_block = None;
 
-    for shard in log_window.shard_iter(request.order) {
+    for shard in log_window.shard_iter(request.envelope.order) {
         let (local_from, local_to) = log_window.local_range_for_shard(shard);
 
         let Some(candidate_bitmap) =
@@ -65,7 +67,7 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
             continue;
         };
 
-        let locals = locals_in_query_order(candidate_bitmap, request.order);
+        let locals = locals_in_query_order(candidate_bitmap, request.envelope.order);
         for local in locals {
             let id = LogId::from_parts(shard, local);
             let Some(location) = resolver.resolve(id).await? else {
@@ -78,9 +80,11 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
                     return Ok(QueryLogsResponse {
                         logs,
                         blocks: None,
-                        from_block: request_from,
-                        to_block: request_to,
-                        cursor_block,
+                        span: BlockSpan {
+                            from_block: request_from,
+                            to_block: request_to,
+                            cursor_block,
+                        },
                     });
                 }
             }
@@ -97,7 +101,7 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
 
             logs.push(log);
 
-            if stop_after_block.is_none() && logs.len() >= request.limit {
+            if stop_after_block.is_none() && logs.len() >= request.envelope.limit {
                 stop_after_block = Some(location.block_number);
             }
         }
@@ -106,9 +110,11 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
     Ok(QueryLogsResponse {
         logs,
         blocks: None,
-        from_block: request_from,
-        to_block: request_to,
-        cursor_block: request_to,
+        span: BlockSpan {
+            from_block: request_from,
+            to_block: request_to,
+            cursor_block: request_to,
+        },
     })
 }
 

--- a/monad-chain-data/src/query/runner.rs
+++ b/monad-chain-data/src/query/runner.rs
@@ -17,9 +17,8 @@ use crate::{
     error::Result,
     kernel::tables::Tables,
     logs::{LogMaterializer, QueryLogsRequest, QueryLogsResponse},
-    primitives::range::ResolvedBlockWindow,
+    primitives::{range::ResolvedBlockWindow, refs::BlockSpan},
     store::{BlobStore, MetaStore},
-    QueryOrder,
 };
 
 /// Executes the block-scan fallback path for unindexed log queries.
@@ -29,12 +28,12 @@ pub async fn execute_block_scan_query<M: MetaStore, B: BlobStore>(
     window: ResolvedBlockWindow,
 ) -> Result<QueryLogsResponse> {
     let materializer = LogMaterializer::new(tables);
-    let target_log_count = request.limit;
-    let (request_from, request_to) = window.request_endpoints(request.order);
+    let target_log_count = request.envelope.limit;
+    let (request_from, request_to) = window.request_endpoints(request.envelope.order);
     let mut logs = Vec::new();
     let mut cursor_block = request_from;
 
-    for block_number in block_range(window, request.order) {
+    for block_number in window.iter(request.envelope.order) {
         let (block_ref, block_logs) = materializer
             .load_filtered_block_logs_for_block(block_number, request)
             .await?;
@@ -48,17 +47,10 @@ pub async fn execute_block_scan_query<M: MetaStore, B: BlobStore>(
     Ok(QueryLogsResponse {
         logs,
         blocks: None,
-        from_block: request_from,
-        to_block: request_to,
-        cursor_block,
+        span: BlockSpan {
+            from_block: request_from,
+            to_block: request_to,
+            cursor_block,
+        },
     })
-}
-
-fn block_range(window: ResolvedBlockWindow, order: QueryOrder) -> impl Iterator<Item = u64> {
-    let range = window.low.number..=window.high.number;
-    let (fwd, rev) = match order {
-        QueryOrder::Ascending => (Some(range), None),
-        QueryOrder::Descending => (None, Some(range.rev())),
-    };
-    fwd.into_iter().flatten().chain(rev.into_iter().flatten())
 }

--- a/monad-chain-data/tests/log_bitmap_pages.rs
+++ b/monad-chain-data/tests/log_bitmap_pages.rs
@@ -23,7 +23,8 @@ use monad_chain_data::{
     },
     store::MetaStore,
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData, LogFilter,
-    LogsRelations, MonadChainDataService, QueryLimits, QueryLogsRequest, QueryOrder, Topic, B256,
+    LogsRelations, MonadChainDataService, QueryEnvelope, QueryLimits, QueryLogsRequest, QueryOrder,
+    Topic, B256,
 };
 
 mod common;
@@ -111,10 +112,12 @@ async fn ingest_compacts_sealed_pages_and_query_prefers_compacted_page_blobs() {
 
     let old_page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(2),
-            order: QueryOrder::Ascending,
-            limit: 10,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(2),
+                order: QueryOrder::Ascending,
+                limit: 10,
+            },
             filter: LogFilter {
                 address: Some(HashSet::from([old_address])),
                 topics: [Some(HashSet::from([old_topic])), None, None, None],
@@ -130,10 +133,12 @@ async fn ingest_compacts_sealed_pages_and_query_prefers_compacted_page_blobs() {
 
     let frontier_page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(2),
-            order: QueryOrder::Ascending,
-            limit: 10,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(2),
+                order: QueryOrder::Ascending,
+                limit: 10,
+            },
             filter: LogFilter {
                 address: Some(HashSet::from([frontier_address])),
                 topics: [Some(HashSet::from([frontier_topic])), None, None, None],
@@ -189,10 +194,12 @@ async fn query_errors_when_compacted_page_meta_exists_but_blob_is_missing() {
 
     let error = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(2),
-            order: QueryOrder::Ascending,
-            limit: 10,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(2),
+                order: QueryOrder::Ascending,
+                limit: 10,
+            },
             filter: LogFilter {
                 address: Some(HashSet::from([address])),
                 topics: [Some(HashSet::from([topic])), None, None, None],

--- a/monad-chain-data/tests/query_logs_blocks_relation.rs
+++ b/monad-chain-data/tests/query_logs_blocks_relation.rs
@@ -17,8 +17,8 @@ use std::collections::HashSet;
 
 use monad_chain_data::{
     Address, Bytes, EvmBlockHeader, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log,
-    LogData, LogFilter, LogsRelations, MonadChainDataService, QueryLimits, QueryLogsRequest,
-    QueryOrder, B256,
+    LogData, LogFilter, LogsRelations, MonadChainDataService, QueryEnvelope, QueryLimits,
+    QueryLogsRequest, QueryOrder, B256,
 };
 
 mod common;
@@ -31,10 +31,12 @@ async fn include_blocks_false_omits_block_headers() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(3),
-            order: QueryOrder::Ascending,
-            limit: 100,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(3),
+                order: QueryOrder::Ascending,
+                limit: 100,
+            },
             filter: LogFilter::default(),
             relations: LogsRelations::default(),
         })
@@ -69,10 +71,12 @@ async fn include_blocks_true_returns_deduped_headers_for_matched_blocks() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(3),
-            order: QueryOrder::Ascending,
-            limit: 100,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(3),
+                order: QueryOrder::Ascending,
+                limit: 100,
+            },
             filter: LogFilter {
                 address: Some(HashSet::from([matching])),
                 topics: [None, None, None, None],
@@ -98,10 +102,12 @@ async fn descending_query_still_returns_blocks_ascending() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(3),
-            to_block: Some(1),
-            order: QueryOrder::Descending,
-            limit: 100,
+            envelope: QueryEnvelope {
+                from_block: Some(3),
+                to_block: Some(1),
+                order: QueryOrder::Descending,
+                limit: 100,
+            },
             filter: LogFilter::default(),
             relations: LogsRelations { blocks: true },
         })
@@ -119,10 +125,12 @@ async fn include_blocks_empty_result_returns_empty_blocks() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(3),
-            order: QueryOrder::Ascending,
-            limit: 100,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(3),
+                order: QueryOrder::Ascending,
+                limit: 100,
+            },
             filter: LogFilter {
                 address: Some(HashSet::from([Address::repeat_byte(0xEE)])),
                 topics: [None, None, None, None],

--- a/monad-chain-data/tests/query_logs_indexed.rs
+++ b/monad-chain-data/tests/query_logs_indexed.rs
@@ -18,7 +18,8 @@ use std::collections::HashSet;
 use monad_chain_data::{
     kernel::{bitmap::STREAM_PAGE_LOCAL_ID_SPAN, primary_dir::DIRECTORY_BUCKET_SIZE},
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData, LogFilter,
-    LogsRelations, MonadChainDataService, QueryLimits, QueryLogsRequest, QueryOrder, Topic, B256,
+    LogsRelations, MonadChainDataService, QueryEnvelope, QueryLimits, QueryLogsRequest, QueryOrder,
+    Topic, B256,
 };
 
 mod common;
@@ -53,10 +54,12 @@ async fn indexed_query_logs_respects_and_or_filter_semantics() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(1),
-            order: QueryOrder::Ascending,
-            limit: 10,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(1),
+                order: QueryOrder::Ascending,
+                limit: 10,
+            },
             filter: LogFilter {
                 address: Some(HashSet::from([
                     Address::repeat_byte(2),
@@ -76,7 +79,7 @@ async fn indexed_query_logs_respects_and_or_filter_semantics() {
 
     assert_eq!(page.logs.len(), 1);
     assert_eq!(page.logs[0].address, Address::repeat_byte(2));
-    assert_eq!(page.cursor_block.number, 1);
+    assert_eq!(page.span.cursor_block.number, 1);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -114,12 +117,14 @@ async fn indexed_query_logs_descending_returns_newest_first() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            // Spec semantics: in descending order from_block is the upper
-            // bound and to_block is the lower bound.
-            from_block: Some(2),
-            to_block: Some(1),
-            order: QueryOrder::Descending,
-            limit: 1,
+            envelope: QueryEnvelope {
+                // Spec semantics: in descending order from_block is the upper
+                // bound and to_block is the lower bound.
+                from_block: Some(2),
+                to_block: Some(1),
+                order: QueryOrder::Descending,
+                limit: 1,
+            },
             filter: LogFilter {
                 address: Some(HashSet::from([Address::repeat_byte(7)])),
                 topics: [
@@ -139,7 +144,7 @@ async fn indexed_query_logs_descending_returns_newest_first() {
     assert_eq!(page.logs[0].log_index, 1);
     assert_eq!(page.logs[1].block_number, 2);
     assert_eq!(page.logs[1].log_index, 0);
-    assert_eq!(page.cursor_block.number, 2);
+    assert_eq!(page.span.cursor_block.number, 2);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -177,10 +182,12 @@ async fn indexed_query_logs_paginates_at_block_boundaries() {
 
     let first_page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(2),
-            order: QueryOrder::Ascending,
-            limit: 1,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(2),
+                order: QueryOrder::Ascending,
+                limit: 1,
+            },
             filter: LogFilter {
                 address: Some(HashSet::from([Address::repeat_byte(7)])),
                 topics: [
@@ -196,14 +203,16 @@ async fn indexed_query_logs_paginates_at_block_boundaries() {
         .expect("first page");
 
     assert_eq!(first_page.logs.len(), 2);
-    assert_eq!(first_page.cursor_block.number, 1);
+    assert_eq!(first_page.span.cursor_block.number, 1);
 
     let second_page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(first_page.cursor_block.number + 1),
-            to_block: Some(2),
-            order: QueryOrder::Ascending,
-            limit: 1,
+            envelope: QueryEnvelope {
+                from_block: Some(first_page.span.cursor_block.number + 1),
+                to_block: Some(2),
+                order: QueryOrder::Ascending,
+                limit: 1,
+            },
             filter: LogFilter {
                 address: Some(HashSet::from([Address::repeat_byte(7)])),
                 topics: [
@@ -219,7 +228,7 @@ async fn indexed_query_logs_paginates_at_block_boundaries() {
         .expect("second page");
 
     assert_eq!(second_page.logs.len(), 1);
-    assert_eq!(second_page.cursor_block.number, 2);
+    assert_eq!(second_page.span.cursor_block.number, 2);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -260,10 +269,12 @@ async fn indexed_query_logs_scans_across_bucket_and_page_boundaries() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(2),
-            order: QueryOrder::Ascending,
-            limit: 10,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(2),
+                order: QueryOrder::Ascending,
+                limit: 10,
+            },
             filter: LogFilter {
                 address: Some(HashSet::from([Address::repeat_byte(7)])),
                 topics: [
@@ -283,7 +294,7 @@ async fn indexed_query_logs_scans_across_bucket_and_page_boundaries() {
         usize::try_from(DIRECTORY_BUCKET_SIZE + 4).expect("directory bucket size fits usize")
     );
     assert!(page.logs.iter().all(|log| log.block_number == 2));
-    assert_eq!(page.cursor_block.number, 2);
+    assert_eq!(page.span.cursor_block.number, 2);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -336,10 +347,12 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(3),
-            order: QueryOrder::Ascending,
-            limit: 2,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(3),
+                order: QueryOrder::Ascending,
+                limit: 2,
+            },
             filter: LogFilter {
                 address: Some(HashSet::from([Address::repeat_byte(7)])),
                 topics: [
@@ -357,7 +370,7 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block() {
     assert_eq!(page.logs.len(), 6);
     assert!(page.logs.iter().take(1).all(|l| l.block_number == 1));
     assert!(page.logs.iter().skip(1).all(|l| l.block_number == 2));
-    assert_eq!(page.cursor_block.number, 2);
+    assert_eq!(page.span.cursor_block.number, 2);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -410,10 +423,12 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block_desc
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(3),
-            to_block: Some(1),
-            order: QueryOrder::Descending,
-            limit: 2,
+            envelope: QueryEnvelope {
+                from_block: Some(3),
+                to_block: Some(1),
+                order: QueryOrder::Descending,
+                limit: 2,
+            },
             filter: LogFilter {
                 address: Some(HashSet::from([Address::repeat_byte(7)])),
                 topics: [
@@ -431,7 +446,7 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block_desc
     assert_eq!(page.logs.len(), 6);
     assert!(page.logs.iter().take(1).all(|l| l.block_number == 3));
     assert!(page.logs.iter().skip(1).all(|l| l.block_number == 2));
-    assert_eq!(page.cursor_block.number, 2);
+    assert_eq!(page.span.cursor_block.number, 2);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -469,10 +484,12 @@ async fn indexed_query_stops_at_block_when_limit_equals_block_match_count() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(2),
-            order: QueryOrder::Ascending,
-            limit: 2,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(2),
+                order: QueryOrder::Ascending,
+                limit: 2,
+            },
             filter: LogFilter {
                 address: Some(HashSet::from([Address::repeat_byte(7)])),
                 topics: [
@@ -489,7 +506,7 @@ async fn indexed_query_stops_at_block_when_limit_equals_block_match_count() {
 
     assert_eq!(page.logs.len(), 2);
     assert!(page.logs.iter().all(|l| l.block_number == 1));
-    assert_eq!(page.cursor_block.number, 1);
+    assert_eq!(page.span.cursor_block.number, 1);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -513,10 +530,12 @@ async fn unindexed_query_logs_still_uses_block_scan_fallback() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(1),
-            order: QueryOrder::Ascending,
-            limit: 1,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(1),
+                order: QueryOrder::Ascending,
+                limit: 1,
+            },
             filter: LogFilter::default(),
             relations: LogsRelations::default(),
         })
@@ -524,7 +543,7 @@ async fn unindexed_query_logs_still_uses_block_scan_fallback() {
         .expect("query");
 
     assert_eq!(page.logs.len(), 2);
-    assert_eq!(page.cursor_block.number, 1);
+    assert_eq!(page.span.cursor_block.number, 1);
 }
 
 fn repeated_logs(address: Address, topics: Vec<Topic>, count: usize) -> Vec<Log> {

--- a/monad-chain-data/tests/query_logs_limits.rs
+++ b/monad-chain-data/tests/query_logs_limits.rs
@@ -15,8 +15,8 @@
 
 use monad_chain_data::{
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, LimitExceededKind, Log,
-    LogData, LogFilter, LogsRelations, MonadChainDataError, MonadChainDataService, QueryLimits,
-    QueryLogsRequest, QueryOrder, B256,
+    LogData, LogFilter, LogsRelations, MonadChainDataError, MonadChainDataService, QueryEnvelope,
+    QueryLimits, QueryLogsRequest, QueryOrder, B256,
 };
 
 mod common;
@@ -29,10 +29,12 @@ async fn limit_above_max_limit_returns_limit_exceeded() {
 
     let err = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(3),
-            order: QueryOrder::Ascending,
-            limit: 10,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(3),
+                order: QueryOrder::Ascending,
+                limit: 10,
+            },
             filter: LogFilter::default(),
             relations: LogsRelations::default(),
         })
@@ -59,10 +61,12 @@ async fn block_range_above_max_block_range_returns_limit_exceeded() {
 
     let err = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(3),
-            order: QueryOrder::Ascending,
-            limit: 10,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(3),
+                order: QueryOrder::Ascending,
+                limit: 10,
+            },
             filter: LogFilter::default(),
             relations: LogsRelations::default(),
         })
@@ -89,18 +93,20 @@ async fn block_range_at_max_block_range_succeeds() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(3),
-            order: QueryOrder::Ascending,
-            limit: 10,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(3),
+                order: QueryOrder::Ascending,
+                limit: 10,
+            },
             filter: LogFilter::default(),
             relations: LogsRelations::default(),
         })
         .await
         .expect("query at max should succeed");
 
-    assert_eq!(page.from_block.number, 1);
-    assert_eq!(page.to_block.number, 3);
+    assert_eq!(page.span.from_block.number, 1);
+    assert_eq!(page.span.to_block.number, 3);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -111,10 +117,12 @@ async fn defaulted_block_range_is_bounded_by_max_block_range() {
 
     let err = service
         .query_logs(QueryLogsRequest {
-            from_block: None,
-            to_block: None,
-            order: QueryOrder::Ascending,
-            limit: 10,
+            envelope: QueryEnvelope {
+                from_block: None,
+                to_block: None,
+                order: QueryOrder::Ascending,
+                limit: 10,
+            },
             filter: LogFilter::default(),
             relations: LogsRelations::default(),
         })

--- a/monad-chain-data/tests/query_logs_range_resolution.rs
+++ b/monad-chain-data/tests/query_logs_range_resolution.rs
@@ -15,8 +15,8 @@
 
 use monad_chain_data::{
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData, LogFilter,
-    LogsRelations, MonadChainDataError, MonadChainDataService, QueryLimits, QueryLogsRequest,
-    QueryOrder, B256,
+    LogsRelations, MonadChainDataError, MonadChainDataService, QueryEnvelope, QueryLimits,
+    QueryLogsRequest, QueryOrder, B256,
 };
 
 mod common;
@@ -29,10 +29,12 @@ async fn from_block_above_head_returns_invalid_request() {
 
     let err = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(50),
-            to_block: Some(60),
-            order: QueryOrder::Ascending,
-            limit: 10,
+            envelope: QueryEnvelope {
+                from_block: Some(50),
+                to_block: Some(60),
+                order: QueryOrder::Ascending,
+                limit: 10,
+            },
             filter: LogFilter::default(),
             relations: LogsRelations::default(),
         })
@@ -51,19 +53,21 @@ async fn to_block_above_head_clips_to_head() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(50),
-            order: QueryOrder::Ascending,
-            limit: 100,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(50),
+                order: QueryOrder::Ascending,
+                limit: 100,
+            },
             filter: LogFilter::default(),
             relations: LogsRelations::default(),
         })
         .await
         .expect("query");
 
-    assert_eq!(page.from_block.number, 1);
-    assert_eq!(page.to_block.number, 2);
-    assert_eq!(page.cursor_block.number, 2);
+    assert_eq!(page.span.from_block.number, 1);
+    assert_eq!(page.span.to_block.number, 2);
+    assert_eq!(page.span.cursor_block.number, 2);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -72,10 +76,12 @@ async fn inverted_range_returns_invalid_request() {
 
     let err = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(2),
-            to_block: Some(1),
-            order: QueryOrder::Ascending,
-            limit: 10,
+            envelope: QueryEnvelope {
+                from_block: Some(2),
+                to_block: Some(1),
+                order: QueryOrder::Ascending,
+                limit: 10,
+            },
             filter: LogFilter::default(),
             relations: LogsRelations::default(),
         })
@@ -98,10 +104,12 @@ async fn descending_to_block_above_head_returns_invalid_request() {
     // from the inverted-range path.
     let err = service
         .query_logs(QueryLogsRequest {
-            from_block: None,
-            to_block: Some(50),
-            order: QueryOrder::Descending,
-            limit: 10,
+            envelope: QueryEnvelope {
+                from_block: None,
+                to_block: Some(50),
+                order: QueryOrder::Descending,
+                limit: 10,
+            },
             filter: LogFilter::default(),
             relations: LogsRelations::default(),
         })
@@ -123,19 +131,21 @@ async fn descending_from_above_head_clips_to_head() {
     // to_block-above-head behavior.
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(50),
-            to_block: Some(1),
-            order: QueryOrder::Descending,
-            limit: 100,
+            envelope: QueryEnvelope {
+                from_block: Some(50),
+                to_block: Some(1),
+                order: QueryOrder::Descending,
+                limit: 100,
+            },
             filter: LogFilter::default(),
             relations: LogsRelations::default(),
         })
         .await
         .expect("query");
 
-    assert_eq!(page.from_block.number, 2);
-    assert_eq!(page.to_block.number, 1);
-    assert_eq!(page.cursor_block.number, 1);
+    assert_eq!(page.span.from_block.number, 2);
+    assert_eq!(page.span.to_block.number, 1);
+    assert_eq!(page.span.cursor_block.number, 1);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -144,18 +154,20 @@ async fn from_block_zero_floors_to_earliest_queryable_block() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(0),
-            to_block: Some(2),
-            order: QueryOrder::Ascending,
-            limit: 100,
+            envelope: QueryEnvelope {
+                from_block: Some(0),
+                to_block: Some(2),
+                order: QueryOrder::Ascending,
+                limit: 100,
+            },
             filter: LogFilter::default(),
             relations: LogsRelations::default(),
         })
         .await
         .expect("query");
 
-    assert_eq!(page.from_block.number, 1);
-    assert_eq!(page.to_block.number, 2);
+    assert_eq!(page.span.from_block.number, 1);
+    assert_eq!(page.span.to_block.number, 2);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -166,10 +178,12 @@ async fn descending_inverted_range_returns_invalid_request() {
     // the wrong shape.
     let err = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(2),
-            order: QueryOrder::Descending,
-            limit: 10,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(2),
+                order: QueryOrder::Descending,
+                limit: 10,
+            },
             filter: LogFilter::default(),
             relations: LogsRelations::default(),
         })
@@ -188,18 +202,20 @@ async fn descending_defaulted_range_inverts_endpoints() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: None,
-            to_block: None,
-            order: QueryOrder::Descending,
-            limit: 100,
+            envelope: QueryEnvelope {
+                from_block: None,
+                to_block: None,
+                order: QueryOrder::Descending,
+                limit: 100,
+            },
             filter: LogFilter::default(),
             relations: LogsRelations::default(),
         })
         .await
         .expect("query");
 
-    assert_eq!(page.from_block.number, 2);
-    assert_eq!(page.to_block.number, 1);
+    assert_eq!(page.span.from_block.number, 2);
+    assert_eq!(page.span.to_block.number, 1);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -208,18 +224,20 @@ async fn defaulted_range_resolves_to_full_chain() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: None,
-            to_block: None,
-            order: QueryOrder::Ascending,
-            limit: 100,
+            envelope: QueryEnvelope {
+                from_block: None,
+                to_block: None,
+                order: QueryOrder::Ascending,
+                limit: 100,
+            },
             filter: LogFilter::default(),
             relations: LogsRelations::default(),
         })
         .await
         .expect("query");
 
-    assert_eq!(page.from_block.number, 1);
-    assert_eq!(page.to_block.number, 2);
+    assert_eq!(page.span.from_block.number, 1);
+    assert_eq!(page.span.to_block.number, 2);
 }
 
 async fn ingest_two_block_chain() -> MonadChainDataService<InMemoryMetaStore, InMemoryBlobStore> {

--- a/monad-chain-data/tests/query_logs_scan.rs
+++ b/monad-chain-data/tests/query_logs_scan.rs
@@ -17,7 +17,7 @@ use std::collections::HashSet;
 
 use monad_chain_data::{
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData, LogFilter,
-    LogId, LogsRelations, MonadChainDataError, MonadChainDataService, QueryLimits,
+    LogId, LogsRelations, MonadChainDataError, MonadChainDataService, QueryEnvelope, QueryLimits,
     QueryLogsRequest, QueryOrder, B256,
 };
 
@@ -57,10 +57,12 @@ async fn query_logs_paginates_at_block_boundaries() {
 
     let first_page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(2),
-            order: QueryOrder::Ascending,
-            limit: 1,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(2),
+                order: QueryOrder::Ascending,
+                limit: 1,
+            },
             filter: LogFilter {
                 address: Some(HashSet::from([Address::repeat_byte(7)])),
                 topics: [
@@ -76,16 +78,18 @@ async fn query_logs_paginates_at_block_boundaries() {
         .expect("first page");
 
     assert_eq!(first_page.logs.len(), 2);
-    assert_eq!(first_page.cursor_block.number, 1);
+    assert_eq!(first_page.span.cursor_block.number, 1);
     assert_eq!(first_page.logs[0].block_number, 1);
     assert_eq!(first_page.logs[1].block_number, 1);
 
     let second_page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(first_page.cursor_block.number + 1),
-            to_block: Some(2),
-            order: QueryOrder::Ascending,
-            limit: 1,
+            envelope: QueryEnvelope {
+                from_block: Some(first_page.span.cursor_block.number + 1),
+                to_block: Some(2),
+                order: QueryOrder::Ascending,
+                limit: 1,
+            },
             filter: LogFilter {
                 address: Some(HashSet::from([Address::repeat_byte(7)])),
                 topics: [
@@ -101,7 +105,7 @@ async fn query_logs_paginates_at_block_boundaries() {
         .expect("second page");
 
     assert_eq!(second_page.logs.len(), 1);
-    assert_eq!(second_page.cursor_block.number, 2);
+    assert_eq!(second_page.span.cursor_block.number, 2);
     assert_eq!(second_page.logs[0].block_number, 2);
 }
 
@@ -126,10 +130,12 @@ async fn query_logs_descending_returns_newest_first() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(1),
-            order: QueryOrder::Descending,
-            limit: 1,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(1),
+                order: QueryOrder::Descending,
+                limit: 1,
+            },
             filter: LogFilter {
                 address: Some(HashSet::from([Address::repeat_byte(5)])),
                 topics: [
@@ -167,8 +173,11 @@ async fn query_logs_rejects_from_block_above_published_head() {
 
     let err = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(2),
-            to_block: None,
+            envelope: QueryEnvelope {
+                from_block: Some(2),
+                to_block: None,
+                ..QueryEnvelope::default()
+            },
             ..QueryLogsRequest::default()
         })
         .await
@@ -282,10 +291,12 @@ async fn block_scan_completes_current_block_when_limit_reached_mid_block() {
 
     let page = service
         .query_logs(QueryLogsRequest {
-            from_block: Some(1),
-            to_block: Some(2),
-            order: QueryOrder::Ascending,
-            limit: 1,
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(2),
+                order: QueryOrder::Ascending,
+                limit: 1,
+            },
             filter: LogFilter::default(),
             relations: LogsRelations::default(),
         })
@@ -294,7 +305,7 @@ async fn block_scan_completes_current_block_when_limit_reached_mid_block() {
 
     assert_eq!(page.logs.len(), 3);
     assert!(page.logs.iter().all(|l| l.block_number == 1));
-    assert_eq!(page.cursor_block.number, 1);
+    assert_eq!(page.span.cursor_block.number, 1);
 }
 
 fn log(address: Address, topic0: B256) -> Log {


### PR DESCRIPTION
Extracts the shared query envelope primitives used by `query_logs` and the upcoming `query_blocks` path.

- Adds `QueryEnvelope` as the common `(from_block, to_block, order, limit)` carrier for range-style query requests. `QueryLogsRequest` now embeds this envelope instead of owning those fields directly.
- Updates `ResolvedBlockWindow::resolve` to take a `QueryEnvelope` reference, removing its dependency on the log-specific request type while preserving queryX from/to semantics.
- Hoists `ResolvedBlockWindow::iter(order)` from the local query runner helper so range executors can share traversal behavior.
- Adds `BlockSpan` for response pagination metadata and moves `QueryLimits::check_limit` into the shared limits primitive.

No behavior change: the query_logs path is still the only caller in this PR, and its semantics are unchanged.