### PR TITLE
monad-wireauth: rework filtering

### DIFF
--- a/monad-wireauth/README.md
+++ b/monad-wireauth/README.md
@@ -22,18 +22,17 @@ session management layer:
 
 high-level api with dos protection:
 
-the filter operates in three modes based on load:
+the filter operates using two global handshake rate limits plus a hard session cap:
 
 | condition | action |
 |-----------|--------|
-| cookie invalid and handshakes >= `handshake_cookie_unverified_rate_limit` | send cookie reply (if `handshake_cookie_verified_rate_limit` has remaining budget), otherwise drop request |
+| cookie invalid and handshakes >= `handshake_cookie_unverified_rate_limit` | send cookie reply |
 | cookie valid and handshakes >= `handshake_cookie_verified_rate_limit` | drop request |
+| cookie valid and last verified request from the same ip is within `ip_rate_limit_window` | drop request |
 | sessions >= `high_watermark_sessions` | drop request |
-| sessions >= `low_watermark_sessions` and cookie invalid | send cookie reply |
-| sessions >= `low_watermark_sessions` and cookie valid | apply per-ip rate limiting via lru cache |
-| sessions < `low_watermark_sessions` | no additional measures |
+| otherwise | accept request |
 
-defaults: `high_watermark_sessions`=40,000, `handshake_cookie_unverified_rate_limit`=300/sec, `handshake_cookie_verified_rate_limit`=300/sec, `connect_rate_limit`=300/sec, `low_watermark_sessions`=5,000, `ip_rate_limit_window`=10s, `max_sessions_per_ip`=4, `ip_history_capacity`=1,000,000
+defaults: `high_watermark_sessions`=40,000, `handshake_cookie_unverified_rate_limit`=500/sec, `handshake_cookie_verified_rate_limit`=1,000/sec, `ip_rate_limit_window`=10s, `ip_history_capacity`=1,000,000, `connect_rate_limit`=300/sec
 
 these defaults are per instance. we expect to run more than one wireauth instance, so the per-instance handshake and session limits are intentionally lower and aggregate capacity should come from running multiple instances.
 
@@ -68,7 +67,7 @@ session_decrypt         time:   [166.11 ns 168.75 ns 171.20 ns]
 | `monad.wireauth.state.packet_queue_size` | outbound packets waiting to be sent |
 | `monad.wireauth.state.initiated_session_by_peer_size` | tracks one initiating session per peer to prevent duplicates |
 | `monad.wireauth.state.accepted_sessions_by_peer_size` | tracks accepted sessions per peer for limiting |
-| `monad.wireauth.state.ip_session_counts_size` | tracks session count per ip for rate limiting |
+| `monad.wireauth.state.ip_session_counts_size` | tracks session count per ip |
 
 ### state counters
 
@@ -83,9 +82,9 @@ session_decrypt         time:   [166.11 ns 168.75 ns 171.20 ns]
 
 | metric | description |
 |--------|-------------|
-| `monad.wireauth.filter.ip_request_history_size` | lru cache tracking recent handshake requests per ip |
+| `monad.wireauth.filter.ip_request_history_size` | lru cache tracking recent verified handshake requests per ip |
 | `monad.wireauth.filter.pass` | handshake requests that passed all filters |
-| `monad.wireauth.filter.send_cookie` | cookie challenges sent (between low and high watermark) |
+| `monad.wireauth.filter.send_cookie` | cookie challenges sent due to the unverified handshake rate limit |
 | `monad.wireauth.filter.drop` | handshake requests rejected due to rate limits |
 | `monad.wireauth.rate_limit.connect` | outbound connect attempts rejected due to rate limits |
 
@@ -160,17 +159,15 @@ session_decrypt         time:   [166.11 ns 168.75 ns 171.20 ns]
 | `rekey_interval` | Duration | 6h | time before initiating new handshake to rotate keys |
 | `rekey_jitter` | Duration | 60s | randomization to avoid synchronized rekey storms |
 | `max_session_duration` | Duration | 6h5m | absolute session lifetime regardless of activity (forces rekey) |
-| `handshake_cookie_unverified_rate_limit` | u64 | 300 | max handshake initiations per second without a valid cookie |
-| `handshake_cookie_verified_rate_limit` | u64 | 300 | max handshake initiations per second with a valid cookie |
+| `handshake_cookie_unverified_rate_limit` | u64 | 500 | max handshake initiations per second without a valid cookie |
+| `handshake_cookie_verified_rate_limit` | u64 | 1000 | max handshake initiations per second with a valid cookie |
 | `handshake_rate_reset_interval` | Duration | 1s | window for handshake rate limiting |
 | `connect_rate_limit` | u64 | 300 | max outbound connect attempts per second (dos protection) |
 | `connect_rate_reset_interval` | Duration | 1s | window for outbound connect rate limiting |
 | `cookie_refresh_duration` | Duration | 120s | cookie validity period (responder rotates cookie key) |
