### PR TITLE
MIP-9: Bump validator set max to 300

### DIFF
--- a/monad-consensus-types/src/timeout.rs
+++ b/monad-consensus-types/src/timeout.rs
@@ -28,12 +28,12 @@ use monad_validator::{
         SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
     },
     validator_mapping::ValidatorMapping,
+    validator_set::MAX_VALIDATOR_SET_SIZE,
 };
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    quorum_certificate::QuorumCertificate, tip::ConsensusTip, validator_data::MAX_VALIDATORS,
-    voting::Vote, RoundCertificate,
+    quorum_certificate::QuorumCertificate, tip::ConsensusTip, voting::Vote, RoundCertificate,
 };
 
 /// Timeout message to broadcast to other nodes after a local timeout
@@ -455,7 +455,7 @@ where
     /// to create a TC
     pub round: Round,
     /// signatures over the round of the TC and the high tip round,
-    pub tip_rounds: LimitedVec<HighTipRoundSigColTuple<SCT>, MAX_VALIDATORS>,
+    pub tip_rounds: LimitedVec<HighTipRoundSigColTuple<SCT>, MAX_VALIDATOR_SET_SIZE>,
 
     // corresponds to the highest tip (or qc if no tip) in tip_rounds
     pub high_extend: HighExtend<ST, SCT, EPT>,
@@ -523,7 +523,7 @@ where
 {
     pub epoch: Epoch,
     pub round: Round,
-    pub tip_rounds: LimitedVec<HighTipRoundSigColTuple<SCT>, MAX_VALIDATORS>,
+    pub tip_rounds: LimitedVec<HighTipRoundSigColTuple<SCT>, MAX_VALIDATOR_SET_SIZE>,
 
     pub high_qc: QuorumCertificate<SCT>,
 }

--- a/monad-consensus-types/src/validator_data.rs
+++ b/monad-consensus-types/src/validator_data.rs
@@ -20,14 +20,13 @@ use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
 };
 use monad_types::{Epoch, ExecutionProtocol, LimitedVec, NodeId, Stake};
-use monad_validator::signature_collection::{SignatureCollection, SignatureCollectionPubKeyType};
+use monad_validator::{
+    signature_collection::{SignatureCollection, SignatureCollectionPubKeyType},
+    validator_set::MAX_VALIDATOR_SET_SIZE,
+};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::checkpoint::Checkpoint;
-
-/// Maximum validator set size with some additional buffer.
-/// Needs to be updated alongside constant in <execution>/monad/staking/util/constants.hpp
-pub const MAX_VALIDATORS: usize = 300;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, RlpEncodable, RlpDecodable)]
 pub struct ValidatorSetDataWithEpoch<SCT: SignatureCollection> {
@@ -44,7 +43,7 @@ pub struct ValidatorSetDataWithEpoch<SCT: SignatureCollection> {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, RlpEncodable, RlpDecodable)]
 pub struct ValidatorSetData<SCT: SignatureCollection>(
     #[serde(bound(serialize = "", deserialize = ""))]
-    pub LimitedVec<ValidatorData<SCT>, MAX_VALIDATORS>,
+    pub LimitedVec<ValidatorData<SCT>, MAX_VALIDATOR_SET_SIZE>,
 );
 
 #[derive(
