### PR TITLE
Reject fullnode_raptorcast.max_group_size > 500 at boot

### DIFF
--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -207,6 +207,20 @@ where
             );
         }
 
+        let max_group_size = config.secondary_instance.max_group_size;
+        if max_group_size == 0
+            || max_group_size > raptorcast_secondary::group_message::MAX_PEERS_IN_GROUP
+        {
+            panic!(
+                "Configuration value fullnode_raptorcast.max_group_size must be in 1..={}, \
+                but got {}. Receivers reject ConfirmGroup messages with more than {} \
+                name_records at RLP decode time (LimitedVec capacity).",
+                raptorcast_secondary::group_message::MAX_PEERS_IN_GROUP,
+                max_group_size,
+                raptorcast_secondary::group_message::MAX_PEERS_IN_GROUP,
+            );
+        }
+
         let self_id = NodeId::new(config.shared_key.pubkey());
         let is_dynamic_fullnode = matches!(secondary_mode, SecondaryRaptorCastModeConfig::Client);
         debug!(

--- a/monad-raptorcast/src/raptorcast_secondary/group_message.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/group_message.rs
@@ -23,7 +23,7 @@ use monad_types::{BoundedU64, LimitedVec, NodeId, Round, RoundSpan};
 
 /// Maximum number of peers/name records allowed in a secondary raptorcast message.
 /// This is to set an upper bound on RLP deserialization memory usage.
-const MAX_PEERS_IN_GROUP: usize = 500;
+pub(crate) const MAX_PEERS_IN_GROUP: usize = 500;
 
 #[derive(RlpEncodable, RlpDecodable, Debug, Eq, PartialEq, Clone)]
 pub struct PrepareGroup<PT: PubKey> {


### PR DESCRIPTION
ConfirmGroup.name_records is typed `LimitedVec<_,MAX_PEERS_IN_GROUP=500>`. Receivers reject oversize messages at decode time. If an operator misconfigures max_group_size above 500 the proposer keeps emitting ConfirmGroup messages every round and every full node silently drops them, with no proximal cause in proposer logs. `max_group_size = 0` is also nonsensical: no candidate can ever be accepted into a group.

Reject both at `Raptorcast::new()` with a panic

This code was generated using Claude Opus 4.7.