### PR TITLE
Add descending block-alignment test for query_logs

### DIFF
--- a/monad-chain-data/tests/query_logs_indexed.rs
+++ b/monad-chain-data/tests/query_logs_indexed.rs
@@ -341,6 +341,78 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn indexed_query_completes_current_block_when_limit_reached_mid_block_descending() {
+    let service =
+        MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 1,
+            block_hash: B256::repeat_byte(1),
+            parent_hash: B256::ZERO,
+            logs_by_tx: vec![vec![log(
+                Address::repeat_byte(7),
+                vec![B256::repeat_byte(9)],
+            )]],
+        })
+        .await
+        .expect("ingest block 1");
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 2,
+            block_hash: B256::repeat_byte(2),
+            parent_hash: B256::repeat_byte(1),
+            logs_by_tx: vec![vec![
+                log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
+                log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
+                log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
+                log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
+                log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
+            ]],
+        })
+        .await
+        .expect("ingest block 2");
+
+    service
+        .ingest_block(FinalizedBlock {
+            block_number: 3,
+            block_hash: B256::repeat_byte(3),
+            parent_hash: B256::repeat_byte(2),
+            logs_by_tx: vec![vec![log(
+                Address::repeat_byte(7),
+                vec![B256::repeat_byte(9)],
+            )]],
+        })
+        .await
+        .expect("ingest block 3");
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            from_block: Some(1),
+            to_block: Some(3),
+            order: QueryOrder::Descending,
+            limit: 2,
+            filter: LogFilter {
+                address: Some(HashSet::from([Address::repeat_byte(7)])),
+                topics: [
+                    Some(HashSet::from([B256::repeat_byte(9)])),
+                    None,
+                    None,
+                    None,
+                ],
+            },
+        })
+        .await
+        .expect("query");
+
+    assert_eq!(page.logs.len(), 6);
+    assert!(page.logs.iter().take(1).all(|l| l.block_number == 3));
+    assert!(page.logs.iter().skip(1).all(|l| l.block_number == 2));
+    assert_eq!(page.cursor_block.number, 2);
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn indexed_query_stops_at_block_when_limit_equals_block_match_count() {
     let service =
         MonadChainDataService::new(InMemoryMetaStore::default(), InMemoryBlobStore::default());


### PR DESCRIPTION
Adds the descending indexed query coverage for the queryX invariant that a page completes the current block before stopping when the limit is reached mid-block.

This branch is intentionally a one-test delta above `jhow/chain-data/bitmap-pages-index`; the higher query branches are stacked on top of it.