### PR TITLE
statesync: thread chain_config from monad-node through to the FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6169,6 +6169,7 @@ dependencies = [
  "alloy-rlp",
  "criterion",
  "futures",
+ "monad-chain-config",
  "monad-crypto",
  "monad-cxx",
  "monad-eth-types",

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -307,6 +307,7 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         .expect("uds bind failed"),
         loopback: LoopbackExecutor::default(),
         state_sync: StateSyncExecutor::<SignatureType, SignatureCollectionType>::new(
+            node_state.chain_config.chain_id(),
             vec![statesync_triedb_path.to_string_lossy().to_string()],
             node_state.statesync_sq_thread_cpu,
             state_sync_init_peers,

--- a/monad-statesync-executor/Cargo.toml
+++ b/monad-statesync-executor/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 bench = false
 
 [dependencies]
+monad-chain-config = { workspace = true }
 monad-crypto = { workspace = true }
 monad-cxx = { workspace = true }
 monad-eth-types = { workspace = true }

--- a/monad-statesync-executor/src/client/mod.rs
+++ b/monad-statesync-executor/src/client/mod.rs
@@ -74,6 +74,7 @@ pub(crate) struct StateSyncClient<PT: PubKey> {
 
 impl<PT: PubKey> StateSyncClient<PT> {
     pub fn start(
+        chain_config: u32,
         db_paths: &[String],
         sq_thread_cpu: Option<u32>,
         state_sync_init_peers: &[NodeId<PT>],
@@ -122,6 +123,7 @@ impl<PT: PubKey> StateSyncClient<PT> {
                 });
 
                 let mut sync_ctx = ffi::StateSyncCtx::new(
+                    chain_config,
                     db_paths_ptr,
                     num_db_paths,
                     sq_thread_cpu.map(|n| n as ::std::os::raw::c_uint),

--- a/monad-statesync-executor/src/lib.rs
+++ b/monad-statesync-executor/src/lib.rs
@@ -103,11 +103,39 @@ where
     _phantom: PhantomData<(ST, SCT)>,
 }
 
+/// Map a chain_id to the `enum monad_chain_config` value the statesync FFI
+/// expects, using the bindgen-generated constants (single source of truth from
+/// category/execution/ethereum/chain/chain_config.h). Panics on an unmapped
+/// chain_id — `MonadChainConfig::new` already rejects unknown chain_ids
+/// upstream, so this is a contract-violation tripwire, not a reachable branch.
+fn statesync_chain_config(chain_id: u64) -> u32 {
+    use monad_chain_config::{
+        ETHEREUM_MAINNET_CHAIN_ID, HIVE_CHAIN_ID, MONAD_DEVNET_CHAIN_ID, MONAD_MAINNET_CHAIN_ID,
+        MONAD_TESTNET_CHAIN_ID,
+    };
+    use monad_statesync::ffi::{
+        monad_chain_config_CHAIN_CONFIG_ETHEREUM_MAINNET, monad_chain_config_CHAIN_CONFIG_HIVE_NET,
+        monad_chain_config_CHAIN_CONFIG_MONAD_DEVNET,
+        monad_chain_config_CHAIN_CONFIG_MONAD_MAINNET,
+        monad_chain_config_CHAIN_CONFIG_MONAD_TESTNET,
+    };
+
+    match chain_id {
+        ETHEREUM_MAINNET_CHAIN_ID => monad_chain_config_CHAIN_CONFIG_ETHEREUM_MAINNET,
+        MONAD_DEVNET_CHAIN_ID => monad_chain_config_CHAIN_CONFIG_MONAD_DEVNET,
+        MONAD_TESTNET_CHAIN_ID => monad_chain_config_CHAIN_CONFIG_MONAD_TESTNET,
+        MONAD_MAINNET_CHAIN_ID => monad_chain_config_CHAIN_CONFIG_MONAD_MAINNET,
+        HIVE_CHAIN_ID => monad_chain_config_CHAIN_CONFIG_HIVE_NET,
+        other => panic!("no statesync chain_config mapping for chain_id {other}"),
+    }
+}
+
 impl<ST, SCT> StateSyncExecutor<ST, SCT>
 where
     ST: CertificateSignatureRecoverable,
 {
     pub fn new(
+        chain_id: u64,
         db_paths: Vec<String>,
         sq_thread_cpu: Option<u32>,
         state_sync_init_peers: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
@@ -123,6 +151,7 @@ where
             uds_path,
 
             mode: StateSyncMode::Sync(StateSyncClient::start(
+                statesync_chain_config(chain_id),
                 &db_paths,
                 sq_thread_cpu,
                 &state_sync_init_peers,


### PR DESCRIPTION
Threads a `chain_config` value through the statesync client FFI so it works with the new statesync API on current execution `main`.

## Execution pin bump
`monad-execution` is bumped to current `main` (`69d927b81`), which includes the FFI re-export of the `monad_chain_config_CHAIN_CONFIG_*` constants from `monad-statesync` (merged via category-labs/monad#2390). The underlying statesync rewrite added a `chain_config` parameter (`enum monad_chain_config`) as the first argument of `monad_statesync_client_context_create`.

## Mapping (uses the bindgen constants — single source of truth)
- `monad-node` passes `node_state.chain_config.chain_id()` to `StateSyncExecutor::new`.
- `monad-statesync-executor` maps the chain_id to the bindgen-generated `monad_chain_config_CHAIN_CONFIG_*` constant (sourced from `chain_config.h`), then hands it to `StateSyncClient::start` -> `ffi::StateSyncCtx::new`. This needs a new `monad-chain-config` dep on the executor (for the chain_id consts).

No constants are duplicated: only the chain_id↔chain association is hand-written (no source has both halves), and the enum discriminants come straight from bindgen.

## Verification
- `cargo build -p monad-node` and `-p monad-rpc` link cleanly against the new FFI.
- rustfmt clean. CI green on the prior revision (build + Jenkins CI).

Out of scope: the triedb page-encoding RPC-reads FFI is a separate follow-up.
