### PR TITLE
Enable atomic resolve+query on HistoricalDataSource

### DIFF
--- a/monad-rpc/src/data/mod.rs
+++ b/monad-rpc/src/data/mod.rs
@@ -49,7 +49,7 @@ use self::{
     },
 };
 use crate::{
-    data::source::{DataSourceError, TriedbDataSource},
+    data::source::{DataSourceError, HistoricalDataSourceExt, TriedbDataSource},
     handlers::eth::txn::FilterError,
     types::{
         eth_json::{BlockTagOrHash, BlockTags, MonadLog, MonadTransactionReceipt},
@@ -390,23 +390,16 @@ where
             }
         }
 
-        if let Some(block_pointer) = self
+        if let Some(header) = self
             .historical
-            .try_resolve(block)
+            .try_resolve_and_then(block, |source, pointer| source.get_block_header(pointer))
             .await
             .map_err(ChainStateError::DataSource)?
         {
-            if let Some(header) = self
-                .historical
-                .get_block_header(block_pointer)
-                .await
-                .map_err(ChainStateError::DataSource)?
-            {
-                return Ok(header);
-            }
+            Ok(header)
+        } else {
+            Err(ChainStateError::ResourceNotFound)
         }
-
-        Err(ChainStateError::ResourceNotFound)
     }
 
     pub async fn get_block(
@@ -425,28 +418,20 @@ where
             }
         }
 
-        if let Some(block_pointer) = self
+        let result = self
             .historical
-            .try_resolve(block)
+            .try_resolve_and_then(block, |source, pointer| source.get_block(pointer))
             .await
             .map_err(ChainStateError::DataSource)?
-        {
-            if let Some((header, transactions)) = self
-                .historical
-                .get_block(block_pointer)
-                .await
-                .map_err(ChainStateError::DataSource)?
-            {
-                return Ok(parse_block_content(
-                    header.hash_slow(),
-                    header,
-                    transactions,
-                    return_full_txns,
-                ));
-            }
-        }
+            .ok_or(ChainStateError::ResourceNotFound)?;
 
-        Err(ChainStateError::ResourceNotFound)
+        let (header, transactions) = result;
+        Ok(parse_block_content(
+            header.hash_slow(),
+            header,
+            transactions,
+            return_full_txns,
+        ))
     }
 
     /// Returns raw transaction receipts for a block.

--- a/monad-rpc/src/data/source/archive.rs
+++ b/monad-rpc/src/data/source/archive.rs
@@ -24,6 +24,7 @@ use monad_eth_types::TxEnvelopeWithSender;
 
 use super::{
     BlockCommitState, BlockPointer, DataSourceError, DataSourceResult, HistoricalDataSource,
+    HistoricalDataSourceExt,
 };
 
 #[derive(Clone)]
@@ -116,3 +117,5 @@ impl HistoricalDataSource for ArchiveDataSource {
         Ok(block.map(|b| b.header))
     }
 }
+
+impl HistoricalDataSourceExt for ArchiveDataSource {}

--- a/monad-rpc/src/data/source/historical.rs
+++ b/monad-rpc/src/data/source/historical.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::{future::Future, pin::Pin};
+
 use alloy_consensus::Header;
 use alloy_primitives::BlockHash;
 use async_trait::async_trait;
