### PR TITLE
monad-node: persist wal events on waltrace thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5405,9 +5405,12 @@ dependencies = [
  "monad-consensus",
  "monad-consensus-types",
  "monad-crypto",
+ "monad-eth-types",
+ "monad-multi-sig",
  "monad-state-backend",
  "monad-types",
  "monad-validator",
+ "monad-wal",
  "serde",
  "serde_with",
 ]
@@ -6291,11 +6294,20 @@ dependencies = [
  "monad-secp",
  "monad-types",
  "monad-version",
+ "monad-wal-derive",
  "rayon",
  "serde_json",
  "tempfile",
  "test-case",
  "tracing",
+]
+
+[[package]]
+name = "monad-wal-derive"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ monad-updaters = { path = "./monad-updaters" }
 monad-validator = { path = "./monad-validator" }
 monad-version = { path = "./monad-version" }
 monad-wal = { path = "./monad-wal" }
+monad-wal-derive = { path = "./monad-wal-derive" }
 monad-wireauth = { path = "./monad-wireauth" }
 
 monad-cxx = { path = "./monad-execution/rust/crates/monad-cxx" }

--- a/monad-executor-glue/Cargo.toml
+++ b/monad-executor-glue/Cargo.toml
@@ -17,6 +17,7 @@ monad-crypto = { workspace = true }
 monad-state-backend = { workspace = true }
 monad-types = { workspace = true }
 monad-validator = { workspace = true }
+monad-wal = { workspace = true }
 
 alloy-rlp = { workspace = true }
 bincode = { workspace = true }
@@ -28,6 +29,8 @@ serde_with = { workspace = true, features = ["hex"] }
 
 [dev-dependencies]
 criterion = { workspace = true }
+monad-eth-types = { workspace = true }
+monad-multi-sig = { workspace = true }
 
 [[bench]]
 name = "rlp_bench"

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -795,24 +795,28 @@ where
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, monad_wal::WALLog)]
 pub enum ConsensusEvent<ST, SCT, EPT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
 {
+    #[wal(enable)]
     Message {
         sender: NodeId<SCT::NodeIdPubKey>,
         unverified_message: Unverified<ST, Unvalidated<ConsensusMessage<ST, SCT, EPT>>>,
     },
+    #[wal(enable)]
     Timeout(Round),
     /// a block that was previously requested
     /// this is an invariant
+    #[wal(enable)]
     BlockSync {
         block_range: BlockRange,
         full_blocks: Vec<ConsensusFullBlock<ST, SCT, EPT>>,
     },
+    #[wal(enable)]
     SendVote(Round),
 }
 
@@ -924,7 +928,7 @@ where
 }
 
 /// BlockSync related events
-#[derive(Clone, PartialEq, Eq, Serialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, monad_wal::WALLog)]
 pub enum BlockSyncEvent<ST, SCT, EPT>
 where
     ST: CertificateSignatureRecoverable,
@@ -932,29 +936,35 @@ where
     EPT: ExecutionProtocol,
 {
     /// A peer (not self) requesting for a missing block
+    #[wal(enable)]
     Request {
         sender: NodeId<SCT::NodeIdPubKey>,
         request: BlockSyncRequestMessage,
     },
     /// Outbound request timed out
+    #[wal(enable)]
     Timeout(BlockSyncRequestMessage),
     /// self requesting for a missing block
     /// this request must be retried if necessary
+    #[wal(enable)]
     SelfRequest {
         requester: BlockSyncSelfRequester,
         block_range: BlockRange,
     },
     /// cancel request for block
+    #[wal(enable)]
     SelfCancelRequest {
         requester: BlockSyncSelfRequester,
         block_range: BlockRange,
     },
     /// A peer (not self) sending us a block
+    #[wal(enable)]
     Response {
         sender: NodeId<SCT::NodeIdPubKey>,
         response: BlockSyncResponseMessage<ST, SCT, EPT>,
     },
     /// self sending us missing block (from ledger)
+    #[wal(enable)]
     SelfResponse {
         response: BlockSyncResponseMessage<ST, SCT, EPT>,
     },
@@ -1094,8 +1104,9 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, monad_wal::WALLog)]
 pub enum ValidatorEvent<SCT: SignatureCollection> {
+    #[wal(enable)]
     UpdateValidators(ValidatorSetDataWithEpoch<SCT>),
 }
 
