### PR TITLE
Update vote pace and block reward activation

### DIFF
--- a/monad-chain-config/src/lib.rs
+++ b/monad-chain-config/src/lib.rs
@@ -41,7 +41,7 @@ pub trait ChainConfig<CR: ChainRevision>: Copy + Clone {
     fn get_epoch_length(&self) -> SeqNum;
     fn get_epoch_start_delay(&self) -> Round;
     fn get_staking_activation(&self) -> Epoch;
-    fn get_block_reward_mon(&self, epoch: Epoch) -> u64;
+    fn get_block_reward_mon(&self, epoch: Epoch, round: Round) -> u64;
     fn get_chain_revision(&self, round: Round) -> CR;
     fn get_execution_chain_revision(&self, execution_timestamp_s: u64) -> MonadExecutionRevision;
 }
@@ -57,6 +57,7 @@ pub struct MonadChainConfig {
     pub v_0_8_0_activation: Round,
     pub v_0_10_0_activation: Round,
     pub v_0_11_0_activation: Round,
+    pub v_0_12_0_activation: Round,
 
     pub staking_config: MonadStakingConfig,
 
@@ -129,13 +130,15 @@ impl ChainConfig<MonadChainRevision> for MonadChainConfig {
         self.staking_config.get_staking_activation()
     }
 
-    fn get_block_reward_mon(&self, epoch: Epoch) -> u64 {
-        self.staking_config.get_block_reward_mon(epoch)
+    fn get_block_reward_mon(&self, epoch: Epoch, round: Round) -> u64 {
+        self.staking_config.get_block_reward_mon(epoch, round)
     }
 
     #[allow(clippy::if_same_then_else)]
     fn get_chain_revision(&self, round: Round) -> MonadChainRevision {
-        if round >= self.v_0_11_0_activation {
+        if round >= self.v_0_12_0_activation {
+            MonadChainRevision::V_0_12_0
+        } else if round >= self.v_0_11_0_activation {
             MonadChainRevision::V_0_11_0
         } else if round >= self.v_0_10_0_activation {
             MonadChainRevision::V_0_10_0
@@ -170,6 +173,7 @@ const MONAD_DEVNET_CHAIN_CONFIG: MonadChainConfig = MonadChainConfig {
     v_0_8_0_activation: Round::MIN,
     v_0_10_0_activation: Round::MIN,
     v_0_11_0_activation: Round::MIN,
+    v_0_12_0_activation: Round::MAX,
 
     staking_config: MONAD_DEVNET_STAKING_CONFIG,
 
@@ -187,6 +191,7 @@ const MONAD_TESTNET_CHAIN_CONFIG: MonadChainConfig = MonadChainConfig {
     v_0_8_0_activation: Round::MIN,
     v_0_10_0_activation: Round::MIN,
     v_0_11_0_activation: Round::MIN,
+    v_0_12_0_activation: Round::MAX,
 
     staking_config: MONAD_TESTNET_STAKING_CONFIG,
 
@@ -205,6 +210,7 @@ const MONAD_MAINNET_CHAIN_CONFIG: MonadChainConfig = MonadChainConfig {
     v_0_8_0_activation: Round::MIN,
     v_0_10_0_activation: Round(15_643_179), // 2025-08-13T13:30:00.000Z
     v_0_11_0_activation: Round(33_493_399), // Approx 2025-11-04T14:00:00.000Z
+    v_0_12_0_activation: Round::MAX,
 
     staking_config: MONAD_MAINNET_STAKING_CONFIG,
 
@@ -271,7 +277,7 @@ impl ChainConfig<MockChainRevision> for MockChainConfig {
         Epoch::MAX
     }
 
-    fn get_block_reward_mon(&self, _epoch: Epoch) -> u64 {
+    fn get_block_reward_mon(&self, _epoch: Epoch, _round: Round) -> u64 {
         0
     }
 

--- a/monad-chain-config/src/revision.rs
+++ b/monad-chain-config/src/revision.rs
@@ -39,7 +39,7 @@ macro_rules! chain_params {
     }};
 }
 
-pub const CHAIN_PARAMS_LATEST: ChainParams = CHAIN_PARAMS_V_0_11_0;
+pub const CHAIN_PARAMS_LATEST: ChainParams = CHAIN_PARAMS_V_0_12_0;
 
 pub trait ChainRevision: Copy + Clone {
     fn chain_params(&self) -> &'static ChainParams;
@@ -52,6 +52,7 @@ pub enum MonadChainRevision {
     V_0_8_0,
     V_0_10_0,
     V_0_11_0,
+    V_0_12_0,
 }
 
 impl ChainRevision for MonadChainRevision {
@@ -61,6 +62,7 @@ impl ChainRevision for MonadChainRevision {
             MonadChainRevision::V_0_8_0 => &CHAIN_PARAMS_V_0_8_0,
             MonadChainRevision::V_0_10_0 => &CHAIN_PARAMS_V_0_10_0,
             MonadChainRevision::V_0_11_0 => &CHAIN_PARAMS_V_0_11_0,
+            MonadChainRevision::V_0_12_0 => &CHAIN_PARAMS_V_0_12_0,
         }
     }
 }
@@ -124,6 +126,14 @@ const CHAIN_PARAMS_V_0_11_0: ChainParams = chain_params! {
     vote_pace: Duration::from_millis(400),
 };
 
+const CHAIN_PARAMS_V_0_12_0: ChainParams = chain_params! {
+    tx_limit: 3_750,
+    proposal_gas_limit: 150_000_000,
+    proposal_byte_limit: 1_500_000,
+    max_reserve_balance: 10_000_000_000_000_000_000, // 10 MON
+    vote_pace: Duration::from_millis(300),
+};
+
 // NOTE: when adding a new revision, chain_params! asserts that tx_limit is <= MAX_TRANSACTIONS_PER_BLOCK
 
 #[cfg(test)]
@@ -135,5 +145,6 @@ mod test {
         assert!(MonadChainRevision::V_0_7_0 < MonadChainRevision::V_0_8_0);
         assert!(MonadChainRevision::V_0_8_0 < MonadChainRevision::V_0_10_0);
         assert!(MonadChainRevision::V_0_10_0 < MonadChainRevision::V_0_11_0);
+        assert!(MonadChainRevision::V_0_11_0 < MonadChainRevision::V_0_12_0);
     }
 }

--- a/monad-chain-config/src/staking_config.rs
+++ b/monad-chain-config/src/staking_config.rs
@@ -13,19 +13,34 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use monad_types::Epoch;
+use monad_types::{Epoch, Round};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+enum BlockRewardActivation {
+    Epoch(Epoch),
+    Round(Round),
+}
+
+impl BlockRewardActivation {
+    fn is_active(&self, epoch: Epoch, round: Round) -> bool {
+        match self {
+            BlockRewardActivation::Epoch(activation_epoch) => epoch >= *activation_epoch,
+            BlockRewardActivation::Round(activation_round) => round >= *activation_round,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 struct BlockRewardConfig {
-    block_reward_activation: Epoch,
+    block_reward_activation: BlockRewardActivation,
     block_reward_mon: u64,
 }
 
 impl BlockRewardConfig {
     pub const fn unused() -> Self {
         Self {
-            block_reward_activation: Epoch::MAX,
+            block_reward_activation: BlockRewardActivation::Epoch(Epoch::MAX),
             block_reward_mon: 0,
         }
     }
@@ -36,6 +51,7 @@ pub struct MonadStakingConfig {
     staking_activation: Epoch,
 
     block_reward_v_one: BlockRewardConfig,
+    block_reward_v_two: BlockRewardConfig,
 }
 
 impl MonadStakingConfig {
@@ -43,8 +59,18 @@ impl MonadStakingConfig {
         self.staking_activation
     }
 
-    pub fn get_block_reward_mon(&self, epoch: Epoch) -> u64 {
-        if epoch >= self.block_reward_v_one.block_reward_activation {
+    pub fn get_block_reward_mon(&self, epoch: Epoch, round: Round) -> u64 {
+        if self
+            .block_reward_v_two
+            .block_reward_activation
+            .is_active(epoch, round)
+        {
+            self.block_reward_v_two.block_reward_mon
+        } else if self
+            .block_reward_v_one
+            .block_reward_activation
+            .is_active(epoch, round)
+        {
             self.block_reward_v_one.block_reward_mon
         } else {
             0
@@ -56,25 +82,52 @@ pub const MONAD_DEVNET_STAKING_CONFIG: MonadStakingConfig = MonadStakingConfig {
     staking_activation: Epoch(2),
 
     block_reward_v_one: BlockRewardConfig {
-        block_reward_activation: Epoch(3),
+        block_reward_activation: BlockRewardActivation::Epoch(Epoch(3)),
         block_reward_mon: 1,
     },
+    block_reward_v_two: BlockRewardConfig::unused(),
 };
 
 pub const MONAD_TESTNET_STAKING_CONFIG: MonadStakingConfig = MonadStakingConfig {
     staking_activation: Epoch(2),
 
     block_reward_v_one: BlockRewardConfig {
-        block_reward_activation: Epoch(3),
+        block_reward_activation: BlockRewardActivation::Epoch(Epoch(3)),
         block_reward_mon: 25,
     },
+    block_reward_v_two: BlockRewardConfig::unused(),
 };
 
 pub const MONAD_MAINNET_STAKING_CONFIG: MonadStakingConfig = MonadStakingConfig {
     staking_activation: Epoch(675),
 
     block_reward_v_one: BlockRewardConfig {
-        block_reward_activation: Epoch(747),
+        block_reward_activation: BlockRewardActivation::Epoch(Epoch(747)),
         block_reward_mon: 25,
     },
+    block_reward_v_two: BlockRewardConfig::unused(),
 };
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_block_reward_activation() {
+        let staking_config = MonadStakingConfig {
+            staking_activation: Epoch(1),
+            block_reward_v_one: BlockRewardConfig {
+                block_reward_activation: BlockRewardActivation::Epoch(Epoch(2)),
+                block_reward_mon: 5,
+            },
+            block_reward_v_two: BlockRewardConfig {
+                block_reward_activation: BlockRewardActivation::Round(Round(10)),
+                block_reward_mon: 10,
+            },
+        };
+
+        assert_eq!(staking_config.get_block_reward_mon(Epoch(1), Round(8)), 0);
+        assert_eq!(staking_config.get_block_reward_mon(Epoch(2), Round(9)), 5);
+        assert_eq!(staking_config.get_block_reward_mon(Epoch(2), Round(10)), 10);
+    }
+}

--- a/monad-eth-txpool/src/pool/mod.rs
+++ b/monad-eth-txpool/src/pool/mod.rs
@@ -335,6 +335,7 @@ where
         let self_eth_address = node_id.pubkey().get_eth_address();
         let system_transactions = self.get_system_transactions(
             epoch,
+            round,
             proposed_seq_num,
             self_eth_address,
             &extending_blocks.iter().collect(),
@@ -566,6 +567,7 @@ where
     fn get_system_transactions(
         &self,
         proposed_epoch: Epoch,
+        proposed_round: Round,
         proposed_seq_num: SeqNum,
         block_author: Address,
         extending_blocks: &Vec<&EthValidatedBlock<ST, SCT>>,
@@ -597,6 +599,7 @@ where
         let sys_txns = SystemTransactionGenerator::generate_system_transactions(
             proposed_seq_num,
             proposed_epoch,
+            proposed_round,
             parent_block_epoch,
             block_author,
             next_system_txn_nonce,

--- a/monad-system-calls/src/lib.rs
+++ b/monad-system-calls/src/lib.rs
@@ -28,7 +28,7 @@ use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use monad_chain_config::{ChainConfig, revision::ChainRevision};
 use monad_eth_types::ValidatedTx;
-use monad_types::{Epoch, GENESIS_SEQ_NUM, SeqNum};
+use monad_types::{Epoch, GENESIS_SEQ_NUM, Round, SeqNum};
 use staking_contract::{StakingContractCall, StakingContractTransaction};
 use validator::SystemTransactionError;
 
@@ -134,6 +134,7 @@ impl From<SystemTransaction> for Recovered<TxEnvelope> {
 fn generate_system_calls<CCT, CRT>(
     proposed_seq_num: SeqNum,
     proposed_epoch: Epoch,
+    proposed_round: Round,
     parent_block_epoch: Epoch,
     block_author_address: Address,
     chain_config: &CCT,
@@ -178,7 +179,7 @@ where
     // starting at the first block in Epoch N
     let generate_reward_txn = proposed_epoch >= staking_activation;
     if generate_reward_txn {
-        let block_reward_mon = chain_config.get_block_reward_mon(proposed_epoch);
+        let block_reward_mon = chain_config.get_block_reward_mon(proposed_epoch, proposed_round);
         let block_reward = U256::from(StakingContractCall::MON) * U256::from(block_reward_mon);
 
         system_calls.push(SystemCall::StakingContractCall(
@@ -200,6 +201,7 @@ impl SystemTransactionGenerator {
     pub fn generate_system_transactions<CCT, CRT>(
         proposed_seq_num: SeqNum,
         proposed_epoch: Epoch,
+        proposed_round: Round,
         parent_block_epoch: Epoch,
         block_author: Address,
         mut next_system_txn_nonce: u64,
@@ -212,6 +214,7 @@ impl SystemTransactionGenerator {
         let system_calls = generate_system_calls(
             proposed_seq_num,
             proposed_epoch,
+            proposed_round,
             parent_block_epoch,
             block_author,
             chain_config,

--- a/monad-system-calls/src/validator.rs
+++ b/monad-system-calls/src/validator.rs
@@ -222,6 +222,7 @@ impl SystemTransactionValidator {
         let expected_sys_calls = generate_system_calls(
             block_header.seq_num,
             block_header.epoch,
+            block_header.block_round,
             parent_block_epoch,
             block_header.author.pubkey().get_eth_address(),
             chain_config,


### PR DESCRIPTION
Changes include:
- New chain revision v0.12.0 with 300ms vote pace
- Functionality to fork block reward by round