### PR TITLE
debian: remove wal cleanup from clear artifacts

### DIFF
--- a/debian/opt/monad/scripts/clear-old-artifacts.sh
+++ b/debian/opt/monad/scripts/clear-old-artifacts.sh
@@ -6,9 +6,8 @@ TARGET_DIR="/home/monad/monad-bft/ledger/"
 RETENTION_FORKPOINT=${RETENTION_FORKPOINT:-300}      # 5 hours (forkpoint.rlp.* and forkpoint.toml.*)
 RETENTION_VALIDATORS=${RETENTION_VALIDATORS:-43200}  # 30 days (validators.toml.*)
 RETENTION_LEDGER=${RETENTION_LEDGER:-600}            # 10 hours (headers and bodies)
-RETENTION_WAL=${RETENTION_WAL:-300}                  # 5 hours (wal_* files)
 
-echo "Cleanup script started: RETENTION_LEDGER=${RETENTION_LEDGER}min, RETENTION_WAL=${RETENTION_WAL}min, RETENTION_FORKPOINT=${RETENTION_FORKPOINT}min, RETENTION_VALIDATORS=${RETENTION_VALIDATORS}min"
+echo "Cleanup script started: RETENTION_LEDGER=${RETENTION_LEDGER}min, RETENTION_FORKPOINT=${RETENTION_FORKPOINT}min, RETENTION_VALIDATORS=${RETENTION_VALIDATORS}min"
 
 NEW_FILES=$(find "$TARGET_DIR" -type f -name "*" -mmin -20)
 if [ -n "$NEW_FILES" ]; then
@@ -18,7 +17,6 @@ if [ -n "$NEW_FILES" ]; then
     find /home/monad/monad-bft/config/validators/ -type f -name "validators.toml.*" -mmin +${RETENTION_VALIDATORS} -delete 2>/dev/null
     find /home/monad/monad-bft/ledger/headers -type f -mmin +${RETENTION_LEDGER} -delete 2>/dev/null
     find /home/monad/monad-bft/ledger/bodies -type f -mmin +${RETENTION_LEDGER} -delete 2>/dev/null
-    find /home/monad/monad-bft/ -type f -name "wal_*" -mmin +${RETENTION_WAL} -delete 2>/dev/null
     echo "Cleanup completed successfully"
 else
     echo "No new files detected. Skipping deletion of ledger files."


### PR DESCRIPTION
the node now manages wal chunk retention internally, so the package cleanup script should not delete wal files independently.

external cleanup can interfere with the node's internal wal cleanup when a chunk is not filled within the 5 hour retention window. in that case monad-cruft may delete the chunk while the waltrace thread still expects to append to it, leading to missing-file errors and the waltrace thread stopping.
