### PR TITLE
Code cleanup for deterministic secondary raptorcast

### DIFF
--- a/monad-raptorcast/src/packet/assigner.rs
+++ b/monad-raptorcast/src/packet/assigner.rs
@@ -58,6 +58,15 @@ where
     fn len(&self) -> usize;
 }
 
+pub(crate) trait Partition<PT>: OrderedNodes<PT>
+where
+    PT: PubKey,
+{
+    fn assign(&self, num_base_symbols: usize, redundancy: Redundancy) -> Result<ChunkAssignment>;
+
+    fn num_chunks_hint(&self, num_base_symbols: usize, redundancy: Redundancy) -> Option<usize>;
+}
+
 impl<PT> OrderedNodes<PT> for NodeId<PT>
 where
     PT: PubKey,
@@ -275,12 +284,8 @@ where
     }
 }
 
-impl<PT: PubKey> EvenPartition<PT> {
-    pub fn assign(
-        &self,
-        num_base_symbols: usize,
-        redundancy: Redundancy,
-    ) -> Result<ChunkAssignment> {
+impl<PT: PubKey> Partition<PT> for EvenPartition<PT> {
+    fn assign(&self, num_base_symbols: usize, redundancy: Redundancy) -> Result<ChunkAssignment> {
         let num_symbols = redundancy
             .scale(num_base_symbols)
             .ok_or(BuildError::TooManyChunks)?;
@@ -299,7 +304,7 @@ impl<PT: PubKey> EvenPartition<PT> {
         Ok(assignment)
     }
 
-    pub fn num_chunks(&self, num_base_symbols: usize, redundancy: Redundancy) -> Option<usize> {
+    fn num_chunks_hint(&self, num_base_symbols: usize, redundancy: Redundancy) -> Option<usize> {
         even_partition_num_chunks(num_base_symbols, redundancy)
     }
 }
@@ -352,6 +357,16 @@ pub fn stake_partition_num_chunks_hint(
     let num_validators = group_size.checked_sub(1)?; // exclude author
     let num_scaled_symbols = redundancy.scale(num_base_symbols)?;
     num_scaled_symbols.checked_add(num_validators)
+}
+
+impl<PT: PubKey> Partition<PT> for StakePartition<PT> {
+    fn assign(&self, num_base_symbols: usize, redundancy: Redundancy) -> Result<ChunkAssignment> {
+        self.assign(num_base_symbols, redundancy)
+    }
+
+    fn num_chunks_hint(&self, num_base_symbols: usize, redundancy: Redundancy) -> Option<usize> {
+        self.num_chunks_hint(num_base_symbols, redundancy)
+    }
 }
 
 impl<PT: PubKey> StakePartition<PT> {
@@ -533,7 +548,9 @@ mod tests {
     use rand_chacha::ChaCha20Rng;
     use rstest::rstest;
 
-    use super::{ChunkAssignment, EvenPartition, NodeIndex, OrderedNodes, StakePartition};
+    use super::{
+        ChunkAssignment, EvenPartition, NodeIndex, OrderedNodes, Partition, StakePartition,
+    };
     use crate::{
         packet::{assigner::stake_partition_num_chunks_hint, BuildError, Result},
         util::Redundancy,

--- a/monad-raptorcast/src/packet/deterministic.rs
+++ b/monad-raptorcast/src/packet/deterministic.rs
@@ -30,13 +30,13 @@ use monad_wireauth::messages::DataPacketHeader;
 use super::{
     assigner::{
         even_partition_num_chunks, stake_partition_num_chunks_hint, ChunkAssignment, EvenPartition,
-        StakePartition,
+        Partition, StakePartition,
     },
     Chunk,
 };
 use crate::{
     message::MAX_MESSAGE_SIZE,
-    packet::{assigner::OrderedNodes, BuildError},
+    packet::BuildError,
     util::{
         ensure, BroadcastMode, Collector, EncodingScheme, PrimaryBroadcastGroup, Redundancy,
         SecondaryBroadcastGroup, UdpMessage,
@@ -368,36 +368,30 @@ impl<PT: PubKey> InnerDeterministicEncoding<PT> {
     }
 }
 
-pub(crate) struct PrimaryEncoding<PT: PubKey> {
+pub(crate) struct DeterministicEncoding<PT: PubKey, P: Partition<PT>> {
     layout: PacketLayout,
     redundancy: Redundancy,
     app_message_len: usize,
-    partition: StakePartition<PT>,
+    partition: P,
+    _pd: std::marker::PhantomData<PT>,
 }
 
-impl<PT: PubKey> PrimaryEncoding<PT> {
-    pub fn new<'a>(
-        encoding_scheme: EncodingScheme,
-        group: &'a PrimaryBroadcastGroup<'a, PT>,
-        app_message_len: usize,
-        unix_ts_ms: u64,
-    ) -> Result<Self, BuildError> {
-        let EncodingScheme::Deterministic25(round) = encoding_scheme else {
-            return Err(BuildError::InvalidEncodingScheme);
-        };
+pub(crate) type PrimaryEncoding<PT> = DeterministicEncoding<PT, StakePartition<PT>>;
+pub(crate) type SecondaryEncoding<PT> = DeterministicEncoding<PT, EvenPartition<PT>>;
 
+impl<PT: PubKey, P: Partition<PT>> DeterministicEncoding<PT, P> {
+    // validate message size, find a merkle-tree depth that fits,
+    // shuffle the partition with the caller-derived seed.
+    fn build(app_message_len: usize, mut partition: P, seed: [u8; 32]) -> Result<Self, BuildError> {
         ensure!(app_message_len > 0, BuildError::AppMessageEmpty);
         ensure!(
             app_message_len <= MAX_MESSAGE_SIZE,
             BuildError::AppMessageTooLarge
         );
 
-        // Encoding scheme for Deterministic25
-        let mut partition = StakePartition::from_group(group);
         let redundancy = DEFAULT_REDUNDANCY;
         let segment_len = DEFAULT_SEGMENT_LEN;
 
-        // Search for optimal tree depth.
         let depth = optimal_merkle_tree_depth(|d| {
             let layout = PacketLayout::new(segment_len, d);
             let num_base_symbols = layout.num_base_symbols(app_message_len);
@@ -406,9 +400,6 @@ impl<PT: PubKey> PrimaryEncoding<PT> {
         .ok_or(BuildError::MerkleTreeTooDeep)?;
         let layout = PacketLayout::new(segment_len, depth);
 
-        // Shuffle the validator set
-        let author = group.author();
-        let seed = derive_seed(author, round, unix_ts_ms);
         partition.shuffle(seed);
 
         Ok(Self {
@@ -416,6 +407,7 @@ impl<PT: PubKey> PrimaryEncoding<PT> {
             layout,
             app_message_len,
             partition,
+            _pd: std::marker::PhantomData,
         })
     }
 
@@ -431,83 +423,44 @@ impl<PT: PubKey> PrimaryEncoding<PT> {
 
     pub fn make_assignment(&self) -> Result<ChunkAssignment, BuildError> {
         let num_base_symbols = self.layout.num_base_symbols(self.app_message_len);
-        let assignment = self.partition.assign(num_base_symbols, self.redundancy)?;
-        Ok(assignment)
+        self.partition.assign(num_base_symbols, self.redundancy)
     }
 
-    pub fn partition(&self) -> &StakePartition<PT> {
+    pub fn partition(&self) -> &P {
         &self.partition
     }
 }
 
-pub(crate) struct SecondaryEncoding<PT: PubKey> {
-    layout: PacketLayout,
-    redundancy: Redundancy,
-    app_message_len: usize,
-    partition: EvenPartition<PT>,
-}
-
-impl<PT: PubKey> SecondaryEncoding<PT> {
-    pub fn new<'a>(
+impl<PT: PubKey> PrimaryEncoding<PT> {
+    pub fn new(
         encoding_scheme: EncodingScheme,
-        group: &'a SecondaryBroadcastGroup<'a, PT>,
+        group: &PrimaryBroadcastGroup<'_, PT>,
         app_message_len: usize,
         unix_ts_ms: u64,
     ) -> Result<Self, BuildError> {
         let EncodingScheme::Deterministic25(round) = encoding_scheme else {
             return Err(BuildError::InvalidEncodingScheme);
         };
+        let partition = StakePartition::from_group(group);
+        let seed = derive_seed(group.author(), round, unix_ts_ms);
+        Self::build(app_message_len, partition, seed)
+    }
+}
 
-        ensure!(app_message_len > 0, BuildError::AppMessageEmpty);
-        ensure!(
-            app_message_len <= MAX_MESSAGE_SIZE,
-            BuildError::AppMessageTooLarge
-        );
-
-        let mut partition = EvenPartition::from_group(group);
-        let redundancy = DEFAULT_REDUNDANCY;
-        let segment_len = DEFAULT_SEGMENT_LEN;
-
-        // Search for optimal tree depth.
-        let depth = optimal_merkle_tree_depth(|d| {
-            let layout = PacketLayout::new(segment_len, d);
-            let num_base_symbols = layout.num_base_symbols(app_message_len);
-            partition.num_chunks(num_base_symbols, redundancy)
-        })
-        .ok_or(BuildError::MerkleTreeTooDeep)?;
-        let layout = PacketLayout::new(segment_len, depth);
-
-        // Shuffle the full-node group members.
-        // Seed derivation does not have to be the same as primary raptorcast
+impl<PT: PubKey> SecondaryEncoding<PT> {
+    pub fn new(
+        encoding_scheme: EncodingScheme,
+        group: &SecondaryBroadcastGroup<'_, PT>,
+        app_message_len: usize,
+        unix_ts_ms: u64,
+    ) -> Result<Self, BuildError> {
+        let EncodingScheme::Deterministic25(round) = encoding_scheme else {
+            return Err(BuildError::InvalidEncodingScheme);
+        };
+        let partition = EvenPartition::from_group(group);
+        // Seed derivation does not have to be the same as primary raptorcast.
         let seed = derive_seed(group.publisher(), round, unix_ts_ms);
-        partition.shuffle(seed);
-
-        Ok(Self {
-            redundancy,
-            layout,
-            app_message_len,
-            partition,
-        })
-    }
-
-    pub fn layout(&self) -> PacketLayout {
-        self.layout
-    }
-
-    pub fn make_chunks(&self) -> Result<Vec<Chunk<PT>>, BuildError> {
-        let assignment = self.make_assignment()?;
-        let chunks = assignment.materialize(self.layout.segment_len(), &self.partition)?;
-        Ok(chunks)
-    }
-
-    pub fn make_assignment(&self) -> Result<ChunkAssignment, BuildError> {
-        let num_base_symbols = self.layout.num_base_symbols(self.app_message_len);
-        let assignment = self.partition.assign(num_base_symbols, self.redundancy)?;
-        Ok(assignment)
-    }
-
-    pub fn partition(&self) -> &EvenPartition<PT> {
-        &self.partition
+        Self::build(app_message_len, partition, seed)
     }
 }
 

--- a/monad-raptorcast/src/packet/regular.rs
+++ b/monad-raptorcast/src/packet/regular.rs
@@ -32,7 +32,7 @@ use monad_types::NodeId;
 use rand::Rng;
 
 use super::{
-    assigner::{ChunkAssignment, EvenPartition, OrderedNodes as _, StakePartition},
+    assigner::{ChunkAssignment, EvenPartition, OrderedNodes as _, Partition as _, StakePartition},
     chunk::Chunk,
     BuildError, Result,
 };

--- a/monad-raptorcast/src/parser/packet_parser.rs
+++ b/monad-raptorcast/src/parser/packet_parser.rs
@@ -648,7 +648,7 @@ impl<'a> RaptorcastPacketV1<'a> {
             BroadcastMode::Secondary => {
                 even_partition_num_chunks(num_source_symbols, deterministic::DEFAULT_REDUNDANCY)
             }
-            BroadcastMode::Unspecified => None,
+            BroadcastMode::Unspecified => return Err(InvalidChunk::InvalidBroadcastMode),
         }
         .ok_or(InvalidChunk::InvalidChunkId)?;
         let chunk_id = self.chunk_header.chunk_id.get() as usize;

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -44,8 +44,8 @@ use crate::{
     },
     round_info::RoundInfoCache,
     util::{
-        compute_app_message_hash, compute_hash, unix_ts_ms_now, AppMessageHash, BroadcastMode,
-        EncodingScheme, FullNodeGroupMap, GlobalMerkleRoot, MerkleRoot, NodeIdHash,
+        compute_app_message_hash, compute_hash, unix_ts_ms_now, AppMessageHash, BroadcastGroup,
+        BroadcastMode, EncodingScheme, FullNodeGroupMap, GlobalMerkleRoot, MerkleRoot, NodeIdHash,
         PrimaryBroadcastGroup, SecondaryBroadcastGroup,
     },
     v1_rollout::{self, DeterministicProtocolRolloutStage},
@@ -165,19 +165,20 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
         message
     }
 
-    pub fn handle_primary_raptorcast(
+    pub fn handle_raptorcast(
         &mut self,
         epoch_validators: &BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
+        full_node_group_map: &FullNodeGroupMap<CertificateSignaturePubKey<ST>>,
         chunk: &ValidatedChunk<CertificateSignaturePubKey<ST>>,
         rebroadcast_to: &mut impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
         sender: Option<&NodeId<CertificateSignaturePubKey<ST>>>,
     ) -> Option<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
-        let epoch = match chunk.group_id {
-            GroupId::Primary(epoch) => epoch,
-            GroupId::Secondary(_round) => unreachable!(),
-        };
-        let Ok(group) = PrimaryBroadcastGroup::of_epoch(epoch, &chunk.author, epoch_validators)
-        else {
+        let Ok(group) = BroadcastGroup::from_group_id(
+            chunk.group_id,
+            &chunk.author,
+            epoch_validators,
+            full_node_group_map,
+        ) else {
             tracing::debug!(
                 ?chunk.group_id,
                 author =? chunk.author,
@@ -198,18 +199,18 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
             }
         }
 
-        let validator_set = group.validator_set();
-        let decoding_context = DecodingContext::new(Some(validator_set), unix_ts_ms_now());
+        let validator_set = match &group {
+            BroadcastGroup::Primary(g) => Some(g.validator_set()),
+            BroadcastGroup::Secondary(_) => None,
+        };
+        let decoding_context = DecodingContext::new(validator_set, unix_ts_ms_now());
 
-        match chunk.encoding_scheme {
-            EncodingScheme::Deterministic25(round) => self.handle_deterministic_primary(
-                &group,
-                round,
-                chunk,
-                &decoding_context,
-                rebroadcast_to,
-            ),
-            _ => self.handle_regular_primary(&group, chunk, &decoding_context, rebroadcast_to),
+        match (chunk.encoding_scheme, &group) {
+            (EncodingScheme::Deterministic25(round), BroadcastGroup::Primary(g)) => self
+                .handle_deterministic_primary(g, round, chunk, &decoding_context, rebroadcast_to),
+            (EncodingScheme::Deterministic25(round), BroadcastGroup::Secondary(g)) => self
+                .handle_deterministic_secondary(g, round, chunk, &decoding_context, rebroadcast_to),
+            _ => self.handle_regular(&group, chunk, &decoding_context, rebroadcast_to),
         }
     }
 
@@ -243,111 +244,16 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
             );
             return None;
         };
+        let rebroadcast_targets =
+            (*routing.recipient() == self.self_id).then(|| routing.rebroadcast_targets());
 
-        let is_recipient = *routing.recipient() == self.self_id;
-        let rebroadcast_targets = if is_recipient {
-            Some(routing.rebroadcast_targets())
-        } else {
-            None
-        };
-
-        let message = self.try_decode(chunk, decoding_context)?;
-        if let Some((_author, message)) = &message {
-            if let Some(encoding_valid) = chunk.check_deterministic_encoding(message, group) {
-                if !encoding_valid {
-                    self.decoder_cache.mark_tainted(chunk);
-                    tracing::warn!(
-                        author =? chunk.author,
-                        "message failed deterministic encoding validation"
-                    );
-                    return None;
-                }
-            }
-        }
-
-        if let Some(targets) = rebroadcast_targets {
-            rebroadcast_to(targets);
-        }
-
-        message
-    }
-
-    fn handle_regular_primary(
-        &mut self,
-        group: &PrimaryBroadcastGroup<'_, CertificateSignaturePubKey<ST>>,
-        chunk: &ValidatedChunk<CertificateSignaturePubKey<ST>>,
-        decoding_context: &DecodingContext<CertificateSignaturePubKey<ST>>,
-        rebroadcast_to: &mut impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
-    ) -> Option<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
-        let message = self.try_decode(chunk, decoding_context)?;
-
-        if let Some((_author, message)) = &message {
-            if let Some(hash_valid) = chunk.check_message_hash(message) {
-                if !hash_valid {
-                    self.decoder_cache.mark_tainted(chunk);
-                    tracing::warn!(
-                        author =? chunk.author,
-                        "message failed hash validation"
-                    );
-                    return None;
-                }
-            }
-        }
-
-        let is_first_hop_recipient = chunk.recipient_hash == Some(self.self_id_hash);
-        if let Some(ctx) = group.try_rebroadcast(&self.self_id, is_first_hop_recipient) {
-            rebroadcast_to(ctx.peers().cloned().collect());
-        }
-
-        message
-    }
-
-    pub fn handle_secondary_raptorcast(
-        &mut self,
-        full_node_group_map: &FullNodeGroupMap<CertificateSignaturePubKey<ST>>,
-        chunk: &ValidatedChunk<CertificateSignaturePubKey<ST>>,
-        rebroadcast_to: &mut impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
-        sender: Option<&NodeId<CertificateSignaturePubKey<ST>>>,
-    ) -> Option<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
-        let round = match chunk.group_id {
-            GroupId::Secondary(round) => round,
-            _ => unreachable!(),
-        };
-        let Ok(group) =
-            SecondaryBroadcastGroup::of_round(round, &chunk.author, full_node_group_map)
-        else {
-            tracing::debug!(
-                ?chunk.group_id,
-                author =? chunk.author,
-                "dropping message from unknown author/group"
-            );
-            return None;
-        };
-
-        if let Some(sender) = sender {
-            if !group.is_sender_valid(sender) {
-                tracing::debug!(
-                    ?chunk.group_id,
-                    author =? chunk.author,
-                    ?sender,
-                    "dropping message from invalid sender"
-                );
-                return None;
-            }
-        }
-
-        let decoding_context = DecodingContext::new(None, unix_ts_ms_now());
-
-        match chunk.encoding_scheme {
-            EncodingScheme::Deterministic25(round) => self.handle_deterministic_secondary(
-                &group,
-                round,
-                chunk,
-                &decoding_context,
-                rebroadcast_to,
-            ),
-            _ => self.handle_regular_secondary(&group, chunk, &decoding_context, rebroadcast_to),
-        }
+        self.finalize_deterministic(
+            chunk,
+            decoding_context,
+            rebroadcast_targets,
+            rebroadcast_to,
+            |msg| chunk.check_deterministic_encoding(msg, group),
+        )
     }
 
     fn handle_deterministic_secondary(
@@ -383,24 +289,40 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
             );
             return None;
         };
+        let rebroadcast_targets =
+            (*routing.recipient() == self.self_id).then(|| routing.rebroadcast_targets());
 
-        let is_recipient = *routing.recipient() == self.self_id;
-        let rebroadcast_targets = if is_recipient {
-            Some(routing.rebroadcast_targets())
-        } else {
-            None
-        };
+        self.finalize_deterministic(
+            chunk,
+            decoding_context,
+            rebroadcast_targets,
+            rebroadcast_to,
+            |msg| chunk.check_deterministic_encoding_secondary(msg, group),
+        )
+    }
 
+    // Post-routing pipeline for deterministic raptorcast: decode
+    // the symbol, verify the deterministic encoding, and rebroadcast if
+    // self was the assigned recipient.
+    fn finalize_deterministic<F>(
+        &mut self,
+        chunk: &ValidatedChunk<CertificateSignaturePubKey<ST>>,
+        decoding_context: &DecodingContext<CertificateSignaturePubKey<ST>>,
+        rebroadcast_targets: Option<Vec<NodeId<CertificateSignaturePubKey<ST>>>>,
+        rebroadcast_to: &mut impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
+        check_encoding: F,
+    ) -> Option<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)>
+    where
+        F: FnOnce(&[u8]) -> Option<bool>,
+    {
         let message = self.try_decode(chunk, decoding_context)?;
         if let Some((_author, message)) = &message {
-            if let Some(encoding_valid) =
-                chunk.check_deterministic_encoding_secondary(message, group)
-            {
+            if let Some(encoding_valid) = check_encoding(message) {
                 if !encoding_valid {
                     self.decoder_cache.mark_tainted(chunk);
                     tracing::warn!(
                         author =? chunk.author,
-                        "secondary message failed deterministic encoding validation"
+                        "message failed deterministic encoding validation"
                     );
                     return None;
                 }
@@ -414,9 +336,9 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
         message
     }
 
-    fn handle_regular_secondary(
+    fn handle_regular(
         &mut self,
-        group: &SecondaryBroadcastGroup<'_, CertificateSignaturePubKey<ST>>,
+        group: &BroadcastGroup<'_, CertificateSignaturePubKey<ST>>,
         chunk: &ValidatedChunk<CertificateSignaturePubKey<ST>>,
         decoding_context: &DecodingContext<CertificateSignaturePubKey<ST>>,
         rebroadcast_to: &mut impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
@@ -427,7 +349,7 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
             if let Some(hash_valid) = chunk.check_message_hash(message) {
                 if !hash_valid {
                     self.decoder_cache.mark_tainted(chunk);
-                    tracing::error!(
+                    tracing::warn!(
                         author =? chunk.author,
                         "message failed hash validation"
                     );
@@ -587,37 +509,38 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
                 BroadcastMode::Unspecified => {
                     self.handle_unicast(epoch_validators, &chunk, message.sender.as_ref())
                 }
-                BroadcastMode::Primary => {
+                BroadcastMode::Primary | BroadcastMode::Secondary => {
                     if !v1_rollout::should_accept(self.v1_rollout, &chunk) {
-                        self.metrics.executor_metrics_mut()
-                            [COUNTER_RAPTORCAST_CHUNKS_DROPPED_INCOMPATIBLE_VERSION] += 1;
+                        let dropped_metric = match chunk.broadcast_mode {
+                            BroadcastMode::Primary => {
+                                COUNTER_RAPTORCAST_CHUNKS_DROPPED_INCOMPATIBLE_VERSION
+                            }
+                            BroadcastMode::Secondary => {
+                                COUNTER_RAPTORCAST_SECONDARY_CHUNKS_DROPPED_INCOMPATIBLE_VERSION
+                            }
+                            BroadcastMode::Unspecified => unreachable!(),
+                        };
+                        self.metrics.executor_metrics_mut()[dropped_metric] += 1;
                         continue;
                     }
-                    let accepted_metric = match chunk.version {
-                        ChunkVersion::V0 => COUNTER_RAPTORCAST_V0_PRIMARY_CHUNKS_ACCEPTED,
-                        ChunkVersion::V1 => COUNTER_RAPTORCAST_V1_PRIMARY_CHUNKS_ACCEPTED,
+                    let accepted_metric = match (chunk.broadcast_mode, chunk.version) {
+                        (BroadcastMode::Primary, ChunkVersion::V0) => {
+                            COUNTER_RAPTORCAST_V0_PRIMARY_CHUNKS_ACCEPTED
+                        }
+                        (BroadcastMode::Primary, ChunkVersion::V1) => {
+                            COUNTER_RAPTORCAST_V1_PRIMARY_CHUNKS_ACCEPTED
+                        }
+                        (BroadcastMode::Secondary, ChunkVersion::V0) => {
+                            COUNTER_RAPTORCAST_V0_SECONDARY_CHUNKS_ACCEPTED
+                        }
+                        (BroadcastMode::Secondary, ChunkVersion::V1) => {
+                            COUNTER_RAPTORCAST_V1_SECONDARY_CHUNKS_ACCEPTED
+                        }
+                        (BroadcastMode::Unspecified, _) => unreachable!(),
                     };
                     self.metrics.executor_metrics_mut()[accepted_metric] += 1;
-                    self.handle_primary_raptorcast(
+                    self.handle_raptorcast(
                         epoch_validators,
-                        &chunk,
-                        rebroadcast_to,
-                        message.sender.as_ref(),
-                    )
-                }
-
-                BroadcastMode::Secondary => {
-                    if !v1_rollout::should_accept(self.v1_rollout, &chunk) {
-                        self.metrics.executor_metrics_mut()
-                            [COUNTER_RAPTORCAST_SECONDARY_CHUNKS_DROPPED_INCOMPATIBLE_VERSION] += 1;
-                        continue;
-                    }
-                    let accepted_metric = match chunk.version {
-                        ChunkVersion::V0 => COUNTER_RAPTORCAST_V0_SECONDARY_CHUNKS_ACCEPTED,
-                        ChunkVersion::V1 => COUNTER_RAPTORCAST_V1_SECONDARY_CHUNKS_ACCEPTED,
-                    };
-                    self.metrics.executor_metrics_mut()[accepted_metric] += 1;
-                    self.handle_secondary_raptorcast(
                         full_node_group_map,
                         &chunk,
                         rebroadcast_to,
@@ -758,6 +681,7 @@ pub enum InvalidChunk {
 
     // Chunk metadata validation error
     InvalidAppMessageLen(usize),
+    InvalidBroadcastMode,
     InvalidChunkLen,
     InvalidChunkId,
     InvalidMerkleTreeDepth,

--- a/monad-raptorcast/src/v1_rollout.rs
+++ b/monad-raptorcast/src/v1_rollout.rs
@@ -22,7 +22,7 @@ use crate::{
     util::{BuildTarget, PrimaryBroadcastGroup, SecondaryBroadcastGroup},
 };
 
-// should only be called on receiving a v0 or v1 primary raptorcast chunk
+// should only be called on receiving a v0 or v1 raptorcast chunk
 pub(crate) fn should_accept<PT: PubKey>(
     stage: DeterministicProtocolRolloutStage,
     chunk: &ValidatedChunk<PT>,


### PR DESCRIPTION
Reducing some code duplication between primary and secondary deterministic raptorcast