### PR TITLE
Add eth_subscribe notification for storage slots

### DIFF
--- a/monad-rpc/src/data/buffer.rs
+++ b/monad-rpc/src/data/buffer.rs
@@ -83,6 +83,7 @@ impl ExecEventsBuffer {
                 commit_state,
                 header,
                 transactions,
+                ..
             } => (commit_state, header, transactions),
             EventServerEvent::Gap => return,
         };
@@ -429,7 +430,10 @@ mod tests {
     use monad_types::BlockId;
 
     use super::*;
-    use crate::types::{eth_json::MonadNotification, serialize::JsonSerialized};
+    use crate::{
+        event::StorageChange,
+        types::{eth_json::MonadNotification, serialize::JsonSerialized},
+    };
 
     #[tokio::test]
     async fn test_many_proposed_blocks() {
@@ -805,6 +809,7 @@ mod tests {
             commit_state: BlockCommitState::Proposed,
             header: serialized_monad_header,
             transactions: Arc::new(txs.into_boxed_slice()),
+            storage_changes: Arc::from([] as [StorageChange; 0]),
         }
     }
 }

--- a/monad-rpc/src/event/events.rs
+++ b/monad-rpc/src/event/events.rs
@@ -15,7 +15,10 @@
 
 use std::sync::Arc;
 
-use monad_exec_events::BlockCommitState;
+use monad_exec_events::{
+    ffi::{monad_c_address, monad_c_bytes32},
+    BlockCommitState,
+};
 
 use crate::types::{eth_json::MonadNotification, serialize::SharedJsonSerialized};
 
@@ -31,6 +34,16 @@ pub type TransactionReceipt = SharedJsonSerialized<alloy_rpc_types::TransactionR
 pub type LogNotification = SharedJsonSerialized<MonadNotification<Log>>;
 pub type Log = SharedJsonSerialized<alloy_rpc_types::eth::Log>;
 
+/// A storage change extracted from execution events.
+#[derive(Debug)]
+pub struct StorageChange {
+    pub address: monad_c_address,
+    pub key: monad_c_bytes32,
+    pub old_value: monad_c_bytes32,
+    pub new_value: monad_c_bytes32,
+    pub txn_index: usize,
+}
+
 #[derive(Clone, Debug)]
 pub enum EventServerEvent {
     Gap,
@@ -39,6 +52,7 @@ pub enum EventServerEvent {
         commit_state: BlockCommitState,
         header: HeaderNotification,
         transactions: BlockTransactions,
+        storage_changes: Arc<[StorageChange]>,
     },
 }
 
@@ -48,6 +62,6 @@ mod test {
 
     #[test]
     fn size() {
-        assert_eq!(std::mem::size_of::<EventServerEvent>(), 24);
+        assert_eq!(std::mem::size_of::<EventServerEvent>(), 40);
     }
 }

