### PR TITLE
Enforce N in all LimitedVec constructors

### DIFF
--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -1422,7 +1422,9 @@ where
                 // next val_set might not be ready
                 get_locked_epoch(base_epoch + Epoch(1)),
             )
-            .collect(),
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("checkpoint validator_sets exceeds MAX_VALIDATOR_SETS"),
         }
     }
 
@@ -2637,7 +2639,7 @@ mod test {
 
     fn generate_block_body(eth_tx_list: Vec<TxEnvelope>) -> EthBlockBody {
         EthBlockBody {
-            transactions: eth_tx_list.into(),
+            transactions: eth_tx_list.try_into().unwrap(),
             ommers: Default::default(),
             withdrawals: Default::default(),
         }

--- a/monad-consensus-types/src/timeout.rs
+++ b/monad-consensus-types/src/timeout.rs
@@ -506,7 +506,9 @@ where
         Ok(Self {
             epoch,
             round,
-            tip_rounds: tip_rounds.into(),
+            tip_rounds: tip_rounds
+                .try_into()
+                .expect("tip_rounds length exceeds MAX_VALIDATOR_SET_SIZE"),
             high_extend: highest_extend,
         })
     }

--- a/monad-consensus-types/src/validator_data.rs
+++ b/monad-consensus-types/src/validator_data.rs
@@ -180,12 +180,6 @@ impl<SCT: SignatureCollection> ValidatorSetData<SCT> {
     pub fn new(
         validators: Vec<(SCT::NodeIdPubKey, Stake, SignatureCollectionPubKeyType<SCT>)>,
     ) -> Self {
-        assert!(
-            validators.len() <= MAX_VALIDATOR_SET_SIZE,
-            "validator set size {} exceeds MAX_VALIDATOR_SET_SIZE {}",
-            validators.len(),
-            MAX_VALIDATOR_SET_SIZE,
-        );
         Self(
             validators
                 .into_iter()
@@ -194,7 +188,9 @@ impl<SCT: SignatureCollection> ValidatorSetData<SCT> {
                     stake,
                     cert_pubkey,
                 })
-                .collect(),
+                .collect::<Vec<_>>()
+                .try_into()
+                .expect("validator set size exceeds MAX_VALIDATOR_SET_SIZE"),
         )
     }
 
@@ -278,15 +274,17 @@ where
 
 #[cfg(test)]
 mod test {
-    use monad_crypto::NopSignature;
-    use monad_testutil::signing::MockSignatures;
-    use monad_types::{BlockId, Epoch, Hash, LimitedVec, Round};
+    use monad_crypto::{certificate_signature::CertificateKeyPair, NopSignature};
+    use monad_testutil::signing::{create_certificate_keys, create_keys, MockSignatures};
+    use monad_types::{BlockId, Epoch, Hash, NodeId, Round, Stake};
+    use monad_validator::validator_set::MAX_VALIDATOR_SET_SIZE;
+    use serde::Serialize;
 
     use crate::{
         block::MockExecutionProtocol,
         checkpoint::{Checkpoint, LockedEpoch},
         quorum_certificate::QuorumCertificate,
-        validator_data::{ValidatorSetData, ValidatorsConfig},
+        validator_data::{ValidatorData, ValidatorSetData, ValidatorsConfig},
         RoundCertificate,
     };
 
@@ -310,7 +308,7 @@ mod test {
         let forkpoint_success = Checkpoint {
             root: BlockId(Hash::default()),
             high_certificate: RoundCertificate::Qc(QuorumCertificate::genesis_qc()),
-            validator_sets: LimitedVec(vec![
+            validator_sets: vec![
                 LockedEpoch {
                     epoch: Epoch(1),
                     round: Round(10),
@@ -319,7 +317,9 @@ mod test {
                     epoch: Epoch(2),
                     round: Round(20),
                 },
-            ]),
+            ]
+            .try_into()
+            .unwrap(),
         };
         assert!(validators_config
             .get_locked_validator_sets::<SignatureType, ExecutionProtocolType>(&forkpoint_success)
@@ -328,7 +328,7 @@ mod test {
         let forkpoint_failure = Checkpoint {
             root: BlockId(Hash::default()),
             high_certificate: RoundCertificate::Qc(QuorumCertificate::genesis_qc()),
-            validator_sets: LimitedVec(vec![
+            validator_sets: vec![
                 LockedEpoch {
                     epoch: Epoch(2),
                     round: Round(10),
@@ -337,10 +337,108 @@ mod test {
                     epoch: Epoch(3),
                     round: Round(20),
                 },
-            ]),
+            ]
+            .try_into()
+            .unwrap(),
         };
         assert!(validators_config
             .get_locked_validator_sets::<SignatureType, ExecutionProtocolType>(&forkpoint_failure)
             .is_err_and(|missing_epoch| missing_epoch == Epoch(3)));
+    }
+
+    fn make_validator_data(num: u32) -> Vec<ValidatorData<SignatureCollectionType>> {
+        let keys = create_keys::<SignatureType>(num);
+        let cert_keys = create_certificate_keys::<SignatureCollectionType>(num);
+        keys.iter()
+            .zip(cert_keys.iter())
+            .map(|(k, ck)| ValidatorData {
+                node_id: NodeId::new(k.pubkey()),
+                stake: Stake::ONE,
+                cert_pubkey: ck.pubkey(),
+            })
+            .collect()
+    }
+
+    /// Mirror of `ValidatorsConfigFile` whose innermost validator list is an
+    /// unbounded `Vec` instead of `LimitedVec<_, MAX_VALIDATOR_SET_SIZE>`.
+    /// Serializes to the same TOML wire shape, so the produced string can be
+    /// fed to `ValidatorsConfig::read_from_str` to drive the rejection path
+    /// for oversize input. Test-only.
+    #[derive(Serialize)]
+    struct OversizeConfigFile {
+        validator_sets: Vec<OversizeSetWithEpoch>,
+    }
+
+    #[derive(Serialize)]
+    struct OversizeSetWithEpoch {
+        epoch: Epoch,
+        validators: Vec<ValidatorData<SignatureCollectionType>>,
+    }
+
+    #[test]
+    fn read_from_str_rejects_oversize_validator_set() {
+        let oversize = (MAX_VALIDATOR_SET_SIZE + 1) as u32;
+        let validators = make_validator_data(oversize);
+        let config_file = OversizeConfigFile {
+            validator_sets: vec![OversizeSetWithEpoch {
+                epoch: Epoch(1),
+                validators,
+            }],
+        };
+        let toml_str = toml::to_string(&config_file).expect("serialize oversize config");
+
+        let err = match ValidatorsConfig::<SignatureCollectionType>::read_from_str(&toml_str) {
+            Ok(_) => panic!("read_from_str must reject oversize validator set"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("LimitedVec length") && msg.contains("exceeds maximum"),
+            "unexpected error message: {msg}",
+        );
+    }
+
+    #[test]
+    fn read_from_str_accepts_max_validator_set() {
+        let exact = MAX_VALIDATOR_SET_SIZE as u32;
+        let validators = make_validator_data(exact);
+        let config_file = OversizeConfigFile {
+            validator_sets: vec![OversizeSetWithEpoch {
+                epoch: Epoch(1),
+                validators,
+            }],
+        };
+        let toml_str = toml::to_string(&config_file).expect("serialize exact-size config");
+
+        ValidatorsConfig::<SignatureCollectionType>::read_from_str(&toml_str)
+            .expect("read_from_str must accept exact-size validator set");
+    }
+
+    #[test]
+    #[should_panic(expected = "validator set size exceeds MAX_VALIDATOR_SET_SIZE")]
+    fn new_panics_on_oversize_input() {
+        let oversize = (MAX_VALIDATOR_SET_SIZE + 1) as u32;
+        let keys = create_keys::<SignatureType>(oversize);
+        let cert_keys = create_certificate_keys::<SignatureCollectionType>(oversize);
+        let triples: Vec<_> = keys
+            .iter()
+            .zip(cert_keys.iter())
+            .map(|(k, ck)| (k.pubkey(), Stake::ONE, ck.pubkey()))
+            .collect();
+        let _ = ValidatorSetData::<SignatureCollectionType>::new(triples);
+    }
+
+    #[test]
+    fn new_accepts_max_input() {
+        let exact = MAX_VALIDATOR_SET_SIZE as u32;
+        let keys = create_keys::<SignatureType>(exact);
+        let cert_keys = create_certificate_keys::<SignatureCollectionType>(exact);
+        let triples: Vec<_> = keys
+            .iter()
+            .zip(cert_keys.iter())
+            .map(|(k, ck)| (k.pubkey(), Stake::ONE, ck.pubkey()))
+            .collect();
+        let set = ValidatorSetData::<SignatureCollectionType>::new(triples);
+        assert_eq!(set.0.len(), MAX_VALIDATOR_SET_SIZE);
     }
 }

--- a/monad-consensus/src/messages/consensus_message.rs
+++ b/monad-consensus/src/messages/consensus_message.rs
@@ -345,7 +345,7 @@ mod tests {
         TimeoutCertificate {
             epoch: Epoch(1),
             round,
-            tip_rounds: vec![].into(),
+            tip_rounds: vec![].try_into().unwrap(),
             high_extend: HighExtend::Qc(QuorumCertificate::genesis_qc()),
         }
     }

--- a/monad-consensus/src/validation/signing.rs
+++ b/monad-consensus/src/validation/signing.rs
@@ -1346,7 +1346,8 @@ mod test {
                 high_tip_round: GENESIS_ROUND,
                 sigs: sigcol,
             }]
-            .into(),
+            .try_into()
+            .unwrap(),
             high_extend,
         }
     }
@@ -1398,7 +1399,9 @@ mod test {
                 sigs: sigcol,
             }
         })
-        .collect();
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
 
         let qc = {
             let vote = Vote {
@@ -1573,7 +1576,9 @@ mod test {
                 sigs: sigcol,
             }
         })
-        .collect();
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
 
         let qc = {
             let vote = Vote {
@@ -1652,7 +1657,9 @@ mod test {
                 sigs: sigcol,
             }
         })
-        .collect();
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
 
         let tc: TimeoutCertificate<SignatureType, SignatureCollectionType, ExecutionProtocolType> =
             TimeoutCertificate {
@@ -1710,7 +1717,9 @@ mod test {
                     sigs: sigcol,
                 }
             })
