### PR TITLE
wireauth: remove unsafe mutation before responder key is verified

### DIFF
--- a/monad-wireauth/src/protocol/handshake.rs
+++ b/monad-wireauth/src/protocol/handshake.rs
@@ -285,51 +285,43 @@ pub fn send_handshake_response<R: secp256k1::rand::Rng + secp256k1::rand::Crypto
 
 pub fn accept_handshake_response(
     initiator_static_keypair: &monad_secp::KeyPair,
+    initiator_ephemeral_private: &monad_secp::KeyPair,
+    initiator_hash: &HashOutput,
+    initiator_chaining_key: &HashOutput,
     msg: &mut HandshakeResponse,
-    state: &mut HandshakeState,
     psk: &[u8; 32],
 ) -> Result<TransportKeys, HandshakeError> {
-    state.receiver_index = msg.sender_index.get();
     let remote_ephemeral = monad_secp::PubKey::from_slice(&msg.ephemeral_public)
         .map_err(|e| HandshakeError::StaticKeyDecryptionFailed(CryptoError::InvalidKey(e)))?;
-    state.remote_ephemeral = Some(remote_ephemeral);
-    state.hash = hash!(state.hash.as_ref(), &msg.ephemeral_public).into();
+    let mut handshake_hash = hash!(initiator_hash.as_ref(), &msg.ephemeral_public);
 
-    let temp = keyed_hash!(state.chaining_key.as_ref(), &msg.ephemeral_public);
-    state.chaining_key = keyed_hash!(temp.as_ref(), &[0x1]).into();
+    let temp = keyed_hash!(initiator_chaining_key.as_ref(), &msg.ephemeral_public);
+    let mut chaining_key: Zeroizing<HashOutput> = keyed_hash!(temp.as_ref(), &[0x1]).into();
 
-    let ecdh_ee = ecdh(
-        state
-            .ephemeral_private
-            .as_ref()
-            .expect("ephemeral private key must be set"),
-        &remote_ephemeral,
-    );
-    let temp = keyed_hash!(state.chaining_key.as_ref(), ecdh_ee.as_ref());
-    state.chaining_key = keyed_hash!(temp.as_ref(), &[0x1]).into();
+    let ecdh_ee = ecdh(initiator_ephemeral_private, &remote_ephemeral);
+    let temp = keyed_hash!(chaining_key.as_ref(), ecdh_ee.as_ref());
+    chaining_key = keyed_hash!(temp.as_ref(), &[0x1]).into();
 
     let ecdh_se = ecdh(initiator_static_keypair, &remote_ephemeral);
-    let temp = keyed_hash!(state.chaining_key.as_ref(), ecdh_se.as_ref());
-    state.chaining_key = keyed_hash!(temp.as_ref(), &[0x1]).into();
+    let temp = keyed_hash!(chaining_key.as_ref(), ecdh_se.as_ref());
+    chaining_key = keyed_hash!(temp.as_ref(), &[0x1]).into();
 
-    let temp = keyed_hash!(state.chaining_key.as_ref(), psk);
-    state.chaining_key = keyed_hash!(temp.as_ref(), &[0x1]).into();
-    let temp2 = keyed_hash!(temp.as_ref(), state.chaining_key.as_ref(), &[0x2]);
-    let key = keyed_hash!(temp.as_ref(), temp2.as_ref(), &[0x3]);
-    state.hash = hash!(state.hash.as_ref(), temp2.as_ref()).into();
+    let temp = keyed_hash!(chaining_key.as_ref(), psk);
+    chaining_key = keyed_hash!(temp.as_ref(), &[0x1]).into();
+    let temp2 = keyed_hash!(temp.as_ref(), chaining_key.as_ref(), &[0x2]);
+    let key: Zeroizing<HashOutput> = keyed_hash!(temp.as_ref(), temp2.as_ref(), &[0x3]).into();
+    handshake_hash = hash!(handshake_hash.as_ref(), temp2.as_ref());
 
-    let hash = state.hash.clone();
-    state.hash = hash!(state.hash.as_ref(), &msg.encrypted_nothing_tag).into();
     decrypt_in_place(
-        &(&key).into(),
+        &CipherKey::from(&*key),
         &(0u64).into(),
         &mut [],
         &msg.encrypted_nothing_tag,
-        hash.as_ref(),
+        handshake_hash.as_ref(),
     )
     .map_err(HandshakeError::EmptyMessageDecryptionFailed)?;
 
-    Ok(derive_transport_keys(&state.chaining_key, true))
+    Ok(derive_transport_keys(&chaining_key, true))
 }
 
 pub fn derive_transport_keys(chaining_key: &HashOutput, is_initiator: bool) -> TransportKeys {
@@ -512,11 +504,16 @@ mod tests {
         let response_trace = extract_response_trace(&resp_msg);
 
         let mut resp_msg_mut = resp_msg;
-        let mut init_state_mut = init_state;
+        let initiator_ephemeral_private = init_state
+            .ephemeral_private
+            .as_ref()
+            .expect("ephemeral private key must be set");
         let initiator_transport_keys = accept_handshake_response(
             &initiator_static_keypair,
+            initiator_ephemeral_private,
+            &init_state.hash,
+            &init_state.chaining_key,
             &mut resp_msg_mut,
-            &mut init_state_mut,
             &psk,
         )
         .unwrap();
@@ -680,11 +677,16 @@ mod tests {
         );
 
         let mut resp_msg_mut = resp_msg;
-        let mut init_state_mut = init_state;
+        let initiator_ephemeral_private = init_state
+            .ephemeral_private
+            .as_ref()
+            .expect("ephemeral private key must be set");
         let initiator_transport_keys = accept_handshake_response(
             &initiator_static_keypair,
+            initiator_ephemeral_private,
+            &init_state.hash,
+            &init_state.chaining_key,
             &mut resp_msg_mut,
-            &mut init_state_mut,
             &psk,
         )
         .unwrap();
@@ -799,11 +801,16 @@ mod tests {
             let response_trace = extract_response_trace(&resp_msg);
 
             let mut resp_msg_mut = resp_msg;
-            let mut init_state_mut = init_state;
+            let initiator_ephemeral_private = init_state
+                .ephemeral_private
+                .as_ref()
+                .expect("ephemeral private key must be set");
             let initiator_keys = accept_handshake_response(
                 &initiator_static_keypair,
+                initiator_ephemeral_private,
+                &init_state.hash,
+                &init_state.chaining_key,
                 &mut resp_msg_mut,
-                &mut init_state_mut,
                 &psk,
             )
             .unwrap();

--- a/monad-wireauth/src/session/initiator.rs
+++ b/monad-wireauth/src/session/initiator.rs
@@ -111,17 +111,24 @@ impl InitiatorState {
         local_static_key: &monad_secp::KeyPair,
         msg: &mut HandshakeResponse,
     ) -> Result<ValidatedHandshakeResponse, SessionError> {
+        let initiator_ephemeral_private = self
+            .handshake_state
+            .ephemeral_private
+            .as_ref()
+            .expect("ephemeral private key must be set");
         let transport_keys = handshake::accept_handshake_response(
             local_static_key,
+            initiator_ephemeral_private,
+            &self.handshake_state.hash,
+            &self.handshake_state.chaining_key,
             msg,
-            &mut self.handshake_state,
             &config.psk,
         )
         .map_err(SessionError::HandshakeError)?;
 
         Ok(ValidatedHandshakeResponse {
             transport_keys,
-            remote_index: self.handshake_state.receiver_index.into(),
+            remote_index: msg.sender_index.into(),
         })
     }
 

--- a/monad-wireauth/tests/tests.rs
+++ b/monad-wireauth/tests/tests.rs
@@ -868,6 +868,66 @@ fn test_handshake_response_address_mismatch_rejected() {
 }
 
 #[test]
+fn test_stale_handshake_response_does_not_poison_pending_initiator() {
+    init_tracing();
+    let config = Config::default();
+    let stale_peer1_keypair = monad_secp::KeyPair::from_ikm(b"initiator key").unwrap();
+    let peer1_keypair = monad_secp::KeyPair::from_ikm(b"initiator key").unwrap();
+    let peer1_context = TestContext::new();
+    peer1_context.advance_time(Duration::from_secs(1));
+
+    let mut stale_peer1 = API::new(
+        DEFAULT_METRICS,
+        config.clone(),
+        stale_peer1_keypair,
+        TestContext::new(),
+    );
+    let mut peer1 = API::new(DEFAULT_METRICS, config, peer1_keypair, peer1_context);
+    let (mut peer2, peer2_pubkey, _, _) = create_manager();
+    let peer1_addr: SocketAddr = "127.0.0.1:8001".parse().unwrap();
+    let peer2_addr: SocketAddr = "127.0.0.1:8002".parse().unwrap();
+
+    // stale_peer1 creates a valid but obsolete initiation from the same static key.
+    stale_peer1
+        .connect(peer2_pubkey, peer2_addr, DEFAULT_RETRY_ATTEMPTS)
+        .unwrap();
+    let stale_init = collect::<HandshakeInitiation>(&mut stale_peer1);
+    dispatch(&mut peer2, &stale_init, peer1_addr);
+    let stale_response = collect::<HandshakeResponse>(&mut peer2);
+
+    // peer1 creates the real pending initiation with the same receiver index and a newer timestamp.
+    peer1
+        .connect(peer2_pubkey, peer2_addr, DEFAULT_RETRY_ATTEMPTS)
+        .unwrap();
+    let init = collect::<HandshakeInitiation>(&mut peer1);
+    dispatch(&mut peer2, &init, peer1_addr);
+    let response = collect::<HandshakeResponse>(&mut peer2);
+
+    // the stale response passes source address, receiver index, and mac1 checks before auth fails.
+    let mut stale_response_packet = stale_response;
+    let parsed_packet = Packet::try_from(&mut stale_response_packet[..]).unwrap();
+    let err = match parsed_packet {
+        Packet::Control(control) => peer1.dispatch_control(control, peer2_addr).unwrap_err(),
+        Packet::Data(_) => panic!("expected control packet"),
+    };
+    assert!(matches!(err, monad_wireauth::Error::Session(_)));
+
+    // the authentic response still succeeds because the stale response did not mutate state.
+    let mut response_packet = response;
+    let parsed_packet = Packet::try_from(&mut response_packet[..]).unwrap();
+    match parsed_packet {
+        Packet::Control(control) => peer1.dispatch_control(control, peer2_addr).unwrap(),
+        Packet::Data(_) => panic!("expected control packet"),
+    }
+
+    // data can flow on the session established by the authentic response.
+    let mut plaintext = b"handshake survives stale response".to_vec();
+    let packet = encrypt(&mut peer1, &peer2_pubkey, &mut plaintext);
+    let decrypted = decrypt(&mut peer2, &packet, peer1_addr);
+    assert_eq!(decrypted, b"handshake survives stale response");
+}
+
+#[test]
 fn test_max_initiated_sessions_limit() {
     init_tracing();
     let config = Config {


### PR DESCRIPTION
a spoofed handshake response can match the pending initiator receiver index and pass mac1 because mac1 is keyed to the initiator static key.

before this change, accept_handshake_response updated the pending transcript before encrypted_nothing_tag authenticated the responder ephemeral key. a spoofed response from the expected address could fail authentication while leaving the pending initiator state poisoned.

validate the response against local transcript copies and only use the authenticated result to establish transport keys, so the authentic response can still complete after a spoofed response is rejected.