### PR TITLE
Use StateBackend through &mut

### DIFF
--- a/monad-blocktree/src/blocktree.rs
+++ b/monad-blocktree/src/blocktree.rs
@@ -239,7 +239,7 @@ where
         metrics: &mut Metrics,
         block_id: BlockId,
         block_policy: &mut BPT,
-        state_backend: &SBT,
+        state_backend: &mut SBT,
         chain_config: &CCT,
     ) -> Vec<BPT::ValidatedBlock> {
         let Some(path_from_root) = self.get_blocks_on_path_from_root(&block_id) else {
@@ -774,7 +774,7 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(SeqNum(4));
+        let mut state_backend = InMemoryStateInner::genesis(SeqNum(4));
         let mut block_policy = PassthruBlockPolicy;
         blocktree.add(g.clone().into());
 
@@ -790,7 +790,7 @@ mod test {
             &mut metrics,
             b1.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b1.get_id()));
@@ -798,7 +798,7 @@ mod test {
             &mut metrics,
             b2.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b2.get_id()));
@@ -806,7 +806,7 @@ mod test {
             &mut metrics,
             b3.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b3.get_id()));
@@ -814,7 +814,7 @@ mod test {
             &mut metrics,
             b4.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b4.get_id()));
@@ -822,7 +822,7 @@ mod test {
             &mut metrics,
             b5.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b5.get_id()));
@@ -830,7 +830,7 @@ mod test {
             &mut metrics,
             b6.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b6.get_id()));
@@ -890,7 +890,7 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(SeqNum(4));
+        let mut state_backend = InMemoryStateInner::genesis(SeqNum(4));
         let mut block_policy = PassthruBlockPolicy;
         blocktree.add(g.into());
 
@@ -908,7 +908,7 @@ mod test {
             &mut metrics,
             b1.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b1.get_id()));
@@ -916,7 +916,7 @@ mod test {
             &mut metrics,
             b2.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b2.get_id()));
@@ -952,7 +952,7 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(SeqNum(4));
+        let mut state_backend = InMemoryStateInner::genesis(SeqNum(4));
         let mut block_policy = PassthruBlockPolicy;
         blocktree.add(g.clone().into());
         blocktree.add(b1.clone().into());
@@ -970,7 +970,7 @@ mod test {
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&g.get_id()));
@@ -978,7 +978,7 @@ mod test {
             &mut metrics,
             b1.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b1.get_id()));
@@ -1004,7 +1004,7 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend =
+        let mut state_backend =
             InMemoryStateInner::<NopSignature, MockSignatures<NopSignature>>::genesis(SeqNum(4));
         let block_policy = PassthruBlockPolicy;
         blocktree.add(g.into());
@@ -1032,14 +1032,14 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(SeqNum(4));
+        let mut state_backend = InMemoryStateInner::genesis(SeqNum(4));
         let mut block_policy = PassthruBlockPolicy;
         blocktree.add(g.clone().into());
         blocktree.try_update_coherency(
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&g.get_id()));
@@ -1059,7 +1059,7 @@ mod test {
             &mut metrics,
             b1.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b1.get_id()));
@@ -1067,7 +1067,7 @@ mod test {
             &mut metrics,
             b2.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b2.get_id()));
@@ -1075,7 +1075,7 @@ mod test {
             &mut metrics,
             b3.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b3.get_id()));
@@ -1083,7 +1083,7 @@ mod test {
             &mut metrics,
             b4.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b4.get_id()));
@@ -1119,14 +1119,14 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(SeqNum(4));
+        let mut state_backend = InMemoryStateInner::genesis(SeqNum(4));
         let mut block_policy = PassthruBlockPolicy;
         blocktree.add(g.clone().into());
         blocktree.try_update_coherency(
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.maybe_fill_path_to_root(&g.header().qc).is_none()); // root naturally don't have missing ancestor
@@ -1136,7 +1136,7 @@ mod test {
             &mut metrics,
             b2.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(
@@ -1152,7 +1152,7 @@ mod test {
             &mut metrics,
             b3.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(
@@ -1168,7 +1168,7 @@ mod test {
             &mut metrics,
             b4.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(
@@ -1184,7 +1184,7 @@ mod test {
             &mut metrics,
             b1.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
 
@@ -1228,7 +1228,7 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(SeqNum(4));
+        let mut state_backend = InMemoryStateInner::genesis(SeqNum(4));
         let mut block_policy = PassthruBlockPolicy;
         blocktree.add(g.clone().into());
         blocktree.add(b1.clone().into());
@@ -1236,7 +1236,7 @@ mod test {
             &mut metrics,
             b1.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
 
@@ -1254,7 +1254,7 @@ mod test {
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&g.get_id()));
@@ -1262,7 +1262,7 @@ mod test {
             &mut metrics,
             b1.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b1.get_id()));
@@ -1270,7 +1270,7 @@ mod test {
             &mut metrics,
             b2.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b2.get_id()));
@@ -1300,7 +1300,7 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(SeqNum(4));
+        let mut state_backend = InMemoryStateInner::genesis(SeqNum(4));
         let mut block_policy = PassthruBlockPolicy;
         blocktree.add(g.clone().into());
         assert!(blocktree.maybe_fill_path_to_root(&g.header().qc).is_none()); // root naturally don't have missing ancestor
@@ -1319,7 +1319,7 @@ mod test {
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&g.get_id()));
@@ -1333,7 +1333,7 @@ mod test {
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&g.get_id()));
@@ -1341,7 +1341,7 @@ mod test {
             &mut metrics,
             b1.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b1.get_id()));
@@ -1349,7 +1349,7 @@ mod test {
             &mut metrics,
             b2.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b2.get_id()));
@@ -1380,7 +1380,7 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(SeqNum(4));
+        let mut state_backend = InMemoryStateInner::genesis(SeqNum(4));
         let mut block_policy = PassthruBlockPolicy;
         blocktree.add(g.clone().into());
         assert!(blocktree.maybe_fill_path_to_root(&g.header().qc).is_none()); // root naturally don't have missing ancestor
@@ -1399,7 +1399,7 @@ mod test {
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&g.get_id()));
@@ -1427,7 +1427,7 @@ mod test {
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&g.get_id()));
@@ -1444,7 +1444,7 @@ mod test {
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&g.get_id()));
@@ -1452,7 +1452,7 @@ mod test {
             &mut metrics,
             b1.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b1.get_id()));
