### PR TITLE
Upgrade alloy version to 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,9 +419,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-consensus"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47bb488c4bb618b7e48e31c4c1c7f5cf57bd1c9dca57920fe5c9e523d342f346"
+checksum = "e3d64da86c616b5092ea64eea648f311bbd58630a0b384c42d699175d6f9122b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -447,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61db9f76859e9aebb5a847a7558aa10b6c61bc3b7cee3e97ca1372f37b0399a7"
+checksum = "8fd98696ca3617d3a9ba1a6f2011880cbfd5618228dab6400c9f8bca457859a8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff88430c522ea8ac12ea59e16584219ba98883544da7f3f2d32fbbe3038826d2"
+checksum = "64c0456f5f7a4497e9342d20f528e30f5288ddfa0d6a012bd5044afee46cd8a0"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -540,7 +540,6 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -557,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccab6c0f99d9bf6105a79b89ffb13894e4dbe76e0653863ca005980b7687f46"
+checksum = "19e352478b756bad5d7203148e4b461861282ea2ded3da406ba24868b52cd098"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -572,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c82ad550f7bf0cfa1436ddb7cb86c71d1b2173fb63475c5495d8c94736a3159"
+checksum = "ed08ae169869e08370ed121612e0d3dadac33d1a256e9f2465926b23f0bd7d95"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -598,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7e97a2f0287a34823b1cf56fefc69844adb93cf11ea1a3310f7b155d3c59f"
+checksum = "02e6c7ad28afe348a9a9c5624b67ee5b3607b8de98d5816b3056ecdfa6fa2697"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -663,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89775927b9acbae5cab344cb08c20a9785a0cc65296dd11e5aa93cb5765d70b9"
+checksum = "5beb5c2fe6b960c8e8b038e69fd502a90a2e930afa4770efb748b163b0767729"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -673,7 +672,7 @@ dependencies = [
  "alloy-transport-http",
  "futures",
  "pin-project",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "tokio",
@@ -686,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85470a4e122a98473e847d9815bfbe1bdecb50b92f7be3d29f5598fddd595a3"
+checksum = "4ee1257a278f6d293e05c5162c5940a1561b1aa85ded0028b464c81de37ebfa5"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -699,20 +698,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aaa72d8b85b29cdbc36933a984f995e8c94a37bcf0224369e035b5c3c405431"
+checksum = "6a234bfbdf7a76c3d13808f729af5321852de3dedcaa6fc6d5f54787aaf54c6a"
 dependencies = [
  "alloy-consensus-any",
+ "alloy-network-primitives",
+ "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48476e376d4522593b2fbc6fbe784f7f4f1375674d695d8bc95da12ec8ffaf5"
+checksum = "73b12366c96f4013e1aeebc96c6b56e5f33f07853c42ea2f485045c0c157a4a1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -728,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6620d67aebea3f4f74d95a37ce045068b7a8591dc3e9ce0661fffaeeff92488b"
+checksum = "56a282daf869eeb7383d3d5c2deb35b0b3fb45ecb329513af4090fc61245ee18"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -750,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4a33c02a623e86c09b3b5e6b2fdc1fb5e7c1946002e75d5b9ef56c3bb9ffbf"
+checksum = "6184b5d14152b68b0bb8beb621339d94f0b761a37958bb365fbf7c00922125c2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -764,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664c5ade19f3ee19af72042f9ca9b32dba611e98fce241d5f0a51e98f5a28a9d"
+checksum = "a0eada2558e921b39dfcead33c487364df9b31374f5733c1c9d2c891c4529933"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -776,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fab11d0faa065959a38d1485bdf34a41d6164a08dc06a0414da34ec0b3923963"
+checksum = "41eb29f7a8adcd8941fbb8e134022a133e6f8dfd345f2e3b7109599f8a7dca08"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -791,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f57ca1c6c94c61ca02548e15b6af65c2069223b0096491d38ccaabc1498d9a46"
+checksum = "bef839e7ce9b59aa60fa9a175e97986c6145c888d643b0f1fb0a3e7b8e56a2e2"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -877,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08888d58ac7a1ceb05e89714d41742eb614e45c2b521d98def8a768a753177d6"
+checksum = "3ac7a80c0bac3e44559d53d002e34c461dc2f23262b42cafec019bc70551abbe"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -900,14 +903,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a143ffc7529bf2e5213bf98b78d12695a54285ae9dedb9f11a729a0e41f495"
+checksum = "eed3ed3300a998f88639ed619fdbbd88bd82865e00c6a8ecb796c99eb12358f6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "itertools 0.13.0",
- "reqwest",
+ "reqwest 0.13.3",
  "serde_json",
  "tower",
  "tracing",
@@ -937,11 +940,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.7.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d58bb83c3a5d01cde1cefa06cf212c22d8416d71d0f61a998afa366965e998"
+checksum = "99fce0350197dcd4ba4e9a7dd43915d908c0eb0e7352755791709a705e1c76b6"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.113",
@@ -2842,7 +2845,6 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "serde",
  "strsim",
  "syn 2.0.113",
 ]
@@ -2856,6 +2858,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "serde",
  "strsim",
  "syn 2.0.113",
 ]
