### PR TITLE
Add transaction queries and lookup

### DIFF
--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -19,9 +19,9 @@ use crate::{
     blocks::{
         execute_query_blocks, load_blocks_by_numbers, QueryBlocksRequest, QueryBlocksResponse,
     },
-    engine::{family::Family, tables::Tables},
+    engine::{family::Family, query::family_runner::IndexedFamilyQuery, tables::Tables},
     error::{MonadChainDataError, Result},
-    family::FinalizedBlock,
+    family::{FinalizedBlock, Hash32},
     logs::{
         execute_block_scan_query, execute_indexed_log_query, LogIngestPlan, QueryLogsRequest,
         QueryLogsResponse,
@@ -34,7 +34,7 @@ use crate::{
     store::{BlobStore, MetaStore},
     txs::{
         execute_block_scan_tx_query, execute_indexed_tx_query, load_txs_by_positions,
-        QueryTransactionsRequest, QueryTransactionsResponse, TxIngestPlan,
+        QueryTransactionsRequest, QueryTransactionsResponse, TxEntry, TxIngestPlan, TxMaterializer,
     },
 };
 
@@ -107,6 +107,7 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
             block_tx_header,
             block_tx_blob,
             bitmap_fragments: tx_bitmap_fragments,
+            hash_locations: tx_hash_locations,
             written_txs,
         } = TxIngestPlan::build(&block, next_tx_id)?;
 
@@ -140,6 +141,9 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
         blocks
             .store_hash_index(&block.block_hash(), block.block_number())
             .await?;
+        for (tx_hash, location) in tx_hash_locations {
+            self.tables.tx_hash_index().put(&tx_hash, location).await?;
+        }
         blocks
             .store_record(block.block_number(), &block_record)
             .await?;
@@ -237,6 +241,29 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
         }
 
         Ok(response)
+    }
+
+    /// Resolves a finalized transaction by hash. Returns `None` if the
+    /// hash was never indexed. A hit in the index that fails to
+    /// materialize inside the published range indicates a data-layer
+    /// inconsistency and surfaces as `MissingData`; it is not silently
+    /// flattened to `None`.
+    pub async fn get_transaction(&self, tx_hash: Hash32) -> Result<Option<TxEntry>> {
+        let Some(location) = self.tables.tx_hash_index().get(&tx_hash).await? else {
+            return Ok(None);
+        };
+        let Some(head) = self.tables.publication().load_published_head().await? else {
+            return Ok(None);
+        };
+        if location.block_number > head {
+            return Ok(None);
+        }
+
+        let materializer = TxMaterializer::new(&self.tables);
+        let entry = materializer
+            .load_record_at(location.block_number, location.tx_idx as usize)
+            .await?;
+        Ok(Some(entry))
     }
 
     /// Executes a finalized blocks query over the current published head.

--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -16,7 +16,9 @@
 use bytes::Bytes;
 
 use crate::{
-    blocks::{execute_query_blocks, load_blocks_for_logs, QueryBlocksRequest, QueryBlocksResponse},
+    blocks::{
+        execute_query_blocks, load_blocks_by_numbers, QueryBlocksRequest, QueryBlocksResponse,
+    },
     engine::{family::Family, tables::Tables},
     error::{MonadChainDataError, Result},
     family::FinalizedBlock,
@@ -30,7 +32,10 @@ use crate::{
         state::{BlockRecord, LogId, TxId},
     },
     store::{BlobStore, MetaStore},
-    txs::TxIngestPlan,
+    txs::{
+        execute_block_scan_tx_query, execute_indexed_tx_query, QueryTransactionsRequest,
+        QueryTransactionsResponse, TxIngestPlan,
+    },
 };
 
 pub struct MonadChainDataService<M: MetaStore, B: BlobStore> {
@@ -175,8 +180,50 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
         };
 
         if request.relations.blocks {
-            response.blocks =
-                Some(load_blocks_for_logs(self.tables.blocks(), &response.logs).await?);
+            response.blocks = Some(
+                load_blocks_by_numbers(
+                    self.tables.blocks(),
+                    response.logs.iter().map(|l| l.block_number),
+                )
+                .await?,
+            );
+        }
+
+        Ok(response)
+    }
+
+    /// Executes a finalized transactions query over the current published
+    /// head. The service's configured `QueryLimits` bound the request
+    /// shape and the resolved block-range span.
+    pub async fn query_transactions(
+        &self,
+        request: QueryTransactionsRequest,
+    ) -> Result<QueryTransactionsResponse> {
+        self.limits.check_limit(request.envelope.limit)?;
+
+        let head = self.load_published_head().await?;
+        let window = ResolvedBlockWindow::resolve(
+            &request.envelope,
+            head,
+            &self.limits,
+            self.tables.blocks(),
+        )
+        .await?;
+
+        let mut response = if request.filter.has_indexed_clause() {
+            execute_indexed_tx_query(&self.tables, &request, window).await?
+        } else {
+            execute_block_scan_tx_query(&self.tables, &request, window).await?
+        };
+
+        if request.relations.blocks {
+            response.blocks = Some(
+                load_blocks_by_numbers(
+                    self.tables.blocks(),
+                    response.txs.iter().map(|t| t.block_number),
+                )
+                .await?,
+            );
         }
 
         Ok(response)

--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -33,8 +33,8 @@ use crate::{
     },
     store::{BlobStore, MetaStore},
     txs::{
-        execute_block_scan_tx_query, execute_indexed_tx_query, QueryTransactionsRequest,
-        QueryTransactionsResponse, TxIngestPlan,
+        execute_block_scan_tx_query, execute_indexed_tx_query, load_txs_by_positions,
+        QueryTransactionsRequest, QueryTransactionsResponse, TxIngestPlan,
     },
 };
 
