### PR TITLE
Add transactionReceipts to Websockets

### DIFF
--- a/monad-rpc/src/data/buffer.rs
+++ b/monad-rpc/src/data/buffer.rs
@@ -429,7 +429,10 @@ mod tests {
     use monad_types::BlockId;
 
     use super::*;
-    use crate::types::{eth_json::MonadNotification, serialize::JsonSerialized};
+    use crate::{
+        event::events::BlockTransactionList,
+        types::{eth_json::MonadNotification, serialize::JsonSerialized},
+    };
 
     #[tokio::test]
     async fn test_many_proposed_blocks() {
@@ -804,7 +807,7 @@ mod tests {
         EventServerEvent::Block {
             commit_state: BlockCommitState::Proposed,
             header: serialized_monad_header,
-            transactions: Arc::new(txs.into_boxed_slice()),
+            transactions: Arc::new(BlockTransactionList::new(txs.into_boxed_slice())),
         }
     }
 }

--- a/monad-rpc/src/event/events.rs
+++ b/monad-rpc/src/event/events.rs
@@ -13,16 +13,20 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::Arc;
+use std::{
+    ops::Deref,
+    sync::{Arc, OnceLock},
+};
 
 use monad_exec_events::BlockCommitState;
+use serde_json::value::RawValue;
 
 use crate::types::{eth_json::MonadNotification, serialize::SharedJsonSerialized};
 
 pub type HeaderNotification = SharedJsonSerialized<MonadNotification<Header>>;
 pub type Header = SharedJsonSerialized<alloy_rpc_types::eth::Header>;
 
-pub type BlockTransactions = Arc<Box<[BlockTransaction]>>;
+pub type BlockTransactions = Arc<BlockTransactionList>;
 pub type BlockTransaction = (Transaction, TransactionReceipt, Box<[LogNotification]>);
 
 pub type Transaction = SharedJsonSerialized<alloy_rpc_types::Transaction>;
@@ -30,6 +34,45 @@ pub type TransactionReceipt = SharedJsonSerialized<alloy_rpc_types::TransactionR
 
 pub type LogNotification = SharedJsonSerialized<MonadNotification<Log>>;
 pub type Log = SharedJsonSerialized<alloy_rpc_types::eth::Log>;
+
+#[derive(Debug)]
+pub struct BlockTransactionList {
+    transactions: Box<[BlockTransaction]>,
+    receipts_json: OnceLock<Box<RawValue>>,
+}
+
+impl BlockTransactionList {
+    pub fn new(transactions: Box<[BlockTransaction]>) -> Self {
+        Self {
+            transactions,
+            receipts_json: OnceLock::new(),
+        }
+    }
+
+    pub fn receipts_json<F, E>(&self, build: F) -> Result<&Box<RawValue>, E>
+    where
+        F: FnOnce(&[BlockTransaction]) -> Result<Box<RawValue>, E>,
+    {
+        if let Some(serialized) = self.receipts_json.get() {
+            return Ok(serialized);
+        }
+
+        let serialized = build(&self.transactions)?;
+        let _ = self.receipts_json.set(serialized);
+        Ok(self
+            .receipts_json
+            .get()
+            .expect("receipts json populated above"))
+    }
+}
+
+impl Deref for BlockTransactionList {
+    type Target = [BlockTransaction];
+
+    fn deref(&self) -> &Self::Target {
+        &self.transactions
+    }
+}
 
 #[derive(Clone, Debug)]
 pub enum EventServerEvent {

--- a/monad-rpc/src/event/server.rs
+++ b/monad-rpc/src/event/server.rs
@@ -25,7 +25,9 @@ use monad_types::BlockId;
 use tokio::sync::broadcast;
 use tracing::{debug, warn};
 
-use super::{EventServerClient, EventServerEvent, BROADCAST_CHANNEL_SIZE};
+use super::{
+    events::BlockTransactionList, EventServerClient, EventServerEvent, BROADCAST_CHANNEL_SIZE,
+};
 use crate::types::{eth_json::MonadNotification, serialize::JsonSerialized};
 
 pub struct EventServer<R>
@@ -181,7 +183,7 @@ fn broadcast_block_updates(
         EventServerEvent::Block {
             commit_state,
             header: serialized_monad_header,
-            transactions: Arc::new(transactions.into_boxed_slice()),
+            transactions: Arc::new(BlockTransactionList::new(transactions.into_boxed_slice())),
         },
     );
 }

--- a/monad-rpc/src/types/eth_json.rs
+++ b/monad-rpc/src/types/eth_json.rs
@@ -19,13 +19,14 @@ use alloy_consensus::TxEnvelope;
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, FixedBytes, LogData, U256};
 use alloy_rpc_types::{
-    pubsub::Params, AccessList, Block, FeeHistory, Header, Log, Transaction, TransactionReceipt,
+    pubsub::{Params, TransactionReceiptsParams},
+    AccessList, Block, FeeHistory, Header, Log, Transaction, TransactionReceipt,
 };
 use monad_exec_events::BlockCommitState;
 use monad_types::BlockId;
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_json::value::RawValue;
+use serde_json::{value::RawValue, Value};
 use tracing::debug;
 
 use crate::{
@@ -436,10 +437,50 @@ impl Default for BlockTagOrHash {
 }
 
 #[derive(Deserialize)]
+#[serde(try_from = "RawEthSubscribeRequest")]
 pub struct EthSubscribeRequest {
     pub kind: SubscriptionKind,
-    #[serde(default)]
     pub params: Params,
+}
+
+#[derive(Deserialize)]
+struct RawEthSubscribeRequest(
+    SubscriptionKind,
+    #[serde(default, deserialize_with = "deserialize_raw_subscribe_params")] Option<Value>,
+);
+
+impl TryFrom<RawEthSubscribeRequest> for EthSubscribeRequest {
+    type Error = serde_json::Error;
+
+    fn try_from(raw: RawEthSubscribeRequest) -> Result<Self, Self::Error> {
+        let kind = raw.0;
+        let params = deserialize_subscribe_params(&kind, raw.1)?;
+
+        Ok(Self { kind, params })
+    }
+}
+
+fn deserialize_raw_subscribe_params<'de, D>(deserializer: D) -> Result<Option<Value>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<Value>::deserialize(deserializer)
+}
+
+fn deserialize_subscribe_params(
+    kind: &SubscriptionKind,
+    params: Option<Value>,
+) -> Result<Params, serde_json::Error> {
+    let Some(params) = params else {
+        return Ok(Params::None);
+    };
+
+    if matches!(kind, SubscriptionKind::TransactionReceipts) {
+        return serde_json::from_value::<TransactionReceiptsParams>(params)
+            .map(Params::TransactionReceipts);
+    }
+
+    Params::from_json_value(params)
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Hash)]
@@ -455,6 +496,8 @@ pub enum SubscriptionKind {
     MonadNewHeads,
     // Subscribes to all logs with their corresponding commit state.
     MonadLogs,
+    // Subscribes to all transaction receipts with an optional transaction hash filter.
+    TransactionReceipts,
 }
 
 #[derive(Deserialize)]
