### PR TITLE
monad-wireauth: split pending and transport limits

### DIFF
--- a/monad-wireauth/README.md
+++ b/monad-wireauth/README.md
@@ -22,17 +22,20 @@ session management layer:
 
 high-level api with dos protection:
 
-the filter operates using two global handshake rate limits plus a hard session cap:
+the filter operates using two global handshake rate limits plus transport and pending session caps:
 
 | condition | action |
 |-----------|--------|
 | cookie invalid and handshakes >= `handshake_cookie_unverified_rate_limit` | send cookie reply |
 | cookie valid and handshakes >= `handshake_cookie_verified_rate_limit` | drop request |
 | cookie valid and last verified request from the same ip is within `ip_rate_limit_window` | drop request |
-| sessions >= `high_watermark_sessions` | drop request |
+| transport sessions >= `total_transport_sessions` | drop request |
+| pending sessions >= `total_pending_sessions` | drop request |
 | otherwise | accept request |
 
-defaults: `high_watermark_sessions`=40,000, `handshake_cookie_unverified_rate_limit`=500/sec, `handshake_cookie_verified_rate_limit`=1,000/sec, `ip_rate_limit_window`=10s, `ip_history_capacity`=1,000,000, `connect_rate_limit`=300/sec
+defaults: `total_transport_sessions`=40,000, `total_pending_sessions`=20,000, `max_sessions_per_ip`=4, `pending_session_timeout`=1s, `handshake_cookie_unverified_rate_limit`=500/sec, `handshake_cookie_verified_rate_limit`=1,000/sec, `ip_rate_limit_window`=10s, `ip_history_capacity`=1,000,000, `connect_rate_limit`=300/sec
+
+the `total_transport_sessions` watermark only counts established transport sessions. the pending-session limit applies to both initiated and accepted handshakes. the per-ip session cap is checked when a handshake is about to become an established transport session, so pending handshakes do not consume that budget.
 
 these defaults are per instance. we expect to run more than one wireauth instance, so the per-instance handshake and session limits are intentionally lower and aggregate capacity should come from running multiple instances.
 
@@ -152,7 +155,8 @@ session_decrypt         time:   [166.11 ns 168.75 ns 171.20 ns]
 
 | parameter | type | default | description |
 |-----------|------|---------|-------------|
-| `session_timeout` | Duration | 10s | idle time before session expires (reset on any packet exchange) |
+| `session_timeout` | Duration | 10s | idle time before an established session expires (reset on any packet exchange) |
+| `pending_session_timeout` | Duration | 1s | time to wait for a handshake reply or the first authenticated packet on a pending session |
 | `session_timeout_jitter` | Duration | 1s | randomization to prevent thundering herd on timeout |
 | `keepalive_interval` | Duration | 3s | send empty packet after this idle time to maintain session |
 | `keepalive_jitter` | Duration | 300ms | randomization to spread keepalive traffic |
@@ -167,9 +171,10 @@ session_decrypt         time:   [166.11 ns 168.75 ns 171.20 ns]
 | `cookie_refresh_duration` | Duration | 120s | cookie validity period (responder rotates cookie key) |
 | `ip_rate_limit_window` | Duration | 10s | time window for counting verified handshake requests per ip |
 | `ip_history_capacity` | usize | 1000000 | lru cache size for tracking recent verified handshake requests per ip |
-| `high_watermark_sessions` | usize | 40000 | at this threshold, drop all incoming handshake requests |
+| `total_transport_sessions` | usize | 40000 | at this threshold of established transport sessions, drop all incoming handshake requests |
+| `total_pending_sessions` | usize | 20000 | upper limit for concurrent pending sessions (initiated + accepted handshakes) |
+| `max_sessions_per_ip` | usize | 4 | limit concurrent established sessions from a single ip |
 | `psk` | [u8; 32] | zeros | optional pre-shared key mixed into handshake for additional auth |
-| `max_initiated_sessions` | usize | 1000 | max concurrent initiated sessions (handshakes in progress) |
 | `max_buffered_bytes_per_session` | usize | 131072 | max bytes of buffered messages per initiated session (128KB) |
 | `gc_idle_timeout` | Duration | 120s | idle time without useful data before session is garbage collected (keepalives don't reset) |
 | `max_expired_timers_per_tick` | usize | 10000 | cap expired timers processed per `API::tick` |

--- a/monad-wireauth/src/api.rs
+++ b/monad-wireauth/src/api.rs
@@ -81,7 +81,8 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
             config.handshake_rate_reset_interval,
             config.ip_rate_limit_window,
             config.ip_history_capacity,
-            config.high_watermark_sessions,
+            config.total_transport_sessions,
+            config.total_pending_sessions,
         );
         let local_serialized_public = CompressedPublicKey::from(&local_static_public);
         debug!(local_public_key=?local_serialized_public, "initialized manager");
@@ -306,11 +307,11 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         debug!(retry_attempts, "initiating connection");
 
         self.check_connect_rate_limit()?;
