### PR TITLE
Add tracing serialization heuristic limit

### DIFF
--- a/monad-rpc/src/cli.rs
+++ b/monad-rpc/src/cli.rs
@@ -121,6 +121,11 @@ pub struct Cli {
     #[arg(long, default_value_t = 20)]
     pub eth_trace_block_max_concurrent_requests: u32,
 
+    /// Set the max concurrent `debug_trace*` block/transaction requests served from triedb
+    /// (CallTracer reads, not EVM replay). Separate from the eth_call semaphore.
+    #[arg(long, default_value_t = 20)]
+    pub debug_trace_max_concurrent_requests: u32,
+
     /// Set the number of threads used for trace operations (shared by block and transaction execution)
     #[arg(long, default_value_t = 1)]
     pub eth_trace_block_executor_threads: u32,

--- a/monad-rpc/src/data/debug_trace_handler.rs
+++ b/monad-rpc/src/data/debug_trace_handler.rs
@@ -1,0 +1,60 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Concurrency limiter for `debug_trace*` block/transaction methods that read pre-computed
+//! call frames from triedb. Separate from the eth_call semaphore because these don't run the
+//! EVM — they share no resources with `eth_call` / `eth_estimateGas` / `debug_traceCall` and
+//! their per-call cost profile is different (memory-heavy rather than CPU-heavy).
+
+use std::sync::Arc;
+
+use tokio::sync::{Semaphore, SemaphorePermit, TryAcquireError};
+use tracing::error;
+
+use crate::types::jsonrpc::JsonRpcError;
+
+#[derive(Clone)]
+pub struct DebugTraceHandler {
+    rate_limiter: Arc<Semaphore>,
+}
+
+impl DebugTraceHandler {
+    pub fn new(max_concurrent_permits: usize) -> Self {
+        Self {
+            rate_limiter: Arc::new(Semaphore::new(max_concurrent_permits)),
+        }
+    }
+
+    pub fn acquire(&self) -> Result<DebugTracePermit<'_>, JsonRpcError> {
+        match self.rate_limiter.try_acquire() {
+            Ok(permit) => Ok(DebugTracePermit { _permit: permit }),
+            Err(TryAcquireError::Closed) => {
+                error!("DebugTraceHandler acquire rate_limiter closed");
+                Err(JsonRpcError::internal_error("method unavailable".into()))
+            }
+            Err(TryAcquireError::NoPermits) => Err(JsonRpcError::internal_error(
+                "concurrent requests limit".into(),
+            )),
+        }
+    }
+
+    pub fn available_permits(&self) -> usize {
+        self.rate_limiter.available_permits()
+    }
+}
+
+pub struct DebugTracePermit<'a> {
+    _permit: SemaphorePermit<'a>,
+}

--- a/monad-rpc/src/data/mod.rs
+++ b/monad-rpc/src/data/mod.rs
@@ -59,6 +59,7 @@ use crate::{
 };
 
 pub mod buffer;
+pub mod debug_trace_handler;
 pub mod eth_call_handler;
 mod source;
 

--- a/monad-rpc/src/handlers/debug.rs
+++ b/monad-rpc/src/handlers/debug.rs
@@ -35,7 +35,7 @@ use crate::{
             UnformattedData,
         },
         ethhex,
-        heuristic_size::HeuristicSize,
+        heuristic_size::{serialized_size_at_most, HeuristicSize},
         jsonrpc::{ChainStateResultExt, JsonRpcError, JsonRpcResult},
     },
 };
@@ -444,11 +444,12 @@ pub struct MonadDebugTraceBlockByHashParams {
     pub tracer: TracerObject,
 }
 
-#[rpc(method = "debug_traceBlockByHash")]
+#[rpc(method = "debug_traceBlockByHash", ignore = "max_response_size")]
 #[allow(non_snake_case)]
 /// Returns the tracing result by executing all transactions in the block specified by the block hash with a tracer.
 pub async fn monad_debug_traceBlockByHash<T: Triedb>(
     data_provider: &DataProvider<T>,
+    max_response_size: usize,
     params: MonadDebugTraceBlockByHashParams,
 ) -> JsonRpcResult<Vec<MonadDebugTraceBlockResult>> {
     trace!("monad_debugTraceBlockByHash: {params:?}");
@@ -465,6 +466,7 @@ pub async fn monad_debug_traceBlockByHash<T: Triedb>(
         tx_hashes,
         call_frames,
         &params.tracer,
+        max_response_size,
     )
     .await
 }
