### PR TITLE
Stricter round lookup for secondary raptorcast group

### DIFF
--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -421,11 +421,7 @@ impl<'a, PT: PubKey> SecondaryBroadcastGroup<'a, PT> {
         let group = full_node_group_map
             .get_group_map(publisher)
             .ok_or(BroadcastGroupError::GroupNotFound(group_id))?
-            // FIXME: should use `get` method. `get_current_or_next`
-            // implements the old behavior, which can be hit if full node is
-            // upgraded before the validator. It'll be removed after the
-            // upgrade
-            .get_current_or_next(round)
+            .get(round)
             .ok_or(BroadcastGroupError::GroupNotFound(group_id))?;
         Ok(Self {
             round,


### PR DESCRIPTION
A tech debt from a long time ago, it was when validator still populates epoch in the header for secondary groups (now switched to round).

Since we want to switch secondary raptorcast to use deterministic raptorcast, this prevents future footgun of not actually selecting the correct broadcast group