### PR TITLE
Discrete event simulation engine for MockSwarm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6138,6 +6138,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-sim-swarm"
+version = "0.1.0"
+dependencies = [
+ "monad-sim",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+]
+
+[[package]]
 name = "monad-state"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6130,6 +6130,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-sim"
+version = "0.1.0"
+dependencies = [
+ "rand 0.8.5",
+ "rand_distr",
+]
+
+[[package]]
 name = "monad-state"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ monad-router-scheduler = { path = "./monad-router-scheduler" }
 monad-rpc-docs = { path = "./monad-rpc/monad-rpc-docs" }
 monad-rpc-docs-derive = { path = "./monad-rpc/monad-rpc-docs/monad-rpc-docs-derive" }
 monad-secp = { path = "./monad-secp" }
+monad-sim = { path = "./monad-sim" }
 monad-state = { path = "./monad-state" }
 monad-statesync-executor = { path = "./monad-statesync-executor" }
 monad-system-calls = { path = "./monad-system-calls" }

--- a/monad-sim-swarm/Cargo.toml
+++ b/monad-sim-swarm/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "monad-sim-swarm"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+monad-sim = { workspace = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }

--- a/monad-sim-swarm/README.md
+++ b/monad-sim-swarm/README.md
@@ -1,0 +1,98 @@
+# monad-sim-swarm
+
+Generic network + swarm infrastructure on top of the
+[`monad-sim`](../monad-sim) discrete-event engine. Still protocol-agnostic:
+everything here is parameterized only by a node address type `Addr` and a wire
+message type `Msg`, with no Monad or consensus knowledge. Protocol-specific
+harnesses sit on top — the Monad BFT mock-swarm in this repository is one
+consumer. See [`docs/design.md`](docs/design.md) for the design, and
+[`monad-sim/docs/design.md`](../monad-sim/docs/design.md) for the underlying
+engine.
+
+## Pieces
+
+- **`Net<Addr, Msg>`** — the network as a simulation *process*: a routing
+  table plus a swappable `NetworkModel`. A node sends by scheduling a step on
+  the `Net` handle; the net samples the model and schedules the surviving
+  deliveries on the recipients.
+- **`Network`** — the declarative model builder:
+
+  ```rust
+  Network::reliable(delta)                    // constant latency, lossless
+  Network::with_latency(distribution)         // per-message sampled latency
+      .loss(p)                                // independent drop probability
+      .partition(window, [group_a, group_b])  // time-bounded network split
+      .drop_if(|link, msg| ...)               // predicate drop
+  Network::custom(model)                      // a full NetworkModel impl
+  ```
+
+  A model returns the delays at which *copies* of a message are delivered: an
+  empty result drops it, more than one duplicates it, and reordering needs no
+  special handling — a smaller delay simply arrives first.
+- **`Deliver` / `deliver_to`** — a *type-erased* per-node delivery thunk, so
+  the network only ever names `Addr` and `Msg`. One net can therefore carry
+  heterogeneous node process types (different protocol versions, a Byzantine
+  node) as long as they share the wire type.
+- **`Swarm<N>` + `SimClient`** — the minimal harness: implement `SimClient`
+  for your node type (a `receive` handler, plus an optional `wire` hook that
+  hands the node its own and the network's handles), and `Swarm::build` spawns
+  the nodes and the net, wires them together, and forwards run control to the
+  engine.
+- **`Timers<K>`** — at most one armed timeout per key, re-arming resets — the
+  pacemaker pattern every node needs.
+
+## Example
+
+```rust
+use monad_sim::{time::millis, Ctx, Handle, StepLabel, Time};
+use monad_sim_swarm::{Net, Network, SimClient, Swarm};
+
+struct Counter { addr: u32, net: Option<Handle<Net<u32, u64>>>, got: u32 }
+
+impl SimClient for Counter {
+    type Addr = u32;
+    type Message = u64;
+    fn wire(&mut self, _me: Handle<Self>, net: Handle<Net<u32, u64>>) {
+        self.net = Some(net);
+    }
+    fn receive(&mut self, _from: u32, _msg: u64, _ctx: &mut Ctx) {
+        self.got += 1;
+    }
+}
+
+let nodes = (0..3).map(|a| (a, Counter { addr: a, net: None, got: 0 }));
+let mut swarm = Swarm::build(0, Network::reliable(millis(5)), nodes);
+
+// Kick node 0: broadcast once. Sending = scheduling a step on the net.
+let h = swarm.handle(&0).unwrap();
+swarm.sim().schedule(h, Time(0), StepLabel::source("start"), |c, ctx| {
+    let (net, from) = (c.net.unwrap(), c.addr);
+    ctx.schedule(net, ctx.now(), StepLabel::source("route"), move |net, ctx| {
+        net.broadcast(ctx, from, 7)
+    });
+});
+
+swarm.run_to_completion();
+for a in 0..3 {
+    assert_eq!(swarm.with_node(&a, |c| c.got), 1); // everyone, one hop later
+}
+```
+
+Determinism comes from the engine; the net additionally keeps its own
+independently-seeded RNG, so network randomness is reproducible on its own.
+
+## Inspection & lifecycle
+
+`with_node` / `with_node_mut` inspect or mutate a node between steps;
+`add_node` / `remove_node` support restart scenarios (in-flight messages to a
+removed node are dropped); `set_network` swaps the model mid-run; and
+`swarm.sim()` exposes the raw engine for kickoff steps and custom run loops.
+
+## Running
+
+```sh
+cargo test -p monad-sim-swarm
+```
+
+`tests/swarm.rs` demonstrates heterogeneous node types sharing one network,
+the swarm broadcast, and predicate drops.

--- a/monad-sim-swarm/docs/design.md
+++ b/monad-sim-swarm/docs/design.md
@@ -1,0 +1,77 @@
+# monad-sim-swarm — design
+
+The protocol-agnostic network + swarm layer between the
+[`monad-sim`](../../monad-sim) engine and protocol-specific simulation
+harnesses. This document covers the design of its pieces and the seams they
+expose; the [README](../README.md) is the quick tour, and
+[`monad-sim/docs/design.md`](../../monad-sim/docs/design.md) describes the
+underlying engine.
+
+## Position in the stack
+
+Everything in this crate is parameterized only by a node address type `Addr`
+and a wire message type `Msg`; it carries no Monad or consensus knowledge
+(dependencies: `monad-sim`, `rand`, `rand_chacha`). Protocol-specific
+harnesses layer on top — the Monad BFT mock-swarm in this repository is one
+consumer, other protocols build on it elsewhere, and further harnesses are
+expected. Anything that requires knowing a protocol's events, rounds, or
+assertions belongs in those harnesses, not here.
+
+## The network as a process
+
+The network is just another `monad-sim` process — no dedicated framework
+concept. `Net<Addr, Msg>`'s state is a routing table plus a `NetworkModel`; a
+node sends by scheduling a routing step on the `Net` handle, and the net
+samples the model and schedules the surviving deliveries on the recipients.
+This makes the network model modular and swappable, including mid-run
+(`set_model`).
+
+A `NetworkModel` answers one question per message: at which delays are copies
+of it delivered? An empty answer drops the message, more than one duplicates
+it, and reordering needs no special handling — a smaller delay simply arrives
+first. The declarative `Network` builder covers the common cases (constant or
+sampled latency, independent loss, time-bounded partitions, predicate drops);
+`Network::custom` accepts a full `NetworkModel` implementation.
+
+The net keeps its own ChaCha RNG, seeded independently of the engine's
+scheduling RNG, so network randomness is reproducible on its own.
+
+## The type-erased delivery boundary
+
+`Net` routes to nodes through `Deliver<Addr, Msg>` thunks (built by
+`deliver_to`): each thunk captures a recipient's *concrete* `Handle<N>` and
+monomorphizes the `ctx.schedule` call, so the network itself only ever names
+`Addr` and `Msg`. A single network can therefore carry *heterogeneous* node
+process types as long as they share the wire type — the seam for simulating
+different protocol versions, or a Byzantine node, in one swarm.
+
+## The swarm harness
+
+`Swarm<N>` is a minimal builder over the `SimClient` seam: spawn a set of
+nodes plus a `Net`, wire them together (each node learns its own handle and
+the net handle once, via `SimClient::wire`), and forward run control to the
+engine. Inspection and lifecycle go through the harness: `with_node` /
+`with_node_mut` between steps, `add_node` / `remove_node` for restart
+scenarios (in-flight messages to a removed node are dropped on arrival), and
+`set_network` for mid-run reconfiguration.
+
+The harness is deliberately homogeneous for now (one node type `N`); the
+`Net` delivery boundary is already type-erased, so a future heterogeneous
+swarm builder reuses the network unchanged.
+
+Protocol-specific inspection (finalized blocks, current round, agreement
+assertions) deliberately does *not* live here; it belongs to each protocol's
+harness, layered over `Swarm::with_node`.
+
+## Timers
+
+`Timers<K>` is the re-arming timer set every protocol node needs for
+pacemaker-style timeouts: at most one armed timer per key, and arming a key
+cancels the previous one. It holds the engine's `CancelToken`s; the caller
+schedules the step and hands the token to `arm`. `reset` cancels a pending
+timer; `clear` forgets one that has just fired.
+
+## Future work
+
+- **A heterogeneous swarm builder** (mixed node process types over one `Net`).
+  The delivery boundary already supports it; only the builder is missing.

--- a/monad-sim-swarm/src/lib.rs
+++ b/monad-sim-swarm/src/lib.rs
@@ -1,0 +1,48 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Generic simulation infrastructure that sits *between* the domain-agnostic
+//! engine ([`monad_sim`], "Layer A") and a protocol-specific adapter ("Layer
+//! B"). It carries no consensus or Monad knowledge — everything here is
+//! parameterized only by a node address type `Addr` and a wire message type
+//! `Msg`.
+//!
+//! Three pieces, all reusable across protocols:
+//!
+//! - [`Net`] — the network as a `monad_sim` *process*: a routing table plus a
+//!   swappable [`NetworkModel`] (latency / loss / partition / duplication),
+//!   built declaratively with [`Network`]. Crucially, `Net` addresses nodes
+//!   through a **type-erased** delivery boundary ([`Deliver`] / [`deliver_to`]),
+//!   so a single network can carry *heterogeneous* node process types as long as
+//!   they share `Msg` — the seam for testing different protocol versions (or a
+//!   Byzantine node) in one swarm.
+//! - [`Swarm`] — a minimal builder/harness: spawn a set of [`SimClient`] nodes
+//!   plus a `Net`, wire them together, and forward run-control to the engine.
+//!   Deliberately homogeneous for now (one node type `N`); the `Net` boundary is
+//!   already erased, so a future heterogeneous swarm reuses it unchanged.
+//! - [`Timers`] — the re-arming timer set (one armed timeout per key) that every
+//!   node needs for pacemaker-style timeouts.
+//!
+//! Protocol-specific inspection (finalized blocks, current round, agreement
+//! assertions) deliberately does *not* live here; it belongs to each protocol's
+//! adapter, layered over [`Swarm::with_node`].
+
+mod net;
+mod swarm;
+mod timers;
+
+pub use net::{Conditions, Deliver, Link, Net, Network, NetworkModel};
+pub use swarm::{deliver_to, SimClient, Swarm};
+pub use timers::Timers;

--- a/monad-sim-swarm/src/net.rs
+++ b/monad-sim-swarm/src/net.rs
@@ -1,0 +1,263 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The network as a simulation process, generic over the node address `Addr`
+//! and the wire message `Msg`. A node sends by scheduling a step on the [`Net`]
+//! handle; the net samples its [`NetworkModel`] and schedules the surviving
+//! deliveries against the recipients.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::Range,
+    rc::Rc,
+    time::Duration,
+};
+
+use monad_sim::{Ctx, Time};
+use rand::{distributions::Distribution, Rng, SeedableRng};
+use rand_chacha::ChaChaRng;
+
+/// A type-erased "deliver this message to one node at this time" operation.
+///
+/// Registered per address (see [`Net::register`] / [`crate::deliver_to`]), it
+/// captures the recipient's *concrete* `Handle` and monomorphizes the
+/// `ctx.schedule` call, so the network itself only ever names `Addr` and `Msg`.
+/// This is what lets one [`Net`] carry heterogeneous node process types.
+pub type Deliver<Addr, Msg> = Rc<dyn Fn(&mut Ctx, Time, Addr, Msg)>;
+
+/// Per-message context handed to a [`NetworkModel`].
+pub struct Link<Addr> {
+    pub now: Time,
+    pub from: Addr,
+    pub to: Addr,
+}
+
+/// Decides the fate of a single message: the delays at which copies are
+/// delivered to `link.to`. An empty result drops the message; more than one
+/// duplicates it. Reordering needs no special handling — a smaller delay simply
+/// arrives first.
+pub trait NetworkModel<Addr, Msg> {
+    fn deliveries(
+        &mut self,
+        link: &Link<Addr>,
+        message: &Msg,
+        rng: &mut ChaChaRng,
+    ) -> Vec<Duration>;
+}
+
+type LatencyFn = Box<dyn FnMut(&mut ChaChaRng) -> Duration>;
+type DropFn<Addr, Msg> = Box<dyn Fn(&Link<Addr>, &Msg) -> bool>;
+type Partition<Addr> = (Range<Time>, Vec<BTreeSet<Addr>>);
+
+/// A declarative network model: a base latency plus optional, independent
+/// conditions. Anything left unconfigured behaves reliably.
+pub struct Conditions<Addr, Msg> {
+    latency: LatencyFn,
+    loss: f64,
+    partitions: Vec<Partition<Addr>>,
+    drop_if: Option<DropFn<Addr, Msg>>,
+}
+
+impl<Addr: Ord, Msg> NetworkModel<Addr, Msg> for Conditions<Addr, Msg> {
+    fn deliveries(
+        &mut self,
+        link: &Link<Addr>,
+        message: &Msg,
+        rng: &mut ChaChaRng,
+    ) -> Vec<Duration> {
+        if let Some(drop_if) = &self.drop_if {
+            if drop_if(link, message) {
+                return Vec::new();
+            }
+        }
+        let split = self.partitions.iter().any(|(window, groups)| {
+            window.contains(&link.now)
+                && groups
+                    .iter()
+                    .any(|group| group.contains(&link.from) != group.contains(&link.to))
+        });
+        if split {
+            return Vec::new();
+        }
+        if self.loss > 0.0 && rng.gen::<f64>() < self.loss {
+            return Vec::new();
+        }
+        vec![(self.latency)(rng)]
+    }
+}
+
+/// Declarative builder for a swarm's network behaviour. Start from
+/// [`reliable`](Network::reliable) or [`with_latency`](Network::with_latency)
+/// and layer conditions, or supply a [`custom`](Network::custom) model.
+pub enum Network<Addr, Msg> {
+    Conditions(Conditions<Addr, Msg>),
+    Custom(Box<dyn NetworkModel<Addr, Msg>>),
+}
+
+impl<Addr, Msg> Default for Network<Addr, Msg> {
+    fn default() -> Self {
+        Network::reliable(Duration::from_millis(1))
+    }
+}
+
+impl<Addr, Msg> Network<Addr, Msg> {
+    /// Constant-latency, lossless network.
+    pub fn reliable(latency: Duration) -> Self {
+        Network::Conditions(Conditions {
+            latency: Box::new(move |_| latency),
+            loss: 0.0,
+            partitions: Vec::new(),
+            drop_if: None,
+        })
+    }
+
+    /// Latency sampled per message from `distribution`.
+    pub fn with_latency(distribution: impl Distribution<Duration> + 'static) -> Self {
+        let mut network = Network::reliable(Duration::ZERO);
+        network.conditions().latency = Box::new(move |rng| distribution.sample(rng));
+        network
+    }
+
+    /// A fully custom model.
+    pub fn custom(model: impl NetworkModel<Addr, Msg> + 'static) -> Self {
+        Network::Custom(Box::new(model))
+    }
+
+    /// Drop each message independently with probability `probability`.
+    pub fn loss(mut self, probability: f64) -> Self {
+        self.conditions().loss = probability;
+        self
+    }
+
+    /// While `window` is active, drop messages crossing between the given groups
+    /// (a network split). Nodes absent from every group stay fully connected.
+    pub fn partition(
+        mut self,
+        window: Range<Time>,
+        groups: impl IntoIterator<Item = impl IntoIterator<Item = Addr>>,
+    ) -> Self
+    where
+        Addr: Ord,
+    {
+        let groups = groups
+            .into_iter()
+            .map(|group| group.into_iter().collect())
+            .collect();
+        self.conditions().partitions.push((window, groups));
+        self
+    }
+
+    /// Drop messages for which `predicate` holds.
+    pub fn drop_if(mut self, predicate: impl Fn(&Link<Addr>, &Msg) -> bool + 'static) -> Self {
+        self.conditions().drop_if = Some(Box::new(predicate));
+        self
+    }
+
+    /// Panics if called on a [`custom`](Network::custom) model.
+    fn conditions(&mut self) -> &mut Conditions<Addr, Msg> {
+        match self {
+            Network::Conditions(conditions) => conditions,
+            Network::Custom(_) => panic!("cannot layer conditions onto a custom network model"),
+        }
+    }
+
+    fn into_model(self) -> Box<dyn NetworkModel<Addr, Msg>>
+    where
+        Addr: Ord + 'static,
+        Msg: 'static,
+    {
+        match self {
+            Network::Conditions(conditions) => Box::new(conditions),
+            Network::Custom(model) => model,
+        }
+    }
+}
+
+/// The network process: a routing table (type-erased per-node delivery) plus a
+/// [`NetworkModel`] and an independent RNG (kept separate from the engine's
+/// scheduling RNG so network randomness is reproducible on its own).
+pub struct Net<Addr, Msg> {
+    routes: BTreeMap<Addr, Deliver<Addr, Msg>>,
+    model: Box<dyn NetworkModel<Addr, Msg>>,
+    rng: ChaChaRng,
+}
+
+impl<Addr, Msg> Net<Addr, Msg>
+where
+    Addr: Ord + Copy + 'static,
+    Msg: Clone + 'static,
+{
+    /// A fresh network with the given model, seeded independently of the engine.
+    pub fn new(seed: u64, network: Network<Addr, Msg>) -> Self {
+        Self {
+            routes: BTreeMap::new(),
+            model: network.into_model(),
+            rng: ChaChaRng::seed_from_u64(seed),
+        }
+    }
+
+    /// Register a node's delivery entry point (see [`crate::deliver_to`]).
+    pub fn register(&mut self, addr: Addr, deliver: Deliver<Addr, Msg>) {
+        self.routes.insert(addr, deliver);
+    }
+
+    /// Drop a node from the routing table (e.g. a restart/removal); messages to
+    /// it are silently discarded thereafter.
+    pub fn deregister(&mut self, addr: &Addr) {
+        self.routes.remove(addr);
+    }
+
+    /// Replace the network model (mid-run reconfiguration).
+    pub fn set_model(&mut self, network: Network<Addr, Msg>) {
+        self.model = network.into_model();
+    }
+
+    /// Send one message `from` -> `to`: apply the model and schedule the
+    /// surviving deliveries. A recipient not in the routing table drops it.
+    pub fn send(&mut self, ctx: &mut Ctx, from: Addr, to: Addr, msg: Msg) {
+        let link = Link {
+            now: ctx.now(),
+            from,
+            to,
+        };
+        let delays = self.model.deliveries(&link, &msg, &mut self.rng);
+        let Some(deliver) = self.routes.get(&to).cloned() else {
+            return;
+        };
+        match delays.as_slice() {
+            [] => {}
+            [delay] => deliver(ctx, ctx.now() + *delay, from, msg),
+            _ => {
+                for delay in delays {
+                    deliver(ctx, ctx.now() + delay, from, msg.clone());
+                }
+            }
+        }
+    }
+
+    /// Send `msg` to every registered node (including `from` itself, if
+    /// registered). The model is applied independently per recipient.
+    pub fn broadcast(&mut self, ctx: &mut Ctx, from: Addr, msg: Msg) {
+        let targets: Vec<Addr> = self.routes.keys().copied().collect();
+        for to in targets {
+            self.send(ctx, from, to, msg.clone());
+        }
+    }
+
+    /// The set of currently-routable node addresses.
+    pub fn addrs(&self) -> impl Iterator<Item = &Addr> {
+        self.routes.keys()
+    }
+}

