### PR TITLE
Kai/secondary deterministic raptorcast

### DIFF
--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -453,6 +453,7 @@ where
             }
             SecondaryOutboundMessage::SendToGroup {
                 msg_bytes,
+                epoch,
                 round,
                 group,
             } => {
@@ -461,7 +462,8 @@ where
                 // consistent with the round.
                 let broadcast_group =
                     SecondaryBroadcastGroup::as_publisher(&self.self_id, round, &group);
-                let build_target = BuildTarget::FullNodeRaptorCast(broadcast_group);
+                let build_target =
+                    v1_rollout::secondary_build_target(self.v1_rollout, epoch, broadcast_group);
                 builder
                     .build_into(&msg_bytes, &build_target, &mut sink)
                     .unwrap_log_on_error(&msg_bytes, &build_target)

--- a/monad-raptorcast/src/metrics.rs
+++ b/monad-raptorcast/src/metrics.rs
@@ -60,6 +60,18 @@ monad_executor::metric_consts! {
         name: "monad.raptorcast.v1_primary_chunks_accepted",
         help: "V1 (deterministic) primary raptorcast chunks accepted",
     }
+    pub COUNTER_RAPTORCAST_SECONDARY_CHUNKS_DROPPED_INCOMPATIBLE_VERSION {
+        name: "monad.raptorcast.secondary_chunks_dropped_incompatible_version",
+        help: "Secondary raptorcast chunks dropped due to incompatible version",
+    }
+    pub COUNTER_RAPTORCAST_V0_SECONDARY_CHUNKS_ACCEPTED {
+        name: "monad.raptorcast.v0_secondary_chunks_accepted",
+        help: "V0 (regular) secondary raptorcast chunks accepted",
+    }
+    pub COUNTER_RAPTORCAST_V1_SECONDARY_CHUNKS_ACCEPTED {
+        name: "monad.raptorcast.v1_secondary_chunks_accepted",
+        help: "V1 (deterministic) secondary raptorcast chunks accepted",
+    }
     pub GAUGE_RAPTORCAST_DETERMINISTIC_ROLLOUT_STAGE {
         name: "monad.raptorcast.deterministic_rollout_stage",
         help: "Current deterministic raptorcast rollout stage (0=always_v0, 1=accept_both_publish_v0, 2=accept_both_publish_v1, 3=always_v1)",

--- a/monad-raptorcast/src/packet/assigner.rs
+++ b/monad-raptorcast/src/packet/assigner.rs
@@ -297,6 +297,17 @@ impl<PT: PubKey> EvenPartition<PT> {
 
         Ok(assignment)
     }
+
+    pub fn num_chunks(&self, num_base_symbols: usize, redundancy: Redundancy) -> Option<usize> {
+        even_partition_num_chunks(num_base_symbols, redundancy)
+    }
+}
+
+#[inline(always)]
+pub fn even_partition_num_chunks(num_base_symbols: usize, redundancy: Redundancy) -> Option<usize> {
+    // EvenPartition::assign emits exactly redundancy.scale(num_base_symbols)
+    // chunks regardless of group size.
+    redundancy.scale(num_base_symbols)
 }
 
 // Proportional to stake, plus each validator gets an optional

--- a/monad-raptorcast/src/packet/builder.rs
+++ b/monad-raptorcast/src/packet/builder.rs
@@ -208,7 +208,7 @@ where
     {
         if let BuildTarget::Raptorcast {
             group,
-            mode: RaptorcastMode::Deterministic { round },
+            mode: RaptorcastMode::Deterministic { round, .. },
         } = build_target
         {
             let unix_ts_ms = self.unwrap_unix_ts_ms()?;
@@ -217,6 +217,23 @@ where
                 unix_ts_ms,
                 app_message,
                 group,
+                EncodingScheme::Deterministic25(*round),
+                collector,
+            );
+        }
+
+        if let BuildTarget::FullNodeRaptorCast {
+            group,
+            mode: RaptorcastMode::Deterministic { round, epoch },
+        } = build_target
+        {
+            let unix_ts_ms = self.unwrap_unix_ts_ms()?;
+            return deterministic::build_secondary::<ST, C>(
+                self.key.as_ref(),
+                unix_ts_ms,
+                app_message,
+                group,
+                *epoch,
                 EncodingScheme::Deterministic25(*round),
                 collector,
             );

--- a/monad-raptorcast/src/packet/deterministic.rs
+++ b/monad-raptorcast/src/packet/deterministic.rs
@@ -290,25 +290,37 @@ where
     Ok(buffer.freeze())
 }
 
-pub(super) struct GlobalMerkleTree<'a, PT: PubKey> {
-    chunks: &'a mut [Chunk<PT>],
-    tree: MerkleTree,
+// Shared inner pipeline for deterministic raptorcast encoding. Given
+// an assigned set of chunks for a group, this struct encodes Raptor
+// symbols into them and builds the global merkle tree, yielding the
+// global merkle root. Callers can then compute a header, write
+// headers and merkle proofs into each chunk, and emit them.
+pub(super) struct InnerDeterministicEncoding<PT: PubKey> {
     layout: PacketLayout,
+    chunks: Vec<Chunk<PT>>,
+    tree: MerkleTree,
 }
 
-impl<'a, PT: PubKey> GlobalMerkleTree<'a, PT> {
-    fn build(chunks: &'a mut [Chunk<PT>], layout: PacketLayout) -> Result<Self, BuildError> {
+impl<PT: PubKey> InnerDeterministicEncoding<PT> {
+    pub fn new(
+        layout: PacketLayout,
+        mut chunks: Vec<Chunk<PT>>,
+        app_message: &[u8],
+    ) -> Result<Self, BuildError> {
+        // Encode Raptor symbols into each chunk's payload.
+        encode_unique_symbols(app_message, &mut chunks, layout)?;
+
+        // Build the global merkle tree over (chunk header + symbol).
         chunks.sort_by_key(|c| c.chunk_id());
 
-        let mut hashes = Vec::with_capacity(chunks.len());
         let depth = layout.merkle_tree_depth();
         debug_assert!(chunks.len() <= 2usize.pow((depth - 1) as u32));
 
+        let mut hashes = Vec::with_capacity(chunks.len());
         for (leaf_index, chunk) in chunks.iter_mut().enumerate() {
             if chunk.chunk_id() != leaf_index {
                 return Err(BuildError::NonContiguousChunkIds);
             }
-
             layout.write_chunk_header(chunk)?;
             let hash = layout.chunk_hash(chunk);
             hashes.push(hash);
@@ -316,21 +328,23 @@ impl<'a, PT: PubKey> GlobalMerkleTree<'a, PT> {
 
         let tree = MerkleTree::new_with_depth(&hashes, depth);
         Ok(Self {
+            layout,
             chunks,
             tree,
-            layout,
         })
     }
 
-    fn write_header_and_proofs(&mut self, header: &[u8]) -> Result<(), BuildError> {
+    pub fn root(&self) -> &MerkleHash {
+        self.tree.root()
+    }
+
+    pub fn write_header_and_proofs(&mut self, header: &[u8]) -> Result<(), BuildError> {
         for (leaf_idx, chunk) in self.chunks.iter_mut().enumerate() {
             // for deterministic rc, leaf_idx === chunk_id
             debug_assert_eq!(leaf_idx, chunk.chunk_id());
 
-            // write header
             self.layout.write_header(chunk, header);
 
-            // write merkle proof
             let leaf_idx: u16 = leaf_idx
                 .try_into()
                 .map_err(|_| BuildError::ChunkIdOverflow)?;
@@ -340,8 +354,14 @@ impl<'a, PT: PubKey> GlobalMerkleTree<'a, PT> {
         Ok(())
     }
 
-    fn root(&self) -> &MerkleHash {
-        self.tree.root()
+    pub fn finalize_into<C>(self, collector: &mut C)
+    where
+        C: Collector<UdpMessage<PT>>,
+    {
+        collector.reserve(self.chunks.len());
+        for chunk in self.chunks.into_iter() {
+            collector.push(chunk.into());
+        }
     }
 }
 
@@ -452,23 +472,13 @@ where
     PT: PubKey,
     C: Collector<UdpMessage<PT>>,
 {
-    // step 1: chunk assignment
     let encoding = PrimaryEncoding::new(encoding_scheme, group, app_message.len(), unix_ts_ms)?;
     let layout = encoding.layout();
-    let mut chunks = encoding.make_chunks()?;
+    let chunks = encoding.make_chunks()?;
 
-    // step 2: write the encoded symbols into chunk's payload
-    encode_unique_symbols(app_message, &mut chunks, layout)?;
-
-    // step 3: build merkle tree & write chunk header
-    let mut merkle_tree = GlobalMerkleTree::build(&mut chunks[..], layout)?;
-    merkle_tree.write_header_and_proofs(header)?;
-
-    // step 4: send out the chunks
-    collector.reserve(chunks.len());
-    for chunk in chunks.into_iter() {
-        collector.push(chunk.into());
-    }
+    let mut inner = InnerDeterministicEncoding::new(layout, chunks, app_message)?;
+    inner.write_header_and_proofs(header)?;
+    inner.finalize_into(collector);
 
     Ok(())
 }
@@ -485,18 +495,12 @@ where
     ST: CertificateSignatureRecoverable,
     C: Collector<UdpMessage<CertificateSignaturePubKey<ST>>>,
 {
-    // step 1: chunk assignment
     let encoding = PrimaryEncoding::new(encoding_scheme, group, app_message.len(), unix_ts_ms)?;
     let layout = encoding.layout();
-    let mut chunks = encoding.make_chunks()?;
+    let chunks = encoding.make_chunks()?;
 
-    // step 2: write the encoded symbols into chunk's payload
-    encode_unique_symbols(app_message, &mut chunks, layout)?;
+    let mut inner = InnerDeterministicEncoding::new(layout, chunks, app_message)?;
 
-    // step 3: build merkle tree & write chunk header
-    let mut merkle_tree = GlobalMerkleTree::build(&mut chunks[..], layout)?;
-
-    // step 4: write header
     let header = build_header::<ST>(
         key,
         BroadcastMode::Primary,
@@ -504,16 +508,11 @@ where
         layout.merkle_tree_depth(),
         group.epoch(),
         unix_ts_ms,
-        merkle_tree.root(),
+        inner.root(),
         app_message.len(),
     )?;
-    merkle_tree.write_header_and_proofs(&header)?;
-
-    // step 5: send out the chunks
-    collector.reserve(chunks.len());
-    for chunk in chunks.into_iter() {
-        collector.push(chunk.into());
-    }
+    inner.write_header_and_proofs(&header)?;
+    inner.finalize_into(collector);
 
     Ok(())
 }
@@ -526,19 +525,12 @@ pub(crate) fn calc_global_merkle_root<PT: PubKey>(
     encoding_scheme: EncodingScheme,
     unix_ts_ms: u64,
 ) -> Result<MerkleHash, BuildError> {
-    // step 1: chunk assignment
     let encoding = PrimaryEncoding::new(encoding_scheme, group, app_message.len(), unix_ts_ms)?;
     let layout = encoding.layout();
-    let mut chunks = encoding.make_chunks()?;
+    let chunks = encoding.make_chunks()?;
 
-    // step 2: write the encoded symbols into chunk's payload
-    encode_unique_symbols(app_message, &mut chunks, layout)?;
-
-    // step 3: write the chunk header & build a global merkle tree
-    let merkle_tree = GlobalMerkleTree::build(&mut chunks[..], layout)?;
-
-    // step 4: find the merkle root
-    Ok(*merkle_tree.root())
+    let inner = InnerDeterministicEncoding::new(layout, chunks, app_message)?;
+    Ok(*inner.root())
 }
 
 fn encode_unique_symbols<PT: PubKey>(

--- a/monad-raptorcast/src/packet/deterministic.rs
+++ b/monad-raptorcast/src/packet/deterministic.rs
@@ -24,7 +24,7 @@ use monad_crypto::{
 use monad_dataplane::udp::segment_size_for_mtu;
 use monad_merkle::{MerkleHash, MerkleTree};
 use monad_raptor::Encoder;
-use monad_types::{NodeId, Round, ETHERNET_MTU};
+use monad_types::{Epoch, NodeId, Round, ETHERNET_MTU};
 use monad_wireauth::messages::DataPacketHeader;
 
 use super::{
@@ -34,7 +34,6 @@ use super::{
 use crate::{
     message::MAX_MESSAGE_SIZE,
     packet::{assigner::OrderedNodes, BuildError},
-    udp::GroupId,
     util::{
         ensure, BroadcastMode, Collector, EncodingScheme, PrimaryBroadcastGroup, Redundancy,
         UdpMessage,
@@ -207,7 +206,7 @@ fn build_header<ST>(
     broadcast_mode: BroadcastMode,
     encoding_scheme: EncodingScheme,
     merkle_tree_depth: u8,
-    group_id: GroupId,
+    epoch: Epoch,
     unix_ts_ms: u64,
     global_merkle_root: &MerkleHash,
     app_message_len: usize,
@@ -237,6 +236,7 @@ where
 
     let broadcast_bits: u8 = match broadcast_mode {
         BroadcastMode::Primary => 0b10 << 6,
+        BroadcastMode::Secondary => 0b01 << 6,
         _ => return Err(BuildError::InvalidBroadcastMode(broadcast_mode)),
     };
     if (merkle_tree_depth & 0b1111_0000) != 0 {
@@ -251,9 +251,11 @@ where
     };
     cursor_encoding_scheme[0] = 0x1; // Deterministic25
 
-    let GroupId::Primary(epoch) = group_id else {
-        return Err(BuildError::InvalidGroupId(group_id));
-    };
+    // For both Primary and Secondary, the header's epoch field
+    // carries the group's epoch. For Primary, the epoch is also the
+    // group identifier; for Secondary, the group is identified by the
+    // (publisher, round) pair, and the epoch is the publisher's epoch
+    // at the time of publication.
     let (cursor_round, cursor) = cursor.split_at_mut_checked(8).expect("header too short");
     cursor_round.copy_from_slice(&round.0.to_le_bytes());
 
@@ -495,13 +497,12 @@ where
     let mut merkle_tree = GlobalMerkleTree::build(&mut chunks[..], layout)?;
 
     // step 4: write header
-    let group_id = group.group_id();
     let header = build_header::<ST>(
         key,
         BroadcastMode::Primary,
         encoding_scheme,
         layout.merkle_tree_depth(),
-        group_id,
+        group.epoch(),
         unix_ts_ms,
         merkle_tree.root(),
         app_message.len(),
@@ -584,18 +585,28 @@ fn optimal_merkle_tree_depth(calc_total_symbols: impl Fn(u8) -> Option<usize>) -
 
 #[cfg(test)]
 mod tests {
-    use monad_merkle::MerkleTree;
+    use monad_crypto::hasher::Hasher as _;
+    use monad_merkle::{MerkleHash, MerkleTree};
     use monad_raptor::r10::lt::MAX_TRIPLES;
+    use monad_secp::{KeyPair, SecpSignature};
+    use monad_types::{Epoch, Round};
     use monad_validator::validator_set::MAX_VALIDATOR_SET_SIZE;
+    use zerocopy::Ref;
 
     use super::{
-        calc_tree_depth, PacketLayout, DEFAULT_REDUNDANCY, DEFAULT_SEGMENT_LEN,
+        build_header, calc_tree_depth, PacketLayout, DEFAULT_REDUNDANCY, DEFAULT_SEGMENT_LEN,
         MAX_MERKLE_TREE_DEPTH, MAX_SYMBOL_LEN, MIN_MERKLE_TREE_DEPTH, MIN_SYMBOL_LEN,
     };
     use crate::{
-        message::MAX_MESSAGE_SIZE, packet::assigner::stake_partition_num_chunks_hint,
-        udp::MAX_NUM_PACKETS,
+        message::MAX_MESSAGE_SIZE,
+        packet::assigner::stake_partition_num_chunks_hint,
+        parser::packet_parser::RaptorcastHeaderV1,
+        udp::{GroupId, MAX_NUM_PACKETS},
+        util::{BroadcastMode, EncodingScheme},
+        SIGNATURE_SIZE,
     };
+
+    type ST = SecpSignature;
 
     // Statically asserted properties
     const _: () = assert!(
@@ -672,5 +683,88 @@ mod tests {
                 validate_d25_layout(app_msg_len, val_set_size);
             }
         }
+    }
+
+    fn test_keypair() -> KeyPair {
+        let mut hasher = monad_crypto::hasher::HasherType::new();
+        hasher.update(b"deterministic-header-test");
+        let mut hash = hasher.hash();
+        KeyPair::from_bytes(&mut hash.0).unwrap()
+    }
+
+    fn parse_v1_header(header: &[u8]) -> Ref<&[u8], RaptorcastHeaderV1> {
+        assert_eq!(header.len(), PacketLayout::HEADER_LEN);
+        // Common header = signature (SIGNATURE_SIZE) + version (2 bytes).
+        let common_size = SIGNATURE_SIZE + 2;
+        let (_common_bytes, rest) = header.split_at(common_size);
+        Ref::from_bytes(rest).expect("v1 header")
+    }
+
+    #[test]
+    fn test_primary_header_round_trip() {
+        let key = test_keypair();
+        let merkle_root: MerkleHash = [7u8; 20];
+        let round = Round(123);
+        let epoch = Epoch(9);
+        let depth = 6u8;
+        let unix_ts_ms = 1_700_000_000_000;
+        let app_message_len = 4242;
+
+        let header = build_header::<ST>(
+            &key,
+            BroadcastMode::Primary,
+            EncodingScheme::Deterministic25(round),
+            depth,
+            epoch,
+            unix_ts_ms,
+            &merkle_root,
+            app_message_len,
+        )
+        .expect("primary header build");
+
+        let v1 = parse_v1_header(&header);
+        assert_eq!(v1.broadcast_mode().unwrap(), BroadcastMode::Primary);
+        assert_eq!(
+            v1.encoding_scheme().unwrap(),
+            EncodingScheme::Deterministic25(round)
+        );
+        assert_eq!(v1.tree_depth().unwrap(), depth);
+        assert_eq!(v1.group_id().unwrap(), GroupId::Primary(epoch));
+    }
+
+    #[test]
+    fn test_secondary_header_round_trip() {
+        let key = test_keypair();
+        let merkle_root: MerkleHash = [3u8; 20];
+        let round = Round(555);
+        let epoch = Epoch(7);
+        let depth = 4u8;
+        let unix_ts_ms = 1_700_000_000_000;
+        let app_message_len = 1_234_567;
+
+        let header = build_header::<ST>(
+            &key,
+            BroadcastMode::Secondary,
+            EncodingScheme::Deterministic25(round),
+            depth,
+            epoch,
+            unix_ts_ms,
+            &merkle_root,
+            app_message_len,
+        )
+        .expect("secondary header build");
+
+        let v1 = parse_v1_header(&header);
+        assert_eq!(v1.broadcast_mode().unwrap(), BroadcastMode::Secondary);
+        assert_eq!(
+            v1.encoding_scheme().unwrap(),
+            EncodingScheme::Deterministic25(round)
+        );
+        assert_eq!(v1.tree_depth().unwrap(), depth);
+        assert_eq!(v1.group_id().unwrap(), GroupId::Secondary(round));
+
+        // Secondary headers carry the publisher's epoch on the wire,
+        // even though the group is identified by (publisher, round).
+        assert_eq!(v1.raw_epoch(), epoch.0);
     }
 }

--- a/monad-raptorcast/src/packet/deterministic.rs
+++ b/monad-raptorcast/src/packet/deterministic.rs
@@ -478,6 +478,7 @@ impl<PT: PubKey> SecondaryEncoding<PT> {
         let layout = PacketLayout::new(segment_len, depth);
 
         // Shuffle the full-node group members.
+        // Seed derivation does not have to be the same as primary raptorcast
         let seed = derive_seed(group.publisher(), round, unix_ts_ms);
         partition.shuffle(seed);
 

--- a/monad-raptorcast/src/packet/deterministic.rs
+++ b/monad-raptorcast/src/packet/deterministic.rs
@@ -28,7 +28,10 @@ use monad_types::{Epoch, NodeId, Round, ETHERNET_MTU};
 use monad_wireauth::messages::DataPacketHeader;
 
 use super::{
-    assigner::{stake_partition_num_chunks_hint, ChunkAssignment, StakePartition},
+    assigner::{
+        even_partition_num_chunks, stake_partition_num_chunks_hint, ChunkAssignment, EvenPartition,
+        StakePartition,
+    },
     Chunk,
 };
 use crate::{
@@ -36,7 +39,7 @@ use crate::{
     packet::{assigner::OrderedNodes, BuildError},
     util::{
         ensure, BroadcastMode, Collector, EncodingScheme, PrimaryBroadcastGroup, Redundancy,
-        UdpMessage,
+        SecondaryBroadcastGroup, UdpMessage,
     },
     SIGNATURE_SIZE,
 };
@@ -437,6 +440,76 @@ impl<PT: PubKey> PrimaryEncoding<PT> {
     }
 }
 
+pub(crate) struct SecondaryEncoding<PT: PubKey> {
+    layout: PacketLayout,
+    redundancy: Redundancy,
+    app_message_len: usize,
+    partition: EvenPartition<PT>,
+}
+
+impl<PT: PubKey> SecondaryEncoding<PT> {
+    pub fn new<'a>(
+        encoding_scheme: EncodingScheme,
+        group: &'a SecondaryBroadcastGroup<'a, PT>,
+        app_message_len: usize,
+        unix_ts_ms: u64,
+    ) -> Result<Self, BuildError> {
+        let EncodingScheme::Deterministic25(round) = encoding_scheme else {
+            return Err(BuildError::InvalidEncodingScheme);
+        };
+
+        ensure!(app_message_len > 0, BuildError::AppMessageEmpty);
+        ensure!(
+            app_message_len <= MAX_MESSAGE_SIZE,
+            BuildError::AppMessageTooLarge
+        );
+
+        let mut partition = EvenPartition::from_group(group);
+        let redundancy = DEFAULT_REDUNDANCY;
+        let segment_len = DEFAULT_SEGMENT_LEN;
+
+        // Search for optimal tree depth.
+        let depth = optimal_merkle_tree_depth(|d| {
+            let layout = PacketLayout::new(segment_len, d);
+            let num_base_symbols = layout.num_base_symbols(app_message_len);
+            partition.num_chunks(num_base_symbols, redundancy)
+        })
+        .ok_or(BuildError::MerkleTreeTooDeep)?;
+        let layout = PacketLayout::new(segment_len, depth);
+
+        // Shuffle the full-node group members.
+        let seed = derive_seed(group.publisher(), round, unix_ts_ms);
+        partition.shuffle(seed);
+
+        Ok(Self {
+            redundancy,
+            layout,
+            app_message_len,
+            partition,
+        })
+    }
+
+    pub fn layout(&self) -> PacketLayout {
+        self.layout
+    }
+
+    pub fn make_chunks(&self) -> Result<Vec<Chunk<PT>>, BuildError> {
+        let assignment = self.make_assignment()?;
+        let chunks = assignment.materialize(self.layout.segment_len(), &self.partition)?;
+        Ok(chunks)
+    }
+
+    pub fn make_assignment(&self) -> Result<ChunkAssignment, BuildError> {
+        let num_base_symbols = self.layout.num_base_symbols(self.app_message_len);
+        let assignment = self.partition.assign(num_base_symbols, self.redundancy)?;
+        Ok(assignment)
+    }
+
+    pub fn partition(&self) -> &EvenPartition<PT> {
+        &self.partition
+    }
+}
+
 pub fn calc_tree_depth(
     encoding_scheme: EncodingScheme,
     app_message_len: usize,
@@ -457,6 +530,26 @@ pub fn calc_tree_depth(
     })?;
 
     Some(depth)
+}
+
+pub fn calc_tree_depth_secondary(
+    encoding_scheme: EncodingScheme,
+    app_message_len: usize,
+) -> Option<u8> {
+    let EncodingScheme::Deterministic25(_) = encoding_scheme else {
+        return None;
+    };
+
+    let redundancy = DEFAULT_REDUNDANCY;
+    let segment_len = DEFAULT_SEGMENT_LEN;
+
+    // For an even partition the total chunks are independent of the
+    // group size so we don't need to pass the group size in here.
+    optimal_merkle_tree_depth(|d| {
+        let layout = PacketLayout::new(segment_len, d);
+        let num_base_symbols = layout.num_base_symbols(app_message_len);
+        even_partition_num_chunks(num_base_symbols, redundancy)
+    })
 }
 
 #[cfg(test)]
@@ -533,6 +626,58 @@ pub(crate) fn calc_global_merkle_root<PT: PubKey>(
     Ok(*inner.root())
 }
 
+pub(crate) fn build_secondary<ST, C>(
+    key: &ST::KeyPairType,
+    unix_ts_ms: u64,
+    app_message: &[u8],
+    group: &SecondaryBroadcastGroup<'_, CertificateSignaturePubKey<ST>>,
+    epoch: Epoch,
+    encoding_scheme: EncodingScheme,
+    collector: &mut C,
+) -> Result<(), BuildError>
+where
+    ST: CertificateSignatureRecoverable,
+    C: Collector<UdpMessage<CertificateSignaturePubKey<ST>>>,
+{
+    let encoding = SecondaryEncoding::new(encoding_scheme, group, app_message.len(), unix_ts_ms)?;
+    let layout = encoding.layout();
+    let chunks = encoding.make_chunks()?;
+
+    let mut inner = InnerDeterministicEncoding::new(layout, chunks, app_message)?;
+
+    let header = build_header::<ST>(
+        key,
+        BroadcastMode::Secondary,
+        encoding_scheme,
+        layout.merkle_tree_depth(),
+        epoch,
+        unix_ts_ms,
+        inner.root(),
+        app_message.len(),
+    )?;
+    inner.write_header_and_proofs(&header)?;
+    inner.finalize_into(collector);
+
+    Ok(())
+}
+
+// Calculate the deterministic global merkle root of a given app
+// message for a secondary (validator-to-fullnode) broadcast, without
+// actually building the packets.
+pub(crate) fn calc_global_merkle_root_secondary<PT: PubKey>(
+    app_message: &[u8],
+    group: &SecondaryBroadcastGroup<'_, PT>,
+    encoding_scheme: EncodingScheme,
+    unix_ts_ms: u64,
+) -> Result<MerkleHash, BuildError> {
+    let encoding = SecondaryEncoding::new(encoding_scheme, group, app_message.len(), unix_ts_ms)?;
+    let layout = encoding.layout();
+    let chunks = encoding.make_chunks()?;
+
+    let inner = InnerDeterministicEncoding::new(layout, chunks, app_message)?;
+    Ok(*inner.root())
+}
+
 fn encode_unique_symbols<PT: PubKey>(
     app_message: &[u8],
     chunks: &mut [Chunk<PT>],
@@ -577,16 +722,19 @@ fn optimal_merkle_tree_depth(calc_total_symbols: impl Fn(u8) -> Option<usize>) -
 
 #[cfg(test)]
 mod tests {
-    use monad_crypto::hasher::Hasher as _;
+    use std::collections::BTreeSet;
+
+    use monad_crypto::{certificate_signature::CertificateSignaturePubKey, hasher::Hasher as _};
     use monad_merkle::{MerkleHash, MerkleTree};
     use monad_raptor::r10::lt::MAX_TRIPLES;
     use monad_secp::{KeyPair, SecpSignature};
-    use monad_types::{Epoch, Round};
+    use monad_types::{Epoch, NodeId, Round};
     use monad_validator::validator_set::MAX_VALIDATOR_SET_SIZE;
     use zerocopy::Ref;
 
     use super::{
-        build_header, calc_tree_depth, PacketLayout, DEFAULT_REDUNDANCY, DEFAULT_SEGMENT_LEN,
+        build_header, build_secondary, calc_global_merkle_root_secondary, calc_tree_depth,
+        calc_tree_depth_secondary, PacketLayout, DEFAULT_REDUNDANCY, DEFAULT_SEGMENT_LEN,
         MAX_MERKLE_TREE_DEPTH, MAX_SYMBOL_LEN, MIN_MERKLE_TREE_DEPTH, MIN_SYMBOL_LEN,
     };
     use crate::{
@@ -594,10 +742,13 @@ mod tests {
         packet::assigner::stake_partition_num_chunks_hint,
         parser::packet_parser::RaptorcastHeaderV1,
         udp::{GroupId, MAX_NUM_PACKETS},
-        util::{BroadcastMode, EncodingScheme},
+        util::{
+            BroadcastMode, EncodingScheme, SecondaryBroadcastGroup, SecondaryGroup, UdpMessage,
+        },
         SIGNATURE_SIZE,
     };
 
+    type PubKeyType = CertificateSignaturePubKey<ST>;
     type ST = SecpSignature;
 
     // Statically asserted properties
@@ -758,5 +909,112 @@ mod tests {
         // Secondary headers carry the publisher's epoch on the wire,
         // even though the group is identified by (publisher, round).
         assert_eq!(v1.raw_epoch(), epoch.0);
+    }
+
+    fn fullnode_id(n: u8) -> NodeId<PubKeyType> {
+        let mut hasher = monad_crypto::hasher::HasherType::new();
+        hasher.update([0xF0_u8, n]);
+        let mut hash = hasher.hash();
+        let key = KeyPair::from_bytes(&mut hash.0).unwrap();
+        NodeId::new(key.pubkey())
+    }
+
+    fn make_secondary_group(num_full_nodes: u8) -> SecondaryGroup<PubKeyType> {
+        let nodes: BTreeSet<_> = (0..num_full_nodes).map(fullnode_id).collect();
+        SecondaryGroup::new(nodes).expect("non-empty group")
+    }
+
+    #[test]
+    fn test_build_secondary_is_deterministic() {
+        let key = test_keypair();
+        let publisher = NodeId::new(key.pubkey());
+        let round = Round(42);
+        let epoch = Epoch(3);
+        let unix_ts_ms = 1_700_000_000_000_u64;
+        let app_message: Vec<u8> = (0..8192).map(|i| (i % 251) as u8).collect();
+
+        let group = make_secondary_group(16);
+        let bg1 = SecondaryBroadcastGroup::as_publisher(&publisher, round, &group);
+        let bg2 = SecondaryBroadcastGroup::as_publisher(&publisher, round, &group);
+
+        let mut packets_a: Vec<UdpMessage<_>> = Vec::new();
+        build_secondary::<ST, _>(
+            &key,
+            unix_ts_ms,
+            &app_message,
+            &bg1,
+            epoch,
+            EncodingScheme::Deterministic25(round),
+            &mut packets_a,
+        )
+        .expect("first build");
+
+        let mut packets_b: Vec<UdpMessage<_>> = Vec::new();
+        build_secondary::<ST, _>(
+            &key,
+            unix_ts_ms,
+            &app_message,
+            &bg2,
+            epoch,
+            EncodingScheme::Deterministic25(round),
+            &mut packets_b,
+        )
+        .expect("second build");
+
+        assert!(!packets_a.is_empty());
+        assert_eq!(packets_a.len(), packets_b.len());
+        for (a, b) in packets_a.iter().zip(packets_b.iter()) {
+            assert_eq!(a.payload, b.payload, "chunk payloads must be identical");
+            assert_eq!(a.recipient.node_id(), b.recipient.node_id());
+        }
+    }
+
+    #[test]
+    fn test_calc_global_merkle_root_secondary_matches_build() {
+        let key = test_keypair();
+        let publisher = NodeId::new(key.pubkey());
+        let round = Round(99);
+        let epoch = Epoch(11);
+        let unix_ts_ms = 1_700_000_000_000_u64;
+        let app_message: Vec<u8> = (0..4096).map(|i| (i % 241) as u8).collect();
+
+        let group = make_secondary_group(10);
+        let bg = SecondaryBroadcastGroup::as_publisher(&publisher, round, &group);
+
+        let mut packets: Vec<UdpMessage<_>> = Vec::new();
+        build_secondary::<ST, _>(
+            &key,
+            unix_ts_ms,
+            &app_message,
+            &bg,
+            epoch,
+            EncodingScheme::Deterministic25(round),
+            &mut packets,
+        )
+        .expect("build");
+
+        let standalone_root = calc_global_merkle_root_secondary(
+            &app_message,
+            &bg,
+            EncodingScheme::Deterministic25(round),
+            unix_ts_ms,
+        )
+        .expect("calc root");
+
+        // The global merkle root is the first 20 bytes of the root
+        // field inside the V1 header. Extract it from any built chunk.
+        let first_packet = &packets[0].payload;
+        let v1 = parse_v1_header(&first_packet[..PacketLayout::HEADER_LEN]);
+        assert_eq!(v1.global_merkle_root(), standalone_root);
+    }
+
+    #[test]
+    fn test_calc_tree_depth_secondary_in_range() {
+        for app_msg_len in [1_usize, 1024, 64 * 1024, MAX_MESSAGE_SIZE] {
+            let depth =
+                calc_tree_depth_secondary(EncodingScheme::Deterministic25(Round(0)), app_msg_len)
+                    .expect("should find a valid depth");
+            assert!((MIN_MERKLE_TREE_DEPTH..=MAX_MERKLE_TREE_DEPTH).contains(&depth));
+        }
     }
 }

--- a/monad-raptorcast/src/packet/mod.rs
+++ b/monad-raptorcast/src/packet/mod.rs
@@ -28,10 +28,7 @@ use monad_crypto::certificate_signature::{
 use monad_types::NodeId;
 
 pub(crate) use self::{builder::MessageBuilder, chunk::Chunk};
-use crate::{
-    udp::GroupId,
-    util::{BroadcastMode, BuildTarget, Redundancy},
-};
+use crate::util::{BroadcastMode, BuildTarget, Redundancy};
 
 #[derive(Debug)]
 pub enum BuildError {
@@ -55,8 +52,6 @@ pub enum BuildError {
     ZeroTotalStake,
     // redundancy is too high
     RedundancyTooHigh,
-    // group id not supported with the broadcast mode
-    InvalidGroupId(GroupId),
     // broadcast mode not supported
     InvalidBroadcastMode(BroadcastMode),
     // encoding scheme not supported

--- a/monad-raptorcast/src/packet/regular.rs
+++ b/monad-raptorcast/src/packet/regular.rs
@@ -643,7 +643,10 @@ fn generate_chunks<PT: PubKey>(
             assignment.materialize(segment_len, &partition)?
         }
 
-        BuildTarget::FullNodeRaptorCast(secondary_group) => {
+        BuildTarget::FullNodeRaptorCast {
+            group: secondary_group,
+            ..
+        } => {
             let seed = rand::thread_rng().gen::<[u8; 32]>();
             let mut partition = EvenPartition::from_group(secondary_group);
             partition.shuffle(seed);

--- a/monad-raptorcast/src/parser/packet_parser.rs
+++ b/monad-raptorcast/src/parser/packet_parser.rs
@@ -227,6 +227,7 @@ impl RaptorcastHeaderV1 {
     pub fn broadcast_mode(&self) -> Result<BroadcastMode, MalformedPacket> {
         match (self.broadcast_tree_depth & 0b1100_0000) >> 6 {
             0b10 => Ok(BroadcastMode::Primary),
+            0b01 => Ok(BroadcastMode::Secondary),
             bits => Err(MalformedPacket::InvalidBroadcastBits(bits)),
         }
     }
@@ -252,12 +253,22 @@ impl RaptorcastHeaderV1 {
     }
 
     pub fn group_id(&self) -> Result<GroupId, MalformedPacket> {
-        let epoch = Epoch(self.epoch.get());
         match self.broadcast_mode()? {
-            BroadcastMode::Primary => Ok(GroupId::Primary(epoch)),
-            // broadcast_mode() only returns Primary for v1
+            BroadcastMode::Primary => {
+                let epoch = Epoch(self.epoch.get());
+                Ok(GroupId::Primary(epoch))
+            }
+            BroadcastMode::Secondary => {
+                let round = Round(self.round.get());
+                Ok(GroupId::Secondary(round))
+            }
+            // broadcast_mode() only returns Primary or Secondary for v1
             _broadcast_mode => unreachable!(),
         }
+    }
+
+    pub fn raw_epoch(&self) -> u64 {
+        self.epoch.get()
     }
 }
 

--- a/monad-raptorcast/src/parser/packet_parser.rs
+++ b/monad-raptorcast/src/parser/packet_parser.rs
@@ -28,7 +28,10 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Ref, LE, U16, U32, 
 
 use crate::{
     message::MAX_MESSAGE_SIZE,
-    packet::{assigner::stake_partition_num_chunks_hint, deterministic, regular},
+    packet::{
+        assigner::{even_partition_num_chunks, stake_partition_num_chunks_hint},
+        deterministic, regular,
+    },
     udp::{ChunkSignatureVerifier, ChunkVersion, GroupId, InvalidChunk, ValidatedChunk},
     util::{ensure, BroadcastMode, EncodingScheme, HexBytes},
     SIGNATURE_SIZE,
@@ -269,6 +272,10 @@ impl RaptorcastHeaderV1 {
 
     pub fn raw_epoch(&self) -> u64 {
         self.epoch.get()
+    }
+
+    pub fn global_merkle_root(&self) -> MerkleHash {
+        self.global_merkle_root
     }
 }
 
@@ -632,11 +639,17 @@ impl<'a> RaptorcastPacketV1<'a> {
         );
 
         let broadcast_mode = self.header.broadcast_mode()?;
-        let chunk_id_cap = stake_partition_num_chunks_hint(
-            num_source_symbols,
-            deterministic::DEFAULT_REDUNDANCY,
-            MAX_VALIDATOR_SET_SIZE,
-        )
+        let chunk_id_cap = match broadcast_mode {
+            BroadcastMode::Primary => stake_partition_num_chunks_hint(
+                num_source_symbols,
+                deterministic::DEFAULT_REDUNDANCY,
+                MAX_VALIDATOR_SET_SIZE,
+            ),
+            BroadcastMode::Secondary => {
+                even_partition_num_chunks(num_source_symbols, deterministic::DEFAULT_REDUNDANCY)
+            }
+            BroadcastMode::Unspecified => None,
+        }
         .ok_or(InvalidChunk::InvalidChunkId)?;
         let chunk_id = self.chunk_header.chunk_id.get() as usize;
         ensure!(chunk_id < chunk_id_cap, InvalidChunk::InvalidChunkId);

--- a/monad-raptorcast/src/raptorcast_secondary/group_message.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/group_message.rs
@@ -22,7 +22,8 @@ use monad_peer_discovery::MonadNameRecord;
 use monad_types::{BoundedU64, LimitedVec, NodeId, Round, RoundSpan};
 
 /// Maximum number of peers/name records allowed in a secondary raptorcast message.
-/// This is to set an upper bound on RLP deserialization memory usage.
+/// This is to set an upper bound on RLP deserialization memory usage, and the upper
+/// bound on full-node group size used by deterministic secondary raptorcast.
 pub(crate) const MAX_PEERS_IN_GROUP: usize = 500;
 
 #[derive(RlpEncodable, RlpDecodable, Debug, Eq, PartialEq, Clone)]

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -65,6 +65,7 @@ pub enum SecondaryOutboundMessage<PT: PubKey> {
     },
     SendToGroup {
         msg_bytes: bytes::Bytes,
+        epoch: Epoch,
         round: Round,
         group: SecondaryGroup<PT>,
     },
@@ -335,7 +336,7 @@ where
                 },
 
                 Self::Command::PublishToFullNodes {
-                    epoch: _,
+                    epoch,
                     round,
                     message,
                 } => {
@@ -372,6 +373,7 @@ where
 
                     let outbound = SecondaryOutboundMessage::SendToGroup {
                         msg_bytes: outbound_message,
+                        epoch,
                         round,
                         group,
                     };

--- a/monad-raptorcast/src/round_info.rs
+++ b/monad-raptorcast/src/round_info.rs
@@ -13,18 +13,18 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use monad_crypto::certificate_signature::PubKey;
-use monad_types::Round;
+use monad_types::{NodeId, Round};
 
 use crate::{
     packet::{
-        assigner::{ChunkAssignment, ChunkRouting, StakePartition},
+        assigner::{ChunkAssignment, ChunkRouting, EvenPartition, StakePartition},
         deterministic,
     },
     udp::ValidatedChunk,
-    util::{EncodingScheme, GlobalMerkleRoot, PrimaryBroadcastGroup},
+    util::{EncodingScheme, GlobalMerkleRoot, PrimaryBroadcastGroup, SecondaryBroadcastGroup},
     SIGNATURE_SIZE,
 };
 
@@ -35,6 +35,10 @@ const CACHE_MAX_PAST_ROUNDS: Round = Round(100);
 pub struct RoundInfoCache<PT: PubKey> {
     current_round: Option<Round>,
     primary: BTreeMap<Round, PrimaryRoundInfo<PT>>,
+    // Per-publisher secondary round info. Multiple validators can
+    // publish secondary broadcasts in the same round to independent
+    // full-node groups, so we key by publisher as well.
+    secondary: HashMap<NodeId<PT>, BTreeMap<Round, SecondaryGroupRoundInfo<PT>>>,
 }
 
 impl<PT: PubKey> RoundInfoCache<PT> {
@@ -42,6 +46,7 @@ impl<PT: PubKey> RoundInfoCache<PT> {
         Self {
             current_round: None,
             primary: BTreeMap::new(),
+            secondary: HashMap::new(),
         }
     }
 
@@ -60,11 +65,19 @@ impl<PT: PubKey> RoundInfoCache<PT> {
         // Evict rounds from the cache
         if let Some(cutoff_future) = round.checked_add(CACHE_MAX_FUTURE_ROUNDS) {
             drop(self.primary.split_off(&cutoff_future));
+            for by_round in self.secondary.values_mut() {
+                drop(by_round.split_off(&cutoff_future));
+            }
         };
         if let Some(cutoff_past) = round.checked_sub(CACHE_MAX_PAST_ROUNDS) {
             let mut active = self.primary.split_off(&cutoff_past);
             std::mem::swap(&mut self.primary, &mut active);
+            for by_round in self.secondary.values_mut() {
+                let mut active = by_round.split_off(&cutoff_past);
+                std::mem::swap(by_round, &mut active);
+            }
         }
+        self.secondary.retain(|_, by_round| !by_round.is_empty());
     }
 
     // Returns None on out-of-window round
@@ -76,9 +89,29 @@ impl<PT: PubKey> RoundInfoCache<PT> {
         self.primary.get_mut(&round)
     }
 
+    // Returns None on out-of-window round
+    pub fn get_or_insert_secondary(
+        &mut self,
+        publisher: NodeId<PT>,
+        round: Round,
+    ) -> Option<&mut SecondaryGroupRoundInfo<PT>> {
+        self.check_round(round)?;
+        let by_round = self.secondary.entry(publisher).or_default();
+        Some(by_round.entry(round).or_default())
+    }
+
     #[cfg(test)]
     fn get_primary(&self, round: Round) -> Option<&PrimaryRoundInfo<PT>> {
         self.primary.get(&round)
+    }
+
+    #[cfg(test)]
+    fn get_secondary(
+        &self,
+        publisher: &NodeId<PT>,
+        round: Round,
+    ) -> Option<&SecondaryGroupRoundInfo<PT>> {
+        self.secondary.get(publisher)?.get(&round)
     }
 
     fn check_round(&self, round: Round) -> Option<()> {
@@ -149,36 +182,90 @@ impl<PT: PubKey> PrimaryRoundInfo<PT> {
     // publisher equivocation.
     #[must_use]
     pub fn try_commit(&mut self, chunk: &ValidatedChunk<PT>) -> Option<()> {
-        let Ok(claim) = ChunkCommitmentClaim::try_from(chunk) else {
-            // not applicable, so we ignore this chunk for commitment.
-            return Some(());
-        };
+        try_commit_into(&mut self.commitment, chunk)
+    }
+}
 
-        let Some(commitment) = &mut self.commitment else {
-            // no commitment for this round yet, so we will commit to
-            // the first claim we see.
-            self.commitment = Some(EncodingCommitment::from(claim));
-            return Some(());
-        };
-        if commitment.is_compatible_with(claim) {
-            return Some(());
+pub struct SecondaryGroupRoundInfo<PT: PubKey> {
+    encoding: Option<(deterministic::SecondaryEncoding<PT>, ChunkAssignment)>,
+    commitment: Option<EncodingCommitment>,
+}
+
+impl<PT: PubKey> Default for SecondaryGroupRoundInfo<PT> {
+    fn default() -> Self {
+        Self {
+            encoding: None,
+            commitment: None,
+        }
+    }
+}
+
+impl<PT: PubKey> SecondaryGroupRoundInfo<PT> {
+    pub fn chunk_routing(
+        &mut self,
+        group: &SecondaryBroadcastGroup<'_, PT>,
+        chunk: &ValidatedChunk<PT>,
+    ) -> Option<ChunkRouting<'_, PT, EvenPartition<PT>>> {
+        if self.encoding.is_none() {
+            let encoding = deterministic::SecondaryEncoding::new(
+                chunk.encoding_scheme,
+                group,
+                chunk.app_message_len as usize,
+                chunk.unix_ts_ms,
+            )
+            .ok()?;
+            let assignment = encoding.make_assignment().ok()?;
+            self.encoding = Some((encoding, assignment));
         }
 
-        // log conflicting commitment once
-        if !commitment.conflict_logged {
-            tracing::error!(
-                author = ?chunk.author,
-                round = ?claim.round,
-                chunk_merkle_root = ?claim.global_merkle_root,
-                commit_merkle_root = ?commitment.global_merkle_root,
-                chunk_signature = ?claim.signature,
-                commit_signature = ?commitment.signature,
-                "Conflicting commitment"
-            );
-            commitment.conflict_logged = true;
+        if let Some((encoding, assignment)) = &self.encoding {
+            return assignment.resolve_chunk_id(chunk.chunk_id as usize, encoding.partition());
         }
+
         None
     }
+
+    // Returns None if there is a conflicting commitment suggesting
+    // publisher equivocation.
+    #[must_use]
+    pub fn try_commit(&mut self, chunk: &ValidatedChunk<PT>) -> Option<()> {
+        try_commit_into(&mut self.commitment, chunk)
+    }
+}
+
+fn try_commit_into<PT: PubKey>(
+    slot: &mut Option<EncodingCommitment>,
+    chunk: &ValidatedChunk<PT>,
+) -> Option<()> {
+    let Ok(claim) = ChunkCommitmentClaim::try_from(chunk) else {
+        // not applicable, so we ignore this chunk for commitment.
+        return Some(());
+    };
+
+    let Some(commitment) = slot else {
+        // no commitment for this round yet, so we will commit to the
+        // first claim we see.
+        *slot = Some(EncodingCommitment::from(claim));
+        return Some(());
+    };
+    if commitment.is_compatible_with(claim) {
+        return Some(());
+    }
+
+    // log conflicting commitment once
+    if !commitment.conflict_logged {
+        tracing::error!(
+            author = ?chunk.author,
+            round = ?claim.round,
+            chunk_merkle_root = ?claim.global_merkle_root,
+            commit_merkle_root = ?commitment.global_merkle_root,
+            chunk_signature = ?claim.signature,
+            commit_signature = ?commitment.signature,
+            "Conflicting commitment"
+        );
+        commitment.conflict_logged = true;
+    }
+    None
 }
 
 type Signature = [u8; SIGNATURE_SIZE];

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -304,7 +304,6 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
 
     pub fn handle_secondary_raptorcast(
         &mut self,
-        epoch_validators: &BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
         full_node_group_map: &FullNodeGroupMap<CertificateSignaturePubKey<ST>>,
         chunk: &ValidatedChunk<CertificateSignaturePubKey<ST>>,
         rebroadcast_to: &mut impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
@@ -337,13 +336,92 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
             }
         }
 
-        let validator_set = match chunk.group_id {
-            GroupId::Primary(epoch) => epoch_validators.get(&epoch),
-            GroupId::Secondary(_round) => None,
+        let decoding_context = DecodingContext::new(None, unix_ts_ms_now());
+
+        match chunk.encoding_scheme {
+            EncodingScheme::Deterministic25(round) => self.handle_deterministic_secondary(
+                &group,
+                round,
+                chunk,
+                &decoding_context,
+                rebroadcast_to,
+            ),
+            _ => self.handle_regular_secondary(&group, chunk, &decoding_context, rebroadcast_to),
+        }
+    }
+
+    fn handle_deterministic_secondary(
+        &mut self,
+        group: &SecondaryBroadcastGroup<'_, CertificateSignaturePubKey<ST>>,
+        round: Round,
+        chunk: &ValidatedChunk<CertificateSignaturePubKey<ST>>,
+        decoding_context: &DecodingContext<CertificateSignaturePubKey<ST>>,
+        rebroadcast_to: &mut impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
+    ) -> Option<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
+        let Some(round_info) = self
+            .round_info_cache
+            .get_or_insert_secondary(chunk.author, round)
+        else {
+            tracing::debug!(
+                ?chunk.group_id,
+                ?chunk.chunk_id,
+                author =? chunk.author,
+                "dropping secondary chunk for round that is too far in the past or future"
+            );
+            return None;
         };
 
-        let decoding_context = DecodingContext::new(validator_set, unix_ts_ms_now());
-        let message = self.try_decode(chunk, &decoding_context)?;
+        // already logged the equivocation in try_commit.
+        round_info.try_commit(chunk)?;
+
+        let Some(routing) = round_info.chunk_routing(group, chunk) else {
+            tracing::debug!(
+                ?chunk.group_id,
+                ?chunk.chunk_id,
+                author =? chunk.author,
+                "dropping secondary chunk that is not routed to self or any peers"
+            );
+            return None;
+        };
+
+        let is_recipient = *routing.recipient() == self.self_id;
+        let rebroadcast_targets = if is_recipient {
+            Some(routing.rebroadcast_targets())
+        } else {
+            None
+        };
+
+        let message = self.try_decode(chunk, decoding_context)?;
+        if let Some((_author, message)) = &message {
+            if let Some(encoding_valid) =
+                chunk.check_deterministic_encoding_secondary(message, group)
+            {
+                if !encoding_valid {
+                    self.decoder_cache.mark_tainted(chunk);
+                    tracing::warn!(
+                        author =? chunk.author,
+                        "secondary message failed deterministic encoding validation"
+                    );
+                    return None;
+                }
+            }
+        }
+
+        if let Some(targets) = rebroadcast_targets {
+            rebroadcast_to(targets);
+        }
+
+        message
+    }
+
+    fn handle_regular_secondary(
+        &mut self,
+        group: &SecondaryBroadcastGroup<'_, CertificateSignaturePubKey<ST>>,
+        chunk: &ValidatedChunk<CertificateSignaturePubKey<ST>>,
+        decoding_context: &DecodingContext<CertificateSignaturePubKey<ST>>,
+        rebroadcast_to: &mut impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
+    ) -> Option<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
+        let message = self.try_decode(chunk, decoding_context)?;
 
         if let Some((_author, message)) = &message {
             if let Some(hash_valid) = chunk.check_message_hash(message) {
@@ -540,7 +618,6 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
                     };
                     self.metrics.executor_metrics_mut()[accepted_metric] += 1;
                     self.handle_secondary_raptorcast(
-                        epoch_validators,
                         full_node_group_map,
                         &chunk,
                         rebroadcast_to,
@@ -631,6 +708,27 @@ impl<PT: PubKey> ValidatedChunk<PT> {
         }
 
         match deterministic::calc_global_merkle_root(
+            app_message,
+            group,
+            self.encoding_scheme,
+            self.unix_ts_ms,
+        ) {
+            Ok(expected_root) => Some(expected_root == self.merkle_root.0),
+            Err(_err) => Some(false),
+        }
+    }
+
+    // Return None if chunk is not encoded using deterministic raptorcast
+    pub fn check_deterministic_encoding_secondary(
+        &self,
+        app_message: &[u8],
+        group: &SecondaryBroadcastGroup<'_, PT>,
+    ) -> Option<bool> {
+        if !matches!(self.encoding_scheme, EncodingScheme::Deterministic25(_)) {
+            return None;
+        }
+
+        match deterministic::calc_global_merkle_root_secondary(
             app_message,
             group,
             self.encoding_scheme,

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -1072,7 +1072,7 @@ mod tests {
         let app_message: Bytes = vec![1_u8; 1024 * 1024].into();
         let build_targets = vec![
             BuildTarget::raptorcast(primary_group),
-            BuildTarget::FullNodeRaptorCast(secondary_group),
+            BuildTarget::fullnode_raptorcast(secondary_group),
         ];
 
         let mut parser = ChunkParser::new();
@@ -1096,7 +1096,7 @@ mod tests {
                         BuildTarget::Raptorcast { .. } => {
                             assert!(matches!(chunk.broadcast_mode, BroadcastMode::Primary));
                         }
-                        BuildTarget::FullNodeRaptorCast(_) => {
+                        BuildTarget::FullNodeRaptorCast { .. } => {
                             assert!(matches!(chunk.broadcast_mode, BroadcastMode::Secondary));
                         }
                         _ => unreachable!(),

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -29,8 +29,11 @@ use crate::{
     decoding::{DecoderCache, DecodingContext, TryDecodeError, TryDecodeStatus},
     metrics::{
         UdpStateMetrics, COUNTER_RAPTORCAST_CHUNKS_DROPPED_INCOMPATIBLE_VERSION,
+        COUNTER_RAPTORCAST_SECONDARY_CHUNKS_DROPPED_INCOMPATIBLE_VERSION,
         COUNTER_RAPTORCAST_V0_PRIMARY_CHUNKS_ACCEPTED,
+        COUNTER_RAPTORCAST_V0_SECONDARY_CHUNKS_ACCEPTED,
         COUNTER_RAPTORCAST_V1_PRIMARY_CHUNKS_ACCEPTED,
+        COUNTER_RAPTORCAST_V1_SECONDARY_CHUNKS_ACCEPTED,
         GAUGE_RAPTORCAST_DECODING_CACHE_SIGNATURE_VERIFICATIONS_RATE_LIMITED,
         GAUGE_RAPTORCAST_DETERMINISTIC_ROLLOUT_STAGE,
     },
@@ -525,13 +528,25 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
                     )
                 }
 
-                BroadcastMode::Secondary => self.handle_secondary_raptorcast(
-                    epoch_validators,
-                    full_node_group_map,
-                    &chunk,
-                    rebroadcast_to,
-                    message.sender.as_ref(),
-                ),
+                BroadcastMode::Secondary => {
+                    if !v1_rollout::should_accept(self.v1_rollout, &chunk) {
+                        self.metrics.executor_metrics_mut()
+                            [COUNTER_RAPTORCAST_SECONDARY_CHUNKS_DROPPED_INCOMPATIBLE_VERSION] += 1;
+                        continue;
+                    }
+                    let accepted_metric = match chunk.version {
+                        ChunkVersion::V0 => COUNTER_RAPTORCAST_V0_SECONDARY_CHUNKS_ACCEPTED,
+                        ChunkVersion::V1 => COUNTER_RAPTORCAST_V1_SECONDARY_CHUNKS_ACCEPTED,
+                    };
+                    self.metrics.executor_metrics_mut()[accepted_metric] += 1;
+                    self.handle_secondary_raptorcast(
+                        epoch_validators,
+                        full_node_group_map,
+                        &chunk,
+                        rebroadcast_to,
+                        message.sender.as_ref(),
+                    )
+                }
             };
 
             if let Some((author, decoded_message)) = maybe_decoded_message {

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -432,6 +432,10 @@ impl<'a, PT: PubKey> PrimaryBroadcastGroup<'a, PT> {
     pub fn group_id(&self) -> GroupId {
         GroupId::Primary(self.epoch)
     }
+
+    pub fn epoch(&self) -> Epoch {
+        self.epoch
+    }
 }
 
 // Invariances:

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -66,8 +66,9 @@ pub enum BuildTarget<'a, PT: PubKey> {
         group_id: GroupId,
         recipient: &'a NodeId<PT>,
     },
-    // raptorcast to a set of full nodes, assuming equal stake
-    // distribution
+    // raptorcast to a set of full nodes. In regular mode, chunks are
+    // assigned round-robin; in deterministic mode, chunks are
+    // assigned by the seeded shuffle of the full-node group.
     FullNodeRaptorCast {
         group: SecondaryBroadcastGroup<'a, PT>,
         mode: RaptorcastMode,

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -511,6 +511,18 @@ impl<'a, PT: PubKey> SecondaryBroadcastGroup<'a, PT> {
     pub fn group_id(&self) -> GroupId {
         GroupId::Secondary(self.round)
     }
+
+    pub fn publisher(&self) -> &NodeId<PT> {
+        self.publisher
+    }
+
+    pub fn round(&self) -> Round {
+        self.round
+    }
+
+    pub fn len(&self) -> NonZero<usize> {
+        self.group.len()
+    }
 }
 
 pub struct RebroadcastContext<'a, PT: PubKey> {

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -46,7 +46,7 @@ use crate::udp::GroupId;
 #[derive(Debug, Clone, Copy)]
 pub enum RaptorcastMode {
     Regular,
-    Deterministic { round: Round },
+    Deterministic { round: Round, epoch: Epoch },
 }
 
 // Argument for raptorcast send
@@ -68,7 +68,10 @@ pub enum BuildTarget<'a, PT: PubKey> {
     },
     // raptorcast to a set of full nodes, assuming equal stake
     // distribution
-    FullNodeRaptorCast(SecondaryBroadcastGroup<'a, PT>),
+    FullNodeRaptorCast {
+        group: SecondaryBroadcastGroup<'a, PT>,
+        mode: RaptorcastMode,
+    },
 }
 
 impl<'a, PT: PubKey> BuildTarget<'a, PT> {
@@ -80,9 +83,28 @@ impl<'a, PT: PubKey> BuildTarget<'a, PT> {
     }
 
     pub fn deterministic_raptorcast(group: PrimaryBroadcastGroup<'a, PT>, round: Round) -> Self {
+        let epoch = group.epoch();
         BuildTarget::Raptorcast {
             group,
-            mode: RaptorcastMode::Deterministic { round },
+            mode: RaptorcastMode::Deterministic { round, epoch },
+        }
+    }
+
+    pub fn fullnode_raptorcast(group: SecondaryBroadcastGroup<'a, PT>) -> Self {
+        BuildTarget::FullNodeRaptorCast {
+            group,
+            mode: RaptorcastMode::Regular,
+        }
+    }
+
+    pub fn deterministic_fullnode_raptorcast(
+        group: SecondaryBroadcastGroup<'a, PT>,
+        epoch: Epoch,
+    ) -> Self {
+        let round = group.round();
+        BuildTarget::FullNodeRaptorCast {
+            group,
+            mode: RaptorcastMode::Deterministic { round, epoch },
         }
     }
 
@@ -99,7 +121,7 @@ impl<'a, PT: PubKey> BuildTarget<'a, PT> {
                 Box::new(group.iter().map(|(n, _)| n))
             }
             BuildTarget::PointToPoint { recipient, .. } => Box::new(std::iter::once(*recipient)),
-            BuildTarget::FullNodeRaptorCast(group) => Box::new(group.iter()),
+            BuildTarget::FullNodeRaptorCast { group, .. } => Box::new(group.iter()),
         }
     }
 
@@ -108,7 +130,7 @@ impl<'a, PT: PubKey> BuildTarget<'a, PT> {
             BuildTarget::Broadcast(group) | BuildTarget::Raptorcast { group, .. } => {
                 group.group_id()
             }
-            BuildTarget::FullNodeRaptorCast(group) => group.group_id(),
+            BuildTarget::FullNodeRaptorCast { group, .. } => group.group_id(),
             BuildTarget::PointToPoint { group_id, .. } => *group_id,
         }
     }

--- a/monad-raptorcast/src/v1_rollout.rs
+++ b/monad-raptorcast/src/v1_rollout.rs
@@ -15,11 +15,11 @@
 
 use monad_crypto::certificate_signature::PubKey;
 pub use monad_node_config::raptorcast::{DeterministicProtocolRolloutStage, CURRENT_STAGE};
-use monad_types::Round;
+use monad_types::{Epoch, Round};
 
 use crate::{
     udp::{ChunkVersion, ValidatedChunk},
-    util::{BuildTarget, PrimaryBroadcastGroup},
+    util::{BuildTarget, PrimaryBroadcastGroup, SecondaryBroadcastGroup},
 };
 
 // should only be called on receiving a v0 or v1 primary raptorcast chunk
@@ -46,6 +46,19 @@ pub(crate) fn build_target<'a, PT: PubKey>(
     }
 }
 
+// should only be called when building secondary raptorcast message
+pub(crate) fn secondary_build_target<'a, PT: PubKey>(
+    stage: DeterministicProtocolRolloutStage,
+    epoch: Epoch,
+    group: SecondaryBroadcastGroup<'a, PT>,
+) -> BuildTarget<'a, PT> {
+    if should_publish_v1(stage) {
+        BuildTarget::deterministic_fullnode_raptorcast(group, epoch)
+    } else {
+        BuildTarget::fullnode_raptorcast(group)
+    }
+}
+
 fn should_accept_v0(stage: DeterministicProtocolRolloutStage) -> bool {
     !matches!(stage, DeterministicProtocolRolloutStage::AlwaysV1)
 }
@@ -64,7 +77,10 @@ fn should_publish_v1(stage: DeterministicProtocolRolloutStage) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::{
+        collections::BTreeSet,
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+    };
 
     use bytes::Bytes;
     use itertools::Itertools as _;
@@ -76,12 +92,15 @@ mod tests {
     use monad_types::{Epoch, NodeId, Round, Stake};
     use monad_validator::validator_set::{ValidatorSet, ValidatorSetType as _};
 
-    use super::{build_target, DeterministicProtocolRolloutStage};
+    use super::{build_target, secondary_build_target, DeterministicProtocolRolloutStage};
     use crate::{
         auth::AuthRecvMsg,
         packet::MessageBuilder,
         udp::UdpState,
-        util::{FullNodeGroupMap, PrimaryBroadcastGroup, Redundancy},
+        util::{
+            BuildTarget, FullNodeGroupMap, PrimaryBroadcastGroup, RaptorcastMode, Redundancy,
+            SecondaryBroadcastGroup, SecondaryGroup,
+        },
     };
 
     type SignatureType = SecpSignature;
@@ -185,6 +204,41 @@ mod tests {
             let count1 = rollout_publish_and_receive(*a, *b);
             let count2 = rollout_publish_and_receive(*b, *a);
             assert!(count1 == 0 || count2 == 0);
+        }
+    }
+
+    #[test]
+    fn test_secondary_build_target_picks_mode_by_stage() {
+        use DeterministicProtocolRolloutStage::*;
+
+        let publisher = NodeId::new(make_key_pair(0).pubkey());
+        let full_nodes: BTreeSet<_> = (1_u8..=4)
+            .map(|n| NodeId::new(make_key_pair(n).pubkey()))
+            .collect();
+        let group = SecondaryGroup::new(full_nodes).unwrap();
+
+        for stage in [AlwaysV0, AcceptBothPublishV0] {
+            let bg = SecondaryBroadcastGroup::as_publisher(&publisher, ROUND, &group);
+            let target = secondary_build_target(stage, EPOCH, bg);
+            assert!(matches!(
+                target,
+                BuildTarget::FullNodeRaptorCast {
+                    mode: RaptorcastMode::Regular,
+                    ..
+                }
+            ));
+        }
+
+        for stage in [AcceptBothPublishV1, AlwaysV1] {
+            let bg = SecondaryBroadcastGroup::as_publisher(&publisher, ROUND, &group);
+            let target = secondary_build_target(stage, EPOCH, bg);
+            assert!(matches!(
+                target,
+                BuildTarget::FullNodeRaptorCast {
+                    mode: RaptorcastMode::Deterministic { .. },
+                    ..
+                }
+            ));
         }
     }
 }

--- a/monad-raptorcast/src/v1_rollout.rs
+++ b/monad-raptorcast/src/v1_rollout.rs
@@ -326,4 +326,155 @@ mod tests {
             ));
         }
     }
+
+    #[test]
+    fn test_v1_secondary_rebroadcast_matches_deterministic_assignment() {
+        use crate::{packet::deterministic::SecondaryEncoding, util::EncodingScheme};
+
+        let publisher_key = make_key_pair(0);
+        let publisher_id = NodeId::new(publisher_key.pubkey());
+
+        let full_nodes: BTreeSet<NodeId<PubKeyType>> = (1_u8..=20)
+            .map(|n| NodeId::new(make_key_pair(n).pubkey()))
+            .collect();
+        let group = SecondaryGroup::new(full_nodes.clone()).unwrap();
+
+        let bg = SecondaryBroadcastGroup::as_publisher(&publisher_id, ROUND, &group);
+        let build_target =
+            secondary_build_target(DeterministicProtocolRolloutStage::AlwaysV1, EPOCH, bg);
+
+        let app_message: Bytes = vec![0xCD_u8; 64 * 1024].into();
+        let unix_ts_ms = 1_700_000_000_000_u64;
+        let packets = MessageBuilder::<SignatureType>::new(&publisher_key)
+            .unix_ts_ms(unix_ts_ms)
+            .redundancy(Redundancy::from_u8(2))
+            .build_vec(&app_message, &build_target)
+            .expect("build should succeed");
+        assert!(!packets.is_empty());
+
+        let receiver_id = *full_nodes.iter().next().unwrap();
+        let mut fn_group_map = FullNodeGroupMap::<PubKeyType>::default();
+        let round_span = RoundSpan::new(Round(0), Round(u64::MAX)).unwrap();
+        fn_group_map
+            .try_insert(SecondaryGroupAssignment::new(
+                publisher_id,
+                round_span,
+                group.clone(),
+            ))
+            .expect("group insert");
+
+        let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
+        udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
+
+        let group_map: std::collections::BTreeMap<_, _> = std::collections::BTreeMap::new();
+        let mut rebroadcast_count = 0usize;
+        for packet in &packets {
+            let recv_msg = AuthRecvMsg {
+                src_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8000),
+                payload: packet.payload.clone(),
+                stride: packet.stride as u16,
+                sender: None,
+            };
+            udp_state.handle_message(
+                &group_map,
+                &fn_group_map,
+                |_targets, _payload, _stride| rebroadcast_count += 1,
+                recv_msg,
+            );
+        }
+
+        // Reconstruct the deterministic chunk assignment to count how
+        // many chunks were addressed to the receiver.
+        let bg2 = SecondaryBroadcastGroup::as_publisher(&publisher_id, ROUND, &group);
+        let encoding = SecondaryEncoding::new(
+            EncodingScheme::Deterministic25(ROUND),
+            &bg2,
+            app_message.len(),
+            unix_ts_ms,
+        )
+        .unwrap();
+        let chunks = encoding.make_chunks().unwrap();
+        let addressed_to_receiver = chunks
+            .iter()
+            .filter(|c| *c.recipient().node_id() == receiver_id)
+            .count();
+
+        assert_eq!(rebroadcast_count, addressed_to_receiver);
+        assert!(
+            rebroadcast_count > 0,
+            "receiver should be assigned some chunks"
+        );
+    }
+
+    #[test]
+    fn test_v1_secondary_conflicting_commitment_rejected() {
+        let publisher_key = make_key_pair(0);
+        let publisher_id = NodeId::new(publisher_key.pubkey());
+
+        let full_nodes: BTreeSet<NodeId<PubKeyType>> = (1_u8..=20)
+            .map(|n| NodeId::new(make_key_pair(n).pubkey()))
+            .collect();
+        let group = SecondaryGroup::new(full_nodes.clone()).unwrap();
+
+        let bg1 = SecondaryBroadcastGroup::as_publisher(&publisher_id, ROUND, &group);
+        let build_target_a =
+            secondary_build_target(DeterministicProtocolRolloutStage::AlwaysV1, EPOCH, bg1);
+        let bg2 = SecondaryBroadcastGroup::as_publisher(&publisher_id, ROUND, &group);
+        let build_target_b =
+            secondary_build_target(DeterministicProtocolRolloutStage::AlwaysV1, EPOCH, bg2);
+
+        // Two different messages at the same round, both signed by the
+        // same publisher: the second must not decode.
+        let app_a: Bytes = vec![0xAA_u8; 64 * 1024].into();
+        let app_b: Bytes = vec![0xBB_u8; 64 * 1024].into();
+        let unix_ts_ms = 1_700_000_000_000_u64;
+
+        let packets_a = MessageBuilder::<SignatureType>::new(&publisher_key)
+            .unix_ts_ms(unix_ts_ms)
+            .redundancy(Redundancy::from_u8(2))
+            .build_vec(&app_a, &build_target_a)
+            .expect("build a");
+        let packets_b = MessageBuilder::<SignatureType>::new(&publisher_key)
+            .unix_ts_ms(unix_ts_ms)
+            .redundancy(Redundancy::from_u8(2))
+            .build_vec(&app_b, &build_target_b)
+            .expect("build b");
+
+        let receiver_id = *full_nodes.iter().next().unwrap();
+        let mut fn_group_map = FullNodeGroupMap::<PubKeyType>::default();
+        let round_span = RoundSpan::new(Round(0), Round(u64::MAX)).unwrap();
+        fn_group_map
+            .try_insert(SecondaryGroupAssignment::new(
+                publisher_id,
+                round_span,
+                group.clone(),
+            ))
+            .expect("group insert");
+
+        let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
+        udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
+
+        let group_map: std::collections::BTreeMap<_, _> = std::collections::BTreeMap::new();
+        let mut decoded = Vec::new();
+        for packet in packets_a.iter().chain(packets_b.iter()) {
+            let recv_msg = AuthRecvMsg {
+                src_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8000),
+                payload: packet.payload.clone(),
+                stride: packet.stride as u16,
+                sender: None,
+            };
+            decoded.extend(udp_state.handle_message(
+                &group_map,
+                &fn_group_map,
+                |_, _, _| {},
+                recv_msg,
+            ));
+        }
+
+        // Only one of the two broadcasts should decode, whichever the
+        // receiver committed to first.
+        assert_eq!(decoded.len(), 1);
+        let (_, msg) = &decoded[0];
+        assert!(*msg == app_a || *msg == app_b);
+    }
 }

--- a/monad-raptorcast/src/v1_rollout.rs
+++ b/monad-raptorcast/src/v1_rollout.rs
@@ -89,7 +89,7 @@ mod tests {
         hasher::{Hasher, HasherType},
     };
     use monad_secp::{KeyPair, SecpSignature};
-    use monad_types::{Epoch, NodeId, Round, Stake};
+    use monad_types::{Epoch, NodeId, Round, RoundSpan, Stake};
     use monad_validator::validator_set::{ValidatorSet, ValidatorSetType as _};
 
     use super::{build_target, secondary_build_target, DeterministicProtocolRolloutStage};
@@ -99,7 +99,7 @@ mod tests {
         udp::UdpState,
         util::{
             BuildTarget, FullNodeGroupMap, PrimaryBroadcastGroup, RaptorcastMode, Redundancy,
-            SecondaryBroadcastGroup, SecondaryGroup,
+            SecondaryBroadcastGroup, SecondaryGroup, SecondaryGroupAssignment,
         },
     };
 
@@ -203,6 +203,91 @@ mod tests {
         for (a, b) in NON_ADJACENT_PAIRS {
             let count1 = rollout_publish_and_receive(*a, *b);
             let count2 = rollout_publish_and_receive(*b, *a);
+            assert!(count1 == 0 || count2 == 0);
+        }
+    }
+
+    // Secondary-rollout analogue of rollout_publish_and_receive:
+    // publisher is a validator, receiver is a full node in the
+    // publisher's secondary group.
+    fn rollout_secondary_publish_and_receive(
+        publisher_stage: DeterministicProtocolRolloutStage,
+        receiver_stage: DeterministicProtocolRolloutStage,
+    ) -> usize {
+        let publisher_key = make_key_pair(0);
+        let publisher_id = NodeId::new(publisher_key.pubkey());
+
+        let full_nodes: BTreeSet<NodeId<PubKeyType>> = (1_u8..=20)
+            .map(|n| NodeId::new(make_key_pair(n).pubkey()))
+            .collect();
+        let group = SecondaryGroup::new(full_nodes.clone()).unwrap();
+
+        let bg = SecondaryBroadcastGroup::as_publisher(&publisher_id, ROUND, &group);
+        let build_target = secondary_build_target(publisher_stage, EPOCH, bg);
+
+        let app_message: Bytes = vec![0xAB_u8; 64 * 1024].into();
+        let packets = MessageBuilder::<SignatureType>::new(&publisher_key)
+            .redundancy(Redundancy::from_u8(2))
+            .build_vec(&app_message, &build_target)
+            .expect("build should succeed");
+        assert!(!packets.is_empty());
+
+        // Set up receiver (a full node in the group).
+        let receiver_id = *full_nodes.iter().next().unwrap();
+        let group_map: std::collections::BTreeMap<_, _> = std::collections::BTreeMap::new();
+        let mut fn_group_map = FullNodeGroupMap::<PubKeyType>::default();
+        let round_span = RoundSpan::new(Round(0), Round(u64::MAX)).unwrap();
+        fn_group_map
+            .try_insert(SecondaryGroupAssignment::new(
+                publisher_id,
+                round_span,
+                group.clone(),
+            ))
+            .expect("group insert");
+
+        let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
+        udp_state.set_v1_rollout(receiver_stage);
+
+        let mut decoded_count = 0;
+        for packet in &packets {
+            let recv_msg = AuthRecvMsg {
+                src_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8000),
+                payload: packet.payload.clone(),
+                stride: packet.stride as u16,
+                sender: None,
+            };
+            let decoded =
+                udp_state.handle_message(&group_map, &fn_group_map, |_, _, _| {}, recv_msg);
+            decoded_count += decoded.len();
+        }
+        decoded_count
+    }
+
+    #[test]
+    fn test_rollout_secondary_adjacent_stages_compatible() {
+        use DeterministicProtocolRolloutStage::*;
+        let stages = [AlwaysV0, AcceptBothPublishV0, AcceptBothPublishV1, AlwaysV1];
+
+        for window in stages.windows(2) {
+            let (a, b) = (window[0], window[1]);
+            assert_eq!(rollout_secondary_publish_and_receive(a, b), 1);
+            assert_eq!(rollout_secondary_publish_and_receive(b, a), 1);
+        }
+    }
+
+    #[test]
+    fn test_rollout_secondary_non_adjacent_stages_incompatible() {
+        use DeterministicProtocolRolloutStage::{self as Stage, *};
+
+        const NON_ADJACENT_PAIRS: &[(Stage, Stage)] = &[
+            (AlwaysV0, AcceptBothPublishV1),
+            (AcceptBothPublishV0, AlwaysV1),
+            (AlwaysV0, AlwaysV1),
+        ];
+
+        for (a, b) in NON_ADJACENT_PAIRS {
+            let count1 = rollout_secondary_publish_and_receive(*a, *b);
+            let count2 = rollout_secondary_publish_and_receive(*b, *a);
             assert!(count1 == 0 || count2 == 0);
         }
     }


### PR DESCRIPTION
Integrate secondary raptorcast to also follow the rollout plan as primary raptorcast to use deterministic encoding. Tested on flexnet with AlwaysV1 enabled. Probably worth reviewing commit by commit. 

There are some code which can be further modularized in PrimaryEncoding and SecondaryEncoding. Right now the main difference is just using different chunk assignments (stake weighted vs even partitioned). Can address in a separate PR to keep this PR simple enough.

This PR also makes the node operator controlled full node redundancy obselete, to be removed from node.toml in a future PR. 