@@ -184,6 +184,16 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
                 load_blocks_by_numbers(
                     self.tables.blocks(),
                     response.logs.iter().map(|l| l.block_number),
+                )
+                .await?,
+            );
+        }
+
+        if request.relations.transactions {
+            response.transactions = Some(
+                load_txs_by_positions(
+                    &self.tables,
+                    response.logs.iter().map(|l| (l.block_number, l.tx_index)),
                 )
                 .await?,
             );

--- a/monad-chain-data/src/blocks.rs
+++ b/monad-chain-data/src/blocks.rs
@@ -19,7 +19,6 @@ use crate::{
     engine::tables::{BlockTables, Tables},
     error::{MonadChainDataError, Result},
     family::Hash32,
-    logs::LogEntry,
     primitives::{
         limits::QueryEnvelope,
         range::ResolvedBlockWindow,
@@ -85,14 +84,13 @@ pub async fn execute_query_blocks<M: MetaStore, B: BlobStore>(
     })
 }
 
-/// Loads the blocks referenced by `logs` in ascending block-number order,
-/// deduped. Used to fulfill the `blocks` relation on a logs query when the
-/// caller opts in.
-pub async fn load_blocks_for_logs<M: MetaStore>(
+/// Loads the blocks for the given numbers in ascending order, deduped.
+/// Used to fulfill the `blocks` relation on family queries.
+pub async fn load_blocks_by_numbers<M: MetaStore, I: IntoIterator<Item = u64>>(
     blocks: &BlockTables<M>,
-    logs: &[LogEntry],
+    numbers: I,
 ) -> Result<Vec<Block>> {
-    let distinct: BTreeSet<u64> = logs.iter().map(|l| l.block_number).collect();
+    let distinct: BTreeSet<u64> = numbers.into_iter().collect();
     let mut out = Vec::with_capacity(distinct.len());
     for number in distinct {
         out.push(load_block(blocks, number).await?);

--- a/monad-chain-data/src/engine/tables.rs
+++ b/monad-chain-data/src/engine/tables.rs
@@ -31,11 +31,13 @@ use crate::{
         EvmBlockHeader,
     },
     store::{BlobStore, BlobTable, KvTable, MetaStore, ScannableTableId, TableId},
+    txs::TxHashIndexTable,
 };
 
 pub struct Tables<M: MetaStore, B: BlobStore> {
     publication: PublicationTables<M>,
     blocks: BlockTables<M>,
+    tx_hash_index: TxHashIndexTable<M>,
     families: BTreeMap<Family, FamilyTables<M, B>>,
 }
 
@@ -52,7 +54,8 @@ impl<M: MetaStore, B: BlobStore> Tables<M, B> {
         );
         Self {
             publication: PublicationTables::new(meta_store.clone()),
-            blocks: BlockTables::new(meta_store),
+            blocks: BlockTables::new(meta_store.clone()),
+            tx_hash_index: TxHashIndexTable::new(meta_store),
             families,
         }
     }
@@ -63,6 +66,10 @@ impl<M: MetaStore, B: BlobStore> Tables<M, B> {
 
     pub fn blocks(&self) -> &BlockTables<M> {
         &self.blocks
+    }
+
+    pub fn tx_hash_index(&self) -> &TxHashIndexTable<M> {
+        &self.tx_hash_index
     }
 
     /// Returns the table set for a family. Panics if the family was not

--- a/monad-chain-data/src/logs/indexed_query.rs
+++ b/monad-chain-data/src/logs/indexed_query.rs
@@ -39,6 +39,7 @@ pub(crate) async fn execute_indexed_log_query<M: MetaStore, B: BlobStore>(
     Ok(QueryLogsResponse {
         logs: outcome.records,
         blocks: None,
+        transactions: None,
         span: outcome.span,
     })
 }

--- a/monad-chain-data/src/logs/materialize.rs
+++ b/monad-chain-data/src/logs/materialize.rs
@@ -36,6 +36,7 @@ use crate::{
         state::BlockRecord,
     },
     store::{BlobStore, MetaStore},
+    txs::TxEntry,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -53,6 +54,11 @@ pub struct LogsRelations {
     /// headers (sorted ascending by number) for the blocks that
     /// contributed logs in this page.
     pub blocks: bool,
+    /// When true, `QueryLogsResponse::transactions` is populated with
+    /// deduped txs (sorted ascending by block number, then tx index) for
+    /// the `(block_number, tx_index)` pairs carried on the logs in this
+    /// page.
+    pub transactions: bool,
 }
 
 /// Public log query in queryX spec semantics: `from_block`/`to_block` are
@@ -74,6 +80,10 @@ pub struct QueryLogsResponse {
     /// Deduped blocks for the `logs` in this page, sorted ascending by
     /// block number. `None` unless `QueryLogsRequest::relations.blocks`.
     pub blocks: Option<Vec<Block>>,
+    /// Deduped transactions for the `logs` in this page, sorted ascending
+    /// by `(block_number, tx_index)`. `None` unless
+    /// `QueryLogsRequest::relations.transactions`.
+    pub transactions: Option<Vec<TxEntry>>,
     pub span: BlockSpan,
 }
 

--- a/monad-chain-data/src/logs/scan_query.rs
+++ b/monad-chain-data/src/logs/scan_query.rs
@@ -39,6 +39,7 @@ pub async fn execute_block_scan_query<M: MetaStore, B: BlobStore>(
     Ok(QueryLogsResponse {
         logs: outcome.records,
         blocks: None,
+        transactions: None,
         span: outcome.span,
     })
 }

--- a/monad-chain-data/src/txs/hash_index.rs
+++ b/monad-chain-data/src/txs/hash_index.rs
@@ -1,0 +1,54 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use bytes::Bytes;
+
+use crate::{
+    error::Result,
+    family::Hash32,
+    store::{KvTable, MetaStore, TableId},
+    txs::types::TxLocation,
+};
+
+pub struct TxHashIndexTable<M: MetaStore> {
+    table: KvTable<M>,
+}
+
+impl<M: MetaStore> TxHashIndexTable<M> {
+    pub const TABLE: TableId = TableId::new("tx_hash_index");
+
+    pub(crate) fn new(meta_store: M) -> Self {
+        Self {
+            table: meta_store.table(Self::TABLE),
+        }
+    }
+
+    pub(crate) async fn get(&self, tx_hash: &Hash32) -> Result<Option<TxLocation>> {
+        let Some(record) = self.table.get(tx_hash.as_slice()).await? else {
+            return Ok(None);
+        };
+        TxLocation::decode(record.value.as_ref()).map(Some)
+    }
+
+    pub(crate) async fn put(&self, tx_hash: &Hash32, location: TxLocation) -> Result<()> {
+        self.table
+            .put(
+                tx_hash.as_slice(),
+                Bytes::copy_from_slice(&location.encode()),
+            )
+            .await?;
+        Ok(())
+    }
+}

--- a/monad-chain-data/src/txs/indexed_query.rs
+++ b/monad-chain-data/src/txs/indexed_query.rs
@@ -1,0 +1,44 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{
+    engine::{query::family_runner::execute_indexed_family_query, tables::Tables},
+    error::Result,
+    primitives::range::ResolvedBlockWindow,
+    store::{BlobStore, MetaStore},
+    txs::{QueryTransactionsRequest, QueryTransactionsResponse, TxMaterializer},
+};
+
+pub(crate) async fn execute_indexed_tx_query<M: MetaStore, B: BlobStore>(
+    tables: &Tables<M, B>,
+    request: &QueryTransactionsRequest,
+    block_window: ResolvedBlockWindow,
+) -> Result<QueryTransactionsResponse> {
+    let materializer = TxMaterializer::new(tables);
+    let outcome = execute_indexed_family_query(
+        tables,
+        &materializer,
+        &request.filter,
+        block_window,
+        request.envelope.order,
+        request.envelope.limit,
+    )
+    .await?;
+    Ok(QueryTransactionsResponse {
+        txs: outcome.records,
+        blocks: None,
+        span: outcome.span,
+    })
+}

--- a/monad-chain-data/src/txs/ingest.rs
+++ b/monad-chain-data/src/txs/ingest.rs
@@ -19,8 +19,9 @@ use super::types::{decode_envelope, selector_from_envelope, BlockTxHeader, Store
 use crate::{
     engine::bitmap::{encode_grouped_bitmap_fragments, sharded_stream_id, BitmapFragmentWrite},
     error::{MonadChainDataError, Result},
-    family::{FinalizedBlock, IngestTx},
+    family::{FinalizedBlock, Hash32, IngestTx},
     primitives::state::{FamilyWindowRecord, TxId},
+    txs::types::TxLocation,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -29,6 +30,9 @@ pub struct TxIngestPlan {
     pub block_tx_header: BlockTxHeader,
     pub block_tx_blob: Vec<u8>,
     pub bitmap_fragments: Vec<BitmapFragmentWrite>,
+    /// (tx_hash, location) pairs to write into `tx_hash_index` for this
+    /// block. Caller-authoritative `tx_hash`; collisions last-write-win.
+    pub(crate) hash_locations: Vec<(Hash32, TxLocation)>,
     pub written_txs: usize,
 }
 
@@ -40,6 +44,7 @@ impl TxIngestPlan {
 
         let (block_tx_header, block_tx_blob) = Self::encode_block_txs(&block.txs)?;
         let bitmap_fragments = Self::collect_bitmap_fragments(&block.txs, first_tx_id)?;
+        let hash_locations = Self::collect_hash_locations(block)?;
         let tx_window = FamilyWindowRecord {
             first_primary_id: first_tx_id.into(),
             count: tx_count,
@@ -50,8 +55,28 @@ impl TxIngestPlan {
             block_tx_header,
             block_tx_blob,
             bitmap_fragments,
+            hash_locations,
             written_txs: block.txs.len(),
         })
+    }
+
+    fn collect_hash_locations(block: &FinalizedBlock) -> Result<Vec<(Hash32, TxLocation)>> {
+        block
+            .txs
+            .iter()
+            .enumerate()
+            .map(|(idx, tx)| {
+                let tx_idx = u32::try_from(idx)
+                    .map_err(|_| MonadChainDataError::Decode("tx index overflow"))?;
+                Ok((
+                    tx.tx_hash,
+                    TxLocation {
+                        block_number: block.block_number(),
+                        tx_idx,
+                    },
+                ))
+            })
+            .collect()
     }
 
     fn encode_block_txs(txs: &[IngestTx]) -> Result<(BlockTxHeader, Vec<u8>)> {

--- a/monad-chain-data/src/txs/materialize.rs
+++ b/monad-chain-data/src/txs/materialize.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 
 use alloy_consensus::Transaction;
 use alloy_primitives::{Address, Bytes};
@@ -277,6 +277,29 @@ fn load_filtered_block_txs(
     }
 
     Ok(txs)
+}
+
+/// Loads txs for the given `(block_number, tx_index)` pairs in ascending
+/// order, deduped. Used to fulfill the `transactions` relation on logs
+/// queries.
+pub(crate) async fn load_txs_by_positions<M: MetaStore, B: BlobStore, I>(
+    tables: &Tables<M, B>,
+    positions: I,
+) -> Result<Vec<TxEntry>>
+where
+    I: IntoIterator<Item = (u64, u32)>,
+{
+    let distinct: BTreeSet<(u64, u32)> = positions.into_iter().collect();
+    let materializer = TxMaterializer::new(tables);
+    let mut out = Vec::with_capacity(distinct.len());
+    for (block_number, tx_idx) in distinct {
+        out.push(
+            materializer
+                .load_record_at(block_number, tx_idx as usize)
+                .await?,
+        );
+    }
+    Ok(out)
 }
 
 pub(crate) fn decode_tx_at(

--- a/monad-chain-data/src/txs/materialize.rs
+++ b/monad-chain-data/src/txs/materialize.rs
@@ -16,7 +16,7 @@
 use std::collections::HashSet;
 
 use alloy_consensus::Transaction;
-use alloy_primitives::Address;
+use alloy_primitives::{Address, Bytes};
 use bytes::Bytes as RawBytes;
 
 use super::types::{selector_from_envelope, BlockTxHeader, StoredTxEnvelope, TxEntry};
@@ -25,12 +25,16 @@ use crate::{
     engine::{
         clause::{IndexedClause, IndexedFilter},
         family::Family,
+        query::family_runner::IndexedFamilyQuery,
         tables::Tables,
     },
     error::{MonadChainDataError, Result},
+    family::Hash32,
     primitives::{
         limits::QueryEnvelope,
+        page::QueryOrder,
         refs::{BlockRef, BlockSpan},
+        state::BlockRecord,
     },
     store::{BlobStore, MetaStore},
 };
@@ -145,18 +149,25 @@ impl IndexedFilter for TxFilter {
     }
 }
 
-#[allow(dead_code)]
 pub struct TxMaterializer<'a, M: MetaStore, B: BlobStore> {
     tables: &'a Tables<M, B>,
 }
 
-#[allow(dead_code)]
 impl<'a, M: MetaStore, B: BlobStore> TxMaterializer<'a, M, B> {
     pub fn new(tables: &'a Tables<M, B>) -> Self {
         Self { tables }
     }
+}
 
-    pub async fn load_block_ref(&self, block_number: u64) -> Result<BlockRef> {
+impl<'a, M: MetaStore, B: BlobStore> IndexedFamilyQuery<M, B> for TxMaterializer<'a, M, B> {
+    type Filter = TxFilter;
+    type Record = TxEntry;
+
+    fn family() -> Family {
+        Family::Tx
+    }
+
+    async fn load_block_ref(&self, block_number: u64) -> Result<BlockRef> {
         let block_record = self
             .tables
             .blocks()
@@ -166,8 +177,7 @@ impl<'a, M: MetaStore, B: BlobStore> TxMaterializer<'a, M, B> {
         Ok(BlockRef::from(&block_record))
     }
 
-    /// Resolves and materializes one tx by block number and block-local index.
-    pub async fn load_tx_at(&self, block_number: u64, tx_idx: usize) -> Result<TxEntry> {
+    async fn load_record_at(&self, block_number: u64, idx_in_block: usize) -> Result<TxEntry> {
         let block_record = self
             .tables
             .blocks()
@@ -182,11 +192,11 @@ impl<'a, M: MetaStore, B: BlobStore> TxMaterializer<'a, M, B> {
             .ok_or(MonadChainDataError::MissingData("missing block tx header"))?;
         let header = BlockTxHeader::decode(&header_bytes)?;
 
-        if tx_idx + 1 >= header.offsets.len() {
+        if idx_in_block + 1 >= header.offsets.len() {
             return Err(MonadChainDataError::Decode("tx index out of range"));
         }
-        let start = header.offsets[tx_idx] as usize;
-        let end = header.offsets[tx_idx + 1] as usize;
+        let start = header.offsets[idx_in_block] as usize;
+        let end = header.offsets[idx_in_block + 1] as usize;
 
         let bytes = self
             .tables
@@ -196,12 +206,98 @@ impl<'a, M: MetaStore, B: BlobStore> TxMaterializer<'a, M, B> {
             .ok_or(MonadChainDataError::MissingData("missing block tx blob"))?;
 
         let stored = StoredTxEnvelope::decode(&bytes)?;
-        let tx_idx_u32 =
-            u32::try_from(tx_idx).map_err(|_| MonadChainDataError::Decode("tx index overflow"))?;
+        let tx_idx_u32 = u32::try_from(idx_in_block)
+            .map_err(|_| MonadChainDataError::Decode("tx index overflow"))?;
         Ok(stored.into_tx_entry(
             block_record.block_number,
             block_record.block_hash,
             tx_idx_u32,
         ))
     }
+
+    async fn load_filtered_block_records(
+        &self,
+        block_number: u64,
+        order: QueryOrder,
+        filter: &TxFilter,
+    ) -> Result<(BlockRef, Vec<TxEntry>)> {
+        let block_record = self
+            .tables
+            .blocks()
+            .load_record(block_number)
+            .await?
+            .ok_or(MonadChainDataError::MissingData("missing block record"))?;
+        let block_ref = BlockRef::from(&block_record);
+
+        let header_bytes = self
+            .tables
+            .family(Family::Tx)
+            .load_block_header(block_number)
+            .await?
+            .ok_or(MonadChainDataError::MissingData("missing block tx header"))?;
+        let header = BlockTxHeader::decode(&header_bytes)?;
+        let blob = self
+            .tables
+            .family(Family::Tx)
+            .load_block_blob(block_number)
+            .await?
+            .ok_or(MonadChainDataError::MissingData("missing block tx blob"))?;
+
+        let txs = load_filtered_block_txs(&header, &blob, &block_record, order, filter)?;
+
+        Ok((block_ref, txs))
+    }
+}
+
+fn load_filtered_block_txs(
+    header: &BlockTxHeader,
+    blob: &Bytes,
+    block_record: &BlockRecord,
+    order: QueryOrder,
+    filter: &TxFilter,
+) -> Result<Vec<TxEntry>> {
+    let count = header.tx_count();
+    let indices: Box<dyn Iterator<Item = usize>> = match order {
+        QueryOrder::Ascending => Box::new(0..count),
+        QueryOrder::Descending => Box::new((0..count).rev()),
+    };
+
+    let mut txs = Vec::new();
+    for tx_idx in indices {
+        let tx = decode_tx_at(
+            header,
+            blob.as_ref(),
+            tx_idx,
+            block_record.block_number,
+            block_record.block_hash,
+        )?;
+        if filter.matches(&tx) {
+            txs.push(tx);
+        }
+    }
+
+    Ok(txs)
+}
+
+pub(crate) fn decode_tx_at(
+    header: &BlockTxHeader,
+    blob: &[u8],
+    tx_idx: usize,
+    block_number: u64,
+    block_hash: Hash32,
+) -> Result<TxEntry> {
+    if tx_idx + 1 >= header.offsets.len() {
+        return Err(MonadChainDataError::Decode("tx index out of range"));
+    }
+
+    let start = header.offsets[tx_idx] as usize;
+    let end = header.offsets[tx_idx + 1] as usize;
+    if start > end || end > blob.len() {
+        return Err(MonadChainDataError::Decode("invalid tx range"));
+    }
+
+    let stored = StoredTxEnvelope::decode(&blob[start..end])?;
+    let tx_idx_u32 =
+        u32::try_from(tx_idx).map_err(|_| MonadChainDataError::Decode("tx index overflow"))?;
+    Ok(stored.into_tx_entry(block_number, block_hash, tx_idx_u32))
 }

--- a/monad-chain-data/src/txs/mod.rs
+++ b/monad-chain-data/src/txs/mod.rs
@@ -21,7 +21,7 @@ mod types;
 
 pub(crate) use indexed_query::execute_indexed_tx_query;
 pub use ingest::TxIngestPlan;
-pub(crate) use materialize::TxMaterializer;
+pub(crate) use materialize::{load_txs_by_positions, TxMaterializer};
 pub use materialize::{
     QueryTransactionsRequest, QueryTransactionsResponse, TxFilter, TxsRelations,
 };

--- a/monad-chain-data/src/txs/mod.rs
+++ b/monad-chain-data/src/txs/mod.rs
@@ -13,12 +13,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+mod hash_index;
 mod indexed_query;
 mod ingest;
 mod materialize;
 mod scan_query;
 mod types;
 
+pub use hash_index::TxHashIndexTable;
 pub(crate) use indexed_query::execute_indexed_tx_query;
 pub use ingest::TxIngestPlan;
 pub(crate) use materialize::{load_txs_by_positions, TxMaterializer};

--- a/monad-chain-data/src/txs/mod.rs
+++ b/monad-chain-data/src/txs/mod.rs
@@ -13,14 +13,17 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+mod indexed_query;
 mod ingest;
 mod materialize;
+mod scan_query;
 mod types;
 
+pub(crate) use indexed_query::execute_indexed_tx_query;
 pub use ingest::TxIngestPlan;
-#[allow(unused_imports)]
 pub(crate) use materialize::TxMaterializer;
 pub use materialize::{
     QueryTransactionsRequest, QueryTransactionsResponse, TxFilter, TxsRelations,
 };
+pub(crate) use scan_query::execute_block_scan_tx_query;
 pub use types::{BlockTxHeader, StoredTxEnvelope, TxEntry};

--- a/monad-chain-data/src/txs/scan_query.rs
+++ b/monad-chain-data/src/txs/scan_query.rs
@@ -1,0 +1,44 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{
+    engine::{query::family_runner::execute_block_scan_family_query, tables::Tables},
+    error::Result,
+    primitives::range::ResolvedBlockWindow,
+    store::{BlobStore, MetaStore},
+    txs::{QueryTransactionsRequest, QueryTransactionsResponse, TxMaterializer},
+};
+
+/// Walks blocks in query order, applying `TxFilter` to each block's txs.
+pub(crate) async fn execute_block_scan_tx_query<M: MetaStore, B: BlobStore>(
+    tables: &Tables<M, B>,
+    request: &QueryTransactionsRequest,
+    window: ResolvedBlockWindow,
+) -> Result<QueryTransactionsResponse> {
+    let materializer = TxMaterializer::new(tables);
+    let outcome = execute_block_scan_family_query(
+        &materializer,
+        &request.filter,
+        window,
+        request.envelope.order,
+        request.envelope.limit,
+    )
+    .await?;
+    Ok(QueryTransactionsResponse {
+        txs: outcome.records,
+        blocks: None,
+        span: outcome.span,
+    })
+}

--- a/monad-chain-data/src/txs/types.rs
+++ b/monad-chain-data/src/txs/types.rs
@@ -74,6 +74,39 @@ impl TxEntry {
     }
 }
 
+/// Fixed 12-byte address of a transaction in the block-tx blobs:
+/// 8 bytes big-endian `block_number` followed by 4 bytes big-endian
+/// `tx_idx`. Written at ingest, keyed by `tx_hash`, and resolved by
+/// `get_transaction` into a `TxEntry` via the tx materializer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TxLocation {
+    pub block_number: u64,
+    pub tx_idx: u32,
+}
+
+impl TxLocation {
+    pub const ENCODED_LEN: usize = 12;
+
+    pub fn encode(&self) -> [u8; Self::ENCODED_LEN] {
+        let mut out = [0u8; Self::ENCODED_LEN];
+        out[..8].copy_from_slice(&self.block_number.to_be_bytes());
+        out[8..].copy_from_slice(&self.tx_idx.to_be_bytes());
+        out
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        let bytes: [u8; Self::ENCODED_LEN] = bytes
+            .try_into()
+            .map_err(|_| MonadChainDataError::Decode("invalid tx_location length"))?;
+        let block_number = u64::from_be_bytes(bytes[..8].try_into().expect("8-byte prefix"));
+        let tx_idx = u32::from_be_bytes(bytes[8..].try_into().expect("4-byte suffix"));
+        Ok(Self {
+            block_number,
+            tx_idx,
+        })
+    }
+}
+
 /// Per-tx fields stored in the block blob. Block-level fields
 /// (block_number, block_hash, tx_idx) are reconstructed from the
 /// `BlockRecord` and `BlockTxHeader` at read time.

--- a/monad-chain-data/tests/common/mod.rs
+++ b/monad-chain-data/tests/common/mod.rs
@@ -33,18 +33,34 @@ pub fn chain_header(number: u64, parent: &EvmBlockHeader) -> EvmBlockHeader {
 /// creation, empty calldata). Tests use it when they need `TxIngestPlan`
 /// to decode the envelope successfully but don't care about the contents.
 pub fn minimal_ingest_tx() -> IngestTx {
+    use alloy_primitives::Address;
+
+    ingest_tx(Address::ZERO, None, Vec::new())
+}
+
+/// Builds an `IngestTx` with the given `sender`, recipient, and calldata.
+/// `to = None` produces a contract-creation envelope. The signed-tx bytes
+/// always use `Signature::test_signature`; the recovered address of the
+/// envelope signer therefore does NOT equal `sender`. Filter semantics
+/// read `IngestTx::sender` (the ingest-declared `from`), not the
+/// envelope-recovered signer, so tests can set `sender` freely.
+pub fn ingest_tx(
+    sender: alloy_primitives::Address,
+    to: Option<alloy_primitives::Address>,
+    input: Vec<u8>,
+) -> IngestTx {
     use alloy_consensus::{SignableTransaction, TxEnvelope, TxLegacy};
     use alloy_eips::eip2718::Encodable2718;
-    use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
+    use alloy_primitives::{Signature, TxKind, U256};
 
     let signed = TxLegacy {
         chain_id: Some(1),
         nonce: 0,
         gas_price: 0,
         gas_limit: 21_000,
-        to: TxKind::Create,
+        to: to.map_or(TxKind::Create, TxKind::Call),
         value: U256::ZERO,
-        input: Bytes::new(),
+        input: input.into(),
     }
     .into_signed(Signature::test_signature());
 
@@ -53,7 +69,7 @@ pub fn minimal_ingest_tx() -> IngestTx {
 
     IngestTx {
         tx_hash: B256::ZERO,
-        sender: Address::ZERO,
+        sender,
         signed_tx_bytes: signed_tx_bytes.into(),
     }
 }

--- a/monad-chain-data/tests/get_transaction.rs
+++ b/monad-chain-data/tests/get_transaction.rs
@@ -1,0 +1,256 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use monad_chain_data::{
+    engine::tables::PublicationTables, Address, Family, FinalizedBlock, InMemoryBlobStore,
+    InMemoryMetaStore, IngestTx, MonadChainDataService, QueryLimits, B256,
+};
+
+mod common;
+
+use common::{chain_header, ingest_tx, test_header};
+
+#[tokio::test(flavor = "current_thread")]
+async fn get_transaction_returns_entry_for_ingested_hash() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let alice = Address::repeat_byte(0xaa);
+    let bob = Address::repeat_byte(0xbb);
+    let recipient = Address::repeat_byte(0x11);
+    let hash_alice = B256::repeat_byte(0x01);
+    let hash_bob = B256::repeat_byte(0x02);
+
+    service
+        .ingest_block(FinalizedBlock {
+            header: test_header(1, B256::ZERO),
+            logs_by_tx: vec![vec![], vec![]],
+            txs: vec![
+                with_hash(ingest_tx(alice, Some(recipient), Vec::new()), hash_alice),
+                with_hash(ingest_tx(bob, Some(recipient), Vec::new()), hash_bob),
+            ],
+        })
+        .await
+        .expect("ingest");
+
+    let entry = service
+        .get_transaction(hash_bob)
+        .await
+        .expect("lookup")
+        .expect("hit");
+    assert_eq!(entry.block_number, 1);
+    assert_eq!(entry.tx_idx, 1);
+    assert_eq!(entry.tx_hash, hash_bob);
+    assert_eq!(entry.sender, bob);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn get_transaction_returns_none_for_unknown_hash() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+    let sender = Address::repeat_byte(0xaa);
+    let recipient = Address::repeat_byte(0x11);
+    let known = B256::repeat_byte(0x01);
+    let unknown = B256::repeat_byte(0xff);
+
+    service
+        .ingest_block(FinalizedBlock {
+            header: test_header(1, B256::ZERO),
+            logs_by_tx: vec![vec![]],
+            txs: vec![with_hash(
+                ingest_tx(sender, Some(recipient), Vec::new()),
+                known,
+            )],
+        })
+        .await
+        .expect("ingest");
+
+    assert!(service
+        .get_transaction(unknown)
+        .await
+        .expect("lookup")
+        .is_none());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn get_transaction_resolves_contract_creation_tx() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+    let sender = Address::repeat_byte(0xaa);
+    let hash = B256::repeat_byte(0x07);
+
+    service
+        .ingest_block(FinalizedBlock {
+            header: test_header(1, B256::ZERO),
+            logs_by_tx: vec![vec![]],
+            txs: vec![with_hash(ingest_tx(sender, None, Vec::new()), hash)],
+        })
+        .await
+        .expect("ingest");
+
+    let entry = service
+        .get_transaction(hash)
+        .await
+        .expect("lookup")
+        .expect("hit");
+    assert_eq!(entry.tx_hash, hash);
+    assert!(entry.to().expect("decode").is_none());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn get_transaction_resolves_across_multiple_blocks() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+    let sender = Address::repeat_byte(0xaa);
+    let recipient = Address::repeat_byte(0x11);
+    let hash_b1 = B256::repeat_byte(0x01);
+    let hash_b2 = B256::repeat_byte(0x02);
+
+    let h1 = test_header(1, B256::ZERO);
+    service
+        .ingest_block(FinalizedBlock {
+            header: h1.clone(),
+            logs_by_tx: vec![vec![]],
+            txs: vec![with_hash(
+                ingest_tx(sender, Some(recipient), Vec::new()),
+                hash_b1,
+            )],
+        })
+        .await
+        .expect("ingest 1");
+
+    service
+        .ingest_block(FinalizedBlock {
+            header: chain_header(2, &h1),
+            logs_by_tx: vec![vec![]],
+            txs: vec![with_hash(
+                ingest_tx(sender, Some(recipient), Vec::new()),
+                hash_b2,
+            )],
+        })
+        .await
+        .expect("ingest 2");
+
+    let e1 = service
+        .get_transaction(hash_b1)
+        .await
+        .expect("lookup 1")
+        .expect("hit 1");
+    let e2 = service
+        .get_transaction(hash_b2)
+        .await
+        .expect("lookup 2")
+        .expect("hit 2");
+    assert_eq!(e1.block_number, 1);
+    assert_eq!(e1.tx_idx, 0);
+    assert_eq!(e2.block_number, 2);
+    assert_eq!(e2.tx_idx, 0);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn failed_tx_ingest_does_not_index_transaction_hash() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+    let tx_hash = B256::repeat_byte(0x44);
+
+    service
+        .ingest_block(FinalizedBlock {
+            header: test_header(1, B256::ZERO),
+            logs_by_tx: vec![vec![]],
+            txs: vec![IngestTx {
+                tx_hash,
+                signed_tx_bytes: vec![0x01].into(),
+                ..Default::default()
+            }],
+        })
+        .await
+        .expect_err("invalid signed tx should fail ingest");
+
+    assert!(service
+        .get_transaction(tx_hash)
+        .await
+        .expect("lookup")
+        .is_none());
+    assert!(service
+        .tables()
+        .family(Family::Tx)
+        .load_block_header(1)
+        .await
+        .expect("load tx header")
+        .is_none());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn get_transaction_ignores_index_hits_without_published_head() {
+    let meta_store = InMemoryMetaStore::default();
+    let service = MonadChainDataService::new(
+        meta_store.clone(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+    let sender = Address::repeat_byte(0xaa);
+    let recipient = Address::repeat_byte(0x11);
+    let tx_hash = B256::repeat_byte(0x55);
+
+    service
+        .ingest_block(FinalizedBlock {
+            header: test_header(1, B256::ZERO),
+            logs_by_tx: vec![vec![]],
+            txs: vec![with_hash(
+                ingest_tx(sender, Some(recipient), Vec::new()),
+                tx_hash,
+            )],
+        })
+        .await
+        .expect("ingest");
+
+    meta_store.clear_key(
+        PublicationTables::<InMemoryMetaStore>::PUBLICATION_STATE_TABLE,
+        PublicationTables::<InMemoryMetaStore>::PUBLICATION_STATE_KEY,
+    );
+
+    assert!(service
+        .get_transaction(tx_hash)
+        .await
+        .expect("lookup")
+        .is_none());
+    assert!(service
+        .tables()
+        .family(Family::Tx)
+        .load_block_header(1)
+        .await
+        .expect("load tx header")
+        .is_some());
+}
+
+fn with_hash(mut tx: IngestTx, tx_hash: B256) -> IngestTx {
+    tx.tx_hash = tx_hash;
+    tx
+}

--- a/monad-chain-data/tests/query_logs_blocks_relation.rs
+++ b/monad-chain-data/tests/query_logs_blocks_relation.rs
@@ -81,7 +81,10 @@ async fn include_blocks_true_returns_deduped_headers_for_matched_blocks() {
                 address: Some(HashSet::from([matching])),
                 topics: [None, None, None, None],
             },
-            relations: LogsRelations { blocks: true },
+            relations: LogsRelations {
+                blocks: true,
+                transactions: false,
+            },
         })
         .await
         .expect("query");
@@ -109,7 +112,10 @@ async fn descending_query_still_returns_blocks_ascending() {
                 limit: 100,
             },
             filter: LogFilter::default(),
-            relations: LogsRelations { blocks: true },
+            relations: LogsRelations {
+                blocks: true,
+                transactions: false,
+            },
         })
         .await
         .expect("query");
@@ -135,7 +141,10 @@ async fn include_blocks_empty_result_returns_empty_blocks() {
                 address: Some(HashSet::from([Address::repeat_byte(0xEE)])),
                 topics: [None, None, None, None],
             },
-            relations: LogsRelations { blocks: true },
+            relations: LogsRelations {
+                blocks: true,
+                transactions: false,
+            },
         })
         .await
         .expect("query");

--- a/monad-chain-data/tests/query_logs_transactions_relation.rs
+++ b/monad-chain-data/tests/query_logs_transactions_relation.rs
@@ -1,0 +1,192 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+
+use monad_chain_data::{
+    Address, Bytes, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, Log, LogData, LogFilter,
+    LogsRelations, MonadChainDataService, QueryEnvelope, QueryLimits, QueryLogsRequest, QueryOrder,
+    B256,
+};
+
+mod common;
+
+use common::{chain_header, ingest_tx, test_header};
+
+#[tokio::test(flavor = "current_thread")]
+async fn include_transactions_false_omits_transactions() {
+    let service = build_service().await;
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(2),
+                order: QueryOrder::Ascending,
+                limit: 100,
+            },
+            filter: LogFilter::default(),
+            relations: LogsRelations::default(),
+        })
+        .await
+        .expect("query");
+
+    assert!(!page.logs.is_empty());
+    assert!(page.transactions.is_none());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn include_transactions_true_returns_deduped_txs_sorted() {
+    let service = build_service().await;
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(2),
+                order: QueryOrder::Ascending,
+                limit: 100,
+            },
+            filter: LogFilter::default(),
+            relations: LogsRelations {
+                blocks: false,
+                transactions: true,
+            },
+        })
+        .await
+        .expect("query");
+
+    // Block 1 has two txs each emitting logs; block 2 has one tx with a log.
+    // Block 1's first tx emits two logs, so dedup must collapse them.
+    let transactions = page.transactions.expect("transactions relation");
+    assert_eq!(transactions.len(), 3);
+    let keys: Vec<(u64, u32)> = transactions
+        .iter()
+        .map(|t| (t.block_number, t.tx_idx))
+        .collect();
+    assert_eq!(keys, vec![(1, 0), (1, 1), (2, 0)]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn include_transactions_true_filtered_logs_returns_only_referenced_txs() {
+    let service = build_service().await;
+    let target = Address::repeat_byte(0x77);
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(2),
+                order: QueryOrder::Ascending,
+                limit: 100,
+            },
+            filter: LogFilter {
+                address: Some(HashSet::from([target])),
+                topics: [None, None, None, None],
+            },
+            relations: LogsRelations {
+                blocks: false,
+                transactions: true,
+            },
+        })
+        .await
+        .expect("query");
+
+    // Only the log on block 1 tx 1 matches `target`.
+    assert_eq!(page.logs.len(), 1);
+    let transactions = page.transactions.expect("transactions relation");
+    assert_eq!(transactions.len(), 1);
+    assert_eq!(transactions[0].block_number, 1);
+    assert_eq!(transactions[0].tx_idx, 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn include_transactions_true_empty_logs_returns_empty_transactions() {
+    let service = build_service().await;
+
+    let page = service
+        .query_logs(QueryLogsRequest {
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(2),
+                order: QueryOrder::Ascending,
+                limit: 100,
+            },
+            filter: LogFilter {
+                address: Some(HashSet::from([Address::repeat_byte(0xEE)])),
+                topics: [None, None, None, None],
+            },
+            relations: LogsRelations {
+                blocks: false,
+                transactions: true,
+            },
+        })
+        .await
+        .expect("query");
+
+    assert!(page.logs.is_empty());
+    let transactions = page.transactions.expect("transactions relation");
+    assert!(transactions.is_empty());
+}
+
+async fn build_service() -> MonadChainDataService<InMemoryMetaStore, InMemoryBlobStore> {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let alice = Address::repeat_byte(0xaa);
+    let bob = Address::repeat_byte(0xbb);
+    let carol = Address::repeat_byte(0xcc);
+    let addr_default = Address::repeat_byte(1);
+    let target = Address::repeat_byte(0x77);
+
+    let h1 = test_header(1, B256::ZERO);
+    service
+        .ingest_block(FinalizedBlock {
+            header: h1.clone(),
+            // tx0 emits two logs; tx1 emits one log matching `target`.
+            logs_by_tx: vec![
+                vec![log(addr_default), log(addr_default)],
+                vec![log(target)],
+            ],
+            txs: vec![
+                ingest_tx(alice, Some(addr_default), Vec::new()),
+                ingest_tx(bob, Some(target), Vec::new()),
+            ],
+        })
+        .await
+        .expect("ingest block 1");
+
+    let h2 = chain_header(2, &h1);
+    service
+        .ingest_block(FinalizedBlock {
+            header: h2,
+            logs_by_tx: vec![vec![log(addr_default)]],
+            txs: vec![ingest_tx(carol, Some(addr_default), Vec::new())],
+        })
+        .await
+        .expect("ingest block 2");
+
+    service
+}
+
+fn log(address: Address) -> Log {
+    Log {
+        address,
+        data: LogData::new_unchecked(vec![B256::repeat_byte(0xAA)], Bytes::from(vec![1, 2, 3])),
+    }
+}

--- a/monad-chain-data/tests/query_transactions.rs
+++ b/monad-chain-data/tests/query_transactions.rs
@@ -1,0 +1,270 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+
+use monad_chain_data::{
+    Address, FinalizedBlock, InMemoryBlobStore, InMemoryMetaStore, MonadChainDataService,
+    QueryEnvelope, QueryLimits, QueryOrder, QueryTransactionsRequest, TxFilter, TxsRelations, B256,
+};
+
+mod common;
+
+use common::{chain_header, ingest_tx, test_header};
+
+#[tokio::test(flavor = "current_thread")]
+async fn indexed_query_transactions_filters_by_from_across_blocks() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let alice = Address::repeat_byte(0xaa);
+    let bob = Address::repeat_byte(0xbb);
+    let recipient = Address::repeat_byte(0x11);
+
+    let h1 = test_header(1, B256::ZERO);
+    service
+        .ingest_block(FinalizedBlock {
+            header: h1.clone(),
+            logs_by_tx: vec![vec![], vec![]],
+            txs: vec![
+                ingest_tx(alice, Some(recipient), Vec::new()),
+                ingest_tx(bob, Some(recipient), Vec::new()),
+            ],
+        })
+        .await
+        .expect("ingest block 1");
+
+    let h2 = chain_header(2, &h1);
+    service
+        .ingest_block(FinalizedBlock {
+            header: h2,
+            logs_by_tx: vec![vec![]],
+            txs: vec![ingest_tx(alice, Some(recipient), Vec::new())],
+        })
+        .await
+        .expect("ingest block 2");
+
+    let response = service
+        .query_transactions(QueryTransactionsRequest {
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(2),
+                order: QueryOrder::Ascending,
+                limit: 10,
+            },
+            filter: TxFilter {
+                from: Some(HashSet::from([alice])),
+                ..Default::default()
+            },
+            relations: TxsRelations::default(),
+        })
+        .await
+        .expect("query");
+
+    assert_eq!(response.txs.len(), 2);
+    assert!(response.txs.iter().all(|t| t.sender == alice));
+    let block_numbers: Vec<u64> = response.txs.iter().map(|t| t.block_number).collect();
+    assert_eq!(block_numbers, vec![1, 2]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn indexed_query_transactions_rejects_contract_creation_under_to_filter() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let sender = Address::repeat_byte(0x01);
+    let target = Address::repeat_byte(0x22);
+
+    service
+        .ingest_block(FinalizedBlock {
+            header: test_header(1, B256::ZERO),
+            logs_by_tx: vec![vec![], vec![]],
+            txs: vec![
+                ingest_tx(sender, None, Vec::new()),
+                ingest_tx(sender, Some(target), Vec::new()),
+            ],
+        })
+        .await
+        .expect("ingest");
+
+    let response = service
+        .query_transactions(QueryTransactionsRequest {
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(1),
+                order: QueryOrder::Ascending,
+                limit: 10,
+            },
+            filter: TxFilter {
+                to: Some(HashSet::from([target])),
+                ..Default::default()
+            },
+            relations: TxsRelations::default(),
+        })
+        .await
+        .expect("query");
+
+    assert_eq!(response.txs.len(), 1);
+    assert_eq!(response.txs[0].tx_idx, 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn indexed_query_transactions_filters_by_selector() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let sender = Address::repeat_byte(0x01);
+    let target = Address::repeat_byte(0x22);
+    let selector = [0xde, 0xad, 0xbe, 0xef];
+
+    service
+        .ingest_block(FinalizedBlock {
+            header: test_header(1, B256::ZERO),
+            logs_by_tx: vec![vec![], vec![]],
+            txs: vec![
+                ingest_tx(sender, Some(target), vec![0xaa, 0xbb, 0xcc, 0xdd, 0x01]),
+                ingest_tx(sender, Some(target), vec![0xde, 0xad, 0xbe, 0xef, 0x02]),
+            ],
+        })
+        .await
+        .expect("ingest");
+
+    let response = service
+        .query_transactions(QueryTransactionsRequest {
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(1),
+                order: QueryOrder::Ascending,
+                limit: 10,
+            },
+            filter: TxFilter {
+                selector: Some(HashSet::from([selector])),
+                ..Default::default()
+            },
+            relations: TxsRelations::default(),
+        })
+        .await
+        .expect("query");
+
+    assert_eq!(response.txs.len(), 1);
+    assert_eq!(response.txs[0].tx_idx, 1);
+    assert_eq!(
+        response.txs[0].selector().expect("selector"),
+        Some(selector)
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn indexed_query_transactions_selector_filter_skips_short_input() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let sender = Address::repeat_byte(0x01);
+    let target = Address::repeat_byte(0x22);
+    let selector = [0xde, 0xad, 0xbe, 0xef];
+
+    service
+        .ingest_block(FinalizedBlock {
+            header: test_header(1, B256::ZERO),
+            logs_by_tx: vec![vec![]],
+            txs: vec![ingest_tx(sender, Some(target), vec![0xde, 0xad, 0xbe])],
+        })
+        .await
+        .expect("ingest");
+
+    let response = service
+        .query_transactions(QueryTransactionsRequest {
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(1),
+                order: QueryOrder::Ascending,
+                limit: 10,
+            },
+            filter: TxFilter {
+                selector: Some(HashSet::from([selector])),
+                ..Default::default()
+            },
+            relations: TxsRelations::default(),
+        })
+        .await
+        .expect("query");
+
+    assert!(response.txs.is_empty());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn block_scan_query_transactions_returns_all_txs_in_block_order() {
+    let service = MonadChainDataService::new(
+        InMemoryMetaStore::default(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    let a = Address::repeat_byte(1);
+    let b = Address::repeat_byte(2);
+    let c = Address::repeat_byte(3);
+
+    let h1 = test_header(1, B256::ZERO);
+    service
+        .ingest_block(FinalizedBlock {
+            header: h1.clone(),
+            logs_by_tx: vec![vec![], vec![]],
+            txs: vec![
+                ingest_tx(a, None, Vec::new()),
+                ingest_tx(b, None, Vec::new()),
+            ],
+        })
+        .await
+        .expect("ingest block 1");
+
+    let h2 = chain_header(2, &h1);
+    service
+        .ingest_block(FinalizedBlock {
+            header: h2,
+            logs_by_tx: vec![vec![]],
+            txs: vec![ingest_tx(c, None, Vec::new())],
+        })
+        .await
+        .expect("ingest block 2");
+
+    let response = service
+        .query_transactions(QueryTransactionsRequest {
+            envelope: QueryEnvelope {
+                from_block: Some(1),
+                to_block: Some(2),
+                order: QueryOrder::Ascending,
+                limit: 10,
+            },
+            filter: TxFilter::default(),
+            relations: TxsRelations::default(),
+        })
+        .await
+        .expect("query");
+
+    let senders: Vec<Address> = response.txs.iter().map(|t| t.sender).collect();
+    assert_eq!(senders, vec![a, b, c]);
+}


### PR DESCRIPTION
Adds the public transaction query surface, with indexed and unfiltered block-scan paths sharing the same engine runner as logs. Query filters support from, to, and selector streams, optional block relation hydration, and exact-match behavior for contract creation and short calldata.

Logs can also opt into a transactions relation, hydrating matched log transaction references into sorted TxEntry results. Ingest persists a tx-hash index and get_transaction resolves eth_getTransactionByHash-style point lookups, returning MissingData if an indexed location cannot materialize.