### PR TITLE
monad-executor-glue: split peer entry ports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5412,6 +5412,7 @@ dependencies = [
  "monad-wal",
  "serde",
  "serde_with",
+ "toml",
 ]
 
 [[package]]

--- a/monad-debug-node/src/main.rs
+++ b/monad-debug-node/src/main.rs
@@ -168,19 +168,19 @@ fn main() -> Result<(), Error> {
             if let ControlPanelCommand::Read(ReadCommand::GetPeers(GetPeers::Response(peers))) =
                 response
             {
-                // build toml config from peer list
-                let mut peer_configs = Vec::new();
-                for peer in peers {
-                    let peer_config = NodeBootstrapPeerConfig {
-                        address: format!("{}:{}", peer.ip(), peer.tcp_port()),
+                let peer_configs = peers
+                    .into_iter()
+                    .map(|peer| NodeBootstrapPeerConfig {
+                        address: peer.ip().to_string(),
+                        tcp_port: Some(peer.tcp_port()),
+                        udp_port: peer.udp_port(),
                         secp256k1_pubkey: peer.pubkey,
                         name_record_sig: peer.signature,
                         record_seq_num: peer.record_seq_num,
                         auth_port: peer.auth_port,
                         direct_udp_port: peer.direct_udp_port,
-                    };
-                    peer_configs.push(peer_config);
-                }
+                    })
+                    .collect();
                 let bootstrap_config = NodeBootstrapConfig {
                     peers: peer_configs,
                 };

--- a/monad-debug-node/src/main.rs
+++ b/monad-debug-node/src/main.rs
@@ -172,7 +172,7 @@ fn main() -> Result<(), Error> {
                 let mut peer_configs = Vec::new();
                 for peer in peers {
                     let peer_config = NodeBootstrapPeerConfig {
-                        address: peer.addr.to_string(),
+                        address: format!("{}:{}", peer.ip(), peer.tcp_port()),
                         secp256k1_pubkey: peer.pubkey,
                         name_record_sig: peer.signature,
                         record_seq_num: peer.record_seq_num,

--- a/monad-executor-glue/Cargo.toml
+++ b/monad-executor-glue/Cargo.toml
@@ -31,6 +31,7 @@ serde_with = { workspace = true, features = ["hex"] }
 criterion = { workspace = true }
 monad-eth-types = { workspace = true }
 monad-multi-sig = { workspace = true }
+toml = { workspace = true }
 
 [[bench]]
 name = "rlp_bench"

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -15,7 +15,7 @@
 
 use std::{
     fmt::Debug,
-    net::{SocketAddr, SocketAddrV4},
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     num::NonZeroU16,
 };
 
@@ -276,13 +276,14 @@ pub enum GetMetrics {
     Response(Metrics),
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(bound = "ST: CertificateSignatureRecoverable")]
 pub struct PeerEntry<ST: CertificateSignatureRecoverable> {
     #[serde(serialize_with = "serialize_pubkey::<_, CertificateSignaturePubKey<ST>>")]
     #[serde(deserialize_with = "deserialize_pubkey::<_, CertificateSignaturePubKey<ST>>")]
     pub pubkey: CertificateSignaturePubKey<ST>,
-    pub addr: SocketAddrV4,
+    #[serde(flatten)]
+    pub address: PeerEntryAddress,
 
     pub signature: ST,
     pub record_seq_num: u64,
@@ -296,33 +297,93 @@ pub struct PeerEntry<ST: CertificateSignatureRecoverable> {
     pub direct_udp_port: Option<NonZeroU16>,
 }
 
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum PeerEntryAddress {
+    Split(PeerEntrySplitEndpoint),
+    SocketAddr(PeerEntrySocketAddrEndpoint),
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PeerEntrySocketAddrEndpoint {
+    address: SocketAddrV4,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PeerEntrySplitEndpoint {
+    address: Ipv4Addr,
+    tcp_port: NonZeroU16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    udp_port: Option<NonZeroU16>,
+}
+
+impl PeerEntryAddress {
+    pub fn new(address: Ipv4Addr, tcp_port: NonZeroU16, udp_port: Option<NonZeroU16>) -> Self {
+        Self::Split(PeerEntrySplitEndpoint {
+            address,
+            tcp_port,
+            udp_port,
+        })
+    }
+
+    pub fn ip(&self) -> Ipv4Addr {
+        match self {
+            Self::Split(endpoint) => endpoint.address,
+            Self::SocketAddr(endpoint) => *endpoint.address.ip(),
+        }
+    }
+
+    pub fn tcp_port(&self) -> NonZeroU16 {
+        match self {
+            Self::Split(endpoint) => Ok(endpoint.tcp_port),
+            Self::SocketAddr(endpoint) => NonZeroU16::new(endpoint.address.port())
+                .ok_or("socket address port must be non-zero"),
+        }
+        .expect("peer entry TCP port must be non-zero")
+    }
+
+    pub fn udp_port(&self) -> Option<NonZeroU16> {
+        match self {
+            Self::Split(endpoint) => endpoint.udp_port,
+            Self::SocketAddr(_) => Some(self.tcp_port()),
+        }
+    }
+}
+
+impl<ST: CertificateSignatureRecoverable> PeerEntry<ST> {
+    pub fn ip(&self) -> Ipv4Addr {
+        self.address.ip()
+    }
+
+    pub fn tcp_port(&self) -> NonZeroU16 {
+        self.address.tcp_port()
+    }
+
+    pub fn udp_port(&self) -> Option<NonZeroU16> {
+        self.address.udp_port()
+    }
+}
+
 impl<ST: CertificateSignatureRecoverable> Encodable for PeerEntry<ST> {
     fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
-        let addr = self.addr.to_string();
+        let address = self.ip().to_string();
         let auth_port = self.auth_port.get();
-        let base = [
+        let direct_udp_port = self.direct_udp_port.map_or(0, NonZeroU16::get);
+        let tcp_port = self.tcp_port().get();
+        let udp_port = self.udp_port().map_or(0, NonZeroU16::get);
+        let enc = [
             &self.pubkey as &dyn Encodable,
-            &addr as &dyn Encodable,
+            &address as &dyn Encodable,
             &self.signature as &dyn Encodable,
             &self.record_seq_num as &dyn Encodable,
             &auth_port as &dyn Encodable,
+            &direct_udp_port as &dyn Encodable,
+            &tcp_port as &dyn Encodable,
+            &udp_port as &dyn Encodable,
         ];
-
-        match self.direct_udp_port {
-            None => encode_list::<_, dyn Encodable>(&base, out),
-            Some(direct_udp_port) => {
-                let direct_udp_port = direct_udp_port.get();
-                let enc = [
-                    base[0],
-                    base[1],
-                    base[2],
-                    base[3],
-                    base[4],
-                    &direct_udp_port as &dyn Encodable,
-                ];
-                encode_list::<_, dyn Encodable>(&enc, out);
-            }
-        }
+        encode_list::<_, dyn Encodable>(&enc, out);
     }
 }
 
@@ -331,24 +392,35 @@ impl<ST: CertificateSignatureRecoverable> Decodable for PeerEntry<ST> {
         let mut payload = alloy_rlp::Header::decode_bytes(buf, true)?;
 
         let pubkey = CertificateSignaturePubKey::<ST>::decode(&mut payload)?;
-        let s = <String as Decodable>::decode(&mut payload)?;
-        let addr = s
-            .parse::<SocketAddrV4>()
-            .map_err(|_| alloy_rlp::Error::Custom("invalid SocketAddrV4"))?;
+        let address = <String as Decodable>::decode(&mut payload)?;
+        let (address, legacy_port) = if let Ok(address) = address.parse::<Ipv4Addr>() {
+            (address, None)
+        } else {
+            let address = address
+                .parse::<SocketAddrV4>()
+                .map_err(|_| alloy_rlp::Error::Custom("invalid peer entry address"))?;
+            let port = NonZeroU16::new(address.port())
+                .ok_or(alloy_rlp::Error::Custom("invalid SocketAddrV4"))?;
+            (*address.ip(), Some(port))
+        };
         let signature = ST::decode(&mut payload)?;
         let record_seq_num = u64::decode(&mut payload)?;
-
-        if payload.is_empty() {
-            return Err(alloy_rlp::Error::Custom("missing auth port"));
-        }
-
         let auth_port = NonZeroU16::new(u16::decode(&mut payload)?)
             .ok_or(alloy_rlp::Error::Custom("invalid auth port"))?;
-
-        let direct_udp_port = if !payload.is_empty() {
-            NonZeroU16::new(u16::decode(&mut payload)?)
-        } else {
+        let direct_udp_port = if payload.is_empty() {
             None
+        } else {
+            decode_optional_non_zero_u16(&mut payload)?
+        };
+        let (tcp_port, udp_port) = if payload.is_empty() {
+            let port = legacy_port.ok_or(alloy_rlp::Error::Custom(
+                "missing tcp/udp ports for peer entry",
+            ))?;
+            (port, Some(port))
+        } else {
+            let tcp_port = decode_non_zero_u16(&mut payload, "invalid tcp port")?;
+            let udp_port = decode_optional_non_zero_u16(&mut payload)?;
+            (tcp_port, udp_port)
         };
 
         if !payload.is_empty() {
@@ -357,13 +429,21 @@ impl<ST: CertificateSignatureRecoverable> Decodable for PeerEntry<ST> {
 
         Ok(Self {
             pubkey,
-            addr,
+            address: PeerEntryAddress::new(address, tcp_port, udp_port),
             signature,
             record_seq_num,
             auth_port,
             direct_udp_port,
         })
     }
+}
+
+fn decode_non_zero_u16(payload: &mut &[u8], error: &'static str) -> alloy_rlp::Result<NonZeroU16> {
+    NonZeroU16::new(u16::decode(payload)?).ok_or(alloy_rlp::Error::Custom(error))
+}
+
+fn decode_optional_non_zero_u16(payload: &mut &[u8]) -> alloy_rlp::Result<Option<NonZeroU16>> {
+    Ok(NonZeroU16::new(u16::decode(payload)?))
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -2383,7 +2463,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{net::SocketAddrV4, num::NonZeroU16};
+    use std::{net::Ipv4Addr, num::NonZeroU16};
 
     use alloy_rlp::{encode_list, Encodable};
     use monad_blocksync::messages::message::BlockSyncRequestMessage;
@@ -2398,7 +2478,7 @@ mod tests {
     use monad_wal::wal::WALLog;
 
     use crate::{
-        BlockSyncEvent, MempoolEvent, MonadEvent, PeerEntry, StateSyncEvent,
+        BlockSyncEvent, MempoolEvent, MonadEvent, PeerEntry, PeerEntryAddress, StateSyncEvent,
         StateSyncNetworkMessage, StateSyncRequest, StateSyncResponse, StateSyncUpsertType,
         StateSyncUpsertV1, StateSyncVersion, SELF_STATESYNC_VERSION, STATESYNC_VERSION_V0,
         STATESYNC_VERSION_V1,
@@ -2573,18 +2653,75 @@ mod tests {
         assert_eq!(deserialized_request.old_target, 0);
     }
 
+    fn peer_entry_toml(address_fields: &str) -> String {
+        let pubkey = "01".repeat(32);
+        let signature_pubkey = ["1"; 32].join(", ");
+
+        format!(
+            r#"{address_fields}
+pubkey = "0x{pubkey}"
+signature = {{ pubkey = [{signature_pubkey}], id = 1234 }}
+record_seq_num = 42
+auth_port = 9000
+direct_udp_port = 9001
+"#
+        )
+    }
+
+    #[test]
+    fn peer_entry_decodes_legacy_socket_addr_toml() {
+        let peer: PeerEntry<NopSignature> =
+            toml::from_str(&peer_entry_toml(r#"address = "127.0.0.1:8000""#)).unwrap();
+
+        assert_eq!(peer.ip(), "127.0.0.1".parse::<Ipv4Addr>().unwrap());
+        assert_eq!(peer.tcp_port().get(), 8000);
+        assert_eq!(peer.udp_port().map(NonZeroU16::get), Some(8000));
+        assert_eq!(peer.direct_udp_port.map(NonZeroU16::get), Some(9001));
+    }
+
+    #[test]
+    fn peer_entry_decodes_split_port_toml() {
+        let peer: PeerEntry<NopSignature> = toml::from_str(&peer_entry_toml(
+            r#"address = "127.0.0.2"
+tcp_port = 8001
+udp_port = 8002"#,
+        ))
+        .unwrap();
+
+        assert_eq!(peer.ip(), "127.0.0.2".parse::<Ipv4Addr>().unwrap());
+        assert_eq!(peer.tcp_port().get(), 8001);
+        assert_eq!(peer.udp_port().map(NonZeroU16::get), Some(8002));
+    }
+
+    #[test]
+    fn peer_entry_decodes_split_port_toml_without_udp_port() {
+        let peer: PeerEntry<NopSignature> = toml::from_str(&peer_entry_toml(
+            r#"address = "127.0.0.3"
+tcp_port = 8003"#,
+        ))
+        .unwrap();
+
+        assert_eq!(peer.ip(), "127.0.0.3".parse::<Ipv4Addr>().unwrap());
+        assert_eq!(peer.tcp_port().get(), 8003);
+        assert_eq!(peer.udp_port(), None);
+    }
+
     #[test]
     fn peer_entry_rlp_encode_decode() {
         let pubkey = CertificateSignaturePubKey::<NopSignature>::from_bytes(&[1u8; 32]).unwrap();
-        let addr: SocketAddrV4 = "127.0.0.1:8000".parse().unwrap();
+        let address: Ipv4Addr = "127.0.0.1".parse().unwrap();
         let signature = NopSignature { pubkey, id: 1234 };
         let record_seq_num = 0;
         let entry = PeerEntry {
             pubkey,
-            addr,
+            address: PeerEntryAddress::new(
+                address,
+                NonZeroU16::new(8000).unwrap(),
+                Some(NonZeroU16::new(8000).unwrap()),
+            ),
             signature,
             record_seq_num,
-            auth_port: NonZeroU16::new(addr.port()).unwrap(),
+            auth_port: NonZeroU16::new(8000).unwrap(),
             direct_udp_port: None,
         };
         let encoded = alloy_rlp::encode(&entry);
@@ -2595,11 +2732,15 @@ mod tests {
     #[test]
     fn peer_entry_rlp_encode_decode_with_direct_udp() {
         let pubkey = CertificateSignaturePubKey::<NopSignature>::from_bytes(&[2u8; 32]).unwrap();
-        let addr: SocketAddrV4 = "127.0.0.1:8001".parse().unwrap();
+        let address: Ipv4Addr = "127.0.0.1".parse().unwrap();
         let signature = NopSignature { pubkey, id: 4321 };
         let entry = PeerEntry {
             pubkey,
-            addr,
+            address: PeerEntryAddress::new(
+                address,
+                NonZeroU16::new(8001).unwrap(),
+                Some(NonZeroU16::new(8001).unwrap()),
+            ),
             signature,
             record_seq_num: 7,
             auth_port: NonZeroU16::new(9000).unwrap(),
@@ -2612,15 +2753,35 @@ mod tests {
     }
 
     #[test]
-    fn peer_entry_rlp_decode_legacy_auth_only_form() {
+    fn peer_entry_rlp_encode_decode_ip_form() {
         let pubkey = CertificateSignaturePubKey::<NopSignature>::from_bytes(&[3u8; 32]).unwrap();
-        let addr: SocketAddrV4 = "127.0.0.1:8002".parse().unwrap();
+        let ip: Ipv4Addr = "127.0.0.2".parse().unwrap();
         let signature = NopSignature { pubkey, id: 99 };
         let record_seq_num = 11u64;
         let auth_port = 9002u16;
+        let entry = PeerEntry {
+            pubkey,
+            address: PeerEntryAddress::new(ip, NonZeroU16::new(8002).unwrap(), None),
+            signature,
+            record_seq_num,
+            auth_port: NonZeroU16::new(auth_port).unwrap(),
+            direct_udp_port: None,
+        };
+
+        let encoded = alloy_rlp::encode(&entry);
+        let decoded: PeerEntry<NopSignature> = alloy_rlp::decode_exact(&encoded).unwrap();
+        assert_eq!(entry, decoded);
+    }
+
+    #[test]
+    fn peer_entry_rlp_decode_legacy_auth_only_form() {
+        let pubkey = CertificateSignaturePubKey::<NopSignature>::from_bytes(&[7u8; 32]).unwrap();
+        let signature = NopSignature { pubkey, id: 10 };
+        let record_seq_num = 15u64;
+        let auth_port = 9006u16;
         let enc: [&dyn Encodable; 5] = [
             &pubkey,
-            &addr.to_string(),
+            &"127.0.0.3:8006".to_string(),
             &signature,
             &record_seq_num,
             &auth_port,
@@ -2629,17 +2790,59 @@ mod tests {
         encode_list::<_, dyn Encodable>(&enc, &mut encoded);
 
         let decoded: PeerEntry<NopSignature> = alloy_rlp::decode_exact(&encoded).unwrap();
-        assert_eq!(decoded.auth_port, NonZeroU16::new(auth_port).unwrap());
+        assert_eq!(decoded.ip(), "127.0.0.3".parse::<Ipv4Addr>().unwrap());
+        assert_eq!(decoded.tcp_port().get(), 8006);
+        assert_eq!(decoded.udp_port().map(NonZeroU16::get), Some(8006));
+        assert_eq!(decoded.auth_port.get(), auth_port);
         assert_eq!(decoded.direct_udp_port, None);
     }
 
     #[test]
-    fn peer_entry_rlp_decode_rejects_missing_auth_port() {
+    fn peer_entry_rlp_decode_legacy_direct_udp_form() {
+        let pubkey = CertificateSignaturePubKey::<NopSignature>::from_bytes(&[8u8; 32]).unwrap();
+        let signature = NopSignature { pubkey, id: 11 };
+        let record_seq_num = 16u64;
+        let auth_port = 9007u16;
+        let direct_udp_port = 9008u16;
+        let enc: [&dyn Encodable; 6] = [
+            &pubkey,
+            &"127.0.0.4:8007".to_string(),
+            &signature,
+            &record_seq_num,
+            &auth_port,
+            &direct_udp_port,
+        ];
+        let mut encoded = Vec::new();
+        encode_list::<_, dyn Encodable>(&enc, &mut encoded);
+
+        let decoded: PeerEntry<NopSignature> = alloy_rlp::decode_exact(&encoded).unwrap();
+        assert_eq!(decoded.ip(), "127.0.0.4".parse::<Ipv4Addr>().unwrap());
+        assert_eq!(decoded.tcp_port().get(), 8007);
+        assert_eq!(decoded.udp_port().map(NonZeroU16::get), Some(8007));
+        assert_eq!(decoded.auth_port.get(), auth_port);
+        assert_eq!(
+            decoded.direct_udp_port.map(NonZeroU16::get),
+            Some(direct_udp_port)
+        );
+    }
+
+    #[test]
+    fn peer_entry_rlp_decode_rejects_zero_auth_port() {
         let pubkey = CertificateSignaturePubKey::<NopSignature>::from_bytes(&[5u8; 32]).unwrap();
-        let addr: SocketAddrV4 = "127.0.0.1:8004".parse().unwrap();
+        let address = "127.0.0.1".to_string();
         let signature = NopSignature { pubkey, id: 8 };
         let record_seq_num = 13u64;
-        let enc: [&dyn Encodable; 4] = [&pubkey, &addr.to_string(), &signature, &record_seq_num];
+        let auth_port = 0u16;
+        let enc: [&dyn Encodable; 8] = [
+            &pubkey,
+            &address,
+            &signature,
+            &record_seq_num,
+            &auth_port,
+            &0u16,
+            &8004u16,
+            &8004u16,
+        ];
         let mut encoded = Vec::new();
         encode_list::<_, dyn Encodable>(&enc, &mut encoded);
 
@@ -2648,18 +2851,21 @@ mod tests {
     }
 
     #[test]
-    fn peer_entry_rlp_decode_rejects_zero_auth_port() {
+    fn peer_entry_rlp_decode_rejects_zero_tcp_port() {
         let pubkey = CertificateSignaturePubKey::<NopSignature>::from_bytes(&[6u8; 32]).unwrap();
-        let addr: SocketAddrV4 = "127.0.0.1:8005".parse().unwrap();
         let signature = NopSignature { pubkey, id: 9 };
         let record_seq_num = 14u64;
-        let auth_port = 0u16;
-        let enc: [&dyn Encodable; 5] = [
+        let auth_port = 9005u16;
+        let tcp_port = 0u16;
+        let enc: [&dyn Encodable; 8] = [
             &pubkey,
-            &addr.to_string(),
+            &"127.0.0.1".to_string(),
             &signature,
             &record_seq_num,
             &auth_port,
+            &0u16,
+            &tcp_port,
+            &0u16,
         ];
         let mut encoded = Vec::new();
         encode_list::<_, dyn Encodable>(&enc, &mut encoded);
@@ -2671,19 +2877,21 @@ mod tests {
     #[test]
     fn peer_entry_rlp_decode_rejects_extra_fields() {
         let pubkey = CertificateSignaturePubKey::<NopSignature>::from_bytes(&[4u8; 32]).unwrap();
-        let addr: SocketAddrV4 = "127.0.0.1:8003".parse().unwrap();
         let signature = NopSignature { pubkey, id: 7 };
         let record_seq_num = 12u64;
         let auth_port = 9003u16;
         let direct_udp_port = 9004u16;
+        let tcp_port = 8003u16;
         let extra_port = 9005u16;
-        let enc: [&dyn Encodable; 7] = [
+        let enc: [&dyn Encodable; 9] = [
             &pubkey,
-            &addr.to_string(),
+            &"127.0.0.1".to_string(),
             &signature,
             &record_seq_num,
             &auth_port,
             &direct_udp_port,
+            &tcp_port,
+            &0u16,
             &extra_port,
         ];
         let mut encoded = Vec::new();

--- a/monad-node-config/src/bootstrap.rs
+++ b/monad-node-config/src/bootstrap.rs
@@ -77,7 +77,7 @@ where
         .collect()
 }
 
-fn parse_address_fields(
+pub(crate) fn parse_address_fields(
     address: &str,
     tcp_port: Option<NonZeroU16>,
     udp_port: Option<NonZeroU16>,

--- a/monad-node-config/src/bootstrap.rs
+++ b/monad-node-config/src/bootstrap.rs
@@ -13,18 +13,19 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::num::NonZeroU16;
+use std::{net::Ipv4Addr, num::NonZeroU16};
 
 use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_types::{deserialize_pubkey, serialize_pubkey};
-use serde::{Deserialize, Serialize};
+use serde::{de::Error as _, Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct NodeBootstrapConfig<ST: CertificateSignatureRecoverable> {
     #[serde(bound = "ST: CertificateSignatureRecoverable")]
+    #[serde(deserialize_with = "deserialize_bootstrap_peers")]
     pub peers: Vec<NodeBootstrapPeerConfig<ST>>,
 }
 
@@ -32,7 +33,18 @@ pub struct NodeBootstrapConfig<ST: CertificateSignatureRecoverable> {
 #[serde(deny_unknown_fields)]
 #[serde(bound = "ST: CertificateSignatureRecoverable")]
 pub struct NodeBootstrapPeerConfig<ST: CertificateSignatureRecoverable> {
+    // Supported bootstrap address formats:
+    // - Legacy: address = "host:port"
+    // - Split: address = "host", tcp_port = 8000, udp_port = 8001 (optional)
+    // Host is an IPv4 literal or DNS name; IPv6 is not supported here.
+    // Split-format address must not include a port.
     pub address: String,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tcp_port: Option<NonZeroU16>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub udp_port: Option<NonZeroU16>,
 
     pub record_seq_num: u64,
 
@@ -50,4 +62,223 @@ pub struct NodeBootstrapPeerConfig<ST: CertificateSignatureRecoverable> {
         skip_serializing_if = "Option::is_none"
     )]
     pub direct_udp_port: Option<NonZeroU16>,
+}
+
+fn deserialize_bootstrap_peers<'de, D, ST>(
+    deserializer: D,
+) -> Result<Vec<NodeBootstrapPeerConfig<ST>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    ST: CertificateSignatureRecoverable,
+{
+    Vec::<NodeBootstrapPeerConfig<ST>>::deserialize(deserializer)?
+        .into_iter()
+        .map(|peer| peer.validate_address_fields().map_err(D::Error::custom))
+        .collect()
+}
+
+fn parse_address_fields(
+    address: &str,
+    tcp_port: Option<NonZeroU16>,
+    udp_port: Option<NonZeroU16>,
+) -> Result<(String, NonZeroU16, Option<NonZeroU16>), &'static str> {
+    let (host, tcp_port, udp_port) = match tcp_port {
+        Some(tcp_port) => {
+            if address.contains(':') {
+                return Err("split bootstrap peer address must not include a port");
+            }
+            (address, tcp_port, udp_port)
+        }
+        None => {
+            if udp_port.is_some() {
+                return Err("bootstrap peer udp_port requires tcp_port");
+            }
+            let (host, port) = address
+                .rsplit_once(':')
+                .ok_or("bootstrap peer address must include a port")?;
+            let tcp_port = port
+                .parse()
+                .ok()
+                .and_then(NonZeroU16::new)
+                .ok_or("bootstrap peer address port must be non-zero")?;
+            (host, tcp_port, Some(tcp_port))
+        }
+    };
+
+    if host.is_empty() {
+        return Err("bootstrap peer address host must not be empty");
+    }
+
+    Ok((host.to_owned(), tcp_port, udp_port))
+}
+
+impl<ST: CertificateSignatureRecoverable> NodeBootstrapPeerConfig<ST> {
+    fn validate_address_fields(mut self) -> Result<Self, &'static str> {
+        let (address, tcp_port, udp_port) =
+            parse_address_fields(&self.address, self.tcp_port, self.udp_port)?;
+        self.address = address;
+        self.tcp_port = Some(tcp_port);
+        self.udp_port = udp_port;
+        Ok(self)
+    }
+
+    pub fn ip(&self) -> Option<Ipv4Addr> {
+        self.address.parse().ok()
+    }
+
+    pub fn tcp_port(&self) -> NonZeroU16 {
+        self.tcp_port
+            .expect("bootstrap peer tcp_port must be present")
+    }
+
+    pub fn udp_port(&self) -> Option<NonZeroU16> {
+        self.udp_port
+    }
+
+    pub fn domain(&self) -> Option<&str> {
+        if self.address.parse::<Ipv4Addr>().is_ok() {
+            None
+        } else {
+            Some(&self.address)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU16;
+
+    use monad_crypto::NopSignature;
+
+    use super::{NodeBootstrapConfig, NodeBootstrapPeerConfig};
+
+    fn bootstrap_peer_toml(address_fields: &str) -> String {
+        let pubkey = "01".repeat(32);
+        let signature_pubkey = ["1"; 32].join(", ");
+
+        format!(
+            r#"[[peers]]
+{address_fields}
+record_seq_num = 42
+secp256k1_pubkey = "0x{pubkey}"
+name_record_sig = {{ pubkey = [{signature_pubkey}], id = 1234 }}
+auth_port = 9000
+direct_udp_port = 9001
+"#
+        )
+    }
+
+    fn parse_bootstrap_peer(
+        address_fields: &str,
+    ) -> Result<NodeBootstrapPeerConfig<NopSignature>, toml::de::Error> {
+        let mut config = toml::from_str::<NodeBootstrapConfig<NopSignature>>(
+            &bootstrap_peer_toml(address_fields),
+        )?;
+        Ok(config.peers.pop().unwrap())
+    }
+
+    #[test]
+    fn decodes_legacy_socket_addr_toml() {
+        let peer = parse_bootstrap_peer(r#"address = "127.0.0.1:8000""#).unwrap();
+
+        assert_eq!(peer.ip().unwrap().to_string(), "127.0.0.1");
+        assert_eq!(peer.tcp_port().get(), 8000);
+        assert_eq!(peer.udp_port().map(NonZeroU16::get), Some(8000));
+        assert_eq!(peer.domain(), None);
+        assert_eq!(peer.direct_udp_port.map(NonZeroU16::get), Some(9001));
+    }
+
+    #[test]
+    fn decodes_legacy_domain_toml() {
+        let peer = parse_bootstrap_peer(r#"address = "node.example.com:8000""#).unwrap();
+
+        assert_eq!(peer.ip(), None);
+        assert_eq!(peer.tcp_port().get(), 8000);
+        assert_eq!(peer.udp_port().map(NonZeroU16::get), Some(8000));
+        assert_eq!(peer.domain(), Some("node.example.com"));
+    }
+
+    #[test]
+    fn rejects_legacy_address_without_port() {
+        let err = parse_bootstrap_peer(r#"address = "127.0.0.1""#).unwrap_err();
+
+        assert!(err
+            .message()
+            .contains("bootstrap peer address must include a port"));
+    }
+
+    #[test]
+    fn rejects_legacy_address_with_zero_port() {
+        let err = parse_bootstrap_peer(r#"address = "127.0.0.1:0""#).unwrap_err();
+
+        assert!(err
+            .message()
+            .contains("bootstrap peer address port must be non-zero"));
+    }
+
+    #[test]
+    fn decodes_split_port_toml() {
+        let peer = parse_bootstrap_peer(
+            r#"address = "127.0.0.2"
+tcp_port = 8001
+udp_port = 8002"#,
+        )
+        .unwrap();
+
+        assert_eq!(peer.ip().unwrap().to_string(), "127.0.0.2");
+        assert_eq!(peer.tcp_port().get(), 8001);
+        assert_eq!(peer.udp_port().map(NonZeroU16::get), Some(8002));
+        assert_eq!(peer.domain(), None);
+    }
+
+    #[test]
+    fn decodes_split_port_toml_without_udp_port() {
+        let peer = parse_bootstrap_peer(
+            r#"address = "127.0.0.3"
+tcp_port = 8003"#,
+        )
+        .unwrap();
+
+        assert_eq!(peer.ip().unwrap().to_string(), "127.0.0.3");
+        assert_eq!(peer.tcp_port().get(), 8003);
+        assert_eq!(peer.udp_port(), None);
+    }
+
+    #[test]
+    fn decodes_split_domain_toml() {
+        let peer = parse_bootstrap_peer(
+            r#"address = "node.example.com"
+tcp_port = 8004"#,
+        )
+        .unwrap();
+
+        assert_eq!(peer.ip(), None);
+        assert_eq!(peer.tcp_port().get(), 8004);
+        assert_eq!(peer.udp_port(), None);
+        assert_eq!(peer.domain(), Some("node.example.com"));
+    }
+
+    #[test]
+    fn rejects_split_address_with_embedded_port() {
+        let err = parse_bootstrap_peer(
+            r#"address = "127.0.0.1:8000"
+tcp_port = 8000"#,
+        )
+        .unwrap_err();
+
+        assert!(err
+            .message()
+            .contains("split bootstrap peer address must not include a port"));
+    }
+
+    #[test]
+    fn rejects_unknown_peer_field() {
+        let err = parse_bootstrap_peer(
+            r#"address = "127.0.0.1:8000"
+direct_udp_prt = 9001"#,
+        )
+        .unwrap_err();
+
+        assert!(err.message().contains("unknown field"));
+    }
 }

--- a/monad-node-config/src/lib.rs
+++ b/monad-node-config/src/lib.rs
@@ -69,6 +69,7 @@ pub struct NodeConfig<ST: CertificateSignatureRecoverable> {
     pub statesync: StateSyncPeersConfig<CertificateSignaturePubKey<ST>>,
     pub network: NodeNetworkConfig,
 
+    #[serde(deserialize_with = "peers::deserialize_peer_discovery_config")]
     pub peer_discovery: PeerDiscoveryConfig<ST>,
     #[serde(default)]
     pub txpool_peer_score: ema::ScoreConfig,

--- a/monad-node-config/src/peers.rs
+++ b/monad-node-config/src/peers.rs
@@ -13,19 +13,27 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::num::NonZeroU16;
+use std::{net::Ipv4Addr, num::NonZeroU16};
 
 use monad_crypto::certificate_signature::CertificateSignatureRecoverable;
 use monad_types::Round;
-use serde::{Deserialize, Serialize};
+use serde::{de::Error as _, Deserialize, Serialize};
+
+use crate::bootstrap::parse_address_fields;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 #[serde(bound = "ST: CertificateSignatureRecoverable")]
 pub struct PeerDiscoveryConfig<ST: CertificateSignatureRecoverable> {
     pub self_address: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub self_tcp_port: Option<NonZeroU16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub self_udp_port: Option<NonZeroU16>,
+
     pub self_auth_port: NonZeroU16,
     #[serde(alias = "self_direct_udp_auth_port")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub self_direct_udp_port: Option<NonZeroU16>,
     pub self_record_seq_num: u64,
 
@@ -38,4 +46,48 @@ pub struct PeerDiscoveryConfig<ST: CertificateSignatureRecoverable> {
     pub min_num_peers: usize,
     pub max_num_peers: usize,
     pub ping_rate_limit_per_second: u32,
+}
+
+pub(crate) fn deserialize_peer_discovery_config<'de, D, ST>(
+    deserializer: D,
+) -> Result<PeerDiscoveryConfig<ST>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    ST: CertificateSignatureRecoverable,
+{
+    PeerDiscoveryConfig::<ST>::deserialize(deserializer)?
+        .validate_address_fields()
+        .map_err(D::Error::custom)
+}
+
+impl<ST: CertificateSignatureRecoverable> PeerDiscoveryConfig<ST> {
+    fn validate_address_fields(mut self) -> Result<Self, &'static str> {
+        let (self_address, self_tcp_port, self_udp_port) =
+            parse_address_fields(&self.self_address, self.self_tcp_port, self.self_udp_port)?;
+        self.self_address = self_address;
+        self.self_tcp_port = Some(self_tcp_port);
+        self.self_udp_port = self_udp_port;
+        Ok(self)
+    }
+
+    pub fn ip(&self) -> Option<Ipv4Addr> {
+        self.self_address.parse().ok()
+    }
+
+    pub fn tcp_port(&self) -> NonZeroU16 {
+        self.self_tcp_port
+            .expect("peer discovery tcp_port must be present")
+    }
+
+    pub fn udp_port(&self) -> Option<NonZeroU16> {
+        self.self_udp_port
+    }
+
+    pub fn domain(&self) -> Option<&str> {
+        if self.self_address.parse::<Ipv4Addr>().is_ok() {
+            None
+        } else {
+            Some(&self.self_address)
+        }
+    }
 }

--- a/monad-node/examples/ledger-tail.rs
+++ b/monad-node/examples/ledger-tail.rs
@@ -117,7 +117,17 @@ async fn main() {
             config
                 .peers
                 .into_iter()
-                .map(|peer| (peer.secp256k1_pubkey, peer.address))
+                .map(|peer| {
+                    (
+                        peer.secp256k1_pubkey,
+                        format!(
+                            "{}:{}",
+                            peer.ip()
+                                .expect("ledger tail bootstrap peer address must be an IP address"),
+                            peer.tcp_port()
+                        ),
+                    )
+                })
                 .collect()
         })
         .unwrap_or_default();

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -48,7 +48,7 @@ use monad_node_config::{
 };
 use monad_peer_discovery::{
     discovery::{PeerDiscovery, PeerDiscoveryBuilder},
-    MonadNameRecord, NameRecord, PeerEntryConversionError,
+    MonadNameRecord, NameRecord,
 };
 use monad_peer_score::{ema, IdentityScore, StdClock};
 use monad_pprof::start_pprof_server;
@@ -585,14 +585,19 @@ where
         .network
         .direct_udp_bind_address_port
         .map(|port| SocketAddr::new(IpAddr::V4(node_config.network.bind_address_host), port));
-    let Some(name_record_address) = resolve_domain_v4(
-        &NodeId::new(identity.pubkey()),
-        &peer_discovery_config.self_address,
-    ) else {
-        panic!(
-            "Unable to resolve self address: {:?}",
-            peer_discovery_config.self_address
-        );
+    let self_id = NodeId::new(identity.pubkey());
+    let self_tcp_port = peer_discovery_config.tcp_port();
+    let name_record_address = if let Some(ip) = peer_discovery_config.ip() {
+        SocketAddrV4::new(ip, self_tcp_port.get())
+    } else {
+        let domain = peer_discovery_config
+            .domain()
+            .expect("self endpoint must be an IP address or domain");
+        let Some(name_record_address) = resolve_domain_v4(&self_id, (domain, self_tcp_port.get()))
+        else {
+            panic!("Unable to resolve self address: {domain}:{self_tcp_port}");
+        };
+        name_record_address
     };
 
     tracing::debug!(
@@ -640,11 +645,10 @@ where
         network_config.direct_udp_bind_address_port.is_some()
     );
 
-    let self_id = NodeId::new(identity.pubkey());
     let self_record = NameRecord::new_with_ports(
         *name_record_address.ip(),
-        name_record_address.port(),
-        name_record_address.port(),
+        self_tcp_port.get(),
+        peer_discovery_config.udp_port().map(NonZeroU16::get),
         peer_discovery_config.self_auth_port.get(),
         peer_discovery_config
             .self_direct_udp_port
@@ -671,11 +675,7 @@ where
 
             match MonadNameRecord::try_from(&peer_entry) {
                 Ok(monad_name_record) => Some((node_id, monad_name_record)),
-                Err(PeerEntryConversionError::MissingUdpPort) => {
-                    warn!(?node_id, "missing UDP port in config file");
-                    None
-                }
-                Err(PeerEntryConversionError::InvalidSignature(_)) => {
+                Err(_) => {
                     warn!(?node_id, "invalid name record signature in config file");
                     None
                 }

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -16,7 +16,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     marker::PhantomData,
-    net::{IpAddr, SocketAddr, ToSocketAddrs},
+    net::{IpAddr, SocketAddr, SocketAddrV4, ToSocketAddrs},
     num::NonZeroU16,
     path::PathBuf,
     process,
@@ -43,8 +43,8 @@ use monad_executor::{Executor, ExecutorMetricsChain};
 use monad_executor_glue::{LogFriendlyMonadEvent, Message, MonadEvent};
 use monad_ledger::MonadBlockFileLedger;
 use monad_node_config::{
-    ExecutionProtocolType, FullNodeIdentityConfig, NodeBootstrapConfig, NodeConfig,
-    PeerDiscoveryConfig, SignatureCollectionType, SignatureType,
+    ExecutionProtocolType, FullNodeIdentityConfig, NodeBootstrapConfig, NodeBootstrapPeerConfig,
+    NodeConfig, PeerDiscoveryConfig, SignatureCollectionType, SignatureType,
 };
 use monad_peer_discovery::{
     discovery::{PeerDiscovery, PeerDiscoveryBuilder},
@@ -585,7 +585,7 @@ where
         .network
         .direct_udp_bind_address_port
         .map(|port| SocketAddr::new(IpAddr::V4(node_config.network.bind_address_host), port));
-    let Some(SocketAddr::V4(name_record_address)) = resolve_domain_v4(
+    let Some(name_record_address) = resolve_domain_v4(
         &NodeId::new(identity.pubkey()),
         &peer_discovery_config.self_address,
     ) else {
@@ -667,26 +667,7 @@ where
             if node_id == self_id {
                 return None;
             }
-            let address = match resolve_domain_v4(&node_id, &peer.address) {
-                Some(SocketAddr::V4(addr)) => addr,
-                _ => {
-                    warn!(?node_id, ?peer.address, "Unable to resolve");
-                    return None;
-                }
-            };
-
-            let peer_entry = monad_executor_glue::PeerEntry {
-                pubkey: peer.secp256k1_pubkey,
-                address: monad_executor_glue::PeerEntryAddress::new(
-                    *address.ip(),
-                    NonZeroU16::new(address.port()).expect("resolved port must be non-zero"),
-                    Some(NonZeroU16::new(address.port()).expect("resolved port must be non-zero")),
-                ),
-                signature: peer.name_record_sig,
-                record_seq_num: peer.record_seq_num,
-                auth_port: peer.auth_port,
-                direct_udp_port: peer.direct_udp_port,
-            };
+            let peer_entry = bootstrap_peer_entry(&node_id, peer)?;
 
             match MonadNameRecord::try_from(&peer_entry) {
                 Ok(monad_name_record) => Some((node_id, monad_name_record)),
@@ -797,24 +778,55 @@ where
     )
 }
 
-fn resolve_domain_v4<P: PubKey>(node_id: &NodeId<P>, domain: &String) -> Option<SocketAddr> {
-    let resolved = match domain.to_socket_addrs() {
+fn resolve_domain_v4<P, T>(node_id: &NodeId<P>, address: T) -> Option<SocketAddrV4>
+where
+    P: PubKey,
+    T: ToSocketAddrs + std::fmt::Debug,
+{
+    let resolved = match address.to_socket_addrs() {
         Ok(resolved) => resolved,
         Err(err) => {
-            warn!(?node_id, ?domain, ?err, "Unable to resolve");
+            warn!(?node_id, ?address, ?err, "Unable to resolve");
             return None;
         }
     };
 
     for entry in resolved {
         match entry {
-            SocketAddr::V4(_) => return Some(entry),
+            SocketAddr::V4(addr) => return Some(addr),
             SocketAddr::V6(_) => continue,
         }
     }
 
-    warn!(?node_id, ?domain, "No IPv4 DNS record");
+    warn!(?node_id, ?address, "No IPv4 DNS record");
     None
+}
+
+fn bootstrap_peer_entry<ST: CertificateSignatureRecoverable>(
+    node_id: &NodeId<CertificateSignaturePubKey<ST>>,
+    peer: &NodeBootstrapPeerConfig<ST>,
+) -> Option<monad_executor_glue::PeerEntry<ST>> {
+    let address = if let Some(address) = peer.ip() {
+        address
+    } else {
+        let domain = peer
+            .domain()
+            .expect("bootstrap peer address must be an IP address or domain");
+        *resolve_domain_v4(node_id, (domain, peer.tcp_port().get()))?.ip()
+    };
+
+    Some(monad_executor_glue::PeerEntry {
+        pubkey: peer.secp256k1_pubkey,
+        address: monad_executor_glue::PeerEntryAddress::new(
+            address,
+            peer.tcp_port(),
+            peer.udp_port(),
+        ),
+        signature: peer.name_record_sig,
+        record_seq_num: peer.record_seq_num,
+        auth_port: peer.auth_port,
+        direct_udp_port: peer.direct_udp_port,
+    })
 }
 
 monad_executor::metric_consts! {

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -48,7 +48,7 @@ use monad_node_config::{
 };
 use monad_peer_discovery::{
     discovery::{PeerDiscovery, PeerDiscoveryBuilder},
-    MonadNameRecord, NameRecord,
+    MonadNameRecord, NameRecord, PeerEntryConversionError,
 };
 use monad_peer_score::{ema, IdentityScore, StdClock};
 use monad_pprof::start_pprof_server;
@@ -677,7 +677,11 @@ where
 
             let peer_entry = monad_executor_glue::PeerEntry {
                 pubkey: peer.secp256k1_pubkey,
-                addr: address,
+                address: monad_executor_glue::PeerEntryAddress::new(
+                    *address.ip(),
+                    NonZeroU16::new(address.port()).expect("resolved port must be non-zero"),
+                    Some(NonZeroU16::new(address.port()).expect("resolved port must be non-zero")),
+                ),
                 signature: peer.name_record_sig,
                 record_seq_num: peer.record_seq_num,
                 auth_port: peer.auth_port,
@@ -686,7 +690,11 @@ where
 
             match MonadNameRecord::try_from(&peer_entry) {
                 Ok(monad_name_record) => Some((node_id, monad_name_record)),
-                Err(_) => {
+                Err(PeerEntryConversionError::MissingUdpPort) => {
+                    warn!(?node_id, "missing UDP port in config file");
+                    None
+                }
+                Err(PeerEntryConversionError::InvalidSignature(_)) => {
                     warn!(?node_id, "invalid name record signature in config file");
                     None
                 }

--- a/monad-peer-disc-swarm/src/lib.rs
+++ b/monad-peer-disc-swarm/src/lib.rs
@@ -516,8 +516,8 @@ where
                     .peer_disc_driver
                     .get_peer_disc_state();
                 let Some(peer_addr) = peer_disc_state
-                    .get_pending_addr_by_id(message.to.get_peer_id())
-                    .or_else(|| peer_disc_state.get_addr_by_id(message.to.get_peer_id()))
+                    .get_pending_udp_addr_by_id(message.to.get_peer_id())
+                    .or_else(|| peer_disc_state.get_udp_addr_by_id(message.to.get_peer_id()))
                 else {
                     debug!(to=?message.to.get_peer_id(), "dropping outbound message: peer addr not found");
                     continue;

--- a/monad-peer-disc-swarm/tests/peer_discovery.rs
+++ b/monad-peer-disc-swarm/tests/peer_discovery.rs
@@ -134,7 +134,7 @@ fn generate_name_record(keypair: &KeyPairType) -> MonadNameRecord<SignatureType>
     let ipaddr_v4 = Ipv4Addr::from_bits(u32::from_be_bytes(hash.0[28..32].try_into().unwrap()));
     assert_ne!(ipaddr_v4, Ipv4Addr::UNSPECIFIED);
 
-    let name_record = NameRecord::new(ipaddr_v4, 8000, 8000, 8000, 0, 0);
+    let name_record = NameRecord::new(ipaddr_v4, 8000, Some(8000), 8000, 0, 0);
     let mut encoded = Vec::new();
     name_record.encode(&mut encoded);
     let signature = SignatureType::sign::<signing_domain::NameRecord>(&encoded, keypair);
@@ -202,7 +202,9 @@ fn setup_keys_and_swarm_builder(
                         .collect::<BTreeSet<_>>();
                     NodeBuilder {
                         id: NodeId::new(key.pubkey()),
-                        addr: generate_name_record(key).udp_address(),
+                        addr: generate_name_record(key)
+                            .udp_address()
+                            .expect("generated record must have udp address"),
                         algo_builder: PeerDiscoveryBuilder {
                             self_id,
                             self_record: generate_name_record(key),
@@ -374,7 +376,7 @@ fn test_update_name_record() {
     let new_name_record = NameRecord::new(
         *SocketAddrV4::from_str("2.2.2.2:8000").unwrap().ip(),
         8000,
-        8000,
+        Some(8000),
         8000,
         0,
         1,
@@ -389,7 +391,9 @@ fn test_update_name_record() {
 
     let new_node_0_builder = NodeBuilder {
         id: node_0,
-        addr: new_name_record.udp_address(),
+        addr: new_name_record
+            .udp_address()
+            .expect("new name record must have udp address"),
         algo_builder: PeerDiscoveryBuilder {
             self_id: node_0,
             self_record: new_name_record.clone(),
@@ -1248,7 +1252,7 @@ fn test_validator_name_record_change_propagation_to_full_node() {
     let new_name_record = NameRecord::new(
         *SocketAddrV4::from_str("8.8.8.8:8000").unwrap().ip(),
         8000,
-        8000,
+        Some(8000),
         8000,
         0,
         1,
@@ -1263,7 +1267,9 @@ fn test_validator_name_record_change_propagation_to_full_node() {
 
     let new_node_1_builder = NodeBuilder {
         id: node_1,
-        addr: new_node_1_name_record.udp_address(),
+        addr: new_node_1_name_record
+            .udp_address()
+            .expect("new node 1 name record must have udp address"),
         algo_builder: PeerDiscoveryBuilder {
             self_id: node_1,
             self_record: new_node_1_name_record.clone(),

--- a/monad-peer-discovery/examples/sign-name-record.rs
+++ b/monad-peer-discovery/examples/sign-name-record.rs
@@ -78,7 +78,7 @@ fn main() {
     let name_record = NameRecord::new_with_ports(
         *self_address.ip(),
         self_address.port(),
-        self_address.port(),
+        Some(self_address.port()),
         args.authenticated_udp_port,
         args.direct_udp_port,
         self_record_seq_num,

--- a/monad-peer-discovery/src/discovery.rs
+++ b/monad-peer-discovery/src/discovery.rs
@@ -15,7 +15,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    net::{IpAddr, SocketAddrV4},
+    net::{IpAddr, Ipv4Addr, SocketAddrV4},
     num::NonZeroU32,
     path::PathBuf,
     time::Duration,
@@ -500,8 +500,8 @@ impl<ST: CertificateSignatureRecoverable, C: governor::clock::Clock> PeerDiscove
 
         // check if the peer ip address is valid
         if let Err(err) = validate_socket_ipv4_address(
-            &name_record.udp_address(),
-            &self.self_record.udp_address(),
+            &name_record.authenticated_udp_address(),
+            &self.self_record.authenticated_udp_address(),
         ) {
             warn!(
                 ?peer_id,
@@ -1813,25 +1813,45 @@ where
         &self.metrics
     }
 
-    fn get_pending_addr_by_id(
+    fn get_pending_udp_addr_by_id(
         &self,
         id: &NodeId<CertificateSignaturePubKey<ST>>,
     ) -> Option<SocketAddrV4> {
         self.pending_queue
             .get(id)
-            .map(|info| info.name_record.udp_address())
+            .and_then(|info| info.name_record.udp_address())
     }
 
-    fn get_addr_by_id(&self, id: &NodeId<CertificateSignaturePubKey<ST>>) -> Option<SocketAddrV4> {
+    fn get_udp_addr_by_id(
+        &self,
+        id: &NodeId<CertificateSignaturePubKey<ST>>,
+    ) -> Option<SocketAddrV4> {
         self.routing_info
             .get(id)
-            .map(|name_record| name_record.udp_address())
+            .and_then(|name_record| name_record.udp_address())
     }
 
-    fn get_known_addrs(&self) -> HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddrV4> {
+    fn get_tcp_addr_by_id(
+        &self,
+        id: &NodeId<CertificateSignaturePubKey<ST>>,
+    ) -> Option<SocketAddrV4> {
+        self.routing_info
+            .get(id)
+            .map(|name_record| name_record.name_record.tcp_socket())
+    }
+
+    fn get_ip_by_id(&self, id: &NodeId<CertificateSignaturePubKey<ST>>) -> Option<Ipv4Addr> {
+        self.routing_info
+            .get(id)
+            .map(|name_record| name_record.name_record.ip())
+    }
+
+    fn get_known_auth_udp_addrs(
+        &self,
+    ) -> HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddrV4> {
         self.routing_info
             .iter()
-            .map(|(id, name_record)| (*id, name_record.udp_address()))
+            .map(|(id, name_record)| (*id, name_record.authenticated_udp_address()))
             .collect()
     }
 
@@ -1892,7 +1912,7 @@ mod tests {
     const DUMMY_ADDR: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::new(1, 1, 1, 1), 8000);
 
     fn name_record_addr(record: &MonadNameRecord<SignatureType>) -> SocketAddr {
-        SocketAddr::V4(record.udp_address())
+        SocketAddr::V4(record.authenticated_udp_address())
     }
 
     fn peer_source(
@@ -1908,7 +1928,7 @@ mod tests {
     fn peer_source_from_record(
         keypair: &KeyPairType,
     ) -> PeerSource<CertificateSignaturePubKey<SignatureType>> {
-        let addr = SocketAddr::V4(generate_name_record(keypair, 0).udp_address());
+        let addr = SocketAddr::V4(generate_name_record(keypair, 0).authenticated_udp_address());
         peer_source(keypair, addr)
     }
 
@@ -1918,7 +1938,7 @@ mod tests {
         let hash = hasher.hash();
         let ipaddr_v4 = Ipv4Addr::from_bits(u32::from_be_bytes(hash.0[28..32].try_into().unwrap()));
         let port = 8000 + seq_num as u16;
-        let name_record = NameRecord::new(ipaddr_v4, port, port, port + 1000, 0, seq_num);
+        let name_record = NameRecord::new(ipaddr_v4, port, Some(port), port + 1000, 0, seq_num);
         let mut encoded = Vec::new();
         name_record.encode(&mut encoded);
         let signature = SignatureType::sign::<signing_domain::NameRecord>(&encoded, keypair);
@@ -1932,7 +1952,7 @@ mod tests {
         let name_record = NameRecord::new(
             *DUMMY_ADDR.ip(),
             DUMMY_ADDR.port(),
-            DUMMY_ADDR.port(),
+            Some(DUMMY_ADDR.port()),
             DUMMY_ADDR.port() + 1000,
             0,
             0,
@@ -1983,7 +2003,7 @@ mod tests {
             .map(|key| {
                 let node_id = NodeId::new(key.pubkey());
                 let name_record = generate_name_record(key, 0);
-                (name_record.udp_address(), node_id)
+                (name_record.authenticated_udp_address(), node_id)
             })
             .collect::<BTreeMap<_, _>>();
 
@@ -2392,6 +2412,69 @@ mod tests {
     }
 
     #[test]
+    fn test_tcp_lookup_uses_name_record_tcp_socket() {
+        let keys = create_keys::<SignatureType>(2);
+        let peer0 = &keys[0];
+        let peer1 = &keys[1];
+        let peer1_pubkey = NodeId::new(peer1.pubkey());
+        let ip = Ipv4Addr::new(8, 8, 8, 8);
+        let tcp_port = 8100;
+        let udp_port = 8101;
+        let auth_port = 9100;
+
+        let (mut state, _clock) = generate_test_state(peer0, vec![]);
+        let peer1_record = MonadNameRecord::new(
+            NameRecord::new(ip, tcp_port, Some(udp_port), auth_port, 0, 1),
+            peer1,
+        );
+        state
+            .routing_info
+            .insert(peer1_pubkey, peer1_record.clone());
+
+        assert_eq!(
+            state.get_udp_addr_by_id(&peer1_pubkey),
+            peer1_record.udp_address()
+        );
+        assert_eq!(
+            state.get_tcp_addr_by_id(&peer1_pubkey),
+            Some(peer1_record.name_record.tcp_socket())
+        );
+        assert_ne!(
+            state.get_udp_addr_by_id(&peer1_pubkey),
+            state.get_tcp_addr_by_id(&peer1_pubkey)
+        );
+        assert_eq!(state.get_ip_by_id(&peer1_pubkey), Some(ip));
+    }
+
+    #[test]
+    fn test_auth_only_record_has_no_unauthenticated_udp_lookup() {
+        let keys = create_keys::<SignatureType>(2);
+        let peer0 = &keys[0];
+        let peer1 = &keys[1];
+        let peer1_pubkey = NodeId::new(peer1.pubkey());
+        let ip = Ipv4Addr::new(8, 8, 4, 4);
+        let tcp_port = 8100;
+        let auth_port = 9100;
+
+        let (mut state, _clock) = generate_test_state(peer0, vec![]);
+        let name_record =
+            MonadNameRecord::new(NameRecord::new(ip, tcp_port, None, auth_port, 0, 1), peer1);
+        state.routing_info.insert(peer1_pubkey, name_record.clone());
+
+        assert_eq!(name_record.udp_address(), None);
+        assert_eq!(state.get_udp_addr_by_id(&peer1_pubkey), None);
+        assert_eq!(state.get_ip_by_id(&peer1_pubkey), Some(ip));
+        assert_eq!(
+            state.get_tcp_addr_by_id(&peer1_pubkey),
+            Some(name_record.name_record.tcp_socket())
+        );
+        assert_eq!(
+            name_record.authenticated_udp_address(),
+            SocketAddrV4::new(ip, auth_port)
+        );
+    }
+
+    #[test]
     fn test_peer_lookup_target_not_found() {
         let keys = create_keys::<SignatureType>(4);
         let peer0 = &keys[0];
@@ -2489,10 +2572,16 @@ mod tests {
 
         // insert into routing info after ping pong round trip
         assert_eq!(
-            state.socket_to_id.get(&original_name_record.udp_address()),
+            state
+                .socket_to_id
+                .get(&original_name_record.authenticated_udp_address()),
             Some(&peer1_pubkey)
         );
-        assert!(!state.socket_to_id.contains_key(&record.udp_address()));
+        assert!(
+            !state
+                .socket_to_id
+                .contains_key(&record.authenticated_udp_address())
+        );
         state.handle_pong(
             peer_source_from_record(peer1),
             Pong {
@@ -2506,10 +2595,10 @@ mod tests {
         assert!(
             !state
                 .socket_to_id
-                .contains_key(&original_name_record.udp_address())
+                .contains_key(&original_name_record.authenticated_udp_address())
         );
         assert_eq!(
-            state.socket_to_id.get(&record.udp_address()),
+            state.socket_to_id.get(&record.authenticated_udp_address()),
             Some(&peer1_pubkey)
         );
 
@@ -2788,41 +2877,41 @@ mod tests {
 
     #[test_case(
         None,
-        NameRecord::new(*NEW_ADDR.ip(), NEW_ADDR.port(), NEW_ADDR.port(), 9001, 0, 1),
+        NameRecord::new(*NEW_ADDR.ip(), NEW_ADDR.port(), Some(NEW_ADDR.port()), 9001, 0, 1),
         true,
-        NameRecord::new(*NEW_ADDR.ip(), NEW_ADDR.port(), NEW_ADDR.port(), 9001, 0, 1),
+        NameRecord::new(*NEW_ADDR.ip(), NEW_ADDR.port(), Some(NEW_ADDR.port()), 9001, 0, 1),
         true;
         "first record"
     )]
     #[test_case(
-        Some(NameRecord::new(*OLD_ADDR.ip(), OLD_ADDR.port(), OLD_ADDR.port(), 9000, 0, 1)),
-        NameRecord::new(*NEW_ADDR.ip(), NEW_ADDR.port(), NEW_ADDR.port(), 9001, 0, 2),
+        Some(NameRecord::new(*OLD_ADDR.ip(), OLD_ADDR.port(), Some(OLD_ADDR.port()), 9000, 0, 1)),
+        NameRecord::new(*NEW_ADDR.ip(), NEW_ADDR.port(), Some(NEW_ADDR.port()), 9001, 0, 2),
         true,
-        NameRecord::new(*NEW_ADDR.ip(), NEW_ADDR.port(), NEW_ADDR.port(), 9001, 0, 2),
+        NameRecord::new(*NEW_ADDR.ip(), NEW_ADDR.port(), Some(NEW_ADDR.port()), 9001, 0, 2),
         true;
         "newer record"
     )]
     #[test_case(
-        Some(NameRecord::new(*OLD_ADDR.ip(), OLD_ADDR.port(), OLD_ADDR.port(), 9000, 0, 1)),
-        NameRecord::new(*OLD_ADDR.ip(), OLD_ADDR.port(), OLD_ADDR.port(), 9000, 0, 1),
+        Some(NameRecord::new(*OLD_ADDR.ip(), OLD_ADDR.port(), Some(OLD_ADDR.port()), 9000, 0, 1)),
+        NameRecord::new(*OLD_ADDR.ip(), OLD_ADDR.port(), Some(OLD_ADDR.port()), 9000, 0, 1),
         true,
-        NameRecord::new(*OLD_ADDR.ip(), OLD_ADDR.port(), OLD_ADDR.port(), 9000, 0, 1),
+        NameRecord::new(*OLD_ADDR.ip(), OLD_ADDR.port(), Some(OLD_ADDR.port()), 9000, 0, 1),
         false;
         "same record"
     )]
     #[test_case(
-        Some(NameRecord::new(*NEW_ADDR.ip(), NEW_ADDR.port(), NEW_ADDR.port(), 9001, 0, 2)),
-        NameRecord::new(*OLD_ADDR.ip(), OLD_ADDR.port(), OLD_ADDR.port(), 9000, 0, 1),
+        Some(NameRecord::new(*NEW_ADDR.ip(), NEW_ADDR.port(), Some(NEW_ADDR.port()), 9001, 0, 2)),
+        NameRecord::new(*OLD_ADDR.ip(), OLD_ADDR.port(), Some(OLD_ADDR.port()), 9000, 0, 1),
         false,
-        NameRecord::new(*NEW_ADDR.ip(), NEW_ADDR.port(), NEW_ADDR.port(), 9001, 0, 2),
+        NameRecord::new(*NEW_ADDR.ip(), NEW_ADDR.port(), Some(NEW_ADDR.port()), 9001, 0, 2),
         false;
         "older record"
     )]
     #[test_case(
-        Some(NameRecord::new(*OLD_ADDR.ip(), OLD_ADDR.port(), OLD_ADDR.port(), 9000, 0, 1)),
-        NameRecord::new(*NEW_ADDR.ip(), NEW_ADDR.port(), NEW_ADDR.port(), 9001, 0, 1),
+        Some(NameRecord::new(*OLD_ADDR.ip(), OLD_ADDR.port(), Some(OLD_ADDR.port()), 9000, 0, 1)),
+        NameRecord::new(*NEW_ADDR.ip(), NEW_ADDR.port(), Some(NEW_ADDR.port()), 9001, 0, 1),
         false,
-        NameRecord::new(*OLD_ADDR.ip(), OLD_ADDR.port(), OLD_ADDR.port(), 9000, 0, 1),
+        NameRecord::new(*OLD_ADDR.ip(), OLD_ADDR.port(), Some(OLD_ADDR.port()), 9000, 0, 1),
         false;
         "conflicting record"
     )]
@@ -2950,7 +3039,9 @@ mod tests {
         let peer1_record = generate_name_record(peer1, 0);
         assert!(state.routing_info.contains_key(&peer1_pubkey));
         assert_eq!(
-            state.socket_to_id.get(&peer1_record.udp_address()),
+            state
+                .socket_to_id
+                .get(&peer1_record.authenticated_udp_address()),
             Some(&peer1_pubkey)
         );
 
@@ -2966,7 +3057,11 @@ mod tests {
         assert!(!state.participation_info.contains_key(&peer1_pubkey));
 
         // verify socket_to_id is also cleaned up
-        assert!(!state.socket_to_id.contains_key(&peer1_record.udp_address()));
+        assert!(
+            !state
+                .socket_to_id
+                .contains_key(&peer1_record.authenticated_udp_address())
+        );
     }
 
     #[test]
@@ -2981,7 +3076,14 @@ mod tests {
         let (mut state, _clock) = generate_test_state(peer0, vec![]);
 
         let peer1_record = MonadNameRecord::new(
-            NameRecord::new_with_ports(Ipv4Addr::new(8, 8, 8, 8), 8000, 8000, 9100, Some(9000), 1),
+            NameRecord::new_with_ports(
+                Ipv4Addr::new(8, 8, 8, 8),
+                8000,
+                Some(8000),
+                9100,
+                Some(9000),
+                1,
+            ),
             peer1,
         );
         let peer1_entry = PeerEntry::from(peer1_record.with_pubkey(peer1.pubkey()));
@@ -2991,8 +3093,8 @@ mod tests {
         assert_eq!(first_pings.len(), 1);
         assert_eq!(first_pings[0].0, peer1_pubkey);
         assert_eq!(
-            state.get_pending_addr_by_id(&peer1_pubkey),
-            Some(peer1_record.udp_address())
+            state.get_pending_udp_addr_by_id(&peer1_pubkey),
+            peer1_record.udp_address()
         );
 
         state.handle_pong(
@@ -3006,7 +3108,14 @@ mod tests {
         assert_eq!(state.get_name_record(&peer1_pubkey), Some(&peer1_record));
 
         let peer2_record = MonadNameRecord::new(
-            NameRecord::new_with_ports(Ipv4Addr::new(8, 8, 8, 8), 8001, 8001, 9101, Some(9000), 1),
+            NameRecord::new_with_ports(
+                Ipv4Addr::new(8, 8, 8, 8),
+                8001,
+                Some(8001),
+                9101,
+                Some(9000),
+                1,
+            ),
             peer2,
         );
         let peer_entry = PeerEntry::from(peer2_record.with_pubkey(peer2.pubkey()));
@@ -3014,7 +3123,7 @@ mod tests {
         let second_cmds = state.update_peers(vec![peer_entry]);
 
         assert!(second_cmds.is_empty());
-        assert_eq!(state.get_pending_addr_by_id(&peer2_pubkey), None);
+        assert_eq!(state.get_pending_udp_addr_by_id(&peer2_pubkey), None);
         assert_eq!(state.get_name_record(&peer2_pubkey), None);
         assert_eq!(state.metrics()[GAUGE_PEER_DISC_SOCKET_COLLISIONS], 1);
         assert_eq!(state.get_name_record(&peer1_pubkey), Some(&peer1_record));
@@ -3038,7 +3147,7 @@ mod tests {
             .map(|key| {
                 let node_id = NodeId::new(key.pubkey());
                 let record = generate_name_record(key, 0);
-                (node_id, record.udp_address())
+                (node_id, record.authenticated_udp_address())
             })
             .collect();
 
@@ -3252,7 +3361,8 @@ mod tests {
 
         // peer1 has an authenticated UDP port
         let peer1_name_record = {
-            let name_record = NameRecord::new(Ipv4Addr::new(8, 8, 8, 8), 8000, 8000, 9000, 0, 1);
+            let name_record =
+                NameRecord::new(Ipv4Addr::new(8, 8, 8, 8), 8000, Some(8000), 9000, 0, 1);
             let mut encoded = Vec::new();
             name_record.encode(&mut encoded);
             let signature = SecpSignature::sign::<signing_domain::NameRecord>(&encoded, peer1);
@@ -3267,7 +3377,7 @@ mod tests {
             let name_record = NameRecord::new_with_ports(
                 Ipv4Addr::new(8, 8, 4, 4),
                 8001,
-                8001,
+                Some(8001),
                 9001,
                 Some(9002),
                 2,
@@ -3303,7 +3413,7 @@ mod tests {
                 let name_record = NameRecord::new(
                     *DUMMY_ADDR.ip(),
                     DUMMY_ADDR.port(),
-                    DUMMY_ADDR.port(),
+                    Some(DUMMY_ADDR.port()),
                     DUMMY_ADDR.port(),
                     0,
                     0,
@@ -3398,7 +3508,7 @@ mod tests {
         let loaded_peer1 = &state.pending_queue.get(&peer1_pubkey).unwrap().name_record;
         assert_eq!(
             loaded_peer1.udp_address(),
-            SocketAddrV4::new(Ipv4Addr::new(8, 8, 8, 8), 8000),
+            Some(SocketAddrV4::new(Ipv4Addr::new(8, 8, 8, 8), 8000)),
             "peer1 address should match"
         );
         assert_eq!(loaded_peer1.seq(), 1, "peer1 seq should match");
@@ -3412,7 +3522,7 @@ mod tests {
         let loaded_peer2 = &state.pending_queue.get(&peer2_pubkey).unwrap().name_record;
         assert_eq!(
             loaded_peer2.udp_address(),
-            SocketAddrV4::new(Ipv4Addr::new(8, 8, 4, 4), 8001),
+            Some(SocketAddrV4::new(Ipv4Addr::new(8, 8, 4, 4), 8001)),
             "peer2 address should match"
         );
         assert_eq!(loaded_peer2.seq(), 2, "peer2 seq should match");

--- a/monad-peer-discovery/src/driver.rs
+++ b/monad-peer-discovery/src/driver.rs
@@ -15,7 +15,7 @@
 
 use std::{
     collections::{HashMap, VecDeque},
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     task::{Context, Poll, Waker},
     time::Duration,
 };
@@ -277,11 +277,25 @@ impl<PD: PeerDiscoveryAlgo> PeerDiscoveryDriver<PD> {
         self.timer.exec(timer_cmds);
     }
 
-    pub fn get_addr(
+    pub fn get_udp_addr(
         &self,
         node_id: &NodeId<CertificateSignaturePubKey<PD::SignatureType>>,
     ) -> Option<SocketAddr> {
-        self.pd.get_addr_by_id(node_id).map(SocketAddr::V4)
+        self.pd.get_udp_addr_by_id(node_id).map(SocketAddr::V4)
+    }
+
+    pub fn get_tcp_addr(
+        &self,
+        node_id: &NodeId<CertificateSignaturePubKey<PD::SignatureType>>,
+    ) -> Option<SocketAddr> {
+        self.pd.get_tcp_addr_by_id(node_id).map(SocketAddr::V4)
+    }
+
+    pub fn get_ip(
+        &self,
+        node_id: &NodeId<CertificateSignaturePubKey<PD::SignatureType>>,
+    ) -> Option<IpAddr> {
+        self.pd.get_ip_by_id(node_id).map(IpAddr::V4)
     }
 
     pub fn get_direct_udp_addr(
@@ -294,11 +308,11 @@ impl<PD: PeerDiscoveryAlgo> PeerDiscoveryDriver<PD> {
             .map(SocketAddr::V4)
     }
 
-    pub fn get_known_addresses(
+    pub fn get_known_auth_udp_addrs(
         &self,
     ) -> HashMap<NodeId<CertificateSignaturePubKey<PD::SignatureType>>, SocketAddr> {
         self.pd
-            .get_known_addrs()
+            .get_known_auth_udp_addrs()
             .into_iter()
             .map(|(k, v)| (k, SocketAddr::V4(v)))
             .collect()

--- a/monad-peer-discovery/src/lib.rs
+++ b/monad-peer-discovery/src/lib.rs
@@ -30,7 +30,7 @@ use monad_crypto::{
     signing_domain,
 };
 use monad_executor::ExecutorMetrics;
-use monad_executor_glue::PeerEntry;
+use monad_executor_glue::{PeerEntry, PeerEntryAddress};
 use monad_node_config::NodeBootstrapPeerConfig;
 use monad_types::{Epoch, NodeId, Round};
 use tracing::debug;
@@ -277,15 +277,15 @@ impl NameRecord {
             .get()
     }
 
+    pub fn tcp_socket(&self) -> SocketAddrV4 {
+        SocketAddrV4::new(self.ip(), self.tcp_port())
+    }
+
     pub fn udp_port(&self) -> u16 {
         self.ports
             .udp_port()
             .expect("name record must have UDP port")
             .get()
-    }
-
-    pub fn tcp_socket(&self) -> SocketAddrV4 {
-        SocketAddrV4::new(self.ip(), self.tcp_port())
     }
 
     pub fn udp_socket(&self) -> SocketAddrV4 {
@@ -424,14 +424,22 @@ impl<ST: CertificateSignatureRecoverable> MonadNameRecord<ST> {
     }
 }
 
+#[derive(Debug)]
+pub enum PeerEntryConversionError<E> {
+    MissingUdpPort,
+    InvalidSignature(E),
+}
+
 impl<ST: CertificateSignatureRecoverable> TryFrom<&PeerEntry<ST>> for MonadNameRecord<ST> {
-    type Error = <ST as CertificateSignature>::Error;
+    type Error = PeerEntryConversionError<<ST as CertificateSignature>::Error>;
 
     fn try_from(peer: &PeerEntry<ST>) -> Result<Self, Self::Error> {
         let name_record = NameRecord::new_with_ports(
-            *peer.addr.ip(),
-            peer.addr.port(),
-            peer.addr.port(),
+            peer.ip(),
+            peer.tcp_port().get(),
+            peer.udp_port()
+                .ok_or(PeerEntryConversionError::MissingUdpPort)?
+                .get(),
             peer.auth_port.get(),
             peer.direct_udp_port.map(NonZeroU16::get),
             peer.record_seq_num,
@@ -440,7 +448,8 @@ impl<ST: CertificateSignatureRecoverable> TryFrom<&PeerEntry<ST>> for MonadNameR
         let mut encoded = Vec::new();
         name_record.encode(&mut encoded);
         peer.signature
-            .verify::<signing_domain::NameRecord>(&encoded, &peer.pubkey)?;
+            .verify::<signing_domain::NameRecord>(&encoded, &peer.pubkey)
+            .map_err(PeerEntryConversionError::InvalidSignature)?;
 
         Ok(MonadNameRecord {
             name_record,
@@ -457,7 +466,15 @@ impl<ST: CertificateSignatureRecoverable> TryFrom<&MonadNameRecord<ST>> for Peer
 
         Ok(PeerEntry {
             pubkey,
-            addr: record.name_record.udp_socket(),
+            address: PeerEntryAddress::new(
+                record.name_record.ip(),
+                NonZeroU16::new(record.name_record.tcp_port())
+                    .expect("name record TCP port must be non-zero"),
+                Some(
+                    NonZeroU16::new(record.name_record.udp_port())
+                        .expect("name record UDP port must be non-zero"),
+                ),
+            ),
             signature: record.signature,
             record_seq_num: record.name_record.seq(),
             auth_port: NonZeroU16::new(record.name_record.authenticated_udp_port())
@@ -546,7 +563,15 @@ impl<ST: CertificateSignatureRecoverable> From<MonadNameRecordWithPubkey<'_, ST>
     fn from(record_with_pubkey: MonadNameRecordWithPubkey<'_, ST>) -> Self {
         PeerEntry {
             pubkey: record_with_pubkey.pubkey,
-            addr: record_with_pubkey.record.name_record.udp_socket(),
+            address: PeerEntryAddress::new(
+                record_with_pubkey.record.name_record.ip(),
+                NonZeroU16::new(record_with_pubkey.record.name_record.tcp_port())
+                    .expect("name record TCP port must be non-zero"),
+                Some(
+                    NonZeroU16::new(record_with_pubkey.record.name_record.udp_port())
+                        .expect("name record UDP port must be non-zero"),
+                ),
+            ),
             signature: record_with_pubkey.record.signature,
             record_seq_num: record_with_pubkey.record.name_record.seq(),
             auth_port: NonZeroU16::new(
@@ -1117,7 +1142,6 @@ mod tests {
 
         let keypair = KeyPair::from_ikm(b"test invalid sig").unwrap();
         let other_keypair = KeyPair::from_ikm(b"other key").unwrap();
-        let addr = SocketAddrV4::new(ip, port);
 
         let name_record = NameRecord::new(ip, port, port, port, 0, seq);
         let mut encoded = Vec::new();
@@ -1127,7 +1151,11 @@ mod tests {
 
         let peer_entry = PeerEntry {
             pubkey: keypair.pubkey(),
-            addr,
+            address: PeerEntryAddress::new(
+                ip,
+                NonZeroU16::new(port).unwrap(),
+                Some(NonZeroU16::new(port).unwrap()),
+            ),
             signature: wrong_signature,
             record_seq_num: seq,
             auth_port: NonZeroU16::new(port).unwrap(),

--- a/monad-peer-discovery/src/lib.rs
+++ b/monad-peer-discovery/src/lib.rs
@@ -490,31 +490,23 @@ impl<ST: CertificateSignatureRecoverable> From<MonadNameRecordWithPubkey<'_, ST>
     for NodeBootstrapPeerConfig<ST>
 {
     fn from(record_with_pubkey: MonadNameRecordWithPubkey<'_, ST>) -> Self {
+        let peer = PeerEntry::from(record_with_pubkey);
         NodeBootstrapPeerConfig {
-            address: record_with_pubkey.record.udp_address().to_string(),
-            record_seq_num: record_with_pubkey.record.seq(),
-            secp256k1_pubkey: record_with_pubkey.pubkey,
-            name_record_sig: record_with_pubkey.record.signature,
-            auth_port: NonZeroU16::new(
-                record_with_pubkey
-                    .record
-                    .name_record
-                    .authenticated_udp_port(),
-            )
-            .expect("name record authenticated UDP port must be non-zero"),
-            direct_udp_port: record_with_pubkey
-                .record
-                .name_record
-                .direct_udp_port()
-                .map(|port| {
-                    NonZeroU16::new(port).expect("name record direct UDP port must be non-zero")
-                }),
+            address: peer.ip().to_string(),
+            tcp_port: Some(peer.tcp_port()),
+            udp_port: peer.udp_port(),
+            secp256k1_pubkey: peer.pubkey,
+            name_record_sig: peer.signature,
+            record_seq_num: peer.record_seq_num,
+            auth_port: peer.auth_port,
+            direct_udp_port: peer.direct_udp_port,
         }
     }
 }
 
 #[derive(Debug)]
 pub enum PeerConfigConversionError {
+    MissingUdpPort,
     InvalidSignature,
     InvalidAddress(String),
 }
@@ -525,29 +517,34 @@ impl<ST: CertificateSignatureRecoverable> TryFrom<&NodeBootstrapPeerConfig<ST>>
     type Error = PeerConfigConversionError;
 
     fn try_from(peer_config: &NodeBootstrapPeerConfig<ST>) -> Result<Self, Self::Error> {
-        let addr = peer_config
-            .address
-            .parse::<SocketAddrV4>()
-            .map_err(|_| PeerConfigConversionError::InvalidAddress(peer_config.address.clone()))?;
-        let name_record = NameRecord::new_with_ports(
-            *addr.ip(),
-            addr.port(),
-            addr.port(),
-            peer_config.auth_port.get(),
-            peer_config.direct_udp_port.map(NonZeroU16::get),
-            peer_config.record_seq_num,
-        );
-
-        let mut encoded = Vec::new();
-        name_record.encode(&mut encoded);
-        peer_config
-            .name_record_sig
-            .verify::<signing_domain::NameRecord>(&encoded, &peer_config.secp256k1_pubkey)
-            .map_err(|_| PeerConfigConversionError::InvalidSignature)?;
-
-        Ok(MonadNameRecord {
-            name_record,
+        let invalid_address = || {
+            let domain = peer_config
+                .domain()
+                .expect("bootstrap peer address must be an IP address or domain");
+            PeerConfigConversionError::InvalidAddress(format!(
+                "{}:{}",
+                domain,
+                peer_config.tcp_port()
+            ))
+        };
+        let peer_entry = PeerEntry {
+            pubkey: peer_config.secp256k1_pubkey,
+            address: PeerEntryAddress::new(
+                peer_config.ip().ok_or_else(invalid_address)?,
+                peer_config.tcp_port(),
+                peer_config.udp_port(),
+            ),
             signature: peer_config.name_record_sig,
+            record_seq_num: peer_config.record_seq_num,
+            auth_port: peer_config.auth_port,
+            direct_udp_port: peer_config.direct_udp_port,
+        };
+
+        MonadNameRecord::try_from(&peer_entry).map_err(|err| match err {
+            PeerEntryConversionError::MissingUdpPort => PeerConfigConversionError::MissingUdpPort,
+            PeerEntryConversionError::InvalidSignature(_) => {
+                PeerConfigConversionError::InvalidSignature
+            }
         })
     }
 }

--- a/monad-peer-discovery/src/lib.rs
+++ b/monad-peer-discovery/src/lib.rs
@@ -211,9 +211,6 @@ impl NameRecord {
         if self.ports.tcp_port().is_none() {
             return Err(alloy_rlp::Error::Custom("Missing TCP port"));
         }
-        if self.ports.udp_port().is_none() {
-            return Err(alloy_rlp::Error::Custom("Missing UDP port"));
-        }
         if self.ports.authenticated_udp_port().is_none() {
             return Err(alloy_rlp::Error::Custom("Missing Authenticated UDP port"));
         }
@@ -224,7 +221,7 @@ impl NameRecord {
     pub fn new(
         ip: Ipv4Addr,
         tcp_port: u16,
-        udp_port: u16,
+        udp_port: Option<u16>,
         authenticated_udp_port: u16,
         capabilities: u64,
         seq: u64,
@@ -238,14 +235,16 @@ impl NameRecord {
     pub fn new_with_ports(
         ip: Ipv4Addr,
         tcp_port: u16,
-        udp_port: u16,
+        udp_port: Option<u16>,
         authenticated_udp_port: u16,
         direct_udp_port: Option<u16>,
         seq: u64,
     ) -> Self {
         let mut ports_vec = ArrayVec::new();
         ports_vec.push(Port::new(PortTag::TCP, tcp_port));
-        ports_vec.push(Port::new(PortTag::UDP, udp_port));
+        if let Some(udp_port) = udp_port {
+            ports_vec.push(Port::new(PortTag::UDP, udp_port));
+        }
         ports_vec.push(Port::new(PortTag::AuthenticatedUDP, authenticated_udp_port));
         if let Some(direct_udp_port) = direct_udp_port {
             ports_vec.push(Port::new(PortTag::DirectUDP, direct_udp_port));
@@ -281,15 +280,13 @@ impl NameRecord {
         SocketAddrV4::new(self.ip(), self.tcp_port())
     }
 
-    pub fn udp_port(&self) -> u16 {
-        self.ports
-            .udp_port()
-            .expect("name record must have UDP port")
-            .get()
+    pub fn udp_port(&self) -> Option<u16> {
+        self.ports.udp_port().map(NonZeroU16::get)
     }
 
-    pub fn udp_socket(&self) -> SocketAddrV4 {
-        SocketAddrV4::new(self.ip(), self.udp_port())
+    pub fn udp_socket(&self) -> Option<SocketAddrV4> {
+        self.udp_port()
+            .map(|udp_port| SocketAddrV4::new(self.ip(), udp_port))
     }
 
     pub fn authenticated_udp_port(&self) -> u16 {
@@ -387,7 +384,7 @@ impl<ST: CertificateSignatureRecoverable> MonadNameRecord<ST> {
         Ok(NodeId::new(pubkey))
     }
 
-    pub fn udp_address(&self) -> SocketAddrV4 {
+    pub fn udp_address(&self) -> Option<SocketAddrV4> {
         self.name_record.udp_socket()
     }
 
@@ -401,7 +398,7 @@ impl<ST: CertificateSignatureRecoverable> MonadNameRecord<ST> {
 
     pub fn all_udp_sockets(&self) -> impl Iterator<Item = SocketAddrV4> + '_ {
         [
-            Some(self.udp_address()),
+            self.udp_address(),
             Some(self.authenticated_udp_address()),
             self.direct_udp_address(),
         ]
@@ -424,22 +421,14 @@ impl<ST: CertificateSignatureRecoverable> MonadNameRecord<ST> {
     }
 }
 
-#[derive(Debug)]
-pub enum PeerEntryConversionError<E> {
-    MissingUdpPort,
-    InvalidSignature(E),
-}
-
 impl<ST: CertificateSignatureRecoverable> TryFrom<&PeerEntry<ST>> for MonadNameRecord<ST> {
-    type Error = PeerEntryConversionError<<ST as CertificateSignature>::Error>;
+    type Error = <ST as CertificateSignature>::Error;
 
     fn try_from(peer: &PeerEntry<ST>) -> Result<Self, Self::Error> {
         let name_record = NameRecord::new_with_ports(
             peer.ip(),
             peer.tcp_port().get(),
-            peer.udp_port()
-                .ok_or(PeerEntryConversionError::MissingUdpPort)?
-                .get(),
+            peer.udp_port().map(NonZeroU16::get),
             peer.auth_port.get(),
             peer.direct_udp_port.map(NonZeroU16::get),
             peer.record_seq_num,
@@ -448,8 +437,7 @@ impl<ST: CertificateSignatureRecoverable> TryFrom<&PeerEntry<ST>> for MonadNameR
         let mut encoded = Vec::new();
         name_record.encode(&mut encoded);
         peer.signature
-            .verify::<signing_domain::NameRecord>(&encoded, &peer.pubkey)
-            .map_err(PeerEntryConversionError::InvalidSignature)?;
+            .verify::<signing_domain::NameRecord>(&encoded, &peer.pubkey)?;
 
         Ok(MonadNameRecord {
             name_record,
@@ -470,10 +458,9 @@ impl<ST: CertificateSignatureRecoverable> TryFrom<&MonadNameRecord<ST>> for Peer
                 record.name_record.ip(),
                 NonZeroU16::new(record.name_record.tcp_port())
                     .expect("name record TCP port must be non-zero"),
-                Some(
-                    NonZeroU16::new(record.name_record.udp_port())
-                        .expect("name record UDP port must be non-zero"),
-                ),
+                record.name_record.udp_port().map(|port| {
+                    NonZeroU16::new(port).expect("name record UDP port must be non-zero")
+                }),
             ),
             signature: record.signature,
             record_seq_num: record.name_record.seq(),
@@ -506,7 +493,6 @@ impl<ST: CertificateSignatureRecoverable> From<MonadNameRecordWithPubkey<'_, ST>
 
 #[derive(Debug)]
 pub enum PeerConfigConversionError {
-    MissingUdpPort,
     InvalidSignature,
     InvalidAddress(String),
 }
@@ -527,24 +513,25 @@ impl<ST: CertificateSignatureRecoverable> TryFrom<&NodeBootstrapPeerConfig<ST>>
                 peer_config.tcp_port()
             ))
         };
-        let peer_entry = PeerEntry {
-            pubkey: peer_config.secp256k1_pubkey,
-            address: PeerEntryAddress::new(
-                peer_config.ip().ok_or_else(invalid_address)?,
-                peer_config.tcp_port(),
-                peer_config.udp_port(),
-            ),
-            signature: peer_config.name_record_sig,
-            record_seq_num: peer_config.record_seq_num,
-            auth_port: peer_config.auth_port,
-            direct_udp_port: peer_config.direct_udp_port,
-        };
+        let name_record = NameRecord::new_with_ports(
+            peer_config.ip().ok_or_else(invalid_address)?,
+            peer_config.tcp_port().get(),
+            peer_config.udp_port().map(NonZeroU16::get),
+            peer_config.auth_port.get(),
+            peer_config.direct_udp_port.map(NonZeroU16::get),
+            peer_config.record_seq_num,
+        );
 
-        MonadNameRecord::try_from(&peer_entry).map_err(|err| match err {
-            PeerEntryConversionError::MissingUdpPort => PeerConfigConversionError::MissingUdpPort,
-            PeerEntryConversionError::InvalidSignature(_) => {
-                PeerConfigConversionError::InvalidSignature
-            }
+        let mut encoded = Vec::new();
+        name_record.encode(&mut encoded);
+        peer_config
+            .name_record_sig
+            .verify::<signing_domain::NameRecord>(&encoded, &peer_config.secp256k1_pubkey)
+            .map_err(|_| PeerConfigConversionError::InvalidSignature)?;
+
+        Ok(MonadNameRecord {
+            name_record,
+            signature: peer_config.name_record_sig,
         })
     }
 }
@@ -564,10 +551,13 @@ impl<ST: CertificateSignatureRecoverable> From<MonadNameRecordWithPubkey<'_, ST>
                 record_with_pubkey.record.name_record.ip(),
                 NonZeroU16::new(record_with_pubkey.record.name_record.tcp_port())
                     .expect("name record TCP port must be non-zero"),
-                Some(
-                    NonZeroU16::new(record_with_pubkey.record.name_record.udp_port())
-                        .expect("name record UDP port must be non-zero"),
-                ),
+                record_with_pubkey
+                    .record
+                    .name_record
+                    .udp_port()
+                    .map(|port| {
+                        NonZeroU16::new(port).expect("name record UDP port must be non-zero")
+                    }),
             ),
             signature: record_with_pubkey.record.signature,
             record_seq_num: record_with_pubkey.record.name_record.seq(),
@@ -800,17 +790,27 @@ pub trait PeerDiscoveryAlgo {
 
     fn metrics(&self) -> &ExecutorMetrics;
 
-    fn get_pending_addr_by_id(
+    fn get_pending_udp_addr_by_id(
         &self,
         id: &NodeId<CertificateSignaturePubKey<Self::SignatureType>>,
     ) -> Option<SocketAddrV4>;
 
-    fn get_addr_by_id(
+    fn get_udp_addr_by_id(
         &self,
         id: &NodeId<CertificateSignaturePubKey<Self::SignatureType>>,
     ) -> Option<SocketAddrV4>;
 
-    fn get_known_addrs(
+    fn get_tcp_addr_by_id(
+        &self,
+        id: &NodeId<CertificateSignaturePubKey<Self::SignatureType>>,
+    ) -> Option<SocketAddrV4>;
+
+    fn get_ip_by_id(
+        &self,
+        id: &NodeId<CertificateSignaturePubKey<Self::SignatureType>>,
+    ) -> Option<Ipv4Addr>;
+
+    fn get_known_auth_udp_addrs(
         &self,
     ) -> HashMap<NodeId<CertificateSignaturePubKey<Self::SignatureType>>, SocketAddrV4>;
 
@@ -862,7 +862,7 @@ mod tests {
         let name_record = NameRecord::new(
             Ipv4Addr::from_str("1.1.1.1").unwrap(),
             8000,
-            8000,
+            Some(8000),
             8000,
             0,
             2,
@@ -944,7 +944,7 @@ mod tests {
 
         assert_eq!(decoded.ip(), Ipv4Addr::from_str("10.0.0.1").unwrap());
         assert_eq!(decoded.tcp_port(), 9000);
-        assert_eq!(decoded.udp_port(), 9001);
+        assert_eq!(decoded.udp_port(), Some(9001));
         assert_eq!(decoded.capabilities(), 7);
         assert_eq!(decoded.seq(), 100);
 
@@ -978,7 +978,7 @@ mod tests {
         let record = NameRecord::new(
             ip,
             tcp_port,
-            udp_port,
+            Some(udp_port),
             authenticated_udp_port,
             capabilities,
             seq,
@@ -992,7 +992,7 @@ mod tests {
 
         assert_eq!(decoded.ip(), ip);
         assert_eq!(decoded.tcp_port(), tcp_port);
-        assert_eq!(decoded.udp_port(), udp_port);
+        assert_eq!(decoded.udp_port(), Some(udp_port));
         assert_eq!(decoded.authenticated_udp_port(), authenticated_udp_port);
         assert_eq!(decoded.capabilities(), capabilities);
         assert_eq!(decoded.seq(), seq);
@@ -1020,7 +1020,7 @@ mod tests {
             MonadNameRecord::<SecpSignature>::decode(&mut signed_encoded.as_slice()).unwrap();
         assert_eq!(decoded_signed.name_record.ip(), ip);
         assert_eq!(decoded_signed.name_record.tcp_port(), tcp_port);
-        assert_eq!(decoded_signed.name_record.udp_port(), udp_port);
+        assert_eq!(decoded_signed.name_record.udp_port(), Some(udp_port));
         assert_eq!(
             decoded_signed.name_record.authenticated_udp_port(),
             authenticated_udp_port
@@ -1044,7 +1044,7 @@ mod tests {
         let record = NameRecord::new_with_ports(
             ip,
             tcp_port,
-            udp_port,
+            Some(udp_port),
             authenticated_udp_port,
             Some(direct_udp_port),
             seq,
@@ -1052,7 +1052,7 @@ mod tests {
 
         assert_eq!(record.ip(), ip);
         assert_eq!(record.tcp_port(), tcp_port);
-        assert_eq!(record.udp_port(), udp_port);
+        assert_eq!(record.udp_port(), Some(udp_port));
         assert_eq!(record.authenticated_udp_port(), authenticated_udp_port);
         assert_eq!(record.direct_udp_port(), Some(direct_udp_port));
         assert_eq!(
@@ -1067,7 +1067,7 @@ mod tests {
         let decoded = NameRecord::decode(&mut encoded.as_slice()).unwrap();
         assert_eq!(decoded.ip(), ip);
         assert_eq!(decoded.tcp_port(), tcp_port);
-        assert_eq!(decoded.udp_port(), udp_port);
+        assert_eq!(decoded.udp_port(), Some(udp_port));
         assert_eq!(decoded.authenticated_udp_port(), authenticated_udp_port);
         assert_eq!(decoded.direct_udp_port(), Some(direct_udp_port));
         assert_eq!(decoded.seq(), seq);
@@ -1082,7 +1082,7 @@ mod tests {
         NameRecord::new_with_ports(
             Ipv4Addr::new(10, 0, 0, 44),
             9200,
-            9201,
+            Some(9201),
             9202,
             Some(9203),
             102,
@@ -1097,7 +1097,7 @@ mod tests {
         NameRecord::new(
             Ipv4Addr::new(10, 0, 0, 46),
             9400,
-            9401,
+            Some(9401),
             9402,
             0,
             104,
@@ -1111,7 +1111,7 @@ mod tests {
         NameRecord::new(
             Ipv4Addr::new(10, 0, 0, 47),
             9501,
-            9501,
+            Some(9501),
             9501,
             0,
             105,
@@ -1140,7 +1140,7 @@ mod tests {
         let keypair = KeyPair::from_ikm(b"test invalid sig").unwrap();
         let other_keypair = KeyPair::from_ikm(b"other key").unwrap();
 
-        let name_record = NameRecord::new(ip, port, port, port, 0, seq);
+        let name_record = NameRecord::new(ip, port, Some(port), port, 0, seq);
         let mut encoded = Vec::new();
         name_record.encode(&mut encoded);
         let wrong_signature =
@@ -1171,7 +1171,7 @@ mod tests {
         let seq = 99u64;
 
         let keypair = KeyPair::from_ikm(b"test roundtrip auth").unwrap();
-        let name_record = NameRecord::new(ip, port, port, auth_port, 0, seq);
+        let name_record = NameRecord::new(ip, port, Some(port), auth_port, 0, seq);
         let original_monad_record = MonadNameRecord::<SecpSignature>::new(name_record, &keypair);
 
         let pubkey = original_monad_record.recover_pubkey().unwrap().pubkey();
@@ -1201,7 +1201,7 @@ mod tests {
 
         let keypair = KeyPair::from_ikm(b"test roundtrip direct udp").unwrap();
         let name_record =
-            NameRecord::new_with_ports(ip, port, port, auth_port, Some(direct_udp_port), seq);
+            NameRecord::new_with_ports(ip, port, Some(port), auth_port, Some(direct_udp_port), seq);
         let original_monad_record = MonadNameRecord::<SecpSignature>::new(name_record, &keypair);
 
         let pubkey = original_monad_record.recover_pubkey().unwrap().pubkey();
@@ -1242,7 +1242,7 @@ mod tests {
 
         let keypair = KeyPair::from_ikm(b"test bootstrap zero auth port").unwrap();
         let record = MonadNameRecord::<SecpSignature>::new(
-            NameRecord::new(ip, port, port, auth_port, 0, seq),
+            NameRecord::new(ip, port, Some(port), auth_port, 0, seq),
             &keypair,
         );
         let pubkey = record.recover_pubkey().unwrap().pubkey();
@@ -1286,6 +1286,6 @@ mod tests {
     #[test]
     #[should_panic(expected = "name record port must be non-zero")]
     fn test_name_record_new_rejects_zero_port() {
-        let _ = NameRecord::new(Ipv4Addr::new(1, 1, 1, 1), 0, 9001, 9002, 0, 1);
+        let _ = NameRecord::new(Ipv4Addr::new(1, 1, 1, 1), 0, Some(9001), 9002, 0, 1);
     }
 }

--- a/monad-peer-discovery/src/message.rs
+++ b/monad-peer-discovery/src/message.rs
@@ -188,7 +188,7 @@ mod test {
                 NameRecord::new(
                     *SocketAddrV4::from_str("127.0.0.1:8000").unwrap().ip(),
                     8000,
-                    8000,
+                    Some(8000),
                     8000,
                     0,
                     2,
@@ -213,7 +213,7 @@ mod test {
                 NameRecord::new(
                     *SocketAddrV4::from_str("127.0.0.1:8000").unwrap().ip(),
                     8000,
-                    8000,
+                    Some(8000),
                     8000,
                     0,
                     2,
@@ -272,7 +272,7 @@ mod test {
                     NameRecord::new(
                         *SocketAddrV4::from_str("192.168.1.1:8000").unwrap().ip(),
                         8000,
-                        8000,
+                        Some(8000),
                         8000,
                         0,
                         1,
@@ -283,7 +283,7 @@ mod test {
                     NameRecord::new(
                         *SocketAddrV4::from_str("192.168.1.2:8001").unwrap().ip(),
                         8001,
-                        8001,
+                        Some(8001),
                         8001,
                         0,
                         2,
@@ -294,7 +294,7 @@ mod test {
                     NameRecord::new(
                         *SocketAddrV4::from_str("192.168.1.3:8002").unwrap().ip(),
                         8002,
-                        8002,
+                        Some(8002),
                         8002,
                         0,
                         3,

--- a/monad-peer-discovery/src/mock.rs
+++ b/monad-peer-discovery/src/mock.rs
@@ -238,7 +238,13 @@ where
 
         for peer in peers {
             let node_id = NodeId::new(peer.pubkey);
-            self.known_addresses.insert(node_id, peer.addr);
+            let addr = SocketAddrV4::new(
+                peer.ip(),
+                peer.udp_port()
+                    .expect("peer entry must have udp port")
+                    .get(),
+            );
+            self.known_addresses.insert(node_id, addr);
         }
 
         Vec::new()

--- a/monad-peer-discovery/src/mock.rs
+++ b/monad-peer-discovery/src/mock.rs
@@ -16,7 +16,7 @@
 use std::{
     collections::{BTreeSet, HashMap},
     marker::PhantomData,
-    net::SocketAddrV4,
+    net::{Ipv4Addr, SocketAddrV4},
 };
 
 use monad_crypto::certificate_signature::{
@@ -238,12 +238,7 @@ where
 
         for peer in peers {
             let node_id = NodeId::new(peer.pubkey);
-            let addr = SocketAddrV4::new(
-                peer.ip(),
-                peer.udp_port()
-                    .expect("peer entry must have udp port")
-                    .get(),
-            );
+            let addr = SocketAddrV4::new(peer.ip(), peer.auth_port.get());
             self.known_addresses.insert(node_id, addr);
         }
 
@@ -278,19 +273,45 @@ where
         &self.metrics
     }
 
-    fn get_pending_addr_by_id(
+    fn get_pending_udp_addr_by_id(
         &self,
         _id: &NodeId<CertificateSignaturePubKey<ST>>,
     ) -> Option<SocketAddrV4> {
         None
     }
 
-    fn get_addr_by_id(&self, id: &NodeId<CertificateSignaturePubKey<ST>>) -> Option<SocketAddrV4> {
+    fn get_udp_addr_by_id(
+        &self,
+        id: &NodeId<CertificateSignaturePubKey<ST>>,
+    ) -> Option<SocketAddrV4> {
         self.known_addresses.get(id).copied()
     }
 
-    fn get_known_addrs(&self) -> HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddrV4> {
-        self.known_addresses.clone()
+    fn get_tcp_addr_by_id(
+        &self,
+        id: &NodeId<CertificateSignaturePubKey<ST>>,
+    ) -> Option<SocketAddrV4> {
+        self.name_records
+            .get(id)
+            .map(|record| record.name_record.tcp_socket())
+    }
+
+    fn get_ip_by_id(&self, id: &NodeId<CertificateSignaturePubKey<ST>>) -> Option<Ipv4Addr> {
+        self.name_records
+            .get(id)
+            .map(|record| record.name_record.ip())
+    }
+
+    fn get_known_auth_udp_addrs(
+        &self,
+    ) -> HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddrV4> {
+        let mut addresses = self.known_addresses.clone();
+        addresses.extend(
+            self.name_records
+                .iter()
+                .map(|(id, record)| (*id, record.authenticated_udp_address())),
+        );
+        addresses
     }
 
     fn get_secondary_fullnodes(&self) -> Vec<NodeId<CertificateSignaturePubKey<ST>>> {

--- a/monad-peer-discovery/src/snapshots/monad_peer_discovery__discovery__tests__persisted_peers_format.snap
+++ b/monad-peer-discovery/src/snapshots/monad_peer_discovery__discovery__tests__persisted_peers_format.snap
@@ -4,14 +4,18 @@ assertion_line: 3344
 expression: written_content
 ---
 [[peers]]
-address = "8.8.8.8:8000"
+address = "8.8.8.8"
+tcp_port = 8000
+udp_port = 8000
 record_seq_num = 1
 secp256k1_pubkey = "0x0334944627833fe16cc7e21cd5e1442b42b3eb9bbd0cdd266e449a9dc026b45a39"
 name_record_sig = "0x22da25d0c0525eb01f8c37766439fc48f95b02eee0cba578cdbf03038114650c5ce59614af8c51f38f46e174edd7a1ebeb767f5d1d2b215998e95fac1615872f01"
 auth_port = 9000
 
 [[peers]]
-address = "8.8.4.4:8001"
+address = "8.8.4.4"
+tcp_port = 8001
+udp_port = 8001
 record_seq_num = 2
 secp256k1_pubkey = "0x03efb87e9679dd855714c66e0e262b8a73b359cf4ff92124b3f7f556fd3cf15441"
 name_record_sig = "0x9c09a47314535aafd2f51686f0c832fd2acada022f2776f7db157ea15a2b7fe63e080f276a0f6b9b841897a878dcd43f05589fac60689a4bd16bf4b367e3488f00"

--- a/monad-raptorcast/examples/latency.rs
+++ b/monad-raptorcast/examples/latency.rs
@@ -587,7 +587,7 @@ fn setup_node(
         let name_record = NameRecord::new(
             *participant.tcp_addr.ip(),
             participant.tcp_addr.port(),
-            participant.udp_addr.port(),
+            Some(participant.udp_addr.port()),
             participant.authenticated_udp_addr.port(),
             0,
             0,
@@ -639,7 +639,7 @@ fn setup_node(
 
     let mut known_addresses = std::collections::HashMap::new();
     for (node_id, record) in &routing_info {
-        known_addresses.insert(*node_id, record.name_record.udp_socket());
+        known_addresses.insert(*node_id, record.name_record.authenticated_udp_socket());
     }
 
     let noop_builder = NopDiscoveryBuilder {

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -392,7 +392,7 @@ where
         make_app_message: impl FnOnce() -> Bytes,
         completion: Option<oneshot::Sender<()>>,
     ) {
-        match self.peer_discovery_driver.lock().unwrap().get_addr(to) {
+        match self.peer_discovery_driver.lock().unwrap().get_tcp_addr(to) {
             None => {
                 warn!(
                     ?to,
@@ -1025,11 +1025,11 @@ where
                         }
                     };
 
-                    let node_addrs = self
+                    let node_auth_addrs = self
                         .peer_discovery_driver
                         .lock()
                         .unwrap()
-                        .get_known_addresses();
+                        .get_known_auth_udp_addrs();
 
                     let _timer = DropTimer::start(Duration::from_millis(20), |elapsed| {
                         warn!(
@@ -1044,7 +1044,7 @@ where
                             // No need to send to self. TODO: maybe loopback the message.
                             continue;
                         }
-                        if !node_addrs.contains_key(node) {
+                        if !node_auth_addrs.contains_key(node) {
                             continue;
                         }
 
@@ -1138,8 +1138,7 @@ fn iter_ips<'a, ST: CertificateSignatureRecoverable, PD: PeerDiscoveryAlgo<Signa
     validators
         .get_members()
         .keys()
-        .filter_map(|node_id| peer_discovery.get_addr(node_id))
-        .map(|socket| socket.ip())
+        .filter_map(|node_id| peer_discovery.get_ip(node_id))
 }
 
 impl<ST, M, OM, E, PD, AP, DS> Stream for RaptorCast<ST, M, OM, E, PD, AP, DS>
@@ -1690,7 +1689,10 @@ where
                 return Some(addr);
             }
 
-            Some(SocketAddr::V4(target_name_record.name_record.udp_socket()))
+            target_name_record
+                .name_record
+                .udp_socket()
+                .map(SocketAddr::V4)
         } else {
             // otherwise lookup address using peer-discovery
             let peer_lookup = (&*self.dual_socket, self.peer_disc_driver);
@@ -1784,13 +1786,13 @@ fn rebroadcast_packet<ST, PD, AP>(
                 peer_discovery_driver
                     .lock()
                     .ok()
-                    .and_then(|pd| pd.get_addr(target))
+                    .and_then(|pd| pd.get_udp_addr(target))
             })
     } else {
         peer_discovery_driver
             .lock()
             .ok()
-            .and_then(|pd| pd.get_addr(target))
+            .and_then(|pd| pd.get_udp_addr(target))
     };
 
     let Some(target_addr) = target_addr else {

--- a/monad-raptorcast/src/raptorcast_secondary/group_message.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/group_message.rs
@@ -216,7 +216,7 @@ mod tests {
                 let port = (seed + 16) as u16;
 
                 MonadNameRecord::<ST>::new(
-                    NameRecord::new(ip, port, port, port, 0, (seed + 200) as u64),
+                    NameRecord::new(ip, port, Some(port), port, 0, (seed + 200) as u64),
                     &key,
                 )
             })

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -778,7 +778,7 @@ where
     PD: monad_peer_discovery::PeerDiscoveryAlgo<SignatureType = ST>,
 {
     fn lookup(&self, node_id: &NodeId<CertificateSignaturePubKey<ST>>) -> Option<SocketAddr> {
-        self.get_addr(node_id)
+        self.get_udp_addr(node_id)
     }
 }
 

--- a/monad-raptorcast/tests/wireauth_raptorcast.rs
+++ b/monad-raptorcast/tests/wireauth_raptorcast.rs
@@ -154,7 +154,7 @@ impl ValidatorInfo {
         let name_record = NameRecord::new_with_ports(
             Ipv4Addr::new(127, 0, 0, 1),
             tcp_addr.port(),
-            non_auth_addr.port(),
+            Some(non_auth_addr.port()),
             auth_addr.port(),
             direct_udp_addr.map(|addr| addr.port()),
             1,
@@ -921,7 +921,7 @@ async fn run_send_with_record_uses_name_record_address() {
     let bob2_name_record = NameRecord::new(
         Ipv4Addr::new(127, 0, 0, 1),
         bob2_tcp_addr.port(),
-        bob2_non_auth_addr.port(),
+        Some(bob2_non_auth_addr.port()),
         bob2_auth_addr.port(),
         0,
         1,

--- a/monad-updaters/src/config_loader.rs
+++ b/monad-updaters/src/config_loader.rs
@@ -13,7 +13,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{marker::PhantomData, net::SocketAddr, ops::DerefMut, path::PathBuf, task::Poll};
+use std::{
+    marker::PhantomData, net::SocketAddr, num::NonZeroU16, ops::DerefMut, path::PathBuf, task::Poll,
+};
 
 use futures::Stream;
 use monad_crypto::certificate_signature::{
@@ -22,6 +24,7 @@ use monad_crypto::certificate_signature::{
 use monad_executor::Executor;
 use monad_executor_glue::{
     ConfigEvent, ConfigReloadCommand, ConfigUpdate, KnownPeersUpdate, MonadEvent, PeerEntry,
+    PeerEntryAddress,
 };
 use monad_node_config::{NodeBootstrapPeerConfig, NodeConfig};
 use monad_types::{ExecutionProtocol, NodeId};
@@ -214,7 +217,11 @@ where
             };
             peer_entries.push(PeerEntry {
                 pubkey: peer.secp256k1_pubkey,
-                addr,
+                address: PeerEntryAddress::new(
+                    *addr.ip(),
+                    NonZeroU16::new(addr.port()).expect("resolved port must be non-zero"),
+                    Some(NonZeroU16::new(addr.port()).expect("resolved port must be non-zero")),
+                ),
                 signature: peer.name_record_sig,
                 record_seq_num: peer.record_seq_num,
                 auth_port: peer.auth_port,

--- a/monad-updaters/src/config_loader.rs
+++ b/monad-updaters/src/config_loader.rs
@@ -14,7 +14,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{
-    marker::PhantomData, net::SocketAddr, num::NonZeroU16, ops::DerefMut, path::PathBuf, task::Poll,
+    marker::PhantomData,
+    net::{SocketAddr, SocketAddrV4},
+    ops::DerefMut,
+    path::PathBuf,
+    task::Poll,
 };
 
 use futures::Stream;
@@ -208,20 +212,29 @@ where
     ) -> Vec<PeerEntry<ST>> {
         let mut peer_entries = Vec::new();
         for peer in bootstrap_peers {
-            let addr = match resolve_domain_v4(&peer.address).await {
-                Ok(Some(SocketAddr::V4(addr))) => addr,
-                _ => {
-                    warn!("config loader: cannot resolve: {:?}", &peer.address);
-                    continue;
+            let address = if let Some(address) = peer.ip() {
+                address
+            } else {
+                let domain = peer
+                    .domain()
+                    .expect("bootstrap peer address must be an IP address or domain");
+                match resolve_domain_v4((domain, peer.tcp_port().get())).await {
+                    Ok(Some(addr)) => *addr.ip(),
+                    _ => {
+                        warn!(
+                            domain = %domain,
+                            tcp_port = %peer.tcp_port(),
+                            udp_port = ?peer.udp_port(),
+                            "config loader: cannot resolve bootstrap peer",
+                        );
+                        continue;
+                    }
                 }
             };
+
             peer_entries.push(PeerEntry {
                 pubkey: peer.secp256k1_pubkey,
-                address: PeerEntryAddress::new(
-                    *addr.ip(),
-                    NonZeroU16::new(addr.port()).expect("resolved port must be non-zero"),
-                    Some(NonZeroU16::new(addr.port()).expect("resolved port must be non-zero")),
-                ),
+                address: PeerEntryAddress::new(address, peer.tcp_port(), peer.udp_port()),
                 signature: peer.name_record_sig,
                 record_seq_num: peer.record_seq_num,
                 auth_port: peer.auth_port,
@@ -274,12 +287,15 @@ where
     }
 }
 
-async fn resolve_domain_v4(domain: &String) -> Result<Option<SocketAddr>, std::io::Error> {
-    let dns_response = lookup_host(domain).await?;
+async fn resolve_domain_v4<T>(address: T) -> Result<Option<SocketAddrV4>, std::io::Error>
+where
+    T: tokio::net::ToSocketAddrs,
+{
+    let dns_response = lookup_host(address).await?;
 
     for entry in dns_response {
         match entry {
-            SocketAddr::V4(_) => return Ok(Some(entry)),
+            SocketAddr::V4(addr) => return Ok(Some(addr)),
             SocketAddr::V6(_) => continue,
         }
     }


### PR DESCRIPTION
- 2nd refactoring for bootstrap entry records https://github.com/category-labs/monad-bft/pull/3051
- 3rd relaxes validation for udp port in name record itself https://github.com/category-labs/monad-bft/pull/3052