--- a/monad-rpc/src/event/mod.rs
+++ b/monad-rpc/src/event/mod.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pub(super) use self::events::EventServerEvent;
+pub(super) use self::events::{EventServerEvent, StorageChange};
 pub use self::{
     client::{EventServerClient, EventServerClientError},
     server::EventServer,

--- a/monad-rpc/src/event/server.rs
+++ b/monad-rpc/src/event/server.rs
@@ -13,19 +13,19 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use itertools::Itertools;
-use monad_event_ring::{DecodedEventRing, EventNextResult};
+use monad_event_ring::{DecodedEventRing, EventNextResult, EventPayloadResult};
 use monad_exec_events::{
     BlockBuilderError, BlockCommitState, CommitStateBlockBuilder, CommitStateBlockUpdate,
-    ExecEventRing, ExecutedBlock, ExecutedBlockBuilder,
+    ExecEventRef, ExecEventRing, ExecutedBlock, ExecutedBlockBuilder,
 };
 use monad_types::BlockId;
 use tokio::sync::broadcast;
 use tracing::{debug, warn};
 
-use super::{EventServerClient, EventServerEvent, BROADCAST_CHANNEL_SIZE};
+use super::{EventServerClient, EventServerEvent, StorageChange, BROADCAST_CHANNEL_SIZE};
 use crate::types::{eth_json::MonadNotification, serialize::JsonSerialized};
 
 pub struct EventServer<R>
@@ -60,6 +60,9 @@ impl EventServer<ExecEventRing> {
         } = self;
 
         let mut event_reader = event_ring.create_reader();
+        let mut pending_storage_changes: Vec<StorageChange> = Vec::new();
+        let mut current_txn_index: Option<usize> = None;
+        let mut storage_by_block: HashMap<BlockId, Arc<[StorageChange]>> = HashMap::new();
 
         loop {
             let event_descriptor = match event_reader.next_descriptor() {
@@ -69,6 +72,9 @@ impl EventServer<ExecEventRing> {
                     broadcast_event(&broadcast_tx, EventServerEvent::Gap);
                     event_reader.reset();
                     block_builder.reset();
+                    pending_storage_changes.clear();
+                    current_txn_index = None;
+                    storage_by_block.clear();
                     continue;
                 }
                 EventNextResult::NotReady => {
@@ -77,6 +83,41 @@ impl EventServer<ExecEventRing> {
                 }
                 EventNextResult::Ready(event_descriptor) => event_descriptor,
             };
+
+            if let EventPayloadResult::Ready(Some(extracted)) =
+                event_descriptor.try_filter_map(extract_event)
+            {
+                match extracted {
+                    Extracted::StorageChange {
+                        address,
+                        key,
+                        old_value,
+                        new_value,
+                    } => {
+                        let Some(txn_index) = current_txn_index else {
+                            warn!(
+                                "EventServer saw transaction StorageAccess without TxnHeaderStart"
+                            );
+
+                            broadcast_event(&broadcast_tx, EventServerEvent::Gap);
+                            event_reader.reset();
+                            block_builder.reset();
+                            pending_storage_changes.clear();
+                            current_txn_index = None;
+                            storage_by_block.clear();
+                            continue;
+                        };
+                        pending_storage_changes.push(StorageChange {
+                            address,
+                            key,
+                            old_value,
+                            new_value,
+                            txn_index,
+                        });
+                    }
+                    Extracted::TxnIndex(idx) => current_txn_index = Some(idx),
+                }
+            }
 
             let Some(result) = block_builder.process_event_descriptor(&event_descriptor) else {
                 continue;
@@ -92,6 +133,9 @@ impl EventServer<ExecEventRing> {
                     broadcast_event(&broadcast_tx, EventServerEvent::Gap);
                     event_reader.reset();
                     block_builder.reset();
+                    pending_storage_changes.clear();
+                    current_txn_index = None;
+                    storage_by_block.clear();
                     continue;
                 }
                 Err(BlockBuilderError::ImplicitDrop {
@@ -104,10 +148,45 @@ impl EventServer<ExecEventRing> {
                     block,
                     state,
                     abandoned,
-                }) => handle_update(&broadcast_tx, block, state, abandoned),
+                }) => {
+                    let storage_changes = take_or_cached_storage_changes(
+                        &block,
+                        &abandoned,
+                        state,
+                        &mut storage_by_block,
+                        &mut pending_storage_changes,
+                    );
+                    handle_update(&broadcast_tx, block, state, abandoned, storage_changes);
+                }
             }
         }
     }
