### PR TITLE
Raptorcast: Hardening secondary raptorcast client

### DIFF
--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -124,6 +124,9 @@ where
 
     epoch_validators: BTreeMap<Epoch, ValidatorSet<CertificateSignaturePubKey<ST>>>,
     full_node_groups: FullNodeGroupMap<CertificateSignaturePubKey<ST>>,
+    // Far-future cull bound for full_node_groups, mirroring the
+    // secondary client's invite window (same config value).
+    invite_future_dist_max: Round,
     proposer_schedule: BoxedProposerSchedule<CertificateSignaturePubKey<ST>>,
 
     dedicated_full_nodes: Vec<NodeId<CertificateSignaturePubKey<ST>>>,
@@ -286,6 +289,7 @@ where
             is_dynamic_fullnode,
             epoch_validators: Default::default(),
             full_node_groups: Default::default(),
+            invite_future_dist_max: config.secondary_instance.invite_future_dist_max,
             proposer_schedule,
 
             dedicated_full_nodes: config.primary_instance.fullnode_dedicated.clone(),
@@ -1000,6 +1004,8 @@ where
 
                     self.udp_state.update_current_round(round);
                     self.full_node_groups.delete_expired(round);
+                    self.full_node_groups
+                        .delete_far_future(round + self.invite_future_dist_max);
                     let proposer_cutoff = round.saturating_sub(round_info::CACHE_MAX_PAST_ROUNDS);
                     self.proposer_schedule.prune_below(proposer_cutoff);
                     self.peer_discovery_driver