@@ -484,6 +527,7 @@ pub enum SubscriptionResult {
     // NewHeads and Logs are Geth results that return finalized block details.
     NewHeads(alloy_rpc_types::eth::Header),
     Logs(alloy_rpc_types::eth::Log),
+    TransactionReceipts(Vec<TransactionReceipt>),
 
     // Returns all headers with their corresponding commit state.
     MonadNewHeads(MonadNotification<alloy_rpc_types::eth::Header>),
@@ -526,11 +570,14 @@ pub fn serialize_result<T: Serialize>(value: T) -> Result<Box<RawValue>, JsonRpc
 #[cfg(test)]
 mod tests {
     use alloy_eips::BlockNumberOrTag;
-    use alloy_primitives::U256;
+    use alloy_primitives::{B256, U256};
+    use alloy_rpc_types::pubsub::Params;
     use serde::Deserialize;
     use serde_json::json;
 
-    use super::{BlockTags, FixedData, Quantity, UnformattedData};
+    use super::{
+        BlockTags, EthSubscribeRequest, FixedData, Quantity, SubscriptionKind, UnformattedData,
+    };
 
     #[derive(Deserialize, Debug)]
     struct OneDataParam {
@@ -605,6 +652,50 @@ mod tests {
     fn test_deser_quantity() {
         let x: OneQuantity = serde_json::from_value(json!(["0x400"])).unwrap();
         assert_eq!(x.a.0, 1024);
+    }
+
+    #[test]
+    fn eth_subscribe_transaction_receipts_params_deserialize() {
+        let hash = "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060";
+        let req: EthSubscribeRequest = serde_json::from_value(json!([
+            "transactionReceipts",
+            { "transactionHashes": [hash] }
+        ]))
+        .unwrap();
+
+        assert_eq!(req.kind, SubscriptionKind::TransactionReceipts);
+        let Params::TransactionReceipts(params) = req.params else {
+            panic!("expected transaction receipts params");
+        };
+
+        assert_eq!(
+            params.transaction_hashes,
+            Some(vec![hash.parse::<B256>().unwrap()])
+        );
+    }
+
+    #[test]
+    fn eth_subscribe_transaction_receipts_empty_object_deserialize() {
+        let req: EthSubscribeRequest =
+            serde_json::from_value(json!(["transactionReceipts", {}])).unwrap();
+
+        assert_eq!(req.kind, SubscriptionKind::TransactionReceipts);
+        let Params::TransactionReceipts(params) = req.params else {
+            panic!("expected transaction receipts params");
+        };
+
+        assert_eq!(params.transaction_hashes, None);
+    }
+
+    #[test]
+    fn eth_subscribe_existing_subscription_params_deserialize() {
+        let req: EthSubscribeRequest = serde_json::from_value(json!(["newHeads"])).unwrap();
+        assert_eq!(req.kind, SubscriptionKind::NewHeads);
+        assert_eq!(req.params, Params::None);
+
+        let req: EthSubscribeRequest = serde_json::from_value(json!(["logs", {}])).unwrap();
+        assert_eq!(req.kind, SubscriptionKind::Logs);
+        assert!(matches!(req.params, Params::Logs(_)));
     }
 
     #[derive(Deserialize, Debug)]

--- a/monad-rpc/src/types/serialize.rs
+++ b/monad-rpc/src/types/serialize.rs
@@ -64,6 +64,10 @@ where
     pub fn value(&self) -> &T {
         &self.value
     }
+
+    pub fn serialized(&self) -> &RawValue {
+        &self.serialized
+    }
 }
 
 impl<T> AsRef<RawValue> for JsonSerialized<T>

--- a/monad-rpc/src/websocket/handler.rs
+++ b/monad-rpc/src/websocket/handler.rs
@@ -63,11 +63,13 @@ const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(20);
 const CLIENT_TIMEOUT_SECS: u64 = 60;
 const COMMIT_STATE_FILTER: BlockCommitState = BlockCommitState::Proposed;
 const MAX_TRANSACTION_RECEIPT_HASHES: usize = 200;
+const MAX_UNFILTERED_TRANSACTION_RECEIPT_SUBSCRIPTIONS_PER_CONNECTION: usize = 1;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Deserialize, Serialize)]
 pub struct SubscriptionId(pub FixedData<16>);
 
-type Subscriptions = HashMap<SubscriptionKind, Vec<(SubscriptionId, Option<SubscriptionFilter>)>>;
+type ConnectionSubscriptions =
+    HashMap<SubscriptionKind, Vec<(SubscriptionId, Option<SubscriptionFilter>)>>;
 
 #[derive(Clone, Debug)]
 enum SubscriptionFilter {
@@ -184,7 +186,7 @@ pub async fn ws_handler(
             metrics.record_websocket_connection(1);
         }
 
-        let mut subscriptions: Subscriptions = HashMap::default();
+        let mut subscriptions: ConnectionSubscriptions = HashMap::default();
 
         let close_reason = handler(
             &mut session,
@@ -221,7 +223,7 @@ async fn handler(
     msg_stream: actix_ws::MessageStream,
     hostname: &String,
     peer_addr: &Option<String>,
-    subscriptions: &mut Subscriptions,
+    subscriptions: &mut ConnectionSubscriptions,
     rx: broadcast::Receiver<EventServerEvent>,
     app_state: &web::Data<MonadRpcResources>,
     subscription_limit: u16,
@@ -360,7 +362,7 @@ async fn handler(
 
 async fn handle_notification(
     session: &mut actix_ws::Session,
-    subscriptions: &Subscriptions,
+    subscriptions: &ConnectionSubscriptions,
     msg: EventServerEvent,
     max_response_size: usize,
 ) -> Result<(), CloseReason> {
@@ -456,6 +458,12 @@ async fn handle_notification(
                             continue;
                         }
 
+                        if receipts_json_len(receipts.iter().copied()) > max_response_size {
+                            warn!("ws handle_notification transaction receipts notification exceeds size limit");
+                            send_notification_size_limit_error(session, id).await?;
+                            continue;
+                        }
+
                         let receipts = serialize_transaction_receipts(receipts)?;
                         send_notification(session, id, receipts, max_response_size).await?;
                     } else {
@@ -463,9 +471,19 @@ async fn handle_notification(
                             continue;
                         }
 
-                        let receipts = serialize_transaction_receipts(
-                            transactions.iter().map(|(_, receipt, _)| receipt),
-                        )?;
+                        if receipts_json_len(transactions.iter().map(|(_, receipt, _)| receipt))
+                            > max_response_size
+                        {
+                            warn!("ws handle_notification transaction receipts notification exceeds size limit");
+                            send_notification_size_limit_error(session, id).await?;
+                            continue;
+                        }
+
+                        let receipts = transactions.receipts_json(|txs| {
+                            serialize_transaction_receipts(
+                                txs.iter().map(|(_, receipt, _)| receipt),
+                            )
+                        })?;
                         send_notification(session, id, receipts, max_response_size).await?;
                     }
                 }
@@ -556,9 +574,39 @@ fn serialize_transaction_receipts<'a>(
     })
 }
 
+fn receipts_json_len<'a>(receipts: impl IntoIterator<Item = &'a TransactionReceipt>) -> usize {
+    let (count, total_len) = receipts
+        .into_iter()
+        .fold((0usize, 0usize), |(count, total_len), receipt| {
+            (count + 1, total_len + receipt.serialized().get().len())
+        });
+
+    2 + total_len + count.saturating_sub(1)
+}
+
+fn is_unfiltered_transaction_receipts(filter: &Option<SubscriptionFilter>) -> bool {
+    match filter {
+        None => true,
+        Some(filter) => filter
+            .as_transaction_receipts()
+            .is_some_and(|filter| filter.transaction_hashes.is_none()),
+    }
+}
+
+fn connection_unfiltered_receipt_subs(subscriptions: &ConnectionSubscriptions) -> usize {
+    subscriptions
+        .get(&SubscriptionKind::TransactionReceipts)
+        .map(|subs| {
+            subs.iter()
+                .filter(|(_, filter)| is_unfiltered_transaction_receipts(filter))
+                .count()
+        })
+        .unwrap_or(0)
+}
+
 async fn handle_request(
     ctx: &mut actix_ws::Session,
-    subscriptions: &mut Subscriptions,
+    subscriptions: &mut ConnectionSubscriptions,
     subscription_limit: u16,
     app_state: &MonadRpcResources,
     request: Request<'_>,
@@ -662,6 +710,34 @@ async fn handle_request(
                     warn!(
                         ?err,
                         "ws handle_request eth_subscribe failed to send subscription limit reached error"
+                    );
+                    return Err(CloseReason {
+                        code: ws::CloseCode::Error,
+                        description: None,
+                    });
+                }
+
+                return Ok(());
+            }
+
+            if req.kind == SubscriptionKind::TransactionReceipts
+                && is_unfiltered_transaction_receipts(&filter)
+                && connection_unfiltered_receipt_subs(subscriptions)
+                    >= MAX_UNFILTERED_TRANSACTION_RECEIPT_SUBSCRIPTIONS_PER_CONNECTION
+            {
+                if let Err(err) = ctx
+                    .text(to_response(&crate::types::jsonrpc::Response::new(
+                        None,
+                        Some(JsonRpcError::custom(format!(
+                            "transactionReceipts allows at most {MAX_UNFILTERED_TRANSACTION_RECEIPT_SUBSCRIPTIONS_PER_CONNECTION} unfiltered subscription(s) per connection; specify transactionHashes"
+                        ))),
+                        request.id,
+                    )))
+                    .await
+                {
+                    warn!(
+                        ?err,
+                        "ws handle_request eth_subscribe failed to send unfiltered transactionReceipts limit error"
                     );
                     return Err(CloseReason {
                         code: ws::CloseCode::Error,
@@ -800,7 +876,14 @@ async fn send_notification(
     result: impl AsRef<RawValue>,
     max_response_size: usize,
 ) -> Result<(), CloseReason> {
-    let subscribe_result = EthSubscribeResult::new(id.0, result.as_ref());
+    let result = result.as_ref();
+
+    if result.get().len() > max_response_size {
+        warn!("ws send_notification notification payload exceeds size limit");
+        return send_notification_size_limit_error(session, id).await;
+    }
+
+    let subscribe_result = EthSubscribeResult::new(id.0, result);
     let notification = Notification::new("eth_subscription".to_string(), subscribe_result);
 
     let result = match serialize_with_size_limit(&notification, max_response_size) {
@@ -810,19 +893,38 @@ async fn send_notification(
                 "ws send_notification failed to serialize notification, error: {:?}",
                 err
             );
-            let error_result = serde_json::value::to_raw_value(&JsonRpcError::internal_error(
-                "notification exceeds size limit".to_string(),
-            ))
-            .expect("failed to serialize error");
-            let error_notification = Notification::new(
-                "eth_subscription".to_string(),
-                EthSubscribeResult::new(id.0, &error_result),
-            );
-            session.text(to_response(&error_notification)).await
+            return send_notification_size_limit_error(session, id).await;
         }
     };
 
     if let Err(err) = result {
+        warn!(
+            "ws send_notification failed to send notification, error: {:?}",
+            err
+        );
+        return Err(CloseReason {
+            code: CloseCode::Error,
+            description: Some("ws server failed to send notification".to_string()),
+        });
+    }
+
+    Ok(())
+}
+
+async fn send_notification_size_limit_error(
+    session: &mut actix_ws::Session,
+    id: &SubscriptionId,
+) -> Result<(), CloseReason> {
+    let error_result = serde_json::value::to_raw_value(&JsonRpcError::internal_error(
+        "notification exceeds size limit".to_string(),
+    ))
+    .expect("failed to serialize error");
+    let error_notification = Notification::new(
+        "eth_subscription".to_string(),
+        EthSubscribeResult::new(id.0, &error_result),
+    );
+
+    if let Err(err) = session.text(to_response(&error_notification)).await {
         warn!(
             "ws send_notification failed to send notification, error: {:?}",
             err
@@ -882,15 +984,16 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        apply_receipts_filter, ws_handler, ReceiptsFilter, ReceiptsFilterError,
-        MAX_TRANSACTION_RECEIPT_HASHES,
+        apply_receipts_filter, connection_unfiltered_receipt_subs, ws_handler,
+        ConnectionSubscriptions, ReceiptsFilter, ReceiptsFilterError, SubscriptionFilter,
+        SubscriptionId, MAX_TRANSACTION_RECEIPT_HASHES,
     };
     use crate::{
         event::{events::TransactionReceipt, EventServer},
         handlers::resources::MonadRpcResources,
         txpool::EthTxPoolBridgeClient,
         types::{
-            eth_json::{EthSubscribeResult, FixedData},
+            eth_json::{EthSubscribeResult, FixedData, SubscriptionKind},
             ethhex,
             serialize::JsonSerialized,
         },
@@ -1005,6 +1108,38 @@ mod tests {
                 limit: MAX_TRANSACTION_RECEIPT_HASHES,
             }
         );
+    }
+
+    #[test]
+    fn counts_only_unfiltered_receipt_subs_on_connection() {
+        use std::collections::HashMap;
+
+        let sub_id = |n: u8| SubscriptionId(FixedData([n; 16]));
+        let mut subscriptions: ConnectionSubscriptions = HashMap::default();
+
+        let receipts = subscriptions
+            .entry(SubscriptionKind::TransactionReceipts)
+            .or_default();
+        receipts.push((sub_id(1), None));
+        receipts.push((
+            sub_id(2),
+            Some(SubscriptionFilter::TransactionReceipts(ReceiptsFilter {
+                transaction_hashes: Some([B256::from([1; 32])].into_iter().collect()),
+            })),
+        ));
+        receipts.push((
+            sub_id(3),
+            Some(SubscriptionFilter::TransactionReceipts(
+                ReceiptsFilter::default(),
+            )),
+        ));
+
+        subscriptions
+            .entry(SubscriptionKind::Logs)
+            .or_default()
+            .push((sub_id(4), None));
+
+        assert_eq!(connection_unfiltered_receipt_subs(&subscriptions), 2);
     }
 
     fn create_test_server() -> actix_test::TestServer {

--- a/monad-rpc/src/websocket/handler.rs
+++ b/monad-rpc/src/websocket/handler.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     pin::pin,
     sync::Arc,
     time::{Duration, Instant},
@@ -23,7 +23,11 @@ use std::{
 use actix_http::ws;
 use actix_web::{web, HttpRequest, HttpResponse};
 use actix_ws::{AggregatedMessage, CloseCode, CloseReason, Closed};
-use alloy_rpc_types::eth::{pubsub::Params, Filter, FilteredParams};
+use alloy_primitives::TxHash;
+use alloy_rpc_types::eth::{
+    pubsub::{Params, TransactionReceiptsParams},
+    Filter, FilteredParams,
+};
 use futures::StreamExt;
 use itertools::Either;
 use monad_exec_events::BlockCommitState;
@@ -34,7 +38,10 @@ use tokio::sync::{broadcast, Semaphore, TryAcquireError};
 use tracing::{debug, error, warn};
 
 use crate::{
-    event::{events::LogNotification, EventServerClient, EventServerClientError, EventServerEvent},
+    event::{
+        events::{LogNotification, TransactionReceipt},
+        EventServerClient, EventServerClientError, EventServerEvent,
+    },
     handlers::{resources::MonadRpcResources, rpc_select},
     middleware::TimingRequestId,
     types::{
@@ -55,9 +62,77 @@ const RECV_MAX_FRAME_SIZE: usize = 256 * 1024;
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(20);
 const CLIENT_TIMEOUT_SECS: u64 = 60;
 const COMMIT_STATE_FILTER: BlockCommitState = BlockCommitState::Proposed;
+const MAX_TRANSACTION_RECEIPT_HASHES: usize = 200;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Deserialize, Serialize)]
 pub struct SubscriptionId(pub FixedData<16>);
+
+type Subscriptions = HashMap<SubscriptionKind, Vec<(SubscriptionId, Option<SubscriptionFilter>)>>;
+
+#[derive(Clone, Debug)]
+enum SubscriptionFilter {
+    Logs(Filter),
+    TransactionReceipts(ReceiptsFilter),
+}
+
+impl SubscriptionFilter {
+    fn as_logs(&self) -> Option<&Filter> {
+        match self {
+            Self::Logs(filter) => Some(filter),
+            Self::TransactionReceipts(_) => None,
+        }
+    }
+
+    fn as_transaction_receipts(&self) -> Option<&ReceiptsFilter> {
+        match self {
+            Self::Logs(_) => None,
+            Self::TransactionReceipts(filter) => Some(filter),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct ReceiptsFilter {
+    transaction_hashes: Option<HashSet<TxHash>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReceiptsFilterError {
+    TooManyTransactionHashes { count: usize, limit: usize },
+}
+
+impl ReceiptsFilterError {
+    fn into_jsonrpc_error(self) -> JsonRpcError {
+        match self {
+            Self::TooManyTransactionHashes { count, limit } => JsonRpcError::filter_error(format!(
+                "transactionReceipts supports at most {limit} transactionHashes, got {count}"
+            )),
+        }
+    }
+}
+
+impl TryFrom<TransactionReceiptsParams> for ReceiptsFilter {
+    type Error = ReceiptsFilterError;
+
+    fn try_from(params: TransactionReceiptsParams) -> Result<Self, Self::Error> {
+        let transaction_hashes = params
+            .transaction_hashes
+            .filter(|hashes| !hashes.is_empty())
+            .map(|hashes| {
+                if hashes.len() > MAX_TRANSACTION_RECEIPT_HASHES {
+                    return Err(ReceiptsFilterError::TooManyTransactionHashes {
+                        count: hashes.len(),
+                        limit: MAX_TRANSACTION_RECEIPT_HASHES,
+                    });
+                }
+
+                Ok(hashes.into_iter().collect())
+            })
+            .transpose()?;
+
+        Ok(Self { transaction_hashes })
+    }
+}
 
 #[derive(Clone)]
 pub struct ConnectionLimit(Arc<Semaphore>);
@@ -109,8 +184,7 @@ pub async fn ws_handler(
             metrics.record_websocket_connection(1);
         }
 
-        let mut subscriptions: HashMap<SubscriptionKind, Vec<(SubscriptionId, Option<Filter>)>> =
-            HashMap::default();
+        let mut subscriptions: Subscriptions = HashMap::default();
 
         let close_reason = handler(
             &mut session,
@@ -147,7 +221,7 @@ async fn handler(
     msg_stream: actix_ws::MessageStream,
     hostname: &String,
     peer_addr: &Option<String>,
-    subscriptions: &mut HashMap<SubscriptionKind, Vec<(SubscriptionId, Option<Filter>)>>,
+    subscriptions: &mut Subscriptions,
     rx: broadcast::Receiver<EventServerEvent>,
     app_state: &web::Data<MonadRpcResources>,
     subscription_limit: u16,
@@ -286,7 +360,7 @@ async fn handler(
 
 async fn handle_notification(
     session: &mut actix_ws::Session,
-    subscriptions: &HashMap<SubscriptionKind, Vec<(SubscriptionId, Option<Filter>)>>,
+    subscriptions: &Subscriptions,
     msg: EventServerEvent,
     max_response_size: usize,
 ) -> Result<(), CloseReason> {
@@ -327,8 +401,11 @@ async fn handle_notification(
                 .map(|x| x.iter())
                 .unwrap_or_default()
             {
-                let Some(logs) = apply_logs_filter(filter, header.data.as_ref(), iter_logs())
-                else {
+                let Some(logs) = apply_logs_filter(
+                    filter.as_ref().and_then(SubscriptionFilter::as_logs),
+                    header.data.as_ref(),
+                    iter_logs(),
+                ) else {
                     continue;
                 };
 
@@ -343,14 +420,53 @@ async fn handle_notification(
                     .map(|x| x.iter())
                     .unwrap_or_default()
                 {
-                    let Some(logs) = apply_logs_filter(filter, header.data.as_ref(), iter_logs())
-                    else {
+                    let Some(logs) = apply_logs_filter(
+                        filter.as_ref().and_then(SubscriptionFilter::as_logs),
+                        header.data.as_ref(),
+                        iter_logs(),
+                    ) else {
                         continue;
                     };
 
                     for log in logs {
                         send_notification(session, id, log.data.as_ref(), max_response_size)
                             .await?;
+                    }
+                }
+
+                for (id, filter) in subscriptions
+                    .get(&SubscriptionKind::TransactionReceipts)
+                    .map(|x| x.iter())
+                    .unwrap_or_default()
+                {
+                    let filter = filter
+                        .as_ref()
+                        .and_then(SubscriptionFilter::as_transaction_receipts);
+
+                    if filter
+                        .and_then(|filter| filter.transaction_hashes.as_ref())
+                        .is_some()
+                    {
+                        let receipts = apply_receipts_filter(
+                            filter,
+                            transactions.iter().map(|(_, receipt, _)| receipt),
+                        );
+
+                        if receipts.is_empty() {
+                            continue;
+                        }
+
+                        let receipts = serialize_transaction_receipts(receipts)?;
+                        send_notification(session, id, receipts, max_response_size).await?;
+                    } else {
+                        if transactions.is_empty() {
+                            continue;
+                        }
+
+                        let receipts = serialize_transaction_receipts(
+                            transactions.iter().map(|(_, receipt, _)| receipt),
+                        )?;
+                        send_notification(session, id, receipts, max_response_size).await?;
                     }
                 }
             }
@@ -362,7 +478,7 @@ async fn handle_notification(
 
 #[inline]
 fn apply_logs_filter<'a>(
-    filter: &'a Option<Filter>,
+    filter: Option<&'a Filter>,
     header: &alloy_rpc_types::eth::Header,
     logs: impl Iterator<Item = &'a LogNotification> + 'a,
 ) -> Option<impl Iterator<Item = &'a LogNotification> + 'a> {
@@ -395,9 +511,54 @@ fn apply_logs_filter<'a>(
     }
 }
 
+fn apply_receipts_filter<'a>(
+    filter: Option<&'a ReceiptsFilter>,
+    receipts: impl Iterator<Item = &'a TransactionReceipt> + 'a,
+) -> Vec<&'a TransactionReceipt> {
+    if let Some(transaction_hashes) = filter.and_then(|filter| filter.transaction_hashes.as_ref()) {
+        let mut matched_receipts = Vec::with_capacity(transaction_hashes.len());
+        let mut remaining = transaction_hashes.len();
+
+        for receipt in receipts {
+            if transaction_hashes.contains(&receipt.value().transaction_hash) {
+                matched_receipts.push(receipt);
+                remaining -= 1;
+
+                if remaining == 0 {
+                    break;
+                }
+            }
+        }
+
+        matched_receipts
+    } else {
+        receipts.collect()
+    }
+}
+
+fn serialize_transaction_receipts<'a>(
+    receipts: impl IntoIterator<Item = &'a TransactionReceipt>,
+) -> Result<Box<RawValue>, CloseReason> {
+    let receipts = receipts
+        .into_iter()
+        .map(|receipt| receipt.as_ref())
+        .collect::<Vec<_>>();
+
+    serialize_result(receipts).map_err(|err| {
+        warn!(
+            ?err,
+            "ws handle_notification failed to serialize transaction receipts"
+        );
+        CloseReason {
+            code: CloseCode::Error,
+            description: Some("ws server failed to serialize transaction receipts".to_string()),
+        }
+    })
+}
+
 async fn handle_request(
     ctx: &mut actix_ws::Session,
-    subscriptions: &mut HashMap<SubscriptionKind, Vec<(SubscriptionId, Option<Filter>)>>,
+    subscriptions: &mut Subscriptions,
     subscription_limit: u16,
     app_state: &MonadRpcResources,
     request: Request<'_>,
@@ -426,10 +587,38 @@ async fn handle_request(
                 return Ok(());
             };
 
-            let filter = match req.params {
-                Params::None => None,
-                Params::Logs(filter) => Some(*filter),
-                Params::Bool(_) | Params::TransactionReceipts(_) => {
+            let filter = match (&req.kind, req.params) {
+                (_, Params::None) => None,
+                (SubscriptionKind::Logs | SubscriptionKind::MonadLogs, Params::Logs(filter)) => {
+                    Some(SubscriptionFilter::Logs(*filter))
+                }
+                (SubscriptionKind::TransactionReceipts, Params::TransactionReceipts(filter)) => {
+                    match ReceiptsFilter::try_from(filter) {
+                        Ok(filter) => Some(SubscriptionFilter::TransactionReceipts(filter)),
+                        Err(err) => {
+                            if let Err(err) = ctx
+                                .text(to_response(&crate::types::jsonrpc::Response::new(
+                                    None,
+                                    Some(err.into_jsonrpc_error()),
+                                    request.id,
+                                )))
+                                .await
+                            {
+                                warn!(
+                                    ?err,
+                                    "ws handle_request eth_subscribe failed to send invalid transactionReceipts filter error"
+                                );
+                                return Err(CloseReason {
+                                    code: ws::CloseCode::Error,
+                                    description: None,
+                                });
+                            }
+
+                            return Ok(());
+                        }
+                    }
+                }
+                _ => {
                     if let Err(err) = ctx
                         .text(to_response(&crate::types::jsonrpc::Response::new(
                             None,
@@ -681,23 +870,142 @@ mod tests {
 
     use actix_http::{ws, ws::Frame};
     use actix_web::{web, App};
+    use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
+    use alloy_primitives::{Address, Bloom, B256};
+    use alloy_rpc_types::{
+        eth::pubsub::TransactionReceiptsParams, TransactionReceipt as AlloyTransactionReceipt,
+    };
     use awc::error::WsClientError;
     use bytes::Bytes;
     use futures_util::{SinkExt as _, StreamExt as _};
     use monad_event_ring::SnapshotEventRing;
     use serde_json::json;
 
-    use super::ws_handler;
+    use super::{
+        apply_receipts_filter, ws_handler, ReceiptsFilter, ReceiptsFilterError,
+        MAX_TRANSACTION_RECEIPT_HASHES,
+    };
     use crate::{
-        event::EventServer,
+        event::{events::TransactionReceipt, EventServer},
         handlers::resources::MonadRpcResources,
         txpool::EthTxPoolBridgeClient,
         types::{
             eth_json::{EthSubscribeResult, FixedData},
             ethhex,
+            serialize::JsonSerialized,
         },
         websocket::handler::{ConnectionLimit, SubscriptionLimit},
     };
+
+    fn make_receipt(transaction_hash: B256) -> TransactionReceipt {
+        JsonSerialized::new_shared(AlloyTransactionReceipt {
+            inner: ReceiptEnvelope::Eip1559(
+                ReceiptWithBloom::<Receipt<alloy_rpc_types::Log>>::new(
+                    Receipt {
+                        status: Eip658Value::Eip658(true),
+                        cumulative_gas_used: 0,
+                        logs: vec![],
+                    },
+                    Bloom::default(),
+                ),
+            ),
+            transaction_hash,
+            transaction_index: None,
+            block_hash: None,
+            block_number: None,
+            gas_used: 0,
+            effective_gas_price: 0,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::default(),
+            to: None,
+            contract_address: None,
+        })
+    }
+
+    #[test]
+    fn apply_receipts_filter_matches_transaction_hashes() {
+        let matching_hash = B256::from([1; 32]);
+        let other_hash = B256::from([2; 32]);
+        let receipts = vec![make_receipt(matching_hash), make_receipt(other_hash)];
+        let filter = ReceiptsFilter::try_from(TransactionReceiptsParams {
+            transaction_hashes: Some(vec![matching_hash]),
+        })
+        .unwrap();
+
+        let filtered = apply_receipts_filter(Some(&filter), receipts.iter());
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].value().transaction_hash, matching_hash);
+    }
+
+    #[test]
+    fn apply_receipts_filter_stops_once_all_hashes_match() {
+        let matching_hash = B256::from([1; 32]);
+        let receipts = vec![
+            make_receipt(matching_hash),
+            make_receipt(B256::from([2; 32])),
+            make_receipt(B256::from([3; 32])),
+        ];
+        let filter = ReceiptsFilter::try_from(TransactionReceiptsParams {
+            transaction_hashes: Some(vec![matching_hash]),
+        })
+        .unwrap();
+        let mut visited = 0;
+
+        let filtered = apply_receipts_filter(
+            Some(&filter),
+            receipts.iter().inspect(|_| {
+                visited += 1;
+            }),
+        );
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].value().transaction_hash, matching_hash);
+        assert_eq!(visited, 1);
+    }
+
+    #[test]
+    fn apply_receipts_filter_empty_or_missing_hashes_returns_all() {
+        let receipts = vec![
+            make_receipt(B256::from([1; 32])),
+            make_receipt(B256::from([2; 32])),
+        ];
+
+        let filtered = apply_receipts_filter(None, receipts.iter());
+        assert_eq!(filtered.len(), receipts.len());
+
+        for transaction_hashes in [None, Some(vec![])] {
+            let filter =
+                ReceiptsFilter::try_from(TransactionReceiptsParams { transaction_hashes }).unwrap();
+            let filtered = apply_receipts_filter(Some(&filter), receipts.iter());
+            assert_eq!(filtered.len(), receipts.len());
+        }
+    }
+
+    #[test]
+    fn receipts_filter_rejects_too_many_transaction_hashes() {
+        let transaction_hashes = (0..=MAX_TRANSACTION_RECEIPT_HASHES)
+            .map(|idx| {
+                let mut bytes = [0; 32];
+                bytes[..8].copy_from_slice(&(idx as u64).to_le_bytes());
+                B256::from(bytes)
+            })
+            .collect();
+
+        let err = ReceiptsFilter::try_from(TransactionReceiptsParams {
+            transaction_hashes: Some(transaction_hashes),
+        })
+        .unwrap_err();
+
+        assert_eq!(
+            err,
+            ReceiptsFilterError::TooManyTransactionHashes {
+                count: MAX_TRANSACTION_RECEIPT_HASHES + 1,
+                limit: MAX_TRANSACTION_RECEIPT_HASHES,
+            }
+        );
+    }
 
     fn create_test_server() -> actix_test::TestServer {
         const SNAPSHOT_NAME: &str = "ETHEREUM_MAINNET_30B_15M";
@@ -839,6 +1147,79 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[actix_rt::test]
+    async fn websocket_transaction_receipts_subscription_receives_receipts() {
+        let tx_hash = "0xaedb8ef26125d8ad6e0c5f19fc9cbdd7f4a42eb82de88686b39090b8abcfeb8f";
+        let mut server: actix_test::TestServer = create_test_server();
+        let mut framed = server.ws_at("/ws/").await.unwrap();
+
+        let frame = framed.next().await.unwrap().unwrap();
+        match frame {
+            Frame::Ping(bytes) => {
+                framed.send(ws::Message::Pong(bytes)).await.unwrap();
+            }
+            _ => panic!("Expected initial ping frame"),
+        }
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "method": "eth_subscribe",
+            "params": ["transactionReceipts", { "transactionHashes": [tx_hash] }],
+            "id": 1
+        });
+
+        framed
+            .send(ws::Message::Text(body.to_string().into()))
+            .await
+            .unwrap();
+
+        let subscription_id = loop {
+            let frame = framed.next().await.unwrap().unwrap();
+            match frame {
+                Frame::Ping(bytes) => {
+                    framed.send(ws::Message::Pong(bytes)).await.unwrap();
+                }
+                Frame::Text(resp) => {
+                    let resp: serde_json::Value = serde_json::from_slice(&resp).unwrap();
+                    let resp: crate::types::jsonrpc::Response =
+                        serde_json::from_value(resp).unwrap();
+                    let id: FixedData<16> =
+                        serde_json::from_str(resp.result.unwrap().get()).unwrap();
+                    break id;
+                }
+                _ => panic!("unexpected frame"),
+            }
+        };
+
+        let receipts = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let frame = framed.next().await.unwrap().unwrap();
+                match frame {
+                    Frame::Ping(bytes) => {
+                        framed.send(ws::Message::Pong(bytes)).await.unwrap();
+                    }
+                    Frame::Text(update) => {
+                        let update: crate::types::jsonrpc::Notification<EthSubscribeResult> =
+                            serde_json::from_slice(&update).unwrap();
+                        assert_eq!(update.params.subscription.0, subscription_id.0);
+
+                        let receipts: Vec<serde_json::Value> =
+                            serde_json::from_str(update.params.result.get()).unwrap();
+                        if !receipts.is_empty() {
+                            break receipts;
+                        }
+                    }
+                    _ => panic!("unexpected frame"),
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for transaction receipts notification");
+
+        assert_eq!(receipts.len(), 1);
+        assert_eq!(receipts[0]["transactionHash"].as_str(), Some(tx_hash));
     }
 
     #[actix_rt::test]


### PR DESCRIPTION
Geth and Reth recently added a new `transactionReceipts` eth_subscribe topic to WebSockets so figure its nice to add it too as other tooling catches up. The general behavior is that a user can subscribe to transaction receipts per block or can optionally provide a list of transaction hashes to filter for. 

