### PR TITLE
Fix gas estimation for eth_fillTransaction

### DIFF
--- a/monad-rpc/src/handlers/eth/gas.rs
+++ b/monad-rpc/src/handlers/eth/gas.rs
@@ -63,35 +63,12 @@ fn block_key_to_parts(block_key: BlockKey) -> (u64, Option<[u8; 32]>) {
     }
 }
 
-#[derive(Clone, Copy)]
-enum EstimateGasMode {
-    // Used by eth_estimateGas, which should keep searching until the simulated
-    // transaction executes successfully.
-    RequireSuccess,
-    // Used by eth_fillTransaction, which only needs a gas limit large enough to
-    // execute without running out of gas, even if execution still fails.
-    AllowExecutionFailure,
-}
-
-fn is_terminal_estimate_result(
-    mode: EstimateGasMode,
-    error: &monad_ethcall::FailureCallResult,
-) -> bool {
-    matches!(mode, EstimateGasMode::AllowExecutionFailure)
-        && matches!(
-            error.error_code,
-            monad_ethcall::EthCallResult::ExecutionError
-                | monad_ethcall::EthCallResult::ReserveBalanceViolation
-        )
-}
-
 async fn estimate_gas(
     eth_call_fn: impl AsyncFn(&TxEnvelope) -> CallResult,
     call_request: &mut CallRequest,
     original_tx_gas: U256,
     provider_gas_limit: u64,
     protocol_gas_limit: u64,
-    mode: EstimateGasMode,
 ) -> Result<Quantity, JsonRpcError> {
     estimate_gas_with_builder(
         eth_call_fn,
@@ -99,7 +76,6 @@ async fn estimate_gas(
         original_tx_gas,
         provider_gas_limit,
         protocol_gas_limit,
-        mode,
         |request| request.clone().try_into(),
     )
     .await
@@ -111,7 +87,6 @@ async fn estimate_gas_with_builder(
     original_tx_gas: U256,
     provider_gas_limit: u64,
     protocol_gas_limit: u64,
-    mode: EstimateGasMode,
     build_tx: impl Fn(&CallRequest) -> Result<TxEnvelope, JsonRpcError> + Copy,
 ) -> Result<Quantity, JsonRpcError> {
     let mut txn = build_tx(call_request)?;
@@ -122,9 +97,6 @@ async fn estimate_gas_with_builder(
             gas_refund,
             ..
         }) => (gas_used, gas_refund),
-        monad_ethcall::CallResult::Failure(error) if is_terminal_estimate_result(mode, &error) => {
-            (error.gas_used, error.gas_refund)
-        }
         monad_ethcall::CallResult::Failure(error) => match error.error_code {
             monad_ethcall::EthCallResult::OutOfGas => {
                 if provider_gas_limit < protocol_gas_limit
@@ -161,14 +133,7 @@ async fn estimate_gas_with_builder(
                     gas_used,
                     ..
                 }) => (gas_used.sub(1), txn.gas_limit()),
-                monad_ethcall::CallResult::Failure(error)
-                    if is_terminal_estimate_result(mode, &error) =>
-                {
-                    (error.gas_used.sub(1), txn.gas_limit())
-                }
-                monad_ethcall::CallResult::Failure(_error_message) => {
-                    (txn.gas_limit(), upper_bound_gas_limit)
-                }
+                monad_ethcall::CallResult::Failure(_) => (txn.gas_limit(), upper_bound_gas_limit),
                 _ => {
                     return Err(JsonRpcError::internal_error(
                         "Unexpected CallResult type".into(),
@@ -197,12 +162,7 @@ async fn estimate_gas_with_builder(
             monad_ethcall::CallResult::Success(monad_ethcall::SuccessCallResult { .. }) => {
                 upper_bound_gas_limit = mid;
             }
-            monad_ethcall::CallResult::Failure(error)
-                if is_terminal_estimate_result(mode, &error) =>
-            {
-                upper_bound_gas_limit = mid;
-            }
-            monad_ethcall::CallResult::Failure(_error_message) => {
+            monad_ethcall::CallResult::Failure(_) => {
                 lower_bound_gas_limit = mid;
             }
             _ => {
@@ -449,7 +409,6 @@ pub async fn monad_eth_estimateGas<T: Triedb>(
         original_tx_gas,
         provider_gas_limit,
         protocol_gas_limit,
-        EstimateGasMode::RequireSuccess,
     )
     .await
 }
@@ -587,7 +546,6 @@ async fn fill_transaction_with_provider<T: Triedb>(
             original_tx_gas,
             eth_call_provider_gas_limit,
             protocol_gas_limit,
-            EstimateGasMode::AllowExecutionFailure,
             |request| build_fill_transaction_envelope(request, chain_id),
         )
         .await?;
@@ -1090,7 +1048,6 @@ mod tests {
     enum MockTerminalResult {
         Success,
         ExecutionError,
-        ReserveBalanceViolation,
     }
 
     fn mock_eth_call(
@@ -1113,15 +1070,6 @@ mod tests {
                         message: "execution reverted".to_string(),
                         data: Some("0x".to_string()),
                     }),
-                    MockTerminalResult::ReserveBalanceViolation => {
-                        CallResult::Failure(FailureCallResult {
-                            error_code: EthCallResult::ReserveBalanceViolation,
-                            gas_used,
-                            gas_refund,
-                            message: "reserve balance violation".to_string(),
-                            data: None,
-                        })
-                    }
                 }
             } else {
                 CallResult::Failure(FailureCallResult {
@@ -1204,7 +1152,6 @@ mod tests {
             U256::from(30_000),
             u64::MAX,
             u64::MAX,
-            EstimateGasMode::RequireSuccess,
         )
         .await;
         assert!(result.is_err());
@@ -1223,7 +1170,6 @@ mod tests {
             U256::MAX,
             u64::MAX,
             u64::MAX,
-            EstimateGasMode::RequireSuccess,
         )
         .await;
         assert!(result.is_ok());
@@ -1246,7 +1192,6 @@ mod tests {
             U256::from(70_000),
             u64::MAX,
             u64::MAX,
-            EstimateGasMode::RequireSuccess,
         )
         .await;
         assert!(result.is_ok());
@@ -1269,7 +1214,6 @@ mod tests {
             U256::from(60_000),
             u64::MAX,
             u64::MAX,
-            EstimateGasMode::RequireSuccess,
         )
         .await;
         assert!(result.is_ok());
@@ -1277,7 +1221,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_gas_limit_unspecified_allows_execution_failure_for_fill_transaction() {
+    async fn test_gas_limit_unspecified_rejects_execution_failure() {
         let mut call_request = CallRequest::default();
         let eth_call_fn = mock_eth_call(50_000, 10_000, MockTerminalResult::ExecutionError);
 
@@ -1287,44 +1231,6 @@ mod tests {
             U256::MAX,
             u64::MAX,
             u64::MAX,
-            EstimateGasMode::AllowExecutionFailure,
-        )
-        .await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), Quantity(60795));
-    }
-
-    #[tokio::test]
-    async fn test_gas_limit_unspecified_allows_reserve_balance_failure_for_fill_transaction() {
-        let mut call_request = CallRequest::default();
-        let eth_call_fn =
-            mock_eth_call(50_000, 10_000, MockTerminalResult::ReserveBalanceViolation);
-
-        let result = estimate_gas(
-            eth_call_fn,
-            &mut call_request,
-            U256::MAX,
-            u64::MAX,
-            u64::MAX,
-            EstimateGasMode::AllowExecutionFailure,
-        )
-        .await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), Quantity(60795));
-    }
-
-    #[tokio::test]
-    async fn test_gas_limit_unspecified_rejects_execution_failure_for_estimate_gas() {
-        let mut call_request = CallRequest::default();
-        let eth_call_fn = mock_eth_call(50_000, 10_000, MockTerminalResult::ExecutionError);
-
-        let result = estimate_gas(
-            eth_call_fn,
-            &mut call_request,
-            U256::MAX,
-            u64::MAX,
-            u64::MAX,
-            EstimateGasMode::RequireSuccess,
         )
         .await;
         assert!(result.is_err());
@@ -1657,7 +1563,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_fill_transaction_revert_without_gas_succeeds() {
+    async fn test_fill_transaction_propagates_execution_revert() {
         let chain_id = 12345u64;
         let from = Address::repeat_byte(0x11);
         let to = Address::repeat_byte(0x22);
@@ -1665,7 +1571,7 @@ mod tests {
         let config = mock_eth_call_handler_config();
 
         let eth_call_fn = mock_eth_call(50_000, 10_000, MockTerminalResult::ExecutionError);
-        let result = fill_transaction_with_provider(
+        let err = fill_transaction_with_provider(
             &data_provider,
             &config,
             chain_id,
@@ -1683,43 +1589,9 @@ mod tests {
             async |_, _, _, txn| eth_call_fn(txn).await,
         )
         .await
-        .unwrap();
+        .unwrap_err();
 
-        assert_eq!(result.tx.gas, Some(U256::from(60795)));
-        assert_eq!(
-            result.tx.input.input,
-            Some(Bytes::from(vec![0xde, 0xad, 0xbe, 0xef]))
-        );
-    }
-
-    #[tokio::test]
-    async fn test_fill_transaction_ignores_sender_affordability_and_reserve_balance() {
-        let chain_id = 12345u64;
-        let from = Address::repeat_byte(0x11);
-        let to = Address::repeat_byte(0x22);
-        let data_provider = make_fill_data_provider(from, 0, 0, 1000, 100);
-        let config = mock_eth_call_handler_config();
-
-        let eth_call_fn =
-            mock_eth_call(50_000, 10_000, MockTerminalResult::ReserveBalanceViolation);
-        let result = fill_transaction_with_provider(
-            &data_provider,
-            &config,
-            chain_id,
-            MonadEthFillTransactionParams {
-                tx: CallRequest {
-                    from: Some(from),
-                    to: Some(to),
-                    ..Default::default()
-                },
-            },
-            async |_, _, _, txn| eth_call_fn(txn).await,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(result.tx.gas, Some(U256::from(60795)));
-        assert_eq!(result.tx.nonce, Some(U64::from(0)));
+        assert_eq!(err.message, "execution reverted");
     }
 
     #[tokio::test]


### PR DESCRIPTION
From my understanding, we don't need to have separate behavior for gas estimation in eth_estimateGas and eth_fillTransaction. This commit makes them the same behaviour. 

Previously the subtle difference is that when calling an external contract, only 63/64 gas is forwarded. With the 1/64 reservation the inner frame runs out of gas. The inner OOG causes success=false, which is converted to ExecutionError

Confirmed on a testnet node this fixes discrepancies between eth_estimateGas and eth_fillTransaction