### PR TITLE
Raptorcast: Proposer validation per round (sync version)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5950,6 +5950,7 @@ dependencies = [
  "monad-peer-score",
  "monad-raptorcast",
  "monad-types",
+ "monad-validator",
  "tokio",
  "tracing",
 ]

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -85,6 +85,7 @@ pub enum RouterCommand<ST: CertificateSignatureRecoverable, OM> {
     },
     AddEpochValidatorSet {
         epoch: Epoch,
+        epoch_start: Round,
         validator_set: Vec<(NodeId<CertificateSignaturePubKey<ST>>, Stake)>,
     },
     UpdateCurrentRound(Epoch, Round),
@@ -127,10 +128,12 @@ impl<ST: CertificateSignatureRecoverable, OM> Debug for RouterCommand<ST, OM> {
                 .finish(),
             Self::AddEpochValidatorSet {
                 epoch,
+                epoch_start,
                 validator_set,
             } => f
                 .debug_struct("AddEpochValidatorSet")
                 .field("epoch", epoch)
+                .field("epoch_start", epoch_start)
                 .field("validator_set", validator_set)
                 .finish(),
             Self::UpdateCurrentRound(arg0, arg1) => f

--- a/monad-mock-swarm/benches/two_node_benchmark.rs
+++ b/monad-mock-swarm/benches/two_node_benchmark.rs
@@ -81,7 +81,10 @@ fn two_nodes() {
                     ID::new(NodeId::new(state_builder.key.pubkey())),
                     state_builder,
                     NoSerRouterConfig::new(all_peers.clone()).build(),
-                    MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
+                    // epoch length must match the chain config (MockChainConfig::new
+                    // uses SeqNum::MAX), otherwise the updater fabricates validator-set
+                    // updates for epochs the consensus epoch_manager never schedules.
+                    MockValSetUpdaterNop::new(validators.validators, SeqNum::MAX),
                     MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
                     MockLedger::new(state_backend.clone()),
                     MockStateSyncExecutor::new(state_backend),

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -69,7 +69,9 @@ use monad_updaters::{
     triedb_val_set::ValSetUpdater,
 };
 use monad_validator::{
-    signature_collection::SignatureCollection, validator_set::ValidatorSetFactory,
+    proposer_schedule::{BoxedProposerSchedule, ElectedProposerSchedule},
+    signature_collection::SignatureCollection,
+    validator_set::ValidatorSetFactory,
     weighted_round_robin::WeightedRoundRobin,
 };
 use monad_wal::wal::{WALLog, WALoggerConfig};
@@ -180,6 +182,10 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
             node_state.node_config.txpool_peer_score.clone(),
             StdClock,
         );
+    let leader_election: WeightedRoundRobin<_> = WeightedRoundRobin::default();
+    let proposer_schedule: BoxedProposerSchedule<_> =
+        Box::new(ElectedProposerSchedule::new(leader_election.clone()));
+
     let router = build_raptorcast_router::<
         SignatureType,
         SignatureCollectionType,
@@ -195,6 +201,7 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         locked_epoch_validators.clone(),
         current_epoch,
         current_round,
+        proposer_schedule,
         node_state.persisted_peers_path,
         score_reader.clone(),
     );
@@ -382,7 +389,7 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
 
     let builder = MonadStateBuilder {
         validator_set_factory: ValidatorSetFactory::default(),
-        leader_election: WeightedRoundRobin::default(),
+        leader_election,
         block_validator: EthBlockValidator::default(),
         block_policy: create_block_policy(),
         state_backend,
@@ -621,6 +628,7 @@ fn build_raptorcast_router<ST, SCT, M, OM, DS>(
     locked_epoch_validators: Vec<ValidatorSetDataWithEpoch<SCT>>,
     current_epoch: Epoch,
     current_round: Round,
+    proposer_schedule: BoxedProposerSchedule<CertificateSignaturePubKey<ST>>,
     persisted_peers_path: PathBuf,
     direct_udp_peer_score_reader: DS,
 ) -> MultiRouter<
@@ -846,6 +854,7 @@ where
         auth_protocol,
         direct_udp_auth_protocol,
         direct_udp_peer_score_reader,
+        proposer_schedule,
     )
 }
 

