### PR TITLE
[rpc] Thread max response size through to C++ executor

### DIFF
--- a/monad-rpc/src/handlers/eth/simulate.rs
+++ b/monad-rpc/src/handlers/eth/simulate.rs
@@ -73,7 +73,7 @@ pub struct MonadSimulateParams {
 
 #[rpc(
     method = "eth_simulateV1",
-    ignore = "chain_id,call_gas_limit,simulation_gas_limit,max_simulated_calls,max_simulated_blocks"
+    ignore = "chain_id,call_gas_limit,simulation_gas_limit,max_simulated_calls,max_simulated_blocks,max_response_size"
 )]
 pub async fn monad_simulate_v1<T: Triedb + TriedbPath>(
     data_provider: &DataProvider<T>,
@@ -83,6 +83,7 @@ pub async fn monad_simulate_v1<T: Triedb + TriedbPath>(
     simulation_gas_limit: u64,
     max_simulated_calls: usize,
     max_simulated_blocks: usize,
+    max_response_size: usize,
     params: MonadSimulateParams,
 ) -> JsonRpcResult<Box<RawValue>> {
     if !params.simulation.validation {
@@ -243,6 +244,7 @@ pub async fn monad_simulate_v1<T: Triedb + TriedbPath>(
             grandparent_block_id,
             simulation_gas_limit,
             max_simulated_blocks,
+            max_response_size,
             params.simulation.trace_transfers,
             &overrides,
         )

--- a/monad-rpc/src/handlers/mod.rs
+++ b/monad-rpc/src/handlers/mod.rs
@@ -447,6 +447,7 @@ async fn eth_simulateV1(
                 config.provider_gas_limit_eth_simulate,
                 config.provider_max_calls_eth_simulate,
                 config.provider_max_blocks_eth_simulate,
+                app_state.max_response_size as usize,
                 params,
             )
         })


### PR DESCRIPTION
Enable the C++ executor to enforce response size limit at trace construction time.

Companion execution patch: https://github.com/category-labs/monad/pull/2395