### PR TITLE
Fence publication head updates with CAS

### DIFF
--- a/monad-chain-data/src/api.rs
+++ b/monad-chain-data/src/api.rs
@@ -19,7 +19,11 @@ use crate::{
     blocks::{
         execute_query_blocks, load_blocks_by_numbers, QueryBlocksRequest, QueryBlocksResponse,
     },
-    engine::{family::Family, query::family_runner::IndexedFamilyQuery, tables::Tables},
+    engine::{
+        family::Family,
+        query::family_runner::IndexedFamilyQuery,
+        tables::{PublicationTables, Tables},
+    },
     error::{MonadChainDataError, Result},
     family::{FinalizedBlock, Hash32},
     logs::{
@@ -31,15 +35,16 @@ use crate::{
         range::ResolvedBlockWindow,
         state::{BlockRecord, LogId, TxId},
     },
-    store::{BlobStore, MetaStore},
+    store::{BlobStore, MetaStoreCas},
     txs::{
         execute_block_scan_tx_query, execute_indexed_tx_query, load_txs_by_positions,
         QueryTransactionsRequest, QueryTransactionsResponse, TxEntry, TxIngestPlan, TxMaterializer,
     },
 };
 
-pub struct MonadChainDataService<M: MetaStore, B: BlobStore> {
+pub struct MonadChainDataService<M: MetaStoreCas, B: BlobStore> {
     tables: Tables<M, B>,
+    publication: PublicationTables<M>,
     limits: QueryLimits,
 }
 
@@ -51,9 +56,10 @@ pub struct IngestOutcome {
     pub written_txs: usize,
 }
 
-impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
+impl<M: MetaStoreCas, B: BlobStore> MonadChainDataService<M, B> {
     pub fn new(meta_store: M, blob_store: B, limits: QueryLimits) -> Self {
         Self {
+            publication: PublicationTables::new(meta_store.clone()),
             tables: Tables::new(meta_store, blob_store),
             limits,
         }
@@ -63,21 +69,33 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
         &self.tables
     }
 
+    pub fn publication(&self) -> &PublicationTables<M> {
+        &self.publication
+    }
+
     pub fn limits(&self) -> &QueryLimits {
         &self.limits
     }
 
     // The publication head is the commit boundary: every artifact written before
-    // `store_state` is pre-publication state and must not be treated as valid by
+    // `cas_advance` is pre-publication state and must not be treated as valid by
     // readers until the head advances. Retry/recovery should derive the next block
     // from the published head and may overwrite any matching pre-publication
     // artifacts left by an interrupted ingest.
+    //
+    // The head row is CAS-protected so that during writer+standby failover the
+    // losing writer sees `FencedOut` and steps down rather than racing the new
+    // writer's publish.
     /// Persists one finalized block and advances the published head on success.
     pub async fn ingest_block(&self, block: FinalizedBlock) -> Result<IngestOutcome> {
         let blocks = self.tables.blocks();
         let logs = self.tables.family(Family::Log);
         let txs = self.tables.family(Family::Tx);
-        let current_head = self.tables.publication().load_published_head().await?;
+        let current_state = self.publication.load_state().await?;
+        let (expected_version, current_head) = match &current_state {
+            Some((version, state)) => (Some(*version), Some(state.indexed_finalized_head)),
+            None => (None, None),
+        };
         let previous_record = blocks.validate_continuity(&block, current_head).await?;
         // Lenient: log-only fixtures pass `txs: vec![]` alongside non-empty
         // `logs_by_tx`. When callers do provide txs, the count must line up
@@ -147,11 +165,13 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
         blocks
             .store_record(block.block_number(), &block_record)
             .await?;
-        self.tables
-            .publication()
-            .store_state(crate::primitives::state::PublicationState {
-                indexed_finalized_head: block.block_number(),
-            })
+        self.publication
+            .cas_advance(
+                expected_version,
+                crate::primitives::state::PublicationState {
+                    indexed_finalized_head: block.block_number(),
+                },
+            )
             .await?;
 
         Ok(IngestOutcome {
@@ -252,7 +272,7 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
         let Some(location) = self.tables.tx_hash_index().get(&tx_hash).await? else {
             return Ok(None);
         };
-        let Some(head) = self.tables.publication().load_published_head().await? else {
+        let Some(head) = self.publication.load_published_head().await? else {
             return Ok(None);
         };
         if location.block_number > head {
@@ -285,8 +305,7 @@ impl<M: MetaStore, B: BlobStore> MonadChainDataService<M, B> {
     }
 
     async fn load_published_head(&self) -> Result<u64> {
-        self.tables
-            .publication()
+        self.publication
             .load_published_head()
             .await?
             .ok_or(MonadChainDataError::MissingData("no published blocks"))

--- a/monad-chain-data/src/engine/bitmap.rs
+++ b/monad-chain-data/src/engine/bitmap.rs
@@ -119,10 +119,10 @@ impl<M: MetaStore> BitmapTables<M> {
         let mut fragments = Vec::with_capacity(page.keys.len());
 
         for clustering in page.keys {
-            let record = self.fragments.get(&partition, &clustering).await?.ok_or(
+            let bytes = self.fragments.get(&partition, &clustering).await?.ok_or(
                 MonadChainDataError::MissingData("missing log bitmap fragment"),
             )?;
-            fragments.push(record.value);
+            fragments.push(bytes);
         }
 
         Ok(fragments)
@@ -135,11 +135,11 @@ impl<M: MetaStore> BitmapTables<M> {
         page_start_local: u32,
     ) -> Result<Option<BitmapPageMeta>> {
         let key = stream_page_key(stream_id, page_start_local);
-        let Some(record) = self.page_meta.get(&key).await? else {
+        let Some(bytes) = self.page_meta.get(&key).await? else {
             return Ok(None);
         };
 
-        Ok(Some(BitmapPageMeta::decode(&record.value)?))
+        Ok(Some(BitmapPageMeta::decode(&bytes)?))
     }
 
     pub async fn store_page_meta(
@@ -160,7 +160,7 @@ impl<M: MetaStore> BitmapTables<M> {
         page_start_local: u32,
     ) -> Result<Option<Bytes>> {
         let key = stream_page_key(stream_id, page_start_local);
-        Ok(self.page_blobs.get(&key).await?.map(|record| record.value))
+        self.page_blobs.get(&key).await
     }
 
     pub async fn store_page_blob(

--- a/monad-chain-data/src/engine/primary_dir.rs
+++ b/monad-chain-data/src/engine/primary_dir.rs
@@ -131,11 +131,11 @@ impl<M: MetaStore> PrimaryDirTables<M> {
     /// Loads the compacted summary for one sealed 10k bucket.
     pub async fn load_bucket(&self, bucket_start: u64) -> Result<Option<PrimaryDirBucket>> {
         let key = u64_key(bucket_start);
-        let Some(record) = self.buckets.get(&key).await? else {
+        let Some(bytes) = self.buckets.get(&key).await? else {
             return Ok(None);
         };
 
-        Ok(Some(PrimaryDirBucket::decode(&record.value)?))
+        Ok(Some(PrimaryDirBucket::decode(&bytes)?))
     }
 
     /// Loads all retained fragments for one 10k bucket.
@@ -151,12 +151,12 @@ impl<M: MetaStore> PrimaryDirTables<M> {
         let mut fragments = Vec::with_capacity(page.keys.len());
 
         for clustering in page.keys {
-            let record = self.fragments.get(&partition, &clustering).await?.ok_or(
+            let bytes = self.fragments.get(&partition, &clustering).await?.ok_or(
                 crate::error::MonadChainDataError::MissingData(
                     "missing primary directory fragment",
                 ),
             )?;
-            fragments.push(PrimaryDirFragment::decode(&record.value)?);
+            fragments.push(PrimaryDirFragment::decode(&bytes)?);
         }
 
         Ok(fragments)

--- a/monad-chain-data/src/engine/tables.rs
+++ b/monad-chain-data/src/engine/tables.rs
@@ -101,7 +101,7 @@ impl<M: MetaStore> PublicationTables<M> {
     }
 
     pub async fn load_published_head(&self) -> Result<Option<u64>> {
-        let Some(record) = self
+        let Some(bytes) = self
             .publication_state
             .get(Self::PUBLICATION_STATE_KEY)
             .await?
@@ -110,7 +110,7 @@ impl<M: MetaStore> PublicationTables<M> {
         };
 
         Ok(Some(
-            PublicationState::decode(&record.value)?.indexed_finalized_head,
+            PublicationState::decode(&bytes)?.indexed_finalized_head,
         ))
     }
 
@@ -144,10 +144,10 @@ impl<M: MetaStore> BlockTables<M> {
 
     pub async fn load_record(&self, block_number: u64) -> Result<Option<BlockRecord>> {
         let key = block_number_key(block_number);
-        let Some(record) = self.block_records.get(&key).await? else {
+        let Some(bytes) = self.block_records.get(&key).await? else {
             return Ok(None);
         };
-        Ok(Some(BlockRecord::decode(&record.value)?))
+        Ok(Some(BlockRecord::decode(&bytes)?))
     }
 
     pub async fn store_record(&self, block_number: u64, block_record: &BlockRecord) -> Result<()> {
@@ -160,10 +160,10 @@ impl<M: MetaStore> BlockTables<M> {
 
     pub async fn load_header(&self, block_number: u64) -> Result<Option<EvmBlockHeader>> {
         let key = block_number_key(block_number);
-        let Some(record) = self.block_headers.get(&key).await? else {
+        let Some(bytes) = self.block_headers.get(&key).await? else {
             return Ok(None);
         };
-        let header = EvmBlockHeader::decode(&mut record.value.as_ref())
+        let header = EvmBlockHeader::decode(&mut bytes.as_ref())
             .map_err(|_| MonadChainDataError::Decode("invalid block header rlp"))?;
         Ok(Some(header))
     }
@@ -184,17 +184,17 @@ impl<M: MetaStore> BlockTables<M> {
     /// load should expect `MissingData` if `n > published_head` or if the
     /// follow-up loads fail.
     pub async fn block_number_by_hash(&self, block_hash: &Hash32) -> Result<Option<u64>> {
-        let Some(record) = self
+        let Some(value) = self
             .block_hash_to_number_index
             .get(block_hash.as_slice())
             .await?
         else {
             return Ok(None);
         };
-        let bytes: [u8; 8] =
-            record.value.as_ref().try_into().map_err(|_| {
-                MonadChainDataError::Decode("invalid block_hash_to_number_index value")
-            })?;
+        let bytes: [u8; 8] = value
+            .as_ref()
+            .try_into()
+            .map_err(|_| MonadChainDataError::Decode("invalid block_hash_to_number_index value"))?;
         Ok(Some(u64::from_be_bytes(bytes)))
     }
 
@@ -286,7 +286,7 @@ impl<M: MetaStore, B: BlobStore> FamilyTables<M, B> {
     /// the consumer's responsibility; the engine treats the value as opaque.
     pub async fn load_block_header(&self, block_number: u64) -> Result<Option<Bytes>> {
         let key = block_number_key(block_number);
-        Ok(self.block_headers.get(&key).await?.map(|r| r.value))
+        self.block_headers.get(&key).await
     }
 
     pub async fn store_block_header(&self, block_number: u64, bytes: Bytes) -> Result<()> {

--- a/monad-chain-data/src/engine/tables.rs
+++ b/monad-chain-data/src/engine/tables.rs
@@ -30,12 +30,14 @@ use crate::{
         state::{BlockRecord, PublicationState},
         EvmBlockHeader,
     },
-    store::{BlobStore, BlobTable, KvTable, MetaStore, ScannableTableId, TableId},
+    store::{
+        BlobStore, BlobTable, CasOutcome, CasVersion, KvTable, MetaStore, MetaStoreCas,
+        ScannableTableId, TableId,
+    },
     txs::TxHashIndexTable,
 };
 
 pub struct Tables<M: MetaStore, B: BlobStore> {
-    publication: PublicationTables<M>,
     blocks: BlockTables<M>,
     tx_hash_index: TxHashIndexTable<M>,
     families: BTreeMap<Family, FamilyTables<M, B>>,
@@ -53,15 +55,10 @@ impl<M: MetaStore, B: BlobStore> Tables<M, B> {
             FamilyTables::new(meta_store.clone(), blob_store, Family::Tx),
         );
         Self {
-            publication: PublicationTables::new(meta_store.clone()),
             blocks: BlockTables::new(meta_store.clone()),
             tx_hash_index: TxHashIndexTable::new(meta_store),
             families,
         }
-    }
-
-    pub fn publication(&self) -> &PublicationTables<M> {
-        &self.publication
     }
 
     pub fn blocks(&self) -> &BlockTables<M> {
@@ -86,39 +83,66 @@ fn block_number_key(block_number: u64) -> [u8; 8] {
     block_number.to_be_bytes()
 }
 
-pub struct PublicationTables<M: MetaStore> {
-    publication_state: KvTable<M>,
+pub struct PublicationTables<M: MetaStoreCas> {
+    meta_store: M,
 }
 
-impl<M: MetaStore> PublicationTables<M> {
+impl<M: MetaStoreCas> PublicationTables<M> {
     pub const PUBLICATION_STATE_TABLE: TableId = TableId::new("publication_state");
     pub const PUBLICATION_STATE_KEY: &[u8] = b"state";
 
-    fn new(meta_store: M) -> Self {
-        Self {
-            publication_state: meta_store.table(Self::PUBLICATION_STATE_TABLE),
-        }
+    pub(crate) fn new(meta_store: M) -> Self {
+        Self { meta_store }
     }
 
-    pub async fn load_published_head(&self) -> Result<Option<u64>> {
-        let Some(bytes) = self
-            .publication_state
-            .get(Self::PUBLICATION_STATE_KEY)
+    /// Loads the current publication state along with its CAS version.
+    /// Writers must thread the version into the matching [`Self::cas_advance`]
+    /// call; readers that only want the head can use [`Self::load_published_head`].
+    pub async fn load_state(&self) -> Result<Option<(CasVersion, PublicationState)>> {
+        let Some((version, bytes)) = self
+            .meta_store
+            .cas_get(Self::PUBLICATION_STATE_TABLE, Self::PUBLICATION_STATE_KEY)
             .await?
         else {
             return Ok(None);
         };
 
-        Ok(Some(
-            PublicationState::decode(&bytes)?.indexed_finalized_head,
-        ))
+        Ok(Some((version, PublicationState::decode(&bytes)?)))
     }
 
-    pub async fn store_state(&self, state: PublicationState) -> Result<()> {
-        self.publication_state
-            .put(Self::PUBLICATION_STATE_KEY, Bytes::from(state.encode()))
+    pub async fn load_published_head(&self) -> Result<Option<u64>> {
+        Ok(self
+            .load_state()
+            .await?
+            .map(|(_, state)| state.indexed_finalized_head))
+    }
+
+    /// Atomically advances the publication state. `expected` must be the
+    /// version returned by the load that produced `next`'s preconditions —
+    /// writer+standby failover is the case this guards. On version mismatch
+    /// this returns `Err(FencedOut)` rather than [`CasOutcome::Conflict`]
+    /// so callers can `?` through ingest paths.
+    pub async fn cas_advance(
+        &self,
+        expected: Option<CasVersion>,
+        next: PublicationState,
+    ) -> Result<()> {
+        let outcome = self
+            .meta_store
+            .cas_put(
+                Self::PUBLICATION_STATE_TABLE,
+                Self::PUBLICATION_STATE_KEY,
+                expected,
+                Bytes::from(next.encode()),
+            )
             .await?;
-        Ok(())
+        match outcome {
+            CasOutcome::Applied { .. } => Ok(()),
+            CasOutcome::Conflict { .. } => {
+                let current_head = self.load_published_head().await?;
+                Err(MonadChainDataError::FencedOut { current_head })
+            }
+        }
     }
 }
 

--- a/monad-chain-data/src/error.rs
+++ b/monad-chain-data/src/error.rs
@@ -37,4 +37,9 @@ pub enum MonadChainDataError {
         max_limit: usize,
         max_block_range: u64,
     },
+    /// The publication head was advanced by another writer between this
+    /// writer's read and CAS. The caller is no longer the active writer
+    /// and should step down rather than retry.
+    #[error("fenced out by concurrent writer (current head: {current_head:?})")]
+    FencedOut { current_head: Option<u64> },
 }

--- a/monad-chain-data/src/store/meta/in_memory.rs
+++ b/monad-chain-data/src/store/meta/in_memory.rs
@@ -24,7 +24,7 @@ use crate::{
     error::Result,
     store::{
         common::Page,
-        meta::{MetaStore, PutResult, Record, ScannableTableId, TableId},
+        meta::{MetaStore, ScannableTableId, TableId},
     },
 };
 
@@ -32,8 +32,8 @@ use crate::{
 /// `RwLock`s. Not intended as a deployable backend.
 #[derive(Debug, Clone, Default)]
 pub struct InMemoryMetaStore {
-    kv_records: Arc<RwLock<BTreeMap<(TableId, Vec<u8>), Record>>>,
-    scan_records: Arc<RwLock<BTreeMap<(ScannableTableId, Vec<u8>, Vec<u8>), Record>>>,
+    kv_records: Arc<RwLock<BTreeMap<(TableId, Vec<u8>), Bytes>>>,
+    scan_records: Arc<RwLock<BTreeMap<(ScannableTableId, Vec<u8>, Vec<u8>), Bytes>>>,
 }
 
 impl InMemoryMetaStore {
@@ -63,7 +63,7 @@ impl InMemoryMetaStore {
 }
 
 impl MetaStore for InMemoryMetaStore {
-    async fn get(&self, table: TableId, key: &[u8]) -> Result<Option<Record>> {
+    async fn get(&self, table: TableId, key: &[u8]) -> Result<Option<Bytes>> {
         let guard = self
             .kv_records
             .read()
@@ -76,7 +76,7 @@ impl MetaStore for InMemoryMetaStore {
         table: ScannableTableId,
         partition: &[u8],
         clustering: &[u8],
-    ) -> Result<Option<Record>> {
+    ) -> Result<Option<Bytes>> {
         let guard = self
             .scan_records
             .read()
@@ -86,27 +86,13 @@ impl MetaStore for InMemoryMetaStore {
             .cloned())
     }
 
-    async fn put(&self, table: TableId, key: &[u8], value: Bytes) -> Result<PutResult> {
+    async fn put(&self, table: TableId, key: &[u8], value: Bytes) -> Result<()> {
         let mut guard = self
             .kv_records
             .write()
             .map_err(|_| crate::error::MonadChainDataError::Backend("poisoned lock".to_string()))?;
-
-        let entry_key = (table, key.to_vec());
-        let current = guard.get(&entry_key).cloned();
-        let next_version = current.map_or(1, |record| record.version + 1);
-        guard.insert(
-            entry_key,
-            Record {
-                version: next_version,
-                value,
-            },
-        );
-
-        Ok(PutResult {
-            applied: true,
-            version: Some(next_version),
-        })
+        guard.insert((table, key.to_vec()), value);
+        Ok(())
     }
 
     async fn scan_put(
@@ -115,27 +101,13 @@ impl MetaStore for InMemoryMetaStore {
         partition: &[u8],
         clustering: &[u8],
         value: Bytes,
-    ) -> Result<PutResult> {
+    ) -> Result<()> {
         let mut guard = self
             .scan_records
             .write()
             .map_err(|_| crate::error::MonadChainDataError::Backend("poisoned lock".to_string()))?;
-
-        let entry_key = (table, partition.to_vec(), clustering.to_vec());
-        let current = guard.get(&entry_key).cloned();
-        let next_version = current.map_or(1, |record| record.version + 1);
-        guard.insert(
-            entry_key,
-            Record {
-                version: next_version,
-                value,
-            },
-        );
-
-        Ok(PutResult {
-            applied: true,
-            version: Some(next_version),
-        })
+        guard.insert((table, partition.to_vec(), clustering.to_vec()), value);
+        Ok(())
     }
 
     async fn scan_list(

--- a/monad-chain-data/src/store/meta/in_memory.rs
+++ b/monad-chain-data/src/store/meta/in_memory.rs
@@ -24,7 +24,7 @@ use crate::{
     error::Result,
     store::{
         common::Page,
-        meta::{MetaStore, ScannableTableId, TableId},
+        meta::{CasOutcome, CasVersion, MetaStore, MetaStoreCas, ScannableTableId, TableId},
     },
 };
 
@@ -34,6 +34,7 @@ use crate::{
 pub struct InMemoryMetaStore {
     kv_records: Arc<RwLock<BTreeMap<(TableId, Vec<u8>), Bytes>>>,
     scan_records: Arc<RwLock<BTreeMap<(ScannableTableId, Vec<u8>, Vec<u8>), Bytes>>>,
+    cas_records: Arc<RwLock<BTreeMap<(TableId, Vec<u8>), (u64, Bytes)>>>,
 }
 
 impl InMemoryMetaStore {
@@ -51,12 +52,26 @@ impl InMemoryMetaStore {
                 .read()
                 .map(|guard| guard.len())
                 .unwrap_or_default()
+            + self
+                .cas_records
+                .read()
+                .map(|guard| guard.len())
+                .unwrap_or_default()
     }
 
     /// Test-only: remove a kv row from the fixture to simulate missing data.
     /// Not exposed on the [`MetaStore`] trait — real backends are append-only.
     pub fn clear_key(&self, table: TableId, key: &[u8]) {
         if let Ok(mut guard) = self.kv_records.write() {
+            guard.remove(&(table, key.to_vec()));
+        }
+    }
+
+    /// Test-only: remove a CAS row from the fixture. CAS rows live in a
+    /// physically separate map from plain kv rows, so a [`Self::clear_key`]
+    /// call on the same `(table, key)` does not affect them.
+    pub fn clear_cas_key(&self, table: TableId, key: &[u8]) {
+        if let Ok(mut guard) = self.cas_records.write() {
             guard.remove(&(table, key.to_vec()));
         }
     }
@@ -146,5 +161,42 @@ impl MetaStore for InMemoryMetaStore {
         }
 
         Ok(Page { keys, next_cursor })
+    }
+}
+
+impl MetaStoreCas for InMemoryMetaStore {
+    async fn cas_get(&self, table: TableId, key: &[u8]) -> Result<Option<(CasVersion, Bytes)>> {
+        let guard = self
+            .cas_records
+            .read()
+            .map_err(|_| crate::error::MonadChainDataError::Backend("poisoned lock".to_string()))?;
+        Ok(guard
+            .get(&(table, key.to_vec()))
+            .map(|(version, value)| (CasVersion(*version), value.clone())))
+    }
+
+    async fn cas_put(
+        &self,
+        table: TableId,
+        key: &[u8],
+        expected: Option<CasVersion>,
+        value: Bytes,
+    ) -> Result<CasOutcome> {
+        let mut guard = self
+            .cas_records
+            .write()
+            .map_err(|_| crate::error::MonadChainDataError::Backend("poisoned lock".to_string()))?;
+        let entry_key = (table, key.to_vec());
+        let current = guard.get(&entry_key).map(|(v, _)| CasVersion(*v));
+        if current != expected {
+            return Ok(CasOutcome::Conflict {
+                current_version: current,
+            });
+        }
+        let new_version = current.map_or(1, |v| v.0 + 1);
+        guard.insert(entry_key, (new_version, value));
+        Ok(CasOutcome::Applied {
+            new_version: CasVersion(new_version),
+        })
     }
 }

--- a/monad-chain-data/src/store/meta/mod.rs
+++ b/monad-chain-data/src/store/meta/mod.rs
@@ -133,6 +133,26 @@ impl<M: MetaStore> ScannableKvTable<M> {
     }
 }
 
+/// Monotonic per-row version assigned by [`MetaStoreCas::cas_put`]. Opaque
+/// to callers — only equality with a previously observed value matters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CasVersion(pub u64);
+
+/// Result of a [`MetaStoreCas::cas_put`] attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CasOutcome {
+    Applied {
+        new_version: CasVersion,
+    },
+    /// `expected` did not match the row's current version. `current_version`
+    /// is `None` when the row does not exist but `expected` was `Some(_)`,
+    /// or some version when the row exists but `expected` was `None` or a
+    /// different version.
+    Conflict {
+        current_version: Option<CasVersion>,
+    },
+}
+
 /// Plain key-value and scannable metadata storage.
 ///
 /// All writes are idempotent and content-deterministic at the chain-data
@@ -186,4 +206,36 @@ pub trait MetaStore: Clone + Send + Sync {
         cursor: Option<Vec<u8>>,
         limit: usize,
     ) -> Result<Page>;
+}
+
+/// Versioned compare-and-set storage, used for fencing across writer
+/// failovers. Logically distinct from [`MetaStore`]: a row addressed via
+/// CAS is *not* the same row as one written through `put`, even if the
+/// `(table, key)` tuple is identical.
+///
+/// Local backends (in-memory, single-process Fjall) implement this with a
+/// process-local critical section. A future Scylla backend would map it
+/// to LWT. Either way, the publication head is the only chain-data row
+/// that uses this surface today; everything else is plain idempotent
+/// writes through [`MetaStore`].
+#[allow(async_fn_in_trait)]
+#[auto_impl::auto_impl(Arc)]
+pub trait MetaStoreCas: MetaStore {
+    /// Reads the current row, returning its version alongside the value.
+    async fn cas_get(&self, table: TableId, key: &[u8]) -> Result<Option<(CasVersion, Bytes)>>;
+
+    /// Conditionally writes the row.
+    ///
+    /// `expected = None` requires the row to be absent (insert-if-absent).
+    /// `expected = Some(v)` requires the row's current version to equal `v`.
+    /// On success the row is overwritten and a new monotonic version is
+    /// returned. On mismatch the row is unchanged and the caller learns
+    /// the current version (if any).
+    async fn cas_put(
+        &self,
+        table: TableId,
+        key: &[u8],
+        expected: Option<CasVersion>,
+        value: Bytes,
+    ) -> Result<CasOutcome>;
 }

--- a/monad-chain-data/src/store/meta/mod.rs
+++ b/monad-chain-data/src/store/meta/mod.rs
@@ -57,18 +57,6 @@ impl ScannableTableId {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct Record {
-    pub version: u64,
-    pub value: Bytes,
-}
-
-#[derive(Debug, Clone)]
-pub struct PutResult {
-    pub applied: bool,
-    pub version: Option<u64>,
-}
-
 #[derive(Debug)]
 pub struct KvTable<M> {
     store: M,
@@ -91,11 +79,11 @@ impl<M: Clone> Clone for KvTable<M> {
 }
 
 impl<M: MetaStore> KvTable<M> {
-    pub async fn get(&self, key: &[u8]) -> Result<Option<Record>> {
+    pub async fn get(&self, key: &[u8]) -> Result<Option<Bytes>> {
         self.store.get(self.table, key).await
     }
 
-    pub async fn put(&self, key: &[u8], value: Bytes) -> Result<PutResult> {
+    pub async fn put(&self, key: &[u8], value: Bytes) -> Result<()> {
         self.store.put(self.table, key, value).await
     }
 }
@@ -122,16 +110,11 @@ impl<M: Clone> Clone for ScannableKvTable<M> {
 }
 
 impl<M: MetaStore> ScannableKvTable<M> {
-    pub async fn get(&self, partition: &[u8], clustering: &[u8]) -> Result<Option<Record>> {
+    pub async fn get(&self, partition: &[u8], clustering: &[u8]) -> Result<Option<Bytes>> {
         self.store.scan_get(self.table, partition, clustering).await
     }
 
-    pub async fn put(
-        &self,
-        partition: &[u8],
-        clustering: &[u8],
-        value: Bytes,
-    ) -> Result<PutResult> {
+    pub async fn put(&self, partition: &[u8], clustering: &[u8], value: Bytes) -> Result<()> {
         self.store
             .scan_put(self.table, partition, clustering, value)
             .await
@@ -150,7 +133,13 @@ impl<M: MetaStore> ScannableKvTable<M> {
     }
 }
 
-/// Versioned key-value and scannable metadata storage.
+/// Plain key-value and scannable metadata storage.
+///
+/// All writes are idempotent and content-deterministic at the chain-data
+/// layer (keys are derived from finalized block identity, values are
+/// the encoded artifacts), so the trait surface intentionally has no
+/// versioning or compare-and-set semantics. Fencing for the publication
+/// boundary lives on the separate [`MetaStoreCas`] trait.
 ///
 /// Implementations must be cheaply cloneable (e.g. via internal `Arc`).
 #[allow(async_fn_in_trait)]
@@ -172,22 +161,22 @@ pub trait MetaStore: Clone + Send + Sync {
         ScannableKvTable::new(self.clone(), table)
     }
 
-    async fn get(&self, table: TableId, key: &[u8]) -> Result<Option<Record>>;
+    async fn get(&self, table: TableId, key: &[u8]) -> Result<Option<Bytes>>;
     async fn scan_get(
         &self,
         table: ScannableTableId,
         partition: &[u8],
         clustering: &[u8],
-    ) -> Result<Option<Record>>;
+    ) -> Result<Option<Bytes>>;
 
-    async fn put(&self, table: TableId, key: &[u8], value: Bytes) -> Result<PutResult>;
+    async fn put(&self, table: TableId, key: &[u8], value: Bytes) -> Result<()>;
     async fn scan_put(
         &self,
         table: ScannableTableId,
         partition: &[u8],
         clustering: &[u8],
         value: Bytes,
-    ) -> Result<PutResult>;
+    ) -> Result<()>;
 
     async fn scan_list(
         &self,

--- a/monad-chain-data/src/store/mod.rs
+++ b/monad-chain-data/src/store/mod.rs
@@ -20,5 +20,6 @@ pub mod meta;
 pub use blob::{BlobStore, BlobTable, BlobTableId, InMemoryBlobStore};
 pub use common::Page;
 pub use meta::{
-    InMemoryMetaStore, KvTable, MetaStore, ScannableKvTable, ScannableTableId, TableId,
+    CasOutcome, CasVersion, InMemoryMetaStore, KvTable, MetaStore, MetaStoreCas, ScannableKvTable,
+    ScannableTableId, TableId,
 };

--- a/monad-chain-data/src/store/mod.rs
+++ b/monad-chain-data/src/store/mod.rs
@@ -20,6 +20,5 @@ pub mod meta;
 pub use blob::{BlobStore, BlobTable, BlobTableId, InMemoryBlobStore};
 pub use common::Page;
 pub use meta::{
-    InMemoryMetaStore, KvTable, MetaStore, PutResult, Record, ScannableKvTable, ScannableTableId,
-    TableId,
+    InMemoryMetaStore, KvTable, MetaStore, ScannableKvTable, ScannableTableId, TableId,
 };

--- a/monad-chain-data/src/txs/hash_index.rs
+++ b/monad-chain-data/src/txs/hash_index.rs
@@ -36,10 +36,10 @@ impl<M: MetaStore> TxHashIndexTable<M> {
     }
 
     pub(crate) async fn get(&self, tx_hash: &Hash32) -> Result<Option<TxLocation>> {
-        let Some(record) = self.table.get(tx_hash.as_slice()).await? else {
+        let Some(bytes) = self.table.get(tx_hash.as_slice()).await? else {
             return Ok(None);
         };
-        TxLocation::decode(record.value.as_ref()).map(Some)
+        TxLocation::decode(bytes.as_ref()).map(Some)
     }
 
     pub(crate) async fn put(&self, tx_hash: &Hash32, location: TxLocation) -> Result<()> {

--- a/monad-chain-data/tests/get_transaction.rs
+++ b/monad-chain-data/tests/get_transaction.rs
@@ -231,7 +231,7 @@ async fn get_transaction_ignores_index_hits_without_published_head() {
         .await
         .expect("ingest");
 
-    meta_store.clear_key(
+    meta_store.clear_cas_key(
         PublicationTables::<InMemoryMetaStore>::PUBLICATION_STATE_TABLE,
         PublicationTables::<InMemoryMetaStore>::PUBLICATION_STATE_KEY,
     );

--- a/monad-chain-data/tests/publication_fencing.rs
+++ b/monad-chain-data/tests/publication_fencing.rs
@@ -1,0 +1,151 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use monad_chain_data::{
+    primitives::state::PublicationState, store::CasVersion, FinalizedBlock, InMemoryBlobStore,
+    InMemoryMetaStore, MonadChainDataError, MonadChainDataService, QueryLimits, B256,
+};
+
+mod common;
+
+use common::{minimal_ingest_tx, test_header};
+
+#[tokio::test(flavor = "current_thread")]
+async fn cas_advance_with_stale_version_returns_fenced_out() {
+    let meta_store = InMemoryMetaStore::default();
+    let service = MonadChainDataService::new(
+        meta_store.clone(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    service
+        .ingest_block(FinalizedBlock {
+            header: test_header(1, B256::ZERO),
+            logs_by_tx: vec![vec![]],
+            txs: vec![minimal_ingest_tx()],
+        })
+        .await
+        .expect("first ingest succeeds");
+
+    // Simulate a fenced-out writer: it captured `expected = None` before any
+    // publish, then tries to advance after another writer already advanced
+    // the head to version 1.
+    let outcome = service
+        .publication()
+        .cas_advance(
+            None,
+            PublicationState {
+                indexed_finalized_head: 1,
+            },
+        )
+        .await;
+
+    match outcome {
+        Err(MonadChainDataError::FencedOut { current_head }) => {
+            assert_eq!(current_head, Some(1));
+        }
+        other => panic!("expected FencedOut, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn cas_advance_with_wrong_expected_version_returns_fenced_out() {
+    let meta_store = InMemoryMetaStore::default();
+    let service = MonadChainDataService::new(
+        meta_store.clone(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    service
+        .ingest_block(FinalizedBlock {
+            header: test_header(1, B256::ZERO),
+            logs_by_tx: vec![vec![]],
+            txs: vec![minimal_ingest_tx()],
+        })
+        .await
+        .expect("first ingest succeeds");
+
+    // A failover writer that observed an even older state and is now stepping
+    // on the active writer. Wrong version, should fail.
+    let outcome = service
+        .publication()
+        .cas_advance(
+            Some(CasVersion(99)),
+            PublicationState {
+                indexed_finalized_head: 1,
+            },
+        )
+        .await;
+
+    assert!(matches!(
+        outcome,
+        Err(MonadChainDataError::FencedOut {
+            current_head: Some(1)
+        })
+    ));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn second_writer_capturing_stale_state_is_fenced_at_publish() {
+    // Two services over the same store. The "stale" writer captures the
+    // current state, then a second writer races ahead and advances the head.
+    // When the stale writer tries to publish its own block, CAS fails.
+    let meta_store = InMemoryMetaStore::default();
+    let stale_writer = MonadChainDataService::new(
+        meta_store.clone(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+    let active_writer = MonadChainDataService::new(
+        meta_store.clone(),
+        InMemoryBlobStore::default(),
+        QueryLimits::UNLIMITED,
+    );
+
+    // Stale writer reads the empty initial state (expected_version = None).
+    let stale_state = stale_writer.publication().load_state().await.expect("load");
+    assert!(stale_state.is_none());
+
+    // Active writer publishes block 1 first.
+    active_writer
+        .ingest_block(FinalizedBlock {
+            header: test_header(1, B256::ZERO),
+            logs_by_tx: vec![vec![]],
+            txs: vec![minimal_ingest_tx()],
+        })
+        .await
+        .expect("active writer publishes block 1");
+
+    // Stale writer now tries to publish using its stale (None) expected
+    // version. Should be fenced out.
+    let outcome = stale_writer
+        .publication()
+        .cas_advance(
+            None,
+            PublicationState {
+                indexed_finalized_head: 1,
+            },
+        )
+        .await;
+
+    assert!(matches!(
+        outcome,
+        Err(MonadChainDataError::FencedOut {
+            current_head: Some(1)
+        })
+    ));
+}


### PR DESCRIPTION
Removes the unused versioned PutResult and Record wrappers from ordinary MetaStore reads and writes, leaving content-addressed artifact writes as plain idempotent put/get operations. A separate MetaStoreCas trait is introduced specifically for the publication head boundary.

Publication state moves onto MonadChainDataService and uses CAS rows that are distinct from normal kv rows. A stale publication advance now returns FencedOut, with tests covering stale-none, wrong-version, and a two-writer race.