-| `low_watermark_sessions` | usize | 5000 | below this threshold, accept all handshakes without cookie challenge |
+| `ip_rate_limit_window` | Duration | 10s | time window for counting verified handshake requests per ip |
+| `ip_history_capacity` | usize | 1000000 | lru cache size for tracking recent verified handshake requests per ip |
 | `high_watermark_sessions` | usize | 40000 | at this threshold, drop all incoming handshake requests |
-| `max_sessions_per_ip` | usize | 4 | limit concurrent sessions from single ip (anti-amplification) |
-| `ip_rate_limit_window` | Duration | 10s | time window for counting handshake requests per ip |
-| `ip_history_capacity` | usize | 1000000 | lru cache size for tracking handshake request timestamps per ip |
 | `psk` | [u8; 32] | zeros | optional pre-shared key mixed into handshake for additional auth |
 | `max_initiated_sessions` | usize | 1000 | max concurrent initiated sessions (handshakes in progress) |
 | `max_buffered_bytes_per_session` | usize | 131072 | max bytes of buffered messages per initiated session (128KB) |

--- a/monad-wireauth/src/api.rs
+++ b/monad-wireauth/src/api.rs
@@ -81,8 +81,6 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
             config.handshake_rate_reset_interval,
             config.ip_rate_limit_window,
             config.ip_history_capacity,
-            config.max_sessions_per_ip,
-            config.low_watermark_sessions,
             config.high_watermark_sessions,
         );
         let local_serialized_public = CompressedPublicKey::from(&local_static_public);

