### PR TITLE
Update eth_sendRawTransactionSync to use event server

### DIFF
--- a/monad-rpc/src/event/client.rs
+++ b/monad-rpc/src/event/client.rs
@@ -33,18 +33,24 @@ impl EventServerClient {
         }
     }
 
-    pub fn subscribe(
-        &self,
-    ) -> Result<broadcast::Receiver<EventServerEvent>, EventServerClientError> {
+    pub fn subscribe(&self) -> Result<EventServerSubscription, EventServerClientError> {
         if self.handle.is_finished() {
             return Err(EventServerClientError::ServerCrashed);
         }
 
-        Ok(self.tx.subscribe())
+        Ok(EventServerSubscription(self.tx.subscribe()))
     }
 }
 
 #[derive(Debug)]
 pub enum EventServerClientError {
     ServerCrashed,
+}
+
+pub struct EventServerSubscription(broadcast::Receiver<EventServerEvent>);
+
+impl EventServerSubscription {
+    pub async fn recv(&mut self) -> Result<EventServerEvent, broadcast::error::RecvError> {
+        self.0.recv().await
+    }
 }

--- a/monad-rpc/src/event/mod.rs
+++ b/monad-rpc/src/event/mod.rs
@@ -15,7 +15,7 @@
 
 pub(crate) use self::events::EventServerEvent;
 pub use self::{
-    client::{EventServerClient, EventServerClientError},
+    client::{EventServerClient, EventServerClientError, EventServerSubscription},
     server::EventServer,
 };
 

--- a/monad-rpc/src/handlers/eth/txn.rs
+++ b/monad-rpc/src/handlers/eth/txn.rs
@@ -13,12 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::time::Duration;
+use std::{pin::pin, time::Duration};
 
 use alloy_consensus::{Transaction as _, TxEnvelope};
 use alloy_eips::Decodable2718;
-use alloy_primitives::{Address, FixedBytes, TxHash};
-use alloy_rpc_types::{Filter, TransactionReceipt};
+use alloy_primitives::{Address, FixedBytes};
+use alloy_rpc_types::Filter;
+use monad_exec_events::BlockCommitState;
 use monad_rpc_docs::rpc;
 use monad_triedb_utils::triedb_env::Triedb;
 use schemars::JsonSchema;
@@ -27,13 +28,14 @@ use tracing::{debug, error, trace, warn};
 
 use crate::{
     data::DataProvider,
+    event::{EventServerClient, EventServerEvent},
     txpool::{EthTxPoolBridgeClient, TxStatus},
     types::{
         eth_json::{
             BlockTagOrHash, BlockTags, EthHash, MonadLog, MonadTransaction,
             MonadTransactionReceipt, Quantity, UnformattedData,
         },
-        jsonrpc::{ChainStateResultExt as _, ChainStateResultMap, JsonRpcError, JsonRpcResult},
+        jsonrpc::{ChainStateResultMap, JsonRpcError, JsonRpcResult},
     },
 };
 
@@ -241,49 +243,15 @@ pub struct MonadEthSendRawTransactionSyncParams {
     timeout_ms: Option<u64>,
 }
 
-/// Poll interval in milliseconds for checking receipt availability
-const RECEIPT_POLL_INTERVAL_MS: u64 = 100;
-/// Polls for transaction receipt with timeout
-async fn poll_for_receipt<T: Triedb>(
-    data_provider: &DataProvider<T>,
-    tx_hash: TxHash,
-    timeout_ms: u64,
-) -> Result<TransactionReceipt, JsonRpcError> {
-    let start_time = tokio::time::Instant::now();
-    let timeout = Duration::from_millis(timeout_ms);
-    let poll_interval = Duration::from_millis(RECEIPT_POLL_INTERVAL_MS);
-
-    loop {
-        if let Some(receipt) = data_provider
-            .get_transaction_receipt(&tx_hash)
-            .await
-            .to_jsonrpc_result()?
-        {
-            return Ok(receipt);
-        }
-
-        // Not found yet, check timeout
-        if start_time.elapsed() >= timeout {
-            // EIP-7966: Error code 4 with tx hash in data
-            return Err(JsonRpcError::tx_sync_timeout(
-                tx_hash.to_string(),
-                timeout_ms,
-            ));
-        }
-
-        tokio::time::sleep(poll_interval).await;
-    }
-}
-
 #[rpc(
     method = "eth_sendRawTransactionSync",