@@ -1460,7 +1460,7 @@ mod test {
             &mut metrics,
             b2.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b2.get_id()));
@@ -1468,7 +1468,7 @@ mod test {
             &mut metrics,
             b3.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b3.get_id()));
@@ -1499,7 +1499,7 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(SeqNum(4));
+        let mut state_backend = InMemoryStateInner::genesis(SeqNum(4));
         let mut block_policy = PassthruBlockPolicy;
         blocktree.add(g.clone().into());
         assert!(blocktree.maybe_fill_path_to_root(&g.header().qc).is_none()); // root naturally don't have missing ancestor
@@ -1518,7 +1518,7 @@ mod test {
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&g.get_id()));
@@ -1539,7 +1539,7 @@ mod test {
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&g.get_id()));
@@ -1547,7 +1547,7 @@ mod test {
             &mut metrics,
             b1.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b1.get_id()));
@@ -1563,7 +1563,7 @@ mod test {
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&g.get_id()));
@@ -1571,7 +1571,7 @@ mod test {
             &mut metrics,
             b1.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b1.get_id()));
@@ -1579,7 +1579,7 @@ mod test {
             &mut metrics,
             b2.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b2.get_id()));
@@ -1587,7 +1587,7 @@ mod test {
             &mut metrics,
             b3.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b3.get_id()));
@@ -1618,7 +1618,7 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(SeqNum(4));
+        let mut state_backend = InMemoryStateInner::genesis(SeqNum(4));
         let mut block_policy = PassthruBlockPolicy;
         blocktree.add(g.clone().into());
         assert!(blocktree.maybe_fill_path_to_root(&g.header().qc).is_none()); // root naturally don't have missing ancestor
@@ -1646,7 +1646,7 @@ mod test {
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&g.get_id()));
@@ -1662,7 +1662,7 @@ mod test {
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&g.get_id()));
@@ -1670,7 +1670,7 @@ mod test {
             &mut metrics,
             b1.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b1.get_id()));
@@ -1678,7 +1678,7 @@ mod test {
             &mut metrics,
             b2.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b2.get_id()));
@@ -1686,7 +1686,7 @@ mod test {
             &mut metrics,
             b3.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b3.get_id()));
@@ -1722,7 +1722,7 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(SeqNum(4));
+        let mut state_backend = InMemoryStateInner::genesis(SeqNum(4));
         let mut block_policy = PassthruBlockPolicy;
         blocktree.add(g.clone().into());
         assert!(blocktree.maybe_fill_path_to_root(&g.header().qc).is_none()); // root naturally don't have missing ancestor
@@ -1777,7 +1777,7 @@ mod test {
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&g.get_id()));
@@ -1799,7 +1799,7 @@ mod test {
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&g.get_id()));
@@ -1807,7 +1807,7 @@ mod test {
             &mut metrics,
             b1.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b1.get_id()));
@@ -1815,7 +1815,7 @@ mod test {
             &mut metrics,
             b2.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b2.get_id()));
@@ -1823,7 +1823,7 @@ mod test {
             &mut metrics,
             b3.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b3.get_id()));
@@ -1831,7 +1831,7 @@ mod test {
             &mut metrics,
             b4.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b4.get_id()));
@@ -1839,7 +1839,7 @@ mod test {
             &mut metrics,
             b5.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b5.get_id()));
@@ -1847,7 +1847,7 @@ mod test {
             &mut metrics,
             b6.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b6.get_id()));
@@ -1874,7 +1874,7 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend =
+        let mut state_backend =
             InMemoryStateInner::<NopSignature, MockSignatures<NopSignature>>::genesis(SeqNum(4));
         let block_policy = PassthruBlockPolicy;
         blocktree.add(b2.clone().into());
@@ -1926,7 +1926,7 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(SeqNum(4));
+        let mut state_backend = InMemoryStateInner::genesis(SeqNum(4));
         let mut block_policy = PassthruBlockPolicy;
 
         // insertion order: insert all blocks except b3, then b3
@@ -1945,7 +1945,7 @@ mod test {
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         let high_commit_qc = blocktree.get_high_committable_qc();
@@ -1967,7 +1967,7 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(SeqNum(4));
+        let mut state_backend = InMemoryStateInner::genesis(SeqNum(4));
         let mut block_policy = PassthruBlockPolicy;
 
         blocktree.add(g.clone().into());
@@ -1979,21 +1979,21 @@ mod test {
             &mut metrics,
             g.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         blocktree.try_update_coherency(
             &mut metrics,
             b1.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         blocktree.try_update_coherency(
             &mut metrics,
             b2.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
 
@@ -2041,7 +2041,7 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(SeqNum(10));
+        let mut state_backend = InMemoryStateInner::genesis(SeqNum(10));
         let mut block_policy = PassthruBlockPolicy;
 
         // Add and make blocks on canonical chain coherent
@@ -2054,7 +2054,7 @@ mod test {
             &mut metrics,
             d.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&d.get_id()));
@@ -2069,7 +2069,7 @@ mod test {
             &mut metrics,
             b_prime.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b_prime.get_id()));
@@ -2100,7 +2100,7 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(SeqNum(10));
+        let mut state_backend = InMemoryStateInner::genesis(SeqNum(10));
         let mut block_policy = PassthruBlockPolicy;
 
         // Add all blocks
@@ -2116,14 +2116,14 @@ mod test {
             &mut metrics,
             c.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         blocktree.try_update_coherency(
             &mut metrics,
             c_prime.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
 
@@ -2158,7 +2158,7 @@ mod test {
             block_id: genesis_qc.get_block_id(),
             timestamp_ns: GENESIS_TIMESTAMP,
         });
-        let state_backend = InMemoryStateInner::genesis(SeqNum(10));
+        let mut state_backend = InMemoryStateInner::genesis(SeqNum(10));
         let mut block_policy = PassthruBlockPolicy;
 
         blocktree.add(g.into());
@@ -2171,7 +2171,7 @@ mod test {
             &mut metrics,
             d.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&c.get_id()));
@@ -2195,7 +2195,7 @@ mod test {
             &mut metrics,
             e_prime.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&c_prime.get_id()));
@@ -2220,7 +2220,7 @@ mod test {
             &mut metrics,
             f.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&f.get_id()));
