### PR TITLE
Add transaction family substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4902,6 +4902,7 @@ name = "monad-chain-data"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "auto_impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,6 +4905,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types-eth",
  "auto_impl",
  "bytes",
  "roaring",

--- a/monad-chain-data/Cargo.toml
+++ b/monad-chain-data/Cargo.toml
@@ -13,10 +13,18 @@ alloy-consensus = { workspace = true }
 alloy-eips = { workspace = true }
 alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-rlp = { workspace = true, features = ["derive"] }
+alloy-rpc-types-eth = { workspace = true, optional = true }
 auto_impl = { workspace = true }
 bytes = { workspace = true }
 roaring = "0.11"
 thiserror = { workspace = true }
+
+[features]
+default = []
+# Enables `TxEntry::to_rpc_transaction`, converting a stored tx into an
+# `alloy_rpc_types_eth::Transaction`. Off by default so the crate stays
+# narrow; the consensus envelope is always accessible via `TxEntry::envelope`.
+alloy-rpc-types-eth = ["dep:alloy-rpc-types-eth"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/monad-chain-data/Cargo.toml
+++ b/monad-chain-data/Cargo.toml
@@ -10,6 +10,7 @@ bench = false
 
 [dependencies]
 alloy-consensus = { workspace = true }
+alloy-eips = { workspace = true }
 alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-rlp = { workspace = true, features = ["derive"] }
 auto_impl = { workspace = true }

--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -71,6 +71,11 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
         let logs = self.tables.family(Family::Log);
         let current_head = self.tables.publication().load_published_head().await?;
         let previous_record = blocks.validate_continuity(&block, current_head).await?;
+        if !block.txs.is_empty() && block.txs.len() != block.logs_by_tx.len() {
+            return Err(MonadChainDataError::InvalidRequest(
+                "txs and logs_by_tx lengths must match when txs are provided",
+            ));
+        }
         let next_log_id = match previous_record {
             Some(previous) => LogId::from(previous.logs.next_primary_id_exclusive()?),
             None => LogId::ZERO,

--- a/monad-chain-data/src/engine/family.rs
+++ b/monad-chain-data/src/engine/family.rs
@@ -49,12 +49,14 @@ macro_rules! family_table_ids {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Family {
     Log,
+    Tx,
 }
 
 impl Family {
     pub const fn table_ids(self) -> FamilyTableIds {
         match self {
             Family::Log => family_table_ids!("log"),
+            Family::Tx => family_table_ids!("tx"),
         }
     }
 
@@ -63,6 +65,7 @@ impl Family {
     pub fn window_in(self, block: &BlockRecord) -> Option<FamilyWindowRecord> {
         match self {
             Family::Log => Some(block.logs),
+            Family::Tx => Some(block.txs),
         }
     }
 }

--- a/monad-chain-data/src/engine/tables.rs
+++ b/monad-chain-data/src/engine/tables.rs
@@ -44,7 +44,11 @@ impl<M: MetaStore, B: BlobStore> Tables<M, B> {
         let mut families = BTreeMap::new();
         families.insert(
             Family::Log,
-            FamilyTables::new(meta_store.clone(), blob_store, Family::Log),
+            FamilyTables::new(meta_store.clone(), blob_store.clone(), Family::Log),
+        );
+        families.insert(
+            Family::Tx,
+            FamilyTables::new(meta_store.clone(), blob_store, Family::Tx),
         );
         Self {
             publication: PublicationTables::new(meta_store.clone()),

--- a/monad-chain-data/src/family.rs
+++ b/monad-chain-data/src/family.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use alloy_primitives::{Log, B256};
+use alloy_primitives::{Address, Bytes, Log, B256};
 
 use crate::primitives::EvmBlockHeader;
 
@@ -23,6 +23,18 @@ pub type Hash32 = B256;
 pub struct FinalizedBlock {
     pub header: EvmBlockHeader,
     pub logs_by_tx: Vec<Vec<Log>>,
+    pub txs: Vec<IngestTx>,
+}
+
+/// Per-transaction envelope carried by a finalized block. `sender` is
+/// caller-authoritative and is not recovered from `signed_tx_bytes`;
+/// indexed `from` queries read `sender` directly. Ingest validates
+/// `txs.len() == logs_by_tx.len()` when `txs` is non-empty.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct IngestTx {
+    pub tx_hash: Hash32,
+    pub sender: Address,
+    pub signed_tx_bytes: Bytes,
 }
 
 impl FinalizedBlock {

--- a/monad-chain-data/src/lib.rs
+++ b/monad-chain-data/src/lib.rs
@@ -33,7 +33,7 @@ pub use primitives::{
     limits::{LimitExceededKind, QueryEnvelope, QueryLimits},
     page::{QueryOrder, DEFAULT_QUERY_LIMIT},
     refs::{BlockRef, BlockSpan},
-    state::{BlockRecord, FamilyWindowRecord, LogId, PrimaryId},
+    state::{BlockRecord, FamilyWindowRecord, LogId, PrimaryId, TxId},
     EvmBlockHeader,
 };
 pub use store::{InMemoryBlobStore, InMemoryMetaStore};

--- a/monad-chain-data/src/lib.rs
+++ b/monad-chain-data/src/lib.rs
@@ -21,6 +21,7 @@ pub mod family;
 pub mod logs;
 pub mod primitives;
 pub mod store;
+pub mod txs;
 
 pub use alloy_primitives::{Address, Bytes, Log, LogData, B256};
 pub use api::{IngestOutcome, MonadChainDataService};
@@ -37,5 +38,8 @@ pub use primitives::{
     EvmBlockHeader,
 };
 pub use store::{InMemoryBlobStore, InMemoryMetaStore};
+pub use txs::{
+    QueryTransactionsRequest, QueryTransactionsResponse, TxEntry, TxFilter, TxsRelations,
+};
 
 pub type Topic = B256;

--- a/monad-chain-data/src/lib.rs
+++ b/monad-chain-data/src/lib.rs
@@ -27,7 +27,7 @@ pub use api::{IngestOutcome, MonadChainDataService};
 pub use blocks::{Block, QueryBlocksRequest, QueryBlocksResponse};
 pub use engine::{family::Family, tables::Tables};
 pub use error::MonadChainDataError;
-pub use family::{FinalizedBlock, Hash32};
+pub use family::{FinalizedBlock, Hash32, IngestTx};
 pub use logs::{LogEntry, LogFilter, LogsRelations, QueryLogsRequest, QueryLogsResponse};
 pub use primitives::{
     limits::{LimitExceededKind, QueryEnvelope, QueryLimits},

--- a/monad-chain-data/src/logs/ingest.rs
+++ b/monad-chain-data/src/logs/ingest.rs
@@ -20,7 +20,7 @@ use crate::{
     engine::bitmap::{encode_grouped_bitmap_fragments, sharded_stream_id, BitmapFragmentWrite},
     error::{MonadChainDataError, Result},
     family::FinalizedBlock,
-    primitives::state::{BlockRecord, FamilyWindowRecord, LogId},
+    primitives::state::{BlockRecord, FamilyWindowRecord, LogId, PrimaryId},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -50,6 +50,10 @@ impl LogIngestPlan {
             logs: FamilyWindowRecord {
                 first_primary_id: first_log_id.into(),
                 count: log_count,
+            },
+            txs: FamilyWindowRecord {
+                first_primary_id: PrimaryId::ZERO,
+                count: 0,
             },
         };
 

--- a/monad-chain-data/src/primitives/state.rs
+++ b/monad-chain-data/src/primitives/state.rs
@@ -113,6 +113,51 @@ impl From<LogId> for PrimaryId {
     }
 }
 
+/// `PrimaryId` scoped to the tx family. Kept as a distinct type so tx-domain
+/// signatures don't accept primary ids from other families by mistake.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, RlpEncodable, RlpDecodable)]
+pub struct TxId(PrimaryId);
+
+impl TxId {
+    pub const ZERO: Self = Self(PrimaryId::ZERO);
+
+    pub const fn new(value: u64) -> Self {
+        Self(PrimaryId::new(value))
+    }
+
+    pub const fn as_u64(self) -> u64 {
+        self.0.as_u64()
+    }
+
+    pub fn checked_add(self, rhs: u64) -> Result<Self> {
+        self.0.checked_add(rhs).map(Self)
+    }
+
+    pub const fn shard(self) -> u64 {
+        self.0.shard()
+    }
+
+    pub const fn local(self) -> u32 {
+        self.0.local()
+    }
+
+    pub const fn from_parts(shard: u64, local: u32) -> Self {
+        Self(PrimaryId::from_parts(shard, local))
+    }
+}
+
+impl From<PrimaryId> for TxId {
+    fn from(id: PrimaryId) -> Self {
+        Self(id)
+    }
+}
+
+impl From<TxId> for PrimaryId {
+    fn from(id: TxId) -> Self {
+        id.0
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 pub struct FamilyWindowRecord {
     pub first_primary_id: PrimaryId,
@@ -131,6 +176,7 @@ pub struct BlockRecord {
     pub block_hash: Hash32,
     pub parent_hash: Hash32,
     pub logs: FamilyWindowRecord,
+    pub txs: FamilyWindowRecord,
 }
 
 impl BlockRecord {

--- a/monad-chain-data/src/txs/ingest.rs
+++ b/monad-chain-data/src/txs/ingest.rs
@@ -1,0 +1,124 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use alloy_consensus::Transaction;
+
+use super::types::{decode_envelope, selector_from_envelope, BlockTxHeader, StoredTxEnvelope};
+use crate::{
+    engine::bitmap::{encode_grouped_bitmap_fragments, sharded_stream_id, BitmapFragmentWrite},
+    error::{MonadChainDataError, Result},
+    family::{FinalizedBlock, IngestTx},
+    primitives::state::{FamilyWindowRecord, TxId},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TxIngestPlan {
+    pub tx_window: FamilyWindowRecord,
+    pub block_tx_header: BlockTxHeader,
+    pub block_tx_blob: Vec<u8>,
+    pub bitmap_fragments: Vec<BitmapFragmentWrite>,
+    pub written_txs: usize,
+}
+
+impl TxIngestPlan {
+    /// Derives the per-block tx artifacts and index fragments for one finalized block.
+    pub fn build(block: &FinalizedBlock, first_tx_id: TxId) -> Result<Self> {
+        let tx_count = u32::try_from(block.txs.len())
+            .map_err(|_| MonadChainDataError::Decode("tx count overflow"))?;
+
+        let (block_tx_header, block_tx_blob) = Self::encode_block_txs(&block.txs)?;
+        let bitmap_fragments = Self::collect_bitmap_fragments(&block.txs, first_tx_id)?;
+        let tx_window = FamilyWindowRecord {
+            first_primary_id: first_tx_id.into(),
+            count: tx_count,
+        };
+
+        Ok(Self {
+            tx_window,
+            block_tx_header,
+            block_tx_blob,
+            bitmap_fragments,
+            written_txs: block.txs.len(),
+        })
+    }
+
+    fn encode_block_txs(txs: &[IngestTx]) -> Result<(BlockTxHeader, Vec<u8>)> {
+        let mut offsets = Vec::with_capacity(txs.len() + 1);
+        let mut blob = Vec::new();
+
+        for tx in txs {
+            offsets.push(
+                u32::try_from(blob.len())
+                    .map_err(|_| MonadChainDataError::Decode("block tx blob too large"))?,
+            );
+            let stored = StoredTxEnvelope {
+                tx_hash: tx.tx_hash,
+                sender: tx.sender,
+                signed_tx_bytes: tx.signed_tx_bytes.clone(),
+            };
+            blob.extend_from_slice(&stored.encode());
+        }
+
+        offsets.push(
+            u32::try_from(blob.len())
+                .map_err(|_| MonadChainDataError::Decode("block tx blob too large"))?,
+        );
+
+        Ok((BlockTxHeader { offsets }, blob))
+    }
+
+    fn collect_bitmap_fragments(
+        txs: &[IngestTx],
+        first_tx_id: TxId,
+    ) -> Result<Vec<BitmapFragmentWrite>> {
+        let mut stream_values = Vec::new();
+
+        for (ordinal, tx) in txs.iter().enumerate() {
+            let ordinal = u64::try_from(ordinal)
+                .map_err(|_| MonadChainDataError::Decode("tx ordinal overflow"))?;
+            let tx_id = first_tx_id.checked_add(ordinal)?;
+            stream_values.extend(stream_entries_for_tx(tx, tx_id)?);
+        }
+
+        encode_grouped_bitmap_fragments(stream_values)
+    }
+}
+
+/// Expands one tx into the indexed stream entries written at ingest time.
+/// The "to" and "selector" streams are skipped for contract-creation txs
+/// and for calldata shorter than 4 bytes.
+fn stream_entries_for_tx(tx: &IngestTx, global_tx_id: TxId) -> Result<Vec<(String, u32)>> {
+    let shard = global_tx_id.shard();
+    let local = global_tx_id.local();
+    let envelope = decode_envelope(&tx.signed_tx_bytes)?;
+
+    let mut entries = Vec::with_capacity(3);
+    entries.push((
+        sharded_stream_id("from", tx.sender.as_slice(), shard),
+        local,
+    ));
+
+    if let Some(to) = envelope.to() {
+        entries.push((sharded_stream_id("to", to.as_slice(), shard), local));
+    }
+    if let Some(selector) = selector_from_envelope(&envelope) {
+        entries.push((
+            sharded_stream_id("selector", selector.as_slice(), shard),
+            local,
+        ));
+    }
+
+    Ok(entries)
+}

--- a/monad-chain-data/src/txs/materialize.rs
+++ b/monad-chain-data/src/txs/materialize.rs
@@ -1,0 +1,223 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+
+use alloy_consensus::Transaction;
+use alloy_primitives::Address;
+use bytes::Bytes as RawBytes;
+
+use super::types::{
+    decode_envelope, selector_from_envelope, BlockTxHeader, StoredTxEnvelope, TxEntry,
+};
+use crate::{
+    blocks::Block,
+    engine::{
+        clause::{IndexedClause, IndexedFilter},
+        family::Family,
+        tables::Tables,
+    },
+    error::{MonadChainDataError, Result},
+    primitives::{
+        page::{QueryOrder, DEFAULT_QUERY_LIMIT},
+        refs::BlockRef,
+    },
+    store::{BlobStore, MetaStore},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TxFilter {
+    pub from: Option<HashSet<Address>>,
+    pub to: Option<HashSet<Address>>,
+    pub selector: Option<HashSet<[u8; 4]>>,
+}
+
+impl TxFilter {
+    pub fn has_indexed_clause(&self) -> bool {
+        self.from.is_some() || self.to.is_some() || self.selector.is_some()
+    }
+}
+
+/// Opt-in relations joined onto a transactions query response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TxsRelations {
+    /// When true, `QueryTransactionsResponse::blocks` is populated with
+    /// deduped headers for the blocks that contributed txs in this page.
+    pub blocks: bool,
+}
+
+/// Public transactions query in queryX spec semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryTransactionsRequest {
+    pub from_block: Option<u64>,
+    pub to_block: Option<u64>,
+    pub order: QueryOrder,
+    /// Target tx count. Defaults to [`DEFAULT_QUERY_LIMIT`].
+    pub limit: usize,
+    pub filter: TxFilter,
+    pub relations: TxsRelations,
+}
+
+impl Default for QueryTransactionsRequest {
+    fn default() -> Self {
+        Self {
+            from_block: None,
+            to_block: None,
+            order: QueryOrder::default(),
+            limit: DEFAULT_QUERY_LIMIT,
+            filter: TxFilter::default(),
+            relations: TxsRelations::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryTransactionsResponse {
+    pub txs: Vec<TxEntry>,
+    pub blocks: Vec<Block>,
+    pub from_block: BlockRef,
+    pub to_block: BlockRef,
+    pub cursor_block: BlockRef,
+}
+
+impl IndexedFilter for TxFilter {
+    type Record = TxEntry;
+
+    fn indexed_clauses(&self) -> Vec<IndexedClause> {
+        let mut clauses = Vec::new();
+
+        if let Some(values) = &self.from {
+            clauses.push(IndexedClause {
+                kind: "from",
+                values: values
+                    .iter()
+                    .map(|a| RawBytes::copy_from_slice(a.as_slice()))
+                    .collect(),
+            });
+        }
+        if let Some(values) = &self.to {
+            clauses.push(IndexedClause {
+                kind: "to",
+                values: values
+                    .iter()
+                    .map(|a| RawBytes::copy_from_slice(a.as_slice()))
+                    .collect(),
+            });
+        }
+        if let Some(values) = &self.selector {
+            clauses.push(IndexedClause {
+                kind: "selector",
+                values: values
+                    .iter()
+                    .map(|s| RawBytes::copy_from_slice(s.as_slice()))
+                    .collect(),
+            });
+        }
+
+        clauses
+    }
+
+    fn matches(&self, tx: &TxEntry) -> bool {
+        if let Some(from) = &self.from {
+            if !from.contains(&tx.sender) {
+                return false;
+            }
+        }
+
+        // Contract-creation txs and bad envelopes do not match a `to` or
+        // `selector` filter; parse once and reuse for both.
+        if self.to.is_some() || self.selector.is_some() {
+            let Ok(envelope) = decode_envelope(&tx.signed_tx_bytes) else {
+                return false;
+            };
+
+            if let Some(to) = &self.to {
+                match envelope.to() {
+                    Some(actual) if to.contains(&actual) => {}
+                    _ => return false,
+                }
+            }
+            if let Some(selector) = &self.selector {
+                match selector_from_envelope(&envelope) {
+                    Some(actual) if selector.contains(&actual) => {}
+                    _ => return false,
+                }
+            }
+        }
+
+        true
+    }
+}
+
+#[allow(dead_code)]
+pub struct TxMaterializer<'a, M: MetaStore, B: BlobStore> {
+    tables: &'a Tables<M, B>,
+}
+
+#[allow(dead_code)]
+impl<'a, M: MetaStore, B: BlobStore> TxMaterializer<'a, M, B> {
+    pub fn new(tables: &'a Tables<M, B>) -> Self {
+        Self { tables }
+    }
+
+    pub async fn load_block_ref(&self, block_number: u64) -> Result<BlockRef> {
+        let block_record = self
+            .tables
+            .blocks()
+            .load_record(block_number)
+            .await?
+            .ok_or(MonadChainDataError::MissingData("missing block record"))?;
+        Ok(BlockRef::from(&block_record))
+    }
+
+    /// Resolves and materializes one tx by block number and block-local index.
+    pub async fn load_tx_at(&self, block_number: u64, tx_idx: usize) -> Result<TxEntry> {
+        let block_record = self
+            .tables
+            .blocks()
+            .load_record(block_number)
+            .await?
+            .ok_or(MonadChainDataError::MissingData("missing block record"))?;
+        let header_bytes = self
+            .tables
+            .family(Family::Tx)
+            .load_block_header(block_number)
+            .await?
+            .ok_or(MonadChainDataError::MissingData("missing block tx header"))?;
+        let header = BlockTxHeader::decode(&header_bytes)?;
+
+        if tx_idx + 1 >= header.offsets.len() {
+            return Err(MonadChainDataError::Decode("tx index out of range"));
+        }
+        let start = header.offsets[tx_idx] as usize;
+        let end = header.offsets[tx_idx + 1] as usize;
+
+        let bytes = self
+            .tables
+            .family(Family::Tx)
+            .read_block_blob_range(block_number, start, end)
+            .await?
+            .ok_or(MonadChainDataError::MissingData("missing block tx blob"))?;
+
+        let stored = StoredTxEnvelope::decode(&bytes)?;
+        let tx_idx_u32 =
+            u32::try_from(tx_idx).map_err(|_| MonadChainDataError::Decode("tx index overflow"))?;
+        Ok(stored.into_tx_entry(
+            block_record.block_number,
+            block_record.block_hash,
+            tx_idx_u32,
+        ))
+    }
+}

--- a/monad-chain-data/src/txs/materialize.rs
+++ b/monad-chain-data/src/txs/materialize.rs
@@ -19,9 +19,7 @@ use alloy_consensus::Transaction;
 use alloy_primitives::Address;
 use bytes::Bytes as RawBytes;
 
-use super::types::{
-    decode_envelope, selector_from_envelope, BlockTxHeader, StoredTxEnvelope, TxEntry,
-};
+use super::types::{selector_from_envelope, BlockTxHeader, StoredTxEnvelope, TxEntry};
 use crate::{
     blocks::Block,
     engine::{
@@ -31,8 +29,8 @@ use crate::{
     },
     error::{MonadChainDataError, Result},
     primitives::{
-        page::{QueryOrder, DEFAULT_QUERY_LIMIT},
-        refs::BlockRef,
+        limits::QueryEnvelope,
+        refs::{BlockRef, BlockSpan},
     },
     store::{BlobStore, MetaStore},
 };
@@ -59,37 +57,23 @@ pub struct TxsRelations {
 }
 
 /// Public transactions query in queryX spec semantics.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct QueryTransactionsRequest {
-    pub from_block: Option<u64>,
-    pub to_block: Option<u64>,
-    pub order: QueryOrder,
-    /// Target tx count. Defaults to [`DEFAULT_QUERY_LIMIT`].
-    pub limit: usize,
+    pub envelope: QueryEnvelope,
     pub filter: TxFilter,
     pub relations: TxsRelations,
-}
-
-impl Default for QueryTransactionsRequest {
-    fn default() -> Self {
-        Self {
-            from_block: None,
-            to_block: None,
-            order: QueryOrder::default(),
-            limit: DEFAULT_QUERY_LIMIT,
-            filter: TxFilter::default(),
-            relations: TxsRelations::default(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryTransactionsResponse {
     pub txs: Vec<TxEntry>,
-    pub blocks: Vec<Block>,
-    pub from_block: BlockRef,
-    pub to_block: BlockRef,
-    pub cursor_block: BlockRef,
+    /// Deduped blocks for the `txs` in this page, sorted ascending by
+    /// block number. `None` unless `QueryTransactionsRequest::relations.blocks`.
+    pub blocks: Option<Vec<Block>>,
+    /// The span mirrors the resolved request bounds and records the last
+    /// block scanned. When `txs` is empty there is no next page; callers
+    /// should treat the response as terminal rather than advance the cursor.
+    pub span: BlockSpan,
 }
 
 impl IndexedFilter for TxFilter {
@@ -137,9 +121,9 @@ impl IndexedFilter for TxFilter {
         }
 
         // Contract-creation txs and bad envelopes do not match a `to` or
-        // `selector` filter; parse once and reuse for both.
+        // `selector` filter; decode once and reuse for both.
         if self.to.is_some() || self.selector.is_some() {
-            let Ok(envelope) = decode_envelope(&tx.signed_tx_bytes) else {
+            let Ok(envelope) = tx.envelope() else {
                 return false;
             };
 

--- a/monad-chain-data/src/txs/mod.rs
+++ b/monad-chain-data/src/txs/mod.rs
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+mod ingest;
+mod materialize;
+mod types;
+
+pub use ingest::TxIngestPlan;
+#[allow(unused_imports)]
+pub(crate) use materialize::TxMaterializer;
+pub use materialize::{
+    QueryTransactionsRequest, QueryTransactionsResponse, TxFilter, TxsRelations,
+};
+pub use types::{BlockTxHeader, StoredTxEnvelope, TxEntry};

--- a/monad-chain-data/src/txs/types.rs
+++ b/monad-chain-data/src/txs/types.rs
@@ -35,17 +35,42 @@ pub struct TxEntry {
 }
 
 impl TxEntry {
+    /// Decodes the stored signed-tx bytes into the consensus envelope.
+    /// Callers that need multiple fields should decode once and work
+    /// with the `TxEnvelope`; the per-field accessors each re-parse.
+    pub fn envelope(&self) -> Result<TxEnvelope> {
+        decode_envelope(&self.signed_tx_bytes)
+    }
+
     /// Recipient address; `None` for contract-creation transactions.
     pub fn to(&self) -> Result<Option<Address>> {
-        Ok(decode_envelope(&self.signed_tx_bytes)?.to())
+        Ok(self.envelope()?.to())
     }
 
     /// 4-byte function selector; `None` for contract-creation transactions
     /// or when the calldata is shorter than 4 bytes.
     pub fn selector(&self) -> Result<Option<[u8; 4]>> {
-        Ok(selector_from_envelope(&decode_envelope(
-            &self.signed_tx_bytes,
-        )?))
+        Ok(selector_from_envelope(&self.envelope()?))
+    }
+
+    /// Assembles the queryX-spec `alloy_rpc_types_eth::Transaction` shape
+    /// from the stored envelope, sender, and block context.
+    ///
+    /// `effective_gas_price` is left as `None`: it depends on the block's
+    /// `base_fee_per_gas`, which is not carried on `TxEntry`. RPC layers
+    /// returning this shape directly must load the block header and
+    /// populate it via `envelope.effective_gas_price(Some(base_fee))`.
+    #[cfg(feature = "alloy-rpc-types-eth")]
+    pub fn to_rpc_transaction(&self) -> Result<alloy_rpc_types_eth::Transaction> {
+        use alloy_consensus::transaction::Recovered;
+
+        Ok(alloy_rpc_types_eth::Transaction {
+            inner: Recovered::new_unchecked(self.envelope()?, self.sender),
+            block_hash: Some(self.block_hash),
+            block_number: Some(self.block_number),
+            transaction_index: Some(u64::from(self.tx_idx)),
+            effective_gas_price: None,
+        })
     }
 }
 

--- a/monad-chain-data/src/txs/types.rs
+++ b/monad-chain-data/src/txs/types.rs
@@ -1,0 +1,113 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use alloy_consensus::{Transaction, TxEnvelope};
+use alloy_eips::eip2718::Decodable2718;
+use alloy_primitives::{Address, Bytes};
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+
+use crate::{
+    error::{MonadChainDataError, Result},
+    family::Hash32,
+};
+
+/// Public, owned per-transaction view returned by queries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TxEntry {
+    pub block_number: u64,
+    pub block_hash: Hash32,
+    pub tx_idx: u32,
+    pub tx_hash: Hash32,
+    pub sender: Address,
+    pub signed_tx_bytes: Bytes,
+}
+
+impl TxEntry {
+    /// Recipient address; `None` for contract-creation transactions.
+    pub fn to(&self) -> Result<Option<Address>> {
+        Ok(decode_envelope(&self.signed_tx_bytes)?.to())
+    }
+
+    /// 4-byte function selector; `None` for contract-creation transactions
+    /// or when the calldata is shorter than 4 bytes.
+    pub fn selector(&self) -> Result<Option<[u8; 4]>> {
+        Ok(selector_from_envelope(&decode_envelope(
+            &self.signed_tx_bytes,
+        )?))
+    }
+}
+
+/// Per-tx fields stored in the block blob. Block-level fields
+/// (block_number, block_hash, tx_idx) are reconstructed from the
+/// `BlockRecord` and `BlockTxHeader` at read time.
+#[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+pub struct StoredTxEnvelope {
+    pub tx_hash: Hash32,
+    pub sender: Address,
+    pub signed_tx_bytes: Bytes,
+}
+
+impl StoredTxEnvelope {
+    pub fn encode(&self) -> Vec<u8> {
+        alloy_rlp::encode(self)
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        alloy_rlp::decode_exact(bytes)
+            .map_err(|_| MonadChainDataError::Decode("invalid tx envelope rlp"))
+    }
+
+    pub fn into_tx_entry(self, block_number: u64, block_hash: Hash32, tx_idx: u32) -> TxEntry {
+        TxEntry {
+            block_number,
+            block_hash,
+            tx_idx,
+            tx_hash: self.tx_hash,
+            sender: self.sender,
+            signed_tx_bytes: self.signed_tx_bytes,
+        }
+    }
+}
+
+/// Byte offsets into `block_tx_blob` for each `tx_idx`. Length is
+/// `tx_count + 1`; the final sentinel is the total blob length.
+#[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+pub struct BlockTxHeader {
+    pub offsets: Vec<u32>,
+}
+
+impl BlockTxHeader {
+    pub fn tx_count(&self) -> usize {
+        self.offsets.len().saturating_sub(1)
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        alloy_rlp::encode(self)
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        alloy_rlp::decode_exact(bytes)
+            .map_err(|_| MonadChainDataError::Decode("invalid tx header rlp"))
+    }
+}
+
+pub(crate) fn decode_envelope(signed_tx_bytes: &[u8]) -> Result<TxEnvelope> {
+    TxEnvelope::decode_2718(&mut &signed_tx_bytes[..])
+        .map_err(|_| MonadChainDataError::Decode("invalid signed tx envelope"))
+}
+
+pub(crate) fn selector_from_envelope(envelope: &TxEnvelope) -> Option<[u8; 4]> {
+    envelope.function_selector().map(|s| s.0)
+}

--- a/monad-chain-data/tests/block_hash_index.rs
+++ b/monad-chain-data/tests/block_hash_index.rs
@@ -36,6 +36,7 @@ async fn ingest_persists_block_hash_index_entry() {
         .ingest_block(FinalizedBlock {
             header,
             logs_by_tx: vec![vec![]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -89,6 +90,7 @@ async fn multi_block_chain_indexes_each_hash_distinctly() {
             .ingest_block(FinalizedBlock {
                 header,
                 logs_by_tx: vec![vec![]],
+                txs: Vec::new(),
             })
             .await
             .expect("ingest");

--- a/monad-chain-data/tests/block_header_artifact.rs
+++ b/monad-chain-data/tests/block_header_artifact.rs
@@ -42,6 +42,7 @@ async fn ingest_persists_block_header() {
         .ingest_block(FinalizedBlock {
             header: header.clone(),
             logs_by_tx: vec![vec![]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -111,6 +112,7 @@ async fn block_header_roundtrips_with_all_optional_fields_populated() {
         .ingest_block(FinalizedBlock {
             header: header.clone(),
             logs_by_tx: vec![vec![]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");

--- a/monad-chain-data/tests/ingest_block_shape.rs
+++ b/monad-chain-data/tests/ingest_block_shape.rs
@@ -1,0 +1,64 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use monad_chain_data::{
+    FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, IngestTx, MonadChainDataError,
+    MonadChainDataService, QueryLimits, B256,
+};
+
+mod common;
+
+use common::test_header;
+
+#[tokio::test(flavor = "current_thread")]
+async fn ingest_rejects_mismatched_txs_and_logs_by_tx_lengths() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let err = service
+        .ingest_block(FinalizedBlock {
+            header: test_header(1, B256::ZERO),
+            logs_by_tx: vec![vec![], vec![]],
+            txs: vec![IngestTx::default()],
+        })
+        .await
+        .expect_err("length mismatch should be rejected");
+
+    assert!(
+        matches!(err, MonadChainDataError::InvalidRequest(_)),
+        "expected InvalidRequest, got {err:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn ingest_accepts_matching_txs_and_logs_by_tx_lengths() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    service
+        .ingest_block(FinalizedBlock {
+            header: test_header(1, B256::ZERO),
+            logs_by_tx: vec![vec![], vec![]],
+            txs: vec![IngestTx::default(), IngestTx::default()],
+        })
+        .await
+        .expect("matching lengths should ingest");
+}

--- a/monad-chain-data/tests/log_bitmap_fragments.rs
+++ b/monad-chain-data/tests/log_bitmap_fragments.rs
@@ -41,6 +41,7 @@ async fn ingest_persists_log_bitmap_fragments_for_address_and_topics() {
                 ),
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
             ]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -104,6 +105,7 @@ async fn ingest_persists_log_bitmap_fragments_across_page_boundaries() {
                 vec![B256::repeat_byte(3)],
                 usize::try_from(STREAM_PAGE_LOCAL_ID_SPAN - 2).expect("page span fits usize"),
             )],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -116,6 +118,7 @@ async fn ingest_persists_log_bitmap_fragments_across_page_boundaries() {
                 vec![B256::repeat_byte(9)],
                 4,
             )],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 2");
@@ -166,6 +169,7 @@ async fn ingest_empty_block_writes_no_log_bitmap_fragments() {
         .ingest_block(FinalizedBlock {
             header: test_header(1, B256::ZERO),
             logs_by_tx: vec![vec![]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");

--- a/monad-chain-data/tests/log_bitmap_pages.rs
+++ b/monad-chain-data/tests/log_bitmap_pages.rs
@@ -51,6 +51,7 @@ async fn ingest_compacts_sealed_pages_and_query_prefers_compacted_page_blobs() {
                 vec![old_topic],
                 usize::try_from(STREAM_PAGE_LOCAL_ID_SPAN - 2).expect("page span fits usize"),
             )],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -61,6 +62,7 @@ async fn ingest_compacts_sealed_pages_and_query_prefers_compacted_page_blobs() {
         .ingest_block(FinalizedBlock {
             header: h2,
             logs_by_tx: vec![repeated_logs(frontier_address, vec![frontier_topic], 4)],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 2");
@@ -168,6 +170,7 @@ async fn query_errors_when_compacted_page_meta_exists_but_blob_is_missing() {
                 vec![topic],
                 usize::try_from(STREAM_PAGE_LOCAL_ID_SPAN - 2).expect("page span fits usize"),
             )],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -179,6 +182,7 @@ async fn query_errors_when_compacted_page_meta_exists_but_blob_is_missing() {
                 vec![B256::repeat_byte(10)],
                 4,
             )],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 2");

--- a/monad-chain-data/tests/log_dir_buckets.rs
+++ b/monad-chain-data/tests/log_dir_buckets.rs
@@ -40,6 +40,7 @@ async fn ingest_compacts_a_sealed_directory_bucket_when_crossing_the_boundary() 
             logs_by_tx: vec![repeated_logs(
                 usize::try_from(DIRECTORY_BUCKET_SIZE - 2).expect("bucket size fits usize"),
             )],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -48,6 +49,7 @@ async fn ingest_compacts_a_sealed_directory_bucket_when_crossing_the_boundary() 
         .ingest_block(FinalizedBlock {
             header: h2,
             logs_by_tx: vec![repeated_logs(4)],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 2");

--- a/monad-chain-data/tests/log_dir_fragments.rs
+++ b/monad-chain-data/tests/log_dir_fragments.rs
@@ -35,6 +35,7 @@ async fn ingest_persists_log_dir_fragment_for_single_bucket_block() {
         .ingest_block(FinalizedBlock {
             header: test_header(1, B256::ZERO),
             logs_by_tx: vec![vec![log(), log()]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -68,6 +69,7 @@ async fn ingest_persists_zero_width_fragment_for_empty_block() {
         .ingest_block(FinalizedBlock {
             header: test_header(1, B256::ZERO),
             logs_by_tx: vec![vec![]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -106,6 +108,7 @@ async fn ingest_persists_spanning_fragment_in_each_covered_bucket() {
             logs_by_tx: vec![repeated_logs(
                 usize::try_from(DIRECTORY_BUCKET_SIZE - 2).expect("bucket size fits usize"),
             )],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -114,6 +117,7 @@ async fn ingest_persists_spanning_fragment_in_each_covered_bucket() {
         .ingest_block(FinalizedBlock {
             header: h2,
             logs_by_tx: vec![repeated_logs(4)],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 2");

--- a/monad-chain-data/tests/query_blocks.rs
+++ b/monad-chain-data/tests/query_blocks.rs
@@ -330,6 +330,7 @@ async fn ingest_three_block_chain_with_hashes(
             .ingest_block(FinalizedBlock {
                 header,
                 logs_by_tx: vec![vec![]],
+                txs: Vec::new(),
             })
             .await
             .expect("ingest block");

--- a/monad-chain-data/tests/query_logs_blocks_relation.rs
+++ b/monad-chain-data/tests/query_logs_blocks_relation.rs
@@ -176,6 +176,7 @@ async fn ingest(
         .ingest_block(FinalizedBlock {
             header,
             logs_by_tx: vec![logs],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest");

--- a/monad-chain-data/tests/query_logs_indexed.rs
+++ b/monad-chain-data/tests/query_logs_indexed.rs
@@ -48,6 +48,7 @@ async fn indexed_query_logs_respects_and_or_filter_semantics() {
                     vec![B256::repeat_byte(11), B256::repeat_byte(10)],
                 ),
             ]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block");
@@ -100,6 +101,7 @@ async fn indexed_query_logs_descending_returns_newest_first() {
                 Address::repeat_byte(7),
                 vec![B256::repeat_byte(9)],
             )]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -111,6 +113,7 @@ async fn indexed_query_logs_descending_returns_newest_first() {
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
             ]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 2");
@@ -165,6 +168,7 @@ async fn indexed_query_logs_paginates_at_block_boundaries() {
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
             ]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -176,6 +180,7 @@ async fn indexed_query_logs_paginates_at_block_boundaries() {
                 Address::repeat_byte(7),
                 vec![B256::repeat_byte(9)],
             )]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 2");
@@ -250,6 +255,7 @@ async fn indexed_query_logs_scans_across_bucket_and_page_boundaries() {
                 vec![B256::repeat_byte(3)],
                 usize::try_from(STREAM_PAGE_LOCAL_ID_SPAN - 2).expect("page span fits usize"),
             )],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -263,6 +269,7 @@ async fn indexed_query_logs_scans_across_bucket_and_page_boundaries() {
                 usize::try_from(DIRECTORY_BUCKET_SIZE + 4)
                     .expect("directory bucket size fits usize"),
             )],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 2");
@@ -316,6 +323,7 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block() {
                 Address::repeat_byte(7),
                 vec![B256::repeat_byte(9)],
             )]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -330,6 +338,7 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block() {
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
             ]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 2");
@@ -341,6 +350,7 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block() {
                 Address::repeat_byte(7),
                 vec![B256::repeat_byte(9)],
             )]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 3");
@@ -392,6 +402,7 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block_desc
                 Address::repeat_byte(7),
                 vec![B256::repeat_byte(9)],
             )]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -406,6 +417,7 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block_desc
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
             ]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 2");
@@ -417,6 +429,7 @@ async fn indexed_query_completes_current_block_when_limit_reached_mid_block_desc
                 Address::repeat_byte(7),
                 vec![B256::repeat_byte(9)],
             )]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 3");
@@ -467,6 +480,7 @@ async fn indexed_query_stops_at_block_when_limit_equals_block_match_count() {
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
                 log(Address::repeat_byte(7), vec![B256::repeat_byte(9)]),
             ]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -478,6 +492,7 @@ async fn indexed_query_stops_at_block_when_limit_equals_block_match_count() {
                 Address::repeat_byte(7),
                 vec![B256::repeat_byte(9)],
             )]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 2");
@@ -524,6 +539,7 @@ async fn unindexed_query_logs_still_uses_block_scan_fallback() {
                 log(Address::repeat_byte(5), vec![B256::repeat_byte(8)]),
                 log(Address::repeat_byte(6), vec![B256::repeat_byte(9)]),
             ]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest");

--- a/monad-chain-data/tests/query_logs_limits.rs
+++ b/monad-chain-data/tests/query_logs_limits.rs
@@ -159,6 +159,7 @@ async fn ingest_three_block_chain(
             .ingest_block(FinalizedBlock {
                 header,
                 logs_by_tx: vec![vec![log()]],
+                txs: Vec::new(),
             })
             .await
             .expect("ingest block");

--- a/monad-chain-data/tests/query_logs_range_resolution.rs
+++ b/monad-chain-data/tests/query_logs_range_resolution.rs
@@ -254,6 +254,7 @@ async fn ingest_two_block_chain() -> MonadChainDataService<InMemoryMetaStore, In
         .ingest_block(FinalizedBlock {
             header: h1,
             logs_by_tx: vec![vec![log(Address::repeat_byte(1), B256::repeat_byte(1))]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -262,6 +263,7 @@ async fn ingest_two_block_chain() -> MonadChainDataService<InMemoryMetaStore, In
         .ingest_block(FinalizedBlock {
             header: h2,
             logs_by_tx: vec![vec![log(Address::repeat_byte(2), B256::repeat_byte(2))]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 2");

--- a/monad-chain-data/tests/query_logs_scan.rs
+++ b/monad-chain-data/tests/query_logs_scan.rs
@@ -43,6 +43,7 @@ async fn query_logs_paginates_at_block_boundaries() {
                 log(Address::repeat_byte(7), B256::repeat_byte(9)),
                 log(Address::repeat_byte(7), B256::repeat_byte(9)),
             ]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -51,6 +52,7 @@ async fn query_logs_paginates_at_block_boundaries() {
         .ingest_block(FinalizedBlock {
             header: h2,
             logs_by_tx: vec![vec![log(Address::repeat_byte(7), B256::repeat_byte(9))]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 2");
@@ -124,6 +126,7 @@ async fn query_logs_descending_returns_newest_first() {
                 log(Address::repeat_byte(5), B256::repeat_byte(8)),
                 log(Address::repeat_byte(5), B256::repeat_byte(8)),
             ]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest");
@@ -167,6 +170,7 @@ async fn query_logs_rejects_from_block_above_published_head() {
         .ingest_block(FinalizedBlock {
             header: test_header(1, B256::ZERO),
             logs_by_tx: vec![vec![log(Address::repeat_byte(5), B256::repeat_byte(8))]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest");
@@ -208,6 +212,7 @@ async fn ingest_assigns_contiguous_log_id_windows_across_empty_blocks() {
                 log(Address::repeat_byte(3), B256::repeat_byte(4)),
                 log(Address::repeat_byte(3), B256::repeat_byte(4)),
             ]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -216,6 +221,7 @@ async fn ingest_assigns_contiguous_log_id_windows_across_empty_blocks() {
         .ingest_block(FinalizedBlock {
             header: h2,
             logs_by_tx: vec![vec![]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 2");
@@ -224,6 +230,7 @@ async fn ingest_assigns_contiguous_log_id_windows_across_empty_blocks() {
         .ingest_block(FinalizedBlock {
             header: h3,
             logs_by_tx: vec![vec![log(Address::repeat_byte(3), B256::repeat_byte(4))]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 3");
@@ -277,6 +284,7 @@ async fn block_scan_completes_current_block_when_limit_reached_mid_block() {
                 log(Address::repeat_byte(5), B256::repeat_byte(8)),
                 log(Address::repeat_byte(5), B256::repeat_byte(8)),
             ]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 1");
@@ -285,6 +293,7 @@ async fn block_scan_completes_current_block_when_limit_reached_mid_block() {
         .ingest_block(FinalizedBlock {
             header: h2,
             logs_by_tx: vec![vec![log(Address::repeat_byte(5), B256::repeat_byte(8))]],
+            txs: Vec::new(),
         })
         .await
         .expect("ingest block 2");

--- a/monad-chain-data/tests/tx_rpc_conversion.rs
+++ b/monad-chain-data/tests/tx_rpc_conversion.rs
@@ -1,0 +1,66 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg(feature = "alloy-rpc-types-eth")]
+
+use alloy_consensus::{SignableTransaction, TxEnvelope, TxLegacy};
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::{Signature, TxKind, U256};
+use monad_chain_data::{Address, Bytes, TxEntry, B256};
+
+#[test]
+fn to_rpc_transaction_carries_envelope_sender_and_block_context() {
+    let recipient = Address::repeat_byte(0xaa);
+
+    let signed = TxLegacy {
+        chain_id: Some(1),
+        nonce: 7,
+        gas_price: 10,
+        gas_limit: 21_000,
+        to: TxKind::Call(recipient),
+        value: U256::from(42u64),
+        input: Bytes::from_static(&[0x11, 0x22, 0x33, 0x44, 0x55]),
+    }
+    .into_signed(Signature::test_signature());
+
+    let mut signed_tx_bytes = Vec::new();
+    TxEnvelope::Legacy(signed).encode_2718(&mut signed_tx_bytes);
+
+    let tx = TxEntry {
+        block_number: 123,
+        block_hash: B256::repeat_byte(0xbb),
+        tx_idx: 4,
+        tx_hash: B256::repeat_byte(0xcc),
+        sender: Address::repeat_byte(0xdd),
+        signed_tx_bytes: signed_tx_bytes.into(),
+    };
+
+    let rpc = tx.to_rpc_transaction().expect("convert");
+
+    assert_eq!(rpc.block_number, Some(123));
+    assert_eq!(rpc.block_hash, Some(B256::repeat_byte(0xbb)));
+    assert_eq!(rpc.transaction_index, Some(4));
+    assert_eq!(rpc.effective_gas_price, None);
+    assert_eq!(rpc.inner.signer(), Address::repeat_byte(0xdd));
+
+    // The inner envelope round-trips the original fields.
+    let envelope = rpc.inner.inner();
+    assert_eq!(tx.to().expect("to"), Some(recipient));
+    assert_eq!(
+        tx.selector().expect("selector"),
+        Some([0x11, 0x22, 0x33, 0x44])
+    );
+    assert_eq!(envelope.tx_type() as u8, 0);
+}


### PR DESCRIPTION
Introduces Family::Tx, TxId, tx windows on BlockRecord, and a txs module containing transaction ingest, storage, materialization, filtering, and response types. FinalizedBlock now carries optional transaction inputs, while existing log-only fixtures continue to ingest zero-tx windows until transaction ingest is wired in.

The tx storage shape indexes from, to, and selector streams over signed transaction envelopes and keeps RPC conversion feature-gated. TxEntry remains bytes-first, with alloy decoding exposed through accessors and an optional RPC conversion helper.