--- a/monad-sim-swarm/src/swarm.rs
+++ b/monad-sim-swarm/src/swarm.rs
@@ -1,0 +1,189 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! A minimal swarm builder over [`monad_sim`]: spawn a set of nodes plus a
+//! [`Net`], wire them together, and forward run-control to the engine. The
+//! builder is generic over the node process type `N` and knows nothing about a
+//! node's internals beyond the [`SimClient`] seam.
+
+use std::{collections::BTreeMap, rc::Rc};
+
+use monad_sim::{Ctx, Handle, RunOutcome, Simulation, StepLabel, Time};
+
+use crate::net::{Deliver, Net, Network};
+
+/// A node that can be plugged into a simulated network.
+///
+/// The framework owns the node's state as a `monad_sim` process. A message
+/// addressed to the node arrives as a scheduled [`receive`](SimClient::receive)
+/// step. The node learns its own handle and the network handle once, via
+/// [`wire`](SimClient::wire), so it can schedule self-timers and send messages;
+/// a node that does neither can leave `wire` as the default no-op.
+pub trait SimClient: Sized + 'static {
+    /// Address type used to route to this node on the network.
+    type Addr: Ord + Copy + 'static;
+    /// The wire message type. All nodes on one network share it.
+    type Message: Clone + 'static;
+
+    /// Called once, just after the node is spawned, with its own process handle
+    /// and the network handle. Default: ignore both.
+    fn wire(&mut self, me: Handle<Self>, net: Handle<Net<Self::Addr, Self::Message>>) {
+        let _ = (me, net);
+    }
+
+    /// Handle a message delivered by the network from peer `from`.
+    fn receive(&mut self, from: Self::Addr, msg: Self::Message, ctx: &mut Ctx);
+}
+
+/// Build the type-erased delivery thunk for a concrete node handle: it schedules
+/// `N::receive` against `handle`, capturing the concrete type so the network can
+/// forget it. See [`Deliver`].
+pub fn deliver_to<N: SimClient>(handle: Handle<N>) -> Deliver<N::Addr, N::Message> {
+    Rc::new(
+        move |ctx: &mut Ctx, at: Time, from: N::Addr, msg: N::Message| {
+            ctx.schedule(
+                handle,
+                at,
+                StepLabel::source("deliver"),
+                move |node: &mut N, ctx| node.receive(from, msg, ctx),
+            );
+        },
+    )
+}
+
+/// A running swarm: the [`Simulation`], the network handle, and the node
+/// handles keyed by address. Homogeneous in the node type `N` for now; the
+/// [`Net`] delivery boundary is already type-erased, so a heterogeneous variant
+/// can reuse it without changing the network.
+pub struct Swarm<N: SimClient> {
+    sim: Simulation,
+    net: Handle<Net<N::Addr, N::Message>>,
+    nodes: BTreeMap<N::Addr, Handle<N>>,
+}
+
+impl<N: SimClient> Swarm<N> {
+    /// Spawn a `Net` with the given model and the supplied nodes, wiring each
+    /// node's handles and registering its delivery thunk with the network.
+    pub fn build(
+        seed: u64,
+        network: Network<N::Addr, N::Message>,
+        nodes: impl IntoIterator<Item = (N::Addr, N)>,
+    ) -> Self {
+        let mut sim = Simulation::new(seed);
+        let net = sim.spawn(Net::new(seed, network));
+        let mut map = BTreeMap::new();
+        for (addr, node) in nodes {
+            let handle = sim.spawn(node);
+            sim.with_mut(handle, |n| n.wire(handle, net));
+            let deliver = deliver_to(handle);
+            sim.with_mut(net, move |n| n.register(addr, deliver));
+            map.insert(addr, handle);
+        }
+        Self {
+            sim,
+            net,
+            nodes: map,
+        }
+    }
+
+    /// Add a node to a running swarm (e.g. a restart). Returns its handle.
+    pub fn add_node(&mut self, addr: N::Addr, node: N) -> Handle<N> {
+        let net = self.net;
+        let handle = self.sim.spawn(node);
+        self.sim.with_mut(handle, |n| n.wire(handle, net));
+        let deliver = deliver_to(handle);
+        self.sim.with_mut(net, move |n| n.register(addr, deliver));
+        self.nodes.insert(addr, handle);
+        handle
+    }
+
+    /// Remove a node from the swarm, returning its state. Messages already in
+    /// flight to it are dropped when they arrive.
+    pub fn remove_node(&mut self, addr: &N::Addr) -> Option<N> {
+        let handle = self.nodes.remove(addr)?;
+        let net = self.net;
+        self.sim.with_mut(net, |n| n.deregister(addr));
+        Some(self.sim.despawn(handle))
+    }
+
+    /// Replace the network model between steps.
+    pub fn set_network(&mut self, network: Network<N::Addr, N::Message>) {
+        let net = self.net;
+        self.sim.with_mut(net, |n| n.set_model(network));
+    }
+
+    /// The underlying engine, for scheduling kickoff steps and custom run loops.
+    pub fn sim(&mut self) -> &mut Simulation {
+        &mut self.sim
+    }
+
+    /// Read-only view of the engine (clock, metrics).
+    pub fn simulation(&self) -> &Simulation {
+        &self.sim
+    }
+
+    /// The network process handle.
+    pub fn net(&self) -> Handle<Net<N::Addr, N::Message>> {
+        self.net
+    }
+
+    /// The addresses of all live nodes.
+    pub fn node_ids(&self) -> Vec<N::Addr> {
+        self.nodes.keys().copied().collect()
+    }
+
+    /// The handle for a node, if present.
+    pub fn handle(&self, addr: &N::Addr) -> Option<Handle<N>> {
+        self.nodes.get(addr).copied()
+    }
+
+    /// Inspect a node's state between steps.
+    pub fn with_node<R>(&self, addr: &N::Addr, f: impl FnOnce(&N) -> R) -> R {
+        self.sim.with(self.nodes[addr], f)
+    }
+
+    /// Mutate a node's state between steps (input injection).
+    pub fn with_node_mut<R>(&mut self, addr: &N::Addr, f: impl FnOnce(&mut N) -> R) -> R {
+        let handle = self.nodes[addr];
+        self.sim.with_mut(handle, f)
+    }
+
+    pub fn run_to_completion(&mut self) -> RunOutcome {
+        self.sim.run_to_completion()
+    }
+
+    pub fn run_until_time(&mut self, t: Time) -> RunOutcome {
+        self.sim.run_until_time(t)
+    }
+
+    pub fn run_steps(&mut self, n: u64) -> RunOutcome {
+        self.sim.run_steps(n)
+    }
+
+    /// Run until `done` returns true (checked before each step), so the
+    /// predicate can inspect node state via `&Self`. Returns
+    /// [`RunOutcome::Stopped`] when it fires, or [`RunOutcome::Drained`] if the
+    /// queue empties first.
+    pub fn run_until(&mut self, mut done: impl FnMut(&Self) -> bool) -> RunOutcome {
+        loop {
+            if done(self) {
+                return RunOutcome::Stopped;
+            }
+            if self.sim.next_step().is_none() {
+                return RunOutcome::Drained;
+            }
+        }
+    }
+}

--- a/monad-sim-swarm/src/timers.rs
+++ b/monad-sim-swarm/src/timers.rs
@@ -1,0 +1,69 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! A set of at-most-one-armed timers keyed by `K` — the pacemaker pattern every
+//! node uses (one live timeout per variant, re-arming resets it). Holds the
+//! engine's [`CancelToken`]s; the caller schedules the actual step and hands the
+//! token here.
+
+use std::{collections::HashMap, hash::Hash};
+
+use monad_sim::CancelToken;
+
+/// One armed timer per key. Arming a key cancels any timer previously armed
+/// under it.
+pub struct Timers<K> {
+    armed: HashMap<K, CancelToken>,
+}
+
+impl<K> Default for Timers<K> {
+    fn default() -> Self {
+        Self {
+            armed: HashMap::new(),
+        }
+    }
+}
+
+impl<K: Eq + Hash> Timers<K> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record the token of a freshly-scheduled timer, cancelling any previous
+    /// timer under `key`. Schedule the step first, then pass its token here.
+    pub fn arm(&mut self, key: K, token: CancelToken) {
+        if let Some(previous) = self.armed.insert(key, token) {
+            previous.cancel();
+        }
+    }
+
+    /// Cancel and forget the timer under `key`, if any.
+    pub fn reset(&mut self, key: &K) {
+        if let Some(previous) = self.armed.remove(key) {
+            previous.cancel();
+        }
+    }
+
+    /// Forget the timer under `key` without cancelling it — use when the timer
+    /// has just fired and its step is running.
+    pub fn clear(&mut self, key: &K) {
+        self.armed.remove(key);
+    }
+
+    /// Whether a live (uncancelled, unfired) timer is armed under `key`.
+    pub fn is_armed(&self, key: &K) -> bool {
+        self.armed.contains_key(key)
+    }
+}

