### PR TITLE
Raptorcast: Proposer validation per round

### DIFF
--- a/monad-debugger/src/graphql/mod.rs
+++ b/monad-debugger/src/graphql/mod.rs
@@ -32,7 +32,7 @@ use monad_mock_swarm::{
     swarm_relation::{DebugSwarmRelation, SwarmRelation},
 };
 use monad_transformer::ID;
-use monad_types::{NodeId, Round, SeqNum, Serializable, GENESIS_ROUND, GENESIS_SEQ_NUM};
+use monad_types::{NodeId, Round, RoundSpan, SeqNum, Serializable, GENESIS_ROUND, GENESIS_SEQ_NUM};
 
 use crate::{graphql::message::GraphQLMonadMessage, simulation::Simulation};
 
@@ -377,6 +377,7 @@ enum GraphQLMonadEvent<'s> {
     TimestampEvent(GraphQLTimestampEvent),
     StateSyncEvent(GraphQLStateSyncEvent<'s>),
     ConfigEvent(GraphQLConfigEvent<'s>),
+    RaptorcastEvent(GraphQLRaptorcastEvent<'s>),
 }
 
 impl<'s> From<&'s MonadEventType> for GraphQLMonadEvent<'s> {
@@ -396,6 +397,9 @@ impl<'s> From<&'s MonadEventType> for GraphQLMonadEvent<'s> {
             MonadEvent::StateSyncEvent(event) => Self::StateSyncEvent(GraphQLStateSyncEvent(event)),
             MonadEvent::ConfigEvent(event) => Self::ConfigEvent(GraphQLConfigEvent(event)),
             MonadEvent::SecondaryRaptorcastPeersUpdate { .. } => todo!(),
+            MonadEvent::ProposerScheduleRequest(span) => {
+                Self::RaptorcastEvent(GraphQLRaptorcastEvent(span))
+            }
         }
     }
 }
@@ -470,6 +474,15 @@ struct GraphQLConfigEvent<'s>(&'s ConfigEvent<SignatureType, SignatureCollection
 
 #[Object]
 impl GraphQLConfigEvent<'_> {
+    async fn debug(&self) -> String {
+        format!("{:?}", self.0)
+    }
+}
+
+struct GraphQLRaptorcastEvent<'s>(&'s RoundSpan);
+
+#[Object]
+impl GraphQLRaptorcastEvent<'_> {
     async fn debug(&self) -> String {
         format!("{:?}", self.0)
     }

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{
+    collections::BTreeMap,
     fmt::Debug,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     num::NonZeroU16,
@@ -51,7 +52,7 @@ use monad_crypto::certificate_signature::{
 use monad_state_backend::StateBackend;
 use monad_types::{
     deserialize_pubkey, serialize_pubkey, Epoch, ExecutionProtocol, LimitedVec, NodeId, Round,
-    RouterTarget, SeqNum, Stake, UdpPriority,
+    RoundSpan, RouterTarget, SeqNum, Stake, UdpPriority,
 };
 use monad_validator::signature_collection::SignatureCollection;
 use serde::{Deserialize, Serialize};
@@ -98,6 +99,9 @@ pub enum RouterCommand<ST: CertificateSignatureRecoverable, OM> {
     UpdateFullNodes {
         dedicated_full_nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
         prioritized_full_nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
+    },
+    ProposerScheduleResponse {
+        proposers: BTreeMap<Round, NodeId<CertificateSignaturePubKey<ST>>>,
     },
 }
 
@@ -157,6 +161,10 @@ impl<ST: CertificateSignatureRecoverable, OM> Debug for RouterCommand<ST, OM> {
                 .debug_struct("UpdateFullNodes")
                 .field("dedicated_full_nodes", dedicated_full_nodes)
                 .field("prioritized_full_nodes", prioritized_full_nodes)
+                .finish(),
+            Self::ProposerScheduleResponse { proposers } => f
+                .debug_struct("ProposerScheduleResponse")
+                .field("proposers", proposers)
                 .finish(),
         }
     }
@@ -2149,6 +2157,8 @@ where
         expiry_round: Round,
         confirm_group_peers: Vec<NodeId<SCT::NodeIdPubKey>>,
     },
+    /// Request for proposal schedule information
+    ProposerScheduleRequest(RoundSpan),
 }
 
 impl<ST, SCT, EPT> MonadEvent<ST, SCT, EPT>
@@ -2208,6 +2218,7 @@ where
                 expiry_round: *expiry_round,
                 confirm_group_peers: confirm_group_peers.clone(),
             },
+            MonadEvent::ProposerScheduleRequest(span) => MonadEvent::ProposerScheduleRequest(*span),
         }
     }
 }
@@ -2259,6 +2270,10 @@ where
                 let enc: [&dyn Encodable; 3] = [&9u8, &expiry_round, &confirm_group_peers];
                 encode_list::<_, dyn Encodable>(&enc, out);
             }
+            Self::ProposerScheduleRequest(span) => {
+                let enc: [&dyn Encodable; 2] = [&10u8, span];
+                encode_list::<_, dyn Encodable>(&enc, out);
+            }
         }
     }
 }
@@ -2302,6 +2317,9 @@ where
                     confirm_group_peers,
                 })
             }
+            10 => Ok(Self::ProposerScheduleRequest(RoundSpan::decode(
+                &mut payload,
+            )?)),
             _ => Err(alloy_rlp::Error::Custom(
                 "failed to decode unknown MonadEvent",
             )),
@@ -2374,6 +2392,9 @@ where
             MonadEvent::ConfigEvent(_) => "CONFIGEVENT".to_string(),
             MonadEvent::SecondaryRaptorcastPeersUpdate { .. } => {
                 "SecondaryRaptorcastPeersUpdate".to_string()
+            }
+            MonadEvent::ProposerScheduleRequest(span) => {
+                format!("ProposerScheduleRequest -- span {span:?}")
             }
         };
 

--- a/monad-mock-swarm/src/mock.rs
+++ b/monad-mock-swarm/src/mock.rs
@@ -407,6 +407,9 @@ impl<S: SwarmRelation> Executor for MockExecutor<S> {
                 } => {
                     self.router.send_outbound(self.tick, target, message);
                 }
+                RouterCommand::ProposerScheduleResponse { .. } => {
+                    // TODO
+                }
             }
         }
     }

--- a/monad-peer-disc-swarm/src/lib.rs
+++ b/monad-peer-disc-swarm/src/lib.rs
@@ -161,6 +161,7 @@ impl<S: PeerDiscSwarmRelation> Executor for MockPeerDiscExecutor<S> {
                 RouterCommand::GetFullNodes => {}
                 RouterCommand::UpdateFullNodes { .. } => {}
                 RouterCommand::PublishToFullNodes { .. } => {}
+                RouterCommand::ProposerScheduleResponse { .. } => {}
             }
         }
     }

--- a/monad-raptorcast/examples/latency.rs
+++ b/monad-raptorcast/examples/latency.rs
@@ -264,6 +264,7 @@ where
             RaptorCastEvent::Message(event) => event,
             RaptorCastEvent::PeerManagerResponse(_) => unimplemented!(),
             RaptorCastEvent::SecondaryRaptorcastPeersUpdate(_, _) => unimplemented!(),