@@ -2239,7 +2239,7 @@ mod test {
             &mut metrics,
             g2.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&g2.get_id()));
@@ -2265,14 +2265,14 @@ mod test {
             &mut metrics,
             b_high.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         blocktree.try_update_coherency(
             &mut metrics,
             d2.get_id(),
             &mut block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
         );
         assert!(blocktree.is_coherent(&b_high.get_id()));

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -197,7 +197,7 @@ where
     /// Policy for validating chain extension
     /// Mutable because consensus tip will be updated
     pub block_policy: &'a mut BPT,
-    pub state_backend: &'a SBT,
+    pub state_backend: &'a mut SBT,
 
     pub val_epoch_map: &'a ValidatorsEpochMapping<VTF, SCT>,
     pub election: &'a LT,
@@ -2249,7 +2249,7 @@ mod test {
 
                 block_validator: &self.block_validator,
                 block_policy: &mut self.block_policy,
-                state_backend: &self.state_backend,
+                state_backend: &mut self.state_backend,
                 block_timestamp: &mut self.block_timestamp,
                 beneficiary: &self.beneficiary,
                 nodeid: &self.nodeid,

--- a/monad-consensus-types/src/block.rs
+++ b/monad-consensus-types/src/block.rs
@@ -360,15 +360,15 @@ where
         block: &Self::ValidatedBlock,
         extending_blocks: Vec<&Self::ValidatedBlock>,
         blocktree_root: RootInfo,
-        state_backend: &SBT,
-        chain_cnfig: &CCT,
+        state_backend: &mut SBT,
+        chain_config: &CCT,
     ) -> Result<(), BlockPolicyError>;
 
     fn get_expected_execution_results(
         &self,
         block_seq_num: SeqNum,
         extending_blocks: Vec<&Self::ValidatedBlock>,
-        state_backend: &SBT,
+        state_backend: &mut SBT,
     ) -> Result<Vec<EPT::FinalizedHeader>, StateBackendError>;
 
     // TODO delete this function, pass recently committed blocks to check_coherency instead
@@ -429,7 +429,7 @@ where
         block: &Self::ValidatedBlock,
         extending_blocks: Vec<&Self::ValidatedBlock>,
         blocktree_root: RootInfo,
-        state_backend: &InMemoryState<ST, SCT>,
+        state_backend: &mut InMemoryState<ST, SCT>,
         _chain_config: &MockChainConfig,
     ) -> Result<(), BlockPolicyError> {
         // check coherency against the block being extended or against the root of the blocktree if
@@ -466,7 +466,7 @@ where
         &self,
         _block_seq_num: SeqNum,
         _extending_blocks: Vec<&Self::ValidatedBlock>,
-        _state_backend: &InMemoryState<ST, SCT>,
+        _state_backend: &mut InMemoryState<ST, SCT>,
     ) -> Result<Vec<EPT::FinalizedHeader>, StateBackendError> {
         Ok(Vec::new())
     }

--- a/monad-eth-block-policy/src/lib.rs
+++ b/monad-eth-block-policy/src/lib.rs
@@ -620,7 +620,7 @@ where
     pub fn get_account_base_nonces<'a>(
         &self,
         consensus_block_seq_num: SeqNum,
-        state_backend: &impl StateBackend<ST, SCT>,
+        state_backend: &mut impl StateBackend<ST, SCT>,
         extending_blocks: &Vec<&EthValidatedBlock<ST, SCT>>,
         addresses: impl Iterator<Item = &'a Address>,
     ) -> Result<BTreeMap<&'a Address, Nonce>, StateBackendError> {
@@ -762,7 +762,7 @@ where
 
     fn get_account_statuses<'a>(
         &self,
-        state_backend: &impl StateBackend<ST, SCT>,
+        state_backend: &mut impl StateBackend<ST, SCT>,
         extending_blocks: &Option<&Vec<&EthValidatedBlock<ST, SCT>>>,
         addresses: impl Iterator<Item = &'a Address>,
         base_seq_num: &SeqNum,
@@ -780,7 +780,7 @@ where
     pub fn compute_account_base_balances<'a>(
         &self,
         consensus_block_seq_num: SeqNum,
-        state_backend: &impl StateBackend<ST, SCT>,
+        state_backend: &mut impl StateBackend<ST, SCT>,
         chain_config: &CCT,
         extending_blocks: Option<&Vec<&EthValidatedBlock<ST, SCT>>>,
         addresses: impl Iterator<Item = &'a Address>,
@@ -1145,7 +1145,7 @@ where
         block: &Self::ValidatedBlock,
         extending_blocks: Vec<&Self::ValidatedBlock>,
         blocktree_root: RootInfo,
