### PR TITLE
Fix createAccessList OpenRPC schema

### DIFF
--- a/monad-rpc/src/types/eth_json.rs
+++ b/monad-rpc/src/types/eth_json.rs
@@ -143,7 +143,6 @@ pub struct MonadCreateAccessListResult {
     #[schemars(with = "String")]
     pub gas_used: U256,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(with = "String")]
     pub error: Option<String>,
 }
 


### PR DESCRIPTION
## Summary
- Gives `eth_createAccessList` a typed OpenRPC result instead of `AnyValue`.
- Documents the result as `MonadCreateAccessListResult` with `accessList`, `gasUsed`, and `error`.
- Keeps `accessList` and `gasUsed` required, and lets `error` be nullable.

## Why
`eth_createAccessList` was returning `RawValue`, so the OpenRPC generator could not infer the real response shape and emitted `AnyValue`. Returning a typed result gives the docs a proper schema without changing the runtime JSON shape.

The result can include an optional `error`, so the schema also needs to allow `null` there.

## Validation
- `cargo fmt --all --check`
- `CARGO_TARGET_DIR=/tmp/category-labs-monad-bft-verify cargo check --workspace --all-targets`
- `CARGO_TARGET_DIR=/tmp/category-labs-monad-bft-verify cargo run -q -p monad-rpc --bin monad-rpc-docs > /tmp/category-labs-openrpc-after-merge.json`
- `jq '.methods[] | select(.name=="eth_createAccessList").result' /tmp/category-labs-openrpc-after-merge.json`