@@ -1126,13 +1137,14 @@ impl<SCT: SignatureCollection> Decodable for ValidatorEvent<SCT> {
 }
 
 #[serde_as]
-#[derive(Clone, PartialEq, Eq, Serialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, monad_wal::WALLog)]
 pub enum MempoolEvent<ST, SCT, EPT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
 {
+    #[wal(enable)]
     Proposal {
         epoch: Epoch,
         round: Round,
@@ -1769,7 +1781,7 @@ impl Decodable for StateSyncNetworkMessage {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, monad_wal::WALLog)]
 pub enum StateSyncEvent<ST, SCT, EPT>
 where
     ST: CertificateSignatureRecoverable,
@@ -1784,15 +1796,18 @@ where
     ),
 
     /// Execution done syncing
+    #[wal(enable)]
     DoneSync(SeqNum),
 
     // Statesync-requested block
+    #[wal(enable)]
     BlockSync {
         block_range: BlockRange,
         full_blocks: Vec<ConsensusFullBlock<ST, SCT, EPT>>,
     },
 
     // Statesync re-sync request
+    #[wal(enable)]
     RequestSync {
         root: ConsensusBlockHeader<ST, SCT, EPT>,
         high_qc: QuorumCertificate<SCT>,
@@ -1876,7 +1891,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, monad_wal::WALLog)]
 pub enum ControlPanelEvent<ST>
 where
     ST: CertificateSignatureRecoverable,
@@ -1963,7 +1978,7 @@ where
     pub prioritized_full_nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, monad_wal::WALLog)]
 pub enum ConfigEvent<ST, SCT>
 where
     ST: CertificateSignatureRecoverable,
@@ -2020,7 +2035,7 @@ where
 }
 
 /// MonadEvent are inputs to MonadState
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, monad_wal::WALLog)]
 pub enum MonadEvent<ST, SCT, EPT>
 where
     ST: CertificateSignatureRecoverable,
