### PR TITLE
run ci on all pull requests

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,7 +2,6 @@ name: Benchmark Regression Check
 
 on:
   pull_request:
-    branches: [ master ]
 
 jobs:
   benchmark:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: ["master"]
   pull_request:
-    branches: "*"
     types: [ opened, synchronize, reopened, edited ]
 
 concurrency:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -10,7 +10,6 @@ on:
     paths-ignore:
       - 'debian/**'
   pull_request:
-    branches: ["master"]
     types: [ opened, synchronize, reopened, edited ]
     paths-ignore:
       - 'debian/**'

--- a/.github/workflows/openrpc.yml
+++ b/.github/workflows/openrpc.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["master"]
   pull_request:
-    branches: ["master"]
     paths:
       - "monad-rpc/**"
       - ".github/workflows/openrpc.yml"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: ["master"]
   pull_request:
-    branches: "*"
     types: [ opened, synchronize, reopened, edited ]
 
 permissions:


### PR DESCRIPTION
turns out `branches: "*"` doesn't match branch names with `/` , so if base branch was as `dmitry/somethig-something` ci won't trigger. so it should either use ** or remove all matchers (which i did)