### PR TITLE
Ingest logs and transactions as indexed families

### DIFF
--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -27,9 +27,10 @@ use crate::{
     primitives::{
         limits::QueryLimits,
         range::ResolvedBlockWindow,
-        state::{BlockRecord, LogId},
+        state::{BlockRecord, LogId, TxId},
     },
     store::{BlobStore, MetaStore},
+    txs::TxIngestPlan,
 };
 
 pub struct MonadChainDataService<M: MetaStore, B: BlobStore> {
@@ -42,6 +43,7 @@ pub struct IngestOutcome {
     pub indexed_finalized_head: u64,
     pub block_record: BlockRecord,
     pub written_logs: usize,
+    pub written_txs: usize,
 }
 
 impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
@@ -69,25 +71,48 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
     pub async fn ingest_block(&self, block: FinalizedBlock) -> Result<IngestOutcome> {
         let blocks = self.tables.blocks();
         let logs = self.tables.family(Family::Log);
+        let txs = self.tables.family(Family::Tx);
         let current_head = self.tables.publication().load_published_head().await?;
         let previous_record = blocks.validate_continuity(&block, current_head).await?;
+        // Lenient: log-only fixtures pass `txs: vec![]` alongside non-empty
+        // `logs_by_tx`. When callers do provide txs, the count must line up
+        // with the per-tx log grouping.
         if !block.txs.is_empty() && block.txs.len() != block.logs_by_tx.len() {
             return Err(MonadChainDataError::InvalidRequest(
                 "txs and logs_by_tx lengths must match when txs are provided",
             ));
         }
-        let next_log_id = match previous_record {
-            Some(previous) => LogId::from(previous.logs.next_primary_id_exclusive()?),
-            None => LogId::ZERO,
+        let (next_log_id, next_tx_id) = match previous_record {
+            Some(previous) => (
+                LogId::from(previous.logs.next_primary_id_exclusive()?),
+                TxId::from(previous.txs.next_primary_id_exclusive()?),
+            ),
+            None => (LogId::ZERO, TxId::ZERO),
         };
 
         let LogIngestPlan {
-            block_record,
+            log_window,
             block_log_header,
             block_log_blob,
-            bitmap_fragments,
+            bitmap_fragments: log_bitmap_fragments,
             written_logs,
         } = LogIngestPlan::build(&block, next_log_id)?;
+        let TxIngestPlan {
+            tx_window,
+            block_tx_header,
+            block_tx_blob,
+            bitmap_fragments: tx_bitmap_fragments,
+            written_txs,
+        } = TxIngestPlan::build(&block, next_tx_id)?;
+
+        let block_record = BlockRecord {
+            block_number: block.block_number(),
+            block_hash: block.block_hash(),
+            parent_hash: block.parent_hash(),
+            logs: log_window,
+            txs: tx_window,
+        };
+
         blocks
             .store_header(block.block_number(), &block.header)
             .await?;
@@ -95,8 +120,16 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
             block.block_number(),
             block_log_blob,
             Bytes::from(block_log_header.encode()),
-            block_record.logs,
-            &bitmap_fragments,
+            log_window,
+            &log_bitmap_fragments,
+        )
+        .await?;
+        txs.persist_indexed_family_ingest(
+            block.block_number(),
+            block_tx_blob,
+            Bytes::from(block_tx_header.encode()),
+            tx_window,
+            &tx_bitmap_fragments,
         )
         .await?;
         blocks
@@ -116,6 +149,7 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
             indexed_finalized_head: block.block_number(),
             block_record,
             written_logs,
+            written_txs,
         })
     }
 

