### PR TITLE
Simplify statesync FFI context and IPC message handling

### DIFF
--- a/monad-statesync/src/client.rs
+++ b/monad-statesync/src/client.rs
@@ -98,9 +98,7 @@ impl<PT: PubKey> StateSyncClient<PT> {
                 let db_paths_ptr = db_paths_ptrs.as_ptr();
                 let num_db_paths = db_paths_ptrs.len();
 
-                // callback function must be kept alive until statesync_client_context_destroy is
-                // called
-                let mut request_ctx: Box<ffi::StateSyncContext> = Box::new(Box::new({
+                let request_ctx: ffi::StateSyncContext = Box::new({
                     let request_tx = request_tx.clone();
                     move |request| {
                         let result = request_tx.send(SyncRequest::Request(StateSyncRequest {
@@ -118,13 +116,13 @@ impl<PT: PubKey> StateSyncClient<PT> {
                             std::process::exit(1)
                         }
                     }
-                }));
+                });
 
                 let mut sync_ctx = ffi::SyncCtx::new(
                     db_paths_ptr,
                     num_db_paths,
                     sq_thread_cpu.map(|n| n as ::std::os::raw::c_uint),
-                    &mut *request_ctx as *mut _ as *mut ffi::monad_statesync_client,
+                    request_ctx,
                     Some(ffi::statesync_send_request),
                 );
                 let mut current_target = None;
@@ -167,7 +165,9 @@ impl<PT: PubKey> StateSyncClient<PT> {
                             });
 
                             // handle_response can only be called on an active SyncCtx
-                            let ctx = sync_ctx.ctx.expect("received response on inactive ctx");
+                            let ctx = sync_ctx
+                                .get_ctx()
+                                .expect("received response on inactive ctx");
                             unsafe {
                                 for upsert in &response.response {
                                     let upsert_result = ffi::monad_statesync_client_handle_upsert(
@@ -254,7 +254,7 @@ impl<PT: PubKey> StateSyncClient<PT> {
                     }
                 }
                 // this loop exits when execution is about to start
-                assert!(sync_ctx.ctx.is_none());
+                assert!(sync_ctx.get_ctx().is_none());
             })
             .expect("failed to spawn statesync thread");
 

--- a/monad-statesync/src/ffi.rs
+++ b/monad-statesync/src/ffi.rs
@@ -46,13 +46,13 @@ pub struct SyncCtx {
     dbname_paths: *const *const ::std::os::raw::c_char,
     len: usize,
     sq_thread_cpu: Option<::std::os::raw::c_uint>,
-    request_ctx: *mut monad_statesync_client,
+    request_ctx: StateSyncContext,
     statesync_send_request: ::std::option::Option<
         unsafe extern "C" fn(arg1: *mut monad_statesync_client, arg2: monad_sync_request),
     >,
+    client_version: u32,
 
-    // TODO(andr-dev): Make field non-pub
-    pub ctx: Option<*mut monad_statesync_client_context>,
+    ctx: Option<*mut monad_statesync_client_context>,
 }
 
 impl SyncCtx {
@@ -61,20 +61,28 @@ impl SyncCtx {
         dbname_paths: *const *const ::std::os::raw::c_char,
         len: usize,
         sq_thread_cpu: Option<::std::os::raw::c_uint>,
-        request_ctx: *mut monad_statesync_client,
+        request_ctx: StateSyncContext,
         statesync_send_request: ::std::option::Option<
             unsafe extern "C" fn(arg1: *mut monad_statesync_client, arg2: monad_sync_request),
         >,
     ) -> Self {
+        let client_version = unsafe { bindings::monad_statesync_version() };
+        assert!(unsafe { bindings::monad_statesync_client_compatible(client_version) });
+
         Self {
             dbname_paths,
             len,
             sq_thread_cpu,
             request_ctx,
             statesync_send_request,
+            client_version,
 
             ctx: None,
         }
+    }
+
+    pub fn get_ctx(&self) -> Option<*mut monad_statesync_client_context> {
+        self.ctx
     }
 
     pub fn get_or_create_ctx(&mut self) -> *mut monad_statesync_client_context {
@@ -84,19 +92,15 @@ impl SyncCtx {
                 self.len,
                 self.sq_thread_cpu
                     .unwrap_or(self::bindings::MONAD_SQPOLL_DISABLED),
-                self.request_ctx,
+                (&mut self.request_ctx as *mut StateSyncContext).cast(),
                 self.statesync_send_request,
             );
-            let client_version = self::bindings::monad_statesync_version();
-            assert!(self::bindings::monad_statesync_client_compatible(
-                client_version
-            ));
             let num_prefixes = self::bindings::monad_statesync_client_prefixes();
             for prefix in 0..num_prefixes {
                 self::bindings::monad_statesync_client_handle_new_peer(
                     ctx,
                     prefix as u64,
-                    client_version,
+                    self.client_version,
                 );
             }
             ctx

--- a/monad-statesync/src/ipc.rs
+++ b/monad-statesync/src/ipc.rs
@@ -476,14 +476,14 @@ impl<'a, PT: PubKey> StreamState<'a, PT> {
         message: ExecutionMessage,
     ) -> Result<(), tokio::io::Error> {
         match message {
-            ExecutionMessage::SyncRequest(_request) => {
-                panic!("live-mode execution shouldn't send SyncRequest")
+            ExecutionMessage::SyncRequest(request) => {
+                panic!("live-mode execution sent unexpected SyncRequest: {request:?}");
             }
             ExecutionMessage::SyncUpsert(upsert_type, data) => {
                 let wip_response = self
                     .wip_response
                     .as_mut()
-                    .expect("SyncUpsert with no pending_response");
+                    .expect("SyncUpsert has wip_response");
                 wip_response.response_size += data.len();
                 wip_response
                     .response
@@ -494,10 +494,7 @@ impl<'a, PT: PubKey> StreamState<'a, PT> {
             ExecutionMessage::SyncDone(done) => {
                 // only one request can be handled at once - because no way of identifying which
                 // requests upserts point to
-                let mut wip_response = self
-                    .wip_response
-                    .take()
-                    .expect("syncdone received with no pending_response");
+                let mut wip_response = self.wip_response.take().expect("SyncDone has wip_response");
                 let service_elapsed = wip_response.service_start_time.elapsed();
                 self.metric_total_service_time_us += service_elapsed.as_micros() as usize;
                 tracing::debug!(
@@ -742,7 +739,7 @@ impl<'a, PT: PubKey> StreamState<'a, PT> {
     ) -> Result<ExecutionMessage, tokio::io::Error> {
         let execution_msg = match msg_type {
             ffi::monad_sync_type_SYNC_TYPE_TARGET => {
-                panic!("live-mode execution shouldn't send SyncTarget")
+                panic!("live-mode execution sent unexpected SyncTarget");
             }
             ffi::monad_sync_type_SYNC_TYPE_REQUEST => {
                 let mut buf = [0_u8; std::mem::size_of::<ffi::monad_sync_request>()];
@@ -753,40 +750,24 @@ impl<'a, PT: PubKey> StreamState<'a, PT> {
                 })
             }
             ffi::monad_sync_type_SYNC_TYPE_UPSERT_CODE => {
-                let data_len = self.stream.read_u64_le().await?;
-                let mut data = vec![0_u8; data_len as usize];
-                self.stream.read_exact(&mut data).await?;
-                ExecutionMessage::SyncUpsert(StateSyncUpsertType::Code, data)
+                self.read_sync_upsert(StateSyncUpsertType::Code).await?
             }
             ffi::monad_sync_type_SYNC_TYPE_UPSERT_ACCOUNT => {
-                let data_len = self.stream.read_u64_le().await?;
-                let mut data = vec![0_u8; data_len as usize];
-                self.stream.read_exact(&mut data).await?;
-                ExecutionMessage::SyncUpsert(StateSyncUpsertType::Account, data)
+                self.read_sync_upsert(StateSyncUpsertType::Account).await?
             }
             ffi::monad_sync_type_SYNC_TYPE_UPSERT_STORAGE => {
-                let data_len = self.stream.read_u64_le().await?;
-                let mut data = vec![0_u8; data_len as usize];
-                self.stream.read_exact(&mut data).await?;
-                ExecutionMessage::SyncUpsert(StateSyncUpsertType::Storage, data)
+                self.read_sync_upsert(StateSyncUpsertType::Storage).await?
             }
             ffi::monad_sync_type_SYNC_TYPE_UPSERT_ACCOUNT_DELETE => {
-                let data_len = self.stream.read_u64_le().await?;
-                let mut data = vec![0_u8; data_len as usize];
-                self.stream.read_exact(&mut data).await?;
-                ExecutionMessage::SyncUpsert(StateSyncUpsertType::AccountDelete, data)
+                self.read_sync_upsert(StateSyncUpsertType::AccountDelete)
+                    .await?
             }
             ffi::monad_sync_type_SYNC_TYPE_UPSERT_STORAGE_DELETE => {
-                let data_len = self.stream.read_u64_le().await?;
-                let mut data = vec![0_u8; data_len as usize];
-                self.stream.read_exact(&mut data).await?;
-                ExecutionMessage::SyncUpsert(StateSyncUpsertType::StorageDelete, data)
+                self.read_sync_upsert(StateSyncUpsertType::StorageDelete)
+                    .await?
             }
             ffi::monad_sync_type_SYNC_TYPE_UPSERT_HEADER => {
-                let data_len = self.stream.read_u64_le().await?;
-                let mut data = vec![0_u8; data_len as usize];
-                self.stream.read_exact(&mut data).await?;
-                ExecutionMessage::SyncUpsert(StateSyncUpsertType::Header, data)
+                self.read_sync_upsert(StateSyncUpsertType::Header).await?
             }
             ffi::monad_sync_type_SYNC_TYPE_DONE => {
                 let mut buf = [0_u8; std::mem::size_of::<ffi::monad_sync_done>()];
@@ -796,9 +777,19 @@ impl<'a, PT: PubKey> StreamState<'a, PT> {
                     std::mem::transmute(buf)
                 })
             }
-            t => panic!("unknown msg_type={}", t),
+            t => panic!("unknown msg_type={t}"),
         };
         Ok(execution_msg)
+    }
+
+    async fn read_sync_upsert(
+        &mut self,
+        upsert_type: StateSyncUpsertType,
+    ) -> Result<ExecutionMessage, tokio::io::Error> {
+        let data_len = self.stream.read_u64_le().await?;
+        let mut data = vec![0_u8; data_len as usize];
+        self.stream.read_exact(&mut data).await?;
+        Ok(ExecutionMessage::SyncUpsert(upsert_type, data))
     }
 
     async fn write_execution_request(

--- a/monad-statesync/src/outbound_requests.rs
+++ b/monad-statesync/src/outbound_requests.rs
@@ -150,21 +150,13 @@ impl<PT: PubKey> InFlightRequest<PT> {
         }
 
         if response.response_index == self.response_index {
-            let curr_index = self.response_index;
             self.response_index += 1;
             let mut responses = vec![response];
 
             // Remove consecutive responses from out-of-order queue
-            for index in self.responses.keys() {
-                if *index == self.response_index {
-                    self.response_index += 1;
-                } else {
-                    break;
-                }
-            }
-            for index in curr_index + 1..self.response_index {
-                let response = self.responses.remove(&index).expect("missing response");
+            while let Some(response) = self.responses.remove(&self.response_index) {
                 responses.push(response);
+                self.response_index += 1;
             }
             return responses;
         }


### PR DESCRIPTION
Minor cleanup of a couple odd things I noticed while doing https://github.com/category-labs/monad-bft/pull/3067.