### PR TITLE
Generalize indexed family query execution

### DIFF
--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -17,7 +17,7 @@ use bytes::Bytes;
 
 use crate::{
     blocks::{execute_query_blocks, load_blocks_for_logs, QueryBlocksRequest, QueryBlocksResponse},
-    engine::tables::Tables,
+    engine::{family::Family, tables::Tables},
     error::{MonadChainDataError, Result},
     family::FinalizedBlock,
     logs::{
@@ -68,7 +68,7 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
     /// Persists one finalized block and advances the published head on success.
     pub async fn ingest_block(&self, block: FinalizedBlock) -> Result<IngestOutcome> {
         let blocks = self.tables.blocks();
-        let logs = self.tables.logs();
+        let logs = self.tables.family(Family::Log);
         let current_head = self.tables.publication().load_published_head().await?;
         let previous_record = blocks.validate_continuity(&block, current_head).await?;
         let next_log_id = match previous_record {

--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -83,34 +83,15 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
             bitmap_fragments,
             written_logs,
         } = LogIngestPlan::build(&block, next_log_id)?;
-        let next_log_id_exclusive = block_record.logs.next_primary_id_exclusive()?;
         blocks
             .store_header(block.block_number(), &block.header)
             .await?;
-        logs.store_block_blob(block.block_number(), block_log_blob)
-            .await?;
-        logs.store_block_header(block.block_number(), Bytes::from(block_log_header.encode()))
-            .await?;
-        logs.dir()
-            .persist_block_fragment(
-                block.block_number(),
-                block_record.logs.first_primary_id.as_u64(),
-                block_record.logs.count,
-            )
-            .await?;
-        for fragment in &bitmap_fragments {
-            logs.store_bitmap_fragment(fragment, block.block_number())
-                .await?;
-        }
-        logs.compact_newly_sealed_directory_buckets(
-            next_log_id.as_u64(),
-            next_log_id_exclusive.as_u64(),
-        )
-        .await?;
-        logs.compact_newly_sealed_bitmap_pages(
+        logs.persist_indexed_family_ingest(
+            block.block_number(),
+            block_log_blob,
+            Bytes::from(block_log_header.encode()),
+            block_record.logs,
             &bitmap_fragments,
-            next_log_id.as_u64(),
-            next_log_id_exclusive.as_u64(),
         )
         .await?;
         blocks

--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -72,7 +72,7 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
         let current_head = self.tables.publication().load_published_head().await?;
         let previous_record = blocks.validate_continuity(&block, current_head).await?;
         let next_log_id = match previous_record {
-            Some(previous) => previous.logs.next_log_id()?,
+            Some(previous) => LogId::from(previous.logs.next_primary_id_exclusive()?),
             None => LogId::ZERO,
         };
 
@@ -83,7 +83,7 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
             bitmap_fragments,
             written_logs,
         } = LogIngestPlan::build(&block, next_log_id)?;
-        let next_log_id_exclusive = block_record.logs.next_log_id()?;
+        let next_log_id_exclusive = block_record.logs.next_primary_id_exclusive()?;
         blocks
             .store_header(block.block_number(), &block.header)
             .await?;
@@ -94,7 +94,7 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
         logs.dir()
             .persist_block_fragment(
                 block.block_number(),
-                block_record.logs.first_log_id.as_u64(),
+                block_record.logs.first_primary_id.as_u64(),
                 block_record.logs.count,
             )
             .await?;

--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -17,13 +17,7 @@ use bytes::Bytes;
 
 use crate::{
     blocks::{execute_query_blocks, load_blocks_for_logs, QueryBlocksRequest, QueryBlocksResponse},
-    engine::{
-        ingest::{
-            bitmap_compaction::compact_newly_sealed_log_bitmap_pages,
-            directory_compaction::compact_newly_sealed_log_directory_buckets,
-        },
-        tables::Tables,
-    },
+    engine::tables::Tables,
     error::{MonadChainDataError, Result},
     family::FinalizedBlock,
     logs::{
@@ -108,14 +102,12 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
             logs.store_bitmap_fragment(fragment, block.block_number())
                 .await?;
         }
-        compact_newly_sealed_log_directory_buckets(
-            logs,
+        logs.compact_newly_sealed_directory_buckets(
             next_log_id.as_u64(),
             next_log_id_exclusive.as_u64(),
         )
         .await?;
-        compact_newly_sealed_log_bitmap_pages(
-            logs,
+        logs.compact_newly_sealed_bitmap_pages(
             &bitmap_fragments,
             next_log_id.as_u64(),
             next_log_id_exclusive.as_u64(),

--- a/monad-chain-data/src/engine/family.rs
+++ b/monad-chain-data/src/engine/family.rs
@@ -13,7 +13,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::store::{BlobTableId, ScannableTableId, TableId};
+use crate::{
+    primitives::state::{BlockRecord, FamilyWindowRecord},
+    store::{BlobTableId, ScannableTableId, TableId},
+};
 
 pub struct FamilyTableIds {
     pub block_header: TableId,
@@ -52,6 +55,14 @@ impl Family {
     pub const fn table_ids(self) -> FamilyTableIds {
         match self {
             Family::Log => family_table_ids!("log"),
+        }
+    }
+
+    /// Returns the per-block window for this family, if this block recorded
+    /// any records in the family.
+    pub fn window_in(self, block: &BlockRecord) -> Option<FamilyWindowRecord> {
+        match self {
+            Family::Log => Some(block.logs),
         }
     }
 }

--- a/monad-chain-data/src/engine/ingest/bitmap_compaction.rs
+++ b/monad-chain-data/src/engine/ingest/bitmap_compaction.rs
@@ -34,67 +34,69 @@ struct BitmapCompactionPlan {
     final_open_streams: BTreeSet<String>,
 }
 
-/// Compacts every stream page sealed by the current ingest transition and
-/// updates the frontier open-stream inventory for the page that remains live.
-pub(crate) async fn compact_newly_sealed_log_bitmap_pages<M: MetaStore, B: BlobStore>(
-    logs: &FamilyTables<M, B>,
-    written_fragments: &[BitmapFragmentWrite],
-    from_next_primary_id: u64,
-    next_primary_id: u64,
-) -> Result<()> {
-    if next_primary_id <= from_next_primary_id {
-        return Ok(());
+impl<M: MetaStore, B: BlobStore> FamilyTables<M, B> {
+    /// Compacts every stream page sealed by the current ingest transition and
+    /// updates the frontier open-stream inventory for the page that remains live.
+    pub async fn compact_newly_sealed_bitmap_pages(
+        &self,
+        written_fragments: &[BitmapFragmentWrite],
+        from_next_primary_id: u64,
+        next_primary_id: u64,
+    ) -> Result<()> {
+        if next_primary_id <= from_next_primary_id {
+            return Ok(());
+        }
+
+        let start_open_page = global_page_start(from_next_primary_id);
+        let previous_open_streams = self
+            .load_open_bitmap_streams(start_open_page)
+            .await?
+            .into_iter()
+            .collect();
+        let touched_by_page = touched_streams_by_page(written_fragments)?;
+        let plan = build_compaction_plan(
+            previous_open_streams,
+            touched_by_page,
+            from_next_primary_id,
+            next_primary_id,
+        );
+
+        for (page_start, streams) in &plan.sealed_pages {
+            self.compact_page_streams(*page_start, streams).await?;
+        }
+
+        self.record_open_bitmap_streams(plan.final_open_page_start, &plan.final_open_streams)
+            .await?;
+
+        Ok(())
     }
 
-    let start_open_page = global_page_start(from_next_primary_id);
-    let previous_open_streams = logs
-        .load_open_bitmap_streams(start_open_page)
-        .await?
-        .into_iter()
-        .collect();
-    let touched_by_page = touched_streams_by_page(written_fragments)?;
-    let plan = build_compaction_plan(
-        previous_open_streams,
-        touched_by_page,
-        from_next_primary_id,
-        next_primary_id,
-    );
+    async fn compact_page_streams(
+        &self,
+        global_page_start: u64,
+        streams: &BTreeSet<String>,
+    ) -> Result<()> {
+        let page_start_local = local_page_start(global_page_start);
 
-    for (page_start, streams) in &plan.sealed_pages {
-        compact_page_streams(logs, *page_start, streams).await?;
+        for stream_id in streams {
+            let fragments = self
+                .load_bitmap_fragments(stream_id, page_start_local)
+                .await?;
+            // Sealed-page fragments are intentionally retained after compaction —
+            // the query path falls back to fragments when the compacted page is
+            // missing, and keeping them lets a corrupted page-meta/page-blob write
+            // be reconstructed from source. Storage cost is bounded by retention
+            // policy, which lives outside this slice.
+            let (meta, bitmap_blob) = compact_bitmap_page(page_start_local, &fragments)?;
+
+            self.store_bitmap_page_blob(stream_id, page_start_local, bitmap_blob)
+                .await?;
+            self.store_bitmap_page_meta(stream_id, page_start_local, &meta)
+                .await?;
+        }
+
+        Ok(())
     }
-
-    logs.record_open_bitmap_streams(plan.final_open_page_start, &plan.final_open_streams)
-        .await?;
-
-    Ok(())
-}
-
-async fn compact_page_streams<M: MetaStore, B: BlobStore>(
-    logs: &FamilyTables<M, B>,
-    global_page_start: u64,
-    streams: &BTreeSet<String>,
-) -> Result<()> {
-    let page_start_local = local_page_start(global_page_start);
-
-    for stream_id in streams {
-        let fragments = logs
-            .load_bitmap_fragments(stream_id, page_start_local)
-            .await?;
-        // Sealed-page fragments are intentionally retained after compaction —
-        // the query path falls back to fragments when the compacted page is
-        // missing, and keeping them lets a corrupted page-meta/page-blob write
-        // be reconstructed from source. Storage cost is bounded by retention
-        // policy, which lives outside this slice.
-        let (meta, bitmap_blob) = compact_bitmap_page(page_start_local, &fragments)?;
-
-        logs.store_bitmap_page_blob(stream_id, page_start_local, bitmap_blob)
-            .await?;
-        logs.store_bitmap_page_meta(stream_id, page_start_local, &meta)
-            .await?;
-    }
-
-    Ok(())
 }
 
 fn touched_streams_by_page(

--- a/monad-chain-data/src/engine/ingest/directory_compaction.rs
+++ b/monad-chain-data/src/engine/ingest/directory_compaction.rs
@@ -25,13 +25,15 @@ use crate::{
     store::{BlobStore, MetaStore},
 };
 
-/// Compacts every directory bucket sealed by the given ingest transition.
-pub(crate) async fn compact_newly_sealed_log_directory_buckets<M: MetaStore, B: BlobStore>(
-    logs: &FamilyTables<M, B>,
-    from_next_primary_id: u64,
-    next_primary_id: u64,
-) -> Result<()> {
-    compact_newly_sealed_buckets(logs.dir(), from_next_primary_id, next_primary_id).await
+impl<M: MetaStore, B: BlobStore> FamilyTables<M, B> {
+    /// Compacts every directory bucket sealed by the given ingest transition.
+    pub async fn compact_newly_sealed_directory_buckets(
+        &self,
+        from_next_primary_id: u64,
+        next_primary_id: u64,
+    ) -> Result<()> {
+        compact_newly_sealed_buckets(self.dir(), from_next_primary_id, next_primary_id).await
+    }
 }
 
 async fn compact_newly_sealed_buckets<M: MetaStore>(

--- a/monad-chain-data/src/engine/ingest/mod.rs
+++ b/monad-chain-data/src/engine/ingest/mod.rs
@@ -15,3 +15,4 @@
 
 pub(crate) mod bitmap_compaction;
 pub(crate) mod directory_compaction;
+pub(crate) mod persist;

--- a/monad-chain-data/src/engine/ingest/persist.rs
+++ b/monad-chain-data/src/engine/ingest/persist.rs
@@ -1,0 +1,61 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use bytes::Bytes;
+
+use crate::{
+    engine::{bitmap::BitmapFragmentWrite, tables::FamilyTables},
+    error::Result,
+    primitives::state::FamilyWindowRecord,
+    store::{BlobStore, MetaStore},
+};
+
+impl<M: MetaStore, B: BlobStore> FamilyTables<M, B> {
+    /// Persists one block's family artifacts: the per-block blob and
+    /// header bytes, the primary-directory fragment, and the bitmap
+    /// fragments — followed by the directory-bucket and bitmap-page
+    /// compactions sealed by the ingest transition.
+    pub async fn persist_indexed_family_ingest(
+        &self,
+        block_number: u64,
+        block_blob: Vec<u8>,
+        block_header_bytes: Bytes,
+        window: FamilyWindowRecord,
+        bitmap_fragments: &[BitmapFragmentWrite],
+    ) -> Result<()> {
+        let first_primary_id = window.first_primary_id.as_u64();
+        let next_primary_id_exclusive = window.next_primary_id_exclusive()?.as_u64();
+
+        self.store_block_blob(block_number, block_blob).await?;
+        self.store_block_header(block_number, block_header_bytes)
+            .await?;
+        self.dir()
+            .persist_block_fragment(block_number, first_primary_id, window.count)
+            .await?;
+        for fragment in bitmap_fragments {
+            self.store_bitmap_fragment(fragment, block_number).await?;
+        }
+        self.compact_newly_sealed_directory_buckets(first_primary_id, next_primary_id_exclusive)
+            .await?;
+        self.compact_newly_sealed_bitmap_pages(
+            bitmap_fragments,
+            first_primary_id,
+            next_primary_id_exclusive,
+        )
+        .await?;
+
+        Ok(())
+    }
+}

--- a/monad-chain-data/src/engine/query/bitmap.rs
+++ b/monad-chain-data/src/engine/query/bitmap.rs
@@ -25,110 +25,112 @@ use crate::{
     store::{BlobStore, MetaStore},
 };
 
-async fn load_clause_bitmap_for_shard<M: MetaStore, B: BlobStore>(
-    logs: &FamilyTables<M, B>,
-    clause: &IndexedClause,
-    shard: u64,
-    local_from: u32,
-    local_to: u32,
-) -> Result<RoaringBitmap> {
-    let stream_ids = clause.stream_ids_for_shard(shard);
-    if stream_ids.is_empty() {
-        return Ok(RoaringBitmap::new());
-    }
+impl<M: MetaStore, B: BlobStore> FamilyTables<M, B> {
+    /// Loads the AND-intersection of all clauses for one shard, clipped to
+    /// the local-id range. Returns `None` if any clause yields an empty
+    /// bitmap, meaning the shard cannot contribute candidates.
+    pub async fn load_intersection_bitmap(
+        &self,
+        clauses: &[IndexedClause],
+        shard: u64,
+        local_from: u32,
+        local_to: u32,
+    ) -> Result<Option<RoaringBitmap>> {
+        let mut accumulator: Option<RoaringBitmap> = None;
 
-    let first_page_start = page_start_local(local_from);
-    let last_page_start = page_start_local(local_to);
-    let mut clause_bitmap = RoaringBitmap::new();
-
-    for stream_id in stream_ids {
-        let mut page_start = first_page_start;
-        loop {
-            clause_bitmap |=
-                load_bitmap_page(logs, &stream_id, page_start, local_from, local_to).await?;
-
-            if page_start == last_page_start {
-                break;
+        for clause in clauses {
+            let clause_bitmap = self
+                .load_clause_bitmap(clause, shard, local_from, local_to)
+                .await?;
+            if clause_bitmap.is_empty() {
+                return Ok(None);
             }
-            page_start = page_start.saturating_add(STREAM_PAGE_LOCAL_ID_SPAN);
-        }
-    }
 
-    clip_bitmap_to_local_range(&mut clause_bitmap, local_from, local_to);
-    Ok(clause_bitmap)
-}
-
-/// Loads the AND-intersection of all clauses for one shard, clipped to
-/// the local-id range. Returns `None` if any clause yields an empty
-/// bitmap, meaning the shard cannot contribute candidates.
-pub(crate) async fn load_intersection_bitmap_for_shard<M: MetaStore, B: BlobStore>(
-    family: &FamilyTables<M, B>,
-    clauses: &[IndexedClause],
-    shard: u64,
-    local_from: u32,
-    local_to: u32,
-) -> Result<Option<RoaringBitmap>> {
-    let mut accumulator: Option<RoaringBitmap> = None;
-
-    for clause in clauses {
-        let clause_bitmap =
-            load_clause_bitmap_for_shard(family, clause, shard, local_from, local_to).await?;
-        if clause_bitmap.is_empty() {
-            return Ok(None);
-        }
-
-        match accumulator.as_mut() {
-            Some(current) => {
-                *current &= &clause_bitmap;
-                if current.is_empty() {
-                    return Ok(None);
+            match accumulator.as_mut() {
+                Some(current) => {
+                    *current &= &clause_bitmap;
+                    if current.is_empty() {
+                        return Ok(None);
+                    }
                 }
+                None => accumulator = Some(clause_bitmap),
             }
-            None => accumulator = Some(clause_bitmap),
         }
+
+        Ok(accumulator.filter(|bitmap| !bitmap.is_empty()))
     }
 
-    Ok(accumulator.filter(|bitmap| !bitmap.is_empty()))
-}
-
-async fn load_bitmap_page<M: MetaStore, B: BlobStore>(
-    logs: &FamilyTables<M, B>,
-    stream_id: &str,
-    page_start_local: u32,
-    local_from: u32,
-    local_to: u32,
-) -> Result<RoaringBitmap> {
-    if let Some(meta) = logs
-        .load_bitmap_page_meta(stream_id, page_start_local)
-        .await?
-    {
-        if !overlaps(meta.min_local, meta.max_local, local_from, local_to) {
+    async fn load_clause_bitmap(
+        &self,
+        clause: &IndexedClause,
+        shard: u64,
+        local_from: u32,
+        local_to: u32,
+    ) -> Result<RoaringBitmap> {
+        let stream_ids = clause.stream_ids_for_shard(shard);
+        if stream_ids.is_empty() {
             return Ok(RoaringBitmap::new());
         }
 
-        let page_blob = logs
-            .load_bitmap_page_blob(stream_id, page_start_local)
-            .await?
-            .ok_or(MonadChainDataError::MissingData(
-                "missing log bitmap page blob",
-            ))?;
-        // Page loads may include out-of-range bits from a partially overlapping
-        // page; the caller clips the final merged bitmap once per clause.
-        return Ok(decode_bitmap_blob(page_blob.as_ref())?.bitmap);
-    }
+        let first_page_start = page_start_local(local_from);
+        let last_page_start = page_start_local(local_to);
+        let mut clause_bitmap = RoaringBitmap::new();
 
-    let mut page_bitmap = RoaringBitmap::new();
-    for fragment in logs
-        .load_bitmap_fragments(stream_id, page_start_local)
-        .await?
-    {
-        let fragment = decode_bitmap_blob(fragment.as_ref())?;
-        if overlaps(fragment.min_local, fragment.max_local, local_from, local_to) {
-            page_bitmap |= fragment.bitmap;
+        for stream_id in stream_ids {
+            let mut page_start = first_page_start;
+            loop {
+                clause_bitmap |= self
+                    .load_bitmap_page(&stream_id, page_start, local_from, local_to)
+                    .await?;
+
+                if page_start == last_page_start {
+                    break;
+                }
+                page_start = page_start.saturating_add(STREAM_PAGE_LOCAL_ID_SPAN);
+            }
         }
+
+        clip_bitmap_to_local_range(&mut clause_bitmap, local_from, local_to);
+        Ok(clause_bitmap)
     }
 
-    Ok(page_bitmap)
+    async fn load_bitmap_page(
+        &self,
+        stream_id: &str,
+        page_start_local: u32,
+        local_from: u32,
+        local_to: u32,
+    ) -> Result<RoaringBitmap> {
+        if let Some(meta) = self
+            .load_bitmap_page_meta(stream_id, page_start_local)
+            .await?
+        {
+            if !overlaps(meta.min_local, meta.max_local, local_from, local_to) {
+                return Ok(RoaringBitmap::new());
+            }
+
+            let page_blob = self
+                .load_bitmap_page_blob(stream_id, page_start_local)
+                .await?
+                .ok_or(MonadChainDataError::MissingData("missing bitmap page blob"))?;
+            // Page loads may include out-of-range bits from a partially overlapping
+            // page; the caller clips the final merged bitmap once per clause.
+            return Ok(decode_bitmap_blob(page_blob.as_ref())?.bitmap);
+        }
+
+        let mut page_bitmap = RoaringBitmap::new();
+        for fragment in self
+            .load_bitmap_fragments(stream_id, page_start_local)
+            .await?
+        {
+            let fragment = decode_bitmap_blob(fragment.as_ref())?;
+            if overlaps(fragment.min_local, fragment.max_local, local_from, local_to) {
+                page_bitmap |= fragment.bitmap;
+            }
+        }
+
+        Ok(page_bitmap)
+    }
 }
 
 pub(crate) const fn max_local_id() -> u32 {

--- a/monad-chain-data/src/engine/query/directory_resolver.rs
+++ b/monad-chain-data/src/engine/query/directory_resolver.rs
@@ -18,37 +18,40 @@ use std::collections::{hash_map::Entry, HashMap};
 use crate::{
     engine::{
         primary_dir::{bucket_start, PrimaryDirBucket, PrimaryDirFragment},
-        tables::Tables,
+        tables::FamilyTables,
     },
     error::{MonadChainDataError, Result},
-    primitives::state::LogId,
+    primitives::state::PrimaryId,
     store::{BlobStore, MetaStore},
 };
 
-/// Resolves a global log ID to its block number and position within that block.
+/// Resolves a primary id to its block number and position within that block.
 ///
-/// Caches the chosen directory source for each 10k bucket so repeated log-id
+/// Caches the chosen directory source for each 10k bucket so repeated id
 /// lookups do not re-read summaries or fragments.
-pub(crate) struct LogIdResolver<'a, M: MetaStore, B: BlobStore> {
-    tables: &'a Tables<M, B>,
+pub(crate) struct PrimaryIdResolver<'a, M: MetaStore, B: BlobStore> {
+    family: &'a FamilyTables<M, B>,
     bucket_cache: HashMap<u64, CachedBucket>,
 }
 
-impl<'a, M: MetaStore, B: BlobStore> LogIdResolver<'a, M, B> {
-    pub(crate) fn new(tables: &'a Tables<M, B>) -> Self {
+impl<'a, M: MetaStore, B: BlobStore> PrimaryIdResolver<'a, M, B> {
+    pub(crate) fn new(family: &'a FamilyTables<M, B>) -> Self {
         Self {
-            tables,
+            family,
             bucket_cache: HashMap::new(),
         }
     }
 
-    pub(crate) async fn resolve(&mut self, log_id: LogId) -> Result<Option<ResolvedLogLocation>> {
-        let bucket = bucket_start(log_id.as_u64());
+    pub(crate) async fn resolve(
+        &mut self,
+        id: PrimaryId,
+    ) -> Result<Option<ResolvedPrimaryIdLocation>> {
+        let bucket = bucket_start(id.as_u64());
         if let Entry::Vacant(entry) = self.bucket_cache.entry(bucket) {
-            let cached = if let Some(summary) = self.tables.logs().load_bucket(bucket).await? {
+            let cached = if let Some(summary) = self.family.load_bucket(bucket).await? {
                 CachedBucket::Summary(summary)
             } else {
-                CachedBucket::Fragments(self.tables.logs().load_bucket_fragments(bucket).await?)
+                CachedBucket::Fragments(self.family.load_bucket_fragments(bucket).await?)
             };
             entry.insert(cached);
         }
@@ -57,16 +60,16 @@ impl<'a, M: MetaStore, B: BlobStore> LogIdResolver<'a, M, B> {
             .bucket_cache
             .get(&bucket)
             .ok_or(MonadChainDataError::Decode(
-                "missing cached log directory bucket",
+                "missing cached primary directory bucket",
             ))?;
-        cached.resolve(log_id)
+        cached.resolve(id)
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct ResolvedLogLocation {
+pub(crate) struct ResolvedPrimaryIdLocation {
     pub(crate) block_number: u64,
-    pub(crate) log_block_idx: usize,
+    pub(crate) idx_in_block: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -76,16 +79,16 @@ enum CachedBucket {
 }
 
 impl CachedBucket {
-    fn resolve(&self, log_id: LogId) -> Result<Option<ResolvedLogLocation>> {
+    fn resolve(&self, id: PrimaryId) -> Result<Option<ResolvedPrimaryIdLocation>> {
         match self {
-            Self::Summary(bucket) => resolved_location_from_bucket(bucket, log_id)?
+            Self::Summary(bucket) => resolved_location_from_bucket(bucket, id)?
                 .ok_or(MonadChainDataError::Decode(
-                    "compacted primary directory bucket missing queried log id",
+                    "compacted primary directory bucket missing queried id",
                 ))
                 .map(Some),
-            Self::Fragments(fragments) => resolved_location_from_fragments(fragments, log_id)?
+            Self::Fragments(fragments) => resolved_location_from_fragments(fragments, id)?
                 .ok_or(MonadChainDataError::Decode(
-                    "primary directory fragments missing queried log id",
+                    "primary directory fragments missing queried id",
                 ))
                 .map(Some),
         }
@@ -94,49 +97,48 @@ impl CachedBucket {
 
 fn resolved_location_from_bucket(
     bucket: &PrimaryDirBucket,
-    log_id: LogId,
-) -> Result<Option<ResolvedLogLocation>> {
-    let Some(entry_index) = containing_bucket_entry(bucket, log_id.as_u64()) else {
+    id: PrimaryId,
+) -> Result<Option<ResolvedPrimaryIdLocation>> {
+    let Some(entry_index) = containing_bucket_entry(bucket, id.as_u64()) else {
         return Ok(None);
     };
 
-    Ok(Some(ResolvedLogLocation {
+    Ok(Some(ResolvedPrimaryIdLocation {
         block_number: bucket.start_block.saturating_add(entry_index as u64),
-        log_block_idx: log_id.idx_in_block(LogId::new(bucket.first_primary_ids[entry_index]))?,
+        idx_in_block: id.idx_in_block(PrimaryId::new(bucket.first_primary_ids[entry_index]))?,
     }))
 }
 
-fn containing_bucket_entry(bucket: &PrimaryDirBucket, log_id: u64) -> Option<usize> {
+fn containing_bucket_entry(bucket: &PrimaryDirBucket, id: u64) -> Option<usize> {
     if bucket.first_primary_ids.len() < 2 {
         return None;
     }
 
     let upper = bucket
         .first_primary_ids
-        .partition_point(|first_primary_id| *first_primary_id <= log_id);
+        .partition_point(|first_primary_id| *first_primary_id <= id);
     if upper == 0 || upper >= bucket.first_primary_ids.len() {
         return None;
     }
 
     let entry_index = upper - 1;
     let end = bucket.first_primary_ids[upper];
-    (log_id < end).then_some(entry_index)
+    (id < end).then_some(entry_index)
 }
 
 fn resolved_location_from_fragments(
     fragments: &[PrimaryDirFragment],
-    log_id: LogId,
-) -> Result<Option<ResolvedLogLocation>> {
+    id: PrimaryId,
+) -> Result<Option<ResolvedPrimaryIdLocation>> {
     let Some(fragment) = fragments.iter().find(|fragment| {
-        log_id.as_u64() >= fragment.first_primary_id
-            && log_id.as_u64() < fragment.end_primary_id_exclusive
+        id.as_u64() >= fragment.first_primary_id && id.as_u64() < fragment.end_primary_id_exclusive
     }) else {
         return Ok(None);
     };
 
-    Ok(Some(ResolvedLogLocation {
+    Ok(Some(ResolvedPrimaryIdLocation {
         block_number: fragment.block_number,
-        log_block_idx: log_id.idx_in_block(LogId::new(fragment.first_primary_id))?,
+        idx_in_block: id.idx_in_block(PrimaryId::new(fragment.first_primary_id))?,
     }))
 }
 
@@ -145,7 +147,7 @@ mod tests {
     use super::{
         containing_bucket_entry, resolved_location_from_bucket, CachedBucket, PrimaryDirFragment,
     };
-    use crate::{engine::primary_dir::PrimaryDirBucket, primitives::state::LogId};
+    use crate::{engine::primary_dir::PrimaryDirBucket, primitives::state::PrimaryId};
 
     #[test]
     fn bucket_lookup_uses_last_duplicate_boundary() {
@@ -157,10 +159,10 @@ mod tests {
         assert_eq!(containing_bucket_entry(&bucket, 1006), Some(2));
 
         let location =
-            resolved_location_from_bucket(&bucket, LogId::new(1006)).expect("resolve bucket");
+            resolved_location_from_bucket(&bucket, PrimaryId::new(1006)).expect("resolve bucket");
         let location = location.expect("contained");
         assert_eq!(location.block_number, 52);
-        assert_eq!(location.log_block_idx, 3);
+        assert_eq!(location.idx_in_block, 3);
     }
 
     #[test]
@@ -180,12 +182,12 @@ mod tests {
             first_primary_id: 100,
             end_primary_id_exclusive: 103,
         }])
-        .resolve(LogId::new(104))
+        .resolve(PrimaryId::new(104))
         .expect_err("missing fragment candidate should fail loud");
 
         assert_eq!(
             error.to_string(),
-            "decode error: primary directory fragments missing queried log id"
+            "decode error: primary directory fragments missing queried id"
         );
     }
 }

--- a/monad-chain-data/src/engine/query/family_runner.rs
+++ b/monad-chain-data/src/engine/query/family_runner.rs
@@ -1,0 +1,211 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use roaring::RoaringBitmap;
+
+use crate::{
+    engine::{
+        clause::IndexedFilter,
+        family::Family,
+        query::{directory_resolver::PrimaryIdResolver, window::resolve_primary_id_window},
+        tables::Tables,
+    },
+    error::{MonadChainDataError, Result},
+    primitives::{
+        page::QueryOrder,
+        range::ResolvedBlockWindow,
+        refs::{BlockRef, BlockSpan},
+        state::PrimaryId,
+    },
+    store::{BlobStore, MetaStore},
+};
+
+/// Outcome returned by the shared family query runners. Families wrap this
+/// into their own response types.
+pub(crate) struct IndexedQueryOutcome<T> {
+    pub records: Vec<T>,
+    pub span: BlockSpan,
+}
+
+/// Per-family interface consumed by the shared indexed and block-scan
+/// runners. Implemented by each family's materializer.
+pub(crate) trait IndexedFamilyQuery<M: MetaStore, B: BlobStore> {
+    type Filter: IndexedFilter<Record = Self::Record>;
+    type Record;
+
+    fn family() -> Family;
+
+    async fn load_record_at(&self, block_number: u64, idx_in_block: usize) -> Result<Self::Record>;
+
+    async fn load_block_ref(&self, block_number: u64) -> Result<BlockRef>;
+
+    async fn load_filtered_block_records(
+        &self,
+        block_number: u64,
+        order: QueryOrder,
+        filter: &Self::Filter,
+    ) -> Result<(BlockRef, Vec<Self::Record>)>;
+}
+
+/// Shared indexed query runner. Walks the primary-id window for the
+/// runner's family, intersects bitmaps per shard, resolves candidates
+/// through the shared directory, and materializes each match through the
+/// runner. Completes the current block when `limit` is reached.
+pub(crate) async fn execute_indexed_family_query<M, B, R>(
+    tables: &Tables<M, B>,
+    runner: &R,
+    filter: &R::Filter,
+    block_window: ResolvedBlockWindow,
+    order: QueryOrder,
+    limit: usize,
+) -> Result<IndexedQueryOutcome<R::Record>>
+where
+    M: MetaStore,
+    B: BlobStore,
+    R: IndexedFamilyQuery<M, B>,
+{
+    let (from_block, to_block) = block_window.request_endpoints(order);
+    let family = R::family();
+
+    let Some(window) = resolve_primary_id_window(tables.blocks(), family, &block_window).await?
+    else {
+        return Ok(IndexedQueryOutcome {
+            records: Vec::new(),
+            span: BlockSpan {
+                from_block,
+                to_block,
+                cursor_block: to_block,
+            },
+        });
+    };
+
+    let clauses = filter.indexed_clauses();
+    if clauses.is_empty() {
+        return Err(MonadChainDataError::InvalidRequest(
+            "indexed query requires at least one indexed clause",
+        ));
+    }
+
+    let mut resolver = PrimaryIdResolver::new(tables.family(family));
+    let mut records = Vec::new();
+    let mut stop_after_block = None;
+
+    for shard in window.shard_iter(order) {
+        let (local_from, local_to) = window.local_range_for_shard(shard);
+
+        let Some(candidate_bitmap) = tables
+            .family(family)
+            .load_intersection_bitmap(&clauses, shard, local_from, local_to)
+            .await?
+        else {
+            continue;
+        };
+
+        let locals = locals_in_query_order(candidate_bitmap, order);
+        for local in locals {
+            let id = PrimaryId::from_parts(shard, local);
+            let Some(location) = resolver.resolve(id).await? else {
+                continue;
+            };
+
+            if let Some(stop_block) = stop_after_block {
+                if location.block_number != stop_block {
+                    let cursor_block = runner.load_block_ref(stop_block).await?;
+                    return Ok(IndexedQueryOutcome {
+                        records,
+                        span: BlockSpan {
+                            from_block,
+                            to_block,
+                            cursor_block,
+                        },
+                    });
+                }
+            }
+
+            let record = runner
+                .load_record_at(location.block_number, location.idx_in_block)
+                .await?;
+            debug_assert!(
+                filter.matches(&record),
+                "indexed candidate at block {} idx {} should match filter",
+                location.block_number,
+                location.idx_in_block,
+            );
+
+            records.push(record);
+
+            if stop_after_block.is_none() && records.len() >= limit {
+                stop_after_block = Some(location.block_number);
+            }
+        }
+    }
+
+    Ok(IndexedQueryOutcome {
+        records,
+        span: BlockSpan {
+            from_block,
+            to_block,
+            cursor_block: to_block,
+        },
+    })
+}
+
+/// Shared block-scan runner used when the query filter carries no indexed
+/// clause. Walks blocks in query order, lets the family filter each
+/// block's records, and stops once `limit` is reached.
+pub(crate) async fn execute_block_scan_family_query<M, B, R>(
+    runner: &R,
+    filter: &R::Filter,
+    block_window: ResolvedBlockWindow,
+    order: QueryOrder,
+    limit: usize,
+) -> Result<IndexedQueryOutcome<R::Record>>
+where
+    M: MetaStore,
+    B: BlobStore,
+    R: IndexedFamilyQuery<M, B>,
+{
+    let (from_block, to_block) = block_window.request_endpoints(order);
+    let mut records = Vec::new();
+    let mut cursor_block = from_block;
+
+    for block_number in block_window.iter(order) {
+        let (block_ref, block_records) = runner
+            .load_filtered_block_records(block_number, order, filter)
+            .await?;
+        records.extend(block_records);
+        cursor_block = block_ref;
+        if records.len() >= limit {
+            break;
+        }
+    }
+
+    Ok(IndexedQueryOutcome {
+        records,
+        span: BlockSpan {
+            from_block,
+            to_block,
+            cursor_block,
+        },
+    })
+}
+
+fn locals_in_query_order(bitmap: RoaringBitmap, order: QueryOrder) -> Vec<u32> {
+    let mut locals: Vec<u32> = bitmap.into_iter().collect();
+    if order == QueryOrder::Descending {
+        locals.reverse();
+    }
+    locals
+}

--- a/monad-chain-data/src/engine/query/mod.rs
+++ b/monad-chain-data/src/engine/query/mod.rs
@@ -15,4 +15,5 @@
 
 pub(crate) mod bitmap;
 pub(crate) mod directory_resolver;
+pub(crate) mod family_runner;
 pub(crate) mod window;

--- a/monad-chain-data/src/engine/query/window.rs
+++ b/monad-chain-data/src/engine/query/window.rs
@@ -15,23 +15,23 @@
 
 use super::bitmap::max_local_id;
 use crate::{
-    engine::tables::Tables,
+    engine::{family::Family, tables::BlockTables},
     error::Result,
     primitives::{
         page::QueryOrder,
         range::ResolvedBlockWindow,
-        state::{FamilyWindowRecord, LogId},
+        state::{FamilyWindowRecord, PrimaryId},
     },
-    store::{BlobStore, MetaStore},
+    store::MetaStore,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct ResolvedLogWindow {
-    pub start: LogId,
-    pub end_inclusive: LogId,
+pub(crate) struct ResolvedPrimaryIdWindow {
+    pub start: PrimaryId,
+    pub end_inclusive: PrimaryId,
 }
 
-impl ResolvedLogWindow {
+impl ResolvedPrimaryIdWindow {
     /// Returns the local-ID range within the given shard, clipped to this
     /// window's boundaries.
     pub fn local_range_for_shard(&self, shard: u64) -> (u32, u32) {
@@ -58,39 +58,43 @@ impl ResolvedLogWindow {
     }
 }
 
-pub(crate) async fn resolve_log_window<M: MetaStore, B: BlobStore>(
-    tables: &Tables<M, B>,
+pub(crate) async fn resolve_primary_id_window<M: MetaStore>(
+    blocks: &BlockTables<M>,
+    family: Family,
     block_window: &ResolvedBlockWindow,
-) -> Result<Option<ResolvedLogWindow>> {
+) -> Result<Option<ResolvedPrimaryIdWindow>> {
     let start_block = block_window.low.number;
     let end_block = block_window.high.number;
 
-    let Some(start) = first_log_id_in_range(tables, start_block, end_block).await? else {
+    let Some(start) = first_primary_id_in_range(blocks, family, start_block, end_block).await?
+    else {
         return Ok(None);
     };
-    let Some(end_exclusive) = end_log_id_exclusive_in_range(tables, start_block, end_block).await?
+    let Some(end_exclusive) =
+        end_primary_id_exclusive_in_range(blocks, family, start_block, end_block).await?
     else {
         return Ok(None);
     };
 
-    Ok(Some(ResolvedLogWindow {
+    Ok(Some(ResolvedPrimaryIdWindow {
         start,
-        end_inclusive: LogId::new(end_exclusive.as_u64().saturating_sub(1)),
+        end_inclusive: PrimaryId::new(end_exclusive.as_u64().saturating_sub(1)),
     }))
 }
 
-async fn first_log_id_in_range<M: MetaStore, B: BlobStore>(
-    tables: &Tables<M, B>,
+async fn first_primary_id_in_range<M: MetaStore>(
+    blocks: &BlockTables<M>,
+    family: Family,
     start_block: u64,
     end_block: u64,
-) -> Result<Option<LogId>> {
+) -> Result<Option<PrimaryId>> {
     let mut block_number = start_block;
     while block_number <= end_block {
-        let Some(record) = tables.blocks().load_record(block_number).await? else {
+        let Some(record) = blocks.load_record(block_number).await? else {
             return Ok(None);
         };
-        if let Some(first_log_id) = non_empty_window_start(record.logs) {
-            return Ok(Some(first_log_id));
+        if let Some(first) = family.window_in(&record).and_then(non_empty_window_start) {
+            return Ok(Some(first));
         }
         block_number = block_number.saturating_add(1);
     }
@@ -98,18 +102,21 @@ async fn first_log_id_in_range<M: MetaStore, B: BlobStore>(
     Ok(None)
 }
 
-async fn end_log_id_exclusive_in_range<M: MetaStore, B: BlobStore>(
-    tables: &Tables<M, B>,
+async fn end_primary_id_exclusive_in_range<M: MetaStore>(
+    blocks: &BlockTables<M>,
+    family: Family,
     start_block: u64,
     end_block: u64,
-) -> Result<Option<LogId>> {
+) -> Result<Option<PrimaryId>> {
     let mut block_number = end_block;
     loop {
-        let Some(record) = tables.blocks().load_record(block_number).await? else {
+        let Some(record) = blocks.load_record(block_number).await? else {
             return Ok(None);
         };
-        if let Some(end_log_id_exclusive) = non_empty_window_end(record.logs)? {
-            return Ok(Some(end_log_id_exclusive));
+        if let Some(window) = family.window_in(&record) {
+            if let Some(end_exclusive) = non_empty_window_end(window)? {
+                return Ok(Some(end_exclusive));
+            }
         }
         if block_number == start_block {
             break;
@@ -120,14 +127,14 @@ async fn end_log_id_exclusive_in_range<M: MetaStore, B: BlobStore>(
     Ok(None)
 }
 
-fn non_empty_window_start(window: FamilyWindowRecord) -> Option<LogId> {
-    (window.count > 0).then_some(window.first_log_id)
+fn non_empty_window_start(window: FamilyWindowRecord) -> Option<PrimaryId> {
+    (window.count > 0).then(|| window.first_primary_id())
 }
 
-fn non_empty_window_end(window: FamilyWindowRecord) -> Result<Option<LogId>> {
+fn non_empty_window_end(window: FamilyWindowRecord) -> Result<Option<PrimaryId>> {
     if window.count == 0 {
         return Ok(None);
     }
 
-    window.next_log_id().map(Some)
+    window.next_primary_id_exclusive().map(Some)
 }

--- a/monad-chain-data/src/engine/query/window.rs
+++ b/monad-chain-data/src/engine/query/window.rs
@@ -128,7 +128,7 @@ async fn end_primary_id_exclusive_in_range<M: MetaStore>(
 }
 
 fn non_empty_window_start(window: FamilyWindowRecord) -> Option<PrimaryId> {
-    (window.count > 0).then(|| window.first_primary_id())
+    (window.count > 0).then_some(window.first_primary_id)
 }
 
 fn non_empty_window_end(window: FamilyWindowRecord) -> Result<Option<PrimaryId>> {

--- a/monad-chain-data/src/engine/tables.rs
+++ b/monad-chain-data/src/engine/tables.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::BTreeMap;
+
 use alloy_rlp::Decodable;
 use bytes::Bytes;
 
@@ -34,15 +36,20 @@ use crate::{
 pub struct Tables<M: MetaStore, B: BlobStore> {
     publication: PublicationTables<M>,
     blocks: BlockTables<M>,
-    logs: FamilyTables<M, B>,
+    families: BTreeMap<Family, FamilyTables<M, B>>,
 }
 
 impl<M: MetaStore, B: BlobStore> Tables<M, B> {
     pub fn new(meta_store: M, blob_store: B) -> Self {
+        let mut families = BTreeMap::new();
+        families.insert(
+            Family::Log,
+            FamilyTables::new(meta_store.clone(), blob_store, Family::Log),
+        );
         Self {
             publication: PublicationTables::new(meta_store.clone()),
-            blocks: BlockTables::new(meta_store.clone()),
-            logs: FamilyTables::new(meta_store, blob_store, Family::Log),
+            blocks: BlockTables::new(meta_store),
+            families,
         }
     }
 
@@ -54,8 +61,13 @@ impl<M: MetaStore, B: BlobStore> Tables<M, B> {
         &self.blocks
     }
 
-    pub fn logs(&self) -> &FamilyTables<M, B> {
-        &self.logs
+    /// Returns the table set for a family. Panics if the family was not
+    /// registered at construction; the `Family` enum is closed, so missing
+    /// a variant here is a programmer error, not a data error.
+    pub fn family(&self, family: Family) -> &FamilyTables<M, B> {
+        self.families
+            .get(&family)
+            .expect("family registered at construction")
     }
 }
 

--- a/monad-chain-data/src/lib.rs
+++ b/monad-chain-data/src/lib.rs
@@ -25,7 +25,7 @@ pub mod store;
 pub use alloy_primitives::{Address, Bytes, Log, LogData, B256};
 pub use api::{IngestOutcome, MonadChainDataService};
 pub use blocks::{Block, QueryBlocksRequest, QueryBlocksResponse};
-pub use engine::tables::Tables;
+pub use engine::{family::Family, tables::Tables};
 pub use error::MonadChainDataError;
 pub use family::{FinalizedBlock, Hash32};
 pub use logs::{LogEntry, LogFilter, LogsRelations, QueryLogsRequest, QueryLogsResponse};

--- a/monad-chain-data/src/lib.rs
+++ b/monad-chain-data/src/lib.rs
@@ -33,7 +33,7 @@ pub use primitives::{
     limits::{LimitExceededKind, QueryEnvelope, QueryLimits},
     page::{QueryOrder, DEFAULT_QUERY_LIMIT},
     refs::{BlockRef, BlockSpan},
-    state::{BlockRecord, FamilyWindowRecord, LogId},
+    state::{BlockRecord, FamilyWindowRecord, LogId, PrimaryId},
     EvmBlockHeader,
 };
 pub use store::{InMemoryBlobStore, InMemoryMetaStore};

--- a/monad-chain-data/src/logs/indexed_query.rs
+++ b/monad-chain-data/src/logs/indexed_query.rs
@@ -13,18 +13,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use roaring::RoaringBitmap;
-
 use crate::{
-    engine::{
-        clause::IndexedFilter,
-        family::Family,
-        query::{directory_resolver::PrimaryIdResolver, window::resolve_primary_id_window},
-        tables::Tables,
-    },
-    error::{MonadChainDataError, Result},
+    engine::{query::family_runner::execute_indexed_family_query, tables::Tables},
+    error::Result,
     logs::{LogMaterializer, QueryLogsRequest, QueryLogsResponse},
-    primitives::{page::QueryOrder, range::ResolvedBlockWindow, refs::BlockSpan, state::PrimaryId},
+    primitives::range::ResolvedBlockWindow,
     store::{BlobStore, MetaStore},
 };
 
@@ -33,100 +26,19 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
     request: &QueryLogsRequest,
     block_window: ResolvedBlockWindow,
 ) -> Result<QueryLogsResponse> {
-    let (request_from, request_to) = block_window.request_endpoints(request.envelope.order);
-
-    let Some(window) =
-        resolve_primary_id_window(tables.blocks(), Family::Log, &block_window).await?
-    else {
-        return Ok(QueryLogsResponse {
-            logs: Vec::new(),
-            blocks: None,
-            span: BlockSpan {
-                from_block: request_from,
-                to_block: request_to,
-                cursor_block: request_to,
-            },
-        });
-    };
-
-    let clauses = request.filter.indexed_clauses();
-    if clauses.is_empty() {
-        return Err(MonadChainDataError::InvalidRequest(
-            "indexed query requires at least one indexed clause",
-        ));
-    }
-
     let materializer = LogMaterializer::new(tables);
-    let mut resolver = PrimaryIdResolver::new(tables.family(Family::Log));
-    let mut logs = Vec::new();
-    let mut stop_after_block = None;
-
-    for shard in window.shard_iter(request.envelope.order) {
-        let (local_from, local_to) = window.local_range_for_shard(shard);
-
-        let Some(candidate_bitmap) = tables
-            .family(Family::Log)
-            .load_intersection_bitmap(&clauses, shard, local_from, local_to)
-            .await?
-        else {
-            continue;
-        };
-
-        let locals = locals_in_query_order(candidate_bitmap, request.envelope.order);
-        for local in locals {
-            let id = PrimaryId::from_parts(shard, local);
-            let Some(location) = resolver.resolve(id).await? else {
-                continue;
-            };
-
-            if let Some(stop_block) = stop_after_block {
-                if location.block_number != stop_block {
-                    let cursor_block = materializer.load_block_ref(stop_block).await?;
-                    return Ok(QueryLogsResponse {
-                        logs,
-                        blocks: None,
-                        span: BlockSpan {
-                            from_block: request_from,
-                            to_block: request_to,
-                            cursor_block,
-                        },
-                    });
-                }
-            }
-
-            let log = materializer
-                .load_log_at(location.block_number, location.idx_in_block)
-                .await?;
-            debug_assert!(
-                request.filter.matches(&log),
-                "indexed candidate at block {} idx {} should match filter",
-                location.block_number,
-                location.idx_in_block,
-            );
-
-            logs.push(log);
-
-            if stop_after_block.is_none() && logs.len() >= request.envelope.limit {
-                stop_after_block = Some(location.block_number);
-            }
-        }
-    }
-
+    let outcome = execute_indexed_family_query(
+        tables,
+        &materializer,
+        &request.filter,
+        block_window,
+        request.envelope.order,
+        request.envelope.limit,
+    )
+    .await?;
     Ok(QueryLogsResponse {
-        logs,
+        logs: outcome.records,
         blocks: None,
-        span: BlockSpan {
-            from_block: request_from,
-            to_block: request_to,
-            cursor_block: request_to,
-        },
+        span: outcome.span,
     })
-}
-
-fn locals_in_query_order(bitmap: RoaringBitmap, order: QueryOrder) -> Vec<u32> {
-    let mut locals: Vec<u32> = bitmap.into_iter().collect();
-    if order == QueryOrder::Descending {
-        locals.reverse();
-    }
-    locals
 }

--- a/monad-chain-data/src/logs/indexed_query.rs
+++ b/monad-chain-data/src/logs/indexed_query.rs
@@ -57,7 +57,7 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
     }
 
     let materializer = LogMaterializer::new(tables);
-    let mut resolver = PrimaryIdResolver::new(tables.logs());
+    let mut resolver = PrimaryIdResolver::new(tables.family(Family::Log));
     let mut logs = Vec::new();
     let mut stop_after_block = None;
 
@@ -65,7 +65,7 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
         let (local_from, local_to) = window.local_range_for_shard(shard);
 
         let Some(candidate_bitmap) = tables
-            .logs()
+            .family(Family::Log)
             .load_intersection_bitmap(&clauses, shard, local_from, local_to)
             .await?
         else {

--- a/monad-chain-data/src/logs/indexed_query.rs
+++ b/monad-chain-data/src/logs/indexed_query.rs
@@ -20,14 +20,14 @@ use crate::{
         clause::IndexedFilter,
         family::Family,
         query::{
-            bitmap::load_intersection_bitmap_for_shard, directory_resolver::LogIdResolver,
+            bitmap::load_intersection_bitmap_for_shard, directory_resolver::PrimaryIdResolver,
             window::resolve_primary_id_window,
         },
         tables::Tables,
     },
     error::{MonadChainDataError, Result},
     logs::{LogMaterializer, QueryLogsRequest, QueryLogsResponse},
-    primitives::{page::QueryOrder, range::ResolvedBlockWindow, refs::BlockSpan, state::LogId},
+    primitives::{page::QueryOrder, range::ResolvedBlockWindow, refs::BlockSpan, state::PrimaryId},
     store::{BlobStore, MetaStore},
 };
 
@@ -60,7 +60,7 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
     }
 
     let materializer = LogMaterializer::new(tables);
-    let mut resolver = LogIdResolver::new(tables);
+    let mut resolver = PrimaryIdResolver::new(tables.logs());
     let mut logs = Vec::new();
     let mut stop_after_block = None;
 
@@ -81,7 +81,7 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
 
         let locals = locals_in_query_order(candidate_bitmap, request.envelope.order);
         for local in locals {
-            let id = LogId::from_parts(shard, local);
+            let id = PrimaryId::from_parts(shard, local);
             let Some(location) = resolver.resolve(id).await? else {
                 continue;
             };
@@ -102,13 +102,13 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
             }
 
             let log = materializer
-                .load_log_at(location.block_number, location.log_block_idx)
+                .load_log_at(location.block_number, location.idx_in_block)
                 .await?;
             debug_assert!(
                 request.filter.matches(&log),
                 "indexed candidate at block {} idx {} should match filter",
                 location.block_number,
-                location.log_block_idx,
+                location.idx_in_block,
             );
 
             logs.push(log);

--- a/monad-chain-data/src/logs/indexed_query.rs
+++ b/monad-chain-data/src/logs/indexed_query.rs
@@ -19,10 +19,7 @@ use crate::{
     engine::{
         clause::IndexedFilter,
         family::Family,
-        query::{
-            bitmap::load_intersection_bitmap_for_shard, directory_resolver::PrimaryIdResolver,
-            window::resolve_primary_id_window,
-        },
+        query::{directory_resolver::PrimaryIdResolver, window::resolve_primary_id_window},
         tables::Tables,
     },
     error::{MonadChainDataError, Result},
@@ -67,14 +64,10 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
     for shard in window.shard_iter(request.envelope.order) {
         let (local_from, local_to) = window.local_range_for_shard(shard);
 
-        let Some(candidate_bitmap) = load_intersection_bitmap_for_shard(
-            tables.logs(),
-            &clauses,
-            shard,
-            local_from,
-            local_to,
-        )
-        .await?
+        let Some(candidate_bitmap) = tables
+            .logs()
+            .load_intersection_bitmap(&clauses, shard, local_from, local_to)
+            .await?
         else {
             continue;
         };

--- a/monad-chain-data/src/logs/indexed_query.rs
+++ b/monad-chain-data/src/logs/indexed_query.rs
@@ -18,9 +18,10 @@ use roaring::RoaringBitmap;
 use crate::{
     engine::{
         clause::IndexedFilter,
+        family::Family,
         query::{
             bitmap::load_intersection_bitmap_for_shard, directory_resolver::LogIdResolver,
-            window::resolve_log_window,
+            window::resolve_primary_id_window,
         },
         tables::Tables,
     },
@@ -37,7 +38,9 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
 ) -> Result<QueryLogsResponse> {
     let (request_from, request_to) = block_window.request_endpoints(request.envelope.order);
 
-    let Some(log_window) = resolve_log_window(tables, &block_window).await? else {
+    let Some(window) =
+        resolve_primary_id_window(tables.blocks(), Family::Log, &block_window).await?
+    else {
         return Ok(QueryLogsResponse {
             logs: Vec::new(),
             blocks: None,
@@ -61,8 +64,8 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
     let mut logs = Vec::new();
     let mut stop_after_block = None;
 
-    for shard in log_window.shard_iter(request.envelope.order) {
-        let (local_from, local_to) = log_window.local_range_for_shard(shard);
+    for shard in window.shard_iter(request.envelope.order) {
+        let (local_from, local_to) = window.local_range_for_shard(shard);
 
         let Some(candidate_bitmap) = load_intersection_bitmap_for_shard(
             tables.logs(),

--- a/monad-chain-data/src/logs/ingest.rs
+++ b/monad-chain-data/src/logs/ingest.rs
@@ -48,7 +48,7 @@ impl LogIngestPlan {
             block_hash: block.block_hash(),
             parent_hash: block.parent_hash(),
             logs: FamilyWindowRecord {
-                first_log_id,
+                first_primary_id: first_log_id.into(),
                 count: log_count,
             },
         };

--- a/monad-chain-data/src/logs/materialize.rs
+++ b/monad-chain-data/src/logs/materialize.rs
@@ -23,6 +23,7 @@ use crate::{
     blocks::Block,
     engine::{
         clause::{IndexedClause, IndexedFilter},
+        family::Family,
         tables::Tables,
     },
     error::{MonadChainDataError, Result},
@@ -167,7 +168,7 @@ impl<'a, M: MetaStore, B: BlobStore> LogMaterializer<'a, M, B> {
             .ok_or(MonadChainDataError::MissingData("missing block record"))?;
         let header_bytes = self
             .tables
-            .logs()
+            .family(Family::Log)
             .load_block_header(block_number)
             .await?
             .ok_or(MonadChainDataError::MissingData("missing block log header"))?;
@@ -181,7 +182,7 @@ impl<'a, M: MetaStore, B: BlobStore> LogMaterializer<'a, M, B> {
 
         let bytes = self
             .tables
-            .logs()
+            .family(Family::Log)
             .read_block_blob_range(block_number, start, end)
             .await?
             .ok_or(MonadChainDataError::MissingData("missing block log blob"))?;
@@ -206,14 +207,14 @@ impl<'a, M: MetaStore, B: BlobStore> LogMaterializer<'a, M, B> {
 
         let header_bytes = self
             .tables
-            .logs()
+            .family(Family::Log)
             .load_block_header(block_number)
             .await?
             .ok_or(MonadChainDataError::MissingData("missing block log header"))?;
         let header = LogBlockHeader::decode(&header_bytes)?;
         let blob = self
             .tables
-            .logs()
+            .family(Family::Log)
             .load_block_blob(block_number)
             .await?
             .ok_or(MonadChainDataError::MissingData("missing block log blob"))?;

--- a/monad-chain-data/src/logs/materialize.rs
+++ b/monad-chain-data/src/logs/materialize.rs
@@ -24,6 +24,7 @@ use crate::{
     engine::{
         clause::{IndexedClause, IndexedFilter},
         family::Family,
+        query::family_runner::IndexedFamilyQuery,
         tables::Tables,
     },
     error::{MonadChainDataError, Result},
@@ -147,8 +148,17 @@ impl<'a, M: MetaStore, B: BlobStore> LogMaterializer<'a, M, B> {
     pub fn new(tables: &'a Tables<M, B>) -> Self {
         Self { tables }
     }
+}
 
-    pub async fn load_block_ref(&self, block_number: u64) -> Result<BlockRef> {
+impl<'a, M: MetaStore, B: BlobStore> IndexedFamilyQuery<M, B> for LogMaterializer<'a, M, B> {
+    type Filter = LogFilter;
+    type Record = LogEntry;
+
+    fn family() -> Family {
+        Family::Log
+    }
+
+    async fn load_block_ref(&self, block_number: u64) -> Result<BlockRef> {
         let block_record = self
             .tables
             .blocks()
@@ -158,8 +168,7 @@ impl<'a, M: MetaStore, B: BlobStore> LogMaterializer<'a, M, B> {
         Ok(BlockRef::from(&block_record))
     }
 
-    /// Resolves and materializes one log by block number and block-local ordinal.
-    pub async fn load_log_at(&self, block_number: u64, log_idx: usize) -> Result<LogEntry> {
+    async fn load_record_at(&self, block_number: u64, idx_in_block: usize) -> Result<LogEntry> {
         let block_record = self
             .tables
             .blocks()
@@ -174,11 +183,11 @@ impl<'a, M: MetaStore, B: BlobStore> LogMaterializer<'a, M, B> {
             .ok_or(MonadChainDataError::MissingData("missing block log header"))?;
         let header = LogBlockHeader::decode(&header_bytes)?;
 
-        if log_idx + 1 >= header.offsets.len() {
+        if idx_in_block + 1 >= header.offsets.len() {
             return Err(MonadChainDataError::Decode("log index out of range"));
         }
-        let start = header.offsets[log_idx] as usize;
-        let end = header.offsets[log_idx + 1] as usize;
+        let start = header.offsets[idx_in_block] as usize;
+        let end = header.offsets[idx_in_block + 1] as usize;
 
         let bytes = self
             .tables
@@ -191,11 +200,11 @@ impl<'a, M: MetaStore, B: BlobStore> LogMaterializer<'a, M, B> {
         Ok(raw.into_log_entry(block_record.block_number, block_record.block_hash))
     }
 
-    /// Loads and filters all logs for one block in the requested output order.
-    pub async fn load_filtered_block_logs_for_block(
+    async fn load_filtered_block_records(
         &self,
         block_number: u64,
-        request: &QueryLogsRequest,
+        order: QueryOrder,
+        filter: &LogFilter,
     ) -> Result<(BlockRef, Vec<LogEntry>)> {
         let block_record = self
             .tables
@@ -219,7 +228,7 @@ impl<'a, M: MetaStore, B: BlobStore> LogMaterializer<'a, M, B> {
             .await?
             .ok_or(MonadChainDataError::MissingData("missing block log blob"))?;
 
-        let logs = load_filtered_block_logs(&header, &blob, &block_record, request)?;
+        let logs = load_filtered_block_logs(&header, &blob, &block_record, order, filter)?;
 
         Ok((block_ref, logs))
     }
@@ -229,10 +238,11 @@ fn load_filtered_block_logs(
     header: &LogBlockHeader,
     blob: &Bytes,
     block_record: &BlockRecord,
-    request: &QueryLogsRequest,
+    order: QueryOrder,
+    filter: &LogFilter,
 ) -> Result<Vec<LogEntry>> {
     let count = header.log_count();
-    let indices: Box<dyn Iterator<Item = usize>> = match request.envelope.order {
+    let indices: Box<dyn Iterator<Item = usize>> = match order {
         QueryOrder::Ascending => Box::new(0..count),
         QueryOrder::Descending => Box::new((0..count).rev()),
     };
@@ -246,7 +256,7 @@ fn load_filtered_block_logs(
             block_record.block_number,
             block_record.block_hash,
         )?;
-        if request.filter.matches(&log) {
+        if filter.matches(&log) {
             logs.push(log);
         }
     }

--- a/monad-chain-data/src/logs/scan_query.rs
+++ b/monad-chain-data/src/logs/scan_query.rs
@@ -14,10 +14,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-    engine::tables::Tables,
+    engine::{query::family_runner::execute_block_scan_family_query, tables::Tables},
     error::Result,
     logs::{LogMaterializer, QueryLogsRequest, QueryLogsResponse},
-    primitives::{range::ResolvedBlockWindow, refs::BlockSpan},
+    primitives::range::ResolvedBlockWindow,
     store::{BlobStore, MetaStore},
 };
 
@@ -28,29 +28,17 @@ pub async fn execute_block_scan_query<M: MetaStore, B: BlobStore>(
     window: ResolvedBlockWindow,
 ) -> Result<QueryLogsResponse> {
     let materializer = LogMaterializer::new(tables);
-    let target_log_count = request.envelope.limit;
-    let (request_from, request_to) = window.request_endpoints(request.envelope.order);
-    let mut logs = Vec::new();
-    let mut cursor_block = request_from;
-
-    for block_number in window.iter(request.envelope.order) {
-        let (block_ref, block_logs) = materializer
-            .load_filtered_block_logs_for_block(block_number, request)
-            .await?;
-        logs.extend(block_logs);
-        cursor_block = block_ref;
-        if logs.len() >= target_log_count {
-            break;
-        }
-    }
-
+    let outcome = execute_block_scan_family_query(
+        &materializer,
+        &request.filter,
+        window,
+        request.envelope.order,
+        request.envelope.limit,
+    )
+    .await?;
     Ok(QueryLogsResponse {
-        logs,
+        logs: outcome.records,
         blocks: None,
-        span: BlockSpan {
-            from_block: request_from,
-            to_block: request_to,
-            cursor_block,
-        },
+        span: outcome.span,
     })
 }

--- a/monad-chain-data/src/primitives/state.rs
+++ b/monad-chain-data/src/primitives/state.rs
@@ -58,12 +58,13 @@ impl PrimaryId {
         Self((shard << Self::LOCAL_ID_BITS) | (local as u64))
     }
 
-    pub fn idx_in_block(self, first: LogId) -> Result<usize> {
+    pub fn idx_in_block(self, first: PrimaryId) -> Result<usize> {
         let delta = self
             .0
-            .checked_sub(first.as_u64())
-            .ok_or(MonadChainDataError::Decode("log id below block start"))?;
-        usize::try_from(delta).map_err(|_| MonadChainDataError::Decode("log block index overflow"))
+            .checked_sub(first.0)
+            .ok_or(MonadChainDataError::Decode("primary id below block start"))?;
+        usize::try_from(delta)
+            .map_err(|_| MonadChainDataError::Decode("primary block index overflow"))
     }
 }
 
@@ -97,10 +98,6 @@ impl LogId {
 
     pub const fn from_parts(shard: u64, local: u32) -> Self {
         Self(PrimaryId::from_parts(shard, local))
-    }
-
-    pub fn idx_in_block(self, first: LogId) -> Result<usize> {
-        self.0.idx_in_block(first)
     }
 }
 

--- a/monad-chain-data/src/primitives/state.rs
+++ b/monad-chain-data/src/primitives/state.rs
@@ -115,21 +115,13 @@ impl From<LogId> for PrimaryId {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 pub struct FamilyWindowRecord {
-    pub first_log_id: LogId,
+    pub first_primary_id: PrimaryId,
     pub count: u32,
 }
 
 impl FamilyWindowRecord {
-    pub fn next_log_id(self) -> Result<LogId> {
-        self.first_log_id.checked_add(u64::from(self.count))
-    }
-
-    pub fn first_primary_id(self) -> PrimaryId {
-        self.first_log_id.into()
-    }
-
     pub fn next_primary_id_exclusive(self) -> Result<PrimaryId> {
-        self.first_primary_id().checked_add(u64::from(self.count))
+        self.first_primary_id.checked_add(u64::from(self.count))
     }
 }
 

--- a/monad-chain-data/src/primitives/state.rs
+++ b/monad-chain-data/src/primitives/state.rs
@@ -104,6 +104,18 @@ impl LogId {
     }
 }
 
+impl From<PrimaryId> for LogId {
+    fn from(id: PrimaryId) -> Self {
+        Self(id)
+    }
+}
+
+impl From<LogId> for PrimaryId {
+    fn from(id: LogId) -> Self {
+        id.0
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 pub struct FamilyWindowRecord {
     pub first_log_id: LogId,
@@ -113,6 +125,14 @@ pub struct FamilyWindowRecord {
 impl FamilyWindowRecord {
     pub fn next_log_id(self) -> Result<LogId> {
         self.first_log_id.checked_add(u64::from(self.count))
+    }
+
+    pub fn first_primary_id(self) -> PrimaryId {
+        self.first_log_id.into()
+    }
+
+    pub fn next_primary_id_exclusive(self) -> Result<PrimaryId> {
+        self.first_primary_id().checked_add(u64::from(self.count))
     }
 }
 

--- a/monad-chain-data/tests/log_bitmap_fragments.rs
+++ b/monad-chain-data/tests/log_bitmap_fragments.rs
@@ -15,7 +15,7 @@
 
 use monad_chain_data::{
     engine::bitmap::{decode_bitmap_blob, sharded_stream_id, STREAM_PAGE_LOCAL_ID_SPAN},
-    Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData,
+    Address, Bytes, Family, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData,
     MonadChainDataService, QueryLimits, Topic, B256,
 };
 
@@ -48,7 +48,7 @@ async fn ingest_persists_log_bitmap_fragments_for_address_and_topics() {
     let addr_stream = sharded_stream_id("addr", Address::repeat_byte(7).as_slice(), 0);
     let addr_fragments = service
         .tables()
-        .logs()
+        .family(Family::Log)
         .load_bitmap_fragments(&addr_stream, 0)
         .await
         .expect("load address fragments");
@@ -63,7 +63,7 @@ async fn ingest_persists_log_bitmap_fragments_for_address_and_topics() {
     let topic0_stream = sharded_stream_id("topic0", B256::repeat_byte(9).as_slice(), 0);
     let topic0_fragments = service
         .tables()
-        .logs()
+        .family(Family::Log)
         .load_bitmap_fragments(&topic0_stream, 0)
         .await
         .expect("load topic0 fragments");
@@ -75,7 +75,7 @@ async fn ingest_persists_log_bitmap_fragments_for_address_and_topics() {
     let topic1_stream = sharded_stream_id("topic1", B256::repeat_byte(10).as_slice(), 0);
     let topic1_fragments = service
         .tables()
-        .logs()
+        .family(Family::Log)
         .load_bitmap_fragments(&topic1_stream, 0)
         .await
         .expect("load topic1 fragments");
@@ -123,13 +123,13 @@ async fn ingest_persists_log_bitmap_fragments_across_page_boundaries() {
     let target_stream = sharded_stream_id("addr", Address::repeat_byte(7).as_slice(), 0);
     let first_page = service
         .tables()
-        .logs()
+        .family(Family::Log)
         .load_bitmap_fragments(&target_stream, 0)
         .await
         .expect("load first page");
     let second_page = service
         .tables()
-        .logs()
+        .family(Family::Log)
         .load_bitmap_fragments(&target_stream, STREAM_PAGE_LOCAL_ID_SPAN)
         .await
         .expect("load second page");
@@ -173,7 +173,7 @@ async fn ingest_empty_block_writes_no_log_bitmap_fragments() {
     let addr_stream = sharded_stream_id("addr", Address::repeat_byte(7).as_slice(), 0);
     let fragments = service
         .tables()
-        .logs()
+        .family(Family::Log)
         .load_bitmap_fragments(&addr_stream, 0)
         .await
         .expect("load fragments");

--- a/monad-chain-data/tests/log_bitmap_pages.rs
+++ b/monad-chain-data/tests/log_bitmap_pages.rs
@@ -19,9 +19,9 @@ use bytes::Bytes as StorageBytes;
 use monad_chain_data::{
     engine::bitmap::{sharded_stream_id, stream_page_key, STREAM_PAGE_LOCAL_ID_SPAN},
     store::{MetaStore, TableId},
-    Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData, LogFilter,
-    LogsRelations, MonadChainDataService, QueryEnvelope, QueryLimits, QueryLogsRequest, QueryOrder,
-    Topic, B256,
+    Address, Bytes, Family, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData,
+    LogFilter, LogsRelations, MonadChainDataService, QueryEnvelope, QueryLimits, QueryLogsRequest,
+    QueryOrder, Topic, B256,
 };
 
 mod common;
@@ -69,28 +69,28 @@ async fn ingest_compacts_sealed_pages_and_query_prefers_compacted_page_blobs() {
     let frontier_stream = sharded_stream_id("addr", frontier_address.as_slice(), 0);
     assert!(service
         .tables()
-        .logs()
+        .family(Family::Log)
         .load_bitmap_page_meta(&old_stream, 0)
         .await
         .expect("load old page meta")
         .is_some());
     assert!(service
         .tables()
-        .logs()
+        .family(Family::Log)
         .load_bitmap_page_blob(&old_stream, 0)
         .await
         .expect("load old page blob")
         .is_some());
     assert!(service
         .tables()
-        .logs()
+        .family(Family::Log)
         .load_bitmap_page_meta(&frontier_stream, 0)
         .await
         .expect("load sealed frontier page meta")
         .is_some());
     assert!(service
         .tables()
-        .logs()
+        .family(Family::Log)
         .load_bitmap_page_meta(&frontier_stream, STREAM_PAGE_LOCAL_ID_SPAN)
         .await
         .expect("load live frontier page meta")
@@ -99,7 +99,7 @@ async fn ingest_compacts_sealed_pages_and_query_prefers_compacted_page_blobs() {
     let partition = stream_page_key(&old_stream, 0);
     meta_store
         .scan_put(
-            service.tables().logs().bitmap_by_block_table(),
+            service.tables().family(Family::Log).bitmap_by_block_table(),
             &partition,
             &1u64.to_be_bytes(),
             StorageBytes::from_static(b"corrupt-fragment"),

--- a/monad-chain-data/tests/log_bitmap_pages.rs
+++ b/monad-chain-data/tests/log_bitmap_pages.rs
@@ -206,10 +206,7 @@ async fn query_errors_when_compacted_page_meta_exists_but_blob_is_missing() {
         .await
         .expect_err("missing page blob should error");
 
-    assert_eq!(
-        error.to_string(),
-        "missing data: missing log bitmap page blob"
-    );
+    assert_eq!(error.to_string(), "missing data: missing bitmap page blob");
 }
 
 fn repeated_logs(address: Address, topics: Vec<Topic>, count: usize) -> Vec<Log> {

--- a/monad-chain-data/tests/log_dir_buckets.rs
+++ b/monad-chain-data/tests/log_dir_buckets.rs
@@ -15,7 +15,7 @@
 
 use monad_chain_data::{
     engine::primary_dir::{PrimaryDirBucket, PrimaryDirFragment, DIRECTORY_BUCKET_SIZE},
-    Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData,
+    Address, Bytes, Family, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData,
     MonadChainDataService, QueryLimits, B256,
 };
 
@@ -54,7 +54,7 @@ async fn ingest_compacts_a_sealed_directory_bucket_when_crossing_the_boundary() 
 
     let bucket = service
         .tables()
-        .logs()
+        .family(Family::Log)
         .load_bucket(0)
         .await
         .expect("load compacted bucket")
@@ -69,7 +69,7 @@ async fn ingest_compacts_a_sealed_directory_bucket_when_crossing_the_boundary() 
 
     let fragments = service
         .tables()
-        .logs()
+        .family(Family::Log)
         .load_bucket_fragments(0)
         .await
         .expect("load fragments");
@@ -92,7 +92,7 @@ async fn ingest_compacts_a_sealed_directory_bucket_when_crossing_the_boundary() 
     assert!(
         service
             .tables()
-            .logs()
+            .family(Family::Log)
             .load_bucket(DIRECTORY_BUCKET_SIZE)
             .await
             .expect("load frontier bucket")

--- a/monad-chain-data/tests/log_dir_fragments.rs
+++ b/monad-chain-data/tests/log_dir_fragments.rs
@@ -15,7 +15,7 @@
 
 use monad_chain_data::{
     engine::primary_dir::{PrimaryDirFragment, DIRECTORY_BUCKET_SIZE},
-    Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData,
+    Address, Bytes, Family, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData,
     MonadChainDataService, QueryLimits, B256,
 };
 
@@ -41,7 +41,7 @@ async fn ingest_persists_log_dir_fragment_for_single_bucket_block() {
 
     let fragments = service
         .tables()
-        .logs()
+        .family(Family::Log)
         .load_bucket_fragments(0)
         .await
         .expect("load fragments");
@@ -74,7 +74,7 @@ async fn ingest_persists_zero_width_fragment_for_empty_block() {
 
     let fragments = service
         .tables()
-        .logs()
+        .family(Family::Log)
         .load_bucket_fragments(0)
         .await
         .expect("load fragments");
@@ -120,13 +120,13 @@ async fn ingest_persists_spanning_fragment_in_each_covered_bucket() {
 
     let first_partition = service
         .tables()
-        .logs()
+        .family(Family::Log)
         .load_bucket_fragments(0)
         .await
         .expect("load first partition");
     let second_partition = service
         .tables()
-        .logs()
+        .family(Family::Log)
         .load_bucket_fragments(DIRECTORY_BUCKET_SIZE)
         .await
         .expect("load second partition");

--- a/monad-chain-data/tests/query_logs_scan.rs
+++ b/monad-chain-data/tests/query_logs_scan.rs
@@ -17,8 +17,8 @@ use std::collections::HashSet;
 
 use monad_chain_data::{
     Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData, LogFilter,
-    LogId, LogsRelations, MonadChainDataError, MonadChainDataService, QueryEnvelope, QueryLimits,
-    QueryLogsRequest, QueryOrder, B256,
+    LogsRelations, MonadChainDataError, MonadChainDataService, PrimaryId, QueryEnvelope,
+    QueryLimits, QueryLogsRequest, QueryOrder, B256,
 };
 
 mod common;
@@ -250,11 +250,11 @@ async fn ingest_assigns_contiguous_log_id_windows_across_empty_blocks() {
         .expect("load block 3")
         .expect("block 3 record");
 
-    assert_eq!(block_1.logs.first_log_id, LogId::new(0));
+    assert_eq!(block_1.logs.first_primary_id, PrimaryId::new(0));
     assert_eq!(block_1.logs.count, 2);
-    assert_eq!(block_2.logs.first_log_id, LogId::new(2));
+    assert_eq!(block_2.logs.first_primary_id, PrimaryId::new(2));
     assert_eq!(block_2.logs.count, 0);
-    assert_eq!(block_3.logs.first_log_id, LogId::new(2));
+    assert_eq!(block_3.logs.first_primary_id, PrimaryId::new(2));
     assert_eq!(block_3.logs.count, 1);
 }
 


### PR DESCRIPTION
Moves the remaining log-specific engine surfaces onto Family-aware abstractions: primary-id window resolution, directory lookup, table access, and ingest persistence now operate through FamilyTables. Tables owns a deterministic map of all registered families, and log callers access Family::Log through the same path future families will use.

The shared indexed and block-scan query control flow is lifted into an IndexedFamilyQuery runner, with LogMaterializer implementing the family contract. The result is still log-only behavior, but the tx family can plug into the runner without duplicating the query orchestration.