@@ -180,6 +179,12 @@ impl<SCT: SignatureCollection> ValidatorSetData<SCT> {
     pub fn new(
         validators: Vec<(SCT::NodeIdPubKey, Stake, SignatureCollectionPubKeyType<SCT>)>,
     ) -> Self {
+        assert!(
+            validators.len() <= MAX_VALIDATOR_SET_SIZE,
+            "validator set size {} exceeds MAX_VALIDATOR_SET_SIZE {}",
+            validators.len(),
+            MAX_VALIDATOR_SET_SIZE,
+        );
         Self(
             validators
                 .into_iter()

--- a/monad-raptorcast/src/packet/assigner.rs
+++ b/monad-raptorcast/src/packet/assigner.rs
@@ -485,6 +485,7 @@ mod tests {
     use monad_secp::SecpSignature;
     use monad_testutil::signing::get_key;
     use monad_types::{NodeId, Stake};
+    use monad_validator::validator_set::MAX_VALIDATOR_SET_SIZE;
     use rstest::rstest;
 
     use super::{ChunkAssignment, EvenPartition, NodeIndex, OrderedNodes, StakePartition};
@@ -833,7 +834,7 @@ mod tests {
     #[case(vec![(1, 0.001), (2, 0.999)], 100)]
     // large validator set
     #[case({
-        let n = 200;
+        let n = MAX_VALIDATOR_SET_SIZE;
         let share = 1.0 / n as f64;
         (1..=n).map(|i| (i as u64, share)).collect::<Vec<_>>()
     }, 5000)]

--- a/monad-raptorcast/src/parser/packet_parser.rs
+++ b/monad-raptorcast/src/parser/packet_parser.rs
@@ -22,13 +22,14 @@ use monad_crypto::{
 };
 use monad_merkle::{MerkleHash, MerkleProof};
 use monad_types::{Epoch, NodeId, Round};
+use monad_validator::validator_set::MAX_VALIDATOR_SET_SIZE;
 use tracing::warn;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Ref, LE, U16, U32, U64};
 
 use crate::{
     message::MAX_MESSAGE_SIZE,
     packet::regular,
-    udp::{ChunkSignatureVerifier, GroupId, InvalidChunk, ValidatedChunk, MAX_VALIDATOR_SET_SIZE},
+    udp::{ChunkSignatureVerifier, GroupId, InvalidChunk, ValidatedChunk},
     util::{ensure, BroadcastMode, HexBytes},
     SIGNATURE_SIZE,
 };

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -47,10 +47,6 @@ pub const SIGNATURE_CACHE_SIZE: usize = 10_000;
 // if we have many peers to transmit the message to.
 pub const MAX_NUM_PACKETS: usize = 65535;
 
-/// The maximum sane validator set size. Defined in
-/// <execution>/monad/staking/util/constants.hpp.
-pub const MAX_VALIDATOR_SET_SIZE: usize = 200;
-
 /// Cache key for signature verification: header + merkle root
 pub type SignatureCacheKey = SignedOverData;
 pub type ChunkSignatureVerifier<ST> =
@@ -594,7 +590,9 @@ mod tests {
     use monad_dataplane::udp::DEFAULT_SEGMENT_SIZE;
     use monad_secp::{KeyPair, SecpSignature};
     use monad_types::{Epoch, NodeId, Round, Stake};
-    use monad_validator::validator_set::{ValidatorSet, ValidatorSetType as _};
+    use monad_validator::validator_set::{
+        ValidatorSet, ValidatorSetType as _, MAX_VALIDATOR_SET_SIZE,
+    };
     use rstest::*;
 
     use super::{ChunkSignatureVerifier, InvalidChunk, UdpState, ValidatedChunk};
@@ -604,7 +602,7 @@ mod tests {
             packet_parser::{ChunkValidationEnv, MalformedPacket, RaptorcastPacket},
             signature_verifier::SignatureVerifier,
         },
-        udp::{build_messages, MAX_VALIDATOR_SET_SIZE, SIGNATURE_CACHE_SIZE},
+        udp::{build_messages, SIGNATURE_CACHE_SIZE},
         util::{
             compute_app_message_hash, BroadcastMode, BuildTarget, FullNodeGroupMap,
             PrimaryBroadcastGroup, Redundancy, SecondaryBroadcastGroup, SecondaryGroup,

--- a/monad-validator/src/validator_set.rs
+++ b/monad-validator/src/validator_set.rs
@@ -22,6 +22,12 @@ use itertools::Itertools;
 use monad_crypto::certificate_signature::PubKey;
 use monad_types::{NodeId, Stake};
 
+/// Maximum validator set size.
+/// Must be >= the max validator set limit of any active network. The
+/// corresponding execution-side constant in
+/// <execution>/monad/staking/util/constants.hpp will soon be timestamp-gated.
+pub const MAX_VALIDATOR_SET_SIZE: usize = 300;
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum ValidatorSetCreationError<PT: PubKey> {
     EmptyValidatorSet,


### PR DESCRIPTION
[MIP-9](https://github.com/monad-crypto/MIPs/blob/main/MIPS/MIP-9.md) raises the validator set cap from 200 to 300, gated by a hard fork on the execution side. Consensus stays passive (reads whatever the staking contract returns); only the static caps need to move.

Consolidate the two redundant constants (MAX_VALIDATORS in monad-consensus-types and MAX_VALIDATOR_SET_SIZE in monad-raptorcast) into a single MAX_VALIDATOR_SET_SIZE in monad-validator. Both crates already depend on monad-validator.

Drop the "additional buffer" framing on the constant