### PR TITLE
monad-state: limit forwarded txs per message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5572,6 +5572,7 @@ dependencies = [
  "chrono",
  "criterion",
  "futures",
+ "insta",
  "monad-blocksync",
  "monad-chain-config",
  "monad-consensus",
@@ -5584,6 +5585,7 @@ dependencies = [
  "monad-validator",
  "monad-wal",
  "serde",
+ "serde_json",
  "serde_with",
  "toml",
 ]
@@ -6372,6 +6374,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
+ "serde_with",
  "test-case",
  "zerocopy",
 ]

--- a/monad-eth-txpool-executor/src/client.rs
+++ b/monad-eth-txpool-executor/src/client.rs
@@ -33,7 +33,7 @@ use monad_peer_score::{
     StdClock,
 };
 use monad_secp::ExtractEthAddress;
-use monad_types::NodeId;
+use monad_types::{LimitedVec, NodeId, MAX_FORWARDED_TXS_PER_MESSAGE};
 use monad_validator::signature_collection::SignatureCollection;
 
 use crate::{forward::INGRESS_CHUNK_MAX_SIZE, TxPoolExecutorCommand, TxPoolExecutorEvent};
@@ -43,7 +43,7 @@ where
     SCT: SignatureCollection,
 {
     pub sender: NodeId<SCT::NodeIdPubKey>,
-    pub txs: Vec<Bytes>,
+    pub txs: LimitedVec<Bytes, MAX_FORWARDED_TXS_PER_MESSAGE>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -348,7 +348,7 @@ where
             };
             batch.push(ForwardedTxs {
                 sender,
-                txs: vec![tx],
+                txs: vec![tx].into(),
             });
         }
 

