### PR TITLE
Implement HistoricalDataSource for BlockBufferView

### DIFF
--- a/monad-rpc/src/data/mod.rs
+++ b/monad-rpc/src/data/mod.rs
@@ -155,37 +155,6 @@ fn resolve_block_height_from_buffer(view: &BlockBufferView, block: &BlockTagOrHa
     }
 }
 
-async fn resolve_block_tag_or_hash(
-    data_source: &impl HistoricalDataSource,
-    block_tag_or_hash: BlockTagOrHash,
-) -> DataSourceResult<Option<BlockPointer>> {
-    match block_tag_or_hash {
-        BlockTagOrHash::BlockTags(BlockTags::Number(Quantity(block_num))) => {
-            data_source.try_resolve_block_number(block_num).await
-        }
-        BlockTagOrHash::BlockTags(BlockTags::Latest) => {
-            data_source
-                .try_resolve_block_commit_state(BlockCommitState::Proposed)
-                .await
-        }
-        BlockTagOrHash::BlockTags(BlockTags::Safe) => {
-            data_source
-                .try_resolve_block_commit_state(BlockCommitState::Voted)
-                .await
-        }
-        BlockTagOrHash::BlockTags(BlockTags::Finalized) => {
-            data_source
-                .try_resolve_block_commit_state(BlockCommitState::Finalized)
-                .await
-        }
-        BlockTagOrHash::Hash(block_hash) => {
-            data_source
-                .try_resolve_block_hash(BlockHash::from(block_hash.0))
-                .await
-        }
-    }
-}
-
 impl<T> DataProvider<T>
 where
     T: Triedb + Send + Sync + 'static,
@@ -421,7 +390,9 @@ where
             }
         }
 
-        if let Some(block_pointer) = resolve_block_tag_or_hash(&self.historical, block)
+        if let Some(block_pointer) = self
+            .historical
+            .try_resolve(block)
             .await
             .map_err(ChainStateError::DataSource)?
         {
@@ -454,7 +425,9 @@ where
             }
         }
 
-        if let Some(block_pointer) = resolve_block_tag_or_hash(&self.historical, block)
+        if let Some(block_pointer) = self
+            .historical
+            .try_resolve(block)
             .await
             .map_err(ChainStateError::DataSource)?
         {

--- a/monad-rpc/src/data/source/historical.rs
+++ b/monad-rpc/src/data/source/historical.rs
@@ -21,11 +21,40 @@ use dyn_clone::{clone_trait_object, DynClone};
 use monad_eth_types::TxEnvelopeWithSender;
 
 use super::{BlockCommitState, BlockPointer, DataSourceResult, DataSourceStack};
+use crate::types::eth_json::{BlockTagOrHash, BlockTags};
 
 /// Trait for read-only queries against historical chain data.
 #[async_trait]
 #[auto_impl(Box)]
 pub trait HistoricalDataSource: DynClone + Send + Sync {
+    async fn try_resolve(
+        &self,
+        block_tag_or_hash: BlockTagOrHash,
+    ) -> DataSourceResult<Option<BlockPointer>> {
+        match block_tag_or_hash {
+            BlockTagOrHash::BlockTags(block_tags) => match block_tags {
+                BlockTags::Number(block_number) => {
+                    self.try_resolve_block_number(block_number.0).await
+                }
+                BlockTags::Latest => {
+                    self.try_resolve_block_commit_state(BlockCommitState::Proposed)
+                        .await
+                }
+                BlockTags::Safe => {
+                    self.try_resolve_block_commit_state(BlockCommitState::Voted)
+                        .await
+                }
+                BlockTags::Finalized => {
+                    self.try_resolve_block_commit_state(BlockCommitState::Finalized)
+                        .await
+                }
+            },
+            BlockTagOrHash::Hash(hash) => {
+                self.try_resolve_block_hash(BlockHash::from(hash.0)).await
+            }
+        }
+    }
+
     async fn try_resolve_block_commit_state(
         &self,
         commit_state: BlockCommitState,


### PR DESCRIPTION
This change implements `HistoricalDataSource` for `BlockBufferView`, completing the vertical integration of unified RPC with `get_block` and `get_block_headers` methods completely migrated.