@@ -4804,7 +4807,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tempfile",
@@ -5206,7 +5209,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -5602,7 +5605,7 @@ dependencies = [
  "opentelemetry_sdk",
  "rand_chacha 0.3.1",
  "rayon",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 1.0.69",
  "tikv-jemallocator",
  "tokio",
@@ -5881,7 +5884,7 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "rayon",
- "reqwest",
+ "reqwest 0.12.28",
  "schemars 0.8.22",
  "serde",
  "serde_cbor",
@@ -6824,7 +6827,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
@@ -6839,7 +6842,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 2.0.17",
  "tokio",
  "tonic",
@@ -7297,7 +7300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.113",
@@ -7651,6 +7654,41 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,22 +86,22 @@ actix-ws = "0.3.0"
 aegis = "0.5"
 aes = "0.8.3"
 agent = { git = "https://github.com/category-labs/manytrace.git", tag = "v0.1.1" }
-alloy-consensus = "1.7"
-alloy-eips = "1.7"
-alloy-json-rpc = "1.7"
-alloy-network = "1.7"
+alloy-consensus = "2.0"
+alloy-eips = "2.0"
+alloy-json-rpc = "2.0"
+alloy-network = "2.0"
 alloy-primitives = "1.5"
 alloy-rlp = { version = "0.3", features = ["arrayvec"] }
-alloy-rpc-client = "1.7"
-alloy-rpc-types = { version = "1.7", default-features = false, features = ["eth"] }
-alloy-rpc-types-eth = "1.7"
-alloy-rpc-types-trace = "1.7"
-alloy-signer = "1.7"
-alloy-signer-local = "1.7"
+alloy-rpc-client = "2.0"
+alloy-rpc-types = { version = "2.0", default-features = false, features = ["eth"] }
+alloy-rpc-types-eth = "2.0"
+alloy-rpc-types-trace = "2.0"
+alloy-signer = "2.0"
+alloy-signer-local = "2.0"
 alloy-sol-macro = "1.5"
 alloy-sol-types = "1.5"
-alloy-transport = "1.7"
-alloy-transport-http = { version = "1.7", default-features = false, features = ["reqwest", "reqwest-native-tls"] }
+alloy-transport = "2.0"
+alloy-transport-http = { version = "2.0", default-features = false, features = ["reqwest", "reqwest-native-tls"] }
 arbitrary = "1.4.1"
 arrayvec = { version = "0.7", features = ["serde"] }
 as-any = "0.3.1"

--- a/monad-eth-testutil/Cargo.toml
+++ b/monad-eth-testutil/Cargo.toml
@@ -56,7 +56,6 @@ opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true, features = ["metrics", "grpc-tonic"] }
 opentelemetry-semantic-conventions = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