--- a/monad-chain-data/src/logs/ingest.rs
+++ b/monad-chain-data/src/logs/ingest.rs
@@ -20,12 +20,12 @@ use crate::{
     engine::bitmap::{encode_grouped_bitmap_fragments, sharded_stream_id, BitmapFragmentWrite},
     error::{MonadChainDataError, Result},
     family::FinalizedBlock,
-    primitives::state::{BlockRecord, FamilyWindowRecord, LogId, PrimaryId},
+    primitives::state::{FamilyWindowRecord, LogId},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LogIngestPlan {
-    pub block_record: BlockRecord,
+    pub log_window: FamilyWindowRecord,
     pub block_log_header: LogBlockHeader,
     pub block_log_blob: Vec<u8>,
     pub bitmap_fragments: Vec<BitmapFragmentWrite>,
@@ -35,35 +35,37 @@ pub struct LogIngestPlan {
 impl LogIngestPlan {
     /// Derives the per-block log artifacts and index fragments for one finalized block.
     pub fn build(block: &FinalizedBlock, first_log_id: LogId) -> Result<Self> {
-        // First pass writes only per-block payload/header artifacts plus the shared block record.
-        // Later commits add global log IDs, directory fragments, and bitmap index artifacts.
+        Self::validate_logs(block)?;
         let logs = Self::flatten_logs(block)?;
         let log_count = u32::try_from(logs.len())
             .map_err(|_| MonadChainDataError::Decode("log count overflow"))?;
 
         let (block_log_header, block_log_blob) = Self::encode_block_logs(&logs)?;
         let bitmap_fragments = Self::collect_bitmap_fragments(&logs, first_log_id)?;
-        let block_record = BlockRecord {
-            block_number: block.block_number(),
-            block_hash: block.block_hash(),
-            parent_hash: block.parent_hash(),
-            logs: FamilyWindowRecord {
-                first_primary_id: first_log_id.into(),
-                count: log_count,
-            },
-            txs: FamilyWindowRecord {
-                first_primary_id: PrimaryId::ZERO,
-                count: 0,
-            },
+        let log_window = FamilyWindowRecord {
+            first_primary_id: first_log_id.into(),
+            count: log_count,
         };
 
         Ok(Self {
-            block_record,
+            log_window,
             block_log_header,
             block_log_blob,
             bitmap_fragments,
             written_logs: logs.len(),
         })
+    }
+
+    fn validate_logs(block: &FinalizedBlock) -> Result<()> {
+        for tx_logs in &block.logs_by_tx {
+            for log in tx_logs {
+                if log.data.topics().len() > 4 {
+                    return Err(MonadChainDataError::InvalidRequest("log topics exceed 4"));
+                }
+            }
+        }
+
+        Ok(())
     }
 
     fn flatten_logs(block: &FinalizedBlock) -> Result<Vec<RawLogEntry>> {

--- a/monad-chain-data/tests/common/mod.rs
+++ b/monad-chain-data/tests/common/mod.rs
@@ -15,7 +15,7 @@
 
 #![allow(dead_code)]
 
-use monad_chain_data::{EvmBlockHeader, B256};
+use monad_chain_data::{EvmBlockHeader, IngestTx, B256};
 
 pub fn test_header(number: u64, parent_hash: B256) -> EvmBlockHeader {
     EvmBlockHeader {
@@ -27,4 +27,33 @@ pub fn test_header(number: u64, parent_hash: B256) -> EvmBlockHeader {
 
 pub fn chain_header(number: u64, parent: &EvmBlockHeader) -> EvmBlockHeader {
     test_header(number, parent.hash_slow())
+}
+
+/// Valid, minimal EIP-2718-encoded signed tx envelope (legacy, contract
+/// creation, empty calldata). Tests use it when they need `TxIngestPlan`
+/// to decode the envelope successfully but don't care about the contents.
+pub fn minimal_ingest_tx() -> IngestTx {
+    use alloy_consensus::{SignableTransaction, TxEnvelope, TxLegacy};
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
+
+    let signed = TxLegacy {
+        chain_id: Some(1),
+        nonce: 0,
+        gas_price: 0,
+        gas_limit: 21_000,
+        to: TxKind::Create,
+        value: U256::ZERO,
+        input: Bytes::new(),
+    }
+    .into_signed(Signature::test_signature());
+
+    let mut signed_tx_bytes = Vec::new();
+    TxEnvelope::Legacy(signed).encode_2718(&mut signed_tx_bytes);
+
+    IngestTx {
+        tx_hash: B256::ZERO,
+        sender: Address::ZERO,
+        signed_tx_bytes: signed_tx_bytes.into(),
+    }
 }

--- a/monad-chain-data/tests/ingest_block_shape.rs
+++ b/monad-chain-data/tests/ingest_block_shape.rs
@@ -20,7 +20,7 @@ use monad_chain_data::{
 
 mod common;
 
-use common::test_header;
+use common::{minimal_ingest_tx, test_header};
 
 #[tokio::test(flavor = "current_thread")]
 async fn ingest_rejects_mismatched_txs_and_logs_by_tx_lengths() {
@@ -57,7 +57,7 @@ async fn ingest_accepts_matching_txs_and_logs_by_tx_lengths() {
         .ingest_block(FinalizedBlock {
             header: test_header(1, B256::ZERO),
             logs_by_tx: vec![vec![], vec![]],
-            txs: vec![IngestTx::default(), IngestTx::default()],
+            txs: vec![minimal_ingest_tx(), minimal_ingest_tx()],
         })
         .await
         .expect("matching lengths should ingest");

--- a/monad-chain-data/tests/log_ingest_validation.rs
+++ b/monad-chain-data/tests/log_ingest_validation.rs
@@ -1,0 +1,73 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use monad_chain_data::{
+    Bytes, Family, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData,
+    MonadChainDataError, MonadChainDataService, QueryLimits, B256,
+};
+
+mod common;
+
+use common::test_header;
+
+#[tokio::test(flavor = "current_thread")]
+async fn ingest_rejects_log_with_more_than_four_topics_before_writing_log_artifacts() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let err = service
+        .ingest_block(FinalizedBlock {
+            header: test_header(1, B256::ZERO),
+            logs_by_tx: vec![vec![Log {
+                address: Default::default(),
+                data: LogData::new_unchecked(
+                    vec![
+                        B256::repeat_byte(1),
+                        B256::repeat_byte(2),
+                        B256::repeat_byte(3),
+                        B256::repeat_byte(4),
+                        B256::repeat_byte(5),
+                    ],
+                    Bytes::new(),
+                ),
+            }]],
+            txs: Vec::new(),
+        })
+        .await
+        .expect_err("log with too many topics should fail ingest");
+
+    assert!(
+        matches!(
+            err,
+            MonadChainDataError::InvalidRequest("log topics exceed 4")
+        ),
+        "expected invalid request for topic count, got {err:?}"
+    );
+
+    let log_family = service.tables().family(Family::Log);
+    assert!(log_family
+        .load_block_header(1)
+        .await
+        .expect("load log header")
+        .is_none());
+    assert!(log_family
+        .load_block_blob(1)
+        .await
+        .expect("load log blob")
+        .is_none());
+}

--- a/monad-chain-data/tests/tx_ingest.rs
+++ b/monad-chain-data/tests/tx_ingest.rs
@@ -1,0 +1,142 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use monad_chain_data::{
+    txs::BlockTxHeader, Family, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, IngestTx,
+    MonadChainDataError, MonadChainDataService, PrimaryId, QueryLimits, B256,
+};
+
+mod common;
+
+use common::{chain_header, minimal_ingest_tx, test_header};
+
+#[tokio::test(flavor = "current_thread")]
+async fn ingest_persists_tx_artifacts_for_block_with_txs() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let outcome = service
+        .ingest_block(FinalizedBlock {
+            header: test_header(1, B256::ZERO),
+            logs_by_tx: vec![vec![], vec![]],
+            txs: vec![minimal_ingest_tx(), minimal_ingest_tx()],
+        })
+        .await
+        .expect("ingest block 1");
+
+    assert_eq!(outcome.written_txs, 2);
+    assert_eq!(outcome.block_record.txs.count, 2);
+    assert_eq!(outcome.block_record.txs.first_primary_id, PrimaryId::ZERO);
+
+    let tx_family = service.tables().family(Family::Tx);
+    let header_bytes = tx_family
+        .load_block_header(1)
+        .await
+        .expect("load tx header")
+        .expect("tx header present");
+    let tx_header = BlockTxHeader::decode(&header_bytes).expect("decode tx header");
+    assert_eq!(tx_header.tx_count(), 2);
+
+    let blob = tx_family
+        .load_block_blob(1)
+        .await
+        .expect("load tx blob")
+        .expect("tx blob present");
+    assert_eq!(
+        blob.len(),
+        usize::try_from(*tx_header.offsets.last().unwrap()).unwrap()
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tx_id_window_advances_across_blocks() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let h1 = test_header(1, B256::ZERO);
+    let outcome1 = service
+        .ingest_block(FinalizedBlock {
+            header: h1.clone(),
+            logs_by_tx: vec![vec![], vec![]],
+            txs: vec![minimal_ingest_tx(), minimal_ingest_tx()],
+        })
+        .await
+        .expect("ingest block 1");
+    assert_eq!(outcome1.block_record.txs.first_primary_id, PrimaryId::ZERO);
+    assert_eq!(outcome1.block_record.txs.count, 2);
+
+    let h2 = chain_header(2, &h1);
+    let outcome2 = service
+        .ingest_block(FinalizedBlock {
+            header: h2,
+            logs_by_tx: vec![vec![]],
+            txs: vec![minimal_ingest_tx()],
+        })
+        .await
+        .expect("ingest block 2");
+    assert_eq!(
+        outcome2.block_record.txs.first_primary_id,
+        PrimaryId::new(2)
+    );
+    assert_eq!(outcome2.block_record.txs.count, 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn ingest_rejects_invalid_signed_tx_bytes_before_writing_tx_artifacts() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let err = service
+        .ingest_block(FinalizedBlock {
+            header: test_header(1, B256::ZERO),
+            logs_by_tx: vec![vec![]],
+            txs: vec![IngestTx {
+                tx_hash: B256::repeat_byte(0x33),
+                signed_tx_bytes: vec![0x01].into(),
+                ..Default::default()
+            }],
+        })
+        .await
+        .expect_err("invalid signed tx should fail ingest");
+
+    assert!(
+        matches!(
+            err,
+            MonadChainDataError::Decode("invalid signed tx envelope")
+        ),
+        "expected invalid envelope decode error, got {err:?}"
+    );
+
+    let tx_family = service.tables().family(Family::Tx);
+    assert!(tx_family
+        .load_block_header(1)
+        .await
+        .expect("load tx header")
+        .is_none());
+    assert!(tx_family
+        .load_block_blob(1)
+        .await
+        .expect("load tx blob")
+        .is_none());
+}


### PR DESCRIPTION
Wires tx ingest into MonadChainDataService::ingest_block alongside log ingest. The service builds both family ingest plans, persists each through the shared FamilyTables helper, and publishes a single BlockRecord containing both log and tx windows.

LogIngestPlan and TxIngestPlan now each own only their family window and artifacts, while api.rs composes the shared block record. Tests cover tx artifact persistence, tx-id window advancement, and valid signed transaction fixture construction.