--- a/monad-raptorcast/examples/latency.rs
+++ b/monad-raptorcast/examples/latency.rs
@@ -676,10 +676,12 @@ fn setup_node(
         dataplane_control,
         Arc::new(std::sync::Mutex::new(pd)),
         Epoch(0),
+        monad_raptorcast::dummy_proposer_schedule(),
     );
 
     raptorcast.exec(vec![RouterCommand::AddEpochValidatorSet {
         epoch: Epoch(0),
+        epoch_start: monad_types::Round(0),
         validator_set: epoch_validators
             .iter()
             .map(|(id, stake)| (*id, *stake))

--- a/monad-raptorcast/examples/service.rs
+++ b/monad-raptorcast/examples/service.rs
@@ -138,6 +138,7 @@ fn service(
 
                 service.exec(vec![RouterCommand::AddEpochValidatorSet {
                     epoch: Epoch(0),
+                    epoch_start: monad_types::Round(0),
                     validator_set: all_peers.iter().map(|peer| (*peer, Stake::ONE)).collect(),
                 }]);
 

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -56,6 +56,7 @@ use monad_peer_discovery::{
 use monad_peer_score::IdentityScore;
 use monad_types::{DropTimer, Epoch, ExecutionProtocol, NodeId, Round, RouterTarget, UdpPriority};
 use monad_validator::{
+    proposer_schedule::BoxedProposerSchedule,
     signature_collection::SignatureCollection,
     validator_set::{ValidatorSet, ValidatorSetType as _},
 };
@@ -123,6 +124,7 @@ where
 
     epoch_validators: BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
     full_node_groups: FullNodeGroupMap<CertificateSignaturePubKey<ST>>,
+    proposer_schedule: BoxedProposerSchedule<CertificateSignaturePubKey<ST>>,
 
     dedicated_full_nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
     peer_discovery_driver: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
@@ -184,6 +186,7 @@ where
         control: DataplaneControl,
         peer_discovery_driver: Arc<Mutex<PeerDiscoveryDriver<PD>>>,
         current_epoch: Epoch,
+        proposer_schedule: BoxedProposerSchedule<CertificateSignaturePubKey<ST>>,
     ) -> Self {
         let (tcp_reader, tcp_writer) = tcp_socket.split();
 
@@ -283,6 +286,7 @@ where
             is_dynamic_fullnode,
             epoch_validators: Default::default(),
             full_node_groups: Default::default(),
+            proposer_schedule,
 
             dedicated_full_nodes: config.primary_instance.fullnode_dedicated.clone(),
             peer_discovery_driver,
@@ -782,6 +786,12 @@ pub fn create_dataplane_for_tests(with_direct_udp: bool) -> DataplaneHandles {
     }
 }
 
+// used where the proposer schedule is irrelevant (e.g. v0): every round
+// resolves to an unknown proposer.
+pub fn dummy_proposer_schedule<PT: PubKey>() -> BoxedProposerSchedule<PT> {
+    Box::new(crate::util::StubProposerSchedule::default())
+}
+
 pub fn new_defaulted_raptorcast_for_tests<ST, M, OM, SE>(
     dataplane: DataplaneHandles,
     known_addresses: HashMap<NodeId<CertificateSignaturePubKey<ST>>, SocketAddrV4>,
@@ -844,6 +854,7 @@ where
         dataplane.control,
         shared_pd,
         current_epoch,
+        dummy_proposer_schedule(),
     )
 }
 
@@ -910,6 +921,7 @@ where
         dataplane.control,
         shared_pd,
         current_epoch,
+        dummy_proposer_schedule(),
     )
 }
 
@@ -958,6 +970,8 @@ where
 
                     self.udp_state.update_current_round(round);
                     self.full_node_groups.delete_expired(round);
+                    let proposer_cutoff = round.saturating_sub(round_info::CACHE_MAX_PAST_ROUNDS);
+                    self.proposer_schedule.prune_below(proposer_cutoff);
                     self.peer_discovery_driver
                         .lock()
                         .unwrap()
@@ -965,9 +979,20 @@ where
                 }
                 RouterCommand::AddEpochValidatorSet {
                     epoch,
+                    epoch_start,
                     validator_set,
                 } => {
-                    trace!(?epoch, ?validator_set, "RaptorCast AddEpochValidatorSet");
+                    trace!(
+                        ?epoch,
+                        ?epoch_start,
+                        ?validator_set,
+                        "RaptorCast AddEpochValidatorSet"
+                    );
+                    // SAFETY: the validator_set comes from
+                    // ValidatorSetData, which should not have duplicates
+                    // or invalid entries.
+                    let validators =
+                        ValidatorSet::new_unchecked(validator_set.iter().cloned().collect());
                     if let Some(epoch_validators) = self.epoch_validators.get(&epoch) {
                         assert_eq!(validator_set.len(), epoch_validators.len());
 
@@ -980,15 +1005,12 @@ where
 
                         warn!("duplicate validator set update (this is safe but unexpected)")
                     } else {
-                        // SAFETY: the validator_set comes from
-                        // ValidatorSetData, which should not have
-                        // duplicates or invalid entries.
-                        let validators = ValidatorSet::new_unchecked(
-                            validator_set.clone().into_iter().collect(),
-                        );
-                        let removed = self.epoch_validators.insert(epoch, validators);
+                        let removed = self.epoch_validators.insert(epoch, validators.clone());
                         assert!(removed.is_none());
                     }
+
+                    self.proposer_schedule
+                        .insert_epoch(epoch, epoch_start, validators);
                     self.peer_discovery_driver.lock().unwrap().update(
                         PeerDiscoveryEvent::UpdateValidatorSet {
                             epoch,
@@ -1212,6 +1234,7 @@ where
                 this.udp_state.handle_message(
                     &this.epoch_validators,
                     &this.full_node_groups,
+                    &*this.proposer_schedule,
                     |targets, payload, bcast_stride| {
                         for target in targets {
                             rebroadcast_packet(
@@ -1515,11 +1538,11 @@ where
                         if this.full_node_groups.try_insert(group).is_none() {
                             // TODO: convert to an assertion?
                             error!(
-                                round_span =? round_span,
-                                publisher_id =? publisher_id,
+                                round_span = ?round_span,
+                                publisher_id = ?publisher_id,
                                 "Accepted group assignment contains overlaps"
                             );
-                        };
+                        }
                     }
                     Poll::Ready(None) => {
                         error!("RaptorCast secondary->primary channel disconnected.");

--- a/monad-raptorcast/src/round_info.rs
+++ b/monad-raptorcast/src/round_info.rs
@@ -28,8 +28,8 @@ use crate::{
     SIGNATURE_SIZE,
 };
 
-const CACHE_MAX_FUTURE_ROUNDS: Round = Round(100);
-const CACHE_MAX_PAST_ROUNDS: Round = Round(100);
+pub(crate) const CACHE_MAX_FUTURE_ROUNDS: Round = Round(100);
+pub(crate) const CACHE_MAX_PAST_ROUNDS: Round = Round(100);
 
 // Stores information related to the current round.
 pub struct RoundInfoCache<PT: PubKey> {

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -22,7 +22,10 @@ use monad_crypto::{
 };
 use monad_executor::ExecutorMetricsChain;
 use monad_types::{Epoch, NodeId, Round};
-use monad_validator::validator_set::{ValidatorSet, ValidatorSetType as _};
+use monad_validator::{
+    proposer_schedule::ProposerSchedule,
+    validator_set::{ValidatorSet, ValidatorSetType as _},
+};
 
 pub use crate::packet::build_messages;
 use crate::{
@@ -171,6 +174,7 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
         &mut self,
         epoch_validators: &BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
         full_node_group_map: &FullNodeGroupMap<CertificateSignaturePubKey<ST>>,
+        proposer_schedule: &dyn ProposerSchedule<CertificateSignaturePubKey<ST>>,
         chunk: &ValidatedChunk<CertificateSignaturePubKey<ST>>,
         rebroadcast_to: &mut impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
         sender: Option<&NodeId<CertificateSignaturePubKey<ST>>>,
@@ -209,7 +213,14 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
 
         match (chunk.encoding_scheme, &group) {
             (EncodingScheme::Deterministic25(round), BroadcastGroup::Primary(g)) => self
-                .handle_deterministic_primary(g, round, chunk, &decoding_context, rebroadcast_to),
+                .handle_deterministic_primary(
+                    g,
+                    proposer_schedule,
+                    round,
+                    chunk,
+                    &decoding_context,
+                    rebroadcast_to,
+                ),
             (EncodingScheme::Deterministic25(round), BroadcastGroup::Secondary(g)) => self
                 .handle_deterministic_secondary(g, round, chunk, &decoding_context, rebroadcast_to),
             _ => self.handle_regular(&group, chunk, &decoding_context, rebroadcast_to),
@@ -219,11 +230,22 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
     fn handle_deterministic_primary(
         &mut self,
         group: &PrimaryBroadcastGroup<'_, CertificateSignaturePubKey<ST>>,
+        proposer_schedule: &dyn ProposerSchedule<CertificateSignaturePubKey<ST>>,
         round: Round,
         chunk: &ValidatedChunk<CertificateSignaturePubKey<ST>>,
         decoding_context: &DecodingContext<CertificateSignaturePubKey<ST>>,
         rebroadcast_to: &mut impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>),
     ) -> Option<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
+        if proposer_schedule.check_epoch(group.epoch(), round) != Some(true) {
+            tracing::debug!(
+                ?round,
+                group_epoch = ?group.epoch(),
+                author = ?chunk.author,
+                "dropping deterministic primary chunk with round/epoch mismatch"
+            );
+            return None;
+        }
+
         let Some(round_info) = self.round_info_cache.get_or_insert_primary(round) else {
             tracing::debug!(
                 ?chunk.group_id,
@@ -233,6 +255,28 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
             );
             return None;
         };
+
+        match proposer_schedule.check_proposer(&chunk.author, round) {
+            Some(true) => {
+                // proposer expected, proceed
+            }
+            Some(false) => {
+                tracing::debug!(
+                    ?round,
+                    author = ?chunk.author,
+                    "dropping deterministic primary chunk from non-proposer"
+                );
+                return None;
+            }
+            None => {
+                tracing::debug!(
+                    ?round,
+                    author = ?chunk.author,
+                    "dropping deterministic primary chunk with unknown proposer"
+                );
+                return None;
+            }
+        }
 
         // already logged the equivocation in try_commit.
         round_info.try_commit(chunk)?;
@@ -426,6 +470,7 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
         &mut self,
         epoch_validators: &BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
         full_node_group_map: &FullNodeGroupMap<CertificateSignaturePubKey<ST>>,
+        proposer_schedule: &dyn ProposerSchedule<CertificateSignaturePubKey<ST>>,
         rebroadcast: impl FnMut(Vec<NodeId<CertificateSignaturePubKey<ST>>>, Bytes, u16),
         message: crate::auth::AuthRecvMsg<CertificateSignaturePubKey<ST>>,
     ) -> Vec<(NodeId<CertificateSignaturePubKey<ST>>, Bytes)> {
@@ -552,6 +597,7 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
                     self.handle_raptorcast(
                         epoch_validators,
                         full_node_group_map,
+                        proposer_schedule,
                         &chunk,
                         rebroadcast_to,
                         message.sender.as_ref(),
@@ -877,7 +923,7 @@ mod tests {
         util::{
             compute_app_message_hash, BroadcastMode, BuildTarget, FullNodeGroupMap,
             PrimaryBroadcastGroup, Redundancy, SecondaryBroadcastGroup, SecondaryGroup,
-            ValidatorGroupMap,
+            StubProposerSchedule, ValidatorGroupMap,
         },
     };
 
@@ -1210,6 +1256,7 @@ mod tests {
         udp_state.handle_message(
             &epoch_validators,
             &full_node_groups,
+            &StubProposerSchedule::default(),
             |_targets, _payload, _stride| {},
             recv_msg,
         );
@@ -1444,7 +1491,7 @@ mod tests_deterministic {
         udp::SIGNATURE_CACHE_SIZE,
         util::{
             BroadcastMode, BuildTarget, EncodingScheme, FullNodeGroupMap, PrimaryBroadcastGroup,
-            UdpMessage, ValidatorGroupMap,
+            StubProposerSchedule, UdpMessage, ValidatorGroupMap,
         },
         v1_rollout::DeterministicProtocolRolloutStage,
     };
@@ -1687,6 +1734,7 @@ mod tests_deterministic {
         udp_state.handle_message(
             &epoch_validators,
             &full_node_groups,
+            &StubProposerSchedule::default(),
             |_targets, _payload, _stride| {},
             recv_msg,
         );
@@ -1834,6 +1882,7 @@ mod tests_deterministic {
             .unwrap();
         let epoch_validators: BTreeMap<_, _> = [(EPOCH, validators)].into();
         let full_node_groups = FullNodeGroupMap::default();
+        let proposer_schedule = StubProposerSchedule::VALID;
         let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
         udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
 
@@ -1851,6 +1900,7 @@ mod tests_deterministic {
             let decoded = udp_state.handle_message(
                 &epoch_validators,
                 &full_node_groups,
+                &proposer_schedule,
                 |_targets, _payload, _stride| rebroadcast_count += 1,
                 recv_msg,
             );
@@ -1969,6 +2019,7 @@ mod tests_deterministic {
             .unwrap();
         let epoch_validators: BTreeMap<_, _> = [(EPOCH, validators)].into();
         let full_node_groups = FullNodeGroupMap::default();
+        let proposer_schedule = StubProposerSchedule::VALID;
         let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
         udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
 
@@ -1986,6 +2037,7 @@ mod tests_deterministic {
             decoded.extend(udp_state.handle_message(
                 &epoch_validators,
                 &full_node_groups,
+                &proposer_schedule,
                 |_, _, _| {},
                 recv_msg,
             ));
@@ -1994,6 +2046,62 @@ mod tests_deterministic {
         assert_eq!(decoded.len(), 1, "should decode from 2/3 of chunks");
         assert_eq!(decoded[0].0, sender_id);
         assert_eq!(decoded[0].1, app_message);
+    }
+
+    #[rstest]
+    #[case::valid(StubProposerSchedule::VALID, true)]
+    #[case::non_proposer(StubProposerSchedule { check_proposer: Some(false), check_epoch: Some(true) }, false)]
+    #[case::epoch_mismatch(StubProposerSchedule { check_proposer: Some(false), check_epoch: Some(false) }, false)]
+    #[case::schedule_unknown(StubProposerSchedule::default(), false)]
+    fn test_deterministic_primary_proposer_schedule(
+        #[case] proposer_schedule: StubProposerSchedule,
+        #[case] expect_decode: bool,
+    ) {
+        let (sender_key, validators, _) = validator_set();
+        let sender_id = NodeId::new(sender_key.pubkey());
+        let group_map = make_group_map(&validators);
+        let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &sender_id, &group_map).unwrap();
+        let app_message: Bytes = vec![0xCD_u8; 64 * 1024].into();
+        let packets = build_packets(&sender_key, &app_message, group);
+
+        let receiver_id = validators
+            .get_members()
+            .keys()
+            .find(|id| **id != sender_id)
+            .copied()
+            .unwrap();
+        let epoch_validators: BTreeMap<_, _> = [(EPOCH, validators)].into();
+        let full_node_groups = FullNodeGroupMap::default();
+        let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
+        udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
+
+        let mut decoded = Vec::new();
+        for packet in &packets {
+            let recv_msg = AuthRecvMsg {
+                src_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8000),
+                payload: packet.payload.clone(),
+                stride: deterministic::DEFAULT_SEGMENT_LEN as u16,
+                sender: None,
+            };
+            decoded.extend(udp_state.handle_message(
+                &epoch_validators,
+                &full_node_groups,
+                &proposer_schedule,
+                |_, _, _| {},
+                recv_msg,
+            ));
+        }
+
+        if expect_decode {
+            assert_eq!(decoded.len(), 1, "valid schedule must decode the message");
+            assert_eq!(decoded[0].0, sender_id);
+            assert_eq!(decoded[0].1, app_message);
+        } else {
+            assert!(
+                decoded.is_empty(),
+                "deterministic primary chunks must not decode when the proposer schedule rejects them"
+            );
+        }
     }
 
     #[test]
@@ -2022,6 +2130,7 @@ mod tests_deterministic {
         // Step 2: Validator receives and decodes
         let epoch_validators: BTreeMap<_, _> = [(EPOCH, validators)].into();
         let full_node_groups = FullNodeGroupMap::default();
+        let proposer_schedule = StubProposerSchedule::VALID;
         let mut udp_state = UdpState::<SignatureType>::new(validator_id, u64::MAX, 10_000);
         udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
 
@@ -2038,6 +2147,7 @@ mod tests_deterministic {
             for (_, msg) in udp_state.handle_message(
                 &epoch_validators,
                 &full_node_groups,
+                &proposer_schedule,
                 |_, _, _| {},
                 recv_msg,
             ) {

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -39,7 +39,10 @@ use monad_crypto::{
     hasher::{Hasher, HasherType},
 };
 use monad_types::{Epoch, NodeId, Round, RoundSpan, Stake};
-use monad_validator::validator_set::{ValidatorSet, ValidatorSetType as _};
+use monad_validator::{
+    proposer_schedule::ProposerSchedule,
+    validator_set::{ValidatorSet, ValidatorSetType as _},
+};
 
 use crate::udp::GroupId;
 
@@ -970,6 +973,35 @@ pub fn unix_ts_ms_now() -> u64 {
         .as_millis()
         .try_into()
         .expect("unix epoch doesn't fit in u64")
+}
+
+// A proposer schedule with a constant verdict for check_*. Only used in testing.
+#[derive(Default)]
+pub struct StubProposerSchedule {
+    pub check_proposer: Option<bool>,
+    pub check_epoch: Option<bool>,
+}
+
+impl StubProposerSchedule {
+    // A schedule that accepts every proposer and epoch. For deterministic
+    // raptorcast tests where the proposer schedule itself is irrelevant.
+    pub const VALID: Self = Self {
+        check_proposer: Some(true),
+        check_epoch: Some(true),
+    };
+}
+
+impl<PT: PubKey> ProposerSchedule<PT> for StubProposerSchedule {
+    fn check_proposer(&self, _node: &NodeId<PT>, _round: Round) -> Option<bool> {
+        self.check_proposer
+    }
+
+    fn check_epoch(&self, _epoch: Epoch, _round: Round) -> Option<bool> {
+        self.check_epoch
+    }
+
+    fn insert_epoch(&mut self, _epoch: Epoch, _epoch_start: Round, _val_set: ValidatorSet<PT>) {}
+    fn prune_below(&mut self, _cutoff: Round) {}
 }
 
 #[cfg(test)]

--- a/monad-raptorcast/src/v1_rollout.rs
+++ b/monad-raptorcast/src/v1_rollout.rs
@@ -100,6 +100,7 @@ mod tests {
         util::{
             BuildTarget, FullNodeGroupMap, PrimaryBroadcastGroup, RaptorcastMode, Redundancy,
             SecondaryBroadcastGroup, SecondaryGroup, SecondaryGroupAssignment,
+            StubProposerSchedule,
         },
     };
 
@@ -135,6 +136,7 @@ mod tests {
         let sender_id = NodeId::new(sender_key.pubkey());
         let group_map = [(EPOCH, validators.clone())].into();
         let fn_group_map = FullNodeGroupMap::default();
+        let proposer_schedule = StubProposerSchedule::VALID;
         let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &sender_id, &group_map).unwrap();
 
         let app_message: Bytes = vec![0xAB_u8; 64 * 1024].into();
@@ -167,8 +169,13 @@ mod tests {
                 stride: packet.stride as u16,
                 sender: None,
             };
-            let decoded =
-                udp_state.handle_message(&group_map, &fn_group_map, |_, _, _| {}, recv_msg);
+            let decoded = udp_state.handle_message(
+                &group_map,
+                &fn_group_map,
+                &proposer_schedule,
+                |_, _, _| {},
+                recv_msg,
+            );
             decoded_count += decoded.len();
         }
 
@@ -248,6 +255,7 @@ mod tests {
         let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
         udp_state.set_v1_rollout(receiver_stage);
 
+        let proposer_map = StubProposerSchedule::default();
         let mut decoded_count = 0;
         for packet in &packets {
             let recv_msg = AuthRecvMsg {
@@ -256,8 +264,13 @@ mod tests {
                 stride: packet.stride as u16,
                 sender: None,
             };
-            let decoded =
-                udp_state.handle_message(&group_map, &fn_group_map, |_, _, _| {}, recv_msg);
+            let decoded = udp_state.handle_message(
+                &group_map,
+                &fn_group_map,
+                &proposer_map,
+                |_, _, _| {},
+                recv_msg,
+            );
             decoded_count += decoded.len();
         }
         decoded_count
@@ -367,6 +380,7 @@ mod tests {
         udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
 
         let group_map: std::collections::BTreeMap<_, _> = std::collections::BTreeMap::new();
+        let proposer_map = StubProposerSchedule::default();
         let mut rebroadcast_count = 0usize;
         for packet in &packets {
             let recv_msg = AuthRecvMsg {
@@ -378,6 +392,7 @@ mod tests {
             udp_state.handle_message(
                 &group_map,
                 &fn_group_map,
+                &proposer_map,
                 |_targets, _payload, _stride| rebroadcast_count += 1,
                 recv_msg,
             );
@@ -455,6 +470,7 @@ mod tests {
         udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
 
         let group_map: std::collections::BTreeMap<_, _> = std::collections::BTreeMap::new();
+        let proposer_map = StubProposerSchedule::default();
         let mut decoded = Vec::new();
         for packet in packets_a.iter().chain(packets_b.iter()) {
             let recv_msg = AuthRecvMsg {
@@ -466,6 +482,7 @@ mod tests {
             decoded.extend(udp_state.handle_message(
                 &group_map,
                 &fn_group_map,
+                &proposer_map,
                 |_, _, _| {},
                 recv_msg,
             ));

--- a/monad-raptorcast/tests/raptorcast_instance.rs
+++ b/monad-raptorcast/tests/raptorcast_instance.rs
@@ -358,6 +358,7 @@ pub fn set_up_test(
 
             service.exec(vec![RouterCommand::AddEpochValidatorSet {
                 epoch: Epoch(0),
+                epoch_start: monad_types::Round(0),
                 validator_set,
             }]);
 
@@ -511,6 +512,7 @@ async fn raptorcast_forwards_fullnodes_group_invite_at_cold_start() {
 
     fullnode_rc.exec(vec![RouterCommand::AddEpochValidatorSet {
         epoch,
+        epoch_start: monad_types::Round(0),
         validator_set: vec![(validator_nodeid, Stake::ONE)],
     }]);
 
@@ -645,6 +647,7 @@ async fn publish_to_full_nodes() {
     for service in [&mut validator_rc, &mut full_node1_rc, &mut full_node2_rc] {
         service.exec(vec![RouterCommand::AddEpochValidatorSet {
             epoch: Epoch(0),
+            epoch_start: monad_types::Round(0),
             validator_set: validator_set.clone(),
         }]);
     }
@@ -790,11 +793,13 @@ async fn test_priority_messages() {
 
     tx_rc.exec(vec![RouterCommand::AddEpochValidatorSet {
         epoch,
+        epoch_start: monad_types::Round(0),
         validator_set: validator_set.clone(),
     }]);
 
     rx_rc.exec(vec![RouterCommand::AddEpochValidatorSet {
         epoch,
+        epoch_start: monad_types::Round(0),
         validator_set: validator_set.clone(),
     }]);
 
@@ -938,16 +943,19 @@ async fn test_raptorcast_forwarding_priority() {
 
     validator1_rc.exec(vec![RouterCommand::AddEpochValidatorSet {
         epoch,
+        epoch_start: monad_types::Round(0),
         validator_set: validator_set.clone(),
     }]);
 
     validator2_rc.exec(vec![RouterCommand::AddEpochValidatorSet {
         epoch,
+        epoch_start: monad_types::Round(0),
         validator_set: validator_set.clone(),
     }]);
 
     validator_fullnode_rc.exec(vec![RouterCommand::AddEpochValidatorSet {
         epoch,
+        epoch_start: monad_types::Round(0),
         validator_set: validator_set.clone(),
     }]);
 

--- a/monad-raptorcast/tests/wireauth_raptorcast.rs
+++ b/monad-raptorcast/tests/wireauth_raptorcast.rs
@@ -257,6 +257,7 @@ fn spawn_noop_validator(
             dataplane.control,
             shared_pd,
             monad_types::Epoch(0),
+            monad_raptorcast::dummy_proposer_schedule(),
         );
 
         let mut cmd_rx = cmd_rx;
@@ -346,6 +347,7 @@ fn spawn_wireauth_validator(
             dataplane.control,
             shared_pd,
             monad_types::Epoch(0),
+            monad_raptorcast::dummy_proposer_schedule(),
         );
 
         let mut cmd_rx = cmd_rx;
@@ -407,6 +409,7 @@ async fn establish_connections(
         cmd_tx
             .send(RouterCommand::AddEpochValidatorSet {
                 epoch,
+                epoch_start: monad_types::Round(0),
                 validator_set: validator_set.clone(),
             })
             .unwrap();
@@ -908,6 +911,7 @@ async fn run_send_with_record_uses_name_record_address() {
     bob2.cmd_tx
         .send(RouterCommand::AddEpochValidatorSet {
             epoch,
+            epoch_start: monad_types::Round(0),
             validator_set,
         })
         .unwrap();

--- a/monad-router-multi/Cargo.toml
+++ b/monad-router-multi/Cargo.toml
@@ -13,6 +13,7 @@ monad-peer-discovery = { workspace = true }
 monad-peer-score = { workspace = true }
 monad-raptorcast = { workspace = true }
 monad-types = { workspace = true }
+monad-validator = { workspace = true }
 
 alloy-rlp = { workspace = true }
 futures = { workspace = true }

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -50,6 +50,7 @@ use monad_raptorcast::{
     RaptorCast, RaptorCastEvent,
 };
 use monad_types::{Epoch, NodeId};
+use monad_validator::proposer_schedule::BoxedProposerSchedule;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 pub use tracing::{debug, error, info, warn, Level};
 
@@ -86,6 +87,7 @@ where
     AP: AuthenticationProtocol<PublicKey = CertificateSignaturePubKey<ST>>,
     DS: IdentityScore<Identity = NodeId<CertificateSignaturePubKey<ST>>>,
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new<B>(
         self_node_id: NodeId<CertificateSignaturePubKey<ST>>,
         cfg: RaptorCastConfig<ST>,
@@ -96,6 +98,7 @@ where
         auth_protocol: AP,
         direct_udp_auth_protocol: Option<AP>,
         direct_udp_peer_score: DS,
+        proposer_schedule: BoxedProposerSchedule<CertificateSignaturePubKey<ST>>,
     ) -> Self
     where
         B: PeerDiscoveryAlgoBuilder<PeerDiscoveryAlgoType = PD>,
@@ -175,6 +178,7 @@ where
             control,
             shared_pdd.clone(),
             current_epoch,
+            proposer_schedule,
         );
         rc_primary.bind_channel_to_secondary_raptorcast(
             secondary_mode,
@@ -327,10 +331,12 @@ where
                 RouterCommand::PublishWithPriority { .. } => validator_cmds.push(cmd),
                 RouterCommand::AddEpochValidatorSet {
                     epoch,
+                    epoch_start,
                     validator_set,
                 } => {
                     let cmd_cpy = RouterCommand::AddEpochValidatorSet {
                         epoch,
+                        epoch_start,
                         validator_set: validator_set.clone(),
                     };
                     debug!(?validator_set, "Updating validator set in multi router");

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -1074,15 +1074,33 @@ where
                     ValidatorMapping::new(validator_set_data.validators.get_cert_pubkeys()),
                 );
 
-                let mut cmds = vec![
-                    Command::RouterCommand(RouterCommand::AddEpochValidatorSet {
-                        epoch: validator_set_data.epoch,
-                        validator_set: validator_set_data.validators.get_stakes(),
-                    }),
-                    Command::ConfigFileCommand(ConfigFileCommand::ValidatorSetData {
-                        validator_set_data,
-                    }),
-                ];
+                let mut cmds = Vec::new();
+
+                // The epoch start should already be scheduled in the
+                // epoch manager before its validator set update
+                // arrives. A missing start signals a bug or config
+                // mismatch.
+                match self.epoch_manager.get_epoch_start(validator_set_data.epoch) {
+                    Some(epoch_start) => {
+                        cmds.push(Command::RouterCommand(
+                            RouterCommand::AddEpochValidatorSet {
+                                epoch: validator_set_data.epoch,
+                                epoch_start,
+                                validator_set: validator_set_data.validators.get_stakes(),
+                            },
+                        ));
+                    }
+                    None => {
+                        tracing::error!(
+                            epoch = ?validator_set_data.epoch,
+                            "epoch start not scheduled for updated validator set"
+                        );
+                    }
+                }
+
+                cmds.push(Command::ConfigFileCommand(
+                    ConfigFileCommand::ValidatorSetData { validator_set_data },
+                ));
 
                 // if expand_to_group and not live and is_validator, emit
                 // validator peers to statesync
@@ -1517,6 +1535,10 @@ where
 
         // commit blocks
         for block in last_two_delay_committed_blocks {
+            // ensure that epoch_manager covers epochs for
+            // locked_epoch_validators.
+            self.epoch_manager
+                .schedule_epoch_start(block.get_seq_num(), block.get_block_round());
             commands.push(Command::LedgerCommand(LedgerCommand::LedgerCommit(
                 OptimisticCommit::Proposed {
                     block: block.deref().to_owned(),

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -203,6 +203,7 @@ where
                     control,
                     shared_peer_discovery_driver,
                     Epoch(0),
+                    monad_raptorcast::dummy_proposer_schedule(),
                 ))
             }
         },

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -79,8 +79,16 @@ impl Round {
             .is_some_and(|next_round| next_round == self.as_u64())
     }
 
+    pub fn saturating_sub(self, count: Round) -> Self {
+        Round(self.0.saturating_sub(count.0))
+    }
+
     pub fn checked_sub(self, count: Round) -> Option<Self> {
         self.0.checked_sub(count.0).map(Round)
+    }
+
+    pub fn saturating_add(self, count: Round) -> Self {
+        Round(self.0.saturating_add(count.0))
     }
 
     pub fn checked_add(self, count: Round) -> Option<Self> {
@@ -188,6 +196,7 @@ impl RoundSpan {
     pub fn contains(&self, round: Round) -> bool {
         self.start <= round && round < self.end
     }
+
     pub fn overlaps(&self, other: &RoundSpan) -> bool {
         self.start < other.end && other.start < self.end
     }

--- a/monad-validator/src/epoch_manager.rs
+++ b/monad-validator/src/epoch_manager.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::BTreeMap;
+use std::collections::{btree_map, BTreeMap};
 
 use monad_types::{Epoch, Round, SeqNum};
 use tracing::info;
@@ -57,10 +57,10 @@ impl EpochManager {
         // when we commit the same boundary block again. Assert that value is
         // the same if entry exists
         match self.epoch_starts.entry(epoch) {
-            std::collections::btree_map::Entry::Vacant(entry) => {
+            btree_map::Entry::Vacant(entry) => {
                 entry.insert(round);
             }
-            std::collections::btree_map::Entry::Occupied(entry) => {
+            btree_map::Entry::Occupied(entry) => {
                 assert_eq!(*entry.get(), round, "Conflicting epoch start round");
             }
         }
@@ -68,17 +68,24 @@ impl EpochManager {
 
     /// Schedule next epoch start if the committed block is the last one in the current epoch
     pub fn schedule_epoch_start(&mut self, block_num: SeqNum, block_round: Round) {
-        if block_num.is_boundary_block(self.epoch_length) {
-            let next_epoch = block_num.to_epoch(self.epoch_length) + Epoch(1);
-            let epoch_start_round = block_round + self.epoch_start_delay;
-            self.insert_epoch_start(next_epoch, epoch_start_round);
-            info!(
-                ?next_epoch,
-                ?epoch_start_round,
-                ?block_round,
-                "schedule epoch start epoch",
-            );
+        if !block_num.is_boundary_block(self.epoch_length) {
+            return;
         }
+
+        let next_epoch = block_num.to_epoch(self.epoch_length) + Epoch(1);
+        let epoch_start_round = block_round + self.epoch_start_delay;
+        self.insert_epoch_start(next_epoch, epoch_start_round);
+        info!(
+            ?next_epoch,
+            ?epoch_start_round,
+            ?block_round,
+            "schedule epoch start epoch",
+        );
+    }
+
+    /// Get the start round of the given epoch, if known.
+    pub fn get_epoch_start(&self, epoch: Epoch) -> Option<Round> {
+        self.epoch_starts.get(&epoch).copied()
     }
 
     /// Get the epoch of the given round. Returns None if round is from an older

--- a/monad-validator/src/leader_election.rs
+++ b/monad-validator/src/leader_election.rs
@@ -19,7 +19,6 @@ use auto_impl::auto_impl;
 use monad_crypto::certificate_signature::PubKey;
 use monad_types::{NodeId, Round, Stake};
 
-// VotingPower is i64
 #[auto_impl(Box)]
 pub trait LeaderElection {
     type NodeIdPubKey: PubKey;

--- a/monad-validator/src/lib.rs
+++ b/monad-validator/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod epoch_manager;
 pub mod leader_election;
+pub mod proposer_schedule;
 pub mod signature_collection;
 pub mod simple_round_robin;
 pub mod validator_mapping;

--- a/monad-validator/src/proposer_schedule.rs
+++ b/monad-validator/src/proposer_schedule.rs
@@ -1,0 +1,254 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{cell::RefCell, collections::BTreeMap};
+
+use monad_crypto::certificate_signature::PubKey;
+use monad_types::{Epoch, NodeId, Round};
+
+use crate::{
+    leader_election::LeaderElection,
+    validator_set::{ValidatorSet, ValidatorSetType},
+};
+
+pub trait ProposerSchedule<PT: PubKey> {
+    /// Checks if a proposer is legitimate for a given round.
+    ///
+    /// Returns None when round falls outside the known epochs.
+    fn check_proposer(&self, node: &NodeId<PT>, round: Round) -> Option<bool>;
+
+    /// Check if a round is within the given epoch.
+    fn check_epoch(&self, epoch: Epoch, round: Round) -> Option<bool>;
+
+    /// The inserted epoch is expected to be consecutive and
+    /// non-overlapping with the existing epochs.
+    fn insert_epoch(&mut self, epoch: Epoch, epoch_start: Round, val_set: ValidatorSet<PT>);
+
+    /// The pruning is expected to be called on every new round. The
+    /// purpose of this method avoid leak only. Querying pruned rounds
+    /// does not guarantee None results
+    fn prune_below(&mut self, cutoff: Round);
+}
+
+pub type BoxedProposerSchedule<PT> = Box<dyn ProposerSchedule<PT> + Send>;
+
+pub struct ElectedProposerSchedule<PT, LT>
+where
+    PT: PubKey,
+    LT: LeaderElection<NodeIdPubKey = PT>,
+{
+    epoch_starts: BTreeMap<Epoch, Round>,
+    val_sets: BTreeMap<Epoch, ValidatorSet<PT>>,
+    election: LT,
+
+    /// Memoized round -> proposer mapping
+    cache: RefCell<BTreeMap<Round, NodeId<PT>>>,
+}
+
+impl<PT, LT> ElectedProposerSchedule<PT, LT>
+where
+    PT: PubKey,
+    LT: LeaderElection<NodeIdPubKey = PT>,
+{
+    pub fn new(election: LT) -> Self {
+        Self {
+            epoch_starts: BTreeMap::new(),
+            val_sets: BTreeMap::new(),
+            election,
+            cache: RefCell::new(BTreeMap::new()),
+        }
+    }
+
+    // Get the epoch for a given round. This intentionally matches
+    // EpochManager::get_epoch: the latest known epoch remains active
+    // until a later epoch start is inserted.
+    fn epoch_of(&self, round: Round) -> Option<Epoch> {
+        self.epoch_starts
+            .iter()
+            .rfind(|(_, &start)| start <= round)
+            .map(|(&epoch, _)| epoch)
+    }
+
+    fn leader(&self, round: Round) -> Option<NodeId<PT>> {
+        if let Some(leader) = self.cache.borrow().get(&round) {
+            return Some(*leader);
+        }
+        let epoch = self.epoch_of(round)?;
+        let val_set = self.val_sets.get(&epoch)?;
+        let leader = self.election.get_leader(round, val_set.get_members());
+        // only positive matches are cached.
+        self.cache.borrow_mut().insert(round, leader);
+        Some(leader)
+    }
+}
+
+impl<PT, LT> ProposerSchedule<PT> for ElectedProposerSchedule<PT, LT>
+where
+    PT: PubKey,
+    LT: LeaderElection<NodeIdPubKey = PT>,
+{
+    /// Caveats:
+    ///
+    /// - this method can return differently for the same round query
+    ///   if the schedule is updated with new epochs. The caller should
+    ///   avoid caching the output.
+    ///
+    /// - The caller should avoid call this method with unbounded
+    ///   round to avoid potential cache exploitation.
+    fn check_proposer(&self, node: &NodeId<PT>, round: Round) -> Option<bool> {
+        Some(self.leader(round)? == *node)
+    }
+
+    /// Caveats:
+    ///
+    /// - this method can return differently for the same round query
+    ///   if the schedule is updated with new epochs. The caller should
+    ///   avoid caching the output.
+    fn check_epoch(&self, epoch: Epoch, round: Round) -> Option<bool> {
+        Some(self.epoch_of(round)? == epoch)
+    }
+
+    fn insert_epoch(&mut self, epoch: Epoch, epoch_start: Round, val_set: ValidatorSet<PT>) {
+        if let Some(&existing) = self.epoch_starts.get(&epoch) {
+            assert_eq!(existing, epoch_start, "conflicting epoch start round");
+            return;
+        }
+
+        if let Some((prev_epoch, &max_start)) = self.epoch_starts.last_key_value() {
+            // Sanity-check: the new epoch must start after the previous one.
+            if epoch_start <= max_start {
+                tracing::error!(
+                    "new epoch_start {epoch_start:?} does not advance previous start {max_start:?}"
+                );
+            }
+
+            // Sanity-check: the new epoch must be consecutive to the previous one.
+            if let Some(expected_epoch) = prev_epoch.0.checked_add(1) {
+                if epoch.0 != expected_epoch {
+                    tracing::error!(
+                        "new epoch {epoch:?} is not consecutive to previous epoch {prev_epoch:?}"
+                    );
+                }
+            }
+        }
+
+        self.cache
+            .borrow_mut()
+            .retain(|&round, _| round < epoch_start);
+        self.epoch_starts.insert(epoch, epoch_start);
+        self.val_sets.insert(epoch, val_set);
+    }
+
+    fn prune_below(&mut self, cutoff: Round) {
+        if let Some(min_epoch) = self.epoch_of(cutoff) {
+            self.cache.get_mut().retain(|&round, _| round >= cutoff);
+            self.val_sets.retain(|&epoch, _| epoch >= min_epoch);
+            self.epoch_starts.retain(|&epoch, _| epoch >= min_epoch);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use monad_crypto::NopPubKey;
+    use monad_types::Stake;
+
+    use super::*;
+    use crate::simple_round_robin::SimpleRoundRobin;
+
+    type PT = NopPubKey;
+
+    fn nid(seed: u8) -> NodeId<PT> {
+        NodeId::new(NopPubKey::from_bytes(&[seed; 32]).unwrap())
+    }
+
+    fn val_set(members: &[NodeId<PT>]) -> ValidatorSet<PT> {
+        ValidatorSet::new_unchecked(members.iter().map(|id| (*id, Stake::ONE)).collect())
+    }
+
+    fn schedule() -> ElectedProposerSchedule<PT, SimpleRoundRobin<PT>> {
+        ElectedProposerSchedule::new(SimpleRoundRobin::default())
+    }
+
+    #[test]
+    fn unknown_round_resolves_to_none() {
+        let mut sched = schedule();
+        // No epochs inserted yet.
+        assert_eq!(sched.leader(Round(5)), None);
+
+        sched.insert_epoch(Epoch(1), Round(0), val_set(&[nid(1), nid(2)]));
+        assert!(sched.leader(Round(99)).is_some());
+        assert!(sched.leader(Round(100)).is_some());
+    }
+
+    #[test]
+    fn resolves_and_caches_leader() {
+        let mut sched = schedule();
+        let members = [nid(1), nid(2), nid(3)];
+        sched.insert_epoch(Epoch(1), Round(0), val_set(&members));
+
+        let election = SimpleRoundRobin::<PT>::default();
+        let vs = val_set(&members);
+        for r in 0..50u64 {
+            let expected = election.get_leader(Round(r), vs.get_members());
+            assert_eq!(sched.leader(Round(r)), Some(expected));
+        }
+    }
+
+    #[test]
+    fn prune_drops_old_rounds_and_epochs() {
+        let mut sched = schedule();
+        // Epoch 1 [0, ?), epoch 2 starts at round 110 (boundary at block
+        // 99, round 100, + delay 10).
+        sched.insert_epoch(Epoch(1), Round(0), val_set(&[nid(1)]));
+        sched.insert_epoch(Epoch(2), Round(110), val_set(&[nid(2)]));
+
+        // Populate the cache across both epochs.
+        assert!(sched.leader(Round(50)).is_some());
+        assert!(sched.leader(Round(150)).is_some());
+
+        // Prune below a round inside epoch 2.
+        sched.prune_below(Round(120));
+
+        // Epoch 1 data is gone; epoch 2 still resolves.
+        assert_eq!(sched.epoch_of(Round(50)), None);
+        assert!(!sched.val_sets.contains_key(&Epoch(1)));
+        assert!(sched.val_sets.contains_key(&Epoch(2)));
+        assert!(sched.leader(Round(150)).is_some());
+        // Cache entry below cutoff dropped.
+        assert!(!sched.cache.borrow().contains_key(&Round(50)));
+    }
+
+    #[test]
+    fn insert_epoch_invalidates_cached_future_leaders() {
+        let mut sched = schedule();
+        let epoch_1_members = [nid(1), nid(2), nid(3)];
+        let epoch_2_members = [nid(4), nid(5), nid(6)];
+        sched.insert_epoch(Epoch(1), Round(0), val_set(&epoch_1_members));
+
+        let election = SimpleRoundRobin::<PT>::default();
+        let epoch_1_vs = val_set(&epoch_1_members);
+        let stale_leader = election.get_leader(Round(120), epoch_1_vs.get_members());
+        assert_eq!(sched.leader(Round(120)), Some(stale_leader));
+        assert!(sched.cache.borrow().contains_key(&Round(120)));
+
+        let epoch_2_vs = val_set(&epoch_2_members);
+        let expected_leader = election.get_leader(Round(120), epoch_2_vs.get_members());
+        sched.insert_epoch(Epoch(2), Round(110), epoch_2_vs);
+
+        assert_eq!(sched.epoch_of(Round(120)), Some(Epoch(2)));
+        assert_eq!(sched.leader(Round(120)), Some(expected_leader));
+    }
+}


### PR DESCRIPTION
This PR implements the same thing in https://github.com/category-labs/monad-bft/pull/3083. Instead of requesting an internal service hosted within MonadState, raptorcast now owns a opaque type (`impl ProposerSchedule`) that exposes the needed information. `ProposerSchedule` trait and its concrete implementation stays inside `monad-validator` alongside EpochManager and LeaderElection, so raptorcast can stay ignorant of the logic for locating the proposer of a round.

```rust
pub trait ProposerSchedule<PT: PubKey> {
    // Returns None when round falls outside the known epochs
    fn check_proposer(&self, node: &NodeId<PT>, round: Round) -> Option<bool>;
    fn check_epoch(&self, epoch: Epoch, round: Round) -> Option<bool>;

    fn insert_epoch(&mut self, epoch: Epoch, epoch_start: Round, val_set: ValidatorSet<PT>);
    fn prune_below(&mut self, cutoff: Round);
}
```
