### PR TITLE
Bump execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,6 +2292,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4984,6 +5017,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-build"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
+ "cargo_metadata",
+ "cc",
+ "cmake",
+]
+
+[[package]]
 name = "monad-chain-config"
 version = "0.1.0"
 dependencies = [
@@ -5108,8 +5151,7 @@ dependencies = [
 name = "monad-cxx"
 version = "0.1.0"
 dependencies = [
- "bindgen",
- "cmake",
+ "monad-build",
  "tracing",
 ]
 
@@ -5440,9 +5482,9 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",
- "bindgen",
  "futures",
  "hex",
+ "monad-build",
  "monad-cxx",
  "serde",
  "tracing",
@@ -5452,10 +5494,8 @@ dependencies = [
 name = "monad-event-ring"
 version = "0.1.0"
 dependencies = [
- "bindgen",
- "cc",
- "cmake",
  "libc",
+ "monad-build",
 ]
 
 [[package]]
@@ -5466,9 +5506,8 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types",
- "bindgen",
- "cc",
  "itertools 0.10.5",
+ "monad-build",
  "monad-event-ring",
  "serde",
  "strum",
@@ -6106,7 +6145,7 @@ dependencies = [
 name = "monad-statesync"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "monad-build",
  "monad-cxx",
 ]
 
@@ -6246,9 +6285,8 @@ dependencies = [
 name = "monad-triedb"
 version = "0.1.0"
 dependencies = [
- "bindgen",
- "cmake",
  "futures",
+ "monad-build",
  "monad-cxx",
  "tracing",
 ]
@@ -8374,6 +8412,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "semver-parser"


### PR DESCRIPTION
This change bumps the execution submodule to include some changes to the execution crate build systems that avoid unnecessary rebuilds when there are no modifications to the execution repo. This is a huge DX win when developing as `monad-cxx` et al. will no longer recompile on every `cargo ...` invocation.