--- a/monad-sim-swarm/tests/swarm.rs
+++ b/monad-sim-swarm/tests/swarm.rs
@@ -1,0 +1,182 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Worked examples for `monad-sim-swarm`, with toy app-defined node types.
+//! `Sender`/`Receiver`/`Counter` live here, not in the crate — the swarm
+//! infrastructure never names a concrete node type. These exercise the two
+//! guarantees a protocol adapter relies on: a single network carrying
+//! *different* node process types (the type-erased delivery boundary), and the
+//! `Swarm` builder over one node type with a real latency model.
+
+use monad_sim::{time::millis, Ctx, Handle, Simulation, StepLabel, Time};
+use monad_sim_swarm::{deliver_to, Net, Network, SimClient, Swarm};
+
+type Addr = u32;
+type Msg = u64;
+
+/// A node that only ever sends.
+struct Sender {
+    addr: Addr,
+    target: Addr,
+    net: Option<Handle<Net<Addr, Msg>>>,
+}
+
+impl Sender {
+    fn emit(&mut self, ctx: &mut Ctx) {
+        let (net, from, to) = (self.net.unwrap(), self.addr, self.target);
+        ctx.schedule(
+            net,
+            ctx.now(),
+            StepLabel::source("route"),
+            move |net, ctx| net.send(ctx, from, to, 42),
+        );
+    }
+}
+
+impl SimClient for Sender {
+    type Addr = Addr;
+    type Message = Msg;
+    fn wire(&mut self, _me: Handle<Self>, net: Handle<Net<Addr, Msg>>) {
+        self.net = Some(net);
+    }
+    fn receive(&mut self, _from: Addr, _msg: Msg, _ctx: &mut Ctx) {}
+}
+
+/// A node that only ever receives.
+struct Receiver {
+    got: u32,
+    last: Option<Msg>,
+}
+
+impl SimClient for Receiver {
+    type Addr = Addr;
+    type Message = Msg;
+    fn receive(&mut self, _from: Addr, msg: Msg, _ctx: &mut Ctx) {
+        self.got += 1;
+        self.last = Some(msg);
+    }
+}
+
+/// A homogeneous node that broadcasts once and counts what it receives.
+struct Counter {
+    addr: Addr,
+    net: Option<Handle<Net<Addr, Msg>>>,
+    got: u32,
+}
+
+impl Counter {
+    fn new(addr: Addr) -> Self {
+        Self {
+            addr,
+            net: None,
+            got: 0,
+        }
+    }
+    fn emit(&mut self, ctx: &mut Ctx) {
+        let (net, from) = (self.net.unwrap(), self.addr);
+        ctx.schedule(
+            net,
+            ctx.now(),
+            StepLabel::source("route"),
+            move |net, ctx| net.broadcast(ctx, from, 7),
+        );
+    }
+}
+
+impl SimClient for Counter {
+    type Addr = Addr;
+    type Message = Msg;
+    fn wire(&mut self, _me: Handle<Self>, net: Handle<Net<Addr, Msg>>) {
+        self.net = Some(net);
+    }
+    fn receive(&mut self, _from: Addr, _msg: Msg, _ctx: &mut Ctx) {
+        self.got += 1;
+    }
+}
+
+/// Two *different* node types (`Sender`, `Receiver`) share one `Net<Addr, Msg>`:
+/// the network only names `Addr`/`Msg`, and the concrete node type is erased
+/// behind the delivery thunk. This is the seam for heterogeneous swarms.
+#[test]
+fn heterogeneous_nodes_share_one_network() {
+    let mut sim = Simulation::new(0);
+    let net = sim.spawn(Net::new(0, Network::reliable(millis(10))));
+    let recv = sim.spawn(Receiver { got: 0, last: None });
+    let send = sim.spawn(Sender {
+        addr: 2,
+        target: 1,
+        net: None,
+    });
+    sim.with_mut(send, |s| s.wire(send, net));
+    sim.with_mut(net, |n| n.register(1, deliver_to(recv)));
+    sim.with_mut(net, |n| n.register(2, deliver_to(send)));
+
+    sim.schedule(send, Time(0), StepLabel::source("start"), |s, ctx| {
+        s.emit(ctx)
+    });
+    sim.run_to_completion();
+
+    assert_eq!(sim.with(recv, |r| r.got), 1);
+    assert_eq!(sim.with(recv, |r| r.last), Some(42));
+    // One 10ms network hop.
+    assert_eq!(sim.now(), Time(0) + millis(10));
+}
+
+/// The `Swarm` builder wires a set of homogeneous nodes to a network; a
+/// broadcast (including to self) reaches everyone after one latency hop.
+#[test]
+fn swarm_broadcast_reaches_all() {
+    let nodes = (0..3).map(|a| (a, Counter::new(a)));
+    let mut swarm = Swarm::build(0, Network::reliable(millis(5)), nodes);
+
+    let node0 = swarm.handle(&0).unwrap();
+    swarm
+        .sim()
+        .schedule(node0, Time(0), StepLabel::source("start"), |c, ctx| {
+            c.emit(ctx)
+        });
+    swarm.run_to_completion();
+
+    for a in 0..3 {
+        assert_eq!(swarm.with_node(&a, |c| c.got), 1);
+    }
+    assert_eq!(swarm.simulation().now(), Time(0) + millis(5));
+}
+
+/// `drop_if` removes a message before delivery.
+#[test]
+fn drop_if_suppresses_delivery() {
+    let mut sim = Simulation::new(0);
+    let net = sim.spawn(Net::new(
+        0,
+        Network::reliable(millis(10)).drop_if(|link, _msg| link.from == 2),
+    ));
+    let recv = sim.spawn(Receiver { got: 0, last: None });
+    let send = sim.spawn(Sender {
+        addr: 2,
+        target: 1,
+        net: None,
+    });
+    sim.with_mut(send, |s| s.wire(send, net));
+    sim.with_mut(net, |n| n.register(1, deliver_to(recv)));
+    sim.with_mut(net, |n| n.register(2, deliver_to(send)));
+
+    sim.schedule(send, Time(0), StepLabel::source("start"), |s, ctx| {
+        s.emit(ctx)
+    });
+    sim.run_to_completion();
+
+    assert_eq!(sim.with(recv, |r| r.got), 0);
+}

--- a/monad-sim/Cargo.toml
+++ b/monad-sim/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "monad-sim"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rand = { workspace = true }
+rand_distr = { workspace = true }

--- a/monad-sim/README.md
+++ b/monad-sim/README.md
@@ -1,0 +1,81 @@
+# monad-sim
+
+A generic, single-threaded, deterministic discrete-event simulation engine.
+Standalone and domain-agnostic: it knows nothing about Monad, consensus, or any
+particular message type. Protocol simulations layer on top — for instance
+[`monad-sim-swarm`](../monad-sim-swarm) (generic network + swarm harness) and
+the Monad BFT mock-swarm harness. See
+[`docs/design.md`](docs/design.md) for the architecture and rationale.
+
+## Model
+
+A simulation is a time-ordered queue of **steps** over a set of
+framework-owned **processes**:
+
+- **Process** — any value `S: 'static`, registered with `Simulation::spawn` and
+  addressed by a typed, `Copy` `Handle<S>`.
+- **Step** — a closure scheduled against a handle to run at a `Time`. While it
+  runs, the framework lends it `&mut S` *exclusively*, plus a `Ctx` that can
+  read the clock, sample randomness, and schedule further steps — but cannot
+  reach any other process's state.
+
+Cross-process interaction is therefore always "schedule a step on that
+handle". This keeps the engine agnostic to event and state types, and makes
+reentrancy (self-send, broadcast-to-self) non-representable: within a step you
+hold the only `&mut S`, and there is no `RefCell::borrow()` to panic.
+
+```rust
+use monad_sim::{time::millis, Simulation, StepLabel, Time};
+
+let mut sim = Simulation::new(7); // the seed; the unit of isolation & reset
+let a = sim.spawn(0u64);          // any S: 'static is a process
+let b = sim.spawn(Vec::<u64>::new());
+
+sim.schedule(a, Time(0), StepLabel::source("kick"), move |count, ctx| {
+    *count += 1;
+    // interact with b by scheduling a step on it, one hop later
+    ctx.schedule_after(b, millis(5), StepLabel::source("deliver"), |log, _| {
+        log.push(42);
+    });
+});
+
+sim.run_to_completion();
+assert_eq!(sim.now(), Time(0) + millis(5));
+sim.with(b, |log| assert_eq!(*log, vec![42])); // inspect between steps
+```
+
+## Determinism
+
+A run is exactly reproducible from `(configuration, seed)`. Steps execute in
+the total order `(time, tie_break, priority, seq)`:
+
+- The default `TieBreak::Fifo` orders same-time steps by priority class, then
+  creation order — stable enough that tests can assert exact ticks.
+- `TieBreak::Randomized` shuffles same-time steps with a seeded permutation
+  (still fully reproducible); sweep the seed to fuzz for order-dependence bugs.
+
+All randomness flows through the seeded generator, via `sim.sample(..)` /
+`ctx.sample(..)`.
+
+## Toolbox
+
+| | |
+|---|---|
+| `schedule` / `schedule_after` / `schedule_global` | timed steps on a process, or process-less (setup, fan-out) |
+| `CancelToken` | cancellable steps — schedule = arm a timer, cancel = reset it |
+| `run_to_completion` / `run_until_time` / `run_steps` / `run_while` | bounded run control, each returning why it stopped (`RunOutcome`) |
+| `with` / `with_mut` / `despawn` | inspect, inject, or remove process state between steps |
+| `on_step` / `StepInfo` | observe every executed step (source/kind/priority labels) |
+| `SimMetrics` | step counts, queue depth, critical-path length, available `parallelism()` |
+| `time` | `Time` (ns-resolution simulation clock), `ClockDiff`, `millis`/`secs`/… shorthands |
+| `dist` | latency distributions (`uniform_duration`, `lognormal_duration2`, `global_udp_duration`, …) |
+
+`tests/processes.rs` is a worked example with toy processes: nodes exchanging
+messages through a swappable network process, sampled latency, and a
+resettable watchdog timer.
+
+## Running
+
+```sh
+cargo test -p monad-sim
+```