-            .collect();
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
 
         let tc: TimeoutCertificate<SignatureType, SignatureCollectionType, ExecutionProtocolType> =
             TimeoutCertificate {
@@ -1771,7 +1780,8 @@ mod test {
                     high_tip_round: GENESIS_ROUND,
                     sigs: sigcol,
                 }]
-                .into(),
+                .try_into()
+                .unwrap(),
                 high_extend: HighExtend::Qc(QuorumCertificate::genesis_qc()),
             };
 
@@ -1901,7 +1911,8 @@ mod test {
                     high_tip_round: GENESIS_ROUND,
                     sigs: sigcol,
                 }]
-                .into(),
+                .try_into()
+                .unwrap(),
                 high_extend: HighExtend::Qc(QuorumCertificate::genesis_qc()),
             };
 
@@ -2883,7 +2894,7 @@ mod test {
             TimeoutCertificate {
                 epoch: Epoch(2), // wrong epoch here
                 round: Round(11),
-                tip_rounds: vec![high_qc_sig_tuple].into(),
+                tip_rounds: vec![high_qc_sig_tuple].try_into().unwrap(),
                 high_extend: HighExtend::Qc(qc.clone()),
             };
 

--- a/monad-consensus/tests/proposal.rs
+++ b/monad-consensus/tests/proposal.rs
@@ -229,7 +229,7 @@ fn define_proposal_with_tc(
     let tc = TimeoutCertificate {
         epoch: tc_epoch, // wrong epoch here
         round: tc_round,
-        tip_rounds: vec![tip_round].into(),
+        tip_rounds: vec![tip_round].try_into().unwrap(),
         high_extend: HighExtend::Qc(qc.clone()),
     };
 
@@ -1179,7 +1179,8 @@ fn test_validate_tc_invalid_tc_signature() {
             high_tip_round: GENESIS_ROUND,
             sigs: sigcol,
         }]
-        .into(),
+        .try_into()
+        .unwrap(),
         high_extend: HighExtend::Qc(QuorumCertificate::genesis_qc()),
     };
 

