### PR TITLE
Bump Docker base images to Ubuntu 26.04 LTS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,6 +2167,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-rs"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe808acca98fccf920154ee7833e791bfb683299be4aae7ec222ddffad8cd4f8"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5495,6 +5504,7 @@ dependencies = [
 name = "monad-event-ring"
 version = "0.1.0"
 dependencies = [
+ "build-rs",
  "libc",
  "monad-build",
 ]

--- a/docker/archive/Dockerfile
+++ b/docker/archive/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.10 AS base
+FROM ubuntu:26.04 AS base
 
 WORKDIR /usr/src/monad-bft
 

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.10 AS base
+FROM ubuntu:26.04 AS base
 
 RUN apt update && apt install -y \
   binutils \

--- a/docker/devnet/Dockerfile
+++ b/docker/devnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.10 AS base
+FROM ubuntu:26.04 AS base
 
 WORKDIR /usr/src/monad-bft
 

--- a/docker/rpc-request-gen/Dockerfile
+++ b/docker/rpc-request-gen/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM ubuntu:25.10 AS base
+FROM ubuntu:26.04 AS base
 
 RUN apt update && apt upgrade -y
 RUN apt update && apt install -y binutils ca-certificates curl iproute2 pkg-config gnupg software-properties-common wget cgroup-tools
@@ -88,7 +88,7 @@ RUN cargo build --release --example rpc-request-generator && \
     mv target/release/examples/rpc-request-generator rpc-request-generator
 
 # Runner
-FROM ubuntu:25.10 AS runner
+FROM ubuntu:26.04 AS runner
 WORKDIR /usr/src/monad-bft
 
 COPY --from=builder /usr/src/monad-bft/rpc-request-generator /usr/local/bin/rpc-request-generator

--- a/docker/rpc/Dockerfile
+++ b/docker/rpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.10 AS base
+FROM ubuntu:26.04 AS base
 
 WORKDIR /usr/src/monad-bft
 

--- a/docker/txgen/Dockerfile
+++ b/docker/txgen/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM ubuntu:25.10 AS base
+FROM ubuntu:26.04 AS base
 
 RUN apt update && apt upgrade -y
 RUN apt update && apt install -y binutils ca-certificates curl iproute2 pkg-config gnupg software-properties-common wget cgroup-tools


### PR DESCRIPTION
## Summary

- Update the `monad-execution` submodule to current `main` (`2d0a1eba1`), which upgrades the C++ execution build container from `ubuntu:25.10` (interim) to `ubuntu:26.04` (LTS).
- Bump the analogous `monad-bft` Dockerfiles that were still on `ubuntu:25.10` to match: `builder`, `rpc`, `archive`, `devnet`, `txgen`, and `rpc-request-gen` (both build and runner stages).

## Notes

- The `testground` / `gossip-testground` images are Debian-based (`rust:1-buster` / `debian:buster-slim`) and were intentionally left unchanged.
- The Kitware apt repo `jammy` codename lines in `txgen`/`rpc-request-gen` are pre-existing and unrelated to the base image; left as-is.
- Mirrors the upstream submodule change (`Upgrade Docker build base image to Ubuntu 26.04 LTS`), which only touched the `FROM` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)