--- a/monad-sim/docs/design.md
+++ b/monad-sim/docs/design.md
@@ -1,0 +1,173 @@
+# monad-sim — engine design
+
+The generic, deterministic discrete-event simulation engine. This document
+covers the architecture, the seam consumers build on, determinism, the
+concurrency metric, and the rationale behind the main design choices. For a
+quick tour of the API, start with the [README](../README.md).
+
+## Purpose & scope
+
+`monad-sim` is the domain-agnostic bottom layer for deterministic protocol
+simulations: a time-ordered queue of scheduled steps over framework-owned
+process state, with bounded run control, seeded randomness, cancellable
+timers, and metrics. It knows nothing about Monad, consensus, or any
+particular event or message type.
+
+The engine is written for multiple consumers, present and future. In this
+repository, [`monad-sim-swarm`](../../monad-sim-swarm) layers a generic
+network + swarm harness on top, and the Monad BFT mock-swarm harness drives
+the production consensus code in simulation; the engine is also used by other
+protocol simulations outside this repository, and further harnesses are
+expected. The rule that keeps this possible: nothing in this crate may name a
+protocol, an event type, or a component layout — anything protocol-specific
+belongs in a consumer crate.
+
+## The model
+
+A simulation is a time-ordered queue of *steps*. A step is a closure that runs
+at a specific `Time` and may schedule further steps. State lives in
+*processes*: any value `S: 'static` registered with `Simulation::spawn`,
+addressed by a typed `Handle<S>`. When a step scheduled against a handle runs,
+the framework lends it `&mut S` **exclusively** for that step, via a `Ctx`
+that can read time, sample randomness, and schedule more work — but cannot
+reach any other process's state.
+
+```rust
+impl Simulation {
+    pub fn new(seed: u64) -> Self;                 // fresh, isolated; the unit of reset
+    pub fn now(&self) -> Time;
+
+    pub fn spawn<S: 'static>(&mut self, state: S) -> Handle<S>;
+    pub fn schedule<S: 'static>(&mut self, who: Handle<S>, at: Time, label: StepLabel,
+                                step: impl FnOnce(&mut S, &mut Ctx) + 'static) -> CancelToken;
+    pub fn schedule_global(&mut self, at: Time, label: StepLabel,
+                           step: impl FnOnce(&mut Ctx) + 'static) -> CancelToken;
+
+    // run control — each returns why it stopped (RunOutcome)
+    pub fn run_to_completion(&mut self) -> RunOutcome;
+    pub fn run_until_time(&mut self, t: Time) -> RunOutcome;
+    pub fn run_steps(&mut self, n: u64) -> RunOutcome;
+    pub fn run_while(&mut self, pred: impl FnMut(&Simulation) -> bool) -> RunOutcome;
+
+    // between-step inspection / lifecycle
+    pub fn with<S: 'static, R>(&self, who: Handle<S>, f: impl FnOnce(&S) -> R) -> R;
+    pub fn with_mut<S: 'static, R>(&mut self, who: Handle<S>, f: impl FnOnce(&mut S) -> R) -> R;
+    pub fn despawn<S: 'static>(&mut self, who: Handle<S>) -> S;
+}
+```
+
+`Ctx` is the only capability a running step has besides its own `&mut S`: it
+can read time, `sample` randomness, and `schedule` / `schedule_global` /
+`spawn` more work. Cross-process interaction is therefore always "schedule a
+step on that handle". This keeps the engine agnostic about event and state
+types, and makes reentrancy impossible by construction (within a step you hold
+the only `&mut S`, and there is no `borrow()` to call) — see
+[Why the lent-state model](#why-the-lent-state-model).
+
+Every step carries a `StepLabel` (`source`, `kind`, `priority`) and is owned
+by a `ProcessId`, so steps are introspectable rather than opaque closures.
+Timers are expressed with `CancelToken` (schedule = arm, cancel = reset;
+cancellation is lazy — a cancelled step is skipped when popped).
+
+## The consumer seam
+
+`Handle<S>` / `Ctx` *is* the engine's public seam. The engine defines no
+`Process`, `Network`, or `EffectHandler` trait — a process is just some
+`S: 'static`, and event/effect dispatch is the consumer's job. Concrete event
+types (for the Monad BFT harness: `MonadEvent`, `Command`) appear only inside
+consumer closures, never in an engine signature. A new consumer brings its own
+state, address, and message types and only ever talks to the scheduler; that
+is what makes the engine reusable across protocols and protocol versions.
+
+## Determinism & event ordering
+
+The scheduler is deterministic: a run is exactly reproducible from
+`(configuration, seed)`. Steps are ordered by the total key
+`(time, tie_break, priority, seq)`:
+
+- **`priority`** is a same-time ordering class (lower runs first); consumers
+  use it to encode policies such as "drain a node's ready internal work before
+  servicing a same-tick network message".
+- **`tie_break`** selects the policy. The default `TieBreak::Fifo` makes
+  `tie_break` a constant, so ordering reduces to `(time, priority, seq)` —
+  fully reproducible, which is what lets test suites assert *exact* ticks with
+  no tolerance window. `TieBreak::Randomized` shuffles same-time steps with a
+  seeded permutation (still deterministic per seed); sweeping the seed
+  explores different same-instant orderings — fuzzing for order-dependence
+  bugs.
+
+`tie_break` deliberately precedes `priority` in the key: under `Randomized`
+the per-step tie-break dominates, so same-time steps are shuffled *across*
+priority classes. Priority-respecting fuzzing (shuffle only within a class)
+would put `priority` first instead; it is a clean future toggle, not
+implemented until a consumer needs it.
+
+All randomness flows through the simulation's seeded generator
+(`Simulation::sample` / `Ctx::sample`); the `dist` module provides latency and
+clock-drift distributions to sample through it.
+
+## Concurrency metric
+
+The engine maintains a deterministic concurrency metric in `SimMetrics`: the
+critical-path length `D` (`critical_path_len`, the longest chain of causally
+dependent steps), the total step count `W` (`steps_executed`), and
+`parallelism() = W / D`, the average available parallelism. A step depends
+only on the step that scheduled it and on the previous step on its own process
+(processes are serial), so the lent-state model makes the metric exact.
+
+`W / D` is an *upper bound*, in steps, on the speedup any parallel execution
+of the same run could achieve — a property of the simulated system, not of the
+engine. It is deterministic for a given `(configuration, seed)`, so it doubles
+as a regression metric, and it is the measurement that decides whether
+parallel execution is worth building (see [Future work](#future-work)).
+
+## Design rationale
+
+### Why the lent-state model
+
+The alternative was a shared `Rc<RefCell>` / `Arc<Mutex>` process captured by
+closures. That converts aliasing bugs into *runtime* borrow panics or
+deadlocks on reentrancy — self-send, broadcast-to-self, synchronous signal
+handlers. With the framework owning process state and lending `&mut`
+exclusively per step, reentrancy is **non-representable**: within a step you
+hold the only `&mut S` and there is no `borrow()` to fail, and you cannot
+reach another process's state at all. Work that must happen "now" elsewhere is
+a zero-delay scheduled step. Every queued step also names its `ProcessId`,
+which is the basis for debugging, the critical-path metric, and any future
+cross-process parallelism.
+
+### Concurrency stance
+
+A simulation is single-threaded and deterministic. Internal parallelism in
+pure consumer computation that never touches the simulation environment (e.g.
+cryptographic primitives) is allowed and invisible — it produces no observable
+scheduling effect. Independent simulations run in parallel across threads —
+per-simulation isolation (`Simulation::new` owns all its state; no shared
+`thread_local`) is what makes that safe, and that is the parallelism that
+scales (seed sweeps, independent scenarios).
+
+Parallelizing a *single* run is deliberately deferred. The measured ceiling on
+the first consumer is low and flat: the Monad BFT harness measured `W / D`
+plateauing around ~2.9× regardless of swarm size (see that harness's
+documentation), and conservative-window execution would realize only a
+fraction of the ceiling. The `StepLabel` schema reserves the metadata a
+parallel executor would need (`min_propagation`).
+
+## Future work
+
+- **Per-process local clocks** (NTP-style drift) and the clock-scheduling
+  strategy that orders steps across them; the engine runs a single global
+  clock today. `Time` / `ClockDiff` already support negative offsets.
+  Synchronous signal fan-out is deferred with it.
+- **Offline concurrency analyzer.** Building on the critical-path metric: log
+  per-step `{id, parent_id, process, time, cost}` and analyze the run's
+  dependency DAG — cost-weighted parallelism, a parallelism-over-time profile,
+  a `speedup(P)` curve, and sub-process re-attribution (relabel processes to
+  evaluate a finer decomposition). This measures *whether* a protocol or
+  scenario has parallelism worth exploiting, and is the trigger for the next
+  item.
+- **Parallel execution of a single run** — conservative windowing with
+  lookahead bounded by the minimum event latency; needs the per-step
+  `min_propagation` metadata and a per-process RNG. Revisit when a consumer's
+  measured `W / D` makes it worthwhile. Batching same-tick steps is a cheaper,
+  deterministic intermediate win.

--- a/monad-sim/src/dist.rs
+++ b/monad-sim/src/dist.rs
@@ -1,0 +1,162 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Probability distributions for modelling clock and network behaviour.
+//!
+//! These return `impl Distribution<_>` values intended to be sampled through
+//! [`crate::Simulation::sample`] or [`crate::Ctx::sample`] so that all randomness
+//! is driven by the simulation's seeded generator.
+
+// See `crate::time::DurationFromNanosU128`: local shim for the 1.93-only
+// `Duration::from_nanos_u128` while the workspace builds on 1.91.1.
+#![allow(unstable_name_collisions)]
+
+use std::time::Duration;
+
+use rand::{distributions::Distribution, Rng};
+use rand_distr::{LogNormal, Normal};
+
+use crate::time::{ClockDiff, DurationFromNanosU128};
+
+/// The pair of two independent distributions, sampled jointly.
+#[derive(Clone)]
+struct Pair<D0, D1> {
+    d0: D0,
+    d1: D1,
+}
+
+impl<D0, T0, D1, T1> Distribution<(T0, T1)> for Pair<D0, D1>
+where
+    D0: Distribution<T0>,
+    D1: Distribution<T1>,
+{
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> (T0, T1) {
+        (self.d0.sample(rng), self.d1.sample(rng))
+    }
+}
+
+/// Normally distributed duration. Negative samples are clipped to zero; use
+/// [`normal_clock_diff`] when negative values are meaningful.
+pub fn normal_duration(mean: Duration, stddev: Duration) -> impl Distribution<Duration> + 'static {
+    Normal::new(mean.as_nanos() as f64, stddev.as_nanos() as f64)
+        .unwrap()
+        .map(|ns| Duration::from_nanos_u128(ns.max(0.0) as u128))
+}
+
+/// Normally distributed signed clock difference.
+pub fn normal_clock_diff(
+    mean: ClockDiff,
+    stddev: Duration,
+) -> impl Distribution<ClockDiff> + 'static {
+    Normal::new(mean.0 as f64, stddev.as_nanos() as f64)
+        .unwrap()
+        .map(|ns| ClockDiff(ns as i128))
+}
+
+/// Log-normal duration parameterised by the mean and standard deviation of the
+/// underlying normal distribution (i.e. of `ln` of the variable). See
+/// [`lognormal_duration2`] for the more intuitive parameterisation by the mean
+/// and standard deviation of the duration itself.
+///
+/// Panics if a sample exceeds the representable [`Duration`] range.
+pub fn lognormal_duration(
+    normal_mean: f64,
+    normal_stddev: f64,
+) -> impl Distribution<Duration> + 'static {
+    LogNormal::new(normal_mean, normal_stddev)
+        .unwrap()
+        .map(|ns| {
+            assert!(
+                ns <= Duration::MAX.as_nanos() as f64,
+                "lognormal sample too large to represent as a Duration"
+            );
+            Duration::from_nanos_u128(ns as u128)
+        })
+}
+
+/// Log-normal duration parameterised directly by its `mean` and `stddev`.
+pub fn lognormal_duration2(
+    mean: Duration,
+    stddev: Duration,
+) -> impl Distribution<Duration> + 'static {
+    let mean_f64 = mean.as_nanos() as f64;
+    let var = (stddev.as_nanos() as f64).powi(2);
+    let normal_var = (1.0 + var / mean_f64.powi(2)).ln();
+    let normal_mean = mean_f64.ln() - 0.5 * normal_var;
+    lognormal_duration(normal_mean, normal_var.sqrt())
+}
+
+/// Uniformly distributed duration in the inclusive range `[min, max]`.
+pub fn uniform_duration(min: Duration, max: Duration) -> impl Distribution<Duration> + 'static {
+    rand::distributions::Uniform::new_inclusive(min.as_nanos(), max.as_nanos())
+        .map(Duration::from_nanos_u128)
+}
+
+/// Lower bound estimate on global UDP latency.
+const MINIMUM_NETWORK_DELAY: Duration = Duration::from_micros(100);
+/// Upper bound estimate on global UDP latency.
+const MAXIMUM_NETWORK_DELAY: Duration = Duration::from_millis(100);
+
+/// Latency model for a globally distributed UDP network: a uniform baseline
+/// (geographic distance) plus log-normal jitter (network conditions). Reasonable
+/// jitter parameters for inter-datacenter links are mean 5ms, stddev 500us.
+pub fn global_udp_duration(
+    mean_jitter: Duration,
+    stddev_jitter: Duration,
+) -> impl Distribution<Duration> + 'static {
+    Pair {
+        d0: uniform_duration(MINIMUM_NETWORK_DELAY, MAXIMUM_NETWORK_DELAY),
+        d1: lognormal_duration2(mean_jitter, stddev_jitter),
+    }
+    .map(|(baseline, jitter)| baseline + jitter)
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{rngs::StdRng, SeedableRng};
+
+    use super::*;
+    use crate::time::{micros, millis};
+
+    #[test]
+    fn uniform_duration_respects_bounds() {
+        let mut rng = StdRng::seed_from_u64(1);
+        let d = uniform_duration(millis(10), millis(20));
+        for _ in 0..1000 {
+            let s = d.sample(&mut rng);
+            assert!(s >= millis(10) && s <= millis(20));
+        }
+    }
+
+    #[test]
+    fn global_udp_duration_at_least_baseline() {
+        let mut rng = StdRng::seed_from_u64(2);
+        let d = global_udp_duration(millis(5), micros(500));
+        for _ in 0..1000 {
+            assert!(d.sample(&mut rng) >= MINIMUM_NETWORK_DELAY);
+        }
+    }
+
+    #[test]
+    fn same_seed_same_samples() {
+        let sample = |seed| {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let d = normal_duration(millis(5), millis(1));
+            (0..16).map(|_| d.sample(&mut rng)).collect::<Vec<_>>()
+        };
+        assert_eq!(sample(7), sample(7));
+        assert_ne!(sample(7), sample(8));
+    }
+}

--- a/monad-sim/src/lib.rs
+++ b/monad-sim/src/lib.rs
@@ -1,0 +1,46 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Generic, single-threaded discrete-event simulation infrastructure.
+//!
+//! The simulation is a time-ordered queue of *steps*. A step is a closure that
+//! runs at a specific [`time::Time`] and may schedule further steps. State lives
+//! in *processes*: any value `S: 'static` registered with [`Simulation::spawn`]
+//! and addressed by a typed [`Handle`]. When a step scheduled against a handle
+//! runs, the framework lends it `&mut S` exclusively for the duration of that
+//! step, via a [`Ctx`] that can read time, sample randomness, and schedule more
+//! work — but cannot reach any other process's state. Cross-process interaction
+//! is therefore always "schedule a step on that handle", which keeps the engine
+//! agnostic about event and component-state types and makes reentrancy
+//! impossible by construction.
+//!
+//! [`time`] provides the simulation time type; [`dist`] provides
+//! network-latency distributions for modelling message delays.
+//!
+//! # Not yet implemented
+//!
+//! The engine runs a single global clock with a deterministic per-step total
+//! order. Per-process local clocks (NTP-style drift), the clock-scheduling
+//! strategy that orders steps across them, and synchronous signal fan-out are
+//! deferred; see `docs/design.md` ("Future work") for the rationale.
+
+pub mod dist;
+mod sim;
+pub mod time;
+
+pub use sim::{
+    CancelToken, Ctx, Handle, ProcessId, RunOutcome, SimMetrics, Simulation, StepInfo, StepLabel,
+};
+pub use time::{ClockDiff, Time};

