### PR TITLE
monad-chain-data: add onboarding + deep-dive documentation

### DIFF
--- a/monad-chain-data/.gitignore
+++ b/monad-chain-data/.gitignore
@@ -1,2 +1,1 @@
 /plans/
-/docs/

--- a/monad-chain-data/docs/deep-dive-bitmap-index.md
+++ b/monad-chain-data/docs/deep-dive-bitmap-index.md
@@ -1,0 +1,258 @@
+# Deep dive: the bitmap inverted-index lifecycle
+
+> Prerequisite: read `docs/onboarding.md` and `docs/deep-dive-frontier-model.md`
+> (this index is the canonical instance of the sealed/open split). This dive
+> follows one indexed value from ingest-time fragment, through open page, to
+> sealed page + manifest, and back out at query time.
+
+## What this is and why it exists
+
+The bitmap index is the engine's main filtered-query accelerator. Every filtered
+query — logs by address/topic, txs by from/to/selector, traces by
+from/to/selector/top_level/has_transfer — is answered by intersecting roaring
+bitmaps that record `field-value → record-local-id` membership. Without it, those
+queries would be full block scans.
+
+The whole thing is built on one symmetry: **the same function,
+`sharded_stream_id(kind, value, shard)`, names a posting list at ingest and looks
+it up at query.** Write and read can't drift apart because they compute the same
+string.
+
+## The coordinate system
+
+A record's `PrimaryId` is `(shard, local)` with `local` in the low 24 bits
+(`src/primitives/state.rs:31`). Within a shard's `2^24` local ids:
+
+```
+STREAM_PAGE_LOCAL_ID_SPAN = 64 * 1024 = 65536        // src/engine/bitmap.rs:35
+STREAM_PAGES_PER_SHARD    = 2^24 / 65536 = 256       // src/engine/bitmap.rs:40
+page_start_local(local)   = (local / 65536) * 65536  // round down to page boundary
+```
+
+So: **a shard is exactly 256 pages of 64K locals.** (Pages nest cleanly in
+shards; the 10k directory bucket does not — see the frontier dive.)
+
+## 1. Streams — the posting list
+
+A **stream** is one inverted-index posting list: "which record local-ids *within
+one shard* have field `kind` = byte-value `value`?" Its id is a string
+(`sharded_stream_id`, `bitmap.rs:687`):
+
+```
+"{kind}/{hex(value)}/{shard:010x}"      e.g.  addr/a0b1…/0000000000
+```
+
+The shard is zero-padded to a fixed 10 hex digits so the shard is **recoverable
+from the stream id** (`parse_stream_shard`, `bitmap.rs:762`). That's why the
+page-count manifest can be keyed by `stream_id` alone — the shard is already baked
+in.
+
+The indexed **kinds** differ per family (emitted at ingest):
+
+- **Logs** (`src/logs/ingest.rs:169`): `addr` always; `topic0..3` for each present
+  topic (absent topics emit nothing).
+- **Txs** (`src/txs/ingest.rs:159`): `from` always; `to` only if a recipient
+  (skipped for contract-creation); `selector` only if calldata ≥ 4 bytes.
+- **Traces** (`src/traces/ingest.rs:139`): `from`; `to` if present; `selector` if
+  input ≥ 4 bytes; `top_level` (empty-bytes value) for the root frame only;
+  `has_transfer` (empty-bytes value) when the frame is a successful, committed,
+  value-moving call. The `has_transfer` stream *is* the entire transfers feature —
+  transfers queries just AND in that one bit (see `onboarding.md`).
+
+**Why shard the stream id?** It bounds each posting list to one shard's `2^24`
+local space, so a stream's bitmap can never grow unbounded, the index partitions
+cleanly by shard, and **shards seal independently**.
+
+## 2. Pages — partitioning the local space
+
+Within a shard, the local space is sub-partitioned into the 256 disjoint 64K
+pages. Pages exist for four reasons, and the fourth is the important one:
+
+1. Bounded bitmaps (each ≤ 64K locals).
+2. Page-level skip (the sealed-shard manifest can drop a whole page).
+3. Page-level concurrency (the query pipeline runs pages in parallel).
+4. **The distributive law** that makes per-page intersection + short-circuit
+   correct (§6).
+
+A page's bitmap is a `roaring::RoaringBitmap`. The stored blob carries
+`(min_local, max_local, count)` in a header *plus* the serialized roaring payload.
+Query-time skip decisions trust the header bounds, so `decode_bitmap_blob`
+**re-derives the bounds from the payload and fails loud on drift** — a corrupted
+too-narrow header would otherwise silently drop a matching page.
+
+## 3. Ingest-side: fragments
+
+A **fragment** is *one block's contribution to one stream's one page* — the local
+ids that block added for that field-value, within that 64K page.
+
+At plan time each record expands into `(stream_id, local_id)` pairs
+(`stream_entries_for_log` etc.), and `encode_grouped_bitmap_fragments`
+(`bitmap.rs:622`) groups them into `stream → page → roaring bitmap`:
+
+```rust
+grouped.entry(stream_id).or_default()
+       .entry(page_start_local(local_id)).or_default()
+       .insert(local_id);
+```
+
+A single block whose ids cross a page boundary therefore yields **multiple**
+page-fragments for one stream. Each non-empty page bitmap becomes a
+`BitmapFragmentWrite { stream_id, page_start_local, bitmap_blob }`.
+
+Two tables hold the open state:
+
+- **`bitmap_by_block`** (the fragments) — partition key
+  `stream_page_key(stream_id, page)`, clustering key `block_number`. So all of one
+  page's per-block fragments live under one partition, listed by prefix.
+- **`open_bitmap_stream`** (the inventory) — per global frontier page, the *set of
+  stream ids* that have any fragment in that page. It's **append-only by design**
+  so replay can't lose membership. This is the seal-time index telling the
+  compactor *which* streams to compact for a sealing page (computed per block as
+  `touched_streams_by_page`, `bitmap.rs:712`).
+
+## 4. The seal transition: fragments → page artifact + manifest
+
+While a shard holds the frontier, its pages stay open (many small per-block
+fragments, membership in the inventory). The seal trigger is the frontier moving
+*past* the unit — driven from Phase B of ingest
+(`src/engine/ingest/bitmap_compaction.rs`):
+
+- **Page seals** when the frontier moves to a later page. Every touched stream's
+  retained fragments for that page are OR-merged into one **`bitmap_page_blob`**
+  artifact (`compact_bitmap_page`, `bitmap.rs:658` — an empty merge is corrupted
+  state and fails loud). Reads of a sealed page hit this artifact; reads of the
+  still-open page fall through to scanning fragments.
+- **Shard seals** when the frontier crosses its last (256th) page. Now the shard's
+  per-stream **`bitmap_page_counts`** manifest is written.
+
+### The manifest (`BitmapPageCounts`)
+
+A sparse, per-stream, per-page roll-up of compacted counts for one fully-sealed
+shard, immutable once written. Key = the `stream_id` (which already encodes the
+shard). Built by walking all 256 page slots of the shard, taking each
+(stream, page)'s count from this batch's fresh compacted metas or the durable
+artifact's stored count.
+
+Two semantics to internalize (`bitmap.rs:541`):
+
+- **Zero-count pages are dropped** (`from_pairs` filters `count != 0`), and
+  `count_for_page` binary-searches and **never returns `Some(0)`** — a missing
+  page means "this stream contributes nothing here."
+- **A touched-but-missing artifact is a hard error** (`SealedShardPageMissingArtifact`).
+  Why so strict: on a *present* manifest an absent page reads as count 0, which on
+  a sealed shard would skip the page with zero fetches and silently drop matches.
+  So the manifest must be complete or fail.
+
+## 5. Query-side: the read
+
+Per shard, `build_shard_page_plan` (`src/engine/query/bitmap.rs:71`) precomputes a
+`ShardPagePlan`:
+
+- `clause_streams` — per clause, its OR-set of value-streams in this shard. (If
+  any clause has *no* streams in this shard, the whole shard intersection is empty
+  → return `None`, bail before any fetch.)
+- `clause_counts` — per clause, its summed manifest (`None` = unknown, never
+  empty).
+- `shard_sealed = shard < frontier_shard` — the gate that decides whether `Some(0)`
+  may skip.
+
+Then per candidate page, `intersect_shard_page` (`query/bitmap.rs:186`):
+
+1. **Sealed-shard zero-fetch skip**: `if shard_sealed && counts.contains(&Some(0))`
+   → skip, no fetch. On the frontier shard `shard_sealed` is false, so its
+   (borrowed) manifest never skips — it only *orders* fetches.
+2. **Order clauses most-selective-first** by manifest count (unknowns last,
+   stable).
+3. **AND down with short-circuit**: fetch each clause's page bitmap (a sealed page
+   reads the artifact; an open page scans fragments), AND into the running set,
+   and **the moment it goes empty, `break`** — skipping every remaining clause's
+   fetch for this page.
+4. **Clip** the surviving bitmap to the query's local range (only the two boundary
+   pages can carry out-of-range bits).
+
+A clause's per-page count is the **sum over its OR value-streams** — so a clause
+is empty in a page iff all its value-streams are. And if *any* value-stream lacks
+a manifest row, the whole clause estimate degrades to `None` ("unknown"), never an
+under-count that could wrongly skip.
+
+## 6. The distributive law — the keystone invariant
+
+Documented at `query/bitmap.rs:121`:
+
+```
+⋂_clauses ( ⋃_pages bits )  ==  ⋃_pages ( ⋂_clauses bits_on_that_page )
+```
+
+It holds because pages **partition** the local space and **every clause bit in a
+page comes only from that page's stream rows** — so intersecting whole-clause
+bitmaps (each a union over pages) equals unioning the per-page intersections, and
+the disjoint pages never double-count on the outer OR.
+
+This is what licenses everything in §5: per-page short-circuit (an empty page
+prunes the rest of *that page's* clause fetches — the old clause-outer loop could
+only prune a clause empty across the *whole* shard) and per-page concurrency. Two
+equivalence tests pin the optimized path against a serial reference:
+`tests/query_bitmap_page_intersection.rs` (serial == concurrent, with fetch
+counting) and `tests/query_bitmap_page_counts_manifest.rs` (manifest skips fetch
+nothing on a sealed shard).
+
+`load_intersection_bitmap` (`query/bitmap.rs:145`) is that serial reference — no
+longer on the production path (the pipeline calls `build_shard_page_plan` +
+`intersect_shard_page` directly) but kept behavior-equivalent for the tests.
+
+## 7. Clauses → streams (the symmetry, restated)
+
+An `IndexedClause` (`src/engine/clause.rs:23`) is `{ kind, values }`: one field,
+its `values` OR'd together. Clauses AND together. `stream_ids_for_shard` maps each
+value through the *same* `sharded_stream_id` the ingest side used. So for clauses
+`C1..Cn`, page P contributes:
+
+```
+⋂_i ( ⋃_{v ∈ Ci.values}  stream(Ci.kind, v, shard).page(P) )
+```
+
+fetched most-selective-first, short-circuiting on empty, clipped to the local
+range. The `matches()` method on each filter is an *invariant check* on
+materialized records, not a release-mode post-filter — with one documented trace
+exception (`is_top_level: Some(false)` combined with other clauses) the runner
+must drop.
+
+## The lifecycle, end to end
+
+```
+INGEST   record --stream_entries--> (stream_id, local_id) pairs
+         --encode_grouped_bitmap_fragments--> per (stream,page) fragment
+         --> bitmap_by_block (fragment)  +  open_bitmap_stream (inventory)
+
+SEAL     frontier passes page  --compact_bitmap_page--> bitmap_page_blob
+(Phase B) frontier passes shard --roll up counts------> bitmap_page_counts (manifest)
+
+QUERY    clause --stream_ids_for_shard--> streams
+         --build_shard_page_plan--> candidate pages (manifest skips empties)
+         --intersect_shard_page--> AND clauses most-selective-first, short-circuit
+         survivors --(+shard)--> PrimaryId --directory--> (block, idx) --materialize-->
+```
+
+## The mental model to keep
+
+> An inverted index of `(kind, value, shard) → local-id bitmap`, partitioned into
+> 64K pages. Ingest writes small per-block fragments to the open frontier page;
+> compaction OR-merges sealed pages into single artifacts and, once a shard fully
+> seals, writes a per-stream page-count manifest. Queries AND clause bitmaps
+> *per page* (legal by the distributive law), fetching most-selective-first and
+> short-circuiting on empty, with the sealed-shard manifest skipping provably-empty
+> pages for free. The same `sharded_stream_id` builds and reads the index, so they
+> never drift.
+
+## Start-here pointers
+
+- Stream id + arithmetic: `src/engine/bitmap.rs:35,687`
+- Ingest expansion: `src/logs/ingest.rs:169`, `txs/ingest.rs:159`,
+  `traces/ingest.rs:139`
+- Fragment grouping: `src/engine/bitmap.rs:622`; tables in `family.rs:21`
+- Seal/compaction + manifest: `src/engine/ingest/bitmap_compaction.rs`;
+  `compact_bitmap_page` `bitmap.rs:658`; manifest `bitmap.rs:530`
+- Query plan + intersect: `src/engine/query/bitmap.rs:71,186`; distributive law `:121`
+- Clauses: `src/engine/clause.rs:23`
+- Equivalence tests: `tests/query_bitmap_page_intersection.rs`,
+  `tests/query_bitmap_page_counts_manifest.rs`