@@ -483,11 +485,12 @@ pub struct MonadDebugTraceBlockResult {
     result: MonadCallFrame,
 }
 
-#[rpc(method = "debug_traceBlockByNumber")]
+#[rpc(method = "debug_traceBlockByNumber", ignore = "max_response_size")]
 #[allow(non_snake_case)]
 /// Returns the tracing result by executing all transactions in the block specified by the block number with a tracer.
 pub async fn monad_debug_traceBlockByNumber<T: Triedb>(
     data_provider: &DataProvider<T>,
+    max_response_size: usize,
     params: MonadDebugTraceBlockByNumberParams,
 ) -> JsonRpcResult<Vec<MonadDebugTraceBlockResult>> {
     trace!("monad_debugTraceBlockByNumber: {params:?}");
@@ -504,15 +507,17 @@ pub async fn monad_debug_traceBlockByNumber<T: Triedb>(
         tx_hashes,
         call_frames,
         &params.tracer,
+        max_response_size,
     )
     .await
 }
 
-#[rpc(method = "debug_traceTransaction")]
+#[rpc(method = "debug_traceTransaction", ignore = "max_response_size")]
 #[allow(non_snake_case)]
 /// Returns all traces of a given transaction.
 pub async fn monad_debug_traceTransaction<T: Triedb>(
     data_provider: &DataProvider<T>,
+    max_response_size: usize,
     params: MonadDebugTraceTransactionParams,
 ) -> JsonRpcResult<Option<MonadCallFrame>> {
     trace!("monad_eth_debugTraceTransaction: {params:?}");
@@ -527,13 +532,17 @@ pub async fn monad_debug_traceTransaction<T: Triedb>(
     };
 
     let rlp_call_frame = &mut call_frame.as_slice();
-    decode_call_frame(
+    let result = decode_call_frame(
         &data_provider.triedb_env,
         rlp_call_frame,
         block_key,
         &params.tracer,
     )
-    .await
+    .await?;
+    if let Some(frame) = &result {
+        serialized_size_at_most(frame, max_response_size)?;
+    }
+    Ok(result)
 }
 
 async fn decode_block_call_frames<T: Triedb>(
@@ -542,8 +551,10 @@ async fn decode_block_call_frames<T: Triedb>(
     tx_hashes: Vec<alloy_primitives::TxHash>,
     call_frames: Vec<Vec<u8>>,
     tracer: &TracerObject,
+    max_response_size: usize,
 ) -> JsonRpcResult<Vec<MonadDebugTraceBlockResult>> {
     let mut resp = Vec::new();
+    let mut accumulated_size: usize = 0;
 
     for (call_frame, tx_id) in call_frames.into_iter().zip(tx_hashes.into_iter()) {
         let rlp_call_frame = &mut call_frame.as_slice();
@@ -551,10 +562,18 @@ async fn decode_block_call_frames<T: Triedb>(
         else {
             return Err(JsonRpcError::internal_error("traces not found".to_string()));
         };
-        resp.push(MonadDebugTraceBlockResult {
+        let result = MonadDebugTraceBlockResult {
             tx_hash: FixedData::<32>::from(tx_id),
             result: traces,
-        });
+        };
+
+        // Enforce a running cumulative budget across the block's transactions. The remaining
+        // budget shrinks each iteration; `serialized_size_at_most` rejects as soon as a tx
+        // would push the total over the cap.
+        let remaining = max_response_size.saturating_sub(accumulated_size);
+        let result_size = serialized_size_at_most(&result, remaining)?;
+        accumulated_size = accumulated_size.saturating_add(result_size);
+        resp.push(result);
     }
     Ok(resp)
 }
@@ -903,6 +922,7 @@ mod tests {
         let data_provider = DataProvider::new(None, Arc::new(mock_triedb), None);
         let resp = monad_debug_traceTransaction(
             &data_provider,
+            usize::MAX,
             MonadDebugTraceTransactionParams {
                 tx_hash: FixedData::<32>([0u8; 32]),
                 tracer: TracerObject::default(),
@@ -960,6 +980,7 @@ mod tests {
         let data_provider = DataProvider::new(None, Arc::new(mock_triedb), None);
         let resp: Option<MonadCallFrame> = monad_debug_traceTransaction(
             &data_provider,
+            usize::MAX,
             MonadDebugTraceTransactionParams {
                 tx_hash: FixedData::<32>([0u8; 32]),
                 tracer: TracerObject::default(),
@@ -1013,6 +1034,7 @@ mod tests {
         let data_provider = DataProvider::new(None, Arc::new(mock_triedb), None);
         let resp: Option<MonadCallFrame> = monad_debug_traceTransaction(
             &data_provider,
+            usize::MAX,
             MonadDebugTraceTransactionParams {
                 tx_hash: FixedData::<32>([0u8; 32]),
                 tracer: TracerObject {
@@ -1119,6 +1141,7 @@ mod tests {
         let data_provider = DataProvider::new(None, Arc::new(mock_triedb), None);
         let resp: Option<MonadCallFrame> = monad_debug_traceTransaction(
             &data_provider,
+            usize::MAX,
             MonadDebugTraceTransactionParams {
                 tx_hash: FixedData::<32>([0u8; 32]),
                 tracer: TracerObject {
@@ -1172,6 +1195,7 @@ mod tests {
         let data_provider = DataProvider::new(None, Arc::new(mock_triedb), None);
         let with_logs_resp = monad_debug_traceTransaction(
             &data_provider,
+            usize::MAX,
             MonadDebugTraceTransactionParams {
                 tx_hash: FixedData::<32>([0u8; 32]),
                 tracer: TracerObject {
@@ -1194,6 +1218,7 @@ mod tests {
 
         let no_logs_resp = monad_debug_traceTransaction(
             &data_provider,
+            usize::MAX,
             MonadDebugTraceTransactionParams {
                 tx_hash: FixedData::<32>([0u8; 32]),
                 tracer: TracerObject {
@@ -1269,6 +1294,90 @@ mod tests {
         assert_eq!(result.receipts.len(), 1);
         let expected_receipt = "0x02f9010801825208b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0";
         assert_eq!(result.receipts[0], expected_receipt);
+    }
+
+    #[tokio::test]
+    async fn debug_block_call_frames_cumulative_size_exceeded() {
+        // Two single-frame traces; each individually fits under `max_response_size`, but the
+        // cumulative size of both exceeds the cap. This exercises the running budget in
+        // `decode_block_call_frames` that this PR introduces — without the cumulative check,
+        // both frames would be materialized before the post-batch limit fires.
+        use monad_triedb_utils::triedb_env::{BlockKey, FinalizedBlockKey};
+
+        let frame_bytes = encode_trace(vec![make_frame_with_positions(1, &[0])]);
+        let mock_triedb = mock_triedb::MockTriedb::default();
+        let block_key = BlockKey::Finalized(FinalizedBlockKey(SeqNum(1)));
+
+        // Measure the size of one tx's serialized result so we can pick a `max_response_size`
+        // that admits one but not two.
+        let frame_decoded = decode_call_frame(
+            &mock_triedb,
+            &mut frame_bytes.as_slice(),
+            block_key,
+            &TracerObject::default(),
+        )
+        .await
+        .unwrap()
+        .expect("decoded frame should be present");
+        let wrapped = MonadDebugTraceBlockResult {
+            tx_hash: FixedData::<32>([0u8; 32]),
+            result: frame_decoded,
+        };
+        let one_tx_size = serde_json::to_string(&wrapped).unwrap().len();
+        // Budget admits the first tx but not the cumulative pair.
+        let max_response_size = one_tx_size + (one_tx_size / 2);
+
+        let error = decode_block_call_frames(
+            &mock_triedb,
+            block_key,
+            vec![
+                alloy_primitives::TxHash::ZERO,
+                alloy_primitives::TxHash::ZERO,
+            ],
+            vec![frame_bytes.clone(), frame_bytes],
+            &TracerObject::default(),
+            max_response_size,
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error, JsonRpcError::max_size_exceeded());
+    }
+
+    #[tokio::test]
+    async fn debug_trace_transaction_max_size_exceeded() {
+        // Single-frame trace; with max_response_size = 1 byte we must hit the size limit
+        // regardless of payload contents.
+        let frame = encode_trace(vec![make_frame_with_positions(1, &[0])]);
+        let mut mock_triedb = mock_triedb::MockTriedb::default();
+        mock_triedb.set_transaction_location_by_hash(
+            EthTxHash::default(),
+            TransactionLocation {
+                block_num: 1,
+                tx_index: 0,
+            },
+        );
+        mock_triedb.set_call_frame(
+            TransactionLocation {
+                block_num: 1,
+                tx_index: 0,
+            },
+            frame,
+        );
+
+        let data_provider = DataProvider::new(None, Arc::new(mock_triedb), None);
+        let error = monad_debug_traceTransaction(
+            &data_provider,
+            1,
+            MonadDebugTraceTransactionParams {
+                tx_hash: FixedData::<32>([0u8; 32]),
+                tracer: TracerObject::default(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error, JsonRpcError::max_size_exceeded());
     }
 
     #[tokio::test]

--- a/monad-rpc/src/handlers/debug_replay.rs
+++ b/monad-rpc/src/handlers/debug_replay.rs
@@ -34,6 +34,7 @@ use crate::{
     middleware::TimingRequestId,
     types::{
         eth_json::{BlockTagOrHash, BlockTags, EthHash},
+        heuristic_size::serialized_size_at_most,
         jsonrpc::{JsonRpcError, JsonRpcResult, JsonRpcResultExt},
     },
 };
@@ -138,6 +139,7 @@ pub async fn monad_debug_trace_replay<T: Triedb>(
     data_provider: &DataProvider<T>,
     eth_call_executor: &EthCallExecutor,
     chain_id: ChainId,
+    max_response_size: usize,
     params: &impl DebugTraceParams,
 ) -> JsonRpcResult<Box<RawValue>> {
     let block_key =
@@ -258,6 +260,7 @@ pub async fn monad_debug_trace_replay<T: Triedb>(
     };
     let v: serde_cbor::Value = serde_cbor::from_slice(&raw_payload)
         .map_err(|e| JsonRpcError::internal_error(format!("cbor decode error: {}", e)))?;
+    serialized_size_at_most(&v, max_response_size)?;
     serde_json::value::to_raw_value(&v)
         .map_err(|e| JsonRpcError::internal_error(format!("json serialization error: {}", e)))
 }
@@ -271,8 +274,11 @@ pub async fn collect_debug_trace_via_replay(
     let eth_call_handler = app_state.eth_call_handler.as_ref().method_not_supported()?;
     let permit = eth_call_handler.acquire(request_id).await?;
     let chain_id = parse_ethcall_chain_id(app_state.chain_id)?;
+    let max_response_size = app_state.max_response_size as usize;
 
     permit
-        .execute(|_, executor| monad_debug_trace_replay(data_provider, executor, chain_id, params))
+        .execute(|_, executor| {
+            monad_debug_trace_replay(data_provider, executor, chain_id, max_response_size, params)
+        })
         .await
 }

--- a/monad-rpc/src/handlers/eth/call.rs
+++ b/monad-rpc/src/handlers/eth/call.rs
@@ -48,6 +48,7 @@ use crate::{
     types::{
         eth_json::{BlockTagOrHash, MonadCreateAccessListResult},
         ethhex,
+        heuristic_size::serialized_size_at_most,
         jsonrpc::{JsonRpcError, JsonRpcResult},
     },
 };
@@ -745,7 +746,8 @@ pub async fn monad_eth_call<T: Triedb + TriedbPath>(
     method = "debug_traceCall",
     ignore = "eth_call_handler_config",
     ignore = "eth_call_executor",
-    ignore = "chain_id"
+    ignore = "chain_id",
+    ignore = "max_response_size"
 )]
 #[allow(non_snake_case)]
 pub async fn monad_debug_traceCall<T: Triedb + TriedbPath>(
@@ -753,6 +755,7 @@ pub async fn monad_debug_traceCall<T: Triedb + TriedbPath>(
     eth_call_handler_config: &EthCallHandlerConfig,
     eth_call_executor: &EthCallExecutor,
     chain_id: u64,
+    max_response_size: usize,
     params: MonadDebugTraceCallParams,
 ) -> JsonRpcResult<Box<RawValue>> {
     debug!(?params, "monad_debug_traceCall");
@@ -787,6 +790,9 @@ pub async fn monad_debug_traceCall<T: Triedb + TriedbPath>(
                 &tracer_params,
             )
             .await?;
+            if let Some(f) = &frame {
+                serialized_size_at_most(f, max_response_size)?;
+            }
             serde_json::value::to_raw_value(&frame).map_err(|e| {
                 JsonRpcError::internal_error(format!("json serialization error: {}", e))
             })
@@ -795,6 +801,7 @@ pub async fn monad_debug_traceCall<T: Triedb + TriedbPath>(
         MonadTracer::PreStateTracer | MonadTracer::StateDiffTracer => {
             let v: serde_cbor::Value = serde_cbor::from_slice(&raw_payload)
                 .map_err(|e| JsonRpcError::internal_error(format!("cbor decode error: {}", e)))?;
+            serialized_size_at_most(&v, max_response_size)?;
             serde_json::value::to_raw_value(&v).map_err(|e| {
                 JsonRpcError::internal_error(format!("json serialization error: {}", e))
             })

--- a/monad-rpc/src/handlers/mod.rs
+++ b/monad-rpc/src/handlers/mod.rs
@@ -289,7 +289,12 @@ async fn debug_traceBlockByHash(
             .await
             .map(serialize_result)?;
     }
-    monad_debug_traceBlockByHash(data_provider, params)
+    // CallTracer reads call frames from triedb rather than running the EVM, but block-level
+    // traces can still materialize hundreds of MB. Gate on the dedicated debug-trace
+    // semaphore so a 1000-element batch can't fan out unbounded. Permit drops at scope end.
+    let _permit = app_state.debug_trace_handler.acquire()?;
+    let max_response_size = app_state.max_response_size as usize;
+    monad_debug_traceBlockByHash(data_provider, max_response_size, params)
         .await
         .map(serialize_result)?
 }
@@ -308,8 +313,9 @@ async fn debug_traceBlockByNumber(
             .await
             .map(serialize_result)?;
     }
-
-    monad_debug_traceBlockByNumber(data_provider, params)
+    let _permit = app_state.debug_trace_handler.acquire()?;
+    let max_response_size = app_state.max_response_size as usize;
+    monad_debug_traceBlockByNumber(data_provider, max_response_size, params)
         .await
         .map(serialize_result)?
 }
@@ -325,6 +331,7 @@ async fn debug_traceCall(
     let params = serde_json::from_str(params.get()).invalid_params()?;
     let permit = eth_call_handler.acquire(request_id).await?;
 
+    let max_response_size = app_state.max_response_size as usize;
     permit
         .execute(|eth_call_handler_config, executor| {
             monad_debug_traceCall(
@@ -332,6 +339,7 @@ async fn debug_traceCall(
                 eth_call_handler_config,
                 executor,
                 app_state.chain_id,
+                max_response_size,
                 params,
             )
         })
@@ -353,8 +361,9 @@ async fn debug_traceTransaction(
             .await
             .map(serialize_result)?;
     }
-
-    monad_debug_traceTransaction(data_provider, params)
+    let _permit = app_state.debug_trace_handler.acquire()?;
+    let max_response_size = app_state.max_response_size as usize;
+    monad_debug_traceTransaction(data_provider, max_response_size, params)
         .await
         .map(serialize_result)?
 }

--- a/monad-rpc/src/handlers/resources.rs
+++ b/monad-rpc/src/handlers/resources.rs
@@ -23,7 +23,9 @@ use tracing_actix_web::RootSpanBuilder;
 
 use crate::{
     comparator::RpcComparator,
-    data::{eth_call_handler::EthCallHandler, DataProvider},
+    data::{
+        debug_trace_handler::DebugTraceHandler, eth_call_handler::EthCallHandler, DataProvider,
+    },
     event::EventServerClient,
     middleware::Metrics,
     txpool::EthTxPoolBridgeClient,
@@ -33,6 +35,7 @@ use crate::{
 pub struct MonadRpcResources {
     pub txpool_bridge_client: Option<EthTxPoolBridgeClient>,
     pub eth_call_handler: Option<EthCallHandler>,
+    pub debug_trace_handler: DebugTraceHandler,
     pub chain_id: u64,
     pub data_provider: Option<DataProvider<TriedbEnv>>,
     pub event_server_client: Option<EventServerClient>,
@@ -54,6 +57,7 @@ impl MonadRpcResources {
     pub fn new(
         txpool_bridge_client: Option<EthTxPoolBridgeClient>,
         eth_call_handler: Option<EthCallHandler>,
+        debug_trace_handler: DebugTraceHandler,
         chain_id: u64,
         data_provider: Option<DataProvider<TriedbEnv>>,
         event_server_client: Option<EventServerClient>,
@@ -72,6 +76,7 @@ impl MonadRpcResources {
         Self {
             txpool_bridge_client,
             eth_call_handler,
+            debug_trace_handler,
             chain_id,
             data_provider,
             event_server_client,

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -26,6 +26,7 @@ use monad_rpc::{
     comparator::RpcComparator,
     data::{
         buffer::BlockBuffer,
+        debug_trace_handler::DebugTraceHandler,
         eth_call_handler::{EthCallHandler, EthCallHandlerConfig},
         DataProvider,
     },
@@ -361,9 +362,13 @@ async fn main() -> std::io::Result<()> {
 
     let enable_websockets = event_server_client.is_some();
 
+    let debug_trace_handler =
+        DebugTraceHandler::new(args.debug_trace_max_concurrent_requests as usize);
+
     let app_state = MonadRpcResources::new(
         txpool_bridge_client,
         eth_call_handler,
+        debug_trace_handler,
         node_config.chain_id,
         data_provider,
         event_server_client.clone(),

--- a/monad-rpc/src/tests.rs
+++ b/monad-rpc/src/tests.rs
@@ -24,6 +24,7 @@ use test_case::test_case;
 use tracing_actix_web::TracingLogger;
 
 use crate::{
+    data::debug_trace_handler::DebugTraceHandler,
     handlers::{
         resources::{MonadJsonRootSpanBuilder, MonadRpcResources},
         rpc_handler,
@@ -38,6 +39,7 @@ pub async fn init_server(
     let app_state = MonadRpcResources {
         txpool_bridge_client: Some(EthTxPoolBridgeClient::for_testing()),
         eth_call_handler: None,
+        debug_trace_handler: DebugTraceHandler::new(20),
         chain_id: 1337,
         data_provider: None,
         event_server_client: None,

--- a/monad-rpc/src/types/heuristic_size.rs
+++ b/monad-rpc/src/types/heuristic_size.rs
@@ -17,9 +17,65 @@ use alloy_consensus::TxEnvelope;
 use alloy_primitives::FixedBytes;
 use alloy_rlp::Encodable;
 use alloy_rpc_types::Log;
+use serde::Serialize;
+
+use crate::types::jsonrpc::JsonRpcError;
 
 pub trait HeuristicSize {
     fn heuristic_json_len(&self) -> usize;
+}
+
+/// Returns the JSON-serialized byte length of `value`, aborting early once the running count
+/// exceeds `max_size` (returns [`JsonRpcError::max_size_exceeded`] in that case).
+///
+/// Prefer a [`HeuristicSize`] impl when the type is flat and stable — closed-form arithmetic
+/// is cheaper and pre-empts the work that produces the response. Use this helper when:
+///
+/// - the type is recursive (e.g. `MonadCallFrame`'s `calls` tree), so a `HeuristicSize` impl
+///   would need to walk it anyway, or
+/// - the type has many `skip_serializing_if`/`rename`/`skip` attributes that a hand-written
+///   heuristic would duplicate (and silently drift from) on every schema change.
+///
+/// The check counts bytes via a [`std::io::Write`] sink rather than materializing the JSON,
+/// so it doesn't allocate the serialized form just to measure it.
+pub fn serialized_size_at_most<T: Serialize>(
+    value: &T,
+    max_size: usize,
+) -> Result<usize, JsonRpcError> {
+    struct LimitedCounter {
+        count: usize,
+        limit: usize,
+        exceeded: bool,
+    }
+
+    impl std::io::Write for LimitedCounter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.count = self.count.saturating_add(buf.len());
+            if self.count > self.limit {
+                self.exceeded = true;
+                return Err(std::io::Error::other("response exceeds size limit"));
+            }
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let mut counter = LimitedCounter {
+        count: 0,
+        limit: max_size,
+        exceeded: false,
+    };
+    match serde_json::to_writer(&mut counter, value) {
+        Ok(()) => Ok(counter.count),
+        Err(_) if counter.exceeded => Err(JsonRpcError::max_size_exceeded()),
+        Err(e) => Err(JsonRpcError::internal_error(format!(
+            "serialization error: {}",
+            e
+        ))),
+    }
 }
 
 impl HeuristicSize for String {

--- a/monad-rpc/src/websocket/handler.rs
+++ b/monad-rpc/src/websocket/handler.rs
@@ -696,6 +696,7 @@ mod tests {
 
     use super::ws_handler;
     use crate::{
+        data::debug_trace_handler::DebugTraceHandler,
         event::EventServer,
         handlers::resources::MonadRpcResources,
         txpool::EthTxPoolBridgeClient,
@@ -722,6 +723,7 @@ mod tests {
         let app_state = MonadRpcResources {
             txpool_bridge_client: Some(EthTxPoolBridgeClient::for_testing()),
             eth_call_handler: None,
+            debug_trace_handler: DebugTraceHandler::new(20),
             chain_id: 1337,
             data_provider: None,
             event_server_client: Some(event_server_client),


### PR DESCRIPTION
This PR does two things:
1. Response size limits on tracing endpoints, where a running total is kept and abort mid stream if as soon as the running byte count exceeds the size limit
2. Since traces response can be large, a separate semaphore for debug_trace call tracers request.