### PR TITLE
fix(readme): update broken triedb readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This repository contains implementation for the Monad consensus client and JsonRpc server. Monad consensus collects transactions and produces blocks which are written to a ledger filestream. These blocks are consumed by Monad execution, which then updates the state of the blockchain. The [triedb](monad-triedb/README.md) is a database which stores block information and the blockchain state.
+This repository contains implementation for the Monad consensus client and JsonRpc server. Monad consensus collects transactions and produces blocks which are written to a ledger filestream. These blocks are consumed by Monad execution, which then updates the state of the blockchain. The [triedb](https://github.com/category-labs/monad/blob/38f91f93efcdec8bad56fc07004bb982c9327d81/rust/crates/monad-triedb/README.md) is a database which stores block information and the blockchain state.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

This change fixes the `triedb` link in the top-level `README.md`.

The previous link pointed to `monad-triedb/README.md`, which doesn't exist in this repository. `triedb` now lives inside the `monad-execution` submodule.

The README link is updated to point to the `monad-triedb` README in the `category-labs/monad` repository at the exact submodule commit currently pinned by this repo.