### PR TITLE
rpc: page-aware eth_getStorageAt on a page-encoded primary

### DIFF
--- a/monad-triedb-utils/src/triedb_env.rs
+++ b/monad-triedb-utils/src/triedb_env.rs
@@ -34,7 +34,9 @@ use monad_eth_types::{
     BlockHeader, EthAccount, EthAddress, EthBlockHash, EthCode, EthCodeHash, EthStorageKey,
     EthStorageSlot, EthTxHash, ReceiptWithLogIndex, TransactionLocation, TxEnvelopeWithSender,
 };
-use monad_triedb::{TraverseEntry, TriedbHandle};
+use monad_triedb::{
+    compute_page_key, compute_slot_offset, decode_storage_page_slot, TraverseEntry, TriedbHandle,
+};
 use monad_types::{BlockId, Hash, SeqNum};
 use tracing::{error, warn};
 
@@ -521,6 +523,12 @@ pub struct TriedbEnv {
     mpsc_sender_traverse: mpsc::SyncSender<TriedbRequest>,
 
     meta: Arc<Mutex<TriedbEnvMeta>>,
+
+    // True if the primary timeline is page-encoded (Monad state machine). Read
+    // once at open; safe because the primary's encoding only changes via an
+    // offline promote (node stopped, then restarted), so a running RPC re-reads
+    // it on the next open.
+    page_encoded: bool,
 }
 
 struct TriedbEnvMeta {
@@ -618,6 +626,7 @@ impl TriedbEnv {
     ) -> Self {
         let triedb_handle: TriedbHandle = TriedbHandle::try_new(triedb_path, node_lru_max_mem)
             .expect("triedb should exist in path");
+        let page_encoded = triedb_handle.is_page_encoded();
         let latest_finalized = FinalizedBlockKey(SeqNum(
             triedb_handle.latest_finalized_block().unwrap_or_default(),
         ));
@@ -665,6 +674,7 @@ impl TriedbEnv {
             mpsc_sender: sender_read,
             mpsc_sender_traverse: sender_traverse,
             meta,
+            page_encoded,
         }
     }
 
@@ -930,11 +940,32 @@ impl Triedb for TriedbEnv {
         addr: EthAddress,
         at: EthStorageKey,
     ) -> Result<EthStorageSlot, String> {
-        self.handle_async_request(block_key, KeyInput::Storage(&addr, &at), |data| {
-            rlp_decode_storage_slot(data).ok_or_else(|| String::from("Decoding storage slot error"))
-        })
-        .await
-        .map(Option::unwrap_or_default)
+        if self.page_encoded {
+            // Page-encoded: storage is keyed by keccak(page_key) where
+            // page_key = slot >> 7, and the leaf is an encoded page. Look up the
+            // page key and extract the slot at its offset within the page. The
+            // page geometry (the >> 7 shift and the in-page offset) and the page
+            // decode all live in C++ so the format has one source of truth.
+            let page_key = compute_page_key(at);
+            let offset = compute_slot_offset(at);
+            self.handle_async_request(
+                block_key,
+                KeyInput::Storage(&addr, &page_key),
+                move |data| {
+                    decode_storage_page_slot(&data, offset)
+                        .ok_or_else(|| String::from("Decoding storage page error"))
+                },
+            )
+            .await
+            .map(Option::unwrap_or_default)
+        } else {
+            self.handle_async_request(block_key, KeyInput::Storage(&addr, &at), |data| {
+                rlp_decode_storage_slot(data)
+                    .ok_or_else(|| String::from("Decoding storage slot error"))
+            })
+            .await
+            .map(Option::unwrap_or_default)
+        }
     }
 
     #[tracing::instrument(level = "debug")]


### PR DESCRIPTION
## What

Makes `eth_getStorageAt` page-aware in `monad-triedb-utils`:
- adds a `TriedbEnv.page_encoded` flag, read once at open from `triedb_handle.is_page_encoded()`;
- in `get_storage_at`, when page-encoded: compute `page_key = slot >> 7` and the low-7-bit `offset`, look up `keccak(page_key)`, and decode the page via the C++ `decode_storage_page_slot` FFI. Slot-encoded path is unchanged.

## Why

After the dual-db migration promotes the page timeline, the primary is page-encoded. master's `get_storage_at` is slot-only, so it looks up `keccak(slot)`, finds nothing, and returns `0` for all real storage on a page-encoded node. The committed data is intact (monad-cli reads it correctly) — only the RPC read path is wrong, so this is a silent, customer-facing correctness hole (`eth_getStorageAt` is a public method used by wallets/indexers/explorers).

Found while running the page-store migration integration test against latest master: every crafted storage slot read back `0` via RPC post-promote, while the on-disk data was present. Adding this read path turns that test green.

## Dependencies / CI

Depends on the execution-side FFI: **monad-crypto/monad#2393** (`triedb_is_page_encoded` + `triedb_decode_storage_page_slot`). This PR's CI will be **red** until that lands and the `monad-execution` submodule is bumped to include it (and an execution build that serves page-encoded primaries). Opening now to start the design discussion, not to merge as-is.

## Discussion — is this the right seam?

This PR computes `page_key` / `offset` in Rust and delegates only the **page decode** to C++. The alternative is a single C++ entry point `triedb_read_storage(addr, slot)` that owns the whole page-aware read. Trade-off (also noted on #2393):
- *Current split* keeps the async/LRU cache keyed by `page_key`, so the 128 slots in a page share one read + cache entry; only the format decode is in C++.
- *C++-owned read* removes the page-key duplication but the Rust async poller + cache (keyed by nibble path) would need to lose page-level sharing or become page-aware.

Keen on input on which way to go before this solidifies.
