### PR TITLE
feat: Enable spec test execution using runloop

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "monad-execution"]
 	path = monad-execution
-	url = https://github.com/category-labs/monad.git
+	url = https://github.com/pdobacz/monad.git

--- a/docker/archive/Dockerfile
+++ b/docker/archive/Dockerfile
@@ -45,6 +45,7 @@ RUN apt update && apt install -y \
   libhugetlbfs-dev \
   libmagicenum-dev \
   libmimalloc-dev \
+  libsecp256k1-dev \
   libtbb-dev \
   liburing-dev \
   libzstd-dev

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04 AS base
+FROM ubuntu:26.04 AS base
 
 RUN apt update && apt install -y \
   binutils \

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -50,6 +50,7 @@ RUN apt update && apt install -y \
   libgmp-dev \
   libgtest-dev \
   libmimalloc-dev \
+  libsecp256k1-dev \
   libtbb-dev \
   liburing-dev \
   libzstd-dev

--- a/docker/devnet/Dockerfile
+++ b/docker/devnet/Dockerfile
@@ -45,6 +45,7 @@ RUN apt update && apt install -y \
   libhugetlbfs-dev \
   libmagicenum-dev \
   libmimalloc-dev \
+  libsecp256k1-dev \
   libtbb-dev \
   liburing-dev \
   libzstd-dev

--- a/docker/rpc/Dockerfile
+++ b/docker/rpc/Dockerfile
@@ -43,6 +43,7 @@ RUN apt update && apt install -y \
   libhugetlbfs-dev \
   libmagicenum-dev \
   libmimalloc-dev \
+  libsecp256k1-dev \
   libtbb-dev \
   liburing-dev \
   libzstd-dev


### PR DESCRIPTION
Just tracks changes to the `monad` execution client done in https://github.com/category-labs/monad/pull/2405, intended to be used with https://github.com/monad-developers/execution-specs/pull/32