### PR TITLE
Remove ranged lookup from validators config file

### DIFF
--- a/monad-consensus-types/src/validator_data.rs
+++ b/monad-consensus-types/src/validator_data.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{collections::BTreeMap, error::Error, ops::Bound, path::Path};
+use std::{collections::BTreeMap, error::Error, path::Path};
 
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 use monad_crypto::certificate_signature::{
@@ -116,31 +116,32 @@ impl<SCT: SignatureCollection> ValidatorsConfig<SCT> {
         })
     }
 
-    pub fn get_validator_set(&self, epoch: &Epoch) -> &ValidatorSetData<SCT> {
-        self.validators
-            .range((Bound::Included(Epoch(0)), Bound::Included(*epoch)))
-            .last()
-            .expect("no validator set <= block.epoch")
-            .1
+    pub fn get_validator_set(&self, epoch: &Epoch) -> Option<&ValidatorSetData<SCT>> {
+        self.validators.get(epoch)
     }
 
     pub fn get_locked_validator_sets<ST, EPT>(
         &self,
         forkpoint: &Checkpoint<ST, SCT, EPT>,
-    ) -> Vec<ValidatorSetDataWithEpoch<SCT>>
+    ) -> Result<Vec<ValidatorSetDataWithEpoch<SCT>>, Epoch>
     where
         ST: CertificateSignatureRecoverable,
         SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
         EPT: ExecutionProtocol,
     {
-        forkpoint
-            .validator_sets
-            .iter()
-            .map(|locked_epoch| ValidatorSetDataWithEpoch {
+        let mut validator_sets = Vec::new();
+        for locked_epoch in &forkpoint.validator_sets {
+            let validators = match self.get_validator_set(&locked_epoch.epoch) {
+                Some(v) => v.clone(),
+                None => return Err(locked_epoch.epoch),
+            };
+            validator_sets.push(ValidatorSetDataWithEpoch {
                 epoch: locked_epoch.epoch,
-                validators: self.get_validator_set(&locked_epoch.epoch).clone(),
-            })
-            .collect()
+                validators,
+            });
+        }
+
+        Ok(validator_sets)
     }
 }
 
@@ -273,4 +274,73 @@ where
         <SCT as SignatureCollection>::NodeIdPubKey::from_bytes(&bytes)
             .map_err(<D::Error as serde::de::Error>::custom)?,
     ))
+}
+
+#[cfg(test)]
+mod test {
+    use monad_crypto::NopSignature;
+    use monad_testutil::signing::MockSignatures;
+    use monad_types::{BlockId, Epoch, Hash, LimitedVec, Round};
+
+    use crate::{
+        block::MockExecutionProtocol,
+        checkpoint::{Checkpoint, LockedEpoch},
+        quorum_certificate::QuorumCertificate,
+        validator_data::{ValidatorSetData, ValidatorsConfig},
+        RoundCertificate,
+    };
+
+    type SignatureType = NopSignature;
+    type SignatureCollectionType = MockSignatures<SignatureType>;
+    type ExecutionProtocolType = MockExecutionProtocol;
+
+    #[test]
+    fn test_get_locked_validator_sets() {
+        let mut validators = std::collections::BTreeMap::new();
+        validators.insert(
+            Epoch(1),
+            ValidatorSetData::<SignatureCollectionType>(Default::default()),
+        );
+        validators.insert(
+            Epoch(2),
+            ValidatorSetData::<SignatureCollectionType>(Default::default()),
+        );
+        let validators_config = ValidatorsConfig { validators };
+
+        let forkpoint_success = Checkpoint {
+            root: BlockId(Hash::default()),
+            high_certificate: RoundCertificate::Qc(QuorumCertificate::genesis_qc()),
+            validator_sets: LimitedVec(vec![
+                LockedEpoch {
+                    epoch: Epoch(1),
+                    round: Round(10),
+                },
+                LockedEpoch {
+                    epoch: Epoch(2),
+                    round: Round(20),
+                },
+            ]),
+        };
+        assert!(validators_config
+            .get_locked_validator_sets::<SignatureType, ExecutionProtocolType>(&forkpoint_success)
+            .is_ok());
+
+        let forkpoint_failure = Checkpoint {
+            root: BlockId(Hash::default()),
+            high_certificate: RoundCertificate::Qc(QuorumCertificate::genesis_qc()),
+            validator_sets: LimitedVec(vec![
+                LockedEpoch {
+                    epoch: Epoch(2),
+                    round: Round(10),
+                },
+                LockedEpoch {
+                    epoch: Epoch(3),
+                    round: Round(20),
+                },
+            ]),
+        };
+        assert!(validators_config
+            .get_locked_validator_sets::<SignatureType, ExecutionProtocolType>(&forkpoint_failure)
+            .is_err_and(|missing_epoch| missing_epoch == Epoch(3)));
+    }
 }