--- a/monad-sim/src/sim.rs
+++ b/monad-sim/src/sim.rs
@@ -1,0 +1,1227 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The discrete-event scheduler: [`Simulation`], process [`Handle`]s, and the
+//! per-step [`Ctx`].
+
+use std::{
+    any::Any,
+    cell::Cell,
+    cmp::{Ordering, Reverse},
+    collections::{BinaryHeap, HashMap},
+    marker::PhantomData,
+    rc::Rc,
+    time::Duration,
+};
+
+use rand::{distributions::Distribution, rngs::StdRng, SeedableRng};
+
+use crate::time::Time;
+
+/// Identifies a process registered in a [`Simulation`]. Stable for the lifetime
+/// of that process; ids are never reused.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct ProcessId(u64);
+
+/// The reserved root process that owns process-less ([`Simulation::schedule_global`])
+/// steps. Its state is `()`.
+const ROOT: ProcessId = ProcessId(0);
+
+/// A typed reference to a process's state owned by the [`Simulation`].
+///
+/// `Copy` regardless of `S`; cheap to capture in closures. A step scheduled
+/// against a handle is lent `&mut S` while it runs.
+///
+/// The `id`→`S` binding is fixed at [`spawn`](Simulation::spawn) — ids are never
+/// reused and a process's state type never changes — and handles are minted only
+/// there. That is the invariant that makes the erased `Action` downcast
+/// infallible.
+pub struct Handle<S> {
+    id: ProcessId,
+    _pd: PhantomData<fn() -> S>,
+}
+
+impl<S> Clone for Handle<S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<S> Copy for Handle<S> {}
+
+impl<S> Handle<S> {
+    /// The id of the referenced process.
+    pub fn id(&self) -> ProcessId {
+        self.id
+    }
+}
+
+/// Optional metadata attached to a scheduled step, surfaced in [`StepInfo`] for
+/// observability. `min_propagation` is reserved for future causal-independence
+/// inference and is otherwise ignored.
+///
+/// `priority` is a same-time ordering class (lower runs first); see [`TieBreak`]
+/// and `Entry`'s ordering for how it interacts with the tie-break. The default
+/// `0` leaves a step in the highest-priority class.
+#[derive(Clone, Debug, Default)]
+pub struct StepLabel {
+    pub source: Option<&'static str>,
+    pub kind: Option<&'static str>,
+    pub min_propagation: Option<Duration>,
+    pub priority: u32,
+}
+
+impl StepLabel {
+    /// A label tagged with the component that scheduled the step.
+    pub fn source(source: &'static str) -> Self {
+        Self {
+            source: Some(source),
+            ..Self::default()
+        }
+    }
+
+    /// Set the step kind (builder style).
+    pub fn kind(mut self, kind: &'static str) -> Self {
+        self.kind = Some(kind);
+        self
+    }
+
+    /// Set the same-time priority class (builder style); lower runs first at the
+    /// same simulated time under `TieBreak::Fifo`.
+    pub fn priority(mut self, priority: u32) -> Self {
+        self.priority = priority;
+        self
+    }
+}
+
+/// Description of an executed step, passed to the observer and available for
+/// run-control predicates.
+#[derive(Clone, Debug)]
+pub struct StepInfo {
+    pub time: Time,
+    pub seq: u64,
+    pub process: ProcessId,
+    pub label: StepLabel,
+    /// This step's critical-path depth (see [`SimMetrics::critical_path_len`]);
+    /// `0` if the step was skipped because its process had been despawned.
+    pub depth: u64,
+}
+
+/// Why a bounded run returned.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RunOutcome {
+    /// The queue emptied.
+    Drained,
+    /// Reached the requested time; later steps remain queued.
+    ReachedTime(Time),
+    /// Executed the requested number of steps; more remain.
+    ReachedStepLimit,
+    /// A `run_while` predicate asked to stop.
+    Stopped,
+}
+
+/// Handle to a scheduled step that lets it be cancelled before it runs.
+///
+/// Cancellation is lazy: the step stays in the queue and is skipped when popped.
+/// Cancelling after the step has already run is a no-op.
+#[derive(Clone)]
+pub struct CancelToken(Rc<Cell<bool>>);
+
+impl CancelToken {
+    fn new() -> Self {
+        CancelToken(Rc::new(Cell::new(false)))
+    }
+
+    /// Prevent the associated step from running.
+    pub fn cancel(&self) {
+        self.0.set(true);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.0.get()
+    }
+}
+
+/// Counters describing what a [`Simulation`] has done. Purely informational.
+#[derive(Clone, Debug, Default)]
+pub struct SimMetrics {
+    pub steps_executed: u64,
+    pub steps_scheduled: u64,
+    /// Steps skipped because they were cancelled before being popped.
+    pub steps_cancelled: u64,
+    pub max_queue_len: usize,
+    /// Longest chain of causally-dependent steps, in steps. A step depends on
+    /// the step that scheduled it and on the previous step on its own process
+    /// (processes are serial). This is the run's critical path: the fewest
+    /// sequential steps any execution — parallel or not — must take. Together
+    /// with `steps_executed` (the total work) it bounds the available
+    /// parallelism (see [`parallelism`](Self::parallelism)). Deterministic for a
+    /// given `(config, seed)`, so it is usable as a regression metric.
+    pub critical_path_len: u64,
+}
+
+impl SimMetrics {
+    /// Average available parallelism: total steps over the critical path. `1.0`
+    /// for a fully sequential run; higher means more steps could, in principle,
+    /// run concurrently. An upper bound on achievable speedup, not a measurement
+    /// of any actual parallel run.
+    pub fn parallelism(&self) -> f64 {
+        self.steps_executed as f64 / self.critical_path_len.max(1) as f64
+    }
+}
+
+/// A queued step with its state type erased, so one heap can hold steps for
+/// heterogeneous processes. The closure (built by `enqueue::<S>`) downcasts the
+/// erased `&mut dyn Any` back to its scheduling `Handle<S>`'s `S`; that is
+/// infallible because a process keeps its state type for life (see [`Handle`]),
+/// so the downcast `expect` there is a defensive assert, not a reachable failure.
+type Action = Box<dyn FnOnce(&mut dyn Any, &mut Ctx<'_>)>;
+type Observer = Box<dyn FnMut(&StepInfo)>;
+
+/// How same-time steps are ordered.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum TieBreak {
+    /// Deterministic FIFO: ties break by creation order (`seq`). The default,
+    /// and the only mode that yields exact, stable ticks.
+    #[default]
+    Fifo,
+    /// Seeded pseudo-random: ties break by a hash of `(seed, seq)`, decoupled
+    /// from creation order. Still fully reproducible from `(config, seed)` — it
+    /// is a deterministic reshuffle, not true non-determinism. Sweep the seed to
+    /// explore different same-time orderings (fuzzing for order-dependence bugs).
+    Randomized,
+}
+
+struct Entry {
+    time: Time,
+    /// Same-time ordering key (see [`TieBreak`]); always 0 under `Fifo`.
+    tie_break: u64,
+    /// Same-time priority class (from [`StepLabel::priority`]); lower runs first.
+    priority: u32,
+    seq: u64,
+    process: ProcessId,
+    /// Critical-path depth of the step that scheduled this one (`0` if scheduled
+    /// outside any step). See [`SimMetrics::critical_path_len`].
+    parent_depth: u64,
+    label: StepLabel,
+    cancel: CancelToken,
+    action: Action,
+}
+
+// Ordering is by (time, tie_break, priority, seq). `seq` is unique and monotonic,
+// so the order is always total. Note `tie_break` precedes `priority`:
+// - under `TieBreak::Fifo` every `tie_break` is 0, so this reduces to
+//   (time, priority, seq) — priority classes are honored at a tick, FIFO within
+//   a class, with stable exact ticks;
+// - under `TieBreak::Randomized` the per-seq `tie_break` is distinct, so it
+//   dominates and `priority` is effectively ignored — same-time steps are fully
+//   shuffled across classes (priority-respecting within-class fuzzing would put
+//   `priority` first instead; deliberately not done here).
+impl PartialEq for Entry {
+    fn eq(&self, other: &Self) -> bool {
+        self.time == other.time
+            && self.tie_break == other.tie_break
+            && self.priority == other.priority
+            && self.seq == other.seq
+    }
+}
+impl Eq for Entry {}
+impl Ord for Entry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.time
+            .cmp(&other.time)
+            .then(self.tie_break.cmp(&other.tie_break))
+            .then(self.priority.cmp(&other.priority))
+            .then(self.seq.cmp(&other.seq))
+    }
+}
+impl PartialOrd for Entry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// SplitMix64 finalizer. Maps the unique, monotonic `seq` (combined with the
+/// simulation seed) to a well-distributed, collision-free `tie_break`, so
+/// same-time steps get a deterministic pseudo-random order under
+/// [`TieBreak::Randomized`].
+fn tie_break_key(seed: u64, seq: u64) -> u64 {
+    let mut z = seq.wrapping_add(seed.wrapping_mul(0x9e37_79b9_7f4a_7c15));
+    z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    z ^ (z >> 31)
+}
+
+/// A single-threaded discrete-event simulation: a time-ordered queue of steps
+/// over a set of framework-owned processes.
+///
+/// Construct with [`Simulation::new`], register state with [`spawn`](Self::spawn),
+/// schedule work with [`schedule`](Self::schedule) / [`schedule_global`](Self::schedule_global),
+/// then drive it with one of the `run_*` methods.
+pub struct Simulation {
+    seed: u64,
+    tie_break: TieBreak,
+    rng: StdRng,
+    now: Time,
+    seq: u64,
+    next_id: u64,
+    processes: HashMap<ProcessId, Option<Box<dyn Any>>>,
+    queue: BinaryHeap<Reverse<Entry>>,
+    metrics: SimMetrics,
+    observer: Option<Observer>,
+    /// Critical-path depth of the last executed step on each process; maintains
+    /// [`SimMetrics::critical_path_len`] incrementally.
+    proc_depth: HashMap<ProcessId, u64>,
+}
+
+impl Simulation {
+    /// A fresh, empty simulation seeded for deterministic randomness. The clock
+    /// starts at [`Time(0)`](Time).
+    pub fn new(seed: u64) -> Self {
+        let mut processes = HashMap::new();
+        processes.insert(ROOT, Some(Box::new(()) as Box<dyn Any>));
+        Simulation {
+            seed,
+            tie_break: TieBreak::Fifo,
+            rng: StdRng::seed_from_u64(seed),
+            now: Time(0),
+            seq: 0,
+            next_id: 1,
+            processes,
+            queue: BinaryHeap::new(),
+            metrics: SimMetrics::default(),
+            observer: None,
+            proc_depth: HashMap::new(),
+        }
+    }
+
+    /// Choose how same-time steps are ordered (default [`TieBreak::Fifo`]).
+    ///
+    /// Set this before scheduling any steps — e.g. immediately after
+    /// construction — so the chosen order applies to the whole run. Changing it
+    /// mid-run only affects steps enqueued afterwards.
+    pub fn set_tie_break(&mut self, tie_break: TieBreak) {
+        self.tie_break = tie_break;
+    }
+
+    /// The current same-time ordering policy.
+    pub fn tie_break(&self) -> TieBreak {
+        self.tie_break
+    }
+
+    /// Return the simulation to its just-constructed state: all processes and
+    /// scheduled steps are discarded, the clock and metrics reset, and the
+    /// generator reseeded from the original seed. Handles obtained before the
+    /// reset are invalid afterwards.
+    pub fn reset(&mut self) {
+        *self = Simulation::new(self.seed);
+    }
+
+    pub fn seed(&self) -> u64 {
+        self.seed
+    }
+
+    /// The current global clock time. During a step this is the step's time;
+    /// otherwise it is the time of the most recently executed step (or the
+    /// target of the last [`run_until_time`](Self::run_until_time)).
+    pub fn now(&self) -> Time {
+        self.now
+    }
+
+    /// Number of steps executed so far. Cancelled (skipped) steps do not count.
+    pub fn step_count(&self) -> u64 {
+        self.metrics.steps_executed
+    }
+
+    pub fn metrics(&self) -> &SimMetrics {
+        &self.metrics
+    }
+
+    /// Sample from `d` using the simulation's seeded generator.
+    pub fn sample<T>(&mut self, d: impl Distribution<T>) -> T {
+        d.sample(&mut self.rng)
+    }
+
+    /// Register process state and return a handle to it.
+    pub fn spawn<S: 'static>(&mut self, state: S) -> Handle<S> {
+        let id = ProcessId(self.next_id);
+        self.next_id += 1;
+        self.processes.insert(id, Some(Box::new(state)));
+        Handle {
+            id,
+            _pd: PhantomData,
+        }
+    }
+
+    /// Schedule `step` to run at absolute time `at` with exclusive `&mut S`
+    /// access to the process behind `who`.
+    ///
+    /// Panics if `at` is before [`now`](Self::now). Panics when the step is
+    /// executed if `who` does not refer to a live process or its state type does
+    /// not match `S`.
+    pub fn schedule<S: 'static>(
+        &mut self,
+        who: Handle<S>,
+        at: Time,
+        label: StepLabel,
+        step: impl FnOnce(&mut S, &mut Ctx<'_>) + 'static,
+    ) -> CancelToken {
+        enqueue(
+            &mut self.queue,
+            &mut self.seq,
+            self.seed,
+            self.tie_break,
+            &mut self.metrics,
+            self.now,
+            0,
+            who.id,
+            at,
+            label,
+            step,
+        )
+    }
+
+    /// Like [`schedule`](Self::schedule) but at `now + delay`.
+    pub fn schedule_after<S: 'static>(
+        &mut self,
+        who: Handle<S>,
+        delay: Duration,
+        label: StepLabel,
+        step: impl FnOnce(&mut S, &mut Ctx<'_>) + 'static,
+    ) -> CancelToken {
+        self.schedule(who, self.now + delay, label, step)
+    }
+
+    /// Schedule a process-less step (setup, observation, fan-out scheduling)
+    /// owned by the reserved root process. The step receives only a [`Ctx`].
+    ///
+    /// Panics if `at` is before [`now`](Self::now).
+    pub fn schedule_global(
+        &mut self,
+        at: Time,
+        label: StepLabel,
+        step: impl FnOnce(&mut Ctx<'_>) + 'static,
+    ) -> CancelToken {
+        enqueue::<()>(
+            &mut self.queue,
+            &mut self.seq,
+            self.seed,
+            self.tie_break,
+            &mut self.metrics,
+            self.now,
+            0,
+            ROOT,
+            at,
+            label,
+            move |_unit, ctx| step(ctx),
+        )
+    }
+
+    /// Read the state behind `who`. Intended for use between steps (run-control
+    /// predicates, assertions, the debugger).
+    ///
+    /// Panics if `who` is not a live process, its state is unavailable because a
+    /// step on it is currently executing, or its state type does not match `S`.
+    pub fn with<S: 'static, R>(&self, who: Handle<S>, f: impl FnOnce(&S) -> R) -> R {
+        let state = self
+            .processes
+            .get(&who.id)
+            .expect("unknown process handle")
+            .as_ref()
+            .expect("process state unavailable (called during its own step?)")
+            .downcast_ref::<S>()
+            .expect("handle/state type mismatch");
+        f(state)
+    }
+
+    /// Mutable counterpart of [`with`](Self::with), for injecting input between
+    /// steps. Same panic conditions.
+    pub fn with_mut<S: 'static, R>(&mut self, who: Handle<S>, f: impl FnOnce(&mut S) -> R) -> R {
+        let state = self
+            .processes
+            .get_mut(&who.id)
+            .expect("unknown process handle")
+            .as_mut()
+            .expect("process state unavailable (called during its own step?)")
+            .downcast_mut::<S>()
+            .expect("handle/state type mismatch");
+        f(state)
+    }
+
+    /// Remove a process and return its state. Steps already scheduled against it
+    /// will be skipped when popped (their state is gone). The handle is invalid
+    /// afterwards.
+    ///
+    /// Panics if `who` is not a live process, its state is unavailable because a
+    /// step on it is currently executing, or its state type does not match `S`.
+    pub fn despawn<S: 'static>(&mut self, who: Handle<S>) -> S {
+        let boxed = self
+            .processes
+            .remove(&who.id)
+            .expect("unknown process handle")
+            .expect("process state unavailable (despawn during its own step?)");
+        self.proc_depth.remove(&who.id);
+        *boxed.downcast::<S>().expect("handle/state type mismatch")
+    }
+
+    /// Register a callback invoked after every executed step. Replaces any
+    /// previously registered observer.
+    pub fn on_step(&mut self, observer: impl FnMut(&StepInfo) + 'static) {
+        self.observer = Some(Box::new(observer));
+    }
+
+    /// Time of the next queued step, ignoring whether it is cancelled. `None`
+    /// when the queue is empty.
+    pub fn peek_time(&self) -> Option<Time> {
+        self.queue.peek().map(|Reverse(e)| e.time)
+    }
+
+    /// Execute the earliest queued step (skipping cancelled ones), returning its
+    /// [`StepInfo`], or `None` if the queue is empty.
+    pub fn next_step(&mut self) -> Option<StepInfo> {
+        loop {
+            let Reverse(entry) = self.queue.pop()?;
+            if entry.cancel.is_cancelled() {
+                self.metrics.steps_cancelled += 1;
+                continue;
+            }
+            let time = entry.time;
+            let seq = entry.seq;
+            let process = entry.process;
+            let label = entry.label.clone();
+            let depth = self.dispatch(entry);
+            self.metrics.steps_executed += 1;
+            let info = StepInfo {
+                time,
+                seq,
+                process,
+                label,
+                depth,
+            };
+            if let Some(observer) = self.observer.as_mut() {
+                observer(&info);
+            }
+            return Some(info);
+        }
+    }
+
+    /// Run until the queue is empty.
+    pub fn run_to_completion(&mut self) -> RunOutcome {
+        while self.next_step().is_some() {}
+        RunOutcome::Drained
+    }
+
+    /// Run every step scheduled at time `<= t`, then advance the clock to `t`
+    /// (never backwards). Returns [`RunOutcome::Drained`] if the queue emptied,
+    /// otherwise [`RunOutcome::ReachedTime`].
+    pub fn run_until_time(&mut self, t: Time) -> RunOutcome {
+        loop {
+            // Drop cancelled entries first so the time bound is applied to the
+            // next step that will actually run, not to a skipped one.
+            self.purge_cancelled_front();
+            match self.peek_time() {
+                Some(next) if next <= t => {
+                    self.next_step();
+                }
+                Some(_) => {
+                    self.advance_to(t);
+                    return RunOutcome::ReachedTime(t);
+                }
+                None => {
+                    self.advance_to(t);
+                    return RunOutcome::Drained;
+                }
+            }
+        }
+    }
+
+    /// Discard cancelled entries at the front of the queue so the next peek sees
+    /// a runnable step.
+    fn purge_cancelled_front(&mut self) {
+        while let Some(Reverse(entry)) = self.queue.peek() {
+            if entry.cancel.is_cancelled() {
+                self.queue.pop();
+                self.metrics.steps_cancelled += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Run up to `n` steps. Returns [`RunOutcome::Drained`] if the queue emptied
+    /// first, otherwise [`RunOutcome::ReachedStepLimit`].
+    pub fn run_steps(&mut self, n: u64) -> RunOutcome {
+        for _ in 0..n {
+            if self.next_step().is_none() {
+                return RunOutcome::Drained;
+            }
+        }
+        RunOutcome::ReachedStepLimit
+    }
+
+    /// Run while `pred` holds, evaluating it before each step. `pred` may inspect
+    /// process state (via [`with`](Self::with)) and the clock. Returns
+    /// [`RunOutcome::Stopped`] when `pred` returns `false`, or
+    /// [`RunOutcome::Drained`] if the queue empties first.
+    pub fn run_while(&mut self, mut pred: impl FnMut(&Simulation) -> bool) -> RunOutcome {
+        while pred(&*self) {
+            if self.next_step().is_none() {
+                return RunOutcome::Drained;
+            }
+        }
+        RunOutcome::Stopped
+    }
+
+    fn advance_to(&mut self, t: Time) {
+        if t > self.now {
+            self.now = t;
+        }
+    }
+
+    fn dispatch(&mut self, entry: Entry) -> u64 {
+        let pid = entry.process;
+        self.now = entry.time;
+        // A step may be left over for a process that was despawned after it was
+        // scheduled; skip it (it does no work, so it is off the critical path).
+        if !self.processes.contains_key(&pid) {
+            return 0;
+        }
+        // Critical-path depth: one past the later of the step that scheduled this
+        // one and the previous step on this process.
+        let depth = entry
+            .parent_depth
+            .max(self.proc_depth.get(&pid).copied().unwrap_or(0))
+            + 1;
+        self.proc_depth.insert(pid, depth);
+        self.metrics.critical_path_len = self.metrics.critical_path_len.max(depth);
+        // Take the process's state out so `Ctx` can borrow the rest of `self`
+        // (including `processes`, for spawns) without aliasing it.
+        let mut state = self
+            .processes
+            .get_mut(&pid)
+            .expect("scheduled step references an unknown process")
+            .take()
+            .expect("process state unavailable (reentrant step?)");
+        {
+            let mut ctx = Ctx {
+                now: self.now,
+                seed: self.seed,
+                tie_break: self.tie_break,
+                current_depth: depth,
+                rng: &mut self.rng,
+                queue: &mut self.queue,
+                seq: &mut self.seq,
+                next_id: &mut self.next_id,
+                processes: &mut self.processes,
+                metrics: &mut self.metrics,
+            };
+            (entry.action)(&mut *state, &mut ctx);
+        }
+        self.processes
+            .get_mut(&pid)
+            .expect("process slot vanished during step")
+            .replace(state);
+        depth
+    }
+}
+
+/// Capabilities granted to a step while it runs: read the clock, sample
+/// randomness, and schedule further work. It deliberately cannot reach any
+/// process's state — cross-process interaction is always a scheduled step.
+pub struct Ctx<'a> {
+    now: Time,
+    seed: u64,
+    tie_break: TieBreak,
+    /// Critical-path depth of the running step; stamped onto steps it schedules.
+    current_depth: u64,
+    rng: &'a mut StdRng,
+    queue: &'a mut BinaryHeap<Reverse<Entry>>,
+    seq: &'a mut u64,
+    next_id: &'a mut u64,
+    processes: &'a mut HashMap<ProcessId, Option<Box<dyn Any>>>,
+    metrics: &'a mut SimMetrics,
+}
+
+impl<'a> Ctx<'a> {
+    /// The time of the currently executing step (the owning process's clock).
+    pub fn now(&self) -> Time {
+        self.now
+    }
+
+    /// Sample from `d` using the simulation's seeded generator.
+    pub fn sample<T>(&mut self, d: impl Distribution<T>) -> T {
+        d.sample(&mut *self.rng)
+    }
+
+    /// Schedule a step on `who` at absolute time `at`. Panics if `at` is before
+    /// [`now`](Self::now).
+    pub fn schedule<S: 'static>(
+        &mut self,
+        who: Handle<S>,
+        at: Time,
+        label: StepLabel,
+        step: impl FnOnce(&mut S, &mut Ctx<'_>) + 'static,
+    ) -> CancelToken {
+        enqueue(
+            &mut *self.queue,
+            &mut *self.seq,
+            self.seed,
+            self.tie_break,
+            &mut *self.metrics,
+            self.now,
+            self.current_depth,
+            who.id,
+            at,
+            label,
+            step,
+        )
+    }
+
+    /// Like [`schedule`](Self::schedule) but at `now + delay`.
+    pub fn schedule_after<S: 'static>(
+        &mut self,
+        who: Handle<S>,
+        delay: Duration,
+        label: StepLabel,
+        step: impl FnOnce(&mut S, &mut Ctx<'_>) + 'static,
+    ) -> CancelToken {
+        self.schedule(who, self.now + delay, label, step)
+    }
+
+    /// Schedule a process-less step on the reserved root process.
+    pub fn schedule_global(
+        &mut self,
+        at: Time,
+        label: StepLabel,
+        step: impl FnOnce(&mut Ctx<'_>) + 'static,
+    ) -> CancelToken {
+        enqueue::<()>(
+            &mut *self.queue,
+            &mut *self.seq,
+            self.seed,
+            self.tie_break,
+            &mut *self.metrics,
+            self.now,
+            self.current_depth,
+            ROOT,
+            at,
+            label,
+            move |_unit, ctx| step(ctx),
+        )
+    }
+
+    /// Register a new process during a step. The handle is usable immediately
+    /// (steps can be scheduled against it), and the process becomes runnable on
+    /// the next popped step.
+    pub fn spawn<S: 'static>(&mut self, state: S) -> Handle<S> {
+        let id = ProcessId(*self.next_id);
+        *self.next_id += 1;
+        self.processes.insert(id, Some(Box::new(state)));
+        Handle {
+            id,
+            _pd: PhantomData,
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn enqueue<S: 'static>(
+    queue: &mut BinaryHeap<Reverse<Entry>>,
+    seq: &mut u64,
+    seed: u64,
+    mode: TieBreak,
+    metrics: &mut SimMetrics,
+    now: Time,
+    parent_depth: u64,
+    who: ProcessId,
+    at: Time,
+    label: StepLabel,
+    step: impl FnOnce(&mut S, &mut Ctx<'_>) + 'static,
+) -> CancelToken {
+    assert!(
+        at >= now,
+        "cannot schedule a step in the past: now={now:?}, at={at:?}"
+    );
+    let s = *seq;
+    *seq += 1;
+    let tie_break = match mode {
+        TieBreak::Fifo => 0,
+        TieBreak::Randomized => tie_break_key(seed, s),
+    };
+    let priority = label.priority;
+    let cancel = CancelToken::new();
+    let action: Action = Box::new(move |any, ctx| {
+        let state = any
+            .downcast_mut::<S>()
+            .expect("scheduled step state type does not match its handle");
+        step(state, ctx);
+    });
+    queue.push(Reverse(Entry {
+        time: at,
+        tie_break,
+        priority,
+        seq: s,
+        process: who,
+        parent_depth,
+        label,
+        cancel: cancel.clone(),
+        action,
+    }));
+    metrics.steps_scheduled += 1;
+    metrics.max_queue_len = metrics.max_queue_len.max(queue.len());
+    cancel
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use rand::distributions::Uniform;
+
+    use super::*;
+    use crate::time::millis;
+
+    #[derive(Default)]
+    struct Counter(u64);
+    #[derive(Default)]
+    struct Log(Vec<u64>);
+
+    #[test]
+    fn steps_run_in_time_order_and_advance_clock() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Log::default());
+        sim.schedule(h, Time(30), StepLabel::default(), |s, _| s.0.push(30));
+        sim.schedule(h, Time(10), StepLabel::default(), |s, _| s.0.push(10));
+        sim.schedule(h, Time(20), StepLabel::default(), |s, _| s.0.push(20));
+
+        assert_eq!(sim.run_to_completion(), RunOutcome::Drained);
+        sim.with(h, |s| assert_eq!(s.0, vec![10, 20, 30]));
+        assert_eq!(sim.now(), Time(30));
+        assert_eq!(sim.step_count(), 3);
+    }
+
+    #[test]
+    fn same_time_steps_run_fifo() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Log::default());
+        for v in [1, 2, 3] {
+            sim.schedule(h, Time(10), StepLabel::default(), move |s, _| s.0.push(v));
+        }
+        sim.run_to_completion();
+        sim.with(h, |s| assert_eq!(s.0, vec![1, 2, 3]));
+    }
+
+    /// Run `n` steps all scheduled at the same time and return the order in
+    /// which they executed, under the given tie-break policy and seed.
+    fn same_time_order(seed: u64, mode: TieBreak, n: u64) -> Vec<u64> {
+        let mut sim = Simulation::new(seed);
+        sim.set_tie_break(mode);
+        let h = sim.spawn(Log::default());
+        for v in 0..n {
+            sim.schedule(h, Time(10), StepLabel::default(), move |s, _| s.0.push(v));
+        }
+        sim.run_to_completion();
+        sim.with(h, |s| s.0.clone())
+    }
+
+    #[test]
+    fn fifo_tie_break_preserves_creation_order() {
+        // The default policy: same-time steps run in creation order, regardless
+        // of seed — this is what keeps exact-tick assertions stable.
+        assert_eq!(
+            same_time_order(7, TieBreak::Fifo, 8),
+            (0..8).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            same_time_order(7, TieBreak::Fifo, 8),
+            same_time_order(99, TieBreak::Fifo, 8)
+        );
+    }
+
+    #[test]
+    fn randomized_tie_break_reorders_but_stays_reproducible() {
+        let a = same_time_order(7, TieBreak::Randomized, 8);
+
+        // Reproducible: same (config, seed) yields the same order.
+        assert_eq!(a, same_time_order(7, TieBreak::Randomized, 8));
+        // It is a permutation of the creation order...
+        let mut sorted = a.clone();
+        sorted.sort();
+        assert_eq!(sorted, (0..8).collect::<Vec<_>>());
+        // ...but decoupled from it (not FIFO).
+        assert_ne!(a, (0..8).collect::<Vec<_>>());
+        // A different seed explores a different ordering (fuzzing).
+        assert_ne!(a, same_time_order(8, TieBreak::Randomized, 8));
+    }
+
+    #[test]
+    fn priority_orders_same_time_steps_under_fifo() {
+        // Same-time steps run by ascending priority class (lower first), FIFO
+        // within a class — regardless of creation order.
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Log::default());
+        for (v, p) in [(0u64, 7u32), (1, 7), (2, 2), (3, 0), (4, 2)] {
+            sim.schedule(
+                h,
+                Time(10),
+                StepLabel::default().priority(p),
+                move |s, _| s.0.push(v),
+            );
+        }
+        sim.run_to_completion();
+        // class 0: [3]; class 2: [2, 4] (FIFO); class 7: [0, 1] (FIFO).
+        sim.with(h, |s| assert_eq!(s.0, vec![3, 2, 4, 0, 1]));
+    }
+
+    #[test]
+    fn randomized_tie_break_ignores_priority() {
+        // Under Randomized the per-seq tie-break dominates the priority class, so
+        // assigning priorities does not constrain the order: it is identical to
+        // the priority-free Randomized order at the same seed (full shuffle).
+        let mut sim = Simulation::new(7);
+        sim.set_tie_break(TieBreak::Randomized);
+        let h = sim.spawn(Log::default());
+        for v in 0..8u64 {
+            // Later-created steps get higher priority — this WOULD reorder them
+            // under Fifo, but must not under Randomized.
+            let p = (8 - v) as u32;
+            sim.schedule(
+                h,
+                Time(10),
+                StepLabel::default().priority(p),
+                move |s, _| s.0.push(v),
+            );
+        }
+        sim.run_to_completion();
+        let with_priority = sim.with(h, |s| s.0.clone());
+        assert_eq!(with_priority, same_time_order(7, TieBreak::Randomized, 8));
+    }
+
+    #[test]
+    fn despawn_returns_state_and_skips_pending_steps() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        sim.schedule(h, Time(10), StepLabel::default(), |s, _| s.0 += 5);
+        // a step scheduled for after the despawn must be skipped, not panic
+        sim.schedule(h, Time(30), StepLabel::default(), |s, _| s.0 += 100);
+        sim.run_until_time(Time(20));
+
+        let taken = sim.despawn(h);
+        assert_eq!(taken.0, 5);
+        assert_eq!(sim.run_to_completion(), RunOutcome::Drained);
+    }
+
+    #[test]
+    fn cross_process_scheduling() {
+        let mut sim = Simulation::new(0);
+        let a = sim.spawn(());
+        let b = sim.spawn(Counter::default());
+        sim.schedule(a, Time(0), StepLabel::default(), move |_, ctx| {
+            let now = ctx.now();
+            ctx.schedule(b, now, StepLabel::default(), |s, _| s.0 += 1);
+        });
+        sim.run_to_completion();
+        sim.with(b, |s| assert_eq!(s.0, 1));
+    }
+
+    #[test]
+    fn self_rescheduling_step() {
+        fn tick(s: &mut Counter, ctx: &mut Ctx<'_>, me: Handle<Counter>) {
+            s.0 += 1;
+            if s.0 < 3 {
+                ctx.schedule_after(me, millis(1), StepLabel::default(), move |s, ctx| {
+                    tick(s, ctx, me)
+                });
+            }
+        }
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        sim.schedule(h, Time(0), StepLabel::default(), move |s, ctx| {
+            tick(s, ctx, h)
+        });
+        sim.run_to_completion();
+        sim.with(h, |s| assert_eq!(s.0, 3));
+        assert_eq!(sim.now(), Time(0) + millis(2));
+    }
+
+    #[test]
+    fn cancelled_step_does_not_run() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        let token = sim.schedule(h, Time(10), StepLabel::default(), |s, _| s.0 += 1);
+        token.cancel();
+        sim.run_to_completion();
+        sim.with(h, |s| assert_eq!(s.0, 0));
+        assert_eq!(sim.metrics().steps_executed, 0);
+        assert_eq!(sim.metrics().steps_cancelled, 1);
+    }
+
+    #[test]
+    fn rearmed_timer_only_fires_latest() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Log::default());
+        let first = sim.schedule(h, Time(10), StepLabel::default(), |s, _| s.0.push(10));
+        first.cancel();
+        sim.schedule(h, Time(20), StepLabel::default(), |s, _| s.0.push(20));
+        sim.run_to_completion();
+        sim.with(h, |s| assert_eq!(s.0, vec![20]));
+    }
+
+    #[test]
+    fn run_until_time_bounds_execution() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Log::default());
+        for t in [10, 20, 30] {
+            sim.schedule(h, Time(t), StepLabel::default(), move |s, _| {
+                s.0.push(t as u64)
+            });
+        }
+
+        assert_eq!(
+            sim.run_until_time(Time(20)),
+            RunOutcome::ReachedTime(Time(20))
+        );
+        assert_eq!(sim.now(), Time(20));
+        sim.with(h, |s| assert_eq!(s.0, vec![10, 20]));
+
+        // Advancing to a time before the next step runs nothing but moves the clock.
+        assert_eq!(
+            sim.run_until_time(Time(25)),
+            RunOutcome::ReachedTime(Time(25))
+        );
+        assert_eq!(sim.now(), Time(25));
+        sim.with(h, |s| assert_eq!(s.0, vec![10, 20]));
+
+        assert_eq!(sim.run_until_time(Time(40)), RunOutcome::Drained);
+        assert_eq!(sim.now(), Time(40));
+        sim.with(h, |s| assert_eq!(s.0, vec![10, 20, 30]));
+    }
+
+    #[test]
+    fn run_steps_counts_executed_steps() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        for t in 1..=5 {
+            sim.schedule(h, Time(t), StepLabel::default(), |s, _| s.0 += 1);
+        }
+        assert_eq!(sim.run_steps(3), RunOutcome::ReachedStepLimit);
+        assert_eq!(sim.step_count(), 3);
+        assert_eq!(sim.run_steps(10), RunOutcome::Drained);
+        assert_eq!(sim.step_count(), 5);
+    }
+
+    #[test]
+    fn run_while_observes_process_state() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        for t in 1..=10 {
+            sim.schedule(h, Time(t), StepLabel::default(), |s, _| s.0 += 1);
+        }
+        let outcome = sim.run_while(|sim| sim.with(h, |c| c.0) < 5);
+        assert_eq!(outcome, RunOutcome::Stopped);
+        assert_eq!(sim.with(h, |c| c.0), 5);
+
+        assert_eq!(
+            sim.run_while(|sim| sim.with(h, |c| c.0) < 100),
+            RunOutcome::Drained
+        );
+        assert_eq!(sim.with(h, |c| c.0), 10);
+    }
+
+    #[test]
+    fn global_step_schedules_onto_process() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        sim.schedule_global(Time(0), StepLabel::default(), move |ctx| {
+            let now = ctx.now();
+            ctx.schedule(h, now, StepLabel::default(), |s, _| s.0 += 1);
+        });
+        sim.run_to_completion();
+        sim.with(h, |s| assert_eq!(s.0, 1));
+    }
+
+    #[test]
+    fn spawn_during_step() {
+        let mut sim = Simulation::new(0);
+        let out = Rc::new(Cell::new(0u64));
+        let out2 = out.clone();
+        sim.schedule_global(Time(0), StepLabel::default(), move |ctx| {
+            let h = ctx.spawn(out2);
+            let now = ctx.now();
+            ctx.schedule(h, now, StepLabel::default(), |s: &mut Rc<Cell<u64>>, _| {
+                s.set(s.get() + 1)
+            });
+        });
+        sim.run_to_completion();
+        assert_eq!(out.get(), 1);
+    }
+
+    #[test]
+    fn deterministic_for_a_given_seed() {
+        let run = |seed| {
+            let mut sim = Simulation::new(seed);
+            let h = sim.spawn(Log::default());
+            sim.schedule(h, Time(0), StepLabel::default(), |s, ctx| {
+                for _ in 0..8 {
+                    s.0.push(ctx.sample(Uniform::new(0u64, 1_000)));
+                }
+            });
+            sim.run_to_completion();
+            sim.with(h, |s| s.0.clone())
+        };
+        assert_eq!(run(7), run(7));
+        assert_ne!(run(7), run(8));
+    }
+
+    #[test]
+    fn observer_sees_every_step() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        let sink = seen.clone();
+        sim.on_step(move |info| {
+            sink.borrow_mut()
+                .push((info.time, info.process, info.label.source))
+        });
+        sim.schedule(h, Time(5), StepLabel::source("a"), |s, _| s.0 += 1);
+        sim.schedule(h, Time(7), StepLabel::source("b"), |s, _| s.0 += 1);
+        sim.run_to_completion();
+
+        let seen = seen.borrow();
+        assert_eq!(seen.len(), 2);
+        assert_eq!(seen[0], (Time(5), h.id(), Some("a")));
+        assert_eq!(seen[1], (Time(7), h.id(), Some("b")));
+    }
+
+    #[test]
+    fn with_mut_injects_state() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        sim.with_mut(h, |c| c.0 = 42);
+        sim.with(h, |c| assert_eq!(c.0, 42));
+    }
+
+    #[test]
+    fn reset_clears_everything() {
+        let mut sim = Simulation::new(1);
+        let h = sim.spawn(Counter::default());
+        sim.schedule(h, Time(5), StepLabel::default(), |s, _| s.0 += 1);
+        sim.run_to_completion();
+        assert_eq!(sim.now(), Time(5));
+
+        sim.reset();
+        assert_eq!(sim.now(), Time(0));
+        assert_eq!(sim.step_count(), 0);
+        assert!(sim.peek_time().is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "in the past")]
+    fn scheduling_in_the_past_panics() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(());
+        sim.schedule(h, Time(10), StepLabel::default(), |_, _| {});
+        sim.run_to_completion(); // now == Time(10)
+        sim.schedule(h, Time(5), StepLabel::default(), |_, _| {});
+    }
+
+    #[test]
+    fn critical_path_of_serial_chain_equals_its_length() {
+        // A self-rescheduling chain on one process: every step depends on the
+        // previous, so the critical path is the whole run and parallelism is 1.
+        fn tick(s: &mut Counter, ctx: &mut Ctx<'_>, me: Handle<Counter>) {
+            s.0 += 1;
+            if s.0 < 5 {
+                ctx.schedule_after(me, millis(1), StepLabel::default(), move |s, ctx| {
+                    tick(s, ctx, me)
+                });
+            }
+        }
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        sim.schedule(h, Time(0), StepLabel::default(), move |s, ctx| {
+            tick(s, ctx, h)
+        });
+        sim.run_to_completion();
+
+        assert_eq!(sim.metrics().steps_executed, 5);
+        assert_eq!(sim.metrics().critical_path_len, 5);
+        assert_eq!(sim.metrics().parallelism(), 1.0);
+    }
+
+    #[test]
+    fn critical_path_of_fan_out_is_two() {
+        // One step schedules N independent children, each on its own process.
+        // Depth: root = 1, every child = 2 (no child depends on another), so the
+        // critical path is 2 and parallelism is (N + 1) / 2.
+        let n = 5u64;
+        let mut sim = Simulation::new(0);
+        let handles: Vec<_> = (0..n).map(|_| sim.spawn(Counter::default())).collect();
+        sim.schedule_global(Time(0), StepLabel::default(), move |ctx| {
+            let now = ctx.now();
+            for h in handles {
+                ctx.schedule(h, now, StepLabel::default(), |s, _| s.0 += 1);
+            }
+        });
+        sim.run_to_completion();
+
+        assert_eq!(sim.metrics().steps_executed, n + 1);
+        assert_eq!(sim.metrics().critical_path_len, 2);
+        assert_eq!(sim.metrics().parallelism(), (n + 1) as f64 / 2.0);
+    }
+
+    #[test]
+    fn same_process_steps_serialize_in_critical_path() {
+        // Independent steps scheduled onto one process still serialize (shared
+        // state), so the critical path equals the step count.
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        for t in 1..=4 {
+            sim.schedule(h, Time(t), StepLabel::default(), |s, _| s.0 += 1);
+        }
+        sim.run_to_completion();
+
+        assert_eq!(sim.metrics().steps_executed, 4);
+        assert_eq!(sim.metrics().critical_path_len, 4);
+    }
+
+    #[test]
+    fn cancelled_steps_are_off_the_critical_path() {
+        let mut sim = Simulation::new(0);
+        let h = sim.spawn(Counter::default());
+        sim.schedule(h, Time(10), StepLabel::default(), |s, _| s.0 += 1)
+            .cancel();
+        sim.schedule(h, Time(20), StepLabel::default(), |s, _| s.0 += 1);
+        sim.run_to_completion();
+
+        // only the one surviving step contributes
+        assert_eq!(sim.metrics().steps_executed, 1);
+        assert_eq!(sim.metrics().critical_path_len, 1);
+    }
+
+    #[test]
+    fn critical_path_is_deterministic() {
+        let run = || {
+            let mut sim = Simulation::new(0);
+            let h = sim.spawn(Counter::default());
+            for t in 1..=6 {
+                sim.schedule(h, Time(t), StepLabel::default(), |s, _| s.0 += 1);
+            }
+            sim.run_to_completion();
+            sim.metrics().critical_path_len
+        };
+        assert_eq!(run(), run());
+    }
+}

