### PR TITLE
Generic simulation scheduler for MockSwarm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5697,6 +5697,7 @@ dependencies = [
  "monad-router-scheduler",
  "monad-secp",
  "monad-sim",
+ "monad-sim-swarm",
  "monad-state",
  "monad-testutil",
  "monad-tfm",
@@ -6136,6 +6137,15 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "rand_distr",
+]
+
+[[package]]
+name = "monad-sim-swarm"
+version = "0.1.0"
+dependencies = [
+ "monad-sim",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5696,6 +5696,7 @@ dependencies = [
  "monad-raptorcast",
  "monad-router-scheduler",
  "monad-secp",
+ "monad-sim",
  "monad-state",
  "monad-testutil",
  "monad-tfm",
@@ -6127,6 +6128,14 @@ dependencies = [
  "tiny-keccak",
  "wycheproof",
  "zeroize",
+]
+
+[[package]]
+name = "monad-sim"
+version = "0.1.0"
+dependencies = [
+ "rand 0.8.5",
+ "rand_distr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ monad-router-scheduler = { path = "./monad-router-scheduler" }
 monad-rpc-docs = { path = "./monad-rpc/monad-rpc-docs" }
 monad-rpc-docs-derive = { path = "./monad-rpc/monad-rpc-docs/monad-rpc-docs-derive" }
 monad-secp = { path = "./monad-secp" }
+monad-sim = { path = "./monad-sim" }
 monad-state = { path = "./monad-state" }
 monad-statesync-executor = { path = "./monad-statesync-executor" }
 monad-system-calls = { path = "./monad-system-calls" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ monad-rpc-docs = { path = "./monad-rpc/monad-rpc-docs" }
 monad-rpc-docs-derive = { path = "./monad-rpc/monad-rpc-docs/monad-rpc-docs-derive" }
 monad-secp = { path = "./monad-secp" }
 monad-sim = { path = "./monad-sim" }
+monad-sim-swarm = { path = "./monad-sim-swarm" }
 monad-state = { path = "./monad-state" }
 monad-statesync-executor = { path = "./monad-statesync-executor" }
 monad-system-calls = { path = "./monad-system-calls" }

--- a/monad-mock-swarm/Cargo.toml
+++ b/monad-mock-swarm/Cargo.toml
@@ -24,6 +24,8 @@ monad-executor-glue = { workspace = true }
 monad-multi-sig = { workspace = true }
 monad-raptorcast = { workspace = true, optional = true }
 monad-router-scheduler = { workspace = true }
+monad-sim = { workspace = true }
+monad-sim-swarm = { workspace = true }
 monad-state = { workspace = true }
 monad-testutil = { workspace = true }
 monad-tfm = { workspace = true }
@@ -64,4 +66,8 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [[bench]]
 name = "two_node_benchmark"
+harness = false
+
+[[bench]]
+name = "sim_engine"
 harness = false

--- a/monad-mock-swarm/README.md
+++ b/monad-mock-swarm/README.md
@@ -1,0 +1,39 @@
+# monad-mock-swarm
+
+Deterministic, single-threaded simulation of Monad consensus, for testing.
+
+The simulation drives the **real** production consensus code — `MonadState::update`
+plus the `Executor` / `Command` / `MonadEvent` contract — so tests exercise the
+same logic that runs in production. Only the surrounding environment (clock,
+network, ledger/mempool/state-sync) is mocked.
+
+During a transition this crate contains **two** engines:
+
+- **Simulation framework** (`sim`, `sim_verify`) — the going-forward engine: a
+  Monad-node harness built on the generic [`monad-sim`](../monad-sim)
+  discrete-event scheduler. See [`docs/simulation_framework.md`](docs/simulation_framework.md).
+- **Legacy engine** (`mock`, `mock_swarm`, `node`, `verifier`, `swarm`,
+  `transformer`, `terminator`) — per-component event queues. Retained until the
+  framework above is reviewed, then removed.
+
+## Layout
+
+| Path | Role |
+|---|---|
+| `src/sim.rs` | Layer B: node / network / harness (`SimNode`, `SimNet`, `Network`, `SimSwarm`) |
+| `src/sim_verify.rs` | assertions (`SimVerifier`) |
+| `tests/sim_*.rs` | the test suite on the new framework |
+| `tests/sim_common`, `tests/eth_swarm_common` | shared test helpers |
+| `benches/sim_engine.rs` | engine throughput vs the legacy engine |
+
+`monad-sim` (a separate crate) is Layer A — the generic, Monad-agnostic engine.
+
+## Running
+
+```sh
+cargo test  -p monad-sim -p monad-mock-swarm        # full suite (both engines)
+cargo test  -p monad-mock-swarm --test sim_two_nodes # one scenario
+cargo bench -p monad-mock-swarm --bench sim_engine   # throughput comparison
+```
+
+Heavy statistical tests are `#[ignore]`d; run them with `--ignored`.

--- a/monad-mock-swarm/benches/sim_engine.rs
+++ b/monad-mock-swarm/benches/sim_engine.rs
@@ -1,0 +1,159 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Wall-clock comparison of the legacy `Nodes` engine and the `monad-sim`
+//! harness driving the same `NoSerSwarm` consensus to the same committed-block
+//! target. Build time is excluded (measured per iteration via `iter_batched`).
+
+use std::{collections::BTreeSet, time::Duration};
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use monad_chain_config::{revision::ChainParams, MockChainConfig};
+use monad_consensus_types::{block::PassthruBlockPolicy, block_validator::MockValidator};
+use monad_crypto::certificate_signature::CertificateKeyPair;
+use monad_execution_state_read::InMemoryStateInner;
+use monad_mock_swarm::{
+    mock::TimestamperConfig,
+    mock_swarm::{Nodes, SwarmBuilder},
+    node::NodeBuilder,
+    sim::{build_swarm_with, Network, SimSwarm},
+    swarm::make_state_configs,
+    swarm_relation::NoSerSwarm,
+    terminator::UntilTerminator,
+};
+use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+use monad_sim::Time;
+use monad_transformer::{GenericTransformer, LatencyTransformer, ID};
+use monad_types::{NodeId, SeqNum};
+use monad_updaters::{
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
+};
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
+
+static CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(5),
+};
+
+const LATENCY: Duration = Duration::from_millis(1);
+const DELTA: Duration = Duration::from_millis(100);
+const TARGET: usize = 100;
+const NODE_COUNTS: [u16; 4] = [4, 16, 40, 64];
+
+fn build_existing(num_nodes: u16) -> Nodes<NoSerSwarm> {
+    let state_configs = make_state_configs::<NoSerSwarm>(
+        num_nodes,
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        || MockValidator,
+        || PassthruBlockPolicy,
+        || InMemoryStateInner::genesis(SeqNum(4)),
+        SeqNum(4),
+        DELTA,
+        MockChainConfig::new(&CHAIN_PARAMS),
+        SeqNum(100),
+    );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|c| NodeId::new(c.key.pubkey()))
+        .collect();
+    SwarmBuilder::<NoSerSwarm>(
+        state_configs
+            .into_iter()
+            .enumerate()
+            .map(|(seed, sb)| {
+                let state_read = sb.state_read.clone();
+                let validators = sb.locked_epoch_validators[0].clone();
+                NodeBuilder::<NoSerSwarm>::new(
+                    ID::new(NodeId::new(sb.key.pubkey())),
+                    sb,
+                    NoSerRouterConfig::new(all_peers.clone()).build(),
+                    MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
+                    MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
+                    MockLedger::new(state_read.clone()),
+                    MockStateSyncExecutor::new(state_read),
+                    vec![GenericTransformer::Latency(LatencyTransformer::new(
+                        LATENCY,
+                    ))],
+                    vec![],
+                    TimestamperConfig::default(),
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
+    )
+    .build()
+}
+
+fn run_existing(swarm: &mut Nodes<NoSerSwarm>) {
+    while swarm
+        .step_until(&mut UntilTerminator::new().until_block(TARGET))
+        .is_some()
+    {}
+}
+
+/// The legacy *parallel* path (rayon `batch_step_until`) — the one the new
+/// serial heap replaces. Benchmarked so the "dropping parallelism" trade is
+/// measured, not assumed.
+fn run_existing_batch(swarm: &mut Nodes<NoSerSwarm>) {
+    swarm.batch_step_until(&mut UntilTerminator::new().until_block(TARGET));
+}
+
+fn build_sim(num_nodes: u16) -> SimSwarm<NoSerSwarm> {
+    build_swarm_with(num_nodes, 0, |_| Network::reliable(LATENCY))
+}
+
+fn run_sim(swarm: &mut SimSwarm<NoSerSwarm>) {
+    swarm.run_until_blocks(TARGET, Time(i128::MAX));
+}
+
+fn benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("commit_blocks");
+    for n in NODE_COUNTS {
+        group.bench_function(format!("existing/{n}"), |b| {
+            b.iter_batched(
+                || build_existing(n),
+                |mut swarm| run_existing(&mut swarm),
+                BatchSize::SmallInput,
+            )
+        });
+        group.bench_function(format!("sim/{n}"), |b| {
+            b.iter_batched(
+                || build_sim(n),
+                |mut swarm| run_sim(&mut swarm),
+                BatchSize::SmallInput,
+            )
+        });
+        group.bench_function(format!("existing_batch/{n}"), |b| {
+            b.iter_batched(
+                || build_existing(n),
+                |mut swarm| run_existing_batch(&mut swarm),
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(20);
+    targets = benchmark
+}
+criterion_main!(benches);

--- a/monad-mock-swarm/docs/simulation_framework.md
+++ b/monad-mock-swarm/docs/simulation_framework.md
@@ -228,10 +228,10 @@ internal events through the scheduler:
 
 | nodes | legacy serial | new serial | new vs legacy |
 |------:|--------------:|-----------:|:-------------:|
-| 4     | 16.5 ms       | 14.6 ms    | 1.13×         |
-| 16    | 105.0 ms      | 90.1 ms    | 1.17×         |
-| 40    | 440.7 ms      | 363.0 ms   | 1.21×         |
-| 64    | 1001.7 ms     | 802.6 ms   | 1.25×         |
+| 4     | 17.0 ms       | 14.1 ms    | 1.21×         |
+| 16    | 112.8 ms      | 81.2 ms    | 1.39×         |
+| 40    | 488.9 ms      | 326.8 ms   | 1.50×         |
+| 64    | 1122.7 ms     | 723.0 ms   | 1.55×         |
 
 The new serial engine is faster than the legacy serial engine, the margin
 widening with node count — mostly from the `O(log E)` heap replacing the legacy's
@@ -242,6 +242,34 @@ favour of determinism + a single heap is deliberate. The step-metadata schema
 leaves room to parallelize the new queue later if large-swarm throughput ever
 matters (see [Future work](#future-work)). More detail in
 [Performance attribution](#performance-attribution).
+
+## Concurrency
+
+The engine maintains a deterministic **concurrency metric** in `SimMetrics`: the
+critical-path length `D` (`critical_path_len` — the longest chain of
+causally-dependent steps), the total step count `W` (`steps_executed`), and
+`parallelism() = W / D` (the average available parallelism). A step depends only
+on the step that scheduled it and the previous step on its own process, so the
+lent-state model makes this exact. It is an *upper bound*, in ticks, on the
+speedup any parallel execution of a run could reach.
+
+Measured on the happy-path `NoSerSwarm` (reliable 1 ms network, 100 committed
+blocks):
+
+| nodes | steps `W` | critical path `D` | parallelism `W/D` |
+|------:|----------:|------------------:|:-----------------:|
+| 2     | 2,836     | 1,470             | 1.93              |
+| 4     | 5,608     | 2,196             | 2.55              |
+| 16    | 22,710    | 7,951             | 2.86              |
+| 64    | 99,750    | 34,463            | 2.89              |
+
+Available parallelism rises then **plateaus around ~2.9× by 16 nodes** and does
+not grow with network size: both `W` and `D` scale ≈ linearly in N (each round the
+leader handles O(N) votes as a serial chain — the fan-in spine — so per-round
+depth ≈ O(N)). This is why *analyzing* the simulated system's concurrency is
+currently more valuable than parallelizing a single run; see
+[Concurrency, and why not to parallelize yet](#concurrency-and-why-not-to-parallelize-yet)
+and [Future work](#future-work).
 
 ## Test coverage
 
@@ -279,10 +307,25 @@ Coverage not yet ported is listed in [Future work](#future-work).
   cluster (and ideally that both orders of a same-instant internal-vs-external
   race are reached). This turns the same-tick-permutation capability into actual
   bug-finding leverage.
-- **Scheduler parallelism.** Parallelizing the top-level queue needs per-step
-  causal / minimum-latency metadata; the `StepLabel` schema reserves room for it
-  (`min_propagation`), but no parallel executor is built. Batching same-tick steps
-  is a cheaper intermediate win.
+- **Offline concurrency analyzer (higher priority).** Building on the shipped
+  critical-path metric, log per-step `{id, parent_id, process, time, cost}` and
+  analyze the run's dependency DAG: cost-weighted parallelism, the
+  parallelism-over-time profile, a `speedup(P)` curve, a conservative-window
+  replay (sweep lookahead `l`), and sub-process re-attribution (relabel processes
+  to test decomposition). This measures *whether* a protocol or scenario has
+  parallelism worth exploiting — and is the trigger for the next item. Its
+  per-source cost model is the same hook as the compute-cost model.
+- **Parallelize a single simulation run (lower priority for now).** Conservative
+  windowing (lookahead = min network latency); needs the per-step
+  `min_propagation` metadata (`StepLabel` reserves room) and per-process RNG. The
+  measured parallelism ceiling is only ~2.9× and **flat in N** (see
+  [Concurrency](#concurrency)), so real gains would be a fraction of that and
+  would not scale with network size — while independent simulations already
+  parallelize near-linearly. Revisit only if a future protocol lifts `W/D` (e.g.
+  pipelined / overlapping rounds — the analyzer will show it) or a single
+  un-shardable large run becomes a wall-clock bottleneck. Batching same-tick steps
+  is a cheaper, deterministic intermediate win. See
+  [Concurrency, and why not to parallelize yet](#concurrency-and-why-not-to-parallelize-yet).
 - **Compute-cost / backpressure model.** Today component executors emit at the
   current tick (zero local-processing latency) and buffers are unbounded. A
   per-operation cost hook would schedule internal reactions at `now + cost`
@@ -394,13 +437,42 @@ isolation (`Simulation::new` owns all its state; no shared `thread_local`) is wh
 makes that safe, which also unblocks the heavily-used independent-swarm
 parallelism in `forkpoint` / `randomized-tests`.
 
+### Concurrency, and why not to parallelize yet
+
+The [Concurrency](#concurrency) metric bounds what parallelizing a single run
+could buy, and for this protocol the bound is both small and non-scaling:
+
+- **`W/D` plateaus at ~2.9× and is flat in N.** Total work and critical path both
+  grow ≈ linearly with node count — `W` because per-node work is roughly constant,
+  `D` because each round the leader handles O(N) votes as a serial chain (the
+  fan-in spine). Their ratio stops rising once the fan-in dominates (~16 nodes
+  here), so more nodes or cores buy no more intra-run speedup.
+- **The achievable gain is a fraction of that ceiling.** Conservative windowing is
+  bounded by the lookahead (min network latency) plus barrier / load-imbalance
+  overhead, and is a net loss below ~8 nodes. The legacy rayon experiment (~3× at
+  large N) is the empirical anchor and matches the ~2.9 ceiling.
+- **The parallelism that scales is already exploited.** Independent simulations run
+  near-linearly across cores (seed sweeps, `forkpoint`, `randomized-tests`) — the
+  dominant workload. Intra-run parallelism only helps a single, un-shardable
+  simulation.
+- **It is also the wrong lever for larger networks.** A flat ~3× extends the
+  reachable node count by only ~2-3× (less under O(N²) messaging). Going
+  materially bigger means reducing `W` — cheaper per-event handling, same-tick
+  batching, abstracting all-to-all traffic — not a constant-factor parallel speedup.
+
+So the priority is to *analyze* the simulated system's concurrency (the metric,
+then the offline analyzer) rather than to parallelize the engine; the metric is
+the trigger to revisit. `W/D` here is unit-cost; the cost-weighted ceiling may be
+somewhat higher but, being flat in N, does not change the conclusion.
+
 ### Performance attribution
 
 The speedup has two sources, now measured separately. Converting the internal
 drain from synchronous calls to zero-delay scheduled steps (so internal events go
 through the heap in *both* engines, an apples-to-apples comparison) cost ~8% at
-N=4 rising to ~14% at N=64. Even after that, the new engine is 1.13×→1.25× faster
-than legacy serial, the margin widening with N. So the **data structure** (the
+N=4 rising to ~14% at N=64. Even after that, the new engine is still faster than
+legacy serial at every size (see [Performance](#performance)), the margin widening
+with N. So the **data structure** (the
 `O(log E)` heap replacing three nested `peek` scans) is the majority of the win
 and all of the scaling advantage; the drain conversion is a modest top-up. Batching
 same-tick steps could recover most of that ~14% later, alongside parallelization.

--- a/monad-mock-swarm/docs/simulation_framework.md
+++ b/monad-mock-swarm/docs/simulation_framework.md
@@ -1,0 +1,406 @@
+# Monad Simulation Framework
+
+## Status
+
+Implemented on branch `lars/mock-swarm-for-mcp`. The framework reproduces at
+least the coverage of the legacy `monad-mock-swarm` engine (every category of
+legacy test runs on it; see [Test coverage](#test-coverage)). The legacy engine
+remains in place until this is reviewed, then is removed.
+
+This document describes the architecture, the public seams, performance, and the
+work left for later. The deeper trade-off analysis behind the design choices is
+collected in [Design notes & rationale](#design-notes--rationale) so it does not
+interrupt the main read.
+
+## Motivation
+
+A simulation is valuable only if it exercises the *real* consensus code. The
+legacy engine does, but the machinery around it had grown hard to extend:
+
+- **Three nested event queues.** "What happens next?" was recomputed by scanning
+  a tree top to bottom every step: a swarm (`Nodes`) took the minimum over all
+  nodes (`O(N)`), each node (`Node`) took the minimum of its executor and a
+  per-node inbound queue, and each node's `MockExecutor` took the minimum over
+  eight heterogeneous component sources with two different readiness semantics,
+  glued together by an enum ordering and a per-node RNG.
+- The same simulated time was threaded through four data structures, and finding
+  the next event cost `O(N · components)` per step.
+- Adding a new component, protocol variant, or process kind (network, adversary)
+  meant touching all three layers.
+
+The framework separates three concerns cleanly and collapses the three queues
+into one:
+
+1. **Generic simulation infrastructure** (Layer A, `monad-sim`) — a
+   domain-agnostic discrete-event scheduler. No knowledge of Monad, consensus,
+   `MonadEvent`, or `Command`.
+2. **Application mocks & adapters** (Layer B, `monad-mock-swarm`) — the glue that
+   drives the real consensus logic inside the generic framework.
+3. **Shared production logic** (Layer C, unchanged) — `MonadState` and the
+   consensus / blocksync / mempool / statesync implementation.
+
+Secondary goals, both achieved: **simplify** (one heap instead of three nested
+scans) and, for the common serial case, **speed up** (`O(log E)` event selection;
+see [Performance](#performance)).
+
+**Hard invariant — no production-logic change.** Layer C, the seam-2 contract,
+and genuine production executors (e.g. `LoopbackExecutor`, the same struct
+`monad-node` runs) are untouched; that is what guarantees the simulation tests
+production code. The one trait-level change required was adding `+ Clone` to
+`SwarmRelation::TransportMessage` (needed for message duplication; every relation
+already satisfied it). Test/simulation code — including the mock executors — may
+change freely.
+
+## Architecture
+
+```
++---------------------------------------------------------------------+
+| Layer A - GENERIC simulation infrastructure          (monad-sim)    |
+|   Time, scheduler + queue, process handles + lent-state steps        |
+|   (Handle<S> / Ctx), run control, RNG/distributions, metrics.        |
+|   Agnostic about event types and component state.                    |
+|   ZERO knowledge of Monad / consensus / MonadEvent / Command.        |
++---------------------------------------------------------------------+
+        ^  seam 1:  Handle<S> / Ctx scheduler API
++---------------------------------------------------------------------+
+| Layer B - APP-SPECIFIC sim adapters & mocks      (monad-mock-swarm) |
+|   SimNode = framework-owned node state; in-process Command dispatch; |
+|   mock/prod executors driven via exec()+drain; SimNet network        |
+|   process with a declarative Network model; SimSwarm/SimVerifier.    |
++---------------------------------------------------------------------+
+        ^  seam 2:  Executor + Command + MonadEvent contract (unchanged)
++---------------------------------------------------------------------+
+| Layer C - SHARED production logic                     (unchanged)    |
+|   MonadState::update, Command/MonadEvent, split_commands,            |
+|   consensus / blocksync / mempool / statesync logic.                |
++---------------------------------------------------------------------+
+```
+
+### Layer A — the generic engine (`monad-sim`)
+
+A simulation is a time-ordered queue of *steps*. A step is a closure that runs at
+a specific `Time` and may schedule further steps. State lives in *processes*: any
+value `S: 'static` registered with `Simulation::spawn`, addressed by a typed
+`Handle<S>`. When a step scheduled against a handle runs, the framework lends it
+`&mut S` **exclusively** for that step, via a `Ctx` that can read time, sample
+randomness, and schedule more work — but cannot reach any other process's state.
+
+```rust
+impl Simulation {
+    pub fn new(seed: u64) -> Self;                 // fresh, isolated; the unit of reset
+    pub fn now(&self) -> Time;
+
+    pub fn spawn<S: 'static>(&mut self, state: S) -> Handle<S>;
+    pub fn schedule<S: 'static>(&mut self, who: Handle<S>, at: Time, label: StepLabel,
+                                step: impl FnOnce(&mut S, &mut Ctx) + 'static);
+    pub fn schedule_global(&mut self, at: Time, label: StepLabel,
+                           step: impl FnOnce(&mut Ctx) + 'static);
+
+    // run control — each returns why it stopped (RunOutcome)
+    pub fn run_to_completion(&mut self) -> RunOutcome;
+    pub fn run_until_time(&mut self, t: Time) -> RunOutcome;
+    pub fn run_steps(&mut self, n: u64) -> RunOutcome;
+    pub fn run_while(&mut self, pred: impl FnMut(&Simulation) -> bool) -> RunOutcome;
+
+    // between-step inspection / lifecycle
+    pub fn with<S: 'static, R>(&self, who: Handle<S>, f: impl FnOnce(&S) -> R) -> R;
+    pub fn with_mut<S: 'static, R>(&mut self, who: Handle<S>, f: impl FnOnce(&mut S) -> R) -> R;
+    pub fn despawn<S: 'static>(&mut self, who: Handle<S>) -> S;
+}
+```
+
+`Ctx` is the only capability a running step has besides its own `&mut S`: it can
+read time, `sample` randomness, and `schedule` / `schedule_global` / `spawn` more
+work. Cross-process interaction is therefore always "schedule a step on that
+handle." This keeps the engine agnostic about event and state types, and makes
+reentrancy impossible by construction (within a step you hold the only `&mut S`,
+and there is no `borrow()` to call) — see
+[Why the lent-state model](#why-the-lent-state-model).
+
+Every step carries a `StepLabel` (`source`, `kind`, `priority`) and is owned by a
+`ProcessId`, so steps are introspectable rather than opaque closures. Timers are
+expressed with `CancelToken` (schedule = arm, drop/cancel = reset).
+
+### Seam 1 — the scheduler API
+
+`Handle<S>` / `Ctx` (above) *is* seam 1. It is the boundary the legacy engine
+lacked: there was no abstraction between "the scheduler" and "a node," only
+ad-hoc closures capturing shared state. Concrete event types (`MonadEvent`) and
+component internals appear **only** inside Layer-B closures, never in a Layer-A
+signature. Layer A defines no `Process`, `Network`, or `EffectHandler` trait — a
+process is just some `S: 'static`, and command/effect dispatch is Layer B's job.
+
+### Layer B — a Monad node on the scheduler (`monad-mock-swarm::sim`)
+
+Each node is a `SimNode<S>` process. A scheduled step feeds one event to
+`state.update`, then dispatches the resulting commands in-process:
+
+- **Router / network** → outbound messages go to a `SimNet` network *process*
+  (seam 1b, below), which applies the network model and schedules delivery steps
+  on recipients.
+- **Timers** → `TimerCommand::Schedule` arms a `CancelToken`; `ScheduleReset`
+  cancels it.
+- **Ledger / TxPool / ValSet / StateSync / Loopback** → the existing executors
+  (production `LoopbackExecutor`, or mocks shared with `monad-testground` /
+  `monad-eth-ledger`) are reused unmodified: call `exec()`, then drain their
+  buffered events (`pop` / `next`) and re-inject each as a zero-delay step. Their
+  `ready()` / `Stream` / `pop` surface is used purely as a drain, never polled.
+
+`MonadEvent` and `Command` live only inside these closures. Routing internal
+reactions through the scheduler as zero-delay steps (rather than draining them
+synchronously) is what lets a same-tick network delivery interleave between a
+node's internal reactions, and is the hook a future compute-cost model would use
+(see [Future work](#future-work) and
+[Event ordering & interleaving](#event-ordering--interleaving)).
+
+### Seam 1b — the network as a process
+
+The network is just another process. `SimNet`'s state is a routing table plus a
+`NetworkModel`; a node's send schedules a routing step on `SimNet`, which samples
+the model and schedules deliver steps on the recipients. This makes the network
+model modular and swappable with no extra framework concept. The default is a
+declarative `Network` builder:
+
+```rust
+Network::reliable(delta)                       // constant latency, lossless
+Network::with_latency(distribution)            // per-message sampled latency
+    .loss(p)                                    // independent drop probability
+    .partition(window, [group_a, group_b])      // time-bounded network split
+    .drop_if(|link, msg| ...)                   // predicate drop (sees link.now)
+Network::custom(model)                          // a full NetworkModel impl
+```
+
+A `NetworkModel` returns the delays at which copies of a message are delivered:
+an empty result drops it, more than one duplicates it, and reordering needs no
+special handling (a smaller delay simply arrives first).
+
+### Seam 2 — the shared production contract (unchanged)
+
+`state.update(event) -> Vec<Command>`, `Command::split_commands`, and the
+`Executor` trait. Defined in Layer C, preserved exactly. This is what guarantees
+the simulation exercises production logic, and it is why the migration was
+possible without touching consensus.
+
+### Harness
+
+`SimSwarm<S>` wraps a `Simulation` and its node handles, exposing what tests need:
+
+- construction — `SimSwarm::from_builders(seed, builders, network)` (generic over
+  any `SwarmRelation`); `build_swarm` / `build_swarm_with` are `NoSerSwarm`
+  conveniences.
+- bounded run control — `run_until`, `run_until_blocks` (all nodes),
+  `run_until_any_blocks` (some node), `run_until_round`.
+- inspection / mutation between steps — `with_node`, `with_node_mut`,
+  `finalized_blocks`, `current_rounds`, `send_transaction`, `assert_agreement`.
+- node lifecycle — `remove_node` / `add_node` (restart-from-forkpoint tests),
+  `set_network` (mid-run reconfiguration).
+
+`SimVerifier` (`sim_verify.rs`) accumulates tick / ledger-length / per-node-metric
+expectations and checks them through `SimSwarm`'s public surface; metric selectors
+are written with the `sim_metric!` macro.
+
+## Determinism & event ordering
+
+The scheduler is deterministic. Steps are ordered by a total key
+`(time, tie_break, priority, seq)`:
+
+- **`priority`** classes mirror production's `ParentExecutor::poll_next` order, so
+  a node drains ready internal work before it services a same-tick network message
+  — production's anti-starvation direction.
+- **`tie_break`** selects the policy. The default `Fifo` makes `tie_break` a
+  constant, so ordering reduces to `(time, priority, seq)` — fully reproducible,
+  and the reason the test suite can assert *exact* ticks with no tolerance window.
+  `Randomized` shuffles same-tick steps across priority classes for fuzzing
+  (implemented in `monad-sim`; not yet wired through the `SimSwarm` harness — see
+  [Future work](#future-work)).
+
+Fuzzing in the legacy `monad-randomized-tests` comes from seeded transformers
+(latency jitter), which the network model preserves; the framework is therefore
+fuzzed Monte-Carlo over the simulation seed, not per-event. The fidelity
+trade-offs are analysed in
+[Event ordering & interleaving](#event-ordering--interleaving).
+
+## Performance
+
+`benches/sim_engine.rs` (criterion, 100 committed blocks, build excluded),
+comparing the legacy serial engine and the new serial engine, both routing
+internal events through the scheduler:
+
+| nodes | legacy serial | new serial | new vs legacy |
+|------:|--------------:|-----------:|:-------------:|
+| 4     | 16.5 ms       | 14.6 ms    | 1.13×         |
+| 16    | 105.0 ms      | 90.1 ms    | 1.17×         |
+| 40    | 440.7 ms      | 363.0 ms   | 1.21×         |
+| 64    | 1001.7 ms     | 802.6 ms   | 1.25×         |
+
+The new serial engine is faster than the legacy serial engine, the margin
+widening with node count — mostly from the `O(log E)` heap replacing the legacy's
+three nested `peek` scans. The legacy *parallel* (`rayon`) path was faster on
+large swarms, but it was used by exactly one test, was fragile (a safe-window
+bound sound only under uniform latency), and was non-deterministic; dropping it in
+favour of determinism + a single heap is deliberate. The step-metadata schema
+leaves room to parallelize the new queue later if large-swarm throughput ever
+matters (see [Future work](#future-work)). More detail in
+[Performance attribution](#performance-attribution).
+
+## Test coverage
+
+Tests for the new framework live in `tests/sim_*.rs`, added *additively* — the
+legacy tests stay in place and untouched until the legacy engine is removed, which
+minimizes merge conflicts and keeps a reference for parity. Shared helpers:
+`tests/sim_common` (the `NoSerConfig` builder and reusable custom network models)
+and `tests/eth_swarm_common` (the Eth relation and its `SimSwarm` builders).
+
+Ported categories: two-node and multi-node consensus + agreement; BLS signature
+collection; message delays and random latency; many-node (40) swarms; metrics;
+Eth execution with real transactions; nonces / NEC; reserve balance; epoch
+validator switching and boundary handling; blocksync (blackout / delay / timeout
+recovery); message-reordering recovery; forkpoint restart/recovery.
+
+Notable scenarios are expressed *declaratively* where the legacy mutated the
+transformer pipeline mid-run: a blackout becomes a time-bounded
+`Network::partition`, message filtering a `drop_if`, and restart-from-forkpoint
+uses the `remove_node` / `add_node` lifecycle API.
+
+`tests/sim_epoch_missing_valset.rs` is a regression gate (`#[should_panic]`) for
+an open production `todo!()` reachable at an epoch boundary under outage; it turns
+red when the production case is handled.
+
+Coverage not yet ported is listed in [Future work](#future-work).
+
+## Future work
+
+- **Per-node local / NTP clocks** and the clock-scheduling strategy that orders
+  steps across them. Prototyped privately but not extracted into `monad-sim`;
+  the engine runs a single global clock today. Porting the legacy
+  `timestamp_drift` test depends on this.
+- **Wire `TieBreak::Randomized` through the `SimSwarm` harness**, then add a
+  Monte-Carlo-over-seed test asserting agreement + liveness on a low-latency
+  cluster (and ideally that both orders of a same-instant internal-vs-external
+  race are reached). This turns the same-tick-permutation capability into actual
+  bug-finding leverage.
+- **Scheduler parallelism.** Parallelizing the top-level queue needs per-step
+  causal / minimum-latency metadata; the `StepLabel` schema reserves room for it
+  (`min_propagation`), but no parallel executor is built. Batching same-tick steps
+  is a cheaper intermediate win.
+- **Compute-cost / backpressure model.** Today component executors emit at the
+  current tick (zero local-processing latency) and buffers are unbounded. A
+  per-operation cost hook would schedule internal reactions at `now + cost`
+  instead of `now + 0` (the injection point already exists); bounded queues +
+  push-back would model backpressure. Both are Layer-B additions; no engine
+  rewrite. See [Compute-time fidelity](#compute-time-fidelity).
+- **Mock relocation (optional, separable).** Moving the sim-only mocks out of the
+  production crates (`monad-updaters`, `monad-router-scheduler`) into a
+  test-support crate. More entangled than it looks — `monad-testground` and
+  `monad-eth-ledger` consume the mocks / the `Mockable*` contract — so it is kept
+  off the critical path.
+- **Port other swarm/sim consumers.** `monad-debugger`, `monad-twins`,
+  `monad-peer-disc-swarm`, and `monad-randomized-tests` are separate one-off
+  drivers today; each could model its components as processes over `monad-sim`.
+  The `monad-debugger` port must preserve its GraphQL schema for the external UI.
+- **Relocate engine-independent coverage before deleting the legacy engine.** The
+  per-event `MonadEvent` RLP/serde round-trips in `two_nodes_bls` / `nonces` are
+  serialization coverage independent of the engine; extract them into standalone
+  serialization tests.
+
+---
+
+## Design notes & rationale
+
+Detail behind the choices above. Not needed to use or review the framework; kept
+for whoever revisits the design.
+
+### Why the lent-state model
+
+The alternative was a shared `Rc<RefCell>` / `Arc<Mutex>` node captured by
+closures. That converts aliasing bugs into *runtime* borrow panics / deadlocks on
+reentrancy — self-send, broadcast-to-self, synchronous signal handlers. With the
+framework owning node state and lending `&mut` exclusively per step, reentrancy is
+**non-representable**: within a step you hold the only `&mut S` and there is no
+`borrow()` to fail, and you cannot reach another process's state at all. Work that
+must happen "now" elsewhere is a zero-delay scheduled step. Every queued step also
+names its `ProcessId`, which is the basis for debugging and any future
+cross-handle parallelism. The migration cost was real (every `&mut Node` site
+became a scheduled step), but the bug class is designed out rather than merely
+discouraged.
+
+### Event ordering & interleaving
+
+Same-instant event ordering differs across the three engines, and *none* exactly
+reproduces production's priority. Two axes matter; do not conflate them.
+
+**1. Priority direction (internal vs. network).** Production
+(`ParentExecutor::poll_next`) polls the network *nearly last* — draining timers /
+ledger / txpool first — a deliberate anti-starvation design. The legacy sim
+*inverted* this (router first in its tie-break), exploring orderings production
+rules out. The framework is on the correct side: under `Fifo` the `priority`
+classes finish a node's ready internal work before the engine services the
+same-tick network `rx`, matching production's intent, enforced by the scheduler
+key rather than by an atomic drain.
+
+**2. Granularity (can a network event interleave *between* two internal
+reactions).** The legacy could (per-event peek-min). An early version of the
+framework drained a node's internal cascade synchronously and could *not* — a
+potential coverage gap. That is why internal reactions are now individual
+zero-delay steps: a same-tick delivery can again weave between them.
+
+Both axes are now covered, and they no longer conflict because `tie_break`
+precedes `priority` in the key: `Fifo` honours the production poll-order while
+`Randomized` fully shuffles across classes. `Randomized` is in fact a capability
+the legacy never had — the legacy fuzzed *timing* (latency jitter shifting events
+onto different ticks) and resolved genuinely same-tick collisions with fixed
+tie-breaks; a direct same-tick permutation is strictly more. This only ever
+concerns events at the *exact same tick*; with nonzero link latency a node's
+cascade and a delivery are strictly time-ordered, so the question is narrow, and
+consensus is designed to be robust to event order regardless. Deliberately *not*
+done: priority-respecting fuzzing (shuffle only within a class) — a clean future
+toggle (`priority` before `tie_break`), currently unneeded.
+
+### Compute-time fidelity
+
+A distinct axis from ordering, stated exactly so the sim's results are not
+over-read:
+
+- **No simulated-time latency for local processing.** Component executors emit at
+  the current tick; only timers, the timestamper period, and network latency
+  carry simulated-time delays. (Same in the legacy engine.)
+- **No backpressure.** Every component buffer is unbounded; `ready()` is never
+  false due to a full queue.
+- **Deferred execution/finalization *is* modeled, but as a fixed block count, not
+  a duration** (`execution_delay` / `state_root_delay` / `finalization_delay` are
+  `SeqNum`s). So a configured, deterministic, structural execution lag is in scope
+  (and its consequences, e.g. the statesync threshold), but emergent,
+  *compute-induced* slowness (CPU/DB/GC) is not.
+
+So the sim produces "a node falls behind / triggers blocksync / times out" from
+network-induced lag or a configured block-count offset, never from compute. The
+A/B/C separation makes growing into this safe and Layer-B-only: internal reactions
+already flow through the scheduler, so a per-operation cost hook would schedule
+them at `now + cost`; bounded queues + a feedback path would add backpressure, and
+global backpressure then *emerges* from per-node cost plus the network model. No
+engine rewrite — that would only be needed for real preemption/threads, which
+this does not require. (The legacy engine does not model this either, so it is not
+a cutover gate.)
+
+### Concurrency stance
+
+The simulation is single-threaded and deterministic. Internal parallelism in pure
+Layer-C computation that never touches the simulation environment (e.g.
+cryptographic primitives) is allowed and invisible — it produces no observable
+scheduling effect. Intra-simulation parallelism (the legacy `rayon`
+`batch_step_until`) was dropped on purpose (see [Performance](#performance)).
+Independent simulations still run in parallel across threads — the per-simulation
+isolation (`Simulation::new` owns all its state; no shared `thread_local`) is what
+makes that safe, which also unblocks the heavily-used independent-swarm
+parallelism in `forkpoint` / `randomized-tests`.
+
+### Performance attribution
+
+The speedup has two sources, now measured separately. Converting the internal
+drain from synchronous calls to zero-delay scheduled steps (so internal events go
+through the heap in *both* engines, an apples-to-apples comparison) cost ~8% at
+N=4 rising to ~14% at N=64. Even after that, the new engine is 1.13×→1.25× faster
+than legacy serial, the margin widening with N. So the **data structure** (the
+`O(log E)` heap replacing three nested `peek` scans) is the majority of the win
+and all of the scaling advantage; the drain conversion is a modest top-up. Batching
+same-tick steps could recover most of that ~14% later, alongside parallelization.

--- a/monad-mock-swarm/src/lib.rs
+++ b/monad-mock-swarm/src/lib.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// Legacy engine (per-component event queues). Retired once the simulation
+// framework below has been reviewed.
 pub mod mock;
 pub mod mock_swarm;
 pub mod node;
@@ -24,3 +26,8 @@ pub mod terminator;
 pub mod transformer;
 mod utils;
 pub mod verifier;
+
+// Simulation framework: a Monad-node harness over the generic `monad-sim`
+// discrete-event engine. See `sim` and the crate README / design doc.
+pub mod sim;
+pub mod sim_verify;

--- a/monad-mock-swarm/src/sim.rs
+++ b/monad-mock-swarm/src/sim.rs
@@ -1,0 +1,1014 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Layer B: drive real `MonadState` nodes (Layer C) through the generic
+//! `monad-sim` engine (Layer A).
+//!
+//! Each node is registered as a `monad-sim` process and driven entirely by
+//! scheduled steps: events feed `state.update`, and the resulting commands are
+//! dispatched in-process. Timers become [`CancelToken`]s; the
+//! ledger / txpool / valset / statesync / loopback executors are reused
+//! unmodified via `exec` + drain; outbound messages are routed through the
+//! generic network process ([`monad_sim_swarm::Net`], aliased `SimNet<S>`) whose
+//! behaviour is a declarative [`Network`] model. A [`SimNode`] plugs into that
+//! network via the [`monad_sim_swarm::SimClient`] seam, so any node process
+//! sharing the wire type could share one network.
+//!
+//! [`SimNode`] / [`Network`] are generic over [`SwarmRelation`]; the network,
+//! delivery, and swarm scaffolding are the protocol-agnostic `monad-sim-swarm`.
+//! [`SimSwarm`] is the harness — construction, bounded run control, and
+//! between-step inspection. [`SimSwarm::from_builders`] is the generic entry
+//! point; [`build_swarm`] / [`build_swarm_with`] are `NoSerSwarm` conveniences.
+
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    marker::PhantomData,
+    ops::Range,
+    time::Duration,
+};
+
+use bytes::Bytes;
+use futures::{executor::block_on, StreamExt};
+use monad_consensus_types::metrics::Metrics;
+use monad_crypto::certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey};
+use monad_executor::Executor;
+use monad_executor_glue::{
+    Command, Message, MonadEvent, RouterCommand, TimeoutVariant, TimerCommand,
+};
+use monad_router_scheduler::{RouterEvent, RouterScheduler};
+use monad_sim::{CancelToken, Ctx, Handle, Simulation, StepLabel, Time};
+/// The network model trait / its per-message context, from [`monad_sim_swarm`].
+/// `NetworkModel` is the generic (`Addr`, `Msg`) trait; a custom model for a
+/// Monad swarm implements it at `NetworkModel<NodeId<Pk<S>>, Transport<S>>`. The
+/// declarative builder is [`Network`] (below), a thin `SwarmRelation`-flavored
+/// facade over [`monad_sim_swarm::Network`].
+pub use monad_sim_swarm::NetworkModel;
+use monad_sim_swarm::{deliver_to, Net, SimClient};
+use monad_state::{Forkpoint, MonadStateBuilder, VerifiedMonadMessage};
+use monad_types::{NodeId, Round, GENESIS_ROUND};
+use monad_updaters::{
+    config_file::MockConfigFile, ledger::MockableLedger, loopback::LoopbackExecutor,
+    statesync::MockableStateSync, txpool::MockableTxPool, val_set::MockableValSetUpdater,
+};
+use monad_validator::validator_set::BoxedValidatorSetTypeFactory;
+use rand::distributions::Distribution;
+
+use crate::swarm_relation::{
+    DebugSwarmRelation, NoSerSwarm, SwarmRelation, SwarmRelationStateType,
+};
+pub type Link<S> = monad_sim_swarm::Link<NodeId<Pk<S>>>;
+
+type Pk<S> = CertificateSignaturePubKey<<S as SwarmRelation>::SignatureType>;
+type Ev<S> = MonadEvent<
+    <S as SwarmRelation>::SignatureType,
+    <S as SwarmRelation>::SignatureCollectionType,
+    <S as SwarmRelation>::ExecutionProtocolType,
+>;
+type Cmd<S> = Command<
+    Ev<S>,
+    VerifiedMonadMessage<
+        <S as SwarmRelation>::SignatureType,
+        <S as SwarmRelation>::SignatureCollectionType,
+        <S as SwarmRelation>::ExecutionProtocolType,
+    >,
+    <S as SwarmRelation>::SignatureType,
+    <S as SwarmRelation>::SignatureCollectionType,
+    <S as SwarmRelation>::ExecutionProtocolType,
+    <S as SwarmRelation>::BlockPolicyType,
+    <S as SwarmRelation>::ExecutionStateReadType,
+    <S as SwarmRelation>::ChainConfigType,
+    <S as SwarmRelation>::ChainRevisionType,
+>;
+type StateBuilder<S> = MonadStateBuilder<
+    <S as SwarmRelation>::SignatureType,
+    <S as SwarmRelation>::SignatureCollectionType,
+    <S as SwarmRelation>::ExecutionProtocolType,
+    <S as SwarmRelation>::BlockPolicyType,
+    <S as SwarmRelation>::ExecutionStateReadType,
+    <S as SwarmRelation>::ValidatorSetTypeFactory,
+    <S as SwarmRelation>::LeaderElection,
+    <S as SwarmRelation>::BlockValidator,
+    <S as SwarmRelation>::ChainConfigType,
+    <S as SwarmRelation>::ChainRevisionType,
+>;
+type Transport<S> = <S as SwarmRelation>::TransportMessage;
+
+type NodeEntry<S> = (NodeId<Pk<S>>, Handle<SimNode<S>>);
+
+/// The network process for a Monad swarm: the generic [`Net`] instantiated at
+/// this relation's node id and transport message.
+type SimNet<S> = Net<NodeId<Pk<S>>, Transport<S>>;
+
+fn dur(t: Time) -> Duration {
+    Duration::from_nanos(u64::try_from(t.0).expect("negative simulation time"))
+}
+
+/// Default wall-clock estimate period for a node.
+pub const DEFAULT_TIMESTAMP_PERIOD: Duration = Duration::from_millis(10);
+
+/// Same-time priority classes for a node's scheduled steps, mirroring
+/// production's `ParentExecutor::poll_next` order (lower runs first at a tick).
+/// Under `TieBreak::Fifo` this makes a node drain ready internal work before it
+/// services a same-tick network message (`RX`) — production's anti-starvation
+/// ordering, and the opposite of the legacy sim's network-first tie-break. Under
+/// `TieBreak::Randomized` these are ignored and same-tick steps are fully
+/// shuffled (see `monad_sim::TieBreak`). `ControlPanel` (1) and `ConfigLoader`
+/// (9) have no simulation analogue.
+///
+/// The values keep the *relative* order of `poll_next`; the absolute numbers
+/// (and the gaps) don't matter beyond that. NOTE: production's order is itself
+/// provisional — `poll_next` carries TODOs to deprioritize txpool ingestion and
+/// to prioritize consensus (router) messages. If those land, update these
+/// classes to match. Verified against `monad-updaters/src/parent.rs`.
+mod prio {
+    pub const TIMER: u32 = 0;
+    pub const LEDGER: u32 = 2;
+    pub const TXPOOL: u32 = 3;
+    pub const VAL_SET: u32 = 4;
+    pub const TIMESTAMP: u32 = 5;
+    pub const LOOPBACK: u32 = 6;
+    /// Network inbound (`Router`): serviced after ready internal work.
+    pub const RX: u32 = 7;
+    pub const STATESYNC: u32 = 8;
+}
+
+/// Configuration for one node in a [`SimSwarm`].
+///
+/// The new framework's node descriptor: it carries only what the simulation
+/// drives, keyed by [`NodeId`] directly, with no transformer pipelines (the
+/// network model lives in [`Network`] instead). Construct it with a struct
+/// literal; [`SimNodeBuilder::debug`] type-erases it into [`DebugSwarmRelation`].
+pub struct SimNodeBuilder<S: SwarmRelation> {
+    pub id: NodeId<Pk<S>>,
+    pub state_builder: StateBuilder<S>,
+    pub router_scheduler: S::RouterScheduler,
+    pub val_set_updater: S::ValSetUpdater,
+    pub txpool_executor: S::TxPoolExecutor,
+    pub ledger: S::Ledger,
+    pub statesync_executor: S::StateSyncExecutor,
+    pub timestamp_period: Duration,
+}
+
+impl<S: SwarmRelation> SimNodeBuilder<S> {
+    /// Box this builder into the debugger's type-erased [`DebugSwarmRelation`],
+    /// proving the simulation is generic over the swarm relation.
+    pub fn debug(self) -> SimNodeBuilder<DebugSwarmRelation>
+    where
+        S: SwarmRelation<
+            SignatureType = <DebugSwarmRelation as SwarmRelation>::SignatureType,
+            SignatureCollectionType = <DebugSwarmRelation as SwarmRelation>::SignatureCollectionType,
+            ExecutionProtocolType = <DebugSwarmRelation as SwarmRelation>::ExecutionProtocolType,
+            TransportMessage = <DebugSwarmRelation as SwarmRelation>::TransportMessage,
+            BlockPolicyType = <DebugSwarmRelation as SwarmRelation>::BlockPolicyType,
+            BlockValidator = <DebugSwarmRelation as SwarmRelation>::BlockValidator,
+            ExecutionStateReadType = <DebugSwarmRelation as SwarmRelation>::ExecutionStateReadType,
+            ChainConfigType = <DebugSwarmRelation as SwarmRelation>::ChainConfigType,
+            ChainRevisionType = <DebugSwarmRelation as SwarmRelation>::ChainRevisionType,
+        >,
+        S::RouterScheduler: Sync,
+        S::Ledger: Sync,
+    {
+        SimNodeBuilder {
+            id: self.id,
+            state_builder: MonadStateBuilder {
+                validator_set_factory: BoxedValidatorSetTypeFactory::new(
+                    self.state_builder.validator_set_factory,
+                ),
+                leader_election: Box::new(self.state_builder.leader_election),
+                block_validator: self.state_builder.block_validator,
+                block_policy: self.state_builder.block_policy,
+                state_read: self.state_builder.state_read,
+                key: self.state_builder.key,
+                certkey: self.state_builder.certkey,
+                beneficiary: self.state_builder.beneficiary,
+                forkpoint: self.state_builder.forkpoint,
+                locked_epoch_validators: self.state_builder.locked_epoch_validators,
+                block_sync_override_peers: self.state_builder.block_sync_override_peers,
+                maybe_blocksync_rng_seed: self.state_builder.maybe_blocksync_rng_seed,
+                consensus_config: self.state_builder.consensus_config,
+                whitelisted_statesync_nodes: self.state_builder.whitelisted_statesync_nodes,
+                statesync_expand_to_group: self.state_builder.statesync_expand_to_group,
+                _phantom: PhantomData,
+            },
+            router_scheduler: Box::new(self.router_scheduler),
+            val_set_updater: Box::new(self.val_set_updater),
+            txpool_executor: Box::new(self.txpool_executor),
+            ledger: Box::new(self.ledger),
+            statesync_executor: Box::new(self.statesync_executor),
+            timestamp_period: self.timestamp_period,
+        }
+    }
+}
+
+/// A single consensus node as a `monad-sim` process.
+pub struct SimNode<S: SwarmRelation> {
+    id: NodeId<Pk<S>>,
+    state: SwarmRelationStateType<S>,
+
+    router: S::RouterScheduler,
+    ledger: S::Ledger,
+    txpool: S::TxPoolExecutor,
+    val_set: S::ValSetUpdater,
+    statesync: S::StateSyncExecutor,
+    loopback: LoopbackExecutor<Ev<S>>,
+    config_file:
+        MockConfigFile<S::SignatureType, S::SignatureCollectionType, S::ExecutionProtocolType>,
+
+    /// One armed timer per variant; re-arming or resetting cancels the previous.
+    timers: HashMap<TimeoutVariant, CancelToken>,
+
+    // Wiring, set after the node and network are spawned.
+    me: Option<Handle<SimNode<S>>>,
+    net: Option<Handle<SimNet<S>>>,
+
+    timestamp_period: Duration,
+}
+
+impl<S: SwarmRelation> SimNode<S> {
+    fn me(&self) -> Handle<SimNode<S>> {
+        self.me.expect("node not wired")
+    }
+
+    fn net(&self) -> Handle<SimNet<S>> {
+        self.net.expect("node not wired")
+    }
+
+    /// Feed one event to the state machine and dispatch the resulting commands.
+    fn handle_event(&mut self, event: Ev<S>, ctx: &mut Ctx) {
+        let commands = self.state.update(event);
+        self.dispatch(commands, ctx);
+    }
+
+    fn dispatch(&mut self, commands: Vec<Cmd<S>>, ctx: &mut Ctx) {
+        let (
+            router_cmds,
+            timer_cmds,
+            ledger_cmds,
+            config_file_cmds,
+            val_set_cmds,
+            _timestamp_cmds,
+            txpool_cmds,
+            _control_panel_cmds,
+            loopback_cmds,
+            statesync_cmds,
+            _config_reload_cmds,
+        ) = <Cmd<S>>::split_commands(commands);
+
+        for command in timer_cmds {
+            match command {
+                TimerCommand::Schedule {
+                    duration,
+                    variant,
+                    on_timeout,
+                } => {
+                    if let Some(previous) = self.timers.remove(&variant) {
+                        previous.cancel();
+                    }
+                    let me = self.me();
+                    let token = ctx.schedule_after(
+                        me,
+                        duration,
+                        StepLabel::source("timer").priority(prio::TIMER),
+                        move |node, ctx| {
+                            node.timers.remove(&variant);
+                            node.handle_event(on_timeout, ctx);
+                        },
+                    );
+                    self.timers.insert(variant, token);
+                }
+                TimerCommand::ScheduleReset(variant) => {
+                    if let Some(previous) = self.timers.remove(&variant) {
+                        previous.cancel();
+                    }
+                }
+            }
+        }
+
+        self.ledger.exec(ledger_cmds);
+        self.txpool.exec(txpool_cmds);
+        self.val_set.exec(val_set_cmds);
+        self.loopback.exec(loopback_cmds);
+        self.statesync.exec(statesync_cmds);
+        self.config_file.exec(config_file_cmds);
+
+        let now = dur(ctx.now());
+        for command in router_cmds {
+            match command {
+                RouterCommand::Publish { target, message }
+                | RouterCommand::PublishWithPriority {
+                    target, message, ..
+                } => {
+                    self.router.send_outbound(now, target, message);
+                }
+                RouterCommand::AddEpochValidatorSet {
+                    epoch,
+                    epoch_start,
+                    validator_set,
+                } => {
+                    self.router
+                        .add_epoch_validator_set(epoch, epoch_start, validator_set);
+                }
+                RouterCommand::UpdateCurrentRound(epoch, round) => {
+                    self.router.update_current_round(epoch, round);
+                }
+                _ => {}
+            }
+        }
+
+        self.drain_router(ctx);
+        self.drain_executors(ctx);
+    }
+
+    /// Schedule an internal reaction as a zero-delay step on this node, so it
+    /// flows through the engine queue rather than being handled synchronously.
+    /// The step is tagged with its source's priority class (see [`prio`]), so
+    /// internal reactions interleave per the scheduler's ordering (see the
+    /// design doc, "Event ordering & interleaving").
+    fn schedule_event(&self, ctx: &mut Ctx, source: &'static str, event: Ev<S>) {
+        let priority = match source {
+            "ledger" => prio::LEDGER,
+            "txpool" => prio::TXPOOL,
+            "val_set" => prio::VAL_SET,
+            "loopback" => prio::LOOPBACK,
+            "rx" => prio::RX,
+            "statesync" => prio::STATESYNC,
+            other => unreachable!("unclassified internal step source: {other}"),
+        };
+        let me = self.me();
+        let label = StepLabel::source(source).priority(priority);
+        ctx.schedule(me, ctx.now(), label, move |node, ctx| {
+            node.handle_event(event, ctx)
+        });
+    }
+
+    /// Drain router events: hand outbound messages to the network process, and
+    /// schedule inbound messages for the state machine (zero-delay step).
+    fn drain_router(&mut self, ctx: &mut Ctx) {
+        let now = ctx.now();
+        while let Some(event) = self.router.step_until(dur(now)) {
+            match event {
+                RouterEvent::Tx(to, transport) => {
+                    let from = self.id;
+                    let net = self.net();
+                    ctx.schedule(net, now, StepLabel::source("route"), move |net, ctx| {
+                        net.send(ctx, from, to, transport)
+                    });
+                }
+                RouterEvent::Rx(from, message) => {
+                    self.schedule_event(ctx, "rx", message.event(from));
+                }
+            }
+        }
+    }
+
+    /// Drain the executors that emit events when ready, scheduling each as a
+    /// zero-delay step. Unlike a synchronous drain, a node's internal reaction
+    /// cascade unfolds across same-tick engine steps and can interleave with
+    /// other same-tick steps — finer-grained, and observable in the step log.
+    fn drain_executors(&mut self, ctx: &mut Ctx) {
+        while self.ledger.ready() {
+            if let Some(event) = block_on(self.ledger.next()) {
+                self.schedule_event(ctx, "ledger", event);
+            }
+        }
+        while self.txpool.ready() {
+            if let Some(event) = block_on(self.txpool.next()) {
+                self.schedule_event(ctx, "txpool", event);
+            }
+        }
+        while self.val_set.ready() {
+            if let Some(event) = block_on(self.val_set.next()) {
+                self.schedule_event(ctx, "val_set", event);
+            }
+        }
+        while self.loopback.ready() {
+            if let Some(event) = block_on(self.loopback.next()) {
+                self.schedule_event(ctx, "loopback", event);
+            }
+        }
+        while let Some(event) = self.statesync.pop() {
+            self.schedule_event(ctx, "statesync", event);
+        }
+    }
+
+    /// Periodic wall-clock estimate, re-scheduling itself every period.
+    fn timestamp_tick(&mut self, ctx: &mut Ctx) {
+        self.handle_event(
+            MonadEvent::TimestampUpdateEvent(dur(ctx.now()).as_nanos()),
+            ctx,
+        );
+        let me = self.me();
+        ctx.schedule_after(
+            me,
+            self.timestamp_period,
+            StepLabel::source("timestamp").priority(prio::TIMESTAMP),
+            |node, ctx| node.timestamp_tick(ctx),
+        );
+    }
+
+    /// Number of committed blocks (excluding genesis).
+    pub fn finalized_blocks(&self) -> usize {
+        self.ledger.get_finalized_blocks().len()
+    }
+
+    /// Current consensus round, or [`GENESIS_ROUND`] before consensus starts.
+    pub fn current_round(&self) -> Round {
+        self.state
+            .consensus()
+            .map_or(GENESIS_ROUND, |consensus| consensus.get_current_round())
+    }
+
+    /// Consensus metrics for this node.
+    pub fn metrics(&self) -> &Metrics {
+        self.state.metrics()
+    }
+
+    /// The node's full consensus state (epoch manager, role, live consensus,
+    /// …), for inspection between steps. Mirrors the legacy `Node::state` field.
+    pub fn state(&self) -> &SwarmRelationStateType<S> {
+        &self.state
+    }
+
+    /// Mutable access to the node's consensus state, for inspection that needs
+    /// `&mut` (e.g. [`MonadState::get_role`]).
+    pub fn state_mut(&mut self) -> &mut SwarmRelationStateType<S> {
+        &mut self.state
+    }
+
+    /// This node's committed ledger.
+    pub fn ledger(&self) -> &S::Ledger {
+        &self.ledger
+    }
+
+    /// The latest forkpoint the node has checkpointed, for restarting it. Panics
+    /// if none has been generated yet.
+    pub fn get_forkpoint(
+        &self,
+    ) -> Forkpoint<S::SignatureType, S::SignatureCollectionType, S::ExecutionProtocolType> {
+        self.config_file
+            .checkpoint
+            .clone()
+            .expect("no forkpoint generated")
+            .into()
+    }
+}
+
+impl<S: SwarmRelation> SimClient for SimNode<S> {
+    type Addr = NodeId<Pk<S>>;
+    type Message = Transport<S>;
+
+    fn wire(&mut self, me: Handle<Self>, net: Handle<SimNet<S>>) {
+        self.me = Some(me);
+        self.net = Some(net);
+    }
+
+    /// A message arrives from `from`: hand it to the router and process it.
+    fn receive(&mut self, from: NodeId<Pk<S>>, transport: Transport<S>, ctx: &mut Ctx) {
+        self.router.process_inbound(dur(ctx.now()), from, transport);
+        self.drain_router(ctx);
+    }
+}
+
+/* ************************************************************************** */
+/* Network */
+
+/// Declarative builder for a swarm's network behaviour — a `SwarmRelation`-typed
+/// facade over [`monad_sim_swarm::Network`], so callers keep the `Network<S>`
+/// ergonomics (and type inference from a `SwarmRelation` context) while the model
+/// itself lives in the generic crate. Start from [`reliable`](Network::reliable)
+/// or [`with_latency`](Network::with_latency) and layer conditions, or supply a
+/// [`custom`](Network::custom) model.
+pub struct Network<S: SwarmRelation>(monad_sim_swarm::Network<NodeId<Pk<S>>, Transport<S>>);
+
+impl<S: SwarmRelation> Default for Network<S> {
+    fn default() -> Self {
+        Self(monad_sim_swarm::Network::default())
+    }
+}
+
+impl<S: SwarmRelation> Network<S> {
+    /// Constant-latency, lossless network.
+    pub fn reliable(latency: Duration) -> Self {
+        Self(monad_sim_swarm::Network::reliable(latency))
+    }
+
+    /// Latency sampled per message from `distribution`.
+    pub fn with_latency(distribution: impl Distribution<Duration> + 'static) -> Self {
+        Self(monad_sim_swarm::Network::with_latency(distribution))
+    }
+
+    /// A fully custom model.
+    pub fn custom(model: impl NetworkModel<NodeId<Pk<S>>, Transport<S>> + 'static) -> Self {
+        Self(monad_sim_swarm::Network::custom(model))
+    }
+
+    /// Drop each message independently with probability `probability`.
+    pub fn loss(self, probability: f64) -> Self {
+        Self(self.0.loss(probability))
+    }
+
+    /// While `window` is active, drop messages crossing between the given groups
+    /// (a network split). Nodes absent from every group stay fully connected.
+    pub fn partition(
+        self,
+        window: Range<Time>,
+        groups: impl IntoIterator<Item = impl IntoIterator<Item = NodeId<Pk<S>>>>,
+    ) -> Self {
+        Self(self.0.partition(window, groups))
+    }
+
+    /// Drop messages for which `predicate` holds.
+    pub fn drop_if(self, predicate: impl Fn(&Link<S>, &Transport<S>) -> bool + 'static) -> Self {
+        Self(self.0.drop_if(predicate))
+    }
+}
+
+/* ************************************************************************** */
+/* Harness */
+
+/// A running swarm: the [`Simulation`] plus its node handles. Mirrors the parts
+/// of the legacy `Nodes` engine that tests need — bounded run control and
+/// ledger inspection — over the `monad-sim` runner.
+pub struct SimSwarm<S: SwarmRelation> {
+    sim: Simulation,
+    nodes: Vec<NodeEntry<S>>,
+    net: Handle<SimNet<S>>,
+}
+
+impl<S: SwarmRelation> SimSwarm<S> {
+    pub fn sim(&mut self) -> &mut Simulation {
+        &mut self.sim
+    }
+
+    pub fn node_ids(&self) -> Vec<NodeId<Pk<S>>> {
+        self.nodes.iter().map(|(id, _)| *id).collect()
+    }
+
+    /// Replace the network model between runs (mid-run reconfiguration). Like the
+    /// legacy `update_outbound_pipeline_for_all`, this affects messages sent
+    /// after the call; steps already scheduled keep their original delivery.
+    pub fn set_network(&mut self, network: impl FnOnce(&[NodeId<Pk<S>>]) -> Network<S>) {
+        let ids: Vec<NodeId<Pk<S>>> = self.node_ids();
+        let network = network(&ids);
+        let net = self.net;
+        self.sim.with_mut(net, |n| n.set_model(network.0));
+    }
+
+    /// Run every step scheduled at or before `deadline`.
+    pub fn run_until(&mut self, deadline: Time) {
+        self.sim.run_until_time(deadline);
+    }
+
+    /// Run until every node has committed `target` blocks or `deadline` passes.
+    /// Returns whether the target was reached (`false` on timeout, e.g. a stalled
+    /// network).
+    pub fn run_until_blocks(&mut self, target: usize, deadline: Time) -> bool {
+        let nodes = self.nodes.clone();
+        self.sim.run_while(|sim| {
+            sim.now() < deadline
+                && nodes
+                    .iter()
+                    .any(|(_, h)| sim.with(*h, SimNode::finalized_blocks) < target)
+        });
+        self.finalized_blocks().into_iter().min().unwrap_or(0) >= target
+    }
+
+    /// Run until *some* node has committed `target` blocks or `deadline` passes
+    /// (mirrors the legacy `until_block` terminator). Use this instead of
+    /// [`run_until_blocks`](Self::run_until_blocks) when a node is expected to lag
+    /// permanently (byzantine / blacked-out). Returns whether the target was
+    /// reached.
+    pub fn run_until_any_blocks(&mut self, target: usize, deadline: Time) -> bool {
+        let nodes = self.nodes.clone();
+        self.sim.run_while(|sim| {
+            sim.now() < deadline
+                && nodes
+                    .iter()
+                    .map(|(_, h)| sim.with(*h, SimNode::finalized_blocks))
+                    .max()
+                    .unwrap_or(0)
+                    < target
+        });
+        self.finalized_blocks().into_iter().max().unwrap_or(0) >= target
+    }
+
+    /// Run until some node reaches `target` round or `deadline` passes. Returns
+    /// whether the target was reached (`false` on timeout, e.g. a stalled network).
+    pub fn run_until_round(&mut self, target: Round, deadline: Time) -> bool {
+        let nodes = self.nodes.clone();
+        self.sim.run_while(|sim| {
+            sim.now() < deadline
+                && nodes
+                    .iter()
+                    .map(|(_, h)| sim.with(*h, SimNode::current_round))
+                    .max()
+                    .unwrap_or(GENESIS_ROUND)
+                    < target
+        });
+        self.current_rounds()
+            .into_iter()
+            .max()
+            .unwrap_or(GENESIS_ROUND)
+            >= target
+    }
+
+    /// Time of the next scheduled step, or `None` if the queue is empty.
+    pub fn peek_tick(&self) -> Option<Time> {
+        self.sim.peek_time()
+    }
+
+    /// The current simulation time.
+    pub fn current_tick(&self) -> Time {
+        self.sim.now()
+    }
+
+    /// Committed block count per node.
+    pub fn finalized_blocks(&self) -> Vec<usize> {
+        self.nodes
+            .iter()
+            .map(|(_, h)| self.sim.with(*h, SimNode::finalized_blocks))
+            .collect()
+    }
+
+    /// Current consensus round per node.
+    pub fn current_rounds(&self) -> Vec<Round> {
+        self.nodes
+            .iter()
+            .map(|(_, h)| self.sim.with(*h, SimNode::current_round))
+            .collect()
+    }
+
+    /// Submit a transaction to a node's mempool (as the test harness would).
+    pub fn send_transaction(&mut self, id: NodeId<Pk<S>>, tx: Bytes) {
+        let handle = self.handle(id);
+        self.sim
+            .with_mut(handle, |node| node.txpool.send_transaction(tx));
+    }
+
+    /// Read a node's state (ledger, consensus, metrics, ...).
+    pub fn with_node<R>(&self, id: NodeId<Pk<S>>, f: impl FnOnce(&SimNode<S>) -> R) -> R {
+        let handle = self.handle(id);
+        self.sim.with(handle, f)
+    }
+
+    /// Mutably access a node between steps — for inspection that needs `&mut`
+    /// (e.g. `MonadState::get_role`). Does not advance the simulation.
+    pub fn with_node_mut<R>(
+        &mut self,
+        id: NodeId<Pk<S>>,
+        f: impl FnOnce(&mut SimNode<S>) -> R,
+    ) -> R {
+        let handle = self.handle(id);
+        self.sim.with_mut(handle, f)
+    }
+
+    /// Remove a node from a running swarm and return it, so its ledger /
+    /// forkpoint / state-backend can be read before restarting it. Messages to
+    /// the node are dropped afterwards; steps already queued on it are skipped.
+    pub fn remove_node(&mut self, id: NodeId<Pk<S>>) -> SimNode<S> {
+        let pos = self
+            .nodes
+            .iter()
+            .position(|(node_id, _)| *node_id == id)
+            .expect("unknown node id");
+        let (_, handle) = self.nodes.remove(pos);
+        let net = self.net;
+        self.sim.with_mut(net, |n| n.deregister(&id));
+        self.sim.despawn(handle)
+    }
+
+    /// Add a node to a running swarm (e.g. a restarted node): wire it into the
+    /// network and dispatch its initial commands at the current time.
+    pub fn add_node(&mut self, builder: SimNodeBuilder<S>) {
+        let SimNodeBuilder {
+            id,
+            state_builder,
+            router_scheduler,
+            val_set_updater,
+            txpool_executor,
+            ledger,
+            statesync_executor,
+            timestamp_period,
+        } = builder;
+        assert!(
+            !self.nodes.iter().any(|(node_id, _)| *node_id == id),
+            "node {id} already present"
+        );
+        let net = self.net;
+        let (state, init_commands) = state_builder.build();
+        let handle = self.sim.spawn(SimNode {
+            id,
+            state,
+            router: router_scheduler,
+            ledger,
+            txpool: txpool_executor,
+            val_set: val_set_updater,
+            statesync: statesync_executor,
+            loopback: LoopbackExecutor::default(),
+            config_file: MockConfigFile::default(),
+            timers: HashMap::new(),
+            me: None,
+            net: None,
+            timestamp_period,
+        });
+        self.sim.with_mut(handle, |n| n.wire(handle, net));
+        let deliver = deliver_to(handle);
+        self.sim.with_mut(net, move |n| n.register(id, deliver));
+        self.nodes.push((id, handle));
+
+        let now = self.sim.now();
+        self.sim
+            .schedule(handle, now, StepLabel::source("init"), move |n, ctx| {
+                n.dispatch(init_commands, ctx);
+                n.timestamp_tick(ctx);
+            });
+    }
+
+    /// Panics if `id` is not a node in this swarm.
+    fn handle(&self, id: NodeId<Pk<S>>) -> Handle<SimNode<S>> {
+        self.nodes
+            .iter()
+            .find(|(node_id, _)| *node_id == id)
+            .map(|(_, handle)| *handle)
+            .expect("unknown node id")
+    }
+
+    /// Assert that every node agrees on the common prefix of committed blocks.
+    pub fn assert_agreement(&self) {
+        let ledgers: Vec<_> = self
+            .nodes
+            .iter()
+            .map(|(_, h)| {
+                self.sim
+                    .with(*h, |n| n.ledger.get_finalized_blocks().clone())
+            })
+            .collect();
+        let min_len = ledgers.iter().map(BTreeMap::len).min().unwrap_or(0);
+        let reference: Vec<_> = ledgers[0].iter().take(min_len).collect();
+        for ledger in &ledgers {
+            assert!(
+                ledger.iter().take(min_len).collect::<Vec<_>>() == reference,
+                "ledgers disagree on the committed prefix"
+            );
+        }
+    }
+
+    /// Build a running swarm from pre-built node components and kick it off. This
+    /// is the generic construction path: each [`SimNodeBuilder`] already carries
+    /// its node's executors, so any [`SwarmRelation`] works (e.g. the debugger's
+    /// boxed relation). Network behaviour comes from `network`, which receives the
+    /// node ids.
+    pub fn from_builders(
+        seed: u64,
+        builders: Vec<SimNodeBuilder<S>>,
+        network: impl FnOnce(&[NodeId<Pk<S>>]) -> Network<S>,
+    ) -> SimSwarm<S> {
+        let ids: Vec<NodeId<Pk<S>>> = builders.iter().map(|b| b.id).collect();
+
+        let mut sim = Simulation::new(seed);
+        let net = sim.spawn(SimNet::<S>::new(seed, network(&ids).0));
+
+        let mut pending = Vec::new();
+        for builder in builders {
+            let SimNodeBuilder {
+                id,
+                state_builder,
+                router_scheduler,
+                val_set_updater,
+                txpool_executor,
+                ledger,
+                statesync_executor,
+                timestamp_period,
+            } = builder;
+            let (state, init_commands) = state_builder.build();
+
+            let handle = sim.spawn(SimNode {
+                id,
+                state,
+                router: router_scheduler,
+                ledger,
+                txpool: txpool_executor,
+                val_set: val_set_updater,
+                statesync: statesync_executor,
+                loopback: LoopbackExecutor::default(),
+                config_file: MockConfigFile::default(),
+                timers: HashMap::new(),
+                me: None,
+                net: None,
+                timestamp_period,
+            });
+            sim.with_mut(handle, |n| n.wire(handle, net));
+            let deliver = deliver_to(handle);
+            sim.with_mut(net, move |n| n.register(id, deliver));
+            pending.push((id, handle, init_commands));
+        }
+
+        let nodes = pending
+            .iter()
+            .map(|(id, handle, _)| (*id, *handle))
+            .collect();
+        for (_, handle, init_commands) in pending {
+            sim.schedule(handle, Time(0), StepLabel::source("init"), move |n, ctx| {
+                n.dispatch(init_commands, ctx);
+                n.timestamp_tick(ctx);
+            });
+        }
+
+        SimSwarm { sim, nodes, net }
+    }
+}
+
+/* ************************************************************************** */
+/* NoSerSwarm construction */
+
+/// Build a `NoSerSwarm` swarm with the default (reliable) network.
+pub fn build_swarm(num_nodes: u16, seed: u64) -> SimSwarm<NoSerSwarm> {
+    build_swarm_with(num_nodes, seed, |_| Network::default())
+}
+
+/// Build a `num_nodes`-validator `NoSerSwarm` simulation and kick it off.
+/// `network` receives the node ids (so partitions can reference specific nodes)
+/// and returns the network behaviour.
+pub fn build_swarm_with(
+    num_nodes: u16,
+    seed: u64,
+    network: impl FnOnce(&[NodeId<Pk<NoSerSwarm>>]) -> Network<NoSerSwarm>,
+) -> SimSwarm<NoSerSwarm> {
+    SimSwarm::from_builders(seed, noser_builders(num_nodes), network)
+}
+
+/// Construct `NoSerSwarm` node builders with mock executors and the default
+/// chain config.
+fn noser_builders(num_nodes: u16) -> Vec<SimNodeBuilder<NoSerSwarm>> {
+    use monad_chain_config::{revision::ChainParams, MockChainConfig};
+    use monad_consensus_types::{block::PassthruBlockPolicy, block_validator::MockValidator};
+    use monad_execution_state_read::InMemoryStateInner;
+    use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+    use monad_types::SeqNum;
+    use monad_updaters::{
+        ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+        val_set::MockValSetUpdaterNop,
+    };
+    use monad_validator::{
+        simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory,
+    };
+
+    use crate::swarm::make_state_configs;
+
+    static CHAIN_PARAMS: ChainParams = ChainParams {
+        tx_limit: 10_000,
+        proposal_gas_limit: 300_000_000,
+        proposal_byte_limit: 4_000_000,
+        max_reserve_balance: 1_000_000_000_000_000_000,
+        vote_pace: Duration::from_millis(5),
+    };
+    let delta = Duration::from_millis(100);
+
+    let state_configs = make_state_configs::<NoSerSwarm>(
+        num_nodes,
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        || MockValidator,
+        || PassthruBlockPolicy,
+        || InMemoryStateInner::genesis(SeqNum(4)),
+        SeqNum(4),
+        delta,
+        MockChainConfig::new(&CHAIN_PARAMS),
+        SeqNum(100),
+    );
+    let all_peers: BTreeSet<NodeId<Pk<NoSerSwarm>>> = state_configs
+        .iter()
+        .map(|config| NodeId::new(config.key.pubkey()))
+        .collect();
+
+    state_configs
+        .into_iter()
+        .map(|config| {
+            let state_read = config.state_read.clone();
+            let validators = config.locked_epoch_validators[0].clone();
+            SimNodeBuilder {
+                id: NodeId::new(config.key.pubkey()),
+                state_builder: config,
+                router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                val_set_updater: MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
+                txpool_executor: MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
+                ledger: MockLedger::new(state_read.clone()),
+                statesync_executor: MockStateSyncExecutor::new(state_read),
+                timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use monad_sim::{
+        dist::normal_duration,
+        time::{millis, secs},
+    };
+
+    use super::*;
+
+    #[test]
+    fn generic_over_swarm_relation() {
+        use crate::swarm_relation::DebugSwarmRelation;
+
+        // The same nodes, boxed into the debugger's relation, run through the
+        // generic `from_builders` path — proving the sim is not tied to NoSerSwarm.
+        let builders = noser_builders(4)
+            .into_iter()
+            .map(SimNodeBuilder::debug)
+            .collect();
+        let mut swarm =
+            SimSwarm::<DebugSwarmRelation>::from_builders(0, builders, |_| Network::default());
+        swarm.run_until(Time(0) + secs(2));
+        assert!(swarm.finalized_blocks().iter().all(|&n| n >= 5));
+    }
+
+    #[test]
+    fn happy_path_tick_and_metrics() {
+        let mut swarm = build_swarm(4, 0);
+        assert!(swarm.run_until_blocks(20, Time(0) + secs(10)));
+
+        swarm.assert_agreement();
+        for id in swarm.node_ids() {
+            swarm.with_node(id, |node| {
+                let committed = node.finalized_blocks() as u64;
+                let m = node.metrics();
+                // happy path: voted on / handled at least every committed block,
+                // no blocksync, no out-of-order proposals.
+                assert!(m.consensus_events.created_vote.get() >= committed);
+                assert!(m.consensus_events.handle_proposal.get() >= committed);
+                assert_eq!(m.blocksync_events.self_headers_request.get(), 0);
+                assert_eq!(m.consensus_events.out_of_order_proposals.get(), 0);
+            });
+        }
+
+        // The scheduler is deterministic, so the final tick is an exact value;
+        // no `tick_range` tolerance is needed.
+        assert_eq!(swarm.current_tick(), Time(0) + millis(104));
+    }
+
+    #[test]
+    fn single_validator_commits_blocks() {
+        let mut swarm = build_swarm(1, 0);
+        swarm.run_until(Time(0) + secs(2));
+        assert!(swarm.finalized_blocks()[0] >= 10);
+    }
+
+    #[test]
+    fn multi_validator_commits_and_agrees() {
+        let mut swarm = build_swarm(4, 0);
+        assert!(swarm.run_until_blocks(10, Time(0) + secs(2)));
+        swarm.assert_agreement();
+    }
+
+    #[test]
+    fn run_until_round_reaches_target() {
+        use monad_types::Round;
+
+        let mut swarm = build_swarm(4, 0);
+        assert!(swarm.run_until_round(Round(20), Time(0) + secs(2)));
+        assert!(swarm.current_rounds().iter().any(|&r| r >= Round(20)));
+        swarm.assert_agreement();
+    }
+
+    #[test]
+    fn progresses_under_jittery_latency() {
+        let mut swarm = build_swarm_with(4, 0, |_| {
+            Network::with_latency(normal_duration(millis(2), millis(1)))
+        });
+        swarm.run_until(Time(0) + secs(2));
+        assert!(swarm.finalized_blocks().iter().all(|&n| n >= 5));
+    }
+
+    #[test]
+    fn even_split_partition_halts_progress() {
+        // A 2|2 split: neither side has a supermajority (3 of 4), so no blocks
+        // can commit while the partition holds.
+        let mut swarm = build_swarm_with(4, 0, |ids| {
+            Network::reliable(millis(1)).partition(
+                Time(0)..Time(i128::MAX),
+                [vec![ids[0], ids[1]], vec![ids[2], ids[3]]],
+            )
+        });
+        swarm.run_until(Time(0) + secs(2));
+        assert!(
+            swarm.finalized_blocks().iter().all(|&n| n == 0),
+            "expected no progress under an even split, got {:?}",
+            swarm.finalized_blocks()
+        );
+    }
+}

--- a/monad-mock-swarm/src/sim_verify.rs
+++ b/monad-mock-swarm/src/sim_verify.rs
@@ -1,0 +1,412 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Assertions for swarms driven through the `monad-sim` harness.
+//!
+//! This is the new framework's self-contained replacement for the legacy
+//! `MockSwarmVerifier` / `swarm_ledger_verification`. It drives a [`SimSwarm`]
+//! purely through its public surface ([`SimSwarm::with_node`],
+//! [`SimSwarm::node_ids`], [`SimSwarm::current_tick`]) and depends on none of
+//! the legacy engine.
+//!
+//! Collect expectations on a [`SimVerifier`] and call [`SimVerifier::assert`]
+//! (or [`SimVerifier::check`] for the `Result`). Metric selectors are written
+//! with the [`sim_metric!`] macro, e.g.
+//! `verifier.metric_min(&ids, sim_metric!(consensus_events.created_vote), n)`.
+
+use std::collections::BTreeMap;
+
+use monad_consensus_types::metrics::Metrics;
+use monad_crypto::certificate_signature::CertificateSignaturePubKey;
+use monad_sim::Time;
+use monad_types::NodeId;
+use monad_updaters::ledger::MockableLedger;
+
+use crate::{sim::SimSwarm, swarm_relation::SwarmRelation};
+
+type Pk<S> = CertificateSignaturePubKey<<S as SwarmRelation>::SignatureType>;
+type MetricSelector = Box<dyn Fn(&Metrics) -> u64>;
+
+/// Builds a `(name, selector)` pair for a [`Metrics`] field, for the
+/// `metric_*` methods on [`SimVerifier`]. The path is the field access minus
+/// the trailing `.get()`, e.g. `sim_metric!(consensus_events.local_timeout)`.
+#[macro_export]
+macro_rules! sim_metric {
+    ( $( $k:ident ).+ ) => {
+        (stringify!($($k).+), |m| m.$($k).+.get())
+    };
+}
+
+enum ExpectedTick {
+    Exact(Time),
+    Range(Time, Time),
+}
+
+#[derive(Clone, Debug)]
+enum ExpectedMetric {
+    Exact(u64),
+    Range(u64, u64),
+    Minimum(u64),
+    Maximum(u64),
+}
+
+/// Accumulates tick / ledger / per-node-metric expectations, then checks them
+/// against a [`SimSwarm`].
+pub struct SimVerifier<S: SwarmRelation> {
+    tick: Option<ExpectedTick>,
+    min_ledger_len: Option<usize>,
+    metrics: BTreeMap<(NodeId<Pk<S>>, &'static str), (MetricSelector, ExpectedMetric)>,
+}
+
+impl<S: SwarmRelation> Default for SimVerifier<S> {
+    fn default() -> Self {
+        Self {
+            tick: None,
+            min_ledger_len: None,
+            metrics: BTreeMap::new(),
+        }
+    }
+}
+
+impl<S: SwarmRelation> SimVerifier<S> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Expect the final tick to equal `tick` exactly.
+    pub fn tick_exact(&mut self, tick: Time) -> &mut Self {
+        self.tick = Some(ExpectedTick::Exact(tick));
+        self
+    }
+
+    /// Expect the final tick to fall within `[lower, upper]`.
+    pub fn tick_range(&mut self, lower: Time, upper: Time) -> &mut Self {
+        self.tick = Some(ExpectedTick::Range(lower, upper));
+        self
+    }
+
+    /// Expect every node's ledger to hold at least `min` finalized blocks.
+    pub fn ledger_min_len(&mut self, min: usize) -> &mut Self {
+        self.min_ledger_len = Some(min);
+        self
+    }
+
+    pub fn metric_exact<F: Fn(&Metrics) -> u64 + Clone + 'static>(
+        &mut self,
+        node_ids: &[NodeId<Pk<S>>],
+        metric: (&'static str, F),
+        value: u64,
+    ) -> &mut Self {
+        self.insert(node_ids, metric, ExpectedMetric::Exact(value))
+    }
+
+    pub fn metric_range<F: Fn(&Metrics) -> u64 + Clone + 'static>(
+        &mut self,
+        node_ids: &[NodeId<Pk<S>>],
+        metric: (&'static str, F),
+        lower: u64,
+        upper: u64,
+    ) -> &mut Self {
+        self.insert(node_ids, metric, ExpectedMetric::Range(lower, upper))
+    }
+
+    pub fn metric_min<F: Fn(&Metrics) -> u64 + Clone + 'static>(
+        &mut self,
+        node_ids: &[NodeId<Pk<S>>],
+        metric: (&'static str, F),
+        minimum: u64,
+    ) -> &mut Self {
+        self.insert(node_ids, metric, ExpectedMetric::Minimum(minimum))
+    }
+
+    pub fn metric_max<F: Fn(&Metrics) -> u64 + Clone + 'static>(
+        &mut self,
+        node_ids: &[NodeId<Pk<S>>],
+        metric: (&'static str, F),
+        maximum: u64,
+    ) -> &mut Self {
+        self.insert(node_ids, metric, ExpectedMetric::Maximum(maximum))
+    }
+
+    fn insert<F: Fn(&Metrics) -> u64 + Clone + 'static>(
+        &mut self,
+        node_ids: &[NodeId<Pk<S>>],
+        metric: (&'static str, F),
+        expected: ExpectedMetric,
+    ) -> &mut Self {
+        let (name, selector) = metric;
+        // Last write for a given (id, name) wins, matching the legacy map.
+        for &id in node_ids {
+            self.metrics
+                .insert((id, name), (Box::new(selector.clone()), expected.clone()));
+        }
+        self
+    }
+
+    /// Check all expectations, collecting every failure.
+    pub fn check(&self, swarm: &SimSwarm<S>) -> Result<(), Vec<String>> {
+        let mut failures = Vec::new();
+
+        if let Some(expected) = &self.tick {
+            let actual = swarm.current_tick();
+            match expected {
+                ExpectedTick::Exact(t) => {
+                    if actual != *t {
+                        failures.push(format!("tick: expected {:?}, got {:?}", t, actual));
+                    }
+                }
+                ExpectedTick::Range(lower, upper) => {
+                    if actual < *lower || actual > *upper {
+                        failures.push(format!(
+                            "tick: expected [{:?}, {:?}], got {:?}",
+                            lower, upper, actual
+                        ));
+                    }
+                }
+            }
+        }
+
+        if let Some(min) = self.min_ledger_len {
+            for id in swarm.node_ids() {
+                let len = swarm.with_node(id, |node| node.ledger().get_finalized_blocks().len());
+                if len < min {
+                    failures.push(format!(
+                        "ledger: node {} has {} finalized blocks, expected >= {}",
+                        id, len, min
+                    ));
+                }
+            }
+        }
+
+        for ((id, name), (selector, expected)) in &self.metrics {
+            let actual = swarm.with_node(*id, |node| selector(node.metrics()));
+            let ok = match expected {
+                ExpectedMetric::Exact(v) => actual == *v,
+                ExpectedMetric::Range(l, u) => actual >= *l && actual <= *u,
+                ExpectedMetric::Minimum(v) => actual >= *v,
+                ExpectedMetric::Maximum(v) => actual <= *v,
+            };
+            if !ok {
+                failures.push(format!(
+                    "metric {} on node {}: expected {:?}, got {}",
+                    name, id, expected, actual
+                ));
+            }
+        }
+
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(failures)
+        }
+    }
+
+    /// Check all expectations, panicking with every failure if any fail.
+    pub fn assert(&self, swarm: &SimSwarm<S>) {
+        if let Err(failures) = self.check(swarm) {
+            panic!("SimVerifier failed:\n  {}", failures.join("\n  "));
+        }
+    }
+
+    /// Happy-path consensus/blocksync expectations for the given nodes,
+    /// independent of the path their peers take. Mirrors the legacy
+    /// `MockSwarmVerifier::metrics_happy_path`. Call after running the swarm
+    /// (it reads each node's ledger to derive the per-node bounds).
+    pub fn metrics_happy_path(
+        &mut self,
+        node_ids: &[NodeId<Pk<S>>],
+        swarm: &SimSwarm<S>,
+    ) -> &mut Self {
+        let num_nodes_total = swarm.node_ids().len() as u64;
+        // TODO: add stake awareness
+        let super_majority_nodes = num_nodes_total * 2 / 3 + 1;
+        let max_byzantine_nodes = num_nodes_total - super_majority_nodes;
+
+        // initial local timeout
+        self.metric_exact(node_ids, sim_metric!(consensus_events.local_timeout), 1)
+            .metric_exact(
+                node_ids,
+                sim_metric!(consensus_events.failed_txn_validation),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(consensus_events.invalid_proposal_round_leader),
+                0,
+            )
+            // should not miss a block in between
+            .metric_exact(
+                node_ids,
+                sim_metric!(consensus_events.out_of_order_proposals),
+                0,
+            )
+            // initial TC. In the happy path a node should never create a TC otherwise.
+            .metric_exact(node_ids, sim_metric!(consensus_events.created_tc), 1)
+            .metric_exact(
+                node_ids,
+                sim_metric!(consensus_events.rx_execution_lagging),
+                0,
+            )
+            // first proposal in Round 2 with TC
+            .metric_max(node_ids, sim_metric!(consensus_events.proposal_with_tc), 1)
+            .metric_exact(
+                node_ids,
+                sim_metric!(consensus_events.failed_verify_randao_reveal_sig),
+                0,
+            )
+            // blocksync metrics: should not request blocksync
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.self_headers_request),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.self_payload_request),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.headers_response_successful),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.headers_response_failed),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.headers_response_unexpected),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.headers_validation_failed),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.payload_response_successful),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.payload_response_failed),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.payload_response_unexpected),
+                0,
+            );
+
+        for &node_id in node_ids {
+            let (ledger_len, num_blocks_authored) = swarm.with_node(node_id, |node| {
+                let ledger = node.ledger().get_finalized_blocks();
+                let ledger_len = ledger.len() as u64;
+                // ledger should have genesis block
+                assert!(ledger_len > 0);
+                // number of blocks authored in the ledger <= number of rounds as
+                // leader. NOTE: '<=' since blocks can be rejected.
+                let authored = ledger
+                    .values()
+                    .filter(|b| b.get_author() == &node_id)
+                    .count() as u64;
+                (ledger_len, authored)
+            });
+
+            // should handle a proposal for all blocks in the ledger
+            self.metric_min(
+                &[node_id],
+                sim_metric!(consensus_events.handle_proposal),
+                ledger_len,
+            )
+            // should vote for every block in the ledger
+            .metric_min(
+                &[node_id],
+                sim_metric!(consensus_events.created_vote),
+                ledger_len,
+            )
+            // votes from f peers after receiving 2f+1 votes as a leader; 2x
+            // because votes are sent to the current and next leader
+            .metric_max(
+                &[node_id],
+                sim_metric!(consensus_events.old_vote_received),
+                2 * (num_blocks_authored + 1) * max_byzantine_nodes,
+            )
+            // votes from 2f+1 peers as a leader, except if the node is leader in
+            // round 2 when it receives timeouts instead
+            .metric_min(
+                &[node_id],
+                sim_metric!(consensus_events.vote_received),
+                num_blocks_authored.saturating_sub(1) * super_majority_nodes,
+            )
+            // should create a QC every time the node is a leader, except for the
+            // block produced in round 2 which uses the TC from round 1
+            .metric_min(
+                &[node_id],
+                sim_metric!(consensus_events.created_qc),
+                num_blocks_authored.saturating_sub(1),
+            )
+            // a node processes an old QC (generated by itself) when it receives
+            // it in the proposal for the next round
+            .metric_min(
+                &[node_id],
+                sim_metric!(consensus_events.process_old_qc),
+                num_blocks_authored,
+            )
+            // should create proposals for all blocks authored in the ledger
+            .metric_min(
+                &[node_id],
+                sim_metric!(consensus_events.creating_proposal),
+                num_blocks_authored,
+            );
+        }
+
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use monad_sim::{time::secs, Time};
+
+    use super::*;
+    use crate::sim::build_swarm;
+
+    #[test]
+    fn happy_path_verifier_passes() {
+        let mut swarm = build_swarm(4, 0);
+        assert!(swarm.run_until_blocks(20, Time(0) + secs(10)));
+        let ids = swarm.node_ids();
+
+        let mut verifier = SimVerifier::new();
+        verifier.ledger_min_len(1).metrics_happy_path(&ids, &swarm);
+        verifier.assert(&swarm);
+    }
+
+    #[test]
+    fn detects_metric_mismatch() {
+        let mut swarm = build_swarm(4, 0);
+        assert!(swarm.run_until_blocks(10, Time(0) + secs(10)));
+        let ids = swarm.node_ids();
+
+        // local_timeout is 1 on the happy path; expecting 999 must fail.
+        let mut verifier = SimVerifier::new();
+        verifier.metric_exact(&ids, sim_metric!(consensus_events.local_timeout), 999);
+        assert!(verifier.check(&swarm).is_err());
+    }
+}

--- a/monad-mock-swarm/src/swarm_relation.rs
+++ b/monad-mock-swarm/src/swarm_relation.rs
@@ -89,7 +89,7 @@ where
     type ChainConfigType: ChainConfig<Self::ChainRevisionType> + Send + Unpin;
     type ChainRevisionType: ChainRevision + Send + Unpin;
 
-    type TransportMessage: PartialEq + Eq + Send + Sync + Unpin;
+    type TransportMessage: PartialEq + Eq + Send + Sync + Unpin + Clone;
 
     type BlockValidator: BlockValidator<
             Self::SignatureType,

--- a/monad-mock-swarm/tests/eth_swarm_common/mod.rs
+++ b/monad-mock-swarm/tests/eth_swarm_common/mod.rs
@@ -39,6 +39,7 @@ use monad_mock_swarm::{
     mock::TimestamperConfig,
     mock_swarm::{Nodes, SwarmBuilder},
     node::NodeBuilder,
+    sim::{SimNodeBuilder, SimSwarm, DEFAULT_TIMESTAMP_PERIOD},
     swarm::make_state_configs,
     swarm_relation::SwarmRelation,
 };
@@ -134,12 +135,12 @@ pub static CHAIN_PARAMS: ChainParams = ChainParams {
     vote_pace: Duration::from_millis(0),
 };
 
-pub fn generate_eth_swarm_with_accounts(
+pub fn eth_swarm_config_with_accounts(
     num_nodes: u16,
     existing_accounts: BTreeMap<Address, AccountState>,
     txpool_byzantine_config: impl Fn(usize) -> ByzantineConfig,
     validate_reserve_balance: bool,
-) -> Nodes<EthSwarm> {
+) -> SwarmBuilder<EthSwarm> {
     let epoch_length = SeqNum(2000);
     let execution_delay = SeqNum(4);
 
@@ -172,7 +173,7 @@ pub fn generate_eth_swarm_with_accounts(
         .iter()
         .map(|state_config| NodeId::new(state_config.key.pubkey()))
         .collect();
-    let swarm_config = SwarmBuilder::<EthSwarm>(
+    SwarmBuilder::<EthSwarm>(
         state_configs
             .into_iter()
             .enumerate()
@@ -198,9 +199,98 @@ pub fn generate_eth_swarm_with_accounts(
                 )
             })
             .collect(),
-    );
+    )
+}
 
-    swarm_config.build()
+pub fn generate_eth_swarm_with_accounts(
+    num_nodes: u16,
+    existing_accounts: BTreeMap<Address, AccountState>,
+    txpool_byzantine_config: impl Fn(usize) -> ByzantineConfig,
+    validate_reserve_balance: bool,
+) -> Nodes<EthSwarm> {
+    eth_swarm_config_with_accounts(
+        num_nodes,
+        existing_accounts,
+        txpool_byzantine_config,
+        validate_reserve_balance,
+    )
+    .build()
+}
+
+/// The `monad-sim` counterpart of [`generate_eth_swarm`]: returns the node
+/// builders ready to feed into [`SimSwarm::from_builders`]. Constructed directly
+/// (no transformer pipelines) so the new framework stays independent of the
+/// legacy `SwarmBuilder` / `NodeBuilder` path.
+pub fn eth_swarm_config(
+    num_nodes: u16,
+    existing_accounts: impl IntoIterator<Item = Address>,
+    txpool_byzantine_config: impl Fn(usize) -> ByzantineConfig,
+) -> Vec<SimNodeBuilder<EthSwarm>> {
+    let existing_accounts: BTreeMap<Address, AccountState> = existing_accounts
+        .into_iter()
+        .map(|acc| (acc, AccountState::max_balance()))
+        .collect();
+    eth_sim_builders_with_accounts(num_nodes, existing_accounts, txpool_byzantine_config, false)
+}
+
+/// `monad-sim` builders mirroring [`eth_swarm_config_with_accounts`].
+pub fn eth_sim_builders_with_accounts(
+    num_nodes: u16,
+    existing_accounts: BTreeMap<Address, AccountState>,
+    txpool_byzantine_config: impl Fn(usize) -> ByzantineConfig,
+    validate_reserve_balance: bool,
+) -> Vec<SimNodeBuilder<EthSwarm>> {
+    let epoch_length = SeqNum(2000);
+    let execution_delay = SeqNum(4);
+    let chain_config = MockChainConfig::new(&CHAIN_PARAMS);
+    let create_block_policy = || EthBlockPolicy::new(GENESIS_SEQ_NUM, execution_delay.0);
+
+    let state_configs = make_state_configs::<EthSwarm>(
+        num_nodes,
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        EthBlockValidator::default,
+        create_block_policy,
+        || {
+            let state = InMemoryStateInner::new(
+                execution_delay,
+                InMemoryBlockState::genesis(existing_accounts.clone()),
+            );
+            if validate_reserve_balance {
+                state.lock().unwrap().validate_reserve_balance = true;
+            }
+            state
+        },
+        execution_delay,
+        CONSENSUS_DELTA,
+        chain_config,
+        SeqNum(100),
+    );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|state_config| NodeId::new(state_config.key.pubkey()))
+        .collect();
+
+    state_configs
+        .into_iter()
+        .enumerate()
+        .map(|(idx, state_builder)| {
+            let validators = state_builder.locked_epoch_validators[0].clone();
+            let state_read = state_builder.state_read.clone();
+            SimNodeBuilder {
+                id: NodeId::new(state_builder.key.pubkey()),
+                state_builder,
+                router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                val_set_updater: MockValSetUpdaterNop::new(validators.validators, epoch_length),
+                txpool_executor: MockTxPoolExecutor::new(create_block_policy(), state_read.clone())
+                    .with_chain_params(&CHAIN_PARAMS)
+                    .with_byzantine_config(txpool_byzantine_config(idx)),
+                ledger: MockEthLedger::new(state_read.clone()),
+                statesync_executor: MockStateSyncExecutor::new(state_read),
+                timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+            }
+        })
+        .collect()
 }
 
 pub fn generate_eth_swarm(
@@ -244,6 +334,36 @@ pub fn verify_transactions_in_ledger(
                 "Expected transactions don't exist. NodeID: {}, TxnHashes: {:?}",
                 node_id, txns_to_see
             );
+            return false;
+        }
+    }
+
+    true
+}
+
+/// [`verify_transactions_in_ledger`] for a swarm driven by the `monad-sim` harness.
+pub fn verify_transactions_in_sim(swarm: &SimSwarm<EthSwarm>, txns: Vec<TxEnvelope>) -> bool {
+    let txns: HashSet<_> = HashSet::from_iter(txns.iter().map(|t| *t.tx_hash()));
+    for node_id in swarm.node_ids() {
+        let mut txns_to_see = txns.clone();
+        let consistent = swarm.with_node(node_id, |node| {
+            for (round, block) in node.ledger().get_finalized_blocks() {
+                for txn in &block.body().execution_body.transactions {
+                    let txn_hash = txn.tx_hash();
+                    if txns_to_see.contains(txn_hash) {
+                        txns_to_see.remove(txn_hash);
+                    } else {
+                        println!(
+                            "Unexpected transaction in block round {}. SeqNum: {}, NodeID: {}, TxnHash: {}, Nonce: {}",
+                            round.0, block.get_seq_num().0, node_id, txn_hash, txn.nonce()
+                        );
+                        return false;
+                    }
+                }
+            }
+            txns_to_see.is_empty()
+        });
+        if !consistent {
             return false;
         }
     }

--- a/monad-mock-swarm/tests/sim_block_sync.rs
+++ b/monad-mock-swarm/tests/sim_block_sync.rs
@@ -1,0 +1,321 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Blocksync-recovery coverage, ported onto the `monad-sim` harness (mirrors
+//! the legacy `block_sync.rs`, which it does not replace).
+//!
+//! The legacy tests blackout nodes by mutating the transformer pipeline mid-run
+//! (`Partition + Periodic(from,to) + Drop`); the new framework expresses the
+//! same thing declaratively with a time-bounded `Network::partition(from..to,
+//! groups)` — no mid-run mutation. After the window the partition heals and the
+//! blacked-out nodes catch up via blocksync.
+//!
+//! Ported here: `black_out_recovery_with_block_sync` (6 cases),
+//! `lack_of_progress`, `extreme_delay_recovery_with_block_sync`,
+//! `bsync_timeout_recovery`.
+//!
+//! NOTE on `bsync_timeout_recovery`: the legacy test's middle phase (reconnected
+//! but blocksync still banned) was effectively a no-op — its `until_tick(5s)`
+//! fired immediately because the clock was already at 5s. The port here
+//! implements the *intended* scenario with real time windows, which is stronger
+//! coverage: blackout `[0,5s)`, then `[5s,10s)` reconnected but blocksync
+//! dropped (the node can follow new rounds but can't backfill the gap), then
+//! open — only then can it catch up.
+
+mod sim_common;
+
+#[cfg(test)]
+mod test {
+    use std::{collections::BTreeSet, time::Duration};
+
+    use monad_chain_config::{revision::ChainParams, MockChainConfig};
+    use monad_consensus_types::{block::PassthruBlockPolicy, block_validator::MockValidator};
+    use monad_crypto::{
+        certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey},
+        NopSignature,
+    };
+    use monad_execution_state_read::InMemoryStateInner;
+    use monad_mock_swarm::{
+        sim::{Network, SimNodeBuilder, SimSwarm, DEFAULT_TIMESTAMP_PERIOD},
+        sim_metric,
+        sim_verify::SimVerifier,
+        swarm::make_state_configs,
+        swarm_relation::MonadMessageNoSerSwarm,
+    };
+    use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+    use monad_sim::{time::secs, Time};
+    use monad_state::VerifiedMonadMessage;
+    use monad_types::{NodeId, SeqNum};
+    use monad_updaters::{
+        ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+        val_set::MockValSetUpdaterNop,
+    };
+    use monad_validator::{
+        simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory,
+    };
+    use test_case::test_case;
+
+    use crate::sim_common::{NoSerConfig, WindowedDelay};
+
+    static CHAIN_PARAMS: ChainParams = ChainParams {
+        tx_limit: 10_000,
+        proposal_gas_limit: 300_000_000,
+        proposal_byte_limit: 4_000_000,
+        max_reserve_balance: 1_000_000_000_000_000_000,
+        vote_pace: Duration::from_millis(5),
+    };
+
+    #[test_case(4, Duration::from_millis(100), Duration::from_millis(200), Duration::from_secs(4), 1; "test 1")]
+    #[test_case(50, Duration::from_secs(1), Duration::from_secs(2), Duration::from_secs(4), 10; "test 2")]
+    #[test_case(50, Duration::from_secs(1), Duration::from_secs(2), Duration::from_secs(4), 25; "test 3")]
+    #[test_case(50, Duration::from_secs(1), Duration::from_secs(2), Duration::from_secs(4), 50; "test 4")]
+    #[test_case(10, Duration::from_secs(0), Duration::from_secs(2), Duration::from_secs(4), 3; "test 5")]
+    #[test_case(10, Duration::from_secs(0), Duration::from_secs(10), Duration::from_secs(20), 3; "test 6")]
+    fn black_out_recovery_with_block_sync(
+        num_nodes: u16,
+        from: Duration,
+        to: Duration,
+        until: Duration,
+        black_out_cnt: usize,
+    ) {
+        let delta = Duration::from_millis(20);
+        assert!(
+            from < to
+                && to < until
+                && black_out_cnt <= (num_nodes as usize)
+                && black_out_cnt >= 1
+                && num_nodes >= 4
+        );
+
+        // high execution delay so the state root doesn't trigger
+        let mut swarm = NoSerConfig::new(num_nodes, delta, &CHAIN_PARAMS)
+            .execution_delay(SeqNum::MAX)
+            .genesis_seqnum(SeqNum::MAX)
+            .statesync_threshold(SeqNum(2000))
+            .swarm(|ids| {
+                // blackout the first `black_out_cnt` nodes (key-gen order, matching
+                // the legacy `state_configs.iter().take(black_out_cnt)`) by
+                // partitioning them off from the rest during [from, to).
+                let blacked: Vec<_> = ids[..black_out_cnt].to_vec();
+                Network::reliable(delta).partition((Time(0) + from)..(Time(0) + to), [blacked])
+            });
+
+        swarm.run_until(Time(0) + until);
+
+        let ids = swarm.node_ids();
+        let running: Vec<_> = ids[black_out_cnt..].to_vec();
+        let ledger_len = swarm.finalized_blocks().into_iter().max().unwrap_or(0) as u64;
+
+        let mut verifier = SimVerifier::new();
+        verifier
+            // every node (incl. recovered) commits at least 20 blocks
+            .ledger_min_len(20)
+            // the never-partitioned nodes never need blocksync
+            .metric_exact(
+                &running,
+                sim_metric!(blocksync_events.self_headers_request),
+                0,
+            )
+            .metric_exact(
+                &running,
+                sim_metric!(blocksync_events.self_payload_request),
+                0,
+            )
+            .metric_min(
+                &running,
+                sim_metric!(consensus_events.handle_proposal),
+                ledger_len,
+            )
+            .metric_min(
+                &running,
+                sim_metric!(consensus_events.created_vote),
+                ledger_len,
+            );
+        verifier.assert(&swarm);
+    }
+
+    #[test]
+    fn extreme_delay_recovery_with_block_sync() {
+        // A few messages to/from the first node are delayed ~800ms during the
+        // window [1s, 2s); the node recovers via blocksync afterwards.
+        let delta = Duration::from_millis(50);
+        let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+            .execution_delay(SeqNum::MAX)
+            .genesis_seqnum(SeqNum::MAX)
+            .swarm(|ids| {
+                Network::custom(WindowedDelay {
+                    slow: ids[0],
+                    delta,
+                    window: (Time(0) + secs(1))..(Time(0) + secs(2)),
+                    extra: Duration::from_millis(800),
+                })
+            });
+
+        swarm.run_until(Time(0) + secs(8));
+
+        let ids = swarm.node_ids();
+        let running: Vec<_> = ids[1..].to_vec();
+        let ledger_len = swarm.finalized_blocks().into_iter().max().unwrap_or(0) as u64;
+
+        let mut verifier = SimVerifier::new();
+        verifier
+            .ledger_min_len(20)
+            .metric_exact(
+                &running,
+                sim_metric!(blocksync_events.self_headers_request),
+                0,
+            )
+            .metric_exact(
+                &running,
+                sim_metric!(blocksync_events.self_payload_request),
+                0,
+            )
+            .metric_min(
+                &running,
+                sim_metric!(consensus_events.handle_proposal),
+                ledger_len,
+            )
+            .metric_min(
+                &running,
+                sim_metric!(consensus_events.created_vote),
+                ledger_len,
+            );
+        verifier.assert(&swarm);
+    }
+
+    #[test]
+    fn lack_of_progress() {
+        let delta = Duration::from_millis(50);
+        let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+            .execution_delay(SeqNum::MAX)
+            .genesis_seqnum(SeqNum::MAX)
+            .swarm(|ids| {
+                // the first node is partitioned off forever — it can never make
+                // progress (the legacy asserts this via a ProgressTerminator that
+                // times out; here we assert the stuck node stays at zero).
+                let stuck = vec![ids[0]];
+                Network::reliable(delta).partition(Time(0)..Time(i128::MAX), [stuck])
+            });
+
+        swarm.run_until(Time(0) + secs(3));
+
+        let ids = swarm.node_ids();
+        let stuck = swarm.with_node(ids[0], |n| n.finalized_blocks());
+        assert_eq!(stuck, 0, "partitioned node should make no progress");
+        // the remaining supermajority keeps committing
+        for &id in &ids[1..] {
+            assert!(
+                swarm.with_node(id, |n| n.finalized_blocks()) > 0,
+                "connected node {id} made no progress"
+            );
+        }
+    }
+
+    /// A 4-node `MonadMessageNoSerSwarm` (its transport is `VerifiedMonadMessage`,
+    /// so the network model can match on message type).
+    fn mm_swarm(
+        delta: Duration,
+        network: impl FnOnce(
+            &[NodeId<CertificateSignaturePubKey<NopSignature>>],
+        ) -> Network<MonadMessageNoSerSwarm>,
+    ) -> SimSwarm<MonadMessageNoSerSwarm> {
+        let state_configs = make_state_configs::<MonadMessageNoSerSwarm>(
+            4,
+            ValidatorSetFactory::default,
+            SimpleRoundRobin::default,
+            || MockValidator,
+            || PassthruBlockPolicy,
+            || InMemoryStateInner::genesis(SeqNum::MAX),
+            SeqNum::MAX,
+            delta,
+            MockChainConfig::new(&CHAIN_PARAMS),
+            SeqNum(1000),
+        );
+        let all_peers: BTreeSet<_> = state_configs
+            .iter()
+            .map(|config| NodeId::new(config.key.pubkey()))
+            .collect();
+        let builders: Vec<SimNodeBuilder<MonadMessageNoSerSwarm>> = state_configs
+            .into_iter()
+            .map(|config| {
+                let state_read = config.state_read.clone();
+                let validators = config.locked_epoch_validators[0].clone();
+                SimNodeBuilder {
+                    id: NodeId::new(config.key.pubkey()),
+                    state_builder: config,
+                    router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                    val_set_updater: MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
+                    txpool_executor: MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
+                    ledger: MockLedger::new(state_read.clone()),
+                    statesync_executor: MockStateSyncExecutor::new(state_read),
+                    timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+                }
+            })
+            .collect();
+        SimSwarm::from_builders(0, builders, network)
+    }
+
+    #[test]
+    fn bsync_timeout_recovery() {
+        let delta = Duration::from_millis(50);
+        let blackout_end = Time(0) + secs(5);
+        let blocksync_ban_end = Time(0) + secs(10);
+
+        let mut swarm = mm_swarm(delta, |ids| {
+            let first = ids[0];
+            Network::reliable(delta)
+                // phase 1: first node fully partitioned off
+                .partition(Time(0)..blackout_end, [vec![first]])
+                // phases 1+2: blocksync messages dropped everywhere, so even once
+                // reconnected the first node cannot backfill the gap
+                .drop_if(move |link, msg| {
+                    link.now < blocksync_ban_end
+                        && matches!(
+                            msg,
+                            VerifiedMonadMessage::BlockSyncRequest(_)
+                                | VerifiedMonadMessage::BlockSyncResponse(_)
+                        )
+                })
+        });
+
+        let ids = swarm.node_ids();
+        let first = ids[0];
+        let running: Vec<_> = ids[1..].to_vec();
+
+        // phase 1: others make progress, the partitioned node commits nothing
+        swarm.run_until(blackout_end);
+        assert_eq!(
+            swarm.with_node(first, |n| n.finalized_blocks()),
+            0,
+            "blacked-out node should commit nothing"
+        );
+        for &id in &running {
+            assert!(swarm.with_node(id, |n| n.finalized_blocks()) >= 10);
+        }
+
+        // phase 2: reconnected, but blocksync still banned — still can't backfill
+        swarm.run_until(blocksync_ban_end);
+        assert_eq!(
+            swarm.with_node(first, |n| n.finalized_blocks()),
+            0,
+            "node cannot backfill while blocksync is banned"
+        );
+
+        // phase 3: blocksync allowed — the node catches up
+        swarm.run_until(Time(0) + secs(30));
+        SimVerifier::new().ledger_min_len(10).assert(&swarm);
+        swarm.assert_agreement();
+    }
+}

--- a/monad-mock-swarm/tests/sim_common/mod.rs
+++ b/monad-mock-swarm/tests/sim_common/mod.rs
@@ -1,0 +1,286 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Shared `NoSerSwarm` test wiring for the `monad-sim` ports. Self-contained
+//! (no legacy engine): builds [`SimNodeBuilder`]s and custom [`NetworkModel`]s.
+
+#![allow(dead_code)]
+
+use std::{collections::BTreeSet, ops::Range, time::Duration};
+
+use monad_chain_config::{revision::ChainParams, MockChainConfig};
+use monad_consensus_types::{block::PassthruBlockPolicy, block_validator::MockValidator};
+use monad_crypto::certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey, PubKey};
+use monad_execution_state_read::InMemoryStateInner;
+use monad_mock_swarm::{
+    sim::{Link, Network, NetworkModel, SimNodeBuilder, SimSwarm, DEFAULT_TIMESTAMP_PERIOD},
+    swarm::make_state_configs,
+    swarm_relation::{NoSerSwarm, SwarmRelation},
+};
+use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+use monad_sim::Time;
+use monad_types::{NodeId, Round, SeqNum};
+use monad_updaters::{
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
+};
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaChaRng;
+
+pub type NoSerPk = CertificateSignaturePubKey<<NoSerSwarm as SwarmRelation>::SignatureType>;
+type NoSerTransport = <NoSerSwarm as SwarmRelation>::TransportMessage;
+
+/// A configurable `NoSerSwarm` builder for the sim ports. Construct with
+/// [`NoSerConfig::new`], override knobs fluently, then [`builders`] or [`swarm`].
+pub struct NoSerConfig {
+    pub num_nodes: u16,
+    pub delta: Duration,
+    pub chain_params: &'static ChainParams,
+    pub execution_delay: SeqNum,
+    pub genesis_seqnum: SeqNum,
+    pub statesync_threshold: SeqNum,
+    pub epoch_length: SeqNum,
+    /// When set, the chain config uses epoch params (epoch boundaries every
+    /// `epoch_length` blocks, new epoch starting `epoch_start_delay` rounds
+    /// after the boundary block).
+    pub epoch_start_delay: Option<Round>,
+    pub seed: u64,
+}
+
+impl NoSerConfig {
+    pub fn new(num_nodes: u16, delta: Duration, chain_params: &'static ChainParams) -> Self {
+        Self {
+            num_nodes,
+            delta,
+            chain_params,
+            execution_delay: SeqNum(4),
+            genesis_seqnum: SeqNum(4),
+            statesync_threshold: SeqNum(100),
+            epoch_length: SeqNum(2000),
+            epoch_start_delay: None,
+            seed: 0,
+        }
+    }
+
+    pub fn execution_delay(mut self, v: SeqNum) -> Self {
+        self.execution_delay = v;
+        self
+    }
+
+    pub fn genesis_seqnum(mut self, v: SeqNum) -> Self {
+        self.genesis_seqnum = v;
+        self
+    }
+
+    pub fn statesync_threshold(mut self, v: SeqNum) -> Self {
+        self.statesync_threshold = v;
+        self
+    }
+
+    pub fn epoch_length(mut self, v: SeqNum) -> Self {
+        self.epoch_length = v;
+        self
+    }
+
+    pub fn epoch_start_delay(mut self, v: Round) -> Self {
+        self.epoch_start_delay = Some(v);
+        self
+    }
+
+    pub fn seed(mut self, v: u64) -> Self {
+        self.seed = v;
+        self
+    }
+
+    pub fn builders(&self) -> Vec<SimNodeBuilder<NoSerSwarm>> {
+        let genesis = self.genesis_seqnum;
+        let chain_config = match self.epoch_start_delay {
+            Some(delay) => {
+                MockChainConfig::new_with_epoch_params(self.chain_params, self.epoch_length, delay)
+            }
+            None => MockChainConfig::new(self.chain_params),
+        };
+        let state_configs = make_state_configs::<NoSerSwarm>(
+            self.num_nodes,
+            ValidatorSetFactory::default,
+            SimpleRoundRobin::default,
+            || MockValidator,
+            || PassthruBlockPolicy,
+            move || InMemoryStateInner::genesis(genesis),
+            self.execution_delay,
+            self.delta,
+            chain_config,
+            self.statesync_threshold,
+        );
+        let all_peers: BTreeSet<_> = state_configs
+            .iter()
+            .map(|config| NodeId::new(config.key.pubkey()))
+            .collect();
+        let epoch_length = self.epoch_length;
+        let chain_params = self.chain_params;
+        state_configs
+            .into_iter()
+            .map(|config| {
+                let state_read = config.state_read.clone();
+                let validators = config.locked_epoch_validators[0].clone();
+                SimNodeBuilder {
+                    id: NodeId::new(config.key.pubkey()),
+                    state_builder: config,
+                    router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                    val_set_updater: MockValSetUpdaterNop::new(validators.validators, epoch_length),
+                    txpool_executor: MockTxPoolExecutor::default().with_chain_params(chain_params),
+                    ledger: MockLedger::new(state_read.clone()),
+                    statesync_executor: MockStateSyncExecutor::new(state_read),
+                    timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+                }
+            })
+            .collect()
+    }
+
+    pub fn swarm(
+        &self,
+        network: impl FnOnce(&[NodeId<NoSerPk>]) -> Network<NoSerSwarm>,
+    ) -> SimSwarm<NoSerSwarm> {
+        SimSwarm::from_builders(self.seed, self.builders(), network)
+    }
+}
+
+/// Deterministic per-link latency = `max * (xor_of_pubkey_bytes / 255)`,
+/// matching the legacy `XorLatencyTransformer`.
+pub struct XorLatency {
+    pub max: Duration,
+}
+
+impl NetworkModel<NodeId<NoSerPk>, NoSerTransport> for XorLatency {
+    fn deliveries(
+        &mut self,
+        link: &Link<NoSerSwarm>,
+        _message: &NoSerTransport,
+        _rng: &mut ChaChaRng,
+    ) -> Vec<Duration> {
+        let mut ck: u8 = 0;
+        for b in link.from.pubkey().bytes() {
+            ck ^= b;
+        }
+        for b in link.to.pubkey().bytes() {
+            ck ^= b;
+        }
+        vec![self.max.mul_f32(ck as f32 / u8::MAX as f32)]
+    }
+}
+
+/// Base `delta` latency, plus `extra` for messages crossing the `slow` node's
+/// boundary while `window` is active. Matches the legacy
+/// `Partition(slow) + Periodic(window) + Latency(extra)` pipeline.
+pub struct WindowedDelay {
+    pub slow: NodeId<NoSerPk>,
+    pub delta: Duration,
+    pub window: Range<Time>,
+    pub extra: Duration,
+}
+
+impl NetworkModel<NodeId<NoSerPk>, NoSerTransport> for WindowedDelay {
+    fn deliveries(
+        &mut self,
+        link: &Link<NoSerSwarm>,
+        _message: &NoSerTransport,
+        _rng: &mut ChaChaRng,
+    ) -> Vec<Duration> {
+        let crossing = (link.from == self.slow) != (link.to == self.slow);
+        let extra = if crossing && self.window.contains(&link.now) {
+            self.extra
+        } else {
+            Duration::ZERO
+        };
+        vec![self.delta + extra]
+    }
+}
+
+/// Order in which [`ReplayNetwork`] bursts held messages.
+#[derive(Clone, Copy)]
+pub enum ReplayOrder {
+    Forward,
+    Reverse,
+    Random(u64),
+}
+
+/// Isolates `node` by holding every message crossing its boundary until
+/// `release`, then delivering the held messages in a tight burst at `release`,
+/// ordered per [`ReplayOrder`]. Everything else gets the base `delta` latency.
+/// Models the legacy inbound `Partition(node) + Replay(release, order)`.
+pub struct ReplayNetwork {
+    node: NodeId<NoSerPk>,
+    release: Time,
+    delta: Duration,
+    order: ReplayOrder,
+    rng: ChaChaRng,
+    held: u64,
+}
+
+impl ReplayNetwork {
+    pub fn new(node: NodeId<NoSerPk>, release: Time, delta: Duration, order: ReplayOrder) -> Self {
+        let seed = match order {
+            ReplayOrder::Random(seed) => seed,
+            _ => 0,
+        };
+        Self {
+            node,
+            release,
+            delta,
+            order,
+            rng: ChaChaRng::seed_from_u64(seed),
+            held: 0,
+        }
+    }
+}
+
+impl NetworkModel<NodeId<NoSerPk>, NoSerTransport> for ReplayNetwork {
+    fn deliveries(
+        &mut self,
+        link: &Link<NoSerSwarm>,
+        _message: &NoSerTransport,
+        _rng: &mut ChaChaRng,
+    ) -> Vec<Duration> {
+        let crossing = (link.from == self.node) != (link.to == self.node);
+        if crossing && link.now < self.release {
+            // Held: deliver at `release`, with a sub-ms offset that orders the
+            // burst. (Same delivery instant, different offsets -> the scheduler
+            // processes them in offset order.)
+            let to_release = (self.release.0 - link.now.0) as u64;
+            let idx = self.held % 1_000_000;
+            self.held += 1;
+            let offset = match self.order {
+                ReplayOrder::Forward => idx,
+                ReplayOrder::Reverse => 999_999 - idx,
+                ReplayOrder::Random(_) => self.rng.gen_range(0..1_000_000),
+            };
+            vec![Duration::from_nanos(to_release + offset)]
+        } else {
+            vec![self.delta]
+        }
+    }
+}
+
+/// A [`Network`] that holds and replays one node's messages — see
+/// [`ReplayNetwork`].
+pub fn replay_network(
+    node: NodeId<NoSerPk>,
+    release: Time,
+    delta: Duration,
+    order: ReplayOrder,
+) -> Network<NoSerSwarm> {
+    Network::custom(ReplayNetwork::new(node, release, delta, order))
+}

--- a/monad-mock-swarm/tests/sim_epoch.rs
+++ b/monad-mock-swarm/tests/sim_epoch.rs
@@ -1,0 +1,497 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Epoch / validator-set-change coverage, ported onto the `monad-sim` harness
+//! (mirrors the legacy `epoch.rs`, which it does not replace). All four legacy
+//! tests are ported: `validator_switching`, `schedule_and_advance_epoch`,
+//! `verify_correct_leaders_in_epoch`, and `schedule_epoch_after_blocksync`.
+//!
+//! `schedule_epoch_after_blocksync` uses `SimSwarm::set_network` (mid-run
+//! reconfiguration) to blackout a node for exactly the few blocks around the
+//! epoch boundary — matching the legacy's event-triggered blackout, so the node
+//! recovers via blocksync rather than statesync (and avoids a production
+//! `todo!` reached only when a node falls many blocks behind across a boundary).
+
+mod sim_common;
+
+#[cfg(test)]
+mod test {
+    use std::{collections::BTreeSet, time::Duration};
+
+    use monad_chain_config::{
+        revision::{ChainParams, MockChainRevision},
+        MockChainConfig,
+    };
+    use monad_consensus_types::{
+        block::{MockExecutionProtocol, PassthruBlockPolicy},
+        block_validator::MockValidator,
+    };
+    use monad_crypto::{
+        certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey},
+        NopSignature,
+    };
+    use monad_execution_state_read::{InMemoryState, InMemoryStateInner};
+    use monad_mock_swarm::{
+        sim::{Network, SimNodeBuilder, SimSwarm, DEFAULT_TIMESTAMP_PERIOD},
+        sim_metric,
+        sim_verify::SimVerifier,
+        swarm::make_state_configs,
+        swarm_relation::SwarmRelation,
+    };
+    use monad_multi_sig::MultiSig;
+    use monad_router_scheduler::{NoSerRouterConfig, NoSerRouterScheduler, RouterSchedulerBuilder};
+    use monad_sim::{time::secs, Time};
+    use monad_state::{MonadMessage, Role, VerifiedMonadMessage};
+    use monad_transformer::GenericTransformerPipeline;
+    use monad_types::{Epoch, NodeId, Round, SeqNum};
+    use monad_updaters::{
+        ledger::{MockLedger, MockableLedger},
+        statesync::MockStateSyncExecutor,
+        txpool::MockTxPoolExecutor,
+        val_set::MockValSetUpdaterSwap,
+    };
+    use monad_validator::{
+        simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory,
+    };
+    use test_case::test_case;
+
+    use crate::sim_common::NoSerConfig;
+
+    type Pk<S> = CertificateSignaturePubKey<<S as SwarmRelation>::SignatureType>;
+
+    static EPOCH_LENGTH: SeqNum = SeqNum(1000);
+
+    struct ValidatorSwapSwarm;
+    impl SwarmRelation for ValidatorSwapSwarm {
+        type SignatureType = NopSignature;
+        type SignatureCollectionType = MultiSig<Self::SignatureType>;
+        type ExecutionProtocolType = MockExecutionProtocol;
+        type ExecutionStateReadType =
+            InMemoryState<Self::SignatureType, Self::SignatureCollectionType>;
+        type BlockPolicyType = PassthruBlockPolicy;
+        type ChainConfigType = MockChainConfig;
+        type ChainRevisionType = MockChainRevision;
+
+        type TransportMessage = VerifiedMonadMessage<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >;
+
+        type BlockValidator = MockValidator;
+        type ValidatorSetTypeFactory =
+            ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
+        type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
+        type Ledger = MockLedger<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >;
+
+        type RouterScheduler = NoSerRouterScheduler<
+            CertificateSignaturePubKey<Self::SignatureType>,
+            MonadMessage<
+                Self::SignatureType,
+                Self::SignatureCollectionType,
+                Self::ExecutionProtocolType,
+            >,
+            VerifiedMonadMessage<
+                Self::SignatureType,
+                Self::SignatureCollectionType,
+                Self::ExecutionProtocolType,
+            >,
+        >;
+        type Pipeline = GenericTransformerPipeline<
+            CertificateSignaturePubKey<Self::SignatureType>,
+            Self::TransportMessage,
+        >;
+
+        type ValSetUpdater = MockValSetUpdaterSwap<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >;
+        type TxPoolExecutor = MockTxPoolExecutor<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+            Self::BlockPolicyType,
+            Self::ExecutionStateReadType,
+            Self::ChainConfigType,
+            Self::ChainRevisionType,
+        >;
+        type StateSyncExecutor = MockStateSyncExecutor<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >;
+    }
+
+    static CHAIN_PARAMS: ChainParams = ChainParams {
+        tx_limit: 10_000,
+        proposal_gas_limit: 300_000_000,
+        proposal_byte_limit: 4_000_000,
+        max_reserve_balance: 1_000_000_000_000_000_000,
+        vote_pace: Duration::from_millis(0),
+    };
+
+    /// Build a 4-node `ValidatorSwapSwarm` (consensus `delta`, network
+    /// `latency`) and return it alongside the genesis validator order (which the
+    /// swap updater rotates through across epochs).
+    fn swap_swarm(
+        epoch_length: SeqNum,
+        epoch_start_delay: Round,
+        delta: Duration,
+        latency: Duration,
+    ) -> (
+        SimSwarm<ValidatorSwapSwarm>,
+        Vec<NodeId<Pk<ValidatorSwapSwarm>>>,
+    ) {
+        let state_configs = make_state_configs::<ValidatorSwapSwarm>(
+            4,
+            ValidatorSetFactory::default,
+            SimpleRoundRobin::default,
+            || MockValidator,
+            || PassthruBlockPolicy,
+            || InMemoryStateInner::genesis(SeqNum(4)),
+            SeqNum(4),
+            delta,
+            MockChainConfig::new_with_epoch_params(&CHAIN_PARAMS, epoch_length, epoch_start_delay),
+            SeqNum(100),
+        );
+        let all_peers: BTreeSet<_> = state_configs
+            .iter()
+            .map(|config| NodeId::new(config.key.pubkey()))
+            .collect();
+        let genesis_validators: Vec<NodeId<Pk<ValidatorSwapSwarm>>> = state_configs[0]
+            .locked_epoch_validators[0]
+            .validators
+            .0
+            .iter()
+            .map(|vdata| vdata.node_id)
+            .collect();
+
+        let builders: Vec<SimNodeBuilder<ValidatorSwapSwarm>> = state_configs
+            .into_iter()
+            .map(|config| {
+                let state_read = config.state_read.clone();
+                let validators = config.locked_epoch_validators[0].clone();
+                SimNodeBuilder {
+                    id: NodeId::new(config.key.pubkey()),
+                    state_builder: config,
+                    router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                    val_set_updater: MockValSetUpdaterSwap::new(
+                        validators.validators,
+                        epoch_length,
+                    ),
+                    txpool_executor: MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
+                    ledger: MockLedger::new(state_read.clone()),
+                    statesync_executor: MockStateSyncExecutor::new(state_read),
+                    timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+                }
+            })
+            .collect();
+
+        let swarm = SimSwarm::from_builders(0, builders, |_| Network::reliable(latency));
+        (swarm, genesis_validators)
+    }
+
+    #[test_case(SeqNum(100), Round(10), 1000; "update_interval: 100, epoch_start_delay: 10")]
+    #[test_case(SeqNum(500), Round(10), 5000; "update_interval: 500, epoch_start_delay: 10")]
+    #[test_case(SeqNum(2000), Round(50), 20000; "update_interval: 2000, epoch_start_delay: 50")]
+    fn validator_switching(epoch_length: SeqNum, epoch_start_delay: Round, until_block: usize) {
+        let delta = Duration::from_millis(20);
+        let (mut swarm, _) = swap_swarm(epoch_length, epoch_start_delay, delta, delta);
+
+        assert!(
+            swarm.run_until_blocks(until_block, Time(0) + secs(6000)),
+            "did not reach {until_block} blocks"
+        );
+
+        let ids = swarm.node_ids();
+        // NOTE (carried from the legacy test): validator switching is mimicked
+        // with unstaked validators that still send messages, so metrics aren't
+        // pure happy-path. Only the timeout counts are pinned.
+        SimVerifier::new()
+            .ledger_min_len(until_block)
+            .metric_exact(&ids, sim_metric!(consensus_events.local_timeout), 1)
+            .metric_exact(&ids, sim_metric!(consensus_events.remote_timeout_msg), 3)
+            .assert(&swarm);
+    }
+
+    /* ---- epoch-manager inspection helpers (over the SimSwarm view) ---- */
+
+    fn verify_nodes_in_epoch<S: SwarmRelation>(
+        swarm: &SimSwarm<S>,
+        ids: &[NodeId<Pk<S>>],
+        epoch: Epoch,
+    ) {
+        assert!(!ids.is_empty());
+        for &id in ids {
+            swarm.with_node(id, |node| {
+                let round = node
+                    .state()
+                    .consensus()
+                    .expect("consensus is live")
+                    .get_current_round();
+                let current = node
+                    .state()
+                    .epoch_manager()
+                    .get_epoch(round)
+                    .expect("epoch exists");
+                assert_eq!(current, epoch, "node {id} not in {epoch:?}");
+            });
+        }
+    }
+
+    /// Verify every node scheduled `expected` to start the right number of
+    /// rounds after the boundary block, and that they agree on that round.
+    fn verify_nodes_scheduled_epoch<S: SwarmRelation>(
+        swarm: &SimSwarm<S>,
+        ids: &[NodeId<Pk<S>>],
+        boundary_block_num: SeqNum,
+        expected: Epoch,
+    ) -> Round {
+        assert!(!ids.is_empty());
+        let mut rounds = Vec::new();
+        for &id in ids {
+            let esr = swarm.with_node(id, |node| {
+                let blocks = node.ledger().get_finalized_blocks();
+                let boundary = blocks
+                    .values()
+                    .find(|b| b.get_seq_num() == boundary_block_num)
+                    .expect("boundary block committed");
+                let em = node.state().epoch_manager();
+                let esr = boundary.get_block_round() + em.epoch_start_delay;
+                assert_ne!(
+                    em.get_epoch(esr - Round(1)).expect("epoch exists"),
+                    expected
+                );
+                assert_eq!(em.get_epoch(esr).expect("epoch exists"), expected);
+                esr
+            });
+            rounds.push(esr);
+        }
+        assert!(
+            rounds.iter().all(|r| *r == rounds[0]),
+            "nodes disagree on epoch start round: {rounds:?}"
+        );
+        rounds[0]
+    }
+
+    fn verify_nodes_not_schedule_epoch<S: SwarmRelation>(
+        swarm: &SimSwarm<S>,
+        ids: &[NodeId<Pk<S>>],
+        expected: Epoch,
+    ) {
+        for &id in ids {
+            swarm.with_node(id, |node| {
+                assert!(
+                    !node
+                        .state()
+                        .epoch_manager()
+                        .epoch_starts
+                        .contains_key(&expected),
+                    "node {id} unexpectedly scheduled {expected:?}"
+                );
+            });
+        }
+    }
+
+    #[test]
+    fn schedule_and_advance_epoch() {
+        let delta = Duration::from_millis(20);
+        let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+            .execution_delay(SeqNum::MAX)
+            .genesis_seqnum(SeqNum::MAX)
+            .epoch_length(EPOCH_LENGTH)
+            .epoch_start_delay(Round(20))
+            .swarm(|_| Network::reliable(delta));
+
+        let boundary = EPOCH_LENGTH - SeqNum(1); // 999, the block that schedules epoch 2
+        let ids = swarm.node_ids();
+
+        // before the boundary: still epoch 1, epoch 2 not yet scheduled (run with
+        // a margin so no node has committed the boundary block).
+        assert!(swarm.run_until_blocks(boundary.0 as usize - 5, Time(0) + secs(600)));
+        verify_nodes_in_epoch(&swarm, &ids, Epoch(1));
+        verify_nodes_not_schedule_epoch(&swarm, &ids, Epoch(2));
+
+        // every node commits the boundary block: still epoch 1, but epoch 2 scheduled
+        assert!(swarm.run_until_blocks(boundary.0 as usize + 1, Time(0) + secs(600)));
+        verify_nodes_in_epoch(&swarm, &ids, Epoch(1));
+        let epoch_start_round = verify_nodes_scheduled_epoch(&swarm, &ids, boundary, Epoch(2));
+
+        // advance into epoch 2 (a few rounds past the boundary so every node,
+        // not just the leader, has crossed it)
+        assert!(swarm.run_until_round(epoch_start_round + Round(5), Time(0) + secs(600)));
+        verify_nodes_in_epoch(&swarm, &ids, Epoch(2));
+    }
+
+    #[test]
+    fn verify_correct_leaders_in_epoch() {
+        let delta = Duration::from_millis(40);
+        let latency = Duration::from_millis(20);
+        let (mut swarm, genesis) = swap_swarm(EPOCH_LENGTH, Round(20), delta, latency);
+        let ids = swarm.node_ids();
+
+        // the swap updater uses genesis validators for epoch 1, the first half
+        // for epoch 2, the second half for epoch 3.
+        let (epoch_2_vals, epoch_3_vals) = genesis.split_at(2);
+        let epoch_2_vals = epoch_2_vals.to_vec();
+        let epoch_3_vals = epoch_3_vals.to_vec();
+
+        let boundary_1 = EPOCH_LENGTH - SeqNum(1); // 999
+        assert!(swarm.run_until_blocks(boundary_1.0 as usize + 1, Time(0) + secs(600)));
+        // epoch 1: all genesis validators are Validators
+        for &v in &genesis {
+            assert_eq!(
+                swarm.with_node_mut(v, |n| n.state_mut().get_role()),
+                Role::Validator
+            );
+        }
+        verify_nodes_in_epoch(&swarm, &ids, Epoch(1));
+        let epoch_2_start = verify_nodes_scheduled_epoch(&swarm, &ids, boundary_1, Epoch(2));
+
+        // epoch 2: first half are Validators, second half become FullNodes
+        assert!(swarm.run_until_round(epoch_2_start + Round(5), Time(0) + secs(600)));
+        verify_nodes_in_epoch(&swarm, &ids, Epoch(2));
+        for &v in &epoch_2_vals {
+            assert_eq!(
+                swarm.with_node_mut(v, |n| n.state_mut().get_role()),
+                Role::Validator
+            );
+        }
+        for &v in &epoch_3_vals {
+            assert_eq!(
+                swarm.with_node_mut(v, |n| n.state_mut().get_role()),
+                Role::FullNode
+            );
+        }
+
+        let boundary_2 = SeqNum(EPOCH_LENGTH.0 * 2) - SeqNum(1); // 1999
+        assert!(swarm.run_until_blocks(boundary_2.0 as usize + 1, Time(0) + secs(1200)));
+        verify_nodes_in_epoch(&swarm, &ids, Epoch(2));
+        let epoch_3_start = verify_nodes_scheduled_epoch(&swarm, &ids, boundary_2, Epoch(3));
+
+        // epoch 3: the second half are Validators, first half are FullNodes
+        assert!(swarm.run_until_round(epoch_3_start + Round(5), Time(0) + secs(1200)));
+        verify_nodes_in_epoch(&swarm, &ids, Epoch(3));
+        for &v in &epoch_3_vals {
+            assert_eq!(
+                swarm.with_node_mut(v, |n| n.state_mut().get_role()),
+                Role::Validator
+            );
+        }
+        for &v in &epoch_2_vals {
+            assert_eq!(
+                swarm.with_node_mut(v, |n| n.state_mut().get_role()),
+                Role::FullNode
+            );
+        }
+
+        // every committed block's author belongs to that round's validator set
+        for &id in &ids {
+            swarm.with_node(id, |node| {
+                for block in node.ledger().get_finalized_blocks().values() {
+                    let author = block.get_author();
+                    let round = block.get_block_round();
+                    let set = if round < epoch_2_start {
+                        &genesis
+                    } else if round < epoch_3_start {
+                        &epoch_2_vals
+                    } else {
+                        &epoch_3_vals
+                    };
+                    assert!(
+                        set.iter().any(|v| v == author),
+                        "block author {author} not in the active validator set"
+                    );
+                }
+            });
+        }
+
+        let max_ledger = swarm.finalized_blocks().into_iter().max().unwrap() as u64;
+        SimVerifier::new()
+            .metric_exact(&ids, sim_metric!(blocksync_events.self_headers_request), 0)
+            .metric_exact(&ids, sim_metric!(blocksync_events.self_payload_request), 0)
+            .metric_min(
+                &ids,
+                sim_metric!(consensus_events.handle_proposal),
+                max_ledger,
+            )
+            .metric_min(&ids, sim_metric!(consensus_events.created_vote), max_ledger)
+            .metric_max(&ids, sim_metric!(consensus_events.local_timeout), 4)
+            .assert(&swarm);
+    }
+
+    #[test]
+    fn schedule_epoch_after_blocksync() {
+        // A node blacked out across the epoch boundary defers scheduling the new
+        // epoch until it blocksyncs the boundary block. Uses a smaller
+        // epoch_length than the legacy (1000) so the boundary is reached in a few
+        // seconds, making the fixed blackout window tractable; the behavior under
+        // test is identical.
+        let epoch_length = SeqNum(100);
+        let delta = Duration::from_millis(20);
+        let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+            .execution_delay(SeqNum::MAX)
+            .genesis_seqnum(SeqNum::MAX)
+            .epoch_length(epoch_length)
+            .epoch_start_delay(Round(20))
+            .swarm(|_| Network::reliable(delta));
+        let ids = swarm.node_ids();
+        let blackout = ids[0];
+        let running: Vec<_> = ids[1..].to_vec();
+        let boundary = epoch_length - SeqNum(1); // 99
+
+        // run to just before the boundary (all connected): epoch 1, none scheduled
+        assert!(swarm.run_until_any_blocks(boundary.0 as usize - 2, Time(0) + secs(60)));
+        verify_nodes_in_epoch(&swarm, &ids, Epoch(1));
+        verify_nodes_not_schedule_epoch(&swarm, &ids, Epoch(2));
+
+        // blackout the first node via mid-run reconfiguration (as the legacy
+        // does): it misses only the few blocks around the boundary, so it later
+        // recovers via blocksync rather than statesync.
+        swarm.set_network(|ids| {
+            let first = ids[0];
+            Network::reliable(delta).partition(Time(0)..Time(i128::MAX), [vec![first]])
+        });
+        // running supermajority commits the boundary (run a little past so every
+        // running node has it); the blacked-out node is frozen just short of it
+        assert!(swarm.run_until_any_blocks(boundary.0 as usize + 3, Time(0) + secs(60)));
+        verify_nodes_scheduled_epoch(&swarm, &running, boundary, Epoch(2));
+        verify_nodes_not_schedule_epoch(&swarm, &[blackout], Epoch(2));
+
+        // restore connectivity; the node blocksyncs the boundary and schedules epoch 2
+        swarm.set_network(|_| Network::reliable(delta));
+        assert!(swarm.run_until_blocks(boundary.0 as usize + 10, Time(0) + secs(60)));
+        verify_nodes_scheduled_epoch(&swarm, &ids, boundary, Epoch(2));
+
+        // the never-partitioned nodes never needed blocksync
+        SimVerifier::new()
+            .metric_exact(
+                &running,
+                sim_metric!(blocksync_events.self_headers_request),
+                0,
+            )
+            .metric_exact(
+                &running,
+                sim_metric!(blocksync_events.self_payload_request),
+                0,
+            )
+            .assert(&swarm);
+    }
+}

--- a/monad-mock-swarm/tests/sim_epoch_missing_valset.rs
+++ b/monad-mock-swarm/tests/sim_epoch_missing_valset.rs
@@ -1,0 +1,112 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Regression gate for an open production `todo!()` in shared consensus code:
+//! a node computes upcoming leaders for an epoch whose validator set has not yet
+//! been delivered.
+//!
+//! Panic site: `monad-consensus-state/src/lib.rs`,
+//! `compute_upcoming_leader_round_pairs` — "handle non-existent validatorset for
+//! next k round epoch".
+//!
+//! Epoch E's validator set is delivered only once epoch (E-1)'s boundary block is
+//! *finalized*. But a node's leader look-ahead keys off `current_round`, which can
+//! outrun finalized height — rounds advance via timeouts (TCs) under a validator
+//! outage. When the look-ahead reaches E before E's set is delivered,
+//! `val_epoch_map` has no entry and the `todo!()` fires. `epoch_start_delay` is
+//! the buffer that normally hides this.
+//!
+//! The reproducing test is `#[should_panic]`: GREEN while the bug exists, RED
+//! once the case is handled. The epoch parameters are tiny for tractability, so
+//! this proves the path is *reachable*, not its production-scale frequency
+//! (production `epoch_start_delay` is 1k-5k, so the gap there needs a prolonged
+//! liveness disruption near a boundary, not the single-validator outage
+//! compressed here). The `healthy_baseline_crosses_boundaries` control confirms
+//! the trigger is the fault, not the small parameter alone.
+
+mod sim_common;
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use monad_chain_config::revision::ChainParams;
+    use monad_mock_swarm::sim::Network;
+    use monad_sim::{time::secs, Time};
+    use monad_types::{Round, SeqNum};
+
+    use crate::sim_common::NoSerConfig;
+
+    static CHAIN_PARAMS: ChainParams = ChainParams {
+        tx_limit: 10_000,
+        proposal_gas_limit: 300_000_000,
+        proposal_byte_limit: 4_000_000,
+        max_reserve_balance: 1_000_000_000_000_000_000,
+        vote_pace: Duration::from_millis(0),
+    };
+
+    // Tiny epoch params: an epoch boundary is reached in a few simulated seconds.
+    // (Production uses epoch_length 10k-50k, epoch_start_delay 1k-5k.)
+    const EPOCH_LENGTH: SeqNum = SeqNum(20);
+    const EPOCH_START_DELAY: Round = Round(5);
+
+    /// REPRO: with one validator partitioned off, the surviving supermajority's
+    /// rounds advance via timeouts faster than blocks finalize; approaching the
+    /// first epoch boundary, the leader look-ahead reaches epoch 2 before epoch
+    /// 2's validator set has been delivered -> production `todo!()` at
+    /// `monad-consensus-state/src/lib.rs:2023`.
+    ///
+    /// `#[should_panic]` so this is GREEN while the bug exists and turns RED when
+    /// the missing-validator-set case is handled (a built-in regression signal).
+    #[test]
+    #[should_panic(expected = "non-existent validatorset")]
+    fn epoch_boundary_missing_valset_under_outage() {
+        let delta = Duration::from_millis(20);
+        let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+            .execution_delay(SeqNum(4))
+            .genesis_seqnum(SeqNum(4))
+            .epoch_length(EPOCH_LENGTH)
+            .epoch_start_delay(EPOCH_START_DELAY)
+            // node 0 is a partitioned (down) validator for the whole run
+            .swarm(|ids| {
+                let down = ids[0];
+                Network::reliable(delta).partition(Time(0)..Time(i128::MAX), [vec![down]])
+            });
+
+        // drive the surviving supermajority forward. Epochs 1-2 are genesis-
+        // locked (their sets are present without any finalization), so the gap
+        // first bites at a later boundary, whose set must be delivered by
+        // finalizing the boundary block while rounds outrun finalization under the
+        // outage. It panics well before reaching this target.
+        swarm.run_until_any_blocks(EPOCH_LENGTH.0 as usize * 6, Time(0) + secs(300));
+    }
+
+    /// Baseline / control: with no fault, the same tiny `epoch_start_delay`
+    /// crosses several epoch boundaries cleanly. Confirms the panic above is
+    /// caused by the outage, not by the parameter value alone.
+    #[test]
+    fn healthy_baseline_crosses_boundaries() {
+        let delta = Duration::from_millis(20);
+        let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+            .execution_delay(SeqNum(4))
+            .genesis_seqnum(SeqNum(4))
+            .epoch_length(EPOCH_LENGTH)
+            .epoch_start_delay(EPOCH_START_DELAY)
+            .swarm(|_| Network::reliable(delta));
+
+        // crosses boundaries at blocks 19, 39, 59 with all four nodes healthy
+        assert!(swarm.run_until_blocks(70, Time(0) + secs(120)));
+    }
+}

--- a/monad-mock-swarm/tests/sim_eth.rs
+++ b/monad-mock-swarm/tests/sim_eth.rs
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The Eth execution relation (real transactions) driven through the `monad-sim`
+//! harness, mirroring the `nonces`/`reserve_balance` engine tests. This is the
+//! highest-coverage test category and the main thing the new engine must host
+//! before the legacy `Nodes` engine can be retired.
+
+mod eth_swarm_common;
+
+#[cfg(test)]
+mod test {
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::B256;
+    use monad_eth_testutil::{make_legacy_tx, secret_to_eth_address};
+    use monad_mock_swarm::sim::{Network, SimSwarm};
+    use monad_sim::{time::secs, Time};
+    use monad_updaters::txpool::ByzantineConfig;
+
+    use crate::eth_swarm_common::{
+        eth_swarm_config, verify_transactions_in_sim, BASE_FEE, GAS_LIMIT,
+    };
+
+    #[test]
+    fn eth_transactions_commit_through_monad_sim() {
+        let sender = B256::repeat_byte(15);
+        let config = eth_swarm_config(2, vec![secret_to_eth_address(sender)], |_| {
+            ByzantineConfig::default()
+        });
+        let mut swarm = SimSwarm::from_builders(0, config, |_| Network::default());
+        let node = swarm.node_ids()[0];
+
+        let deadline = Time(0) + secs(20);
+        // Step past initial sync until the nodes are committing blocks.
+        assert!(swarm.run_until_blocks(1, deadline), "no initial progress");
+
+        let mut expected = Vec::new();
+        for nonce in 0..5 {
+            let tx = make_legacy_tx(sender, BASE_FEE, GAS_LIMIT, nonce, 10);
+            swarm.send_transaction(node, tx.encoded_2718().into());
+            expected.push(tx);
+        }
+
+        assert!(
+            swarm.run_until_blocks(5, deadline),
+            "stalled before committing txns"
+        );
+        assert!(verify_transactions_in_sim(&swarm, expected));
+        swarm.assert_agreement();
+    }
+}

--- a/monad-mock-swarm/tests/sim_forkpoint.rs
+++ b/monad-mock-swarm/tests/sim_forkpoint.rs
@@ -1,0 +1,377 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Forkpoint restart / recovery, ported onto the `monad-sim` harness (mirrors
+//! the legacy `forkpoint.rs`). A node is removed mid-run and restarted from a
+//! reconstructed forkpoint (via `SimSwarm::remove_node` / `add_node` /
+//! `SimNode::get_forkpoint`), then must catch up to the rest of the swarm.
+//!
+//! The two `#[ignore]`'d exhaustive sweeps from the legacy
+//! (`test_forkpoint_restart_f`, `test_forkpoint_restart_below_all`, run over a
+//! rayon pool) are not ported; the focused configs below exercise the same
+//! restart paths (simple blocksync, statesync, delayed execution, target reset,
+//! epoch boundary).
+
+#[cfg(test)]
+mod test {
+    use std::{collections::BTreeSet, time::Duration};
+
+    use monad_chain_config::{
+        revision::{ChainParams, MockChainRevision},
+        MockChainConfig,
+    };
+    use monad_consensus_types::validator_data::ValidatorSetDataWithEpoch;
+    use monad_crypto::{
+        certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey},
+        NopSignature,
+    };
+    use monad_eth_block_policy::EthBlockPolicy;
+    use monad_eth_block_validator::EthBlockValidator;
+    use monad_eth_types::EthExecutionProtocol;
+    use monad_execution_state_read::{InMemoryState, InMemoryStateInner};
+    use monad_mock_swarm::{
+        sim::{Network, SimNodeBuilder, SimSwarm, DEFAULT_TIMESTAMP_PERIOD},
+        swarm::make_state_configs,
+        swarm_relation::SwarmRelation,
+    };
+    use monad_multi_sig::MultiSig;
+    use monad_router_scheduler::{NoSerRouterConfig, NoSerRouterScheduler, RouterSchedulerBuilder};
+    use monad_sim::{time::secs, Time};
+    use monad_state::{MonadMessage, VerifiedMonadMessage};
+    use monad_transformer::GenericTransformerPipeline;
+    use monad_types::{NodeId, Round, SeqNum, GENESIS_SEQ_NUM};
+    use monad_updaters::{
+        ledger::{MockLedger, MockableLedger},
+        statesync::MockStateSyncExecutor,
+        txpool::MockTxPoolExecutor,
+        val_set::MockValSetUpdaterNop,
+    };
+    use monad_validator::{
+        simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory,
+    };
+
+    pub struct ForkpointSwarm;
+    impl SwarmRelation for ForkpointSwarm {
+        type SignatureType = NopSignature;
+        type SignatureCollectionType = MultiSig<Self::SignatureType>;
+        type ExecutionProtocolType = EthExecutionProtocol;
+        type ExecutionStateReadType =
+            InMemoryState<Self::SignatureType, Self::SignatureCollectionType>;
+        type BlockPolicyType = EthBlockPolicy<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ChainConfigType,
+            Self::ChainRevisionType,
+        >;
+        type ChainConfigType = MockChainConfig;
+        type ChainRevisionType = MockChainRevision;
+
+        type TransportMessage = VerifiedMonadMessage<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >;
+
+        type BlockValidator = EthBlockValidator<Self::SignatureType, Self::SignatureCollectionType>;
+        type ValidatorSetTypeFactory =
+            ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
+        type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
+        type Ledger = MockLedger<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >;
+
+        type RouterScheduler = NoSerRouterScheduler<
+            CertificateSignaturePubKey<Self::SignatureType>,
+            MonadMessage<
+                Self::SignatureType,
+                Self::SignatureCollectionType,
+                Self::ExecutionProtocolType,
+            >,
+            VerifiedMonadMessage<
+                Self::SignatureType,
+                Self::SignatureCollectionType,
+                Self::ExecutionProtocolType,
+            >,
+        >;
+        type Pipeline = GenericTransformerPipeline<
+            CertificateSignaturePubKey<Self::SignatureType>,
+            Self::TransportMessage,
+        >;
+
+        type ValSetUpdater = MockValSetUpdaterNop<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >;
+        type TxPoolExecutor = MockTxPoolExecutor<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+            Self::BlockPolicyType,
+            Self::ExecutionStateReadType,
+            Self::ChainConfigType,
+            Self::ChainRevisionType,
+        >;
+        type StateSyncExecutor = MockStateSyncExecutor<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >;
+    }
+
+    static CHAIN_PARAMS: ChainParams = ChainParams {
+        tx_limit: 10_000,
+        proposal_gas_limit: 300_000_000,
+        proposal_byte_limit: 4_000_000,
+        max_reserve_balance: 1_000_000_000_000_000_000,
+        vote_pace: Duration::from_millis(0),
+    };
+
+    const DELTA: Duration = Duration::from_millis(100);
+    const STATE_ROOT_DELAY: SeqNum = SeqNum(4);
+
+    fn forkpoint_restart_one(
+        num_nodes: u16,
+        blocks_before_failure: SeqNum,
+        time_before_new_forkpoint: SeqNum,
+        recovery_time: SeqNum,
+        epoch_length: SeqNum,
+        statesync_threshold: SeqNum,
+        statesync_service_window: SeqNum,
+        finalization_delay: SeqNum,
+    ) {
+        assert!(time_before_new_forkpoint <= recovery_time);
+        let chain_config =
+            MockChainConfig::new_with_epoch_params(&CHAIN_PARAMS, epoch_length, Round(50));
+        let create_block_policy = || EthBlockPolicy::new(GENESIS_SEQ_NUM, STATE_ROOT_DELAY.0);
+
+        // state configs are deterministic per call (keys aren't Clone), so we
+        // regenerate them where needed and match nodes by pubkey.
+        let configs = || {
+            make_state_configs::<ForkpointSwarm>(
+                num_nodes,
+                ValidatorSetFactory::default,
+                SimpleRoundRobin::default,
+                EthBlockValidator::default,
+                create_block_policy,
+                || InMemoryStateInner::genesis(STATE_ROOT_DELAY),
+                STATE_ROOT_DELAY,
+                DELTA,
+                chain_config,
+                statesync_threshold,
+            )
+        };
+
+        let restart_ids: Vec<NodeId<_>> = configs()
+            .iter()
+            .map(|c| NodeId::new(c.key.pubkey()))
+            .collect();
+
+        // enumerate the restarting node to cover the different leader cases
+        for restart_node_id in restart_ids {
+            let validators = configs()[0].locked_epoch_validators[0].validators.clone();
+            let mut restart_builder = configs()
+                .into_iter()
+                .find(|s| s.key.pubkey() == restart_node_id.pubkey())
+                .expect("restart node exists");
+
+            let state_configs = configs();
+            let all_peers: BTreeSet<_> = state_configs
+                .iter()
+                .map(|c| NodeId::new(c.key.pubkey()))
+                .collect();
+            let builders: Vec<SimNodeBuilder<ForkpointSwarm>> = state_configs
+                .into_iter()
+                .map(|state_builder| {
+                    let state_read = state_builder.state_read.clone();
+                    SimNodeBuilder {
+                        id: NodeId::new(state_builder.key.pubkey()),
+                        state_builder,
+                        router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                        val_set_updater: MockValSetUpdaterNop::new(
+                            validators.clone(),
+                            epoch_length,
+                        ),
+                        txpool_executor: MockTxPoolExecutor::new(
+                            create_block_policy(),
+                            state_read.clone(),
+                        )
+                        .with_chain_params(&CHAIN_PARAMS),
+                        ledger: MockLedger::new(state_read.clone())
+                            .with_finalization_delay(finalization_delay),
+                        statesync_executor: MockStateSyncExecutor::new(state_read)
+                            .with_max_service_window(statesync_service_window),
+                        timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+                    }
+                })
+                .collect();
+
+            let mut swarm = SimSwarm::from_builders(0, builders, |_| Network::reliable(DELTA));
+            let deadline = Time(0) + secs(6000);
+
+            assert!(swarm.run_until_blocks(blocks_before_failure.0 as usize, deadline));
+
+            // eject the failing node; read its forkpoint / ledger / state-backend
+            let failed_node = swarm.remove_node(restart_node_id);
+
+            let forkpoint = if time_before_new_forkpoint == SeqNum(0) {
+                failed_node.get_forkpoint()
+            } else {
+                let forkpoint_block = blocks_before_failure + time_before_new_forkpoint;
+                assert!(swarm.run_until_any_blocks(forkpoint_block.0 as usize, deadline));
+                let any = swarm.node_ids()[0];
+                swarm.with_node(any, |n| n.get_forkpoint())
+            };
+
+            let recover_block = blocks_before_failure + recovery_time;
+            assert!(swarm.run_until_any_blocks(recover_block.0 as usize, deadline));
+
+            // reconstruct the restart node from the forkpoint and re-add it
+            restart_builder.locked_epoch_validators = forkpoint
+                .validator_sets
+                .iter()
+                .map(|locked_epoch| ValidatorSetDataWithEpoch {
+                    epoch: locked_epoch.epoch,
+                    validators: validators.clone(),
+                })
+                .collect();
+            restart_builder.forkpoint = forkpoint.clone();
+            restart_builder.state_read = failed_node.state().state_read().clone();
+            let backend = restart_builder.state_read.clone();
+            swarm.add_node(SimNodeBuilder {
+                id: restart_node_id,
+                state_builder: restart_builder,
+                router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                val_set_updater: MockValSetUpdaterNop::new(validators.clone(), epoch_length),
+                txpool_executor: MockTxPoolExecutor::new(create_block_policy(), backend.clone()),
+                ledger: MockLedger::new(backend.clone())
+                    .with_finalization_delay(finalization_delay)
+                    .with_blocks(failed_node.ledger()),
+                statesync_executor: MockStateSyncExecutor::new(backend),
+                timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+            });
+
+            // run until 3 more epochs are produced so epoch switching exercises
+            let terminate_block = recover_block.0 as usize + epoch_length.0 as usize * 3;
+            assert!(swarm.run_until_any_blocks(terminate_block, deadline));
+
+            // the restarted node caught up and is voting
+            let metrics_voting = swarm.with_node(restart_node_id, |n| {
+                n.metrics().consensus_events.created_vote.get() > 0
+            });
+            let caught_up = swarm.with_node(restart_node_id, |n| {
+                n.ledger()
+                    .get_finalized_blocks()
+                    .values()
+                    .last()
+                    .map(|fb| fb.header().seq_num >= SeqNum(terminate_block as u64 - 2))
+                    .unwrap_or(false)
+            });
+            assert!(
+                caught_up && metrics_voting,
+                "restart {restart_node_id}: caught_up={caught_up} voting={metrics_voting}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_quick_restart() {
+        forkpoint_restart_one(
+            20,
+            SeqNum(10),
+            SeqNum(0),
+            SeqNum(0),
+            SeqNum(3),
+            SeqNum(5),
+            SeqNum::MAX,
+            SeqNum(0),
+        );
+    }
+
+    #[test]
+    fn test_forkpoint_restart_f_simple_blocksync() {
+        forkpoint_restart_one(
+            4,
+            SeqNum(10),
+            SeqNum(0),
+            SeqNum(50),
+            SeqNum(200),
+            SeqNum(100),
+            SeqNum::MAX,
+            SeqNum(0),
+        );
+    }
+
+    #[test]
+    fn test_forkpoint_restart_f_delayed_execution_no_statesync() {
+        forkpoint_restart_one(
+            4,
+            SeqNum(10),
+            SeqNum(0),
+            SeqNum(50),
+            SeqNum(200),
+            SeqNum(100),
+            SeqNum::MAX,
+            SeqNum(8),
+        );
+    }
+
+    #[test]
+    fn test_forkpoint_restart_f_simple_statesync() {
+        // restart from a fresh forkpoint 150 blocks in (statesync_threshold*3/2)
+        forkpoint_restart_one(
+            4,
+            SeqNum(10),
+            SeqNum(150),
+            SeqNum(150),
+            SeqNum(200),
+            SeqNum(100),
+            SeqNum::MAX,
+            SeqNum(0),
+        );
+    }
+
+    #[test]
+    fn test_forkpoint_restart_f_target_reset_statesync() {
+        // service window (50) < recovery (150): the statesync target must reset
+        forkpoint_restart_one(
+            4,
+            SeqNum(10),
+            SeqNum(10),
+            SeqNum(150),
+            SeqNum(200),
+            SeqNum(100),
+            SeqNum(50),
+            SeqNum(0),
+        );
+    }
+
+    #[test]
+    fn test_forkpoint_restart_f_epoch_boundary_statesync() {
+        // restart spans an epoch boundary (blocks_before_failure 275, epoch 200)
+        forkpoint_restart_one(
+            4,
+            SeqNum(275),
+            SeqNum(150),
+            SeqNum(150),
+            SeqNum(200),
+            SeqNum(100),
+            SeqNum::MAX,
+            SeqNum(0),
+        );
+    }
+}

--- a/monad-mock-swarm/tests/sim_many_nodes.rs
+++ b/monad-mock-swarm/tests/sim_many_nodes.rs
@@ -1,0 +1,99 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Larger swarms, ported onto the `monad-sim` harness (mirrors the legacy
+//! `many_nodes.rs`): a 40-node happy path, and a 10-node swarm with one node
+//! whose outbound messages are dropped (offline).
+
+mod sim_common;
+
+use std::time::Duration;
+
+use monad_chain_config::revision::ChainParams;
+use monad_mock_swarm::{sim::Network, sim_verify::SimVerifier};
+use monad_sim::{dist::uniform_duration, time::secs, Time};
+use monad_types::Round;
+
+use crate::sim_common::NoSerConfig;
+
+static CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(5),
+};
+
+#[test]
+fn many_nodes_noser() {
+    let delta = Duration::from_millis(20);
+    let mut swarm = NoSerConfig::new(40, delta, &CHAIN_PARAMS).swarm(|_| Network::reliable(delta));
+
+    assert!(
+        swarm.run_until_blocks(1024, Time(0) + secs(120)),
+        "did not reach 1024 blocks"
+    );
+
+    let ids = swarm.node_ids();
+    let mut verifier = SimVerifier::new();
+    verifier
+        // Deterministic exact tick (legacy ran to a fixed 47s window).
+        .tick_exact(Time(0) + Duration::from_millis(41_040))
+        .ledger_min_len(1024)
+        .metrics_happy_path(&ids, &swarm);
+    verifier.assert(&swarm);
+    swarm.assert_agreement();
+}
+
+#[test]
+fn many_nodes_noser_one_offline() {
+    let delta = Duration::from_millis(20);
+    let num_nodes = 10u16;
+    let num_offline_nodes = 1u64;
+    let num_rounds = 100u64;
+
+    // base 1ms + uniform [1, 20)ms, matching Latency(1ms) + RandLatency(0, 19ms).
+    let mut swarm = NoSerConfig::new(num_nodes, delta, &CHAIN_PARAMS).swarm(|ids| {
+        let offline = ids[0];
+        Network::with_latency(uniform_duration(
+            Duration::from_millis(2),
+            Duration::from_millis(20),
+        ))
+        .drop_if(move |link, _| link.from == offline)
+    });
+
+    assert!(
+        swarm.run_until_round(Round(num_rounds), Time(0) + secs(120)),
+        "did not reach round 100"
+    );
+
+    let max_observed_local_timeouts = swarm
+        .node_ids()
+        .iter()
+        .map(|&id| swarm.with_node(id, |node| node.metrics().consensus_events.local_timeout.get()))
+        .max()
+        .unwrap()
+        // subtract 1 for the initial timeout on startup
+        - 1;
+
+    let max_allowed_local_timeouts = (num_rounds * num_offline_nodes).div_ceil(num_nodes.into());
+
+    assert!(
+        max_observed_local_timeouts <= max_allowed_local_timeouts,
+        "max observed timeouts {} > allowed {}",
+        max_observed_local_timeouts,
+        max_allowed_local_timeouts
+    );
+}

--- a/monad-mock-swarm/tests/sim_msg_delays.rs
+++ b/monad-mock-swarm/tests/sim_msg_delays.rs
@@ -1,0 +1,60 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Per-link XOR latency, ported onto the `monad-sim` harness (mirrors the
+//! legacy `msg_delays.rs`). The deterministic XOR latency lets the final tick
+//! be asserted exactly (the legacy engine only bounded it below the max).
+
+mod sim_common;
+
+use std::time::Duration;
+
+use monad_chain_config::revision::ChainParams;
+use monad_mock_swarm::{sim::Network, sim_verify::SimVerifier};
+use monad_sim::{time::secs, Time};
+
+use crate::sim_common::{NoSerConfig, XorLatency};
+
+static CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(5),
+};
+
+#[test]
+fn xor_latency_four_nodes() {
+    let delta = Duration::from_millis(u8::MAX as u64);
+    let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+        .swarm(|_| Network::custom(XorLatency { max: delta }));
+
+    assert!(
+        swarm.run_until_blocks(100, Time(0) + secs(600)),
+        "did not reach 100 blocks"
+    );
+
+    let ids = swarm.node_ids();
+    let mut verifier = SimVerifier::new();
+    verifier
+        // Deterministic: exact tick (sub-ms tail comes from the float XOR
+        // latency). The legacy engine only bounded this below the theoretical
+        // max because its same-tick ordering was randomized.
+        .tick_exact(Time(8_954_000_078))
+        .ledger_min_len(98)
+        .metrics_happy_path(&ids, &swarm);
+    verifier.assert(&swarm);
+    swarm.assert_agreement();
+}

--- a/monad-mock-swarm/tests/sim_nonces.rs
+++ b/monad-mock-swarm/tests/sim_nonces.rs
@@ -1,0 +1,445 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Nonce / transaction-commitment coverage, ported onto the `monad-sim`
+//! harness (mirrors the legacy `nonces.rs`, which it does not replace).
+//!
+//! NOT ported here (tracked for follow-up):
+//! - `test_forkpoint_serde_roundtrip`: per-step `high_certificate` RLP/JSON/TOML
+//!   round-trip — serialization coverage, independent of the engine; extract to
+//!   a standalone serialization test before the legacy engine is deleted.
+
+mod eth_swarm_common;
+
+#[cfg(test)]
+mod test {
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::B256;
+    use monad_eth_testutil::{
+        make_eip7702_tx, make_legacy_tx, make_signed_authorization, secret_to_eth_address,
+    };
+    use monad_mock_swarm::{
+        sim::{Network, SimNodeBuilder, SimSwarm},
+        sim_verify::SimVerifier,
+    };
+    use monad_sim::{time::secs, Time};
+    use monad_updaters::txpool::ByzantineConfig;
+    use rand::Rng;
+    use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
+    use seq_macro::seq;
+
+    use crate::eth_swarm_common::{
+        eth_swarm_config, verify_transactions_in_sim, EthSwarm, BASE_FEE, CONSENSUS_DELTA,
+        GAS_LIMIT,
+    };
+
+    fn deadline() -> Time {
+        Time(0) + secs(120)
+    }
+
+    /// Build an Eth `SimSwarm` over a reliable `CONSENSUS_DELTA` link and run it
+    /// past initial sync (block 1) so nodes are ready to receive transactions.
+    fn eth_sim(builders: Vec<SimNodeBuilder<EthSwarm>>) -> SimSwarm<EthSwarm> {
+        let mut swarm =
+            SimSwarm::from_builders(0, builders, |_| Network::reliable(CONSENSUS_DELTA));
+        assert!(swarm.run_until_blocks(1, deadline()), "no initial progress");
+        swarm
+    }
+
+    #[test]
+    fn non_sequential_nonces() {
+        let sender = B256::repeat_byte(15);
+        let builders = eth_swarm_config(2, vec![secret_to_eth_address(sender)], |_| {
+            ByzantineConfig::default()
+        });
+        let mut swarm = eth_sim(builders);
+        let node_1 = swarm.node_ids()[0];
+
+        let mut expected = Vec::new();
+        for nonce in 0..10 {
+            let tx = make_legacy_tx(sender, BASE_FEE, GAS_LIMIT, nonce, 10);
+            swarm.send_transaction(node_1, tx.encoded_2718().into());
+            expected.push(tx);
+        }
+        // a gap (20..30): these can never commit and must not appear
+        for nonce in 20..30 {
+            let tx = make_legacy_tx(sender, BASE_FEE, GAS_LIMIT, nonce, 10);
+            swarm.send_transaction(node_1, tx.encoded_2718().into());
+        }
+
+        assert!(
+            swarm.run_until_blocks(5, deadline()),
+            "stalled before block 5"
+        );
+
+        let ids = swarm.node_ids();
+        SimVerifier::new()
+            .ledger_min_len(2)
+            .metrics_happy_path(&ids, &swarm)
+            .assert(&swarm);
+        assert!(verify_transactions_in_sim(&swarm, expected));
+        swarm.assert_agreement();
+    }
+
+    #[test]
+    fn sanity_7702() {
+        let sender_1 = B256::repeat_byte(0xA);
+        let sender_2 = B256::repeat_byte(0xB);
+        let builders = eth_swarm_config(
+            2,
+            vec![
+                secret_to_eth_address(sender_1),
+                secret_to_eth_address(sender_2),
+            ],
+            |_| ByzantineConfig::default(),
+        );
+        let mut swarm = eth_sim(builders);
+        let node_1 = swarm.node_ids()[0];
+
+        let mut expected = Vec::new();
+        let txn1 = make_legacy_tx(sender_1, BASE_FEE, GAS_LIMIT, 0, 10);
+        swarm.send_transaction(node_1, txn1.encoded_2718().into());
+        expected.push(txn1);
+
+        let auth_list = vec![
+            make_signed_authorization(sender_2, secret_to_eth_address(B256::repeat_byte(0x1)), 0),
+            make_signed_authorization(sender_2, secret_to_eth_address(B256::repeat_byte(0x3)), 5),
+        ];
+        let txn2 = make_eip7702_tx(sender_1, BASE_FEE, 1, 1_000_000, 1, auth_list, 0);
+        swarm.send_transaction(node_1, txn2.encoded_2718().into());
+        expected.push(txn2);
+
+        let txn3 = make_legacy_tx(sender_2, BASE_FEE, GAS_LIMIT, 1, 10);
+        swarm.send_transaction(node_1, txn3.encoded_2718().into());
+        expected.push(txn3);
+
+        assert!(
+            swarm.run_until_blocks(10, deadline()),
+            "stalled before block 10"
+        );
+
+        let ids = swarm.node_ids();
+        SimVerifier::new()
+            .ledger_min_len(2)
+            .metrics_happy_path(&ids, &swarm)
+            .assert(&swarm);
+        assert!(verify_transactions_in_sim(&swarm, expected));
+        swarm.assert_agreement();
+    }
+
+    seq!(N in 0..512 {
+        #[test]
+        fn test_rand_nonces_7702_~N() {
+            rand_nonces_7702(N);
+        }
+    });
+
+    fn rand_nonces_7702(seed: u64) {
+        let test_sender = B256::repeat_byte(0xA);
+        let sender_7702 = B256::repeat_byte(0xB);
+        let builders = eth_swarm_config(
+            2,
+            vec![
+                secret_to_eth_address(test_sender),
+                secret_to_eth_address(sender_7702),
+            ],
+            |_| ByzantineConfig::default(),
+        );
+        let mut swarm = eth_sim(builders);
+        let node_1 = swarm.node_ids()[0];
+
+        let mut rng = ChaChaRng::seed_from_u64(seed);
+        let nonces: Vec<u64> = (0..10).map(|_| rng.gen_range(1..=10)).collect();
+        let mut auths = Vec::new();
+        for nonce in nonces {
+            if rng.gen_bool(0.5) {
+                // a legacy tx with a (likely non-sequential) nonce — dropped by
+                // the pool, exercises validation under random nonces
+                swarm.send_transaction(
+                    node_1,
+                    make_legacy_tx(test_sender, BASE_FEE, GAS_LIMIT, nonce, 10)
+                        .encoded_2718()
+                        .into(),
+                );
+            } else {
+                auths.push(make_signed_authorization(
+                    test_sender,
+                    secret_to_eth_address(B256::repeat_byte(0x1)),
+                    nonce,
+                ));
+            }
+        }
+
+        let txn1 = make_legacy_tx(test_sender, BASE_FEE, GAS_LIMIT, 0, 10);
+        swarm.send_transaction(node_1, txn1.encoded_2718().into());
+        let txn2 = make_eip7702_tx(sender_7702, BASE_FEE, 1, 1_000_000, 1, auths, 0);
+        swarm.send_transaction(node_1, txn2.encoded_2718().into());
+
+        assert!(
+            swarm.run_until_blocks(10, deadline()),
+            "seed {seed}: stalled"
+        );
+
+        let ids = swarm.node_ids();
+        SimVerifier::new()
+            .ledger_min_len(2)
+            .metrics_happy_path(&ids, &swarm)
+            .assert(&swarm);
+        swarm.assert_agreement();
+    }
+
+    #[test]
+    fn duplicate_nonces_multi_nodes() {
+        let sender = B256::repeat_byte(15);
+        let builders = eth_swarm_config(2, vec![secret_to_eth_address(sender)], |_| {
+            ByzantineConfig::default()
+        });
+        let mut swarm = eth_sim(builders);
+        let node_1 = swarm.node_ids()[0];
+        let node_2 = swarm.node_ids()[1];
+
+        let mut expected = Vec::new();
+        for nonce in 0..10 {
+            let tx = make_legacy_tx(sender, BASE_FEE, GAS_LIMIT, nonce, 10);
+            swarm.send_transaction(node_1, tx.encoded_2718().into());
+            expected.push(tx);
+        }
+        assert!(
+            swarm.run_until_blocks(5, deadline()),
+            "stalled before block 5"
+        );
+        assert!(verify_transactions_in_sim(&swarm, expected.clone()));
+
+        // duplicate nonces (different value) to node 2 — must not commit
+        for nonce in 0..10 {
+            let tx = make_legacy_tx(sender, BASE_FEE, GAS_LIMIT, nonce, 1000);
+            swarm.send_transaction(node_2, tx.encoded_2718().into());
+        }
+        assert!(
+            swarm.run_until_blocks(8, deadline()),
+            "stalled before block 8"
+        );
+
+        let ids = swarm.node_ids();
+        SimVerifier::new()
+            .ledger_min_len(8)
+            .metrics_happy_path(&ids, &swarm)
+            .assert(&swarm);
+        // still only the first 10
+        assert!(verify_transactions_in_sim(&swarm, expected));
+        swarm.assert_agreement();
+    }
+
+    #[test]
+    fn committed_nonces() {
+        let sender_1 = B256::repeat_byte(15);
+        let sender_2 = B256::repeat_byte(16);
+        let builders = eth_swarm_config(
+            2,
+            vec![
+                secret_to_eth_address(sender_1),
+                secret_to_eth_address(sender_2),
+            ],
+            |_| ByzantineConfig::default(),
+        );
+        let mut swarm = eth_sim(builders);
+        let node_1 = swarm.node_ids()[0];
+        let node_2 = swarm.node_ids()[1];
+
+        let mut expected = Vec::new();
+        for nonce in 0..10 {
+            let tx1 = make_legacy_tx(sender_1, BASE_FEE, GAS_LIMIT, nonce, 10);
+            let tx2 = make_legacy_tx(sender_2, BASE_FEE, GAS_LIMIT, nonce, 10);
+            swarm.send_transaction(node_1, tx1.encoded_2718().into());
+            swarm.send_transaction(node_1, tx2.encoded_2718().into());
+            expected.push(tx1);
+            expected.push(tx2);
+        }
+        assert!(
+            swarm.run_until_blocks(10, deadline()),
+            "stalled before block 10"
+        );
+
+        let ids = swarm.node_ids();
+        SimVerifier::new()
+            .ledger_min_len(8)
+            .metrics_happy_path(&ids, &swarm)
+            .assert(&swarm);
+        assert!(verify_transactions_in_sim(&swarm, expected.clone()));
+
+        // already-committed nonces (5..10) to node 2 must not re-commit
+        for nonce in 5..10 {
+            swarm.send_transaction(
+                node_2,
+                make_legacy_tx(sender_1, BASE_FEE, GAS_LIMIT, nonce, 10)
+                    .encoded_2718()
+                    .into(),
+            );
+            swarm.send_transaction(
+                node_2,
+                make_legacy_tx(sender_2, BASE_FEE, GAS_LIMIT, nonce, 10)
+                    .encoded_2718()
+                    .into(),
+            );
+        }
+        // fresh nonces (10..20) should commit
+        for nonce in 10..20 {
+            let tx1 = make_legacy_tx(sender_1, BASE_FEE, GAS_LIMIT, nonce, 10);
+            let tx2 = make_legacy_tx(sender_2, BASE_FEE, GAS_LIMIT, nonce, 10);
+            swarm.send_transaction(node_2, tx1.encoded_2718().into());
+            swarm.send_transaction(node_2, tx2.encoded_2718().into());
+            expected.push(tx1);
+            expected.push(tx2);
+        }
+        assert!(
+            swarm.run_until_blocks(20, deadline()),
+            "stalled before block 20"
+        );
+
+        SimVerifier::new()
+            .ledger_min_len(18)
+            .metrics_happy_path(&ids, &swarm)
+            .assert(&swarm);
+        assert!(verify_transactions_in_sim(&swarm, expected));
+        swarm.assert_agreement();
+    }
+
+    #[test]
+    fn test_nec() {
+        let sender = B256::repeat_byte(15);
+        let builders = eth_swarm_config(4, vec![secret_to_eth_address(sender)], |_| {
+            ByzantineConfig::default()
+        });
+        // The round-robin "second node" (2nd by sorted id) proposes in the first
+        // `delay` blocks; corrupt its state root so its block 4 fails validation
+        // (it produces an equivocating tip). `builders` is in key-gen order, so
+        // select by id to match the legacy `states().iter().nth(1)`.
+        let mut by_id: Vec<usize> = (0..builders.len()).collect();
+        by_id.sort_by_key(|&i| builders[i].id);
+        let bad_idx = by_id[1];
+        let bad_id = builders[bad_idx].id;
+        builders[bad_idx]
+            .state_builder
+            .state_read
+            .lock()
+            .unwrap()
+            .extra_data = 1;
+
+        let mut swarm =
+            SimSwarm::from_builders(0, builders, |_| Network::reliable(CONSENSUS_DELTA));
+        // Run the good nodes well past block 10 (leader/follower commit lag means
+        // stopping the instant one node hits 10 leaves laggards behind). The bad
+        // node is permanently stuck, so its ledger length and the NEC count don't
+        // grow while the good nodes keep progressing.
+        assert!(
+            swarm.run_until_any_blocks(15, deadline()),
+            "good nodes did not progress"
+        );
+
+        let ids = swarm.node_ids();
+        // exactly one NEC is constructed (for the first block the bad node makes)
+        let max_nec = ids
+            .iter()
+            .map(|&id| swarm.with_node(id, |n| n.metrics().consensus_events.created_nec.get()))
+            .max()
+            .unwrap();
+        assert_eq!(max_nec, 1, "expected exactly one NEC");
+
+        for &id in &ids {
+            let len = swarm.with_node(id, |n| n.finalized_blocks());
+            if id == bad_id {
+                // bad node can't validate block 4, so block 3 is never committed
+                assert_eq!(len, 2, "bad node ledger length");
+            } else {
+                assert!(len >= 10, "good node {id} only has {len} blocks");
+            }
+        }
+    }
+
+    #[test]
+    fn non_sequential_seqnum() {
+        for byz_idx in 0..4 {
+            let builders = eth_swarm_config(4, Vec::new(), move |idx| {
+                if idx == byz_idx {
+                    ByzantineConfig {
+                        no_increment_seq_num: true,
+                        ..Default::default()
+                    }
+                } else {
+                    ByzantineConfig::default()
+                }
+            });
+            let mut swarm =
+                SimSwarm::from_builders(0, builders, |_| Network::reliable(CONSENSUS_DELTA));
+
+            // some node reaches block 20; every node should be at >= 18
+            assert!(
+                swarm.run_until_any_blocks(20, deadline()),
+                "byz_idx {byz_idx}: did not reach block 20"
+            );
+            SimVerifier::new().ledger_min_len(18).assert(&swarm);
+        }
+    }
+
+    #[test]
+    fn blocksync_missing_nonces() {
+        let sender = B256::repeat_byte(15);
+        let builders = eth_swarm_config(4, vec![secret_to_eth_address(sender)], |_| {
+            ByzantineConfig::default()
+        });
+        // Blackout the first node during [2s, 7s): the window starts *after*
+        // every node is post-statesync, so the blacked-out node is initialized
+        // (and will hold txns it's sent), then can only catch up via blocksync
+        // once the partition heals.
+        let mut swarm = SimSwarm::from_builders(0, builders, move |peers| {
+            let first = peers[0];
+            Network::reliable(CONSENSUS_DELTA)
+                .partition((Time(0) + secs(2))..(Time(0) + secs(7)), [vec![first]])
+        });
+        let ids = swarm.node_ids();
+        let node_1 = ids[0];
+        let node_2 = ids[1];
+
+        // post-statesync: every node reaches block 1 before the blackout begins
+        swarm.run_until(Time(0) + secs(2));
+
+        // txns 0..10 to a connected node — the blacked-out node misses them
+        let mut expected = Vec::new();
+        for nonce in 0..10 {
+            let tx = make_legacy_tx(sender, BASE_FEE, GAS_LIMIT, nonce, 10);
+            swarm.send_transaction(node_2, tx.encoded_2718().into());
+            expected.push(tx);
+        }
+        swarm.run_until(Time(0) + secs(5));
+        // the blacked-out node has fallen behind the connected supermajority
+        assert!(
+            swarm.with_node(node_1, |n| n.finalized_blocks())
+                < swarm.with_node(node_2, |n| n.finalized_blocks()),
+            "blacked-out node should fall behind"
+        );
+
+        // txns 10..20 to the blacked-out node; it proposes them once it catches up
+        for nonce in 10..20 {
+            let tx = make_legacy_tx(sender, BASE_FEE, GAS_LIMIT, nonce, 10);
+            swarm.send_transaction(node_1, tx.encoded_2718().into());
+            expected.push(tx);
+        }
+        // partition heals at 7s; run well past it so the recovered node
+        // blocksyncs, becomes leader, and gets its own txns committed everywhere.
+        swarm.run_until(Time(0) + secs(30));
+        assert!(verify_transactions_in_sim(&swarm, expected));
+        swarm.assert_agreement();
+    }
+}

--- a/monad-mock-swarm/tests/sim_order.rs
+++ b/monad-mock-swarm/tests/sim_order.rs
@@ -1,0 +1,108 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Message-reordering recovery, ported onto the `monad-sim` harness (mirrors
+//! the legacy `order.rs`). One node is isolated for the first 500ms; its
+//! messages are then burst-delivered in Forward / Reverse / Random order, and
+//! it must catch up (via blocksync) regardless of the order.
+
+mod sim_common;
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use monad_chain_config::revision::ChainParams;
+    use monad_mock_swarm::{sim_metric, sim_verify::SimVerifier};
+    use monad_sim::{time::millis, Time};
+    use monad_types::SeqNum;
+    use test_case::test_case;
+
+    use crate::sim_common::{replay_network, NoSerConfig, ReplayOrder};
+
+    static CHAIN_PARAMS: ChainParams = ChainParams {
+        tx_limit: 10_000,
+        proposal_gas_limit: 300_000_000,
+        proposal_byte_limit: 4_000_000,
+        max_reserve_balance: 1_000_000_000_000_000_000,
+        vote_pace: Duration::from_millis(0),
+    };
+
+    #[test_case(ReplayOrder::Forward; "in order")]
+    #[test_case(ReplayOrder::Reverse; "reverse order")]
+    #[test_case(ReplayOrder::Random(1); "random seed 1")]
+    #[test_case(ReplayOrder::Random(2); "random seed 2")]
+    #[test_case(ReplayOrder::Random(3); "random seed 3")]
+    #[test_case(ReplayOrder::Random(4); "random seed 4")]
+    #[test_case(ReplayOrder::Random(5); "random seed 5")]
+    fn all_messages_delayed(order: ReplayOrder) {
+        let delta = Duration::from_millis(20);
+        let release = Time(0) + millis(500);
+
+        // execution_delay 1 so the replay-transformer burst can deliver within a
+        // single Duration without tripping the state-root check (as in legacy).
+        let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+            .execution_delay(SeqNum(1))
+            .genesis_seqnum(SeqNum(1))
+            .swarm(|ids| replay_network(ids[0], release, delta, order));
+        let ids = swarm.node_ids();
+        let running: Vec<_> = ids[1..].to_vec();
+
+        // run to just before the replay: the running nodes have progressed and
+        // never needed blocksync; the isolated node is behind.
+        swarm.run_until(Time(0) + millis(499));
+        let longest_before = swarm.finalized_blocks().into_iter().max().unwrap();
+        SimVerifier::new()
+            .metric_exact(
+                &running,
+                sim_metric!(blocksync_events.self_headers_request),
+                0,
+            )
+            .metric_exact(
+                &running,
+                sim_metric!(blocksync_events.self_payload_request),
+                0,
+            )
+            .metric_min(
+                &running,
+                sim_metric!(consensus_events.handle_proposal),
+                longest_before as u64,
+            )
+            .metric_min(
+                &running,
+                sim_metric!(consensus_events.created_vote),
+                longest_before as u64,
+            )
+            // enter rounds via QC, except round 2
+            .metric_min(
+                &running,
+                sim_metric!(consensus_events.enter_new_round_qc),
+                longest_before as u64 - 1,
+            )
+            .assert(&swarm);
+
+        // run past the replay: the isolated node receives the reordered burst and
+        // catches up, so every node reaches the same progress as a healthy swarm.
+        swarm.run_until(Time(0) + millis(1000));
+        // inverse of the happy-path block->tick formula over the 500ms / 20ms
+        // window, minus 3 (2 uncommitted blocks in the tree + the blackout node
+        // can't propose while it has unvalidated blocks): (500/20 - 1)/2 - 3 = 9.
+        let expected_blocks: usize = (500 / 20 - 1) / 2 - 3;
+        SimVerifier::new()
+            .ledger_min_len(longest_before + expected_blocks)
+            .assert(&swarm);
+        swarm.assert_agreement();
+    }
+}

--- a/monad-mock-swarm/tests/sim_rand_lat.rs
+++ b/monad-mock-swarm/tests/sim_rand_lat.rs
@@ -1,0 +1,108 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Four nodes under random per-message latency, ported onto the `monad-sim`
+//! harness (mirrors the legacy `rand_lat.rs`). The fuzzing seed parametrizes
+//! the simulation seed (which seeds the network latency RNG), so each case
+//! exercises a distinct latency schedule. Latency is non-deterministic across
+//! seeds, so the final tick is not asserted exactly; the metric bounds and
+//! ledger length carry the coverage.
+
+mod sim_common;
+
+use std::time::Duration;
+
+use monad_chain_config::revision::ChainParams;
+use monad_mock_swarm::{sim::Network, sim_metric, sim_verify::SimVerifier};
+use monad_sim::{dist::uniform_duration, time::secs, Time};
+use monad_types::SeqNum;
+use test_case::test_case;
+
+use crate::sim_common::NoSerConfig;
+
+static CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(10),
+};
+
+#[test_case(1; "seed1")]
+#[test_case(2; "seed2")]
+#[test_case(3; "seed3")]
+#[test_case(4; "seed4")]
+#[test_case(5; "seed5")]
+#[test_case(6; "seed6")]
+#[test_case(7; "seed7")]
+#[test_case(8; "seed8")]
+#[test_case(9; "seed9")]
+#[test_case(10; "seed10")]
+#[test_case(14710580201381303742; "seed11")]
+#[test_case(11282773634027867923; "seed12")]
+#[test_case(11868595526945931122; "seed13")]
+#[test_case(4712443726697299681; "seed14")]
+#[test_case(5153471631950140680; "seed15")]
+#[test_case(4180491672667595808; "seed16")]
+#[test_case(3250401801427586510; "seed17")]
+#[test_case(13102732628471206412; "seed18")]
+fn nodes_with_random_latency(latency_seed: u64) {
+    let delta = Duration::from_millis(200);
+    let last_block = 2000usize;
+    let min_ledger_len = last_block - 5;
+    let max_blocksync_requests = 55u64;
+
+    let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+        // avoid the state_root trigger in the random-latency setting
+        .execution_delay(SeqNum::MAX)
+        .genesis_seqnum(SeqNum::MAX)
+        .epoch_length(SeqNum(3000))
+        .seed(latency_seed)
+        .swarm(|_| Network::with_latency(uniform_duration(Duration::from_millis(1), delta)));
+
+    assert!(
+        swarm.run_until_blocks(last_block, Time(0) + secs(2000)),
+        "seed {}: did not reach {} blocks",
+        latency_seed,
+        last_block
+    );
+
+    let ids = swarm.node_ids();
+    let mut verifier = SimVerifier::new();
+    verifier
+        .ledger_min_len(min_ledger_len)
+        // nodes time out only on init
+        .metric_exact(&ids, sim_metric!(consensus_events.local_timeout), 1)
+        // last_block is committed by processing 2 QCs after it; no branching.
+        // the node with the most blocksync requests may have the fewest blocks.
+        .metric_range(
+            &ids,
+            sim_metric!(consensus_events.process_qc),
+            min_ledger_len as u64 - max_blocksync_requests,
+            last_block as u64 + 2,
+        )
+        .metric_max(
+            &ids,
+            sim_metric!(blocksync_events.self_headers_request),
+            max_blocksync_requests,
+        )
+        .metric_max(
+            &ids,
+            sim_metric!(blocksync_events.self_payload_request),
+            max_blocksync_requests,
+        );
+    verifier.assert(&swarm);
+    swarm.assert_agreement();
+}

--- a/monad-mock-swarm/tests/sim_raptorcast.rs
+++ b/monad-mock-swarm/tests/sim_raptorcast.rs
@@ -1,0 +1,100 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg(feature = "raptorcast")]
+
+//! RaptorCast-chunk transport over the `monad-sim` harness, ported from the
+//! legacy `raptorcast.rs` (which it does not replace). Drives the
+//! `RaptorcastSwarm` relation — whose `RouterScheduler` chunks outbound messages
+//! and reassembles inbound chunks — across several epoch boundaries, exercising
+//! the harness's forwarding of `AddEpochValidatorSet` / `UpdateCurrentRound`
+//! (which the chunk scheduler needs to resolve broadcast recipients).
+
+use std::time::Duration;
+
+use monad_chain_config::{revision::ChainParams, MockChainConfig};
+use monad_consensus_types::{block::PassthruBlockPolicy, block_validator::MockValidator};
+use monad_crypto::certificate_signature::CertificateKeyPair;
+use monad_execution_state_read::InMemoryStateInner;
+use monad_mock_swarm::{
+    raptorcast::{RaptorcastRouterConfig, RaptorcastSwarm},
+    sim::{Network, SimNodeBuilder, SimSwarm, DEFAULT_TIMESTAMP_PERIOD},
+    swarm::make_state_configs,
+};
+use monad_router_scheduler::RouterSchedulerBuilder;
+use monad_sim::{time::secs, Time};
+use monad_types::{Epoch, NodeId, Round, SeqNum};
+use monad_updaters::{
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
+};
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
+
+static CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(5),
+};
+
+#[test]
+fn raptorcast_smoke_four_nodes() {
+    let delta = Duration::from_millis(100);
+    let epoch_length = SeqNum(20);
+    let epoch_start_delay = Round(5);
+
+    let builders: Vec<SimNodeBuilder<RaptorcastSwarm>> = make_state_configs::<RaptorcastSwarm>(
+        4,
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        || MockValidator,
+        || PassthruBlockPolicy,
+        || InMemoryStateInner::genesis(SeqNum(4)),
+        SeqNum(4),
+        delta,
+        MockChainConfig::new_with_epoch_params(&CHAIN_PARAMS, epoch_length, epoch_start_delay),
+        SeqNum(100),
+    )
+    .into_iter()
+    .map(|state_builder| {
+        let state_read = state_builder.state_read.clone();
+        let validators = state_builder.locked_epoch_validators[0].clone();
+        let self_id = NodeId::new(state_builder.key.pubkey());
+        SimNodeBuilder {
+            id: self_id,
+            state_builder,
+            router_scheduler: RaptorcastRouterConfig::<_, _, _>::new(self_id).build(),
+            val_set_updater: MockValSetUpdaterNop::new(validators.validators, epoch_length),
+            txpool_executor: MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
+            ledger: MockLedger::new(state_read.clone()),
+            statesync_executor: MockStateSyncExecutor::new(state_read),
+            timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+        }
+    })
+    .collect();
+
+    let mut swarm =
+        SimSwarm::<RaptorcastSwarm>::from_builders(0, builders, |_| Network::reliable(delta));
+
+    // Run past epoch 4, i.e. (4 - 1) * epoch_length committed blocks — enough to
+    // cross several boundaries with the chunked transport.
+    let min_blocks = ((Epoch(4).0 - 1) * epoch_length.0) as usize;
+    assert!(
+        swarm.run_until_blocks(min_blocks, Time(0) + secs(120)),
+        "raptorcast swarm did not reach {min_blocks} blocks"
+    );
+    swarm.assert_agreement();
+}

--- a/monad-mock-swarm/tests/sim_reserve_balance.rs
+++ b/monad-mock-swarm/tests/sim_reserve_balance.rs
@@ -1,0 +1,179 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Reserve-balance coverage: random transactions (mixed types, including
+//! insufficient-balance cases) against accounts with bounded balances. With
+//! reserve-balance validation enabled, execution asserts the reserve-balance
+//! invariant as blocks commit, so the test checks that consensus makes progress
+//! and never violates it. Ported onto the `monad-sim` harness (mirrors the
+//! legacy `reserve_balance.rs`, which it does not replace).
+
+mod eth_swarm_common;
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeMap;
+
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::B256;
+    use monad_eth_testutil::{
+        make_eip1559_tx_with_value, make_eip7702_tx_with_value, make_legacy_tx_with_value,
+        make_signed_authorization, secret_to_eth_address,
+    };
+    use monad_execution_state_read::AccountState;
+    use monad_mock_swarm::{
+        sim::{Network, SimSwarm},
+        sim_verify::SimVerifier,
+    };
+    use monad_sim::{time::secs, Time};
+    use monad_types::Balance;
+    use monad_updaters::txpool::ByzantineConfig;
+    use rand::Rng;
+    use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
+    use seq_macro::seq;
+
+    use crate::eth_swarm_common::{
+        eth_sim_builders_with_accounts, BASE_FEE, CONSENSUS_DELTA, GAS_LIMIT,
+    };
+
+    const GAS_COST: u128 = BASE_FEE * GAS_LIMIT as u128;
+    const GAS_LIMIT_7702: u64 = 70_000;
+
+    fn deadline() -> Time {
+        Time(0) + secs(120)
+    }
+
+    seq!(N in 0..512 {
+        #[test]
+        fn test_rand_reserve_balance_~N() {
+            rand_reserve_balance(N);
+        }
+    });
+
+    fn rand_reserve_balance(seed: u64) {
+        let mut rng = ChaChaRng::seed_from_u64(seed);
+
+        // 2-4 senders, each with a random balance between 0 and 10 * GAS_COSTs
+        // (a multiplier of 0 exercises the insufficient-balance path).
+        let num_senders = rng.gen_range(2..=4u8);
+        let sender_keys: Vec<B256> = (0..num_senders)
+            .map(|i| B256::repeat_byte(0x40 + i))
+            .collect();
+        let existing_accounts: BTreeMap<_, _> = sender_keys
+            .iter()
+            .map(|key| {
+                let balance_multiplier = rng.gen_range(0..=10u128);
+                (
+                    secret_to_eth_address(*key),
+                    AccountState::new_with_balance(Balance::from(balance_multiplier * GAS_COST)),
+                )
+            })
+            .collect();
+
+        let builders = eth_sim_builders_with_accounts(
+            2,
+            existing_accounts,
+            |_| ByzantineConfig::default(),
+            true,
+        );
+        let mut swarm =
+            SimSwarm::from_builders(0, builders, |_| Network::reliable(CONSENSUS_DELTA));
+        // post-statesync: every node reaches block 1 before any transactions.
+        assert!(swarm.run_until_blocks(1, deadline()), "no initial progress");
+        let node_1_id = swarm.node_ids()[0];
+
+        let mut sender_nonces: Vec<u64> = vec![0; num_senders as usize];
+        let mut current_block: usize = 2;
+
+        for (sender_idx, sender_key) in sender_keys.iter().enumerate() {
+            let num_txns = rng.gen_range(1..=8u64);
+
+            for _ in 0..num_txns {
+                let nonce = sender_nonces[sender_idx];
+                let gas_price = BASE_FEE * rng.gen_range(1..=3u128);
+                let value = rng.gen_range(0..=2u128) * GAS_COST;
+                let tx_type = rng.gen_range(0..=2u8);
+
+                let txn = match tx_type {
+                    0 => make_legacy_tx_with_value(
+                        *sender_key,
+                        value,
+                        gas_price,
+                        GAS_LIMIT,
+                        nonce,
+                        10,
+                    ),
+                    1 => make_eip1559_tx_with_value(
+                        *sender_key,
+                        value,
+                        gas_price,
+                        0,
+                        GAS_LIMIT,
+                        nonce,
+                        10,
+                    ),
+                    _ => {
+                        let auth_target_idx = (sender_idx + 1) % num_senders as usize;
+                        let auth_key = sender_keys[auth_target_idx];
+                        let auth_nonce = sender_nonces[auth_target_idx];
+                        let auth_list = vec![make_signed_authorization(
+                            auth_key,
+                            alloy_primitives::Address::repeat_byte(0xDD),
+                            auth_nonce,
+                        )];
+                        sender_nonces[auth_target_idx] += 1;
+                        make_eip7702_tx_with_value(
+                            *sender_key,
+                            value,
+                            gas_price,
+                            0,
+                            GAS_LIMIT_7702,
+                            nonce,
+                            auth_list,
+                            10,
+                        )
+                    }
+                };
+
+                sender_nonces[sender_idx] += 1;
+                swarm.send_transaction(node_1_id, txn.encoded_2718().into());
+
+                // advance a block with 10% probability
+                if rng.gen_bool(0.1) {
+                    current_block += 1;
+                    assert!(
+                        swarm.run_until_blocks(current_block, deadline()),
+                        "stalled before block {current_block}"
+                    );
+                }
+            }
+        }
+
+        // run consensus block policy to filter invalid transactions; execution
+        // asserts the reserve-balance invariant as each block commits.
+        let total_blocks = current_block + 10;
+        assert!(
+            swarm.run_until_blocks(total_blocks, deadline()),
+            "stalled before block {total_blocks}"
+        );
+
+        let ids = swarm.node_ids();
+        SimVerifier::new()
+            .ledger_min_len(2)
+            .metrics_happy_path(&ids, &swarm)
+            .assert(&swarm);
+        swarm.assert_agreement();
+    }
+}

--- a/monad-mock-swarm/tests/sim_two_nodes.rs
+++ b/monad-mock-swarm/tests/sim_two_nodes.rs
@@ -1,0 +1,47 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Two-node happy-path coverage, ported onto the `monad-sim` harness (mirrors
+//! the legacy `two_nodes.rs`, which it does not replace). The deterministic
+//! scheduler lets the final tick be asserted exactly, with no tolerance window.
+
+use std::time::Duration;
+
+use monad_mock_swarm::{
+    sim::{build_swarm_with, Network},
+    sim_verify::SimVerifier,
+};
+use monad_sim::{time::secs, Time};
+
+#[test]
+fn two_nodes_noser() {
+    let delta = Duration::from_millis(100);
+    let mut swarm = build_swarm_with(2, 0, |_| Network::reliable(delta));
+
+    assert!(
+        swarm.run_until_blocks(1026, Time(0) + secs(600)),
+        "did not reach 1026 blocks"
+    );
+
+    let ids = swarm.node_ids();
+    let mut verifier = SimVerifier::new();
+    verifier
+        // The deterministic scheduler yields an exact tick (no tolerance window).
+        .tick_exact(Time(0) + Duration::from_millis(205_500))
+        .ledger_min_len(1024)
+        .metrics_happy_path(&ids, &swarm);
+    verifier.assert(&swarm);
+    swarm.assert_agreement();
+}

--- a/monad-mock-swarm/tests/sim_two_nodes_bls.rs
+++ b/monad-mock-swarm/tests/sim_two_nodes_bls.rs
@@ -1,0 +1,187 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Two-node consensus over a BLS signature collection, ported onto the
+//! `monad-sim` harness (mirrors the legacy `two_nodes_bls.rs`, which it does
+//! not replace).
+//!
+//! NOTE: the legacy test additionally round-trips every emitted `MonadEvent`
+//! through RLP and serde on each step. That is serialization coverage,
+//! independent of the simulation engine; the new harness drives events
+//! internally and has no per-event hook. The round-trip coverage stays in the
+//! (still-present) legacy test; it should be extracted into a standalone
+//! serialization test before the legacy engine is deleted.
+
+use std::{collections::BTreeSet, time::Duration};
+
+use monad_bls::BlsSignatureCollection;
+use monad_chain_config::{
+    revision::{ChainParams, MockChainRevision},
+    MockChainConfig,
+};
+use monad_consensus_types::{
+    block::{MockExecutionProtocol, PassthruBlockPolicy},
+    block_validator::MockValidator,
+};
+use monad_crypto::certificate_signature::CertificateSignaturePubKey;
+use monad_execution_state_read::{InMemoryState, InMemoryStateInner};
+use monad_mock_swarm::{
+    sim::{Network, SimNodeBuilder, SimSwarm, DEFAULT_TIMESTAMP_PERIOD},
+    sim_verify::SimVerifier,
+    swarm::make_state_configs,
+    swarm_relation::SwarmRelation,
+};
+use monad_router_scheduler::{NoSerRouterConfig, NoSerRouterScheduler, RouterSchedulerBuilder};
+use monad_secp::SecpSignature;
+use monad_sim::{time::secs, Time};
+use monad_state::{MonadMessage, VerifiedMonadMessage};
+use monad_transformer::GenericTransformerPipeline;
+use monad_types::{NodeId, SeqNum};
+use monad_updaters::{
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
+};
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
+
+struct BLSSwarm;
+impl SwarmRelation for BLSSwarm {
+    type SignatureType = SecpSignature;
+    type SignatureCollectionType =
+        BlsSignatureCollection<CertificateSignaturePubKey<Self::SignatureType>>;
+    type ExecutionProtocolType = MockExecutionProtocol;
+    type ExecutionStateReadType = InMemoryState<Self::SignatureType, Self::SignatureCollectionType>;
+    type BlockPolicyType = PassthruBlockPolicy;
+    type ChainConfigType = MockChainConfig;
+    type ChainRevisionType = MockChainRevision;
+
+    type TransportMessage = VerifiedMonadMessage<
+        Self::SignatureType,
+        Self::SignatureCollectionType,
+        Self::ExecutionProtocolType,
+    >;
+
+    type BlockValidator = MockValidator;
+    type ValidatorSetTypeFactory =
+        ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
+    type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
+    type Ledger =
+        MockLedger<Self::SignatureType, Self::SignatureCollectionType, Self::ExecutionProtocolType>;
+
+    type RouterScheduler = NoSerRouterScheduler<
+        CertificateSignaturePubKey<Self::SignatureType>,
+        MonadMessage<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >,
+        VerifiedMonadMessage<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >,
+    >;
+
+    type Pipeline = GenericTransformerPipeline<
+        CertificateSignaturePubKey<Self::SignatureType>,
+        Self::TransportMessage,
+    >;
+
+    type ValSetUpdater = MockValSetUpdaterNop<
+        Self::SignatureType,
+        Self::SignatureCollectionType,
+        Self::ExecutionProtocolType,
+    >;
+    type TxPoolExecutor = MockTxPoolExecutor<
+        Self::SignatureType,
+        Self::SignatureCollectionType,
+        Self::ExecutionProtocolType,
+        Self::BlockPolicyType,
+        Self::ExecutionStateReadType,
+        Self::ChainConfigType,
+        Self::ChainRevisionType,
+    >;
+    type StateSyncExecutor = MockStateSyncExecutor<
+        Self::SignatureType,
+        Self::SignatureCollectionType,
+        Self::ExecutionProtocolType,
+    >;
+}
+
+static CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(5),
+};
+
+fn bls_sim(num_nodes: u16, delta: Duration) -> SimSwarm<BLSSwarm> {
+    let state_configs = make_state_configs::<BLSSwarm>(
+        num_nodes,
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        || MockValidator,
+        || PassthruBlockPolicy,
+        || InMemoryStateInner::genesis(SeqNum(4)),
+        SeqNum(4),
+        delta,
+        MockChainConfig::new(&CHAIN_PARAMS),
+        SeqNum(100),
+    );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|config| NodeId::new(config.key.pubkey()))
+        .collect();
+
+    let builders: Vec<SimNodeBuilder<BLSSwarm>> = state_configs
+        .into_iter()
+        .map(|config| {
+            let state_read = config.state_read.clone();
+            let validators = config.locked_epoch_validators[0].clone();
+            SimNodeBuilder {
+                id: NodeId::new(config.key.pubkey()),
+                state_builder: config,
+                router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                val_set_updater: MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
+                txpool_executor: MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
+                ledger: MockLedger::new(state_read.clone()),
+                statesync_executor: MockStateSyncExecutor::new(state_read),
+                timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+            }
+        })
+        .collect();
+
+    SimSwarm::from_builders(0, builders, |_| Network::reliable(delta))
+}
+
+#[test]
+fn two_nodes_bls() {
+    let delta = Duration::from_millis(20);
+    let mut swarm = bls_sim(2, delta);
+
+    assert!(
+        swarm.run_until_blocks(100, Time(0) + secs(60)),
+        "did not reach 100 blocks"
+    );
+
+    let ids = swarm.node_ids();
+    let mut verifier = SimVerifier::new();
+    verifier
+        .tick_exact(Time(0) + Duration::from_millis(4_060))
+        .ledger_min_len(98)
+        .metrics_happy_path(&ids, &swarm);
+    verifier.assert(&swarm);
+    swarm.assert_agreement();
+}

--- a/monad-mock-swarm/tests/sim_vote_delay_metrics.rs
+++ b/monad-mock-swarm/tests/sim_vote_delay_metrics.rs
@@ -1,0 +1,149 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Vote-delay metrics, ported onto the `monad-sim` harness. This mirrors the
+//! coverage of the legacy `vote_delay_metrics.rs` (which it does not replace)
+//! using the new framework's self-contained surface.
+
+use std::{collections::BTreeSet, time::Duration};
+
+use monad_chain_config::{revision::ChainParams, MockChainConfig};
+use monad_consensus_types::{block::PassthruBlockPolicy, block_validator::MockValidator};
+use monad_crypto::certificate_signature::CertificateKeyPair;
+use monad_execution_state_read::InMemoryStateInner;
+use monad_mock_swarm::{
+    sim::{Network, SimNodeBuilder, SimSwarm, DEFAULT_TIMESTAMP_PERIOD},
+    swarm::make_state_configs,
+    swarm_relation::NoSerSwarm,
+};
+use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+use monad_sim::{time::secs, Time};
+use monad_types::{NodeId, SeqNum};
+use monad_updaters::{
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
+};
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
+
+static ON_TIME_CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(500),
+};
+
+static LATE_CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(5),
+};
+
+/// A two-node `NoSerSwarm` driven through the `monad-sim` harness, with link
+/// latency `delta`.
+fn two_node_sim(chain_params: &'static ChainParams, delta: Duration) -> SimSwarm<NoSerSwarm> {
+    let state_configs = make_state_configs::<NoSerSwarm>(
+        2,
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        || MockValidator,
+        || PassthruBlockPolicy,
+        || InMemoryStateInner::genesis(SeqNum(4)),
+        SeqNum(4),
+        delta,
+        MockChainConfig::new(chain_params),
+        SeqNum(100),
+    );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|config| NodeId::new(config.key.pubkey()))
+        .collect();
+
+    let builders: Vec<SimNodeBuilder<NoSerSwarm>> = state_configs
+        .into_iter()
+        .map(|config| {
+            let state_read = config.state_read.clone();
+            let validators = config.locked_epoch_validators[0].clone();
+            SimNodeBuilder {
+                id: NodeId::new(config.key.pubkey()),
+                state_builder: config,
+                router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                val_set_updater: MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
+                txpool_executor: MockTxPoolExecutor::default().with_chain_params(chain_params),
+                ledger: MockLedger::new(state_read.clone()),
+                statesync_executor: MockStateSyncExecutor::new(state_read),
+                timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+            }
+        })
+        .collect();
+
+    SimSwarm::from_builders(0, builders, |_| Network::reliable(delta))
+}
+
+#[test]
+fn vote_delay_metrics_record_ready_after_timer_start_on_happy_path() {
+    let delta = Duration::from_millis(100);
+    let mut swarm = two_node_sim(&ON_TIME_CHAIN_PARAMS, delta);
+
+    assert!(
+        swarm.run_until_blocks(64, Time(0) + secs(120)),
+        "did not reach 64 blocks"
+    );
+    assert!(swarm.finalized_blocks().iter().all(|&n| n >= 62));
+    swarm.assert_agreement();
+
+    for id in swarm.node_ids() {
+        swarm.with_node(id, |node| {
+            let metrics = node.metrics();
+            let p50 = metrics.vote_delay.ready_after_timer_start_p50_ms.get();
+            let p90 = metrics.vote_delay.ready_after_timer_start_p90_ms.get();
+            let p99 = metrics.vote_delay.ready_after_timer_start_p99_ms.get();
+
+            assert!(p50 > 0);
+            assert!(p50 <= p90);
+            assert!(p90 <= p99);
+            assert!(p99 < ON_TIME_CHAIN_PARAMS.vote_pace.as_millis() as u64);
+            assert!(metrics.consensus_events.local_timeout.get() <= 1);
+        });
+    }
+}
+
+#[test]
+fn vote_delay_metrics_record_large_ready_after_timer_start_when_vote_pace_is_too_small() {
+    let delta = Duration::from_millis(100);
+    let mut swarm = two_node_sim(&LATE_CHAIN_PARAMS, delta);
+
+    assert!(
+        swarm.run_until_blocks(64, Time(0) + secs(120)),
+        "did not reach 64 blocks"
+    );
+    assert!(swarm.finalized_blocks().iter().all(|&n| n >= 62));
+    swarm.assert_agreement();
+
+    for id in swarm.node_ids() {
+        swarm.with_node(id, |node| {
+            let metrics = node.metrics();
+            let p50 = metrics.vote_delay.ready_after_timer_start_p50_ms.get();
+            let p90 = metrics.vote_delay.ready_after_timer_start_p90_ms.get();
+            let p99 = metrics.vote_delay.ready_after_timer_start_p99_ms.get();
+
+            assert!(p50 > LATE_CHAIN_PARAMS.vote_pace.as_millis() as u64);
+            assert!(p50 <= p90);
+            assert!(p90 <= p99);
+        });
+    }
+}

--- a/monad-mock-swarm/tests/vote_delay_metrics.rs
+++ b/monad-mock-swarm/tests/vote_delay_metrics.rs
@@ -52,7 +52,10 @@ static LATE_CHAIN_PARAMS: ChainParams = ChainParams {
     vote_pace: Duration::from_millis(5),
 };
 
-fn build_two_node_swarm(chain_params: &'static ChainParams, delta: Duration) -> Nodes<NoSerSwarm> {
+fn build_two_node_config(
+    chain_params: &'static ChainParams,
+    delta: Duration,
+) -> SwarmBuilder<NoSerSwarm> {
     let chain_config = MockChainConfig::new(chain_params);
     let state_configs = make_state_configs::<NoSerSwarm>(
         2,
@@ -94,7 +97,10 @@ fn build_two_node_swarm(chain_params: &'static ChainParams, delta: Duration) -> 
             })
             .collect(),
     )
-    .build()
+}
+
+fn build_two_node_swarm(chain_params: &'static ChainParams, delta: Duration) -> Nodes<NoSerSwarm> {
+    build_two_node_config(chain_params, delta).build()
 }
 
 fn run_until_block(swarm: &mut Nodes<NoSerSwarm>, block: usize) {

--- a/monad-sim-swarm/Cargo.toml
+++ b/monad-sim-swarm/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "monad-sim-swarm"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+monad-sim = { workspace = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }

--- a/monad-sim-swarm/src/lib.rs
+++ b/monad-sim-swarm/src/lib.rs
@@ -1,0 +1,48 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Generic simulation infrastructure that sits *between* the domain-agnostic
+//! engine ([`monad_sim`], "Layer A") and a protocol-specific adapter ("Layer
+//! B"). It carries no consensus or Monad knowledge — everything here is
+//! parameterized only by a node address type `Addr` and a wire message type
+//! `Msg`.
+//!
+//! Three pieces, all reusable across protocols:
+//!
+//! - [`Net`] — the network as a `monad_sim` *process*: a routing table plus a
+//!   swappable [`NetworkModel`] (latency / loss / partition / duplication),
+//!   built declaratively with [`Network`]. Crucially, `Net` addresses nodes
+//!   through a **type-erased** delivery boundary ([`Deliver`] / [`deliver_to`]),
+//!   so a single network can carry *heterogeneous* node process types as long as
+//!   they share `Msg` — the seam for testing different protocol versions (or a
+//!   Byzantine node) in one swarm.
+//! - [`Swarm`] — a minimal builder/harness: spawn a set of [`SimClient`] nodes
+//!   plus a `Net`, wire them together, and forward run-control to the engine.
+//!   Deliberately homogeneous for now (one node type `N`); the `Net` boundary is
+//!   already erased, so a future heterogeneous swarm reuses it unchanged.
+//! - [`Timers`] — the re-arming timer set (one armed timeout per key) that every
+//!   node needs for pacemaker-style timeouts.
+//!
+//! Protocol-specific inspection (finalized blocks, current round, agreement
+//! assertions) deliberately does *not* live here; it belongs to each protocol's
+//! adapter, layered over [`Swarm::with_node`].
+
+mod net;
+mod swarm;
+mod timers;
+
+pub use net::{Conditions, Deliver, Link, Net, Network, NetworkModel};
+pub use swarm::{deliver_to, SimClient, Swarm};
+pub use timers::Timers;

--- a/monad-sim-swarm/src/net.rs
+++ b/monad-sim-swarm/src/net.rs
@@ -1,0 +1,263 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The network as a simulation process, generic over the node address `Addr`
+//! and the wire message `Msg`. A node sends by scheduling a step on the [`Net`]
+//! handle; the net samples its [`NetworkModel`] and schedules the surviving
+//! deliveries against the recipients.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::Range,
+    rc::Rc,
+    time::Duration,
+};
+
+use monad_sim::{Ctx, Time};
+use rand::{distributions::Distribution, Rng, SeedableRng};
+use rand_chacha::ChaChaRng;
+
+/// A type-erased "deliver this message to one node at this time" operation.
+///
+/// Registered per address (see [`Net::register`] / [`crate::deliver_to`]), it
+/// captures the recipient's *concrete* `Handle` and monomorphizes the
+/// `ctx.schedule` call, so the network itself only ever names `Addr` and `Msg`.
+/// This is what lets one [`Net`] carry heterogeneous node process types.
+pub type Deliver<Addr, Msg> = Rc<dyn Fn(&mut Ctx, Time, Addr, Msg)>;
+
+/// Per-message context handed to a [`NetworkModel`].
+pub struct Link<Addr> {
+    pub now: Time,
+    pub from: Addr,
+    pub to: Addr,
+}
+
+/// Decides the fate of a single message: the delays at which copies are
+/// delivered to `link.to`. An empty result drops the message; more than one
+/// duplicates it. Reordering needs no special handling — a smaller delay simply
+/// arrives first.
+pub trait NetworkModel<Addr, Msg> {
+    fn deliveries(
+        &mut self,
+        link: &Link<Addr>,
+        message: &Msg,
+        rng: &mut ChaChaRng,
+    ) -> Vec<Duration>;
+}
+
+type LatencyFn = Box<dyn FnMut(&mut ChaChaRng) -> Duration>;
+type DropFn<Addr, Msg> = Box<dyn Fn(&Link<Addr>, &Msg) -> bool>;
+type Partition<Addr> = (Range<Time>, Vec<BTreeSet<Addr>>);
+
+/// A declarative network model: a base latency plus optional, independent
+/// conditions. Anything left unconfigured behaves reliably.
+pub struct Conditions<Addr, Msg> {
+    latency: LatencyFn,
+    loss: f64,
+    partitions: Vec<Partition<Addr>>,
+    drop_if: Option<DropFn<Addr, Msg>>,
+}
+
+impl<Addr: Ord, Msg> NetworkModel<Addr, Msg> for Conditions<Addr, Msg> {
+    fn deliveries(
+        &mut self,
+        link: &Link<Addr>,
+        message: &Msg,
+        rng: &mut ChaChaRng,
+    ) -> Vec<Duration> {
+        if let Some(drop_if) = &self.drop_if {
+            if drop_if(link, message) {
+                return Vec::new();
+            }
+        }
+        let split = self.partitions.iter().any(|(window, groups)| {
+            window.contains(&link.now)
+                && groups
+                    .iter()
+                    .any(|group| group.contains(&link.from) != group.contains(&link.to))
+        });
+        if split {
+            return Vec::new();
+        }
+        if self.loss > 0.0 && rng.gen::<f64>() < self.loss {
+            return Vec::new();
+        }
+        vec![(self.latency)(rng)]
+    }
+}
+
+/// Declarative builder for a swarm's network behaviour. Start from
+/// [`reliable`](Network::reliable) or [`with_latency`](Network::with_latency)
+/// and layer conditions, or supply a [`custom`](Network::custom) model.
+pub enum Network<Addr, Msg> {
+    Conditions(Conditions<Addr, Msg>),
+    Custom(Box<dyn NetworkModel<Addr, Msg>>),
+}
+
+impl<Addr, Msg> Default for Network<Addr, Msg> {
+    fn default() -> Self {
+        Network::reliable(Duration::from_millis(1))
+    }
+}
+
+impl<Addr, Msg> Network<Addr, Msg> {
+    /// Constant-latency, lossless network.
+    pub fn reliable(latency: Duration) -> Self {
+        Network::Conditions(Conditions {
+            latency: Box::new(move |_| latency),
+            loss: 0.0,
+            partitions: Vec::new(),
+            drop_if: None,
+        })
+    }
+
+    /// Latency sampled per message from `distribution`.
+    pub fn with_latency(distribution: impl Distribution<Duration> + 'static) -> Self {
+        let mut network = Network::reliable(Duration::ZERO);
+        network.conditions().latency = Box::new(move |rng| distribution.sample(rng));
+        network
+    }
+
+    /// A fully custom model.
+    pub fn custom(model: impl NetworkModel<Addr, Msg> + 'static) -> Self {
+        Network::Custom(Box::new(model))
+    }
+
+    /// Drop each message independently with probability `probability`.
+    pub fn loss(mut self, probability: f64) -> Self {
+        self.conditions().loss = probability;
+        self
+    }
+
+    /// While `window` is active, drop messages crossing between the given groups
+    /// (a network split). Nodes absent from every group stay fully connected.
+    pub fn partition(
+        mut self,
+        window: Range<Time>,
+        groups: impl IntoIterator<Item = impl IntoIterator<Item = Addr>>,
+    ) -> Self
+    where
+        Addr: Ord,
+    {
+        let groups = groups
+            .into_iter()
+            .map(|group| group.into_iter().collect())
+            .collect();
+        self.conditions().partitions.push((window, groups));
+        self
+    }
+
+    /// Drop messages for which `predicate` holds.
+    pub fn drop_if(mut self, predicate: impl Fn(&Link<Addr>, &Msg) -> bool + 'static) -> Self {
+        self.conditions().drop_if = Some(Box::new(predicate));
+        self
+    }
+
+    /// Panics if called on a [`custom`](Network::custom) model.
+    fn conditions(&mut self) -> &mut Conditions<Addr, Msg> {
+        match self {
+            Network::Conditions(conditions) => conditions,
+            Network::Custom(_) => panic!("cannot layer conditions onto a custom network model"),
+        }
+    }
+
+    fn into_model(self) -> Box<dyn NetworkModel<Addr, Msg>>
+    where
+        Addr: Ord + 'static,
+        Msg: 'static,
+    {
+        match self {
+            Network::Conditions(conditions) => Box::new(conditions),
+            Network::Custom(model) => model,
+        }
+    }
+}
+
+/// The network process: a routing table (type-erased per-node delivery) plus a
+/// [`NetworkModel`] and an independent RNG (kept separate from the engine's
+/// scheduling RNG so network randomness is reproducible on its own).
+pub struct Net<Addr, Msg> {
+    routes: BTreeMap<Addr, Deliver<Addr, Msg>>,
+    model: Box<dyn NetworkModel<Addr, Msg>>,
+    rng: ChaChaRng,
+}
+
+impl<Addr, Msg> Net<Addr, Msg>
+where
+    Addr: Ord + Copy + 'static,
+    Msg: Clone + 'static,
+{
+    /// A fresh network with the given model, seeded independently of the engine.
+    pub fn new(seed: u64, network: Network<Addr, Msg>) -> Self {
+        Self {
+            routes: BTreeMap::new(),
+            model: network.into_model(),
+            rng: ChaChaRng::seed_from_u64(seed),
+        }
+    }
+
+    /// Register a node's delivery entry point (see [`crate::deliver_to`]).
+    pub fn register(&mut self, addr: Addr, deliver: Deliver<Addr, Msg>) {
+        self.routes.insert(addr, deliver);
+    }
+
+    /// Drop a node from the routing table (e.g. a restart/removal); messages to
+    /// it are silently discarded thereafter.
+    pub fn deregister(&mut self, addr: &Addr) {
+        self.routes.remove(addr);
+    }
+
+    /// Replace the network model (mid-run reconfiguration).
+    pub fn set_model(&mut self, network: Network<Addr, Msg>) {
+        self.model = network.into_model();
+    }
+
+    /// Send one message `from` -> `to`: apply the model and schedule the
+    /// surviving deliveries. A recipient not in the routing table drops it.
+    pub fn send(&mut self, ctx: &mut Ctx, from: Addr, to: Addr, msg: Msg) {
+        let link = Link {
+            now: ctx.now(),
+            from,
+            to,
+        };
+        let delays = self.model.deliveries(&link, &msg, &mut self.rng);
+        let Some(deliver) = self.routes.get(&to).cloned() else {
+            return;
+        };
+        match delays.as_slice() {
+            [] => {}
+            [delay] => deliver(ctx, ctx.now() + *delay, from, msg),
+            _ => {
+                for delay in delays {
+                    deliver(ctx, ctx.now() + delay, from, msg.clone());
+                }
+            }
+        }
+    }
+
+    /// Send `msg` to every registered node (including `from` itself, if
+    /// registered). The model is applied independently per recipient.
+    pub fn broadcast(&mut self, ctx: &mut Ctx, from: Addr, msg: Msg) {
+        let targets: Vec<Addr> = self.routes.keys().copied().collect();
+        for to in targets {
+            self.send(ctx, from, to, msg.clone());
+        }
+    }
+
+    /// The set of currently-routable node addresses.
+    pub fn addrs(&self) -> impl Iterator<Item = &Addr> {
+        self.routes.keys()
+    }
+}

--- a/monad-sim-swarm/src/swarm.rs
+++ b/monad-sim-swarm/src/swarm.rs
@@ -1,0 +1,189 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! A minimal swarm builder over [`monad_sim`]: spawn a set of nodes plus a
+//! [`Net`], wire them together, and forward run-control to the engine. The
+//! builder is generic over the node process type `N` and knows nothing about a
+//! node's internals beyond the [`SimClient`] seam.
+
+use std::{collections::BTreeMap, rc::Rc};
+
+use monad_sim::{Ctx, Handle, RunOutcome, Simulation, StepLabel, Time};
+
+use crate::net::{Deliver, Net, Network};
+
+/// A node that can be plugged into a simulated network.
+///
+/// The framework owns the node's state as a `monad_sim` process. A message
+/// addressed to the node arrives as a scheduled [`receive`](SimClient::receive)
+/// step. The node learns its own handle and the network handle once, via
+/// [`wire`](SimClient::wire), so it can schedule self-timers and send messages;
+/// a node that does neither can leave `wire` as the default no-op.
+pub trait SimClient: Sized + 'static {
+    /// Address type used to route to this node on the network.
+    type Addr: Ord + Copy + 'static;
+    /// The wire message type. All nodes on one network share it.
+    type Message: Clone + 'static;
+
+    /// Called once, just after the node is spawned, with its own process handle
+    /// and the network handle. Default: ignore both.
+    fn wire(&mut self, me: Handle<Self>, net: Handle<Net<Self::Addr, Self::Message>>) {
+        let _ = (me, net);
+    }
+
+    /// Handle a message delivered by the network from peer `from`.
+    fn receive(&mut self, from: Self::Addr, msg: Self::Message, ctx: &mut Ctx);
+}
+
+/// Build the type-erased delivery thunk for a concrete node handle: it schedules
+/// `N::receive` against `handle`, capturing the concrete type so the network can
+/// forget it. See [`Deliver`].
+pub fn deliver_to<N: SimClient>(handle: Handle<N>) -> Deliver<N::Addr, N::Message> {
+    Rc::new(
+        move |ctx: &mut Ctx, at: Time, from: N::Addr, msg: N::Message| {
+            ctx.schedule(
+                handle,
+                at,
+                StepLabel::source("deliver"),
+                move |node: &mut N, ctx| node.receive(from, msg, ctx),
+            );
+        },
+    )
+}
+
+/// A running swarm: the [`Simulation`], the network handle, and the node
+/// handles keyed by address. Homogeneous in the node type `N` for now; the
+/// [`Net`] delivery boundary is already type-erased, so a heterogeneous variant
+/// can reuse it without changing the network.
+pub struct Swarm<N: SimClient> {
+    sim: Simulation,
+    net: Handle<Net<N::Addr, N::Message>>,
+    nodes: BTreeMap<N::Addr, Handle<N>>,
+}
+
+impl<N: SimClient> Swarm<N> {
+    /// Spawn a `Net` with the given model and the supplied nodes, wiring each
+    /// node's handles and registering its delivery thunk with the network.
+    pub fn build(
+        seed: u64,
+        network: Network<N::Addr, N::Message>,
+        nodes: impl IntoIterator<Item = (N::Addr, N)>,
+    ) -> Self {
+        let mut sim = Simulation::new(seed);
+        let net = sim.spawn(Net::new(seed, network));
+        let mut map = BTreeMap::new();
+        for (addr, node) in nodes {
+            let handle = sim.spawn(node);
+            sim.with_mut(handle, |n| n.wire(handle, net));
+            let deliver = deliver_to(handle);
+            sim.with_mut(net, move |n| n.register(addr, deliver));
+            map.insert(addr, handle);
+        }
+        Self {
+            sim,
+            net,
+            nodes: map,
+        }
+    }
+
+    /// Add a node to a running swarm (e.g. a restart). Returns its handle.
+    pub fn add_node(&mut self, addr: N::Addr, node: N) -> Handle<N> {
+        let net = self.net;
+        let handle = self.sim.spawn(node);
+        self.sim.with_mut(handle, |n| n.wire(handle, net));
+        let deliver = deliver_to(handle);
+        self.sim.with_mut(net, move |n| n.register(addr, deliver));
+        self.nodes.insert(addr, handle);
+        handle
+    }
+
+    /// Remove a node from the swarm, returning its state. Messages already in
+    /// flight to it are dropped when they arrive.
+    pub fn remove_node(&mut self, addr: &N::Addr) -> Option<N> {
+        let handle = self.nodes.remove(addr)?;
+        let net = self.net;
+        self.sim.with_mut(net, |n| n.deregister(addr));
+        Some(self.sim.despawn(handle))
+    }
+
+    /// Replace the network model between steps.
+    pub fn set_network(&mut self, network: Network<N::Addr, N::Message>) {
+        let net = self.net;
+        self.sim.with_mut(net, |n| n.set_model(network));
+    }
+
+    /// The underlying engine, for scheduling kickoff steps and custom run loops.
+    pub fn sim(&mut self) -> &mut Simulation {
+        &mut self.sim
+    }
+
+    /// Read-only view of the engine (clock, metrics).
+    pub fn simulation(&self) -> &Simulation {
+        &self.sim
+    }
+
+    /// The network process handle.
+    pub fn net(&self) -> Handle<Net<N::Addr, N::Message>> {
+        self.net
+    }
+
+    /// The addresses of all live nodes.
+    pub fn node_ids(&self) -> Vec<N::Addr> {
+        self.nodes.keys().copied().collect()
+    }
+
+    /// The handle for a node, if present.
+    pub fn handle(&self, addr: &N::Addr) -> Option<Handle<N>> {
+        self.nodes.get(addr).copied()
+    }
+
+    /// Inspect a node's state between steps.
+    pub fn with_node<R>(&self, addr: &N::Addr, f: impl FnOnce(&N) -> R) -> R {
+        self.sim.with(self.nodes[addr], f)
+    }
+
+    /// Mutate a node's state between steps (input injection).
+    pub fn with_node_mut<R>(&mut self, addr: &N::Addr, f: impl FnOnce(&mut N) -> R) -> R {
+        let handle = self.nodes[addr];
+        self.sim.with_mut(handle, f)
+    }
+
+    pub fn run_to_completion(&mut self) -> RunOutcome {
+        self.sim.run_to_completion()
+    }
+
+    pub fn run_until_time(&mut self, t: Time) -> RunOutcome {
+        self.sim.run_until_time(t)
+    }
+
+    pub fn run_steps(&mut self, n: u64) -> RunOutcome {
+        self.sim.run_steps(n)
+    }
+
+    /// Run until `done` returns true (checked before each step), so the
+    /// predicate can inspect node state via `&Self`. Returns
+    /// [`RunOutcome::Stopped`] when it fires, or [`RunOutcome::Drained`] if the
+    /// queue empties first.
+    pub fn run_until(&mut self, mut done: impl FnMut(&Self) -> bool) -> RunOutcome {
+        loop {
+            if done(self) {
+                return RunOutcome::Stopped;
+            }
+            if self.sim.next_step().is_none() {
+                return RunOutcome::Drained;
+            }
+        }
+    }
+}

--- a/monad-sim-swarm/src/timers.rs
+++ b/monad-sim-swarm/src/timers.rs
@@ -1,0 +1,69 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! A set of at-most-one-armed timers keyed by `K` — the pacemaker pattern every
+//! node uses (one live timeout per variant, re-arming resets it). Holds the
+//! engine's [`CancelToken`]s; the caller schedules the actual step and hands the
+//! token here.
+
+use std::{collections::HashMap, hash::Hash};
+
+use monad_sim::CancelToken;
+
+/// One armed timer per key. Arming a key cancels any timer previously armed
+/// under it.
+pub struct Timers<K> {
+    armed: HashMap<K, CancelToken>,
+}
+
+impl<K> Default for Timers<K> {
+    fn default() -> Self {
+        Self {
+            armed: HashMap::new(),
+        }
+    }
+}
+
+impl<K: Eq + Hash> Timers<K> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record the token of a freshly-scheduled timer, cancelling any previous
+    /// timer under `key`. Schedule the step first, then pass its token here.
+    pub fn arm(&mut self, key: K, token: CancelToken) {
+        if let Some(previous) = self.armed.insert(key, token) {
+            previous.cancel();
+        }
+    }
+
+    /// Cancel and forget the timer under `key`, if any.
+    pub fn reset(&mut self, key: &K) {
+        if let Some(previous) = self.armed.remove(key) {
+            previous.cancel();
+        }
+    }
+
+    /// Forget the timer under `key` without cancelling it — use when the timer
+    /// has just fired and its step is running.
+    pub fn clear(&mut self, key: &K) {
+        self.armed.remove(key);
+    }
+
+    /// Whether a live (uncancelled, unfired) timer is armed under `key`.
+    pub fn is_armed(&self, key: &K) -> bool {
+        self.armed.contains_key(key)
+    }
+}

--- a/monad-sim-swarm/tests/swarm.rs
+++ b/monad-sim-swarm/tests/swarm.rs
@@ -1,0 +1,182 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Worked examples for `monad-sim-swarm`, with toy app-defined node types.
+//! `Sender`/`Receiver`/`Counter` live here, not in the crate — the swarm
+//! infrastructure never names a concrete node type. These exercise the two
+//! guarantees a protocol adapter relies on: a single network carrying
+//! *different* node process types (the type-erased delivery boundary), and the
+//! `Swarm` builder over one node type with a real latency model.
+
+use monad_sim::{time::millis, Ctx, Handle, Simulation, StepLabel, Time};
+use monad_sim_swarm::{deliver_to, Net, Network, SimClient, Swarm};
+
+type Addr = u32;
+type Msg = u64;
+
+/// A node that only ever sends.
+struct Sender {
+    addr: Addr,
+    target: Addr,
+    net: Option<Handle<Net<Addr, Msg>>>,
+}
+
+impl Sender {
+    fn emit(&mut self, ctx: &mut Ctx) {
+        let (net, from, to) = (self.net.unwrap(), self.addr, self.target);
+        ctx.schedule(
+            net,
+            ctx.now(),
+            StepLabel::source("route"),
+            move |net, ctx| net.send(ctx, from, to, 42),
+        );
+    }
+}
+
+impl SimClient for Sender {
+    type Addr = Addr;
+    type Message = Msg;
+    fn wire(&mut self, _me: Handle<Self>, net: Handle<Net<Addr, Msg>>) {
+        self.net = Some(net);
+    }
+    fn receive(&mut self, _from: Addr, _msg: Msg, _ctx: &mut Ctx) {}
+}
+
+/// A node that only ever receives.
+struct Receiver {
+    got: u32,
+    last: Option<Msg>,
+}
+
+impl SimClient for Receiver {
+    type Addr = Addr;
+    type Message = Msg;
+    fn receive(&mut self, _from: Addr, msg: Msg, _ctx: &mut Ctx) {
+        self.got += 1;
+        self.last = Some(msg);
+    }
+}
+
+/// A homogeneous node that broadcasts once and counts what it receives.
+struct Counter {
+    addr: Addr,
+    net: Option<Handle<Net<Addr, Msg>>>,
+    got: u32,
+}
+
+impl Counter {
+    fn new(addr: Addr) -> Self {
+        Self {
+            addr,
+            net: None,
+            got: 0,
+        }
+    }
+    fn emit(&mut self, ctx: &mut Ctx) {
+        let (net, from) = (self.net.unwrap(), self.addr);
+        ctx.schedule(
+            net,
+            ctx.now(),
+            StepLabel::source("route"),
+            move |net, ctx| net.broadcast(ctx, from, 7),
+        );
+    }
+}
+
+impl SimClient for Counter {
+    type Addr = Addr;
+    type Message = Msg;
+    fn wire(&mut self, _me: Handle<Self>, net: Handle<Net<Addr, Msg>>) {
+        self.net = Some(net);
+    }
+    fn receive(&mut self, _from: Addr, _msg: Msg, _ctx: &mut Ctx) {
+        self.got += 1;
+    }
+}
+
+/// Two *different* node types (`Sender`, `Receiver`) share one `Net<Addr, Msg>`:
+/// the network only names `Addr`/`Msg`, and the concrete node type is erased
+/// behind the delivery thunk. This is the seam for heterogeneous swarms.
+#[test]
+fn heterogeneous_nodes_share_one_network() {
+    let mut sim = Simulation::new(0);
+    let net = sim.spawn(Net::new(0, Network::reliable(millis(10))));
+    let recv = sim.spawn(Receiver { got: 0, last: None });
+    let send = sim.spawn(Sender {
+        addr: 2,
+        target: 1,
+        net: None,
+    });
+    sim.with_mut(send, |s| s.wire(send, net));
+    sim.with_mut(net, |n| n.register(1, deliver_to(recv)));
+    sim.with_mut(net, |n| n.register(2, deliver_to(send)));
+
+    sim.schedule(send, Time(0), StepLabel::source("start"), |s, ctx| {
+        s.emit(ctx)
+    });
+    sim.run_to_completion();
+
+    assert_eq!(sim.with(recv, |r| r.got), 1);
+    assert_eq!(sim.with(recv, |r| r.last), Some(42));
+    // One 10ms network hop.
+    assert_eq!(sim.now(), Time(0) + millis(10));
+}
+
+/// The `Swarm` builder wires a set of homogeneous nodes to a network; a
+/// broadcast (including to self) reaches everyone after one latency hop.
+#[test]
+fn swarm_broadcast_reaches_all() {
+    let nodes = (0..3).map(|a| (a, Counter::new(a)));
+    let mut swarm = Swarm::build(0, Network::reliable(millis(5)), nodes);
+
+    let node0 = swarm.handle(&0).unwrap();
+    swarm
+        .sim()
+        .schedule(node0, Time(0), StepLabel::source("start"), |c, ctx| {
+            c.emit(ctx)
+        });
+    swarm.run_to_completion();
+
+    for a in 0..3 {
+        assert_eq!(swarm.with_node(&a, |c| c.got), 1);
+    }
+    assert_eq!(swarm.simulation().now(), Time(0) + millis(5));
+}
+
+/// `drop_if` removes a message before delivery.
+#[test]
+fn drop_if_suppresses_delivery() {
+    let mut sim = Simulation::new(0);
+    let net = sim.spawn(Net::new(
+        0,
+        Network::reliable(millis(10)).drop_if(|link, _msg| link.from == 2),
+    ));
+    let recv = sim.spawn(Receiver { got: 0, last: None });
+    let send = sim.spawn(Sender {
+        addr: 2,
+        target: 1,
+        net: None,
+    });
+    sim.with_mut(send, |s| s.wire(send, net));
+    sim.with_mut(net, |n| n.register(1, deliver_to(recv)));
+    sim.with_mut(net, |n| n.register(2, deliver_to(send)));
+
+    sim.schedule(send, Time(0), StepLabel::source("start"), |s, ctx| {
+        s.emit(ctx)
+    });
+    sim.run_to_completion();
+
+    assert_eq!(sim.with(recv, |r| r.got), 0);
+}

--- a/monad-sim/Cargo.toml
+++ b/monad-sim/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "monad-sim"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rand = { workspace = true }
+rand_distr = { workspace = true }

--- a/monad-sim/src/dist.rs
+++ b/monad-sim/src/dist.rs
@@ -1,0 +1,162 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Probability distributions for modelling clock and network behaviour.
+//!
+//! These return `impl Distribution<_>` values intended to be sampled through
+//! [`crate::Simulation::sample`] or [`crate::Ctx::sample`] so that all randomness
+//! is driven by the simulation's seeded generator.
+
+// See `crate::time::DurationFromNanosU128`: local shim for the 1.93-only
+// `Duration::from_nanos_u128` while the workspace builds on 1.91.1.
+#![allow(unstable_name_collisions)]
+
+use std::time::Duration;
+
+use rand::{distributions::Distribution, Rng};
+use rand_distr::{LogNormal, Normal};
+
+use crate::time::{ClockDiff, DurationFromNanosU128};
+
+/// The pair of two independent distributions, sampled jointly.
+#[derive(Clone)]
+struct Pair<D0, D1> {
+    d0: D0,
+    d1: D1,
+}
+
+impl<D0, T0, D1, T1> Distribution<(T0, T1)> for Pair<D0, D1>
+where
+    D0: Distribution<T0>,
+    D1: Distribution<T1>,
+{
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> (T0, T1) {
+        (self.d0.sample(rng), self.d1.sample(rng))
+    }
+}
+
+/// Normally distributed duration. Negative samples are clipped to zero; use
+/// [`normal_clock_diff`] when negative values are meaningful.
+pub fn normal_duration(mean: Duration, stddev: Duration) -> impl Distribution<Duration> + 'static {
+    Normal::new(mean.as_nanos() as f64, stddev.as_nanos() as f64)
+        .unwrap()
+        .map(|ns| Duration::from_nanos_u128(ns.max(0.0) as u128))
+}
+
+/// Normally distributed signed clock difference.
+pub fn normal_clock_diff(
+    mean: ClockDiff,
+    stddev: Duration,
+) -> impl Distribution<ClockDiff> + 'static {
+    Normal::new(mean.0 as f64, stddev.as_nanos() as f64)
+        .unwrap()
+        .map(|ns| ClockDiff(ns as i128))
+}
+
+/// Log-normal duration parameterised by the mean and standard deviation of the
+/// underlying normal distribution (i.e. of `ln` of the variable). See
+/// [`lognormal_duration2`] for the more intuitive parameterisation by the mean
+/// and standard deviation of the duration itself.
+///
+/// Panics if a sample exceeds the representable [`Duration`] range.
+pub fn lognormal_duration(
+    normal_mean: f64,
+    normal_stddev: f64,
+) -> impl Distribution<Duration> + 'static {
+    LogNormal::new(normal_mean, normal_stddev)
+        .unwrap()
+        .map(|ns| {
+            assert!(
+                ns <= Duration::MAX.as_nanos() as f64,
+                "lognormal sample too large to represent as a Duration"
+            );
+            Duration::from_nanos_u128(ns as u128)
+        })
+}
+
+/// Log-normal duration parameterised directly by its `mean` and `stddev`.
+pub fn lognormal_duration2(
+    mean: Duration,
+    stddev: Duration,
+) -> impl Distribution<Duration> + 'static {
+    let mean_f64 = mean.as_nanos() as f64;
+    let var = (stddev.as_nanos() as f64).powi(2);
+    let normal_var = (1.0 + var / mean_f64.powi(2)).ln();
+    let normal_mean = mean_f64.ln() - 0.5 * normal_var;
+    lognormal_duration(normal_mean, normal_var.sqrt())
+}
+
+/// Uniformly distributed duration in the inclusive range `[min, max]`.
+pub fn uniform_duration(min: Duration, max: Duration) -> impl Distribution<Duration> + 'static {
+    rand::distributions::Uniform::new_inclusive(min.as_nanos(), max.as_nanos())
+        .map(Duration::from_nanos_u128)
+}
+
+/// Lower bound estimate on global UDP latency.
+const MINIMUM_NETWORK_DELAY: Duration = Duration::from_micros(100);
+/// Upper bound estimate on global UDP latency.
+const MAXIMUM_NETWORK_DELAY: Duration = Duration::from_millis(100);
+
+/// Latency model for a globally distributed UDP network: a uniform baseline
+/// (geographic distance) plus log-normal jitter (network conditions). Reasonable
+/// jitter parameters for inter-datacenter links are mean 5ms, stddev 500us.
+pub fn global_udp_duration(
+    mean_jitter: Duration,
+    stddev_jitter: Duration,
+) -> impl Distribution<Duration> + 'static {
+    Pair {
+        d0: uniform_duration(MINIMUM_NETWORK_DELAY, MAXIMUM_NETWORK_DELAY),
+        d1: lognormal_duration2(mean_jitter, stddev_jitter),
+    }
+    .map(|(baseline, jitter)| baseline + jitter)
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{rngs::StdRng, SeedableRng};
+
+    use super::*;
+    use crate::time::{micros, millis};
+
+    #[test]
+    fn uniform_duration_respects_bounds() {
+        let mut rng = StdRng::seed_from_u64(1);
+        let d = uniform_duration(millis(10), millis(20));
+        for _ in 0..1000 {
+            let s = d.sample(&mut rng);
+            assert!(s >= millis(10) && s <= millis(20));
+        }
+    }
+
+    #[test]
+    fn global_udp_duration_at_least_baseline() {
+        let mut rng = StdRng::seed_from_u64(2);
+        let d = global_udp_duration(millis(5), micros(500));
+        for _ in 0..1000 {
+            assert!(d.sample(&mut rng) >= MINIMUM_NETWORK_DELAY);
+        }
+    }
+
+    #[test]
+    fn same_seed_same_samples() {
+        let sample = |seed| {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let d = normal_duration(millis(5), millis(1));
+            (0..16).map(|_| d.sample(&mut rng)).collect::<Vec<_>>()
+        };
+        assert_eq!(sample(7), sample(7));
+        assert_ne!(sample(7), sample(8));
+    }
+}

--- a/monad-sim/src/lib.rs
+++ b/monad-sim/src/lib.rs
@@ -1,0 +1,47 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Generic, single-threaded discrete-event simulation infrastructure.
+//!
+//! The simulation is a time-ordered queue of *steps*. A step is a closure that
+//! runs at a specific [`time::Time`] and may schedule further steps. State lives
+//! in *processes*: any value `S: 'static` registered with [`Simulation::spawn`]
+//! and addressed by a typed [`Handle`]. When a step scheduled against a handle
+//! runs, the framework lends it `&mut S` exclusively for the duration of that
+//! step, via a [`Ctx`] that can read time, sample randomness, and schedule more
+//! work — but cannot reach any other process's state. Cross-process interaction
+//! is therefore always "schedule a step on that handle", which keeps the engine
+//! agnostic about event and component-state types and makes reentrancy
+//! impossible by construction.
+//!
+//! [`time`] provides the simulation time type; [`dist`] provides
+//! network-latency distributions for modelling message delays.
+//!
+//! # Not yet implemented
+//!
+//! The engine runs a single global clock with a deterministic per-step total
+//! order. Per-process local clocks (NTP-style drift), the clock-scheduling
+//! strategy that orders steps across them, and synchronous signal fan-out are
+//! deferred; see the `monad-mock-swarm` design doc ("Future work") for the
+//! rationale.
+
+pub mod dist;
+mod sim;
+pub mod time;
+
+pub use sim::{
+    CancelToken, Ctx, Handle, ProcessId, RunOutcome, SimMetrics, Simulation, StepInfo, StepLabel,
+};
+pub use time::{ClockDiff, Time};

--- a/monad-sim/src/sim.rs
+++ b/monad-sim/src/sim.rs
@@ -1,0 +1,1227 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The discrete-event scheduler: [`Simulation`], process [`Handle`]s, and the
+//! per-step [`Ctx`].
+
+use std::{
+    any::Any,
+    cell::Cell,
+    cmp::{Ordering, Reverse},
+    collections::{BinaryHeap, HashMap},
+    marker::PhantomData,
+    rc::Rc,
+    time::Duration,
+};
+
+use rand::{distributions::Distribution, rngs::StdRng, SeedableRng};
+
+use crate::time::Time;
+
+/// Identifies a process registered in a [`Simulation`]. Stable for the lifetime
+/// of that process; ids are never reused.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct ProcessId(u64);
+
+/// The reserved root process that owns process-less ([`Simulation::schedule_global`])
+/// steps. Its state is `()`.
+const ROOT: ProcessId = ProcessId(0);
+
+/// A typed reference to a process's state owned by the [`Simulation`].
+///
+/// `Copy` regardless of `S`; cheap to capture in closures. A step scheduled
+/// against a handle is lent `&mut S` while it runs.
+///
+/// The `id`→`S` binding is fixed at [`spawn`](Simulation::spawn) — ids are never
+/// reused and a process's state type never changes — and handles are minted only
+/// there. That is the invariant that makes the erased `Action` downcast
+/// infallible.
+pub struct Handle<S> {
+    id: ProcessId,
+    _pd: PhantomData<fn() -> S>,
+}
+
+impl<S> Clone for Handle<S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<S> Copy for Handle<S> {}
+
+impl<S> Handle<S> {
+    /// The id of the referenced process.
+    pub fn id(&self) -> ProcessId {
+        self.id
+    }
+}
+
+/// Optional metadata attached to a scheduled step, surfaced in [`StepInfo`] for
+/// observability. `min_propagation` is reserved for future causal-independence
+/// inference and is otherwise ignored.
+///
+/// `priority` is a same-time ordering class (lower runs first); see [`TieBreak`]
+/// and `Entry`'s ordering for how it interacts with the tie-break. The default
+/// `0` leaves a step in the highest-priority class.
+#[derive(Clone, Debug, Default)]
+pub struct StepLabel {
+    pub source: Option<&'static str>,
+    pub kind: Option<&'static str>,
+    pub min_propagation: Option<Duration>,
+    pub priority: u32,
+}
+
+impl StepLabel {
+    /// A label tagged with the component that scheduled the step.
+    pub fn source(source: &'static str) -> Self {
+        Self {
+            source: Some(source),
+            ..Self::default()
+        }
+    }
+
+    /// Set the step kind (builder style).
+    pub fn kind(mut self, kind: &'static str) -> Self {
+        self.kind = Some(kind);
+        self
+    }
+
+    /// Set the same-time priority class (builder style); lower runs first at the
+    /// same simulated time under `TieBreak::Fifo`.
+    pub fn priority(mut self, priority: u32) -> Self {
+        self.priority = priority;
+        self
+    }
+}
+
+/// Description of an executed step, passed to the observer and available for
+/// run-control predicates.
+#[derive(Clone, Debug)]
+pub struct StepInfo {
+    pub time: Time,
+    pub seq: u64,
+    pub process: ProcessId,
+    pub label: StepLabel,
+    /// This step's critical-path depth (see [`SimMetrics::critical_path_len`]);
+    /// `0` if the step was skipped because its process had been despawned.
+    pub depth: u64,
+}
+
+/// Why a bounded run returned.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RunOutcome {
+    /// The queue emptied.
+    Drained,
+    /// Reached the requested time; later steps remain queued.
+    ReachedTime(Time),
+    /// Executed the requested number of steps; more remain.
+    ReachedStepLimit,
+    /// A `run_while` predicate asked to stop.
+    Stopped,
+}
+
+/// Handle to a scheduled step that lets it be cancelled before it runs.
+///
+/// Cancellation is lazy: the step stays in the queue and is skipped when popped.
+/// Cancelling after the step has already run is a no-op.
+#[derive(Clone)]
+pub struct CancelToken(Rc<Cell<bool>>);
+
+impl CancelToken {
+    fn new() -> Self {
+        CancelToken(Rc::new(Cell::new(false)))
+    }
+
+    /// Prevent the associated step from running.
+    pub fn cancel(&self) {
+        self.0.set(true);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.0.get()
+    }
+}
+
+/// Counters describing what a [`Simulation`] has done. Purely informational.
+#[derive(Clone, Debug, Default)]
+pub struct SimMetrics {
+    pub steps_executed: u64,
+    pub steps_scheduled: u64,
+    /// Steps skipped because they were cancelled before being popped.
+    pub steps_cancelled: u64,
+    pub max_queue_len: usize,
+    /// Longest chain of causally-dependent steps, in steps. A step depends on
+    /// the step that scheduled it and on the previous step on its own process
+    /// (processes are serial). This is the run's critical path: the fewest
+    /// sequential steps any execution — parallel or not — must take. Together
+    /// with `steps_executed` (the total work) it bounds the available
+    /// parallelism (see [`parallelism`](Self::parallelism)). Deterministic for a
+    /// given `(config, seed)`, so it is usable as a regression metric.
+    pub critical_path_len: u64,
+}
+
+impl SimMetrics {
+    /// Average available parallelism: total steps over the critical path. `1.0`
+    /// for a fully sequential run; higher means more steps could, in principle,
+    /// run concurrently. An upper bound on achievable speedup, not a measurement
+    /// of any actual parallel run.
+    pub fn parallelism(&self) -> f64 {
+        self.steps_executed as f64 / self.critical_path_len.max(1) as f64
+    }
+}
+
+/// A queued step with its state type erased, so one heap can hold steps for
+/// heterogeneous processes. The closure (built by `enqueue::<S>`) downcasts the
+/// erased `&mut dyn Any` back to its scheduling `Handle<S>`'s `S`; that is
+/// infallible because a process keeps its state type for life (see [`Handle`]),
+/// so the downcast `expect` there is a defensive assert, not a reachable failure.
+type Action = Box<dyn FnOnce(&mut dyn Any, &mut Ctx<'_>)>;
+type Observer = Box<dyn FnMut(&StepInfo)>;
+
+/// How same-time steps are ordered.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum TieBreak {
+    /// Deterministic FIFO: ties break by creation order (`seq`). The default,
+    /// and the only mode that yields exact, stable ticks.
+    #[default]
+    Fifo,
+    /// Seeded pseudo-random: ties break by a hash of `(seed, seq)`, decoupled
+    /// from creation order. Still fully reproducible from `(config, seed)` — it
+    /// is a deterministic reshuffle, not true non-determinism. Sweep the seed to
+    /// explore different same-time orderings (fuzzing for order-dependence bugs).
+    Randomized,
+}
+
+struct Entry {
+    time: Time,
+    /// Same-time ordering key (see [`TieBreak`]); always 0 under `Fifo`.
+    tie_break: u64,
+    /// Same-time priority class (from [`StepLabel::priority`]); lower runs first.
+    priority: u32,
+    seq: u64,
+    process: ProcessId,
+    /// Critical-path depth of the step that scheduled this one (`0` if scheduled
+    /// outside any step). See [`SimMetrics::critical_path_len`].
+    parent_depth: u64,
+    label: StepLabel,
+    cancel: CancelToken,
+    action: Action,
+}
+
+// Ordering is by (time, tie_break, priority, seq). `seq` is unique and monotonic,
+// so the order is always total. Note `tie_break` precedes `priority`:
+// - under `TieBreak::Fifo` every `tie_break` is 0, so this reduces to
+//   (time, priority, seq) — priority classes are honored at a tick, FIFO within
+//   a class, with stable exact ticks;
+// - under `TieBreak::Randomized` the per-seq `tie_break` is distinct, so it
+//   dominates and `priority` is effectively ignored — same-time steps are fully
+//   shuffled across classes (priority-respecting within-class fuzzing would put
+//   `priority` first instead; deliberately not done here).
+impl PartialEq for Entry {
+    fn eq(&self, other: &Self) -> bool {
+        self.time == other.time
+            && self.tie_break == other.tie_break
+            && self.priority == other.priority
+            && self.seq == other.seq
+    }
+}
+impl Eq for Entry {}
+impl Ord for Entry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.time
+            .cmp(&other.time)
+            .then(self.tie_break.cmp(&other.tie_break))
+            .then(self.priority.cmp(&other.priority))
+            .then(self.seq.cmp(&other.seq))
+    }
+}
+impl PartialOrd for Entry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// SplitMix64 finalizer. Maps the unique, monotonic `seq` (combined with the
+/// simulation seed) to a well-distributed, collision-free `tie_break`, so
+/// same-time steps get a deterministic pseudo-random order under
+/// [`TieBreak::Randomized`].
+fn tie_break_key(seed: u64, seq: u64) -> u64 {
+    let mut z = seq.wrapping_add(seed.wrapping_mul(0x9e37_79b9_7f4a_7c15));
+    z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    z ^ (z >> 31)
+}
+
+/// A single-threaded discrete-event simulation: a time-ordered queue of steps
+/// over a set of framework-owned processes.
+///
+/// Construct with [`Simulation::new`], register state with [`spawn`](Self::spawn),
+/// schedule work with [`schedule`](Self::schedule) / [`schedule_global`](Self::schedule_global),
+/// then drive it with one of the `run_*` methods.
+pub struct Simulation {
+    seed: u64,
+    tie_break: TieBreak,
+    rng: StdRng,
+    now: Time,
+    seq: u64,
+    next_id: u64,
+    processes: HashMap<ProcessId, Option<Box<dyn Any>>>,
+    queue: BinaryHeap<Reverse<Entry>>,
+    metrics: SimMetrics,
+    observer: Option<Observer>,
+    /// Critical-path depth of the last executed step on each process; maintains
+    /// [`SimMetrics::critical_path_len`] incrementally.
+    proc_depth: HashMap<ProcessId, u64>,
+}
+
+impl Simulation {
+    /// A fresh, empty simulation seeded for deterministic randomness. The clock
+    /// starts at [`Time(0)`](Time).
+    pub fn new(seed: u64) -> Self {
+        let mut processes = HashMap::new();
+        processes.insert(ROOT, Some(Box::new(()) as Box<dyn Any>));
+        Simulation {
+            seed,
+            tie_break: TieBreak::Fifo,
+            rng: StdRng::seed_from_u64(seed),
+            now: Time(0),
+            seq: 0,
+            next_id: 1,
+            processes,
+            queue: BinaryHeap::new(),
+            metrics: SimMetrics::default(),
+            observer: None,
+            proc_depth: HashMap::new(),
+        }
+    }
+
+    /// Choose how same-time steps are ordered (default [`TieBreak::Fifo`]).
+    ///
+    /// Set this before scheduling any steps — e.g. immediately after
+    /// construction — so the chosen order applies to the whole run. Changing it
+    /// mid-run only affects steps enqueued afterwards.
+    pub fn set_tie_break(&mut self, tie_break: TieBreak) {
+        self.tie_break = tie_break;
+    }
+
+    /// The current same-time ordering policy.
+    pub fn tie_break(&self) -> TieBreak {
+        self.tie_break
+    }
+
+    /// Return the simulation to its just-constructed state: all processes and
+    /// scheduled steps are discarded, the clock and metrics reset, and the
+    /// generator reseeded from the original seed. Handles obtained before the
+    /// reset are invalid afterwards.
+    pub fn reset(&mut self) {
+        *self = Simulation::new(self.seed);
+    }
+
+    pub fn seed(&self) -> u64 {
+        self.seed
+    }
+
+    /// The current global clock time. During a step this is the step's time;
+    /// otherwise it is the time of the most recently executed step (or the
+    /// target of the last [`run_until_time`](Self::run_until_time)).
+    pub fn now(&self) -> Time {
+        self.now
+    }
+
+    /// Number of steps executed so far. Cancelled (skipped) steps do not count.
+    pub fn step_count(&self) -> u64 {
+        self.metrics.steps_executed
+    }
+
+    pub fn metrics(&self) -> &SimMetrics {
+        &self.metrics
+    }
+
+    /// Sample from `d` using the simulation's seeded generator.
+    pub fn sample<T>(&mut self, d: impl Distribution<T>) -> T {
+        d.sample(&mut self.rng)
+    }
+
+    /// Register process state and return a handle to it.
+    pub fn spawn<S: 'static>(&mut self, state: S) -> Handle<S> {
+        let id = ProcessId(self.next_id);
+        self.next_id += 1;
+        self.processes.insert(id, Some(Box::new(state)));
+        Handle {
+            id,
+            _pd: PhantomData,
+        }
+    }
+
+    /// Schedule `step` to run at absolute time `at` with exclusive `&mut S`
+    /// access to the process behind `who`.
+    ///
+    /// Panics if `at` is before [`now`](Self::now). Panics when the step is
+    /// executed if `who` does not refer to a live process or its state type does
+    /// not match `S`.
+    pub fn schedule<S: 'static>(
+        &mut self,
+        who: Handle<S>,
+        at: Time,
+        label: StepLabel,
+        step: impl FnOnce(&mut S, &mut Ctx<'_>) + 'static,
+    ) -> CancelToken {
+        enqueue(
+            &mut self.queue,
+            &mut self.seq,
+            self.seed,
+            self.tie_break,
+            &mut self.metrics,
+            self.now,
+            0,
+            who.id,
+            at,
+            label,
+            step,
+        )
+    }
+
+    /// Like [`schedule`](Self::schedule) but at `now + delay`.
+    pub fn schedule_after<S: 'static>(
+        &mut self,
+        who: Handle<S>,
+        delay: Duration,
+        label: StepLabel,
+        step: impl FnOnce(&mut S, &mut Ctx<'_>) + 'static,
+    ) -> CancelToken {
+        self.schedule(who, self.now + delay, label, step)
+    }
+
+    /// Schedule a process-less step (setup, observation, fan-out scheduling)
+    /// owned by the reserved root process. The step receives only a [`Ctx`].
+    ///
+    /// Panics if `at` is before [`now`](Self::now).
+    pub fn schedule_global(
+        &mut self,
+        at: Time,
+        label: StepLabel,
+        step: impl FnOnce(&mut Ctx<'_>) + 'static,
+    ) -> CancelToken {
+        enqueue::<()>(
+            &mut self.queue,
+            &mut self.seq,
+            self.seed,
+            self.tie_break,
+            &mut self.metrics,
+            self.now,
+            0,
+            ROOT,
+            at,
+            label,
+            move |_unit, ctx| step(ctx),
+        )
+    }
+
+    /// Read the state behind `who`. Intended for use between steps (run-control
+    /// predicates, assertions, the debugger).
+    ///
+    /// Panics if `who` is not a live process, its state is unavailable because a
+    /// step on it is currently executing, or its state type does not match `S`.
+    pub fn with<S: 'static, R>(&self, who: Handle<S>, f: impl FnOnce(&S) -> R) -> R {
+        let state = self
+            .processes
+            .get(&who.id)
+            .expect("unknown process handle")
+            .as_ref()
+            .expect("process state unavailable (called during its own step?)")
+            .downcast_ref::<S>()
+            .expect("handle/state type mismatch");
+        f(state)
+    }
+
+    /// Mutable counterpart of [`with`](Self::with), for injecting input between
+    /// steps. Same panic conditions.
+    pub fn with_mut<S: 'static, R>(&mut self, who: Handle<S>, f: impl FnOnce(&mut S) -> R) -> R {
+        let state = self
+            .processes
+            .get_mut(&who.id)
+            .expect("unknown process handle")
+            .as_mut()
+            .expect("process state unavailable (called during its own step?)")
+            .downcast_mut::<S>()
+            .expect("handle/state type mismatch");
+        f(state)
+    }
+
+    /// Remove a process and return its state. Steps already scheduled against it
+    /// will be skipped when popped (their state is gone). The handle is invalid
+    /// afterwards.
+    ///
+    /// Panics if `who` is not a live process, its state is unavailable because a
+    /// step on it is currently executing, or its state type does not match `S`.
+    pub fn despawn<S: 'static>(&mut self, who: Handle<S>) -> S {
+        let boxed = self
+            .processes
+            .remove(&who.id)
+            .expect("unknown process handle")
+            .expect("process state unavailable (despawn during its own step?)");
+        self.proc_depth.remove(&who.id);
+        *boxed.downcast::<S>().expect("handle/state type mismatch")
+    }
+
+    /// Register a callback invoked after every executed step. Replaces any
+    /// previously registered observer.
+    pub fn on_step(&mut self, observer: impl FnMut(&StepInfo) + 'static) {
+        self.observer = Some(Box::new(observer));
+    }
+
+    /// Time of the next queued step, ignoring whether it is cancelled. `None`
+    /// when the queue is empty.
+    pub fn peek_time(&self) -> Option<Time> {
+        self.queue.peek().map(|Reverse(e)| e.time)
+    }
+
+    /// Execute the earliest queued step (skipping cancelled ones), returning its
+    /// [`StepInfo`], or `None` if the queue is empty.
+    pub fn next_step(&mut self) -> Option<StepInfo> {
+        loop {
+            let Reverse(entry) = self.queue.pop()?;
+            if entry.cancel.is_cancelled() {
+                self.metrics.steps_cancelled += 1;
+                continue;
+            }
+            let time = entry.time;
+            let seq = entry.seq;
+            let process = entry.process;
+            let label = entry.label.clone();
+            let depth = self.dispatch(entry);
+            self.metrics.steps_executed += 1;
+            let info = StepInfo {
+                time,
+                seq,
+                process,
+                label,
+                depth,
+            };
+            if let Some(observer) = self.observer.as_mut() {
+                observer(&info);
+            }
+            return Some(info);
+        }
+    }
+
+    /// Run until the queue is empty.
+    pub fn run_to_completion(&mut self) -> RunOutcome {
+        while self.next_step().is_some() {}
+        RunOutcome::Drained
+    }
+
+    /// Run every step scheduled at time `<= t`, then advance the clock to `t`
+    /// (never backwards). Returns [`RunOutcome::Drained`] if the queue emptied,
+    /// otherwise [`RunOutcome::ReachedTime`].
+    pub fn run_until_time(&mut self, t: Time) -> RunOutcome {
+        loop {
+            // Drop cancelled entries first so the time bound is applied to the
+            // next step that will actually run, not to a skipped one.
+            self.purge_cancelled_front();
+            match self.peek_time() {
+                Some(next) if next <= t => {
+                    self.next_step();
+                }
+                Some(_) => {
+                    self.advance_to(t);
+                    return RunOutcome::ReachedTime(t);
+                }
+                None => {
+                    self.advance_to(t);
+                    return RunOutcome::Drained;
+                }
+            }
+        }
+    }
+
+    /// Discard cancelled entries at the front of the queue so the next peek sees
+    /// a runnable step.
+    fn purge_cancelled_front(&mut self) {
+        while let Some(Reverse(entry)) = self.queue.peek() {
+            if entry.cancel.is_cancelled() {
+                self.queue.pop();
+                self.metrics.steps_cancelled += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Run up to `n` steps. Returns [`RunOutcome::Drained`] if the queue emptied
+    /// first, otherwise [`RunOutcome::ReachedStepLimit`].
+    pub fn run_steps(&mut self, n: u64) -> RunOutcome {
+        for _ in 0..n {
+            if self.next_step().is_none() {
+                return RunOutcome::Drained;
+            }
+        }
+        RunOutcome::ReachedStepLimit
+    }
+
+    /// Run while `pred` holds, evaluating it before each step. `pred` may inspect
+    /// process state (via [`with`](Self::with)) and the clock. Returns
+    /// [`RunOutcome::Stopped`] when `pred` returns `false`, or
+    /// [`RunOutcome::Drained`] if the queue empties first.
+    pub fn run_while(&mut self, mut pred: impl FnMut(&Simulation) -> bool) -> RunOutcome {
+        while pred(&*self) {
+            if self.next_step().is_none() {
+                return RunOutcome::Drained;
+            }
+        }
+        RunOutcome::Stopped
+    }
+
+    fn advance_to(&mut self, t: Time) {
+        if t > self.now {
+            self.now = t;
+        }
+    }
+
+    fn dispatch(&mut self, entry: Entry) -> u64 {
+        let pid = entry.process;
+        self.now = entry.time;
+        // A step may be left over for a process that was despawned after it was
+        // scheduled; skip it (it does no work, so it is off the critical path).
+        if !self.processes.contains_key(&pid) {
+            return 0;
+        }
+        // Critical-path depth: one past the later of the step that scheduled this
+        // one and the previous step on this process.
+        let depth = entry
+            .parent_depth
+            .max(self.proc_depth.get(&pid).copied().unwrap_or(0))
+            + 1;
+        self.proc_depth.insert(pid, depth);
+        self.metrics.critical_path_len = self.metrics.critical_path_len.max(depth);
+        // Take the process's state out so `Ctx` can borrow the rest of `self`
+        // (including `processes`, for spawns) without aliasing it.
+        let mut state = self
+            .processes
+            .get_mut(&pid)
+            .expect("scheduled step references an unknown process")
+            .take()
+            .expect("process state unavailable (reentrant step?)");
+        {
+            let mut ctx = Ctx {
+                now: self.now,
+                seed: self.seed,
+                tie_break: self.tie_break,
+                current_depth: depth,
+                rng: &mut self.rng,
+                queue: &mut self.queue,
+                seq: &mut self.seq,
+                next_id: &mut self.next_id,
+                processes: &mut self.processes,
+                metrics: &mut self.metrics,
+            };
+            (entry.action)(&mut *state, &mut ctx);
+        }
+        self.processes
+            .get_mut(&pid)
+            .expect("process slot vanished during step")
+            .replace(state);
+        depth
+    }
+}
+
+/// Capabilities granted to a step while it runs: read the clock, sample
+/// randomness, and schedule further work. It deliberately cannot reach any
+/// process's state — cross-process interaction is always a scheduled step.
+pub struct Ctx<'a> {
+    now: Time,
+    seed: u64,
+    tie_break: TieBreak,
+    /// Critical-path depth of the running step; stamped onto steps it schedules.
+    current_depth: u64,
+    rng: &'a mut StdRng,
+    queue: &'a mut BinaryHeap<Reverse<Entry>>,
+    seq: &'a mut u64,
+    next_id: &'a mut u64,
+    processes: &'a mut HashMap<ProcessId, Option<Box<dyn Any>>>,
+    metrics: &'a mut SimMetrics,
+}
+
+impl<'a> Ctx<'a> {
+    /// The time of the currently executing step (the owning process's clock).
+    pub fn now(&self) -> Time {
+        self.now
+    }
+
+    /// Sample from `d` using the simulation's seeded generator.
+    pub fn sample<T>(&mut self, d: impl Distribution<T>) -> T {
+        d.sample(&mut *self.rng)
+    }
+
+    /// Schedule a step on `who` at absolute time `at`. Panics if `at` is before
+    /// [`now`](Self::now).
+    pub fn schedule<S: 'static>(
+        &mut self,
+        who: Handle<S>,
+        at: Time,
+        label: StepLabel,
+        step: impl FnOnce(&mut S, &mut Ctx<'_>) + 'static,
+    ) -> CancelToken {
+        enqueue(
+            &mut *self.queue,
+            &mut *self.seq,
+            self.seed,
+            self.tie_break,
+            &mut *self.metrics,
+            self.now,
+            self.current_depth,
+            who.id,
+            at,
+            label,
+            step,
+        )
+    }
+
+    /// Like [`schedule`](Self::schedule) but at `now + delay`.
+    pub fn schedule_after<S: 'static>(
+        &mut self,
+        who: Handle<S>,
+        delay: Duration,
+        label: StepLabel,
+        step: impl FnOnce(&mut S, &mut Ctx<'_>) + 'static,
+    ) -> CancelToken {
+        self.schedule(who, self.now + delay, label, step)
+    }
+
+    /// Schedule a process-less step on the reserved root process.
+    pub fn schedule_global(
+        &mut self,
+        at: Time,
+        label: StepLabel,
+        step: impl FnOnce(&mut Ctx<'_>) + 'static,
+    ) -> CancelToken {
+        enqueue::<()>(
+            &mut *self.queue,
+            &mut *self.seq,
+            self.seed,
+            self.tie_break,
+            &mut *self.metrics,
+            self.now,
+            self.current_depth,
+            ROOT,
+            at,
+            label,
+            move |_unit, ctx| step(ctx),
+        )
+    }
+
+    /// Register a new process during a step. The handle is usable immediately
+    /// (steps can be scheduled against it), and the process becomes runnable on
+    /// the next popped step.
+    pub fn spawn<S: 'static>(&mut self, state: S) -> Handle<S> {
+        let id = ProcessId(*self.next_id);
+        *self.next_id += 1;
+        self.processes.insert(id, Some(Box::new(state)));
+        Handle {
+            id,
+            _pd: PhantomData,
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn enqueue<S: 'static>(
+    queue: &mut BinaryHeap<Reverse<Entry>>,
+    seq: &mut u64,
+    seed: u64,
+    mode: TieBreak,
+    metrics: &mut SimMetrics,
+    now: Time,
+    parent_depth: u64,
+    who: ProcessId,
+    at: Time,
+    label: StepLabel,
+    step: impl FnOnce(&mut S, &mut Ctx<'_>) + 'static,
+) -> CancelToken {
+    assert!(
+        at >= now,
+        "cannot schedule a step in the past: now={now:?}, at={at:?}"
+    );
+    let s = *seq;
+    *seq += 1;
+    let tie_break = match mode {
+        TieBreak::Fifo => 0,
+        TieBreak::Randomized => tie_break_key(seed, s),
+    };
+    let priority = label.priority;
+    let cancel = CancelToken::new();
+    let action: Action = Box::new(move |any, ctx| {
+        let state = any
+            .downcast_mut::<S>()
+            .expect("scheduled step state type does not match its handle");
+        step(state, ctx);
+    });
+    queue.push(Reverse(Entry {
+        time: at,
+        tie_break,
+        priority,
+        seq: s,
+        process: who,
+        parent_depth,
+        label,
+        cancel: cancel.clone(),
+        action,
+    }));
+    metrics.steps_scheduled += 1;
+    metrics.max_queue_len = metrics.max_queue_len.max(queue.len());
+    cancel
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use rand::distributions::Uniform;
+
+    use super::*;
+    use crate::time::millis;
+
+    #[derive(Default)]
+    struct Counter(u64);
+    #[derive(Default)]
+    struct Log(Vec<u64>);
+
+    #[test]
+    fn steps_run_in_time_order_and_advance_clock() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Log::default());
+        sim.schedule(h, Time(30), StepLabel::default(), |s, _| s.0.push(30));
+        sim.schedule(h, Time(10), StepLabel::default(), |s, _| s.0.push(10));
+        sim.schedule(h, Time(20), StepLabel::default(), |s, _| s.0.push(20));
+
+        assert_eq!(sim.run_to_completion(), RunOutcome::Drained);
+        sim.with(h, |s| assert_eq!(s.0, vec![10, 20, 30]));
+        assert_eq!(sim.now(), Time(30));
+        assert_eq!(sim.step_count(), 3);
+    }
+
+    #[test]
+    fn same_time_steps_run_fifo() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Log::default());
+        for v in [1, 2, 3] {
+            sim.schedule(h, Time(10), StepLabel::default(), move |s, _| s.0.push(v));
+        }
+        sim.run_to_completion();
+        sim.with(h, |s| assert_eq!(s.0, vec![1, 2, 3]));
+    }
+
+    /// Run `n` steps all scheduled at the same time and return the order in
+    /// which they executed, under the given tie-break policy and seed.
+    fn same_time_order(seed: u64, mode: TieBreak, n: u64) -> Vec<u64> {
+        let mut sim = Simulation::new(seed);
+        sim.set_tie_break(mode);
+        let h = sim.spawn(Log::default());
+        for v in 0..n {
+            sim.schedule(h, Time(10), StepLabel::default(), move |s, _| s.0.push(v));
+        }
+        sim.run_to_completion();
+        sim.with(h, |s| s.0.clone())
+    }
+
+    #[test]
+    fn fifo_tie_break_preserves_creation_order() {
+        // The default policy: same-time steps run in creation order, regardless
+        // of seed — this is what keeps exact-tick assertions stable.
+        assert_eq!(
+            same_time_order(7, TieBreak::Fifo, 8),
+            (0..8).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            same_time_order(7, TieBreak::Fifo, 8),
+            same_time_order(99, TieBreak::Fifo, 8)
+        );
+    }
+
+    #[test]
+    fn randomized_tie_break_reorders_but_stays_reproducible() {
+        let a = same_time_order(7, TieBreak::Randomized, 8);
+
+        // Reproducible: same (config, seed) yields the same order.
+        assert_eq!(a, same_time_order(7, TieBreak::Randomized, 8));
+        // It is a permutation of the creation order...
+        let mut sorted = a.clone();
+        sorted.sort();
+        assert_eq!(sorted, (0..8).collect::<Vec<_>>());
+        // ...but decoupled from it (not FIFO).
+        assert_ne!(a, (0..8).collect::<Vec<_>>());
+        // A different seed explores a different ordering (fuzzing).
+        assert_ne!(a, same_time_order(8, TieBreak::Randomized, 8));
+    }
+
+    #[test]
+    fn priority_orders_same_time_steps_under_fifo() {
+        // Same-time steps run by ascending priority class (lower first), FIFO
+        // within a class — regardless of creation order.
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Log::default());
+        for (v, p) in [(0u64, 7u32), (1, 7), (2, 2), (3, 0), (4, 2)] {
+            sim.schedule(
+                h,
+                Time(10),
+                StepLabel::default().priority(p),
+                move |s, _| s.0.push(v),
+            );
+        }
+        sim.run_to_completion();
+        // class 0: [3]; class 2: [2, 4] (FIFO); class 7: [0, 1] (FIFO).
+        sim.with(h, |s| assert_eq!(s.0, vec![3, 2, 4, 0, 1]));
+    }
+
+    #[test]
+    fn randomized_tie_break_ignores_priority() {
+        // Under Randomized the per-seq tie-break dominates the priority class, so
+        // assigning priorities does not constrain the order: it is identical to
+        // the priority-free Randomized order at the same seed (full shuffle).
+        let mut sim = Simulation::new(7);
+        sim.set_tie_break(TieBreak::Randomized);
+        let h = sim.spawn(Log::default());
+        for v in 0..8u64 {
+            // Later-created steps get higher priority — this WOULD reorder them
+            // under Fifo, but must not under Randomized.
+            let p = (8 - v) as u32;
+            sim.schedule(
+                h,
+                Time(10),
+                StepLabel::default().priority(p),
+                move |s, _| s.0.push(v),
+            );
+        }
+        sim.run_to_completion();
+        let with_priority = sim.with(h, |s| s.0.clone());
+        assert_eq!(with_priority, same_time_order(7, TieBreak::Randomized, 8));
+    }
+
+    #[test]
+    fn despawn_returns_state_and_skips_pending_steps() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        sim.schedule(h, Time(10), StepLabel::default(), |s, _| s.0 += 5);
+        // a step scheduled for after the despawn must be skipped, not panic
+        sim.schedule(h, Time(30), StepLabel::default(), |s, _| s.0 += 100);
+        sim.run_until_time(Time(20));
+
+        let taken = sim.despawn(h);
+        assert_eq!(taken.0, 5);
+        assert_eq!(sim.run_to_completion(), RunOutcome::Drained);
+    }
+
+    #[test]
+    fn cross_process_scheduling() {
+        let mut sim = Simulation::new(0);
+        let a = sim.spawn(());
+        let b = sim.spawn(Counter::default());
+        sim.schedule(a, Time(0), StepLabel::default(), move |_, ctx| {
+            let now = ctx.now();
+            ctx.schedule(b, now, StepLabel::default(), |s, _| s.0 += 1);
+        });
+        sim.run_to_completion();
+        sim.with(b, |s| assert_eq!(s.0, 1));
+    }
+
+    #[test]
+    fn self_rescheduling_step() {
+        fn tick(s: &mut Counter, ctx: &mut Ctx<'_>, me: Handle<Counter>) {
+            s.0 += 1;
+            if s.0 < 3 {
+                ctx.schedule_after(me, millis(1), StepLabel::default(), move |s, ctx| {
+                    tick(s, ctx, me)
+                });
+            }
+        }
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        sim.schedule(h, Time(0), StepLabel::default(), move |s, ctx| {
+            tick(s, ctx, h)
+        });
+        sim.run_to_completion();
+        sim.with(h, |s| assert_eq!(s.0, 3));
+        assert_eq!(sim.now(), Time(0) + millis(2));
+    }
+
+    #[test]
+    fn cancelled_step_does_not_run() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        let token = sim.schedule(h, Time(10), StepLabel::default(), |s, _| s.0 += 1);
+        token.cancel();
+        sim.run_to_completion();
+        sim.with(h, |s| assert_eq!(s.0, 0));
+        assert_eq!(sim.metrics().steps_executed, 0);
+        assert_eq!(sim.metrics().steps_cancelled, 1);
+    }
+
+    #[test]
+    fn rearmed_timer_only_fires_latest() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Log::default());
+        let first = sim.schedule(h, Time(10), StepLabel::default(), |s, _| s.0.push(10));
+        first.cancel();
+        sim.schedule(h, Time(20), StepLabel::default(), |s, _| s.0.push(20));
+        sim.run_to_completion();
+        sim.with(h, |s| assert_eq!(s.0, vec![20]));
+    }
+
+    #[test]
+    fn run_until_time_bounds_execution() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Log::default());
+        for t in [10, 20, 30] {
+            sim.schedule(h, Time(t), StepLabel::default(), move |s, _| {
+                s.0.push(t as u64)
+            });
+        }
+
+        assert_eq!(
+            sim.run_until_time(Time(20)),
+            RunOutcome::ReachedTime(Time(20))
+        );
+        assert_eq!(sim.now(), Time(20));
+        sim.with(h, |s| assert_eq!(s.0, vec![10, 20]));
+
+        // Advancing to a time before the next step runs nothing but moves the clock.
+        assert_eq!(
+            sim.run_until_time(Time(25)),
+            RunOutcome::ReachedTime(Time(25))
+        );
+        assert_eq!(sim.now(), Time(25));
+        sim.with(h, |s| assert_eq!(s.0, vec![10, 20]));
+
+        assert_eq!(sim.run_until_time(Time(40)), RunOutcome::Drained);
+        assert_eq!(sim.now(), Time(40));
+        sim.with(h, |s| assert_eq!(s.0, vec![10, 20, 30]));
+    }
+
+    #[test]
+    fn run_steps_counts_executed_steps() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        for t in 1..=5 {
+            sim.schedule(h, Time(t), StepLabel::default(), |s, _| s.0 += 1);
+        }
+        assert_eq!(sim.run_steps(3), RunOutcome::ReachedStepLimit);
+        assert_eq!(sim.step_count(), 3);
+        assert_eq!(sim.run_steps(10), RunOutcome::Drained);
+        assert_eq!(sim.step_count(), 5);
+    }
+
+    #[test]
+    fn run_while_observes_process_state() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        for t in 1..=10 {
+            sim.schedule(h, Time(t), StepLabel::default(), |s, _| s.0 += 1);
+        }
+        let outcome = sim.run_while(|sim| sim.with(h, |c| c.0) < 5);
+        assert_eq!(outcome, RunOutcome::Stopped);
+        assert_eq!(sim.with(h, |c| c.0), 5);
+
+        assert_eq!(
+            sim.run_while(|sim| sim.with(h, |c| c.0) < 100),
+            RunOutcome::Drained
+        );
+        assert_eq!(sim.with(h, |c| c.0), 10);
+    }
+
+    #[test]
+    fn global_step_schedules_onto_process() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        sim.schedule_global(Time(0), StepLabel::default(), move |ctx| {
+            let now = ctx.now();
+            ctx.schedule(h, now, StepLabel::default(), |s, _| s.0 += 1);
+        });
+        sim.run_to_completion();
+        sim.with(h, |s| assert_eq!(s.0, 1));
+    }
+
+    #[test]
+    fn spawn_during_step() {
+        let mut sim = Simulation::new(0);
+        let out = Rc::new(Cell::new(0u64));
+        let out2 = out.clone();
+        sim.schedule_global(Time(0), StepLabel::default(), move |ctx| {
+            let h = ctx.spawn(out2);
+            let now = ctx.now();
+            ctx.schedule(h, now, StepLabel::default(), |s: &mut Rc<Cell<u64>>, _| {
+                s.set(s.get() + 1)
+            });
+        });
+        sim.run_to_completion();
+        assert_eq!(out.get(), 1);
+    }
+
+    #[test]
+    fn deterministic_for_a_given_seed() {
+        let run = |seed| {
+            let mut sim = Simulation::new(seed);
+            let h = sim.spawn(Log::default());
+            sim.schedule(h, Time(0), StepLabel::default(), |s, ctx| {
+                for _ in 0..8 {
+                    s.0.push(ctx.sample(Uniform::new(0u64, 1_000)));
+                }
+            });
+            sim.run_to_completion();
+            sim.with(h, |s| s.0.clone())
+        };
+        assert_eq!(run(7), run(7));
+        assert_ne!(run(7), run(8));
+    }
+
+    #[test]
+    fn observer_sees_every_step() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        let sink = seen.clone();
+        sim.on_step(move |info| {
+            sink.borrow_mut()
+                .push((info.time, info.process, info.label.source))
+        });
+        sim.schedule(h, Time(5), StepLabel::source("a"), |s, _| s.0 += 1);
+        sim.schedule(h, Time(7), StepLabel::source("b"), |s, _| s.0 += 1);
+        sim.run_to_completion();
+
+        let seen = seen.borrow();
+        assert_eq!(seen.len(), 2);
+        assert_eq!(seen[0], (Time(5), h.id(), Some("a")));
+        assert_eq!(seen[1], (Time(7), h.id(), Some("b")));
+    }
+
+    #[test]
+    fn with_mut_injects_state() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        sim.with_mut(h, |c| c.0 = 42);
+        sim.with(h, |c| assert_eq!(c.0, 42));
+    }
+
+    #[test]
+    fn reset_clears_everything() {
+        let mut sim = Simulation::new(1);
+        let h = sim.spawn(Counter::default());
+        sim.schedule(h, Time(5), StepLabel::default(), |s, _| s.0 += 1);
+        sim.run_to_completion();
+        assert_eq!(sim.now(), Time(5));
+
+        sim.reset();
+        assert_eq!(sim.now(), Time(0));
+        assert_eq!(sim.step_count(), 0);
+        assert!(sim.peek_time().is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "in the past")]
+    fn scheduling_in_the_past_panics() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(());
+        sim.schedule(h, Time(10), StepLabel::default(), |_, _| {});
+        sim.run_to_completion(); // now == Time(10)
+        sim.schedule(h, Time(5), StepLabel::default(), |_, _| {});
+    }
+
+    #[test]
+    fn critical_path_of_serial_chain_equals_its_length() {
+        // A self-rescheduling chain on one process: every step depends on the
+        // previous, so the critical path is the whole run and parallelism is 1.
+        fn tick(s: &mut Counter, ctx: &mut Ctx<'_>, me: Handle<Counter>) {
+            s.0 += 1;
+            if s.0 < 5 {
+                ctx.schedule_after(me, millis(1), StepLabel::default(), move |s, ctx| {
+                    tick(s, ctx, me)
+                });
+            }
+        }
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        sim.schedule(h, Time(0), StepLabel::default(), move |s, ctx| {
+            tick(s, ctx, h)
+        });
+        sim.run_to_completion();
+
+        assert_eq!(sim.metrics().steps_executed, 5);
+        assert_eq!(sim.metrics().critical_path_len, 5);
+        assert_eq!(sim.metrics().parallelism(), 1.0);
+    }
+
+    #[test]
+    fn critical_path_of_fan_out_is_two() {
+        // One step schedules N independent children, each on its own process.
+        // Depth: root = 1, every child = 2 (no child depends on another), so the
+        // critical path is 2 and parallelism is (N + 1) / 2.
+        let n = 5u64;
+        let mut sim = Simulation::new(0);
+        let handles: Vec<_> = (0..n).map(|_| sim.spawn(Counter::default())).collect();
+        sim.schedule_global(Time(0), StepLabel::default(), move |ctx| {
+            let now = ctx.now();
+            for h in handles {
+                ctx.schedule(h, now, StepLabel::default(), |s, _| s.0 += 1);
+            }
+        });
+        sim.run_to_completion();
+
+        assert_eq!(sim.metrics().steps_executed, n + 1);
+        assert_eq!(sim.metrics().critical_path_len, 2);
+        assert_eq!(sim.metrics().parallelism(), (n + 1) as f64 / 2.0);
+    }
+
+    #[test]
+    fn same_process_steps_serialize_in_critical_path() {
+        // Independent steps scheduled onto one process still serialize (shared
+        // state), so the critical path equals the step count.
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        for t in 1..=4 {
+            sim.schedule(h, Time(t), StepLabel::default(), |s, _| s.0 += 1);
+        }
+        sim.run_to_completion();
+
+        assert_eq!(sim.metrics().steps_executed, 4);
+        assert_eq!(sim.metrics().critical_path_len, 4);
+    }
+
+    #[test]
+    fn cancelled_steps_are_off_the_critical_path() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        sim.schedule(h, Time(10), StepLabel::default(), |s, _| s.0 += 1)
+            .cancel();
+        sim.schedule(h, Time(20), StepLabel::default(), |s, _| s.0 += 1);
+        sim.run_to_completion();
+
+        // only the one surviving step contributes
+        assert_eq!(sim.metrics().steps_executed, 1);
+        assert_eq!(sim.metrics().critical_path_len, 1);
+    }
+
+    #[test]
+    fn critical_path_is_deterministic() {
+        let run = || {
+            let mut sim = Simulation::new(0);
+            let h = sim.spawn(Counter::default());
+            for t in 1..=6 {
+                sim.schedule(h, Time(t), StepLabel::default(), |s, _| s.0 += 1);
+            }
+            sim.run_to_completion();
+            sim.metrics().critical_path_len
+        };
+        assert_eq!(run(), run());
+    }
+}

