### PR TITLE
Add fjall-backed local chain-data store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,6 +2246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2272,6 +2278,12 @@ checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
 dependencies = [
  "bytes",
 ]
+
+[[package]]
+name = "byteview"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c53ba0f290bfc610084c05582d9c5d421662128fc69f4bf236707af6fd321b9"
 
 [[package]]
 name = "c-kzg"
@@ -2454,6 +2466,12 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "compare"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
 
 [[package]]
 name = "concurrent-queue"
@@ -2730,6 +2748,16 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -3402,6 +3430,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "fjall"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62b25b4d815ae178d7d9e4aa32ee59f072efd5431c736abede1e6ee13c8c453"
+dependencies = [
+ "byteorder-lite",
+ "byteview",
+ "dashmap",
+ "flume 0.12.0",
+ "log",
+ "lsm-tree",
+ "lz4_flex",
+ "tempfile",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3420,6 +3465,15 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
+ "spin 0.9.8",
+]
+
+[[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
  "spin 0.9.8",
 ]
 
@@ -4305,6 +4359,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "interval-heap"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11274e5e8e89b8607cfedc2910b6626e998779b48a019151c7604d0adcb86ac6"
+dependencies = [
+ "compare",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4572,6 +4635,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "lsm-tree"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e447ac67ff6aef4ec07fc19e507b219336cbba90a697c0dbeb1bf51b91536b67"
+dependencies = [
+ "byteorder-lite",
+ "byteview",
+ "crossbeam-skiplist",
+ "enum_dispatch",
+ "interval-heap",
+ "log",
+ "lz4_flex",
+ "quick_cache",
+ "rustc-hash",
+ "self_cell",
+ "sfa",
+ "tempfile",
+ "varint-rs",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "lz4"
 version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4588,6 +4673,15 @@ checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]
@@ -4908,7 +5002,9 @@ dependencies = [
  "alloy-rpc-types-eth",
  "auto_impl",
  "bytes",
+ "fjall",
  "roaring",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -5863,7 +5959,7 @@ dependencies = [
  "criterion",
  "dashmap",
  "flate2",
- "flume",
+ "flume 0.11.1",
  "futures",
  "futures-util",
  "hex",
@@ -6422,7 +6518,7 @@ source = "git+https://github.com/category-labs/monoio.git?tag=0.2.4-category#de9
 dependencies = [
  "auto-const-array",
  "bytes",
- "flume",
+ "flume 0.11.1",
  "fxhash",
  "io-uring",
  "libc",
@@ -7379,6 +7475,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick_cache"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a70b1b8b47e31d0498ecbc3c5470bb931399a8bfed1fd79d1717a61ce7f96e3"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "quickcheck"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8199,6 +8305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
 name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8372,6 +8484,17 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct 0.2.0",
  "serde",
+]
+
+[[package]]
+name = "sfa"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1296838937cab56cd6c4eeeb8718ec777383700c33f060e2869867bd01d1175"
+dependencies = [
+ "byteorder-lite",
+ "log",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -9389,6 +9512,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "typed-builder"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9549,6 +9678,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "varint-rs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f54a172d0620933a27a4360d3db3e2ae0dd6cceae9730751a036bbf182c4b23"
 
 [[package]]
 name = "vcpkg"
@@ -10228,6 +10363,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"

--- a/monad-chain-data/Cargo.toml
+++ b/monad-chain-data/Cargo.toml
@@ -16,8 +16,10 @@ alloy-rlp = { workspace = true, features = ["derive"] }
 alloy-rpc-types-eth = { workspace = true, optional = true }
 auto_impl = { workspace = true }
 bytes = { workspace = true }
+fjall = { version = "3.1", optional = true }
 roaring = "0.11"
 thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt"], optional = true }
 
 [features]
 default = []
@@ -25,6 +27,10 @@ default = []
 # `alloy_rpc_types_eth::Transaction`. Off by default so the crate stays
 # narrow; the consensus envelope is always accessible via `TxEntry::envelope`.
 alloy-rpc-types-eth = ["dep:alloy-rpc-types-eth"]
+# Enables the embedded fjall backend (FjallStore). Pulls in tokio because
+# fjall is sync and the trait impls wrap blocking work in spawn_blocking.
+fjall = ["dep:fjall", "dep:tokio"]
 
 [dev-dependencies]
+tempfile = "3"
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/monad-chain-data/src/store/blob/mod.rs
+++ b/monad-chain-data/src/store/blob/mod.rs
@@ -108,9 +108,17 @@ pub trait BlobStore: Clone + Send + Sync {
         let Some(blob) = self.get_blob(table, key).await? else {
             return Ok(None);
         };
-        if start > end_exclusive || start > blob.len() {
-            return Err(MonadChainDataError::Decode("invalid blob range"));
-        }
-        Ok(Some(blob.slice(start..end_exclusive.min(blob.len()))))
+        copy_blob_range(&blob, start, end_exclusive).map(Some)
     }
+}
+
+// Copying rather than slicing keeps a small range from pinning the full
+// blob allocation.
+pub(crate) fn copy_blob_range(blob: &[u8], start: usize, end_exclusive: usize) -> Result<Bytes> {
+    if start > end_exclusive || start > blob.len() {
+        return Err(MonadChainDataError::Decode("invalid blob range"));
+    }
+    Ok(Bytes::copy_from_slice(
+        &blob[start..end_exclusive.min(blob.len())],
+    ))
 }

--- a/monad-chain-data/src/store/fjall/mod.rs
+++ b/monad-chain-data/src/store/fjall/mod.rs
@@ -13,17 +13,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pub mod blob;
-pub mod common;
-#[cfg(feature = "fjall")]
-pub mod fjall;
-pub mod meta;
+mod store;
 
-pub use blob::{BlobStore, BlobTable, BlobTableId, InMemoryBlobStore};
-pub use common::Page;
-#[cfg(feature = "fjall")]
-pub use fjall::FjallStore;
-pub use meta::{
-    CasOutcome, CasVersion, InMemoryMetaStore, KvTable, MetaStore, MetaStoreCas, ScannableKvTable,
-    ScannableTableId, TableId,
-};
+pub use store::FjallStore;

--- a/monad-chain-data/src/store/fjall/store.rs
+++ b/monad-chain-data/src/store/fjall/store.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use fjall::{Config, Database, Keyspace, KeyspaceCreateOptions};
+use fjall::{Config, Database, Keyspace, KeyspaceCreateOptions, KvSeparationOptions};
 
 use crate::{
     error::{MonadChainDataError, Result},
@@ -43,6 +43,16 @@ const BLOB_PREFIX: &str = "blob:";
 /// and [`BlobStore`]. Single-process only: CAS rows are protected by a
 /// process-local mutex around their read-modify-write critical section,
 /// not by the storage engine itself.
+///
+/// Blob keyspaces are opened with key-value separation enabled, so the
+/// LSM holds only `(key → blob_file_id, offset, length)` pointers and
+/// the actual bytes live in append-only blob files. Chain-data blobs
+/// are written once and never deleted, so blob-file GC effectively never
+/// fires; we just append. Sized for ~280M+ objects in the 10s of KB to
+/// 16 MiB range. Operators that want to colocate the meta store and
+/// blob store on different disks should construct two `FjallStore`s
+/// pointed at different paths and pass them as the meta and blob
+/// arguments.
 pub struct FjallStore {
     inner: Arc<Inner>,
 }
@@ -77,10 +87,22 @@ impl FjallStore {
         if let Some(ks) = guard.get(name) {
             return Ok(ks.clone());
         }
+        let is_blob = name.starts_with(BLOB_PREFIX);
         let ks = self
             .inner
             .db
-            .keyspace(name, KeyspaceCreateOptions::default)
+            .keyspace(name, || {
+                let opts = KeyspaceCreateOptions::default();
+                if is_blob {
+                    // KV separation: defaults are 1 KiB separation threshold,
+                    // 64 MiB blob files, LZ4. Suits 10s of KB - 16 MiB blobs;
+                    // staleness/age GC thresholds never fire under our
+                    // append-only workload.
+                    opts.with_kv_separation(Some(KvSeparationOptions::default()))
+                } else {
+                    opts
+                }
+            })
             .map_err(|e| MonadChainDataError::Backend(format!("fjall keyspace {name}: {e}")))?;
         guard.insert(name.to_string(), ks.clone());
         Ok(ks)

--- a/monad-chain-data/src/store/fjall/store.rs
+++ b/monad-chain-data/src/store/fjall/store.rs
@@ -1,0 +1,349 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    collections::HashMap,
+    path::Path,
+    sync::{Arc, Mutex},
+};
+
+use bytes::Bytes;
+use fjall::{Config, Database, Keyspace, KeyspaceCreateOptions};
+
+use crate::{
+    error::{MonadChainDataError, Result},
+    store::{
+        blob::{BlobStore, BlobTableId},
+        common::Page,
+        meta::{CasOutcome, CasVersion, MetaStore, MetaStoreCas, ScannableTableId, TableId},
+    },
+};
+
+// Logical-table namespacing on top of fjall keyspaces. Each logical table
+// gets its own physical fjall keyspace, prefixed by the kind so the four
+// trait surfaces never share storage even if their logical names collide.
+const KV_PREFIX: &str = "kv:";
+const SCAN_PREFIX: &str = "scan:";
+const CAS_PREFIX: &str = "cas:";
+const BLOB_PREFIX: &str = "blob:";
+
+/// Embedded fjall-backed implementation of [`MetaStore`], [`MetaStoreCas`],
+/// and [`BlobStore`]. Single-process only: CAS rows are protected by a
+/// process-local mutex around their read-modify-write critical section,
+/// not by the storage engine itself.
+pub struct FjallStore {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    db: Database,
+    keyspaces: Mutex<HashMap<String, Keyspace>>,
+    // Held only inside `spawn_blocking`, never across an await. The
+    // publication-state row is the only chain-data row touching the CAS
+    // surface today, so contention is bounded to a single hot key.
+    cas_lock: Mutex<()>,
+}
+
+impl FjallStore {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let db = Database::create_or_recover(Config::new(path.as_ref()))
+            .map_err(|e| MonadChainDataError::Backend(format!("fjall open: {e}")))?;
+        Ok(Self {
+            inner: Arc::new(Inner {
+                db,
+                keyspaces: Mutex::new(HashMap::new()),
+                cas_lock: Mutex::new(()),
+            }),
+        })
+    }
+
+    fn keyspace(&self, name: &str) -> Result<Keyspace> {
+        let mut guard =
+            self.inner.keyspaces.lock().map_err(|_| {
+                MonadChainDataError::Backend("fjall keyspace cache poisoned".into())
+            })?;
+        if let Some(ks) = guard.get(name) {
+            return Ok(ks.clone());
+        }
+        let ks = self
+            .inner
+            .db
+            .keyspace(name, KeyspaceCreateOptions::default)
+            .map_err(|e| MonadChainDataError::Backend(format!("fjall keyspace {name}: {e}")))?;
+        guard.insert(name.to_string(), ks.clone());
+        Ok(ks)
+    }
+}
+
+impl Clone for FjallStore {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+async fn blocking<F, R>(f: F) -> Result<R>
+where
+    F: FnOnce() -> Result<R> + Send + 'static,
+    R: Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| MonadChainDataError::Backend(format!("fjall spawn_blocking join: {e}")))?
+}
+
+// `2 BE bytes len(partition) | partition | clustering`. Length-prefixing
+// keeps clustering decoding unambiguous and lets us derive a fjall prefix
+// from `(partition, scan_prefix)` directly.
+fn scan_key(partition: &[u8], clustering: &[u8]) -> Vec<u8> {
+    let len = u16::try_from(partition.len()).expect("scan partition length fits in u16");
+    let mut key = Vec::with_capacity(2 + partition.len() + clustering.len());
+    key.extend_from_slice(&len.to_be_bytes());
+    key.extend_from_slice(partition);
+    key.extend_from_slice(clustering);
+    key
+}
+
+fn encode_cas_row(version: u64, value: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(8 + value.len());
+    out.extend_from_slice(&version.to_be_bytes());
+    out.extend_from_slice(value);
+    out
+}
+
+fn decode_cas_row(bytes: &[u8]) -> Result<(u64, Bytes)> {
+    if bytes.len() < 8 {
+        return Err(MonadChainDataError::Decode(
+            "cas row missing version prefix",
+        ));
+    }
+    let mut version_bytes = [0u8; 8];
+    version_bytes.copy_from_slice(&bytes[..8]);
+    Ok((
+        u64::from_be_bytes(version_bytes),
+        Bytes::copy_from_slice(&bytes[8..]),
+    ))
+}
+
+impl MetaStore for FjallStore {
+    async fn get(&self, table: TableId, key: &[u8]) -> Result<Option<Bytes>> {
+        let store = self.clone();
+        let key = key.to_vec();
+        let name = format!("{KV_PREFIX}{}", table.as_str());
+        blocking(move || {
+            let ks = store.keyspace(&name)?;
+            let value = ks
+                .get(&key)
+                .map_err(|e| MonadChainDataError::Backend(format!("fjall get: {e}")))?;
+            Ok(value.map(|v| Bytes::copy_from_slice(&v)))
+        })
+        .await
+    }
+
+    async fn scan_get(
+        &self,
+        table: ScannableTableId,
+        partition: &[u8],
+        clustering: &[u8],
+    ) -> Result<Option<Bytes>> {
+        let store = self.clone();
+        let composite = scan_key(partition, clustering);
+        let name = format!("{SCAN_PREFIX}{}", table.as_str());
+        blocking(move || {
+            let ks = store.keyspace(&name)?;
+            let value = ks
+                .get(&composite)
+                .map_err(|e| MonadChainDataError::Backend(format!("fjall scan_get: {e}")))?;
+            Ok(value.map(|v| Bytes::copy_from_slice(&v)))
+        })
+        .await
+    }
+
+    async fn put(&self, table: TableId, key: &[u8], value: Bytes) -> Result<()> {
+        let store = self.clone();
+        let key = key.to_vec();
+        let name = format!("{KV_PREFIX}{}", table.as_str());
+        let value = value.to_vec();
+        blocking(move || {
+            let ks = store.keyspace(&name)?;
+            ks.insert(&key, value)
+                .map_err(|e| MonadChainDataError::Backend(format!("fjall put: {e}")))?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn scan_put(
+        &self,
+        table: ScannableTableId,
+        partition: &[u8],
+        clustering: &[u8],
+        value: Bytes,
+    ) -> Result<()> {
+        let store = self.clone();
+        let composite = scan_key(partition, clustering);
+        let name = format!("{SCAN_PREFIX}{}", table.as_str());
+        let value = value.to_vec();
+        blocking(move || {
+            let ks = store.keyspace(&name)?;
+            ks.insert(&composite, value)
+                .map_err(|e| MonadChainDataError::Backend(format!("fjall scan_put: {e}")))?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn scan_list(
+        &self,
+        table: ScannableTableId,
+        partition: &[u8],
+        prefix: &[u8],
+        cursor: Option<Vec<u8>>,
+        limit: usize,
+    ) -> Result<Page> {
+        let store = self.clone();
+        let partition = partition.to_vec();
+        let prefix = prefix.to_vec();
+        let name = format!("{SCAN_PREFIX}{}", table.as_str());
+        blocking(move || {
+            let ks = store.keyspace(&name)?;
+            let search = scan_key(&partition, &prefix);
+            // Skip past `len(2) + partition` to get the clustering portion.
+            let header_len = 2 + partition.len();
+            let mut keys: Vec<Vec<u8>> = Vec::new();
+            let mut next_cursor: Option<Vec<u8>> = None;
+
+            for guard in ks.prefix(&search) {
+                let user_key = guard
+                    .key()
+                    .map_err(|e| MonadChainDataError::Backend(format!("fjall scan_list: {e}")))?;
+                let key_bytes: &[u8] = user_key.as_ref();
+                if key_bytes.len() < header_len {
+                    return Err(MonadChainDataError::Decode(
+                        "scan row missing partition prefix",
+                    ));
+                }
+                let clustering = &key_bytes[header_len..];
+
+                if let Some(ref cursor_bytes) = cursor {
+                    if clustering <= cursor_bytes.as_slice() {
+                        continue;
+                    }
+                }
+                if keys.len() == limit {
+                    next_cursor = keys.last().cloned();
+                    break;
+                }
+                keys.push(clustering.to_vec());
+            }
+
+            Ok(Page { keys, next_cursor })
+        })
+        .await
+    }
+}
+
+impl MetaStoreCas for FjallStore {
+    async fn cas_get(&self, table: TableId, key: &[u8]) -> Result<Option<(CasVersion, Bytes)>> {
+        let store = self.clone();
+        let key = key.to_vec();
+        let name = format!("{CAS_PREFIX}{}", table.as_str());
+        blocking(move || {
+            let ks = store.keyspace(&name)?;
+            let raw = ks
+                .get(&key)
+                .map_err(|e| MonadChainDataError::Backend(format!("fjall cas_get: {e}")))?;
+            let Some(raw) = raw else {
+                return Ok(None);
+            };
+            let (version, value) = decode_cas_row(raw.as_ref())?;
+            Ok(Some((CasVersion(version), value)))
+        })
+        .await
+    }
+
+    async fn cas_put(
+        &self,
+        table: TableId,
+        key: &[u8],
+        expected: Option<CasVersion>,
+        value: Bytes,
+    ) -> Result<CasOutcome> {
+        let store = self.clone();
+        let key = key.to_vec();
+        let name = format!("{CAS_PREFIX}{}", table.as_str());
+        let value = value.to_vec();
+        blocking(move || {
+            let ks = store.keyspace(&name)?;
+            let _guard = store
+                .inner
+                .cas_lock
+                .lock()
+                .map_err(|_| MonadChainDataError::Backend("fjall cas lock poisoned".into()))?;
+
+            let raw = ks
+                .get(&key)
+                .map_err(|e| MonadChainDataError::Backend(format!("fjall cas_put read: {e}")))?;
+            let current_version = match raw {
+                None => None,
+                Some(raw) => {
+                    let (version, _) = decode_cas_row(raw.as_ref())?;
+                    Some(CasVersion(version))
+                }
+            };
+            if current_version != expected {
+                return Ok(CasOutcome::Conflict { current_version });
+            }
+            let new_version = current_version.map_or(1, |v| v.0 + 1);
+            ks.insert(&key, encode_cas_row(new_version, &value))
+                .map_err(|e| MonadChainDataError::Backend(format!("fjall cas_put write: {e}")))?;
+            Ok(CasOutcome::Applied {
+                new_version: CasVersion(new_version),
+            })
+        })
+        .await
+    }
+}
+
+impl BlobStore for FjallStore {
+    async fn put_blob(&self, table: BlobTableId, key: &[u8], value: Bytes) -> Result<()> {
+        let store = self.clone();
+        let key = key.to_vec();
+        let name = format!("{BLOB_PREFIX}{}", table.as_str());
+        let value = value.to_vec();
+        blocking(move || {
+            let ks = store.keyspace(&name)?;
+            ks.insert(&key, value)
+                .map_err(|e| MonadChainDataError::Backend(format!("fjall put_blob: {e}")))?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn get_blob(&self, table: BlobTableId, key: &[u8]) -> Result<Option<Bytes>> {
+        let store = self.clone();
+        let key = key.to_vec();
+        let name = format!("{BLOB_PREFIX}{}", table.as_str());
+        blocking(move || {
+            let ks = store.keyspace(&name)?;
+            let value = ks
+                .get(&key)
+                .map_err(|e| MonadChainDataError::Backend(format!("fjall get_blob: {e}")))?;
+            Ok(value.map(|v| Bytes::copy_from_slice(&v)))
+        })
+        .await
+    }
+}

--- a/monad-chain-data/src/store/fjall/store.rs
+++ b/monad-chain-data/src/store/fjall/store.rs
@@ -25,7 +25,7 @@ use fjall::{Config, Database, Keyspace, KeyspaceCreateOptions, KvSeparationOptio
 use crate::{
     error::{MonadChainDataError, Result},
     store::{
-        blob::{BlobStore, BlobTableId},
+        blob::{copy_blob_range, BlobStore, BlobTableId},
         common::Page,
         meta::{CasOutcome, CasVersion, MetaStore, MetaStoreCas, ScannableTableId, TableId},
     },
@@ -365,6 +365,30 @@ impl BlobStore for FjallStore {
                 .get(&key)
                 .map_err(|e| MonadChainDataError::Backend(format!("fjall get_blob: {e}")))?;
             Ok(value.map(|v| Bytes::copy_from_slice(&v)))
+        })
+        .await
+    }
+
+    // fjall has no positioned sub-value reads; this avoids the per-record
+    // full-blob copy, not the underlying I/O on a cache miss.
+    async fn read_range(
+        &self,
+        table: BlobTableId,
+        key: &[u8],
+        start: usize,
+        end_exclusive: usize,
+    ) -> Result<Option<Bytes>> {
+        let store = self.clone();
+        let key = key.to_vec();
+        let name = format!("{BLOB_PREFIX}{}", table.as_str());
+        blocking(move || {
+            let ks = store.keyspace(&name)?;
+            let value = ks
+                .get(&key)
+                .map_err(|e| MonadChainDataError::Backend(format!("fjall read_range: {e}")))?;
+            value
+                .map(|v| copy_blob_range(&v, start, end_exclusive))
+                .transpose()
         })
         .await
     }

--- a/monad-chain-data/tests/fjall_smoke.rs
+++ b/monad-chain-data/tests/fjall_smoke.rs
@@ -1,0 +1,133 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg(feature = "fjall")]
+
+use monad_chain_data::{
+    primitives::state::PublicationState, store::FjallStore, Family, FinalizedBlock,
+    MonadChainDataError, MonadChainDataService, QueryLimits, B256,
+};
+use tempfile::tempdir;
+
+mod common;
+
+use common::{chain_header, minimal_ingest_tx, test_header};
+
+#[tokio::test(flavor = "current_thread")]
+async fn fjall_round_trip_two_block_ingest() {
+    let dir = tempdir().expect("tempdir");
+    let store = FjallStore::open(dir.path()).expect("open fjall");
+    let service = MonadChainDataService::new(store.clone(), store, QueryLimits::UNLIMITED);
+
+    let h1 = test_header(1, B256::ZERO);
+    let outcome1 = service
+        .ingest_block(FinalizedBlock {
+            header: h1.clone(),
+            logs_by_tx: vec![vec![], vec![]],
+            txs: vec![minimal_ingest_tx(), minimal_ingest_tx()],
+        })
+        .await
+        .expect("ingest block 1");
+    assert_eq!(outcome1.written_txs, 2);
+
+    let h2 = chain_header(2, &h1);
+    let outcome2 = service
+        .ingest_block(FinalizedBlock {
+            header: h2,
+            logs_by_tx: vec![vec![]],
+            txs: vec![minimal_ingest_tx()],
+        })
+        .await
+        .expect("ingest block 2");
+    assert_eq!(outcome2.written_txs, 1);
+    assert_eq!(outcome2.indexed_finalized_head, 2);
+
+    // Round-trip read of the published state.
+    let published_head = service
+        .publication()
+        .load_published_head()
+        .await
+        .expect("load head");
+    assert_eq!(published_head, Some(2));
+
+    // Round-trip read of a per-family block header from the blob path.
+    let tx_family = service.tables().family(Family::Tx);
+    let header_bytes = tx_family
+        .load_block_header(1)
+        .await
+        .expect("load tx header")
+        .expect("present");
+    assert!(!header_bytes.is_empty());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn fjall_persists_across_reopen() {
+    let dir = tempdir().expect("tempdir");
+
+    {
+        let store = FjallStore::open(dir.path()).expect("open fjall");
+        let service = MonadChainDataService::new(store.clone(), store, QueryLimits::UNLIMITED);
+        service
+            .ingest_block(FinalizedBlock {
+                header: test_header(1, B256::ZERO),
+                logs_by_tx: vec![vec![]],
+                txs: vec![minimal_ingest_tx()],
+            })
+            .await
+            .expect("ingest");
+    }
+
+    let store = FjallStore::open(dir.path()).expect("reopen fjall");
+    let service = MonadChainDataService::new(store.clone(), store, QueryLimits::UNLIMITED);
+    let head = service
+        .publication()
+        .load_published_head()
+        .await
+        .expect("load head");
+    assert_eq!(head, Some(1));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn fjall_cas_advance_with_stale_version_returns_fenced_out() {
+    let dir = tempdir().expect("tempdir");
+    let store = FjallStore::open(dir.path()).expect("open fjall");
+    let service = MonadChainDataService::new(store.clone(), store, QueryLimits::UNLIMITED);
+
+    service
+        .ingest_block(FinalizedBlock {
+            header: test_header(1, B256::ZERO),
+            logs_by_tx: vec![vec![]],
+            txs: vec![minimal_ingest_tx()],
+        })
+        .await
+        .expect("first ingest");
+
+    let outcome = service
+        .publication()
+        .cas_advance(
+            None,
+            PublicationState {
+                indexed_finalized_head: 1,
+            },
+        )
+        .await;
+
+    assert!(matches!(
+        outcome,
+        Err(MonadChainDataError::FencedOut {
+            current_head: Some(1)
+        })
+    ));
+}

--- a/monad-chain-data/tests/fjall_smoke.rs
+++ b/monad-chain-data/tests/fjall_smoke.rs
@@ -15,9 +15,11 @@
 
 #![cfg(feature = "fjall")]
 
+use bytes::Bytes;
 use monad_chain_data::{
-    primitives::state::PublicationState, store::FjallStore, Family, FinalizedBlock,
-    MonadChainDataError, MonadChainDataService, QueryLimits, B256,
+    primitives::state::PublicationState,
+    store::{BlobStore, BlobTableId, FjallStore},
+    Family, FinalizedBlock, MonadChainDataError, MonadChainDataService, QueryLimits, B256,
 };
 use tempfile::tempdir;
 
@@ -97,6 +99,28 @@ async fn fjall_persists_across_reopen() {
         .await
         .expect("load head");
     assert_eq!(head, Some(1));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn fjall_blob_roundtrips_value_above_kv_separation_threshold() {
+    // KV separation kicks in at 1 KiB by default; this test puts a 64 KiB
+    // value to exercise the blob-file path, then reads it back.
+    const TEST_TABLE: BlobTableId = BlobTableId::new("kv_sep_smoke");
+
+    let dir = tempdir().expect("tempdir");
+    let store = FjallStore::open(dir.path()).expect("open fjall");
+
+    let payload = Bytes::from(vec![0xAB; 64 * 1024]);
+    store
+        .put_blob(TEST_TABLE, b"big", payload.clone())
+        .await
+        .expect("put");
+    let got = store
+        .get_blob(TEST_TABLE, b"big")
+        .await
+        .expect("get")
+        .expect("present");
+    assert_eq!(got, payload);
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/monad-chain-data/tests/fjall_smoke.rs
+++ b/monad-chain-data/tests/fjall_smoke.rs
@@ -124,6 +124,53 @@ async fn fjall_blob_roundtrips_value_above_kv_separation_threshold() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn fjall_blob_read_range_validates_and_clamps() {
+    const TEST_TABLE: BlobTableId = BlobTableId::new("read_range_smoke");
+
+    let dir = tempdir().expect("tempdir");
+    let store = FjallStore::open(dir.path()).expect("open fjall");
+    let table = store.table(TEST_TABLE);
+
+    let payload: Vec<u8> = (0..64 * 1024).map(|i| (i % 251) as u8).collect();
+    table
+        .put(b"big", Bytes::from(payload.clone()))
+        .await
+        .expect("put");
+
+    let interior = table
+        .read_range(b"big", 100, 132)
+        .await
+        .expect("read interior")
+        .expect("present");
+    assert_eq!(interior, payload[100..132]);
+
+    let clamped = table
+        .read_range(b"big", payload.len() - 16, payload.len() + 1000)
+        .await
+        .expect("read past end clamps")
+        .expect("present");
+    assert_eq!(clamped, payload[payload.len() - 16..]);
+
+    let empty_tail = table
+        .read_range(b"big", payload.len(), payload.len() + 1000)
+        .await
+        .expect("read at exact end clamps to empty")
+        .expect("present");
+    assert!(empty_tail.is_empty());
+
+    let err = table
+        .read_range(b"big", payload.len() + 1, payload.len() + 2)
+        .await;
+    assert!(matches!(err, Err(MonadChainDataError::Decode(_))));
+
+    let missing = table
+        .read_range(b"missing", 0, 8)
+        .await
+        .expect("read missing key");
+    assert!(missing.is_none());
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn fjall_cas_advance_with_stale_version_returns_fenced_out() {
     let dir = tempdir().expect("tempdir");
     let store = FjallStore::open(dir.path()).expect("open fjall");


### PR DESCRIPTION
Adds a feature-gated embedded fjall backend implementing the chain-data meta, scan, CAS, and blob store traits. Each logical table opens as its own keyspace, with prefixed keyspace names separating kv, scan, cas, and blob storage and all sync fjall calls isolated behind spawn_blocking.

The blob path enables fjall KV separation for large append-only chain-data artifacts, keeping the LSM focused on small pointers while blob bytes live in append-only files. Smoke tests cover ingest persistence, reopen behavior, stale CAS fencing, and a large blob round trip through the KV-separated path.