### PR TITLE
Emit UpdateCurrentRound on boot

### DIFF
--- a/monad-raptorcast/examples/latency.rs
+++ b/monad-raptorcast/examples/latency.rs
@@ -675,7 +675,6 @@ fn setup_node(
         non_authenticated_socket,
         dataplane_control,
         Arc::new(std::sync::Mutex::new(pd)),
-        Epoch(0),
     );
 
     raptorcast.exec(vec![RouterCommand::AddEpochValidatorSet {

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -183,7 +183,6 @@ where
         non_authenticated_socket: UdpSocketHandle,
         control: DataplaneControl,
         peer_discovery_driver: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
-        current_epoch: Epoch,
     ) -> Self {
         let (tcp_reader, tcp_writer) = tcp_socket.split();
 
@@ -290,10 +289,8 @@ where
             message_builder,
             secondary_message_builder: Some(secondary_message_builder),
 
-            // TODO: call UpdateCurrentRound instead of pass in
-            // current_{epoch,round} as argument to allow downstream
-            // components to initialize appropriately.
-            current_epoch,
+            // Updated by the first RouterCommand::UpdateCurrentRound.
+            current_epoch: Epoch(0),
 
             udp_state,
             v1_rollout: config.deterministic_protocol_rollout,
@@ -436,17 +433,13 @@ where
         let mut sink = DualUdpPacketSender::new(&mut self.dual_socket, &self.peer_discovery_driver);
 
         match outbound_msg {
-            SecondaryOutboundMessage::SendSingle {
-                msg_bytes,
-                dest,
-                epoch,
-            } => {
+            SecondaryOutboundMessage::SendSingle { msg_bytes, dest } => {
                 trace!(
                     ?dest,
                     msg_len = msg_bytes.len(),
                     "raptorcastprimary handling single message from secondary"
                 );
-                let build_target = BuildTarget::point_to_point(epoch, &dest);
+                let build_target = BuildTarget::point_to_point(self.current_epoch, &dest);
                 builder
                     .build_into(&msg_bytes, &build_target, &mut sink)
                     .unwrap_log_on_error(&msg_bytes, &build_target)
@@ -838,7 +831,6 @@ where
         dataplane.non_authenticated_socket,
         dataplane.control,
         shared_pd,
-        Epoch(0),
     )
 }
 
@@ -903,7 +895,6 @@ where
         dataplane.non_authenticated_socket,
         dataplane.control,
         shared_pd,
-        Epoch(0),
     )
 }
 

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -61,7 +61,6 @@ pub enum SecondaryOutboundMessage<PT: PubKey> {
     SendSingle {
         msg_bytes: bytes::Bytes,
         dest: NodeId<PT>,
-        epoch: Epoch,
     },
     SendToGroup {
         msg_bytes: bytes::Bytes,
@@ -92,8 +91,6 @@ where
     // Represents only the group logic, excluding everything network related.
     role: Role<ST>,
 
-    curr_epoch: Epoch,
-
     peer_discovery_driver: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
 
     channel_from_primary: UnboundedReceiver<FullNodesGroupMessage<ST>>,
@@ -123,7 +120,6 @@ where
         channel_to_primary_outbound: UnboundedSender<
             SecondaryOutboundMessage<CertificateSignaturePubKey<ST>>,
         >,
-        current_epoch: Epoch,
     ) -> Self {
         let node_id = NodeId::new(config.shared_key.pubkey());
 
@@ -148,7 +144,6 @@ where
 
         Self {
             role,
-            curr_epoch: current_epoch,
             peer_discovery_driver,
             channel_from_primary,
             channel_to_primary_outbound,
@@ -180,7 +175,6 @@ where
         let outbound = SecondaryOutboundMessage::SendSingle {
             msg_bytes,
             dest: dest_node,
-            epoch: self.curr_epoch,
         };
         if let Err(err) = self.channel_to_primary_outbound.send(outbound) {
             error!(?err, "failed to send message to primary");
@@ -299,7 +293,6 @@ where
                             ?round,
                             "RaptorCastSecondary UpdateCurrentRound (Publisher)"
                         );
-                        self.curr_epoch = epoch;
                         // The publisher needs to be periodically informed about new nodes out there,
                         // so that it can randomize when creating new groups.
                         let full_nodes = self

--- a/monad-raptorcast/tests/wireauth_raptorcast.rs
+++ b/monad-raptorcast/tests/wireauth_raptorcast.rs
@@ -256,7 +256,6 @@ fn spawn_noop_validator(
             dataplane.non_authenticated_socket,
             dataplane.control,
             shared_pd,
-            Epoch(0),
         );
 
         let mut cmd_rx = cmd_rx;
@@ -345,7 +344,6 @@ fn spawn_wireauth_validator(
             dataplane.non_authenticated_socket,
             dataplane.control,
             shared_pd,
-            Epoch(0),
         );
 
         let mut cmd_rx = cmd_rx;

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -163,7 +163,6 @@ where
             recv_group_messages,
             send_group_infos,
             send_outbound_to_primary,
-            current_epoch,
         );
 
         let mut rc_primary = RaptorCast::new(
@@ -175,7 +174,6 @@ where
             non_authenticated_socket,
             control,
             shared_pdd.clone(),
-            current_epoch,
         );
         rc_primary.bind_channel_to_secondary_raptorcast(
             secondary_mode,
@@ -222,7 +220,6 @@ where
             recv_group_messages,
             send_group_infos,
             send_outbound_to_primary,
-            current_epoch,
         );
         self.rc_secondary = rc_secondary;
     }
@@ -236,7 +233,6 @@ where
         channel_to_primary_outbound: UnboundedSender<
             SecondaryOutboundMessage<CertificateSignaturePubKey<ST>>,
         >,
-        current_epoch: Epoch,
     ) -> Option<RaptorCastSecondary<ST, M, OM, SE, PD>> {
         let secondary_instance: RaptorCastConfigSecondary<CertificateSignaturePubKey<ST>> =
             match mode {
@@ -303,7 +299,6 @@ where
                 recv_group_messages,
                 send_group_infos,
                 channel_to_primary_outbound,
-                current_epoch,
             )),
         }
     }

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1574,12 +1574,20 @@ where
             high_certificate.clone(),
         );
         let current_round = consensus.get_current_round();