+}
+
+fn take_or_cached_storage_changes(
+    block: &Arc<ExecutedBlock>,
+    abandoned: &[Arc<ExecutedBlock>],
+    state: BlockCommitState,
+    storage_by_block: &mut HashMap<BlockId, Arc<[StorageChange]>>,
+    pending_storage_changes: &mut Vec<StorageChange>,
+) -> Arc<[StorageChange]> {
+    let block_id = BlockId(monad_types::Hash(block.start.block_tag.id.bytes));
+
+    let storage_changes = storage_by_block
+        .entry(block_id)
+        .or_insert_with(|| Arc::from(std::mem::take(pending_storage_changes)))
+        .clone();
+
+    for ab in abandoned {
+        let ab_id = BlockId(monad_types::Hash(ab.start.block_tag.id.bytes));
+        storage_by_block.remove(&ab_id);
+    }
+
+    if state == BlockCommitState::Verified {
+        storage_by_block.remove(&block_id);
+    }
+
+    storage_changes
 }
 
 fn handle_update(
@@ -115,6 +194,7 @@ fn handle_update(
     block: Arc<ExecutedBlock>,
     commit_state: BlockCommitState,
     abandoned: Vec<Arc<ExecutedBlock>>,
+    storage_changes: Arc<[StorageChange]>,
 ) {
     for abandoned in abandoned {
         debug!(
@@ -123,7 +203,41 @@ fn handle_update(
         );
     }
 
-    broadcast_block_updates(broadcast_tx, block, commit_state);
+    broadcast_block_updates(broadcast_tx, block, commit_state, storage_changes);
+}
+
+/// State extracted from a single execution event in one decode pass.
+enum Extracted {
+    StorageChange {
+        address: monad_exec_events::ffi::monad_c_address,
+        key: monad_exec_events::ffi::monad_c_bytes32,
+        old_value: monad_exec_events::ffi::monad_c_bytes32,
+        new_value: monad_exec_events::ffi::monad_c_bytes32,
+    },
+    TxnIndex(usize),
+}
+
+fn extract_event(event_ref: ExecEventRef<'_>) -> Option<Extracted> {
+    match event_ref {
+        ExecEventRef::StorageAccess(sa)
+            if sa.modified
+                && !sa.transient
+                && sa.access_context == 1 /* MONAD_ACCT_ACCESS_TRANSACTION */
+                // `modified` is set whenever the slot is touched; skip events
+                // where the value didn't actually change so we avoid carrying
+                // them through pending state, the broadcast, and the cache.
+                && sa.start_value.bytes != sa.end_value.bytes =>
+        {
+            Some(Extracted::StorageChange {
+                address: sa.address,
+                key: sa.key,
+                old_value: sa.start_value,
+                new_value: sa.end_value,
+            })
+        }
+        ExecEventRef::TxnHeaderStart { txn_index, .. } => Some(Extracted::TxnIndex(txn_index)),
+        _ => None,
+    }
 }
 
 fn broadcast_event(broadcast_tx: &broadcast::Sender<EventServerEvent>, event: EventServerEvent) {
@@ -137,6 +251,7 @@ fn broadcast_block_updates(
     broadcast_tx: &broadcast::Sender<EventServerEvent>,
     block: Arc<ExecutedBlock>,
     commit_state: BlockCommitState,
+    storage_changes: Arc<[StorageChange]>,
 ) {
     let block_id = BlockId(monad_types::Hash(block.start.block_tag.id.bytes));
 
@@ -182,6 +297,7 @@ fn broadcast_block_updates(
             commit_state,
             header: serialized_monad_header,
             transactions: Arc::new(transactions.into_boxed_slice()),
+            storage_changes,
         },
     );
 }
@@ -234,6 +350,9 @@ mod test {
             } = self;
 
             let mut event_reader = event_ring.create_reader();
+            let mut pending_storage_changes: Vec<StorageChange> = Vec::new();
+            let mut current_txn_index: Option<usize> = None;
+            let mut storage_by_block: HashMap<BlockId, Arc<[StorageChange]>> = HashMap::new();
 
             loop {
                 let event_descriptor = match event_reader.next_descriptor() {
@@ -243,6 +362,41 @@ mod test {
                         unreachable!("SnapshotEventDescriptor cannot gap")
                     }
                 };
+
+                if let EventPayloadResult::Ready(Some(extracted)) =
+                    event_descriptor.try_filter_map(extract_event)
+                {
+                    match extracted {
+                        Extracted::StorageChange {
+                            address,
+                            key,
+                            old_value,
+                            new_value,
+                        } => {
+                            let Some(txn_index) = current_txn_index else {
+                                warn!(
+                                    "EventServer saw transaction StorageAccess without TxnHeaderStart"
+                                );
+
+                                broadcast_event(&broadcast_tx, EventServerEvent::Gap);
+                                event_reader.reset();
+                                block_builder.reset();
+                                pending_storage_changes.clear();
+                                current_txn_index = None;
+                                storage_by_block.clear();
+                                continue;
+                            };
+                            pending_storage_changes.push(StorageChange {
+                                address,
+                                key,
+                                old_value,
+                                new_value,
+                                txn_index,
+                            });
+                        }
+                        Extracted::TxnIndex(idx) => current_txn_index = Some(idx),
+                    }
+                }
 
                 let Some(result) = block_builder.process_event_descriptor(&event_descriptor) else {
                     continue;
@@ -265,7 +419,16 @@ mod test {
                         block,
                         state,
                         abandoned,
-                    }) => handle_update(&broadcast_tx, block, state, abandoned),
+                    }) => {
+                        let storage_changes = take_or_cached_storage_changes(
+                            &block,
+                            &abandoned,
+                            state,
+                            &mut storage_by_block,
+                            &mut pending_storage_changes,
+                        );
+                        handle_update(&broadcast_tx, block, state, abandoned, storage_changes);
+                    }
                 }
             }
         }
@@ -297,6 +460,29 @@ mod test {
             }
             EventServerEvent::Block { .. } => {}
         }
+
+        let mut saw_storage_change = false;
+        for _ in 0..1024 {
+            let event =
+                match tokio::time::timeout(Duration::from_secs(1), subscription.recv()).await {
+                    Ok(Ok(event)) => event,
+                    Ok(Err(_lagged)) => continue,
+                    Err(_elapsed) => break,
+                };
+            if let EventServerEvent::Block {
+                storage_changes, ..
+            } = event
+            {
+                if !storage_changes.is_empty() {
+                    saw_storage_change = true;
+                    break;
+                }
+            }
+        }
+        assert!(
+            saw_storage_change,
+            "expected at least one broadcast Block to carry non-empty storage_changes"
+        );
     }
 
     #[tokio::test]
