### PR TITLE
monad-state: limit forwarded txs per message

### DIFF
--- a/monad-eth-txpool-executor/src/client.rs
+++ b/monad-eth-txpool-executor/src/client.rs
@@ -33,7 +33,7 @@ use monad_peer_score::{
 };
 use monad_secp::ExtractEthAddress;
 use monad_state_backend::StateBackend;
-use monad_types::NodeId;
+use monad_types::{ForwardedTxList, NodeId};
 use monad_validator::signature_collection::SignatureCollection;
 
 use crate::{forward::INGRESS_CHUNK_MAX_SIZE, TxPoolExecutorCommand, TxPoolExecutorEvent};
@@ -43,7 +43,7 @@ where
     SCT: SignatureCollection,
 {
     pub sender: NodeId<SCT::NodeIdPubKey>,
-    pub txs: Vec<Bytes>,
+    pub txs: ForwardedTxList,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -332,7 +332,9 @@ where
             };
             batch.push(ForwardedTxs {
                 sender,
-                txs: vec![tx],
+                txs: vec![tx]
+                    .try_into()
+                    .expect("forwarded tx list limit must be greater than 0"),
             });
         }
 

--- a/monad-eth-txpool-executor/src/forward.rs
+++ b/monad-eth-txpool-executor/src/forward.rs
@@ -31,6 +31,7 @@ use monad_crypto::certificate_signature::{
 use monad_eth_txpool::{max_eip2718_encoded_length, EthTxPool};
 use monad_eth_types::ExtractEthAddress;
 use monad_state_backend::StateBackend;
+use monad_types::ForwardedTxList;
 use monad_validator::signature_collection::SignatureCollection;
 use pin_project::pin_project;
 use tracing::error;
@@ -94,7 +95,7 @@ impl<S> EthTxPoolForwardingManager<S> {
         self: Pin<&mut Self>,
         execution_params: &ExecutionChainParams,
         cx: &mut Context<'_>,
-    ) -> Poll<Vec<Bytes>> {
+    ) -> Poll<ForwardedTxList> {
         let EthTxPoolForwardingManagerProjected {
             egress,
             egress_waker,
@@ -113,15 +114,21 @@ impl<S> EthTxPoolForwardingManager<S> {
 
             let egress_max_size_bytes = egress_max_size_bytes(execution_params);
 
-            let mut txs = Vec::default();
+            let mut txs = ForwardedTxList::default();
             let mut total_bytes = 0;
 
             while let Some(tx) = egress.front() {
                 let new_total_bytes = total_bytes + tx.len();
 
                 if new_total_bytes <= egress_max_size_bytes {
-                    txs.push(egress.pop_front().unwrap());
-                    total_bytes = new_total_bytes;
+                    let tx = egress.pop_front().unwrap();
+                    match txs.try_push(tx) {
+                        Ok(()) => total_bytes = new_total_bytes,
+                        Err(tx) => {
+                            egress.push_front(tx);
+                            break;
+                        }
+                    }
                     continue;
                 }
 

--- a/monad-eth-txpool-executor/src/lib.rs
+++ b/monad-eth-txpool-executor/src/lib.rs
@@ -26,7 +26,6 @@ use std::{
 use alloy_consensus::{transaction::Recovered, TxEnvelope};
 use alloy_eips::Decodable2718;
 use alloy_primitives::Address;
-use bytes::Bytes;
 use futures::Stream;
 use monad_chain_config::{revision::ChainRevision, ChainConfig};
 use monad_consensus_types::{
@@ -52,7 +51,7 @@ use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_peer_score::{ema, StdClock};
 use monad_secp::RecoverableAddress;
 use monad_state_backend::StateBackend;
-use monad_types::{DropTimer, Epoch, ExecutionProtocol, NodeId, Round, SeqNum};
+use monad_types::{DropTimer, Epoch, ExecutionProtocol, ForwardedTxList, NodeId, Round, SeqNum};
 use monad_validator::signature_collection::SignatureCollection;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use tokio::{sync::mpsc, time::Instant};
@@ -147,7 +146,7 @@ where
         sender_gas: BTreeMap<NodeId<SCT::NodeIdPubKey>, u64>,
     },
 
-    ForwardTxs(Vec<Bytes>),
+    ForwardTxs(ForwardedTxList),
 }
 
 pub struct EthTxPoolExecutor<ST, SCT, SBT, CCT, CRT, TIS>
@@ -805,6 +804,7 @@ mod test {
 
     use alloy_consensus::transaction::SignerRecoverable;
     use alloy_primitives::TxHash;
+    use bytes::Bytes;
     use futures::StreamExt;
     use monad_chain_config::{revision::MockChainRevision, ChainConfig, MockChainConfig};
     use monad_consensus_types::{
@@ -880,7 +880,7 @@ mod test {
         }
     }
 
-    fn make_forwarded_txs(start_nonce: u64, count: usize) -> Vec<bytes::Bytes> {
+    fn make_forwarded_txs(start_nonce: u64, count: usize) -> Vec<Bytes> {
         (start_nonce..(start_nonce + count as u64))
             .map(|nonce| {
                 alloy_rlp::encode(make_legacy_tx(S1, MIN_BASE_FEE.into(), 100_000, nonce, 512))
@@ -914,7 +914,7 @@ mod test {
 
     fn collect_forwarded_txs(
         event: MonadEvent<SignatureType, SignatureCollectionType, EthExecutionProtocol>,
-    ) -> Vec<bytes::Bytes> {
+    ) -> Vec<Bytes> {
         let expected_signer = secret_to_eth_address(S1);
 
         match event {
@@ -934,10 +934,7 @@ mod test {
         }
     }
 
-    fn assert_no_proposal(
-        proposal_rx: &mut mpsc::UnboundedReceiver<Vec<bytes::Bytes>>,
-        context: &str,
-    ) {
+    fn assert_no_proposal(proposal_rx: &mut mpsc::UnboundedReceiver<Vec<Bytes>>, context: &str) {
         assert!(
             matches!(
                 proposal_rx.try_recv(),
@@ -950,10 +947,10 @@ mod test {
     const MAX_YIELDS: usize = 10;
 
     async fn recv_proposal_with_yields(
-        proposal_rx: &mut mpsc::UnboundedReceiver<Vec<bytes::Bytes>>,
+        proposal_rx: &mut mpsc::UnboundedReceiver<Vec<Bytes>>,
         yields: usize,
         context: &str,
-    ) -> Vec<bytes::Bytes> {
+    ) -> Vec<Bytes> {
         assert!(yields <= MAX_YIELDS, "yield limit exceeded");
 
         for _ in 0..yields {
@@ -1079,7 +1076,7 @@ mod test {
 
         client.exec(vec![TxPoolCommand::InsertForwardedTxs {
             sender: node_id::<SignatureType>(),
-            txs: make_forwarded_txs(0, 4),
+            txs: make_forwarded_txs(0, 4).try_into().unwrap(),
         }]);
 
         let metrics = client.metrics().into_inner();
@@ -1160,7 +1157,7 @@ mod test {
                         "initial proposal did not arrive within yield budget",
                     )
                     .await,
-                    Vec::<bytes::Bytes>::default()
+                    Vec::<Bytes>::default()
                 );
                 assert_no_proposal(
                     &mut proposal_rx,
@@ -1170,7 +1167,7 @@ mod test {
                 command_tx
                     .send(vec![TxPoolCommand::InsertForwardedTxs {
                         sender: node_id::<SignatureType>(),
-                        txs: expected_txs.clone(),
+                        txs: expected_txs.clone().try_into().unwrap(),
                     }])
                     .expect("forwarded txs are queued");
                 tokio::task::yield_now().await;
@@ -1186,7 +1183,7 @@ mod test {
                         "proposal after 4ms did not arrive within yield budget",
                     )
                     .await,
-                    Vec::<bytes::Bytes>::default()
+                    Vec::<Bytes>::default()
                 );
 
                 tokio::time::advance(Duration::from_millis(INGRESS_CHUNK_INTERVAL_MS - 4)).await;
@@ -1208,7 +1205,7 @@ mod test {
                 command_tx
                     .send(vec![TxPoolCommand::InsertForwardedTxs {
                         sender: node_id::<SignatureType>(),
-                        txs: expected_txs_after_second_batch.clone(),
+                        txs: expected_txs_after_second_batch.clone().try_into().unwrap(),
                     }])
                     .expect("forwarded txs are queued");
                 tokio::task::yield_now().await;

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -50,8 +50,8 @@ use monad_crypto::certificate_signature::{
 };
 use monad_state_backend::StateBackend;
 use monad_types::{
-    deserialize_pubkey, serialize_pubkey, Epoch, ExecutionProtocol, LimitedVec, NodeId, Round,
-    RouterTarget, SeqNum, Stake, UdpPriority,
+    deserialize_pubkey, serialize_pubkey, Epoch, ExecutionProtocol, ForwardedTxList, LimitedVec,
+    NodeId, Round, RouterTarget, SeqNum, Stake, UdpPriority,
 };
 use monad_validator::signature_collection::SignatureCollection;
 use serde::{Deserialize, Serialize};
@@ -581,7 +581,7 @@ where
 
     InsertForwardedTxs {
         sender: NodeId<SCT::NodeIdPubKey>,
-        txs: Vec<Bytes>,
+        txs: ForwardedTxList,
     },
 
     EnterRound {
@@ -1153,12 +1153,11 @@ where
     /// Txs that are incoming via other nodes
     ForwardedTxs {
         sender: NodeId<SCT::NodeIdPubKey>,
-        #[serde_as(as = "Vec<serde_with::hex::Hex>")]
-        txs: Vec<Bytes>,
+        txs: ForwardedTxList,
     },
 
     /// Txs that should be forwarded to upcoming leaders
-    ForwardTxs(#[serde_as(as = "Vec<serde_with::hex::Hex>")] Vec<Bytes>),
+    ForwardTxs(ForwardedTxList),
 }
 
 impl<ST, SCT, EPT> Encodable for MempoolEvent<ST, SCT, EPT>
@@ -1293,11 +1292,11 @@ where
             }
             2 => {
                 let sender = NodeId::<SCT::NodeIdPubKey>::decode(&mut payload)?;
-                let txs = Vec::<Bytes>::decode(&mut payload)?;
+                let txs = ForwardedTxList::decode(&mut payload)?;
                 Ok(Self::ForwardedTxs { sender, txs })
             }
             3 => {
-                let txs = Vec::<Bytes>::decode(&mut payload)?;
+                let txs = ForwardedTxList::decode(&mut payload)?;
                 Ok(Self::ForwardTxs(txs))
             }
             _ => Err(alloy_rlp::Error::Custom(

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -62,8 +62,8 @@ use monad_executor_glue::{
 };
 use monad_state_backend::StateBackend;
 use monad_types::{
-    Epoch, ExecutionProtocol, MonadVersion, NodeId, Round, RouterTarget, SeqNum, Stake,
-    GENESIS_BLOCK_ID, GENESIS_ROUND, GENESIS_SEQ_NUM,
+    Epoch, ExecutionProtocol, ForwardedTxList, MonadVersion, NodeId, Round, RouterTarget, SeqNum,
+    Stake, GENESIS_BLOCK_ID, GENESIS_ROUND, GENESIS_SEQ_NUM,
 };
 use monad_validator::{
     epoch_manager::EpochManager,
@@ -574,7 +574,7 @@ where
     Consensus(Verified<ST, Validated<ConsensusMessage<ST, SCT, EPT>>>),
     BlockSyncRequest(BlockSyncRequestMessage),
     BlockSyncResponse(BlockSyncResponseMessage<ST, SCT, EPT>),
-    ForwardedTx(Vec<Bytes>),
+    ForwardedTx(ForwardedTxList),
     StateSyncMessage(StateSyncNetworkMessage),
 }
 
@@ -674,7 +674,7 @@ where
     BlockSyncResponse(BlockSyncResponseMessage<ST, SCT, EPT>),
 
     /// Forwarded transactions
-    ForwardedTx(Vec<Bytes>),
+    ForwardedTx(ForwardedTxList),
     /// State Sync msgs
     StateSyncMessage(StateSyncNetworkMessage),
 }
@@ -697,7 +697,7 @@ where
             ),
             2 => Self::BlockSyncRequest(BlockSyncRequestMessage::decode(&mut payload)?),
             3 => Self::BlockSyncResponse(BlockSyncResponseMessage::decode(&mut payload)?),
-            4 => Self::ForwardedTx(Vec::<Bytes>::decode(&mut payload)?),
+            4 => Self::ForwardedTx(ForwardedTxList::decode(&mut payload)?),
             5 => Self::StateSyncMessage(StateSyncNetworkMessage::decode(&mut payload)?),
             _ => {
                 return Err(alloy_rlp::Error::Custom(
@@ -1621,6 +1621,7 @@ where
 
 #[cfg(test)]
 mod test {
+    use bytes::Bytes;
     use monad_bls::BlsSignatureCollection;
     use monad_consensus_types::{
         quorum_certificate::QuorumCertificate,
@@ -1631,7 +1632,7 @@ mod test {
     use monad_eth_types::EthExecutionProtocol;
     use monad_secp::SecpSignature;
     use monad_testutil::validators::create_keys_w_validators;
-    use monad_types::{BlockId, Hash, NodeId, Round, Stake};
+    use monad_types::{BlockId, Hash, NodeId, Round, Stake, MAX_FORWARDED_TXS_PER_MESSAGE};
     use monad_validator::{
         signature_collection::SignatureCollection, validator_set::ValidatorSetFactory,
         weighted_round_robin::WeightedRoundRobin,
@@ -1901,6 +1902,21 @@ mod test {
         let decoded = alloy_rlp::decode_exact::<
             MonadMessage<SignatureType, SignatureCollectionType, ExecutionProtocolType>,
         >(rlp_encoded_monad_message);
+
+        assert!(decoded.is_err());
+    }
+
+    #[test]
+    fn monad_message_forwarded_txs_decode_rejects_over_limit() {
+        let monad_version = MonadVersion::version();
+        let txs = vec![Bytes::from_static(&[0]); MAX_FORWARDED_TXS_PER_MESSAGE + 1];
+        let enc: [&dyn Encodable; 3] = [&monad_version, &4u8, &txs];
+        let mut encoded = Vec::new();
+        encode_list::<_, dyn Encodable>(&enc, &mut encoded);
+
+        let decoded = alloy_rlp::decode_exact::<
+            MonadMessage<SignatureType, SignatureCollectionType, ExecutionProtocolType>,
+        >(&encoded);
 
         assert!(decoded.is_err());
     }

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -24,7 +24,8 @@ use std::{
 
 use alloy_primitives::U256;
 use alloy_rlp::{
-    Decodable, Encodable, RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper,
+    bytes::Bytes, Decodable, Encodable, RlpDecodable, RlpDecodableWrapper, RlpEncodable,
+    RlpEncodableWrapper,
 };
 use monad_crypto::certificate_signature::PubKey;
 pub use monad_crypto::hasher::Hash;
@@ -37,6 +38,7 @@ pub const GENESIS_ROUND: Round = Round(0);
 
 pub const ETHERNET_MTU: u16 = 1500;
 pub const DEFAULT_MTU: u16 = ETHERNET_MTU;
+pub const MAX_FORWARDED_TXS_PER_MESSAGE: usize = 5_000;
 
 const PROTOCOL_VERSION: u32 = 1;
 
@@ -839,6 +841,14 @@ impl<T, const N: usize> Default for LimitedVec<T, N> {
 }
 
 impl<T, const N: usize> LimitedVec<T, N> {
+    pub fn try_push(&mut self, value: T) -> Result<(), T> {
+        if self.0.len() >= N {
+            return Err(value);
+        }
+        self.0.push(value);
+        Ok(())
+    }
+
     pub fn into_inner(self) -> Vec<T> {
         self.0
     }
@@ -918,6 +928,103 @@ impl<'a, T, const N: usize> IntoIterator for &'a LimitedVec<T, N> {
 impl<T, const N: usize> IntoIterator for LimitedVec<T, N> {
     type Item = T;
     type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ForwardedTxList(LimitedVec<Bytes, MAX_FORWARDED_TXS_PER_MESSAGE>);
+
+impl ForwardedTxList {
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, Bytes> {
+        self.0.iter()
+    }
+
+    pub fn try_push(&mut self, value: Bytes) -> Result<(), Bytes> {
+        self.0.try_push(value)
+    }
+
+    pub fn into_inner(self) -> Vec<Bytes> {
+        self.0.into_inner()
+    }
+}
+
+impl TryFrom<Vec<Bytes>> for ForwardedTxList {
+    type Error = Vec<Bytes>;
+
+    fn try_from(vec: Vec<Bytes>) -> Result<Self, Self::Error> {
+        if vec.len() > MAX_FORWARDED_TXS_PER_MESSAGE {
+            return Err(vec);
+        }
+        Ok(Self(LimitedVec(vec)))
+    }
+}
+
+impl Encodable for ForwardedTxList {
+    fn length(&self) -> usize {
+        self.0.length()
+    }
+
+    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+        self.0.encode(out);
+    }
+}
+
+impl Decodable for ForwardedTxList {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        LimitedVec::decode(buf).map(Self)
+    }
+}
+
+impl Serialize for ForwardedTxList {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            let txs = self.iter().map(hex::encode).collect::<Vec<_>>();
+            return Serialize::serialize(&txs, serializer);
+        }
+        Serialize::serialize(&self.0, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ForwardedTxList {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let txs = if deserializer.is_human_readable() {
+            <Vec<String> as Deserialize>::deserialize(deserializer)?
+                .into_iter()
+                .map(|tx| hex::decode(tx).map(Bytes::from))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(<D::Error as serde::de::Error>::custom)?
+        } else {
+            <Vec<Bytes> as Deserialize>::deserialize(deserializer)?
+        };
+
+        txs.try_into()
+            .map_err(|_| <D::Error as serde::de::Error>::custom("list exceeds maximum length"))
+    }
+}
+
+impl<'a> IntoIterator for &'a ForwardedTxList {
+    type Item = &'a Bytes;
+    type IntoIter = std::slice::Iter<'a, Bytes>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl IntoIterator for ForwardedTxList {
+    type Item = Bytes;
+    type IntoIter = std::vec::IntoIter<Bytes>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -1089,6 +1196,35 @@ mod test {
 
         let decoded = LimitedVec::<u32, 0>::decode(&mut buf.as_slice()).unwrap();
         assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn test_limited_vec_try_push_rejects_overflow() {
+        let mut vec: LimitedVec<u32, 3> = vec![1, 2, 3].into();
+        assert_eq!(vec.try_push(4), Err(4));
+    }
+
+    #[test]
+    fn test_forwarded_tx_list_try_from_rejects_overflow() {
+        let result: Result<ForwardedTxList, _> =
+            vec![Bytes::from_static(&[0]); MAX_FORWARDED_TXS_PER_MESSAGE + 1].try_into();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_forwarded_tx_list_json_uses_hex_strings() {
+        let txs: ForwardedTxList = vec![Bytes::from_static(&[0x12, 0x34]), Bytes::new()]
+            .try_into()
+            .unwrap();
+
+        let json = serde_json::to_string(&txs).unwrap();
+        assert_eq!(json, "[\"1234\",\"\"]");
+
+        let decoded: ForwardedTxList = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            decoded.into_inner(),
+            vec![Bytes::from_static(&[0x12, 0x34]), Bytes::new()]
+        );
     }
 
     #[test]

--- a/monad-updaters/src/txpool.rs
+++ b/monad-updaters/src/txpool.rs
@@ -594,10 +594,11 @@ where
             &MockChainConfig::DEFAULT,
             vec![(tx, PoolTxKind::owned_default())],
             |tx| {
-                self.events.push_back(MempoolEvent::ForwardTxs(vec![tx
-                    .raw()
-                    .encoded_2718()
-                    .into()]));
+                self.events.push_back(MempoolEvent::ForwardTxs(
+                    vec![tx.raw().encoded_2718().into()]
+                        .try_into()
+                        .expect("forwarded tx list must allow at least one transaction"),
+                ));
             },
         );
 


### PR DESCRIPTION
collection without limits allows to setup 3M 1 byte transactions over tcp, which takes ~100ms to decode, and then has some downstream effects as well where we need to loop over them, that potentially can be abused to slow down a node.

this wraps txs with limited vector, with 5_000 length

related https://github.com/category-labs/monad-bft/issues/2999