### PR TITLE
Add NodeId map data-structure benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5938,6 +5938,7 @@ dependencies = [
  "monad-crypto",
  "monad-eth-types",
  "monad-testutil",
+ "monad-types",
  "proptest",
  "rand 0.8.5",
  "rstest",

--- a/monad-secp/Cargo.toml
+++ b/monad-secp/Cargo.toml
@@ -26,6 +26,7 @@ zeroize = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 monad-testutil = { workspace = true }
+monad-types = { workspace = true }
 
 alloy-consensus = { workspace = true, features = ["k256"] }
 alloy-signer = { workspace = true }
@@ -41,4 +42,8 @@ wycheproof = { workspace = true }
 
 [[bench]]
 name = "secp"
+harness = false
+
+[[bench]]
+name = "nodeid_map"
 harness = false

--- a/monad-secp/benches/nodeid_map.rs
+++ b/monad-secp/benches/nodeid_map.rs
@@ -1,0 +1,387 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    hint::black_box,
+};
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use monad_secp::{PubKey, SecpSignature};
+use monad_testutil::signing::create_keys;
+use monad_types::NodeId;
+use rand::{seq::SliceRandom, thread_rng};
+
+type SignatureType = SecpSignature;
+type Key = NodeId<PubKey>;
+
+const SIZES: &[usize] = &[200, 250, 300];
+
+fn make_keys(n: usize) -> Vec<Key> {
+    create_keys::<SignatureType>(n as u32)
+        .iter()
+        .map(|kp| NodeId::new(kp.pubkey()))
+        .collect()
+}
+
+fn make_miss_keys(n: usize, offset: u32) -> Vec<Key> {
+    (0..n)
+        .map(|i| {
+            let kp = monad_testutil::signing::get_key::<SignatureType>(offset as u64 + i as u64);
+            NodeId::new(kp.pubkey())
+        })
+        .collect()
+}
+
+fn make_sorted_vec(keys: &[Key]) -> Vec<(Key, u64)> {
+    let mut v: Vec<(Key, u64)> = keys
+        .iter()
+        .enumerate()
+        .map(|(i, k)| (*k, i as u64))
+        .collect();
+    v.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    v
+}
+
+fn bench_lookup_hit(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lookup_hit");
+    for &n in SIZES {
+        let keys = make_keys(n);
+        let hashmap: HashMap<Key, u64> = keys
+            .iter()
+            .enumerate()
+            .map(|(i, k)| (*k, i as u64))
+            .collect();
+        let btreemap: BTreeMap<Key, u64> = keys
+            .iter()
+            .enumerate()
+            .map(|(i, k)| (*k, i as u64))
+            .collect();
+        let sortedvec = make_sorted_vec(&keys);
+
+        // Shuffle a lookup sequence so we don't bias toward insertion order.
+        let mut shuffled = keys.clone();
+        shuffled.shuffle(&mut thread_rng());
+
+        group.bench_function(format!("hashmap/{}", n), |b| {
+            let mut idx = 0usize;
+            b.iter(|| {
+                let k = &shuffled[idx % shuffled.len()];
+                idx = idx.wrapping_add(1);
+                black_box(hashmap.get(k))
+            })
+        });
+
+        group.bench_function(format!("btreemap/{}", n), |b| {
+            let mut idx = 0usize;
+            b.iter(|| {
+                let k = &shuffled[idx % shuffled.len()];
+                idx = idx.wrapping_add(1);
+                black_box(btreemap.get(k))
+            })
+        });
+
+        group.bench_function(format!("sortedvec_binsearch/{}", n), |b| {
+            let mut idx = 0usize;
+            b.iter(|| {
+                let k = &shuffled[idx % shuffled.len()];
+                idx = idx.wrapping_add(1);
+                let r = sortedvec
+                    .binary_search_by(|(kk, _)| kk.cmp(k))
+                    .map(|i| &sortedvec[i].1)
+                    .ok();
+                black_box(r)
+            })
+        });
+
+        // sortedvec_linear: same sorted Vec storage as sortedvec_binsearch,
+        // but lookup is a linear scan with Eq. This shines because PubKey's
+        // Eq runs eq_fast_unstable on the internal 64-byte buffer, whereas
+        // Ord (used by binary_search) goes through the secp256k1_ec_pubkey_cmp
+        // FFI call.
+        group.bench_function(format!("sortedvec_linear/{}", n), |b| {
+            let mut idx = 0usize;
+            b.iter(|| {
+                let k = &shuffled[idx % shuffled.len()];
+                idx = idx.wrapping_add(1);
+                let r = sortedvec.iter().find(|(kk, _)| kk == k).map(|(_, v)| v);
+                black_box(r)
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_lookup_miss(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lookup_miss");
+    for &n in SIZES {
+        let keys = make_keys(n);
+        // Disjoint key set (offset by 1_000_000 from validator seeds).
+        let misses = make_miss_keys(n, 1_000_000);
+
+        let hashmap: HashMap<Key, u64> = keys
+            .iter()
+            .enumerate()
+            .map(|(i, k)| (*k, i as u64))
+            .collect();
+        let btreemap: BTreeMap<Key, u64> = keys
+            .iter()
+            .enumerate()
+            .map(|(i, k)| (*k, i as u64))
+            .collect();
+        let sortedvec = make_sorted_vec(&keys);
+
+        group.bench_function(format!("hashmap/{}", n), |b| {
+            let mut idx = 0usize;
+            b.iter(|| {
+                let k = &misses[idx % misses.len()];
+                idx = idx.wrapping_add(1);
+                black_box(hashmap.get(k))
+            })
+        });
+
+        group.bench_function(format!("btreemap/{}", n), |b| {
+            let mut idx = 0usize;
+            b.iter(|| {
+                let k = &misses[idx % misses.len()];
+                idx = idx.wrapping_add(1);
+                black_box(btreemap.get(k))
+            })
+        });
+
+        group.bench_function(format!("sortedvec_binsearch/{}", n), |b| {
+            let mut idx = 0usize;
+            b.iter(|| {
+                let k = &misses[idx % misses.len()];
+                idx = idx.wrapping_add(1);
+                let r = sortedvec
+                    .binary_search_by(|(kk, _)| kk.cmp(k))
+                    .map(|i| &sortedvec[i].1)
+                    .ok();
+                black_box(r)
+            })
+        });
+
+        group.bench_function(format!("sortedvec_linear/{}", n), |b| {
+            let mut idx = 0usize;
+            b.iter(|| {
+                let k = &misses[idx % misses.len()];
+                idx = idx.wrapping_add(1);
+                let r = sortedvec.iter().find(|(kk, _)| kk == k).map(|(_, v)| v);
+                black_box(r)
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_contains_random(c: &mut Criterion) {
+    // 50/50 hit/miss mix to approximate a "is this peer in my validator set" probe
+    // where some lookups land outside the set.
+    let mut group = c.benchmark_group("contains_50_50");
+    for &n in SIZES {
+        let keys = make_keys(n);
+        let misses = make_miss_keys(n, 2_000_000);
+        let hashmap: HashMap<Key, u64> = keys
+            .iter()
+            .enumerate()
+            .map(|(i, k)| (*k, i as u64))
+            .collect();
+        let btreemap: BTreeMap<Key, u64> = keys
+            .iter()
+            .enumerate()
+            .map(|(i, k)| (*k, i as u64))
+            .collect();
+        let sortedvec = make_sorted_vec(&keys);
+
+        let mut probe: Vec<Key> = keys.iter().chain(misses.iter()).copied().collect();
+        probe.shuffle(&mut thread_rng());
+
+        group.bench_function(format!("hashmap/{}", n), |b| {
+            let mut idx = 0usize;
+            b.iter(|| {
+                let k = &probe[idx % probe.len()];
+                idx = idx.wrapping_add(1);
+                black_box(hashmap.contains_key(k))
+            })
+        });
+        group.bench_function(format!("btreemap/{}", n), |b| {
+            let mut idx = 0usize;
+            b.iter(|| {
+                let k = &probe[idx % probe.len()];
+                idx = idx.wrapping_add(1);
+                black_box(btreemap.contains_key(k))
+            })
+        });
+
+        group.bench_function(format!("sortedvec_binsearch/{}", n), |b| {
+            let mut idx = 0usize;
+            b.iter(|| {
+                let k = &probe[idx % probe.len()];
+                idx = idx.wrapping_add(1);
+                black_box(sortedvec.binary_search_by(|(kk, _)| kk.cmp(k)).is_ok())
+            })
+        });
+
+        group.bench_function(format!("sortedvec_linear/{}", n), |b| {
+            let mut idx = 0usize;
+            b.iter(|| {
+                let k = &probe[idx % probe.len()];
+                idx = idx.wrapping_add(1);
+                black_box(sortedvec.iter().any(|(kk, _)| kk == k))
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_iter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("iter_sum");
+    for &n in SIZES {
+        let keys = make_keys(n);
+        let hashmap: HashMap<Key, u64> = keys
+            .iter()
+            .enumerate()
+            .map(|(i, k)| (*k, i as u64))
+            .collect();
+        let btreemap: BTreeMap<Key, u64> = keys
+            .iter()
+            .enumerate()
+            .map(|(i, k)| (*k, i as u64))
+            .collect();
+
+        group.bench_function(format!("hashmap/{}", n), |b| {
+            b.iter(|| {
+                let mut s = 0u64;
+                for (_, v) in hashmap.iter() {
+                    s = s.wrapping_add(*v);
+                }
+                black_box(s)
+            })
+        });
+
+        group.bench_function(format!("btreemap/{}", n), |b| {
+            b.iter(|| {
+                let mut s = 0u64;
+                for (_, v) in btreemap.iter() {
+                    s = s.wrapping_add(*v);
+                }
+                black_box(s)
+            })
+        });
+
+        let sortedvec = make_sorted_vec(&keys);
+        group.bench_function(format!("sortedvec_binsearch/{}", n), |b| {
+            b.iter(|| {
+                let mut s = 0u64;
+                for (_, v) in sortedvec.iter() {
+                    s = s.wrapping_add(*v);
+                }
+                black_box(s)
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_clone(c: &mut Criterion) {
+    let mut group = c.benchmark_group("clone");
+    for &n in SIZES {
+        let keys = make_keys(n);
+        let hashmap: HashMap<Key, u64> = keys
+            .iter()
+            .enumerate()
+            .map(|(i, k)| (*k, i as u64))
+            .collect();
+        let btreemap: BTreeMap<Key, u64> = keys
+            .iter()
+            .enumerate()
+            .map(|(i, k)| (*k, i as u64))
+            .collect();
+
+        group.bench_function(format!("hashmap/{}", n), |b| {
+            b.iter(|| black_box(hashmap.clone()))
+        });
+        group.bench_function(format!("btreemap/{}", n), |b| {
+            b.iter(|| black_box(btreemap.clone()))
+        });
+
+        let sortedvec = make_sorted_vec(&keys);
+        group.bench_function(format!("sortedvec_binsearch/{}", n), |b| {
+            b.iter(|| black_box(sortedvec.clone()))
+        });
+    }
+    group.finish();
+}
+
+fn bench_build_from_iter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("build_from_iter");
+    for &n in SIZES {
+        let keys = make_keys(n);
+        let pairs: Vec<(Key, u64)> = keys
+            .iter()
+            .enumerate()
+            .map(|(i, k)| (*k, i as u64))
+            .collect();
+
+        group.bench_function(format!("hashmap/{}", n), |b| {
+            b.iter_batched(
+                || pairs.clone(),
+                |p| {
+                    let m: HashMap<Key, u64> = p.into_iter().collect();
+                    black_box(m)
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        group.bench_function(format!("btreemap/{}", n), |b| {
+            b.iter_batched(
+                || pairs.clone(),
+                |p| {
+                    let m: BTreeMap<Key, u64> = p.into_iter().collect();
+                    black_box(m)
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        // Sorted Vec build: collect + sort. Both sortedvec_binsearch and
+        // sortedvec_linear share this storage, so it has the same build
+        // cost; no separate arms.
+        group.bench_function(format!("sortedvec_binsearch/{}", n), |b| {
+            b.iter_batched(
+                || pairs.clone(),
+                |mut p| {
+                    p.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+                    black_box(p)
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_build_from_iter,
+    bench_lookup_hit,
+    bench_lookup_miss,
+    bench_contains_random,
+    bench_iter,
+    bench_clone,
+);
+criterion_main!(benches);


### PR DESCRIPTION
Add NodeId map data-structure benchmark

Compares four data structures keyed by NodeId<SecpPubkey> at validator-
set sizes N=200, 250, 300

Candidates:
- hashmap:             std::collections::HashMap<NodeId, T>
- btreemap:            std::collections::BTreeMap<NodeId, T>
- sortedvec_binsearch: Vec<(NodeId, T)> sorted by NodeId, looked up via
                       binary_search_by (uses Ord)
- sortedvec_linear:    same sorted Vec storage as sortedvec_binsearch,
                       looked up via iter().find with `==` (uses Eq)

CPU Info
========
```
AMD Ryzen 9 7950X 16-Core Processor @ 4.5GHz
Flags: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good amd_lbr_v2 nopl xtopology nonstop_tsc cpuid extd_apicid aperfmperf rapl pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpuid_fault cpb cat_l3 cdp_l3 hw_pstate ssbd mba perfmon_v2 ibrs ibpb stibp ibrs_enhanced vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local user_shstk avx512_bf16 clzero irperf xsaveerptr rdpru wbnoinvd cppc arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic vgif x2avic v_spec_ctrl vnmi avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntdq rdpid overflow_recov succor smca fsrm flush_l1d amd_lbr_pmc_freeze
```

Criterion 0.8 defaults: warm-up 3s, measurement 5s, 100 samples per case.

Speedup in parentheses is relative to hashmap (>1× = faster than
hashmap, <1× = slower).

## build_from_iter (FromIterator from owned Vec<(K, V)>)

| N   | hashmap           | btreemap            | sortedvec_binsearch |
|-----|-------------------|---------------------|---------------------|
| 200 | 5.669 us  (1.00×) | 76.072 us  (0.07×)  | 71.172 us  (0.08×)  |
| 250 | 11.869 us (1.00×) | 100.224 us (0.12×)  | 94.239 us  (0.13×)  |
| 300 | 9.334 us  (1.00×) | 124.883 us (0.07×)  | 122.118 us (0.08×)  |

(sortedvec_linear shares storage with sortedvec_binsearch; same build cost.)

## lookup_hit (get(), key present)

| N   | hashmap          | btreemap          | sortedvec_binsearch | sortedvec_linear  |
|-----|------------------|-------------------|---------------------|-------------------|
| 200 | 22.63 ns (1.00×) | 509.04 ns (0.04×) | 415.09 ns (0.05×)   | 66.63 ns  (0.34×) |
| 250 | 23.14 ns (1.00×) | 544.45 ns (0.04×) | 415.95 ns (0.06×)   | 105.29 ns (0.22×) |
| 300 | 23.29 ns (1.00×) | 532.35 ns (0.04×) | 460.02 ns (0.05×)   | 126.15 ns (0.18×) |

## lookup_miss (get(), key absent)

| N   | hashmap          | btreemap          | sortedvec_binsearch | sortedvec_linear  |
|-----|------------------|-------------------|---------------------|-------------------|
| 200 | 22.67 ns (1.00×) | 539.99 ns (0.04×) | 396.72 ns (0.06×)   | 120.97 ns (0.19×) |
| 250 | 22.36 ns (1.00×) | 587.55 ns (0.04×) | 397.27 ns (0.06×)   | 147.19 ns (0.15×) |
| 300 | 22.47 ns (1.00×) | 577.76 ns (0.04×) | 442.02 ns (0.05×)   | 176.11 ns (0.13×) |

## contains_50_50 (50/50 hit/miss probe set, shuffled)

| N   | hashmap          | btreemap          | sortedvec_binsearch | sortedvec_linear  |
|-----|------------------|-------------------|---------------------|-------------------|
| 200 | 23.33 ns (1.00×) | 514.83 ns (0.05×) | 405.20 ns (0.06×)   | 93.14 ns  (0.25×) |
| 250 | 25.63 ns (1.00×) | 551.74 ns (0.05×) | 405.50 ns (0.06×)   | 146.29 ns (0.18×) |
| 300 | 25.65 ns (1.00×) | 556.68 ns (0.05×) | 451.45 ns (0.06×)   | 137.41 ns (0.19×) |

## iter_sum (full iteration, sum values)

| N   | hashmap           | btreemap          | sortedvec_binsearch |
|-----|-------------------|-------------------|---------------------|
| 200 | 96.10 ns  (1.00×) | 207.62 ns (0.46×) | 24.04 ns (4.00×)    |
| 250 | 121.18 ns (1.00×) | 258.85 ns (0.47×) | 29.85 ns (4.06×)    |
| 300 | 145.32 ns (1.00×) | 317.53 ns (0.46×) | 35.05 ns (4.15×)    |

## clone (full clone of populated container)

| N   | hashmap           | btreemap            | sortedvec_binsearch |
|-----|-------------------|---------------------|---------------------|
| 200 | 309.14 ns (1.00×) | 666.40 ns  (0.46×)  | 124.46 ns (2.48×)   |
| 250 | 587.66 ns (1.00×) | 990.85 ns  (0.59×)  | 244.56 ns (2.40×)   |
| 300 | 584.67 ns (1.00×) | 1167.95 ns (0.50×)  | 330.51 ns (1.77×)   |

This code was generated using Claude Opus 4.7.