--- a/monad-sim/src/time.rs
+++ b/monad-sim/src/time.rs
@@ -1,0 +1,262 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Simulation time and clock differences.
+
+// `Duration::from_nanos_u128` is stable only since Rust 1.93, but this workspace
+// builds on 1.91.1, so it is provided locally by the `DurationFromNanosU128`
+// extension trait below. This `allow` silences the future-ambiguity lint raised by
+// calling it through the trait while std's (still-unstable) inherent method
+// already exists. Remove the trait and this `allow` once the toolchain reaches 1.93.
+#![allow(unstable_name_collisions)]
+
+use std::{
+    ops::{Add, AddAssign, Sub, SubAssign},
+    time::Duration,
+};
+
+/// Local stand-in for [`Duration::from_nanos_u128`] (stable since Rust 1.93; the
+/// workspace toolchain is 1.91.1). Behaviour matches std, including the panic
+/// when the nanosecond count exceeds [`Duration::MAX`].
+///
+/// Remove once the toolchain reaches 1.93: std's inherent method then shadows
+/// this, and the `use crate::time::DurationFromNanosU128;` imports in sibling
+/// modules surface as `unused_imports` warnings pointing back here.
+pub(crate) trait DurationFromNanosU128 {
+    fn from_nanos_u128(nanos: u128) -> Duration;
+}
+
+impl DurationFromNanosU128 for Duration {
+    #[inline]
+    #[track_caller]
+    fn from_nanos_u128(nanos: u128) -> Duration {
+        const NANOS_PER_SEC: u128 = 1_000_000_000;
+        let secs =
+            u64::try_from(nanos / NANOS_PER_SEC).expect("overflow in `Duration::from_nanos_u128`");
+        // `nanos % NANOS_PER_SEC < 1_000_000_000`, so `Duration::new` takes its
+        // no-carry fast path and the result equals std's `new_unchecked` form.
+        Duration::new(secs, (nanos % NANOS_PER_SEC) as u32)
+    }
+}
+
+/// Discrete simulation time: the affine line over clock differences measured in
+/// nanoseconds. It has no defined epoch; time `0` is the conventional origin of
+/// the global clock. Represented as `i128` so it can hold the full `Duration`
+/// range and negative points (used by local clocks with a negative offset).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
+pub struct Time(pub i128);
+
+impl std::fmt::Debug for Time {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let d = Duration::from_nanos_u128(self.0.unsigned_abs());
+        if self.0 < 0 {
+            write!(f, "Time(-{:?})", d)
+        } else {
+            write!(f, "Time({:?})", d)
+        }
+    }
+}
+
+/// Signed difference between two [`Time`] points, in nanoseconds.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
+pub struct ClockDiff(pub i128);
+
+impl std::fmt::Debug for ClockDiff {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let d = Duration::from_nanos_u128(self.0.unsigned_abs());
+        if self.0 < 0 {
+            write!(f, "-{:?}", d)
+        } else {
+            write!(f, "{:?}", d)
+        }
+    }
+}
+
+impl Time {
+    /// Unsigned magnitude of the difference between two times. Use `self - other`
+    /// (a [`ClockDiff`]) when you need the sign.
+    pub fn abs_diff(self, other: Time) -> Duration {
+        Duration::from_nanos_u128(self.0.abs_diff(other.0))
+    }
+}
+
+/// `Time` is a torsor over [`ClockDiff`]: subtracting two times yields their
+/// signed difference.
+impl Sub<Time> for Time {
+    type Output = ClockDiff;
+    fn sub(self, rhs: Time) -> Self::Output {
+        ClockDiff(self.0 - rhs.0)
+    }
+}
+
+impl Add<Duration> for Time {
+    type Output = Self;
+    fn add(self, d: Duration) -> Self::Output {
+        Time(self.0 + d.as_nanos() as i128)
+    }
+}
+
+impl AddAssign<Duration> for Time {
+    fn add_assign(&mut self, d: Duration) {
+        *self = *self + d;
+    }
+}
+
+impl Sub<Duration> for Time {
+    type Output = Self;
+    fn sub(self, d: Duration) -> Self::Output {
+        Time(self.0 - d.as_nanos() as i128)
+    }
+}
+
+impl SubAssign<Duration> for Time {
+    fn sub_assign(&mut self, d: Duration) {
+        *self = *self - d;
+    }
+}
+
+impl Add<ClockDiff> for Time {
+    type Output = Self;
+    fn add(self, d: ClockDiff) -> Self::Output {
+        Time(self.0 + d.0)
+    }
+}
+
+impl AddAssign<ClockDiff> for Time {
+    fn add_assign(&mut self, d: ClockDiff) {
+        *self = *self + d;
+    }
+}
+
+impl Sub<ClockDiff> for Time {
+    type Output = Self;
+    fn sub(self, d: ClockDiff) -> Self::Output {
+        Time(self.0 - d.0)
+    }
+}
+
+impl SubAssign<ClockDiff> for Time {
+    fn sub_assign(&mut self, d: ClockDiff) {
+        *self = *self - d;
+    }
+}
+
+impl Add<ClockDiff> for ClockDiff {
+    type Output = Self;
+    fn add(self, d: ClockDiff) -> Self::Output {
+        ClockDiff(self.0 + d.0)
+    }
+}
+
+impl Sub<ClockDiff> for ClockDiff {
+    type Output = Self;
+    fn sub(self, d: ClockDiff) -> Self::Output {
+        ClockDiff(self.0 - d.0)
+    }
+}
+
+impl ClockDiff {
+    pub fn as_nanos(self) -> i128 {
+        self.0
+    }
+
+    pub fn from_nanos(ns: i128) -> Self {
+        ClockDiff(ns)
+    }
+
+    pub fn from_duration(d: Duration) -> Self {
+        ClockDiff(d.as_nanos() as i128)
+    }
+
+    /// Convert to a floating-point number of nanoseconds. Beware of precision
+    /// loss for magnitudes beyond `2^53` nanoseconds.
+    pub fn as_f64(self) -> f64 {
+        self.0 as f64
+    }
+
+    /// Build from a floating-point number of nanoseconds, rounding to the nearest
+    /// integer. Beware of precision loss for large magnitudes.
+    pub fn from_nanos_f64(s: f64) -> Self {
+        ClockDiff(s.round() as i128)
+    }
+}
+
+/// Shorthand for a [`Duration`] of `ns` nanoseconds.
+pub const fn nanos(ns: u64) -> Duration {
+    Duration::from_nanos(ns)
+}
+
+/// Shorthand for a [`Duration`] of `us` microseconds.
+pub const fn micros(us: u64) -> Duration {
+    Duration::from_micros(us)
+}
+
+/// Shorthand for a [`Duration`] of `ms` milliseconds.
+pub const fn millis(ms: u64) -> Duration {
+    Duration::from_millis(ms)
+}
+
+/// Shorthand for a [`Duration`] of `s` seconds.
+pub const fn secs(s: u64) -> Duration {
+    Duration::from_secs(s)
+}
+
+/// Shorthand for a [`Duration`] of `m` minutes.
+pub fn mins(m: u64) -> Duration {
+    Duration::from_mins(m)
+}
+
+/// Shorthand for a [`Duration`] of `h` hours.
+pub fn hours(h: u64) -> Duration {
+    Duration::from_hours(h)
+}
+
+/// Shorthand for a [`Duration`] of `d` days.
+pub fn days(d: u64) -> Duration {
+    Duration::from_hours(d * 24)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn time_duration_arithmetic() {
+        let t = Time(0) + millis(100);
+        assert_eq!(t, Time(100_000_000));
+        assert_eq!(t - millis(40), Time(60_000_000));
+
+        let mut t = Time(0);
+        t += secs(1);
+        assert_eq!(t, Time(1_000_000_000));
+    }
+
+    #[test]
+    fn time_difference_is_signed() {
+        assert_eq!(
+            Time(0) + millis(100) - (Time(0) + millis(30)),
+            ClockDiff(70_000_000)
+        );
+        assert_eq!(Time(0) - (Time(0) + millis(30)), ClockDiff(-30_000_000));
+        assert_eq!((Time(0) + millis(30)).abs_diff(Time(0)), millis(30));
+    }
+
+    #[test]
+    fn clock_diff_applies_to_time() {
+        assert_eq!(Time(5) + ClockDiff(10), Time(15));
+        assert_eq!(Time(5) - ClockDiff(10), Time(-5));
+        assert_eq!(ClockDiff::from_duration(millis(2)).as_nanos(), 2_000_000);
+    }
+}