-    ignore = "txpool_bridge_client,data_provider,chain_id,allow_unprotected_txs,eth_send_raw_transaction_sync_default_timeout_ms,eth_send_raw_transaction_sync_max_timeout_ms"
+    ignore = "txpool_bridge_client,event_server_client,chain_id,allow_unprotected_txs,eth_send_raw_transaction_sync_default_timeout_ms,eth_send_raw_transaction_sync_max_timeout_ms"
 )]
 #[allow(non_snake_case)]
 #[tracing::instrument(level = "debug", skip_all)]
-pub async fn monad_eth_sendRawTransactionSync<T: Triedb>(
+pub async fn monad_eth_sendRawTransactionSync(
     txpool_bridge_client: &EthTxPoolBridgeClient,
-    data_provider: &DataProvider<T>,
+    event_server_client: &EventServerClient,
     params: MonadEthSendRawTransactionSyncParams,
     chain_id: u64,
     allow_unprotected_txs: bool,
@@ -304,13 +272,56 @@ pub async fn monad_eth_sendRawTransactionSync<T: Triedb>(
         JsonRpcError::tx_sync_unready,
     )?;
 
+    let Ok(mut event_server_subscription) = event_server_client.subscribe() else {
+        return Err(JsonRpcError::overloaded());
+    };
+
     let tx_hash = *tx.tx_hash();
     debug!(name = "sendRawTransactionSync", txn_hash = ?tx_hash);
     submit_to_txpool(txpool_bridge_client, tx).await?;
 
-    let receipt = poll_for_receipt(data_provider, tx_hash, timeout_ms).await?;
+    let mut timeout = pin!(tokio::time::sleep(Duration::from_millis(timeout_ms)));
 
-    Ok(MonadTransactionReceipt(receipt))
+    loop {
+        let result = tokio::select! {
+            result = event_server_subscription.recv() => result,
+
+            () = &mut timeout => {
+                // EIP-7966: Error code 4 with tx hash in data
+                return Err(JsonRpcError::tx_sync_timeout(
+                    tx_hash.to_string(),
+                    timeout_ms,
+                ));
+            }
+        };
+
+        let Ok(event) = result else {
+            return Err(JsonRpcError::overloaded());
+        };
+
+        match event {
+            EventServerEvent::Gap => {
+                return Err(JsonRpcError::overloaded());
+            }
+            EventServerEvent::Block {
+                commit_state,
+                header: _,
+                transactions,
+            } => {
+                if commit_state != BlockCommitState::Proposed {
+                    continue;
+                }
+
+                for (tx, tx_receipt, _) in transactions.iter() {
+                    if tx.value().inner.tx_hash() != &tx_hash {
+                        continue;
+                    }
+
+                    return Ok(MonadTransactionReceipt(tx_receipt.value().clone()));
+                }
+            }
+        }
+    }
 }
 
 #[derive(Deserialize, Debug, schemars::JsonSchema)]
@@ -407,8 +418,6 @@ pub async fn monad_eth_getTransactionByBlockNumberAndIndex<T: Triedb>(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use alloy_consensus::{SignableTransaction, TxEip1559, TxEnvelope};
     use alloy_eips::eip2718::Encodable2718;
     use alloy_primitives::{Address, FixedBytes, TxKind};
@@ -416,6 +425,7 @@ mod tests {
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use monad_eth_types::EthAccount;
+    use monad_event_ring::SnapshotEventRing;
     use monad_triedb_utils::mock_triedb::MockTriedb;
 
     use super::{
@@ -423,7 +433,7 @@ mod tests {
         MonadEthSendRawTransactionParams, MonadEthSendRawTransactionSyncParams,
     };
     use crate::{
-        data::DataProvider, txpool::EthTxPoolBridgeClient, types::eth_json::UnformattedData,
+        event::EventServer, txpool::EthTxPoolBridgeClient, types::eth_json::UnformattedData,
     };
 
     fn serialize_tx(tx: impl Encodable + Encodable2718) -> UnformattedData {
@@ -516,7 +526,16 @@ mod tests {
             },
         );
 
-        let data_provider = DataProvider::new(None, Arc::new(triedb), None);
+        let snapshot_event_ring = SnapshotEventRing::new_from_zstd_bytes(
+            "TEST",
+            include_bytes!(
+                "../../../../monad-execution/rust/crates/monad-exec-events/test/data/exec-events-emn-30b-15m/snapshot.zst"
+            ),
+            None,
+        )
+        .unwrap();
+
+        let event_server_client = EventServer::start_for_testing(snapshot_event_ring);
 
         // Test the same validation failures as eth_sendRawTransaction
         // to ensure both methods have consistent validation
@@ -547,7 +566,7 @@ mod tests {
             assert!(
                 monad_eth_sendRawTransactionSync(
                     &EthTxPoolBridgeClient::for_testing(),
-                    &data_provider,
+                    &event_server_client,
                     case,
                     1,
                     true,

--- a/monad-rpc/src/handlers/mod.rs
+++ b/monad-rpc/src/handlers/mod.rs
@@ -411,17 +411,19 @@ async fn eth_sendRawTransactionSync(
     app_state: &MonadRpcResources,
     params: RequestParams<'_>,
 ) -> Result<Box<RawValue>, JsonRpcError> {
-    // Require both data_provider and txpool_bridge_client
     let txpool_bridge_client = app_state
         .txpool_bridge_client
         .as_ref()
         .method_not_supported()?;
-    let data_provider = app_state.data_provider.as_ref().method_not_supported()?;
+    let event_server_client = app_state
+        .event_server_client
+        .as_ref()
+        .method_not_supported()?;
     let params = serde_json::from_str(params.get()).invalid_params()?;
 
     monad_eth_sendRawTransactionSync(
         txpool_bridge_client,
-        data_provider,
+        event_server_client,
         params,
         app_state.chain_id,
         app_state.allow_unprotected_txs,

--- a/monad-rpc/src/handlers/resources.rs
+++ b/monad-rpc/src/handlers/resources.rs
@@ -24,6 +24,7 @@ use tracing_actix_web::RootSpanBuilder;
 use crate::{
     comparator::RpcComparator,
     data::{eth_call_handler::EthCallHandler, DataProvider},
+    event::EventServerClient,
     middleware::Metrics,
     txpool::EthTxPoolBridgeClient,
 };
@@ -34,6 +35,7 @@ pub struct MonadRpcResources {
     pub eth_call_handler: Option<EthCallHandler>,
     pub chain_id: u64,
     pub data_provider: Option<DataProvider<TriedbEnv>>,
+    pub event_server_client: Option<EventServerClient>,
     pub batch_request_limit: u16,
     pub max_response_size: u32,
     pub allow_unprotected_txs: bool,
@@ -54,6 +56,7 @@ impl MonadRpcResources {
         eth_call_handler: Option<EthCallHandler>,
         chain_id: u64,
         data_provider: Option<DataProvider<TriedbEnv>>,
+        event_server_client: Option<EventServerClient>,
         batch_request_limit: u16,
         max_response_size: u32,
         allow_unprotected_txs: bool,
@@ -71,6 +74,7 @@ impl MonadRpcResources {
             eth_call_handler,
             chain_id,
             data_provider,
+            event_server_client,
             batch_request_limit,
             max_response_size,
             allow_unprotected_txs,

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -304,37 +304,34 @@ async fn main() -> std::io::Result<()> {
     let decompression_guard = DecompressionGuard::new(args.max_request_size);
 
     // Configure event ring, websocket server and event cache.
-    let (events_client, events_for_cache) = if let Some(exec_event_path) = args.exec_event_path {
+    let event_server_client = if let Some(exec_event_path) = args.exec_event_path {
         let event_ring_path =
             EventRingPath::resolve(exec_event_path).expect("Execution event ring path resolves");
 
         let event_ring = EventRing::new(event_ring_path).expect("Execution event ring is ready");
 
-        let events_client = EventServer::start(event_ring);
-
-        // Subscribe to the event server to populate the event cache.
-        let events_for_cache = events_client
-            .subscribe()
-            .expect("Failed to subscribe to event server");
-
-        (Some(events_client), Some(events_for_cache))
+        Some(EventServer::start(event_ring))
     } else {
         if args.ws_enabled {
             panic!("exec-event-path is not set but is required for websockets");
         }
 
-        (None, None)
+        None
     };
 
-    let event_buffer_view = if let Some(mut events_for_cache) = events_for_cache {
-        let mut event_buffer = BlockBuffer::new(1024);
+    let block_buffer_view = if let Some(event_server_client) = event_server_client.as_ref() {
+        let mut event_server_subscription = event_server_client
+            .subscribe()
+            .expect("Failed to subscribe to event server");
 
-        let event_buffer_view = event_buffer.create_view();
+        let mut block_buffer = BlockBuffer::new(1024);
+
+        let block_buffer_view = block_buffer.create_view();
 
         tokio::spawn(async move {
             loop {
-                match events_for_cache.recv().await {
-                    Ok(event) => event_buffer.insert(event),
+                match event_server_subscription.recv().await {
+                    Ok(event) => block_buffer.insert(event),
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(lag_count)) => {
                         warn!(
                             ?lag_count,
@@ -349,24 +346,27 @@ async fn main() -> std::io::Result<()> {
             }
         });
 
-        Some(event_buffer_view)
+        Some(block_buffer_view)
     } else {
         None
     };
 
     let data_provider =
-        triedb_env.map(|t| DataProvider::new(event_buffer_view, Arc::new(t), archive_reader));
+        triedb_env.map(|t| DataProvider::new(block_buffer_view, Arc::new(t), archive_reader));
 
     let rpc_comparator: Option<RpcComparator> = args
         .rpc_comparison_endpoint
         .as_ref()
         .map(|endpoint| RpcComparator::new(endpoint.to_string(), node_config.node_name));
 
+    let enable_websockets = event_server_client.is_some();
+
     let app_state = MonadRpcResources::new(
         txpool_bridge_client,
         eth_call_handler,
         node_config.chain_id,
         data_provider,
+        event_server_client.clone(),
         args.batch_request_limit,
         args.max_response_size,
         args.allow_unprotected_txs,
@@ -381,30 +381,23 @@ async fn main() -> std::io::Result<()> {
     );
 
     // Configure the websocket server if enabled
-    let ws_server_handle = if let Some(events_client) = events_client {
+    let ws_server_handle = (args.ws_enabled && enable_websockets).then(|| {
         let ws_app_data = app_state.clone();
         let conn_limit = websocket::handler::ConnectionLimit::new(args.ws_conn_limit);
         let sub_limit = websocket::handler::SubscriptionLimit(args.ws_sub_per_conn_limit);
 
-        args.ws_enabled.then(|| {
-            HttpServer::new(move || {
-                App::new()
-                    .app_data(web::Data::new(conn_limit.clone()))
-                    .app_data(web::Data::new(events_client.clone()))
-                    .app_data(web::Data::new(ws_app_data.clone()))
-                    .app_data(web::Data::new(sub_limit.clone()))
-                    .service(
-                        web::resource("/").route(web::get().to(websocket::handler::ws_handler)),
-                    )
-            })
-            .bind((args.rpc_addr.clone(), args.ws_port))
-            .expect("Failed to bind WebSocket server")
-            .shutdown_timeout(1)
-            .workers(args.ws_worker_threads)
+        HttpServer::new(move || {
+            App::new()
+                .app_data(web::Data::new(conn_limit.clone()))
+                .app_data(web::Data::new(ws_app_data.clone()))
+                .app_data(web::Data::new(sub_limit.clone()))
+                .service(web::resource("/").route(web::get().to(websocket::handler::ws_handler)))
         })
-    } else {
-        None
-    };
+        .bind((args.rpc_addr.clone(), args.ws_port))
+        .expect("Failed to bind WebSocket server")
+        .shutdown_timeout(1)
+        .workers(args.ws_worker_threads)
+    });
 
     // Configure the rpc server with or without metrics
     let app = match with_metrics {

--- a/monad-rpc/src/tests.rs
+++ b/monad-rpc/src/tests.rs
@@ -40,6 +40,7 @@ pub async fn init_server(
         eth_call_handler: None,
         chain_id: 1337,
         data_provider: None,
+        event_server_client: None,
         batch_request_limit: 5,
         max_response_size: 25_000_000,
         allow_unprotected_txs: false,

--- a/monad-rpc/src/websocket/handler.rs
+++ b/monad-rpc/src/websocket/handler.rs
@@ -34,7 +34,9 @@ use tokio::sync::{broadcast, Semaphore, TryAcquireError};
 use tracing::{debug, error, warn};
 
 use crate::{
-    event::{events::LogNotification, EventServerClient, EventServerClientError, EventServerEvent},
+    event::{
+        events::LogNotification, EventServerClientError, EventServerEvent, EventServerSubscription,
+    },
     handlers::{resources::MonadRpcResources, rpc_select},
     middleware::TimingRequestId,
     types::{
@@ -75,7 +77,6 @@ pub async fn ws_handler(
     req: HttpRequest,
     stream: web::Payload,
     app_state: web::Data<MonadRpcResources>,
-    event_server_client: web::Data<EventServerClient>,
     conn_limit: web::Data<ConnectionLimit>,
     sub_limit: web::Data<SubscriptionLimit>,
 ) -> Result<HttpResponse, actix_web::Error> {
@@ -89,7 +90,13 @@ pub async fn ws_handler(
         Err(e) => return Err(actix_web::error::ErrorInternalServerError(e)),
     };
 
-    let rx = event_server_client.subscribe().map_err(|err| {
+    let Some(event_server_client) = app_state.event_server_client.as_ref() else {
+        return Err(actix_web::error::ErrorServiceUnavailable(
+            "WebSocket server is disabled",
+        ));
+    };
+
+    let event_server_subscription = event_server_client.subscribe().map_err(|err| {
         match err {
             EventServerClientError::ServerCrashed => {
                 warn!("Closing websocket connection with internal server error, reason: WebSocketServer crashed!");
@@ -118,7 +125,7 @@ pub async fn ws_handler(
             &hostname,
             &peer_addr,
             &mut subscriptions,
-            rx,
+            event_server_subscription,
             &app_state,
             sub_limit.0,
         )
@@ -148,7 +155,7 @@ async fn handler(
     hostname: &String,
     peer_addr: &Option<String>,
     subscriptions: &mut HashMap<SubscriptionKind, Vec<(SubscriptionId, Option<Filter>)>>,
-    rx: broadcast::Receiver<EventServerEvent>,
+    event_server_subscription: EventServerSubscription,
     app_state: &web::Data<MonadRpcResources>,
     subscription_limit: u16,
 ) -> Option<CloseReason> {
@@ -163,7 +170,7 @@ async fn handler(
         .max_continuation_size(RECV_MAX_CONTINUATION_SIZE);
 
     let mut msg_stream = pin!(msg_stream);
-    let mut broadcast_rx = pin!(rx);
+    let mut event_server_subscription = pin!(event_server_subscription);
 
     loop {
         tokio::select! {
@@ -250,7 +257,7 @@ async fn handler(
                     }
                 }
             }
-            cmd = broadcast_rx.recv() => {
+            cmd = event_server_subscription.recv() => {
                 match cmd {
                     Ok(msg) => {
                         if let Err(close_reason) = handle_notification(
@@ -709,7 +716,7 @@ mod tests {
             SnapshotEventRing::new_from_zstd_bytes(SNAPSHOT_NAME, SNAPSHOT_ZSTD_BYTES, None)
                 .unwrap();
 
-        let ws_server_handle =
+        let event_server_client =
             EventServer::start_for_testing_with_delay(snapshot, Duration::from_secs(1));
 
         let app_state = MonadRpcResources {
@@ -717,6 +724,7 @@ mod tests {
             eth_call_handler: None,
             chain_id: 1337,
             data_provider: None,
+            event_server_client: Some(event_server_client),
             batch_request_limit: 5,
             max_response_size: 25_000_000,
             allow_unprotected_txs: false,
@@ -735,7 +743,6 @@ mod tests {
         actix_test::start(move || {
             App::new()
                 .app_data(web::JsonConfig::default().limit(8192))
-                .app_data(web::Data::new(ws_server_handle.clone()))
                 .app_data(web::Data::new(app_state.clone()))
                 .app_data(web::Data::new(conn_limit.clone()))
                 .app_data(web::Data::new(sub_limit.clone()))


### PR DESCRIPTION
This change updates the event server client usage to enable the `eth_sendRawTransactionSync` method to immediately reply with a tx receipt rather than poll every 100ms. Instead, on every block update, the server scans through every transaction in the block, which is relatively cheap, and responds when a transaction with a matching tx hash is found.

Since the previous polling interval was 100ms, this should reduce the response time of `eth_sendRawTransactionSync` by about 50ms.

After this change, node operators must run their nodes with execution events enabled to enable the `eth_sendRawTransactionSync` endpoint.