--- a/monad-eth-txpool-executor/src/forward.rs
+++ b/monad-eth-txpool-executor/src/forward.rs
@@ -31,6 +31,7 @@ use monad_crypto::certificate_signature::{
 use monad_eth_txpool::{max_eip2718_encoded_length, EthTxPool};
 use monad_eth_types::ExtractEthAddress;
 use monad_execution_state_read::ExecutionStateRead;
+use monad_types::{LimitedVec, MAX_FORWARDED_TXS_PER_MESSAGE};
 use monad_validator::signature_collection::SignatureCollection;
 use pin_project::pin_project;
 use tracing::error;
@@ -94,7 +95,7 @@ impl<S> EthTxPoolForwardingManager<S> {
         self: Pin<&mut Self>,
         execution_params: &ExecutionChainParams,
         cx: &mut Context<'_>,
-    ) -> Poll<Vec<Bytes>> {
+    ) -> Poll<LimitedVec<Bytes, MAX_FORWARDED_TXS_PER_MESSAGE>> {
         let EthTxPoolForwardingManagerProjected {
             egress,
             egress_waker,
@@ -113,16 +114,24 @@ impl<S> EthTxPoolForwardingManager<S> {
 
             let egress_max_size_bytes = egress_max_size_bytes(execution_params);
 
-            let mut txs = Vec::default();
+            let mut txs = LimitedVec::default();
             let mut total_bytes = 0;
 
             while let Some(tx) = egress.front() {
                 let new_total_bytes = total_bytes + tx.len();
 
                 if new_total_bytes <= egress_max_size_bytes {
-                    txs.push(egress.pop_front().unwrap());
-                    total_bytes = new_total_bytes;
-                    continue;
+                    let tx = egress.pop_front().unwrap();
+                    match txs.try_push(tx) {
+                        Ok(()) => {
+                            total_bytes = new_total_bytes;
+                            continue;
+                        }
+                        Err(err) => {
+                            egress.push_front(err.rejected);
+                            break;
+                        }
+                    }
                 }
 
                 if tx.len() > egress_max_size_bytes {

--- a/monad-eth-txpool-executor/src/lib.rs
+++ b/monad-eth-txpool-executor/src/lib.rs
@@ -52,7 +52,10 @@ use monad_execution_state_read::ExecutionStateRead;
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_peer_score::{ema, StdClock};
 use monad_secp::RecoverableAddress;
-use monad_types::{DropTimer, Epoch, ExecutionProtocol, NodeId, Round, SeqNum};
+use monad_types::{
+    DropTimer, Epoch, ExecutionProtocol, LimitedVec, NodeId, Round, SeqNum,
+    MAX_FORWARDED_TXS_PER_MESSAGE,
+};
 use monad_validator::signature_collection::SignatureCollection;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use tokio::{sync::mpsc, time::Instant};
@@ -147,7 +150,7 @@ where
         sender_gas: BTreeMap<NodeId<SCT::NodeIdPubKey>, u64>,
     },
 
-    ForwardTxs(Vec<Bytes>),
+    ForwardTxs(LimitedVec<Bytes, MAX_FORWARDED_TXS_PER_MESSAGE>),
 }
 
 pub struct EthTxPoolExecutor<ST, SCT, ESRT, CCT, CRT, TIS>
@@ -1075,7 +1078,7 @@ mod test {
 
         client.exec(vec![TxPoolCommand::InsertForwardedTxs {
             sender: node_id::<SignatureType>(),
-            txs: make_forwarded_txs(0, 4),
+            txs: make_forwarded_txs(0, 4).into(),
         }]);
 
         let metrics = client.metrics().into_inner();
@@ -1166,7 +1169,7 @@ mod test {
                 command_tx
                     .send(vec![TxPoolCommand::InsertForwardedTxs {
                         sender: node_id::<SignatureType>(),
-                        txs: expected_txs.clone(),
+                        txs: expected_txs.clone().into(),
                     }])
                     .expect("forwarded txs are queued");
                 tokio::task::yield_now().await;
@@ -1204,7 +1207,7 @@ mod test {
                 command_tx
                     .send(vec![TxPoolCommand::InsertForwardedTxs {
                         sender: node_id::<SignatureType>(),
-                        txs: expected_txs_after_second_batch.clone(),
+                        txs: expected_txs_after_second_batch.clone().into(),
                     }])
                     .expect("forwarded txs are queued");
                 tokio::task::yield_now().await;

--- a/monad-executor-glue/Cargo.toml
+++ b/monad-executor-glue/Cargo.toml
@@ -29,8 +29,10 @@ serde_with = { workspace = true, features = ["hex"] }
 
 [dev-dependencies]
 criterion = { workspace = true }
+insta = { workspace = true }
 monad-eth-types = { workspace = true }
 monad-multi-sig = { workspace = true }
+serde_json = { workspace = true }
 toml = { workspace = true }
 
 [[bench]]

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -51,7 +51,7 @@ use monad_crypto::certificate_signature::{
 use monad_execution_state_read::ExecutionStateRead;
 use monad_types::{
     deserialize_pubkey, serialize_pubkey, Epoch, ExecutionProtocol, LimitedVec, NodeId, Round,
-    RouterTarget, SeqNum, Stake, UdpPriority,
+    RouterTarget, SeqNum, Stake, UdpPriority, MAX_FORWARDED_TXS_PER_MESSAGE,
 };
 use monad_validator::signature_collection::SignatureCollection;
 use serde::{Deserialize, Serialize};
@@ -664,7 +664,7 @@ where
 
     InsertForwardedTxs {
         sender: NodeId<SCT::NodeIdPubKey>,
-        txs: Vec<Bytes>,
+        txs: LimitedVec<Bytes, MAX_FORWARDED_TXS_PER_MESSAGE>,
     },
 
     EnterRound {
@@ -1248,12 +1248,15 @@ where
     /// Txs that are incoming via other nodes
     ForwardedTxs {
         sender: NodeId<SCT::NodeIdPubKey>,
-        #[serde_as(as = "Vec<serde_with::hex::Hex>")]
-        txs: Vec<Bytes>,
+        #[serde_as(as = "LimitedVec<serde_with::hex::Hex, MAX_FORWARDED_TXS_PER_MESSAGE>")]
+        txs: LimitedVec<Bytes, MAX_FORWARDED_TXS_PER_MESSAGE>,
     },
 
     /// Txs that should be forwarded to upcoming leaders
-    ForwardTxs(#[serde_as(as = "Vec<serde_with::hex::Hex>")] Vec<Bytes>),
+    ForwardTxs(
+        #[serde_as(as = "LimitedVec<serde_with::hex::Hex, MAX_FORWARDED_TXS_PER_MESSAGE>")]
+        LimitedVec<Bytes, MAX_FORWARDED_TXS_PER_MESSAGE>,
+    ),
 }
 
 impl<ST, SCT, EPT> Encodable for MempoolEvent<ST, SCT, EPT>
@@ -1388,11 +1391,11 @@ where
             }
             2 => {
                 let sender = NodeId::<SCT::NodeIdPubKey>::decode(&mut payload)?;
-                let txs = Vec::<Bytes>::decode(&mut payload)?;
+                let txs = LimitedVec::<Bytes, MAX_FORWARDED_TXS_PER_MESSAGE>::decode(&mut payload)?;
                 Ok(Self::ForwardedTxs { sender, txs })
             }
             3 => {
-                let txs = Vec::<Bytes>::decode(&mut payload)?;
+                let txs = LimitedVec::<Bytes, MAX_FORWARDED_TXS_PER_MESSAGE>::decode(&mut payload)?;
                 Ok(Self::ForwardTxs(txs))
             }
             _ => Err(alloy_rlp::Error::Custom(
@@ -2469,6 +2472,7 @@ mod tests {
     use std::{net::Ipv4Addr, num::NonZeroU16};
 
     use alloy_rlp::{encode_list, Encodable};
+    use bytes::Bytes;
     use monad_blocksync::messages::message::BlockSyncRequestMessage;
     use monad_consensus_types::block::BlockRange;
     use monad_crypto::{
@@ -2477,7 +2481,9 @@ mod tests {
     };
     use monad_eth_types::EthExecutionProtocol;
     use monad_multi_sig::MultiSig;
-    use monad_types::{NodeId, SeqNum, GENESIS_BLOCK_ID};
+    use monad_types::{
+        LimitedVec, NodeId, SeqNum, GENESIS_BLOCK_ID, MAX_FORWARDED_TXS_PER_MESSAGE,
+    };
     use monad_wal::wal::WALLog;
 
     use crate::{
@@ -2931,7 +2937,7 @@ tcp_port = 8003"#,
             TestSignature,
             TestSignatureCollection,
             TestExecutionProtocol,
-        >::MempoolEvent(MempoolEvent::ForwardTxs(Vec::new()));
+        >::MempoolEvent(MempoolEvent::ForwardTxs(LimitedVec::default()));
         assert!(!mempool_event.is_wal_logged());
 
         let timestamp_event = MonadEvent::<
@@ -2960,5 +2966,19 @@ tcp_port = 8003"#,
             StateSyncNetworkMessage::NotWhitelisted,
         ));
         assert!(!inbound_statesync.is_wal_logged());
+    }
+
+    #[test]
+    fn forwarded_tx_mempool_event_json_matches_original_snapshot() {
+        let txs: LimitedVec<Bytes, MAX_FORWARDED_TXS_PER_MESSAGE> =
+            vec![Bytes::from_static(&[0x12, 0x34]), Bytes::new()].into();
+        let event = MempoolEvent::<
+            TestSignature,
+            TestSignatureCollection,
+            TestExecutionProtocol,
+        >::ForwardTxs(txs);
+
+        let json = serde_json::to_string(&event).unwrap();
+        insta::assert_snapshot!("forwarded_tx_mempool_event_original_json", json);
     }
 }

--- a/monad-executor-glue/src/snapshots/monad_executor_glue__tests__forwarded_tx_mempool_event_original_json.snap
+++ b/monad-executor-glue/src/snapshots/monad_executor_glue__tests__forwarded_tx_mempool_event_original_json.snap
@@ -1,0 +1,5 @@
+---
+source: monad-executor-glue/src/lib.rs
+expression: json
+---
+{"ForwardTxs":["1234",""]}

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -62,8 +62,8 @@ use monad_executor_glue::{
     ValSetCommand, ValidatorEvent, WriteCommand,
 };
 use monad_types::{
-    Epoch, ExecutionProtocol, MonadVersion, NodeId, Round, RouterTarget, SeqNum, Stake,
-    GENESIS_BLOCK_ID, GENESIS_ROUND, GENESIS_SEQ_NUM,
+    Epoch, ExecutionProtocol, LimitedVec, MonadVersion, NodeId, Round, RouterTarget, SeqNum, Stake,
+    GENESIS_BLOCK_ID, GENESIS_ROUND, GENESIS_SEQ_NUM, MAX_FORWARDED_TXS_PER_MESSAGE,
 };
 use monad_validator::{
     epoch_manager::EpochManager,
@@ -574,7 +574,7 @@ where
     Consensus(Verified<ST, Validated<ConsensusMessage<ST, SCT, EPT>>>),
     BlockSyncRequest(BlockSyncRequestMessage),
     BlockSyncResponse(BlockSyncResponseMessage<ST, SCT, EPT>),
-    ForwardedTx(Vec<Bytes>),
+    ForwardedTx(LimitedVec<Bytes, MAX_FORWARDED_TXS_PER_MESSAGE>),
     StateSyncMessage(StateSyncNetworkMessage),
 }
 
@@ -674,7 +674,7 @@ where
     BlockSyncResponse(BlockSyncResponseMessage<ST, SCT, EPT>),
 
     /// Forwarded transactions
-    ForwardedTx(Vec<Bytes>),
+    ForwardedTx(LimitedVec<Bytes, MAX_FORWARDED_TXS_PER_MESSAGE>),
     /// State Sync msgs
     StateSyncMessage(StateSyncNetworkMessage),
 }
@@ -697,7 +697,9 @@ where
             ),
             2 => Self::BlockSyncRequest(BlockSyncRequestMessage::decode(&mut payload)?),
             3 => Self::BlockSyncResponse(BlockSyncResponseMessage::decode(&mut payload)?),
-            4 => Self::ForwardedTx(Vec::<Bytes>::decode(&mut payload)?),
+            4 => Self::ForwardedTx(LimitedVec::<Bytes, MAX_FORWARDED_TXS_PER_MESSAGE>::decode(
+                &mut payload,
+            )?),
             5 => Self::StateSyncMessage(StateSyncNetworkMessage::decode(&mut payload)?),
             _ => {
                 return Err(alloy_rlp::Error::Custom(
@@ -1663,6 +1665,7 @@ where
 
 #[cfg(test)]
 mod test {
+    use bytes::Bytes;
     use monad_bls::BlsSignatureCollection;
     use monad_consensus_types::{
         quorum_certificate::QuorumCertificate, validator_data::ValidatorSetData, voting::Vote,
@@ -1671,7 +1674,7 @@ mod test {
     use monad_eth_types::EthExecutionProtocol;
     use monad_secp::SecpSignature;
     use monad_testutil::validators::create_keys_w_validators;
-    use monad_types::{BlockId, Hash, NodeId, Round, Stake};
+    use monad_types::{BlockId, Hash, NodeId, Round, Stake, MAX_FORWARDED_TXS_PER_MESSAGE};
     use monad_validator::{
         signature_collection::SignatureCollection, validator_set::ValidatorSetFactory,
         weighted_round_robin::WeightedRoundRobin,
@@ -1881,6 +1884,21 @@ mod test {
         let decoded = alloy_rlp::decode_exact::<
             MonadMessage<SignatureType, SignatureCollectionType, ExecutionProtocolType>,
         >(rlp_encoded_monad_message);
+
+        assert!(decoded.is_err());
+    }
+
+    #[test]
+    fn monad_message_forwarded_txs_decode_rejects_over_limit() {
+        let monad_version = MonadVersion::version();
+        let txs = vec![Bytes::from_static(&[0]); MAX_FORWARDED_TXS_PER_MESSAGE + 1];
+        let enc: [&dyn Encodable; 3] = [&monad_version, &4u8, &txs];
+        let mut encoded = Vec::new();
+        encode_list::<_, dyn Encodable>(&enc, &mut encoded);
+
+        let decoded = alloy_rlp::decode_exact::<
+            MonadMessage<SignatureType, SignatureCollectionType, ExecutionProtocolType>,
+        >(&encoded);
 
         assert!(decoded.is_err());
     }

--- a/monad-types/Cargo.toml
+++ b/monad-types/Cargo.toml
@@ -17,6 +17,7 @@ futures = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+serde_with = { workspace = true, features = ["hex"] }
 zerocopy = { workspace = true }
 
 [dev-dependencies]

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -17,6 +17,7 @@ use std::{
     error::Error,
     fmt::{Debug, Display},
     io,
+    marker::PhantomData,
     ops::{Add, AddAssign, Div, Rem, Sub, SubAssign},
     str::FromStr,
     time::{Duration, Instant},
@@ -28,8 +29,12 @@ use alloy_rlp::{
 };
 use monad_crypto::certificate_signature::PubKey;
 pub use monad_crypto::hasher::Hash;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{
+    de::{IgnoredAny, SeqAccess, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 use serde_json::Value;
+use serde_with::{de::DeserializeAsWrap, DeserializeAs, SerializeAs};
 use zerocopy::IntoBytes;
 
 pub const GENESIS_SEQ_NUM: SeqNum = SeqNum(0);
@@ -37,6 +42,7 @@ pub const GENESIS_ROUND: Round = Round(0);
 
 pub const ETHERNET_MTU: u16 = 1500;
 pub const DEFAULT_MTU: u16 = ETHERNET_MTU;
+pub const MAX_FORWARDED_TXS_PER_MESSAGE: usize = 5_000;
 
 const PROTOCOL_VERSION: u32 = 1;
 
@@ -956,9 +962,85 @@ impl<T: Serialize, const N: usize> Serialize for LimitedVec<T, N> {
     }
 }
 
+struct LimitedVecVisitor<T, const N: usize> {
+    marker: PhantomData<T>,
+}
+
+impl<T, const N: usize> LimitedVecVisitor<T, N> {
+    fn new() -> Self {
+        Self {
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'de, T: Deserialize<'de>, const N: usize> Visitor<'de> for LimitedVecVisitor<T, N> {
+    type Value = LimitedVec<T, N>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "a sequence with at most {N} elements")
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+        let capacity = match seq.size_hint() {
+            Some(len) if len > N => {
+                return Err(<A::Error as serde::de::Error>::custom(
+                    "list exceeds maximum length",
+                ));
+            }
+            Some(len) => len,
+            None => 0,
+        };
+        let mut vec = Vec::with_capacity(capacity);
+
+        while vec.len() < N {
+            let Some(item) = seq.next_element()? else {
+                return Ok(LimitedVec(vec));
+            };
+            vec.push(item);
+        }
+
+        if seq.next_element::<IgnoredAny>()?.is_some() {
+            return Err(<A::Error as serde::de::Error>::custom(
+                "list exceeds maximum length",
+            ));
+        }
+
+        Ok(LimitedVec(vec))
+    }
+}
+
 impl<'de, T: Deserialize<'de>, const N: usize> Deserialize<'de> for LimitedVec<T, N> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Vec::<T>::deserialize(deserializer).map(Self)
+        deserializer.deserialize_seq(LimitedVecVisitor::<T, N>::new())
+    }
+}
+
+impl<T, TAs, const N: usize> SerializeAs<LimitedVec<T, N>> for LimitedVec<TAs, N>
+where
+    TAs: SerializeAs<T>,
+{
+    fn serialize_as<S: Serializer>(
+        source: &LimitedVec<T, N>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        <Vec<TAs> as SerializeAs<Vec<T>>>::serialize_as(&source.0, serializer)
+    }
+}
+
+impl<'de, T, TAs, const N: usize> DeserializeAs<'de, LimitedVec<T, N>> for LimitedVec<TAs, N>
+where
+    TAs: DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D: Deserializer<'de>>(deserializer: D) -> Result<LimitedVec<T, N>, D::Error> {
+        LimitedVec::<DeserializeAsWrap<T, TAs>, N>::deserialize(deserializer).map(|vec| {
+            LimitedVec(
+                vec.0
+                    .into_iter()
+                    .map(DeserializeAsWrap::into_inner)
+                    .collect(),
+            )
+        })
     }
 }
 
@@ -1022,12 +1104,13 @@ impl<const MAX: u64> Decodable for BoundedU64<MAX> {
 
 #[cfg(test)]
 mod test {
-    use alloy_rlp::{Decodable, Encodable};
+    use alloy_rlp::{bytes::Bytes, Decodable, Encodable};
     use serde::de::{
         value::{Error as SerdeError, StrDeserializer, U64Deserializer},
         IntoDeserializer,
     };
     use serde_test::{assert_ser_tokens, Token};
+    use serde_with::serde_as;
     use test_case::test_case;
 
     use super::*;
@@ -1180,6 +1263,26 @@ mod test {
         let err = v.try_push(7).unwrap_err();
         assert_eq!(err.rejected, 7);
         assert_eq!(err.capacity, 0);
+    }
+
+    #[test]
+    fn test_limited_vec_serde_deserialize_rejects_overflow() {
+        let err = serde_json::from_str::<LimitedVec<u32, 3>>("[1,2,3,4]").unwrap_err();
+        assert!(err.to_string().contains("list exceeds maximum length"));
+    }
+
+    #[test]
+    fn test_limited_vec_serde_as_deserialize_rejects_overflow() {
+        #[serde_as]
+        #[derive(Debug, serde::Deserialize)]
+        #[allow(dead_code)]
+        struct HexTxs {
+            #[serde_as(as = "LimitedVec<serde_with::hex::Hex, 1>")]
+            txs: LimitedVec<Bytes, 1>,
+        }
+
+        let err = serde_json::from_str::<HexTxs>(r#"{"txs":["00","01"]}"#).unwrap_err();
+        assert!(err.to_string().contains("list exceeds maximum length"));
     }
 
     #[test]

--- a/monad-updaters/src/txpool.rs
+++ b/monad-updaters/src/txpool.rs
@@ -44,7 +44,7 @@ use monad_eth_types::{EthExecutionProtocol, ExtractEthAddress};
 use monad_execution_state_read::ExecutionStateRead;
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{MempoolEvent, MonadEvent, TxPoolCommand};
-use monad_types::{ExecutionProtocol, SeqNum};
+use monad_types::{ExecutionProtocol, LimitedVec, SeqNum};
 use monad_validator::signature_collection::SignatureCollection;
 
 pub trait MockableTxPool:
@@ -613,10 +613,11 @@ where
             &MockChainConfig::DEFAULT,
             vec![(tx, PoolTxKind::owned_default())],
             |tx| {
-                self.events.push_back(MempoolEvent::ForwardTxs(vec![tx
-                    .raw()
-                    .encoded_2718()
-                    .into()]));
+                self.events
+                    .push_back(MempoolEvent::ForwardTxs(LimitedVec::from(vec![tx
+                        .raw()
+                        .encoded_2718()
+                        .into()])));
             },
         );
 


### PR DESCRIPTION
collection without limits allows to setup 3M 1 byte transactions over tcp, which takes ~100ms to decode and significant memory pressure about ~200 MiB to decode, and then has some downstream effects as well where we need to loop over them, that potentially can be abused to slow down a node.

this wraps txs with limited vector, with 5_000 length

related https://github.com/category-labs/monad-bft/issues/2999