--- a/monad-sim/tests/processes.rs
+++ b/monad-sim/tests/processes.rs
@@ -1,0 +1,229 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Worked examples on top of `monad-sim` using toy, app-defined processes.
+//!
+//! `Msg`, `Node`, `Net`, and `Watchdog` are all defined here, not in the crate:
+//! the simulation framework never names a message or component-state type. These
+//! exercise the patterns the mock-swarm migration relies on — cross-process
+//! message passing, a swappable network process, sampled latency, and a
+//! resettable timer.
+
+use std::{collections::HashMap, time::Duration};
+
+use monad_sim::{
+    dist::uniform_duration, time::millis, CancelToken, Ctx, Handle, RunOutcome, Simulation,
+    StepLabel, Time,
+};
+
+// ---------------------------------------------------------------------------
+// A two-node ping/pong over a network process.
+// ---------------------------------------------------------------------------
+
+type NodeId = u32;
+
+/// Stop after this many round trips.
+const BUDGET: u32 = 3;
+
+#[derive(Clone, Copy)]
+enum Msg {
+    Ping(u32),
+    Pong(u32),
+}
+
+impl Msg {
+    fn seq(self) -> u32 {
+        match self {
+            Msg::Ping(n) | Msg::Pong(n) => n,
+        }
+    }
+}
+
+struct Node {
+    net: Handle<Net>,
+    peer: NodeId,
+    pongs: u32,
+    /// (arrival time, sequence number) of every message received.
+    log: Vec<(Time, u32)>,
+}
+
+impl Node {
+    fn send(&self, ctx: &mut Ctx, msg: Msg) {
+        let (net, to, now) = (self.net, self.peer, ctx.now());
+        ctx.schedule(net, now, StepLabel::source("send"), move |net, ctx| {
+            net.deliver(ctx, to, msg)
+        });
+    }
+
+    fn recv(&mut self, ctx: &mut Ctx, msg: Msg) {
+        self.log.push((ctx.now(), msg.seq()));
+        match msg {
+            Msg::Ping(n) => self.send(ctx, Msg::Pong(n)),
+            Msg::Pong(n) => {
+                self.pongs += 1;
+                if n + 1 < BUDGET {
+                    self.send(ctx, Msg::Ping(n + 1));
+                }
+            }
+        }
+    }
+}
+
+enum Latency {
+    Const(Duration),
+    Uniform(Duration, Duration),
+}
+
+/// The network: a routing table and a latency model. Swapping this process out
+/// is how a different network model would be plugged in.
+struct Net {
+    routes: HashMap<NodeId, Handle<Node>>,
+    latency: Latency,
+}
+
+impl Net {
+    fn deliver(&self, ctx: &mut Ctx, to: NodeId, msg: Msg) {
+        let dst = self.routes[&to];
+        let delay = match self.latency {
+            Latency::Const(d) => d,
+            Latency::Uniform(lo, hi) => ctx.sample(uniform_duration(lo, hi)),
+        };
+        let at = ctx.now() + delay;
+        ctx.schedule(dst, at, StepLabel::source("deliver"), move |node, ctx| {
+            node.recv(ctx, msg)
+        });
+    }
+}
+
+/// Spawn the network and two nodes, wire up routing, and kick off the first ping.
+fn build_ping_pong(sim: &mut Simulation, latency: Latency) -> (Handle<Node>, Handle<Node>) {
+    let net = sim.spawn(Net {
+        routes: HashMap::new(),
+        latency,
+    });
+    let a = sim.spawn(Node {
+        net,
+        peer: 1,
+        pongs: 0,
+        log: Vec::new(),
+    });
+    let b = sim.spawn(Node {
+        net,
+        peer: 0,
+        pongs: 0,
+        log: Vec::new(),
+    });
+    sim.with_mut(net, |net| {
+        net.routes.insert(0, a);
+        net.routes.insert(1, b);
+    });
+    sim.schedule(a, Time(0), StepLabel::source("start"), |node, ctx| {
+        node.send(ctx, Msg::Ping(0))
+    });
+    (a, b)
+}
+
+#[test]
+fn ping_pong_completes() {
+    let mut sim = Simulation::new(0);
+    let (a, b) = build_ping_pong(&mut sim, Latency::Const(millis(10)));
+
+    assert_eq!(sim.run_to_completion(), RunOutcome::Drained);
+
+    // BUDGET round trips, each 2 * 10ms, the last pong landing at 60ms.
+    assert_eq!(sim.with(a, |n| n.pongs), BUDGET);
+    assert_eq!(sim.with(a, |n| n.log.len()), BUDGET as usize);
+    assert_eq!(sim.with(b, |n| n.log.len()), BUDGET as usize);
+    assert_eq!(sim.now(), Time(0) + millis(60));
+}
+
+#[test]
+fn run_until_time_stops_mid_exchange() {
+    let mut sim = Simulation::new(0);
+    let (a, b) = build_ping_pong(&mut sim, Latency::Const(millis(10)));
+
+    // First pong lands at 20ms; the second ping is delivered at 30ms.
+    assert_eq!(
+        sim.run_until_time(Time(0) + millis(25)),
+        RunOutcome::ReachedTime(Time(0) + millis(25))
+    );
+    assert_eq!(sim.with(a, |n| n.pongs), 1);
+    assert_eq!(sim.with(a, |n| n.log.len()), 1);
+    assert_eq!(sim.with(b, |n| n.log.len()), 1);
+    assert_eq!(sim.now(), Time(0) + millis(25));
+}
+
+#[test]
+fn random_latency_is_deterministic_per_seed() {
+    let run = |seed| {
+        let mut sim = Simulation::new(seed);
+        let (a, _) = build_ping_pong(&mut sim, Latency::Uniform(millis(5), millis(15)));
+        sim.run_to_completion();
+        sim.with(a, |n| n.log.clone())
+    };
+    assert_eq!(run(11), run(11));
+    assert_ne!(run(11), run(12));
+}
+
+// ---------------------------------------------------------------------------
+// A watchdog timer that resets on every heartbeat (the pacemaker pattern).
+// ---------------------------------------------------------------------------
+
+struct Watchdog {
+    timeout: Duration,
+    armed: Option<CancelToken>,
+    fired: u32,
+}
+
+impl Watchdog {
+    /// Cancel any pending timeout and arm a fresh one.
+    fn heartbeat(&mut self, me: Handle<Watchdog>, ctx: &mut Ctx) {
+        if let Some(pending) = self.armed.take() {
+            pending.cancel();
+        }
+        let token = ctx.schedule_after(me, self.timeout, StepLabel::source("timeout"), |w, _| {
+            w.fired += 1;
+        });
+        self.armed = Some(token);
+    }
+}
+
+#[test]
+fn timeout_resets_on_heartbeat() {
+    let mut sim = Simulation::new(0);
+    let wd = sim.spawn(Watchdog {
+        timeout: millis(10),
+        armed: None,
+        fired: 0,
+    });
+
+    // Heartbeats every 5ms keep re-arming the 10ms timeout; the last one is at
+    // 20ms, so the only timeout that survives fires at 30ms.
+    for t in [0, 5, 10, 15, 20] {
+        sim.schedule(
+            wd,
+            Time(0) + millis(t),
+            StepLabel::source("heartbeat"),
+            move |w, ctx| w.heartbeat(wd, ctx),
+        );
+    }
+
+    sim.run_until_time(Time(0) + millis(29));
+    assert_eq!(sim.with(wd, |w| w.fired), 0);
+    assert_eq!(sim.metrics().steps_cancelled, 4);
+
+    sim.run_until_time(Time(0) + millis(31));
+    assert_eq!(sim.with(wd, |w| w.fired), 1);
+}


### PR DESCRIPTION
A new generic discrete-event scheduler for MockSwarm. It supports simulation of different protocols by abstracting over the internal state and logic of the simulated system. The use of a single event queue simplifies the implementation, improves performance, results in a more robust simulation with respect to control of non-determinism and randomness, and is also more faithful with respect to production behavior.

- **`monad-sim`** (new crate): a generic, Monad-agnostic discrete-event engine — scheduled steps over framework-owned process state, deterministic ordering, bounded run control, and a concurrency metric.
- **`monad-mock-swarm::sim`**: the node/network harness (`SimNode` / `SimNet` / `SimSwarm`) and `SimVerifier`, with a declarative `Network` model.
- The legacy test suite ported additively onto it (`tests/sim_*.rs`), a benchmark, and docs (`README.md`, `docs/simulation_framework.md`).

No production-logic change (only `+ Clone` on `SwarmRelation::TransportMessage`). The legacy engine stays until this is reviewed, then a follow-up removes it. Commits are layered for incremental review.