--- a/monad-node/examples/ledger-tail.rs
+++ b/monad-node/examples/ledger-tail.rs
@@ -147,6 +147,7 @@ async fn main() {
                             .unwrap_or_else(|err| panic!("failed to read validators.toml, or validators.toml corrupt. was this edited manually? err={:?}", err));
                     validators
                         .get_validator_set(&tc.epoch)
+                        .expect("validator set should exist for current epoch")
                         .get_stakes()
                         .into_iter()
                         .collect()

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -148,7 +148,13 @@ fn main() {
 async fn run(node_state: NodeState) -> Result<(), ()> {
     let locked_epoch_validators = node_state
         .validators_config
-        .get_locked_validator_sets(&node_state.forkpoint_config);
+        .get_locked_validator_sets(&node_state.forkpoint_config)
+        .unwrap_or_else(|epoch| {
+            panic!(
+                "validators config missing validator set for epoch {}",
+                epoch
+            )
+        });
 
     let current_epoch = node_state
         .forkpoint_config

--- a/monad-node/src/state.rs
+++ b/monad-node/src/state.rs
@@ -368,15 +368,33 @@ fn get_latest_configs(
 
             // if remote config is more recent, use that over local config
             if remote_forkpoint_round > local_forkpoint_round + remote_configs_threshold {
-                info!(
-                    ?remote_forkpoint_round,
-                    ?local_forkpoint_round,
-                    "local forkpoint over {} rounds older than remote forkpoint, using remote configs",
-                    remote_configs_threshold.0
-                );
+                let maybe_missing_epoch =
+                    remote_forkpoint_config
+                        .validator_sets
+                        .iter()
+                        .find_map(|locked_epoch| {
+                            remote_validators_config
+                                .get_validator_set(&locked_epoch.epoch)
+                                .is_none()
+                                .then_some(locked_epoch.epoch)
+                        });
+                if let Some(epoch) = maybe_missing_epoch {
+                    info!(
+                        "remote validators config missing validator set for remote forkpoint at epoch {}, using local configs",
+                        epoch
+                    );
+                    return Ok((local_forkpoint_config, local_validators_config));
+                } else {
+                    info!(
+                        ?remote_forkpoint_round,
+                        ?local_forkpoint_round,
+                        "local forkpoint over {} rounds older than remote forkpoint, using remote configs",
+                        remote_configs_threshold
+                    );
 
-                replace_local_configs(&remote_forkpoint_config, &remote_validators_config);
-                return Ok((remote_forkpoint_config, remote_validators_config));
+                    replace_local_configs(&remote_forkpoint_config, &remote_validators_config);
+                    return Ok((remote_forkpoint_config, remote_validators_config));
+                }
             }
 
             info!(

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1632,9 +1632,7 @@ where
 mod test {
     use monad_bls::BlsSignatureCollection;
     use monad_consensus_types::{
-        quorum_certificate::QuorumCertificate,
-        validator_data::{ValidatorData, ValidatorSetData, ValidatorsConfig},
-        voting::Vote,
+        quorum_certificate::QuorumCertificate, validator_data::ValidatorSetData, voting::Vote,
     };
     use monad_crypto::{certificate_signature::CertificateSignaturePubKey, signing_domain};
     use monad_eth_types::EthExecutionProtocol;
@@ -1844,56 +1842,6 @@ mod test {
             ),
             Err(ForkpointValidationError::InvalidQC)
         );
-    }
-
-    #[test]
-    fn test_validators_config() {
-        let (keys, cert_keys, _valset, _valmap) = create_keys_w_validators::<
-            SignatureType,
-            SignatureCollectionType,
-            _,
-        >(1, ValidatorSetFactory::default());
-
-        let make_val_set_data = |stake: Stake| {
-            ValidatorSetData(
-                vec![ValidatorData {
-                    node_id: NodeId::new(keys[0].pubkey()),
-                    cert_pubkey: cert_keys[0].pubkey(),
-                    stake,
-                }]
-                .into(),
-            )
-        };
-
-        let validators_config: ValidatorsConfig<SignatureCollectionType> = ValidatorsConfig {
-            validators: vec![
-                (Epoch(1), make_val_set_data(Stake::ONE)),
-                (Epoch(2), make_val_set_data(Stake::from(2))),
-                (Epoch(4), make_val_set_data(Stake::from(3))),
-                (Epoch(10), make_val_set_data(Stake::from(4))),
-            ]
-            .into_iter()
-            .collect(),
-        };
-
-        let expected = vec![
-            (Epoch(1), make_val_set_data(Stake::ONE)),
-            (Epoch(2), make_val_set_data(Stake::from(2))),
-            (Epoch(3), make_val_set_data(Stake::from(2))),
-            (Epoch(4), make_val_set_data(Stake::from(3))),
-            (Epoch(5), make_val_set_data(Stake::from(3))),
-            (Epoch(6), make_val_set_data(Stake::from(3))),
-            (Epoch(7), make_val_set_data(Stake::from(3))),
-            (Epoch(8), make_val_set_data(Stake::from(3))),
-            (Epoch(9), make_val_set_data(Stake::from(3))),
-            (Epoch(10), make_val_set_data(Stake::from(4))),
-            (Epoch(11), make_val_set_data(Stake::from(4))),
-            (Epoch(12), make_val_set_data(Stake::from(4))),
-        ];
-
-        for (epoch, val_set) in &expected {
-            assert_eq!(val_set, validators_config.get_validator_set(epoch))
-        }
     }
 
     // Confirm that version values greather than 2^16 for version fields don't cause deser issue

--- a/monad-updaters/src/triedb_val_set.rs
+++ b/monad-updaters/src/triedb_val_set.rs
@@ -139,6 +139,12 @@ impl ValSetUpdater<SecpSignature, BlsSignatureCollection<PubKey>> {
             // This file should never be manually edited anyways.
             .expect("failed to read validators_path")
             .get_validator_set(&locked_epoch)
+            .unwrap_or_else(|| {
+                panic!(
+                    "validators config missing validator set for epoch {}",
+                    locked_epoch
+                )
+            })
             .clone();
         self.valset_sender
             .send((validator_set_data, seq_num, locked_epoch))


### PR DESCRIPTION
The ranged lookup was used before staking activation as a way to onboard new validators. This is not required anymore.