### PR TITLE
fix(rpc): align debug_traceCall params with geth

### DIFF
--- a/monad-rpc/src/handlers/eth/call.rs
+++ b/monad-rpc/src/handlers/eth/call.rs
@@ -478,8 +478,8 @@ pub struct EnrichedTracerObject {
 #[derive(Debug, Deserialize, schemars::JsonSchema, Clone)]
 pub struct MonadDebugTraceCallParams {
     transaction: CallRequest,
-    #[serde(default)]
     block: BlockTagOrHash,
+    #[serde(default)]
     tracer: EnrichedTracerObject,
 }
 
@@ -1226,6 +1226,43 @@ mod tests {
         let params: MonadDebugTraceCallParams = from_str(raw).unwrap();
 
         assert_eq!(params.tracer.tracer_params.tracer, Tracer::PreStateTracer);
+    }
+
+    #[test]
+    fn parse_trace_call_request_with_default_tracer() {
+        let raw = r#"
+        [
+          {
+            "from": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+            "to": "0x0000000000a39bb272e79075ade125fd351887ac",
+            "gas": "0x1E9EF",
+            "gasPrice": "0xBD32B2ABC",
+            "data": "0xd0e30db0"
+          },
+          "latest"
+        ]
+        "#;
+
+        let params: MonadDebugTraceCallParams = from_str(raw).unwrap();
+
+        assert_eq!(params.tracer.tracer_params.tracer, Tracer::CallTracer);
+    }
+
+    #[test]
+    fn parse_trace_call_request_requires_block() {
+        let raw = r#"
+        [
+          {
+            "from": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+            "to": "0x0000000000a39bb272e79075ade125fd351887ac",
+            "gas": "0x1E9EF",
+            "gasPrice": "0xBD32B2ABC",
+            "data": "0xd0e30db0"
+          }
+        ]
+        "#;
+
+        assert!(from_str::<MonadDebugTraceCallParams>(raw).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

While working on the debug trace docs, I noticed that Monad's `debug_traceCall` shape does not line up with Geth or the other Ethereum-style RPC providers I checked.

Right now, Monad effectively treats the `tracer` / options object as required and the `block` argument as optional. The Geth-style shape is:

```text
debug_traceCall(transaction, blockNrOrHash, [options])
```

So this PR changes `debug_traceCall` to match that shape:

- `transaction` is required
- `block` is required
- `tracer` / options is optional and defaults to `callTracer`

This also makes `debug_traceCall` consistent with the nearby trace methods, where the tracer config is already optional:

- `debug_traceBlockByHash`
- `debug_traceBlockByNumber`
- `debug_traceTransaction`

## Breaking change

This does tighten one bit of existing Monad behavior.

Before this PR, callers could omit the `block` argument and Monad would default it to `latest`. After this PR, callers need to pass the block argument explicitly, which matches the Geth-style API shape.

I think this is the right direction for Ethereum compatibility and for the docs I am generating, but I want to flag it clearly for review. If the team feels strongly that we should preserve Monad's existing block default for compatibility, we can keep `block` optional and only make the tracer/options object optional.

## Validation

- `cargo fmt -p monad-rpc`
- `cargo check -p monad-rpc --tests`
- Generated OpenRPC locally and confirmed `debug_traceCall` now marks `transaction` and `block` as required, with `tracer` optional