--- a/monad-wireauth/src/config/mod.rs
+++ b/monad-wireauth/src/config/mod.rs
@@ -51,16 +51,12 @@ pub struct Config {
     pub connect_rate_reset_interval: Duration,
     /// cookie validity period (responder rotates cookie key)
     pub cookie_refresh_duration: Duration,
-    /// below this threshold, accept all handshakes without cookie challenge
-    pub low_watermark_sessions: usize,
+    /// time window for counting cookie-valid handshake requests per ip
+    pub ip_rate_limit_window: Duration,
+    /// lru cache size for tracking recent cookie-valid handshake requests per ip
+    pub ip_history_capacity: usize,
     /// at this threshold, drop all incoming handshake requests
     pub high_watermark_sessions: usize,
-    /// limit concurrent sessions from single ip (anti-amplification)
-    pub max_sessions_per_ip: usize,
-    /// time window for counting handshake requests per ip
-    pub ip_rate_limit_window: Duration,
-    /// lru cache size for tracking handshake request timestamps per ip
-    pub ip_history_capacity: usize,
     /// optional pre-shared key mixed into handshake for additional auth
     pub psk: Zeroizing<[u8; 32]>,
     /// max concurrent initiated sessions (handshakes in progress)
@@ -83,17 +79,15 @@ impl Default for Config {
             rekey_interval: Duration::from_secs(6 * 60 * 60),
             rekey_jitter: Duration::from_secs(60),
             max_session_duration: Duration::from_secs(6 * 60 * 60 + 5 * 60),
-            handshake_cookie_unverified_rate_limit: 300,
-            handshake_cookie_verified_rate_limit: 300,
+            handshake_cookie_unverified_rate_limit: 500,
+            handshake_cookie_verified_rate_limit: 1000,
             handshake_rate_reset_interval: Duration::from_secs(1),
             connect_rate_limit: 300,
             connect_rate_reset_interval: Duration::from_secs(1),
             cookie_refresh_duration: Duration::from_secs(120),
-            low_watermark_sessions: 5_000,
-            high_watermark_sessions: 40_000,
-            max_sessions_per_ip: 4,
             ip_rate_limit_window: Duration::from_secs(10),
             ip_history_capacity: 1_000_000,
+            high_watermark_sessions: 40_000,
             psk: Zeroizing::new([0u8; 32]),
             max_initiated_sessions: 1000,
             max_buffered_bytes_per_session: 128 * 1024,

--- a/monad-wireauth/src/filter.rs
+++ b/monad-wireauth/src/filter.rs
@@ -45,8 +45,6 @@ pub struct Filter {
     handshake_rate_reset_interval: Duration,
     ip_request_history: LruCache<IpAddr, Duration>,
     ip_rate_limit_window: Duration,
-    max_sessions_per_ip: usize,
-    low_watermark_sessions: usize,
     high_watermark_sessions: usize,
     metrics: ExecutorMetrics,
     metric_names: &'static MetricNames,
@@ -64,8 +62,6 @@ impl Filter {
         handshake_rate_reset_interval: Duration,
         ip_rate_limit_window: Duration,
         ip_history_capacity: usize,
-        max_sessions_per_ip: usize,
-        low_watermark_sessions: usize,
         high_watermark_sessions: usize,
     ) -> Self {
         Self {
@@ -77,8 +73,6 @@ impl Filter {
             handshake_rate_reset_interval,
             ip_request_history: LruCache::new(NonZeroUsize::new(ip_history_capacity).unwrap()),
             ip_rate_limit_window,
-            max_sessions_per_ip,
-            low_watermark_sessions,
             high_watermark_sessions,
             metrics: init_filter_executor_metrics(metric_names),
             metric_names,
@@ -125,16 +119,24 @@ impl Filter {
     ) -> FilterAction {
         trace!(remote_addr = %remote_addr, cookie_valid = cookie_valid, "applying filter");
         let total_sessions = state.total_sessions();
-        let ip = remote_addr.ip();
 
         let action = self
             .check_high_watermark(total_sessions, remote_addr)
-            .or_else(|| self.check_cookie_rate_limit(remote_addr, cookie_valid))
-            .or_else(|| self.check_low_watermark(total_sessions))
-            .or_else(|| self.check_cookie_validity(cookie_valid))
-            .or_else(|| self.check_ip_rate_limit(ip, duration_since_start))
-            .or_else(|| self.check_max_sessions_per_ip(state, ip))
-            .unwrap_or(FilterAction::Pass);
+            .unwrap_or_else(|| {
+                if cookie_valid {
+                    self.check_verified_request(remote_addr, duration_since_start)
+                } else {
+                    self.check_unverified_request(remote_addr)
+                }
+            });
+
+        if action == FilterAction::Pass {
+            if cookie_valid {
+                self.cookie_verified_counter += 1;
+            } else {
+                self.cookie_unverified_counter += 1;
+            }
+        }
 
         self.record_metric(action);
         action
@@ -156,94 +158,54 @@ impl Filter {
         })
     }
 
-    fn check_cookie_rate_limit(
+    fn check_unverified_request(&self, remote_addr: SocketAddr) -> FilterAction {
+        if self.cookie_unverified_counter >= self.handshake_cookie_unverified_rate_limit {
+            debug!(
+                remote_addr = %remote_addr,
+                unverified_counter = self.cookie_unverified_counter,
+                unverified_rate_limit = self.handshake_cookie_unverified_rate_limit,
+                "cookie-unverified rate limit exceeded - sending cookie reply"
+            );
+            FilterAction::SendCookie
+        } else {
+            FilterAction::Pass
+        }
+    }
+
+    fn check_verified_request(
         &mut self,
         remote_addr: SocketAddr,
-        cookie_valid: bool,
-    ) -> Option<FilterAction> {
-        if cookie_valid {
-            if self.cookie_verified_counter >= self.handshake_cookie_verified_rate_limit {
-                debug!(
-                    remote_addr = %remote_addr,
-                    counter = self.cookie_verified_counter,
-                    verified_rate_limit = self.handshake_cookie_verified_rate_limit,
-                    "cookie-verified rate limit exceeded - dropping handshake"
-                );
-                return Some(FilterAction::Drop);
-            }
-            self.cookie_verified_counter += 1;
-        } else {
-            if self.cookie_unverified_counter >= self.handshake_cookie_unverified_rate_limit {
-                if self.cookie_verified_counter < self.handshake_cookie_verified_rate_limit {
-                    debug!(
-                        remote_addr = %remote_addr,
-                        unverified_counter = self.cookie_unverified_counter,
-                        unverified_rate_limit = self.handshake_cookie_unverified_rate_limit,
-                        verified_counter = self.cookie_verified_counter,
-                        verified_rate_limit = self.handshake_cookie_verified_rate_limit,
-                        "cookie-unverified budget exhausted - sending cookie reply"
-                    );
-                    return Some(FilterAction::SendCookie);
-                }
-                debug!(
-                    remote_addr = %remote_addr,
-                    counter = self.cookie_unverified_counter,
-                    unverified_rate_limit = self.handshake_cookie_unverified_rate_limit,
-                    verified_counter = self.cookie_verified_counter,
-                    verified_rate_limit = self.handshake_cookie_verified_rate_limit,
-                    "cookie-unverified rate limit exceeded - dropping handshake (no verified budget for cookie replies)"
-                );
-                return Some(FilterAction::Drop);
-            }
-            self.cookie_unverified_counter += 1;
-        }
-
-        None
-    }
-
-    fn check_low_watermark(&self, total_sessions: usize) -> Option<FilterAction> {
-        (total_sessions < self.low_watermark_sessions).then_some(FilterAction::Pass)
-    }
-
-    fn check_cookie_validity(&self, cookie_valid: bool) -> Option<FilterAction> {
-        (!cookie_valid).then_some(FilterAction::SendCookie)
-    }
-
-    fn check_ip_rate_limit(
-        &mut self,
-        ip: IpAddr,
         duration_since_start: Duration,
-    ) -> Option<FilterAction> {
-        let window_start = duration_since_start.saturating_sub(self.ip_rate_limit_window);
-
-        match self.ip_request_history.get_mut(&ip) {
-            Some(last_time) if *last_time >= window_start => {
-                debug!(ip = %ip, "ip rate limit exceeded");
-                Some(FilterAction::Drop)
-            }
-            Some(last_time) => {
-                *last_time = duration_since_start;
-                None
-            }
-            None => {
-                self.ip_request_history.put(ip, duration_since_start);
-                self.metrics
-                    .gauge(self.metric_names.filter_ip_request_history_size)
-                    .set(self.ip_request_history.len() as u64);
-                None
-            }
+    ) -> FilterAction {
+        if self.cookie_verified_counter >= self.handshake_cookie_verified_rate_limit {
+            debug!(
+                remote_addr = %remote_addr,
+                counter = self.cookie_verified_counter,
+                verified_rate_limit = self.handshake_cookie_verified_rate_limit,
+                "cookie-verified rate limit exceeded - dropping handshake"
+            );
+            return FilterAction::Drop;
         }
+
+        if self.check_ip_rate_limit(remote_addr.ip(), duration_since_start) {
+            debug!(remote_addr = %remote_addr, "ip rate limit exceeded");
+            return FilterAction::Drop;
+        }
+
+        self.ip_request_history
+            .put(remote_addr.ip(), duration_since_start);
+        self.metrics
+            .gauge(self.metric_names.filter_ip_request_history_size)
+            .set(self.ip_request_history.len() as u64);
+        FilterAction::Pass
     }
 
-    fn check_max_sessions_per_ip(&self, state: &State, ip: IpAddr) -> Option<FilterAction> {
-        (state.ip_session_count(&ip) >= self.max_sessions_per_ip).then(|| {
-            debug!(
-                ip = %ip,
-                max = self.max_sessions_per_ip,
-                "too many sessions for ip"
-            );
-            FilterAction::Drop
-        })
+    fn check_ip_rate_limit(&mut self, ip: IpAddr, duration_since_start: Duration) -> bool {
+        let window_start = duration_since_start.saturating_sub(self.ip_rate_limit_window);
+        matches!(
+            self.ip_request_history.peek(&ip),
+            Some(last_time) if *last_time >= window_start
+        )
     }
 
     fn record_metric(&mut self, action: FilterAction) {
@@ -268,9 +230,7 @@ mod tests {
             100,
             Duration::from_secs(60),
             Duration::from_secs(60),
-            1000,
-            10,
-            50,
+            1_000,
             100,
         )
     }
@@ -280,7 +240,7 @@ mod tests {
         let mut filter = default_filter();
         let state = State::new(DEFAULT_METRICS);
         let addr = "127.0.0.1:8080".parse().unwrap();
-        let action = filter.apply(&state, addr, Duration::from_secs(1), false);
+        let action = filter.apply(&state, addr, Duration::ZERO, false);
         assert_eq!(action, FilterAction::Pass);
     }
 
@@ -293,67 +253,40 @@ mod tests {
             100,
             Duration::from_secs(60),
             Duration::from_secs(60),
-            1000,
-            10,
-            5,
+            1_000,
             high_watermark,
         );
         let mut state = State::new(DEFAULT_METRICS);
         for i in 0..high_watermark {
-            let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
-            insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
+            let addr: SocketAddr = format!("10.0.0.{}:51820", i).parse().unwrap();
+            insert_test_initiator_session(&mut state, addr);
         }
         let addr = "127.0.0.1:8080".parse().unwrap();
-        let action = filter.apply(&state, addr, Duration::from_secs(1), false);
+        let action = filter.apply(&state, addr, Duration::ZERO, false);
         assert_eq!(action, FilterAction::Drop);
     }
 
     #[test]
-    fn test_between_watermarks_requires_cookie() {
-        let low_watermark = 5;
+    fn test_unverified_rate_limit_sends_cookie_after_limit() {
+        let unverified_rate_limit = 5;
         let mut filter = Filter::new(
             DEFAULT_METRICS,
-            100,
+            unverified_rate_limit,
             100,
             Duration::from_secs(60),
             Duration::from_secs(60),
-            1000,
-            10,
-            low_watermark,
-            10,
+            1_000,
+            100,
         );
-        let mut state = State::new(DEFAULT_METRICS);
-        for i in 0..low_watermark {
-            let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
-            insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
-        }
+        let state = State::new(DEFAULT_METRICS);
         let addr = "127.0.0.1:8080".parse().unwrap();
-        let action = filter.apply(&state, addr, Duration::from_secs(1), false);
+        for _ in 0..unverified_rate_limit {
+            let action = filter.apply(&state, addr, Duration::ZERO, false);
+            assert_eq!(action, FilterAction::Pass);
+        }
+        let action = filter.apply(&state, addr, Duration::ZERO, false);
         assert_eq!(action, FilterAction::SendCookie);
-    }
-
-    #[test]
-    fn test_between_watermarks_passes_with_cookie() {
-        let low_watermark = 5;
-        let mut filter = Filter::new(
-            DEFAULT_METRICS,
-            100,
-            100,
-            Duration::from_secs(60),
-            Duration::from_secs(60),
-            1000,
-            10,
-            low_watermark,
-            10,
-        );
-        let mut state = State::new(DEFAULT_METRICS);
-        for i in 0..low_watermark {
-            let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
-            insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
-        }
-        let addr = "127.0.0.1:8080".parse().unwrap();
-        let action = filter.apply(&state, addr, Duration::from_secs(1), true);
-        assert_eq!(action, FilterAction::Pass);
+        assert_eq!(filter.cookie_unverified_counter, unverified_rate_limit);
     }
 
     #[test]
@@ -366,28 +299,27 @@ mod tests {
             verified_rate_limit,
             Duration::from_secs(60),
             Duration::from_secs(60),
-            1000,
-            10,
-            50,
+            1_000,
             100,
         );
         let state = State::new(DEFAULT_METRICS);
         let addr = "127.0.0.1:8080".parse().unwrap();
         for _ in 0..handshake_rate_limit {
-            let action = filter.apply(&state, addr, Duration::from_secs(1), false);
+            let action = filter.apply(&state, addr, Duration::ZERO, false);
             assert_eq!(action, FilterAction::Pass);
         }
 
-        let action = filter.apply(&state, addr, Duration::from_secs(1), false);
+        let action = filter.apply(&state, addr, Duration::ZERO, false);
         assert_eq!(action, FilterAction::SendCookie);
 
-        for _ in 0..verified_rate_limit {
-            let action = filter.apply(&state, addr, Duration::from_secs(1), true);
+        for i in 0..verified_rate_limit {
+            let verified_addr: SocketAddr = format!("127.0.0.{}:8080", i + 2).parse().unwrap();
+            let action = filter.apply(&state, verified_addr, Duration::from_secs(61), true);
             assert_eq!(action, FilterAction::Pass);
         }
 
-        let action = filter.apply(&state, addr, Duration::from_secs(1), false);
-        assert_eq!(action, FilterAction::Drop);
+        let action = filter.apply(&state, addr, Duration::ZERO, false);
+        assert_eq!(action, FilterAction::SendCookie);
     }
 
     #[test]
@@ -399,63 +331,49 @@ mod tests {
             verified_rate_limit,
             Duration::from_secs(60),
             Duration::from_secs(60),
-            1000,
-            10,
-            50,
+            1_000,
             100,
         );
         let state = State::new(DEFAULT_METRICS);
-        let addr = "127.0.0.1:8080".parse().unwrap();
-        for _ in 0..verified_rate_limit {
-            let action = filter.apply(&state, addr, Duration::from_secs(1), true);
+        for i in 0..verified_rate_limit {
+            let addr: SocketAddr = format!("127.0.0.{}:8080", i + 2).parse().unwrap();
+            let action = filter.apply(&state, addr, Duration::from_secs(61), true);
             assert_eq!(action, FilterAction::Pass);
         }
-        let action = filter.apply(&state, addr, Duration::from_secs(1), true);
+        let action = filter.apply(
+            &state,
+            "127.0.0.2:8080".parse().unwrap(),
+            Duration::from_secs(61),
+            true,
+        );
         assert_eq!(action, FilterAction::Drop);
     }
 
     #[test]
-    fn test_unverified_rate_limit_does_not_starve_verified_rate_limit() {
+    fn test_unverified_rate_limit_does_not_depend_on_verified_budget() {
         let mut filter = Filter::new(
             DEFAULT_METRICS,
             2, // unverified
-            2, // verified
+            0, // verified
             Duration::from_secs(60),
             Duration::from_secs(60),
-            1000,
-            10,
-            50,
+            1_000,
             100,
         );
         let state = State::new(DEFAULT_METRICS);
         let addr = "127.0.0.1:8080".parse().unwrap();
 
-        // Exhaust unverified budget.
         assert_eq!(
-            filter.apply(&state, addr, Duration::from_secs(1), false),
+            filter.apply(&state, addr, Duration::ZERO, false),
             FilterAction::Pass
         );
         assert_eq!(
-            filter.apply(&state, addr, Duration::from_secs(1), false),
+            filter.apply(&state, addr, Duration::ZERO, false),
             FilterAction::Pass
         );
         assert_eq!(
-            filter.apply(&state, addr, Duration::from_secs(1), false),
+            filter.apply(&state, addr, Duration::ZERO, false),
             FilterAction::SendCookie
-        );
-
-        // Verified budget is still available.
-        assert_eq!(
-            filter.apply(&state, addr, Duration::from_secs(1), true),
-            FilterAction::Pass
-        );
-        assert_eq!(
-            filter.apply(&state, addr, Duration::from_secs(1), true),
-            FilterAction::Pass
-        );
-        assert_eq!(
-            filter.apply(&state, addr, Duration::from_secs(1), true),
-            FilterAction::Drop
         );
     }
 
@@ -468,18 +386,16 @@ mod tests {
             handshake_rate_limit,
             Duration::from_secs(1),
             Duration::from_secs(60),
-            1000,
-            10,
-            50,
+            1_000,
             100,
         );
         let state = State::new(DEFAULT_METRICS);
         let addr = "127.0.0.1:8080".parse().unwrap();
         for _ in 0..handshake_rate_limit {
-            filter.apply(&state, addr, Duration::from_secs(0), false);
+            filter.apply(&state, addr, Duration::ZERO, false);
         }
         filter.tick(Duration::from_secs(1));
-        let action = filter.apply(&state, addr, Duration::from_secs(1), false);
+        let action = filter.apply(&state, addr, Duration::ZERO, false);
         assert_eq!(action, FilterAction::Pass);
     }
 
@@ -492,15 +408,13 @@ mod tests {
             handshake_rate_limit,
             Duration::from_secs(10),
             Duration::from_secs(60),
-            1000,
-            10,
-            50,
+            1_000,
             100,
         );
         let state = State::new(DEFAULT_METRICS);
         let addr = "127.0.0.1:8080".parse().unwrap();
         for _ in 0..handshake_rate_limit {
-            filter.apply(&state, addr, Duration::from_secs(0), false);
+            filter.apply(&state, addr, Duration::ZERO, false);
         }
         filter.tick(Duration::from_secs(5));
         let action = filter.apply(&state, addr, Duration::from_secs(5), false);
@@ -508,165 +422,196 @@ mod tests {
     }
 
     #[test]
-    fn test_ip_rate_limit_within_window() {
-        let low_watermark = 5;
-        let mut filter = Filter::new(
-            DEFAULT_METRICS,
-            100,
-            100,
-            Duration::from_secs(60),
-            Duration::from_secs(5),
-            1000,
-            10,
-            low_watermark,
-            10,
-        );
-        let mut state = State::new(DEFAULT_METRICS);
-        for i in 0..low_watermark {
-            let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
-            insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
-        }
-        let addr = "127.0.0.1:8080".parse().unwrap();
-        filter.apply(&state, addr, Duration::from_secs(0), true);
-        let action = filter.apply(&state, addr, Duration::from_secs(3), true);
-        assert_eq!(action, FilterAction::Drop);
-    }
-
-    #[test]
-    fn test_ip_rate_limit_after_window() {
-        let low_watermark = 5;
-        let mut filter = Filter::new(
-            DEFAULT_METRICS,
-            100,
-            100,
-            Duration::from_secs(60),
-            Duration::from_secs(5),
-            1000,
-            10,
-            low_watermark,
-            10,
-        );
-        let mut state = State::new(DEFAULT_METRICS);
-        for i in 0..low_watermark {
-            let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
-            insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
-        }
-        let addr = "127.0.0.1:8080".parse().unwrap();
-        filter.apply(&state, addr, Duration::from_secs(0), true);
-        let action = filter.apply(&state, addr, Duration::from_secs(6), true);
-        assert_eq!(action, FilterAction::Pass);
-    }
-
-    #[test]
-    fn test_max_sessions_per_ip_drops() {
-        let low_watermark = 5;
-        let max_sessions_per_ip = 2;
-        let mut filter = Filter::new(
-            DEFAULT_METRICS,
-            100,
-            100,
-            Duration::from_secs(60),
-            Duration::from_secs(60),
-            1000,
-            max_sessions_per_ip,
-            low_watermark,
-            10,
-        );
-        let mut state = State::new(DEFAULT_METRICS);
-        for i in 0..low_watermark {
-            let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
-            insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
-        }
-        let ip: IpAddr = "192.168.1.1".parse().unwrap();
-        for _ in 0..max_sessions_per_ip {
-            insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
-        }
-        let addr = "192.168.1.1:8080".parse().unwrap();
-        let action = filter.apply(&state, addr, Duration::from_secs(1), true);
-        assert_eq!(action, FilterAction::Drop);
-    }
-
-    #[test]
-    fn test_max_sessions_per_ip_passes_under_limit() {
-        let low_watermark = 5;
-        let max_sessions_per_ip = 2;
-        let mut filter = Filter::new(
-            DEFAULT_METRICS,
-            100,
-            100,
-            Duration::from_secs(60),
-            Duration::from_secs(60),
-            1000,
-            max_sessions_per_ip,
-            low_watermark,
-            10,
-        );
-        let mut state = State::new(DEFAULT_METRICS);
-        for i in 0..low_watermark {
-            let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
-            insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
-        }
-        let ip: IpAddr = "192.168.1.1".parse().unwrap();
-        insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
-        let addr = "192.168.1.1:8080".parse().unwrap();
-        let action = filter.apply(&state, addr, Duration::from_secs(1), true);
-        assert_eq!(action, FilterAction::Pass);
-    }
-
-    #[test]
-    fn test_combined_rate_limit_and_watermark() {
+    fn test_verified_rate_limit_remains_available_after_unverified_limit() {
         let handshake_rate_limit = 5;
-        let low_watermark = 5;
         let mut filter = Filter::new(
             DEFAULT_METRICS,
             handshake_rate_limit,
             handshake_rate_limit,
             Duration::from_secs(60),
             Duration::from_secs(60),
-            1000,
-            10,
-            low_watermark,
-            10,
+            1_000,
+            100,
         );
-        let mut state = State::new(DEFAULT_METRICS);
-        for i in 0..low_watermark {
-            let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
-            insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
-        }
+        let state = State::new(DEFAULT_METRICS);
         let addr = "127.0.0.1:8080".parse().unwrap();
         for _ in 0..handshake_rate_limit {
-            filter.apply(&state, addr, Duration::from_secs(1), false);
+            filter.apply(&state, addr, Duration::ZERO, false);
         }
-        let action = filter.apply(&state, addr, Duration::from_secs(1), false);
-        assert_eq!(action, FilterAction::SendCookie);
+        assert_eq!(
+            filter.apply(&state, addr, Duration::ZERO, false),
+            FilterAction::SendCookie
+        );
+        for i in 0..handshake_rate_limit {
+            let verified_addr: SocketAddr = format!("127.0.0.{}:8080", i + 2).parse().unwrap();
+            assert_eq!(
+                filter.apply(&state, verified_addr, Duration::from_secs(61), true,),
+                FilterAction::Pass
+            );
+        }
+        assert_eq!(
+            filter.apply(
+                &state,
+                "127.0.0.3:8080".parse().unwrap(),
+                Duration::from_secs(61),
+                true,
+            ),
+            FilterAction::Drop
+        );
     }
 
     #[test]
-    fn test_lru_cache_eviction() {
-        let low_watermark = 5;
+    fn test_ip_rate_limit_only_applies_to_verified_requests() {
         let mut filter = Filter::new(
             DEFAULT_METRICS,
             100,
             100,
             Duration::from_secs(60),
             Duration::from_secs(5),
-            2,
-            10,
-            low_watermark,
-            10,
+            1_000,
+            100,
         );
-        let mut state = State::new(DEFAULT_METRICS);
-        for i in 0..low_watermark {
-            let ip: IpAddr = format!("10.0.0.{}", i).parse().unwrap();
-            insert_test_initiator_session(&mut state, SocketAddr::new(ip, 51820));
-        }
-        let addr1 = "192.168.1.1:8080".parse().unwrap();
-        let addr2 = "192.168.1.2:8080".parse().unwrap();
-        let addr3 = "192.168.1.3:8080".parse().unwrap();
-        filter.apply(&state, addr1, Duration::from_secs(0), true);
-        filter.apply(&state, addr2, Duration::from_secs(1), true);
-        filter.apply(&state, addr3, Duration::from_secs(2), true);
-        let action = filter.apply(&state, addr1, Duration::from_secs(3), true);
-        assert_eq!(action, FilterAction::Pass);
+        let state = State::new(DEFAULT_METRICS);
+        let addr = "127.0.0.1:8080".parse().unwrap();
+
+        assert_eq!(
+            filter.apply(&state, addr, Duration::ZERO, false),
+            FilterAction::Pass
+        );
+        assert_eq!(
+            filter.apply(&state, addr, Duration::from_secs(1), false),
+            FilterAction::Pass
+        );
+        assert_eq!(
+            filter.apply(&state, addr, Duration::from_secs(2), true),
+            FilterAction::Pass
+        );
+        assert_eq!(
+            filter.apply(&state, addr, Duration::from_secs(3), true),
+            FilterAction::Drop
+        );
+    }
+
+    #[test]
+    fn test_drop_does_not_increment_verified_counter() {
+        let mut filter = Filter::new(
+            DEFAULT_METRICS,
+            100,
+            2,
+            Duration::from_secs(60),
+            Duration::from_secs(10),
+            1_000,
+            100,
+        );
+        let state = State::new(DEFAULT_METRICS);
+
+        assert_eq!(
+            filter.apply(
+                &state,
+                "127.0.0.1:8080".parse().unwrap(),
+                Duration::ZERO,
+                true,
+            ),
+            FilterAction::Pass
+        );
+        assert_eq!(
+            filter.apply(
+                &state,
+                "127.0.0.1:8080".parse().unwrap(),
+                Duration::from_secs(1),
+                true,
+            ),
+            FilterAction::Drop
+        );
+        assert_eq!(filter.cookie_verified_counter, 1);
+        assert_eq!(
+            filter.apply(
+                &state,
+                "127.0.0.2:8080".parse().unwrap(),
+                Duration::from_secs(2),
+                true,
+            ),
+            FilterAction::Pass
+        );
+        assert_eq!(
+            filter.apply(
+                &state,
+                "127.0.0.3:8080".parse().unwrap(),
+                Duration::from_secs(3),
+                true,
+            ),
+            FilterAction::Drop
+        );
+        assert_eq!(filter.cookie_verified_counter, 2);
+    }
+
+    #[test]
+    fn test_send_cookie_does_not_increment_unverified_counter() {
+        let mut filter = Filter::new(
+            DEFAULT_METRICS,
+            1,
+            100,
+            Duration::from_secs(60),
+            Duration::from_secs(10),
+            1_000,
+            100,
+        );
+        let state = State::new(DEFAULT_METRICS);
+        let addr = "127.0.0.1:8080".parse().unwrap();
+
+        assert_eq!(
+            filter.apply(&state, addr, Duration::ZERO, false),
+            FilterAction::Pass
+        );
+        assert_eq!(filter.cookie_unverified_counter, 1);
+        assert_eq!(
+            filter.apply(&state, addr, Duration::from_secs(1), false),
+            FilterAction::SendCookie
+        );
+        assert_eq!(filter.cookie_unverified_counter, 1);
+        assert_eq!(
+            filter.apply(&state, addr, Duration::from_secs(2), false),
+            FilterAction::SendCookie
+        );
+        assert_eq!(filter.cookie_unverified_counter, 1);
+    }
+
+    #[test]
+    fn test_ip_rate_limit_check_does_not_refresh_lru_recency() {
+        let mut filter = Filter::new(
+            DEFAULT_METRICS,
+            100,
+            100,
+            Duration::from_secs(60),
+            Duration::from_secs(30),
+            2,
+            100,
+        );
+        let state = State::new(DEFAULT_METRICS);
+
+        let addr1: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+        let addr2: SocketAddr = "127.0.0.2:8080".parse().unwrap();
+        let addr3: SocketAddr = "127.0.0.3:8080".parse().unwrap();
+
+        assert_eq!(
+            filter.apply(&state, addr1, Duration::ZERO, true),
+            FilterAction::Pass
+        );
+        assert_eq!(
+            filter.apply(&state, addr2, Duration::from_secs(20), true),
+            FilterAction::Pass
+        );
+        assert_eq!(
+            filter.apply(&state, addr1, Duration::from_secs(25), true),
+            FilterAction::Drop
+        );
+        assert_eq!(
+            filter.apply(&state, addr3, Duration::from_secs(40), true),
+            FilterAction::Pass
+        );
+        assert_eq!(
+            filter.apply(&state, addr2, Duration::from_secs(41), true),
+            FilterAction::Drop
+        );
     }
 }

--- a/monad-wireauth/src/metrics.rs
+++ b/monad-wireauth/src/metrics.rs
@@ -252,7 +252,7 @@ macro_rules! define_metric_names {
             ),
             state_ip_session_counts_size: &monad_executor::MetricDef::new(
                 concat!("monad.wireauth.", $transport, ".state.ip_session_counts_size"),
-                "tracks session count per ip for rate limiting",
+                "tracks session count per ip",
             ),
 
             filter_pass: &monad_executor::MetricDef::new(
@@ -261,7 +261,7 @@ macro_rules! define_metric_names {
             ),
             filter_send_cookie: &monad_executor::MetricDef::new(
                 concat!("monad.wireauth.", $transport, ".filter.send_cookie"),
-                "cookie challenges sent (between low and high watermark)",
+                "cookie challenges sent due to the unverified handshake rate limit",
             ),
             filter_drop: &monad_executor::MetricDef::new(
                 concat!("monad.wireauth.", $transport, ".filter.drop"),

--- a/monad-wireauth/src/state.rs
+++ b/monad-wireauth/src/state.rs
@@ -675,6 +675,7 @@ impl State {
         self.total_sessions
     }
 
+    #[cfg(test)]
     pub fn ip_session_count(&self, ip: &IpAddr) -> usize {
         self.ip_session_counts.get(ip).copied().unwrap_or(0)
     }

--- a/monad-wireauth/tests/tests.rs
+++ b/monad-wireauth/tests/tests.rs
@@ -224,11 +224,10 @@ fn test_encrypt_by_pubkey_and_socket() {
 #[test]
 fn test_cookie_reply_on_init() {
     init_tracing();
-    // 1. create managers with low_watermark_sessions=0 to trigger cookie immediate cookie reply under load
+    // 1. create managers with zero unverified budget to trigger an immediate cookie reply
     let config = Config {
-        handshake_cookie_unverified_rate_limit: 10,
+        handshake_cookie_unverified_rate_limit: 0,
         handshake_cookie_verified_rate_limit: 10,
-        low_watermark_sessions: 0,
         session_timeout_jitter: Duration::ZERO, // to avoid randomness in tests
         ..Config::default()
     };
@@ -247,7 +246,7 @@ fn test_cookie_reply_on_init() {
     let peer1_addr: SocketAddr = "192.0.0.1:8001".parse().unwrap();
     let peer2_addr: SocketAddr = "192.0.0.2:8002".parse().unwrap();
 
-    // 2. peer1 initiates again - peer2 is now at low_watermark, sends cookie reply
+    // 2. peer1 initiates again and peer2 immediately sends a cookie reply
     peer1
         .connect(public_key2, peer2_addr, DEFAULT_RETRY_ATTEMPTS)
         .unwrap();
@@ -368,7 +367,6 @@ fn test_too_many_accepted_sessions() {
     init_tracing();
     // 1. create responder with max 5 accepted sessions
     let config = Config {
-        low_watermark_sessions: 5,
         high_watermark_sessions: 5,
         ..Default::default()
     };


### PR DESCRIPTION
Previously, one IP with a valid cookie could repeatedly hit the per-IP limiter, but those rejected requests still consumed the global verified budget. Once exhausted:

  - Other participants’ valid cookie-bearing handshakes were dropped.
  - Participants without cookies were dropped instead of receiving cookie challenges.

The PR fixes this by counting only requests that actually pass the filter and by issuing cookies independently of the verified budget.