+            RaptorCastEvent::ProposerScheduleRequest(_) => unimplemented!(),
         }
     }
 }

--- a/monad-raptorcast/examples/service.rs
+++ b/monad-raptorcast/examples/service.rs
@@ -264,6 +264,7 @@ where
             RaptorCastEvent::SecondaryRaptorcastPeersUpdate(..) => {
                 unimplemented!()
             }
+            RaptorCastEvent::ProposerScheduleRequest(_) => unimplemented!(),
         }
     }
 }

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -54,7 +54,9 @@ use monad_peer_discovery::{
     NameRecord, PeerDiscoveryAlgo, PeerDiscoveryEvent,
 };
 use monad_peer_score::IdentityScore;
-use monad_types::{DropTimer, Epoch, ExecutionProtocol, NodeId, Round, RouterTarget, UdpPriority};
+use monad_types::{
+    DropTimer, Epoch, ExecutionProtocol, NodeId, Round, RoundSpan, RouterTarget, UdpPriority,
+};
 use monad_validator::{
     signature_collection::SignatureCollection,
     validator_set::{ValidatorSet, ValidatorSetType as _},
@@ -64,8 +66,8 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::{debug, debug_span, error, info, trace, warn};
 use util::{
     AutoRebroadcast, BroadcastGroup, BroadcastGroupError, BuildTarget, Collector, FullNodeGroupMap,
-    PeerAddrLookup, PrimaryBroadcastGroup, Recipient, Redundancy, SecondaryBroadcastGroup,
-    SecondaryGroupAssignment, UdpMessage,
+    PeerAddrLookup, PrimaryBroadcastGroup, ProposerMap, Recipient, Redundancy,
+    SecondaryBroadcastGroup, SecondaryGroupAssignment, UdpMessage,
 };
 
 use crate::{
@@ -123,6 +125,7 @@ where
 
     epoch_validators: BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
     full_node_groups: FullNodeGroupMap<CertificateSignaturePubKey<ST>>,
+    proposer_map: ProposerMap<CertificateSignaturePubKey<ST>>,
 
     dedicated_full_nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
     peer_discovery_driver: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
@@ -162,6 +165,7 @@ pub enum RaptorCastEvent<E, ST: CertificateSignatureRecoverable> {
     Message(E),
     PeerManagerResponse(PeerManagerResponse<ST>),
     SecondaryRaptorcastPeersUpdate(Round, Vec<NodeId<CertificateSignaturePubKey<ST>>>),
+    ProposerScheduleRequest(RoundSpan),
 }
 
 impl<ST, M, OM, SE, PD, AP, DS> RaptorCast<ST, M, OM, SE, PD, AP, DS>
@@ -282,6 +286,7 @@ where
             is_dynamic_fullnode,
             epoch_validators: Default::default(),
             full_node_groups: Default::default(),
+            proposer_map: Default::default(),
 
             dedicated_full_nodes: config.primary_instance.fullnode_dedicated.clone(),
             peer_discovery_driver,
@@ -464,6 +469,18 @@ where
                     .unwrap_log_on_error(&msg_bytes, &build_target)
             }
         };
+    }
+
+    fn update_proposer_map(&mut self, round: Round) {
+        let cutoff = round.saturating_sub(round_info::CACHE_MAX_PAST_ROUNDS);
+        self.proposer_map.prune_past(cutoff);
+
+        let start = round.saturating_sub(round_info::CACHE_MAX_PAST_ROUNDS);
+        let end = round.saturating_add(round_info::CACHE_MAX_FUTURE_ROUNDS);
+        if let Some(span) = RoundSpan::new(start, end) {
+            self.pending_events
+                .push_back(RaptorCastEvent::ProposerScheduleRequest(span));
+        }
     }
 
     fn handle_publish(
@@ -949,6 +966,7 @@ where
 
                     self.udp_state.update_current_round(round);
                     self.full_node_groups.delete_expired(round);
+                    self.update_proposer_map(round);
                     self.peer_discovery_driver
                         .lock()
                         .unwrap()
@@ -1108,6 +1126,14 @@ where
                 } => {
                     self.dedicated_full_nodes = dedicated_full_nodes;
                 }
+                RouterCommand::ProposerScheduleResponse { proposers } => {
+                    trace!(
+                        num_proposers = proposers.len(),
+                        cached_proposers = self.proposer_map.len(),
+                        "RaptorCast ProposerScheduleResponse"
+                    );
+                    self.proposer_map.extend(proposers);
+                }
             }
         }
     }
@@ -1201,6 +1227,7 @@ where
                 this.udp_state.handle_message(
                     &this.epoch_validators,
                     &this.full_node_groups,
+                    &this.proposer_map,
                     |targets, payload, bcast_stride| {
                         for target in targets {
                             rebroadcast_packet(
@@ -1503,11 +1530,11 @@ where
                         if this.full_node_groups.try_insert(group).is_none() {
                             // TODO: convert to an assertion?
                             error!(
-                                round_span =? round_span,
-                                publisher_id =? publisher_id,
+                                round_span = ?round_span,
+                                publisher_id = ?publisher_id,
                                 "Accepted group assignment contains overlaps"
                             );
-                        };
+                        }
                     }
                     Poll::Ready(None) => {
                         error!("RaptorCast secondary->primary channel disconnected.");
@@ -1571,6 +1598,9 @@ where
                     expiry_round,
                     confirm_group_peers,
                 }
+            }
+            RaptorCastEvent::ProposerScheduleRequest(span) => {
+                MonadEvent::ProposerScheduleRequest(span)
             }
         }
     }

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -246,6 +246,9 @@ where
                 Self::Command::PublishWithPriority { .. } => {
                     panic!("Command routed to secondary RaptorCast: PublishWithPriority")
                 }
+                Self::Command::ProposerScheduleResponse { .. } => {
+                    panic!("Command routed to secondary RaptorCast: ProposerScheduleResponse")
+                }
                 Self::Command::AddEpochValidatorSet { .. } => {
                     panic!("Command routed to secondary RaptorCast: AddEpochValidatorSet")
                 }

--- a/monad-raptorcast/src/round_info.rs
+++ b/monad-raptorcast/src/round_info.rs
@@ -28,8 +28,8 @@ use crate::{
     SIGNATURE_SIZE,
 };
 
