### PR TITLE
fix(ci): run license check on GitHub-hosted runner

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -15,9 +15,12 @@ on:
     paths-ignore:
       - 'debian/**'
 
+permissions:
+  contents: read
+
 jobs:
   check-license:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Move license workflow to ubuntu-latest and add explicit permissions since it doesn't require self-hosted infrastructure.