### PR TITLE
Raptorcast: Fix non-dedicated full node cold start

### DIFF
--- a/monad-raptorcast/examples/latency.rs
+++ b/monad-raptorcast/examples/latency.rs
@@ -675,6 +675,7 @@ fn setup_node(
         non_authenticated_socket,
         dataplane_control,
         Arc::new(std::sync::Mutex::new(pd)),
+        Epoch(0),
     );
 
     raptorcast.exec(vec![RouterCommand::AddEpochValidatorSet {

--- a/monad-raptorcast/examples/service.rs
+++ b/monad-raptorcast/examples/service.rs
@@ -128,12 +128,13 @@ fn service(
             let dataplane = monad_raptorcast::create_dataplane_for_tests(false);
 
             rt.spawn(async move {
-                let mut service = new_defaulted_raptorcast_for_tests::<
-                    SignatureType,
-                    MockMessage,
-                    MockMessage,
-                    <MockMessage as Message>::Event,
-                >(dataplane, known_addresses, Arc::new(key));
+                let mut service =
+                    new_defaulted_raptorcast_for_tests::<
+                        SignatureType,
+                        MockMessage,
+                        MockMessage,
+                        <MockMessage as Message>::Event,
+                    >(dataplane, known_addresses, Arc::new(key), Epoch(0));
 
                 service.exec(vec![RouterCommand::AddEpochValidatorSet {
                     epoch: Epoch(0),

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -183,6 +183,7 @@ where
         non_authenticated_socket: UdpSocketHandle,
         control: DataplaneControl,
         peer_discovery_driver: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
+        current_epoch: Epoch,
     ) -> Self {
         let (tcp_reader, tcp_writer) = tcp_socket.split();
 
@@ -289,8 +290,9 @@ where
             message_builder,
             secondary_message_builder: Some(secondary_message_builder),
 
-            // Updated by the first RouterCommand::UpdateCurrentRound.
-            current_epoch: Epoch(0),
+            // Seeded from the forkpoint at boot; updated by
+            // RouterCommand::UpdateCurrentRound.
+            current_epoch,
 
             udp_state,
             v1_rollout: config.deterministic_protocol_rollout,
@@ -775,6 +777,7 @@ pub fn new_defaulted_raptorcast_for_tests<ST, M, OM, SE>(
     dataplane: DataplaneHandles,
     known_addresses: HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddrV4>,
     shared_key: Arc<ST::KeyPairType>,
+    current_epoch: Epoch,
 ) -> RaptorCast<
     ST,
     M,
@@ -831,6 +834,7 @@ where
         dataplane.non_authenticated_socket,
         dataplane.control,
         shared_pd,
+        current_epoch,
     )
 }
 
@@ -838,6 +842,7 @@ pub fn new_wireauth_raptorcast_for_tests<ST, M, OM, SE>(
     dataplane: DataplaneHandles,
     known_addresses: HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddrV4>,
     shared_key: Arc<ST::KeyPairType>,
+    current_epoch: Epoch,
 ) -> RaptorCast<
     ST,
     M,
@@ -895,6 +900,7 @@ where
         dataplane.non_authenticated_socket,
         dataplane.control,
         shared_pd,
+        current_epoch,
     )
 }
 

--- a/monad-raptorcast/tests/raptorcast_instance.rs
+++ b/monad-raptorcast/tests/raptorcast_instance.rs
@@ -348,12 +348,13 @@ pub fn set_up_test(
         ));
 
         rt.spawn(async move {
-            let mut service = new_defaulted_raptorcast_for_tests::<
-                SignatureType,
-                MockMessage,
-                MockMessage,
-                <MockMessage as Message>::Event,
-            >(dataplane, peer_addresses, Arc::new(rx_keypair));
+            let mut service =
+                new_defaulted_raptorcast_for_tests::<
+                    SignatureType,
+                    MockMessage,
+                    MockMessage,
+                    <MockMessage as Message>::Event,
+                >(dataplane, peer_addresses, Arc::new(rx_keypair), Epoch(0));
 
             service.exec(vec![RouterCommand::AddEpochValidatorSet {
                 epoch: Epoch(0),
@@ -466,7 +467,124 @@ fn setup_raptorcast_service(
         MockMessage,
         MockMessage,
         <MockMessage as Message>::Event,
-    >(dataplane, known_addresses, Arc::new(keypair))
+    >(dataplane, known_addresses, Arc::new(keypair), Epoch(0))
+}
+
+// a fullnode must be able to forward an incoming FullNodesGroup
+// invite (e.g. PrepareGroup) from a validator to the secondary RC
+// channel even on a freshly booted node, before consensus has caught
+// up, to allow the fullnode to join the group and start receiving
+// proposals.
+#[cfg(test)]
+#[tokio::test]
+async fn raptorcast_forwards_fullnodes_group_invite_at_cold_start() {
+    let epoch = Epoch(5); // non-zero, simulating boot from a real forkpoint
+
+    let validator_keypair = keypair(1);
+    let validator_nodeid = NodeId::new(validator_keypair.pubkey());
+    let fullnode_keypair = keypair(2);
+    let fullnode_nodeid = NodeId::new(fullnode_keypair.pubkey());
+
+    // Only the fullnode is a real RaptorCast instance; the validator side just
+    // constructs and sends a packet manually, so it needs no dataplane.
+    let fullnode_dp = create_dataplane_for_tests(false);
+    let fullnode_addr = fullnode_dp.non_auth_addr;
+
+    let known_addresses: HashMap<NodeId<PubKeyType>, SocketAddrV4> =
+        [(fullnode_nodeid, fullnode_addr)].into_iter().collect();
+    let known_addresses_socketaddr: HashMap<NodeId<PubKeyType>, SocketAddr> = known_addresses
+        .iter()
+        .map(|(k, v)| (*k, SocketAddr::V4(*v)))
+        .collect();
+
+    let mut fullnode_rc = new_defaulted_raptorcast_for_tests::<
+        SignatureType,
+        MockMessage,
+        MockMessage,
+        MockEvent<PubKeyType>,
+    >(
+        fullnode_dp,
+        known_addresses.clone(),
+        Arc::new(fullnode_keypair),
+        epoch,
+    );
+
+    fullnode_rc.exec(vec![RouterCommand::AddEpochValidatorSet {
+        epoch,
+        validator_set: vec![(validator_nodeid, Stake::ONE)],
+    }]);
+
+    // Bind channel_to_secondary so the test can observe the forwarded message.
+    let (channel_to_secondary_tx, mut channel_to_secondary_rx) =
+        unbounded_channel::<FullNodesGroupMessage<SignatureType>>();
+    let (_assignment_tx, assignment_rx) =
+        unbounded_channel::<SecondaryGroupAssignment<PubKeyType>>();
+    let (_outbound_tx, outbound_rx) = unbounded_channel::<SecondaryOutboundMessage<PubKeyType>>();
+    fullnode_rc.bind_channel_to_secondary_raptorcast(
+        SecondaryRaptorCastModeConfig::Client,
+        channel_to_secondary_tx,
+        assignment_rx,
+        outbound_rx,
+    );
+
+    // Construct the invite, mirroring what raptorcast_secondary::publisher
+    // emits when inviting a fullnode into a new group.
+    let prepare = monad_raptorcast::raptorcast_secondary::group_message::PrepareGroup::<PubKeyType> {
+        validator_id: validator_nodeid,
+        max_group_size: 10,
+        start_round: Round(1),
+        end_round: Round(10),
+    };
+    let group_msg = FullNodesGroupMessage::<SignatureType>::PrepareGroup(prepare);
+    let router_msg: monad_raptorcast::message::OutboundRouterMessage<MockMessage, SignatureType> =
+        monad_raptorcast::message::OutboundRouterMessage::FullNodesGroup(group_msg.clone());
+    let msg_bytes = router_msg
+        .try_serialize()
+        .expect("serialize FullNodesGroup");
+
+    // Build a unicast raptorcast packet signed by the validator, targeted at the
+    // fullnode.
+    let packets = build_messages::<SignatureType>(
+        &validator_keypair,
+        DEFAULT_SEGMENT_SIZE,
+        msg_bytes,
+        Redundancy::from_u8(2),
+        0,
+        BuildTarget::point_to_point(epoch, &fullnode_nodeid),
+        &known_addresses_socketaddr,
+    );
+
+    // Drain startup events from the fullnode before sending.
+    loop {
+        tokio::select! {
+            biased;
+            _ = fullnode_rc.next() => {}
+            _ = std::future::ready(()) => break,
+        }
+    }
+
+    let tx_socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+    for (target_addr, payload) in &packets {
+        for chunk in payload.chunks(usize::from(DEFAULT_SEGMENT_SIZE)) {
+            tx_socket.send_to(chunk, target_addr).unwrap();
+        }
+    }
+
+    // Drive the fullnode event loop until the channel receives the message or we time out.
+    let received = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            tokio::select! {
+                biased;
+                msg = channel_to_secondary_rx.recv() => return msg,
+                _ = fullnode_rc.next() => continue,
+            }
+        }
+    })
+    .await
+    .expect("timeout waiting for FullNodesGroup forward")
+    .expect("channel_to_secondary closed");
+
+    assert_eq!(received, group_msg);
 }
 
 #[cfg(test)]
@@ -648,14 +766,24 @@ async fn test_priority_messages() {
         MockMessage,
         MockMessage,
         MockEvent<PubKeyType>,
-    >(tx_dataplane, known_addresses.clone(), tx_key.clone());
+    >(
+        tx_dataplane,
+        known_addresses.clone(),
+        tx_key.clone(),
+        Epoch(0),
+    );
 
     let mut rx_rc = new_defaulted_raptorcast_for_tests::<
         SignatureType,
         MockMessage,
         MockMessage,
         MockEvent<PubKeyType>,
-    >(rx_dataplane, known_addresses.clone(), rx_key.clone());
+    >(
+        rx_dataplane,
+        known_addresses.clone(),
+        rx_key.clone(),
+        Epoch(0),
+    );
 
     let epoch = Epoch(0);
     let validator_set = vec![(tx_nodeid, Stake::ONE), (rx_nodeid, Stake::ONE)];
@@ -774,6 +902,7 @@ async fn test_raptorcast_forwarding_priority() {
         validator1_dataplane,
         known_addresses.clone(),
         validator1_key.clone(),
+        Epoch(0),
     );
 
     let mut validator2_rc = new_defaulted_raptorcast_for_tests::<
@@ -785,6 +914,7 @@ async fn test_raptorcast_forwarding_priority() {
         validator2_dataplane,
         known_addresses.clone(),
         validator2_key.clone(),
+        Epoch(0),
     );
 
     let mut validator_fullnode_rc = new_defaulted_raptorcast_for_tests::<
@@ -796,6 +926,7 @@ async fn test_raptorcast_forwarding_priority() {
         validator_fullnode_dataplane,
         known_addresses.clone(),
         validator_fullnode_key.clone(),
+        Epoch(0),
     );
 
     let epoch = Epoch(0);

--- a/monad-raptorcast/tests/wireauth_raptorcast.rs
+++ b/monad-raptorcast/tests/wireauth_raptorcast.rs
@@ -256,6 +256,7 @@ fn spawn_noop_validator(
             dataplane.non_authenticated_socket,
             dataplane.control,
             shared_pd,
+            monad_types::Epoch(0),
         );
 
         let mut cmd_rx = cmd_rx;
@@ -344,6 +345,7 @@ fn spawn_wireauth_validator(
             dataplane.non_authenticated_socket,
             dataplane.control,
             shared_pd,
+            monad_types::Epoch(0),
         );
 
         let mut cmd_rx = cmd_rx;

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -174,6 +174,7 @@ where
             non_authenticated_socket,
             control,
             shared_pdd.clone(),
+            current_epoch,
         );
         rc_primary.bind_channel_to_secondary_raptorcast(
             secondary_mode,

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -46,7 +46,7 @@ use monad_raptorcast::{
 };
 use monad_state::{Forkpoint, MonadMessage, MonadState, MonadStateBuilder, VerifiedMonadMessage};
 use monad_state_backend::InMemoryState;
-use monad_types::{ExecutionProtocol, NodeId, Round, SeqNum};
+use monad_types::{Epoch, ExecutionProtocol, NodeId, Round, SeqNum};
 use monad_updaters::{
     config_file::MockConfigFile, config_loader::MockConfigLoader, ledger::MockLedger,
     local_router::LocalPeerRouter, loopback::LoopbackExecutor, parent::ParentExecutor,
@@ -202,6 +202,7 @@ where
                     non_authenticated_socket,
                     control,
                     shared_peer_discovery_driver,
+                    Epoch(0),
                 ))
             }
         },


### PR DESCRIPTION
Fix a regression introduced in https://github.com/category-labs/monad-bft/pull/3091.

https://github.com/category-labs/monad-bft/pull/3091 removes the constructor argument `current_epoch` on `RaptorCast` originally seeded from the forkpoint, so the `current_epoch` is set to `Epoch(0)` until consensus becomes live.

In non-dedicated full nodes which are already lagging behind, the check at https://github.com/category-labs/monad-bft/blob/fc13fc1359bb1aa7827b5d74a7649dd5115b41e2/monad-raptorcast/src/lib.rs#L1240-L1257 will fail at finding the validators, results in dropping secondary group invitation messages from publishers. As a result, the full node is unable to participate in secondary groups and keep up with network tip.

This PR fixes the issue by restoring the `current_epoch` argument to be seeded from the forkpoint.

The code is generated using Claude Opus 4.7.