### PR TITLE
Mock-swarm: Transport using raptorcast chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5691,6 +5691,7 @@ dependencies = [
  "monad-executor",
  "monad-executor-glue",
  "monad-multi-sig",
+ "monad-raptorcast",
  "monad-router-scheduler",
  "monad-secp",
  "monad-state",

--- a/monad-eth-block-validator/src/lib.rs
+++ b/monad-eth-block-validator/src/lib.rs
@@ -497,7 +497,7 @@ where
         let mut txn_fees: TxnFees = TxnFees::default();
         for eth_txn in validated_txns.iter() {
             let block_base_fee = header.base_fee;
-            if eth_txn.max_fee_per_gas() < block_base_fee.into() {
+            if eth_txn.max_fee_per_gas() < u128::from(block_base_fee) {
                 debug!(
                     ?eth_txn,
                     block_base_fee, "transaction max fee less than base fee"

--- a/monad-mock-swarm/Cargo.toml
+++ b/monad-mock-swarm/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 [lib]
 bench = false
 
+[features]
+raptorcast = ["dep:monad-raptorcast"]
+
 [dependencies]
 monad-blocksync = { workspace = true }
 monad-chain-config = { workspace = true }
@@ -19,6 +22,7 @@ monad-execution-state-read = { workspace = true }
 monad-executor = { workspace = true }
 monad-executor-glue = { workspace = true }
 monad-multi-sig = { workspace = true }
+monad-raptorcast = { workspace = true, optional = true }
 monad-router-scheduler = { workspace = true }
 monad-state = { workspace = true }
 monad-testutil = { workspace = true }

--- a/monad-mock-swarm/src/lib.rs
+++ b/monad-mock-swarm/src/lib.rs
@@ -16,6 +16,8 @@
 pub mod mock;
 pub mod mock_swarm;
 pub mod node;
+#[cfg(feature = "raptorcast")]
+pub mod raptorcast;
 pub mod swarm;
 pub mod swarm_relation;
 pub mod terminator;

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -379,11 +379,16 @@ impl<S: SwarmRelation> Executor for MockExecutor<S> {
                 RouterCommand::Publish { target, message } => {
                     self.router.send_outbound(self.tick, target, message);
                 }
-                RouterCommand::AddEpochValidatorSet { .. } => {
-                    // TODO
+                RouterCommand::AddEpochValidatorSet {
+                    epoch,
+                    epoch_start,
+                    validator_set,
+                } => {
+                    self.router
+                        .add_epoch_validator_set(epoch, epoch_start, validator_set);
                 }
-                RouterCommand::UpdateCurrentRound(_, _) => {
-                    // TODO
+                RouterCommand::UpdateCurrentRound(epoch, round) => {
+                    self.router.update_current_round(epoch, round);
                 }
                 RouterCommand::GetPeers => {
                     // TODO

--- a/monad-mock-swarm/src/node.rs
+++ b/monad-mock-swarm/src/node.rs
@@ -338,6 +338,7 @@ impl<S: SwarmRelation> Node<S> {
         None
     }
 
+    #[expect(unused)]
     fn build_validator_set_data(
         validator_set: &<S::ValidatorSetTypeFactory as ValidatorSetTypeFactory>::ValidatorSetType,
         validator_mapping: &ValidatorMapping<<<S::SignatureType as CertificateSignature>::KeyPairType as CertificateKeyPair>::PubKeyType, <<S::SignatureCollectionType as SignatureCollection>::SignatureType as CertificateSignature>::KeyPairType>,

--- a/monad-mock-swarm/src/raptorcast.rs
+++ b/monad-mock-swarm/src/raptorcast.rs
@@ -1,0 +1,575 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Raptorcast-aware in-process router scheduler for mock-swarm.
+
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
+    marker::PhantomData,
+    sync::Arc,
+    time::Duration,
+};
+
+use bytes::Bytes;
+use monad_chain_config::{revision::MockChainRevision, MockChainConfig};
+use monad_consensus_types::{
+    block::{MockExecutionProtocol, PassthruBlockPolicy},
+    block_validator::MockValidator,
+};
+use monad_crypto::{
+    certificate_signature::{CertificateSignaturePubKey, PubKey},
+    NopSignature,
+};
+use monad_execution_state_read::InMemoryState;
+use monad_multi_sig::MultiSig;
+use monad_raptorcast::{
+    packet::{deterministic::PrimaryEncoding, regular},
+    util::{EncodingScheme, PrimaryBroadcastGroup},
+};
+use monad_router_scheduler::{RouterEvent, RouterScheduler, RouterSchedulerBuilder};
+use monad_state::{MonadMessage, VerifiedMonadMessage};
+use monad_transformer::GenericTransformerPipeline;
+use monad_types::{Deserializable, Epoch, NodeId, Round, RouterTarget, Serializable, Stake};
+use monad_updaters::{
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
+};
+use monad_validator::{
+    proposer_schedule::{ElectedProposerSchedule, ProposerSchedule},
+    simple_round_robin::SimpleRoundRobin,
+    validator_set::{ValidatorSet, ValidatorSetFactory, ValidatorSetType},
+};
+
+use crate::swarm_relation::SwarmRelation;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChunkMode {
+    Raptorcast,
+    Unicast,
+}
+
+const PROPOSER_SCHEDULE_CACHE_MAX_PAST_ROUNDS: Round = Round(100);
+const PROPOSER_SCHEDULE_CACHE_MAX_FUTURE_ROUNDS: Round = Round(100);
+
+#[derive(Default)]
+struct DecodingState {
+    seen_chunk_ids: BTreeSet<usize>,
+    decoded: bool,
+}
+
+#[derive(Clone)]
+pub struct RaptorcastRouterConfig<
+    PT: PubKey,
+    IM,
+    OM,
+    PS = ElectedProposerSchedule<PT, SimpleRoundRobin<PT>>,
+> where
+    PS: ProposerSchedule<PT>,
+{
+    pub self_id: NodeId<PT>,
+
+    /// The extra fraction of num_source_symbols(K) required for
+    /// successful decode. 0 means decoding at K+1 chunks.
+    pub decoding_threshold: f32,
+
+    /// The parameters for unicast/broadcast (v0). Raptorcast uses
+    /// parameters specified by deterministic encoding.
+    pub unicast_redundancy: f32,
+    pub symbol_len: u32,
+
+    pub proposer_schedule: PS,
+
+    pub _phantom: PhantomData<(IM, OM)>,
+}
+
+impl<PT: PubKey, IM, OM> RaptorcastRouterConfig<PT, IM, OM> {
+    pub fn new(self_id: NodeId<PT>) -> Self {
+        Self::new_with_proposer_schedule(
+            self_id,
+            ElectedProposerSchedule::new(SimpleRoundRobin::default()),
+        )
+    }
+}
+
+impl<PT, IM, OM, PS> RaptorcastRouterConfig<PT, IM, OM, PS>
+where
+    PT: PubKey,
+    PS: ProposerSchedule<PT>,
+{
+    pub fn new_with_proposer_schedule(self_id: NodeId<PT>, proposer_schedule: PS) -> Self {
+        Self {
+            self_id,
+            decoding_threshold: 0.0,
+            unicast_redundancy: 2.5,
+            symbol_len: regular::MIN_CHUNK_LENGTH as u32,
+            proposer_schedule,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<PT, IM, OM, PS> RouterSchedulerBuilder for RaptorcastRouterConfig<PT, IM, OM, PS>
+where
+    IM: Deserializable<Bytes>,
+    OM: Serializable<Bytes>,
+    PT: PubKey,
+    PS: ProposerSchedule<PT>,
+{
+    type RouterScheduler = RaptorcastRouterScheduler<PT, IM, OM, PS>;
+
+    fn build(self) -> Self::RouterScheduler {
+        RaptorcastRouterScheduler {
+            next_msg_id: 0,
+            config: self,
+            events: BTreeMap::new(),
+            decoding_states: HashMap::new(),
+            validator_sets: BTreeMap::new(),
+            current_round: None,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub enum WireMsg<PT: PubKey> {
+    Chunk(ChunkMsg<PT>),
+    // tcp or direct udp
+    Direct(Arc<Bytes>),
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct ChunkMsg<PT: PubKey> {
+    pub msg_id: usize,
+    pub round: Round,
+    pub author: NodeId<PT>,
+    pub chunk_id: usize,
+    pub total_chunks: usize,
+    pub num_source_symbols: usize,
+    pub mode: ChunkMode,
+    pub payload: Arc<Bytes>,
+}
+
+pub struct RaptorcastRouterScheduler<
+    PT: PubKey,
+    IM,
+    OM,
+    PS = ElectedProposerSchedule<PT, SimpleRoundRobin<PT>>,
+> where
+    PS: ProposerSchedule<PT>,
+{
+    next_msg_id: usize,
+    config: RaptorcastRouterConfig<PT, IM, OM, PS>,
+    events: BTreeMap<Duration, VecDeque<RouterEvent<PT, IM, WireMsg<PT>>>>,
+    decoding_states: HashMap<(NodeId<PT>, Round, u64), DecodingState>,
+    validator_sets: BTreeMap<Epoch, ValidatorSet<PT>>,
+    current_round: Option<Round>,
+    _phantom: PhantomData<(IM, OM)>,
+}
+
+impl<PT, IM, OM, PS> RaptorcastRouterScheduler<PT, IM, OM, PS>
+where
+    IM: Deserializable<Bytes>,
+    OM: Serializable<Bytes>,
+
+    PT: PubKey,
+    PS: ProposerSchedule<PT>,
+{
+    fn push_rx_event(&mut self, time: Duration, from: NodeId<PT>, payload: &Bytes) {
+        let msg = IM::deserialize(payload).expect("failed to deserialize");
+        self.events
+            .entry(time)
+            .or_default()
+            .push_back(RouterEvent::Rx(from, msg));
+    }
+
+    fn push_tx_event(&mut self, time: Duration, to: NodeId<PT>, message: WireMsg<PT>) {
+        self.events
+            .entry(time)
+            .or_default()
+            .push_back(RouterEvent::Tx(to, message));
+    }
+
+    fn emit_direct(&mut self, time: Duration, payload: &Arc<Bytes>, to: NodeId<PT>) {
+        self.push_tx_event(time, to, WireMsg::Direct(payload.clone()));
+    }
+
+    fn emit_unicast(
+        &mut self,
+        time: Duration,
+        msg_id: usize,
+        payload: &Arc<Bytes>,
+        to: NodeId<PT>,
+    ) {
+        let num_source_symbols = payload.len().div_ceil(self.config.symbol_len as usize);
+        let num_scaled_chunks =
+            ((num_source_symbols as f32) * self.config.unicast_redundancy).ceil() as usize;
+        let round = self.current_round.unwrap_or(Round(0));
+
+        for chunk_id in 0..num_scaled_chunks {
+            let chunk_msg = ChunkMsg {
+                msg_id,
+                round,
+                mode: ChunkMode::Unicast,
+                author: self.config.self_id,
+                payload: payload.clone(),
+                total_chunks: num_scaled_chunks,
+                num_source_symbols,
+                chunk_id,
+            };
+
+            self.push_tx_event(time, to, WireMsg::Chunk(chunk_msg));
+        }
+    }
+
+    fn primary_encoding(
+        &self,
+        chunk: &ChunkMsg<PT>,
+        epoch: Epoch,
+        validator_set: &ValidatorSet<PT>,
+    ) -> PrimaryEncoding<PT> {
+        // use msg_id to introduce some variability.
+        let unix_ts_ms = chunk.msg_id as u64;
+
+        let encoding_scheme = EncodingScheme::Deterministic25(chunk.round);
+        let group = PrimaryBroadcastGroup::new_unchecked(epoch, &chunk.author, validator_set);
+        PrimaryEncoding::new(encoding_scheme, &group, chunk.payload.len(), unix_ts_ms)
+            .expect("failed to build raptorcast message")
+    }
+
+    fn emit_raptorcast(
+        &mut self,
+        time: Duration,
+        msg_id: usize,
+        round: Round,
+        epoch: Epoch,
+        payload: &Arc<Bytes>,
+    ) {
+        let Some(validator_set) = self.validator_sets.get(&epoch) else {
+            return;
+        };
+
+        let self_id = self.config.self_id;
+        let mut chunk_msg = ChunkMsg {
+            msg_id,
+            round,
+            mode: ChunkMode::Raptorcast,
+            author: self_id,
+            payload: payload.clone(),
+            // to be overridden later
+            num_source_symbols: 0,
+            total_chunks: 0,
+            chunk_id: 0,
+        };
+        let encoding = self.primary_encoding(&chunk_msg, epoch, validator_set);
+        chunk_msg.num_source_symbols = encoding.layout().num_base_symbols(payload.len());
+
+        let chunks = encoding.make_chunks().expect("failed to assign chunks");
+        chunk_msg.total_chunks = chunks.len();
+
+        // raptorcast does not build chunks for the publisher, so we
+        // need to emit a direct message to ensure self reception.
+        self.emit_direct(time, payload, self_id);
+
+        for chunk in chunks {
+            let chunk_msg = ChunkMsg {
+                chunk_id: chunk.chunk_id(),
+                ..chunk_msg.clone()
+            };
+            let recipient = *chunk.recipient().node_id();
+            self.push_tx_event(time, recipient, WireMsg::Chunk(chunk_msg));
+        }
+    }
+
+    fn handle_inbound_direct(&mut self, time: Duration, from: NodeId<PT>, message: &Arc<Bytes>) {
+        self.push_rx_event(time, from, message.as_ref());
+    }
+
+    fn handle_inbound_unicast(&mut self, time: Duration, from: NodeId<PT>, message: ChunkMsg<PT>) {
+        if !self.try_decode(&message) {
+            return;
+        }
+
+        self.push_rx_event(time, from, message.payload.as_ref());
+    }
+
+    fn handle_inbound_raptorcast(
+        &mut self,
+        time: Duration,
+        _from: NodeId<PT>,
+        message: ChunkMsg<PT>,
+    ) {
+        if !self.is_round_in_window(message.round) {
+            return;
+        }
+
+        let Some((epoch, validator_set)) = self.validator_set_for_round(message.round) else {
+            return;
+        };
+
+        if self
+            .config
+            .proposer_schedule
+            .check_proposer(&message.author, message.round)
+            != Some(true)
+        {
+            return;
+        }
+
+        let encoding = self.primary_encoding(&message, epoch, validator_set);
+        let assignment = encoding
+            .make_assignment()
+            .expect("failed to infer chunk assignment");
+        let routing = assignment
+            .resolve_chunk_id(message.chunk_id)
+            .expect("invalid chunk assignment");
+
+        if routing.recipient() == &self.config.self_id {
+            // rebroadcasting
+            for target in routing.rebroadcast_targets() {
+                self.push_tx_event(time, target, WireMsg::Chunk(message.clone()));
+            }
+        }
+
+        // not the first hop, simply consume the message.
+        if !self.try_decode(&message) {
+            return;
+        }
+
+        self.push_rx_event(time, message.author, message.payload.as_ref());
+    }
+
+    // Returns whether the message should be processed as decoded.
+    fn try_decode(&mut self, message: &ChunkMsg<PT>) -> bool {
+        let key = (message.author, message.round, message.msg_id as u64);
+        let state = self.decoding_states.entry(key).or_default();
+        if state.decoded {
+            return false;
+        }
+
+        if state.seen_chunk_ids.contains(&message.chunk_id) {
+            return false;
+        }
+
+        state.seen_chunk_ids.insert(message.chunk_id);
+
+        let extra_chunks_needed =
+            (message.num_source_symbols as f32 * self.config.decoding_threshold).round() as usize;
+        // ensure decode when receiving all chunks
+        let threshold =
+            (message.num_source_symbols + extra_chunks_needed + 1).min(message.total_chunks);
+        if state.seen_chunk_ids.len() < threshold {
+            return false;
+        }
+
+        state.decoded = true;
+        true
+    }
+
+    fn validator_set_for_round(&self, round: Round) -> Option<(Epoch, &ValidatorSet<PT>)> {
+        self.validator_sets
+            .iter()
+            .find(|(epoch, _)| {
+                self.config.proposer_schedule.check_epoch(**epoch, round) == Some(true)
+            })
+            .map(|(epoch, validator_set)| (*epoch, validator_set))
+    }
+
+    fn is_round_in_window(&self, round: Round) -> bool {
+        let Some(current_round) = self.current_round else {
+            return true;
+        };
+
+        let min_round = current_round.saturating_sub(PROPOSER_SCHEDULE_CACHE_MAX_PAST_ROUNDS);
+        let max_round = current_round.saturating_add(PROPOSER_SCHEDULE_CACHE_MAX_FUTURE_ROUNDS);
+
+        min_round <= round && round <= max_round
+    }
+}
+
+impl<PT, IM, OM, PS> RouterScheduler for RaptorcastRouterScheduler<PT, IM, OM, PS>
+where
+    IM: Deserializable<Bytes>,
+    OM: Serializable<Bytes>,
+    PT: PubKey,
+    PS: ProposerSchedule<PT>,
+{
+    type NodeIdPublicKey = PT;
+    type TransportMessage = WireMsg<PT>;
+    type InboundMessage = IM;
+    type OutboundMessage = OM;
+
+    fn process_inbound(
+        &mut self,
+        time: Duration,
+        from: NodeId<PT>,
+        message: Self::TransportMessage,
+    ) {
+        match message {
+            WireMsg::Direct(payload) => self.handle_inbound_direct(time, from, &payload),
+            WireMsg::Chunk(
+                chunk @ ChunkMsg {
+                    mode: ChunkMode::Raptorcast,
+                    ..
+                },
+            ) => self.handle_inbound_raptorcast(time, from, chunk),
+            WireMsg::Chunk(
+                chunk @ ChunkMsg {
+                    mode: ChunkMode::Unicast,
+                    ..
+                },
+            ) => self.handle_inbound_unicast(time, from, chunk),
+        }
+    }
+
+    fn send_outbound(
+        &mut self,
+        time: Duration,
+        to: RouterTarget<PT>,
+        message: Self::OutboundMessage,
+    ) {
+        let msg_id = self.next_msg_id;
+        self.next_msg_id += 1;
+
+        let message = message.serialize();
+        let payload = Arc::new(message);
+
+        match to {
+            RouterTarget::Raptorcast { round, epoch } => {
+                self.emit_raptorcast(time, msg_id, round, epoch, &payload);
+            }
+            RouterTarget::Broadcast(epoch) => {
+                let Some(validator_set) = self.validator_sets.get(&epoch) else {
+                    return;
+                };
+
+                // .clone() to get around borrowed self
+                for recipient in validator_set.get_members().clone().keys() {
+                    self.emit_unicast(time, msg_id, &payload, *recipient);
+                }
+            }
+            RouterTarget::PointToPoint(to) => {
+                self.emit_unicast(time, msg_id, &payload, to);
+            }
+            RouterTarget::DirectPointToPoint(to) => {
+                self.emit_direct(time, &payload, to);
+            }
+            RouterTarget::TcpPointToPoint { to, completion } => {
+                if let Some(completion) = completion {
+                    let _ = completion.send(());
+                }
+                self.emit_direct(time, &payload, to);
+            }
+        }
+    }
+
+    fn add_epoch_validator_set(
+        &mut self,
+        epoch: Epoch,
+        epoch_start: Round,
+        validator_set: Vec<(NodeId<Self::NodeIdPublicKey>, Stake)>,
+    ) {
+        let validator_set = ValidatorSet::new_unchecked(validator_set.into_iter().collect());
+        self.config
+            .proposer_schedule
+            .insert_epoch(epoch, epoch_start, validator_set.clone());
+        self.validator_sets.insert(epoch, validator_set);
+    }
+
+    fn update_current_round(&mut self, _epoch: Epoch, round: Round) {
+        self.current_round = Some(round);
+
+        let cutoff = round.saturating_sub(PROPOSER_SCHEDULE_CACHE_MAX_PAST_ROUNDS);
+        self.config.proposer_schedule.prune_below(cutoff);
+    }
+
+    fn peek_tick(&self) -> Option<Duration> {
+        self.events.keys().next().copied()
+    }
+
+    fn step_until(
+        &mut self,
+        until: Duration,
+    ) -> Option<RouterEvent<PT, IM, Self::TransportMessage>> {
+        let next_tick = self.peek_tick()?;
+        if next_tick > until {
+            return None;
+        }
+        let mut entry = self.events.first_entry().expect("checked non-empty above");
+        let queue = entry.get_mut();
+        let event = queue.pop_front().expect("non-empty bucket");
+        if queue.is_empty() {
+            entry.remove_entry();
+        }
+        Some(event)
+    }
+}
+
+pub struct RaptorcastSwarm;
+impl SwarmRelation for RaptorcastSwarm {
+    type SignatureType = NopSignature;
+    type SignatureCollectionType = MultiSig<Self::SignatureType>;
+    type ExecutionProtocolType = MockExecutionProtocol;
+    type BlockPolicyType = PassthruBlockPolicy;
+    type ExecutionStateReadType = InMemoryState<Self::SignatureType, Self::SignatureCollectionType>;
+    type ChainConfigType = MockChainConfig;
+    type ChainRevisionType = MockChainRevision;
+
+    type TransportMessage = WireMsg<CertificateSignaturePubKey<Self::SignatureType>>;
+    type BlockValidator = MockValidator;
+    type ValidatorSetTypeFactory =
+        ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
+    type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
+    type Ledger =
+        MockLedger<Self::SignatureType, Self::SignatureCollectionType, Self::ExecutionProtocolType>;
+
+    type RouterScheduler = RaptorcastRouterScheduler<
+        CertificateSignaturePubKey<Self::SignatureType>,
+        MonadMessage<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >,
+        VerifiedMonadMessage<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >,
+    >;
+
+    type Pipeline = GenericTransformerPipeline<
+        CertificateSignaturePubKey<Self::SignatureType>,
+        Self::TransportMessage,
+    >;
+
+    type ValSetUpdater = MockValSetUpdaterNop<
+        Self::SignatureType,
+        Self::SignatureCollectionType,
+        Self::ExecutionProtocolType,
+    >;
+    type TxPoolExecutor = MockTxPoolExecutor<
+        Self::SignatureType,
+        Self::SignatureCollectionType,
+        Self::ExecutionProtocolType,
+        Self::BlockPolicyType,
+        Self::ExecutionStateReadType,
+        Self::ChainConfigType,
+        Self::ChainRevisionType,
+    >;
+    type StateSyncExecutor = MockStateSyncExecutor<
+        Self::SignatureType,
+        Self::SignatureCollectionType,
+        Self::ExecutionProtocolType,
+    >;
+}

--- a/monad-mock-swarm/src/terminator.rs
+++ b/monad-mock-swarm/src/terminator.rs
@@ -17,7 +17,7 @@ use std::{collections::BTreeMap, time::Duration};
 
 use monad_crypto::certificate_signature::{CertificateSignaturePubKey, PubKey};
 use monad_transformer::ID;
-use monad_types::{Round, SeqNum, GENESIS_SEQ_NUM};
+use monad_types::{Epoch, Round, SeqNum, GENESIS_SEQ_NUM};
 use monad_updaters::ledger::MockableLedger;
 
 use crate::{mock_swarm::Nodes, swarm_relation::SwarmRelation};
@@ -33,6 +33,7 @@ where
 pub struct UntilTerminator {
     until_tick: Duration,
     until_block: usize,
+    until_epoch: Epoch,
     until_round: Round,
     until_step: usize,
 }
@@ -48,6 +49,7 @@ impl UntilTerminator {
         UntilTerminator {
             until_tick: Duration::MAX,
             until_block: usize::MAX,
+            until_epoch: Epoch::MAX,
             until_round: Round(u64::MAX),
             until_step: usize::MAX,
         }
@@ -66,6 +68,11 @@ impl UntilTerminator {
 
     pub fn until_round(mut self, round: Round) -> Self {
         self.until_round = round;
+        self
+    }
+
+    pub fn until_epoch(mut self, epoch: Epoch) -> Self {
+        self.until_epoch = epoch;
         self
     }
 
@@ -90,6 +97,11 @@ where
                 .states
                 .values()
                 .any(|node| node.executor.ledger().get_finalized_blocks().len() > self.until_block)
+            || (nodes.states.values().all(|node| {
+                node.state
+                    .consensus()
+                    .is_some_and(|consensus| consensus.get_current_epoch() >= self.until_epoch)
+            }))
             || nodes.states.values().any(|node| {
                 node.state
                     .consensus()
@@ -131,7 +143,7 @@ where
     fn should_terminate(&mut self, nodes: &Nodes<S>, _next_tick: Duration) -> bool {
         if nodes.tick > self.timeout {
             panic!(
-                "ProgressTerminator timed-out, expecting nodes 
+                "ProgressTerminator timed-out, expecting nodes
                 to reach following progress before timeout: {:?},
                 but the actual progress is: {:?}",
                 self.nodes_monitor,

--- a/monad-mock-swarm/tests/raptorcast.rs
+++ b/monad-mock-swarm/tests/raptorcast.rs
@@ -1,0 +1,102 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg(feature = "raptorcast")]
+
+use std::time::Duration;
+
+use monad_chain_config::{revision::ChainParams, MockChainConfig};
+use monad_consensus_types::{block::PassthruBlockPolicy, block_validator::MockValidator};
+use monad_crypto::certificate_signature::CertificateKeyPair;
+use monad_execution_state_read::InMemoryStateInner;
+use monad_mock_swarm::{
+    mock::TimestamperConfig,
+    mock_swarm::SwarmBuilder,
+    node::NodeBuilder,
+    raptorcast::{RaptorcastRouterConfig, RaptorcastSwarm},
+    swarm::{make_state_configs, swarm_ledger_verification},
+    terminator::UntilTerminator,
+};
+use monad_router_scheduler::RouterSchedulerBuilder;
+use monad_transformer::{GenericTransformer, LatencyTransformer, ID};
+use monad_types::{Epoch, NodeId, Round, SeqNum};
+use monad_updaters::{
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
+};
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
+
+static CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(5),
+};
+
+#[test]
+fn raptorcast_smoke_four_nodes() {
+    let delta = Duration::from_millis(100);
+    let epoch_length = SeqNum(20);
+    let epoch_start_delay = Round(5);
+    let state_configs = make_state_configs::<RaptorcastSwarm>(
+        4,
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        || MockValidator,
+        || PassthruBlockPolicy,
+        || InMemoryStateInner::genesis(SeqNum(4)),
+        SeqNum(4),
+        delta,
+        MockChainConfig::new_with_epoch_params(&CHAIN_PARAMS, epoch_length, epoch_start_delay),
+        SeqNum(100),
+    );
+
+    let swarm_config = SwarmBuilder::<RaptorcastSwarm>(
+        state_configs
+            .into_iter()
+            .enumerate()
+            .map(|(seed, state_builder)| {
+                let state_backend = state_builder.state_read.clone();
+                let validators = state_builder.locked_epoch_validators[0].clone();
+                let self_id = NodeId::new(state_builder.key.pubkey());
+                let router_config = RaptorcastRouterConfig::<_, _, _>::new(self_id);
+                NodeBuilder::<RaptorcastSwarm>::new(
+                    ID::new(self_id),
+                    state_builder,
+                    router_config.build(),
+                    MockValSetUpdaterNop::new(validators.validators, epoch_length),
+                    MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
+                    MockLedger::new(state_backend.clone()),
+                    MockStateSyncExecutor::new(state_backend),
+                    vec![GenericTransformer::Latency(LatencyTransformer::new(delta))],
+                    vec![],
+                    TimestamperConfig::default(),
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
+    );
+
+    let mut swarm = swarm_config.build();
+    let target_epoch = Epoch(4);
+    while swarm
+        .step_until(&mut UntilTerminator::new().until_epoch(target_epoch))
+        .is_some()
+    {}
+
+    let min_blocks = (target_epoch.0 - 1) * epoch_length.0;
+    swarm_ledger_verification(&swarm, min_blocks as usize);
+}

--- a/monad-raptorcast/src/packet/assigner.rs
+++ b/monad-raptorcast/src/packet/assigner.rs
@@ -26,8 +26,11 @@ use rand_chacha::ChaCha20Rng;
 use super::{BuildError, Chunk, Result};
 use crate::util::{ensure, PrimaryBroadcastGroup, Recipient, Redundancy, SecondaryBroadcastGroup};
 
+// index of a node in an OrderedNodes instance. Treat as opaque
+// handle, only meaningful when used with the same OrderedNodes
+// instance that produced it.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub(crate) struct NodeIndex(usize);
+pub struct NodeIndex(usize);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChunkTarget {
@@ -51,7 +54,7 @@ impl From<NodeIndex> for ChunkTarget {
 // A frozen ordered list of nodes, indexable by NodeIndex. Captures
 // the concept of "the recipient table for a ChunkAssignment".
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct OrderedNodes<PT: PubKey>(Box<[NodeId<PT>]>);
+pub struct OrderedNodes<PT: PubKey>(Box<[NodeId<PT>]>);
 
 impl<PT: PubKey> OrderedNodes<PT> {
     pub fn singleton(node: NodeId<PT>) -> Self {
@@ -78,7 +81,7 @@ impl<PT: PubKey> FromIterator<NodeId<PT>> for OrderedNodes<PT> {
 }
 
 // A Partition produces a ChunkAssignment from its internal node set.
-pub(crate) trait Partition {
+pub trait Partition {
     type PubKey: PubKey;
 
     // [u8; 32] == <ChaCha20Rng as SeedableRng>::Seed
@@ -295,7 +298,7 @@ pub fn even_partition_num_chunks(num_base_symbols: usize, redundancy: Redundancy
 
 // Proportional to stake, plus each validator gets an optional
 // rounding chunk
-pub(crate) struct StakePartition<PT: PubKey> {
+pub struct StakePartition<PT: PubKey> {
     // Validator set with the publisher node excluded.
     //
     // Invariant: all stake must be non-zero

--- a/monad-raptorcast/src/packet/chunk.rs
+++ b/monad-raptorcast/src/packet/chunk.rs
@@ -18,7 +18,7 @@ use monad_crypto::certificate_signature::PubKey;
 
 use crate::util::{Recipient, UdpMessage};
 
-pub(crate) struct Chunk<PT: PubKey> {
+pub struct Chunk<PT: PubKey> {
     chunk_id: usize,
     recipient: Recipient<PT>,
     payload: BytesMut,

--- a/monad-raptorcast/src/packet/deterministic.rs
+++ b/monad-raptorcast/src/packet/deterministic.rs
@@ -68,7 +68,7 @@ pub const MIN_SYMBOL_LEN: usize = DEFAULT_SEGMENT_LEN - PacketLayout::MAX_HEADER
 pub const MAX_SYMBOL_LEN: usize = DEFAULT_SEGMENT_LEN - PacketLayout::MIN_HEADER_LEN;
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct PacketLayout {
+pub struct PacketLayout {
     segment_len: usize,
     merkle_tree_depth: u8,
 }
@@ -368,14 +368,14 @@ impl<PT: PubKey> InnerDeterministicEncoding<PT> {
     }
 }
 
-pub(crate) struct DeterministicEncoding<P: Partition> {
+pub struct DeterministicEncoding<P: Partition> {
     layout: PacketLayout,
     redundancy: Redundancy,
     app_message_len: usize,
     partition: P,
 }
 
-pub(crate) type PrimaryEncoding<PT> = DeterministicEncoding<StakePartition<PT>>;
+pub type PrimaryEncoding<PT> = DeterministicEncoding<StakePartition<PT>>;
 pub(crate) type SecondaryEncoding<PT> = DeterministicEncoding<EvenPartition<PT>>;
 
 impl<P: Partition> DeterministicEncoding<P> {

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -427,6 +427,19 @@ impl<'a, PT: PubKey> PrimaryBroadcastGroup<'a, PT> {
         })
     }
 
+    // only used in mock-swarm
+    pub fn new_unchecked(
+        epoch: Epoch,
+        author: &'a NodeId<PT>,
+        group: &'a ValidatorSet<PT>,
+    ) -> Self {
+        Self {
+            epoch,
+            author,
+            group,
+        }
+    }
+
     pub fn author(&self) -> &NodeId<PT> {
         self.author
     }

--- a/monad-router-scheduler/src/lib.rs
+++ b/monad-router-scheduler/src/lib.rs
@@ -22,7 +22,7 @@ use std::{
 use auto_impl::auto_impl;
 use bytes::Bytes;
 use monad_crypto::certificate_signature::PubKey;
-use monad_types::{Deserializable, NodeId, RouterTarget, Serializable};
+use monad_types::{Deserializable, Epoch, NodeId, Round, RouterTarget, Serializable, Stake};
 
 #[derive(Debug)]
 pub enum RouterEvent<PT: PubKey, InboundMessage, TransportMessage> {
@@ -59,6 +59,14 @@ pub trait RouterScheduler {
         to: RouterTarget<Self::NodeIdPublicKey>,
         message: Self::OutboundMessage,
     );
+    fn add_epoch_validator_set(
+        &mut self,
+        _epoch: Epoch,
+        _epoch_start: Round,
+        _validator_set: Vec<(NodeId<Self::NodeIdPublicKey>, Stake)>,
+    ) {
+    }
+    fn update_current_round(&mut self, _epoch: Epoch, _round: Round) {}
 
     fn peek_tick(&self) -> Option<Duration>;
     fn step_until(


### PR DESCRIPTION
This PR implements a mock-swarm router scheduler that uses raptorcast chunks as underlying transport using real deterministic raptorcast chunk assignment algorithm. It can be helpful to simulate scenarios involving two-hop delay, and chunk-based networking conditions.

Note: the scheduler does not (yet) expose the underlying chunks to the consensus.

Note 2: the scheduler doesn't perform actual raptor-code encoding or use real raptorcast packet format. The underlying transport is a simple `(Arc<Bytes>, chunk_id)` of the full serialized message.