### PR TITLE
Raptorcast: rollout deterministic rc stage 1 "accept both publish v0"

### DIFF
--- a/monad-node-config/src/raptorcast.rs
+++ b/monad-node-config/src/raptorcast.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 //  -----------------+------------------+------------------+----------
 
 pub const CURRENT_STAGE: DeterministicProtocolRolloutStage =
-    DeterministicProtocolRolloutStage::AlwaysV0;
+    DeterministicProtocolRolloutStage::AcceptBothPublishV0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
The inclusion of this PR would enable nodes participating primary and secondary raptorcast to accept v1 message format.