@@ -327,6 +513,7 @@ mod test {
                 commit_state,
                 header,
                 transactions,
+                storage_changes: _,
             } => (commit_state, header, transactions),
         };
 

--- a/monad-rpc/src/types/eth_json.rs
+++ b/monad-rpc/src/types/eth_json.rs
@@ -18,9 +18,7 @@ use std::str::FromStr;
 use alloy_consensus::TxEnvelope;
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, FixedBytes, LogData, U256};
-use alloy_rpc_types::{
-    pubsub::Params, Block, FeeHistory, Header, Log, Transaction, TransactionReceipt,
-};
+use alloy_rpc_types::{Block, FeeHistory, Header, Log, Transaction, TransactionReceipt};
 use monad_exec_events::BlockCommitState;
 use monad_types::BlockId;
 use schemars::JsonSchema;
@@ -420,7 +418,7 @@ impl Default for BlockTagOrHash {
 pub struct EthSubscribeRequest {
     pub kind: SubscriptionKind,
     #[serde(default)]
-    pub params: Params,
+    pub params: serde_json::Value,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Hash)]
@@ -436,6 +434,33 @@ pub enum SubscriptionKind {
     MonadNewHeads,
     // Subscribes to all logs with their corresponding commit state.
     MonadLogs,
+    // Subscribes to storage slot changes for specified address/slots.
+    MonadStorageChanges,
+}
+
+/// Bounds the per-subscription notification scan: every storage change for a
+/// matching address is checked against this list via linear scan, so keeping
+/// it small preserves cache locality and limits fan-out cost.
+pub const MAX_STORAGE_SLOTS_PER_SUBSCRIPTION: usize = 8;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageChangesFilter {
+    pub address: alloy_primitives::Address,
+    pub storage_slots: Vec<alloy_primitives::B256>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageChangeNotification {
+    pub address: alloy_primitives::Address,
+    pub storage_slot: alloy_primitives::B256,
+    pub old_value: alloy_primitives::B256,
+    pub new_value: alloy_primitives::B256,
+    pub transaction_hash: alloy_primitives::B256,
+    pub block_number: alloy_primitives::U64,
+    pub block_hash: alloy_primitives::B256,
+    pub commit_state: BlockCommitState,
 }
 
 #[derive(Deserialize)]

--- a/monad-rpc/src/websocket/handler.rs
+++ b/monad-rpc/src/websocket/handler.rs
@@ -40,11 +40,12 @@ use crate::{
     types::{
         eth_json::{
             serialize_result, EthSubscribeRequest, EthSubscribeResult, EthUnsubscribeRequest,
-            FixedData, MonadNotification, SubscriptionKind,
+            FixedData, MonadNotification, StorageChangeNotification, StorageChangesFilter,
+            SubscriptionKind, MAX_STORAGE_SLOTS_PER_SUBSCRIPTION,
         },
         jsonrpc::{
-            serialize_with_size_limit, JsonRpcError, Notification, Request, RequestWrapper,
-            Response,
+            serialize_with_size_limit, JsonRpcError, Notification, Request, RequestId,
+            RequestWrapper, Response,
         },
         serialize::SharedJsonSerialized,
     },
@@ -112,6 +113,7 @@ pub async fn ws_handler(
 
         let mut subscriptions: HashMap<SubscriptionKind, Vec<(SubscriptionId, Option<Filter>)>> =
             HashMap::default();
+        let mut storage_subscriptions: Vec<(SubscriptionId, StorageChangesFilter)> = Vec::new();
 
         let close_reason = handler(
             &mut session,
@@ -119,6 +121,7 @@ pub async fn ws_handler(
             &hostname,
             &peer_addr,
             &mut subscriptions,
+            &mut storage_subscriptions,
             rx,
             &app_state,
             sub_limit.0,
@@ -135,6 +138,7 @@ pub async fn ws_handler(
             subscriptions.into_iter().for_each(|(_, subs)| {
                 metrics.record_websocket_topic(-(subs.len() as i64));
             });
+            metrics.record_websocket_topic(-(storage_subscriptions.len() as i64));
         }
 
         drop(permit);
@@ -149,6 +153,7 @@ async fn handler(
     hostname: &String,
     peer_addr: &Option<String>,
     subscriptions: &mut HashMap<SubscriptionKind, Vec<(SubscriptionId, Option<Filter>)>>,
+    storage_subscriptions: &mut Vec<(SubscriptionId, StorageChangesFilter)>,
     rx: broadcast::Receiver<EventServerEvent>,
     app_state: &web::Data<MonadRpcResources>,
     subscription_limit: u16,
@@ -199,7 +204,7 @@ async fn handler(
 
                         match request {
                             Ok(req) => {
-                                if let Err(close_reason) = handle_request(session, subscriptions, subscription_limit, app_state, req).await {
+                                if let Err(close_reason) = handle_request(session, subscriptions, storage_subscriptions, subscription_limit, app_state, req).await {
                                     return Some(close_reason);
                                 }
                             }
@@ -220,7 +225,7 @@ async fn handler(
 
                         match request {
                             Ok(req) => {
-                                if let Err(close_reason) = handle_request(session,  subscriptions, subscription_limit, app_state, req).await {
+                                if let Err(close_reason) = handle_request(session, subscriptions, storage_subscriptions, subscription_limit, app_state, req).await {
                                     return Some(close_reason);
                                 }
                             }
@@ -257,6 +262,7 @@ async fn handler(
                         if let Err(close_reason) = handle_notification(
                             session,
                             subscriptions,
+                            storage_subscriptions,
                             msg,
                             app_state.max_response_size as usize,
                         ).await {
@@ -288,6 +294,7 @@ async fn handler(
 async fn handle_notification(
     session: &mut actix_ws::Session,
     subscriptions: &HashMap<SubscriptionKind, Vec<(SubscriptionId, Option<Filter>)>>,
+    storage_subscriptions: &[(SubscriptionId, StorageChangesFilter)],
     msg: EventServerEvent,
     max_response_size: usize,
 ) -> Result<(), CloseReason> {
@@ -302,6 +309,7 @@ async fn handle_notification(
             commit_state,
             header,
             transactions,
+            storage_changes,
         } => {
             for (id, _) in subscriptions
                 .get(&SubscriptionKind::MonadNewHeads)
@@ -352,6 +360,56 @@ async fn handle_notification(
                     for log in logs {
                         send_notification(session, id, log.data.as_ref(), max_response_size)
                             .await?;
+                    }
+                }
+            }
+
+            if !storage_subscriptions.is_empty() && !storage_changes.is_empty() {
+                'storage_changes: for storage_change in storage_changes.iter() {
+                    let address = alloy_primitives::Address::from(storage_change.address.bytes);
+                    let key = alloy_primitives::B256::from(storage_change.key.bytes);
+
+                    let mut raw_notification: Option<Box<RawValue>> = None;
+
+                    for (id, filter) in storage_subscriptions.iter() {
+                        if filter.address != address {
+                            continue;
+                        }
+                        if !filter.storage_slots.contains(&key) {
+                            continue;
+                        }
+
+                        let Some((_, tx_receipt, _)) = transactions.get(storage_change.txn_index)
+                        else {
+                            warn!(
+                                txn_index = storage_change.txn_index,
+                                transaction_count = transactions.len(),
+                                "skipping storage change with out-of-range transaction index"
+                            );
+                            continue 'storage_changes;
+                        };
+
+                        let raw = raw_notification.get_or_insert_with(|| {
+                            let notification = StorageChangeNotification {
+                                address,
+                                storage_slot: key,
+                                old_value: alloy_primitives::B256::from(
+                                    storage_change.old_value.bytes,
+                                ),
+                                new_value: alloy_primitives::B256::from(
+                                    storage_change.new_value.bytes,
+                                ),
+                                transaction_hash: tx_receipt.transaction_hash,
+                                block_number: alloy_primitives::U64::from(header.data.number),
+                                block_hash: header.data.hash,
+                                commit_state,
+                            };
+
+                            serde_json::value::to_raw_value(&notification)
+                                .expect("StorageChangeNotification serializes")
+                        });
+
+                        send_notification(session, id, &*raw, max_response_size).await?;
                     }
                 }
             }
@@ -409,6 +467,7 @@ fn apply_logs_filter<'a>(
 async fn handle_request(
     ctx: &mut actix_ws::Session,
     subscriptions: &mut HashMap<SubscriptionKind, Vec<(SubscriptionId, Option<Filter>)>>,
+    storage_subscriptions: &mut Vec<(SubscriptionId, StorageChangesFilter)>,
     subscription_limit: u16,
     app_state: &MonadRpcResources,
     request: Request<'_>,
@@ -416,17 +475,73 @@ async fn handle_request(
     match request.method.as_str() {
         "eth_subscribe" => {
             let Ok(req) = serde_json::from_str::<EthSubscribeRequest>(request.params.get()) else {
-                if let Err(err) = ctx
-                    .text(to_response(&crate::types::jsonrpc::Response::new(
-                        None,
-                        Some(JsonRpcError::invalid_params()),
+                send_subscribe_error(
+                    ctx,
+                    request.id,
+                    JsonRpcError::invalid_params(),
+                    "eth_subscribe parse error",
+                )
+                .await?;
+                return Ok(());
+            };
+
+            if subscription_limit_reached(
+                subscriptions,
+                storage_subscriptions.as_slice(),
+                subscription_limit,
+            ) {
+                send_subscribe_error(
+                    ctx,
+                    request.id,
+                    JsonRpcError::custom("WebSocket subscription limit reached".to_string()),
+                    "eth_subscribe subscription limit reached",
+                )
+                .await?;
+                return Ok(());
+            }
+
+            // For MonadStorageChanges, parse StorageChangesFilter and handle separately.
+            if req.kind == SubscriptionKind::MonadStorageChanges {
+                let Ok(storage_filter) = serde_json::from_value::<StorageChangesFilter>(req.params)
+                else {
+                    send_subscribe_error(
+                        ctx,
                         request.id,
+                        JsonRpcError::invalid_params(),
+                        "monadStorageChanges filter parse error",
+                    )
+                    .await?;
+                    return Ok(());
+                };
+
+                // Validate: non-empty, max 8 slots
+                if storage_filter.storage_slots.is_empty()
+                    || storage_filter.storage_slots.len() > MAX_STORAGE_SLOTS_PER_SUBSCRIPTION
+                {
+                    send_subscribe_error(
+                        ctx,
+                        request.id,
+                        JsonRpcError::invalid_params(),
+                        "monadStorageChanges slot count out of range",
+                    )
+                    .await?;
+                    return Ok(());
+                }
+
+                let mut rng = rand::thread_rng();
+                let random_bytes: [u8; 16] = rng.gen();
+                let id = SubscriptionId(FixedData(random_bytes));
+
+                if let Err(err) = ctx
+                    .text(to_response(&crate::types::jsonrpc::Response::from_result(
+                        request.id,
+                        serialize_result(id),
                     )))
                     .await
                 {
                     warn!(
                         ?err,
-                        "ws handle_request eth_subscribe failed to send invalid_params error"
+                        "ws handle_request eth_subscribe failed to send subscription response"
                     );
                     return Err(CloseReason {
                         code: ws::CloseCode::Error,
@@ -434,65 +549,31 @@ async fn handle_request(
                     });
                 }
 
+                storage_subscriptions.push((id, storage_filter));
+
+                if let Some(metrics) = &app_state.metrics {
+                    metrics.record_websocket_topic(1);
+                }
+
                 return Ok(());
             };
 
-            let filter = match req.params {
-                Params::None => None,
-                Params::Logs(filter) => Some(*filter),
-                Params::Bool(_) | Params::TransactionReceipts(_) => {
-                    if let Err(err) = ctx
-                        .text(to_response(&crate::types::jsonrpc::Response::new(
-                            None,
-                            Some(JsonRpcError::invalid_params()),
-                            request.id,
-                        )))
-                        .await
-                    {
-                        warn!(
-                            ?err,
-                            "ws handle_request eth_subscribe failed to send invalid_params error"
-                        );
-                        return Err(CloseReason {
-                            code: ws::CloseCode::Error,
-                            description: None,
-                        });
-                    }
-
+            let filter = match serde_json::from_value::<Params>(req.params) {
+                Ok(Params::None) => None,
+                Ok(Params::Logs(filter)) => Some(*filter),
+                Ok(Params::Bool(_)) | Ok(Params::TransactionReceipts(_)) | Err(_) => {
+                    send_subscribe_error(
+                        ctx,
+                        request.id,
+                        JsonRpcError::invalid_params(),
+                        "eth_subscribe params shape invalid",
+                    )
+                    .await?;
                     return Ok(());
                 }
             };
 
             debug!(subscription_kind = ?req.kind, "ws handle_request eth_subscribe received subscribe request");
-
-            let subscription_count = subscriptions
-                .values()
-                .map(|vec| vec.len() as u16)
-                .sum::<u16>();
-
-            if (subscription_count + 1) > subscription_limit {
-                if let Err(err) = ctx
-                    .text(to_response(&crate::types::jsonrpc::Response::new(
-                        None,
-                        Some(JsonRpcError::custom(
-                            "WebSocket subscription limit reached".to_string(),
-                        )),
-                        request.id,
-                    )))
-                    .await
-                {
-                    warn!(
-                        ?err,
-                        "ws handle_request eth_subscribe failed to send subscription limit reached error"
-                    );
-                    return Err(CloseReason {
-                        code: ws::CloseCode::Error,
-                        description: None,
-                    });
-                }
-
-                return Ok(());
-            }
 
             let mut rng = rand::thread_rng();
             let random_bytes: [u8; 16] = rng.gen();
@@ -527,24 +608,13 @@ async fn handle_request(
         "eth_unsubscribe" => {
             let Ok(req) = serde_json::from_str::<EthUnsubscribeRequest>(request.params.get())
             else {
-                if let Err(err) = ctx
-                    .text(to_response(&crate::types::jsonrpc::Response::new(
-                        None,
-                        Some(JsonRpcError::invalid_params()),
-                        request.id,
-                    )))
-                    .await
-                {
-                    warn!(
-                        ?err,
-                        "ws handle_request eth_unsubscribe failed to send invalid_params error"
-                    );
-                    return Err(CloseReason {
-                        code: ws::CloseCode::Error,
-                        description: None,
-                    });
-                }
-
+                send_subscribe_error(
+                    ctx,
+                    request.id,
+                    JsonRpcError::invalid_params(),
+                    "eth_unsubscribe parse error",
+                )
+                .await?;
                 return Ok(());
             };
 
@@ -557,6 +627,14 @@ async fn handle_request(
                 if vec.len() < original_len {
                     exists = true;
                     break;
+                }
+            }
+
+            if !exists {
+                let original_len = storage_subscriptions.len();
+                storage_subscriptions.retain(|x| x.0 != SubscriptionId(req.id));
+                if storage_subscriptions.len() < original_len {
+                    exists = true;
                 }
             }
 
@@ -615,6 +693,17 @@ async fn handle_request(
     Ok(())
 }
 
+fn subscription_limit_reached(
+    subscriptions: &HashMap<SubscriptionKind, Vec<(SubscriptionId, Option<Filter>)>>,
+    storage_subscriptions: &[(SubscriptionId, StorageChangesFilter)],
+    subscription_limit: u16,
+) -> bool {
+    let subscription_count =
+        subscriptions.values().map(Vec::len).sum::<usize>() + storage_subscriptions.len();
+
+    subscription_count >= usize::from(subscription_limit)
+}
+
 #[inline]
 async fn send_notification(
     session: &mut actix_ws::Session,
@@ -658,6 +747,28 @@ async fn send_notification(
     Ok(())
 }
 
+async fn send_subscribe_error(
+    ctx: &mut actix_ws::Session,
+    request_id: RequestId,
+    err: JsonRpcError,
+    log_context: &'static str,
+) -> Result<(), CloseReason> {
+    if let Err(send_err) = ctx
+        .text(to_response(&Response::new(None, Some(err), request_id)))
+        .await
+    {
+        warn!(
+            ?send_err,
+            log_context, "ws subscribe error response failed to send"
+        );
+        return Err(CloseReason {
+            code: ws::CloseCode::Error,
+            description: None,
+        });
+    }
+    Ok(())
+}
+
 #[inline]
 fn to_response<S: Serialize + std::fmt::Debug>(resp: &S) -> String {
     match serde_json::to_string(resp) {
@@ -688,7 +799,7 @@ fn parse_request<'p>(body: &'p bytes::Bytes) -> Result<Request<'p>, JsonRpcError
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{collections::HashMap, time::Duration};
 
     use actix_http::{ws, ws::Frame};
     use actix_web::{web, App};
@@ -698,13 +809,13 @@ mod tests {
     use monad_event_ring::SnapshotEventRing;
     use serde_json::json;
 
-    use super::ws_handler;
+    use super::{ws_handler, SubscriptionId};
     use crate::{
         event::EventServer,
         handlers::resources::MonadRpcResources,
         txpool::EthTxPoolBridgeClient,
         types::{
-            eth_json::{EthSubscribeResult, FixedData},
+            eth_json::{EthSubscribeResult, FixedData, SubscriptionKind},
             ethhex,
         },
         websocket::handler::{ConnectionLimit, SubscriptionLimit},
@@ -997,6 +1108,135 @@ mod tests {
                 }
                 _ => panic!("Unexpected frame type"),
             }
+        }
+    }
+
+    #[test]
+    fn websocket_subscription_limit_handles_u16_max_without_overflow() {
+        let mut subscriptions = HashMap::new();
+        subscriptions.insert(
+            SubscriptionKind::NewHeads,
+            std::iter::repeat_with(|| (SubscriptionId(FixedData([0; 16])), None))
+                .take(usize::from(u16::MAX))
+                .collect(),
+        );
+
+        assert!(super::subscription_limit_reached(
+            &subscriptions,
+            &[],
+            u16::MAX
+        ));
+    }
+
+    #[actix_rt::test]
+    async fn websocket_monad_storage_changes_subscribe_and_unsubscribe() {
+        let mut server = create_test_server();
+        let mut framed = server.ws_at("/ws/").await.unwrap();
+
+        // Wait for initial ping
+        let _frame = framed.next().await.unwrap().unwrap();
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "method": "eth_subscribe",
+            "params": ["monadStorageChanges", {
+                "address": "0x0000000000000000000000000000000000000001",
+                "storageSlots": ["0x0000000000000000000000000000000000000000000000000000000000000000"],
+            }],
+            "id": 1,
+        });
+
+        framed
+            .send(ws::Message::Text(body.to_string().into()))
+            .await
+            .unwrap();
+
+        let frame = framed.next().await.unwrap().unwrap();
+        let Frame::Text(resp) = frame else {
+            panic!("expected text frame for subscribe response");
+        };
+        let resp: serde_json::Value = serde_json::from_slice(&resp).unwrap();
+        assert!(resp["error"].is_null(), "subscribe returned error: {resp}");
+        assert!(
+            resp["result"].is_string(),
+            "subscribe should return a subscription id, got: {resp}"
+        );
+        let parsed: crate::types::jsonrpc::Response = serde_json::from_value(resp).unwrap();
+        let subscription_id: FixedData<16> =
+            serde_json::from_str(parsed.result.unwrap().get()).unwrap();
+
+        // unsubscribe with the id we just received
+        let body = json!({
+            "jsonrpc": "2.0",
+            "method": "eth_unsubscribe",
+            "params": [ethhex::encode_bytes(&subscription_id.0)],
+            "id": 2,
+        });
+        framed
+            .send(ws::Message::Text(body.to_string().into()))
+            .await
+            .unwrap();
+
+        // Wait for the unsubscribe response
+        loop {
+            let frame = framed.next().await.unwrap().unwrap();
+            let Frame::Text(resp) = frame else {
+                continue;
+            };
+            let resp: serde_json::Value = serde_json::from_slice(&resp).unwrap();
+            let Ok(resp) = serde_json::from_value::<crate::types::jsonrpc::Response>(resp) else {
+                continue;
+            };
+            let result: bool = serde_json::from_str(resp.result.unwrap().get()).unwrap();
+            assert!(
+                result,
+                "unsubscribe must return true for an active monadStorageChanges subscription"
+            );
+            return;
+        }
+    }
+
+    #[actix_rt::test]
+    async fn websocket_monad_storage_changes_invalid_slot_count() {
+        // Both ends of the cap must reject: 0 slots and >MAX slots
+        let mut server = create_test_server();
+
+        for (case_name, slots) in [
+            ("empty slots", Vec::<String>::new()),
+            (
+                "too many slots",
+                (0..(super::MAX_STORAGE_SLOTS_PER_SUBSCRIPTION + 1) as u64)
+                    .map(|i| format!("0x{:064x}", i))
+                    .collect::<Vec<_>>(),
+            ),
+        ] {
+            let mut framed = server.ws_at("/ws/").await.unwrap();
+            let _frame = framed.next().await.unwrap().unwrap();
+
+            let body = json!({
+                "jsonrpc": "2.0",
+                "method": "eth_subscribe",
+                "params": ["monadStorageChanges", {
+                    "address": "0x0000000000000000000000000000000000000001",
+                    "storageSlots": slots,
+                }],
+                "id": 1,
+            });
+
+            framed
+                .send(ws::Message::Text(body.to_string().into()))
+                .await
+                .unwrap();
+
+            let frame = framed.next().await.unwrap().unwrap();
+            let Frame::Text(resp) = frame else {
+                panic!("[{case_name}] expected text frame");
+            };
+            let resp: serde_json::Value = serde_json::from_slice(&resp).unwrap();
+            assert!(
+                resp["error"].is_object(),
+                "[{case_name}] expected invalid_params error, got: {resp}",
+            );
         }
     }
 }


### PR DESCRIPTION
Adds a new `eth_subscribe` topic that lets users subscribe to specific storage slot changes per block. 

I tested for perf regression against custom blocks in monad-integration. I drove a sustained contract-call workload that wrote slots (3k txns per block) and compared throughput latency with `newHeads`; I did not find a perf change.  With 100 concurrent `monadStorageChanges` subscribers attached, the rate of `newHeads` notifications observed by a separate control connection holds at the newHead block notification pace. 

  | | Baseline (K=0) | K=10 subs | K=100 subs |
  |---|---|---|---|
  | Time to commit 30 blocks | 11.86 s | 11.50 s | 11.46 s |
  | blocks/s | 2.53 | 2.61 | 2.62 |
  | Throughput ratio vs. baseline | — | 1.031 | 1.041 |
  | Notifications per subscriber | — | 109,409–109,505 | 13,665–14,049 |
