### PR TITLE
Remove DerefMut from LimitedVec, add try_push

### DIFF
--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -213,7 +213,20 @@ where
             filled_confirm_msg.name_records = Default::default();
             for node_id in dest_node_ids.iter() {
                 if let Some(name_record) = name_records.get(node_id) {
-                    filled_confirm_msg.name_records.push(name_record.clone());
+                    if let Err(err) = filled_confirm_msg
+                        .name_records
+                        .try_push(name_record.clone())
+                    {
+                        warn!(
+                            ?node_id,
+                            ?group_msg,
+                            capacity = err.capacity,
+                            "RaptorCastSecondary: ConfirmGroup.name_records at capacity; \
+                             dropping remaining records. Should be unreachable given \
+                             boot-time max_group_size validation.",
+                        );
+                        break;
+                    }
                 } else {
                     // Maybe can happen if peer discovery gets pruned just
                     // before sending a ConfirmGroup message.

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1775,33 +1775,23 @@ mod test {
 
     #[test]
     fn test_forkpoint_validate_1() {
-        let (mut forkpoint, mut locked_validator_sets, election) = get_forkpoint();
-        let locked_epoch_1 = forkpoint.0.validator_sets.pop().unwrap();
-        let locked_val_set_1 = locked_validator_sets.pop().unwrap();
-        let _ = forkpoint.0.validator_sets.pop().unwrap();
-        let _ = locked_validator_sets.pop().unwrap();
+        let (mut forkpoint, _locked, election) = get_forkpoint();
+        let one = forkpoint.0.validator_sets[0].clone();
 
+        // Stage 1: validator-set count bounds. Both checks return before
+        // `validate` touches the locked sets, so `&[]` suffices.
+
+        // Too few: zero validator sets.
+        forkpoint.0.validator_sets = Vec::new().into();
         assert_eq!(
-            forkpoint.validate(
-                &ValidatorSetFactory::default(),
-                &locked_validator_sets,
-                &election
-            ),
+            forkpoint.validate(&ValidatorSetFactory::default(), &[], &election),
             Err(ForkpointValidationError::TooFewValidatorSets)
         );
 
-        forkpoint.0.validator_sets.push(locked_epoch_1.clone());
-        forkpoint.0.validator_sets.push(locked_epoch_1.clone());
-        forkpoint.0.validator_sets.push(locked_epoch_1);
-        locked_validator_sets.push(locked_val_set_1.clone());
-        locked_validator_sets.push(locked_val_set_1.clone());
-        locked_validator_sets.push(locked_val_set_1);
+        // Too many: > 2 (count rejected before consecutiveness, so dupes are fine).
+        forkpoint.0.validator_sets = vec![one.clone(), one.clone(), one].into();
         assert_eq!(
-            forkpoint.validate(
-                &ValidatorSetFactory::default(),
-                &locked_validator_sets,
-                &election
-            ),
+            forkpoint.validate(&ValidatorSetFactory::default(), &[], &election),
             Err(ForkpointValidationError::TooManyValidatorSets)
         );
     }

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -862,7 +862,35 @@ impl<T, const N: usize> LimitedVec<T, N> {
     pub fn into_inner(self) -> Vec<T> {
         self.0
     }
+
+    /// Append `item` if the vector has not reached the capacity bound `N`.
+    /// Returns the rejected item on overflow so the caller can decide how to recover.
+    pub fn try_push(&mut self, item: T) -> Result<(), LimitedVecCapacityError<T>> {
+        if self.0.len() >= N {
+            return Err(LimitedVecCapacityError {
+                rejected: item,
+                capacity: N,
+            });
+        }
+        self.0.push(item);
+        Ok(())
+    }
 }
+
+/// Error returned by [`LimitedVec::try_push`] when the vector is already at capacity.
+#[derive(Debug, PartialEq, Eq)]
+pub struct LimitedVecCapacityError<T> {
+    pub rejected: T,
+    pub capacity: usize,
+}
+
+impl<T> std::fmt::Display for LimitedVecCapacityError<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "LimitedVec at capacity {}", self.capacity)
+    }
+}
+
+impl<T: std::fmt::Debug> std::error::Error for LimitedVecCapacityError<T> {}
 
 impl<T: Encodable, const N: usize> Encodable for LimitedVec<T, N> {
     fn length(&self) -> usize {
@@ -896,9 +924,23 @@ impl<T, const N: usize> std::ops::Deref for LimitedVec<T, N> {
     }
 }
 
-impl<T, const N: usize> std::ops::DerefMut for LimitedVec<T, N> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+impl<T, I, const N: usize> std::ops::Index<I> for LimitedVec<T, N>
+where
+    Vec<T>: std::ops::Index<I>,
+{
+    type Output = <Vec<T> as std::ops::Index<I>>::Output;
+
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl<T, I, const N: usize> std::ops::IndexMut<I> for LimitedVec<T, N>
+where
+    Vec<T>: std::ops::IndexMut<I>,
+{
+    fn index_mut(&mut self, index: I) -> &mut Self::Output {
+        &mut self.0[index]
     }
 }
 
@@ -1109,6 +1151,35 @@ mod test {
 
         let decoded = LimitedVec::<u32, 0>::decode(&mut buf.as_slice()).unwrap();
         assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn test_limited_vec_try_push_within_capacity() {
+        let mut v: LimitedVec<u32, 3> = LimitedVec::default();
+        assert!(v.try_push(1).is_ok());
+        assert!(v.try_push(2).is_ok());
+        assert!(v.try_push(3).is_ok());
+        assert_eq!(v.len(), 3);
+        assert_eq!(v.0, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_limited_vec_try_push_rejects_at_capacity() {
+        let mut v: LimitedVec<u32, 2> = LimitedVec::default();
+        v.try_push(1).unwrap();
+        v.try_push(2).unwrap();
+        let err = v.try_push(99).unwrap_err();
+        assert_eq!(err.rejected, 99);
+        assert_eq!(err.capacity, 2);
+        assert_eq!(v.len(), 2);
+    }
+
+    #[test]
+    fn test_limited_vec_try_push_zero_capacity() {
+        let mut v: LimitedVec<u32, 0> = LimitedVec::default();
+        let err = v.try_push(7).unwrap_err();
+        assert_eq!(err.rejected, 7);
+        assert_eq!(err.capacity, 0);
     }
 
     #[test]

--- a/monad-updaters/src/val_set.rs
+++ b/monad-updaters/src/val_set.rs
@@ -230,13 +230,13 @@ where
 {
     pub fn new(genesis_validator_data: ValidatorSetData<SCT>, epoch_length: SeqNum) -> Self {
         let num_validators = genesis_validator_data.0.len();
-        let mut val_data_1 = genesis_validator_data.0.clone();
+        let mut val_data_1 = genesis_validator_data.0.clone().into_inner();
         let val_data_2 = val_data_1.split_off(num_validators / 2);
 
         Self {
             epoch: Epoch(1),
             genesis_val_data: genesis_validator_data,
-            val_data_1: ValidatorSetData(val_data_1),
+            val_data_1: ValidatorSetData(val_data_1.into()),
             val_data_2: ValidatorSetData(val_data_2.into()),
             next_val_data: None,
             epoch_length,


### PR DESCRIPTION
Prevents callers from bypassing the capacity bound N via `&mut Vec<T>` methods (push/extend/insert/...). Adds `LimitedVec::try_push` as the fallible bounded alternative and `Index/IndexMut` forwarding impls for length-safe element access. Migrates the one production push site in raptorcast_secondary to `try_push`

This code was generated using Claude Opus 4.7.