### PR TITLE
docs: link execution cargo build requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,27 @@ To run a Monad consensus client, follow instructions [here](monad-node/README.md
  
 To run a JsonRpc server, follow instructions [here](monad-rpc/README.md).
 
+#### Cargo targets that link Monad execution
+
+Some Rust targets depend on the execution C++ library through crates such as
+`monad-ethcall`, `monad-triedb`, or `monad-cxx`. When building or testing those
+targets directly with Cargo on x86, use the compiler and CPU feature settings
+documented by Monad execution:
+
+- [minimum development tool requirements](monad-execution/README.md#minimum-development-tool-requirements)
+- [CPU compilation requirements](monad-execution/README.md#cpu-compilation-requirements)
+- [compiling the execution code](monad-execution/README.md#compiling-the-execution-code)
+
+Set `TRIEDB_TARGET=triedb_driver` when the Cargo target needs the Rust build
+scripts to build and link the execution C++ library.
+
+If CMake was first configured with the wrong compiler or flags, remove the
+generated `monad-cxx` build directory before retrying:
+
+```bash
+rm -rf target/release/build/monad-cxx-*
+```
+
 ## Architecture
 
 ```mermaid

--- a/README.md
+++ b/README.md
@@ -111,18 +111,20 @@ Some Rust targets depend on the execution C++ library through crates such as
 targets directly with Cargo on x86, use the compiler and CPU feature settings
 documented by Monad execution:
 
-- [minimum development tool requirements](monad-execution/README.md#minimum-development-tool-requirements)
-- [CPU compilation requirements](monad-execution/README.md#cpu-compilation-requirements)
-- [compiling the execution code](monad-execution/README.md#compiling-the-execution-code)
+- [minimum development tool requirements](https://github.com/category-labs/monad/blob/184baba1c5f4f04cd80ae6df2b4bc06602496aa9/README.md#minimum-development-tool-requirements)
+- [CPU compilation requirements](https://github.com/category-labs/monad/blob/184baba1c5f4f04cd80ae6df2b4bc06602496aa9/README.md#cpu-compilation-requirements)
+- [compiling the execution code](https://github.com/category-labs/monad/blob/184baba1c5f4f04cd80ae6df2b4bc06602496aa9/README.md#compiling-the-execution-code)
 
 Set `TRIEDB_TARGET=triedb_driver` when the Cargo target needs the Rust build
 scripts to build and link the execution C++ library.
 
 If CMake was first configured with the wrong compiler or flags, remove the
-generated `monad-cxx` build directory before retrying:
+generated `monad-cxx` build directory for the relevant Cargo profile before
+retrying:
 
 ```bash
-rm -rf target/release/build/monad-cxx-*
+rm -rf "${CARGO_TARGET_DIR:-target}"/debug/build/monad-cxx-*
+rm -rf "${CARGO_TARGET_DIR:-target}"/release/build/monad-cxx-*
 ```
 
 ## Architecture


### PR DESCRIPTION
## Summary

- Add a root README note for Cargo targets that link Monad execution.
- Point readers to the execution README as the source of truth for compiler and CPU feature requirements.
- Mention the Cargo-specific TRIEDB_TARGET switch and the stale generated monad-cxx CMake build directory recovery step.

## Why

While testing the eth_createAccessList changes on an x86 dev box, getting to the actual Rust tests took several attempts. The target linked through Monad execution, so the build needed the execution compiler and CPU feature setup, TRIEDB_TARGET for the Rust build scripts to build and link the C++ execution library, and a clean generated monad-cxx CMake build directory after an initial bad configure.

This README pointer should make that path easier for the next developer without duplicating the execution documentation that owns the detailed build requirements.

## Validation

- git diff --check