### PR TITLE
Raptorcast: Bound memory usage on RoundInfoCache

### DIFF
--- a/monad-raptorcast/src/round_info.rs
+++ b/monad-raptorcast/src/round_info.rs
@@ -31,9 +31,16 @@ use crate::{
 pub(crate) const CACHE_MAX_FUTURE_ROUNDS: Round = Round(100);
 pub(crate) const CACHE_MAX_PAST_ROUNDS: Round = Round(100);
 
+pub(crate) const AUTHOR_QUOTA_DURING_SYNC: usize = 512; // max ~80KB per author
+pub(crate) const AUTHOR_QUOTA_DURING_LIVE: usize = 32;
+
 // Stores information related to the current round.
 pub struct RoundInfoCache<PT: PubKey> {
     current_round: Option<Round>,
+
+    // number of new slots an author is allowed to open on primary
+    // round info cache. Replenishes on every local round advance.
+    author_quota: HashMap<NodeId<PT>, usize>,
     primary: BTreeMap<Round, PrimaryRoundInfo<PT>>,
     // Per-publisher secondary round info. Multiple validators can
     // publish secondary broadcasts in the same round to independent
@@ -45,6 +52,7 @@ impl<PT: PubKey> RoundInfoCache<PT> {
     pub fn new() -> Self {
         Self {
             current_round: None,
+            author_quota: HashMap::new(),
             primary: BTreeMap::new(),
             secondary: HashMap::new(),
         }
@@ -78,12 +86,21 @@ impl<PT: PubKey> RoundInfoCache<PT> {
             }
         }
         self.secondary.retain(|_, by_round| !by_round.is_empty());
+
+        // replenish author quota
+        self.author_quota.clear();
     }
 
-    // Returns None on out-of-window round
-    pub fn get_or_insert_primary(&mut self, round: Round) -> Option<&mut PrimaryRoundInfo<PT>> {
+    // Returns None on out-of-window round or if the author has
+    // exhausted their quota of opening new rounds.
+    pub fn get_or_insert_primary(
+        &mut self,
+        round: Round,
+        author: &NodeId<PT>,
+    ) -> Option<&mut PrimaryRoundInfo<PT>> {
         if !self.primary.contains_key(&round) {
             self.check_round(round)?;
+            self.deduct_author_quota(author)?;
             self.primary.insert(round, Default::default());
         }
         self.primary.get_mut(&round)
@@ -96,8 +113,17 @@ impl<PT: PubKey> RoundInfoCache<PT> {
         round: Round,
     ) -> Option<&mut SecondaryGroupRoundInfo<PT>> {
         self.check_round(round)?;
-        let by_round = self.secondary.entry(publisher).or_default();
-        Some(by_round.entry(round).or_default())
+        let slot_exists = self
+            .secondary
+            .get(&publisher)
+            .is_some_and(|by_round| by_round.contains_key(&round));
+        if !slot_exists {
+            self.deduct_author_quota(&publisher)?;
+        }
+
+        let per_validator = self.secondary.entry(publisher).or_default();
+        let per_round = per_validator.entry(round).or_default();
+        Some(per_round)
     }
 
     #[cfg(test)]
@@ -128,6 +154,24 @@ impl<PT: PubKey> RoundInfoCache<PT> {
             }
         }
 
+        Some(())
+    }
+
+    fn deduct_author_quota(&mut self, author: &NodeId<PT>) -> Option<()> {
+        if let Some(quota) = self.author_quota.get_mut(author) {
+            if *quota == 0 {
+                return None;
+            }
+            *quota -= 1;
+            return Some(());
+        }
+
+        let initial_quota = if self.current_round.is_none() {
+            AUTHOR_QUOTA_DURING_SYNC - 1
+        } else {
+            AUTHOR_QUOTA_DURING_LIVE - 1
+        };
+        self.author_quota.insert(*author, initial_quota);
         Some(())
     }
 }
@@ -346,6 +390,10 @@ mod tests {
     const MERKLE_A: MerkleRoot = HexBytes([1; 20]);
     const MERKLE_B: MerkleRoot = HexBytes([2; 20]);
 
+    fn author(seed: u8) -> NodeId<NopPubKey> {
+        NodeId::new(NopPubKey::from_bytes(&[seed; 32]).unwrap())
+    }
+
     fn dummy_chunk(
         round: u64,
         sig: &[u8; SIGNATURE_SIZE],
@@ -376,10 +424,12 @@ mod tests {
     fn get_or_insert() {
         let mut cache = Cache::new();
 
+        let a = author(0);
+
         // Any round accepted before first update_current_round.
-        assert!(cache.get_or_insert_primary(Round(0)).is_some());
-        assert!(cache.get_or_insert_primary(Round(200)).is_some());
-        assert!(cache.get_or_insert_primary(Round(500)).is_some());
+        assert!(cache.get_or_insert_primary(Round(0), &a).is_some());
+        assert!(cache.get_or_insert_primary(Round(200), &a).is_some());
+        assert!(cache.get_or_insert_primary(Round(500), &a).is_some());
 
         // update_current_round evicts out-of-window entries.
         cache.update_current_round(Round(200));
@@ -388,32 +438,34 @@ mod tests {
         assert!(cache.get_primary(Round(500)).is_none());
 
         // Repeated insert returns existing entry.
-        assert!(cache.get_or_insert_primary(Round(200)).is_some());
+        assert!(cache.get_or_insert_primary(Round(200), &a).is_some());
     }
 
     #[test]
     fn round_window_bounds() {
         let mut cache = Cache::new();
         cache.update_current_round(Round(200));
+        let a = author(0);
 
         // Exactly at future boundary: 200 + 100 = 300, accepted.
-        assert!(cache.get_or_insert_primary(Round(300)).is_some());
+        assert!(cache.get_or_insert_primary(Round(300), &a).is_some());
         // One past: rejected.
-        assert!(cache.get_or_insert_primary(Round(301)).is_none());
+        assert!(cache.get_or_insert_primary(Round(301), &a).is_none());
 
         // Exactly at past boundary: 200 - 100 = 100, accepted.
-        assert!(cache.get_or_insert_primary(Round(100)).is_some());
+        assert!(cache.get_or_insert_primary(Round(100), &a).is_some());
         // One past: rejected.
-        assert!(cache.get_or_insert_primary(Round(99)).is_none());
+        assert!(cache.get_or_insert_primary(Round(99), &a).is_none());
     }
 
     #[test]
     fn eviction() {
         let mut cache = Cache::new();
-        cache.get_or_insert_primary(Round(10));
-        cache.get_or_insert_primary(Round(11));
-        cache.get_or_insert_primary(Round(199));
-        cache.get_or_insert_primary(Round(200));
+        let a = author(0);
+        cache.get_or_insert_primary(Round(10), &a);
+        cache.get_or_insert_primary(Round(11), &a);
+        cache.get_or_insert_primary(Round(199), &a);
+        cache.get_or_insert_primary(Round(200), &a);
 
         // Future eviction: cutoff = 100 + 100 = 200, entries >= 200 are dropped.
         cache.update_current_round(Round(100));
@@ -425,11 +477,13 @@ mod tests {
         assert!(cache.get_primary(Round(10)).is_none());
         assert!(cache.get_primary(Round(11)).is_some());
 
-        // In-window entries survive across rounds.
+        // In-window entries survive across rounds. Use a distinct author
+        // per round so the per-author quota does not interfere with the
+        // eviction-window behavior under test.
         let mut cache = Cache::new();
         cache.update_current_round(Round(100));
         for r in 50..=150 {
-            cache.get_or_insert_primary(Round(r));
+            cache.get_or_insert_primary(Round(r), &author(r as u8));
         }
         cache.update_current_round(Round(110));
         for r in 50..=150 {
@@ -476,5 +530,62 @@ mod tests {
         assert!(info_11
             .try_commit(&dummy_chunk(11, &SIG_A, &MERKLE_A))
             .is_none());
+    }
+
+    #[test]
+    fn author_quota_during_sync() {
+        let mut cache = Cache::new();
+        let attacker = author(1);
+        let honest = author(2);
+
+        // An author can open exactly AUTHOR_QUOTA_DURING_SYNC distinct
+        // rounds
+        for r in 0..AUTHOR_QUOTA_DURING_SYNC as u64 {
+            assert!(cache.get_or_insert_primary(Round(r), &attacker).is_some());
+        }
+
+        // Any additional rounds is blocked
+        let blocked = Round(AUTHOR_QUOTA_DURING_SYNC as u64);
+        assert!(cache.get_or_insert_primary(blocked, &attacker).is_none());
+        assert!(cache.get_primary(blocked).is_none());
+
+        // Only misses are charged
+        assert!(cache.get_or_insert_primary(Round(0), &attacker).is_some());
+
+        // The budget is per-author
+        assert!(cache.get_or_insert_primary(blocked, &honest).is_some());
+        assert!(cache.get_primary(blocked).is_some());
+
+        // Entering a new round replenishes the budget
+        cache.update_current_round(blocked);
+        let next = Round(AUTHOR_QUOTA_DURING_SYNC as u64 + 1);
+        assert!(cache.get_or_insert_primary(next, &attacker).is_some());
+    }
+
+    #[test]
+    fn author_quota_during_live() {
+        let mut cache = Cache::new();
+        let a = author(1);
+
+        cache.update_current_round(Round(1000));
+
+        // Out-of-window rounds are rejected and do not charge the budget.
+        assert!(cache.get_or_insert_primary(Round(2000), &a).is_none()); // > 1000 + 100
+        assert!(cache.get_or_insert_primary(Round(800), &a).is_none()); // < 1000 - 100
+
+        // The full live budget is still available for in-window rounds,
+        // confirming the rejected out-of-window rounds were not charged.
+        for i in 0..AUTHOR_QUOTA_DURING_LIVE as u64 {
+            assert!(cache.get_or_insert_primary(Round(1000 + i), &a).is_some());
+        }
+
+        // One past the budget is rejected even though it is in-window.
+        let over = Round(1000 + AUTHOR_QUOTA_DURING_LIVE as u64);
+        assert!(cache.get_or_insert_primary(over, &a).is_none());
+
+        // Entering a new round replenishes the budget, so the same author
+        // can open the previously-blocked round.
+        cache.update_current_round(Round(1001));
+        assert!(cache.get_or_insert_primary(over, &a).is_some());
     }
 }

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -246,12 +246,15 @@ impl<ST: CertificateSignatureRecoverable> UdpState<ST> {
             return None;
         }
 
-        let Some(round_info) = self.round_info_cache.get_or_insert_primary(round) else {
+        let Some(round_info) = self
+            .round_info_cache
+            .get_or_insert_primary(round, &chunk.author)
+        else {
             tracing::debug!(
                 ?chunk.group_id,
                 ?chunk.chunk_id,
                 author =? chunk.author,
-                "dropping primary chunk for round that is too far in the past or future"
+                "dropping primary chunk due to round info cache rejection"
             );
             return None;
         };


### PR DESCRIPTION
This PR implements a per-author enforced quota on the number opening slots in primary round info cache to enforce an upper bound on possible memory usage during consensus sync phase (node bootstrapping).

Design:

- The quota allowance is replenished on advancing local rounds.
- More generous quota during sync (512) comparing to live (32), to allow wider margin of tip-following on boot.
- Cache hits do not consume quota

Estimated numbers for sync phase (assuming per-author quota: 512, at 3.3 blocks/s):

| `valset.len()` | total mem bound | max sync duration |
|--------|--------|--------|
| 300 | 24 MiB | 13 hours |
| 100 | 8 MiB | 4 hours |
| 50 | 4 MiB | 2 hours |
| 10 | 800 KiB | 26 minutes |


The tests are written with the assistance of Claude Opus 4.8.