+        let current_epoch = consensus.get_current_epoch();
         tracing::info!(
             ?root_info,
             ?high_certificate,
             "done syncing, initializing consensus"
         );
         self.consensus = ConsensusMode::Live(consensus);
+        // Pacemaker emits EnterRound only on a strictly higher
+        // certificate, seed RaptorCast/PeerDiscovery/etc with the
+        // bootstrap round here.
+        commands.push(Command::RouterCommand(RouterCommand::UpdateCurrentRound(
+            current_epoch,
+            current_round,
+        )));
         commands.push(Command::StateSyncCommand(StateSyncCommand::StartExecution));
         // technically we should be waiting for the vote pacing timer
         // to expire before we set scheduled_vote to TimerFired

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -46,7 +46,7 @@ use monad_raptorcast::{
 };
 use monad_state::{Forkpoint, MonadMessage, MonadState, MonadStateBuilder, VerifiedMonadMessage};
 use monad_state_backend::InMemoryState;
-use monad_types::{Epoch, ExecutionProtocol, NodeId, Round, SeqNum};
+use monad_types::{ExecutionProtocol, NodeId, Round, SeqNum};
 use monad_updaters::{
     config_file::MockConfigFile, config_loader::MockConfigLoader, ledger::MockLedger,
     local_router::LocalPeerRouter, loopback::LoopbackExecutor, parent::ParentExecutor,
@@ -202,7 +202,6 @@ where
                     non_authenticated_socket,
                     control,
                     shared_peer_discovery_driver,
-                    Epoch(0),
                 ))
             }
         },


### PR DESCRIPTION
- [x] verify that the rounds emitted by any `UpdateCurrentRound` command remain strictly monotonic
- [x] verify that all handlers of `UpdateCurrentRound` can support the change:
  + [x] `RaptorCast::exec`
  + [x] `RaptorCastSecondary::exec`
  + [x] `MultiRouter::exec`
  + [x] `PeerDiscoveryDriver::update`

implements https://github.com/category-labs/monad-bft/issues/3068.