### PR TITLE
Use TxHash and BlockHash aliases in RPC

### DIFF
--- a/monad-rpc/src/data/buffer.rs
+++ b/monad-rpc/src/data/buffer.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 use alloy_consensus::TxEnvelope;
-use alloy_primitives::Bloom;
+use alloy_primitives::{BlockHash, Bloom, TxHash};
 use alloy_rpc_types::{Block, BlockTransactions, Transaction, TransactionReceipt};
 use dashmap::DashMap;
 use itertools::Itertools;
@@ -31,10 +31,7 @@ use monad_exec_events::BlockCommitState;
 use tokio::sync::Mutex;
 use tracing::{error, warn};
 
-use crate::{
-    event::EventServerEvent,
-    types::eth_json::{BlockTags, FixedData},
-};
+use crate::{event::EventServerEvent, types::eth_json::BlockTags};
 
 struct TxLoc {
     block_height: u64,
@@ -52,9 +49,9 @@ pub struct ExecEventsBuffer {
     // Maps a block by its SeqNum
     block_by_height: Arc<DashMap<u64, Block>>,
     // Maps a block by its blockhash
-    block_height_by_hash: Arc<DashMap<FixedData<32>, u64>>,
+    block_height_by_hash: Arc<DashMap<BlockHash, u64>>,
     // Maps a transaction hash to its block location and receipt
-    tx_by_hash: Arc<DashMap<FixedData<32>, (TxLoc, TransactionReceipt)>>,
+    tx_by_hash: Arc<DashMap<TxHash, (TxLoc, TransactionReceipt)>>,
 
     // The latest voted block's SeqNum
     latest_voted: Arc<AtomicU64>,
@@ -92,7 +89,6 @@ impl ExecEventsBuffer {
 
         let block_height = header.data.number;
         let block_hash = header.data.hash;
-        let block_hash_key = FixedData(block_hash.0);
 
         match commit_state {
             BlockCommitState::Verified => {
@@ -102,7 +98,7 @@ impl ExecEventsBuffer {
                 self.latest_finalized
                     .fetch_max(block_height, Ordering::SeqCst);
 
-                if self.block_height_by_hash.contains_key(&block_hash_key) {
+                if self.block_height_by_hash.contains_key(&block_hash) {
                     return;
                 }
             }
@@ -118,7 +114,7 @@ impl ExecEventsBuffer {
                     );
                 }
 
-                if self.block_height_by_hash.contains_key(&block_hash_key) {
+                if self.block_height_by_hash.contains_key(&block_hash) {
                     return;
                 }
             }
@@ -150,13 +146,12 @@ impl ExecEventsBuffer {
             );
 
             // Remove old block's hash from by_hash
-            self.block_height_by_hash
-                .remove(&FixedData(old_block.header.hash.0));
+            self.block_height_by_hash.remove(&old_block.header.hash);
 
             // Remove old block's transactions from tx_loc_by_hash
             if let alloy_rpc_types::BlockTransactions::Full(txs) = &old_block.transactions {
                 for tx in txs {
-                    self.tx_by_hash.remove(&FixedData(tx.inner.tx_hash().0));
+                    self.tx_by_hash.remove(tx.inner.tx_hash());
                 }
             } else {
                 error!(
@@ -169,7 +164,7 @@ impl ExecEventsBuffer {
 
         if self
             .block_height_by_hash
-            .insert(FixedData(block_hash.0), block_height)
+            .insert(block_hash, block_height)
             .is_some()
         {
             warn!(
@@ -188,7 +183,7 @@ impl ExecEventsBuffer {
             if self
                 .tx_by_hash
                 .insert(
-                    FixedData(tx_receipt.transaction_hash.0),
+                    tx_receipt.transaction_hash,
                     (
                         TxLoc {
                             block_height,
@@ -219,7 +214,7 @@ impl ExecEventsBuffer {
                     alloy_rpc_types::BlockTransactions::Full(v) => {
                         v.into_iter().for_each(|tx| {
                             let id = tx.inner.tx_hash();
-                            self.tx_by_hash.remove(&FixedData(id.0));
+                            self.tx_by_hash.remove(id);
                         });
                     }
                     alloy_rpc_types::BlockTransactions::Hashes(_) => {
@@ -230,30 +225,34 @@ impl ExecEventsBuffer {
                     }
                 }
 
-                self.block_height_by_hash
-                    .remove(&FixedData(evicted_block.header.hash.0));
+                self.block_height_by_hash.remove(&evicted_block.header.hash);
             }
         }
     }
 
     pub fn get_block_by_height(&self, height: u64) -> Option<Block> {
-        Some(self.block_by_height.get(&height)?.clone())
+        Some(self.block_by_height.get(&height)?.value().clone())
     }
 
-    pub fn get_block_by_hash(&self, hash: &FixedData<32>) -> Option<Block> {
-        let block_height = *self.block_height_by_hash.get(hash)?;
+    pub fn get_block_by_hash(&self, block_hash: &BlockHash) -> Option<Block> {
+        let block_height: u64 = *self.block_height_by_hash.get(block_hash)?.value();
 
-        Some(self.block_by_height.get(&block_height)?.clone())
+        Some(self.block_by_height.get(&block_height)?.value().clone())
     }
 
     pub fn latest_block(&self) -> Option<Block> {
         let finalized_block_height = self.get_latest_finalized_block_num();
 
-        Some(self.block_by_height.get(&finalized_block_height)?.clone())
+        Some(
+            self.block_by_height
+                .get(&finalized_block_height)?
+                .value()
+                .clone(),
+        )
     }
 
-    pub fn get_receipt_by_tx_hash(&self, hash: &FixedData<32>) -> Option<TransactionReceipt> {
-        Some(self.tx_by_hash.get(hash)?.1.clone())
+    pub fn get_receipt_by_tx_hash(&self, tx_hash: &TxHash) -> Option<TransactionReceipt> {
+        Some(self.tx_by_hash.get(tx_hash)?.value().1.clone())
     }
 
     pub fn get_receipts_by_block_height(&self, height: u64) -> Option<Vec<TransactionReceipt>> {
@@ -269,7 +268,7 @@ impl ExecEventsBuffer {
         let mut receipts = Vec::with_capacity(tx_hashes.len());
 
         for tx_hash in tx_hashes {
-            let receipt = self.tx_by_hash.get(&FixedData(tx_hash.0))?.1.clone();
+            let receipt = self.tx_by_hash.get(tx_hash)?.1.clone();
             receipts.push(receipt);
         }
 
@@ -324,7 +323,7 @@ impl ExecEventsBuffer {
             .map(|transaction| {
                 let tx_hash = transaction.tx.tx_hash();
 
-                let Some(transaction_data) = self.tx_by_hash.get(&FixedData(tx_hash.0)) else {
+                let Some(transaction_data) = self.tx_by_hash.get(tx_hash) else {
                     error!(
                         ?height,
                         ?tx_hash,
@@ -373,8 +372,8 @@ impl ExecEventsBuffer {
         }
     }
 
-    pub fn get_transaction_by_hash(&self, hash: &FixedData<32>) -> Option<Transaction<TxEnvelope>> {
-        let tx_loc = &self.tx_by_hash.get(hash)?.0;
+    pub fn get_transaction_by_hash(&self, tx_hash: &TxHash) -> Option<Transaction<TxEnvelope>> {
+        let tx_loc = &self.tx_by_hash.get(tx_hash)?.0;
 
         self.get_transaction_by_location(tx_loc.block_height, tx_loc.tx_idx)
     }
@@ -579,9 +578,7 @@ mod tests {
             "Should have 1 entry in tx_loc_by_hash after first insert"
         );
         assert!(
-            buffer
-                .get_transaction_by_hash(&FixedData(tx_hash_a.0))
-                .is_some(),
+            buffer.get_transaction_by_hash(&tx_hash_a).is_some(),
             "Block A's transaction should be findable by hash"
         );
 
@@ -612,14 +609,8 @@ mod tests {
             "Block at height 1 should be the most recently inserted block (hash B)"
         );
 
-        let hash_a_exists = buffer
-            .block_height_by_hash
-            .get(&FixedData(block_hash_a.0))
-            .is_some();
-        let hash_b_exists = buffer
-            .block_height_by_hash
-            .get(&FixedData(block_hash_b.0))
-            .is_some();
+        let hash_a_exists = buffer.block_height_by_hash.get(&block_hash_a).is_some();
+        let hash_b_exists = buffer.block_height_by_hash.get(&block_hash_b).is_some();
 
         assert!(!hash_a_exists, "Old hash A should be removed from by_hash");
         assert!(hash_b_exists, "New hash B should exist in by_hash");
@@ -631,15 +622,11 @@ mod tests {
             "tx_loc_by_hash should have exactly 1 entry after replacement"
         );
         assert!(
-            buffer
-                .get_transaction_by_hash(&FixedData(tx_hash_a.0))
-                .is_none(),
+            buffer.get_transaction_by_hash(&tx_hash_a).is_none(),
             "Block A's transaction should be removed from tx_loc_by_hash after replacement"
         );
         assert!(
-            buffer
-                .get_transaction_by_hash(&FixedData(tx_hash_b.0))
-                .is_some(),
+            buffer.get_transaction_by_hash(&tx_hash_b).is_some(),
             "Block B's transaction should be findable by hash after replacement"
         );
     }

--- a/monad-rpc/src/data/mod.rs
+++ b/monad-rpc/src/data/mod.rs
@@ -45,7 +45,7 @@ use self::buffer::{block_height_from_tag, ExecEventsBuffer};
 use crate::{
     handlers::eth::txn::FilterError,
     types::{
-        eth_json::{BlockTagOrHash, BlockTags, FixedData, MonadLog, MonadTransactionReceipt},
+        eth_json::{BlockTagOrHash, BlockTags, MonadLog, MonadTransactionReceipt},
         heuristic_size::HeuristicSize,
         jsonrpc::{ArchiveErrorExt, JsonRpcError, JsonRpcResult},
     },
@@ -135,7 +135,7 @@ fn resolve_block_height_from_buffer(
     match block {
         BlockTagOrHash::BlockTags(tag) => Some(block_height_from_tag(buffer, tag)),
         BlockTagOrHash::Hash(hash) => buffer
-            .get_block_by_hash(hash)
+            .get_block_by_hash(&FixedBytes(hash.0))
             .map(|block| block.header.number),
     }
 }
@@ -163,10 +163,10 @@ impl<T: Triedb> DataProvider<T> {
 
     pub async fn get_transaction_receipt(
         &self,
-        hash: [u8; 32],
+        tx_hash: &TxHash,
     ) -> Result<TransactionReceipt, ChainStateError> {
         if let Some(buffer) = &self.buffer {
-            if let Some(receipt) = buffer.get_receipt_by_tx_hash(&FixedData(hash)) {
+            if let Some(receipt) = buffer.get_receipt_by_tx_hash(tx_hash) {
                 return Ok(receipt);
             }
         }
@@ -177,7 +177,7 @@ impl<T: Triedb> DataProvider<T> {
             block_num,
         }) = self
             .triedb_env
-            .get_transaction_location_by_hash(latest_block_key, hash)
+            .get_transaction_location_by_hash(latest_block_key, tx_hash.0)
             .await
             .map_err(ChainStateError::Triedb)?
         {
@@ -199,7 +199,7 @@ impl<T: Triedb> DataProvider<T> {
                 trace: _,
                 receipt,
                 header_subset,
-            }) = archive_reader.get_tx_indexed_data(&hash.into()).await?
+            }) = archive_reader.get_tx_indexed_data(tx_hash).await?
             {
                 return Ok(parse_tx_receipt(
                     header_subset.block_hash,
@@ -299,9 +299,9 @@ impl<T: Triedb> DataProvider<T> {
         Err(ChainStateError::ResourceNotFound)
     }
 
-    pub async fn get_transaction(&self, hash: [u8; 32]) -> Result<Transaction, ChainStateError> {
+    pub async fn get_transaction(&self, tx_hash: &TxHash) -> Result<Transaction, ChainStateError> {
         if let Some(buffer) = &self.buffer {
-            if let Some(tx) = buffer.get_transaction_by_hash(&FixedData(hash)) {
+            if let Some(tx) = buffer.get_transaction_by_hash(tx_hash) {
                 return Ok(tx);
             }
         }
@@ -312,7 +312,7 @@ impl<T: Triedb> DataProvider<T> {
             block_num,
         }) = self
             .triedb_env
-            .get_transaction_location_by_hash(latest_block_key, hash)
+            .get_transaction_location_by_hash(latest_block_key, tx_hash.0)
             .await
             .map_err(ChainStateError::Triedb)?
         {
@@ -329,7 +329,7 @@ impl<T: Triedb> DataProvider<T> {
 
         // try archive if transaction hash not found and archive reader specified
         if let Some(archive_reader) = &self.archive_reader {
-            if let Some((tx, header_subset)) = archive_reader.get_tx(&hash.into()).await? {
+            if let Some((tx, header_subset)) = archive_reader.get_tx(tx_hash).await? {
                 return Ok(parse_tx_content(
                     header_subset.block_hash,
                     header_subset.block_number,
@@ -1753,12 +1753,12 @@ mod tests {
         assert!(found.is_ok());
 
         data_provider
-            .get_transaction(tx.tx.tx_hash().0)
+            .get_transaction(tx.tx.tx_hash())
             .await
             .unwrap();
 
         data_provider
-            .get_transaction_receipt(tx.tx.tx_hash().0)
+            .get_transaction_receipt(tx.tx.tx_hash())
             .await
             .unwrap();
 

--- a/monad-rpc/src/handlers/debug.rs
+++ b/monad-rpc/src/handlers/debug.rs
@@ -19,7 +19,7 @@ use alloy_consensus::{Block, BlockBody, Header, TxEnvelope};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{
     aliases::{U256, U64, U8},
-    Address, Bytes, Log,
+    Address, Bytes, FixedBytes, Log,
 };
 use alloy_rlp::{Decodable, Encodable, RlpDecodable};
 use monad_rpc_docs::rpc;
@@ -174,7 +174,10 @@ pub async fn monad_debug_getRawTransaction<T: Triedb>(
 ) -> JsonRpcResult<String> {
     trace!("monad_debug_getRawTransaction: {params:?}");
 
-    match data_provider.get_transaction(params.tx_hash.0).await {
+    match data_provider
+        .get_transaction(&FixedBytes(params.tx_hash.0))
+        .await
+    {
         Ok(tx) => {
             let mut res = Vec::new();
             let tx: TxEnvelope = tx.into();

--- a/monad-rpc/src/handlers/eth/txn.rs
+++ b/monad-rpc/src/handlers/eth/txn.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 
 use alloy_consensus::{Transaction as _, TxEnvelope};
 use alloy_eips::Decodable2718;
-use alloy_primitives::{Address, FixedBytes};
+use alloy_primitives::{Address, FixedBytes, TxHash};
 use alloy_rpc_types::{Filter, TransactionReceipt};
 use monad_rpc_docs::rpc;
 use monad_triedb_utils::triedb_env::Triedb;
@@ -246,7 +246,7 @@ const RECEIPT_POLL_INTERVAL_MS: u64 = 100;
 /// Polls for transaction receipt with timeout
 async fn poll_for_receipt<T: Triedb>(
     data_provider: &DataProvider<T>,
-    tx_hash: FixedBytes<32>,
+    tx_hash: TxHash,
     timeout_ms: u64,
 ) -> Result<TransactionReceipt, JsonRpcError> {
     let start_time = tokio::time::Instant::now();
@@ -254,7 +254,7 @@ async fn poll_for_receipt<T: Triedb>(
     let poll_interval = Duration::from_millis(RECEIPT_POLL_INTERVAL_MS);
 
     loop {
-        match data_provider.get_transaction_receipt(*tx_hash).await {
+        match data_provider.get_transaction_receipt(&tx_hash).await {
             Ok(receipt) => return Ok(receipt),
             Err(ChainStateError::ResourceNotFound) => {
                 // Not found yet, check timeout
@@ -332,7 +332,7 @@ pub async fn monad_eth_getTransactionReceipt<T: Triedb>(
     trace!("monad_eth_getTransactionReceipt: {params:?}");
 
     data_provider
-        .get_transaction_receipt(params.tx_hash.0)
+        .get_transaction_receipt(&FixedBytes(params.tx_hash.0))
         .await
         .map_present_and_no_err(MonadTransactionReceipt)
 }
@@ -353,7 +353,7 @@ pub async fn monad_eth_getTransactionByHash<T: Triedb>(
     trace!("monad_eth_getTransactionByHash: {params:?}");
 
     data_provider
-        .get_transaction(params.tx_hash.0)
+        .get_transaction(&FixedBytes(params.tx_hash.0))
         .await
         .map_present_and_no_err(MonadTransaction)
 }


### PR DESCRIPTION
`ExecEventsBuffer` was using `FixedData<32>` for block and tx hashes when alloy aliases both to `FixedBytes<32>`. Changed these aliases and updated `DataProvider` for consistency.