### PR TITLE
Remove redundant PubKey trait bound from NodeId struct definition

### DIFF
--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -425,7 +425,7 @@ impl SeqNum {
     RlpEncodableWrapper,
     RlpDecodableWrapper,
 )]
-pub struct NodeId<P: PubKey>(
+pub struct NodeId<P>(
     #[serde(serialize_with = "serialize_pubkey::<_, P>")]
     #[serde(deserialize_with = "deserialize_pubkey::<_, P>")]
     #[serde(bound = "P:PubKey")]


### PR DESCRIPTION
## Summary
- Drop `P: PubKey` bound on `NodeId<P>` struct declaration in `monad-types/src/lib.rs`
- Bound is still enforced at impl sites and via `#[serde(bound = "P:PubKey")]`, so removing it from the struct declaration is a no-op for callers

Closes category-labs/category-internal#1453

## Test plan
- [x] `cargo check --workspace` clean (pre-existing warnings only)
- [x] `cargo check --workspace --tests` clean
- [x] `cargo test -p monad-types` — 19 passed