### PR TITLE
feat(rpc): gate eth_simulateV1 behind a CLI flag

### DIFF
--- a/monad-rpc/src/cli.rs
+++ b/monad-rpc/src/cli.rs
@@ -173,6 +173,10 @@ pub struct Cli {
     #[arg(long, default_value_t = 2)]
     pub eth_call_executor_queuing_timeout: u32,
 
+    /// Enable the eth_simulateV1 method
+    #[arg(long, default_value_t = false)]
+    pub enable_eth_simulate_v1: bool,
+
     /// Set the gas limit for `eth_simulateV1` (default is 8 times Monad's block gas limit)
     #[arg(long, default_value_t = 200_000_000 * 8)]
     pub eth_simulate_gas_limit: u64,

--- a/monad-rpc/src/handlers/mod.rs
+++ b/monad-rpc/src/handlers/mod.rs
@@ -423,6 +423,9 @@ async fn eth_simulateV1(
     app_state: &MonadRpcResources,
     params: RequestParams<'_>,
 ) -> Result<Box<RawValue>, JsonRpcError> {
+    if !app_state.enable_eth_simulate_v1 {
+        return Err(JsonRpcError::method_not_supported());
+    }
     let data_provider = app_state.data_provider.as_ref().method_not_supported()?;
     let eth_call_handler = app_state.eth_call_handler.as_ref().method_not_supported()?;
     let params = serde_json::from_str(params.get()).invalid_params()?;

--- a/monad-rpc/src/handlers/resources.rs
+++ b/monad-rpc/src/handlers/resources.rs
@@ -46,6 +46,7 @@ pub struct MonadRpcResources {
     pub dry_run_get_logs_index: bool,
     pub use_eth_get_logs_index: bool,
     pub max_finalized_block_cache_len: u64,
+    pub enable_eth_simulate_v1: bool,
     pub metrics: Option<Metrics>,
     pub rpc_comparator: Option<RpcComparator>,
 }
@@ -68,6 +69,7 @@ impl MonadRpcResources {
         dry_run_get_logs_index: bool,
         use_eth_get_logs_index: bool,
         max_finalized_block_cache_len: u64,
+        enable_eth_simulate_v1: bool,
         metrics: Option<Metrics>,
         rpc_comparator: Option<RpcComparator>,
     ) -> Self {
@@ -87,6 +89,7 @@ impl MonadRpcResources {
             dry_run_get_logs_index,
             use_eth_get_logs_index,
             max_finalized_block_cache_len,
+            enable_eth_simulate_v1,
             metrics,
             rpc_comparator,
         }

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -378,6 +378,7 @@ async fn main() -> std::io::Result<()> {
         args.dry_run_get_logs_index,
         args.use_eth_get_logs_index,
         args.max_finalized_block_cache_len,
+        args.enable_eth_simulate_v1,
         with_metrics.clone(),
         rpc_comparator.clone(),
     );

--- a/monad-rpc/src/tests.rs
+++ b/monad-rpc/src/tests.rs
@@ -51,6 +51,7 @@ pub async fn init_server(
         dry_run_get_logs_index: false,
         use_eth_get_logs_index: false,
         max_finalized_block_cache_len: 200,
+        enable_eth_simulate_v1: false,
         metrics: None,
         rpc_comparator: None,
     };

--- a/monad-rpc/src/websocket/handler.rs
+++ b/monad-rpc/src/websocket/handler.rs
@@ -735,6 +735,7 @@ mod tests {
             dry_run_get_logs_index: false,
             use_eth_get_logs_index: false,
             max_finalized_block_cache_len: 200,
+            enable_eth_simulate_v1: false,
             metrics: None,
             rpc_comparator: None,
         };


### PR DESCRIPTION
## Summary

Adds a CLI flag to `monad-rpc` that controls whether the `eth_simulateV1` endpoint is active.

- New flag: `--enable-eth-simulate-v1` (default: `false`).
- When the flag is **not** set, `eth_simulateV1` returns a `Method not supported` JSON-RPC error.
- When set, the endpoint behaves exactly as before.

The flag is threaded `Cli` → `MonadRpcResources` and checked at the top of the `eth_simulateV1` handler, mirroring the existing `admin_ethCallStatistics` gating pattern (`--enable-admin-eth-call-statistics`). The method stays registered in the `enabled_methods!` macro — gating is done at runtime.

## Behavior change

`eth_simulateV1` was previously **always on**. With this change it defaults to **off (opt-in)**, so existing deployments must add `--enable-eth-simulate-v1` to keep it working. This was an explicit choice to match the `admin_*` opt-in precedent.

## Files changed

- `monad-rpc/src/cli.rs` — new `enable_eth_simulate_v1` arg
- `monad-rpc/src/handlers/resources.rs` — new field on `MonadRpcResources` + constructor
- `monad-rpc/src/main.rs` — pass arg into `MonadRpcResources::new`
- `monad-rpc/src/handlers/mod.rs` — runtime guard in the `eth_simulateV1` handler
- `monad-rpc/src/tests.rs`, `monad-rpc/src/websocket/handler.rs` — test struct literals updated

## Testing

- `cargo build -p monad-rpc` succeeds (with the C++ FFI toolchain).
- Integration test (assert rejection without the flag, success with it) to follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNq6gMxAL3443hN6eB1AFg