@@ -2028,18 +2043,24 @@ where
     EPT: ExecutionProtocol,
 {
     /// Events for consensus state
+    #[wal(enable(nested))]
     ConsensusEvent(ConsensusEvent<ST, SCT, EPT>),
     /// Events for block sync responder
+    #[wal(enable(nested))]
     BlockSyncEvent(BlockSyncEvent<ST, SCT, EPT>),
     /// Events to update validator set
+    #[wal(enable(nested))]
     ValidatorEvent(ValidatorEvent<SCT>),
     /// Events to mempool
+    #[wal(enable(nested))]
     MempoolEvent(MempoolEvent<ST, SCT, EPT>),
     /// Events for the debug control panel
     ControlPanelEvent(ControlPanelEvent<ST>),
     /// Events to update the block timestamper
+    #[wal(enable)]
     TimestampUpdateEvent(u128),
     /// Events to statesync
+    #[wal(enable(nested))]
     StateSyncEvent(StateSyncEvent<ST, SCT, EPT>),
     /// Config updates
     ConfigEvent(ConfigEvent<ST, SCT>),
@@ -2365,15 +2386,49 @@ mod tests {
     use std::{net::SocketAddrV4, num::NonZeroU16};
 
     use alloy_rlp::{encode_list, Encodable};
+    use monad_blocksync::messages::message::BlockSyncRequestMessage;
+    use monad_consensus_types::block::BlockRange;
     use monad_crypto::{
         certificate_signature::{CertificateSignaturePubKey, PubKey},
         NopSignature,
     };
+    use monad_eth_types::EthExecutionProtocol;
+    use monad_multi_sig::MultiSig;
+    use monad_types::{NodeId, SeqNum, GENESIS_BLOCK_ID};
+    use monad_wal::wal::WALLog;
 
     use crate::{
-        PeerEntry, StateSyncRequest, StateSyncResponse, StateSyncUpsertType, StateSyncUpsertV1,
-        StateSyncVersion, SELF_STATESYNC_VERSION, STATESYNC_VERSION_V0, STATESYNC_VERSION_V1,
+        BlockSyncEvent, MempoolEvent, MonadEvent, PeerEntry, StateSyncEvent,
+        StateSyncNetworkMessage, StateSyncRequest, StateSyncResponse, StateSyncUpsertType,
+        StateSyncUpsertV1, StateSyncVersion, SELF_STATESYNC_VERSION, STATESYNC_VERSION_V0,
+        STATESYNC_VERSION_V1,
     };
+
+    type TestSignature = NopSignature;
+    type TestSignatureCollection = MultiSig<TestSignature>;
+    type TestExecutionProtocol = EthExecutionProtocol;
+
+    #[derive(monad_wal::WALLog)]
+    enum VariantLoggedTestEvent {
+        #[wal(enable)]
+        Logged,
+        NotLogged,
+    }
+
+    #[derive(monad_wal::WALLog)]
+    enum UnannotatedLoggedTestEvent {
+        First,
+        Second,
+    }
+
+    #[derive(monad_wal::WALLog)]
+    enum NestedLoggedTestEvent {
+        #[wal(enable(nested))]
+        Nested(VariantLoggedTestEvent),
+        #[wal(enable)]
+        Scalar,
+        Hidden,
+    }
 
     #[test]
     fn statesync_version_is_compatible() {
@@ -2636,5 +2691,63 @@ mod tests {
 
         let decoded = alloy_rlp::decode_exact::<PeerEntry<NopSignature>>(&encoded);
         assert!(decoded.is_err());
+    }
+
+    #[test]
+    fn wal_logging_only_keeps_traceable_events() {
+        assert!(VariantLoggedTestEvent::Logged.is_wal_logged());
+        assert!(!VariantLoggedTestEvent::NotLogged.is_wal_logged());
+        assert!(!UnannotatedLoggedTestEvent::First.is_wal_logged());
+        assert!(!UnannotatedLoggedTestEvent::Second.is_wal_logged());
+        assert!(NestedLoggedTestEvent::Nested(VariantLoggedTestEvent::Logged).is_wal_logged());
+        assert!(!NestedLoggedTestEvent::Nested(VariantLoggedTestEvent::NotLogged).is_wal_logged());
+        assert!(NestedLoggedTestEvent::Scalar.is_wal_logged());
+        assert!(!NestedLoggedTestEvent::Hidden.is_wal_logged());
+
+        let logged_event = MonadEvent::<
+            TestSignature,
+            TestSignatureCollection,
+            TestExecutionProtocol,
+        >::BlockSyncEvent(BlockSyncEvent::Timeout(
+            BlockSyncRequestMessage::Headers(BlockRange {
+                last_block_id: GENESIS_BLOCK_ID,
+                num_blocks: SeqNum(1),
+            }),
+        ));
+        assert!(logged_event.is_wal_logged());
+
+        let mempool_event = MonadEvent::<
+            TestSignature,
+            TestSignatureCollection,
+            TestExecutionProtocol,
+        >::MempoolEvent(MempoolEvent::ForwardTxs(Vec::new()));
+        assert!(!mempool_event.is_wal_logged());
+
+        let timestamp_event = MonadEvent::<
+            TestSignature,
+            TestSignatureCollection,
+            TestExecutionProtocol,
+        >::TimestampUpdateEvent(7);
+        assert!(timestamp_event.is_wal_logged());
+
+        let state_sync_event = MonadEvent::<
+            TestSignature,
+            TestSignatureCollection,
+            TestExecutionProtocol,
+        >::StateSyncEvent(StateSyncEvent::DoneSync(SeqNum(2)));
+        assert!(state_sync_event.is_wal_logged());
+
+        let sender = NodeId::new(
+            CertificateSignaturePubKey::<TestSignature>::from_bytes(&[8u8; 32]).unwrap(),
+        );
+        let inbound_statesync = MonadEvent::<
+            TestSignature,
+            TestSignatureCollection,
+            TestExecutionProtocol,
+        >::StateSyncEvent(StateSyncEvent::Inbound(
+            sender,
+            StateSyncNetworkMessage::NotWhitelisted,
+        ));
+        assert!(!inbound_statesync.is_wal_logged());
     }
 }

--- a/monad-node/src/cli.rs
+++ b/monad-node/src/cli.rs
@@ -51,7 +51,7 @@ pub struct Cli {
     #[arg(long)]
     pub wal_path: PathBuf,
 
-    /// Set the maximum number of WAL chunks to retain
+    /// Set the maximum number of WAL chunks to retain. Set to 0 to disable WAL.
     #[arg(long, default_value_t = DEFAULT_WAL_CHUNKS)]
     pub wal_chunks: u64,
 

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -20,7 +20,7 @@ use std::{
     num::NonZeroU16,
     path::PathBuf,
     process,
-    sync::Arc,
+    sync::{mpsc::TrySendError, Arc},
     time::{Duration, Instant},
 };
 
@@ -98,6 +98,7 @@ const MONAD_NODE_VERSION: Option<&str> = option_env!("MONAD_VERSION");
 const STATESYNC_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 const EXECUTION_DELAY: u64 = 3;
+const WALTRACE_CHANNEL_CAPACITY: usize = 1024;
 
 fn main() {
     let mut cmd = Cli::command();
@@ -303,7 +304,7 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         config_loader: ConfigLoader::new(node_state.node_config_path),
     };
 
-    let mut wal = if node_state.wal_chunks == 0 {
+    let waltrace_tx = if node_state.wal_chunks == 0 {
         info!("wal is disabled");
         None
     } else {
@@ -315,18 +316,27 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         )
         .with_chunks(node_state.wal_chunks)
         .with_chunk_size(node_state.wal_chunk_size_bytes);
-        match logger_config.build() {
-            Ok(wal) => Some(wal),
-            Err(err) => {
-                event!(
-                    Level::ERROR,
-                    ?err,
-                    path = node_state.wal_path.as_path().display().to_string(),
-                    "failed to initialize wal",
-                );
-                return Err(());
-            }
-        }
+        let (waltrace_tx, waltrace_rx) = std::sync::mpsc::sync_channel(WALTRACE_CHANNEL_CAPACITY);
+        let _waltrace_thread = std::thread::Builder::new()
+            .name("monad_bft_waltrace".to_string())
+            .spawn(move || {
+                let mut wal = match logger_config.build() {
+                    Ok(wal) => wal,
+                    Err(err) => {
+                        error!(?err, "failed to initialize wal");
+                        return;
+                    }
+                };
+                while let Ok(event) = waltrace_rx.recv() {
+                    let _wal_event_span = tracing::trace_span!("wal_event_span").entered();
+                    if let Err(err) = wal.push(&event) {
+                        event!(Level::ERROR, ?err, "failed to push to wal");
+                        return;
+                    }
+                }
+            })
+            .expect("failed to spawn waltrace thread");
+        Some(waltrace_tx)
     };
 
     let block_sync_override_peers = node_state
@@ -466,21 +476,24 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
                     format!("{:?}", event)
                 };
 
-                let event = LogFriendlyMonadEvent {
-                    timestamp: Utc::now(),
-                    event,
-                };
-
                 {
                     let _ledger_span = ledger_span.enter();
-                    if let Some(wal) = wal.as_mut() {
-                        let _wal_event_span = tracing::trace_span!("wal_event_span").entered();
-                        if let Err(err) = wal.push(&event) {
-                            event!(Level::ERROR, ?err, "failed to push to wal",);
-                            return Err(());
+                    if let Some(waltrace_tx) = waltrace_tx.as_ref() {
+                        let wal_event = LogFriendlyMonadEvent {
+                            timestamp: Utc::now(),
+                            event: event.lossy_clone(),
+                        };
+                        match waltrace_tx.try_send(wal_event) {
+                            Ok(()) => {}
+                            Err(TrySendError::Full(_)) => {
+                                warn!("waltrace is lagging; dropping wal event");
+                            }
+                            Err(TrySendError::Disconnected(_)) => {
+                                event!(Level::ERROR, "waltrace thread stopped");
+                            }
                         }
                     }
-                };
+                }
 
                 let commands = {
                     let _timer = DropTimer::start(Duration::from_millis(50), |elapsed| {
@@ -491,9 +504,9 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
                         )
                     });
                     let _ledger_span = ledger_span.enter();
-                    let _event_span = tracing::trace_span!("event_span", ?event.event).entered();
+                    let _event_span = tracing::trace_span!("event_span", ?event).entered();
                     let start = Instant::now();
-                    let cmds = state.update(event.event);
+                    let cmds = state.update(event);
                     total_state_update_elapsed += start.elapsed();
                     cmds
                 };

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -72,7 +72,7 @@ use monad_validator::{
     signature_collection::SignatureCollection, validator_set::ValidatorSetFactory,
     weighted_round_robin::WeightedRoundRobin,
 };
-use monad_wal::wal::WALoggerConfig;
+use monad_wal::wal::{WALLog, WALoggerConfig};
 use opentelemetry::metrics::MeterProvider;
 use opentelemetry_otlp::{MetricExporter, WithExportConfig};
 use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
@@ -478,18 +478,20 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
 
                 {
                     let _ledger_span = ledger_span.enter();
-                    if let Some(waltrace_tx) = waltrace_tx.as_ref() {
-                        let wal_event = LogFriendlyMonadEvent {
-                            timestamp: Utc::now(),
-                            event: event.lossy_clone(),
-                        };
-                        match waltrace_tx.try_send(wal_event) {
-                            Ok(()) => {}
-                            Err(TrySendError::Full(_)) => {
-                                warn!("waltrace is lagging; dropping wal event");
-                            }
-                            Err(TrySendError::Disconnected(_)) => {
-                                event!(Level::ERROR, "waltrace thread stopped");
+                    if event.is_wal_logged() {
+                        if let Some(waltrace_tx) = waltrace_tx.as_ref() {
+                            let wal_event = LogFriendlyMonadEvent {
+                                timestamp: Utc::now(),
+                                event: event.lossy_clone(),
+                            };
+                            match waltrace_tx.try_send(wal_event) {
+                                Ok(()) => {}
+                                Err(TrySendError::Full(_)) => {
+                                    warn!("waltrace is lagging; dropping wal event");
+                                }
+                                Err(TrySendError::Disconnected(_)) => {
+                                    event!(Level::ERROR, "waltrace thread stopped");
+                                }
                             }
                         }
                     }

--- a/monad-wal-derive/Cargo.toml
+++ b/monad-wal-derive/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "monad-wal-derive"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = { workspace = true }
+syn = { workspace = true }

--- a/monad-wal-derive/src/lib.rs
+++ b/monad-wal-derive/src/lib.rs
@@ -1,0 +1,143 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput, Fields, Meta, NestedMeta};
+
+enum WALLogMode {
+    Disabled,
+    Enabled,
+    Nested,
+}
+
+#[proc_macro_derive(WALLog, attributes(wal))]
+pub fn derive_wal_log(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let ident = input.ident;
+    let generics = input.generics;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let Data::Enum(data) = input.data else {
+        return syn::Error::new_spanned(ident, "WALLog can only be derived on enums")
+            .to_compile_error()
+            .into();
+    };
+
+    let mut arms = Vec::new();
+    for variant in data.variants {
+        let ident = variant.ident;
+        let mode = match wal_log_mode(&variant.attrs) {
+            Ok(mode) => mode,
+            Err(err) => return err.to_compile_error().into(),
+        };
+        let fields = variant.fields;
+        let arm = match mode {
+            WALLogMode::Enabled => match fields {
+                Fields::Named(_) => quote!(Self::#ident { .. } => true),
+                Fields::Unnamed(_) => quote!(Self::#ident(..) => true),
+                Fields::Unit => quote!(Self::#ident => true),
+            },
+            WALLogMode::Nested => match fields {
+                Fields::Named(fields) if fields.named.len() == 1 => {
+                    let field_ident = fields.named.into_iter().next().unwrap().ident.unwrap();
+                    quote!(
+                        Self::#ident { #field_ident: wal_field } =>
+                            ::monad_wal::wal::WALLog::is_wal_logged(wal_field)
+                    )
+                }
+                Fields::Unnamed(fields) if fields.unnamed.len() == 1 => quote!(
+                    Self::#ident(wal_field) => ::monad_wal::wal::WALLog::is_wal_logged(wal_field)
+                ),
+                _ => {
+                    return syn::Error::new_spanned(
+                        ident,
+                        "#[wal(enable(nested))] requires exactly one field",
+                    )
+                    .to_compile_error()
+                    .into()
+                }
+            },
+            WALLogMode::Disabled => match fields {
+                Fields::Named(_) => quote!(Self::#ident { .. } => false),
+                Fields::Unnamed(_) => quote!(Self::#ident(..) => false),
+                Fields::Unit => quote!(Self::#ident => false),
+            },
+        };
+
+        arms.push(arm);
+    }
+
+    let is_wal_logged = quote! {
+        match self {
+            #( #arms, )*
+        }
+    };
+
+    quote! {
+        impl #impl_generics ::monad_wal::wal::WALLog for #ident #ty_generics #where_clause {
+            fn is_wal_logged(&self) -> bool {
+                #is_wal_logged
+            }
+        }
+    }
+    .into()
+}
+
+fn wal_log_mode(attrs: &[syn::Attribute]) -> syn::Result<WALLogMode> {
+    let mut mode = WALLogMode::Disabled;
+    for attr in attrs {
+        let Some(parsed_mode) = parse_wal_log_mode(attr)? else {
+            continue;
+        };
+        mode = parsed_mode;
+    }
+    Ok(mode)
+}
+
+fn parse_wal_log_mode(attr: &syn::Attribute) -> syn::Result<Option<WALLogMode>> {
+    if !attr.path.is_ident("wal") {
+        return Ok(None);
+    }
+
+    match attr.parse_meta()? {
+        Meta::List(list) if list.nested.len() == 1 => match list.nested.first().unwrap() {
+            NestedMeta::Meta(Meta::Path(path)) if path.is_ident("enable") => {
+                Ok(Some(WALLogMode::Enabled))
+            }
+            NestedMeta::Meta(Meta::List(list))
+                if list.path.is_ident("enable")
+                    && list.nested.len() == 1
+                    && matches!(
+                        list.nested.first(),
+                        Some(NestedMeta::Meta(Meta::Path(path))) if path.is_ident("nested")
+                    ) =>
+            {
+                Ok(Some(WALLogMode::Nested))
+            }
+            _ => Err(invalid_wal_attribute(attr)),
+        },
+        _ => Err(invalid_wal_attribute(attr)),
+    }
+}
+
+fn invalid_wal_attribute(attr: &syn::Attribute) -> syn::Error {
+    syn::Error::new_spanned(
+        attr,
+        "unrecognized #[wal(...)] attribute; expected #[wal(enable)] or #[wal(enable(nested))]",
+    )
+}

--- a/monad-wal/Cargo.toml
+++ b/monad-wal/Cargo.toml
@@ -10,6 +10,7 @@ bench = false
 
 [dependencies]
 monad-types = { workspace = true }
+monad-wal-derive = { workspace = true }
 
 bytes = { workspace = true }
 tracing = { workspace = true }

--- a/monad-wal/src/lib.rs
+++ b/monad-wal/src/lib.rs
@@ -18,6 +18,10 @@ pub mod wal;
 
 use std::{error::Error, fmt::Debug, io};
 
+extern crate self as monad_wal;
+
+pub use monad_wal_derive::WALLog;
+
 #[derive(Debug)]
 pub enum WALError {
     IOError(io::Error),

--- a/monad-wal/src/wal.rs
+++ b/monad-wal/src/wal.rs
@@ -29,6 +29,10 @@ use tracing::debug;
 
 use crate::WALError;
 
+pub trait WALLog {
+    fn is_wal_logged(&self) -> bool;
+}
+
 /// Header prepended to each event in the log
 pub(crate) type EventHeaderType = u32;
 pub(crate) const EVENT_HEADER_LEN: usize = std::mem::size_of::<EventHeaderType>();


### PR DESCRIPTION
Create a dedicated monad_bft_waltrace thread that owns the WAL logger. The node forwards log-friendly events over a bounded crossbeam channel in arrival order and never blocks the main event loop on WAL writes.

If the waltrace queue fills, warn and drop the WAL event. If WAL initialization or persistence fails.