### PR TITLE
fix(rpc): correct OpenRPC optional param flags

### DIFF
--- a/monad-rpc/src/docs.rs
+++ b/monad-rpc/src/docs.rs
@@ -37,12 +37,13 @@ pub fn as_openrpc() -> OpenRpc {
             let mut in_sub_schema: schemars::schema::Schema = in_schema.schema.into();
             monad_rpc_docs::clean_schema_refs(&mut in_sub_schema);
 
-            let inputs = in_sub_schema
+            let input_object = in_sub_schema
                 .clone()
                 .into_object()
-                .object()
-                .clone()
-                .properties;
+                .object
+                .unwrap_or_default();
+            let required_fields = input_object.required;
+            let inputs = input_object.properties;
 
             for (k, v) in &inputs {
                 components
@@ -54,7 +55,7 @@ pub fn as_openrpc() -> OpenRpc {
                 let param = monad_rpc_docs::Params {
                     name: k.clone(),
                     description: "".to_string(),
-                    required: true,
+                    required: required_fields.contains(&k),
                     schema: v.clone(),
                 };
                 params.push(param);


### PR DESCRIPTION
## Backstory

While investigating why the public JSON-RPC docs marked the `debug_trace*` trace options object as required, I found that the downstream docs were faithfully rendering the generated OpenRPC method params from `monad-bft`. Runtime behavior and the component schemas both show those trace options are defaulted/optional, so the source-of-truth fix belongs in the OpenRPC generator rather than as a docs-side special case.

## Summary

Fix the OpenRPC generator so flattened method params inherit requiredness from the schemars input object schema instead of always emitting `required: true`.

## Reasoning

The component schemas already encode serde/default optionality correctly. The OpenRPC method params were diverging because `monad-rpc/src/docs.rs` hardcoded every flattened input property as required, which caused downstream docs generated from OpenRPC to mark defaulted JSON-RPC params as required.

## Implementation

The generator now extracts the input object's `required` set and uses `required_fields.contains(&param_name)` when building each OpenRPC method param. This keeps truly required params required while allowing defaulted/optional params to render as optional.

Expected generated OpenRPC required-flag corrections include:

- `debug_traceBlockByHash.tracer`
- `debug_traceBlockByNumber.tracer`
- `debug_traceTransaction.tracer`
- `debug_traceCall.block`
- `eth_call.block`
- `eth_createAccessList.block`
- `eth_estimateGas.block`
- `eth_feeHistory.reward_percentiles`
- `eth_sendRawTransactionSync.timeout_ms`

## Verification

- Generated OpenRPC with `cargo run --bin monad-rpc-docs --quiet | jq . > /tmp/monad-openrpc-fixed.json`
- Confirmed required IDs/options such as `debug_traceCall.tracer` remain required
- Confirmed defaulted params above now emit `required: false`
- Verified runtime behavior by sending JSON-RPC requests to Monad RPC nodes with omitted/defaulted params
- Validated the generated artifact with `check-jsonschema` against the OpenRPC meta-schema