-rand = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/monad-rpc/src/data/buffer.rs
+++ b/monad-rpc/src/data/buffer.rs
@@ -723,6 +723,7 @@ mod tests {
                     inner: tx_recovered,
                     block_hash: Some(block_hash),
                     block_number: Some(height),
+                    block_timestamp: None,
                     transaction_index: Some(tx_idx as u64),
                     effective_gas_price: None,
                 };

--- a/monad-rpc/src/data/mod.rs
+++ b/monad-rpc/src/data/mod.rs
@@ -266,6 +266,7 @@ impl<T: Triedb> DataProvider<T> {
                             return Ok(parse_tx_content(
                                 block.header.hash_slow(),
                                 block.header.number,
+                                block.header.timestamp,
                                 block.header.base_fee_per_gas,
                                 tx.clone(),
                                 index,
@@ -302,6 +303,7 @@ impl<T: Triedb> DataProvider<T> {
                             return Ok(parse_tx_content(
                                 hash.0.into(),
                                 block.header.number,
+                                block.header.timestamp,
                                 block.header.base_fee_per_gas,
                                 tx.clone(),
                                 index,
@@ -349,6 +351,7 @@ impl<T: Triedb> DataProvider<T> {
                 return Ok(parse_tx_content(
                     header_subset.block_hash,
                     header_subset.block_number,
+                    header_subset.block_timestamp,
                     header_subset.base_fee_per_gas,
                     tx,
                     header_subset.tx_index,
@@ -1311,6 +1314,7 @@ fn parse_block_content(
                 parse_tx_content(
                     block_hash,
                     header.number,
+                    header.timestamp,
                     header.base_fee_per_gas,
                     tx,
                     idx as u64,
@@ -1345,6 +1349,7 @@ fn parse_block_content(
 pub fn parse_tx_content(
     block_hash: FixedBytes<32>,
     block_number: u64,
+    block_timestamp: u64,
     base_fee: Option<u64>,
     tx: TxEnvelopeWithSender,
     tx_index: u64,
@@ -1358,6 +1363,7 @@ pub fn parse_tx_content(
         inner: Recovered::new_unchecked(tx, sender),
         block_hash: Some(block_hash),
         block_number: Some(block_number),
+        block_timestamp: Some(block_timestamp),
         effective_gas_price: Some(effective_gas_price),
         transaction_index: Some(tx_index),
     }
@@ -1554,6 +1560,7 @@ async fn get_transaction_from_triedb<T: Triedb>(
         Some(tx) => Ok(Some(parse_tx_content(
             header.hash,
             header.header.number,
+            header.header.timestamp,
             header.header.base_fee_per_gas,
             tx,
             tx_index,

--- a/monad-rpc/src/handlers/eth/gas.rs
+++ b/monad-rpc/src/handlers/eth/gas.rs
@@ -1443,6 +1443,7 @@ mod tests {
                 inner: Recovered::new_unchecked(tx, from_addr),
                 block_hash: None,
                 block_number: None,
+                block_timestamp: None,
                 transaction_index: None,
                 effective_gas_price: None,
             })

--- a/monad-rpc/src/websocket/handler.rs
+++ b/monad-rpc/src/websocket/handler.rs
@@ -440,7 +440,7 @@ async fn handle_request(
             let filter = match req.params {
                 Params::None => None,
                 Params::Logs(filter) => Some(*filter),
-                Params::Bool(_) => {
+                Params::Bool(_) | Params::TransactionReceipts(_) => {
                     if let Err(err) = ctx
                         .text(to_response(&crate::types::jsonrpc::Response::new(
                             None,


### PR DESCRIPTION
Block timestamp is an optional field in rpc responses. The version bump introduces this field, and since we have access to block timestamp, we can populate this field