--- a/monad-chain-data/docs/deep-dive-frontier-model.md
+++ b/monad-chain-data/docs/deep-dive-frontier-model.md
@@ -1,0 +1,238 @@
+# Deep dive: the frontier / sealed-vs-open model
+
+> Prerequisite: read `docs/onboarding.md` first. This dive expands the one idea
+> that quietly governs the whole engine — how index state transitions from
+> *mutable* to *immutable* — and why three different structures all implement it
+> at three different granularities.
+
+## The one idea
+
+Every family's records occupy a gapless, monotonically growing `PrimaryId`
+space. At the published head there is exactly one **frontier id**: the first id
+the family has *not yet* assigned. That single number splits the id-space in two:
+
+- **Below the frontier → sealed.** Immutable. Compacted into summary artifacts.
+  A reader may trust and even *skip* sealed regions because the commit contract
+  guarantees the artifact is present.
+- **The region straddling the frontier → open.** Mutable. Represented as a pile
+  of small per-block fragments that haven't been compacted yet.
+
+Three structures implement this split — the **primary directory**, the **bitmap
+index**, and the **in-memory open-index state** — and once you see it's the same
+split each time, a large amount of the codebase collapses into one pattern.
+
+The deep reason it's safe is an **asymmetry**: getting the boundary slightly
+wrong toward "open" only costs extra fetches; getting it wrong toward "sealed"
+would silently drop data. So every ambiguity resolves toward open, and every
+genuinely-sealed-but-missing artifact is a *loud* error, never a quiet fallback.
+
+## Where the frontier comes from
+
+`family_frontier_id` (`src/engine/query/family_runner.rs:362`) loads the
+`BlockRecord` at the **published head** and returns that family's
+`next_primary_id_exclusive()` — `first_primary_id + count`
+(`src/primitives/state.rs:251`). Two subtleties worth internalizing:
+
+- It's the window's **exclusive end**, the running id cursor — so even a block
+  that emitted *zero* records of a family still carries a meaningful frontier
+  (the cursor is defined, just unchanged).
+- It's derived from the **published head, not the query's block range**
+  (`family_runner.rs:133-138`). If you computed it from the query range, a bucket
+  that's globally sealed but happens to sit *above* your range would get
+  misclassified as the open bucket. The sealed/open classification has to be a
+  global property so every query agrees on it. No published head (nothing
+  published) → frontier is `PrimaryId::ZERO`, so *everything* routes to the open
+  path.
+
+From that one id, each structure derives its own boundary:
+
+```
+frontier_id
+   ├─ bucket boundary :  sealed_below   = bucket_start(frontier_id)   // directory
+   └─ shard           :  frontier_shard = frontier_id.shard()         // bitmap
+```
+
+## The PrimaryId coordinate system
+
+A `PrimaryId` is a `u64` split into `(shard, local)` with `LOCAL_ID_BITS = 24`
+(`src/primitives/state.rs:31`):
+
+```
+   63                    24 23            0
+  +------------------------+--------------+
+  |        shard           |    local     |     local() = id & (2^24 - 1)
+  +------------------------+--------------+     shard() = id >> 24
+```
+
+So a shard spans `2^24 = 16,777,216` local ids. Everything below keys off this.
+
+## Split #1 — the primary directory (granularity: 10k buckets)
+
+The directory answers `id → (block_number, idx_in_block)`. It's chopped into
+**10,000-id buckets** (`DIRECTORY_BUCKET_SIZE`, `src/engine/primary_dir.rs:28`);
+`bucket_start(id) = id - (id % 10_000)` (`primary_dir.rs:305`).
+
+`PrimaryIdResolver::resolve` (`src/engine/query/directory_resolver.rs:71`) routes
+**analytically** on `sealed_below = bucket_start(frontier_id)`:
+
+- `bucket < sealed_below` → **sealed**: one `get` of a compacted `PrimaryDirBucket`
+  summary, then binary-search it (`containing_bucket_entry`,
+  `directory_resolver.rs:165`).
+- otherwise → the single **open** bucket straddling the frontier: scan its
+  retained per-block fragments.
+
+It never probes the summary and falls back to fragments on a miss — it knows
+which world the bucket is in before it reads. The resolver is shared across the
+query's concurrent page futures; its memo is a `Mutex<HashMap>` held only for the
+in-memory check/insert and **never across a fetch await**
+(`directory_resolver.rs:44-60`), so racing tasks just both fetch and last-write
+wins harmlessly.
+
+**The fail-loud invariant.** A bucket classified sealed whose summary is missing
+is *not* a cache miss to recover from — it's a broken commit contract. The
+resolver returns `SealedDirectoryBucketMissingSummary` rather than scanning
+fragments (`directory_resolver.rs:84-94`). There's a test that seeds fragments
+that *would* resolve and asserts the resolver refuses to use them
+(`directory_resolver.rs:293`). Why so strict? Because the summary was flushed in
+the *same* `WriteSession` as the data, *before* the publication CAS — see the
+commit-ordering argument below.
+
+## Split #2 — the bitmap index (granularity: 64k pages, sealed per-shard)
+
+The bitmap inverted index stores, per `(stream, page)`, a roaring bitmap of local
+ids. A stream's local space is partitioned into **64K-wide pages**
+(`STREAM_PAGE_LOCAL_ID_SPAN = 64*1024`, `src/engine/bitmap.rs:35`), exactly **256
+pages per shard** (`STREAM_PAGES_PER_SHARD`, `bitmap.rs:40`).
+
+But the seal boundary here is the **shard**, not the page:
+
+```rust
+shard_sealed = shard < frontier_shard      // src/engine/query/bitmap.rs:92
+```
+
+A sealed shard carries an immutable per-stream **page-count manifest**
+(`BitmapPageCounts`) — how many bits each stream has in each page. That manifest
+lets a query skip a provably-empty page with **zero fetches**: in
+`intersect_shard_page`, `if plan.shard_sealed && page_counts.contains(&Some(0))`
+→ skip (`query/bitmap.rs:200`).
+
+**The frontier shard's manifest is a hint, never a skip.** The frontier shard
+hasn't sealed — its pages are still taking fragments — so its manifest is absent.
+`build_shard_page_plan` *borrows* the last sealed shard's manifest (`shard - 1`)
+purely to order clause fetches most-selective-first, and the skip is hard-gated
+on `shard_sealed` so a stale borrowed count can only *mis-order* fetches, never
+*drop* a page (`query/bitmap.rs:88-105`). That's the asymmetry again: a wrong
+order wastes time; a wrong skip loses data, so skipping is only ever allowed
+where the artifact is authoritative.
+
+(The bitmap-index lifecycle — fragments, pages, manifests, sealing — gets its own
+deep dive. Here it's just the second instance of the split.)
+
+## Split #3 — the in-memory open-index state
+
+`OpenIndexes` (`src/engine/open_index.rs:147`) is the in-memory mirror of exactly
+the *open* (uncompacted) region: the current open directory bucket's fragments
+and the current open bitmap page's fragments + which streams touched it. It's an
+`RwLock` over three maps keyed by `(family, bucket)` / `(family, stream, page)` /
+`(family, page)`, each holding fragments ordered by block number.
+
+Three operations are worth knowing because they thread through ingest and
+recovery:
+
+- **`apply_delta`** advances the open state in place after staging a batch
+  (`OpenIndexesDelta` = the new fragments this batch added, `open_index.rs:51`).
+- **`apply_eviction`** drops keys that just sealed (`OpenIndexesEviction` = the
+  buckets/pages compaction sealed, `open_index.rs:58`).
+- **`projected_with_delta`** *clones* the inner state and applies a delta to the
+  clone (`open_index.rs:181`). This is the trick that lets Phase B compaction
+  *plan* against the post-Phase-A open state without committing it yet.
+
+`rebuilt_for_head` (`open_index.rs:144`) stamps which published head this state
+was rebuilt for — the idempotence key for recovery (covered in the primary &
+standby dive).
+
+## The transition: compaction / sealing
+
+Open fragments become sealed summaries/pages during **Phase B** of ingest. The
+*trigger* in both structures is "the frontier fully crossed the unit":
+
+- **Directory:** `sealed_ranges` yields every 10k bucket whose
+  `bucket_end <= next_primary_id` (`src/engine/ingest/directory_compaction.rs`),
+  and `compact_bucket_from_fragments` folds that bucket's fragments into one
+  `PrimaryDirBucket` summary (validating contiguous blocks + id chaining — fail
+  loud on a gap).
+- **Bitmap:** pages the frontier moved past get OR-merged into one page artifact;
+  when the frontier crosses a shard's last page, that shard's per-stream manifest
+  is written (`newly_sealed_shards`, `src/engine/ingest/bitmap_compaction.rs`).
+  If the open-stream inventory says a page was touched but no compacted artifact
+  exists, it fails loud with `SealedShardPageMissingArtifact` — because an absent
+  page in a *present* manifest reads as count 0 and would be silently skipped on
+  the now-sealed shard.
+
+### Why a sealed artifact is safe to assume present
+
+This is the load-bearing guarantee, and it's pure ordering
+(`src/api.rs:764-772`). During ingest:
+
+```
+1. write ALL artifacts (fragments, bucket summaries, page blobs, manifests)
+2. ... THEN advance the published head with a single CAS        <-- the reveal
+```
+
+The published head **is** the commit boundary. So if a reader sees an id below
+the frontier (i.e. the head moved past it), every sealed artifact for that id —
+its bucket summary, its shard's page blobs and manifest — was durably committed
+*first*. Therefore a sealed-but-missing artifact can't happen under correct
+operation, which is exactly why the code treats it as a loud error rather than
+falling back. (Anything written *above* the head is speculative and gets ignored
+or overwritten on the next attempt — the recovery story, in the primary & standby
+dive.)
+
+## The granularities do NOT nest — and that's intentional
+
+This is the single most counterintuitive fact, so verify the arithmetic
+yourself:
+
+| Split | Unit | Local-id span | Sealed test |
+|---|---|---|---|
+| Directory | bucket | 10,000 | `bucket < bucket_start(frontier)` |
+| Bitmap page | page | 65,536 | (seals with its shard) |
+| Bitmap shard | shard | 16,777,216 | `shard < frontier_shard` |
+
+- **Pages nest cleanly in shards:** `2^24 / 65536 = 256`, exact. A shard *is* 256
+  pages.
+- **Buckets nest in nothing:** `2^24 / 10_000 = 1677.72…` and
+  `65536 / 10_000 = 6.55…` — neither divides. A single 10k directory bucket can
+  straddle a 64K bitmap-page boundary. The code never assumes alignment between
+  the two grids; each computes its own boundary from the raw frontier id. (This
+  is also why one block's fragment is written into *every* 10k bucket its id
+  window overlaps — `fragment_bucket_starts`, `primary_dir.rs:309`.)
+
+The practical consequence: at any instant the directory may have **many** sealed
+buckets while the bitmap's **whole current shard** is still open (no manifest
+yet). The directory seals ~1677× more often than a bitmap shard manifest is
+produced. So the bitmap leans on per-page short-circuit fetching *within* the
+open shard, while the directory already resolves most ids from sealed summaries.
+These are deliberately different precisions: small frequently-sealed buckets vs.
+a coarse once-per-16.7M-ids manifest that amortizes 256 page probes.
+
+## The mental model to keep
+
+> One frontier id, taken from the published head, splits each family's id-space
+> into sealed (immutable, summarized, skippable, must-be-present) and open
+> (mutable, fragmented, scanned, hint-only). Three structures implement that
+> split at three non-aligned granularities. Skips and must-be-present assertions
+> only ever apply on the sealed side; the open side is always demoted to a hint
+> or a scan. The whole thing is made safe by writing artifacts before the
+> single-CAS head advance.
+
+## Start-here pointers
+
+- Frontier derivation: `src/engine/query/family_runner.rs:362` +
+  `src/primitives/state.rs:251`
+- Directory routing & fail-loud: `src/engine/query/directory_resolver.rs:71,84`
+- Bitmap sealed test & manifest-skip rule: `src/engine/query/bitmap.rs:71,200`
+- In-memory open state: `src/engine/open_index.rs:147` (`projected_with_delta:181`)
+- Sealing: `src/engine/ingest/directory_compaction.rs`,
+  `src/engine/ingest/bitmap_compaction.rs`
+- Commit-ordering boundary: `src/api.rs:764`

