### PR TITLE
Raptorcast: fix starvation on networking messages

### DIFF
--- a/monad-raptorcast/Cargo.toml
+++ b/monad-raptorcast/Cargo.toml
@@ -40,7 +40,7 @@ lru = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
 tracing = { workspace = true }
 zerocopy = { workspace = true }
 

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -64,9 +64,9 @@ use packet::regular;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::{debug, debug_span, error, info, trace, warn};
 use util::{
-    AutoRebroadcast, BroadcastGroup, BroadcastGroupError, BuildTarget, Collector, FullNodeGroupMap,
-    PeerAddrLookup, PrimaryBroadcastGroup, Recipient, Redundancy, SecondaryBroadcastGroup,
-    SecondaryGroupAssignment, UdpMessage,
+    budgeted, AutoRebroadcast, BroadcastGroup, BroadcastGroupError, BuildTarget, Collector,
+    FullNodeGroupMap, PeerAddrLookup, PrimaryBroadcastGroup, Recipient, Redundancy,
+    SecondaryBroadcastGroup, SecondaryGroupAssignment, UdpMessage,
 };
 
 use crate::{
@@ -1169,6 +1169,10 @@ fn iter_ips<'a, ST: CertificateSignatureRecoverable, PD: PeerDiscoveryAlgo<Signa
         .filter_map(|node_id| peer_discovery.get_ip(node_id))
 }
 
+const RAPTORCAST_POLL_QUOTA: usize = 256;
+const DIRECT_UDP_POLL_QUOTA: usize = 64;
+const TCP_POLL_QUOTA: usize = 16;
+
 impl<ST, M, OM, E, PD, AP, DS> Stream for RaptorCast<ST, M, OM, E, PD, AP, DS>
 where
     ST: CertificateSignatureRecoverable,
@@ -1197,9 +1201,10 @@ where
             return Poll::Ready(Some(event.into()));
         }
 
+        let mut poll_quota = RAPTORCAST_POLL_QUOTA;
         loop {
             let message = {
-                let mut sock = pin!(this.dual_socket.recv());
+                let mut sock = pin!(budgeted(this.dual_socket.recv(), &mut poll_quota));
 
                 match sock.poll_unpin(cx) {
                     Poll::Ready(Ok(msg)) => {
@@ -1340,8 +1345,9 @@ where
         }
 
         if let Some(socket) = this.direct_udp_transport.as_mut() {
+            let mut poll_quota = DIRECT_UDP_POLL_QUOTA;
             loop {
-                let mut recv_fut = pin!(socket.recv());
+                let mut recv_fut = pin!(budgeted(socket.recv(), &mut poll_quota));
                 match recv_fut.poll_unpin(cx) {
                     Poll::Ready(Ok(msg)) => {
                         let from = msg
@@ -1385,8 +1391,10 @@ where
             }
         }
 
+        let mut poll_quota = TCP_POLL_QUOTA;
         loop {
-            let Poll::Ready(msg) = pin!(this.tcp_reader.recv()).poll_unpin(cx) else {
+            let mut recv_fut = pin!(budgeted(this.tcp_reader.recv(), &mut poll_quota));
+            let Poll::Ready(msg) = recv_fut.poll_unpin(cx) else {
                 break;
             };
             let RecvTcpMsg { payload, src_addr } = msg;

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -24,6 +24,7 @@ use std::{
     cell::OnceCell,
     collections::{BTreeMap, BTreeSet, HashMap},
     fmt,
+    future::Future,
     net::SocketAddr,
     num::NonZero,
     ops::Range,
@@ -45,6 +46,19 @@ use monad_validator::{
 };
 
 use crate::udp::GroupId;
+
+/// Await a future, consuming one unit of shared quota; once depleted,
+/// yield to others and request executor to wake up the task
+/// again. Used to prevent starvation.
+pub async fn budgeted<F: Future>(fut: F, quota: &mut usize) -> F::Output {
+    if *quota == 0 {
+        tokio::task::yield_now().await;
+        *quota = 1; // each yielding restores one more unit
+    }
+    let out = fut.await;
+    *quota -= 1;
+    out
+}
 
 #[derive(Debug, Clone, Copy)]
 pub enum RaptorcastMode {
@@ -1588,5 +1602,62 @@ mod tests {
         .into_iter()
         .collect();
         assert_eq!(actual, expected);
+    }
+
+    mod budgeted {
+        use std::{
+            future::{pending, poll_fn, ready},
+            pin::pin,
+            task::Poll,
+            time::Duration,
+        };
+
+        use futures::{future::poll_immediate, FutureExt};
+        use tokio::time::timeout;
+
+        use crate::util::budgeted;
+
+        #[tokio::test]
+        async fn quota_bounds_drain_pass_and_self_wakes() {
+            let mut polled = 0;
+            let mut drained = 0;
+
+            // expect budgeted to wake the task after first quota
+            // exhaustion. return Ready on second poll.
+            let drain_two_passes = poll_fn(|cx| {
+                polled += 1;
+                let mut quota = 3;
+                while let Poll::Ready(()) = pin!(budgeted(ready(()), &mut quota)).poll_unpin(cx) {
+                    drained += 1;
+                }
+                if polled == 2 {
+                    Poll::Ready(())
+                } else {
+                    Poll::Pending
+                }
+            });
+
+            timeout(Duration::from_secs(1), drain_two_passes)
+                .await
+                .expect("spent quota did not wake the task");
+
+            assert_eq!(drained, 6);
+        }
+
+        #[tokio::test]
+        async fn pending_inner_consumes_no_quota() {
+            let mut quota = 1;
+            let throttled = poll_immediate(budgeted(pending::<()>(), &mut quota)).await;
+            assert_eq!(throttled, None);
+            assert_eq!(quota, 1);
+        }
+
+        #[tokio::test]
+        async fn exhausted_budgeted_resumes_after_yield() {
+            let mut quota = 0;
+            let out = timeout(Duration::from_secs(1), budgeted(ready(7), &mut quota)).await;
+            assert_eq!(out, Ok(7));
+            assert_eq!(quota, 0);
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/category-labs/monad-bft/issues/1915.

Minor notes: I think ideally we should just use `tokio::select!`, but doing so elegantly would require quite some refactories that turns those polling into nice standalone futures. I previously experimented with the idea in f534cd91c8c808bfaea69e8f0bed556a302a051f, 29ce59ceb4f44cd00124cd1a0b8d4a5b2331c09e and eecc50ed42e0930af5fcd0eba4d9b502e69448ed. I believe we should still put forward those refactories even just for the benefit of cleaner codes - but in this PR i shall just tackle this specific issue and leave those changes to the future.