### PR TITLE
monad-executor-glue: arc-wrap MonadEvent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5399,7 +5399,6 @@ dependencies = [
  "bytes",
  "chrono",
  "criterion",
- "futures",
  "monad-blocksync",
  "monad-chain-config",
  "monad-consensus",

--- a/monad-control-panel/src/ipc.rs
+++ b/monad-control-panel/src/ipc.rs
@@ -163,7 +163,7 @@ where
                         GetMetrics::Request => {
                             let event = ControlPanelEvent::GetMetricsEvent;
                             let Ok(_) = event_channel
-                                .send(MonadEvent::ControlPanelEvent(event.clone()))
+                                .send(MonadEvent::control_panel_event(event.clone()))
                                 .await
                             else {
                                 error!("failed to forward request {:?} to executor, closing connection", &event);
@@ -176,7 +176,7 @@ where
                         GetPeers::Request => {
                             let event = ControlPanelEvent::GetPeers(GetPeers::Request);
                             let Ok(_) = event_channel
-                                .send(MonadEvent::ControlPanelEvent(event.clone()))
+                                .send(MonadEvent::control_panel_event(event.clone()))
                                 .await
                             else {
                                 error!("failed to forward request {:?} to executor, closing connection", &event);
@@ -189,7 +189,7 @@ where
                         GetFullNodes::Request => {
                             let event = ControlPanelEvent::GetFullNodes(GetFullNodes::Request);
                             let Ok(_) = event_channel
-                                .send(MonadEvent::ControlPanelEvent(event.clone()))
+                                .send(MonadEvent::control_panel_event(event.clone()))
                                 .await
                             else {
                                 error!("failed to forward request {:?} to executor, closing connection", &event);
@@ -204,7 +204,7 @@ where
                         ClearMetrics::Request => {
                             let event = ControlPanelEvent::ClearMetricsEvent;
                             let Ok(_) = event_channel
-                                .send(MonadEvent::ControlPanelEvent(event.clone()))
+                                .send(MonadEvent::control_panel_event(event.clone()))
                                 .await
                             else {
                                 error!("failed to forward request {:?} to executor, closing connection", &event);
@@ -216,7 +216,7 @@ where
                     WriteCommand::UpdateLogFilter(filter) => {
                         let event = ControlPanelEvent::UpdateLogFilter(filter);
                         let Ok(_) = event_channel
-                            .send(MonadEvent::ControlPanelEvent(event.clone()))
+                            .send(MonadEvent::control_panel_event(event.clone()))
                             .await
                         else {
                             error!(
@@ -230,7 +230,7 @@ where
                         ReloadConfig::Request => {
                             let event = ControlPanelEvent::ReloadConfig(ReloadConfig::Request);
                             let Ok(_) = event_channel
-                                .send(MonadEvent::ControlPanelEvent(event.clone()))
+                                .send(MonadEvent::control_panel_event(event.clone()))
                                 .await
                             else {
                                 error!("failed to forward request {:?} to executor, closing connection", &event);

--- a/monad-debugger/src/graphql/mod.rs
+++ b/monad-debugger/src/graphql/mod.rs
@@ -24,8 +24,8 @@ use bytes::Bytes;
 use monad_consensus_types::metrics::Metrics;
 use monad_crypto::certificate_signature::{CertificateSignaturePubKey, PubKey};
 use monad_executor_glue::{
-    BlockSyncEvent, ConfigEvent, ConsensusEvent, ControlPanelEvent, MempoolEvent, MonadEvent,
-    StateSyncEvent, ValidatorEvent,
+    BlockSyncEvent, ConfigEvent, ConsensusEvent, ControlPanelEvent, InnerMonadEvent, MempoolEvent,
+    MonadEvent, StateSyncEvent, ValidatorEvent,
 };
 use monad_mock_swarm::{
     node::Node,
@@ -381,21 +381,29 @@ enum GraphQLMonadEvent<'s> {
 
 impl<'s> From<&'s MonadEventType> for GraphQLMonadEvent<'s> {
     fn from(event: &'s MonadEventType) -> Self {
-        match event {
-            MonadEvent::ConsensusEvent(event) => Self::ConsensusEvent(GraphQLConsensusEvent(event)),
-            MonadEvent::BlockSyncEvent(event) => Self::BlockSyncEvent(GraphQLBlockSyncEvent(event)),
-            MonadEvent::ValidatorEvent(event) => Self::ValidatorEvent(GraphQLValidatorEvent(event)),
-            MonadEvent::MempoolEvent(event) => Self::MempoolEvent(GraphQLMempoolEvent(event)),
-            MonadEvent::ControlPanelEvent(event) => {
+        match event.as_ref() {
+            InnerMonadEvent::ConsensusEvent(event) => {
+                Self::ConsensusEvent(GraphQLConsensusEvent(event))
+            }
+            InnerMonadEvent::BlockSyncEvent(event) => {
+                Self::BlockSyncEvent(GraphQLBlockSyncEvent(event))
+            }
+            InnerMonadEvent::ValidatorEvent(event) => {
+                Self::ValidatorEvent(GraphQLValidatorEvent(event))
+            }
+            InnerMonadEvent::MempoolEvent(event) => Self::MempoolEvent(GraphQLMempoolEvent(event)),
+            InnerMonadEvent::ControlPanelEvent(event) => {
                 Self::ControlPanelEvent(GraphQLControlPanelEvent(event))
             }
-            MonadEvent::TimestampUpdateEvent(event) => {
+            InnerMonadEvent::TimestampUpdateEvent(event) => {
                 Self::TimestampEvent(GraphQLTimestampEvent(*event as u64)) // TODO: this is wrong but protobuf is not used in
                                                                            // protocol and will be deleted
             }
-            MonadEvent::StateSyncEvent(event) => Self::StateSyncEvent(GraphQLStateSyncEvent(event)),
-            MonadEvent::ConfigEvent(event) => Self::ConfigEvent(GraphQLConfigEvent(event)),
-            MonadEvent::SecondaryRaptorcastPeersUpdate { .. } => todo!(),
+            InnerMonadEvent::StateSyncEvent(event) => {
+                Self::StateSyncEvent(GraphQLStateSyncEvent(event))
+            }
+            InnerMonadEvent::ConfigEvent(event) => Self::ConfigEvent(GraphQLConfigEvent(event)),
+            InnerMonadEvent::SecondaryRaptorcastPeersUpdate { .. } => todo!(),
         }
     }
 }

--- a/monad-eth-ledger/src/lib.rs
+++ b/monad-eth-ledger/src/lib.rs
@@ -195,7 +195,7 @@ where
         let this = self.deref_mut();
 
         if let Some(event) = this.events.pop_front() {
-            return Poll::Ready(Some(MonadEvent::BlockSyncEvent(event)));
+            return Poll::Ready(Some(MonadEvent::block_sync_event(event)));
         }
 
         if let Some(waker) = this.waker.as_mut() {

--- a/monad-eth-txpool-executor/src/client.rs
+++ b/monad-eth-txpool-executor/src/client.rs
@@ -586,7 +586,7 @@ where
             };
 
             if let Some(event) = this.process_event(event) {
-                return Poll::Ready(Some(MonadEvent::MempoolEvent(event)));
+                return Poll::Ready(Some(MonadEvent::mempool_event(event)));
             }
         }
 

--- a/monad-eth-txpool-executor/src/lib.rs
+++ b/monad-eth-txpool-executor/src/lib.rs
@@ -822,7 +822,7 @@ mod test {
     };
     use monad_eth_types::EthExecutionProtocol;
     use monad_executor::{Executor, ExecutorMetrics};
-    use monad_executor_glue::{MempoolEvent, MonadEvent, TxPoolCommand};
+    use monad_executor_glue::{InnerMonadEvent, MempoolEvent, MonadEvent, TxPoolCommand};
     use monad_peer_score::{ema, StdClock};
     use monad_state_backend::{
         AccountState, InMemoryBlockState, InMemoryState, InMemoryStateInner,
@@ -917,14 +917,14 @@ mod test {
     ) -> Vec<bytes::Bytes> {
         let expected_signer = secret_to_eth_address(S1);
 
-        match event {
-            MonadEvent::MempoolEvent(MempoolEvent::Proposal {
+        match event.as_ref() {
+            InnerMonadEvent::MempoolEvent(MempoolEvent::Proposal {
                 proposed_execution_inputs,
                 ..
             }) => proposed_execution_inputs
                 .body
                 .transactions
-                .into_iter()
+                .iter()
                 .filter_map(|tx| {
                     let signer = tx.recover_signer().expect("proposal tx signer recovers");
                     (signer == expected_signer).then(|| alloy_rlp::encode(tx).into())

--- a/monad-eth-txpool-executor/tests/executor.rs
+++ b/monad-eth-txpool-executor/tests/executor.rs
@@ -32,7 +32,7 @@ use monad_eth_txpool_executor::{
 use monad_eth_txpool_ipc::EthTxPoolIpcClient;
 use monad_eth_txpool_types::{EthTxPoolIpcTx, EthTxPoolSnapshot};
 use monad_executor::Executor;
-use monad_executor_glue::{MempoolEvent, MonadEvent, TxPoolCommand};
+use monad_executor_glue::{InnerMonadEvent, MempoolEvent, TxPoolCommand};
 use monad_peer_score::{ema, StdClock};
 use monad_state_backend::{AccountState, InMemoryBlockState, InMemoryState, InMemoryStateInner};
 use monad_testutil::signing::MockSignatures;
@@ -150,8 +150,8 @@ async fn test_ipc_tx_forwarding_pacing() {
             .expect("TxpoolExecutor does not timeout")
             .unwrap();
 
-        match event {
-            MonadEvent::MempoolEvent(mempool_event) => match mempool_event {
+        match event.as_ref() {
+            InnerMonadEvent::MempoolEvent(mempool_event) => match mempool_event {
                 MempoolEvent::ForwardTxs(vec) => {
                     assert!(!vec.is_empty());
                     assert!(vec.len() <= 2, "vec len was {}", vec.len());

--- a/monad-executor-glue/Cargo.toml
+++ b/monad-executor-glue/Cargo.toml
@@ -22,7 +22,6 @@ alloy-rlp = { workspace = true }
 bincode = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
-futures = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true, features = ["hex"] }
 

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -17,12 +17,12 @@ use std::{
     fmt::Debug,
     net::{SocketAddr, SocketAddrV4},
     num::NonZeroU16,
+    sync::Arc,
 };
 
 use alloy_rlp::{encode_list, Decodable, Encodable, Header, RlpDecodable, RlpEncodable};
 use bytes::{BufMut, Bytes, BytesMut};
 use chrono::{DateTime, Utc};
-use futures::channel::oneshot;
 use monad_blocksync::{
     blocksync::BlockSyncSelfRequester,
     messages::message::{BlockSyncRequestMessage, BlockSyncResponseMessage},
@@ -51,7 +51,7 @@ use monad_crypto::certificate_signature::{
 use monad_state_backend::StateBackend;
 use monad_types::{
     deserialize_pubkey, serialize_pubkey, Epoch, ExecutionProtocol, LimitedVec, NodeId, Round,
-    RouterTarget, SeqNum, Stake, UdpPriority,
+    RouterTarget, SeqNum, Stake, TcpCompletionHandle, UdpPriority,
 };
 use monad_validator::signature_collection::SignatureCollection;
 use serde::{Deserialize, Serialize};
@@ -1769,7 +1769,7 @@ impl Decodable for StateSyncNetworkMessage {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub enum StateSyncEvent<ST, SCT, EPT>
 where
     ST: CertificateSignatureRecoverable,
@@ -1780,7 +1780,7 @@ where
     Outbound(
         NodeId<SCT::NodeIdPubKey>,
         StateSyncNetworkMessage,
-        #[serde(skip)] Option<oneshot::Sender<()>>, // completion
+        #[serde(skip)] Option<TcpCompletionHandle>, // completion
     ),
 
     /// Execution done syncing
@@ -2020,8 +2020,8 @@ where
 }
 
 /// MonadEvent are inputs to MonadState
-#[derive(Debug, Serialize)]
-pub enum MonadEvent<ST, SCT, EPT>
+#[derive(Debug, Clone, Serialize)]
+pub enum InnerMonadEvent<ST, SCT, EPT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
@@ -2050,68 +2050,107 @@ where
     },
 }
 
+#[derive(Clone)]
+pub struct MonadEvent<ST, SCT, EPT>(Arc<InnerMonadEvent<ST, SCT, EPT>>)
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    EPT: ExecutionProtocol;
+
 impl<ST, SCT, EPT> MonadEvent<ST, SCT, EPT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
 {
-    /// We don't implement the normal Clone::clone because it's unnecessary in the general case.
-    /// Clone is only used in mock-swarm for added observability.
-    ///
-    /// Currently, the only inconsistency is that the lossy_clone won't clone the statesync
-    /// completion.
-    pub fn lossy_clone(&self) -> Self {
-        match self {
-            MonadEvent::ConsensusEvent(event) => MonadEvent::ConsensusEvent(event.clone()),
-            MonadEvent::BlockSyncEvent(event) => MonadEvent::BlockSyncEvent(event.clone()),
-            MonadEvent::ValidatorEvent(event) => MonadEvent::ValidatorEvent(event.clone()),
-            MonadEvent::MempoolEvent(event) => MonadEvent::MempoolEvent(event.clone()),
-            MonadEvent::ControlPanelEvent(event) => MonadEvent::ControlPanelEvent(event.clone()),
-            MonadEvent::TimestampUpdateEvent(timestamp) => {
-                MonadEvent::TimestampUpdateEvent(*timestamp)
-            }
-            MonadEvent::StateSyncEvent(event) => {
-                let event = match event {
-                    StateSyncEvent::Inbound(node_id, state_sync_network_message) => {
-                        StateSyncEvent::Inbound(*node_id, state_sync_network_message.clone())
-                    }
-                    StateSyncEvent::Outbound(
-                        node_id,
-                        state_sync_network_message,
-                        // completion is NOT cloned
-                        _completion,
-                    ) => {
-                        StateSyncEvent::Outbound(*node_id, state_sync_network_message.clone(), None)
-                    }
-                    StateSyncEvent::DoneSync(seq_num) => StateSyncEvent::DoneSync(*seq_num),
-                    StateSyncEvent::BlockSync {
-                        block_range,
-                        full_blocks,
-                    } => StateSyncEvent::BlockSync {
-                        block_range: *block_range,
-                        full_blocks: full_blocks.clone(),
-                    },
-                    StateSyncEvent::RequestSync { root, high_qc } => StateSyncEvent::RequestSync {
-                        root: root.clone(),
-                        high_qc: high_qc.clone(),
-                    },
-                };
-                MonadEvent::StateSyncEvent(event)
-            }
-            MonadEvent::ConfigEvent(event) => MonadEvent::ConfigEvent(event.clone()),
-            MonadEvent::SecondaryRaptorcastPeersUpdate {
-                expiry_round,
-                confirm_group_peers,
-            } => MonadEvent::SecondaryRaptorcastPeersUpdate {
-                expiry_round: *expiry_round,
-                confirm_group_peers: confirm_group_peers.clone(),
-            },
-        }
+    pub fn new(inner: InnerMonadEvent<ST, SCT, EPT>) -> Self {
+        Self(Arc::new(inner))
+    }
+
+    pub fn consensus_event(event: ConsensusEvent<ST, SCT, EPT>) -> Self {
+        Self::new(InnerMonadEvent::ConsensusEvent(event))
+    }
+
+    pub fn block_sync_event(event: BlockSyncEvent<ST, SCT, EPT>) -> Self {
+        Self::new(InnerMonadEvent::BlockSyncEvent(event))
+    }
+
+    pub fn validator_event(event: ValidatorEvent<SCT>) -> Self {
+        Self::new(InnerMonadEvent::ValidatorEvent(event))
+    }
+
+    pub fn mempool_event(event: MempoolEvent<ST, SCT, EPT>) -> Self {
+        Self::new(InnerMonadEvent::MempoolEvent(event))
+    }
+
+    pub fn control_panel_event(event: ControlPanelEvent<ST>) -> Self {
+        Self::new(InnerMonadEvent::ControlPanelEvent(event))
+    }
+
+    pub fn timestamp_update_event(timestamp: u128) -> Self {
+        Self::new(InnerMonadEvent::TimestampUpdateEvent(timestamp))
+    }
+
+    pub fn state_sync_event(event: StateSyncEvent<ST, SCT, EPT>) -> Self {
+        Self::new(InnerMonadEvent::StateSyncEvent(event))
+    }
+
+    pub fn config_event(event: ConfigEvent<ST, SCT>) -> Self {
+        Self::new(InnerMonadEvent::ConfigEvent(event))
+    }
+
+    pub fn secondary_raptorcast_peers_update(
+        expiry_round: Round,
+        confirm_group_peers: Vec<NodeId<SCT::NodeIdPubKey>>,
+    ) -> Self {
+        Self::new(InnerMonadEvent::SecondaryRaptorcastPeersUpdate {
+            expiry_round,
+            confirm_group_peers,
+        })
+    }
+
+    pub fn into_inner(self) -> InnerMonadEvent<ST, SCT, EPT> {
+        Arc::try_unwrap(self.0).unwrap_or_else(|inner| (*inner).clone())
     }
 }
 
-impl<ST, SCT, EPT> Encodable for MonadEvent<ST, SCT, EPT>
+impl<ST, SCT, EPT> AsRef<InnerMonadEvent<ST, SCT, EPT>> for MonadEvent<ST, SCT, EPT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    EPT: ExecutionProtocol,
+{
+    fn as_ref(&self) -> &InnerMonadEvent<ST, SCT, EPT> {
+        self.0.as_ref()
+    }
+}
+
+impl<ST, SCT, EPT> std::fmt::Debug for MonadEvent<ST, SCT, EPT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    EPT: ExecutionProtocol,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(self.as_ref(), f)
+    }
+}
+
+impl<ST, SCT, EPT> Serialize for MonadEvent<ST, SCT, EPT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    EPT: ExecutionProtocol,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.as_ref().serialize(serializer)
+    }
+}
+
+impl<ST, SCT, EPT> Encodable for InnerMonadEvent<ST, SCT, EPT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
@@ -2162,7 +2201,7 @@ where
     }
 }
 
-impl<ST, SCT, EPT> Decodable for MonadEvent<ST, SCT, EPT>
+impl<ST, SCT, EPT> Decodable for InnerMonadEvent<ST, SCT, EPT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
@@ -2208,6 +2247,28 @@ where
     }
 }
 
+impl<ST, SCT, EPT> Encodable for MonadEvent<ST, SCT, EPT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    EPT: ExecutionProtocol,
+{
+    fn encode(&self, out: &mut dyn BufMut) {
+        self.as_ref().encode(out)
+    }
+}
+
+impl<ST, SCT, EPT> Decodable for MonadEvent<ST, SCT, EPT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    EPT: ExecutionProtocol,
+{
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        InnerMonadEvent::<ST, SCT, EPT>::decode(buf).map(Self::new)
+    }
+}
+
 impl<ST, SCT, EPT> monad_types::Deserializable<[u8]> for MonadEvent<ST, SCT, EPT>
 where
     ST: CertificateSignatureRecoverable,
@@ -2217,7 +2278,7 @@ where
     type ReadError = alloy_rlp::Error;
 
     fn deserialize(data: &[u8]) -> Result<Self, Self::ReadError> {
-        MonadEvent::<ST, SCT, EPT>::decode(&mut data.as_ref())
+        Self::decode(&mut data.as_ref())
     }
 }
 
@@ -2234,49 +2295,61 @@ where
     }
 }
 
+impl<ST, SCT, EPT> std::fmt::Display for InnerMonadEvent<ST, SCT, EPT>
+where
+    ST: CertificateSignatureRecoverable,
+    SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+    EPT: ExecutionProtocol,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s: String = match self {
+            InnerMonadEvent::ConsensusEvent(ConsensusEvent::Message {
+                sender,
+                unverified_message: _,
+            }) => {
+                format!("ConsensusEvent::Message from {sender}")
+            }
+            InnerMonadEvent::ConsensusEvent(ConsensusEvent::Timeout(round)) => {
+                format!("ConsensusEvent::Timeout Pacemaker local timeout round {round:?}")
+            }
+            InnerMonadEvent::ConsensusEvent(_) => "CONSENSUS".to_string(),
+            InnerMonadEvent::BlockSyncEvent(_) => "BLOCKSYNC".to_string(),
+            InnerMonadEvent::ValidatorEvent(_) => "VALIDATOR".to_string(),
+            InnerMonadEvent::MempoolEvent(MempoolEvent::Proposal { round, seq_num, .. }) => {
+                format!("MempoolEvent::Proposal -- round {round:?}, seq_num {seq_num:?}")
+            }
+            InnerMonadEvent::MempoolEvent(MempoolEvent::ForwardedTxs { sender, txs: txns }) => {
+                format!(
+                    "MempoolEvent::ForwardedTxns -- from {sender} number of txns: {}",
+                    txns.len()
+                )
+            }
+            InnerMonadEvent::MempoolEvent(MempoolEvent::ForwardTxs(txs)) => {
+                format!("MempoolEvent::ForwardTxs -- number of txns: {}", txs.len())
+            }
+            InnerMonadEvent::ControlPanelEvent(_) => "CONTROLPANELEVENT".to_string(),
+            InnerMonadEvent::TimestampUpdateEvent(t) => {
+                format!("MempoolEvent::TimestampUpdate: {t}")
+            }
+            InnerMonadEvent::StateSyncEvent(_) => "STATESYNC".to_string(),
+            InnerMonadEvent::ConfigEvent(_) => "CONFIGEVENT".to_string(),
+            InnerMonadEvent::SecondaryRaptorcastPeersUpdate { .. } => {
+                "SecondaryRaptorcastPeersUpdate".to_string()
+            }
+        };
+
+        write!(f, "{}", s)
+    }
+}
+
 impl<ST, SCT, EPT> std::fmt::Display for MonadEvent<ST, SCT, EPT>
 where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
 {
-    // TODO impl Display for each individual event instead
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s: String = match self {
-            MonadEvent::ConsensusEvent(ConsensusEvent::Message {
-                sender,
-                unverified_message: _,
-            }) => {
-                format!("ConsensusEvent::Message from {sender}")
-            }
-            MonadEvent::ConsensusEvent(ConsensusEvent::Timeout(round)) => {
-                format!("ConsensusEvent::Timeout Pacemaker local timeout round {round:?}")
-            }
-            MonadEvent::ConsensusEvent(_) => "CONSENSUS".to_string(),
-            MonadEvent::BlockSyncEvent(_) => "BLOCKSYNC".to_string(),
-            MonadEvent::ValidatorEvent(_) => "VALIDATOR".to_string(),
-            MonadEvent::MempoolEvent(MempoolEvent::Proposal { round, seq_num, .. }) => {
-                format!("MempoolEvent::Proposal -- round {round:?}, seq_num {seq_num:?}")
-            }
-            MonadEvent::MempoolEvent(MempoolEvent::ForwardedTxs { sender, txs: txns }) => {
-                format!(
-                    "MempoolEvent::ForwardedTxns -- from {sender} number of txns: {}",
-                    txns.len()
-                )
-            }
-            MonadEvent::MempoolEvent(MempoolEvent::ForwardTxs(txs)) => {
-                format!("MempoolEvent::ForwardTxs -- number of txns: {}", txs.len())
-            }
-            MonadEvent::ControlPanelEvent(_) => "CONTROLPANELEVENT".to_string(),
-            MonadEvent::TimestampUpdateEvent(t) => format!("MempoolEvent::TimestampUpdate: {t}"),
-            MonadEvent::StateSyncEvent(_) => "STATESYNC".to_string(),
-            MonadEvent::ConfigEvent(_) => "CONFIGEVENT".to_string(),
-            MonadEvent::SecondaryRaptorcastPeersUpdate { .. } => {
-                "SecondaryRaptorcastPeersUpdate".to_string()
-            }
-        };
-
-        write!(f, "{}", s)
+        std::fmt::Display::fmt(self.as_ref(), f)
     }
 }
 

--- a/monad-ledger/src/lib.rs
+++ b/monad-ledger/src/lib.rs
@@ -340,7 +340,7 @@ where
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.fetches.poll_recv(cx).map(|response| {
             let response = response.expect("fetches_tx never dropped");
-            Some(MonadEvent::BlockSyncEvent(BlockSyncEvent::SelfResponse {
+            Some(MonadEvent::block_sync_event(BlockSyncEvent::SelfResponse {
                 response,
             }))
         })

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -473,7 +473,7 @@ impl<S: SwarmRelation> MockExecutor<S> {
                 }
                 ExecutorEventType::Timestamp => {
                     let event = self.timestamper.next_tick();
-                    MockExecutorEvent::Event(MonadEvent::TimestampUpdateEvent(event.as_nanos()))
+                    MockExecutorEvent::Event(MonadEvent::timestamp_update_event(event.as_nanos()))
                 }
                 ExecutorEventType::StateSync => {
                     return self.statesync.pop().map(MockExecutorEvent::Event)

--- a/monad-mock-swarm/src/node.rs
+++ b/monad-mock-swarm/src/node.rs
@@ -275,7 +275,7 @@ impl<S: SwarmRelation> Node<S> {
                             let node_span =
                                 tracing::trace_span!("node", id = format!("{}", self.id));
                             let _guard = node_span.enter();
-                            let event_clone = event.lossy_clone();
+                            let event_clone = event.clone();
                             let commands = self.state.update(event);
 
                             self.executor.exec(commands);

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -252,7 +252,12 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
             node_state.chain_config.get_staking_activation(),
             state_backend.clone(),
         ),
-        timestamp: TokioTimestamp::new(Duration::from_millis(5), 100, 10001),
+        timestamp:
+            TokioTimestamp::<SignatureType, SignatureCollectionType, ExecutionProtocolType>::new(
+                Duration::from_millis(5),
+                100,
+                10001,
+            ),
         txpool: EthTxPoolExecutor::start(
             create_block_policy(),
             state_backend.clone(),
@@ -278,7 +283,11 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
             score_reader,
         )
         .expect("txpool ipc succeeds"),
-        control_panel: ControlPanelIpcReceiver::new(
+        control_panel: ControlPanelIpcReceiver::<
+            SignatureType,
+            SignatureCollectionType,
+            ExecutionProtocolType,
+        >::new(
             node_state.control_panel_ipc_path,
             node_state.reload_handle,
             1000,
@@ -301,7 +310,10 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
                 .expect("invalid file name")
                 .to_owned(),
         ),
-        config_loader: ConfigLoader::new(node_state.node_config_path),
+        config_loader:
+            ConfigLoader::<SignatureType, SignatureCollectionType, ExecutionProtocolType>::new(
+                node_state.node_config_path,
+            ),
     };
 
     let waltrace_tx = if node_state.wal_chunks == 0 {
@@ -504,7 +516,7 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
                     if let Some(waltrace_tx) = waltrace_tx.as_ref() {
                         let wal_event = LogFriendlyMonadEvent {
                             timestamp: Utc::now(),
-                            event: event.lossy_clone(),
+                            event: event.clone(),
                         };
                         match waltrace_tx.try_send(wal_event) {
                             Ok(()) => {}

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -27,7 +27,7 @@ use std::{
 
 use alloy_rlp::{Decodable, Encodable};
 use bytes::{Bytes, BytesMut};
-use futures::{channel::oneshot, FutureExt, Stream, StreamExt};
+use futures::{FutureExt, Stream, StreamExt};
 use itertools::Itertools;
 use message::{InboundRouterMessage, OutboundRouterMessage};
 use monad_crypto::{
@@ -54,7 +54,10 @@ use monad_peer_discovery::{
     NameRecord, PeerDiscoveryAlgo, PeerDiscoveryEvent,
 };
 use monad_peer_score::IdentityScore;
-use monad_types::{DropTimer, Epoch, ExecutionProtocol, NodeId, Round, RouterTarget, UdpPriority};
+use monad_types::{
+    DropTimer, Epoch, ExecutionProtocol, NodeId, Round, RouterTarget, TcpCompletionHandle,
+    UdpPriority,
+};
 use monad_validator::{
     signature_collection::SignatureCollection,
     validator_set::{ValidatorSet, ValidatorSetType as _},
@@ -362,7 +365,7 @@ where
         &mut self,
         to: &NodeId<CertificateSignaturePubKey<ST>>,
         make_app_message: impl FnOnce() -> Bytes,
-        completion: Option<oneshot::Sender<()>>,
+        completion: Option<TcpCompletionHandle>,
     ) {
         match self.peer_discovery_driver.lock().unwrap().get_addr(to) {
             None => {
@@ -389,7 +392,7 @@ where
                     address,
                     TcpMsg {
                         msg: signed_message.freeze(),
-                        completion,
+                        completion: completion.and_then(|completion| completion.take_sender()),
                     },
                 );
             }
@@ -1111,7 +1114,7 @@ where
     ST: CertificateSignatureRecoverable,
     M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
     OM: Encodable + Into<M> + Clone,
-    E: From<RaptorCastEvent<M::Event, ST>>,
+    RaptorCastEvent<M::Event, ST>: Into<E>,
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
     AP: auth::AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
     DS: IdentityScore<Identity = NodeId<CertificateSignaturePubKey<ST>>>,
@@ -1526,19 +1529,16 @@ where
             RaptorCastEvent::Message(event) => event,
             RaptorCastEvent::PeerManagerResponse(peer_manager_response) => {
                 match peer_manager_response {
-                    PeerManagerResponse::PeerList(peer) => MonadEvent::ControlPanelEvent(
+                    PeerManagerResponse::PeerList(peer) => MonadEvent::control_panel_event(
                         ControlPanelEvent::GetPeers(GetPeers::Response(peer)),
                     ),
-                    PeerManagerResponse::FullNodes(full_nodes) => MonadEvent::ControlPanelEvent(
+                    PeerManagerResponse::FullNodes(full_nodes) => MonadEvent::control_panel_event(
                         ControlPanelEvent::GetFullNodes(GetFullNodes::Response(full_nodes)),
                     ),
                 }
             }
             RaptorCastEvent::SecondaryRaptorcastPeersUpdate(expiry_round, confirm_group_peers) => {
-                MonadEvent::SecondaryRaptorcastPeersUpdate {
-                    expiry_round,
-                    confirm_group_peers,
-                }
+                MonadEvent::secondary_raptorcast_peers_update(expiry_round, confirm_group_peers)
             }
         }
     }

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -396,7 +396,7 @@ where
     ST: CertificateSignatureRecoverable,
     M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
     OM: Encodable + Into<M> + Clone,
-    E: From<RaptorCastEvent<M::Event, ST>>,
+    RaptorCastEvent<M::Event, ST>: Into<E>,
     PD: PeerDiscoveryAlgo<SignatureType = ST>,
     Self: Unpin,
 {

--- a/monad-raptorcast/tests/raptorcast_instance.rs
+++ b/monad-raptorcast/tests/raptorcast_instance.rs
@@ -432,7 +432,7 @@ where
             RaptorCastEvent::PeerManagerResponse(_peer_manager_response) => {
                 unimplemented!()
             }
-            RaptorCastEvent::SecondaryRaptorcastPeersUpdate { .. } => {
+            RaptorCastEvent::SecondaryRaptorcastPeersUpdate(..) => {
                 unimplemented!()
             }
         }

--- a/monad-raptorcast/tests/wireauth_raptorcast.rs
+++ b/monad-raptorcast/tests/wireauth_raptorcast.rs
@@ -110,7 +110,7 @@ where
         match value {
             RaptorCastEvent::Message(event) => event,
             RaptorCastEvent::PeerManagerResponse(_) => unimplemented!(),
-            RaptorCastEvent::SecondaryRaptorcastPeersUpdate { .. } => unimplemented!(),
+            RaptorCastEvent::SecondaryRaptorcastPeersUpdate(..) => unimplemented!(),
         }
     }
 }

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -478,7 +478,7 @@ where
     ST: CertificateSignatureRecoverable,
     M: Message<NodeIdPubKey = CertificateSignaturePubKey<ST>> + Decodable,
     OM: Encodable + Into<M> + Clone,
-    E: From<RaptorCastEvent<M::Event, ST>>,
+    RaptorCastEvent<M::Event, ST>: Into<E>,
     Self: Unpin,
     AP: AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
     DS: IdentityScore<Identity = NodeId<CertificateSignaturePubKey<ST>>>,

--- a/monad-router-scheduler/src/lib.rs
+++ b/monad-router-scheduler/src/lib.rs
@@ -155,7 +155,7 @@ where
             }
             RouterTarget::TcpPointToPoint { to, completion } => {
                 if let Some(completion) = completion {
-                    let _ = completion.send(());
+                    completion.notify();
                 }
                 self.events.push_back((time, RouterEvent::Tx(to, message)));
             }
@@ -272,7 +272,7 @@ where
             }
             RouterTarget::TcpPointToPoint { to, completion } => {
                 if let Some(completion) = completion {
-                    let _ = completion.send(());
+                    completion.notify();
                 }
                 self.events.push_back((time, RouterEvent::Tx(to, message)));
             }

--- a/monad-state/src/blocksync.rs
+++ b/monad-state/src/blocksync.rs
@@ -197,7 +197,7 @@ where
                 vec![Command::TimerCommand(TimerCommand::Schedule {
                     duration: wrapped.request_timeout,
                     variant: TimeoutVariant::BlockSync(request),
-                    on_timeout: MonadEvent::BlockSyncEvent(BlockSyncEvent::Timeout(request)),
+                    on_timeout: MonadEvent::block_sync_event(BlockSyncEvent::Timeout(request)),
                 })]
             }
             BlockSyncCommand::ResetTimeout(block_id) => {
@@ -228,13 +228,13 @@ where
                 vec![Command::LoopbackCommand(LoopbackCommand::Forward(
                     match requester {
                         BlockSyncSelfRequester::StateSync => {
-                            MonadEvent::StateSyncEvent(StateSyncEvent::BlockSync {
+                            MonadEvent::state_sync_event(StateSyncEvent::BlockSync {
                                 block_range,
                                 full_blocks,
                             })
                         }
                         BlockSyncSelfRequester::Consensus => {
-                            MonadEvent::ConsensusEvent(ConsensusEvent::BlockSync {
+                            MonadEvent::consensus_event(ConsensusEvent::BlockSync {
                                 block_range,
                                 full_blocks,
                             })

--- a/monad-state/src/consensus.rs
+++ b/monad-state/src/consensus.rs
@@ -716,7 +716,7 @@ where
                 parent_cmds.push(Command::TimerCommand(TimerCommand::Schedule {
                     duration,
                     variant: TimeoutVariant::Pacemaker,
-                    on_timeout: MonadEvent::ConsensusEvent(ConsensusEvent::Timeout(round)),
+                    on_timeout: MonadEvent::consensus_event(ConsensusEvent::Timeout(round)),
                 }))
             }
             ConsensusCommand::ScheduleReset => parent_cmds.push(Command::TimerCommand(
@@ -788,7 +788,7 @@ where
             }
             ConsensusCommand::RequestSync(block_range) => {
                 parent_cmds.push(Command::LoopbackCommand(LoopbackCommand::Forward(
-                    MonadEvent::BlockSyncEvent(BlockSyncEvent::SelfRequest {
+                    MonadEvent::block_sync_event(BlockSyncEvent::SelfRequest {
                         requester: BlockSyncSelfRequester::Consensus,
                         block_range,
                     }),
@@ -796,7 +796,7 @@ where
             }
             ConsensusCommand::CancelSync(block_range) => {
                 parent_cmds.push(Command::LoopbackCommand(LoopbackCommand::Forward(
-                    MonadEvent::BlockSyncEvent(BlockSyncEvent::SelfCancelRequest {
+                    MonadEvent::block_sync_event(BlockSyncEvent::SelfCancelRequest {
                         requester: BlockSyncSelfRequester::Consensus,
                         block_range,
                     }),
@@ -804,7 +804,7 @@ where
             }
             ConsensusCommand::RequestStateSync { root, high_qc } => {
                 parent_cmds.push(Command::LoopbackCommand(LoopbackCommand::Forward(
-                    MonadEvent::StateSyncEvent(StateSyncEvent::RequestSync { root, high_qc }),
+                    MonadEvent::state_sync_event(StateSyncEvent::RequestSync { root, high_qc }),
                 )));
             }
             ConsensusCommand::TimestampUpdate(t) => {
@@ -814,7 +814,7 @@ where
                 parent_cmds.push(Command::TimerCommand(TimerCommand::Schedule {
                     duration,
                     variant: TimeoutVariant::SendVote,
-                    on_timeout: MonadEvent::ConsensusEvent(ConsensusEvent::SendVote(round)),
+                    on_timeout: MonadEvent::consensus_event(ConsensusEvent::SendVote(round)),
                 }))
             }
         }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -55,10 +55,10 @@ use monad_crypto::certificate_signature::{
 };
 use monad_executor_glue::{
     BlockSyncEvent, ClearMetrics, Command, ConfigEvent, ConfigFileCommand, ConfigReloadCommand,
-    ConsensusEvent, ControlPanelCommand, ControlPanelEvent, GetFullNodes, GetMetrics, GetPeers,
-    LedgerCommand, MempoolEvent, Message, MonadEvent, ReadCommand, ReloadConfig, RouterCommand,
-    StateSyncCommand, StateSyncEvent, StateSyncNetworkMessage, StateSyncRequest, TxPoolCommand,
-    ValSetCommand, ValidatorEvent, WriteCommand,
+    ConfigUpdate, ConsensusEvent, ControlPanelCommand, ControlPanelEvent, GetFullNodes, GetMetrics,
+    GetPeers, InnerMonadEvent, LedgerCommand, MempoolEvent, Message, MonadEvent, ReadCommand,
+    ReloadConfig, RouterCommand, StateSyncCommand, StateSyncEvent, StateSyncNetworkMessage,
+    StateSyncRequest, TxPoolCommand, ValSetCommand, ValidatorEvent, WriteCommand,
 };
 use monad_state_backend::StateBackend;
 use monad_types::{
@@ -798,31 +798,30 @@ where
         // `from` must somehow be guaranteed to be staked at this point so that subsequent
         // malformed stuff (that gets added to event log) can be slashed? TODO
         match self {
-            MonadMessage::Consensus(msg) => MonadEvent::ConsensusEvent(ConsensusEvent::Message {
+            MonadMessage::Consensus(msg) => MonadEvent::consensus_event(ConsensusEvent::Message {
                 sender: from,
                 unverified_message: msg,
             }),
-
             MonadMessage::BlockSyncRequest(request) => {
-                MonadEvent::BlockSyncEvent(BlockSyncEvent::Request {
+                MonadEvent::block_sync_event(BlockSyncEvent::Request {
                     sender: from,
                     request,
                 })
             }
             MonadMessage::BlockSyncResponse(response) => {
-                MonadEvent::BlockSyncEvent(BlockSyncEvent::Response {
+                MonadEvent::block_sync_event(BlockSyncEvent::Response {
                     sender: from,
                     response,
                 })
             }
             MonadMessage::ForwardedTx(msg) => {
-                MonadEvent::MempoolEvent(MempoolEvent::ForwardedTxs {
+                MonadEvent::mempool_event(MempoolEvent::ForwardedTxs {
                     sender: from,
                     txs: msg,
                 })
             }
             MonadMessage::StateSyncMessage(msg) => {
-                MonadEvent::StateSyncEvent(StateSyncEvent::Inbound(from, msg))
+                MonadEvent::state_sync_event(StateSyncEvent::Inbound(from, msg))
             }
         }
     }
@@ -964,7 +963,7 @@ where
         }) = self.forkpoint;
 
         for vset in self.locked_epoch_validators {
-            init_cmds.extend(monad_state.update(MonadEvent::ValidatorEvent(
+            init_cmds.extend(monad_state.update(MonadEvent::validator_event(
                 ValidatorEvent::UpdateValidators(vset),
             )));
         }
@@ -1006,8 +1005,8 @@ where
             CRT,
         >,
     > {
-        match event {
-            MonadEvent::ConsensusEvent(consensus_event) => {
+        match event.into_inner() {
+            InnerMonadEvent::ConsensusEvent(consensus_event) => {
                 let consensus_cmds = ConsensusChildState::new(self).update(consensus_event);
 
                 let take_checkpoint = consensus_cmds
@@ -1044,7 +1043,7 @@ where
                 cmds
             }
 
-            MonadEvent::BlockSyncEvent(block_sync_event) => {
+            InnerMonadEvent::BlockSyncEvent(block_sync_event) => {
                 let block_sync_cmds = BlockSyncChildState::new(self).update(block_sync_event);
 
                 block_sync_cmds
@@ -1053,7 +1052,9 @@ where
                     .collect::<Vec<_>>()
             }
 
-            MonadEvent::ValidatorEvent(ValidatorEvent::UpdateValidators(validator_set_data)) => {
+            InnerMonadEvent::ValidatorEvent(ValidatorEvent::UpdateValidators(
+                validator_set_data,
+            )) => {
                 let val_ids = validator_set_data.validators.get_pubkeys();
 
                 self.val_epoch_map.insert(
@@ -1090,15 +1091,15 @@ where
                 cmds
             }
 
-            MonadEvent::MempoolEvent(event) => {
+            InnerMonadEvent::MempoolEvent(event) => {
                 // TODO(andr-dev): Don't allow ConsensusChildState to produce Command<...> directly (requires IPC->TxPool refactor)
                 ConsensusChildState::new(self).handle_mempool_event(event)
             }
-            MonadEvent::StateSyncEvent(state_sync_event) => match state_sync_event {
+            InnerMonadEvent::StateSyncEvent(state_sync_event) => match state_sync_event {
                 StateSyncEvent::Inbound(sender, message) => {
                     // Filter statesync requests based on sender
-                    if let StateSyncNetworkMessage::Request(request) = message {
-                        if !self.should_service_statesync_request(&sender, &request) {
+                    if let StateSyncNetworkMessage::Request(request) = &message {
+                        if !self.should_service_statesync_request(&sender, request) {
                             tracing::debug!(
                                 ?sender,
                                 "dropping statesync request from non-whitelisted sender"
@@ -1206,7 +1207,7 @@ where
                     commands
                 }
             },
-            MonadEvent::ControlPanelEvent(control_panel_event) => match control_panel_event {
+            InnerMonadEvent::ControlPanelEvent(control_panel_event) => match control_panel_event {
                 ControlPanelEvent::GetMetricsEvent => {
                     vec![Command::ControlPanelCommand(ControlPanelCommand::Read(
                         ReadCommand::GetMetrics(GetMetrics::Response(self.metrics)),
@@ -1256,30 +1257,33 @@ where
                     }
                 },
             },
-            MonadEvent::TimestampUpdateEvent(t) => {
+            InnerMonadEvent::TimestampUpdateEvent(t) => {
                 self.block_timestamp.update_time(t);
                 if let ConsensusMode::Live(consensus) = &mut self.consensus {
                     consensus.refresh_vote_delay_metrics(t, &mut self.metrics);
                 }
                 vec![]
             }
-            MonadEvent::ConfigEvent(config_event) => match config_event {
+            InnerMonadEvent::ConfigEvent(config_event) => match config_event {
                 ConfigEvent::ConfigUpdate(config_update) => {
-                    self.block_sync
-                        .set_override_peers(config_update.blocksync_override_peers);
+                    let ConfigUpdate {
+                        dedicated_full_nodes,
+                        prioritized_full_nodes,
+                        blocksync_override_peers,
+                    } = config_update;
+                    self.block_sync.set_override_peers(blocksync_override_peers);
 
                     // Store whitelisted full nodes for statesync filtering
-                    self.whitelisted_statesync_nodes = config_update
-                        .dedicated_full_nodes
+                    self.whitelisted_statesync_nodes = dedicated_full_nodes
                         .iter()
-                        .chain(config_update.prioritized_full_nodes.iter())
+                        .chain(prioritized_full_nodes.iter())
                         .cloned()
                         .collect();
 
                     let mut cmds = Vec::new();
                     cmds.push(Command::RouterCommand(RouterCommand::UpdateFullNodes {
-                        dedicated_full_nodes: config_update.dedicated_full_nodes,
-                        prioritized_full_nodes: config_update.prioritized_full_nodes,
+                        dedicated_full_nodes,
+                        prioritized_full_nodes,
                     }));
 
                     cmds.push(Command::ControlPanelCommand(ControlPanelCommand::Write(
@@ -1301,12 +1305,13 @@ where
                     })]
                 }
             },
-            MonadEvent::SecondaryRaptorcastPeersUpdate {
+            InnerMonadEvent::SecondaryRaptorcastPeersUpdate {
                 expiry_round,
                 confirm_group_peers,
             } => {
                 let peers_excl_self: Vec<_> = confirm_group_peers
-                    .into_iter()
+                    .iter()
+                    .cloned()
                     .filter(|peer| peer != &self.nodeid)
                     .collect();
 
@@ -1376,7 +1381,7 @@ where
                 root_seq_num =? block_buffer.root_seq_num(),
                 "still syncing..."
             );
-            return self.update(MonadEvent::BlockSyncEvent(BlockSyncEvent::SelfRequest {
+            return self.update(MonadEvent::block_sync_event(BlockSyncEvent::SelfRequest {
                 requester: BlockSyncSelfRequester::StateSync,
                 block_range,
             }));
@@ -1421,7 +1426,7 @@ where
 
             if delay_executed {
                 // TODO assert state root matches?
-                return self.update(MonadEvent::StateSyncEvent(StateSyncEvent::DoneSync(
+                return self.update(MonadEvent::state_sync_event(StateSyncEvent::DoneSync(
                     delay_seq_num,
                 )));
             }
@@ -1579,12 +1584,12 @@ where
         // would need to restart at the exact same time and finish
         // statesyncing/blocksyncing within the vote pacing window
         commands.extend(
-            self.update(MonadEvent::ConsensusEvent(ConsensusEvent::SendVote(
+            self.update(MonadEvent::consensus_event(ConsensusEvent::SendVote(
                 current_round,
             ))),
         );
         commands.extend(
-            self.update(MonadEvent::ConsensusEvent(ConsensusEvent::Timeout(
+            self.update(MonadEvent::consensus_event(ConsensusEvent::Timeout(
                 current_round,
             ))),
         );

--- a/monad-statesync/src/lib.rs
+++ b/monad-statesync/src/lib.rs
@@ -30,7 +30,7 @@ use monad_crypto::certificate_signature::{
 use monad_eth_types::EthExecutionProtocol;
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{MonadEvent, StateSyncCommand, StateSyncEvent, StateSyncNetworkMessage};
-use monad_types::{NodeId, SeqNum};
+use monad_types::{NodeId, SeqNum, TcpCompletionHandle};
 use monad_validator::signature_collection::SignatureCollection;
 
 #[allow(dead_code, non_camel_case_types, non_upper_case_globals)]
@@ -326,7 +326,7 @@ where
                             )
                         }
                     };
-                    return Poll::Ready(Some(MonadEvent::StateSyncEvent(event)));
+                    return Poll::Ready(Some(MonadEvent::state_sync_event(event)));
                 }
             }
             StateSyncMode::Live(execution_ipc) => {
@@ -350,8 +350,12 @@ where
                         },
                         "sending response"
                     );
-                    return Poll::Ready(Some(MonadEvent::StateSyncEvent(
-                        StateSyncEvent::Outbound(to, message, Some(completion)),
+                    return Poll::Ready(Some(MonadEvent::state_sync_event(
+                        StateSyncEvent::Outbound(
+                            to,
+                            message,
+                            Some(TcpCompletionHandle::new(completion)),
+                        ),
                     )));
                 }
             }

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -19,6 +19,7 @@ use std::{
     io,
     ops::{Add, AddAssign, Div, Rem, Sub, SubAssign},
     str::FromStr,
+    sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 
@@ -679,6 +680,31 @@ impl<S: Clone> Deserializable<S> for S {
 // FIXME-4: move to monad-executor-glue after spaghetti fixed
 /// RouterTarget specifies the particular node(s) that the router should send
 /// the message toward
+#[derive(Clone)]
+pub struct TcpCompletionHandle(Arc<Mutex<Option<futures::channel::oneshot::Sender<()>>>>);
+
+impl TcpCompletionHandle {
+    pub fn new(sender: futures::channel::oneshot::Sender<()>) -> Self {
+        Self(Arc::new(Mutex::new(Some(sender))))
+    }
+
+    pub fn take_sender(&self) -> Option<futures::channel::oneshot::Sender<()>> {
+        self.0.lock().expect("tcp completion mutex poisoned").take()
+    }
+
+    pub fn notify(&self) {
+        if let Some(sender) = self.take_sender() {
+            let _ = sender.send(());
+        }
+    }
+}
+
+impl Debug for TcpCompletionHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("TcpCompletionHandle")
+    }
+}
+
 #[derive(Debug)]
 pub enum RouterTarget<P: PubKey> {
     Broadcast(Epoch),
@@ -687,7 +713,7 @@ pub enum RouterTarget<P: PubKey> {
     DirectPointToPoint(NodeId<P>),
     TcpPointToPoint {
         to: NodeId<P>,
-        completion: Option<futures::channel::oneshot::Sender<()>>,
+        completion: Option<TcpCompletionHandle>,
     },
 }
 

--- a/monad-updaters/src/config_loader.rs
+++ b/monad-updaters/src/config_loader.rs
@@ -239,9 +239,9 @@ where
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
         let this = self.deref_mut();
-        this.response_rx.poll_recv(cx).map(|maybe_event| {
-            maybe_event.map(|config_event| MonadEvent::ConfigEvent(config_event))
-        })
+        this.response_rx
+            .poll_recv(cx)
+            .map(|maybe_event| maybe_event.map(MonadEvent::config_event))
     }
 }
 

--- a/monad-updaters/src/ledger.rs
+++ b/monad-updaters/src/ledger.rs
@@ -254,7 +254,7 @@ where
         let this = self.deref_mut();
 
         if let Some(event) = this.events.pop_front() {
-            return Poll::Ready(Some(MonadEvent::BlockSyncEvent(event)));
+            return Poll::Ready(Some(MonadEvent::block_sync_event(event)));
         }
 
         if let Some(waker) = this.waker.as_mut() {

--- a/monad-updaters/src/local_router.rs
+++ b/monad-updaters/src/local_router.rs
@@ -154,7 +154,7 @@ where
                     }
                     RouterTarget::TcpPointToPoint { to, completion } => {
                         if let Some(completion) = completion {
-                            let _ = completion.send(());
+                            completion.notify();
                         }
                         self.txs
                             .get(&to)
@@ -183,7 +183,7 @@ where
                     }
                     RouterTarget::TcpPointToPoint { to, completion } => {
                         if let Some(completion) = completion {
-                            let _ = completion.send(());
+                            completion.notify();
                         }
                         self.txs
                             .get(&to)

--- a/monad-updaters/src/statesync.rs
+++ b/monad-updaters/src/statesync.rs
@@ -107,7 +107,7 @@ where
                     if eth_header.seq_num() == GENESIS_SEQ_NUM =>
                 {
                     self.events
-                        .push_back(MonadEvent::StateSyncEvent(StateSyncEvent::DoneSync(
+                        .push_back(MonadEvent::state_sync_event(StateSyncEvent::DoneSync(
                             GENESIS_SEQ_NUM,
                         )));
                 }
@@ -125,7 +125,7 @@ where
                     };
                     self.request = Some(request);
                     self.events.extend(self.peers.iter().map(|peer| {
-                        MonadEvent::StateSyncEvent(StateSyncEvent::Outbound(
+                        MonadEvent::state_sync_event(StateSyncEvent::Outbound(
                             *peer,
                             StateSyncNetworkMessage::Request(request),
                             None, // don't care about completion for mock
@@ -163,12 +163,13 @@ where
                             )],
                             response_n: 1,
                         };
-                        self.events
-                            .push_back(MonadEvent::StateSyncEvent(StateSyncEvent::Outbound(
+                        self.events.push_back(MonadEvent::state_sync_event(
+                            StateSyncEvent::Outbound(
                                 from,
                                 StateSyncNetworkMessage::Response(response),
                                 None, // don't care about completion for mock
-                            )))
+                            ),
+                        ))
                     }
                     StateSyncNetworkMessage::Response(response) => {
                         if !self.started_execution
@@ -181,7 +182,7 @@ where
                                 serde_json::from_slice(&response.response[0].data).unwrap();
                             let mut old_state = self.state_backend.lock().unwrap();
                             old_state.reset_state(deserialized);
-                            self.events.push_back(MonadEvent::StateSyncEvent(
+                            self.events.push_back(MonadEvent::state_sync_event(
                                 StateSyncEvent::DoneSync(SeqNum(response.request.target)),
                             ));
                         }

--- a/monad-updaters/src/tokio_timestamp.rs
+++ b/monad-updaters/src/tokio_timestamp.rs
@@ -86,7 +86,7 @@ where
                     .expect("Clock may have gone backwards");
                 let t = epoch_time.as_nanos();
                 // t += self.adjuster.get_adjustment();
-                Poll::Ready(Some(MonadEvent::TimestampUpdateEvent(t)))
+                Poll::Ready(Some(MonadEvent::timestamp_update_event(t)))
             }
             Poll::Pending => Poll::Pending,
         }

--- a/monad-updaters/src/triedb_val_set.rs
+++ b/monad-updaters/src/triedb_val_set.rs
@@ -178,7 +178,7 @@ where
                     "received validator set data"
                 );
 
-                Poll::Ready(Some(MonadEvent::ValidatorEvent(
+                Poll::Ready(Some(MonadEvent::validator_event(
                     monad_executor_glue::ValidatorEvent::UpdateValidators(
                         validator_set_data_with_epoch,
                     ),

--- a/monad-updaters/src/txpool.rs
+++ b/monad-updaters/src/txpool.rs
@@ -485,7 +485,7 @@ where
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         if let Some(event) = self.events.pop_front() {
-            return Poll::Ready(Some(MonadEvent::MempoolEvent(event)));
+            return Poll::Ready(Some(MonadEvent::mempool_event(event)));
         }
 
         if let Some(waker) = self.waker.as_mut() {

--- a/monad-updaters/src/val_set.rs
+++ b/monad-updaters/src/val_set.rs
@@ -185,7 +185,7 @@ where
         }
 
         if let Some(next_val_data) = this.next_val_data.take() {
-            return Poll::Ready(Some(MonadEvent::ValidatorEvent(
+            return Poll::Ready(Some(MonadEvent::validator_event(
                 monad_executor_glue::ValidatorEvent::<SCT>::UpdateValidators(next_val_data),
             )));
         }
@@ -346,7 +346,7 @@ where
         let this = self.deref_mut();
 
         if let Some(next_val_data) = this.next_val_data.take() {
-            return Poll::Ready(Some(MonadEvent::ValidatorEvent(
+            return Poll::Ready(Some(MonadEvent::validator_event(
                 monad_executor_glue::ValidatorEvent::<SCT>::UpdateValidators(next_val_data),
             )));
         }


### PR DESCRIPTION
Wrap MonadEvent itself around Arc<InnerMonadEvent> so events are heap-allocated at creation time and cloned cheaply everywhere else.

Change-Id: I4b6c6e12ad5927e09f8a84e0efcbca86e43401f8