@@ -83,3 +85,24 @@ pub trait HistoricalDataSource: DynClone + Send + Sync {
 clone_trait_object!(HistoricalDataSource);
 
 pub type HistoricalDataSourceStack = DataSourceStack<Box<dyn HistoricalDataSource>>;
+
+pub trait HistoricalDataSourceExt: HistoricalDataSource + Sized {
+    async fn try_resolve_and_then<T, F>(
+        &self,
+        block: BlockTagOrHash,
+        f: F,
+    ) -> DataSourceResult<Option<T>>
+    where
+        F: for<'s> Fn(
+            &'s dyn HistoricalDataSource,
+            BlockPointer,
+        )
+            -> Pin<Box<dyn Future<Output = DataSourceResult<Option<T>>> + Send + 's>>,
+    {
+        if let Some(pointer) = self.try_resolve(block).await? {
+            f(self, pointer).await
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/monad-rpc/src/data/source/mod.rs
+++ b/monad-rpc/src/data/source/mod.rs
@@ -17,7 +17,7 @@ use monad_types::BlockId;
 
 pub use self::{
     archive::ArchiveDataSource,
-    historical::{HistoricalDataSource, HistoricalDataSourceStack},
+    historical::{HistoricalDataSource, HistoricalDataSourceExt, HistoricalDataSourceStack},
     stack::DataSourceStack,
     triedb::TriedbDataSource,
 };

--- a/monad-rpc/src/data/source/stack.rs
+++ b/monad-rpc/src/data/source/stack.rs
@@ -13,11 +13,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::{future::Future, pin::Pin};
+
 use async_trait::async_trait;
 
 use super::{
     BlockCommitState, BlockPointer, DataSourceError, DataSourceResult, HistoricalDataSource,
+    HistoricalDataSourceExt,
 };
+use crate::types::eth_json::BlockTagOrHash;
 
 #[derive(Clone)]
 pub struct DataSourceStack<T> {
@@ -30,17 +34,23 @@ impl<T> DataSourceStack<T> {
     }
 }
 
+fn split_terminating_error(err: DataSourceError) -> Result<DataSourceError, DataSourceError> {
+    match err {
+        err @ DataSourceError::Internal(_) => Err(err),
+    }
+}
+
 async fn execute_on_sources<S, T>(
     sources: &Box<[S]>,
-    f: impl AsyncFn(&S) -> DataSourceResult<Option<T>>,
+    f: impl for<'s> Fn(&'s S) -> Pin<Box<dyn Future<Output = DataSourceResult<Option<T>>> + Send + 's>>,
 ) -> DataSourceResult<Option<T>> {
     for source in sources {
         match f(source).await {
             Ok(Some(value)) => return Ok(Some(value)),
-            Ok(None) => continue,
-            Err(err) => match err {
-                DataSourceError::Internal(err) => return Err(DataSourceError::Internal(err)),
-            },
+            Ok(None) => {}
+            Err(err) => {
+                let _ = split_terminating_error(err)?;
+            }
         }
     }
 
@@ -56,8 +66,8 @@ where
         &self,
         commit_state: BlockCommitState,
     ) -> DataSourceResult<Option<BlockPointer>> {
-        execute_on_sources(&self.sources, async move |source| {
-            source.try_resolve_block_commit_state(commit_state).await
+        execute_on_sources(&self.sources, move |source| {
+            source.try_resolve_block_commit_state(commit_state)
         })
         .await
     }
@@ -66,8 +76,8 @@ where
         &self,
         block_number: u64,
     ) -> DataSourceResult<Option<BlockPointer>> {
-        execute_on_sources(&self.sources, async move |source| {
-            source.try_resolve_block_number(block_number).await
+        execute_on_sources(&self.sources, move |source| {
+            source.try_resolve_block_number(block_number)
         })
         .await
     }
@@ -76,8 +86,8 @@ where
         &self,
         block_hash: alloy_primitives::BlockHash,
     ) -> DataSourceResult<Option<BlockPointer>> {
-        execute_on_sources(&self.sources, async move |source| {
-            source.try_resolve_block_hash(block_hash).await
+        execute_on_sources(&self.sources, move |source| {
+            source.try_resolve_block_hash(block_hash)
         })
         .await
     }
@@ -91,19 +101,72 @@ where
             Vec<monad_eth_types::TxEnvelopeWithSender>,
         )>,
     > {
-        execute_on_sources(&self.sources, async move |source| {
-            source.get_block(pointer).await
-        })
-        .await
+        execute_on_sources(&self.sources, move |source| source.get_block(pointer)).await
     }
 
     async fn get_block_header(
         &self,
         pointer: BlockPointer,
     ) -> DataSourceResult<Option<alloy_consensus::Header>> {
-        execute_on_sources(&self.sources, async move |source| {
-            source.get_block_header(pointer).await
+        execute_on_sources(&self.sources, move |source| {
+            source.get_block_header(pointer)
         })
         .await
+    }
+}
+
+impl<T> HistoricalDataSourceExt for DataSourceStack<T>
+where
+    T: HistoricalDataSource + Clone,
+{
+    async fn try_resolve_and_then<U, F>(
+        &self,
+        block: BlockTagOrHash,
+        f: F,
+    ) -> DataSourceResult<Option<U>>
+    where
+        F: for<'s> Fn(
+            &'s dyn HistoricalDataSource,
+            BlockPointer,
+        )
+            -> Pin<Box<dyn Future<Output = DataSourceResult<Option<U>>> + Send + 's>>,
+    {
+        let mut last_err = None;
+        let mut pointer = None;
+
+        for source in &self.sources {
+            match source.try_resolve(block.clone()).await {
+                Ok(Some(p)) => {
+                    pointer = Some(p);
+                    break;
+                }
+                Ok(None) => continue,
+                Err(err) => {
+                    let err = split_terminating_error(err)?;
+                    last_err.get_or_insert(err);
+                    continue;
+                }
+            }
+        }
+
+        if let Some(ptr) = pointer {
+            for source in &self.sources {
+                match f(source, ptr).await {
+                    Ok(Some(value)) => return Ok(Some(value)),
+                    Ok(None) => continue,
+                    Err(err) => {
+                        let err = split_terminating_error(err)?;
+                        last_err.get_or_insert(err);
+                        continue;
+                    }
+                }
+            }
+        }
+
+        if let Some(err) = last_err {
+            Err(err)
+        } else {
+            Ok(None)
+        }
     }
 }

--- a/monad-rpc/src/data/source/triedb.rs
+++ b/monad-rpc/src/data/source/triedb.rs
@@ -24,6 +24,7 @@ use monad_types::SeqNum;
 
 use super::{
     BlockCommitState, BlockPointer, DataSourceError, DataSourceResult, HistoricalDataSource,
+    HistoricalDataSourceExt,
 };
 
 #[derive(Debug)]
@@ -151,3 +152,5 @@ where
         Ok(header.map(|h| h.header))
     }
 }
+
+impl<T> HistoricalDataSourceExt for TriedbDataSource<T> where T: Triedb + Send + Sync {}


### PR DESCRIPTION
The commit fixes a consistency gap in `HistoricalDataSource` usage. Previously, block tag resolution and data querying methods ran sequentially one after another. This means a pointer resolved by source A could be queried against source B, which may hold a different/inconsistent view. The new `try_resolve_and_then` implemented on the extension trait keeps resolve+query coupled within the same source. This is required for correct usage of the `DataSourceStack` module once we implement `HistoricalDataSource` for `BlockBufferView` which can resolve non-finalized blocks which could be inconsistent with what `TriedbReader` produces.