### PR TITLE
fix(docker): set default execution toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The most straightforward way to start a consensus client + an execution client +
 
 #### Requirements
 
-* x86 processor - the Monad client is developed exclusively against x86 processors. Emulation techniques for other processors, e.g. ARM (Macbooks) are possible but not supported here
+* x86-64-v3 / AVX2-capable processor - the Monad client is developed exclusively against x86-64 processors. Emulation techniques for other processors, e.g. ARM (Macbooks) are possible but not supported here
 * 4+ physical cores (building times will be faster with more cores and higher clock speed)
 * 60 GB+ available hard drive space - Docker builds are about 500 MB each, but the build cache can consume 50 GB+.
 
@@ -68,6 +68,12 @@ After successfully cloning the `monad-bft` repo, run the following from the `mon
 2. `nets/run.sh`
 
 This script builds the docker images from source, which can take 500s+ depending on available memory and cores.  This will construct a build folder `docker/single-node/logs/$(date +%Y%m%d_%H%M%S)-$rand_hex"` and run `docker compose up` on the execution, consensus and rpc images.
+
+By default, the execution image is built with the `gcc-avx2` toolchain, which maps to `monad-execution/category/core/toolchains/gcc-avx2.cmake` and emits Haswell-era/x86-64-v3 machine code. To build with a different execution toolchain, pass the toolchain basename:
+
+```bash
+nets/run.sh --toolchain gcc-avx512
+```
 
 This will start a single node with chain ID of `20143` and RPC at `localhost:8080`. The known [Foundry/Anvil accounts](https://getfoundry.sh/anvil/overview/) have each been loaded with [large initial balances](https://github.com/category-labs/monad/blob/ce4101b11701bf4ef3a9cd996a6144883735187f/category/execution/monad/chain/monad_devnet_alloc.hpp#L22). The easiest way to fund transactions is to import the private key from one of those pre-allocated accounts.
 

--- a/docker/single-node/nets/run.sh
+++ b/docker/single-node/nets/run.sh
@@ -5,12 +5,14 @@ set -ex
 # --- Default variables ---
 CACHED_VOL_ROOT=""
 USE_PREBUILT=false
+TOOLCHAIN="${TOOLCHAIN:-gcc-avx2}"
 
 # --- Function Definitions ---
 usage() {
-    echo "Usage: $0 [--cached-build /path/to/vol_root] [--use-prebuilt]"
+    echo "Usage: $0 [--cached-build /path/to/vol_root] [--use-prebuilt] [--toolchain toolchain]"
     echo "  --cached-build: Skips all build steps and runs docker-compose from an existing volume root."
     echo "  --use-prebuilt: Uses pre-built images (via compose.override.yaml) instead of building from source."
+    echo "  --toolchain: Execution toolchain basename under monad-execution/category/core/toolchains (default: gcc-avx2)."
     exit 1
 }
 
@@ -27,6 +29,14 @@ while [[ "$#" -gt 0 ]]; do
             ;;
         --use-prebuilt)
             USE_PREBUILT=true
+            ;;
+        --toolchain)
+            if [[ -z "$2" || "$2" == --* ]]; then
+                echo "Error: --toolchain requires a toolchain name argument." >&2
+                usage
+            fi
+            TOOLCHAIN="$2"
+            shift
             ;;
         *)
             echo "Unknown parameter passed: $1"
@@ -65,6 +75,16 @@ export MONAD_EXECUTION_ROOT="${MONAD_BFT_ROOT}/monad-execution"
 
 # Get git describe tag for versioning
 export GIT_TAG_VERSION=$(git -C "$MONAD_BFT_ROOT" describe --always)
+
+if [ -z "$CACHED_VOL_ROOT" ] && [ "$USE_PREBUILT" != true ]; then
+    toolchain_file="$MONAD_EXECUTION_ROOT/category/core/toolchains/${TOOLCHAIN}.cmake"
+    if [ ! -f "$toolchain_file" ]; then
+        echo "Error: execution toolchain file does not exist: $toolchain_file" >&2
+        echo "Set --toolchain to one of:" >&2
+        find "$MONAD_EXECUTION_ROOT/category/core/toolchains" -maxdepth 1 -type f -name '*.cmake' -exec basename {} .cmake \; | sort >&2
+        exit 1
+    fi
+fi
 
 # --- Main Logic: Choose between Fresh Build or Cached Run ---
 
@@ -112,7 +132,8 @@ if [ -z "$CACHED_VOL_ROOT" ]; then
             --build-arg GIT_COMMIT_HASH=$(git -C "$MONAD_EXECUTION_ROOT" rev-parse HEAD) \
             --build-arg CC=gcc-15 \
             --build-arg CXX=g++-15 \
-            --build-arg CMAKE_BUILD_TYPE=RelWithDebInfo
+            --build-arg CMAKE_BUILD_TYPE=RelWithDebInfo \
+            --build-arg TOOLCHAIN="$TOOLCHAIN"
 
         # Run one-off build services and start node services, forcing a build of all images
         docker compose up build_triedb build_genesis monad_execution monad_node monad_rpc --build


### PR DESCRIPTION
## Summary

Fixes the single-node Docker build by passing a default execution toolchain into the `monad-execution` image build.

The execution Dockerfile requires `TOOLCHAIN` when configuring CMake, but `docker/single-node/nets/run.sh` previously passed `CC`, `CXX`, and `CMAKE_BUILD_TYPE` without passing `TOOLCHAIN`. As a result, the documented `nets/run.sh` flow failed during the execution image build with:

```text
/bin/sh: 1: TOOLCHAIN: parameter not set or null
```

## Changes

- Defaults the single-node execution build to `gcc-avx2`, matching the execution repo's documented portable Docker target.
- Adds `--toolchain <name>` to `nets/run.sh` so operators can opt into other supported execution toolchains, such as `gcc-avx512`.
- Validates the selected toolchain before starting the fresh Docker build so typos fail early.
- Updates the README Docker instructions to document the default toolchain, override usage, and x86-64-v3 / AVX2 CPU expectation.

## Validation

- Ran `bash -n docker/single-node/nets/run.sh`.
- Ran `git diff --check`.
- Confirmed the updated Docker workflow works on a dev machine that satisfies the node system requirements.
