### PR TITLE
docker: bump Ubuntu base images from 25.04 to 25.10

### DIFF
--- a/docker/archive/Dockerfile
+++ b/docker/archive/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04 AS base
+FROM ubuntu:25.10 AS base
 
 WORKDIR /usr/src/monad-bft
 

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04 AS base
+FROM ubuntu:25.10 AS base
 
 RUN apt update && apt install -y \
   binutils \

--- a/docker/devnet/Dockerfile
+++ b/docker/devnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04 AS base
+FROM ubuntu:25.10 AS base
 
 WORKDIR /usr/src/monad-bft
 

--- a/docker/rpc-request-gen/Dockerfile
+++ b/docker/rpc-request-gen/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM ubuntu:25.04 AS base
+FROM ubuntu:25.10 AS base
 
 RUN apt update && apt upgrade -y
 RUN apt update && apt install -y binutils ca-certificates curl iproute2 pkg-config gnupg software-properties-common wget cgroup-tools
@@ -88,7 +88,7 @@ RUN cargo build --release --example rpc-request-generator && \
     mv target/release/examples/rpc-request-generator rpc-request-generator
 
 # Runner
-FROM ubuntu:25.04 as runner
+FROM ubuntu:25.10 AS runner
 WORKDIR /usr/src/monad-bft
 
 COPY --from=builder /usr/src/monad-bft/rpc-request-generator /usr/local/bin/rpc-request-generator

--- a/docker/rpc/Dockerfile
+++ b/docker/rpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04 AS base
+FROM ubuntu:25.10 AS base
 
 WORKDIR /usr/src/monad-bft
 

--- a/docker/txgen/Dockerfile
+++ b/docker/txgen/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM ubuntu:25.04 AS base
+FROM ubuntu:25.10 AS base
 
 RUN apt update && apt upgrade -y
 RUN apt update && apt install -y binutils ca-certificates curl iproute2 pkg-config gnupg software-properties-common wget cgroup-tools


### PR DESCRIPTION
## Summary
- Bump `ubuntu:25.04` → `ubuntu:25.10` in all Dockerfiles under `docker/` (archive, builder, devnet, rpc, rpc-request-gen [base + runner], txgen).

## Test plan
- [ ] CI builds all affected Docker images successfully