--- a/monad-chain-data/docs/deep-dive-ingest-batching.md
+++ b/monad-chain-data/docs/deep-dive-ingest-batching.md
@@ -1,0 +1,236 @@
+# Deep dive: ingest batching & the two-phase commit
+
+> Prerequisite: read `docs/onboarding.md`. The
+> `docs/deep-dive-primary-standby.md` dive covers the lease/publish machinery
+> this one leans on; the `docs/deep-dive-frontier-model.md` dive covers the
+> sealing that Phase B performs. This dive is the end-to-end ingest pipeline and
+> *why its ordering is crash-safe*.
+
+## The two things to nail
+
+If you remember only two ideas from this dive:
+
+1. **Artifacts first, head-CAS last.** Every byte of a batch is written before a
+   single compare-and-swap advances the published head. A crash mid-batch leaves
+   *invisible orphans*, never a half-visible block.
+2. **Everything heavy is parallel; only the checksum chain is serial.** Per-block
+   encoding/indexing/digesting fans out across cores. The one unavoidable serial
+   dependency is folding the artifact-checksum chain.
+
+Everything else is plumbing around those two.
+
+## The plan / apply split
+
+Ingest is split into a *reads-only* planning half and an *effectful* commit half:
+
+- **`plan_ingest_blocks`** (`src/api.rs:807`) → produces an `Option<IngestPlan>`.
+  Pure CPU + reads. Builds all encoded artifacts, index fragments, the checksum
+  chain, and the compaction plans, and **stages** writes into in-memory buffers —
+  but applies nothing durable except epoch dictionaries.
+- **`apply_ingest_plan` / `_with_retry`** (`src/api.rs:1628`, `:1636`) → does the
+  durable writes and the publish CAS.
+
+`IngestPlan` (`src/api.rs:347`) carries: per-block `outcomes`, `timings`, the
+combined `writes: StagedWrites` (Phase A + Phase B meta+blob ops), and a
+`PublicationAdvance` — *just the target head + its checksum + the CAS key*. Note
+the published row *bytes* are not in the plan: the lease/owner/session fields are
+stamped only inside the publish CAS at apply time.
+
+Why split it:
+
+- **Pipelining.** The ingest binary runs plan and apply on separate tasks over
+  bounded channels, so block N+1 plans while block N commits.
+- **Plan-without-commit.** The same planning machinery is reused by
+  `verify_artifact_checksums` to re-derive checksums with no lease and no writes
+  (the standby path).
+- **Idempotent retry.** `StagedWrites` is a plain cloneable buffer, so the apply
+  half can re-apply the exact same writes on I/O failure.
+
+## Validation & contiguity
+
+A planned batch must be a contiguous, parent-linked extension of the published
+head. `plan_ingest_blocks` enforces (`src/api.rs:863`):
+
+- First block is block **1** on a fresh store, else `head + 1`.
+- `previous.block_hash == blocks[0].parent_hash()` (chains to the published head),
+  and within the batch each block's `parent_hash` matches the prior block's hash.
+- If `txs` is non-empty it must align in length with `logs_by_tx` (log-only
+  fixtures may pass empty `txs`).
+
+The `planning_state` mutex caches, across calls, the running head and the
+predecessor `BlockRecord` — so warm batches skip re-acquiring the lease and
+re-reading the head. On a cold cache it calls `begin_write` (learning the head +
+continuity) and, if continuity requires it, runs recovery before proceeding.
+
+## Primary-id assignment
+
+Ids are a dense, gap-free global sequence advanced block by block. For each block,
+its starting `LogId/TxId/TraceId` is the previous block's window's exclusive end —
+`first_primary_id + count` (`next_primary_id_exclusive`). A fresh store starts at
+`ZERO`. These starts are computed *sequentially up front* (cheap integer work)
+and frozen into a `plan_starts` array (`src/api.rs:917`) so the heavy per-block
+build has no data dependency between blocks.
+
+## The epoch-dictionary barrier
+
+Row codecs are per-epoch zstd dictionaries (epoch = `block_number /
+epoch_blocks`). The rule: **an epoch's dictionary must be durably published before
+any block of that epoch is framed.** A contiguous batch usually touches one epoch.
+
+Before the parallel build, `plan_ingest_blocks` calls `ensure_epoch_dicts` for
+every epoch the batch spans (`src/api.rs:968`). `ensure_epoch_dict`
+(`src/api.rs:1493`) is the block-until-ready primitive: fast-path if installed;
+otherwise single-flight under a per-family train lock (so it trains at most once
+even when the binary's background pre-train races it); train from the prior
+epoch's leading blocks; and critically — **persist the dict durably *before*
+installing the write codec** (`src/api.rs:1540`), so any block written under a
+version always has its dict (or empty sentinel) present on the read path.
+
+## Stage A — the parallel build + the serial fold
+
+This is the heart of the parallel/serial boundary.
+
+**Parallel** (`src/api.rs:1003`, rayon `par_iter` over blocks — blocks are
+independent): for each block, build the log/tx/trace ingest plans (encode the
+per-family blob + offsets, emit bitmap fragments, fold the *uncompressed* row
+digest in the same pass that compresses), and compute the standalone
+`block_content_digest`. The `BlockRecord.artifact_checksum` is left empty here.
+
+**Serial** (`src/api.rs:1056`) — the one thing the parallel build can't carry:
+
+```
+cumulative = seed_checksum                 // = previous head's checksum, or EMPTY
+for output in planned (contiguous order):
+    cumulative = chain(cumulative, output.block_content_digest)
+    output.staged.block_record.artifact_checksum = cumulative
+```
+
+`chain(prev, block) = blake3(prev ‖ block)` is a strict left fold: block N's
+stored checksum depends on N−1's *chained* value, back to the seed. The per-block
+*content* digests are independent and parallelizable; the *running chain* is
+inherently sequential, order- and history-sensitive. That single 32-byte chained
+value per block is what a standby re-derives to certify equality.
+
+## The two-phase commit
+
+### Phase A — stage all block artifacts into one write session
+
+`stage_writes` (`src/api.rs:1174`) stages, per block, into one `WriteSession`: the
+`BlockRecord` + EVM header + per-family headers; the per-family blobs; directory
+fragments; bitmap fragments; and the block-hash + tx-hash index entries. Staging
+populates the per-table caches as a side effect — which is what makes the Phase B
+*reads* hit cache.
+
+**`PhaseAFragmentWriteFilter`** (`src/api.rs:1115`) withholds bitmap fragments for
+pages that are *not* the open frontier page. Why: pages the batch sealed get
+*compacted* in Phase B (which reads existing page contents + the new fragments and
+writes a consolidated page), so writing their raw fragments in Phase A would be
+redundant work Phase B immediately supersedes. Only the still-open frontier page
+keeps its raw fragments. (Directory fragments are always written in Phase A.)
+
+### Phase B — compaction (needs the just-staged state)
+
+Phase B *planning* runs **concurrently with Phase A staging**:
+
+```rust
+let (phase_a_writes, stage_b_plan) = futures::join!(phase_a_stage, stage_b_plan);
+//                                                   src/api.rs:1280
+```
+
+`stage_b_plan` (`src/api.rs:1251`) is a `try_join!` of six compaction planners
+(directory + bitmap × log/tx/trace). They read the **projected** open-index state
+(`projected_with_delta` — the post-Phase-A open state, applied to a clone without
+committing) and load existing fragments from the store, hitting the caches Phase A
+just populated. The resulting bucket-seals and page-compactions are staged into a
+*second* write session and merged into the combined writes.
+
+> Precision note: "meta and blob commit concurrently" is true but happens at
+> **apply** time, not here. `apply_staged_writes_timed` (`src/engine/tables.rs:541`)
+> `try_join!`s the meta-store and blob-store applies. What runs concurrently
+> *during planning* is Phase A staging ∥ Phase B read-planning.
+
+## The crash-safety argument
+
+End to end, the ordering is:
+
+```
+0. epoch dict durable                                      (before any framing)
+1. apply_staged_writes(writes)   -> ALL artifacts to meta + blob stores
+                                    (block records, blobs, headers, dir/bitmap
+                                     fragments, compacted pages, hash indexes)
+2. authority_publish(new_head, checksum)  -> single ownership-validating CAS
+                                             <-- THE REVEAL happens here, once
+```
+
+Every reader resolves its query window against the published head, and every
+artifact for a block lives at keys for block numbers `> published_head` until step
+2 moves the head. So:
+
+- **Artifacts are addressable the instant step 1 lands, but logically invisible**
+  — no reader or standby looks above the head.
+- **The head is monotone and moves in one atomic CAS** from `h` to `new_head`.
+  There is no intermediate state where some-but-not-all of the batch is readable.
+- **Crash before the CAS** → the written artifacts are orphans for block numbers
+  above the un-advanced head. On restart the writer takes over (fresh session →
+  `Reacquired` → recovery from the old head) and simply overwrites them on
+  re-ingest (same block number → same keys). A standby sees `Pending` for the
+  un-advanced block, never a mismatch.
+
+**Invariant: artifacts first, head-CAS last ⇒ a crash yields invisible orphans,
+never a torn batch.**
+
+## Retry semantics
+
+`apply_ingest_plan_with_retry` (`src/api.rs:1636`) retries **only the staged-writes
+commit**, with exponential backoff (`IoRetryPolicy`: none / bounded / infinite).
+It's safe to repeat because the writes are keyed by block number / primary id /
+stream-page, so re-applying the identical `StagedWrites` overwrites the same keys
+(note the deliberate `writes.clone()` per attempt).
+
+**Publish is *not* in the retry loop.** After the writes commit, `authority_publish`
+is called once. Lease/CAS failures (`LeaseLost` / `FencedOut`) are handled
+*distinctly* from I/O errors: they clear the cached lease (so the next
+`begin_write` reacquires and recovers) and propagate — they are never retried as
+I/O, because a fenced/lost lease means another writer owns publication and
+re-CASing would be wrong.
+
+## The ingest binary
+
+`src/bin/chain-data-ingest.rs` is a **4-stage pipeline of `tokio` tasks over
+bounded channels** (depth `--plan-buffer`), so the stages overlap across batches:
+fetch(N+2) ∥ plan(N+1) ∥ apply(N).
+
+1. **Fetch** — ordered `buffered` stream of per-block fetches (block + receipts +
+   traces in parallel), with a `Semaphore` capping active concurrency; completed
+   fetches coalesce into `--batch-size` consecutive blocks.
+2. **Plan** — `plan_ingest_blocks` per batch.
+3. **Apply/IO** — `apply_ingest_plan_with_retry`; the only stage that writes +
+   publishes, hence serialized (the channel depth is the backpressure on
+   publication).
+4. **Progress consumer** — accumulates totals/metrics and autotunes.
+
+Two knobs worth knowing: **batch size** (default 1 for live-mode parity;
+backfill raises it to 32–256 to amortize the WAL/commit cost), and **adaptive
+fetch concurrency** (an AIMD controller resizing the fetch semaphore by observed
+retry rate, only under `--autotune`). The binary also **pre-trains the next
+epoch's dictionary** in the background once the current epoch passes its sampling
+window, safe against the plan-path `ensure` via the single-flight train lock.
+
+## The mental model to keep
+
+> A batch is planned (parallel encode + serial checksum fold) into staged writes,
+> then applied: all artifacts committed first, the published head advanced last by
+> one CAS. Plan and apply are split so they pipeline, so planning can verify
+> without committing, and so the apply can retry idempotently. The single-CAS
+> reveal at the end is what makes a crash leave invisible orphans rather than a
+> torn batch.
+
+## Start-here pointers
+
+- Plan: `src/api.rs:807` — validation `:863`, id assignment `:917`,
+  epoch-dict barrier `:968`, parallel build `:1003`, serial checksum fold `:1056`
+- Phase A staging: `src/api.rs:1174`; the A∥B `join!`: `:1280`
+- Phase B planners: `src/api.rs:1251`
+- Epoch dict persist-before-install: `src/api.rs:1540`
+- Apply + publish: `src/api.rs:1636`; concurrent commit: `src/engine/tables.rs:541`
+- The binary: `src/bin/chain-data-ingest.rs`

--- a/monad-chain-data/docs/deep-dive-primary-standby.md
+++ b/monad-chain-data/docs/deep-dive-primary-standby.md
@@ -1,0 +1,290 @@
+# Deep dive: primary & standbys — write coordination, leases, recovery, verification
+
+> Prerequisite: read `docs/onboarding.md`, and ideally
+> `docs/deep-dive-frontier-model.md` (the "published head = commit boundary"
+> idea recurs here). This dive covers how multiple processes coordinate who may
+> write, and how a standby proves it agrees with the primary.
+
+## The shape of the problem
+
+Exactly one process — the **primary** — may advance the published head. Every
+other process is a **standby**: it observes and verifies but never writes
+anything a reader will see. There is **no consensus protocol**. Coordination
+flows through just two things:
+
+1. **One CAS-guarded row** — `PublicationState` (`src/primitives/state.rs:301`),
+   written only through compare-and-swap.
+2. **One external clock** — the latest observed upstream finalized block number,
+   threaded in everywhere as `observed_upstream_finalized_block: Option<u64>`.
+
+That's the whole coordination substrate. Everything below is how those two
+pieces produce safe single-writer behavior with automatic takeover.
+
+## The one row, doing two jobs
+
+```rust
+struct PublicationState {        // src/primitives/state.rs:301
+    indexed_finalized_head: u64,     // JOB 1: reader-visible watermark
+    head_artifact_checksum: Hash32,  // JOB 1: chained checksum at that head
+    owner_id: u64,                   // JOB 2: write-coordination (the "outer ring")
+    session_id: SessionId,           // JOB 2
+    lease_valid_through_block: u64,  // JOB 2
+}
+```
+
+Keep these two jobs separate in your head, because the code does:
+
+- **The reader/standby half** — `indexed_finalized_head` + `head_artifact_checksum`.
+  The query path reads *only* `indexed_finalized_head` (via
+  `load_published_head`) and nothing else. It never looks at the lease fields.
+- **The outer coordination ring** — `owner_id` / `session_id` /
+  `lease_valid_through_block`. Only `authority.rs` touches these.
+
+### owner_id vs session_id (and why a restart forces takeover)
+
+- `owner_id` is a **stable per-node** identity — survives restarts.
+- `session_id` is a **fresh per-process** identity, regenerated on every startup
+  (`new_session_id` mixes pid + a startup nonce + wall-clock).
+
+The "is this still my live session?" check requires **both** to match
+(`authority.rs:334`). So a restarted primary reuses its `owner_id` but presents a
+*new* `session_id`, fails the same-session test against the row its previous
+incarnation wrote, and is routed down the **takeover** path → `Reacquired` →
+**recovery runs**. This is deliberate: a crashed process may have left
+speculative artifacts above the published head, and only the takeover path cleans
+up the in-memory open-index state.
+
+### The head-0 sentinel
+
+`indexed_finalized_head == 0` means "nothing published." Block numbers start at
+**1**, so there is never a block-0 record — which is what makes 0 an unambiguous
+sentinel. A `Fresh` acquire writes the row at head 0; the plan path maps head 0 →
+`None` so it never tries to load a nonexistent block-0 record (`src/api.rs:833`).
+
+## The lease lifecycle
+
+`src/engine/authority.rs`. The cached lease (`PublicationLease`) carries the
+`CasVersion` it was last seen at — every renew/publish CASes against that version,
+and a conflict is discriminated by *reloading and comparing owner/session*.
+
+### `WriteContinuity` — the output of acquiring
+
+`begin_write` returns one of three states (`authority.rs:47`), and
+`requires_recovery()` is true for two of them:
+
+| Continuity | Meaning | Recovery? |
+|---|---|---|
+| `Fresh` | created the very first publication row | yes |
+| `Continuous` | same owner+session, lease still valid | **no** |
+| `Reacquired` | took over an expired/foreign lease (or restarted) | yes |
+
+### The acquisition decision tree
+
+`acquire_publication_with_session` (`authority.rs:301`) — runs on a cold cache:
+
+```
+no row?                                   -> CAS-insert at head 0      => Fresh
+same owner AND same session AND in-window -> renew (or no-op)          => Continuous
+foreign owner AND lease still fresh       -> refuse: LeaseStillFresh   (stay passive)
+otherwise (own expired, or foreign past bound) -> CAS-takeover         => Reacquired
+```
+
+Two things to notice:
+
+- **Takeover preserves the head.** Both the renew and takeover branches copy
+  `indexed_finalized_head` and `head_artifact_checksum` from the current row
+  unchanged — **only the lease fields change** (`authority.rs:346-352`,
+  `:376-383`). A successor continues the predecessor's published history and
+  checksum chain; only a *publish* ever advances the head.
+- **"Passive" is an error, not a state.** A standby that finds a fresh foreign
+  lease gets `LeaseStillFresh` and backs off. There's no separate passive enum
+  variant — refusal *is* the error return.
+
+### Lease window math
+
+- `lease_valid_through_block(observed) = observed + lease_blocks - 1`
+  (`authority.rs:276`).
+- `needs_renewal` is true when `lease_valid_through - observed <= renew_threshold`
+  — i.e. renew once the clock enters the last `renew_threshold` blocks of the
+  window.
+- The clock is **mandatory**: `require_observed_finalized_block` maps `None` →
+  `LeaseObservationUnavailable`. A writer never acquires, renews, or publishes
+  without a current clock reading. Fail closed.
+
+## The CAS mechanism and the two publish failures
+
+`MetaStoreCas` (`src/store/meta/mod.rs`) is a versioned compare-and-swap:
+`cas_put(table, key, expected: Option<CasVersion>, value)` → `Applied { new_version }`
+or `Conflict { current_version }`. `expected = None` means insert-if-absent. The
+publication head row is the *only* CAS row in the system; everything else is
+idempotent `put`.
+
+### "Revalidate inside the publish CAS" (D1 option A)
+
+The lease is **not** held as a guard across the plan→apply gap. Instead,
+`publish_current` (`authority.rs:530`) does it all at publish time:
+
+```
+1. renew_if_needed(lease, observed)        // extend the window if we're near expiry
+2. next_state = lease.as_state();
+   next_state.indexed_finalized_head = new_head;
+   next_state.head_artifact_checksum = checksum;
+3. cas_state(expected = lease.version, next_state)   // head advance + renewal, one CAS
+```
+
+The head advance and any lease renewal land in **one version-CAS**. No lock is
+held across the (potentially long) plan/apply work.
+
+### LeaseLost vs FencedOut
+
+On a CAS `Conflict`, `publish_current` reloads the row to discriminate
+(`authority.rs:550`):
+
+- **`LeaseLost`** — the reloaded owner/session **differ** (a foreign takeover
+  happened), or the row is gone. Ownership genuinely moved on.
+- **`FencedOut { current_head }`** — **same** owner+session but the version moved.
+  A same-owner concurrent publish race (e.g. two in-process writers, or a retried
+  publish).
+
+Both are treated as "invalidate the cached lease" (`should_invalidate_cached_lease`),
+so on either, the cache is cleared and the **next `begin_write` reacquires from
+the store** → continuity becomes `Reacquired` → recovery runs. Neither is retried
+as if it were an I/O error — a fenced/lost writer must step down, not hammer the
+CAS.
+
+(There's a simpler `SingleWriter` authority for non-clustered deployments: plain
+version-CAS, no lease/session, writes zeros into the lease fields. A cold start
+reports `Reacquired` so it always rebuilds open indexes; a stale version maps to
+`FencedOut`.)
+
+## Recovery — rebuilding the open frontier
+
+Recovery runs **only** on `Fresh`/`Reacquired` (`src/api.rs:846`); a `Continuous`
+renewal skips it because the in-memory open indexes are already coherent with the
+head this same live session published.
+
+What it rebuilds: the **open-index state** — the in-memory mirror of the
+uncompacted fragments for the current open directory bucket and bitmap page (see
+the frontier-model dive). After an ownership transition the new writer's in-memory
+copy is empty/stale, so `rebuild_family_open_indexes` (`src/api.rs:719`) rescans
+durable fragments **as of the published head**:
+
+- It rebuilds **only the current open bucket/page** (derived from the family
+  window's `next_primary_id_exclusive` — the frontier). Sealed buckets/pages have
+  durable summaries and aren't touched.
+- Both scans filter fragments by `block <= published_head`.
+
+That filter is the whole point. A dead predecessor may have written fragments for
+blocks *above* the published head (it crashed after writing artifacts but before
+the head-advancing CAS). Those are speculative and **never were fenced in** — the
+`<= published_head` filter excludes them, and the next ingest simply overwrites
+them (same block number → same keys). Idempotence on `rebuilt_for_head ==
+Some(head)` keeps repeated `begin_write`s from re-scanning.
+
+This is the standby-safety guarantee restated: **the published head is the commit
+boundary; anything above it is speculative and is ignored on takeover**, so a
+crash mid-batch can't corrupt a successor.
+
+## The artifact-checksum chain — how a standby verifies agreement
+
+`src/engine/digest.rs`. The goal: a standby ingesting the same finalized blocks
+should be able to prove it *would have written byte-equivalent artifacts* —
+without taking the lease and without reading a single stored artifact byte.
+
+### What's hashed
+
+- **Per-block content digest** (`block_content_digest`) folds: block identity
+  (number, hash, parent hash), the EVM header RLP, and the three per-family
+  content digests in fixed order log→tx→trace.
+- **Per-family content digest** (`family_content_digest`) folds: the primary-id
+  window, the dict version, a `RowDigest` over the **uncompressed** rows, and the
+  bitmap fragments.
+- **The chain**: `chain(prev, block) = blake3(prev ‖ block)`, seeded with
+  `EMPTY_CHECKSUM` (zero). The running value is stored in **every**
+  `BlockRecord.artifact_checksum` and mirrored in the head row's
+  `head_artifact_checksum`. One 32-byte value certifies the whole history.
+
+### Two determinism rules that matter
+
+- **Uncompressed rows, on purpose** (`digest.rs:31`). The digest folds row bytes
+  *before* zstd framing and excludes the compressed-frame offsets. So two nodes
+  agree whenever their *logical* content agrees, even if their zstd library
+  versions emit different compressed bytes. The checksum is codec-independent by
+  construction.
+- **Canonical ordering + length-prefixing.** Every variable-length field is
+  length-prefixed (so `["ab","c"]` ≠ `["a","bc"]`), and bitmap fragments — which
+  have no inherent storage order — are folded sorted by `(stream_id,
+  page_start_local)`. Map/iteration order can't perturb the result.
+
+### How verification runs
+
+`verify_artifact_checksums` (`src/api.rs:1700`) takes a contiguous run of
+`FinalizedBlock`s and:
+
+1. Seeds the chain from the published **predecessor** record (or the empty seed
+   if starting at block 1).
+2. For each block: resolves the same epoch codecs, **re-runs the same ingest
+   plan builders** to recompute the content digest, folds the chain, then loads
+   the published `BlockRecord` and compares.
+
+Outcomes (`VerifyOutcome`):
+
+- **`Match { through_block }`** — every block's recomputed chain value equals the
+  published `artifact_checksum`.
+- **`Mismatch { block_number, published, computed }`** — first divergence. The
+  standby would *not* have written the same artifacts.
+- **`Pending { block_number }`** — the primary hasn't published that block yet
+  (the standby is ahead). Not an error.
+
+Crucially it never calls `begin_write`, never CASes, and reads only the 32-byte
+checksums + window metadata from the published records — it recomputes digests
+from the *supplied* blocks. And because the chain is seeded from the published
+predecessor and folded one block at a time, it's **batch-grouping-independent**: a
+standby can call it with any block grouping regardless of how the primary batched
+ingest.
+
+## The concrete primary-side sequence
+
+Putting the two halves of `src/api.rs` together:
+
+```
+plan_ingest_blocks:                                    (begin_write side)
+  cold cache?
+    begin_write(observe_upstream)  -> AuthorityState{ head, continuity }
+    head 0 -> None
+    continuity.requires_recovery() -> ensure_open_indexes_rebuilt(head)
+    load previous head BlockRecord -> cache planning state
+  validate contiguity (block 1 first, else head+1 + parent_hash match)
+  seed checksum chain from previous.artifact_checksum
+
+apply_ingest_plan:                                     (publish side)
+  apply_staged_writes(writes)          // ALL artifacts, with I/O retry/backoff
+  authority_publish(new_head, head_checksum, observe_upstream)
+      -> publish_current: renew_if_needed, then single CAS of head+checksum
+      -> on LeaseLost / FencedOut: clear cached lease (next begin_write reacquires)
+```
+
+The ordering — **artifacts first, head-CAS last** — is the same commit boundary
+that makes speculative artifacts safely ignorable on takeover, and the checksum
+stamped into the head row at publish is exactly what a standby re-derives to prove
+agreement.
+
+## The mental model to keep
+
+> One CAS row + one external clock = single-writer-with-takeover, no consensus.
+> The row's lease fields decide *who may write* (owner+session+window); its head
+> fields decide *what readers see*. Takeover preserves the head and chain;
+> only publish advances them. A restart always takes over (fresh session) and
+> recovers. The checksum chain — folded over *uncompressed* content — lets a
+> standby certify byte-equivalence against the head without the lease or the
+> stored bytes.
+
+## Start-here pointers
+
+- The row: `src/primitives/state.rs:301`
+- Acquisition decision tree: `src/engine/authority.rs:301`
+- Publish + the two failure modes: `src/engine/authority.rs:530`
+- Recovery rebuild: `src/api.rs:719` (+ gating at `:846`)
+- Digest + chain: `src/engine/digest.rs` (uncompressed rationale at `:31`)
+- Standby verification: `src/api.rs:1700`
+- The primary-side begin/publish wiring: `src/api.rs:807` and `:1636`

--- a/monad-chain-data/docs/onboarding.md
+++ b/monad-chain-data/docs/onboarding.md
@@ -1,0 +1,411 @@
+# monad-chain-data — onboarding
+
+## What this crate is
+
+It's a **storage + query engine for EVM execution history**. You feed it
+finalized blocks one batch at a time (the *ingest* path); it lets you ask
+"give me the logs/transactions/traces/transfers matching this filter over this
+block range" (the *query* path). It is not the transport or the JSON-RPC layer —
+those live elsewhere and call into the `MonadChainDataService` API in
+`src/api.rs`.
+
+Everything hangs off three ideas:
+
+1. **Families** — the engine knows three kinds of record, and treats them almost
+   identically.
+2. **Primary IDs** — every record gets a single, gapless, global `u64` id within
+   its family. That id *is* the data model. Indexes map *into* it; the directory
+   maps *out* of it.
+3. **The published head** — a single compare-and-swap'd row is the only thing
+   that makes data visible to readers. Below it: immutable, queryable. Above it:
+   doesn't exist as far as a query is concerned.
+
+---
+
+## The data model
+
+### Families
+
+A **family** (`src/engine/family.rs`) is an indexed, queryable stream of one kind
+of record. There are exactly three, and the `Family` enum is the canonical list:
+
+- **`Log`** — EVM event logs.
+- **`Tx`** — transactions (hash, sender, raw signed bytes).
+- **`Trace`** — call frames (CALL / CREATE / SELFDESTRUCT / …), flattened per
+  block.
+
+There's a fourth thing you can query — **transfers** — but it is *not* a family.
+A transfer is a **view over the trace family**: at ingest, any trace frame that
+moves value gets a `has_transfer` bit set in the index, and the transfers query
+is just a trace query that ANDs in that one bit and projects each matching
+`TraceEntry` into a `TransferEntry` (`src/transfers/materialize.rs`). It reuses
+the trace family's blobs, directory, and bitmaps wholesale. Keep this in your
+head: **transfers ride entirely on trace storage.**
+
+The three families are structurally identical — same set of tables, same
+indexing, same query machinery. That's why so much of the engine is generic over
+a family (`execute_indexed_family_query`, `PrimaryIdResolver`, the bitmap code).
+The per-family modules (`src/logs`, `src/txs`, `src/traces`) mostly just define
+the record type, what fields are indexed, and how to encode/decode a row.
+
+### Primary IDs — the spine
+
+Every record in a family has a `PrimaryId` (`src/primitives/state.rs`): a `u64`
+that counts up, gaplessly, across the whole family's history. Log #0, log #1,
+… log #N regardless of which block they're in. Same for txs, same for traces.
+(They're wrapped in `LogId` / `TxId` / `TraceId` newtypes so you can't cross the
+streams by accident, but underneath it's one `PrimaryId`.)
+
+The id is split into two parts:
+
+```
+   63                    24 23            0
+  +------------------------+--------------+
+  |        shard           |    local     |
+  +------------------------+--------------+
+            (40 bits)         (24 bits)
+```
+
+- **local** (low 24 bits) → up to ~16.7M records per shard.
+- **shard** (the rest) → which 16.7M-record band you're in.
+
+It is split because the bitmap index works in *local* space within a shard,
+and the shard is the unit at which the index seals and becomes immutable. More on
+that below. Just remember: **a `PrimaryId` is a `(shard, local)` pair**, and
+`from_parts` / `.shard()` / `.local()` convert back and forth.
+
+### Blocks tie ids back to chain position
+
+The id-space is continuous and ignores block boundaries. The thing that records
+where the boundaries are is the **`BlockRecord`** (`src/primitives/state.rs`). One per block:
+
+```rust
+struct BlockRecord {
+    block_number, block_hash, parent_hash,
+    logs:   FamilyWindowRecord,   // { first_primary_id, count }
+    txs:    FamilyWindowRecord,
+    traces: FamilyWindowRecord,
+    artifact_checksum,            // chained digest — see standby verification
+}
+```
+
+A `FamilyWindowRecord` is just `{ first_primary_id, count }` — "this block's logs
+are ids `[first, first+count)`". Across all blocks these windows **partition the
+id-space perfectly: contiguous, no gaps, no overlaps.** That invariant is what
+makes everything else work:
+
+- The next block's `first_primary_id` is simply the previous block's
+  `first + count`. Ingest computes ids by running this cursor forward.
+- Given a block, you know its id range. Given an id, you can find its block
+  (that's what the directory index is for).
+- A record stores only its *intra-block* fields in the blob; block-level fields
+  (`block_number`, `block_hash`) are stripped at ingest and re-attached at read
+  from the `BlockRecord`. Compare `RawLogEntry` (stored) vs `LogEntry`
+  (materialized) in `src/logs/types.rs`.
+
+### How a record is physically stored
+
+Per family, per block, there's a **blob** and a **header**
+(`src/logs/materialize.rs`, `src/logs/ingest.rs` show the log version):
+
+- The **blob** is every row in the block, RLP-encoded then zstd-frame-compressed
+  one row at a time, concatenated.
+- The **header** is a list of byte `offsets` into that blob (row *i* lives at
+  `offsets[i]..offsets[i+1]`) plus the `dict_version` the frames were compressed
+  under.
+
+So to read record *i* of a block: load the header, slice `offsets[i..i+2]`, pull
+that byte range out of the blob, decompress, decode. Random access by intra-block
+index, which is exactly what the query path needs.
+
+(The `dict_version` is an epoch-based compression dictionary — every N blocks a
+new dict is trained so common byte patterns compress well. Not important for
+understanding the paths; just know the header tells you which dict decodes the
+blob, and the checksum digest deliberately ignores compression entirely.)
+
+### The two indexes
+
+Every family carries two indexes, and they answer opposite questions.
+
+**1. The primary directory — "id → where is it?"**
+(`src/engine/primary_dir.rs`, `src/engine/query/directory_resolver.rs`)
+
+Maps a `PrimaryId` back to `(block_number, idx_in_block)`. It's bucketed in
+ranges of 10,000 ids. A bucket whose whole range sits below the published-head
+frontier is **sealed** — it has a compacted summary you binary-search. The single
+bucket straddling the frontier is **open** — you scan its per-block fragments.
+The resolver routes analytically: it knows `sealed_below`, so it never probes the
+summary and falls back to fragments; sealed → one summary read, open → fragment
+scan. (A sealed bucket missing its summary is a hard error, not a silent fallback
+— the commit contract guarantees it's there.)
+
+**2. The bitmap index — "value → which ids?"**
+(`src/engine/bitmap.rs`, `src/engine/query/bitmap.rs`)
+
+This is the inverted index that makes filtered queries fast. The core unit is a
+**stream**: `sharded_stream_id(kind, value, shard)`. For a log, ingest emits one
+entry per indexed field into the matching stream
+(`src/logs/ingest.rs::stream_entries_for_log`):
+
+```
+addr=0xABC   shard 3   ->  set local-bit for this log
+topic0=0x12  shard 3   ->  set local-bit
+topic1=...   shard 3   ->  set local-bit
+```
+
+Each stream is a roaring bitmap of *local* ids within its shard. Streams are
+chopped into **pages** spanning 64K local ids each. A sealed shard also carries a
+**page-count manifest** (how many bits each stream has in each page) so the query
+side can skip provably-empty pages without fetching them.
+
+The names `addr` / `topic0..3` (logs), `from` / `to` / `selector` (txs),
+`has_transfer` etc. (traces) are the indexed **kinds**. The exact same
+`sharded_stream_id(kind, value, shard)` call builds the stream id at ingest and
+looks it up at query — that symmetry is the whole trick, so when you read one
+side, read the other.
+
+### The published head
+
+One row, `PublicationState` (`src/primitives/state.rs`), guarded by
+compare-and-swap. Its `indexed_finalized_head` is **the reader-visible
+watermark**: queries only ever see blocks at or below it. Advancing it is the
+atomic act of publication — all the artifacts for a block are written *first*,
+then the head moves in one CAS. The other fields (`owner_id`, `session_id`,
+`lease_valid_through_block`) are write-coordination state the query path never
+looks at, plus `head_artifact_checksum` for standby verification.
+
+---
+
+## The query path
+
+Entry points are `query_logs` / `query_transactions` / `query_traces` /
+`query_transfers` / `query_blocks` in `src/api.rs`. They all follow the same
+shape (read `query_logs` at `src/api.rs:1791` as the canonical one):
+
+```
+1. check the request limit
+2. load the published head
+3. resolve the block window         (clamp to head, enforce max range)
+4. dispatch:  indexed  vs  block-scan
+5. (optional) join "relations" — block headers, txs — onto the results
+```
+
+### Resolving the window
+
+`ResolvedBlockWindow::resolve` (`src/primitives/range.rs`) turns the request's
+`from_block`/`to_block` (whose lower/upper roles depend on query `order`) into a
+clean low≤high block range, clamped to the published head and bounded by
+`QueryLimits::max_block_range`.
+
+For an indexed query that block range then becomes an **id window**
+(`src/engine/query/window.rs`): walk up from the low block to the first non-empty
+family window → first id; walk down from the high block to the last non-empty
+window → last id. (The two walks run concurrently.) Now you have `[start_id,
+end_id]` in the family's primary-id space, which is what the bitmap index speaks.
+
+### Indexed vs block-scan
+
+The fork is one question: **does the filter touch an indexed field?**
+(`filter.has_indexed_clause()`).
+
+- **No indexed clause** → **block scan** (`execute_block_scan_family_query`,
+  `src/engine/query/family_runner.rs:309`). Walk the blocks in order, load each
+  block's whole blob, decode and filter every row, stop when the limit is hit.
+  O(rows in range). Used for e.g. "all logs in blocks 100–110".
+
+- **At least one indexed clause** → **indexed query**
+  (`execute_indexed_family_query`, same file, line 97). The fast path. O(matching
+  rows). This is the heart of the engine — described next.
+
+### The indexed pipeline
+
+A filter is a list of **clauses** (`src/engine/clause.rs`). Each clause is one
+field; its `values` are OR'd together; clauses are AND'd with each other. E.g.
+`address ∈ {A,B} AND topic0 = T` is two clauses.
+
+The runner does, conceptually:
+
+```
+for each shard in the id window:
+    build a per-shard plan: the clause streams + the page-count manifest
+    for each candidate page in this shard's local range:
+        intersect the clauses on this page  ->  surviving local ids
+        resolve each survivor via the directory  ->  (block, idx)
+        materialize  ->  the actual record
+stop once `limit` records are collected (block-aligned), record a cursor
+```
+
+The key insight that makes per-page work correct is the **distributive law**:
+
+```
+⋂_clauses ( ⋃_pages bits )  ==  ⋃_pages ( ⋂_clauses bits_on_that_page )
+```
+
+Because pages partition the local-id space, you can intersect clause bitmaps
+*one page at a time* and union the results. That's a big win over building each
+clause's full bitmap and then ANDing: per page you fetch the most-selective
+clause first, AND down, and the **moment the running intersection goes empty you
+stop fetching the rest of that page's clauses** (`intersect_shard_page` in
+`src/engine/query/bitmap.rs`). On sealed shards the manifest lets you skip pages
+that any clause proves empty with *zero* fetches.
+
+The pipeline is staged and concurrent (`family_runner.rs`): page intersections
+run `PAGE_CONCURRENCY` at a time, materializations `min(limit, ceiling)` at a
+time, all kept in query order so the consumer can apply a clean **block-aligned
+limit** — once it has `limit` records it finishes the current block and stops,
+emitting a `cursor_block` so the caller can paginate.
+
+**Materialize** is the last step (`src/logs/materialize.rs::load_record_at`):
+take a `(block, idx)`, load that block's header + the one row's byte range from
+the blob, decompress, decode, re-attach block-level fields. The directory got you
+the location; materialize turns the location into the object.
+
+So the full indexed flow for one record:
+
+```
+filter clause  --(sharded_stream_id)-->  bitmap streams  --intersect-->
+local ids  --(+shard)-->  PrimaryId  --directory-->  (block, idx)
+  --blob slice + decode-->  LogEntry/TxEntry/TraceEntry
+```
+
+`get_transaction(hash)` is a special case: txs also keep a hash→location index
+(`src/txs/hash_index.rs`), so a by-hash lookup skips the bitmap machinery and
+goes straight to materialize.
+
+### Querying the unfinalized tip
+
+The indexed path only sees finalized data (≤ published head). To answer queries
+that reach `latest` — the proposed, not-yet-indexed blocks — the caller scans
+those blocks **in memory** (`src/mem_scan.rs`). The crucial property:
+`scan_block_logs` / `scan_block_txs` construct the *exact same* `LogEntry` /
+`TxEntry` rows, with the *exact same* `log_index` assignment and the *exact same*
+filter matchers, that the indexed path would produce. So the caller can run the
+indexed query up to the head, run the mem-scan over the tip blocks, and
+concatenate — no semantic divergence between the two halves.
+
+---
+
+## The ingest path
+
+Driven by `src/bin/chain-data-ingest.rs`, but the logic lives in
+`plan_ingest_blocks` → `apply_ingest_plan` in `src/api.rs`. Input is a batch of
+`FinalizedBlock`s (`src/family.rs`): an EVM header plus `logs_by_tx`, `txs`,
+`traces`. The split into *plan* and *apply* matters — planning is pure CPU work
+that can be parallelized and even verified without writing; applying is the I/O
+and the publish.
+
+### Plan (`plan_ingest_blocks`, src/api.rs:807)
+
+```
+1. begin_write: acquire/renew the write lease, learn the authoritative head,
+   and run recovery if ownership just changed
+2. validate the batch is contiguous: block N+1, parent_hash chains correctly
+3. compute each block's starting ids by running the window cursor forward
+4. ensure each epoch's compression dictionary is published before framing
+5. PARALLEL (rayon) per block: build the log/tx/trace ingest plans
+6. SEQUENTIAL: fold the artifact-checksum chain across blocks
+7. stage all artifacts into one write session
+```
+
+Step 5 is where the per-family work happens (`LogIngestPlan::build` etc.). For
+each family it: flattens the records, assigns intra-block indices, encodes each
+row (RLP → frame-compress) into the blob while building the offsets header,
+emits the **bitmap fragments** (the inverted-index entries, keyed by the same
+`sharded_stream_id` the query reads), and folds a **row digest** over the
+*uncompressed* row bytes. Because blocks are independent here, this fans out
+across cores; the only sequential part is the checksum chain (step 6), which by
+nature depends on the previous block.
+
+### Apply (`apply_ingest_plan`, src/api.rs:1628)
+
+```
+1. commit the staged writes: blobs + metadata + index fragments
+   (meta and blob stores commit concurrently)
+   — plus a compaction step that seals directory buckets and compacts
+     bitmap pages as the frontier moves
+2. authority_publish: CAS the publication head forward to the new block,
+   stamping the new head_artifact_checksum
+```
+
+Until step 2's CAS lands, none of the freshly written artifacts are visible to
+any query — the published head is still where it was. Publication is the single
+atomic reveal. This is why a writer can crash mid-batch and a reader never sees a
+half-written block: the artifacts may be on disk, but the head never moved.
+
+### Write authority — who's allowed to publish
+
+`src/engine/authority.rs`. Exactly one process may advance the head at a time. It
+holds a **lease**, recorded in that same `PublicationState` row, tracked against
+an external clock (the latest observed upstream finalized block). Standbys watch
+passively and only take over once the lease expires. Coordination flows entirely
+through CAS on the one row — there's no separate consensus layer. When a process
+takes over (lease expired, or it restarted with a fresh `session_id`), it runs
+**recovery** to rebuild the open (frontier) index state before writing. The query
+path never reads any of this; it's purely the outer ring around publication.
+
+### Standby verification — the artifact checksum chain
+
+`src/engine/digest.rs`. Every block produces a **content digest** over its
+*logical* artifacts: the uncompressed row payloads, the EVM header, the per-family
+windows, dict versions, and the bitmap fragments. These per-block digests are
+folded into a **hash chain** — `chain(prev, block)` — whose running value is
+stored in every `BlockRecord.artifact_checksum` and mirrored in the published
+head.
+
+The point: a **standby** ingesting the same finalized blocks re-derives the same
+chain and compares (`verify_artifact_checksums`, `src/api.rs:1700`). If its
+computed head matches the published head's checksum, it has *proven it would have
+written byte-equivalent artifacts* — without re-reading a single stored byte, and
+without taking the write lease. The digest folds rows *before* compression on
+purpose, so two nodes agree whenever they agree on logical content even if their
+zstd versions emit different bytes. One 32-byte value certifies the whole history.
+
+---
+
+## A map of the crate
+
+| Area | Where | What |
+|---|---|---|
+| Public service API | `src/api.rs` | `MonadChainDataService`: ingest + query entry points |
+| Core types | `src/primitives/state.rs` | `PrimaryId`, `FamilyWindowRecord`, `BlockRecord`, `PublicationState` |
+| Family abstraction | `src/engine/family.rs` | the `Family` enum + its tables |
+| Indexed query runner | `src/engine/query/family_runner.rs` | the staged indexed pipeline + block-scan |
+| Bitmap intersection | `src/engine/query/bitmap.rs`, `src/engine/bitmap.rs` | streams, pages, per-page AND |
+| Directory (id→location) | `src/engine/query/directory_resolver.rs`, `src/engine/primary_dir.rs` | sealed summaries vs open fragments |
+| Clauses | `src/engine/clause.rs` | how a filter becomes AND-of-OR streams |
+| Per-family logic | `src/logs`, `src/txs`, `src/traces` | `types` / `ingest` / `materialize` / `*_query` |
+| Transfers (trace view) | `src/transfers` | `has_transfer` projection over traces |
+| Ingest binary | `src/bin/chain-data-ingest.rs` | fetch → plan → apply driver |
+| Checksums | `src/engine/digest.rs` | content digest + chain for standby verification |
+| Write authority | `src/engine/authority.rs` | lease, takeover, recovery |
+| Unfinalized tip | `src/mem_scan.rs` | in-memory scan matching indexed semantics |
+| Storage backends | `src/store` | meta store (CAS), blob store, cache, write session |
+
+### Deep dives
+
+Once the above makes sense, these go one level deeper on the cross-cutting
+subsystems (each anchored to invariants rather than line numbers, so they age
+gracefully):
+
+- [`deep-dive-frontier-model.md`](deep-dive-frontier-model.md) — the sealed-vs-open
+  split that governs both indexes and the in-memory state. **Read this first** —
+  the others lean on it.
+- [`deep-dive-primary-standby.md`](deep-dive-primary-standby.md) — multi-node write
+  coordination: the lease lifecycle, recovery, and the checksum chain that lets a
+  standby verify agreement.
+- [`deep-dive-ingest-batching.md`](deep-dive-ingest-batching.md) — the plan/apply
+  split, parallel build vs. serial checksum fold, two-phase commit, and why the
+  ordering is crash-safe.
+- [`deep-dive-bitmap-index.md`](deep-dive-bitmap-index.md) — the inverted-index
+  lifecycle from ingest fragment to sealed page + manifest, and the distributive
+  law that makes per-page intersection work.
+
+### The one paragraph to remember
+
+Records get gapless global **primary ids**; `BlockRecord` windows partition that
+id-space by block. A **bitmap inverted index** turns a filter value into a set of
+ids (`value → ids`); the **directory** turns an id back into a block location
+(`id → (block, idx)`); **materialize** turns a location into the row. Ingest
+builds those two indexes and the blob, then makes it all visible with one
+compare-and-swap on the **published head**. Queries read strictly below that head;
+the unfinalized tip is scanned in memory with identical semantics and merged.


### PR DESCRIPTION
Add onboarding material focused on the core query/ingest paths and data model:

- onboarding.md: families, primary ids, the published head, and the query/ingest paths end to end
- deep-dive-frontier-model.md: the sealed-vs-open split across the directory, bitmap index, and in-memory open state
- deep-dive-primary-standby.md: lease lifecycle, recovery, and the artifact-checksum chain for standby verification
- deep-dive-ingest-batching.md: plan/apply split, two-phase commit, and the artifacts-first/head-CAS-last crash-safety ordering
- deep-dive-bitmap-index.md: inverted-index lifecycle from fragment to sealed page + manifest, and the distributive-law intersection
