### PR TITLE
Raptorcast: Reject group invites with unreasonable round span

### DIFF
--- a/monad-raptorcast/src/config.rs
+++ b/monad-raptorcast/src/config.rs
@@ -172,6 +172,7 @@ pub struct RaptorCastConfigSecondaryPublisher<PT: PubKey> {
     pub group_scheduling: GroupSchedulingConfig,
 }
 
+#[cfg(test)]
 impl<PT: PubKey> Default for RaptorCastConfigSecondaryPublisher<PT> {
     fn default() -> RaptorCastConfigSecondaryPublisher<PT> {
         RaptorCastConfigSecondaryPublisher {
@@ -191,6 +192,7 @@ pub struct GroupSchedulingConfig {
     pub init_empty_round_span: Round, // like round_span but for the case when we need an empty, locked group right now
 }
 
+#[cfg(test)]
 impl Default for GroupSchedulingConfig {
     fn default() -> GroupSchedulingConfig {
         // Note: by default a Round lasts 500ms. See config entry ChainParams::vote_pace

--- a/monad-raptorcast/src/raptorcast_secondary/client.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/client.rs
@@ -33,6 +33,10 @@ use crate::{
     util::{SecondaryGroup, SecondaryGroupAssignment},
 };
 
+// Default full_node_raptorcast.round_span is 240. Refuse to accept
+// invites that exceed 4x that.
+pub(crate) const MAX_ACCEPTED_ROUND_SPAN: Round = Round(960);
+
 monad_executor::metric_consts! {
     pub CLIENT_NUM_CURRENT_GROUPS {
         name: "monad.bft.raptorcast.secondary.client.num_current_groups",
@@ -179,11 +183,20 @@ where
         &self,
         invite_msg: &PrepareGroup<CertificateSignaturePubKey<ST>>,
     ) -> bool {
-        // Sanity check the message
+        // Round span sanity checks
         if invite_msg.start_round >= invite_msg.end_round {
             warn!(
-                "RaptorCastSecondary rejecting invite message due to \
-                        failed sanity check: {:?}",
+                "RaptorCastSecondary rejecting invite message with \
+                   empty/malformed round span, invite = {:?}",
+                invite_msg
+            );
+            return false;
+        }
+        let span_len = invite_msg.end_round - invite_msg.start_round;
+        if span_len > MAX_ACCEPTED_ROUND_SPAN {
+            warn!(
+                "RaptorCastSecondary rejecting invite message with \
+                     round span exceeding max accepted span, invite = {:?}",
                 invite_msg
             );
             return false;
@@ -572,12 +585,20 @@ mod tests {
                 start_round: Round(5),
                 end_round: Round(6),
             },
-            // invalid round span
+            // round span backwards
             PrepareGroup {
                 max_group_size: 1,
                 validator_id: nid(2),
                 start_round: Round(7),
                 end_round: Round(5),
+            },
+            // unreasonably long round span
+            PrepareGroup {
+                max_group_size: 1,
+                validator_id: nid(2),
+                start_round: Round(5),
+                // 5 + MAX_ACCEPTED_ROUND_SPAN + 1
+                end_round: Round(966),
             },
         ];
 

--- a/monad-raptorcast/src/raptorcast_secondary/publisher.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/publisher.rs
@@ -234,10 +234,16 @@ where
             scheduling_cfg.max_invite_wait +
             scheduling_cfg.deadline_round_dist;
         if scheduling_cfg.init_empty_round_span < min_allowed_init_span {
-            panic!("init_empty_round_span infeasibly short");
+            panic!("full_node_raptorcast.init_empty_round_span infeasibly short");
         }
         if scheduling_cfg.invite_lookahead < min_allowed_init_span {
-            panic!("invite_lookahead infeasibly short");
+            panic!("full_node_raptorcast.invite_lookahead infeasibly short");
+        }
+        if scheduling_cfg.round_span > super::client::MAX_ACCEPTED_ROUND_SPAN {
+            panic!(
+                "full_node_raptorcast.round_span exceeds MAX_ACCEPTED_ROUND_SPAN({})",
+                super::client::MAX_ACCEPTED_ROUND_SPAN.0
+            );
         }
 
         // Remove duplicate entries from always_ask_full_nodes, but making sure


### PR DESCRIPTION
Impose a defensive limit on the length of accepted group span to avoid abuse.

Note: we can alternatively implement this limit as a config entry on `FullNodeRaptorCastConfig` (e.g. `full_node_raptorcast.invite_max_round_span`). Doing so would require all node ops to update their node config for a small defensive change.

**Note to node operators**: Please review the `full_node_raptorcast.round_span` config if your node participates in secondary raptorcast as a publisher. Please cap this config to be at most `960`, or your secondary group invites may be refused by clients. For reference, the default value defined in devnet node.toml is `240`.