-const CACHE_MAX_FUTURE_ROUNDS: Round = Round(100);
-const CACHE_MAX_PAST_ROUNDS: Round = Round(100);
+pub(crate) const CACHE_MAX_FUTURE_ROUNDS: Round = Round(100);
+pub(crate) const CACHE_MAX_PAST_ROUNDS: Round = Round(100);
 
 // Stores information related to the current round.
 pub struct RoundInfoCache<PT: PubKey> {
@@ -116,14 +116,10 @@ impl<PT: PubKey> RoundInfoCache<PT> {
 
     fn check_round(&self, round: Round) -> Option<()> {
         if let Some(current) = self.current_round {
-            let max_round = current
-                .checked_add(CACHE_MAX_FUTURE_ROUNDS)
-                .unwrap_or(Round::MAX);
-            let min_round = current
-                .checked_sub(CACHE_MAX_PAST_ROUNDS)
-                .unwrap_or(Round::MIN);
+            let max_round = current.saturating_add(CACHE_MAX_FUTURE_ROUNDS);
+            let min_round = current.saturating_sub(CACHE_MAX_PAST_ROUNDS);
 
-            if round > max_round || round < min_round {
+            if round >= max_round || round < min_round {
                 return None;
             }
         }
@@ -402,12 +398,12 @@ mod tests {
         let mut cache = Cache::new();
         cache.update_current_round(Round(200));
 
-        // Exactly at future boundary: 200 + 100 = 300, accepted.
-        assert!(cache.get_or_insert_primary(Round(300)).is_some());
-        // One past: rejected.
-        assert!(cache.get_or_insert_primary(Round(301)).is_none());
+        // Future boundary is half-open: 200 + 100 = 300 is rejected.
+        assert!(cache.get_or_insert_primary(Round(300)).is_none());
+        // One inside: accepted.
+        assert!(cache.get_or_insert_primary(Round(299)).is_some());
 
-        // Exactly at past boundary: 200 - 100 = 100, accepted.
+        // Past boundary is inclusive: 200 - 100 = 100 is accepted.
         assert!(cache.get_or_insert_primary(Round(100)).is_some());
         // One past: rejected.
         assert!(cache.get_or_insert_primary(Round(99)).is_none());

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -46,7 +46,7 @@ use crate::{
     util::{
         compute_app_message_hash, compute_hash, unix_ts_ms_now, AppMessageHash, BroadcastGroup,
         BroadcastMode, EncodingScheme, FullNodeGroupMap, GlobalMerkleRoot, MerkleRoot, NodeIdHash,
-        PrimaryBroadcastGroup, SecondaryBroadcastGroup,
+        PrimaryBroadcastGroup, ProposerMap, SecondaryBroadcastGroup,
     },
     v1_rollout::{self, DeterministicProtocolRolloutStage},
 };
@@ -169,6 +169,7 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
         &mut self,
         epoch_validators: &BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
         full_node_group_map: &FullNodeGroupMap<CertificateSignaturePubKey<ST>>,
+        proposer_map: &ProposerMap<CertificateSignaturePubKey<ST>>,
         chunk: &ValidatedChunk<CertificateSignaturePubKey<ST>>,
         rebroadcast_to: &mut impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
         sender: Option<&NodeId<CertificateSignaturePubKey<ST>>>,
@@ -207,7 +208,14 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
 
         match (chunk.encoding_scheme, &group) {
             (EncodingScheme::Deterministic25(round), BroadcastGroup::Primary(g)) => self
-                .handle_deterministic_primary(g, round, chunk, &decoding_context, rebroadcast_to),
+                .handle_deterministic_primary(
+                    g,
+                    proposer_map,
+                    round,
+                    chunk,
+                    &decoding_context,
+                    rebroadcast_to,
+                ),
             (EncodingScheme::Deterministic25(round), BroadcastGroup::Secondary(g)) => self
                 .handle_deterministic_secondary(g, round, chunk, &decoding_context, rebroadcast_to),
             _ => self.handle_regular(&group, chunk, &decoding_context, rebroadcast_to),
@@ -217,11 +225,35 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
     fn handle_deterministic_primary(
         &mut self,
         group: &PrimaryBroadcastGroup<'_, CertificateSignaturePubKey<ST>>,
+        proposer_map: &ProposerMap<CertificateSignaturePubKey<ST>>,
         round: Round,
         chunk: &ValidatedChunk<CertificateSignaturePubKey<ST>>,
         decoding_context: &DecodingContext<CertificateSignaturePubKey<ST>>,
         rebroadcast_to: &mut impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
     ) -> Option<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
+        match proposer_map.get(&round) {
+            Some(expected_proposer) if expected_proposer == &chunk.author => {
+                // proposer expected, proceed
+            }
+            Some(expected_proposer) => {
+                tracing::debug!(
+                    ?round,
+                    author = ?chunk.author,
+                    ?expected_proposer,
+                    "dropping deterministic primary chunk from non-proposer"
+                );
+                return None;
+            }
+            None => {
+                tracing::debug!(
+                    ?round,
+                    author = ?chunk.author,
+                    "dropping deterministic primary chunk with unknown proposer"
+                );
+                return None;
+            }
+        }
+
         let Some(round_info) = self.round_info_cache.get_or_insert_primary(round) else {
             tracing::debug!(
                 ?chunk.group_id,
@@ -424,6 +456,7 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
         &mut self,
         epoch_validators: &BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
         full_node_group_map: &FullNodeGroupMap<CertificateSignaturePubKey<ST>>,
+        proposer_map: &ProposerMap<CertificateSignaturePubKey<ST>>,
         rebroadcast: impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>, Bytes, u16),
         message: crate::auth::AuthRecvMsg<CertificateSignaturePubKey<ST>>,
     ) -> Vec<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
@@ -542,6 +575,7 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
                     self.handle_raptorcast(
                         epoch_validators,
                         full_node_group_map,
+                        proposer_map,
                         &chunk,
                         rebroadcast_to,
                         message.sender.as_ref(),
@@ -1200,6 +1234,7 @@ mod tests {
         udp_state.handle_message(
             &epoch_validators,
             &full_node_groups,
+            &Default::default(),
             |_targets, _payload, _stride| {},
             recv_msg,
         );
@@ -1434,7 +1469,7 @@ mod tests_deterministic {
         udp::SIGNATURE_CACHE_SIZE,
         util::{
             BroadcastMode, BuildTarget, EncodingScheme, FullNodeGroupMap, PrimaryBroadcastGroup,
-            UdpMessage, ValidatorGroupMap,
+            ProposerMap, UdpMessage, ValidatorGroupMap,
         },
         v1_rollout::DeterministicProtocolRolloutStage,
     };
@@ -1677,6 +1712,7 @@ mod tests_deterministic {
         udp_state.handle_message(
             &epoch_validators,
             &full_node_groups,
+            &Default::default(),
             |_targets, _payload, _stride| {},
             recv_msg,
         );
@@ -1824,6 +1860,8 @@ mod tests_deterministic {
             .unwrap();
         let epoch_validators: BTreeMap<_, _> = [(EPOCH, validators)].into();
         let full_node_groups = FullNodeGroupMap::default();
+        let mut proposer_schedule = ProposerMap::default();
+        proposer_schedule.extend([(ROUND, sender_id)]);
         let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
         udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
 
@@ -1841,6 +1879,7 @@ mod tests_deterministic {
             let decoded = udp_state.handle_message(
                 &epoch_validators,
                 &full_node_groups,
+                &proposer_schedule,
                 |_targets, _payload, _stride| rebroadcast_count += 1,
                 recv_msg,
             );
@@ -1959,6 +1998,8 @@ mod tests_deterministic {
             .unwrap();
         let epoch_validators: BTreeMap<_, _> = [(EPOCH, validators)].into();
         let full_node_groups = FullNodeGroupMap::default();
+        let mut proposer_schedule = ProposerMap::default();
+        proposer_schedule.extend([(ROUND, sender_id)]);
         let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
         udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
 
@@ -1976,6 +2017,7 @@ mod tests_deterministic {
             decoded.extend(udp_state.handle_message(
                 &epoch_validators,
                 &full_node_groups,
+                &proposer_schedule,
                 |_, _, _| {},
                 recv_msg,
             ));
@@ -1984,6 +2026,94 @@ mod tests_deterministic {
         assert_eq!(decoded.len(), 1, "should decode from 2/3 of chunks");
         assert_eq!(decoded[0].0, sender_id);
         assert_eq!(decoded[0].1, app_message);
+    }
+
+    #[test]
+    fn test_deterministic_primary_rejects_non_proposer_when_schedule_known() {
+        let (sender_key, validators, _) = validator_set();
+        let sender_id = NodeId::new(sender_key.pubkey());
+        let expected_proposer = validators
+            .get_members()
+            .keys()
+            .find(|id| **id != sender_id)
+            .copied()
+            .unwrap();
+        let group_map = make_group_map(&validators);
+        let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &sender_id, &group_map).unwrap();
+        let app_message: Bytes = vec![0xCD_u8; 64 * 1024].into();
+        let packets = build_packets(&sender_key, &app_message, group);
+
+        let receiver_id = validators
+            .get_members()
+            .keys()
+            .find(|id| **id != sender_id && **id != expected_proposer)
+            .copied()
+            .unwrap_or(expected_proposer);
+        let epoch_validators: BTreeMap<_, _> = [(EPOCH, validators)].into();
+        let full_node_groups = FullNodeGroupMap::default();
+        let mut proposer_schedule = ProposerMap::default();
+        proposer_schedule.extend([(ROUND, expected_proposer)]);
+        let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
+        udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
+
+        let mut decoded = Vec::new();
+        for packet in &packets {
+            let recv_msg = AuthRecvMsg {
+                src_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8000),
+                payload: packet.payload.clone(),
+                stride: deterministic::DEFAULT_SEGMENT_LEN as u16,
+                sender: None,
+            };
+            decoded.extend(udp_state.handle_message(
+                &epoch_validators,
+                &full_node_groups,
+                &proposer_schedule,
+                |_, _, _| {},
+                recv_msg,
+            ));
+        }
+
+        assert!(
+            decoded.is_empty(),
+            "chunks authored by a non-proposer must not decode"
+        );
+    }
+
+    #[test]
+    fn test_deterministic_primary_drops_when_schedule_unknown() {
+        let (sender_key, validators, _) = validator_set();
+        let sender_id = NodeId::new(sender_key.pubkey());
+        let group_map = make_group_map(&validators);
+        let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &sender_id, &group_map).unwrap();
+        let app_message: Bytes = vec![0xEF_u8; 64 * 1024].into();
+        let packets = build_packets(&sender_key, &app_message, group);
+
+        let receiver_id = validators
+            .get_members()
+            .keys()
+            .find(|id| **id != sender_id)
+            .copied()
+            .unwrap();
+        let epoch_validators: BTreeMap<_, _> = [(EPOCH, validators)].into();
+        let full_node_groups = FullNodeGroupMap::default();
+        let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
+        udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
+        let recv_msg = AuthRecvMsg {
+            src_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8000),
+            payload: packets[0].payload.clone(),
+            stride: deterministic::DEFAULT_SEGMENT_LEN as u16,
+            sender: None,
+        };
+
+        let decoded = udp_state.handle_message(
+            &epoch_validators,
+            &full_node_groups,
+            &Default::default(),
+            |_, _, _| {},
+            recv_msg,
+        );
+
+        assert!(decoded.is_empty());
     }
 
     #[test]
@@ -2012,6 +2142,8 @@ mod tests_deterministic {
         // Step 2: Validator receives and decodes
         let epoch_validators: BTreeMap<_, _> = [(EPOCH, validators)].into();
         let full_node_groups = FullNodeGroupMap::default();
+        let mut proposer_schedule = ProposerMap::default();
+        proposer_schedule.extend([(ROUND, proposer_id)]);
         let mut udp_state = UdpState::<SignatureType>::new(validator_id, u64::MAX, 10_000);
         udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
 
@@ -2028,6 +2160,7 @@ mod tests_deterministic {
             for (_, msg) in udp_state.handle_message(
                 &epoch_validators,
                 &full_node_groups,
+                &proposer_schedule,
                 |_, _, _| {},
                 recv_msg,
             ) {

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -972,6 +972,40 @@ pub fn unix_ts_ms_now() -> u64 {
         .expect("unix epoch doesn't fit in u64")
 }
 
+// Expected proposer per round. Populated via
+// RouterCommand::ProposerScheduleResponse.
+pub struct ProposerMap<PT: PubKey> {
+    inner: BTreeMap<Round, NodeId<PT>>,
+}
+
+impl<PT: PubKey> Default for ProposerMap<PT> {
+    fn default() -> Self {
+        Self {
+            inner: BTreeMap::new(),
+        }
+    }
+}
+
+impl<PT: PubKey> ProposerMap<PT> {
+    pub fn get(&self, round: &Round) -> Option<&NodeId<PT>> {
+        self.inner.get(round)
+    }
+
+    #[expect(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn extend(&mut self, entries: impl IntoIterator<Item = (Round, NodeId<PT>)>) {
+        self.inner.extend(entries);
+    }
+
+    // Drop entries with round strictly less than cutoff.
+    pub fn prune_past(&mut self, cutoff: Round) {
+        self.inner = self.inner.split_off(&cutoff);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
@@ -1556,5 +1590,21 @@ mod tests {
         .into_iter()
         .collect();
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn proposer_map_prune_past_drops_below_cutoff() {
+        let mut map = ProposerMap::<PT>::default();
+        map.extend([
+            (Round(10), nid(1)),
+            (Round(50), nid(2)),
+            (Round(99), nid(3)),
+        ]);
+
+        map.prune_past(Round(50));
+
+        assert!(map.get(&Round(10)).is_none());
+        assert!(map.get(&Round(50)).is_some());
+        assert!(map.get(&Round(99)).is_some());
     }
 }

--- a/monad-raptorcast/src/v1_rollout.rs
+++ b/monad-raptorcast/src/v1_rollout.rs
@@ -98,8 +98,8 @@ mod tests {
         packet::MessageBuilder,
         udp::UdpState,
         util::{
-            BuildTarget, FullNodeGroupMap, PrimaryBroadcastGroup, RaptorcastMode, Redundancy,
-            SecondaryBroadcastGroup, SecondaryGroup, SecondaryGroupAssignment,
+            BuildTarget, FullNodeGroupMap, PrimaryBroadcastGroup, ProposerMap, RaptorcastMode,
+            Redundancy, SecondaryBroadcastGroup, SecondaryGroup, SecondaryGroupAssignment,
         },
     };
 
@@ -135,6 +135,8 @@ mod tests {
         let sender_id = NodeId::new(sender_key.pubkey());
         let group_map = [(EPOCH, validators.clone())].into();
         let fn_group_map = FullNodeGroupMap::default();
+        let mut proposer_schedule = ProposerMap::default();
+        proposer_schedule.extend([(ROUND, sender_id)]);
         let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &sender_id, &group_map).unwrap();
 
         let app_message: Bytes = vec![0xAB_u8; 64 * 1024].into();
@@ -167,8 +169,13 @@ mod tests {
                 stride: packet.stride as u16,
                 sender: None,
             };
-            let decoded =
-                udp_state.handle_message(&group_map, &fn_group_map, |_, _, _| {}, recv_msg);
+            let decoded = udp_state.handle_message(
+                &group_map,
+                &fn_group_map,
+                &proposer_schedule,
+                |_, _, _| {},
+                recv_msg,
+            );
             decoded_count += decoded.len();
         }
 
@@ -248,6 +255,7 @@ mod tests {
         let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
         udp_state.set_v1_rollout(receiver_stage);
 
+        let proposer_map = ProposerMap::default();
         let mut decoded_count = 0;
         for packet in &packets {
             let recv_msg = AuthRecvMsg {
@@ -256,8 +264,13 @@ mod tests {
                 stride: packet.stride as u16,
                 sender: None,
             };
-            let decoded =
-                udp_state.handle_message(&group_map, &fn_group_map, |_, _, _| {}, recv_msg);
+            let decoded = udp_state.handle_message(
+                &group_map,
+                &fn_group_map,
+                &proposer_map,
+                |_, _, _| {},
+                recv_msg,
+            );
             decoded_count += decoded.len();
         }
         decoded_count
@@ -367,6 +380,7 @@ mod tests {
         udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
 
         let group_map: std::collections::BTreeMap<_, _> = std::collections::BTreeMap::new();
+        let proposer_map = ProposerMap::default();
         let mut rebroadcast_count = 0usize;
         for packet in &packets {
             let recv_msg = AuthRecvMsg {
@@ -378,6 +392,7 @@ mod tests {
             udp_state.handle_message(
                 &group_map,
                 &fn_group_map,
+                &proposer_map,
                 |_targets, _payload, _stride| rebroadcast_count += 1,
                 recv_msg,
             );
@@ -455,6 +470,7 @@ mod tests {
         udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
 
         let group_map: std::collections::BTreeMap<_, _> = std::collections::BTreeMap::new();
+        let proposer_map = ProposerMap::default();
         let mut decoded = Vec::new();
         for packet in packets_a.iter().chain(packets_b.iter()) {
             let recv_msg = AuthRecvMsg {
@@ -466,6 +482,7 @@ mod tests {
             decoded.extend(udp_state.handle_message(
                 &group_map,
                 &fn_group_map,
+                &proposer_map,
                 |_, _, _| {},
                 recv_msg,
             ));

--- a/monad-raptorcast/tests/raptorcast_instance.rs
+++ b/monad-raptorcast/tests/raptorcast_instance.rs
@@ -392,7 +392,7 @@ impl Message for MockMessage {
     type Event = MockEvent<Self::NodeIdPubKey>;
 
     fn event(self, from: NodeId<Self::NodeIdPubKey>) -> Self::Event {
-        MockEvent((from, self.id))
+        MockEvent::Message((from, self.id))
     }
 }
 
@@ -420,7 +420,26 @@ impl Deserializable<Bytes> for MockMessage {
 }
 
 #[derive(Clone, Copy, Debug)]
-struct MockEvent<P: PubKey>((NodeId<P>, u32));
+enum MockEvent<P: PubKey> {
+    Message((NodeId<P>, u32)),
+    // Sink for raptorcast-internal events that tests don't inspect.
+    Discarded,
+}
+
+// Filter a MockEvent stream down to the inner Message payloads.
+fn messages_only<S>(
+    stream: S,
+) -> impl futures_util::Stream<Item = (NodeId<PubKeyType>, u32)> + Unpin
+where
+    S: futures_util::Stream<Item = MockEvent<PubKeyType>> + Unpin,
+{
+    stream.filter_map(|event| {
+        std::future::ready(match event {
+            MockEvent::Message(m) => Some(m),
+            MockEvent::Discarded => None,
+        })
+    })
+}
 
 impl<ST> From<RaptorCastEvent<MockEvent<CertificateSignaturePubKey<ST>>, ST>>
     for MockEvent<CertificateSignaturePubKey<ST>>
@@ -436,6 +455,7 @@ where
             RaptorCastEvent::SecondaryRaptorcastPeersUpdate { .. } => {
                 unimplemented!()
             }
+            RaptorCastEvent::ProposerScheduleRequest(_) => MockEvent::Discarded,
         }
     }
 }
@@ -670,20 +690,20 @@ async fn publish_to_full_nodes() {
     validator_rc.exec(vec![command]);
 
     // 7. Assert full nodes receive the message
+    let mut full_node1_messages = messages_only(full_node1_rc);
+    let mut full_node2_messages = messages_only(full_node2_rc);
     let timeout = Duration::from_secs(1);
-    let event1 = tokio::time::timeout(timeout, full_node1_rc.next())
+    let (from, id) = tokio::time::timeout(timeout, full_node1_messages.next())
         .await
         .expect("timeout")
         .expect("stream ended");
-    let MockEvent((from, id)) = event1;
     assert_eq!(from, validator_nodeid);
     assert_eq!(id, 42);
 
-    let event2 = tokio::time::timeout(timeout, full_node2_rc.next())
+    let (from, id) = tokio::time::timeout(timeout, full_node2_messages.next())
         .await
         .expect("timeout")
         .expect("stream ended");
-    let MockEvent((from, id)) = event2;
     assert_eq!(from, validator_nodeid);
     assert_eq!(id, 42);
 }
@@ -829,7 +849,9 @@ async fn test_priority_messages() {
     while received_messages.len() < MESSAGE_COUNT * 2 && start.elapsed() < timeout {
         match tokio::time::timeout(Duration::from_millis(100), rx_rc.next()).await {
             Ok(Some(event)) => {
-                let MockEvent((_, msg_id)) = event;
+                let MockEvent::Message((_, msg_id)) = event else {
+                    continue;
+                };
                 received_messages.push(msg_id);
             }
             Ok(None) => break,
@@ -978,7 +1000,9 @@ async fn test_raptorcast_forwarding_priority() {
 
     while received_messages.len() < 2 && start.elapsed() < timeout {
         if let Some(event) = validator_fullnode_rc.next().await {
-            let MockEvent((from, msg_id)) = event;
+            let MockEvent::Message((from, msg_id)) = event else {
+                continue;
+            };
             received_messages.push((from, msg_id));
         }
     }

--- a/monad-raptorcast/tests/wireauth_raptorcast.rs
+++ b/monad-raptorcast/tests/wireauth_raptorcast.rs
@@ -111,6 +111,7 @@ where
             RaptorCastEvent::Message(event) => event,
             RaptorCastEvent::PeerManagerResponse(_) => unimplemented!(),
             RaptorCastEvent::SecondaryRaptorcastPeersUpdate { .. } => unimplemented!(),
+            RaptorCastEvent::ProposerScheduleRequest(_) => unimplemented!(),
         }
     }
 }

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -325,6 +325,7 @@ where
             match cmd {
                 RouterCommand::Publish { .. } => validator_cmds.push(cmd),
                 RouterCommand::PublishWithPriority { .. } => validator_cmds.push(cmd),
+                RouterCommand::ProposerScheduleResponse { .. } => validator_cmds.push(cmd),
                 RouterCommand::AddEpochValidatorSet {
                     epoch,
                     validator_set,

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -78,11 +78,13 @@ use monad_validator::{
 use tracing::warn;
 
 use self::{
-    blocksync::BlockSyncChildState, consensus::ConsensusChildState, statesync::BlockBuffer,
+    blocksync::BlockSyncChildState, consensus::ConsensusChildState,
+    proposer_schedule::ProposerScheduleService, statesync::BlockBuffer,
 };
 
 mod blocksync;
 mod consensus;
+mod proposer_schedule;
 mod statesync;
 
 const STATESYNC_BLOCK_THRESHOLD: SeqNum = SeqNum(30_000);
@@ -417,6 +419,8 @@ where
     epoch_manager: EpochManager,
     /// Maps the epoch number to validator stakes and certificate pubkeys
     val_epoch_map: ValidatorsEpochMapping<VTF, SCT>,
+    /// Resolves proposer schedule requests
+    proposer_schedule: ProposerScheduleService,
     /// Excludes self node id
     /// Expiry NodeId -> round
     secondary_raptorcast_peers: BTreeMap<NodeId<CertificateSignaturePubKey<ST>>, Round>,
@@ -940,6 +944,7 @@ where
             leader_election: self.leader_election,
             epoch_manager,
             val_epoch_map,
+            proposer_schedule: ProposerScheduleService::new(),
             secondary_raptorcast_peers: Default::default(),
 
             block_timestamp,
@@ -1007,6 +1012,22 @@ where
         >,
     > {
         match event {
+            MonadEvent::ProposerScheduleRequest(span) => {
+                let response = self.proposer_schedule.handle_request(
+                    span,
+                    &self.epoch_manager,
+                    &self.val_epoch_map,
+                    &self.leader_election,
+                );
+                response
+                    .map(|proposers| {
+                        Command::RouterCommand(RouterCommand::ProposerScheduleResponse {
+                            proposers,
+                        })
+                    })
+                    .into_iter()
+                    .collect()
+            }
             MonadEvent::ConsensusEvent(consensus_event) => {
                 let consensus_cmds = ConsensusChildState::new(self).update(consensus_event);
 
@@ -1023,17 +1044,18 @@ where
                     })
                     .is_some();
 
-                if consensus_cmds
+                let entered_round = consensus_cmds
                     .iter()
-                    .any(|cmd| matches!(cmd.command, ConsensusCommand::EnterRound(_, _)))
-                {
-                    self.metrics.node_state.self_stake_bps = self.get_self_stake_bps();
-                }
+                    .any(|cmd| matches!(cmd.command, ConsensusCommand::EnterRound(_, _)));
 
                 let mut cmds = consensus_cmds
                     .into_iter()
                     .flat_map(Into::<Vec<Command<_, _, _, _, _, _, _, _, _>>>::into)
                     .collect::<Vec<_>>();
+
+                if entered_round {
+                    self.metrics.node_state.self_stake_bps = self.get_self_stake_bps();
+                }
 
                 if take_checkpoint {
                     if let Some(checkpoint_cmd) = ConsensusChildState::new(self).checkpoint() {

--- a/monad-state/src/proposer_schedule.rs
+++ b/monad-state/src/proposer_schedule.rs
@@ -1,0 +1,306 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::BTreeMap;
+
+use monad_crypto::certificate_signature::PubKey;
+use monad_types::{Epoch, NodeId, Round};
+use monad_validator::{
+    epoch_manager::EpochManager,
+    leader_election::LeaderElection,
+    signature_collection::SignatureCollection,
+    validator_set::{ValidatorSetType, ValidatorSetTypeFactory},
+    validators_epoch_mapping::ValidatorsEpochMapping,
+};
+
+/// Resolves proposer-schedule requests.
+///
+/// Each request specifies a span of rounds, and the service returns
+/// the proposer for each round in the span. The service avoids
+/// re-resolving proposers for rounds that have already been resolved
+/// in previous requests.
+#[derive(Debug, Eq, PartialEq)]
+pub struct ProposerScheduleService {
+    /// Highest round whose proposer has already been resolved, or
+    /// `None` if no round has been resolved yet. Requests at or below
+    /// this round are skipped.
+    resolved_round: Option<Round>,
+}
+
+impl ProposerScheduleService {
+    pub fn new() -> Self {
+        Self {
+            resolved_round: None,
+        }
+    }
+
+    pub fn handle_request<PT, SCT, VTF, LT>(
+        &mut self,
+        mut span: monad_types::RoundSpan,
+        epoch_manager: &EpochManager,
+        val_epoch_map: &ValidatorsEpochMapping<VTF, SCT>,
+        election: &LT,
+    ) -> Option<BTreeMap<Round, NodeId<PT>>>
+    where
+        PT: PubKey,
+        SCT: SignatureCollection<NodeIdPubKey = PT>,
+        VTF: ValidatorSetTypeFactory<NodeIdPubKey = PT>,
+        LT: LeaderElection<NodeIdPubKey = PT>,
+    {
+        // Clamp rounds below the already resolved round.
+        if let Some(resolved_round) = self.resolved_round {
+            span = span.clamp_below(resolved_round.saturating_add(Round(1)))?;
+        }
+
+        // Clamp rounds from the past where the epoch data is pruned.
+        let first_available_round = span
+            .iter()
+            .find(|round| get_epoch(*round, epoch_manager, val_epoch_map).is_some())?;
+        let span = span.clamp_below(first_available_round)?;
+
+        // Aggregate proposers for the remaining rounds.
+        let mut proposers = BTreeMap::new();
+        for round in span.iter() {
+            let Some(epoch) = get_epoch(round, epoch_manager, val_epoch_map) else {
+                break;
+            };
+            let proposer = get_proposer(epoch, round, val_epoch_map, election);
+            self.resolved_round = Some(round);
+            proposers.insert(round, proposer);
+        }
+
+        (!proposers.is_empty()).then_some(proposers)
+    }
+}
+
+// Return the epoch corresponding to the given round, or None if it
+// cannot be determined.
+fn get_epoch<PT, SCT, VTF>(
+    round: Round,
+    epoch_manager: &EpochManager,
+    val_epoch_map: &ValidatorsEpochMapping<VTF, SCT>,
+) -> Option<Epoch>
+where
+    PT: PubKey,
+    SCT: SignatureCollection<NodeIdPubKey = PT>,
+    VTF: ValidatorSetTypeFactory<NodeIdPubKey = PT>,
+{
+    let epoch = epoch_manager.get_stable_epoch(round)?;
+    val_epoch_map.contains_epoch(&epoch).then_some(epoch)
+}
+
+// Return the proposer for the given round.
+//
+// The caller must have already verified that the epoch for the round
+// is stable and available.
+fn get_proposer<PT, SCT, VTF, LT>(
+    epoch: Epoch,
+    round: Round,
+    val_epoch_map: &ValidatorsEpochMapping<VTF, SCT>,
+    election: &LT,
+) -> NodeId<PT>
+where
+    PT: PubKey,
+    SCT: SignatureCollection<NodeIdPubKey = PT>,
+    VTF: ValidatorSetTypeFactory<NodeIdPubKey = PT>,
+    LT: LeaderElection<NodeIdPubKey = PT>,
+{
+    debug_assert!(val_epoch_map.contains_epoch(&epoch));
+    let validator_set = val_epoch_map
+        .get_val_set(&epoch)
+        .expect("caller should have checked epoch exists");
+    let members = validator_set.get_members();
+    election.get_leader(round, members)
+}
+
+#[cfg(test)]
+mod tests {
+    use monad_crypto::NopPubKey;
+    use monad_types::{Epoch, RoundSpan, SeqNum, Stake};
+    use monad_validator::{
+        simple_round_robin::SimpleRoundRobin, validator_mapping::ValidatorMapping,
+        validator_set::ValidatorSetFactory,
+    };
+
+    use super::*;
+
+    type PT = NopPubKey;
+    #[expect(clippy::upper_case_acronyms)]
+    type VEM = ValidatorsEpochMapping<
+        ValidatorSetFactory<PT>,
+        monad_testutil::signing::MockSignatures<monad_crypto::NopSignature>,
+    >;
+
+    fn span(start: u64, end: u64) -> RoundSpan {
+        RoundSpan::new(Round(start), Round(end)).unwrap()
+    }
+
+    fn nid(seed: u8) -> NodeId<PT> {
+        NodeId::new(NopPubKey::from_bytes(&[seed; 32]).unwrap())
+    }
+
+    // Fixed parameters for testing
+    const EPOCH_LEN: SeqNum = SeqNum(100);
+    const EPOCH_START_DELAY: Round = Round(10);
+
+    struct State {
+        epoch_manager: EpochManager,
+        val_epoch_map: VEM,
+        election: SimpleRoundRobin<PT>,
+        pending_valset: Option<(Epoch, Vec<(NodeId<PT>, Stake)>)>,
+    }
+
+    impl State {
+        fn new() -> Self {
+            Self {
+                epoch_manager: EpochManager::new(EPOCH_LEN, EPOCH_START_DELAY, &[]),
+                val_epoch_map: VEM::new(Default::default()),
+                election: SimpleRoundRobin::default(),
+                pending_valset: None,
+            }
+        }
+
+        // finalize a new epoch at the boundary block of the current epoch.
+        fn finalize(&mut self, epoch: Epoch, round: Round, valset: Vec<(NodeId<PT>, Stake)>) {
+            // the next epoch_start must be outside the stable horizon
+            // of the current epoch.
+            let epoch_start = round + EPOCH_START_DELAY;
+            assert!(self.epoch_manager.get_stable_epoch(epoch_start).is_none());
+
+            // pick the boundary block number
+            let curr_epoch = epoch - Epoch(1);
+            let curr_block_num = SeqNum(curr_epoch.0 * EPOCH_LEN.0 - 1);
+            assert!(curr_block_num.is_boundary_block(EPOCH_LEN));
+
+            // schedule the new epoch
+            self.epoch_manager
+                .schedule_epoch_start(curr_block_num, round);
+            assert_eq!(
+                self.epoch_manager.epoch_starts.last_key_value(),
+                Some((&epoch, &epoch_start))
+            );
+
+            // insert the pending valset which is made available after
+            // EXEC_DELAY.
+            assert!(self.pending_valset.is_none());
+            let locked_epoch = curr_block_num.get_locked_epoch(EPOCH_LEN);
+            self.pending_valset = Some((locked_epoch, valset));
+        }
+
+        // simulate delayed execution
+        fn execute(&mut self) {
+            let (epoch, vs) = self
+                .pending_valset
+                .take()
+                .expect("must call finalize before execute");
+            self.val_epoch_map
+                .insert(epoch, vs, ValidatorMapping::new(std::iter::empty()));
+        }
+
+        // prune old epoch data
+        fn prune_epochs(&mut self, epoch: Epoch) {
+            self.epoch_manager.epoch_starts.retain(|&e, _| e > epoch);
+        }
+
+        fn handle_request(
+            &self,
+            service: &mut ProposerScheduleService,
+            span: RoundSpan,
+        ) -> Option<BTreeMap<Round, NodeId<PT>>> {
+            service.handle_request::<PT, _, _, _>(
+                span,
+                &self.epoch_manager,
+                &self.val_epoch_map,
+                &self.election,
+            )
+        }
+    }
+
+    fn assert_resolution(
+        proposers: &BTreeMap<Round, NodeId<PT>>,
+        expected: &[(std::ops::Range<u64>, NodeId<PT>)],
+    ) {
+        let total_rounds = expected.iter().map(|(r, _)| r.end - r.start).sum::<u64>();
+        assert_eq!(proposers.len(), total_rounds as usize);
+
+        for (range, nid) in expected {
+            for round in range.clone() {
+                assert_eq!(proposers[&Round(round)], *nid);
+            }
+        }
+    }
+
+    #[test]
+    fn resolves_across_epoch_lifecycle() {
+        let e2v = nid(2);
+        let e3v = nid(3);
+        let mut state = State::new();
+        state.finalize(Epoch(2), Round(90), vec![(e2v, Stake::ONE)]);
+        state.execute();
+
+        // Epoch 3 [r=210..] is not finalized.
+        let mut service = ProposerScheduleService::new();
+        let proposers = state.handle_request(&mut service, span(0, 350)).unwrap();
+        assert_resolution(&proposers, &[(100..200, e2v)]);
+
+        // Epoch 3 [r=210..310] is finalized but valset not available yet.
+        state.finalize(Epoch(3), Round(200), vec![(e3v, Stake::ONE)]);
+        let mut service = ProposerScheduleService::new();
+        let proposers = state.handle_request(&mut service, span(0, 350)).unwrap();
+        assert_resolution(&proposers, &[(100..210, e2v)]); // Note: the epoch ending round is stablized
+
+        // Epoch 3 valset is available.
+        state.execute();
+        let mut service = ProposerScheduleService::new();
+        let proposers = state.handle_request(&mut service, span(0, 350)).unwrap();
+        assert_resolution(&proposers, &[(100..210, e2v), (210..310, e3v)]);
+
+        // Epoch 2 pruned
+        state.prune_epochs(Epoch(2));
+        let mut service = ProposerScheduleService::new();
+        let proposers = state.handle_request(&mut service, span(0, 350)).unwrap();
+        assert_resolution(&proposers, &[(210..310, e3v)]);
+    }
+
+    #[test]
+    fn each_round_resolved_at_most_once() {
+        let e2v = nid(2);
+        let mut service = ProposerScheduleService::new();
+        let mut state = State::new();
+        state.finalize(Epoch(2), Round(90), vec![(e2v, Stake::ONE)]);
+        state.execute();
+
+        let proposers = state.handle_request(&mut service, span(0, 150)).unwrap();
+        assert_resolution(&proposers, &[(100..150, e2v)]);
+
+        // Repeated request with same span should return None.
+        let proposers = state.handle_request(&mut service, span(0, 150));
+        assert!(proposers.is_none());
+
+        // Request with extended span should return proposers only
+        // for the unresolved rounds.
+        let proposers = state.handle_request(&mut service, span(0, 180)).unwrap();
+        assert_resolution(&proposers, &[(150..180, e2v)]);
+
+        // Requesting the same span again after updated epoch should
+        // return newly stabilized proposers.
+        let e3v = nid(3);
+        state.finalize(Epoch(3), Round(190), vec![(e3v, Stake::ONE)]);
+        state.execute();
+
+        let proposers = state.handle_request(&mut service, span(0, 300)).unwrap();
+        assert_resolution(&proposers, &[(180..200, e2v), (200..300, e3v)]);
+    }
+}

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -79,8 +79,16 @@ impl Round {
             .is_some_and(|next_round| next_round == self.as_u64())
     }
 
+    pub fn saturating_sub(self, count: Round) -> Self {
+        Round(self.0.saturating_sub(count.0))
+    }
+
     pub fn checked_sub(self, count: Round) -> Option<Self> {
         self.0.checked_sub(count.0).map(Round)
+    }
+
+    pub fn saturating_add(self, count: Round) -> Self {
+        Round(self.0.saturating_add(count.0))
     }
 
     pub fn checked_add(self, count: Round) -> Option<Self> {
@@ -148,7 +156,9 @@ impl FromStr for Round {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, RlpEncodable)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize, RlpEncodable,
+)]
 // A non-empty span of rounds
 pub struct RoundSpan {
     pub start: Round, // inclusive
@@ -188,8 +198,19 @@ impl RoundSpan {
     pub fn contains(&self, round: Round) -> bool {
         self.start <= round && round < self.end
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = Round> {
+        (self.start.0..self.end.0).map(Round)
+    }
+
     pub fn overlaps(&self, other: &RoundSpan) -> bool {
         self.start < other.end && other.start < self.end
+    }
+
+    // Clamp `start` up to `lower`. Returns None if the resulting span
+    // would be empty.
+    pub fn clamp_below(self, lower: Round) -> Option<Self> {
+        RoundSpan::new(self.start.max(lower), self.end)
     }
 }
 
@@ -1110,6 +1131,15 @@ mod test {
 
         let decoded = RoundSpan::decode(&mut buf.as_slice()).unwrap();
         assert_eq!(span, decoded);
+    }
+
+    #[test]
+    fn test_round_span_iter() {
+        let span = RoundSpan::new(Round(10), Round(13)).unwrap();
+        assert_eq!(
+            span.iter().collect::<Vec<_>>(),
+            vec![Round(10), Round(11), Round(12)]
+        );
     }
 
     #[test]

--- a/monad-updaters/src/local_router.rs
+++ b/monad-updaters/src/local_router.rs
@@ -196,6 +196,7 @@ where
                 RouterCommand::UpdatePeers { .. } => {}
                 RouterCommand::GetFullNodes => {}
                 RouterCommand::UpdateFullNodes { .. } => {}
+                RouterCommand::ProposerScheduleResponse { .. } => {}
             }
         }
     }

--- a/monad-validator/src/epoch_manager.rs
+++ b/monad-validator/src/epoch_manager.rs
@@ -88,6 +88,18 @@ impl EpochManager {
 
         epoch_start.map(|(&epoch, _)| epoch)
     }
+
+    /// Like get_epoch, but only returns a value when the answer is guaranteed
+    /// to be stable against future schedule_epoch_start insertions.
+    pub fn get_stable_epoch(&self, round: Round) -> Option<Epoch> {
+        let (_, &max_start) = self.epoch_starts.last_key_value()?;
+        let stable_horizon = max_start.saturating_add(Round(self.epoch_length.0));
+        if round < stable_horizon {
+            self.get_epoch(round)
+        } else {
+            None
+        }
+    }
 }
 
 #[cfg(test)]
@@ -137,5 +149,56 @@ mod tests {
         assert_eq!(epoch_manager.epoch_starts.get(&Epoch(2)), Some(&Round(104)));
         assert_eq!(epoch_manager.get_epoch(Round(103)), Some(Epoch(1)));
         assert_eq!(epoch_manager.get_epoch(Round(104)), Some(Epoch(2)));
+    }
+
+    #[test]
+    fn get_stable_epoch() {
+        // Empty manager: never stable.
+        let empty = EpochManager::new(SeqNum(10), Round(3), &[]);
+        assert_eq!(empty.get_stable_epoch(Round(0)), None);
+        assert_eq!(empty.get_stable_epoch(Round(100)), None);
+
+        // Latest start = Round(20), epoch_length = 10 -> horizon = Round(30).
+        let mut em = EpochManager::new(
+            SeqNum(10),
+            Round(3),
+            &[
+                (Epoch(1), Round(5)),
+                (Epoch(2), Round(12)),
+                (Epoch(3), Round(20)),
+            ],
+        );
+
+        // Below the lowest known start: None.
+        assert_eq!(em.get_stable_epoch(Round(4)), None);
+        // Inside the horizon: matches get_epoch.
+        assert_eq!(em.get_stable_epoch(Round(5)), Some(Epoch(1)));
+        assert_eq!(em.get_stable_epoch(Round(11)), Some(Epoch(1)));
+        assert_eq!(em.get_stable_epoch(Round(12)), Some(Epoch(2)));
+        assert_eq!(em.get_stable_epoch(Round(19)), Some(Epoch(2)));
+        assert_eq!(em.get_stable_epoch(Round(20)), Some(Epoch(3)));
+        assert_eq!(em.get_stable_epoch(Round(29)), Some(Epoch(3)));
+        // At or above the horizon: None.
+        assert_eq!(em.get_epoch(Round(30)), Some(Epoch(3)));
+        assert_eq!(em.get_stable_epoch(Round(30)), None);
+        assert_eq!(em.get_epoch(Round(1000)), Some(Epoch(3)));
+        assert_eq!(em.get_stable_epoch(Round(1000)), None);
+
+        // Capture a stable answer to check invariance after a future insert.
+        let stable_query = Round(29);
+        let before = em.get_stable_epoch(stable_query);
+        assert_eq!(before, Some(Epoch(3)));
+
+        // Boundary block of E3 at block_round=29 -> schedules E4 at Round(32).
+        // New horizon = Round(42).
+        em.schedule_epoch_start(SeqNum(29), Round(29));
+        assert_eq!(em.get_stable_epoch(Round(30)), Some(Epoch(3)));
+        assert_eq!(em.get_stable_epoch(Round(31)), Some(Epoch(3)));
+        assert_eq!(em.get_stable_epoch(Round(32)), Some(Epoch(4)));
+        assert_eq!(em.get_stable_epoch(Round(41)), Some(Epoch(4)));
+        assert_eq!(em.get_stable_epoch(Round(42)), None);
+
+        // Previously stable answer is unchanged.
+        assert_eq!(em.get_stable_epoch(stable_query), before);
     }
 }

--- a/monad-validator/src/validators_epoch_mapping.rs
+++ b/monad-validator/src/validators_epoch_mapping.rs
@@ -54,6 +54,10 @@ where
         }
     }
 
+    pub fn contains_epoch(&self, epoch: &Epoch) -> bool {
+        self.validator_map.contains_key(epoch)
+    }
+
     pub fn get_val_set(&self, epoch: &Epoch) -> Option<&VTF::ValidatorSetType> {
         self.validator_map.get(epoch).map(|(val_set, _)| val_set)
     }


### PR DESCRIPTION
This PR gives raptorcast access to legitimate proposers for a span of rounds. Raptorcast uses this info to validate the author of the chunks in deterministic raptorcast.

fixes: https://github.com/category-labs/monad-bft/issues/3063; depends on https://github.com/category-labs/monad-bft/issues/3068.