-        state_backend: &SBT,
+        state_backend: &mut SBT,
         chain_config: &CCT,
     ) -> Result<(), BlockPolicyError> {
         let chain_id = chain_config.chain_id();
@@ -1272,7 +1272,7 @@ where
         &self,
         block_seq_num: SeqNum,
         extending_blocks: Vec<&Self::ValidatedBlock>,
-        state_backend: &SBT,
+        state_backend: &mut SBT,
     ) -> Result<Vec<EthHeader>, StateBackendError> {
         if block_seq_num < self.execution_delay {
             return Ok(Vec::new());
@@ -1453,7 +1453,7 @@ mod test {
         >,
         incoming_block: EthValidatedBlock<SignatureType, SignatureCollectionType>,
         extending_blocks: Vec<&EthValidatedBlock<SignatureType, SignatureCollectionType>>,
-        state_backend: &impl StateBackend<SignatureType, SignatureCollectionType>,
+        state_backend: &mut impl StateBackend<SignatureType, SignatureCollectionType>,
         addresses: Vec<Address>,
     ) -> Result<(), BlockPolicyError> {
         let mut account_balances = block_policy.compute_account_base_balances(
@@ -1487,7 +1487,7 @@ mod test {
         >,
         incoming_block: EthValidatedBlock<SignatureType, SignatureCollectionType>,
         extending_blocks: Vec<&EthValidatedBlock<SignatureType, SignatureCollectionType>>,
-        state_backend: &impl StateBackend<SignatureType, SignatureCollectionType>,
+        state_backend: &mut impl StateBackend<SignatureType, SignatureCollectionType>,
         addresses: Vec<Address>,
     ) -> Result<(), BlockPolicyError> {
         let mut account_nonces = block_policy.get_account_base_nonces(
@@ -1514,7 +1514,7 @@ mod test {
     fn setup_block_policy_with_txs(
         txs: BTreeMap<u64, Vec<Recovered<TxEnvelope>>>,
         signers: Vec<Address>,
-        state_backend: &impl StateBackend<SignatureType, SignatureCollectionType>,
+        state_backend: &mut impl StateBackend<SignatureType, SignatureCollectionType>,
         num_committed_blocks: usize,
         coherency_check_mode: CoherencyCheckMode,
     ) -> Result<(), BlockPolicyError> {
@@ -1580,7 +1580,7 @@ mod test {
         // balance of signer at block n-3
         // minimum balance required is gas limit * gas bid
         let gas_cost = 50000 * BASE_FEE as u128;
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer, U256::from(gas_cost))]),
             ..Default::default()
         };
@@ -1588,21 +1588,21 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs.clone(),
             vec![signer],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
         assert!(result.is_ok(), "Block coherency check failed: {:?}", result);
 
         // should return error if fall below minimum balance
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer, U256::from(gas_cost - 1))]),
             ..Default::default()
         };
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -1625,7 +1625,7 @@ mod test {
         let txs = BTreeMap::from([(4, vec![tx1, tx2])]); // txs in block n
 
         // balance of signer at block n-3
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer, U256::from(ONE_ETHER + HALF_ETHER))]),
             ..Default::default()
         };
@@ -1633,7 +1633,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -1647,7 +1647,7 @@ mod test {
         // balance of signer at block n-3
         let gas_cost = 50000 * BASE_FEE as u128;
         let balance = ONE_ETHER + (2 * gas_cost) - 1;
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer, U256::from(balance))]),
             ..Default::default()
         };
@@ -1655,7 +1655,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -1676,7 +1676,7 @@ mod test {
 
         // balance of signer at block n-3
         let balance = 100 * ONE_ETHER;
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer, U256::from(balance))]),
             ..Default::default()
         };
@@ -1684,7 +1684,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -1707,7 +1707,7 @@ mod test {
         let first_tx_gas_cost = 50000 * BASE_FEE as u128;
         let second_tx_gas_cost = RESERVE_BALANCE;
         let balance = first_tx_gas_cost + second_tx_gas_cost;
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer, U256::from(balance))]),
             ..Default::default()
         };
@@ -1715,7 +1715,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -1732,7 +1732,7 @@ mod test {
         let txs = BTreeMap::from([(2, vec![tx1]), (4, vec![tx2])]);
 
         // balance of signer at block n-3
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer, U256::from(ONE_ETHER + HALF_ETHER))]),
             ..Default::default()
         };
@@ -1740,7 +1740,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -1755,7 +1755,7 @@ mod test {
         // balance of signer at block n-3
         let gas_cost = 50000 * BASE_FEE as u128;
         let balance = ONE_ETHER + (2 * gas_cost) - 1;
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer, U256::from(balance))]),
             ..Default::default()
         };
@@ -1763,7 +1763,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -1785,7 +1785,7 @@ mod test {
 
         // balance of signer at block n-3
         let balance = 100 * ONE_ETHER;
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer, U256::from(balance))]),
             ..Default::default()
         };
@@ -1793,7 +1793,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -1817,7 +1817,7 @@ mod test {
         let first_tx_gas_cost = 50000 * BASE_FEE as u128;
         let second_tx_gas_cost = RESERVE_BALANCE;
         let balance = first_tx_gas_cost + second_tx_gas_cost;
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer, U256::from(balance))]),
             ..Default::default()
         };
@@ -1825,7 +1825,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -1844,7 +1844,7 @@ mod test {
 
         // balance of signer at block n-3
         let gas_cost = 50000 * 2 * BASE_FEE as u128;
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer, U256::from(gas_cost))]),
             ..Default::default()
         };
@@ -1852,7 +1852,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -1867,7 +1867,7 @@ mod test {
 
         // balance of signer at block n-3
         let gas_cost = 50000 * 2 * BASE_FEE as u128;
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer, U256::from(gas_cost))]),
             ..Default::default()
         };
@@ -1875,7 +1875,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -1900,7 +1900,7 @@ mod test {
 
         // balance of signer at block n-3
         let balance = 100 * ONE_ETHER;
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer, U256::from(balance))]),
             ..Default::default()
         };
@@ -1908,7 +1908,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -1947,7 +1947,7 @@ mod test {
 
         // balance of signer at block n-3
         let gas_cost = 50000 * 2 * BASE_FEE as u128;
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer, U256::from(gas_cost))]),
             ..Default::default()
         };