--- a/monad-sim/src/time.rs
+++ b/monad-sim/src/time.rs
@@ -1,0 +1,262 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Simulation time and clock differences.
+
+// `Duration::from_nanos_u128` is stable only since Rust 1.93, but this workspace
+// builds on 1.91.1, so it is provided locally by the `DurationFromNanosU128`
+// extension trait below. This `allow` silences the future-ambiguity lint raised by
+// calling it through the trait while std's (still-unstable) inherent method
+// already exists. Remove the trait and this `allow` once the toolchain reaches 1.93.
+#![allow(unstable_name_collisions)]
+
+use std::{
+    ops::{Add, AddAssign, Sub, SubAssign},
+    time::Duration,
+};
+
+/// Local stand-in for [`Duration::from_nanos_u128`] (stable since Rust 1.93; the
+/// workspace toolchain is 1.91.1). Behaviour matches std, including the panic
+/// when the nanosecond count exceeds [`Duration::MAX`].
+///
+/// Remove once the toolchain reaches 1.93: std's inherent method then shadows
+/// this, and the `use crate::time::DurationFromNanosU128;` imports in sibling
+/// modules surface as `unused_imports` warnings pointing back here.
+pub(crate) trait DurationFromNanosU128 {
+    fn from_nanos_u128(nanos: u128) -> Duration;
+}
+
+impl DurationFromNanosU128 for Duration {
+    #[inline]
+    #[track_caller]
+    fn from_nanos_u128(nanos: u128) -> Duration {
+        const NANOS_PER_SEC: u128 = 1_000_000_000;
+        let secs =
+            u64::try_from(nanos / NANOS_PER_SEC).expect("overflow in `Duration::from_nanos_u128`");
+        // `nanos % NANOS_PER_SEC < 1_000_000_000`, so `Duration::new` takes its
+        // no-carry fast path and the result equals std's `new_unchecked` form.
+        Duration::new(secs, (nanos % NANOS_PER_SEC) as u32)
+    }
+}
+
+/// Discrete simulation time: the affine line over clock differences measured in
+/// nanoseconds. It has no defined epoch; time `0` is the conventional origin of
+/// the global clock. Represented as `i128` so it can hold the full `Duration`
+/// range and negative points (used by local clocks with a negative offset).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
+pub struct Time(pub i128);
+
+impl std::fmt::Debug for Time {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let d = Duration::from_nanos_u128(self.0.unsigned_abs());
+        if self.0 < 0 {
+            write!(f, "Time(-{:?})", d)
+        } else {
+            write!(f, "Time({:?})", d)
+        }
+    }
+}
+
+/// Signed difference between two [`Time`] points, in nanoseconds.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
+pub struct ClockDiff(pub i128);
+
+impl std::fmt::Debug for ClockDiff {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let d = Duration::from_nanos_u128(self.0.unsigned_abs());
+        if self.0 < 0 {
+            write!(f, "-{:?}", d)
+        } else {
+            write!(f, "{:?}", d)
+        }
+    }
+}
+
+impl Time {
+    /// Unsigned magnitude of the difference between two times. Use `self - other`
+    /// (a [`ClockDiff`]) when you need the sign.
+    pub fn abs_diff(self, other: Time) -> Duration {
+        Duration::from_nanos_u128(self.0.abs_diff(other.0))
+    }
+}
+
+/// `Time` is a torsor over [`ClockDiff`]: subtracting two times yields their
+/// signed difference.
+impl Sub<Time> for Time {
+    type Output = ClockDiff;
+    fn sub(self, rhs: Time) -> Self::Output {
+        ClockDiff(self.0 - rhs.0)
+    }
+}
+
+impl Add<Duration> for Time {
+    type Output = Self;
+    fn add(self, d: Duration) -> Self::Output {
+        Time(self.0 + d.as_nanos() as i128)
+    }
+}
+
+impl AddAssign<Duration> for Time {
+    fn add_assign(&mut self, d: Duration) {
+        *self = *self + d;
+    }
+}
+
+impl Sub<Duration> for Time {
+    type Output = Self;
+    fn sub(self, d: Duration) -> Self::Output {
+        Time(self.0 - d.as_nanos() as i128)
+    }
+}
+
+impl SubAssign<Duration> for Time {
+    fn sub_assign(&mut self, d: Duration) {
+        *self = *self - d;
+    }
+}
+
+impl Add<ClockDiff> for Time {
+    type Output = Self;
+    fn add(self, d: ClockDiff) -> Self::Output {
+        Time(self.0 + d.0)
+    }
+}
+
+impl AddAssign<ClockDiff> for Time {
+    fn add_assign(&mut self, d: ClockDiff) {
+        *self = *self + d;
+    }
+}
+
+impl Sub<ClockDiff> for Time {
+    type Output = Self;
+    fn sub(self, d: ClockDiff) -> Self::Output {
+        Time(self.0 - d.0)
+    }
+}
+
+impl SubAssign<ClockDiff> for Time {
+    fn sub_assign(&mut self, d: ClockDiff) {
+        *self = *self - d;
+    }
+}
+
+impl Add<ClockDiff> for ClockDiff {
+    type Output = Self;
+    fn add(self, d: ClockDiff) -> Self::Output {
+        ClockDiff(self.0 + d.0)
+    }
+}
+
+impl Sub<ClockDiff> for ClockDiff {
+    type Output = Self;
+    fn sub(self, d: ClockDiff) -> Self::Output {
+        ClockDiff(self.0 - d.0)
+    }
+}
+
+impl ClockDiff {
+    pub fn as_nanos(self) -> i128 {
+        self.0
+    }
+
+    pub fn from_nanos(ns: i128) -> Self {
+        ClockDiff(ns)
+    }
+
+    pub fn from_duration(d: Duration) -> Self {
+        ClockDiff(d.as_nanos() as i128)
+    }
+
+    /// Convert to a floating-point number of nanoseconds. Beware of precision
+    /// loss for magnitudes beyond `2^53` nanoseconds.
+    pub fn as_f64(self) -> f64 {
+        self.0 as f64
+    }
+
+    /// Build from a floating-point number of nanoseconds, rounding to the nearest
+    /// integer. Beware of precision loss for large magnitudes.
+    pub fn from_nanos_f64(s: f64) -> Self {
+        ClockDiff(s.round() as i128)
+    }
+}
+
+/// Shorthand for a [`Duration`] of `ns` nanoseconds.
+pub const fn nanos(ns: u64) -> Duration {
+    Duration::from_nanos(ns)
+}
+
+/// Shorthand for a [`Duration`] of `us` microseconds.
+pub const fn micros(us: u64) -> Duration {
+    Duration::from_micros(us)
+}
+
+/// Shorthand for a [`Duration`] of `ms` milliseconds.
+pub const fn millis(ms: u64) -> Duration {
+    Duration::from_millis(ms)
+}
+
+/// Shorthand for a [`Duration`] of `s` seconds.
+pub const fn secs(s: u64) -> Duration {
+    Duration::from_secs(s)
+}
+
+/// Shorthand for a [`Duration`] of `m` minutes.
+pub fn mins(m: u64) -> Duration {
+    Duration::from_mins(m)
+}
+
+/// Shorthand for a [`Duration`] of `h` hours.
+pub fn hours(h: u64) -> Duration {
+    Duration::from_hours(h)
+}
+
+/// Shorthand for a [`Duration`] of `d` days.
+pub fn days(d: u64) -> Duration {
+    Duration::from_hours(d * 24)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn time_duration_arithmetic() {
+        let t = Time(0) + millis(100);
+        assert_eq!(t, Time(100_000_000));
+        assert_eq!(t - millis(40), Time(60_000_000));
+
+        let mut t = Time(0);
+        t += secs(1);
+        assert_eq!(t, Time(1_000_000_000));
+    }
+
+    #[test]
+    fn time_difference_is_signed() {
+        assert_eq!(
+            Time(0) + millis(100) - (Time(0) + millis(30)),
+            ClockDiff(70_000_000)
+        );
+        assert_eq!(Time(0) - (Time(0) + millis(30)), ClockDiff(-30_000_000));
+        assert_eq!((Time(0) + millis(30)).abs_diff(Time(0)), millis(30));
+    }
+
+    #[test]
+    fn clock_diff_applies_to_time() {
+        assert_eq!(Time(5) + ClockDiff(10), Time(15));
+        assert_eq!(Time(5) - ClockDiff(10), Time(-5));
+        assert_eq!(ClockDiff::from_duration(millis(2)).as_nanos(), 2_000_000);
+    }
+}