@@ -1574,8 +1580,7 @@ where
                         let round_span = *group.round_span(); // for logging only
                         let publisher_id = *group.publisher_id();
                         if this.full_node_groups.try_insert(group).is_none() {
-                            // TODO: convert to an assertion?
-                            error!(
+                            warn!(
                                 round_span = ?round_span,
                                 publisher_id = ?publisher_id,
                                 "Accepted group assignment contains overlaps"
@@ -1658,13 +1663,17 @@ where
     ST: CertificateSignatureRecoverable,
 {
     match group_message {
-        // Prepare group message should originate from a validator
+        // Group formation messages should originate from a validator
         FullNodesGroupMessage::PrepareGroup(msg) => {
             &msg.validator_id == sender && validator_set.is_member(sender)
         }
+        FullNodesGroupMessage::ConfirmGroup(msg) => {
+            &msg.prepare.validator_id == sender && validator_set.is_member(sender)
+        }
+        FullNodesGroupMessage::NoConfirm(msg) => {
+            &msg.prepare.validator_id == sender && validator_set.is_member(sender)
+        }
         FullNodesGroupMessage::PrepareGroupResponse(msg) => &msg.node_id == sender,
-        FullNodesGroupMessage::ConfirmGroup(msg) => &msg.prepare.validator_id == sender,
-        FullNodesGroupMessage::NoConfirm(msg) => &msg.prepare.validator_id == sender,
         FullNodesGroupMessage::ParticipationReport(msg) => &msg.reporter == sender,
     }
 }

--- a/monad-raptorcast/src/raptorcast_secondary/client.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/client.rs
@@ -17,7 +17,7 @@ use std::{collections::BTreeMap, time::Instant};
 
 use iset::IntervalMap;
 use monad_crypto::certificate_signature::{
-    CertificateSignaturePubKey, CertificateSignatureRecoverable,
+    CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
 };
 use monad_executor::ExecutorMetrics;
 use monad_types::{NodeId, Round, RoundSpan, GENESIS_ROUND};
@@ -30,7 +30,7 @@ use super::{
 };
 use crate::{
     raptorcast_secondary::group_message::NoConfirm,
-    util::{SecondaryGroup, SecondaryGroupAssignment},
+    util::{SecondaryGroup, SecondaryGroupAssignment, MAX_GROUPS_PER_VALIDATOR},
 };
 
 // Default full_node_raptorcast.round_span is 240. Refuse to accept
@@ -60,6 +60,105 @@ fn init_executor_metrics() -> ExecutorMetrics {
     ])
 }
 
+// The state we hold for a single publishing validator.
+//
+// Invariants, both maintained at invite admission:
+// - live_count() <= MAX_GROUPS_PER_VALIDATOR, by freshest-wins
+//   eviction;
+// - live round spans (pending and confirmed together) are pairwise
+//   disjoint, by rejecting overlapping invites.
+struct ValidatorGroups<PT: PubKey> {
+    // start_round -> accepted group invite awaiting confirmation
+    pending: BTreeMap<Round, PrepareGroup<PT>>,
+    // Confirmed groups
+    confirmed: IntervalMap<Round, SecondaryGroupAssignment<PT>>,
+}
+
+impl<PT: PubKey> Default for ValidatorGroups<PT> {
+    fn default() -> Self {
+        Self {
+            pending: BTreeMap::new(),
+            confirmed: IntervalMap::new(),
+        }
+    }
+}
+
+impl<PT: PubKey> ValidatorGroups<PT> {
+    fn live_count(&self) -> usize {
+        self.pending.len() + self.confirmed.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.pending.is_empty() && self.confirmed.is_empty()
+    }
+
+    // Whether [start, end) overlaps any live (pending or confirmed)
+    // entry.
+    fn has_overlap(&self, start: Round, end: Round) -> bool {
+        let confirmed_overlaps = self.confirmed.has_overlap(start..end);
+        let pending_overlaps = self
+            .pending
+            .range(..end)
+            .any(|(_, invite)| invite.end_round > start);
+        confirmed_overlaps || pending_overlaps
+    }
+
+    // Drop entries that can no longer become active: pending invites
+    // whose start round has passed, confirmed groups that ended, and
+    // entries starting beyond max_start_round (cold-start leftovers
+    // that live admission would have rejected).
+    fn prune(&mut self, curr_round: Round, max_start_round: Round) {
+        self.pending
+            .retain(|&start_round, _| start_round > curr_round && start_round <= max_start_round);
+
+        let expired: Vec<_> = self
+            .confirmed
+            .intervals(..)
+            .filter(|interval| interval.end <= curr_round || interval.start > max_start_round)
+            .collect();
+        for interval in expired {
+            self.confirmed.remove(interval);
+        }
+    }
+
+    // Remove the live entry with the smallest end round, returning
+    // its start round. On a tie, prefer dropping a pending invite.
+    fn evict_stalest(&mut self) -> Option<Round> {
+        let pending = self
+            .pending
+            .iter()
+            .min_by_key(|(_, invite)| invite.end_round)
+            .map(|(&start_round, invite)| (start_round, invite.end_round));
+        let confirmed = self
+            .confirmed
+            .intervals(..)
+            .min_by_key(|interval| interval.end);
+
+        match (pending, confirmed) {
+            (Some((start_round, pending_end)), Some(interval)) => {
+                if pending_end <= interval.end {
+                    self.pending.remove(&start_round);
+                    Some(start_round)
+                } else {
+                    let start_round = interval.start;
+                    self.confirmed.remove(interval);
+                    Some(start_round)
+                }
+            }
+            (Some((start_round, _)), None) => {
+                self.pending.remove(&start_round);
+                Some(start_round)
+            }
+            (None, Some(interval)) => {
+                let start_round = interval.start;
+                self.confirmed.remove(interval);
+                Some(start_round)
+            }
+            (None, None) => None,
+        }
+    }
+}
+
 // This is for when the router is playing the role of a client
 // That is, we are a full-node receiving group invites from a validator
 pub struct Client<ST>
@@ -72,20 +171,12 @@ where
     // upload bandwidth to broadcast chunk to a large group.
     config: RaptorCastConfigSecondaryClient,
 
-    // [start_round, end_round) -> SecondaryGroupAssignment
-    // Represents all raptorcast groups that we have accepted and haven't expired
-    // yet. The groups may overlap.
-    confirmed_groups: IntervalMap<Round, SecondaryGroupAssignment<CertificateSignaturePubKey<ST>>>,
-
-    // start_round -> validator_id -> group invite
-    // Once we receive an invite, we remember how the invite looked like, so
-    // that we don't blindly accept any confirmation message.
-    pending_confirms: BTreeMap<
-        Round,
-        BTreeMap<
-            NodeId<CertificateSignaturePubKey<ST>>,
-            PrepareGroup<CertificateSignaturePubKey<ST>>,
-        >,
+    // Per-validator group formation state: invites we have accepted
+    // and confirmed groups that haven't expired yet. Groups
+    // may overlap across validators.
+    validator_groups: BTreeMap<
+        NodeId<CertificateSignaturePubKey<ST>>,
+        ValidatorGroups<CertificateSignaturePubKey<ST>>,
     >,
 
     // Once a group is confirmed, it is sent to this channel
@@ -124,8 +215,7 @@ where
         Self {
             client_node_id,
             config,
-            confirmed_groups: IntervalMap::new(),
-            pending_confirms: BTreeMap::new(),
+            validator_groups: BTreeMap::new(),
             group_sink_channel,
             curr_round: GENESIS_ROUND,
             last_round_heartbeat,
@@ -154,19 +244,14 @@ where
         self.curr_round = curr_round;
         self.last_round_heartbeat = Instant::now();
 
-        // Clean up old invitations.
-        self.pending_confirms.retain(|&key, _| key > curr_round);
-
-        // Remove all groups that should already have been consumed
-        let mut keys_to_remove = Vec::new();
-        for interval in self.confirmed_groups.intervals(..self.curr_round) {
-            if interval.end <= self.curr_round {
-                keys_to_remove.push(interval.clone());
-            }
-        }
-        for interval_key in keys_to_remove {
-            self.confirmed_groups.remove(interval_key);
-        }
+        // Clean up old invitations and groups that should already
+        // have been consumed, along with cold-start leftovers beyond
+        // the invite window.
+        let max_start_round = curr_round + self.config.invite_future_dist_max;
+        self.validator_groups.retain(|_, groups| {
+            groups.prune(curr_round, max_start_round);
+            !groups.is_empty()
+        });
         let current_group_count = self.get_current_group_count();
         self.metrics
             .gauge(CLIENT_NUM_CURRENT_GROUPS)
@@ -249,17 +334,16 @@ where
         };
         let mut num_current_groups = 0;
 
-        // Check confirmed groups
-        for group in self
-            .confirmed_groups
-            .values(invite_msg.start_round..invite_msg.end_round)
-        {
-            // Check if we already have an overlapping invite from same
-            // validator, e.g. [30, 40)->validator3 but we already
-            // have [25, 35)->validator3
+        for (validator_id, groups) in self.validator_groups.iter() {
+            // Check if we already have an overlapping group from the
+            // same validator, e.g. [30, 40)->validator3 but we already
+            // have [25, 35)->validator3. If so reject the invite.
+            //
             // Note that we accept overlaps across different validators,
             // e.g. [30, 40)->validator3 + [25, 35)->validator4
-            if group.publisher_id() == &invite_msg.validator_id {
+            if validator_id == &invite_msg.validator_id
+                && groups.has_overlap(invite_msg.start_round, invite_msg.end_round)
+            {
                 warn!(
                     "RaptorCastSecondary received self-overlapping \
                             invite for rounds [{:?}, {:?}) from validator {:?}",
@@ -268,31 +352,21 @@ where
                 return false;
             }
 
-            // Check that it doesn't exceed max number of groups during round span
-            num_current_groups += 1;
+            // Check that the confirmed groups, plus the groups we were
+            // invited to but are still unconfirmed, don't exceed max
+            // number of groups during the invite's round span
+            num_current_groups += groups
+                .confirmed
+                .intervals(invite_msg.start_round..invite_msg.end_round)
+                .count();
+            num_current_groups += groups
+                .pending
+                .range(..invite_msg.end_round)
+                .filter(|(_, other)| Self::overlaps(other.start_round, other.end_round, invite_msg))
+                .count();
             if num_current_groups + 1 > self.config.max_num_group {
                 log_exceed_max_num_group();
                 return false;
-            }
-        }
-
-        // Check groups we were invited to but are still unconfirmed
-        for (&key, other_invites) in self.pending_confirms.iter() {
-            if key >= invite_msg.end_round {
-                // Remaining keys are outside the invite range
-                break;
-            }
-
-            for other in other_invites.values() {
-                if !Self::overlaps(other.start_round, other.end_round, invite_msg) {
-                    continue;
-                }
-
-                num_current_groups += 1;
-                if num_current_groups + 1 > self.config.max_num_group {
-                    log_exceed_max_num_group();
-                    return false;
-                }
             }
         }
 
@@ -310,15 +384,45 @@ where
         self.metrics.gauge(CLIENT_RECEIVED_INVITES).inc();
 
         // Check the invite for duplicates & bandwidth requirements
-        let accept = self.validate_prepare_group_message(&invite_msg);
+        if !self.validate_prepare_group_message(&invite_msg) {
+            return PrepareGroupResponse {
+                req: invite_msg,
+                node_id: self.client_node_id,
+                accept: false,
+            };
+        }
 
-        if accept {
-            // Let's remember about this invite so that we don't blindly
-            // accept any confirmation message.
-            self.pending_confirms
-                .entry(invite_msg.start_round)
-                .or_default()
-                .insert(invite_msg.validator_id, invite_msg.clone());
+        let mut accept = true;
+
+        // Let's remember about this invite so that we don't blindly
+        // accept any confirmation message.
+        let groups = self
+            .validator_groups
+            .entry(invite_msg.validator_id)
+            .or_default();
+        groups
+            .pending
+            .insert(invite_msg.start_round, invite_msg.clone());
+
+        // Bound the state a single validator can make us hold across
+        // pending invites and confirmed groups. Caveat: eviction does
+        // not yet revoke groups already forwarded to the primary
+        // instance.
+        while groups.live_count() > MAX_GROUPS_PER_VALIDATOR {
+            let evicted_start = groups.evict_stalest();
+            if evicted_start == Some(invite_msg.start_round) {
+                warn!(
+                    ?invite_msg,
+                    "RaptorCastSecondary rejecting invite staler than all live groups held for its validator"
+                );
+                accept = false;
+            } else {
+                debug!(
+                    ?evicted_start,
+                    ?invite_msg,
+                    "RaptorCastSecondary evicting stalest group to admit fresher invite"
+                );
+            }
         }
 
         PrepareGroupResponse {
@@ -328,7 +432,7 @@ where
         }
     }
 
-    pub fn handle_confirm_group_message(&mut self, confirm_msg: ConfirmGroup<ST>) -> bool {
+    pub fn handle_confirm_group_message(&mut self, confirm_msg: &ConfirmGroup<ST>) -> bool {
         let start_round = &confirm_msg.prepare.start_round;
 
         // Drop the message if the round span is invalid
@@ -353,22 +457,25 @@ where
             return false;
         }
 
-        let Some(invites) = self.pending_confirms.get_mut(start_round) else {
+        let Some(groups) = self
+            .validator_groups
+            .get_mut(&confirm_msg.prepare.validator_id)
+        else {
             warn!(
-                "RaptorCastSecondary Ignoring confirmation message \
-                        for unrecognized start round: {:?}",
-                confirm_msg
+                ?confirm_msg,
+                "RaptorCastSecondary ignoring ConfirmGroup from \
+                            unrecognized validator id"
             );
             return false;
         };
 
         // TODO: discount validator reputation if it has sent an invalid
         // ConfirmGroup
-        let Some(accepted_invite) = invites.get(&confirm_msg.prepare.validator_id) else {
+        let Some(accepted_invite) = groups.pending.get(start_round) else {
             warn!(
-                ?confirm_msg,
-                "RaptorCastSecondary ignoring ConfirmGroup from \
-                            unrecognized validator id"
+                "RaptorCastSecondary Ignoring confirmation message \
+                        for unrecognized start round: {:?}",
+                confirm_msg
             );
             return false;
         };
@@ -411,7 +518,7 @@ where
             return false;
         }
 
-        let members = confirm_msg.peers.into_inner().into_iter().collect();
+        let members = confirm_msg.peers.iter().copied().collect();
         let group = SecondaryGroupAssignment::new(
             confirm_msg.prepare.validator_id,
             round_span,
@@ -442,10 +549,12 @@ where
             confirm_group_size,
         );
 
-        // Remove the invite from pending_confirms and add the group to confirmed_groups
-        invites.remove(&confirm_msg.prepare.validator_id);
-        self.confirmed_groups
-            .force_insert(round_span.start..round_span.end, group);
+        // Move the invite from pending to confirmed. Admission keeps
+        // live spans disjoint, so this can never displace an entry.
+        groups.pending.remove(&confirm_msg.prepare.start_round);
+        groups
+            .confirmed
+            .insert(round_span.start..round_span.end, group);
 
         let current_group_count = self.get_current_group_count();
         self.metrics
@@ -459,21 +568,19 @@ where
         &mut self,
         no_confim_msg: NoConfirm<CertificateSignaturePubKey<ST>>,
     ) {
-        let Some(invites) = self
-            .pending_confirms
-            .get_mut(&no_confim_msg.prepare.start_round)
-        else {
+        let validator_id = no_confim_msg.prepare.validator_id;
+        let Some(groups) = self.validator_groups.get_mut(&validator_id) else {
             warn!(
                 ?no_confim_msg,
-                "RaptorCastSecondary ignoring no confirm message: unrecognized start round",
+                "RaptorCastSecondary ignoring no confirm message: unrecognized validator id",
             );
             return;
         };
 
-        let Some(accepted_invite) = invites.get(&no_confim_msg.prepare.validator_id) else {
+        let Some(accepted_invite) = groups.pending.get(&no_confim_msg.prepare.start_round) else {
             warn!(
                 ?no_confim_msg,
-                "RaptorCastSecondary ignoring no confirm message: unrecognized validator id",
+                "RaptorCastSecondary ignoring no confirm message: unrecognized start round",
             );
             return;
         };
@@ -487,7 +594,10 @@ where
             return;
         };
 
-        invites.remove(&no_confim_msg.prepare.validator_id);
+        groups.pending.remove(&no_confim_msg.prepare.start_round);
+        if groups.is_empty() {
+            self.validator_groups.remove(&validator_id);
+        }
         debug!(
             ?no_confim_msg,
             "RaptorCastSecondary received no confirm message. Releasing round to other invites",
@@ -495,9 +605,15 @@ where
     }
 
     fn get_current_group_count(&self) -> u64 {
-        self.confirmed_groups
-            .intervals(self.curr_round..self.curr_round + Round(1))
-            .count() as u64
+        self.validator_groups
+            .values()
+            .map(|groups| {
+                groups
+                    .confirmed
+                    .intervals(self.curr_round..self.curr_round + Round(1))
+                    .count() as u64
+            })
+            .sum()
     }
 
     fn overlaps(
@@ -521,7 +637,18 @@ where
 
     #[cfg(test)]
     pub fn num_pending_confirms(&self) -> usize {
-        self.pending_confirms.len()
+        self.validator_groups
+            .values()
+            .map(|groups| groups.pending.len())
+            .sum()
+    }
+
+    #[cfg(test)]
+    pub fn num_confirmed_groups(&self) -> usize {
+        self.validator_groups
+            .values()
+            .map(|groups| groups.confirmed.len())
+            .sum()
     }
 }
 
@@ -539,7 +666,7 @@ mod tests {
                 config::RaptorCastConfigSecondaryClient,
                 util::{SecondaryGroup, SecondaryGroupAssignment},
             },
-            group_message::{NoConfirm, NoConfirmReason, PrepareGroup},
+            group_message::{ConfirmGroup, NoConfirm, NoConfirmReason, PrepareGroup},
             Client,
         },
         *,
@@ -575,7 +702,11 @@ mod tests {
         );
         assert!(grp.is_member(&self_id));
 
-        clt.confirmed_groups.insert(Round(1)..Round(5), grp);
+        clt.validator_groups
+            .entry(nid(2))
+            .or_default()
+            .confirmed
+            .insert(Round(1)..Round(5), grp);
 
         let malformed_messages = [
             // group size overflow
@@ -632,19 +763,16 @@ mod tests {
         );
         assert!(grp.is_member(&self_id));
 
-        clt.confirmed_groups.insert(Round(1)..Round(5), grp);
-
-        clt.pending_confirms.insert(
+        let groups = clt.validator_groups.entry(nid(2)).or_default();
+        groups.confirmed.insert(Round(1)..Round(5), grp);
+        groups.pending.insert(
             Round(4),
-            BTreeMap::from([(
-                nid(2),
-                PrepareGroup {
-                    max_group_size: 1,
-                    validator_id: nid(2),
-                    start_round: Round(4),
-                    end_round: Round(7),
-                },
-            )]),
+            PrepareGroup {
+                max_group_size: 1,
+                validator_id: nid(2),
+                start_round: Round(4),
+                end_round: Round(7),
+            },
         );
 
         let malformed_message = PrepareGroup {
@@ -681,7 +809,11 @@ mod tests {
         );
         assert!(grp.is_member(&self_id));
 
-        clt.confirmed_groups.insert(Round(1)..Round(5), grp);
+        clt.validator_groups
+            .entry(nid(2))
+            .or_default()
+            .confirmed
+            .insert(Round(1)..Round(5), grp);
 
         clt.enter_round(Round(3));
         assert_eq!(clt.get_current_group_count(), 1);
@@ -716,10 +848,11 @@ mod tests {
         };
 
         // Set up client state: client has accepted an invite and is waiting for confirmation
-        clt.pending_confirms.insert(
-            Round(5),
-            BTreeMap::from([(validator_id, prepare_invite.clone())]),
-        );
+        clt.validator_groups
+            .entry(validator_id)
+            .or_default()
+            .pending
+            .insert(Round(5), prepare_invite.clone());
 
         // Test 1: Valid NoConfirm message - should be accepted and remove the invite
         let valid_no_confirm = NoConfirm {
@@ -729,14 +862,293 @@ mod tests {
 
         clt.handle_no_confirm_message(valid_no_confirm);
 
-        // Verify the invite was removed from pending_confirms
+        // Verify the invite was removed, together with the validator's
+        // now-empty group state
         assert!(
-            !clt.pending_confirms
-                .get(&Round(5))
-                .unwrap()
-                .contains_key(&validator_id),
-            "Valid NoConfirm should remove the invite from pending_confirms"
+            !clt.validator_groups.contains_key(&validator_id),
+            "Valid NoConfirm should remove the invite from the pending confirms"
         );
+    }
+
+    // During cold-start we are not receiving proposals, so the invite
+    // round window is waived and enter_round() is not called to prune
+    // state. The per-validator cap must bound the state instead:
+    // fresher invites evict the stalest entry, staler ones are
+    // rejected.
+    #[test]
+    fn cold_start_pending_invites_capped_per_validator() {
+        let (clt_tx, _clt_rx): RcToRcChannelGrp = unbounded_channel();
+        let self_id = nid(1);
+        let mut clt = Client::<ST>::new(
+            self_id,
+            clt_tx,
+            RaptorCastConfigSecondaryClient {
+                max_num_group: 5,
+                max_group_size: 10,
+                invite_future_dist_min: Round(1),
+                invite_future_dist_max: Round(100),
+                invite_accept_heartbeat: Duration::from_secs(10),
+            },
+        );
+
+        // Disjoint far-future spans from a single validator, so
+        // neither the self-overlap check nor the max_num_group check
+        // rejects them. Ends are increasing, so every invite past the
+        // cap evicts the stalest one, keeping the freshest
+        // MAX_GROUPS_PER_VALIDATOR.
+        let mut num_accepted = 0;
+        for k in 0..10 * MAX_GROUPS_PER_VALIDATOR as u64 {
+            let invite = PrepareGroup {
+                max_group_size: 10,
+                validator_id: nid(2),
+                start_round: Round(1_000 + 2 * k),
+                end_round: Round(1_001 + 2 * k),
+            };
+            if clt.handle_prepare_group_message(invite).accept {
+                num_accepted += 1;
+            }
+        }
+        assert_eq!(num_accepted, 10 * MAX_GROUPS_PER_VALIDATOR);
+        assert_eq!(clt.num_pending_confirms(), MAX_GROUPS_PER_VALIDATOR);
+
+        // An invite staler than everything we hold is rejected
+        let stale_invite = PrepareGroup {
+            max_group_size: 10,
+            validator_id: nid(2),
+            start_round: Round(900),
+            end_round: Round(901),
+        };
+        assert!(!clt.handle_prepare_group_message(stale_invite).accept);
+
+        // A confirm for the first, since-evicted invite is rejected
+        let evicted_confirm = ConfirmGroup {
+            prepare: PrepareGroup {
+                max_group_size: 10,
+                validator_id: nid(2),
+                start_round: Round(1_000),
+                end_round: Round(1_001),
+            },
+            peers: vec![self_id, nid(3)].into(),
+            name_records: Vec::new().into(),
+        };
+        assert!(!clt.handle_confirm_group_message(&evicted_confirm));
+
+        // A confirm for the freshest, surviving invite succeeds
+        let last_k = 10 * MAX_GROUPS_PER_VALIDATOR as u64 - 1;
+        let survivor_confirm = ConfirmGroup {
+            prepare: PrepareGroup {
+                max_group_size: 10,
+                validator_id: nid(2),
+                start_round: Round(1_000 + 2 * last_k),
+                end_round: Round(1_001 + 2 * last_k),
+            },
+            peers: vec![self_id, nid(3)].into(),
+            name_records: Vec::new().into(),
+        };
+        assert!(clt.handle_confirm_group_message(&survivor_confirm));
+
+        // The cap is per validator: another validator is not affected
+        let invite = PrepareGroup {
+            max_group_size: 10,
+            validator_id: nid(3),
+            start_round: Round(1_000),
+            end_round: Round(1_001),
+        };
+        assert!(clt.handle_prepare_group_message(invite).accept);
+    }
+
+    // Alternating invite -> confirm keeps the pending side empty, so
+    // eviction must cover confirmed groups too: past the cap, each
+    // fresher confirm evicts the stalest confirmed group.
+    //
+    // Note that every confirmed group is still forwarded to the
+    // primary instance and eviction does not revoke it there;
+    // bounding the primary's map is a separate concern.
+    #[test]
+    fn cold_start_confirm_loop_capped_per_validator() {
+        let (clt_tx, mut clt_rx): RcToRcChannelGrp = unbounded_channel();
+        let self_id = nid(1);
+        let mut clt = Client::<ST>::new(
+            self_id,
+            clt_tx,
+            RaptorCastConfigSecondaryClient {
+                max_num_group: 5,
+                max_group_size: 10,
+                invite_future_dist_min: Round(1),
+                invite_future_dist_max: Round(100),
+                invite_accept_heartbeat: Duration::from_secs(10),
+            },
+        );
+
+        let validator_id = nid(2);
+        let mut num_confirmed = 0;
+        for k in 0..10 * MAX_GROUPS_PER_VALIDATOR as u64 {
+            let prepare = PrepareGroup {
+                max_group_size: 10,
+                validator_id,
+                start_round: Round(1_000 + 2 * k),
+                end_round: Round(1_001 + 2 * k),
+            };
+            if !clt.handle_prepare_group_message(prepare.clone()).accept {
+                continue;
+            }
+            let confirm = ConfirmGroup {
+                prepare,
+                peers: vec![self_id, nid(3)].into(),
+                name_records: Vec::new().into(),
+            };
+            if clt.handle_confirm_group_message(&confirm) {
+                num_confirmed += 1;
+            }
+        }
+        assert_eq!(num_confirmed, 10 * MAX_GROUPS_PER_VALIDATOR);
+        assert_eq!(clt.num_confirmed_groups(), MAX_GROUPS_PER_VALIDATOR);
+
+        // The primary instance received every confirmed group,
+        // including since-evicted ones
+        let mut num_forwarded = 0;
+        while clt_rx.try_recv().is_ok() {
+            num_forwarded += 1;
+        }
+        assert_eq!(num_forwarded, 10 * MAX_GROUPS_PER_VALIDATOR);
+
+        // Advancing past the accepted spans frees the budget
+        clt.enter_round(Round(2_000));
+        let invite = PrepareGroup {
+            max_group_size: 10,
+            validator_id,
+            start_round: Round(2_010),
+            end_round: Round(2_011),
+        };
+        assert!(clt.handle_prepare_group_message(invite).accept);
+    }
+
+    // Far-future entries admitted during cold-start can never
+    // activate once rounds advance (live admission would have
+    // rejected them). They must be pruned so they free the
+    // validator's budget instead of consuming it forever.
+    #[test]
+    fn far_future_entries_pruned_on_round_advance() {
+        let (clt_tx, _clt_rx): RcToRcChannelGrp = unbounded_channel();
+        let self_id = nid(1);
+        let mut clt = Client::<ST>::new(
+            self_id,
+            clt_tx,
+            RaptorCastConfigSecondaryClient {
+                max_num_group: 5,
+                max_group_size: 10,
+                invite_future_dist_min: Round(1),
+                invite_future_dist_max: Round(100),
+                invite_accept_heartbeat: Duration::from_secs(10),
+            },
+        );
+
+        let validator_id = nid(2);
+        let invite = |start: u64, end: u64| PrepareGroup {
+            max_group_size: 10,
+            validator_id,
+            start_round: Round(start),
+            end_round: Round(end),
+        };
+
+        // Cold-start: accept an in-window invite, a far-future invite
+        // and a far-future confirmed group
+        assert!(clt.handle_prepare_group_message(invite(50, 60)).accept);
+        assert!(
+            clt.handle_prepare_group_message(invite(5_000, 5_010))
+                .accept
+        );
+        assert!(
+            clt.handle_prepare_group_message(invite(6_000, 6_010))
+                .accept
+        );
+        let confirm = ConfirmGroup {
+            prepare: invite(6_000, 6_010),
+            peers: vec![self_id, nid(3)].into(),
+            name_records: Vec::new().into(),
+        };
+        assert!(clt.handle_confirm_group_message(&confirm));
+
+        // Entering a round prunes everything starting beyond
+        // curr_round + invite_future_dist_max, but keeps the
+        // in-window invite
+        clt.enter_round(Round(10));
+        assert_eq!(clt.num_pending_confirms(), 1);
+        assert_eq!(clt.get_current_group_count(), 0);
+
+        // The validator's budget is freed: once the in-window invite
+        // from above expires too, fresh in-window invites are all
+        // admitted again, evicting the stalest ones past the cap
+        clt.enter_round(Round(60));
+        let mut num_accepted = 0;
+        for k in 0..2 * MAX_GROUPS_PER_VALIDATOR as u64 {
+            let invite = invite(61 + 2 * k, 62 + 2 * k);
+            if clt.handle_prepare_group_message(invite).accept {
+                num_accepted += 1;
+            }
+        }
+        assert_eq!(num_accepted, 2 * MAX_GROUPS_PER_VALIDATOR);
+        assert_eq!(clt.num_pending_confirms(), MAX_GROUPS_PER_VALIDATOR);
+    }
+
+    // Overlapping spans from the same validator are refused outright,
+    // whether the held entry is pending or confirmed, and including
+    // exact re-sends (the publisher never re-invites the same node
+    // for a group, so this refuses no honest invite). Overlaps across
+    // different validators are accepted.
+    #[test]
+    fn overlapping_invites_from_same_validator_rejected() {
+        let (clt_tx, _clt_rx): RcToRcChannelGrp = unbounded_channel();
+        let self_id = nid(1);
+        let mut clt = Client::<ST>::new(
+            self_id,
+            clt_tx,
+            RaptorCastConfigSecondaryClient {
+                max_num_group: 5,
+                max_group_size: 10,
+                invite_future_dist_min: Round(1),
+                invite_future_dist_max: Round(100),
+                invite_accept_heartbeat: Duration::from_secs(10),
+            },
+        );
+
+        let invite = |validator: u64, start: u64, end: u64| PrepareGroup {
+            max_group_size: 10,
+            validator_id: nid(validator),
+            start_round: Round(start),
+            end_round: Round(end),
+        };
+
+        // Hold a pending invite [10, 20) and a confirmed group
+        // [30, 40) from validator 2
+        assert!(clt.handle_prepare_group_message(invite(2, 10, 20)).accept);
+        assert!(clt.handle_prepare_group_message(invite(2, 30, 40)).accept);
+        let confirm = ConfirmGroup {
+            prepare: invite(2, 30, 40),
+            peers: vec![self_id, nid(3)].into(),
+            name_records: Vec::new().into(),
+        };
+        assert!(clt.handle_confirm_group_message(&confirm));
+
+        // Overlapping the pending invite is refused, including an
+        // exact re-send
+        assert!(!clt.handle_prepare_group_message(invite(2, 10, 20)).accept);
+        assert!(!clt.handle_prepare_group_message(invite(2, 15, 25)).accept);
+        assert!(!clt.handle_prepare_group_message(invite(2, 5, 11)).accept);
+
+        // Overlapping the confirmed group is refused
+        assert!(!clt.handle_prepare_group_message(invite(2, 35, 45)).accept);
+        assert!(!clt.handle_prepare_group_message(invite(2, 25, 31)).accept);
+
+        // The refused invites left the held entries untouched
+        assert_eq!(clt.num_pending_confirms(), 1);
+        assert_eq!(clt.num_confirmed_groups(), 1);
+
+        // Touching spans do not overlap
+        assert!(clt.handle_prepare_group_message(invite(2, 20, 30)).accept);
+
+        // Overlaps across validators are accepted
+        assert!(clt.handle_prepare_group_message(invite(3, 15, 35)).accept);
     }
 
     // Creates a node id that we can refer to just from its seed

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -28,7 +28,7 @@ mod publisher;
 use alloy_rlp::{Decodable, Encodable};
 use client::Client;
 use futures::{Future, Stream};
-use group_message::FullNodesGroupMessage;
+use group_message::{ConfirmGroup, FullNodesGroupMessage};
 use monad_crypto::certificate_signature::{
     CertificateKeyPair, CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
 };
@@ -45,7 +45,7 @@ use tracing::{debug, error, trace, warn};
 use crate::{
     config::{RaptorCastConfig, SecondaryRaptorCastMode},
     message::OutboundRouterMessage,
-    util::{SecondaryGroup, SecondaryGroupAssignment},
+    util::{budgeted, SecondaryGroup, SecondaryGroupAssignment},
     RaptorCastEvent,
 };
 
@@ -239,6 +239,112 @@ where
         }
         group_msg
     }
+
+    // Handles one group message forwarded by the primary instance,
+    // returning the event to yield from the stream, if any.
+    fn handle_group_message(
+        &mut self,
+        inbound_grp_msg: FullNodesGroupMessage<ST>,
+    ) -> Option<RaptorCastEvent<M::Event, ST>> {
+        match &mut self.role {
+            Role::Publisher(publisher) => {
+                if let Some((msg, node_id)) = publisher.on_candidate_response(inbound_grp_msg) {
+                    self.send_single_msg(msg, node_id);
+                }
+                None
+            }
+
+            Role::Client(client) => {
+                trace!("RaptorCastSecondary received group message");
+                // Received group message from validator
+                match inbound_grp_msg {
+                    FullNodesGroupMessage::PrepareGroup(invite_msg) => {
+                        let dest_node_id = invite_msg.validator_id;
+                        let resp = client.handle_prepare_group_message(invite_msg);
+
+                        // Send back a response to the validator
+                        trace!("RaptorCastSecondary sending back response for group message");
+                        self.send_single_msg(
+                            FullNodesGroupMessage::PrepareGroupResponse(resp),
+                            dest_node_id,
+                        );
+                        None
+                    }
+                    FullNodesGroupMessage::ConfirmGroup(confirm_msg) => {
+                        if !client.handle_confirm_group_message(&confirm_msg) {
+                            return None;
+                        }
+                        self.on_group_confirmed(confirm_msg)
+                    }
+                    FullNodesGroupMessage::NoConfirm(no_confirm) => {
+                        client.handle_no_confirm_message(no_confirm);
+                        None
+                    }
+                    FullNodesGroupMessage::PrepareGroupResponse(_) => {
+                        error!(
+                            "RaptorCastSecondary client received a PrepareGroupResponse message"
+                        );
+                        None
+                    }
+                    FullNodesGroupMessage::ParticipationReport(_) => {
+                        error!("RaptorCastSecondary client received a ParticipationReport message");
+                        None
+                    }
+                }
+            }
+        }
+    }
+
+    // Reacts to a group we just confirmed as client: feeds the
+    // group's peers to peer discovery and produces the corresponding
+    // peers-update event. Returns None if the message carries no
+    // usable name records.
+    fn on_group_confirmed(
+        &self,
+        confirm_msg: ConfirmGroup<ST>,
+    ) -> Option<RaptorCastEvent<M::Event, ST>> {
+        let num_mappings = confirm_msg.name_records.len();
+        if num_mappings == 0 {
+            return None;
+        }
+        if num_mappings != confirm_msg.peers.len() {
+            warn!(?confirm_msg, num_peers =? confirm_msg.peers.len(), num_name_recs =? confirm_msg.name_records.len(),
+                "Number of peers does not match the number \
+                of name records in ConfirmGroup message. \
+                Skipping PeerDiscovery update"
+            );
+            return None;
+        }
+
+        // Update peer discovery with peers from confirm group message
+        let peers: Vec<PeerEntry<ST>> = confirm_msg
+            .name_records
+            .iter()
+            .zip(confirm_msg.peers.iter())
+            .map(|(rec, peer)| rec.with_pubkey(peer.pubkey()).into())
+            .collect();
+        self.peer_discovery_driver
+            .lock()
+            .unwrap()
+            .update(PeerDiscoveryEvent::UpdatePeers { peers });
+
+        // participated_nodes contains the validator and all full nodes in the group
+        let mut participated_nodes: BTreeSet<NodeId<CertificateSignaturePubKey<ST>>> =
+            confirm_msg.peers.clone().into_iter().collect();
+        participated_nodes.insert(confirm_msg.prepare.validator_id);
+        self.peer_discovery_driver
+            .lock()
+            .unwrap()
+            .update(PeerDiscoveryEvent::UpdateConfirmGroup {
+                end_round: confirm_msg.prepare.end_round,
+                peers: participated_nodes.clone(),
+            });
+
+        Some(RaptorCastEvent::SecondaryRaptorcastPeersUpdate(
+            confirm_msg.prepare.end_round,
+            participated_nodes.into_iter().collect(),
+        ))
+    }
 }
 
 impl<ST, M, OM, SE, PD> Executor for RaptorCastSecondary<ST, M, OM, SE, PD>
@@ -399,6 +505,8 @@ where
     }
 }
 
+const GROUP_MESSAGE_POLL_QUOTA: usize = 64;
+
 impl<ST, M, OM, E, PD> Stream for RaptorCastSecondary<ST, M, OM, E, PD>
 where
     ST: CertificateSignatureRecoverable,
@@ -410,109 +518,34 @@ where
 {
     type Item = E;
 
-    // Since we are sending to full-nodes only, and not receiving anything from them,
-    // we don't need to handle any receive here and this is just to satisfy traits
+    // Drives the group formation protocol from messages forwarded by
+    // the primary instance. All network receiving happens in the
+    // primary; this stream only consumes the forwarding channel.
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
 
-        let inbound_grp_msg = match pin!(this.channel_from_primary.recv()).poll(cx) {
-            Poll::Ready(Some(inbound_grp_msg)) => inbound_grp_msg,
-            Poll::Ready(None) => {
-                tracing::error!("RaptorCastSecondary channel disconnected.");
-                // TODO: should we return Poll::Ready(None) here?
-                return Poll::Pending;
-            }
-            Poll::Pending => {
-                // No group message received, so we are not ready to process anything
-                return Poll::Pending;
-            }
-        };
-
-        let mut ret = Poll::Pending;
-
-        match &mut this.role {
-            Role::Publisher(publisher) => {
-                if let Some((msg, node_id)) = publisher.on_candidate_response(inbound_grp_msg) {
-                    this.send_single_msg(msg, node_id);
+        // Keep draining group messages until the channel is empty to
+        // ensure the waker is registered, within a quota preventing a
+        // continuously non-empty channel from starving other tasks.
+        let mut poll_quota = GROUP_MESSAGE_POLL_QUOTA;
+        loop {
+            let recv = budgeted(this.channel_from_primary.recv(), &mut poll_quota);
+            let inbound_grp_msg = match pin!(recv).poll(cx) {
+                Poll::Ready(Some(inbound_grp_msg)) => inbound_grp_msg,
+                Poll::Ready(None) => {
+                    tracing::error!("RaptorCastSecondary channel disconnected.");
+                    // TODO: should we return Poll::Ready(None) here?
+                    return Poll::Pending;
                 }
-            }
-
-            Role::Client(client) => {
-                trace!("RaptorCastSecondary received group message");
-                // Received group message from validator
-                match inbound_grp_msg {
-                    FullNodesGroupMessage::PrepareGroup(invite_msg) => {
-                        let dest_node_id = invite_msg.validator_id;
-                        let resp = client.handle_prepare_group_message(invite_msg);
-
-                        // Send back a response to the validator
-                        trace!("RaptorCastSecondary sending back response for group message");
-                        this.send_single_msg(
-                            FullNodesGroupMessage::PrepareGroupResponse(resp),
-                            dest_node_id,
-                        );
-                    }
-                    FullNodesGroupMessage::PrepareGroupResponse(_) => {
-                        error!(
-                            "RaptorCastSecondary client received a PrepareGroupResponse message"
-                        );
-                    }
-                    FullNodesGroupMessage::ParticipationReport(_) => {
-                        error!("RaptorCastSecondary client received a ParticipationReport message");
-                    }
-                    FullNodesGroupMessage::ConfirmGroup(confirm_msg) => {
-                        let is_valid = client.handle_confirm_group_message(confirm_msg.clone());
-                        if is_valid {
-                            // Update peer discovery with peers from confirm group message
-                            let num_mappings = confirm_msg.name_records.len();
-                            if num_mappings > 0 && num_mappings == confirm_msg.peers.len() {
-                                let peers: Vec<PeerEntry<ST>> = confirm_msg
-                                    .name_records
-                                    .iter()
-                                    .zip(confirm_msg.peers.iter())
-                                    .map(|(rec, peer)| rec.with_pubkey(peer.pubkey()).into())
-                                    .collect();
-
-                                this.peer_discovery_driver
-                                    .lock()
-                                    .unwrap()
-                                    .update(PeerDiscoveryEvent::UpdatePeers { peers });
-
-                                // participated_nodes contains the validator and all full nodes in the group
-                                let mut participated_nodes: BTreeSet<
-                                    NodeId<CertificateSignaturePubKey<ST>>,
-                                > = confirm_msg.peers.clone().into_iter().collect();
-                                participated_nodes.insert(confirm_msg.prepare.validator_id);
-                                this.peer_discovery_driver.lock().unwrap().update(
-                                    PeerDiscoveryEvent::UpdateConfirmGroup {
-                                        end_round: confirm_msg.prepare.end_round,
-                                        peers: participated_nodes.clone(),
-                                    },
-                                );
-
-                                ret = Poll::Ready(Some(
-                                    RaptorCastEvent::SecondaryRaptorcastPeersUpdate(
-                                        confirm_msg.prepare.end_round,
-                                        participated_nodes.into_iter().collect(),
-                                    )
-                                    .into(),
-                                ));
-                            } else if num_mappings > 0 {
-                                warn!(?confirm_msg, num_peers =? confirm_msg.peers.len(), num_name_recs =? confirm_msg.name_records.len(),
-                                    "Number of peers does not match the number \
-                                    of name records in ConfirmGroup message. \
-                                    Skipping PeerDiscovery update"
-                                );
-                            }
-                        }
-                    }
-                    FullNodesGroupMessage::NoConfirm(no_confirm) => {
-                        client.handle_no_confirm_message(no_confirm);
-                    }
+                Poll::Pending => {
+                    // No group message received, so we are not ready to process anything
+                    return Poll::Pending;
                 }
+            };
+
+            if let Some(event) = this.handle_group_message(inbound_grp_msg) {
+                return Poll::Ready(Some(event.into()));
             }
         }
-
-        ret
     }
 }

--- a/monad-raptorcast/src/raptorcast_secondary/publisher.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/publisher.rs
@@ -1662,20 +1662,20 @@ mod tests {
         assert_eq!(reply_msg.node_id, nid(10));
         assert_eq!(reply_msg.req, make_prep_data(50));
 
-        let is_valid = clt.handle_confirm_group_message(make_confirm_msg(50));
+        let is_valid = clt.handle_confirm_group_message(&make_confirm_msg(50));
         assert!(is_valid, "ConfirmGroup for rounds [50, 52) should be valid");
 
         // Receive invite for rounds [52, 54), from V0
         clt.handle_prepare_group_message(make_invite_msg(52));
-        assert!(clt.handle_confirm_group_message(make_confirm_msg(52)));
+        assert!(clt.handle_confirm_group_message(&make_confirm_msg(52)));
 
         // Receive invite for rounds [60, 62), from V0
         clt.handle_prepare_group_message(make_invite_msg(60));
-        assert!(clt.handle_confirm_group_message(make_confirm_msg(60)));
+        assert!(clt.handle_confirm_group_message(&make_confirm_msg(60)));
 
         // Receive invite for rounds [62, 64), from V0
         clt.handle_prepare_group_message(make_invite_msg(62));
-        assert!(clt.handle_confirm_group_message(make_confirm_msg(62)));
+        assert!(clt.handle_confirm_group_message(&make_confirm_msg(62)));
 
         // Receive raptorcast with proposal 50
         let rc_grp = &group_map.get_rc_group_peers(&clt, &nid(0));
@@ -1805,8 +1805,8 @@ mod tests {
         // This is the last opportunity to receive confirm for group 1.
         // Lets accept both here, out of order.
         assert_eq!(clt.num_pending_confirms(), 2);
-        assert!(clt.handle_confirm_group_message(make_confirm_msg(8)));
-        assert!(clt.handle_confirm_group_message(make_confirm_msg(5)));
+        assert!(clt.handle_confirm_group_message(&make_confirm_msg(8)));
+        assert!(clt.handle_confirm_group_message(&make_confirm_msg(5)));
 
         //-------------------------------------------------------------------[5]
         clt.enter_round(Round(5));
@@ -1923,8 +1923,8 @@ mod tests {
         // Note that make_confirm_msg() return node ids = start_round + 10,
         // so the first node in the second group is 45
         assert_eq!(clt.num_pending_confirms(), 2);
-        assert!(clt.handle_confirm_group_message(make_confirm_msg(38)));
-        assert!(clt.handle_confirm_group_message(make_confirm_msg(35)));
+        assert!(clt.handle_confirm_group_message(&make_confirm_msg(38)));
+        assert!(clt.handle_confirm_group_message(&make_confirm_msg(35)));
 
         //------------------------------------------------------------------[35]
         clt.enter_round(Round(35));
@@ -2027,7 +2027,7 @@ mod tests {
         assert_eq!(validator_id, nid(0));
         assert!(reply_msg.accept);
         assert_eq!(reply_msg.req, invite_data(8, 0));
-        assert!(clt.handle_confirm_group_message(make_confirm_msg(8, 0)));
+        assert!(clt.handle_confirm_group_message(&make_confirm_msg(8, 0)));
 
         // Invite v1.0
         let invite_msg = make_invite_msg(9, 1);
@@ -2037,7 +2037,7 @@ mod tests {
         assert_eq!(validator_id, nid(1));
         assert!(reply_msg.accept);
         assert_eq!(reply_msg.req, invite_data(9, 1));
-        assert!(clt.handle_confirm_group_message(make_confirm_msg(9, 1)));
+        assert!(clt.handle_confirm_group_message(&make_confirm_msg(9, 1)));
 
         //-------------------------------------------------------------------[2]
         clt.enter_round(Round(2));
@@ -2057,7 +2057,7 @@ mod tests {
         assert_eq!(validator_id, nid(2));
         assert!(reply_msg.accept);
         assert_eq!(reply_msg.req, invite_data(me, 2));
-        assert!(clt.handle_confirm_group_message(make_confirm_msg(me, 2)));
+        assert!(clt.handle_confirm_group_message(&make_confirm_msg(me, 2)));
 
         // Invite v0.1
         let invite_msg = make_invite_msg(11, 0);
@@ -2067,7 +2067,7 @@ mod tests {
         assert_eq!(validator_id, nid(0));
         assert!(reply_msg.accept);
         assert_eq!(reply_msg.req, invite_data(11, 0));
-        assert!(clt.handle_confirm_group_message(make_confirm_msg(11, 0)));
+        assert!(clt.handle_confirm_group_message(&make_confirm_msg(11, 0)));
 
         //-------------------------------------------------------------------[3]
         clt.enter_round(Round(3));
@@ -2087,7 +2087,7 @@ mod tests {
         assert_eq!(validator_id, nid(0));
         assert!(reply_msg.accept);
         assert_eq!(reply_msg.req, invite_data(14, 0));
-        assert!(clt.handle_confirm_group_message(make_confirm_msg(14, 0)));
+        assert!(clt.handle_confirm_group_message(&make_confirm_msg(14, 0)));
 
         // Invite v1.1
         let invite_msg = make_invite_msg(14, 1);
@@ -2097,7 +2097,7 @@ mod tests {
         assert_eq!(validator_id, nid(1));
         assert!(reply_msg.accept);
         assert_eq!(reply_msg.req, invite_data(14, 1));
-        assert!(clt.handle_confirm_group_message(make_confirm_msg(14, 1)));
+        assert!(clt.handle_confirm_group_message(&make_confirm_msg(14, 1)));
 
         // Invite v2.1
         let invite_msg = make_invite_msg(14, 2);
@@ -2106,7 +2106,7 @@ mod tests {
 
         assert_eq!(validator_id, nid(2));
         assert_eq!(reply_msg.req, invite_data(14, 2));
-        assert!(clt.handle_confirm_group_message(make_confirm_msg(14, 2)));
+        assert!(clt.handle_confirm_group_message(&make_confirm_msg(14, 2)));
 
         //-----------------------------------------------------------------[4-7]
         // Simulated gap - no receiving proposals

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -279,6 +279,13 @@ impl<PT: PubKey> SecondaryGroupAssignment<PT> {
     }
 }
 
+// Max number of live groups per publishing validator. The secondary
+// client enforces it at invite admission (freshest wins: an invite
+// outliving the stalest live entry evicts it, staler ones are
+// rejected). The primary's group map mirrors it as a backstop, since
+// client-side eviction does not revoke already-forwarded groups.
+pub(crate) const MAX_GROUPS_PER_VALIDATOR: usize = 16;
+
 // An interval map from RoundSpan to SecondaryGroup.
 //
 // Invariance: Each group's round span must be non-overlapping.
@@ -335,6 +342,26 @@ impl<PT: PubKey> SecondaryGroupMap<PT> {
         }
     }
 
+    // cull groups that start beyond max_start: far-future entries
+    // admitted while rounds were not advancing, which may otherwise
+    // never expire through delete_expired
+    pub fn delete_far_future(&mut self, max_start: Round) {
+        while let Some((range, _)) = self.group_map.largest() {
+            if range.start <= max_start {
+                break;
+            }
+            self.group_map.remove(range);
+        }
+    }
+
+    // Evict the stalest groups until holding at most `cap`. Spans are
+    // disjoint, so the smallest interval is the first one to expire.
+    pub fn evict_stalest_to_cap(&mut self, cap: usize) {
+        while self.group_map.len() > cap {
+            self.group_map.remove_smallest();
+        }
+    }
+
     fn is_empty(&self) -> bool {
         self.group_map.is_empty()
     }
@@ -370,13 +397,27 @@ impl<PT: PubKey> FullNodeGroupMap<PT> {
     #[must_use]
     pub fn try_insert(&mut self, assignment: SecondaryGroupAssignment<PT>) -> Option<()> {
         let group_map = self.map.entry(assignment.publisher_id).or_default();
-        group_map.try_insert(assignment.round_span, assignment.group)
+        let inserted = group_map.try_insert(assignment.round_span, assignment.group);
+        // Mirror the client's per-validator freshest-wins cap: without
+        // it a validator could grow this map without limit while
+        // rounds are not advancing, as client-side eviction does not
+        // revoke groups it already forwarded here.
+        group_map.evict_stalest_to_cap(MAX_GROUPS_PER_VALIDATOR);
+        inserted
     }
 
     // cull groups that ends before or at round_cap
     pub fn delete_expired(&mut self, round_cap: Round) {
         self.map.retain(|_publisher_id, group_map| {
             group_map.delete_expired(round_cap);
+            !group_map.is_empty()
+        });
+    }
+
+    // cull groups that start beyond max_start (see SecondaryGroupMap)
+    pub fn delete_far_future(&mut self, max_start: Round) {
+        self.map.retain(|_publisher_id, group_map| {
+            group_map.delete_far_future(max_start);
             !group_map.is_empty()
         });
     }
@@ -1057,6 +1098,47 @@ mod tests {
         assert!(!node_ids.is_empty());
         let members = node_ids.iter().map(|id| (*id, Stake::ONE)).collect();
         ValidatorSet::new_unchecked(members)
+    }
+
+    // The map bounds the groups held per publisher (keeping the
+    // freshest) and culls far-future entries, mirroring the secondary
+    // client's admission rules for the groups it forwards here.
+    #[test]
+    fn full_node_groups_bounded_per_publisher() {
+        let group = |start: u64, end: u64| {
+            SecondaryGroupAssignment::new(
+                nid(0),
+                RoundSpan::new(Round(start), Round(end)).unwrap(),
+                SecondaryGroup::new([nid(1), nid(2)].into_iter().collect()).unwrap(),
+            )
+        };
+        let mut map = FullNodeGroupMap::<PT>::default();
+
+        // Disjoint spans with increasing rounds: each insert past the
+        // cap evicts the stalest entry
+        let num_groups = 10 * MAX_GROUPS_PER_VALIDATOR as u64;
+        for k in 0..num_groups {
+            assert!(map
+                .try_insert(group(1_000 + 2 * k, 1_001 + 2 * k))
+                .is_some());
+        }
+        let group_map = map.get_group_map(&nid(0)).unwrap();
+        let held = (0..num_groups)
+            .filter(|k| group_map.get(Round(1_000 + 2 * k)).is_some())
+            .count();
+        assert_eq!(held, MAX_GROUPS_PER_VALIDATOR);
+        assert!(group_map.get(Round(1_000)).is_none());
+        assert!(group_map.get(Round(1_000 + 2 * (num_groups - 1))).is_some());
+
+        // The far-future cull drops entries starting beyond max_start
+        map.delete_far_future(Round(1_300));
+        let group_map = map.get_group_map(&nid(0)).unwrap();
+        assert!(group_map.get(Round(1_300)).is_some());
+        assert!(group_map.get(Round(1_302)).is_none());
+
+        // Culling every group removes the publisher's slot
+        map.delete_far_future(Round(0));
+        assert!(map.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
This PR implements the following fixes:

- Bound `pending_confirms` and `confirmed_groups` during cold start
- Add validator membership check for `ConfirmGroup`/`NoConfirm` messages
- Fix missing waker call in `RaptorCastSecondary::poll_next`
- Expire far-future entries admitted during cold start
- Reject overlapping group invitation from the same validator

Generated using Claude Fable 5.