-        let initiated_count = self.state.initiated_sessions_count();
-        if initiated_count >= self.config.max_initiated_sessions {
+        let pending_count = self.state.pending_sessions_count();
+        if pending_count >= self.config.total_pending_sessions {
             self.metrics.gauge(self.metric_names.error_connect).inc();
-            return Err(Error::TooManyInitiatedSessions {
-                limit: self.config.max_initiated_sessions,
+            return Err(Error::TooManyPendingSessions {
+                limit: self.config.total_pending_sessions,
             });
         }
 
@@ -396,6 +397,22 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
             .insert_initiator(index, session, remote_static_key);
 
         Ok((index, timer, message))
+    }
+
+    fn ensure_established_ip_capacity(&mut self, remote_addr: SocketAddr) -> Result<()> {
+        if self.state.established_ip_session_count(&remote_addr.ip())
+            < self.config.max_sessions_per_ip
+        {
+            return Ok(());
+        }
+
+        self.metrics
+            .gauge(self.metric_names.error_session_exhausted)
+            .inc();
+        Err(Error::TooManyEstablishedSessionsForIp {
+            ip: remote_addr.ip(),
+            limit: self.config.max_sessions_per_ip,
+        })
     }
 
     fn is_under_load(
@@ -622,9 +639,27 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
             // to prove private key ownership. We implement this by storing the
             // responder separately until it has received that packet.
             let duration_since_start = self.context.duration_since_start();
-            match responder.decrypt(&self.config, duration_since_start, data_packet) {
-                Ok((_timer, plaintext)) => {
-                    let remote_public_key = responder.transport.remote_public_key;
+            let decrypt_result = responder
+                .decrypt(&self.config, duration_since_start, data_packet)
+                .map(|(_timer, plaintext)| {
+                    (
+                        plaintext,
+                        responder.transport.remote_public_key,
+                        responder.transport.remote_addr,
+                    )
+                });
+            match decrypt_result {
+                Ok((plaintext, remote_public_key, responder_remote_addr)) => {
+                    if let Err(err) = self.ensure_established_ip_capacity(responder_remote_addr) {
+                        self.metrics.gauge(self.metric_names.error_decrypt).inc();
+                        self.state.terminate_session(
+                            receiver_index,
+                            &remote_public_key,
+                            responder_remote_addr,
+                        );
+                        return Err(err);
+                    }
+
                     // unwrap() is safe as we have &mut and it was accessed right before this line
                     let responder = self.state.remove_responder(&receiver_index).unwrap();
                     let (transport, establish_timer) =
@@ -676,35 +711,45 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
 
         let receiver_session_index = response.receiver_index.into();
 
-        let initiator = self
-            .state
-            .get_initiator_mut(&receiver_session_index)
-            .ok_or_else(|| {
-                self.metrics
-                    .gauge(self.metric_names.error_session_index_not_found)
-                    .inc();
-                Error::InvalidReceiverIndex {
-                    index: receiver_session_index,
-                }
-            })?;
-        let expected_remote_addr = initiator.remote_addr;
-        if remote_addr != expected_remote_addr {
-            self.metrics
-                .gauge(self.metric_names.error_handshake_response_validation)
-                .inc();
-            return Err(Error::HandshakeResponseAddressMismatch {
-                expected: expected_remote_addr,
-                actual: remote_addr,
-            });
-        }
-
-        let validated_response = initiator
-            .validate_response(&self.config, self.local_static_key.as_ref(), response)
-            .inspect_err(|_| {
+        let (remote_public_key, validated_response) = {
+            let initiator = self
+                .state
+                .get_initiator_mut(&receiver_session_index)
+                .ok_or_else(|| {
+                    self.metrics
+                        .gauge(self.metric_names.error_session_index_not_found)
+                        .inc();
+                    Error::InvalidReceiverIndex {
+                        index: receiver_session_index,
+                    }
+                })?;
+            let expected_remote_addr = initiator.remote_addr;
+            if remote_addr != expected_remote_addr {
                 self.metrics
                     .gauge(self.metric_names.error_handshake_response_validation)
                     .inc();
-            })?;
+                return Err(Error::HandshakeResponseAddressMismatch {
+                    expected: expected_remote_addr,
+                    actual: remote_addr,
+                });
+            }
+
+            let remote_public_key = initiator.remote_public_key;
+            let validated_response = initiator
+                .validate_response(&self.config, self.local_static_key.as_ref(), response)
+                .inspect_err(|_| {
+                    self.metrics
+                        .gauge(self.metric_names.error_handshake_response_validation)
+                        .inc();
+                })?;
+            (remote_public_key, validated_response)
+        };
+
+        if let Err(err) = self.ensure_established_ip_capacity(remote_addr) {
+            self.state
+                .terminate_session(receiver_session_index, &remote_public_key, remote_addr);
+            return Err(err);
+        }
 
         // Code should not be fallible after this point
         let initiator = self

--- a/monad-wireauth/src/config/mod.rs
+++ b/monad-wireauth/src/config/mod.rs
@@ -22,8 +22,10 @@ pub const DEFAULT_RETRY_ATTEMPTS: u64 = 3;
 
 #[derive(Clone)]
 pub struct Config {
-    /// idle time before session expires (reset on any packet exchange)
+    /// idle time before an established session expires (reset on any packet exchange)
     pub session_timeout: Duration,
+    /// time to wait for a handshake reply or the first authenticated packet on a pending session
+    pub pending_session_timeout: Duration,
     /// randomization to prevent thundering herd on timeout
     pub session_timeout_jitter: Duration,
     /// send empty packet after this idle time to maintain session
@@ -55,12 +57,14 @@ pub struct Config {
     pub ip_rate_limit_window: Duration,
     /// lru cache size for tracking recent cookie-valid handshake requests per ip
     pub ip_history_capacity: usize,
-    /// at this threshold, drop all incoming handshake requests
-    pub high_watermark_sessions: usize,
+    /// at this threshold of established transport sessions, drop all incoming handshake requests
+    pub total_transport_sessions: usize,
+    /// upper limit for concurrent pending sessions (initiated + accepted handshakes)
+    pub total_pending_sessions: usize,
+    /// limit concurrent established sessions from a single ip
+    pub max_sessions_per_ip: usize,
     /// optional pre-shared key mixed into handshake for additional auth
     pub psk: Zeroizing<[u8; 32]>,
-    /// max concurrent initiated sessions (handshakes in progress)
-    pub max_initiated_sessions: usize,
     /// max bytes of buffered messages per initiated session
     pub max_buffered_bytes_per_session: usize,
     /// idle time (without useful data) before session is garbage collected
@@ -73,6 +77,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             session_timeout: Duration::from_secs(10),
+            pending_session_timeout: Duration::from_secs(1),
             session_timeout_jitter: Duration::from_secs(1),
             keepalive_interval: Duration::from_secs(3),
             keepalive_jitter: Duration::from_millis(300),
@@ -87,9 +92,10 @@ impl Default for Config {
             cookie_refresh_duration: Duration::from_secs(120),
             ip_rate_limit_window: Duration::from_secs(10),
             ip_history_capacity: 1_000_000,
-            high_watermark_sessions: 40_000,
+            total_transport_sessions: 40_000,
+            total_pending_sessions: 20_000,
+            max_sessions_per_ip: 4,
             psk: Zeroizing::new([0u8; 32]),
-            max_initiated_sessions: 1000,
             max_buffered_bytes_per_session: 128 * 1024,
             gc_idle_timeout: Duration::from_secs(120),
             max_expired_timers_per_tick: 10_000,

--- a/monad-wireauth/src/error.rs
+++ b/monad-wireauth/src/error.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 
 use thiserror::Error as ThisError;
 
@@ -69,8 +69,11 @@ pub enum Error {
         interval: std::time::Duration,
     },
 
-    #[error("too many initiated sessions: limit is {limit}")]
-    TooManyInitiatedSessions { limit: usize },
+    #[error("too many pending sessions: limit is {limit}")]
+    TooManyPendingSessions { limit: usize },
+
+    #[error("too many established sessions for ip {ip}: limit is {limit}")]
+    TooManyEstablishedSessionsForIp { ip: IpAddr, limit: usize },
 
     #[error("buffer limit exceeded: {size} bytes exceeds limit of {limit} bytes")]
     BufferLimitExceeded { size: usize, limit: usize },

--- a/monad-wireauth/src/filter.rs
+++ b/monad-wireauth/src/filter.rs
@@ -45,7 +45,8 @@ pub struct Filter {
     handshake_rate_reset_interval: Duration,
     ip_request_history: LruCache<IpAddr, Duration>,
     ip_rate_limit_window: Duration,
-    high_watermark_sessions: usize,
+    total_transport_sessions: usize,
+    total_pending_sessions: usize,
     metrics: ExecutorMetrics,
     metric_names: &'static MetricNames,
 }
@@ -62,7 +63,8 @@ impl Filter {
         handshake_rate_reset_interval: Duration,
         ip_rate_limit_window: Duration,
         ip_history_capacity: usize,
-        high_watermark_sessions: usize,
+        total_transport_sessions: usize,
+        total_pending_sessions: usize,
     ) -> Self {
         Self {
             cookie_unverified_counter: 0,
@@ -73,7 +75,8 @@ impl Filter {
             handshake_rate_reset_interval,
             ip_request_history: LruCache::new(NonZeroUsize::new(ip_history_capacity).unwrap()),
             ip_rate_limit_window,
-            high_watermark_sessions,
+            total_transport_sessions,
+            total_pending_sessions,
             metrics: init_filter_executor_metrics(metric_names),
             metric_names,
         }
@@ -118,10 +121,12 @@ impl Filter {
         cookie_valid: bool,
     ) -> FilterAction {
         trace!(remote_addr = %remote_addr, cookie_valid = cookie_valid, "applying filter");
-        let total_sessions = state.total_sessions();
+        let transport_sessions = state.transport_sessions_count();
+        let pending_sessions = state.pending_sessions_count();
 
         let action = self
-            .check_high_watermark(total_sessions, remote_addr)
+            .check_total_transport_sessions(transport_sessions, remote_addr)
+            .or_else(|| self.check_pending_session_limit(pending_sessions, remote_addr))
             .unwrap_or_else(|| {
                 if cookie_valid {
                     self.check_verified_request(remote_addr, duration_since_start)
@@ -142,17 +147,33 @@ impl Filter {
         action
     }
 
-    fn check_high_watermark(
+    fn check_total_transport_sessions(
         &self,
-        total_sessions: usize,
+        transport_sessions: usize,
         remote_addr: SocketAddr,
     ) -> Option<FilterAction> {
-        (total_sessions >= self.high_watermark_sessions).then(|| {
+        (transport_sessions >= self.total_transport_sessions).then(|| {
             debug!(
                 remote_addr = %remote_addr,
-                sessions = total_sessions,
-                high_watermark = self.high_watermark_sessions,
-                "high load - rejecting new handshake"
+                transport_sessions,
+                total_transport_sessions = self.total_transport_sessions,
+                "too many established transport sessions - rejecting new handshake"
+            );
+            FilterAction::Drop
+        })
+    }
+
+    fn check_pending_session_limit(
+        &self,
+        pending_sessions: usize,
+        remote_addr: SocketAddr,
+    ) -> Option<FilterAction> {
+        (pending_sessions >= self.total_pending_sessions).then(|| {
+            debug!(
+                remote_addr = %remote_addr,
+                pending_sessions,
+                total_pending_sessions = self.total_pending_sessions,
+                "too many pending sessions - rejecting new handshake"
             );
             FilterAction::Drop
         })
@@ -221,7 +242,10 @@ impl Filter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{metrics::DEFAULT_METRICS, state::insert_test_initiator_session};
+    use crate::{
+        metrics::DEFAULT_METRICS,
+        state::{insert_test_initiator_session, insert_test_transport_session},
+    };
 
     fn default_filter() -> Filter {
         Filter::new(
@@ -231,6 +255,7 @@ mod tests {
             Duration::from_secs(60),
             Duration::from_secs(60),
             1_000,
+            100,
             100,
         )
     }
@@ -245,8 +270,8 @@ mod tests {
     }
 
     #[test]
-    fn test_high_watermark_drops() {
-        let high_watermark = 10;
+    fn test_total_transport_sessions_drops() {
+        let total_transport_sessions = 10;
         let mut filter = Filter::new(
             DEFAULT_METRICS,
             100,
@@ -254,10 +279,34 @@ mod tests {
             Duration::from_secs(60),
             Duration::from_secs(60),
             1_000,
-            high_watermark,
+            total_transport_sessions,
+            100,
         );
         let mut state = State::new(DEFAULT_METRICS);
-        for i in 0..high_watermark {
+        for i in 0..total_transport_sessions {
+            let addr: SocketAddr = format!("10.0.0.{}:51820", i).parse().unwrap();
+            insert_test_transport_session(&mut state, addr);
+        }
+        let addr = "127.0.0.1:8080".parse().unwrap();
+        let action = filter.apply(&state, addr, Duration::ZERO, false);
+        assert_eq!(action, FilterAction::Drop);
+    }
+
+    #[test]
+    fn test_pending_session_limit_drops() {
+        let total_pending_sessions = 10;
+        let mut filter = Filter::new(
+            DEFAULT_METRICS,
+            100,
+            100,
+            Duration::from_secs(60),
+            Duration::from_secs(60),
+            1_000,
+            100,
+            total_pending_sessions,
+        );
+        let mut state = State::new(DEFAULT_METRICS);
+        for i in 0..total_pending_sessions {
             let addr: SocketAddr = format!("10.0.0.{}:51820", i).parse().unwrap();
             insert_test_initiator_session(&mut state, addr);
         }
@@ -276,6 +325,7 @@ mod tests {
             Duration::from_secs(60),
             Duration::from_secs(60),
             1_000,
+            100,
             100,
         );
         let state = State::new(DEFAULT_METRICS);
@@ -300,6 +350,7 @@ mod tests {
             Duration::from_secs(60),
             Duration::from_secs(60),
             1_000,
+            100,
             100,
         );
         let state = State::new(DEFAULT_METRICS);
@@ -333,6 +384,7 @@ mod tests {
             Duration::from_secs(60),
             1_000,
             100,
+            100,
         );
         let state = State::new(DEFAULT_METRICS);
         for i in 0..verified_rate_limit {
@@ -358,6 +410,7 @@ mod tests {
             Duration::from_secs(60),
             Duration::from_secs(60),
             1_000,
+            100,
             100,
         );
         let state = State::new(DEFAULT_METRICS);
@@ -388,6 +441,7 @@ mod tests {
             Duration::from_secs(60),
             1_000,
             100,
+            100,
         );
         let state = State::new(DEFAULT_METRICS);
         let addr = "127.0.0.1:8080".parse().unwrap();
@@ -410,6 +464,7 @@ mod tests {
             Duration::from_secs(60),
             1_000,
             100,
+            100,
         );
         let state = State::new(DEFAULT_METRICS);
         let addr = "127.0.0.1:8080".parse().unwrap();
@@ -431,6 +486,7 @@ mod tests {
             Duration::from_secs(60),
             Duration::from_secs(60),
             1_000,
+            100,
             100,
         );
         let state = State::new(DEFAULT_METRICS);
@@ -470,6 +526,7 @@ mod tests {
             Duration::from_secs(5),
             1_000,
             100,
+            100,
         );
         let state = State::new(DEFAULT_METRICS);
         let addr = "127.0.0.1:8080".parse().unwrap();
@@ -501,6 +558,7 @@ mod tests {
             Duration::from_secs(60),
             Duration::from_secs(10),
             1_000,
+            100,
             100,
         );
         let state = State::new(DEFAULT_METRICS);
@@ -555,6 +613,7 @@ mod tests {
             Duration::from_secs(10),
             1_000,
             100,
+            100,
         );
         let state = State::new(DEFAULT_METRICS);
         let addr = "127.0.0.1:8080".parse().unwrap();
@@ -585,6 +644,7 @@ mod tests {
             Duration::from_secs(60),
             Duration::from_secs(30),
             2,
+            100,
             100,
         );
         let state = State::new(DEFAULT_METRICS);

--- a/monad-wireauth/src/session/initiator.rs
+++ b/monad-wireauth/src/session/initiator.rs
@@ -91,11 +91,9 @@ impl InitiatorState {
             buffered_bytes: 0,
         };
 
-        let timeout_with_jitter =
-            add_jitter(rng, config.session_timeout, config.session_timeout_jitter);
         session
             .common
-            .reset_session_timeout(duration_since_start, timeout_with_jitter);
+            .reset_session_timeout(duration_since_start, config.pending_session_timeout);
 
         let timer = session
             .common

--- a/monad-wireauth/src/session/responder.rs
+++ b/monad-wireauth/src/session/responder.rs
@@ -108,9 +108,7 @@ impl ResponderState {
         );
         common.last_handshake_mac1 = Some(response_mac1);
 
-        let timeout_with_jitter =
-            add_jitter(rng, config.session_timeout, config.session_timeout_jitter);
-        common.reset_session_timeout(duration_since_start, timeout_with_jitter);
+        common.reset_session_timeout(duration_since_start, config.pending_session_timeout);
 
         let timer = common
             .get_next_deadline()

--- a/monad-wireauth/src/state.rs
+++ b/monad-wireauth/src/state.rs
@@ -123,6 +123,7 @@ pub struct State {
     initiated_session_by_peer: HashMap<monad_secp::PubKey, SessionIndex>,
     accepted_sessions_by_peer: BTreeSet<(monad_secp::PubKey, SessionIndex)>,
     ip_session_counts: HashMap<IpAddr, usize>,
+    established_ip_session_counts: HashMap<IpAddr, usize>,
     total_sessions: usize,
     metrics: ExecutorMetrics,
     metric_names: &'static MetricNames,
@@ -141,6 +142,7 @@ impl State {
             initiated_session_by_peer: HashMap::new(),
             accepted_sessions_by_peer: BTreeSet::new(),
             ip_session_counts: HashMap::new(),
+            established_ip_session_counts: HashMap::new(),
             total_sessions: 0,
             metrics: init_state_executor_metrics(metric_names),
             metric_names,
@@ -348,6 +350,10 @@ impl State {
             }
         }
 
+        *self
+            .established_ip_session_counts
+            .entry(remote_addr.ip())
+            .or_insert(0) += 1;
         self.transport_sessions.insert(session_id, transport);
         self.metrics
             .gauge(self.metric_names.state_transport_sessions)
@@ -396,6 +402,16 @@ impl State {
             .set(self.allocated_indices.len() as u64);
 
         if let Some(transport) = transport {
+            if let Some(count) = self
+                .established_ip_session_counts
+                .get_mut(&remote_addr.ip())
+            {
+                *count = count.saturating_sub(1);
+                if *count == 0 {
+                    self.established_ip_session_counts.remove(&remote_addr.ip());
+                }
+            }
+
             if let Some(sessions) = self
                 .last_established_session_by_socket
                 .get_mut(&remote_addr)
@@ -671,17 +687,29 @@ impl State {
         terminated_addrs
     }
 
+    #[cfg(test)]
     pub fn total_sessions(&self) -> usize {
         self.total_sessions
+    }
+
+    pub(crate) fn pending_sessions_count(&self) -> usize {
+        self.initiating_sessions.len() + self.responding_sessions.len()
+    }
+
+    pub(crate) fn transport_sessions_count(&self) -> usize {
+        self.transport_sessions.len()
+    }
+
+    pub(crate) fn established_ip_session_count(&self, ip: &IpAddr) -> usize {
+        self.established_ip_session_counts
+            .get(ip)
+            .copied()
+            .unwrap_or(0)
     }
 
     #[cfg(test)]
     pub fn ip_session_count(&self, ip: &IpAddr) -> usize {
         self.ip_session_counts.get(ip).copied().unwrap_or(0)
-    }
-
-    pub fn initiated_sessions_count(&self) -> usize {
-        self.initiating_sessions.len()
     }
 }
 
@@ -698,7 +726,8 @@ pub(crate) fn insert_test_initiator_session(
     let remote_public_key = keypair.pubkey();
     let local_keypair = monad_secp::KeyPair::generate(&mut rng);
     let config = Config::default();
-    let local_index = SessionIndex::new(1);
+    let reservation = state.reserve_session_index().unwrap();
+    let local_index = reservation.index();
     let (initiator, _) = InitiatorState::new(
         &mut rng,
         std::time::SystemTime::now(),
@@ -711,7 +740,47 @@ pub(crate) fn insert_test_initiator_session(
         None,
         0,
     );
+    reservation.commit();
     state.insert_initiator(local_index, initiator, remote_public_key);
+    local_index
+}
+
+#[cfg(test)]
+pub(crate) fn insert_test_transport_session(
+    state: &mut State,
+    remote_addr: SocketAddr,
+) -> SessionIndex {
+    use secp256k1::rand::rng;
+
+    use crate::{
+        protocol::common::{CipherKey, HashOutput},
+        session::{SessionState, TransportState},
+    };
+
+    let mut rng = rng();
+    let keypair = monad_secp::KeyPair::generate(&mut rng);
+    let remote_public_key = keypair.pubkey();
+    let reservation = state.reserve_session_index().unwrap();
+    let local_index = reservation.index();
+    let hash1 = HashOutput([0u8; 32]);
+    let hash2 = HashOutput([1u8; 32]);
+    let common = SessionState::new(
+        remote_addr,
+        remote_public_key,
+        local_index,
+        Duration::ZERO,
+        0,
+        None,
+        true,
+    );
+    let transport = TransportState::new(
+        local_index,
+        CipherKey::from(&hash1),
+        CipherKey::from(&hash2),
+        common,
+    );
+    reservation.commit();
+    state.insert_transport(local_index, transport);
     local_index
 }
 

--- a/monad-wireauth/tests/tests.rs
+++ b/monad-wireauth/tests/tests.rs
@@ -148,13 +148,13 @@ fn test_retries() {
     let _init1 = collect::<HandshakeInitiation>(&mut peer1);
 
     // 3. advance time and tick - peer1 retries
-    peer1_ctx.advance_time(Duration::from_secs(11));
+    peer1_ctx.advance_time(Duration::from_secs(1));
     peer1.tick();
     // 4. peer1 sends second init - dropped
     let _init2 = collect::<HandshakeInitiation>(&mut peer1);
 
     // 5. advance time and tick - peer1 retries
-    peer1_ctx.advance_time(Duration::from_secs(11));
+    peer1_ctx.advance_time(Duration::from_secs(1));
     peer1.tick();
     // 6. peer1 sends third init - delivered to peer2
     let init3 = collect::<HandshakeInitiation>(&mut peer1);
@@ -231,7 +231,7 @@ fn test_cookie_reply_on_init() {
         session_timeout_jitter: Duration::ZERO, // to avoid randomness in tests
         ..Config::default()
     };
-    let session_timeout = config.session_timeout;
+    let pending_session_timeout = config.pending_session_timeout;
 
     let mut rng = rng();
     let keypair1 = monad_secp::KeyPair::generate(&mut rng);
@@ -258,7 +258,7 @@ fn test_cookie_reply_on_init() {
     dispatch(&mut peer1, &cookie, peer2_addr);
 
     // 4. advance time past session timeout, tick triggers retry with stored cookie
-    context1.advance_time(session_timeout);
+    context1.advance_time(pending_session_timeout);
     peer1.tick();
 
     // 5. peer1 sends init with valid mac2 (using stored cookie)
@@ -365,9 +365,9 @@ fn test_timestamp_replay() {
 #[test]
 fn test_too_many_accepted_sessions() {
     init_tracing();
-    // 1. create responder with max 5 accepted sessions
+    // 1. create responder with max 5 pending sessions
     let config = Config {
-        high_watermark_sessions: 5,
+        total_pending_sessions: 5,
         ..Default::default()
     };
 
@@ -403,7 +403,7 @@ fn test_too_many_accepted_sessions() {
         dispatch(&mut responder, &init, initiator_addr);
     }
 
-    // 3. verify responder only accepted 5 sessions (high_watermark_sessions limit)
+    // 3. verify responder only accepted 5 sessions (total_pending_sessions limit)
     let mut pkts = vec![];
     while let Some(pkt) = responder.next_packet() {
         pkts.push(pkt);
@@ -495,18 +495,18 @@ fn test_next_deadline() {
     assert!(session_deadline.is_some());
     let deadline_instant = session_deadline.unwrap();
     let max_expected_deadline =
-        peer1_ctx.convert_duration_since_start_to_deadline(Duration::from_secs(10));
+        peer1_ctx.convert_duration_since_start_to_deadline(config.pending_session_timeout);
     assert!(deadline_instant <= max_expected_deadline);
 
     // 3. advance time partially and verify deadline remains unchanged
-    peer1_ctx.advance_time(Duration::from_secs(5));
+    peer1_ctx.advance_time(Duration::from_millis(500));
 
     let deadline_after_time_advance = peer1.next_deadline();
     assert!(deadline_after_time_advance.is_some());
     assert_eq!(deadline_after_time_advance.unwrap(), deadline_instant);
 
     // 4. advance time past deadline and verify deadline is now in the past
-    peer1_ctx.advance_time(Duration::from_secs(20));
+    peer1_ctx.advance_time(Duration::from_secs(2));
 
     let deadline_in_past = peer1.next_deadline();
     assert!(deadline_in_past.is_some());
@@ -926,10 +926,10 @@ fn test_stale_handshake_response_does_not_poison_pending_initiator() {
 }
 
 #[test]
-fn test_max_initiated_sessions_limit() {
+fn test_total_pending_sessions_limit() {
     init_tracing();
     let config = Config {
-        max_initiated_sessions: 3,
+        total_pending_sessions: 3,
         ..Config::default()
     };
 
@@ -954,8 +954,163 @@ fn test_max_initiated_sessions_limit() {
     let err = result.unwrap_err();
     assert!(matches!(
         err,
-        monad_wireauth::Error::TooManyInitiatedSessions { limit: 3 }
+        monad_wireauth::Error::TooManyPendingSessions { limit: 3 }
     ));
+}
+
+#[test]
+fn test_max_established_sessions_per_ip_limit_on_initiator() {
+    init_tracing();
+
+    let mut rng = rng();
+    let initiator_keypair = monad_secp::KeyPair::generate(&mut rng);
+    let initiator_ctx = TestContext::new();
+    let mut initiator = API::new(
+        DEFAULT_METRICS,
+        Config {
+            max_sessions_per_ip: 1,
+            ..Config::default()
+        },
+        initiator_keypair,
+        initiator_ctx,
+    );
+
+    let responder1_keypair = monad_secp::KeyPair::generate(&mut rng);
+    let responder1_pubkey = responder1_keypair.pubkey();
+    let responder1_ctx = TestContext::new();
+    let mut responder1 = API::new(
+        DEFAULT_METRICS,
+        Config::default(),
+        responder1_keypair,
+        responder1_ctx,
+    );
+
+    let responder2_keypair = monad_secp::KeyPair::generate(&mut rng);
+    let responder2_pubkey = responder2_keypair.pubkey();
+    let responder2_ctx = TestContext::new();
+    let mut responder2 = API::new(
+        DEFAULT_METRICS,
+        Config::default(),
+        responder2_keypair,
+        responder2_ctx,
+    );
+
+    let initiator_addr: SocketAddr = "127.0.0.1:8001".parse().unwrap();
+    let responder1_addr: SocketAddr = "127.0.0.1:9001".parse().unwrap();
+    let responder2_addr: SocketAddr = "127.0.0.1:9002".parse().unwrap();
+
+    initiator
+        .connect(responder1_pubkey, responder1_addr, DEFAULT_RETRY_ATTEMPTS)
+        .unwrap();
+    let init1 = collect::<HandshakeInitiation>(&mut initiator);
+    dispatch(&mut responder1, &init1, initiator_addr);
+    let resp1 = collect::<HandshakeResponse>(&mut responder1);
+    dispatch(&mut initiator, &resp1, responder1_addr);
+    collect::<DataPacketHeader>(&mut initiator);
+
+    assert!(initiator.is_connected_public_key(&responder1_pubkey));
+
+    initiator
+        .connect(responder2_pubkey, responder2_addr, DEFAULT_RETRY_ATTEMPTS)
+        .unwrap();
+    let init2 = collect::<HandshakeInitiation>(&mut initiator);
+    dispatch(&mut responder2, &init2, initiator_addr);
+    let mut resp2 = collect::<HandshakeResponse>(&mut responder2);
+    let parsed_packet = Packet::try_from(&mut resp2[..]).unwrap();
+    let err = match parsed_packet {
+        Packet::Control(control) => initiator
+            .dispatch_control(control, responder2_addr)
+            .unwrap_err(),
+        Packet::Data(_) => panic!("expected control packet"),
+    };
+
+    assert!(matches!(
+        err,
+        monad_wireauth::Error::TooManyEstablishedSessionsForIp { ip, limit: 1 }
+        if ip == responder2_addr.ip()
+    ));
+    assert!(!initiator.is_connected_public_key(&responder2_pubkey));
+}
+
+#[test]
+fn test_max_established_sessions_per_ip_limit_on_responder() {
+    init_tracing();
+
+    let mut rng = rng();
+    let responder_keypair = monad_secp::KeyPair::generate(&mut rng);
+    let responder_pubkey = responder_keypair.pubkey();
+    let responder_ctx = TestContext::new();
+    let mut responder = API::new(
+        DEFAULT_METRICS,
+        Config {
+            max_sessions_per_ip: 1,
+            ..Config::default()
+        },
+        responder_keypair,
+        responder_ctx,
+    );
+
+    let initiator1_keypair = monad_secp::KeyPair::generate(&mut rng);
+    let initiator1_pubkey = initiator1_keypair.pubkey();
+    let initiator1_ctx = TestContext::new();
+    let mut initiator1 = API::new(
+        DEFAULT_METRICS,
+        Config::default(),
+        initiator1_keypair,
+        initiator1_ctx,
+    );
+
+    let initiator2_keypair = monad_secp::KeyPair::generate(&mut rng);
+    let initiator2_pubkey = initiator2_keypair.pubkey();
+    let initiator2_ctx = TestContext::new();
+    let mut initiator2 = API::new(
+        DEFAULT_METRICS,
+        Config::default(),
+        initiator2_keypair,
+        initiator2_ctx,
+    );
+
+    let responder_addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
+    let initiator1_addr: SocketAddr = "127.0.0.1:8001".parse().unwrap();
+    let initiator2_addr: SocketAddr = "127.0.0.1:8002".parse().unwrap();
+
+    initiator1
+        .connect(responder_pubkey, responder_addr, DEFAULT_RETRY_ATTEMPTS)
+        .unwrap();
+    let init1 = collect::<HandshakeInitiation>(&mut initiator1);
+    dispatch(&mut responder, &init1, initiator1_addr);
+    let resp1 = collect::<HandshakeResponse>(&mut responder);
+    dispatch(&mut initiator1, &resp1, responder_addr);
+    let (_, confirm1) = initiator1.next_packet().unwrap();
+    dispatch(&mut responder, &confirm1, initiator1_addr);
+
+    assert!(responder.is_connected_public_key(&initiator1_pubkey));
+
+    initiator2
+        .connect(responder_pubkey, responder_addr, DEFAULT_RETRY_ATTEMPTS)
+        .unwrap();
+    let init2 = collect::<HandshakeInitiation>(&mut initiator2);
+    dispatch(&mut responder, &init2, initiator2_addr);
+    let resp2 = collect::<HandshakeResponse>(&mut responder);
+    dispatch(&mut initiator2, &resp2, responder_addr);
+
+    let (_, confirm2) = initiator2.next_packet().unwrap();
+    let mut confirm2 = confirm2.to_vec();
+    let parsed_packet = Packet::try_from(&mut confirm2[..]).unwrap();
+    let err = match parsed_packet {
+        Packet::Control(control) => match responder.dispatch_control(control, initiator2_addr) {
+            Ok(_) => panic!("expected established-session-per-ip limit error"),
+            Err(err) => err,
+        },
+        Packet::Data(_) => panic!("expected keepalive control packet"),
+    };
+
+    assert!(matches!(
+        err,
+        monad_wireauth::Error::TooManyEstablishedSessionsForIp { ip, limit: 1 }
+        if ip == initiator2_addr.ip()
+    ));
+    assert!(!responder.is_connected_public_key(&initiator2_pubkey));
 }
 
 #[test]

--- a/monad-wireauth/tests/two_peer_model.rs
+++ b/monad-wireauth/tests/two_peer_model.rs
@@ -43,7 +43,9 @@ mod tests {
 
     fn test_config() -> Config {
         Config {
+            max_sessions_per_ip: usize::MAX,
             rekey_interval: Duration::from_secs(REKEY_INTERVAL_SECS),
+            pending_session_timeout: Duration::from_secs(SESSION_TIMEOUT_SECS),
             session_timeout: Duration::from_secs(SESSION_TIMEOUT_SECS),
             ..Config::default()
         }


### PR DESCRIPTION
Before filter allowed all requests while below low watermark. It effectively disabled ip limit while node had bellow 10k sessions, so one ip could accumulate that many within large interval of time. 

In this change we split pending (accepted/sent) and established. For established the total ip limit is enforced since the start, with low watermark threshold being removed.

For accepted sessions we control admission based on rates, while load is low we don't enforce ip checks, with higher load we allow only 1 request from ip in 10s. Higher load is achievable only during intentional dos.