@@ -1955,7 +1955,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -1987,7 +1987,7 @@ mod test {
 
         // balance of signer at block n-3
         let gas_cost = 50000 * BASE_FEE as u128;
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([
                 (signer1, U256::from(gas_cost)),
                 (signer2, U256::from(gas_cost)),
@@ -1998,7 +1998,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer1, signer2],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -2040,7 +2040,7 @@ mod test {
 
         // balance of signer at block n-3
         let gas_cost = 50000 * BASE_FEE as u128;
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([
                 (signer1, U256::from(gas_cost)),
                 (signer2, U256::from(gas_cost)),
@@ -2051,7 +2051,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer1, signer2],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -2086,7 +2086,7 @@ mod test {
 
         // balance of signer at block n-3
         let gas_cost = 50000 * BASE_FEE as u128;
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([
                 (signer1, U256::from(gas_cost + HALF_ETHER)),
                 (signer2, U256::from(gas_cost)),
@@ -2097,7 +2097,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer1, signer2],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -2135,7 +2135,7 @@ mod test {
         let txs = BTreeMap::from([(4, vec![tx])]);
 
         // balance of signer at block n-3
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer, U256::from(2 * RESERVE_BALANCE))]),
             ..Default::default()
         };
@@ -2145,7 +2145,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -2188,7 +2188,7 @@ mod test {
 
         // balance of signer at block n-3
         let gas_cost = 50000 * BASE_FEE as u128;
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([
                 (signer1, U256::from(gas_cost)),
                 (signer2, U256::from(2 * RESERVE_BALANCE)),
@@ -2199,7 +2199,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer1, signer2],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -2243,7 +2243,7 @@ mod test {
 
         // balance of signer at block n-3
         let gas_cost = 50000 * BASE_FEE as u128;
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([
                 (signer1, U256::from(2 * RESERVE_BALANCE)),
                 (signer2, U256::from(gas_cost)),
@@ -2254,7 +2254,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer1, signer2],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -2276,7 +2276,7 @@ mod test {
 
         // balance of signer at block n-3
         let gas_cost = 2 * 50000 * BASE_FEE as u128;
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([
                 (signer1, U256::from(gas_cost)),
                 (signer2, U256::from(gas_cost)),
@@ -2287,7 +2287,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer1, signer2],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::ReserveBalanceCoherency,
         );
@@ -2309,7 +2309,7 @@ mod test {
         let txs = BTreeMap::from([(2, vec![tx1]), (3, vec![tx2, tx3]), (4, vec![tx4])]);
 
         // balance of signer at block n-3
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer, U256::from(ONE_ETHER))]),
             ..Default::default()
         };
@@ -2317,7 +2317,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::NonceCoherency,
         );
@@ -2349,7 +2349,7 @@ mod test {
         let txs = BTreeMap::from([(2, vec![tx1]), (4, vec![tx2, tx3])]);
 
         // balance of signer at block n-3
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer1, U256::from(ONE_ETHER))]),
             nonces: BTreeMap::from([(signer1, 0), (signer2, 0)]),
         };
@@ -2357,7 +2357,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer1, signer2],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::NonceCoherency,
         );
@@ -2385,7 +2385,7 @@ mod test {
         let txs = BTreeMap::from([(2, vec![tx1]), (4, vec![tx2, tx3])]);
 
         // balance of signer at block n-3
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer1, U256::from(ONE_ETHER))]),
             nonces: BTreeMap::from([(signer1, 0), (signer2, 0)]),
         };
@@ -2393,7 +2393,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer1, signer2],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::NonceCoherency,
         );
@@ -2425,7 +2425,7 @@ mod test {
         let txs = BTreeMap::from([(2, vec![tx1]), (4, vec![tx2, tx3])]);
 
         // balance of signer at block n-3
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer1, U256::from(ONE_ETHER))]),
             nonces: BTreeMap::from([(signer1, 0), (signer2, 0)]),
         };
@@ -2433,7 +2433,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer1, signer2],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::NonceCoherency,
         );
@@ -2470,7 +2470,7 @@ mod test {
         ]);
 
         // balance of signer at block n-3
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer1, U256::from(ONE_ETHER))]),
             nonces: BTreeMap::from([(signer1, 0), (signer2, 0)]),
         };
@@ -2478,7 +2478,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer1, signer2],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::NonceCoherency,
         );