--- a/monad-sim/tests/processes.rs
+++ b/monad-sim/tests/processes.rs
@@ -1,0 +1,229 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Worked examples on top of `monad-sim` using toy, app-defined processes.
+//!
+//! `Msg`, `Node`, `Net`, and `Watchdog` are all defined here, not in the crate:
+//! the simulation framework never names a message or component-state type. These
+//! exercise the patterns protocol harnesses rely on — cross-process message
+//! passing, a swappable network process, sampled latency, and a resettable
+//! timer.
+
+use std::{collections::HashMap, time::Duration};
+
+use monad_sim::{
+    dist::uniform_duration, time::millis, CancelToken, Ctx, Handle, RunOutcome, Simulation,
+    StepLabel, Time,
+};
+
+// ---------------------------------------------------------------------------
+// A two-node ping/pong over a network process.
+// ---------------------------------------------------------------------------
+
+type NodeId = u32;
+
+/// Stop after this many round trips.
+const BUDGET: u32 = 3;
+
+#[derive(Clone, Copy)]
+enum Msg {
+    Ping(u32),
+    Pong(u32),
+}
+
+impl Msg {
+    fn seq(self) -> u32 {
+        match self {
+            Msg::Ping(n) | Msg::Pong(n) => n,
+        }
+    }
+}
+
+struct Node {
+    net: Handle<Net>,
+    peer: NodeId,
+    pongs: u32,
+    /// (arrival time, sequence number) of every message received.
+    log: Vec<(Time, u32)>,
+}
+
+impl Node {
+    fn send(&self, ctx: &mut Ctx, msg: Msg) {
+        let (net, to, now) = (self.net, self.peer, ctx.now());
+        ctx.schedule(net, now, StepLabel::source("send"), move |net, ctx| {
+            net.deliver(ctx, to, msg)
+        });
+    }
+
+    fn recv(&mut self, ctx: &mut Ctx, msg: Msg) {
+        self.log.push((ctx.now(), msg.seq()));
+        match msg {
+            Msg::Ping(n) => self.send(ctx, Msg::Pong(n)),
+            Msg::Pong(n) => {
+                self.pongs += 1;
+                if n + 1 < BUDGET {
+                    self.send(ctx, Msg::Ping(n + 1));
+                }
+            }
+        }
+    }
+}
+
+enum Latency {
+    Const(Duration),
+    Uniform(Duration, Duration),
+}
+
+/// The network: a routing table and a latency model. Swapping this process out
+/// is how a different network model would be plugged in.
+struct Net {
+    routes: HashMap<NodeId, Handle<Node>>,
+    latency: Latency,
+}
+
+impl Net {
+    fn deliver(&self, ctx: &mut Ctx, to: NodeId, msg: Msg) {
+        let dst = self.routes[&to];
+        let delay = match self.latency {
+            Latency::Const(d) => d,
+            Latency::Uniform(lo, hi) => ctx.sample(uniform_duration(lo, hi)),
+        };
+        let at = ctx.now() + delay;
+        ctx.schedule(dst, at, StepLabel::source("deliver"), move |node, ctx| {
+            node.recv(ctx, msg)
+        });
+    }
+}
+
+/// Spawn the network and two nodes, wire up routing, and kick off the first ping.
+fn build_ping_pong(sim: &mut Simulation, latency: Latency) -> (Handle<Node>, Handle<Node>) {
+    let net = sim.spawn(Net {
+        routes: HashMap::new(),
+        latency,
+    });
+    let a = sim.spawn(Node {
+        net,
+        peer: 1,
+        pongs: 0,
+        log: Vec::new(),
+    });
+    let b = sim.spawn(Node {
+        net,
+        peer: 0,
+        pongs: 0,
+        log: Vec::new(),
+    });
+    sim.with_mut(net, |net| {
+        net.routes.insert(0, a);
+        net.routes.insert(1, b);
+    });
+    sim.schedule(a, Time(0), StepLabel::source("start"), |node, ctx| {
+        node.send(ctx, Msg::Ping(0))
+    });
+    (a, b)
+}
+
+#[test]
+fn ping_pong_completes() {
+    let mut sim = Simulation::new(0);
+    let (a, b) = build_ping_pong(&mut sim, Latency::Const(millis(10)));
+
+    assert_eq!(sim.run_to_completion(), RunOutcome::Drained);
+
+    // BUDGET round trips, each 2 * 10ms, the last pong landing at 60ms.
+    assert_eq!(sim.with(a, |n| n.pongs), BUDGET);
+    assert_eq!(sim.with(a, |n| n.log.len()), BUDGET as usize);
+    assert_eq!(sim.with(b, |n| n.log.len()), BUDGET as usize);
+    assert_eq!(sim.now(), Time(0) + millis(60));
+}
+
+#[test]
+fn run_until_time_stops_mid_exchange() {
+    let mut sim = Simulation::new(0);
+    let (a, b) = build_ping_pong(&mut sim, Latency::Const(millis(10)));
+
+    // First pong lands at 20ms; the second ping is delivered at 30ms.
+    assert_eq!(
+        sim.run_until_time(Time(0) + millis(25)),
+        RunOutcome::ReachedTime(Time(0) + millis(25))
+    );
+    assert_eq!(sim.with(a, |n| n.pongs), 1);
+    assert_eq!(sim.with(a, |n| n.log.len()), 1);
+    assert_eq!(sim.with(b, |n| n.log.len()), 1);
+    assert_eq!(sim.now(), Time(0) + millis(25));
+}
+
+#[test]
+fn random_latency_is_deterministic_per_seed() {
+    let run = |seed| {
+        let mut sim = Simulation::new(seed);
+        let (a, _) = build_ping_pong(&mut sim, Latency::Uniform(millis(5), millis(15)));
+        sim.run_to_completion();
+        sim.with(a, |n| n.log.clone())
+    };
+    assert_eq!(run(11), run(11));
+    assert_ne!(run(11), run(12));
+}
+
+// ---------------------------------------------------------------------------
+// A watchdog timer that resets on every heartbeat (the pacemaker pattern).
+// ---------------------------------------------------------------------------
+
+struct Watchdog {
+    timeout: Duration,
+    armed: Option<CancelToken>,
+    fired: u32,
+}
+
+impl Watchdog {
+    /// Cancel any pending timeout and arm a fresh one.
+    fn heartbeat(&mut self, me: Handle<Watchdog>, ctx: &mut Ctx) {
+        if let Some(pending) = self.armed.take() {
+            pending.cancel();
+        }
+        let token = ctx.schedule_after(me, self.timeout, StepLabel::source("timeout"), |w, _| {
+            w.fired += 1;
+        });
+        self.armed = Some(token);
+    }
+}
+
+#[test]
+fn timeout_resets_on_heartbeat() {
+    let mut sim = Simulation::new(0);
+    let wd = sim.spawn(Watchdog {
+        timeout: millis(10),
+        armed: None,
+        fired: 0,
+    });
+
+    // Heartbeats every 5ms keep re-arming the 10ms timeout; the last one is at
+    // 20ms, so the only timeout that survives fires at 30ms.
+    for t in [0, 5, 10, 15, 20] {
+        sim.schedule(
+            wd,
+            Time(0) + millis(t),
+            StepLabel::source("heartbeat"),
+            move |w, ctx| w.heartbeat(wd, ctx),
+        );
+    }
+
+    sim.run_until_time(Time(0) + millis(29));
+    assert_eq!(sim.with(wd, |w| w.fired), 0);
+    assert_eq!(sim.metrics().steps_cancelled, 4);
+
+    sim.run_until_time(Time(0) + millis(31));
+    assert_eq!(sim.with(wd, |w| w.fired), 1);
+}


### PR DESCRIPTION
A generic discrete-event scheduler for MockSwarm with support for Monte Carlo simulations. It allows simulation of heterogeneous components by abstracting over the internal state and logic of the simulated system. It uses a single event queue which
* simplifies the implementation,
* improves performance,
* allows for richer simulation metrics,
* provides robust control of non-determinism and randomness, and
* is more faithful with respect to production behavior than the current implementation.

New crates:
* `monad-sim`: a discrete event simulation engine. *It is completely agnostic about the application domain*. The design supports simulation of concurrent behavior through the notion of "Processes" that act on isolated state. Each discrete simulation step has access to the state of exactly one process. Additionally, a step is provided with a restricted view of the simulation context that gives access to the global clock and grants the capability to schedule simulation steps.
* `monad-sim-swarm`: provides generic components and features that are useful across different application domains. For now, this includes timers, a generic network component, and tools for declaratively assembling processes that are connected via a network into a "swarm".

*This PR introduces only the generic engine and some generic tools.* The code does not depend on any other crate in monad-bft. *The integration with the existing mock-swarm is provided in a separate PR.*