### PR TITLE
Add local archive-to-chain-data ingest binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5005,6 +5005,7 @@ dependencies = [
  "clap",
  "eyre",
  "fjall",
+ "futures",
  "monad-archive",
  "monad-eth-types",
  "roaring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5002,11 +5002,17 @@ dependencies = [
  "alloy-rpc-types-eth",
  "auto_impl",
  "bytes",
+ "clap",
+ "eyre",
  "fjall",
+ "monad-archive",
+ "monad-eth-types",
  "roaring",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/monad-chain-data/Cargo.toml
+++ b/monad-chain-data/Cargo.toml
@@ -19,6 +19,7 @@ bytes = { workspace = true }
 clap = { workspace = true, features = ["derive"], optional = true }
 eyre = { workspace = true, optional = true }
 fjall = { version = "3.1", optional = true }
+futures = { workspace = true, optional = true }
 monad-archive = { workspace = true, optional = true }
 monad-eth-types = { workspace = true, optional = true }
 roaring = "0.11"
@@ -45,6 +46,7 @@ archive-ingest = [
     "fjall",
     "dep:clap",
     "dep:eyre",
+    "dep:futures",
     "dep:monad-archive",
     "dep:monad-eth-types",
     "dep:tokio",

--- a/monad-chain-data/Cargo.toml
+++ b/monad-chain-data/Cargo.toml
@@ -16,10 +16,16 @@ alloy-rlp = { workspace = true, features = ["derive"] }
 alloy-rpc-types-eth = { workspace = true, optional = true }
 auto_impl = { workspace = true }
 bytes = { workspace = true }
+clap = { workspace = true, features = ["derive"], optional = true }
+eyre = { workspace = true, optional = true }
 fjall = { version = "3.1", optional = true }
+monad-archive = { workspace = true, optional = true }
+monad-eth-types = { workspace = true, optional = true }
 roaring = "0.11"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt"], optional = true }
+tracing = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"], optional = true }
 
 [features]
 default = []
@@ -30,6 +36,27 @@ alloy-rpc-types-eth = ["dep:alloy-rpc-types-eth"]
 # Enables the embedded fjall backend (FjallStore). Pulls in tokio because
 # fjall is sync and the trait impls wrap blocking work in spawn_blocking.
 fjall = ["dep:fjall", "dep:tokio"]
+# Enables the chain-data-ingest binary, which reads blocks + receipts from
+# a monad-archive backend (FS, S3, MongoDB, DynamoDB, TrieDB) and feeds
+# them into the chain-data ingest pipeline. Gated because monad-archive
+# pulls in heavy transitive deps (AWS SDK, MongoDB driver, etc.) that
+# don't build on every dev platform.
+archive-ingest = [
+    "fjall",
+    "dep:clap",
+    "dep:eyre",
+    "dep:monad-archive",
+    "dep:monad-eth-types",
+    "dep:tokio",
+    "tokio/rt-multi-thread",
+    "tokio/macros",
+    "dep:tracing",
+    "dep:tracing-subscriber",
+]
+
+[[bin]]
+name = "chain-data-ingest"
+required-features = ["archive-ingest"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/monad-chain-data/src/bin/chain-data-ingest.rs
+++ b/monad-chain-data/src/bin/chain-data-ingest.rs
@@ -1,0 +1,206 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Reads blocks + receipts from any `monad-archive` backend and feeds them
+//! into the chain-data ingest pipeline. Source selection (FS, S3, MongoDB,
+//! DynamoDB, TrieDB) reuses `monad_archive::cli::BlockDataReaderArgs` so
+//! the same `--block-data-source "fs /path"` / `"aws bucket"` / etc.
+//! syntax works as in the other archive bins.
+
+use std::{path::PathBuf, time::Duration};
+
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::Bytes;
+use clap::Parser;
+use eyre::{bail, Context, Result};
+use monad_archive::{
+    cli::BlockDataReaderArgs,
+    metrics::Metrics,
+    model::{
+        block_data_archive::{Block, BlockReceipts},
+        BlockDataReader,
+    },
+};
+use monad_chain_data::{
+    store::FjallStore, FinalizedBlock, IngestTx, MonadChainDataService, QueryLimits,
+};
+use tracing::{info, warn, Level};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "chain-data-ingest",
+    about = "Stream blocks + receipts from a monad-archive source into a local chain-data store"
+)]
+struct Cli {
+    /// fjall data directory. Created on first run.
+    #[arg(long)]
+    data_dir: PathBuf,
+
+    /// Archive source. Examples: `"fs /var/lib/monad-archive"`,
+    /// `"aws my-bucket"`, `"mongodb mongodb://host:27017 dbname"`.
+    /// See `monad_archive::cli::BlockDataReaderArgs` for the full grammar.
+    #[arg(long, value_parser = clap::value_parser!(BlockDataReaderArgs))]
+    block_data_source: BlockDataReaderArgs,
+
+    /// First block to ingest (inclusive). Must be `1` for a fresh data
+    /// directory; on resume it must be `published_head + 1`.
+    #[arg(long)]
+    start: u64,
+
+    /// Last block to ingest (inclusive).
+    #[arg(long)]
+    end: u64,
+
+    /// Optional OTel collector endpoint for archive-side metrics. Off by
+    /// default; archive readers still build without it.
+    #[arg(long)]
+    otel_endpoint: Option<String>,
+
+    /// How often to log progress, in blocks.
+    #[arg(long, default_value_t = 1000)]
+    log_every: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::INFO)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(Level::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let cli = Cli::parse();
+    if cli.start > cli.end {
+        bail!("start ({}) must be <= end ({})", cli.start, cli.end);
+    }
+
+    let store = FjallStore::open(&cli.data_dir)
+        .with_context(|| format!("opening fjall store at {}", cli.data_dir.display()))?;
+    let service = MonadChainDataService::new(store.clone(), store, QueryLimits::UNLIMITED);
+
+    // Sanity check the resume point against the publication head before any
+    // archive I/O, so a misconfigured `--start` fails fast rather than
+    // burning a fetch.
+    let head = service
+        .publication()
+        .load_published_head()
+        .await
+        .context("loading current publication head")?;
+    let expected_start = head.map_or(1, |h| h + 1);
+    if cli.start != expected_start {
+        bail!(
+            "start={} does not match expected next block {} (current head: {:?})",
+            cli.start,
+            expected_start,
+            head
+        );
+    }
+
+    let metrics = Metrics::new(
+        cli.otel_endpoint.as_deref(),
+        "chain-data-ingest",
+        "0".to_string(),
+        Duration::from_secs(60),
+    )
+    .context("building metrics")?;
+    let reader = cli
+        .block_data_source
+        .build(&metrics)
+        .await
+        .context("building block data reader")?;
+
+    info!(
+        start = cli.start,
+        end = cli.end,
+        data_dir = %cli.data_dir.display(),
+        "starting ingest"
+    );
+
+    let mut total_logs: u64 = 0;
+    let mut total_txs: u64 = 0;
+    for n in cli.start..=cli.end {
+        let block = reader
+            .get_block_by_number(n)
+            .await
+            .with_context(|| format!("fetching block {n}"))?;
+        let receipts = reader
+            .get_block_receipts(n)
+            .await
+            .with_context(|| format!("fetching receipts for block {n}"))?;
+
+        let finalized = into_finalized_block(block, receipts)
+            .with_context(|| format!("transforming block {n}"))?;
+        let outcome = service
+            .ingest_block(finalized)
+            .await
+            .with_context(|| format!("ingesting block {n}"))?;
+
+        total_logs += outcome.written_logs as u64;
+        total_txs += outcome.written_txs as u64;
+
+        if n % cli.log_every == 0 || n == cli.end {
+            info!(block = n, total_txs, total_logs, "ingest progress");
+        }
+    }
+
+    info!(end = cli.end, total_txs, total_logs, "ingest complete");
+    Ok(())
+}
+
+fn into_finalized_block(block: Block, receipts: BlockReceipts) -> Result<FinalizedBlock> {
+    let header = block.header;
+    let txs: Vec<IngestTx> = block
+        .body
+        .transactions
+        .into_iter()
+        .map(|tx_w| IngestTx {
+            tx_hash: *tx_w.tx.tx_hash(),
+            sender: tx_w.sender,
+            signed_tx_bytes: Bytes::from(tx_w.tx.encoded_2718()),
+        })
+        .collect();
+
+    if !txs.is_empty() && txs.len() != receipts.len() {
+        bail!(
+            "block {}: tx count {} != receipt count {}",
+            header.number,
+            txs.len(),
+            receipts.len()
+        );
+    }
+    if txs.is_empty() && !receipts.is_empty() {
+        // Should not happen for valid archives, but worth surfacing rather
+        // than silently dropping receipts.
+        warn!(
+            block = header.number,
+            receipts = receipts.len(),
+            "block has receipts but no transactions; ignoring receipts"
+        );
+    }
+
+    let logs_by_tx: Vec<Vec<alloy_primitives::Log>> = receipts
+        .into_iter()
+        .map(|r| r.receipt.logs().to_vec())
+        .collect();
+
+    Ok(FinalizedBlock {
+        header,
+        logs_by_tx,
+        txs,
+    })
+}

--- a/monad-chain-data/src/bin/chain-data-ingest.rs
+++ b/monad-chain-data/src/bin/chain-data-ingest.rs
@@ -25,12 +25,13 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::Bytes;
 use clap::Parser;
 use eyre::{bail, Context, Result};
+use futures::{stream, StreamExt};
 use monad_archive::{
     cli::BlockDataReaderArgs,
     metrics::Metrics,
     model::{
         block_data_archive::{Block, BlockReceipts},
-        BlockDataReader,
+        BlockDataReader, BlockDataReaderErased,
     },
 };
 use monad_chain_data::{
@@ -71,6 +72,16 @@ struct Cli {
     /// How often to log progress, in blocks.
     #[arg(long, default_value_t = 1000)]
     log_every: u64,
+
+    /// Maximum number of block fetches in flight against the archive
+    /// concurrently. Each in-flight slot issues block + receipts in
+    /// parallel via `try_join!`, so peak archive request concurrency is
+    /// roughly `2 * concurrency`. Increase for high-latency archives
+    /// (e.g. S3); leave low for local FS where queueing buys nothing.
+    /// Memory ceiling is bounded by this many fetched-but-not-yet-ingested
+    /// blocks held in the prefetch buffer.
+    #[arg(long, default_value_t = 16)]
+    concurrency: usize,
 }
 
 #[tokio::main]
@@ -87,6 +98,9 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     if cli.start > cli.end {
         bail!("start ({}) must be <= end ({})", cli.start, cli.end);
+    }
+    if cli.concurrency == 0 {
+        bail!("--concurrency must be >= 1");
     }
 
     let store = FjallStore::open(&cli.data_dir)
@@ -127,22 +141,27 @@ async fn main() -> Result<()> {
     info!(
         start = cli.start,
         end = cli.end,
+        concurrency = cli.concurrency,
         data_dir = %cli.data_dir.display(),
         "starting ingest"
     );
 
+    // Bounded prefetch: buffered() polls up to `concurrency` fetches
+    // concurrently and yields results in input (block-number) order, so
+    // the consumer side stays sequential — which it must, since
+    // ingest_block validates parent_hash continuity.
+    let fetch_stream = stream::iter(cli.start..=cli.end)
+        .map(|n| {
+            let reader = reader.clone();
+            async move { fetch_block(&reader, n).await }
+        })
+        .buffered(cli.concurrency);
+    futures::pin_mut!(fetch_stream);
+
     let mut total_logs: u64 = 0;
     let mut total_txs: u64 = 0;
-    for n in cli.start..=cli.end {
-        let block = reader
-            .get_block_by_number(n)
-            .await
-            .with_context(|| format!("fetching block {n}"))?;
-        let receipts = reader
-            .get_block_receipts(n)
-            .await
-            .with_context(|| format!("fetching receipts for block {n}"))?;
-
+    while let Some(item) = fetch_stream.next().await {
+        let (n, block, receipts) = item?;
         let finalized = into_finalized_block(block, receipts)
             .with_context(|| format!("transforming block {n}"))?;
         let outcome = service
@@ -160,6 +179,16 @@ async fn main() -> Result<()> {
 
     info!(end = cli.end, total_txs, total_logs, "ingest complete");
     Ok(())
+}
+
+async fn fetch_block(
+    reader: &BlockDataReaderErased,
+    n: u64,
+) -> Result<(u64, Block, BlockReceipts)> {
+    let (block, receipts) =
+        tokio::try_join!(reader.get_block_by_number(n), reader.get_block_receipts(n),)
+            .with_context(|| format!("fetching block {n}"))?;
+    Ok((n, block, receipts))
 }
 
 fn into_finalized_block(block: Block, receipts: BlockReceipts) -> Result<FinalizedBlock> {

--- a/monad-chain-data/src/bin/chain-data-ingest.rs
+++ b/monad-chain-data/src/bin/chain-data-ingest.rs
@@ -82,6 +82,20 @@ struct Cli {
     /// blocks held in the prefetch buffer.
     #[arg(long, default_value_t = 16)]
     concurrency: usize,
+
+    /// Number of retry attempts after a fetch failure, per block. The
+    /// first attempt is not counted, so `--max-retries 5` means up to 6
+    /// total attempts. Set to 0 to disable retry. Only fetches retry —
+    /// transform and ingest errors are deterministic and bail
+    /// immediately.
+    #[arg(long, default_value_t = 5)]
+    max_retries: u32,
+
+    /// Initial backoff between retry attempts, in milliseconds. Doubles
+    /// after each failure (exponential, no jitter), so the default 200ms
+    /// with 5 retries waits ~6.2s in total worst case.
+    #[arg(long, default_value_t = 200)]
+    retry_backoff_ms: u64,
 }
 
 #[tokio::main]
@@ -150,10 +164,12 @@ async fn main() -> Result<()> {
     // concurrently and yields results in input (block-number) order, so
     // the consumer side stays sequential — which it must, since
     // ingest_block validates parent_hash continuity.
+    let max_retries = cli.max_retries;
+    let initial_backoff = Duration::from_millis(cli.retry_backoff_ms);
     let fetch_stream = stream::iter(cli.start..=cli.end)
         .map(|n| {
             let reader = reader.clone();
-            async move { fetch_block(&reader, n).await }
+            async move { fetch_block_with_retry(&reader, n, max_retries, initial_backoff).await }
         })
         .buffered(cli.concurrency);
     futures::pin_mut!(fetch_stream);
@@ -189,6 +205,43 @@ async fn fetch_block(
         tokio::try_join!(reader.get_block_by_number(n), reader.get_block_receipts(n),)
             .with_context(|| format!("fetching block {n}"))?;
     Ok((n, block, receipts))
+}
+
+/// Retries `fetch_block` with exponential backoff. Total attempts =
+/// `max_retries + 1`. Retries every error indiscriminately — we don't
+/// have a transient-vs-permanent classification on the archive side, so
+/// genuinely permanent failures (e.g. block-not-found past the
+/// archive's tip) waste a fixed retry budget before propagating.
+async fn fetch_block_with_retry(
+    reader: &BlockDataReaderErased,
+    n: u64,
+    max_retries: u32,
+    initial_backoff: Duration,
+) -> Result<(u64, Block, BlockReceipts)> {
+    let mut backoff = initial_backoff;
+    for attempt in 0..=max_retries {
+        match fetch_block(reader, n).await {
+            Ok(item) => return Ok(item),
+            Err(e) if attempt < max_retries => {
+                warn!(
+                    block = n,
+                    attempt = attempt + 1,
+                    max_attempts = max_retries + 1,
+                    backoff_ms = backoff.as_millis() as u64,
+                    error = %e,
+                    "fetch failed, retrying after backoff"
+                );
+                tokio::time::sleep(backoff).await;
+                backoff = backoff.saturating_mul(2);
+            }
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!("fetch_block({n}) failed after {} attempts", max_retries + 1)
+                });
+            }
+        }
+    }
+    unreachable!("loop exits via Ok or final Err arm")
 }
 
 fn into_finalized_block(block: Block, receipts: BlockReceipts) -> Result<FinalizedBlock> {


### PR DESCRIPTION
Adds an archive-ingest-gated chain-data-ingest binary that streams finalized blocks and receipts from monad-archive sources into a local fjall-backed chain-data store. Startup validates resume continuity against the publication head, and block conversion maps archive headers, transactions, and receipts into FinalizedBlock.

Fetches run with bounded in-order concurrency: each slot fetches block and receipts concurrently, while buffered delivery preserves sequential ingest and parent-hash validation. The fetch path retries transient archive failures with exponential backoff, while deterministic transform and ingest errors still fail immediately.