--- a/monad-eth-block-validator/src/lib.rs
+++ b/monad-eth-block-validator/src/lib.rs
@@ -709,7 +709,7 @@ mod test {
         let txs = vec![txn1, txn2];
         let payload = ConsensusBlockBody::new(ConsensusBlockBodyInner {
             execution_body: EthBlockBody {
-                transactions: txs.into(),
+                transactions: txs.try_into().unwrap(),
                 ommers: Default::default(),
                 withdrawals: Default::default(),
             },
@@ -760,7 +760,7 @@ mod test {
         let txs = vec![txn1, txn2, txn3];
         let payload = ConsensusBlockBody::new(ConsensusBlockBodyInner {
             execution_body: EthBlockBody {
-                transactions: txs.into(),
+                transactions: txs.try_into().unwrap(),
                 ommers: Default::default(),
                 withdrawals: Default::default(),
             },
@@ -801,7 +801,7 @@ mod test {
         let txs = vec![txn1, txn2];
         let payload = ConsensusBlockBody::new(ConsensusBlockBodyInner {
             execution_body: EthBlockBody {
-                transactions: txs.into(),
+                transactions: txs.try_into().unwrap(),
                 ommers: Default::default(),
                 withdrawals: Default::default(),
             },
@@ -845,7 +845,7 @@ mod test {
         let txs = vec![txn1, txn2];
         let payload = ConsensusBlockBody::new(ConsensusBlockBodyInner {
             execution_body: EthBlockBody {
-                transactions: txs.into(),
+                transactions: txs.try_into().unwrap(),
                 ommers: Default::default(),
                 withdrawals: Default::default(),
             },
@@ -893,7 +893,7 @@ mod test {
         let txs = vec![txn1, txn2];
         let payload = ConsensusBlockBody::new(ConsensusBlockBodyInner {
             execution_body: EthBlockBody {
-                transactions: txs.into(),
+                transactions: txs.try_into().unwrap(),
                 ommers: Default::default(),
                 withdrawals: Default::default(),
             },
@@ -925,7 +925,7 @@ mod test {
         let txs = vec![txn1, txn2];
         let payload = ConsensusBlockBody::new(ConsensusBlockBodyInner {
             execution_body: EthBlockBody {
-                transactions: txs.into(),
+                transactions: txs.try_into().unwrap(),
                 ommers: Default::default(),
                 withdrawals: Default::default(),
             },
@@ -968,7 +968,7 @@ mod test {
         let txs = vec![txn1];
         let payload = ConsensusBlockBody::new(ConsensusBlockBodyInner {
             execution_body: EthBlockBody {
-                transactions: txs.into(),
+                transactions: txs.try_into().unwrap(),
                 ommers: Default::default(),
                 withdrawals: Default::default(),
             },
@@ -998,7 +998,7 @@ mod test {
         let txs = vec![valid_txn.clone()];
         let payload = ConsensusBlockBody::new(ConsensusBlockBodyInner {
             execution_body: EthBlockBody {
-                transactions: txs.into(),
+                transactions: txs.try_into().unwrap(),
                 ommers: Default::default(),
                 withdrawals: Default::default(),
             },
@@ -1044,7 +1044,7 @@ mod test {
         let txs = vec![invalid_txn];
         let payload = ConsensusBlockBody::new(ConsensusBlockBodyInner {
             execution_body: EthBlockBody {
-                transactions: txs.into(),
+                transactions: txs.try_into().unwrap(),
                 ommers: Default::default(),
                 withdrawals: Default::default(),
             },
@@ -1098,7 +1098,7 @@ mod test {
         let txs = vec![txn1, txn2, txn3];
         let payload = ConsensusBlockBody::new(ConsensusBlockBodyInner {
             execution_body: EthBlockBody {
-                transactions: txs.into(),
+                transactions: txs.try_into().unwrap(),
                 ommers: Default::default(),
                 withdrawals: Default::default(),
             },
@@ -1144,7 +1144,7 @@ mod test {
         let txs = vec![txn1, txn2, txn3];
         let payload = ConsensusBlockBody::new(ConsensusBlockBodyInner {
             execution_body: EthBlockBody {
-                transactions: txs.into(),
+                transactions: txs.try_into().unwrap(),
                 ommers: Default::default(),
                 withdrawals: Default::default(),
             },
@@ -1190,7 +1190,7 @@ mod test {
         let txs = vec![txn1, txn2, txn3];
         let payload = ConsensusBlockBody::new(ConsensusBlockBodyInner {
             execution_body: EthBlockBody {
-                transactions: txs.into(),
+                transactions: txs.try_into().unwrap(),
                 ommers: Default::default(),
                 withdrawals: Default::default(),
             },
@@ -1238,7 +1238,7 @@ mod test {
         let txs = vec![txn1, txn2, txn3, txn4];
         let payload = ConsensusBlockBody::new(ConsensusBlockBodyInner {
             execution_body: EthBlockBody {
-                transactions: txs.into(),
+                transactions: txs.try_into().unwrap(),
                 ommers: Default::default(),
                 withdrawals: Default::default(),
             },
@@ -1291,7 +1291,7 @@ mod test {
         let txs = vec![txn1, txn2, txn3, txn4];
         let payload = ConsensusBlockBody::new(ConsensusBlockBodyInner {
             execution_body: EthBlockBody {
-                transactions: txs.into(),
+                transactions: txs.try_into().unwrap(),
                 ommers: Default::default(),
                 withdrawals: Default::default(),
             },

--- a/monad-eth-block-validator/tests/coherency_test.rs
+++ b/monad-eth-block-validator/tests/coherency_test.rs
@@ -642,7 +642,12 @@ fn create_block_body_helper(
 ) -> ConsensusBlockBody<EthExecutionProtocol> {
     ConsensusBlockBody::new(ConsensusBlockBodyInner {
         execution_body: EthBlockBody {
-            transactions: txs.iter().map(|tx| tx.inner().to_owned()).collect(),
+            transactions: txs
+                .iter()
+                .map(|tx| tx.inner().to_owned())
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap(),
             ommers: Default::default(),
             withdrawals: Default::default(),
         },

--- a/monad-eth-testutil/src/lib.rs
+++ b/monad-eth-testutil/src/lib.rs
@@ -376,7 +376,12 @@ pub fn generate_consensus_test_block(
 
     let body = ConsensusBlockBody::new(ConsensusBlockBodyInner {
         execution_body: EthBlockBody {
-            transactions: txs.iter().map(|tx| tx.inner().to_owned()).collect(),
+            transactions: txs
+                .iter()
+                .map(|tx| tx.inner().to_owned())
+                .collect::<Vec<_>>()
+                .try_into()
+                .expect("block transactions exceeds MAX_TRANSACTIONS_PER_BLOCK"),
             ommers: Default::default(),
             withdrawals: Default::default(),
         },

--- a/monad-eth-txpool/src/pool/mod.rs
+++ b/monad-eth-txpool/src/pool/mod.rs
@@ -365,7 +365,9 @@ where
                 .into_iter()
                 .chain(user_transactions)
                 .map(|tx| tx.into_inner())
-                .collect(),
+                .collect::<Vec<_>>()
+                .try_into()
+                .expect("block transactions exceeds MAX_TRANSACTIONS_PER_BLOCK"),
             ommers: Default::default(),
             withdrawals: Default::default(),
         };

--- a/monad-mock-swarm/src/node.rs
+++ b/monad-mock-swarm/src/node.rs
@@ -354,7 +354,11 @@ impl<S: SwarmRelation> Node<S> {
                 cert_pubkey: *cert_pubkey,
             });
         }
-        ValidatorSetData(validator_set_data.into())
+        ValidatorSetData(
+            validator_set_data
+                .try_into()
+                .expect("validator set size exceeds MAX_VALIDATOR_SET_SIZE"),
+        )
     }
 
     pub fn get_forkpoint(

--- a/monad-peer-discovery/src/discovery.rs
+++ b/monad-peer-discovery/src/discovery.rs
@@ -1217,7 +1217,9 @@ where
         let peer_lookup_response = PeerLookupResponse {
             lookup_id: request.lookup_id,
             target,
-            name_records: name_records.into(),
+            name_records: name_records
+                .try_into()
+                .expect("name_records exceeds MAX_PEER_IN_RESPONSE"),
         };
 
         cmds.push(PeerDiscoveryCommand::RouterCommand {
@@ -1253,17 +1255,6 @@ where
             warn!(
                 ?response,
                 "peer lookup response not in outstanding requests, dropping response..."
-            );
-            self.metrics
-                .gauge(GAUGE_PEER_DISC_DROP_LOOKUP_RESPONSE)
-                .inc();
-            return cmds;
-        }
-
-        if response.name_records.len() > MAX_PEER_IN_RESPONSE {
-            warn!(
-                ?response,
-                "response includes number of peers larger than max, dropping response..."
             );
             self.metrics
                 .gauge(GAUGE_PEER_DISC_DROP_LOOKUP_RESPONSE)
@@ -2451,7 +2442,7 @@ mod tests {
             PeerLookupResponse {
                 lookup_id: requests[0].lookup_id,
                 target: peer2_pubkey,
-                name_records: vec![record.clone()].into(),
+                name_records: vec![record.clone()].try_into().unwrap(),
             },
         );
 
@@ -2693,40 +2684,7 @@ mod tests {
             PeerLookupResponse {
                 lookup_id: 1,
                 target: peer1_pubkey,
-                name_records: vec![record].into(),
-            },
-        );
-        assert!(cmds.is_empty());
-        assert!(!state.pending_queue.contains_key(&peer1_pubkey));
-        assert!(!state.routing_info.contains_key(&peer1_pubkey));
-    }
-
-    #[test]
-    fn test_drop_lookup_response_that_exceeds_max_peers() {
-        let keys = create_keys::<SignatureType>(3);
-        let peer0 = &keys[0];
-        let peer1 = &keys[1];
-        let peer1_pubkey = NodeId::new(peer1.pubkey());
-
-        let lookup_id = 1;
-        let (mut state, _clock) = generate_test_state(peer0, vec![]);
-        state.outstanding_lookup_requests.insert(
-            lookup_id,
-            LookupInfo {
-                num_retries: 0,
-                receiver: peer1_pubkey,
-                open_discovery: false,
-            },
-        );
-
-        // should not record peer lookup response if number of records exceed max
-        let record = generate_name_record(peer1, 0);
-        let cmds = state.handle_peer_lookup_response(
-            peer_source_from_record(peer1),
-            PeerLookupResponse {
-                lookup_id,
-                target: peer1_pubkey,
-                name_records: vec![record; MAX_PEER_IN_RESPONSE + 1].into(),
+                name_records: vec![record].try_into().unwrap(),
             },
         );
         assert!(cmds.is_empty());

--- a/monad-peer-discovery/src/message.rs
+++ b/monad-peer-discovery/src/message.rs
@@ -302,7 +302,8 @@ mod test {
                     &key3,
                 ),
             ]
-            .into(),
+            .try_into()
+            .unwrap(),
         };
         let message = PeerDiscoveryMessage::PeerLookupResponse(response.clone());
 

--- a/monad-raptorcast/src/raptorcast_secondary/group_message.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/group_message.rs
@@ -257,8 +257,8 @@ mod tests {
     fn serialize_roundtrip_group_conf() {
         let org_msg = ConfirmGroup {
             prepare: make_prep_group(7),
-            peers: [nid(8), nid(9), nid(10)].to_vec().into(),
-            name_records: make_name_records(11, 3).into(),
+            peers: [nid(8), nid(9), nid(10)].to_vec().try_into().unwrap(),
+            name_records: make_name_records(11, 3).try_into().unwrap(),
         };
         let org_enum = FullNodesGroupMessage::ConfirmGroup(org_msg);
 
@@ -322,7 +322,8 @@ mod tests {
                     participation_score: BoundedU64::new(0).unwrap(),
                 },
             ]
-            .into(),
+            .try_into()
+            .unwrap(),
         };
         let message = FullNodesGroupMessage::ParticipationReport(org_msg);
 

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -213,7 +213,20 @@ where
             filled_confirm_msg.name_records = Default::default();
             for node_id in dest_node_ids.iter() {
                 if let Some(name_record) = name_records.get(node_id) {
-                    filled_confirm_msg.name_records.push(name_record.clone());
+                    if let Err(err) = filled_confirm_msg
+                        .name_records
+                        .try_push(name_record.clone())
+                    {
+                        warn!(
+                            ?node_id,
+                            ?group_msg,
+                            capacity = err.capacity,
+                            "RaptorCastSecondary: ConfirmGroup.name_records at capacity; \
+                             dropping remaining records. Should be unreachable given \
+                             boot-time max_group_size validation.",
+                        );
+                        break;
+                    }
                 } else {
                     // Maybe can happen if peer discovery gets pruned just
                     // before sending a ConfirmGroup message.

--- a/monad-raptorcast/src/raptorcast_secondary/publisher.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/publisher.rs
@@ -682,7 +682,11 @@ where
             self.next_invite_tp = TimePoint::MAX; // lock the group
             let confirm_data = ConfirmGroup {
                 prepare: prep_grp_data,
-                peers: self.full_nodes_accepted.clone().into(),
+                peers: self
+                    .full_nodes_accepted
+                    .clone()
+                    .try_into()
+                    .expect("full_nodes_accepted exceeds MAX_PEERS_IN_GROUP"),
                 name_records: Default::default(), // to be filled by next layer
             };
             // ConfirmGroup is sent to all accepted peers
@@ -1642,7 +1646,7 @@ mod tests {
 
         let make_confirm_msg = |start_round: u64| ConfirmGroup {
             prepare: make_prep_data(start_round),
-            peers: node_ids_vec![10, 11].into(),
+            peers: node_ids_vec![10, 11].try_into().unwrap(),
             name_records: Default::default(),
         };
 
@@ -1751,7 +1755,7 @@ mod tests {
 
         let make_confirm_msg = |start_round: u64| ConfirmGroup {
             prepare: make_prep_data(start_round),
-            peers: node_ids_vec![10, 10 + start_round].into(),
+            peers: node_ids_vec![10, 10 + start_round].try_into().unwrap(),
             name_records: Default::default(),
         };
 
@@ -1866,7 +1870,7 @@ mod tests {
 
         let make_confirm_msg = |start_round: u64| ConfirmGroup {
             prepare: make_prep_data(start_round),
-            peers: node_ids_vec![10, 10 + start_round].into(),
+            peers: node_ids_vec![10, 10 + start_round].try_into().unwrap(),
             name_records: Default::default(),
         };
 
@@ -1999,7 +2003,7 @@ mod tests {
 
         let make_confirm_msg = |start_round: u64, validator_id: u64| ConfirmGroup {
             prepare: invite_data(start_round, validator_id),
-            peers: node_ids_vec![me, me + start_round].into(),
+            peers: node_ids_vec![me, me + start_round].try_into().unwrap(),
             name_records: Default::default(),
         };
 
@@ -2877,7 +2881,8 @@ mod tests {
                     participation_score: BoundedU64::new(score).unwrap(),
                 })
                 .collect::<Vec<_>>()
-                .into(),
+                .try_into()
+                .unwrap(),
         }
     }
 

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1775,33 +1775,23 @@ mod test {
 
     #[test]
     fn test_forkpoint_validate_1() {
-        let (mut forkpoint, mut locked_validator_sets, election) = get_forkpoint();
-        let locked_epoch_1 = forkpoint.0.validator_sets.pop().unwrap();
-        let locked_val_set_1 = locked_validator_sets.pop().unwrap();
-        let _ = forkpoint.0.validator_sets.pop().unwrap();
-        let _ = locked_validator_sets.pop().unwrap();
+        let (mut forkpoint, _locked, election) = get_forkpoint();
+        let one = forkpoint.0.validator_sets[0].clone();
 
+        // Stage 1: validator-set count bounds. Both checks return before
+        // `validate` touches the locked sets, so `&[]` suffices.
+
+        // Too few: zero validator sets.
+        forkpoint.0.validator_sets = Vec::new().into();
         assert_eq!(
-            forkpoint.validate(
-                &ValidatorSetFactory::default(),
-                &locked_validator_sets,
-                &election
-            ),
+            forkpoint.validate(&ValidatorSetFactory::default(), &[], &election),
             Err(ForkpointValidationError::TooFewValidatorSets)
         );
 
-        forkpoint.0.validator_sets.push(locked_epoch_1.clone());
-        forkpoint.0.validator_sets.push(locked_epoch_1.clone());
-        forkpoint.0.validator_sets.push(locked_epoch_1);
-        locked_validator_sets.push(locked_val_set_1.clone());
-        locked_validator_sets.push(locked_val_set_1.clone());
-        locked_validator_sets.push(locked_val_set_1);
+        // Too many: > 2 (count rejected before consecutiveness, so dupes are fine).
+        forkpoint.0.validator_sets = vec![one.clone(), one.clone(), one].into();
         assert_eq!(
-            forkpoint.validate(
-                &ValidatorSetFactory::default(),
-                &locked_validator_sets,
-                &election
-            ),
+            forkpoint.validate(&ValidatorSetFactory::default(), &[], &election),
             Err(ForkpointValidationError::TooManyValidatorSets)
         );
     }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -195,7 +195,8 @@ where
                 epoch: Epoch(1),
                 round: GENESIS_ROUND,
             }]
-            .into(),
+            .try_into()
+            .expect("genesis checkpoint validator_sets exceeds MAX_VALIDATOR_SETS"),
         }
         .into()
     }
@@ -1734,7 +1735,8 @@ mod test {
                     round: Round(4050),
                 },
             ]
-            .into(),
+            .try_into()
+            .unwrap(),
         }
         .into();
 
@@ -1782,14 +1784,14 @@ mod test {
         // `validate` touches the locked sets, so `&[]` suffices.
 
         // Too few: zero validator sets.
-        forkpoint.0.validator_sets = Vec::new().into();
+        forkpoint.0.validator_sets = Vec::new().try_into().unwrap();
         assert_eq!(
             forkpoint.validate(&ValidatorSetFactory::default(), &[], &election),
             Err(ForkpointValidationError::TooFewValidatorSets)
         );
 
         // Too many: > 2 (count rejected before consecutiveness, so dupes are fine).
-        forkpoint.0.validator_sets = vec![one.clone(), one.clone(), one].into();
+        forkpoint.0.validator_sets = vec![one.clone(), one.clone(), one].try_into().unwrap();
         assert_eq!(
             forkpoint.validate(&ValidatorSetFactory::default(), &[], &election),
             Err(ForkpointValidationError::TooManyValidatorSets)

--- a/monad-testground/src/main.rs
+++ b/monad-testground/src/main.rs
@@ -287,7 +287,9 @@ where
                 stake: Stake::ONE,
                 cert_pubkey: cert_keypair.pubkey(),
             })
-            .collect(),
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("validator set size exceeds MAX_VALIDATOR_SET_SIZE"),
     );
 
     let all_peers: Vec<NodeId<_>> = validators.0.iter().map(|data| data.node_id).collect();

--- a/monad-testutil/src/proposal.rs
+++ b/monad-testutil/src/proposal.rs
@@ -279,7 +279,8 @@ where
                 high_tip_round: GENESIS_ROUND,
                 sigs: tmo_sig_col,
             }]
-            .into(),
+            .try_into()
+            .expect("tip_rounds length exceeds MAX_VALIDATOR_SET_SIZE"),
             high_extend: HighExtend::Qc(self.high_qc.clone()),
         };
 

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -862,7 +862,35 @@ impl<T, const N: usize> LimitedVec<T, N> {
     pub fn into_inner(self) -> Vec<T> {
         self.0
     }
+
+    /// Append `item` if the vector has not reached the capacity bound `N`.
+    /// Returns the rejected item on overflow so the caller can decide how to recover.
+    pub fn try_push(&mut self, item: T) -> Result<(), LimitedVecCapacityError<T>> {
+        if self.0.len() >= N {
+            return Err(LimitedVecCapacityError {
+                rejected: item,
+                capacity: N,
+            });
+        }
+        self.0.push(item);
+        Ok(())
+    }
 }
+
+/// Error returned by [`LimitedVec::try_push`] when the vector is already at capacity.
+#[derive(Debug, PartialEq, Eq)]
+pub struct LimitedVecCapacityError<T> {
+    pub rejected: T,
+    pub capacity: usize,
+}
+
+impl<T> std::fmt::Display for LimitedVecCapacityError<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "LimitedVec at capacity {}", self.capacity)
+    }
+}
+
+impl<T: std::fmt::Debug> std::error::Error for LimitedVecCapacityError<T> {}
 
 impl<T: Encodable, const N: usize> Encodable for LimitedVec<T, N> {
     fn length(&self) -> usize {
@@ -896,9 +924,23 @@ impl<T, const N: usize> std::ops::Deref for LimitedVec<T, N> {
     }
 }
 
-impl<T, const N: usize> std::ops::DerefMut for LimitedVec<T, N> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+impl<T, I, const N: usize> std::ops::Index<I> for LimitedVec<T, N>
+where
+    Vec<T>: std::ops::Index<I>,
+{
+    type Output = <Vec<T> as std::ops::Index<I>>::Output;
+
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl<T, I, const N: usize> std::ops::IndexMut<I> for LimitedVec<T, N>
+where
+    Vec<T>: std::ops::IndexMut<I>,
+{
+    fn index_mut(&mut self, index: I) -> &mut Self::Output {
+        &mut self.0[index]
     }
 }
 
@@ -1109,6 +1151,35 @@ mod test {
 
         let decoded = LimitedVec::<u32, 0>::decode(&mut buf.as_slice()).unwrap();
         assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn test_limited_vec_try_push_within_capacity() {
+        let mut v: LimitedVec<u32, 3> = LimitedVec::default();
+        assert!(v.try_push(1).is_ok());
+        assert!(v.try_push(2).is_ok());
+        assert!(v.try_push(3).is_ok());
+        assert_eq!(v.len(), 3);
+        assert_eq!(v.0, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_limited_vec_try_push_rejects_at_capacity() {
+        let mut v: LimitedVec<u32, 2> = LimitedVec::default();
+        v.try_push(1).unwrap();
+        v.try_push(2).unwrap();
+        let err = v.try_push(99).unwrap_err();
+        assert_eq!(err.rejected, 99);
+        assert_eq!(err.capacity, 2);
+        assert_eq!(v.len(), 2);
+    }
+
+    #[test]
+    fn test_limited_vec_try_push_zero_capacity() {
+        let mut v: LimitedVec<u32, 0> = LimitedVec::default();
+        let err = v.try_push(7).unwrap_err();
+        assert_eq!(err.rejected, 7);
+        assert_eq!(err.capacity, 0);
     }
 
     #[test]

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -848,9 +848,14 @@ impl MonadVersion {
     }
 }
 
-/// A `Vec<T>` that enforces a maximum length during RLP deserialization.
+/// A `Vec<T>` whose length is bounded by `N`. The bound is enforced by every
+/// constructor: RLP `Decodable` and serde `Deserialize` reject oversize input,
+/// and `TryFrom<Vec<T>>` returns an error instead of constructing an oversize
+/// value. The inner `Vec` is private so the invariant cannot be bypassed via
+/// direct construction. Build one from an iterator the same way as `[T; N]`:
+/// `iter.collect::<Vec<_>>().try_into()`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LimitedVec<T, const N: usize>(pub Vec<T>);
+pub struct LimitedVec<T, const N: usize>(Vec<T>);
 
 impl<T, const N: usize> Default for LimitedVec<T, N> {
     fn default() -> Self {
@@ -877,7 +882,10 @@ impl<T, const N: usize> LimitedVec<T, N> {
     }
 }
 
-/// Error returned by [`LimitedVec::try_push`] when the vector is already at capacity.
+/// Error returned by [`LimitedVec`] constructors when the capacity bound `N`
+/// would be exceeded. `rejected` is the payload that did not fit: the item for
+/// [`LimitedVec::try_push`], or the whole `Vec<T>` for [`TryFrom<Vec<T>>`], so
+/// the caller can recover the data.
 #[derive(Debug, PartialEq, Eq)]
 pub struct LimitedVecCapacityError<T> {
     pub rejected: T,
@@ -944,9 +952,17 @@ where
     }
 }
 
-impl<T, const N: usize> From<Vec<T>> for LimitedVec<T, N> {
-    fn from(vec: Vec<T>) -> Self {
-        Self(vec)
+impl<T, const N: usize> TryFrom<Vec<T>> for LimitedVec<T, N> {
+    type Error = LimitedVecCapacityError<Vec<T>>;
+
+    fn try_from(vec: Vec<T>) -> Result<Self, Self::Error> {
+        if vec.len() > N {
+            return Err(LimitedVecCapacityError {
+                rejected: vec,
+                capacity: N,
+            });
+        }
+        Ok(Self(vec))
     }
 }
 
@@ -958,13 +974,15 @@ impl<T: Serialize, const N: usize> Serialize for LimitedVec<T, N> {
 
 impl<'de, T: Deserialize<'de>, const N: usize> Deserialize<'de> for LimitedVec<T, N> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Vec::<T>::deserialize(deserializer).map(Self)
-    }
-}
-
-impl<T, const N: usize> FromIterator<T> for LimitedVec<T, N> {
-    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        Self(iter.into_iter().collect())
+        let vec = Vec::<T>::deserialize(deserializer)?;
+        if vec.len() > N {
+            return Err(serde::de::Error::custom(format!(
+                "LimitedVec length {} exceeds maximum {}",
+                vec.len(),
+                N,
+            )));
+        }
+        Ok(Self(vec))
     }
 }
 
@@ -1120,7 +1138,7 @@ mod test {
 
     #[test]
     fn test_limited_vec_roundtrip() {
-        let original: LimitedVec<u32, 5> = vec![1u32, 2, 3].into();
+        let original: LimitedVec<u32, 5> = vec![1u32, 2, 3].try_into().unwrap();
         let mut buf = Vec::new();
         original.encode(&mut buf);
 
@@ -1130,14 +1148,14 @@ mod test {
 
     #[test]
     fn test_limited_vec_rejects_overflow() {
-        let exact: LimitedVec<u32, 100> = vec![1u32, 2, 3].into();
+        let exact: LimitedVec<u32, 100> = vec![1u32, 2, 3].try_into().unwrap();
         let mut buf = Vec::new();
         exact.encode(&mut buf);
         let decoded = LimitedVec::<u32, 3>::decode(&mut buf.as_slice()).unwrap();
         assert_eq!(decoded.len(), 3);
 
         // N+1 elements should fail
-        let over: LimitedVec<u32, 100> = vec![1u32, 2, 3, 4].into();
+        let over: LimitedVec<u32, 100> = vec![1u32, 2, 3, 4].try_into().unwrap();
         let mut buf = Vec::new();
         over.encode(&mut buf);
         assert!(LimitedVec::<u32, 3>::decode(&mut buf.as_slice()).is_err());
@@ -1145,7 +1163,7 @@ mod test {
 
     #[test]
     fn test_limited_vec_empty() {
-        let empty: LimitedVec<u32, 0> = Vec::new().into();
+        let empty: LimitedVec<u32, 0> = Vec::new().try_into().unwrap();
         let mut buf = Vec::new();
         empty.encode(&mut buf);
 
@@ -1180,6 +1198,39 @@ mod test {
         let err = v.try_push(7).unwrap_err();
         assert_eq!(err.rejected, 7);
         assert_eq!(err.capacity, 0);
+    }
+
+    #[test]
+    fn test_limited_vec_deserialize_rejects_overflow() {
+        let json = "[1,2,3,4]";
+        let result: Result<LimitedVec<u32, 3>, _> = serde_json::from_str(json);
+        let err = result.expect_err("expected Err for length 4 > N=3");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("LimitedVec length 4 exceeds maximum 3"),
+            "unexpected error message: {msg}",
+        );
+    }
+
+    #[test]
+    fn test_limited_vec_deserialize_accepts_exact_capacity() {
+        let json = "[1,2,3]";
+        let decoded: LimitedVec<u32, 3> = serde_json::from_str(json).unwrap();
+        assert_eq!(decoded.len(), 3);
+    }
+
+    #[test]
+    fn test_limited_vec_try_from_vec_rejects_overflow() {
+        let err = LimitedVec::<u32, 3>::try_from(vec![1u32, 2, 3, 4]).unwrap_err();
+        assert_eq!(err.capacity, 3);
+        // The rejected Vec is handed back so the caller can recover the data.
+        assert_eq!(err.rejected, vec![1u32, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_limited_vec_try_from_vec_accepts_exact_capacity() {
+        let v: LimitedVec<u32, 3> = vec![1u32, 2, 3].try_into().unwrap();
+        assert_eq!(v.len(), 3);
     }
 
     #[test]

--- a/monad-updaters/src/val_set.rs
+++ b/monad-updaters/src/val_set.rs
@@ -236,8 +236,16 @@ where
         Self {
             epoch: Epoch(1),
             genesis_val_data: genesis_validator_data,
-            val_data_1: ValidatorSetData(val_data_1.into()),
-            val_data_2: ValidatorSetData(val_data_2.into()),
+            val_data_1: ValidatorSetData(
+                val_data_1
+                    .try_into()
+                    .expect("val_data_1 exceeds MAX_VALIDATOR_SET_SIZE"),
+            ),
+            val_data_2: ValidatorSetData(
+                val_data_2
+                    .try_into()
+                    .expect("val_data_2 exceeds MAX_VALIDATOR_SET_SIZE"),
+            ),
             next_val_data: None,
             epoch_length,
 

--- a/monad-updaters/src/val_set.rs
+++ b/monad-updaters/src/val_set.rs
@@ -230,13 +230,13 @@ where
 {
     pub fn new(genesis_validator_data: ValidatorSetData<SCT>, epoch_length: SeqNum) -> Self {
         let num_validators = genesis_validator_data.0.len();
-        let mut val_data_1 = genesis_validator_data.0.clone();
+        let mut val_data_1 = genesis_validator_data.0.clone().into_inner();
         let val_data_2 = val_data_1.split_off(num_validators / 2);
 
         Self {
             epoch: Epoch(1),
             genesis_val_data: genesis_validator_data,
-            val_data_1: ValidatorSetData(val_data_1),
+            val_data_1: ValidatorSetData(val_data_1.into()),
             val_data_2: ValidatorSetData(val_data_2.into()),
             next_val_data: None,
             epoch_length,


### PR DESCRIPTION
A node could boot with a TOML config holding more than MAX_VALIDATOR_SET_SIZE validators with no error raised going through ValidatorsConfig::read_from_str

This PR enforce N in LimitedVec's Deserialize (Err), From<Vec<T>>, and FromIterator (assert). Decodable already enforced. The redundant assert in ValidatorSetData::new is dropped.

This code was generated using Claude Opus 4.7.

Closes: #3075 