@@ -2489,7 +2489,7 @@ mod test {
         let txs = BTreeMap::from([(2, vec![tx1]), (3, vec![tx2]), (4, vec![tx3])]);
 
         // balance of signer at block n-3
-        let state_backend = NopStateBackend {
+        let mut state_backend = NopStateBackend {
             balances: BTreeMap::from([(signer1, U256::from(ONE_ETHER))]),
             nonces: BTreeMap::from([(signer1, 0), (signer2, 0)]),
         };
@@ -2497,7 +2497,7 @@ mod test {
         let result = setup_block_policy_with_txs(
             txs,
             vec![signer1, signer2],
-            &state_backend,
+            &mut state_backend,
             num_committed_blocks,
             CoherencyCheckMode::NonceCoherency,
         );
@@ -3567,7 +3567,7 @@ mod test {
             ChainRevisionType,
         >::new(GENESIS_SEQ_NUM, EXEC_DELAY.0);
 
-        let state_backend = NopStateBackend::default();
+        let mut state_backend = NopStateBackend::default();
 
         let addresses = [secret_to_eth_address(S2)];
 
@@ -3576,7 +3576,7 @@ mod test {
             let (s2, s2_nonce) = block_policy
                 .get_account_base_nonces(
                     SeqNum(1),
-                    &state_backend,
+                    &mut state_backend,
                     &vec![&make_test_block(
                         Round(1),
                         SeqNum(1),
@@ -3605,7 +3605,7 @@ mod test {
             let (s2, s2_nonce) = block_policy
                 .get_account_base_nonces(
                     SeqNum(1),
-                    &state_backend,
+                    &mut state_backend,
                     &vec![&make_test_block(
                         Round(1),
                         SeqNum(1),
@@ -3634,7 +3634,7 @@ mod test {
             let (s2, s2_nonce) = block_policy
                 .get_account_base_nonces(
                     SeqNum(10),
-                    &state_backend,
+                    &mut state_backend,
                     &vec![
                         // nonces beyond execution_delay should not be taken into account
                         &make_test_block(
@@ -3829,7 +3829,7 @@ mod test {
 
     #[test]
     fn test_non_consecutive_seqnum() {
-        let state_backend = NopStateBackend::default();
+        let mut state_backend = NopStateBackend::default();
         let block_policy = EthBlockPolicy::<
             SignatureType,
             SignatureCollectionType,
@@ -3850,7 +3850,7 @@ mod test {
                 block_id: GENESIS_BLOCK_ID,
                 timestamp_ns: GENESIS_TIMESTAMP,
             },
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::default(),
         );
         assert_eq!(result, Err(BlockPolicyError::BlockNotCoherent));

--- a/monad-eth-block-validator/tests/coherency_test.rs
+++ b/monad-eth-block-validator/tests/coherency_test.rs
@@ -447,7 +447,7 @@ fn check_txpool_coherency(
     chain_config: &MonadChainConfig,
     extending_blocks: &[EthValidatedBlock<NopSignature, MockSignatures<NopSignature>>],
     block_under_test: &EthValidatedBlock<NopSignature, MockSignatures<NopSignature>>,
-    state_backend: &NopStateBackend,
+    state_backend: &mut NopStateBackend,
     root_info: RootInfo,
 ) {
     let block_policy = TestBlockPolicy::new(GENESIS_SEQ_NUM, 3);
@@ -553,7 +553,7 @@ fn check_txpool_coherency(
 fn test_runner(
     chain_config: MonadChainConfig,
     block_policy: TestBlockPolicy,
-    state_backend: NopStateBackend,
+    mut state_backend: NopStateBackend,
     txs: BTreeMap<SeqNum, Vec<Recovered<TxEnvelope>>>,
     expect_coherent: bool,
 ) {
@@ -572,7 +572,7 @@ fn test_runner(
             block_under_test,
             extending.iter().collect(),
             root_info,
-            &state_backend,
+            &mut state_backend,
             &chain_config,
         );
 
@@ -586,7 +586,7 @@ fn test_runner(
                 &chain_config,
                 extending,
                 block_under_test,
-                &state_backend,
+                &mut state_backend,
                 root_info,
             );
         }

--- a/monad-eth-txpool-executor/src/lib.rs
+++ b/monad-eth-txpool-executor/src/lib.rs
@@ -482,7 +482,7 @@ where
                         round_signature.clone(),
                         extending_blocks,
                         &self.block_policy,
-                        &self.state_backend,
+                        &mut self.state_backend,
                         &self.chain_config,
                     ) {
                         Ok(ProposalWithSenderGas {

--- a/monad-eth-txpool/src/pool/mod.rs
+++ b/monad-eth-txpool/src/pool/mod.rs
@@ -136,7 +136,7 @@ where
         &mut self,
         event_tracker: &mut EthTxPoolEventTracker<'_>,
         block_policy: &EthBlockPolicy<ST, SCT, CCT, CRT>,
-        state_backend: &SBT,
+        state_backend: &mut SBT,
         chain_config: &CCT,
         txs: Vec<(
             Recovered<TxEnvelope>,
@@ -282,7 +282,7 @@ where
         extending_blocks: Vec<EthValidatedBlock<ST, SCT>>,
 
         block_policy: &EthBlockPolicy<ST, SCT, CCT, CRT>,
-        state_backend: &SBT,
+        state_backend: &mut SBT,
         chain_config: &CCT,
     ) -> Result<ProposalWithSenderGas<ST>, BlockPolicyError> {
         info!(
@@ -564,7 +564,7 @@ where
         block_author: Address,
         extending_blocks: &Vec<&EthValidatedBlock<ST, SCT>>,
         block_policy: &EthBlockPolicy<ST, SCT, CCT, CRT>,
-        state_backend: &SBT,
+        state_backend: &mut SBT,
         chain_config: &impl ChainConfig<CRT>,
     ) -> Result<Vec<Recovered<TxEnvelope>>, StateBackendError> {
         // TODO this should be inside SystemTransactionGenerator to prevent
@@ -619,7 +619,7 @@ where
         proposal_byte_limit: u64,
         extending_blocks: Vec<&EthValidatedBlock<ST, SCT>>,
         block_policy: &EthBlockPolicy<ST, SCT, CCT, CRT>,
-        state_backend: &SBT,
+        state_backend: &mut SBT,
         chain_config: &CCT,
     ) -> Result<Proposal<ST>, BlockPolicyError> {
         let _timer = DropTimer::start(Duration::ZERO, |elapsed| {

--- a/monad-eth-txpool/tests/forward.rs
+++ b/monad-eth-txpool/tests/forward.rs
@@ -55,7 +55,7 @@ fn with_txpool(
         MockChainConfig,
         MockChainRevision,
     >::new(GENESIS_SEQ_NUM, 4);
-    let state_backend = InMemoryStateInner::new(
+    let mut state_backend = InMemoryStateInner::new(
         SeqNum(4),
         InMemoryBlockState::genesis(BTreeMap::from_iter(vec![(
             tx.signer(),
@@ -98,7 +98,7 @@ fn with_txpool(
     pool.insert_txs(
         &mut event_tracker,
         &eth_block_policy,
-        &state_backend,
+        &mut state_backend,
         &MockChainConfig::DEFAULT,
         vec![(
             tx,

--- a/monad-eth-txpool/tests/performance.rs
+++ b/monad-eth-txpool/tests/performance.rs
@@ -62,7 +62,7 @@ fn txpool_create_proposal_lookups_bound_by_tx_limit() {
 
         let eth_block_policy = EthBlockPolicy::new(GENESIS_SEQ_NUM, u64::MAX);
 
-        let state_backend: StateBackendType = InMemoryStateInner::new(
+        let mut state_backend: StateBackendType = InMemoryStateInner::new(
             SeqNum::MAX,
             InMemoryBlockState::genesis(BTreeMap::from_iter([
                 (secret_to_eth_address(S1), AccountState::max_balance()),
@@ -73,7 +73,7 @@ fn txpool_create_proposal_lookups_bound_by_tx_limit() {
         pool.insert_txs(
             &mut event_tracker,
             &eth_block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
             vec![
                 recover_tx(make_legacy_tx(S1, MIN_BASE_FEE.into(), 100_000, 0, 0)),
@@ -106,7 +106,7 @@ fn txpool_create_proposal_lookups_bound_by_tx_limit() {
                 RoundSignature::new(Round(0), &mock_keypair),
                 vec![],
                 &eth_block_policy,
-                &state_backend,
+                &mut state_backend,
                 &MockChainConfig::DEFAULT,
             )
             .unwrap();
@@ -142,7 +142,7 @@ fn txpool_create_proposal_no_lookup_for_unknown_authorizations() {
 
         let eth_block_policy = EthBlockPolicy::new(GENESIS_SEQ_NUM, u64::MAX);
 
-        let state_backend: StateBackendType = InMemoryStateInner::new(
+        let mut state_backend: StateBackendType = InMemoryStateInner::new(
             SeqNum::MAX,
             InMemoryBlockState::genesis(BTreeMap::from_iter([
                 (secret_to_eth_address(S1), AccountState::max_balance()),
@@ -153,7 +153,7 @@ fn txpool_create_proposal_no_lookup_for_unknown_authorizations() {
         pool.insert_txs(
             &mut event_tracker,
             &eth_block_policy,
-            &state_backend,
+            &mut state_backend,
             &MockChainConfig::DEFAULT,
             vec![recover_tx(make_eip7702_tx(
                 S1,
@@ -191,7 +191,7 @@ fn txpool_create_proposal_no_lookup_for_unknown_authorizations() {
                 RoundSignature::new(Round(0), &mock_keypair),
                 vec![],
                 &eth_block_policy,
-                &state_backend,
+                &mut state_backend,
                 &MockChainConfig::DEFAULT,
             )
             .unwrap();

--- a/monad-eth-txpool/tests/pool.rs
+++ b/monad-eth-txpool/tests/pool.rs
@@ -136,7 +136,7 @@ fn run_custom_iter<const N: usize>(
     events: [TxPoolTestEvent<'_>; N],
     owned: bool,
 ) {
-    let state_backend = {
+    let mut state_backend = {
         let nonces = if let Some(nonces) = nonces_override {
             nonces
         } else {
@@ -209,7 +209,7 @@ fn run_custom_iter<const N: usize>(
                     pool.insert_txs(
                         &mut event_tracker,
                         &eth_block_policy,
-                        &state_backend,
+                        &mut state_backend,
                         &MockChainConfig::DEFAULT,
                         vec![(
                             tx.clone(),
@@ -264,7 +264,7 @@ fn run_custom_iter<const N: usize>(
                 pool.insert_txs(
                     &mut event_tracker,
                     &eth_block_policy,
-                    &state_backend,
+                    &mut state_backend,
                     &MockChainConfig::DEFAULT,
                     txs.into_iter()
                         .map(ToOwned::to_owned)
@@ -308,7 +308,7 @@ fn run_custom_iter<const N: usize>(
                 pool.insert_txs(
                     &mut event_tracker,
                     &eth_block_policy,
-                    &state_backend,
+                    &mut state_backend,
                     &MockChainConfig::DEFAULT,
                     txs.into_iter()
                         .map(|(tx, kind)| (recover_tx(tx.to_owned()), kind))
@@ -344,7 +344,7 @@ fn run_custom_iter<const N: usize>(
                         RoundSignature::new(Round(0), &mock_keypair),
                         pending_blocks.iter().cloned().collect_vec(),
                         &eth_block_policy,
-                        &state_backend,
+                        &mut state_backend,
                         &MockChainConfig::DEFAULT,
                     )
                     .expect("create proposal succeeds");
@@ -450,7 +450,7 @@ fn run_custom_iter<const N: usize>(
                 let mut nonces = eth_block_policy
                     .get_account_base_nonces(
                         SeqNum(current_seq_num),
-                        &state_backend,
+                        &mut state_backend,
                         &pending_blocks.iter().collect_vec(),
                         [&address].into_iter(),
                     )

--- a/monad-state-backend-cache/src/lib.rs
+++ b/monad-state-backend-cache/src/lib.rs
@@ -76,7 +76,7 @@ where
     SBT: StateBackend<ST, SCT>,
 {
     fn get_account_statuses<'a>(
-        &self,
+        &mut self,
         block_id: &BlockId,
         seq_num: &SeqNum,
         is_finalized: bool,
@@ -158,7 +158,7 @@ where
     }
 
     fn get_execution_result(
-        &self,
+        &mut self,
         block_id: &BlockId,
         seq_num: &SeqNum,
         is_finalized: bool,
@@ -196,7 +196,7 @@ where
     }
 
     fn read_valset_at_block(
-        &self,
+        &mut self,
         block_num: SeqNum,
         requested_epoch: Epoch,
     ) -> Vec<(SCT::NodeIdPubKey, SignatureCollectionPubKeyType<SCT>, Stake)> {

--- a/monad-state-backend/src/in_memory.rs
+++ b/monad-state-backend/src/in_memory.rs
@@ -459,7 +459,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
 {
     fn get_account_statuses<'a>(
-        &self,
+        &mut self,
         block_id: &BlockId,
         seq_num: &SeqNum,
         is_finalized: bool,
@@ -505,7 +505,7 @@ where
     }
 
     fn get_execution_result(
-        &self,
+        &mut self,
         block_id: &BlockId,
         seq_num: &SeqNum,
         is_finalized: bool,
@@ -553,7 +553,7 @@ where
     }
 
     fn read_valset_at_block(
-        &self,
+        &mut self,
         _block_num: SeqNum,
         _requested_epoch: Epoch,
     ) -> Vec<(SCT::NodeIdPubKey, SignatureCollectionPubKeyType<SCT>, Stake)> {

--- a/monad-state-backend/src/lib.rs
+++ b/monad-state-backend/src/lib.rs
@@ -49,7 +49,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
 {
     fn get_account_statuses<'a>(
-        &self,
+        &mut self,
         block_id: &BlockId,
         seq_num: &SeqNum,
         is_finalized: bool,
@@ -57,7 +57,7 @@ where
     ) -> Result<Vec<Option<EthAccount>>, StateBackendError>;
 
     fn get_execution_result(
-        &self,
+        &mut self,
         block_id: &BlockId,
         seq_num: &SeqNum,
         is_finalized: bool,
@@ -69,7 +69,7 @@ where
     fn raw_read_latest_finalized_block(&self) -> Option<SeqNum>;
 
     fn read_valset_at_block(
-        &self,
+        &mut self,
         block_num: SeqNum,
         requested_epoch: Epoch,
     ) -> Vec<(SCT::NodeIdPubKey, SignatureCollectionPubKeyType<SCT>, Stake)>;
@@ -101,23 +101,23 @@ where
     T: StateBackend<ST, SCT>,
 {
     fn get_account_statuses<'a>(
-        &self,
+        &mut self,
         block_id: &BlockId,
         seq_num: &SeqNum,
         is_finalized: bool,
         addresses: impl Iterator<Item = &'a Address>,
     ) -> Result<Vec<Option<EthAccount>>, StateBackendError> {
-        let state = self.lock().unwrap();
+        let mut state = self.lock().unwrap();
         state.get_account_statuses(block_id, seq_num, is_finalized, addresses)
     }
 
     fn get_execution_result(
-        &self,
+        &mut self,
         block_id: &BlockId,
         seq_num: &SeqNum,
         is_finalized: bool,
     ) -> Result<EthHeader, StateBackendError> {
-        let state = self.lock().unwrap();
+        let mut state = self.lock().unwrap();
         state.get_execution_result(block_id, seq_num, is_finalized)
     }
 
@@ -132,7 +132,7 @@ where
     }
 
     fn read_valset_at_block(
-        &self,
+        &mut self,
         block_num: SeqNum,
         requested_epoch: Epoch,
     ) -> Vec<(
@@ -140,7 +140,7 @@ where
         SignatureCollectionPubKeyType<SCT>,
         Stake,
     )> {
-        let state = self.lock().unwrap();
+        let mut state = self.lock().unwrap();
         state.read_valset_at_block(block_num, requested_epoch)
     }
 

--- a/monad-state-backend/src/mock.rs
+++ b/monad-state-backend/src/mock.rs
@@ -38,7 +38,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
 {
     fn get_account_statuses<'a>(
-        &self,
+        &mut self,
         _block_id: &BlockId,
         _seq_num: &SeqNum,
         _is_finalized: bool,
@@ -57,7 +57,7 @@ where
     }
 
     fn get_execution_result(
-        &self,
+        &mut self,
         _block_id: &BlockId,
         _seq_num: &SeqNum,
         _is_finalized: bool,
@@ -76,7 +76,7 @@ where
     }
 
     fn read_valset_at_block(
-        &self,
+        &mut self,
         block_num: SeqNum,
         requested_epoch: monad_types::Epoch,
     ) -> Vec<(

--- a/monad-state-backend/src/thread.rs
+++ b/monad-state-backend/src/thread.rs
@@ -125,7 +125,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
 {
     fn get_account_statuses<'a>(
-        &self,
+        &mut self,
         block_id: &BlockId,
         seq_num: &SeqNum,
         is_finalized: bool,
@@ -141,7 +141,7 @@ where
     }
 
     fn get_execution_result(
-        &self,
+        &mut self,
         block_id: &BlockId,
         seq_num: &SeqNum,
         is_finalized: bool,
@@ -167,7 +167,7 @@ where
     }
 
     fn read_valset_at_block(
-        &self,
+        &mut self,
         block_num: SeqNum,
         requested_epoch: Epoch,
     ) -> Vec<(SCT::NodeIdPubKey, SignatureCollectionPubKeyType<SCT>, Stake)> {
@@ -217,7 +217,7 @@ where
 
     fn run(self) {
         let Self {
-            state_backend,
+            mut state_backend,
             request_rx,
             ..
         } = self;
@@ -287,7 +287,7 @@ mod test {
 
     #[test]
     fn all_requests() {
-        let client = StateBackendThreadClient::new(|| {
+        let mut client = StateBackendThreadClient::new(|| {
             InMemoryStateInner::<NopSignature, MultiSig<NopSignature>>::genesis(SeqNum(4))
         });
 

--- a/monad-state/src/consensus.rs
+++ b/monad-state/src/consensus.rs
@@ -99,7 +99,7 @@ where
     metrics: &'a mut Metrics,
     epoch_manager: &'a mut EpochManager,
     block_policy: &'a mut BPT,
-    state_backend: &'a SBT,
+    state_backend: &'a mut SBT,
 
     val_epoch_map: &'a ValidatorsEpochMapping<VTF, SCT>,
     leader_election: &'a LT,
@@ -139,7 +139,7 @@ where
             metrics: &mut monad_state.metrics,
             epoch_manager: &mut monad_state.epoch_manager,
             block_policy: &mut monad_state.block_policy,
-            state_backend: &monad_state.state_backend,
+            state_backend: &mut monad_state.state_backend,
 
             val_epoch_map: &monad_state.val_epoch_map,
             leader_election: &monad_state.leader_election,

--- a/monad-triedb-utils/src/lib.rs
+++ b/monad-triedb-utils/src/lib.rs
@@ -242,7 +242,7 @@ impl TriedbReader {
 
 impl StateBackend<SecpSignature, BlsSignatureCollection<monad_secp::PubKey>> for TriedbReader {
     fn get_account_statuses<'a>(
-        &self,
+        &mut self,
         block_id: &BlockId,
         seq_num: &SeqNum,
         is_finalized: bool,
@@ -295,7 +295,7 @@ impl StateBackend<SecpSignature, BlsSignatureCollection<monad_secp::PubKey>> for
     }
 
     fn get_execution_result(
-        &self,
+        &mut self,
         block_id: &BlockId,
         seq_num: &SeqNum,
         is_finalized: bool,
@@ -333,7 +333,7 @@ impl StateBackend<SecpSignature, BlsSignatureCollection<monad_secp::PubKey>> for
     }
 
     fn read_valset_at_block(
-        &self,
+        &mut self,
         block_num: SeqNum,
         requested_epoch: Epoch,
     ) -> Vec<(monad_secp::PubKey, BlsPubKey, Stake)> {

--- a/monad-updaters/src/triedb_val_set.rs
+++ b/monad-updaters/src/triedb_val_set.rs
@@ -69,7 +69,7 @@ impl ValSetUpdater<SecpSignature, BlsSignatureCollection<PubKey>> {
         validators_path: PathBuf,
         epoch_length: SeqNum,
         staking_activation: Epoch,
-        state_backend: SBT,
+        mut state_backend: SBT,
     ) -> Self
     where
         SBT: StateBackend<SecpSignature, BlsSignatureCollection<PubKey>> + Send + 'static,


### PR DESCRIPTION
Previously, the `StateBackend` trait only had methods on `&self` leading us to pass it around by immutable reference. In a future change of the triedb API from the `monad-triedb` crate, we will change methods that internally mutate the triedb reference to use `&mut self`. As such, this change has been split out into a separate PR for easier reviewing.

This will also allow us to remove the unnecessary synchronization primitives on `StateBackendCache` and completely remove `InMemoryStateInner` (https://github.com/category-labs/monad-bft/pull/3124).