### PR TITLE
Port monad-mock-swarm to use monad-sim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5696,6 +5696,8 @@ dependencies = [
  "monad-raptorcast",
  "monad-router-scheduler",
  "monad-secp",
+ "monad-sim",
+ "monad-sim-swarm",
  "monad-state",
  "monad-testutil",
  "monad-tfm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5752,6 +5752,8 @@ dependencies = [
  "monad-raptorcast",
  "monad-router-scheduler",
  "monad-secp",
+ "monad-sim",
+ "monad-sim-swarm",
  "monad-state",
  "monad-testutil",
  "monad-tfm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ monad-rpc-docs = { path = "./monad-rpc/monad-rpc-docs" }
 monad-rpc-docs-derive = { path = "./monad-rpc/monad-rpc-docs/monad-rpc-docs-derive" }
 monad-secp = { path = "./monad-secp" }
 monad-sim = { path = "./monad-sim" }
+monad-sim-swarm = { path = "./monad-sim-swarm" }
 monad-state = { path = "./monad-state" }
 monad-statesync-executor = { path = "./monad-statesync-executor" }
 monad-system-calls = { path = "./monad-system-calls" }

--- a/monad-mock-swarm/Cargo.toml
+++ b/monad-mock-swarm/Cargo.toml
@@ -24,6 +24,8 @@ monad-executor-glue = { workspace = true }
 monad-multi-sig = { workspace = true }
 monad-raptorcast = { workspace = true, optional = true }
 monad-router-scheduler = { workspace = true }
+monad-sim = { workspace = true }
+monad-sim-swarm = { workspace = true }
 monad-state = { workspace = true }
 monad-testutil = { workspace = true }
 monad-tfm = { workspace = true }
@@ -64,4 +66,8 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [[bench]]
 name = "two_node_benchmark"
+harness = false
+
+[[bench]]
+name = "sim_engine"
 harness = false

--- a/monad-mock-swarm/README.md
+++ b/monad-mock-swarm/README.md
@@ -1,0 +1,39 @@
+# monad-mock-swarm
+
+Deterministic, single-threaded simulation of Monad consensus, for testing.
+
+The simulation drives the **real** production consensus code — `MonadState::update`
+plus the `Executor` / `Command` / `MonadEvent` contract — so tests exercise the
+same logic that runs in production. Only the surrounding environment (clock,
+network, ledger/mempool/state-sync) is mocked.
+
+The harness (`sim`, `sim_verify`) is the Monad-specific top layer of a generic
+simulation stack: the [`monad-sim`](../monad-sim) discrete-event engine and the
+[`monad-sim-swarm`](../monad-sim-swarm) network/swarm layer. See
+[`docs/simulation_framework.md`](docs/simulation_framework.md) for how a Monad
+node runs on that stack, what the simulation does and does not model, and the
+test surface.
+
+The legacy engine (`mock`, `mock_swarm`, `node`, `verifier`, `swarm`,
+`transformer`, `terminator`) and its tests are deprecated and slated for
+removal.
+
+## Layout
+
+| Path | Role |
+|---|---|
+| `src/sim.rs` | Monad adapters: node / network / harness (`SimNode`, `SimNet`, `Network`, `SimSwarm`) |
+| `src/sim_verify.rs` | assertions (`SimVerifier`) |
+| `tests/sim_*.rs` | the test suite |
+| `tests/sim_common`, `tests/eth_swarm_common` | shared test helpers |
+| `benches/sim_engine.rs` | engine throughput (vs the legacy engine, while it remains) |
+
+## Running
+
+```sh
+cargo test  -p monad-sim -p monad-sim-swarm -p monad-mock-swarm  # full suite
+cargo test  -p monad-mock-swarm --test sim_two_nodes             # one scenario
+cargo bench -p monad-mock-swarm --bench sim_engine               # engine throughput
+```
+
+Heavy statistical tests are `#[ignore]`d; run them with `--ignored`.

--- a/monad-mock-swarm/benches/sim_engine.rs
+++ b/monad-mock-swarm/benches/sim_engine.rs
@@ -1,0 +1,159 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Wall-clock comparison of the legacy `Nodes` engine and the `monad-sim`
+//! harness driving the same `NoSerSwarm` consensus to the same committed-block
+//! target. Build time is excluded (measured per iteration via `iter_batched`).
+
+use std::{collections::BTreeSet, time::Duration};
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use monad_chain_config::{revision::ChainParams, MockChainConfig};
+use monad_consensus_types::{block::PassthruBlockPolicy, block_validator::MockValidator};
+use monad_crypto::certificate_signature::CertificateKeyPair;
+use monad_execution_state_read::InMemoryStateInner;
+use monad_mock_swarm::{
+    mock::TimestamperConfig,
+    mock_swarm::{Nodes, SwarmBuilder},
+    node::NodeBuilder,
+    sim::{build_swarm_with, Network, SimSwarm},
+    swarm::make_state_configs,
+    swarm_relation::NoSerSwarm,
+    terminator::UntilTerminator,
+};
+use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+use monad_sim::Time;
+use monad_transformer::{GenericTransformer, LatencyTransformer, ID};
+use monad_types::{NodeId, SeqNum};
+use monad_updaters::{
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
+};
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
+
+static CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(5),
+};
+
+const LATENCY: Duration = Duration::from_millis(1);
+const DELTA: Duration = Duration::from_millis(100);
+const TARGET: usize = 100;
+const NODE_COUNTS: [u16; 4] = [4, 16, 40, 64];
+
+fn build_existing(num_nodes: u16) -> Nodes<NoSerSwarm> {
+    let state_configs = make_state_configs::<NoSerSwarm>(
+        num_nodes,
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        || MockValidator,
+        || PassthruBlockPolicy,
+        || InMemoryStateInner::genesis(SeqNum(4)),
+        SeqNum(4),
+        DELTA,
+        MockChainConfig::new(&CHAIN_PARAMS),
+        SeqNum(100),
+    );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|c| NodeId::new(c.key.pubkey()))
+        .collect();
+    SwarmBuilder::<NoSerSwarm>(
+        state_configs
+            .into_iter()
+            .enumerate()
+            .map(|(seed, sb)| {
+                let state_read = sb.state_read.clone();
+                let validators = sb.locked_epoch_validators[0].clone();
+                NodeBuilder::<NoSerSwarm>::new(
+                    ID::new(NodeId::new(sb.key.pubkey())),
+                    sb,
+                    NoSerRouterConfig::new(all_peers.clone()).build(),
+                    MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
+                    MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
+                    MockLedger::new(state_read.clone()),
+                    MockStateSyncExecutor::new(state_read),
+                    vec![GenericTransformer::Latency(LatencyTransformer::new(
+                        LATENCY,
+                    ))],
+                    vec![],
+                    TimestamperConfig::default(),
+                    seed.try_into().unwrap(),
+                )
+            })
+            .collect(),
+    )
+    .build()
+}
+
+fn run_existing(swarm: &mut Nodes<NoSerSwarm>) {
+    while swarm
+        .step_until(&mut UntilTerminator::new().until_block(TARGET))
+        .is_some()
+    {}
+}
+
+/// The legacy *parallel* path (rayon `batch_step_until`) — the one the new
+/// serial heap replaces. Benchmarked so the "dropping parallelism" trade is
+/// measured, not assumed.
+fn run_existing_batch(swarm: &mut Nodes<NoSerSwarm>) {
+    swarm.batch_step_until(&mut UntilTerminator::new().until_block(TARGET));
+}
+
+fn build_sim(num_nodes: u16) -> SimSwarm<NoSerSwarm> {
+    build_swarm_with(num_nodes, 0, |_| Network::reliable(LATENCY))
+}
+
+fn run_sim(swarm: &mut SimSwarm<NoSerSwarm>) {
+    swarm.run_until_blocks(TARGET, Time(i128::MAX));
+}
+
+fn benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("commit_blocks");
+    for n in NODE_COUNTS {
+        group.bench_function(format!("existing/{n}"), |b| {
+            b.iter_batched(
+                || build_existing(n),
+                |mut swarm| run_existing(&mut swarm),
+                BatchSize::SmallInput,
+            )
+        });
+        group.bench_function(format!("sim/{n}"), |b| {
+            b.iter_batched(
+                || build_sim(n),
+                |mut swarm| run_sim(&mut swarm),
+                BatchSize::SmallInput,
+            )
+        });
+        group.bench_function(format!("existing_batch/{n}"), |b| {
+            b.iter_batched(
+                || build_existing(n),
+                |mut swarm| run_existing_batch(&mut swarm),
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(20);
+    targets = benchmark
+}
+criterion_main!(benches);

--- a/monad-mock-swarm/docs/simulation_framework.md
+++ b/monad-mock-swarm/docs/simulation_framework.md
@@ -1,0 +1,347 @@
+# The Monad BFT simulation harness
+
+Deterministic, single-threaded simulation of Monad BFT consensus. The
+simulation drives the **real** production consensus code — `MonadState::update`
+plus the `Executor` / `Command` / `MonadEvent` contract — so tests exercise the
+same logic that runs in production; only the environment (clock, network,
+ledger / mempool / state-sync) is mocked.
+
+The harness is the Monad-specific top layer of a generic simulation stack. The
+generic layers are separate crates with their own documentation:
+
+- [`monad-sim/docs/design.md`](../../monad-sim/docs/design.md) — the
+  discrete-event engine: the step/process model, determinism, the concurrency
+  metric, and the engine rationale.
+- [`monad-sim-swarm/docs/design.md`](../../monad-sim-swarm/docs/design.md) —
+  the protocol-agnostic network + swarm layer.
+
+This document covers the integration: how a Monad node runs on that stack,
+what the simulation guarantees, what it does and does not model, and the
+harness/test surface. The trade-off analysis behind the integration choices is
+collected in [Design notes & rationale](#design-notes--rationale).
+
+## Architecture
+
+```
++---------------------------------------------------------------------+
+| GENERIC engine                                       (monad-sim)     |
+|   Time, scheduler + queue, process handles + lent-state steps        |
+|   (Handle<S> / Ctx), run control, RNG/distributions, metrics.        |
+|   ZERO knowledge of Monad / consensus / MonadEvent / Command.        |
++---------------------------------------------------------------------+
+        ^  Handle<S> / Ctx scheduler API
++---------------------------------------------------------------------+
+| GENERIC network + swarm layer                  (monad-sim-swarm)     |
+|   Net<Addr, Msg> network process + declarative Network model;        |
+|   type-erased delivery (Deliver / deliver_to); SimClient seam;       |
+|   re-arming Timers. Parameterized only by Addr / Msg.                |
++---------------------------------------------------------------------+
+        ^  Net / SimClient / deliver_to
++---------------------------------------------------------------------+
+| MONAD-SPECIFIC sim adapters & mocks        (monad-mock-swarm::sim)   |
+|   SimNode = framework-owned node state; in-process Command dispatch; |
+|   mock/prod executors driven via exec()+drain; SimNet = the generic  |
+|   Net at (NodeId, TransportMessage); SimSwarm / SimVerifier.         |
++---------------------------------------------------------------------+
+        ^  the production contract:  Executor + Command + MonadEvent
++---------------------------------------------------------------------+
+| SHARED production logic                              (unchanged)     |
+|   MonadState::update, Command/MonadEvent, split_commands,            |
+|   consensus / blocksync / mempool / statesync logic.                 |
++---------------------------------------------------------------------+
+```
+
+In the engine, a simulation is a time-ordered queue of *steps* over
+framework-owned *processes*: any `S: 'static` spawned into the `Simulation`,
+addressed by a typed `Handle<S>`. A step scheduled against a handle is lent
+`&mut S` exclusively while it runs, plus a `Ctx` that can read time, sample
+randomness, and schedule further steps — but cannot reach any other process's
+state, so cross-process interaction is always "schedule a step on that
+handle". `monad-sim-swarm` adds the network as just another process, routing
+to nodes through type-erased delivery thunks. Concrete Monad types
+(`MonadEvent`, `Command`) appear only inside this crate's closures, never in
+a generic-layer signature.
+
+### A Monad node on the scheduler (`sim.rs`)
+
+Each node is a `SimNode<S>` process (`S: SwarmRelation`). A scheduled step
+feeds one event to `state.update`, then dispatches the resulting commands
+in-process:
+
+- **Router / network** → outbound messages go to `SimNet<S>` — the generic
+  `monad_sim_swarm::Net` instantiated at this relation's `NodeId` and
+  `TransportMessage` — which applies the network model and schedules delivery
+  steps on the recipients. `SimNode` plugs into the network via the
+  `monad_sim_swarm::SimClient` seam, and the crate's `Network<S>` is a thin
+  `SwarmRelation`-flavored facade over the generic declarative builder:
+
+  ```rust
+  Network::reliable(delta)                       // constant latency, lossless
+  Network::with_latency(distribution)            // per-message sampled latency
+      .loss(p)                                    // independent drop probability
+      .partition(window, [group_a, group_b])      // time-bounded network split
+      .drop_if(|link, msg| ...)                   // predicate drop (sees link.now)
+  Network::custom(model)                          // a full NetworkModel impl
+  ```
+
+  An empty set of delivery delays drops a message, more than one duplicates
+  it, and reordering needs no special handling (a smaller delay simply
+  arrives first).
+- **Timers** → `TimerCommand::Schedule` arms a `CancelToken`;
+  `ScheduleReset` cancels it.
+- **Ledger / TxPool / ValSet / StateSync / Loopback** → the existing
+  executors (production `LoopbackExecutor`, or the mocks shared with
+  `monad-testground` / `monad-eth-ledger`) are reused unmodified: call
+  `exec()`, then drain their buffered events (`pop` / `next`) and re-inject
+  each as a zero-delay step. Their `ready()` / `Stream` / `pop` surface is
+  used purely as a drain, never polled.
+
+Routing internal reactions through the scheduler as zero-delay steps (rather
+than draining them synchronously) is what lets a same-tick network delivery
+interleave between a node's internal reactions, and is the hook a future
+compute-cost model would use (see [Future work](#future-work) and
+[Event ordering & interleaving](#event-ordering--interleaving)).
+
+### The production contract
+
+`state.update(event) -> Vec<Command>`, `Command::split_commands`, and the
+`Executor` trait are used exactly as production defines them; this is what
+guarantees the simulation exercises production logic. The simulation imposes
+no changes on production code — the one trait-level accommodation is
+`SwarmRelation::TransportMessage: Clone` (needed for message duplication) —
+and genuine production executors (e.g. `LoopbackExecutor`, the same struct
+`monad-node` runs) run unmodified inside the simulation.
+
+### The harness
+
+`SimSwarm<S>` wraps a `Simulation` and its node handles, exposing what tests
+need:
+
+- construction — `SimSwarm::from_builders(seed, builders, network)` (generic
+  over any `SwarmRelation`); `build_swarm` / `build_swarm_with` are
+  `NoSerSwarm` conveniences.
+- bounded run control — `run_until`, `run_until_blocks` (all nodes),
+  `run_until_any_blocks` (some node), `run_until_round`.
+- inspection / mutation between steps — `with_node`, `with_node_mut`,
+  `finalized_blocks`, `current_rounds`, `send_transaction`,
+  `assert_agreement`.
+- node lifecycle — `remove_node` / `add_node` (restart-from-forkpoint
+  scenarios), `set_network` (mid-run reconfiguration).
+
+`SimVerifier` (`sim_verify.rs`) accumulates tick / ledger-length /
+per-node-metric expectations and checks them through `SimSwarm`'s public
+surface; metric selectors are written with the `sim_metric!` macro.
+
+## Determinism & event ordering
+
+The engine orders steps by the total key `(time, tie_break, priority, seq)`
+(see the [engine design doc](../../monad-sim/docs/design.md)). The
+integration maps it to production behaviour:
+
+- **`priority`** classes mirror production's `ParentExecutor::poll_next`
+  order, so a node drains ready internal work before it services a same-tick
+  network message — production's anti-starvation direction.
+- The default `TieBreak::Fifo` is fully reproducible, which is why the test
+  suite can assert *exact* ticks with no tolerance window.
+  `TieBreak::Randomized` (a seeded same-tick permutation, for
+  order-dependence fuzzing) is implemented in the engine but not yet wired
+  through the `SimSwarm` harness — see [Future work](#future-work).
+
+Randomized scenario exploration is Monte-Carlo over the simulation seed:
+seeded latency jitter in the network model shifts events onto different
+ticks. The fidelity trade-offs are analysed in
+[Event ordering & interleaving](#event-ordering--interleaving).
+
+## What the simulation does (and does not) model
+
+Stated exactly so results are not over-read:
+
+- **Network behaviour is modeled**: latency (constant or sampled), loss,
+  partitions, duplication, and reordering, per the `Network` model.
+- **No simulated-time latency for local processing.** Component executors
+  emit at the current tick; only timers, the timestamper period, and network
+  latency carry simulated-time delays.
+- **No backpressure.** Every component buffer is unbounded; `ready()` is
+  never false due to a full queue.
+- **Deferred execution/finalization *is* modeled, but as a fixed block
+  count, not a duration** (`execution_delay` / `state_root_delay` /
+  `finalization_delay` are `SeqNum`s). A configured, deterministic,
+  structural execution lag is in scope (and its consequences, e.g. the
+  statesync threshold), but emergent, *compute-induced* slowness (CPU/DB/GC)
+  is not.
+
+So the simulation produces "a node falls behind / triggers blocksync / times
+out" from network-induced lag or a configured block-count offset, never from
+compute. Growing into a compute-cost model is adapter-only: internal
+reactions already flow through the scheduler, so a per-operation cost hook
+would schedule them at `now + cost`; bounded queues plus a feedback path
+would add backpressure, which then *emerges* from per-node cost plus the
+network model. No engine rewrite would be needed.
+
+## Concurrency of a simulated swarm
+
+The engine's deterministic concurrency metric (critical path `D`, total
+steps `W`, `parallelism() = W / D` — see the
+[engine design doc](../../monad-sim/docs/design.md)), measured on the
+happy-path `NoSerSwarm` (reliable 1 ms network, 100 committed blocks):
+
+| nodes | steps `W` | critical path `D` | parallelism `W/D` |
+|------:|----------:|------------------:|:-----------------:|
+| 2     | 2,836     | 1,470             | 1.93              |
+| 4     | 5,608     | 2,196             | 2.55              |
+| 16    | 22,710    | 7,951             | 2.86              |
+| 64    | 99,750    | 34,463            | 2.89              |
+
+Available parallelism rises then **plateaus around ~2.9× by 16 nodes** and
+does not grow with network size: both `W` and `D` scale ≈ linearly in N
+(each round the leader handles O(N) votes as a serial chain — the fan-in
+spine — so per-round depth ≈ O(N)). This is why *analyzing* a simulated
+system's concurrency is currently more valuable than parallelizing a single
+run; see
+[Concurrency, and why not to parallelize yet](#concurrency-and-why-not-to-parallelize-yet).
+
+## Test suite
+
+The suite lives in `tests/sim_*.rs`, with shared helpers in
+`tests/sim_common` (the `NoSerConfig` builder and reusable custom network
+models) and `tests/eth_swarm_common` (the Eth relation and its `SimSwarm`
+builders). Coverage: two-node and multi-node consensus + agreement; BLS
+signature collection; message delays and random latency; many-node (40)
+swarms; metrics; Eth execution with real transactions; nonces / NEC; reserve
+balance; epoch validator switching and boundary handling; blocksync
+(blackout / delay / timeout recovery); message-reordering recovery;
+forkpoint restart/recovery.
+
+Scenarios are expressed *declaratively*: a blackout is a time-bounded
+`Network::partition`, message filtering a `drop_if`, and
+restart-from-forkpoint uses the `remove_node` / `add_node` lifecycle API.
+
+`tests/sim_epoch_missing_valset.rs` is a regression gate (`#[should_panic]`)
+for an open production `todo!()` reachable at an epoch boundary under
+outage; it turns red when the production case is handled.
+
+## Legacy engine
+
+The crate still contains the previous simulation engine (`mock`,
+`mock_swarm`, `node`, `verifier`, `swarm`, `transformer`, `terminator`) and
+its tests; it is deprecated and slated for removal. While it remains,
+`benches/sim_engine.rs` compares engine throughput (criterion, 100 committed
+blocks, build excluded, both engines routing internal events through their
+scheduler):
+
+| nodes | legacy serial | new serial | new vs legacy |
+|------:|--------------:|-----------:|:-------------:|
+| 4     | 17.0 ms       | 14.1 ms    | 1.21×         |
+| 16    | 112.8 ms      | 81.2 ms    | 1.39×         |
+| 40    | 488.9 ms      | 326.8 ms   | 1.50×         |
+| 64    | 1122.7 ms     | 723.0 ms   | 1.55×         |
+
+Most of the margin comes from the engine's `O(log E)` heap replacing the
+legacy engine's nested `peek` scans; see
+[Performance attribution](#performance-attribution). Before the legacy
+engine is deleted, the per-event `MonadEvent` RLP/serde round-trips embedded
+in its `two_nodes_bls` / `nonces` tests (engine-independent serialization
+coverage) need extracting into standalone serialization tests.
+
+## Future work
+
+Engine-side items — per-process local clocks, the offline concurrency
+analyzer, parallel execution of a single run — are tracked in the
+[engine design doc](../../monad-sim/docs/design.md) ("Future work").
+Integration-side:
+
+- **Wire `TieBreak::Randomized` through the `SimSwarm` harness**, then add a
+  Monte-Carlo-over-seed test asserting agreement + liveness on a low-latency
+  cluster (and ideally that both orders of a same-instant
+  internal-vs-external race are reached). This turns the same-tick
+  permutation capability into actual bug-finding leverage.
+- **Compute-cost / backpressure model** (see
+  [fidelity](#what-the-simulation-does-and-does-not-model)); both are
+  adapter-level additions with existing injection points.
+- **Timestamp drift.** A drifted-clock scenario needs the engine's
+  per-process local clocks; blocked on that.
+- **Mock relocation (optional, separable).** Moving the sim-only mocks out
+  of the production crates (`monad-updaters`, `monad-router-scheduler`) into
+  a test-support crate. More entangled than it looks — `monad-testground`
+  and `monad-eth-ledger` consume the mocks / the `Mockable*` contract.
+- **Port other swarm/sim consumers.** `monad-debugger`, `monad-twins`,
+  `monad-peer-disc-swarm`, and `monad-randomized-tests` are separate one-off
+  drivers today; each could model its components as processes over
+  `monad-sim`. The `monad-debugger` port must preserve its GraphQL schema
+  for the external UI.
+
+---
+
+## Design notes & rationale
+
+Detail behind the integration choices. Not needed to use the harness; kept
+for whoever revisits the design. Generic-engine rationale (the lent-state
+model, the single-threaded concurrency stance) lives in the
+[engine design doc](../../monad-sim/docs/design.md).
+
+### Event ordering & interleaving
+
+Same-instant event ordering in the simulation does not exactly reproduce
+production's; two axes matter, and they should not be conflated.
+
+**1. Priority direction (internal vs. network).** Production
+(`ParentExecutor::poll_next`) polls the network *nearly last* — draining
+timers / ledger / txpool first — a deliberate anti-starvation design. Under
+`Fifo` the harness's `priority` classes finish a node's ready internal work
+before the engine services the same-tick network `rx`, matching production's
+intent, enforced by the scheduler key rather than by an atomic drain.
+
+**2. Granularity (can a network event interleave *between* two internal
+reactions).** Yes — internal reactions are individual zero-delay steps, so a
+same-tick delivery can weave between them, as it can in production.
+
+The two axes do not conflict because `tie_break` precedes `priority` in the
+engine's ordering key: `Fifo` honours the production poll-order while
+`Randomized` fully shuffles across classes — a direct same-tick permutation,
+strictly more than timing-jitter fuzzing alone. This only ever concerns
+events at the *exact same tick*; with nonzero link latency a node's cascade
+and a delivery are strictly time-ordered, so the question is narrow — and
+consensus is designed to be robust to event order regardless. Deliberately
+*not* done: priority-respecting fuzzing (shuffle only within a class) — a
+clean future toggle in the engine, currently unneeded.
+
+### Concurrency, and why not to parallelize yet
+
+The [concurrency measurements](#concurrency-of-a-simulated-swarm) bound what
+parallelizing a single run could buy, and for this protocol the bound is
+both small and non-scaling:
+
+- **`W/D` plateaus at ~2.9× and is flat in N.** Total work and critical path
+  both grow ≈ linearly with node count — `W` because per-node work is
+  roughly constant, `D` because each round the leader handles O(N) votes as
+  a serial chain (the fan-in spine). Their ratio stops rising once the
+  fan-in dominates (~16 nodes here), so more nodes or cores buy no more
+  intra-run speedup.
+- **The achievable gain is a fraction of that ceiling.** Conservative
+  windowing is bounded by the lookahead (min network latency) plus barrier /
+  load-imbalance overhead.
+- **The parallelism that scales is already exploited.** Independent
+  simulations run near-linearly across cores (seed sweeps, forkpoint and
+  randomized tests) — the dominant workload. Intra-run parallelism only
+  helps a single, un-shardable simulation.
+- **It is also the wrong lever for larger networks.** A flat ~3× extends the
+  reachable node count by only ~2-3× (less under O(N²) messaging). Going
+  materially bigger means reducing `W` — cheaper per-event handling,
+  same-tick batching, abstracting all-to-all traffic — not a constant-factor
+  parallel speedup.
+
+So the priority is to *analyze* a simulated system's concurrency (the
+metric, then the offline analyzer) rather than to parallelize the engine;
+the metric is the trigger to revisit. `W/D` here is unit-cost; the
+cost-weighted ceiling may be somewhat higher but, being flat in N, does not
+change the conclusion.
+
+### Performance attribution
+
+Routing a node's internal reactions through the scheduler as zero-delay
+steps (instead of draining them synchronously) costs ~8% at N=4 rising to
+~14% at N=64 — paid deliberately for interleaving fidelity and the
+compute-cost hook. Even including that cost, the engine outperforms the
+legacy engine at every size (see [Legacy engine](#legacy-engine)); the
+`O(log E)` heap is the majority of the win and all of the scaling advantage.
+Batching same-tick steps could recover most of the ~14% later.

--- a/monad-mock-swarm/src/lib.rs
+++ b/monad-mock-swarm/src/lib.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// Legacy engine (per-component event queues). Retired once the simulation
+// framework below has been reviewed.
 pub mod mock;
 pub mod mock_swarm;
 pub mod node;
@@ -24,3 +26,8 @@ pub mod terminator;
 pub mod transformer;
 mod utils;
 pub mod verifier;
+
+// Simulation framework: a Monad-node harness over the generic `monad-sim`
+// discrete-event engine. See `sim` and the crate README / design doc.
+pub mod sim;
+pub mod sim_verify;

--- a/monad-mock-swarm/src/sim.rs
+++ b/monad-mock-swarm/src/sim.rs
@@ -1,0 +1,1014 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Layer B: drive real `MonadState` nodes (Layer C) through the generic
+//! `monad-sim` engine (Layer A).
+//!
+//! Each node is registered as a `monad-sim` process and driven entirely by
+//! scheduled steps: events feed `state.update`, and the resulting commands are
+//! dispatched in-process. Timers become [`CancelToken`]s; the
+//! ledger / txpool / valset / statesync / loopback executors are reused
+//! unmodified via `exec` + drain; outbound messages are routed through the
+//! generic network process ([`monad_sim_swarm::Net`], aliased `SimNet<S>`) whose
+//! behaviour is a declarative [`Network`] model. A [`SimNode`] plugs into that
+//! network via the [`monad_sim_swarm::SimClient`] seam, so any node process
+//! sharing the wire type could share one network.
+//!
+//! [`SimNode`] / [`Network`] are generic over [`SwarmRelation`]; the network,
+//! delivery, and swarm scaffolding are the protocol-agnostic `monad-sim-swarm`.
+//! [`SimSwarm`] is the harness — construction, bounded run control, and
+//! between-step inspection. [`SimSwarm::from_builders`] is the generic entry
+//! point; [`build_swarm`] / [`build_swarm_with`] are `NoSerSwarm` conveniences.
+
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    marker::PhantomData,
+    ops::Range,
+    time::Duration,
+};
+
+use bytes::Bytes;
+use futures::{executor::block_on, StreamExt};
+use monad_consensus_types::metrics::Metrics;
+use monad_crypto::certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey};
+use monad_executor::Executor;
+use monad_executor_glue::{
+    Command, Message, MonadEvent, RouterCommand, TimeoutVariant, TimerCommand,
+};
+use monad_router_scheduler::{RouterEvent, RouterScheduler};
+use monad_sim::{CancelToken, Ctx, Handle, Simulation, StepLabel, Time};
+/// The network model trait / its per-message context, from [`monad_sim_swarm`].
+/// `NetworkModel` is the generic (`Addr`, `Msg`) trait; a custom model for a
+/// Monad swarm implements it at `NetworkModel<NodeId<Pk<S>>, Transport<S>>`. The
+/// declarative builder is [`Network`] (below), a thin `SwarmRelation`-flavored
+/// facade over [`monad_sim_swarm::Network`].
+pub use monad_sim_swarm::NetworkModel;
+use monad_sim_swarm::{deliver_to, Net, SimClient};
+use monad_state::{Forkpoint, MonadStateBuilder, VerifiedMonadMessage};
+use monad_types::{NodeId, Round, GENESIS_ROUND};
+use monad_updaters::{
+    config_file::MockConfigFile, ledger::MockableLedger, loopback::LoopbackExecutor,
+    statesync::MockableStateSync, txpool::MockableTxPool, val_set::MockableValSetUpdater,
+};
+use monad_validator::validator_set::BoxedValidatorSetTypeFactory;
+use rand::distributions::Distribution;
+
+use crate::swarm_relation::{
+    DebugSwarmRelation, NoSerSwarm, SwarmRelation, SwarmRelationStateType,
+};
+pub type Link<S> = monad_sim_swarm::Link<NodeId<Pk<S>>>;
+
+type Pk<S> = CertificateSignaturePubKey<<S as SwarmRelation>::SignatureType>;
+type Ev<S> = MonadEvent<
+    <S as SwarmRelation>::SignatureType,
+    <S as SwarmRelation>::SignatureCollectionType,
+    <S as SwarmRelation>::ExecutionProtocolType,
+>;
+type Cmd<S> = Command<
+    Ev<S>,
+    VerifiedMonadMessage<
+        <S as SwarmRelation>::SignatureType,
+        <S as SwarmRelation>::SignatureCollectionType,
+        <S as SwarmRelation>::ExecutionProtocolType,
+    >,
+    <S as SwarmRelation>::SignatureType,
+    <S as SwarmRelation>::SignatureCollectionType,
+    <S as SwarmRelation>::ExecutionProtocolType,
+    <S as SwarmRelation>::BlockPolicyType,
+    <S as SwarmRelation>::ExecutionStateReadType,
+    <S as SwarmRelation>::ChainConfigType,
+    <S as SwarmRelation>::ChainRevisionType,
+>;
+type StateBuilder<S> = MonadStateBuilder<
+    <S as SwarmRelation>::SignatureType,
+    <S as SwarmRelation>::SignatureCollectionType,
+    <S as SwarmRelation>::ExecutionProtocolType,
+    <S as SwarmRelation>::BlockPolicyType,
+    <S as SwarmRelation>::ExecutionStateReadType,
+    <S as SwarmRelation>::ValidatorSetTypeFactory,
+    <S as SwarmRelation>::LeaderElection,
+    <S as SwarmRelation>::BlockValidator,
+    <S as SwarmRelation>::ChainConfigType,
+    <S as SwarmRelation>::ChainRevisionType,
+>;
+type Transport<S> = <S as SwarmRelation>::TransportMessage;
+
+type NodeEntry<S> = (NodeId<Pk<S>>, Handle<SimNode<S>>);
+
+/// The network process for a Monad swarm: the generic [`Net`] instantiated at
+/// this relation's node id and transport message.
+type SimNet<S> = Net<NodeId<Pk<S>>, Transport<S>>;
+
+fn dur(t: Time) -> Duration {
+    Duration::from_nanos(u64::try_from(t.0).expect("negative simulation time"))
+}
+
+/// Default wall-clock estimate period for a node.
+pub const DEFAULT_TIMESTAMP_PERIOD: Duration = Duration::from_millis(10);
+
+/// Same-time priority classes for a node's scheduled steps, mirroring
+/// production's `ParentExecutor::poll_next` order (lower runs first at a tick).
+/// Under `TieBreak::Fifo` this makes a node drain ready internal work before it
+/// services a same-tick network message (`RX`) — production's anti-starvation
+/// ordering, and the opposite of the legacy sim's network-first tie-break. Under
+/// `TieBreak::Randomized` these are ignored and same-tick steps are fully
+/// shuffled (see `monad_sim::TieBreak`). `ControlPanel` (1) and `ConfigLoader`
+/// (9) have no simulation analogue.
+///
+/// The values keep the *relative* order of `poll_next`; the absolute numbers
+/// (and the gaps) don't matter beyond that. NOTE: production's order is itself
+/// provisional — `poll_next` carries TODOs to deprioritize txpool ingestion and
+/// to prioritize consensus (router) messages. If those land, update these
+/// classes to match. Verified against `monad-updaters/src/parent.rs`.
+mod prio {
+    pub const TIMER: u32 = 0;
+    pub const LEDGER: u32 = 2;
+    pub const TXPOOL: u32 = 3;
+    pub const VAL_SET: u32 = 4;
+    pub const TIMESTAMP: u32 = 5;
+    pub const LOOPBACK: u32 = 6;
+    /// Network inbound (`Router`): serviced after ready internal work.
+    pub const RX: u32 = 7;
+    pub const STATESYNC: u32 = 8;
+}
+
+/// Configuration for one node in a [`SimSwarm`].
+///
+/// The new framework's node descriptor: it carries only what the simulation
+/// drives, keyed by [`NodeId`] directly, with no transformer pipelines (the
+/// network model lives in [`Network`] instead). Construct it with a struct
+/// literal; [`SimNodeBuilder::debug`] type-erases it into [`DebugSwarmRelation`].
+pub struct SimNodeBuilder<S: SwarmRelation> {
+    pub id: NodeId<Pk<S>>,
+    pub state_builder: StateBuilder<S>,
+    pub router_scheduler: S::RouterScheduler,
+    pub val_set_updater: S::ValSetUpdater,
+    pub txpool_executor: S::TxPoolExecutor,
+    pub ledger: S::Ledger,
+    pub statesync_executor: S::StateSyncExecutor,
+    pub timestamp_period: Duration,
+}
+
+impl<S: SwarmRelation> SimNodeBuilder<S> {
+    /// Box this builder into the debugger's type-erased [`DebugSwarmRelation`],
+    /// proving the simulation is generic over the swarm relation.
+    pub fn debug(self) -> SimNodeBuilder<DebugSwarmRelation>
+    where
+        S: SwarmRelation<
+            SignatureType = <DebugSwarmRelation as SwarmRelation>::SignatureType,
+            SignatureCollectionType = <DebugSwarmRelation as SwarmRelation>::SignatureCollectionType,
+            ExecutionProtocolType = <DebugSwarmRelation as SwarmRelation>::ExecutionProtocolType,
+            TransportMessage = <DebugSwarmRelation as SwarmRelation>::TransportMessage,
+            BlockPolicyType = <DebugSwarmRelation as SwarmRelation>::BlockPolicyType,
+            BlockValidator = <DebugSwarmRelation as SwarmRelation>::BlockValidator,
+            ExecutionStateReadType = <DebugSwarmRelation as SwarmRelation>::ExecutionStateReadType,
+            ChainConfigType = <DebugSwarmRelation as SwarmRelation>::ChainConfigType,
+            ChainRevisionType = <DebugSwarmRelation as SwarmRelation>::ChainRevisionType,
+        >,
+        S::RouterScheduler: Sync,
+        S::Ledger: Sync,
+    {
+        SimNodeBuilder {
+            id: self.id,
+            state_builder: MonadStateBuilder {
+                validator_set_factory: BoxedValidatorSetTypeFactory::new(
+                    self.state_builder.validator_set_factory,
+                ),
+                leader_election: Box::new(self.state_builder.leader_election),
+                block_validator: self.state_builder.block_validator,
+                block_policy: self.state_builder.block_policy,
+                state_read: self.state_builder.state_read,
+                key: self.state_builder.key,
+                certkey: self.state_builder.certkey,
+                beneficiary: self.state_builder.beneficiary,
+                forkpoint: self.state_builder.forkpoint,
+                locked_epoch_validators: self.state_builder.locked_epoch_validators,
+                block_sync_override_peers: self.state_builder.block_sync_override_peers,
+                maybe_blocksync_rng_seed: self.state_builder.maybe_blocksync_rng_seed,
+                consensus_config: self.state_builder.consensus_config,
+                whitelisted_statesync_nodes: self.state_builder.whitelisted_statesync_nodes,
+                statesync_expand_to_group: self.state_builder.statesync_expand_to_group,
+                _phantom: PhantomData,
+            },
+            router_scheduler: Box::new(self.router_scheduler),
+            val_set_updater: Box::new(self.val_set_updater),
+            txpool_executor: Box::new(self.txpool_executor),
+            ledger: Box::new(self.ledger),
+            statesync_executor: Box::new(self.statesync_executor),
+            timestamp_period: self.timestamp_period,
+        }
+    }
+}
+
+/// A single consensus node as a `monad-sim` process.
+pub struct SimNode<S: SwarmRelation> {
+    id: NodeId<Pk<S>>,
+    state: SwarmRelationStateType<S>,
+
+    router: S::RouterScheduler,
+    ledger: S::Ledger,
+    txpool: S::TxPoolExecutor,
+    val_set: S::ValSetUpdater,
+    statesync: S::StateSyncExecutor,
+    loopback: LoopbackExecutor<Ev<S>>,
+    config_file:
+        MockConfigFile<S::SignatureType, S::SignatureCollectionType, S::ExecutionProtocolType>,
+
+    /// One armed timer per variant; re-arming or resetting cancels the previous.
+    timers: HashMap<TimeoutVariant, CancelToken>,
+
+    // Wiring, set after the node and network are spawned.
+    me: Option<Handle<SimNode<S>>>,
+    net: Option<Handle<SimNet<S>>>,
+
+    timestamp_period: Duration,
+}
+
+impl<S: SwarmRelation> SimNode<S> {
+    fn me(&self) -> Handle<SimNode<S>> {
+        self.me.expect("node not wired")
+    }
+
+    fn net(&self) -> Handle<SimNet<S>> {
+        self.net.expect("node not wired")
+    }
+
+    /// Feed one event to the state machine and dispatch the resulting commands.
+    fn handle_event(&mut self, event: Ev<S>, ctx: &mut Ctx) {
+        let commands = self.state.update(event);
+        self.dispatch(commands, ctx);
+    }
+
+    fn dispatch(&mut self, commands: Vec<Cmd<S>>, ctx: &mut Ctx) {
+        let (
+            router_cmds,
+            timer_cmds,
+            ledger_cmds,
+            config_file_cmds,
+            val_set_cmds,
+            _timestamp_cmds,
+            txpool_cmds,
+            _control_panel_cmds,
+            loopback_cmds,
+            statesync_cmds,
+            _config_reload_cmds,
+        ) = <Cmd<S>>::split_commands(commands);
+
+        for command in timer_cmds {
+            match command {
+                TimerCommand::Schedule {
+                    duration,
+                    variant,
+                    on_timeout,
+                } => {
+                    if let Some(previous) = self.timers.remove(&variant) {
+                        previous.cancel();
+                    }
+                    let me = self.me();
+                    let token = ctx.schedule_after(
+                        me,
+                        duration,
+                        StepLabel::source("timer").priority(prio::TIMER),
+                        move |node, ctx| {
+                            node.timers.remove(&variant);
+                            node.handle_event(on_timeout, ctx);
+                        },
+                    );
+                    self.timers.insert(variant, token);
+                }
+                TimerCommand::ScheduleReset(variant) => {
+                    if let Some(previous) = self.timers.remove(&variant) {
+                        previous.cancel();
+                    }
+                }
+            }
+        }
+
+        self.ledger.exec(ledger_cmds);
+        self.txpool.exec(txpool_cmds);
+        self.val_set.exec(val_set_cmds);
+        self.loopback.exec(loopback_cmds);
+        self.statesync.exec(statesync_cmds);
+        self.config_file.exec(config_file_cmds);
+
+        let now = dur(ctx.now());
+        for command in router_cmds {
+            match command {
+                RouterCommand::Publish { target, message }
+                | RouterCommand::PublishWithPriority {
+                    target, message, ..
+                } => {
+                    self.router.send_outbound(now, target, message);
+                }
+                RouterCommand::AddEpochValidatorSet {
+                    epoch,
+                    epoch_start,
+                    validator_set,
+                } => {
+                    self.router
+                        .add_epoch_validator_set(epoch, epoch_start, validator_set);
+                }
+                RouterCommand::UpdateCurrentRound(epoch, round) => {
+                    self.router.update_current_round(epoch, round);
+                }
+                _ => {}
+            }
+        }
+
+        self.drain_router(ctx);
+        self.drain_executors(ctx);
+    }
+
+    /// Schedule an internal reaction as a zero-delay step on this node, so it
+    /// flows through the engine queue rather than being handled synchronously.
+    /// The step is tagged with its source's priority class (see [`prio`]), so
+    /// internal reactions interleave per the scheduler's ordering (see the
+    /// design doc, "Event ordering & interleaving").
+    fn schedule_event(&self, ctx: &mut Ctx, source: &'static str, event: Ev<S>) {
+        let priority = match source {
+            "ledger" => prio::LEDGER,
+            "txpool" => prio::TXPOOL,
+            "val_set" => prio::VAL_SET,
+            "loopback" => prio::LOOPBACK,
+            "rx" => prio::RX,
+            "statesync" => prio::STATESYNC,
+            other => unreachable!("unclassified internal step source: {other}"),
+        };
+        let me = self.me();
+        let label = StepLabel::source(source).priority(priority);
+        ctx.schedule(me, ctx.now(), label, move |node, ctx| {
+            node.handle_event(event, ctx)
+        });
+    }
+
+    /// Drain router events: hand outbound messages to the network process, and
+    /// schedule inbound messages for the state machine (zero-delay step).
+    fn drain_router(&mut self, ctx: &mut Ctx) {
+        let now = ctx.now();
+        while let Some(event) = self.router.step_until(dur(now)) {
+            match event {
+                RouterEvent::Tx(to, transport) => {
+                    let from = self.id;
+                    let net = self.net();
+                    ctx.schedule(net, now, StepLabel::source("route"), move |net, ctx| {
+                        net.send(ctx, from, to, transport)
+                    });
+                }
+                RouterEvent::Rx(from, message) => {
+                    self.schedule_event(ctx, "rx", message.event(from));
+                }
+            }
+        }
+    }
+
+    /// Drain the executors that emit events when ready, scheduling each as a
+    /// zero-delay step. Unlike a synchronous drain, a node's internal reaction
+    /// cascade unfolds across same-tick engine steps and can interleave with
+    /// other same-tick steps — finer-grained, and observable in the step log.
+    fn drain_executors(&mut self, ctx: &mut Ctx) {
+        while self.ledger.ready() {
+            if let Some(event) = block_on(self.ledger.next()) {
+                self.schedule_event(ctx, "ledger", event);
+            }
+        }
+        while self.txpool.ready() {
+            if let Some(event) = block_on(self.txpool.next()) {
+                self.schedule_event(ctx, "txpool", event);
+            }
+        }
+        while self.val_set.ready() {
+            if let Some(event) = block_on(self.val_set.next()) {
+                self.schedule_event(ctx, "val_set", event);
+            }
+        }
+        while self.loopback.ready() {
+            if let Some(event) = block_on(self.loopback.next()) {
+                self.schedule_event(ctx, "loopback", event);
+            }
+        }
+        while let Some(event) = self.statesync.pop() {
+            self.schedule_event(ctx, "statesync", event);
+        }
+    }
+
+    /// Periodic wall-clock estimate, re-scheduling itself every period.
+    fn timestamp_tick(&mut self, ctx: &mut Ctx) {
+        self.handle_event(
+            MonadEvent::TimestampUpdateEvent(dur(ctx.now()).as_nanos()),
+            ctx,
+        );
+        let me = self.me();
+        ctx.schedule_after(
+            me,
+            self.timestamp_period,
+            StepLabel::source("timestamp").priority(prio::TIMESTAMP),
+            |node, ctx| node.timestamp_tick(ctx),
+        );
+    }
+
+    /// Number of committed blocks (excluding genesis).
+    pub fn finalized_blocks(&self) -> usize {
+        self.ledger.get_finalized_blocks().len()
+    }
+
+    /// Current consensus round, or [`GENESIS_ROUND`] before consensus starts.
+    pub fn current_round(&self) -> Round {
+        self.state
+            .consensus()
+            .map_or(GENESIS_ROUND, |consensus| consensus.get_current_round())
+    }
+
+    /// Consensus metrics for this node.
+    pub fn metrics(&self) -> &Metrics {
+        self.state.metrics()
+    }
+
+    /// The node's full consensus state (epoch manager, role, live consensus,
+    /// …), for inspection between steps. Mirrors the legacy `Node::state` field.
+    pub fn state(&self) -> &SwarmRelationStateType<S> {
+        &self.state
+    }
+
+    /// Mutable access to the node's consensus state, for inspection that needs
+    /// `&mut` (e.g. [`MonadState::get_role`]).
+    pub fn state_mut(&mut self) -> &mut SwarmRelationStateType<S> {
+        &mut self.state
+    }
+
+    /// This node's committed ledger.
+    pub fn ledger(&self) -> &S::Ledger {
+        &self.ledger
+    }
+
+    /// The latest forkpoint the node has checkpointed, for restarting it. Panics
+    /// if none has been generated yet.
+    pub fn get_forkpoint(
+        &self,
+    ) -> Forkpoint<S::SignatureType, S::SignatureCollectionType, S::ExecutionProtocolType> {
+        self.config_file
+            .checkpoint
+            .clone()
+            .expect("no forkpoint generated")
+            .into()
+    }
+}
+
+impl<S: SwarmRelation> SimClient for SimNode<S> {
+    type Addr = NodeId<Pk<S>>;
+    type Message = Transport<S>;
+
+    fn wire(&mut self, me: Handle<Self>, net: Handle<SimNet<S>>) {
+        self.me = Some(me);
+        self.net = Some(net);
+    }
+
+    /// A message arrives from `from`: hand it to the router and process it.
+    fn receive(&mut self, from: NodeId<Pk<S>>, transport: Transport<S>, ctx: &mut Ctx) {
+        self.router.process_inbound(dur(ctx.now()), from, transport);
+        self.drain_router(ctx);
+    }
+}
+
+/* ************************************************************************** */
+/* Network */
+
+/// Declarative builder for a swarm's network behaviour — a `SwarmRelation`-typed
+/// facade over [`monad_sim_swarm::Network`], so callers keep the `Network<S>`
+/// ergonomics (and type inference from a `SwarmRelation` context) while the model
+/// itself lives in the generic crate. Start from [`reliable`](Network::reliable)
+/// or [`with_latency`](Network::with_latency) and layer conditions, or supply a
+/// [`custom`](Network::custom) model.
+pub struct Network<S: SwarmRelation>(monad_sim_swarm::Network<NodeId<Pk<S>>, Transport<S>>);
+
+impl<S: SwarmRelation> Default for Network<S> {
+    fn default() -> Self {
+        Self(monad_sim_swarm::Network::default())
+    }
+}
+
+impl<S: SwarmRelation> Network<S> {
+    /// Constant-latency, lossless network.
+    pub fn reliable(latency: Duration) -> Self {
+        Self(monad_sim_swarm::Network::reliable(latency))
+    }
+
+    /// Latency sampled per message from `distribution`.
+    pub fn with_latency(distribution: impl Distribution<Duration> + 'static) -> Self {
+        Self(monad_sim_swarm::Network::with_latency(distribution))
+    }
+
+    /// A fully custom model.
+    pub fn custom(model: impl NetworkModel<NodeId<Pk<S>>, Transport<S>> + 'static) -> Self {
+        Self(monad_sim_swarm::Network::custom(model))
+    }
+
+    /// Drop each message independently with probability `probability`.
+    pub fn loss(self, probability: f64) -> Self {
+        Self(self.0.loss(probability))
+    }
+
+    /// While `window` is active, drop messages crossing between the given groups
+    /// (a network split). Nodes absent from every group stay fully connected.
+    pub fn partition(
+        self,
+        window: Range<Time>,
+        groups: impl IntoIterator<Item = impl IntoIterator<Item = NodeId<Pk<S>>>>,
+    ) -> Self {
+        Self(self.0.partition(window, groups))
+    }
+
+    /// Drop messages for which `predicate` holds.
+    pub fn drop_if(self, predicate: impl Fn(&Link<S>, &Transport<S>) -> bool + 'static) -> Self {
+        Self(self.0.drop_if(predicate))
+    }
+}
+
+/* ************************************************************************** */
+/* Harness */
+
+/// A running swarm: the [`Simulation`] plus its node handles. Mirrors the parts
+/// of the legacy `Nodes` engine that tests need — bounded run control and
+/// ledger inspection — over the `monad-sim` runner.
+pub struct SimSwarm<S: SwarmRelation> {
+    sim: Simulation,
+    nodes: Vec<NodeEntry<S>>,
+    net: Handle<SimNet<S>>,
+}
+
+impl<S: SwarmRelation> SimSwarm<S> {
+    pub fn sim(&mut self) -> &mut Simulation {
+        &mut self.sim
+    }
+
+    pub fn node_ids(&self) -> Vec<NodeId<Pk<S>>> {
+        self.nodes.iter().map(|(id, _)| *id).collect()
+    }
+
+    /// Replace the network model between runs (mid-run reconfiguration). Like the
+    /// legacy `update_outbound_pipeline_for_all`, this affects messages sent
+    /// after the call; steps already scheduled keep their original delivery.
+    pub fn set_network(&mut self, network: impl FnOnce(&[NodeId<Pk<S>>]) -> Network<S>) {
+        let ids: Vec<NodeId<Pk<S>>> = self.node_ids();
+        let network = network(&ids);
+        let net = self.net;
+        self.sim.with_mut(net, |n| n.set_model(network.0));
+    }
+
+    /// Run every step scheduled at or before `deadline`.
+    pub fn run_until(&mut self, deadline: Time) {
+        self.sim.run_until_time(deadline);
+    }
+
+    /// Run until every node has committed `target` blocks or `deadline` passes.
+    /// Returns whether the target was reached (`false` on timeout, e.g. a stalled
+    /// network).
+    pub fn run_until_blocks(&mut self, target: usize, deadline: Time) -> bool {
+        let nodes = self.nodes.clone();
+        self.sim.run_while(|sim| {
+            sim.now() < deadline
+                && nodes
+                    .iter()
+                    .any(|(_, h)| sim.with(*h, SimNode::finalized_blocks) < target)
+        });
+        self.finalized_blocks().into_iter().min().unwrap_or(0) >= target
+    }
+
+    /// Run until *some* node has committed `target` blocks or `deadline` passes
+    /// (mirrors the legacy `until_block` terminator). Use this instead of
+    /// [`run_until_blocks`](Self::run_until_blocks) when a node is expected to lag
+    /// permanently (byzantine / blacked-out). Returns whether the target was
+    /// reached.
+    pub fn run_until_any_blocks(&mut self, target: usize, deadline: Time) -> bool {
+        let nodes = self.nodes.clone();
+        self.sim.run_while(|sim| {
+            sim.now() < deadline
+                && nodes
+                    .iter()
+                    .map(|(_, h)| sim.with(*h, SimNode::finalized_blocks))
+                    .max()
+                    .unwrap_or(0)
+                    < target
+        });
+        self.finalized_blocks().into_iter().max().unwrap_or(0) >= target
+    }
+
+    /// Run until some node reaches `target` round or `deadline` passes. Returns
+    /// whether the target was reached (`false` on timeout, e.g. a stalled network).
+    pub fn run_until_round(&mut self, target: Round, deadline: Time) -> bool {
+        let nodes = self.nodes.clone();
+        self.sim.run_while(|sim| {
+            sim.now() < deadline
+                && nodes
+                    .iter()
+                    .map(|(_, h)| sim.with(*h, SimNode::current_round))
+                    .max()
+                    .unwrap_or(GENESIS_ROUND)
+                    < target
+        });
+        self.current_rounds()
+            .into_iter()
+            .max()
+            .unwrap_or(GENESIS_ROUND)
+            >= target
+    }
+
+    /// Time of the next scheduled step, or `None` if the queue is empty.
+    pub fn peek_tick(&self) -> Option<Time> {
+        self.sim.peek_time()
+    }
+
+    /// The current simulation time.
+    pub fn current_tick(&self) -> Time {
+        self.sim.now()
+    }
+
+    /// Committed block count per node.
+    pub fn finalized_blocks(&self) -> Vec<usize> {
+        self.nodes
+            .iter()
+            .map(|(_, h)| self.sim.with(*h, SimNode::finalized_blocks))
+            .collect()
+    }
+
+    /// Current consensus round per node.
+    pub fn current_rounds(&self) -> Vec<Round> {
+        self.nodes
+            .iter()
+            .map(|(_, h)| self.sim.with(*h, SimNode::current_round))
+            .collect()
+    }
+
+    /// Submit a transaction to a node's mempool (as the test harness would).
+    pub fn send_transaction(&mut self, id: NodeId<Pk<S>>, tx: Bytes) {
+        let handle = self.handle(id);
+        self.sim
+            .with_mut(handle, |node| node.txpool.send_transaction(tx));
+    }
+
+    /// Read a node's state (ledger, consensus, metrics, ...).
+    pub fn with_node<R>(&self, id: NodeId<Pk<S>>, f: impl FnOnce(&SimNode<S>) -> R) -> R {
+        let handle = self.handle(id);
+        self.sim.with(handle, f)
+    }
+
+    /// Mutably access a node between steps — for inspection that needs `&mut`
+    /// (e.g. `MonadState::get_role`). Does not advance the simulation.
+    pub fn with_node_mut<R>(
+        &mut self,
+        id: NodeId<Pk<S>>,
+        f: impl FnOnce(&mut SimNode<S>) -> R,
+    ) -> R {
+        let handle = self.handle(id);
+        self.sim.with_mut(handle, f)
+    }
+
+    /// Remove a node from a running swarm and return it, so its ledger /
+    /// forkpoint / state-backend can be read before restarting it. Messages to
+    /// the node are dropped afterwards; steps already queued on it are skipped.
+    pub fn remove_node(&mut self, id: NodeId<Pk<S>>) -> SimNode<S> {
+        let pos = self
+            .nodes
+            .iter()
+            .position(|(node_id, _)| *node_id == id)
+            .expect("unknown node id");
+        let (_, handle) = self.nodes.remove(pos);
+        let net = self.net;
+        self.sim.with_mut(net, |n| n.deregister(&id));
+        self.sim.despawn(handle)
+    }
+
+    /// Add a node to a running swarm (e.g. a restarted node): wire it into the
+    /// network and dispatch its initial commands at the current time.
+    pub fn add_node(&mut self, builder: SimNodeBuilder<S>) {
+        let SimNodeBuilder {
+            id,
+            state_builder,
+            router_scheduler,
+            val_set_updater,
+            txpool_executor,
+            ledger,
+            statesync_executor,
+            timestamp_period,
+        } = builder;
+        assert!(
+            !self.nodes.iter().any(|(node_id, _)| *node_id == id),
+            "node {id} already present"
+        );
+        let net = self.net;
+        let (state, init_commands) = state_builder.build();
+        let handle = self.sim.spawn(SimNode {
+            id,
+            state,
+            router: router_scheduler,
+            ledger,
+            txpool: txpool_executor,
+            val_set: val_set_updater,
+            statesync: statesync_executor,
+            loopback: LoopbackExecutor::default(),
+            config_file: MockConfigFile::default(),
+            timers: HashMap::new(),
+            me: None,
+            net: None,
+            timestamp_period,
+        });
+        self.sim.with_mut(handle, |n| n.wire(handle, net));
+        let deliver = deliver_to(handle);
+        self.sim.with_mut(net, move |n| n.register(id, deliver));
+        self.nodes.push((id, handle));
+
+        let now = self.sim.now();
+        self.sim
+            .schedule(handle, now, StepLabel::source("init"), move |n, ctx| {
+                n.dispatch(init_commands, ctx);
+                n.timestamp_tick(ctx);
+            });
+    }
+
+    /// Panics if `id` is not a node in this swarm.
+    fn handle(&self, id: NodeId<Pk<S>>) -> Handle<SimNode<S>> {
+        self.nodes
+            .iter()
+            .find(|(node_id, _)| *node_id == id)
+            .map(|(_, handle)| *handle)
+            .expect("unknown node id")
+    }
+
+    /// Assert that every node agrees on the common prefix of committed blocks.
+    pub fn assert_agreement(&self) {
+        let ledgers: Vec<_> = self
+            .nodes
+            .iter()
+            .map(|(_, h)| {
+                self.sim
+                    .with(*h, |n| n.ledger.get_finalized_blocks().clone())
+            })
+            .collect();
+        let min_len = ledgers.iter().map(BTreeMap::len).min().unwrap_or(0);
+        let reference: Vec<_> = ledgers[0].iter().take(min_len).collect();
+        for ledger in &ledgers {
+            assert!(
+                ledger.iter().take(min_len).collect::<Vec<_>>() == reference,
+                "ledgers disagree on the committed prefix"
+            );
+        }
+    }
+
+    /// Build a running swarm from pre-built node components and kick it off. This
+    /// is the generic construction path: each [`SimNodeBuilder`] already carries
+    /// its node's executors, so any [`SwarmRelation`] works (e.g. the debugger's
+    /// boxed relation). Network behaviour comes from `network`, which receives the
+    /// node ids.
+    pub fn from_builders(
+        seed: u64,
+        builders: Vec<SimNodeBuilder<S>>,
+        network: impl FnOnce(&[NodeId<Pk<S>>]) -> Network<S>,
+    ) -> SimSwarm<S> {
+        let ids: Vec<NodeId<Pk<S>>> = builders.iter().map(|b| b.id).collect();
+
+        let mut sim = Simulation::new(seed);
+        let net = sim.spawn(SimNet::<S>::new(seed, network(&ids).0));
+
+        let mut pending = Vec::new();
+        for builder in builders {
+            let SimNodeBuilder {
+                id,
+                state_builder,
+                router_scheduler,
+                val_set_updater,
+                txpool_executor,
+                ledger,
+                statesync_executor,
+                timestamp_period,
+            } = builder;
+            let (state, init_commands) = state_builder.build();
+
+            let handle = sim.spawn(SimNode {
+                id,
+                state,
+                router: router_scheduler,
+                ledger,
+                txpool: txpool_executor,
+                val_set: val_set_updater,
+                statesync: statesync_executor,
+                loopback: LoopbackExecutor::default(),
+                config_file: MockConfigFile::default(),
+                timers: HashMap::new(),
+                me: None,
+                net: None,
+                timestamp_period,
+            });
+            sim.with_mut(handle, |n| n.wire(handle, net));
+            let deliver = deliver_to(handle);
+            sim.with_mut(net, move |n| n.register(id, deliver));
+            pending.push((id, handle, init_commands));
+        }
+
+        let nodes = pending
+            .iter()
+            .map(|(id, handle, _)| (*id, *handle))
+            .collect();
+        for (_, handle, init_commands) in pending {
+            sim.schedule(handle, Time(0), StepLabel::source("init"), move |n, ctx| {
+                n.dispatch(init_commands, ctx);
+                n.timestamp_tick(ctx);
+            });
+        }
+
+        SimSwarm { sim, nodes, net }
+    }
+}
+
+/* ************************************************************************** */
+/* NoSerSwarm construction */
+
+/// Build a `NoSerSwarm` swarm with the default (reliable) network.
+pub fn build_swarm(num_nodes: u16, seed: u64) -> SimSwarm<NoSerSwarm> {
+    build_swarm_with(num_nodes, seed, |_| Network::default())
+}
+
+/// Build a `num_nodes`-validator `NoSerSwarm` simulation and kick it off.
+/// `network` receives the node ids (so partitions can reference specific nodes)
+/// and returns the network behaviour.
+pub fn build_swarm_with(
+    num_nodes: u16,
+    seed: u64,
+    network: impl FnOnce(&[NodeId<Pk<NoSerSwarm>>]) -> Network<NoSerSwarm>,
+) -> SimSwarm<NoSerSwarm> {
+    SimSwarm::from_builders(seed, noser_builders(num_nodes), network)
+}
+
+/// Construct `NoSerSwarm` node builders with mock executors and the default
+/// chain config.
+fn noser_builders(num_nodes: u16) -> Vec<SimNodeBuilder<NoSerSwarm>> {
+    use monad_chain_config::{revision::ChainParams, MockChainConfig};
+    use monad_consensus_types::{block::PassthruBlockPolicy, block_validator::MockValidator};
+    use monad_execution_state_read::InMemoryStateInner;
+    use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+    use monad_types::SeqNum;
+    use monad_updaters::{
+        ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+        val_set::MockValSetUpdaterNop,
+    };
+    use monad_validator::{
+        simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory,
+    };
+
+    use crate::swarm::make_state_configs;
+
+    static CHAIN_PARAMS: ChainParams = ChainParams {
+        tx_limit: 10_000,
+        proposal_gas_limit: 300_000_000,
+        proposal_byte_limit: 4_000_000,
+        max_reserve_balance: 1_000_000_000_000_000_000,
+        vote_pace: Duration::from_millis(5),
+    };
+    let delta = Duration::from_millis(100);
+
+    let state_configs = make_state_configs::<NoSerSwarm>(
+        num_nodes,
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        || MockValidator,
+        || PassthruBlockPolicy,
+        || InMemoryStateInner::genesis(SeqNum(4)),
+        SeqNum(4),
+        delta,
+        MockChainConfig::new(&CHAIN_PARAMS),
+        SeqNum(100),
+    );
+    let all_peers: BTreeSet<NodeId<Pk<NoSerSwarm>>> = state_configs
+        .iter()
+        .map(|config| NodeId::new(config.key.pubkey()))
+        .collect();
+
+    state_configs
+        .into_iter()
+        .map(|config| {
+            let state_read = config.state_read.clone();
+            let validators = config.locked_epoch_validators[0].clone();
+            SimNodeBuilder {
+                id: NodeId::new(config.key.pubkey()),
+                state_builder: config,
+                router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                val_set_updater: MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
+                txpool_executor: MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
+                ledger: MockLedger::new(state_read.clone()),
+                statesync_executor: MockStateSyncExecutor::new(state_read),
+                timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use monad_sim::{
+        dist::normal_duration,
+        time::{millis, secs},
+    };
+
+    use super::*;
+
+    #[test]
+    fn generic_over_swarm_relation() {
+        use crate::swarm_relation::DebugSwarmRelation;
+
+        // The same nodes, boxed into the debugger's relation, run through the
+        // generic `from_builders` path — proving the sim is not tied to NoSerSwarm.
+        let builders = noser_builders(4)
+            .into_iter()
+            .map(SimNodeBuilder::debug)
+            .collect();
+        let mut swarm =
+            SimSwarm::<DebugSwarmRelation>::from_builders(0, builders, |_| Network::default());
+        swarm.run_until(Time(0) + secs(2));
+        assert!(swarm.finalized_blocks().iter().all(|&n| n >= 5));
+    }
+
+    #[test]
+    fn happy_path_tick_and_metrics() {
+        let mut swarm = build_swarm(4, 0);
+        assert!(swarm.run_until_blocks(20, Time(0) + secs(10)));
+
+        swarm.assert_agreement();
+        for id in swarm.node_ids() {
+            swarm.with_node(id, |node| {
+                let committed = node.finalized_blocks() as u64;
+                let m = node.metrics();
+                // happy path: voted on / handled at least every committed block,
+                // no blocksync, no out-of-order proposals.
+                assert!(m.consensus_events.created_vote.get() >= committed);
+                assert!(m.consensus_events.handle_proposal.get() >= committed);
+                assert_eq!(m.blocksync_events.self_headers_request.get(), 0);
+                assert_eq!(m.consensus_events.out_of_order_proposals.get(), 0);
+            });
+        }
+
+        // The scheduler is deterministic, so the final tick is an exact value;
+        // no `tick_range` tolerance is needed.
+        assert_eq!(swarm.current_tick(), Time(0) + millis(104));
+    }
+
+    #[test]
+    fn single_validator_commits_blocks() {
+        let mut swarm = build_swarm(1, 0);
+        swarm.run_until(Time(0) + secs(2));
+        assert!(swarm.finalized_blocks()[0] >= 10);
+    }
+
+    #[test]
+    fn multi_validator_commits_and_agrees() {
+        let mut swarm = build_swarm(4, 0);
+        assert!(swarm.run_until_blocks(10, Time(0) + secs(2)));
+        swarm.assert_agreement();
+    }
+
+    #[test]
+    fn run_until_round_reaches_target() {
+        use monad_types::Round;
+
+        let mut swarm = build_swarm(4, 0);
+        assert!(swarm.run_until_round(Round(20), Time(0) + secs(2)));
+        assert!(swarm.current_rounds().iter().any(|&r| r >= Round(20)));
+        swarm.assert_agreement();
+    }
+
+    #[test]
+    fn progresses_under_jittery_latency() {
+        let mut swarm = build_swarm_with(4, 0, |_| {
+            Network::with_latency(normal_duration(millis(2), millis(1)))
+        });
+        swarm.run_until(Time(0) + secs(2));
+        assert!(swarm.finalized_blocks().iter().all(|&n| n >= 5));
+    }
+
+    #[test]
+    fn even_split_partition_halts_progress() {
+        // A 2|2 split: neither side has a supermajority (3 of 4), so no blocks
+        // can commit while the partition holds.
+        let mut swarm = build_swarm_with(4, 0, |ids| {
+            Network::reliable(millis(1)).partition(
+                Time(0)..Time(i128::MAX),
+                [vec![ids[0], ids[1]], vec![ids[2], ids[3]]],
+            )
+        });
+        swarm.run_until(Time(0) + secs(2));
+        assert!(
+            swarm.finalized_blocks().iter().all(|&n| n == 0),
+            "expected no progress under an even split, got {:?}",
+            swarm.finalized_blocks()
+        );
+    }
+}

--- a/monad-mock-swarm/src/sim.rs
+++ b/monad-mock-swarm/src/sim.rs
@@ -1,0 +1,1015 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Layer B: drive real `MonadState` nodes (Layer C) through the generic
+//! `monad-sim` engine (Layer A).
+//!
+//! Each node is registered as a `monad-sim` process and driven entirely by
+//! scheduled steps: events feed `state.update`, and the resulting commands are
+//! dispatched in-process. Timers become [`CancelToken`]s; the
+//! ledger / txpool / valset / statesync / loopback executors are reused
+//! unmodified via `exec` + drain; outbound messages are routed through the
+//! generic network process ([`monad_sim_swarm::Net`], aliased `SimNet<S>`) whose
+//! behaviour is a declarative [`Network`] model. A [`SimNode`] plugs into that
+//! network via the [`monad_sim_swarm::SimClient`] seam, so any node process
+//! sharing the wire type could share one network.
+//!
+//! [`SimNode`] / [`Network`] are generic over [`SwarmRelation`]; the network,
+//! delivery, and swarm scaffolding are the protocol-agnostic `monad-sim-swarm`.
+//! [`SimSwarm`] is the harness — construction, bounded run control, and
+//! between-step inspection. [`SimSwarm::from_builders`] is the generic entry
+//! point; [`build_swarm`] / [`build_swarm_with`] are `NoSerSwarm` conveniences.
+
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    marker::PhantomData,
+    ops::Range,
+    time::Duration,
+};
+
+use bytes::Bytes;
+use futures::{executor::block_on, StreamExt};
+use monad_consensus_types::metrics::Metrics;
+use monad_crypto::certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey};
+use monad_executor::Executor;
+use monad_executor_glue::{
+    Command, Message, MonadEvent, RouterCommand, TimeoutVariant, TimerCommand,
+};
+use monad_router_scheduler::{RouterEvent, RouterScheduler};
+use monad_sim::{CancelToken, Ctx, Handle, Simulation, StepLabel, Time};
+/// The network model trait / its per-message context, from [`monad_sim_swarm`].
+/// `NetworkModel` is the generic (`Addr`, `Msg`) trait; a custom model for a
+/// Monad swarm implements it at `NetworkModel<NodeId<Pk<S>>, Transport<S>>`. The
+/// declarative builder is [`Network`] (below), a thin `SwarmRelation`-flavored
+/// facade over [`monad_sim_swarm::Network`].
+pub use monad_sim_swarm::NetworkModel;
+use monad_sim_swarm::{deliver_to, Net, SimClient};
+use monad_state::{Forkpoint, MonadStateBuilder, VerifiedMonadMessage};
+use monad_types::{NodeId, Round, GENESIS_ROUND};
+use monad_updaters::{
+    config_file::MockConfigFile, ledger::MockableLedger, loopback::LoopbackExecutor,
+    statesync::MockableStateSync, txpool::MockableTxPool, val_set::MockableValSetUpdater,
+};
+use monad_validator::validator_set::BoxedValidatorSetTypeFactory;
+use rand::distributions::Distribution;
+
+use crate::swarm_relation::{
+    DebugSwarmRelation, NoSerSwarm, SwarmRelation, SwarmRelationStateType,
+};
+pub type Link<S> = monad_sim_swarm::Link<NodeId<Pk<S>>>;
+
+type Pk<S> = CertificateSignaturePubKey<<S as SwarmRelation>::SignatureType>;
+type Ev<S> = MonadEvent<
+    <S as SwarmRelation>::SignatureType,
+    <S as SwarmRelation>::SignatureCollectionType,
+    <S as SwarmRelation>::ExecutionProtocolType,
+>;
+type Cmd<S> = Command<
+    Ev<S>,
+    VerifiedMonadMessage<
+        <S as SwarmRelation>::SignatureType,
+        <S as SwarmRelation>::SignatureCollectionType,
+        <S as SwarmRelation>::ExecutionProtocolType,
+    >,
+    <S as SwarmRelation>::SignatureType,
+    <S as SwarmRelation>::SignatureCollectionType,
+    <S as SwarmRelation>::ExecutionProtocolType,
+    <S as SwarmRelation>::BlockPolicyType,
+    <S as SwarmRelation>::ExecutionStateReadType,
+    <S as SwarmRelation>::ChainConfigType,
+    <S as SwarmRelation>::ChainRevisionType,
+>;
+type StateBuilder<S> = MonadStateBuilder<
+    <S as SwarmRelation>::SignatureType,
+    <S as SwarmRelation>::SignatureCollectionType,
+    <S as SwarmRelation>::ExecutionProtocolType,
+    <S as SwarmRelation>::BlockPolicyType,
+    <S as SwarmRelation>::ExecutionStateReadType,
+    <S as SwarmRelation>::ValidatorSetTypeFactory,
+    <S as SwarmRelation>::LeaderElection,
+    <S as SwarmRelation>::BlockValidator,
+    <S as SwarmRelation>::ChainConfigType,
+    <S as SwarmRelation>::ChainRevisionType,
+>;
+type Transport<S> = <S as SwarmRelation>::TransportMessage;
+
+type NodeEntry<S> = (NodeId<Pk<S>>, Handle<SimNode<S>>);
+
+/// The network process for a Monad swarm: the generic [`Net`] instantiated at
+/// this relation's node id and transport message.
+type SimNet<S> = Net<NodeId<Pk<S>>, Transport<S>>;
+
+fn dur(t: Time) -> Duration {
+    Duration::from_nanos(u64::try_from(t.0).expect("negative simulation time"))
+}
+
+/// Default wall-clock estimate period for a node.
+pub const DEFAULT_TIMESTAMP_PERIOD: Duration = Duration::from_millis(10);
+
+/// Same-time priority classes for a node's scheduled steps, mirroring
+/// production's `ParentExecutor::poll_next` order (lower runs first at a tick).
+/// Under `TieBreak::Fifo` this makes a node drain ready internal work before it
+/// services a same-tick network message (`RX`) — production's anti-starvation
+/// ordering, and the opposite of the legacy sim's network-first tie-break. Under
+/// `TieBreak::Randomized` these are ignored and same-tick steps are fully
+/// shuffled (see `monad_sim::TieBreak`). `ControlPanel` (1) and `ConfigLoader`
+/// (9) have no simulation analogue.
+///
+/// The values keep the *relative* order of `poll_next`; the absolute numbers
+/// (and the gaps) don't matter beyond that. NOTE: production's order is itself
+/// provisional — `poll_next` carries TODOs to deprioritize txpool ingestion and
+/// to prioritize consensus (router) messages. If those land, update these
+/// classes to match. Verified against `monad-updaters/src/parent.rs`.
+mod prio {
+    pub const TIMER: u32 = 0;
+    pub const LEDGER: u32 = 2;
+    pub const TXPOOL: u32 = 3;
+    pub const VAL_SET: u32 = 4;
+    pub const TIMESTAMP: u32 = 5;
+    pub const LOOPBACK: u32 = 6;
+    /// Network inbound (`Router`): serviced after ready internal work.
+    pub const RX: u32 = 7;
+    pub const STATESYNC: u32 = 8;
+}
+
+/// Configuration for one node in a [`SimSwarm`].
+///
+/// The new framework's node descriptor: it carries only what the simulation
+/// drives, keyed by [`NodeId`] directly, with no transformer pipelines (the
+/// network model lives in [`Network`] instead). Construct it with a struct
+/// literal; [`SimNodeBuilder::debug`] type-erases it into [`DebugSwarmRelation`].
+pub struct SimNodeBuilder<S: SwarmRelation> {
+    pub id: NodeId<Pk<S>>,
+    pub state_builder: StateBuilder<S>,
+    pub router_scheduler: S::RouterScheduler,
+    pub val_set_updater: S::ValSetUpdater,
+    pub txpool_executor: S::TxPoolExecutor,
+    pub ledger: S::Ledger,
+    pub statesync_executor: S::StateSyncExecutor,
+    pub timestamp_period: Duration,
+}
+
+impl<S: SwarmRelation> SimNodeBuilder<S> {
+    /// Box this builder into the debugger's type-erased [`DebugSwarmRelation`],
+    /// proving the simulation is generic over the swarm relation.
+    pub fn debug(self) -> SimNodeBuilder<DebugSwarmRelation>
+    where
+        S: SwarmRelation<
+            SignatureType = <DebugSwarmRelation as SwarmRelation>::SignatureType,
+            SignatureCollectionType = <DebugSwarmRelation as SwarmRelation>::SignatureCollectionType,
+            ExecutionProtocolType = <DebugSwarmRelation as SwarmRelation>::ExecutionProtocolType,
+            TransportMessage = <DebugSwarmRelation as SwarmRelation>::TransportMessage,
+            BlockPolicyType = <DebugSwarmRelation as SwarmRelation>::BlockPolicyType,
+            BlockValidator = <DebugSwarmRelation as SwarmRelation>::BlockValidator,
+            ExecutionStateReadType = <DebugSwarmRelation as SwarmRelation>::ExecutionStateReadType,
+            ChainConfigType = <DebugSwarmRelation as SwarmRelation>::ChainConfigType,
+            ChainRevisionType = <DebugSwarmRelation as SwarmRelation>::ChainRevisionType,
+        >,
+        S::RouterScheduler: Sync,
+        S::Ledger: Sync,
+    {
+        SimNodeBuilder {
+            id: self.id,
+            state_builder: MonadStateBuilder {
+                validator_set_factory: BoxedValidatorSetTypeFactory::new(
+                    self.state_builder.validator_set_factory,
+                ),
+                leader_election: Box::new(self.state_builder.leader_election),
+                block_validator: self.state_builder.block_validator,
+                block_policy: self.state_builder.block_policy,
+                state_read: self.state_builder.state_read,
+                key: self.state_builder.key,
+                certkey: self.state_builder.certkey,
+                beneficiary: self.state_builder.beneficiary,
+                forkpoint: self.state_builder.forkpoint,
+                locked_epoch_validators: self.state_builder.locked_epoch_validators,
+                block_sync_override_peers: self.state_builder.block_sync_override_peers,
+                maybe_blocksync_rng_seed: self.state_builder.maybe_blocksync_rng_seed,
+                consensus_config: self.state_builder.consensus_config,
+                whitelisted_statesync_nodes: self.state_builder.whitelisted_statesync_nodes,
+                statesync_expand_to_group: self.state_builder.statesync_expand_to_group,
+                serve_statesync: self.state_builder.serve_statesync,
+                _phantom: PhantomData,
+            },
+            router_scheduler: Box::new(self.router_scheduler),
+            val_set_updater: Box::new(self.val_set_updater),
+            txpool_executor: Box::new(self.txpool_executor),
+            ledger: Box::new(self.ledger),
+            statesync_executor: Box::new(self.statesync_executor),
+            timestamp_period: self.timestamp_period,
+        }
+    }
+}
+
+/// A single consensus node as a `monad-sim` process.
+pub struct SimNode<S: SwarmRelation> {
+    id: NodeId<Pk<S>>,
+    state: SwarmRelationStateType<S>,
+
+    router: S::RouterScheduler,
+    ledger: S::Ledger,
+    txpool: S::TxPoolExecutor,
+    val_set: S::ValSetUpdater,
+    statesync: S::StateSyncExecutor,
+    loopback: LoopbackExecutor<Ev<S>>,
+    config_file:
+        MockConfigFile<S::SignatureType, S::SignatureCollectionType, S::ExecutionProtocolType>,
+
+    /// One armed timer per variant; re-arming or resetting cancels the previous.
+    timers: HashMap<TimeoutVariant, CancelToken>,
+
+    // Wiring, set after the node and network are spawned.
+    me: Option<Handle<SimNode<S>>>,
+    net: Option<Handle<SimNet<S>>>,
+
+    timestamp_period: Duration,
+}
+
+impl<S: SwarmRelation> SimNode<S> {
+    fn me(&self) -> Handle<SimNode<S>> {
+        self.me.expect("node not wired")
+    }
+
+    fn net(&self) -> Handle<SimNet<S>> {
+        self.net.expect("node not wired")
+    }
+
+    /// Feed one event to the state machine and dispatch the resulting commands.
+    fn handle_event(&mut self, event: Ev<S>, ctx: &mut Ctx) {
+        let commands = self.state.update(event);
+        self.dispatch(commands, ctx);
+    }
+
+    fn dispatch(&mut self, commands: Vec<Cmd<S>>, ctx: &mut Ctx) {
+        let (
+            router_cmds,
+            timer_cmds,
+            ledger_cmds,
+            config_file_cmds,
+            val_set_cmds,
+            _timestamp_cmds,
+            txpool_cmds,
+            _control_panel_cmds,
+            loopback_cmds,
+            statesync_cmds,
+            _config_reload_cmds,
+        ) = <Cmd<S>>::split_commands(commands);
+
+        for command in timer_cmds {
+            match command {
+                TimerCommand::Schedule {
+                    duration,
+                    variant,
+                    on_timeout,
+                } => {
+                    if let Some(previous) = self.timers.remove(&variant) {
+                        previous.cancel();
+                    }
+                    let me = self.me();
+                    let token = ctx.schedule_after(
+                        me,
+                        duration,
+                        StepLabel::source("timer").priority(prio::TIMER),
+                        move |node, ctx| {
+                            node.timers.remove(&variant);
+                            node.handle_event(on_timeout, ctx);
+                        },
+                    );
+                    self.timers.insert(variant, token);
+                }
+                TimerCommand::ScheduleReset(variant) => {
+                    if let Some(previous) = self.timers.remove(&variant) {
+                        previous.cancel();
+                    }
+                }
+            }
+        }
+
+        self.ledger.exec(ledger_cmds);
+        self.txpool.exec(txpool_cmds);
+        self.val_set.exec(val_set_cmds);
+        self.loopback.exec(loopback_cmds);
+        self.statesync.exec(statesync_cmds);
+        self.config_file.exec(config_file_cmds);
+
+        let now = dur(ctx.now());
+        for command in router_cmds {
+            match command {
+                RouterCommand::Publish { target, message }
+                | RouterCommand::PublishWithPriority {
+                    target, message, ..
+                } => {
+                    self.router.send_outbound(now, target, message);
+                }
+                RouterCommand::AddEpochValidatorSet {
+                    epoch,
+                    epoch_start,
+                    validator_set,
+                } => {
+                    self.router
+                        .add_epoch_validator_set(epoch, epoch_start, validator_set);
+                }
+                RouterCommand::UpdateCurrentRound(epoch, round) => {
+                    self.router.update_current_round(epoch, round);
+                }
+                _ => {}
+            }
+        }
+
+        self.drain_router(ctx);
+        self.drain_executors(ctx);
+    }
+
+    /// Schedule an internal reaction as a zero-delay step on this node, so it
+    /// flows through the engine queue rather than being handled synchronously.
+    /// The step is tagged with its source's priority class (see [`prio`]), so
+    /// internal reactions interleave per the scheduler's ordering (see the
+    /// design doc, "Event ordering & interleaving").
+    fn schedule_event(&self, ctx: &mut Ctx, source: &'static str, event: Ev<S>) {
+        let priority = match source {
+            "ledger" => prio::LEDGER,
+            "txpool" => prio::TXPOOL,
+            "val_set" => prio::VAL_SET,
+            "loopback" => prio::LOOPBACK,
+            "rx" => prio::RX,
+            "statesync" => prio::STATESYNC,
+            other => unreachable!("unclassified internal step source: {other}"),
+        };
+        let me = self.me();
+        let label = StepLabel::source(source).priority(priority);
+        ctx.schedule(me, ctx.now(), label, move |node, ctx| {
+            node.handle_event(event, ctx)
+        });
+    }
+
+    /// Drain router events: hand outbound messages to the network process, and
+    /// schedule inbound messages for the state machine (zero-delay step).
+    fn drain_router(&mut self, ctx: &mut Ctx) {
+        let now = ctx.now();
+        while let Some(event) = self.router.step_until(dur(now)) {
+            match event {
+                RouterEvent::Tx(to, transport) => {
+                    let from = self.id;
+                    let net = self.net();
+                    ctx.schedule(net, now, StepLabel::source("route"), move |net, ctx| {
+                        net.send(ctx, from, to, transport)
+                    });
+                }
+                RouterEvent::Rx(from, message) => {
+                    self.schedule_event(ctx, "rx", message.event(from));
+                }
+            }
+        }
+    }
+
+    /// Drain the executors that emit events when ready, scheduling each as a
+    /// zero-delay step. Unlike a synchronous drain, a node's internal reaction
+    /// cascade unfolds across same-tick engine steps and can interleave with
+    /// other same-tick steps — finer-grained, and observable in the step log.
+    fn drain_executors(&mut self, ctx: &mut Ctx) {
+        while self.ledger.ready() {
+            if let Some(event) = block_on(self.ledger.next()) {
+                self.schedule_event(ctx, "ledger", event);
+            }
+        }
+        while self.txpool.ready() {
+            if let Some(event) = block_on(self.txpool.next()) {
+                self.schedule_event(ctx, "txpool", event);
+            }
+        }
+        while self.val_set.ready() {
+            if let Some(event) = block_on(self.val_set.next()) {
+                self.schedule_event(ctx, "val_set", event);
+            }
+        }
+        while self.loopback.ready() {
+            if let Some(event) = block_on(self.loopback.next()) {
+                self.schedule_event(ctx, "loopback", event);
+            }
+        }
+        while let Some(event) = self.statesync.pop() {
+            self.schedule_event(ctx, "statesync", event);
+        }
+    }
+
+    /// Periodic wall-clock estimate, re-scheduling itself every period.
+    fn timestamp_tick(&mut self, ctx: &mut Ctx) {
+        self.handle_event(
+            MonadEvent::TimestampUpdateEvent(dur(ctx.now()).as_nanos()),
+            ctx,
+        );
+        let me = self.me();
+        ctx.schedule_after(
+            me,
+            self.timestamp_period,
+            StepLabel::source("timestamp").priority(prio::TIMESTAMP),
+            |node, ctx| node.timestamp_tick(ctx),
+        );
+    }
+
+    /// Number of committed blocks (excluding genesis).
+    pub fn finalized_blocks(&self) -> usize {
+        self.ledger.get_finalized_blocks().len()
+    }
+
+    /// Current consensus round, or [`GENESIS_ROUND`] before consensus starts.
+    pub fn current_round(&self) -> Round {
+        self.state
+            .consensus()
+            .map_or(GENESIS_ROUND, |consensus| consensus.get_current_round())
+    }
+
+    /// Consensus metrics for this node.
+    pub fn metrics(&self) -> &Metrics {
+        self.state.metrics()
+    }
+
+    /// The node's full consensus state (epoch manager, role, live consensus,
+    /// …), for inspection between steps. Mirrors the legacy `Node::state` field.
+    pub fn state(&self) -> &SwarmRelationStateType<S> {
+        &self.state
+    }
+
+    /// Mutable access to the node's consensus state, for inspection that needs
+    /// `&mut` (e.g. [`MonadState::get_role`]).
+    pub fn state_mut(&mut self) -> &mut SwarmRelationStateType<S> {
+        &mut self.state
+    }
+
+    /// This node's committed ledger.
+    pub fn ledger(&self) -> &S::Ledger {
+        &self.ledger
+    }
+
+    /// The latest forkpoint the node has checkpointed, for restarting it. Panics
+    /// if none has been generated yet.
+    pub fn get_forkpoint(
+        &self,
+    ) -> Forkpoint<S::SignatureType, S::SignatureCollectionType, S::ExecutionProtocolType> {
+        self.config_file
+            .checkpoint
+            .clone()
+            .expect("no forkpoint generated")
+            .into()
+    }
+}
+
+impl<S: SwarmRelation> SimClient for SimNode<S> {
+    type Addr = NodeId<Pk<S>>;
+    type Message = Transport<S>;
+
+    fn wire(&mut self, me: Handle<Self>, net: Handle<SimNet<S>>) {
+        self.me = Some(me);
+        self.net = Some(net);
+    }
+
+    /// A message arrives from `from`: hand it to the router and process it.
+    fn receive(&mut self, from: NodeId<Pk<S>>, transport: Transport<S>, ctx: &mut Ctx) {
+        self.router.process_inbound(dur(ctx.now()), from, transport);
+        self.drain_router(ctx);
+    }
+}
+
+/* ************************************************************************** */
+/* Network */
+
+/// Declarative builder for a swarm's network behaviour — a `SwarmRelation`-typed
+/// facade over [`monad_sim_swarm::Network`], so callers keep the `Network<S>`
+/// ergonomics (and type inference from a `SwarmRelation` context) while the model
+/// itself lives in the generic crate. Start from [`reliable`](Network::reliable)
+/// or [`with_latency`](Network::with_latency) and layer conditions, or supply a
+/// [`custom`](Network::custom) model.
+pub struct Network<S: SwarmRelation>(monad_sim_swarm::Network<NodeId<Pk<S>>, Transport<S>>);
+
+impl<S: SwarmRelation> Default for Network<S> {
+    fn default() -> Self {
+        Self(monad_sim_swarm::Network::default())
+    }
+}
+
+impl<S: SwarmRelation> Network<S> {
+    /// Constant-latency, lossless network.
+    pub fn reliable(latency: Duration) -> Self {
+        Self(monad_sim_swarm::Network::reliable(latency))
+    }
+
+    /// Latency sampled per message from `distribution`.
+    pub fn with_latency(distribution: impl Distribution<Duration> + 'static) -> Self {
+        Self(monad_sim_swarm::Network::with_latency(distribution))
+    }
+
+    /// A fully custom model.
+    pub fn custom(model: impl NetworkModel<NodeId<Pk<S>>, Transport<S>> + 'static) -> Self {
+        Self(monad_sim_swarm::Network::custom(model))
+    }
+
+    /// Drop each message independently with probability `probability`.
+    pub fn loss(self, probability: f64) -> Self {
+        Self(self.0.loss(probability))
+    }
+
+    /// While `window` is active, drop messages crossing between the given groups
+    /// (a network split). Nodes absent from every group stay fully connected.
+    pub fn partition(
+        self,
+        window: Range<Time>,
+        groups: impl IntoIterator<Item = impl IntoIterator<Item = NodeId<Pk<S>>>>,
+    ) -> Self {
+        Self(self.0.partition(window, groups))
+    }
+
+    /// Drop messages for which `predicate` holds.
+    pub fn drop_if(self, predicate: impl Fn(&Link<S>, &Transport<S>) -> bool + 'static) -> Self {
+        Self(self.0.drop_if(predicate))
+    }
+}
+
+/* ************************************************************************** */
+/* Harness */
+
+/// A running swarm: the [`Simulation`] plus its node handles. Mirrors the parts
+/// of the legacy `Nodes` engine that tests need — bounded run control and
+/// ledger inspection — over the `monad-sim` runner.
+pub struct SimSwarm<S: SwarmRelation> {
+    sim: Simulation,
+    nodes: Vec<NodeEntry<S>>,
+    net: Handle<SimNet<S>>,
+}
+
+impl<S: SwarmRelation> SimSwarm<S> {
+    pub fn sim(&mut self) -> &mut Simulation {
+        &mut self.sim
+    }
+
+    pub fn node_ids(&self) -> Vec<NodeId<Pk<S>>> {
+        self.nodes.iter().map(|(id, _)| *id).collect()
+    }
+
+    /// Replace the network model between runs (mid-run reconfiguration). Like the
+    /// legacy `update_outbound_pipeline_for_all`, this affects messages sent
+    /// after the call; steps already scheduled keep their original delivery.
+    pub fn set_network(&mut self, network: impl FnOnce(&[NodeId<Pk<S>>]) -> Network<S>) {
+        let ids: Vec<NodeId<Pk<S>>> = self.node_ids();
+        let network = network(&ids);
+        let net = self.net;
+        self.sim.with_mut(net, |n| n.set_model(network.0));
+    }
+
+    /// Run every step scheduled at or before `deadline`.
+    pub fn run_until(&mut self, deadline: Time) {
+        self.sim.run_until_time(deadline);
+    }
+
+    /// Run until every node has committed `target` blocks or `deadline` passes.
+    /// Returns whether the target was reached (`false` on timeout, e.g. a stalled
+    /// network).
+    pub fn run_until_blocks(&mut self, target: usize, deadline: Time) -> bool {
+        let nodes = self.nodes.clone();
+        self.sim.run_while(|sim| {
+            sim.now() < deadline
+                && nodes
+                    .iter()
+                    .any(|(_, h)| sim.with(*h, SimNode::finalized_blocks) < target)
+        });
+        self.finalized_blocks().into_iter().min().unwrap_or(0) >= target
+    }
+
+    /// Run until *some* node has committed `target` blocks or `deadline` passes
+    /// (mirrors the legacy `until_block` terminator). Use this instead of
+    /// [`run_until_blocks`](Self::run_until_blocks) when a node is expected to lag
+    /// permanently (byzantine / blacked-out). Returns whether the target was
+    /// reached.
+    pub fn run_until_any_blocks(&mut self, target: usize, deadline: Time) -> bool {
+        let nodes = self.nodes.clone();
+        self.sim.run_while(|sim| {
+            sim.now() < deadline
+                && nodes
+                    .iter()
+                    .map(|(_, h)| sim.with(*h, SimNode::finalized_blocks))
+                    .max()
+                    .unwrap_or(0)
+                    < target
+        });
+        self.finalized_blocks().into_iter().max().unwrap_or(0) >= target
+    }
+
+    /// Run until some node reaches `target` round or `deadline` passes. Returns
+    /// whether the target was reached (`false` on timeout, e.g. a stalled network).
+    pub fn run_until_round(&mut self, target: Round, deadline: Time) -> bool {
+        let nodes = self.nodes.clone();
+        self.sim.run_while(|sim| {
+            sim.now() < deadline
+                && nodes
+                    .iter()
+                    .map(|(_, h)| sim.with(*h, SimNode::current_round))
+                    .max()
+                    .unwrap_or(GENESIS_ROUND)
+                    < target
+        });
+        self.current_rounds()
+            .into_iter()
+            .max()
+            .unwrap_or(GENESIS_ROUND)
+            >= target
+    }
+
+    /// Time of the next scheduled step, or `None` if the queue is empty.
+    pub fn peek_tick(&self) -> Option<Time> {
+        self.sim.peek_time()
+    }
+
+    /// The current simulation time.
+    pub fn current_tick(&self) -> Time {
+        self.sim.now()
+    }
+
+    /// Committed block count per node.
+    pub fn finalized_blocks(&self) -> Vec<usize> {
+        self.nodes
+            .iter()
+            .map(|(_, h)| self.sim.with(*h, SimNode::finalized_blocks))
+            .collect()
+    }
+
+    /// Current consensus round per node.
+    pub fn current_rounds(&self) -> Vec<Round> {
+        self.nodes
+            .iter()
+            .map(|(_, h)| self.sim.with(*h, SimNode::current_round))
+            .collect()
+    }
+
+    /// Submit a transaction to a node's mempool (as the test harness would).
+    pub fn send_transaction(&mut self, id: NodeId<Pk<S>>, tx: Bytes) {
+        let handle = self.handle(id);
+        self.sim
+            .with_mut(handle, |node| node.txpool.send_transaction(tx));
+    }
+
+    /// Read a node's state (ledger, consensus, metrics, ...).
+    pub fn with_node<R>(&self, id: NodeId<Pk<S>>, f: impl FnOnce(&SimNode<S>) -> R) -> R {
+        let handle = self.handle(id);
+        self.sim.with(handle, f)
+    }
+
+    /// Mutably access a node between steps — for inspection that needs `&mut`
+    /// (e.g. `MonadState::get_role`). Does not advance the simulation.
+    pub fn with_node_mut<R>(
+        &mut self,
+        id: NodeId<Pk<S>>,
+        f: impl FnOnce(&mut SimNode<S>) -> R,
+    ) -> R {
+        let handle = self.handle(id);
+        self.sim.with_mut(handle, f)
+    }
+
+    /// Remove a node from a running swarm and return it, so its ledger /
+    /// forkpoint / state-backend can be read before restarting it. Messages to
+    /// the node are dropped afterwards; steps already queued on it are skipped.
+    pub fn remove_node(&mut self, id: NodeId<Pk<S>>) -> SimNode<S> {
+        let pos = self
+            .nodes
+            .iter()
+            .position(|(node_id, _)| *node_id == id)
+            .expect("unknown node id");
+        let (_, handle) = self.nodes.remove(pos);
+        let net = self.net;
+        self.sim.with_mut(net, |n| n.deregister(&id));
+        self.sim.despawn(handle)
+    }
+
+    /// Add a node to a running swarm (e.g. a restarted node): wire it into the
+    /// network and dispatch its initial commands at the current time.
+    pub fn add_node(&mut self, builder: SimNodeBuilder<S>) {
+        let SimNodeBuilder {
+            id,
+            state_builder,
+            router_scheduler,
+            val_set_updater,
+            txpool_executor,
+            ledger,
+            statesync_executor,
+            timestamp_period,
+        } = builder;
+        assert!(
+            !self.nodes.iter().any(|(node_id, _)| *node_id == id),
+            "node {id} already present"
+        );
+        let net = self.net;
+        let (state, init_commands) = state_builder.build();
+        let handle = self.sim.spawn(SimNode {
+            id,
+            state,
+            router: router_scheduler,
+            ledger,
+            txpool: txpool_executor,
+            val_set: val_set_updater,
+            statesync: statesync_executor,
+            loopback: LoopbackExecutor::default(),
+            config_file: MockConfigFile::default(),
+            timers: HashMap::new(),
+            me: None,
+            net: None,
+            timestamp_period,
+        });
+        self.sim.with_mut(handle, |n| n.wire(handle, net));
+        let deliver = deliver_to(handle);
+        self.sim.with_mut(net, move |n| n.register(id, deliver));
+        self.nodes.push((id, handle));
+
+        let now = self.sim.now();
+        self.sim
+            .schedule(handle, now, StepLabel::source("init"), move |n, ctx| {
+                n.dispatch(init_commands, ctx);
+                n.timestamp_tick(ctx);
+            });
+    }
+
+    /// Panics if `id` is not a node in this swarm.
+    fn handle(&self, id: NodeId<Pk<S>>) -> Handle<SimNode<S>> {
+        self.nodes
+            .iter()
+            .find(|(node_id, _)| *node_id == id)
+            .map(|(_, handle)| *handle)
+            .expect("unknown node id")
+    }
+
+    /// Assert that every node agrees on the common prefix of committed blocks.
+    pub fn assert_agreement(&self) {
+        let ledgers: Vec<_> = self
+            .nodes
+            .iter()
+            .map(|(_, h)| {
+                self.sim
+                    .with(*h, |n| n.ledger.get_finalized_blocks().clone())
+            })
+            .collect();
+        let min_len = ledgers.iter().map(BTreeMap::len).min().unwrap_or(0);
+        let reference: Vec<_> = ledgers[0].iter().take(min_len).collect();
+        for ledger in &ledgers {
+            assert!(
+                ledger.iter().take(min_len).collect::<Vec<_>>() == reference,
+                "ledgers disagree on the committed prefix"
+            );
+        }
+    }
+
+    /// Build a running swarm from pre-built node components and kick it off. This
+    /// is the generic construction path: each [`SimNodeBuilder`] already carries
+    /// its node's executors, so any [`SwarmRelation`] works (e.g. the debugger's
+    /// boxed relation). Network behaviour comes from `network`, which receives the
+    /// node ids.
+    pub fn from_builders(
+        seed: u64,
+        builders: Vec<SimNodeBuilder<S>>,
+        network: impl FnOnce(&[NodeId<Pk<S>>]) -> Network<S>,
+    ) -> SimSwarm<S> {
+        let ids: Vec<NodeId<Pk<S>>> = builders.iter().map(|b| b.id).collect();
+
+        let mut sim = Simulation::new(seed);
+        let net = sim.spawn(SimNet::<S>::new(seed, network(&ids).0));
+
+        let mut pending = Vec::new();
+        for builder in builders {
+            let SimNodeBuilder {
+                id,
+                state_builder,
+                router_scheduler,
+                val_set_updater,
+                txpool_executor,
+                ledger,
+                statesync_executor,
+                timestamp_period,
+            } = builder;
+            let (state, init_commands) = state_builder.build();
+
+            let handle = sim.spawn(SimNode {
+                id,
+                state,
+                router: router_scheduler,
+                ledger,
+                txpool: txpool_executor,
+                val_set: val_set_updater,
+                statesync: statesync_executor,
+                loopback: LoopbackExecutor::default(),
+                config_file: MockConfigFile::default(),
+                timers: HashMap::new(),
+                me: None,
+                net: None,
+                timestamp_period,
+            });
+            sim.with_mut(handle, |n| n.wire(handle, net));
+            let deliver = deliver_to(handle);
+            sim.with_mut(net, move |n| n.register(id, deliver));
+            pending.push((id, handle, init_commands));
+        }
+
+        let nodes = pending
+            .iter()
+            .map(|(id, handle, _)| (*id, *handle))
+            .collect();
+        for (_, handle, init_commands) in pending {
+            sim.schedule(handle, Time(0), StepLabel::source("init"), move |n, ctx| {
+                n.dispatch(init_commands, ctx);
+                n.timestamp_tick(ctx);
+            });
+        }
+
+        SimSwarm { sim, nodes, net }
+    }
+}
+
+/* ************************************************************************** */
+/* NoSerSwarm construction */
+
+/// Build a `NoSerSwarm` swarm with the default (reliable) network.
+pub fn build_swarm(num_nodes: u16, seed: u64) -> SimSwarm<NoSerSwarm> {
+    build_swarm_with(num_nodes, seed, |_| Network::default())
+}
+
+/// Build a `num_nodes`-validator `NoSerSwarm` simulation and kick it off.
+/// `network` receives the node ids (so partitions can reference specific nodes)
+/// and returns the network behaviour.
+pub fn build_swarm_with(
+    num_nodes: u16,
+    seed: u64,
+    network: impl FnOnce(&[NodeId<Pk<NoSerSwarm>>]) -> Network<NoSerSwarm>,
+) -> SimSwarm<NoSerSwarm> {
+    SimSwarm::from_builders(seed, noser_builders(num_nodes), network)
+}
+
+/// Construct `NoSerSwarm` node builders with mock executors and the default
+/// chain config.
+fn noser_builders(num_nodes: u16) -> Vec<SimNodeBuilder<NoSerSwarm>> {
+    use monad_chain_config::{revision::ChainParams, MockChainConfig};
+    use monad_consensus_types::{block::PassthruBlockPolicy, block_validator::MockValidator};
+    use monad_execution_state_read::InMemoryStateInner;
+    use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+    use monad_types::SeqNum;
+    use monad_updaters::{
+        ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+        val_set::MockValSetUpdaterNop,
+    };
+    use monad_validator::{
+        simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory,
+    };
+
+    use crate::swarm::make_state_configs;
+
+    static CHAIN_PARAMS: ChainParams = ChainParams {
+        tx_limit: 10_000,
+        proposal_gas_limit: 300_000_000,
+        proposal_byte_limit: 4_000_000,
+        max_reserve_balance: 1_000_000_000_000_000_000,
+        vote_pace: Duration::from_millis(5),
+    };
+    let delta = Duration::from_millis(100);
+
+    let state_configs = make_state_configs::<NoSerSwarm>(
+        num_nodes,
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        || MockValidator,
+        || PassthruBlockPolicy,
+        || InMemoryStateInner::genesis(SeqNum(4)),
+        SeqNum(4),
+        delta,
+        MockChainConfig::new(&CHAIN_PARAMS),
+        SeqNum(100),
+    );
+    let all_peers: BTreeSet<NodeId<Pk<NoSerSwarm>>> = state_configs
+        .iter()
+        .map(|config| NodeId::new(config.key.pubkey()))
+        .collect();
+
+    state_configs
+        .into_iter()
+        .map(|config| {
+            let state_read = config.state_read.clone();
+            let validators = config.locked_epoch_validators[0].clone();
+            SimNodeBuilder {
+                id: NodeId::new(config.key.pubkey()),
+                state_builder: config,
+                router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                val_set_updater: MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
+                txpool_executor: MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
+                ledger: MockLedger::new(state_read.clone()),
+                statesync_executor: MockStateSyncExecutor::new(state_read),
+                timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use monad_sim::{
+        dist::normal_duration,
+        time::{millis, secs},
+    };
+
+    use super::*;
+
+    #[test]
+    fn generic_over_swarm_relation() {
+        use crate::swarm_relation::DebugSwarmRelation;
+
+        // The same nodes, boxed into the debugger's relation, run through the
+        // generic `from_builders` path — proving the sim is not tied to NoSerSwarm.
+        let builders = noser_builders(4)
+            .into_iter()
+            .map(SimNodeBuilder::debug)
+            .collect();
+        let mut swarm =
+            SimSwarm::<DebugSwarmRelation>::from_builders(0, builders, |_| Network::default());
+        swarm.run_until(Time(0) + secs(2));
+        assert!(swarm.finalized_blocks().iter().all(|&n| n >= 5));
+    }
+
+    #[test]
+    fn happy_path_tick_and_metrics() {
+        let mut swarm = build_swarm(4, 0);
+        assert!(swarm.run_until_blocks(20, Time(0) + secs(10)));
+
+        swarm.assert_agreement();
+        for id in swarm.node_ids() {
+            swarm.with_node(id, |node| {
+                let committed = node.finalized_blocks() as u64;
+                let m = node.metrics();
+                // happy path: voted on / handled at least every committed block,
+                // no blocksync, no out-of-order proposals.
+                assert!(m.consensus_events.created_vote.get() >= committed);
+                assert!(m.consensus_events.handle_proposal.get() >= committed);
+                assert_eq!(m.blocksync_events.self_headers_request.get(), 0);
+                assert_eq!(m.consensus_events.out_of_order_proposals.get(), 0);
+            });
+        }
+
+        // The scheduler is deterministic, so the final tick is an exact value;
+        // no `tick_range` tolerance is needed.
+        assert_eq!(swarm.current_tick(), Time(0) + millis(104));
+    }
+
+    #[test]
+    fn single_validator_commits_blocks() {
+        let mut swarm = build_swarm(1, 0);
+        swarm.run_until(Time(0) + secs(2));
+        assert!(swarm.finalized_blocks()[0] >= 10);
+    }
+
+    #[test]
+    fn multi_validator_commits_and_agrees() {
+        let mut swarm = build_swarm(4, 0);
+        assert!(swarm.run_until_blocks(10, Time(0) + secs(2)));
+        swarm.assert_agreement();
+    }
+
+    #[test]
+    fn run_until_round_reaches_target() {
+        use monad_types::Round;
+
+        let mut swarm = build_swarm(4, 0);
+        assert!(swarm.run_until_round(Round(20), Time(0) + secs(2)));
+        assert!(swarm.current_rounds().iter().any(|&r| r >= Round(20)));
+        swarm.assert_agreement();
+    }
+
+    #[test]
+    fn progresses_under_jittery_latency() {
+        let mut swarm = build_swarm_with(4, 0, |_| {
+            Network::with_latency(normal_duration(millis(2), millis(1)))
+        });
+        swarm.run_until(Time(0) + secs(2));
+        assert!(swarm.finalized_blocks().iter().all(|&n| n >= 5));
+    }
+
+    #[test]
+    fn even_split_partition_halts_progress() {
+        // A 2|2 split: neither side has a supermajority (3 of 4), so no blocks
+        // can commit while the partition holds.
+        let mut swarm = build_swarm_with(4, 0, |ids| {
+            Network::reliable(millis(1)).partition(
+                Time(0)..Time(i128::MAX),
+                [vec![ids[0], ids[1]], vec![ids[2], ids[3]]],
+            )
+        });
+        swarm.run_until(Time(0) + secs(2));
+        assert!(
+            swarm.finalized_blocks().iter().all(|&n| n == 0),
+            "expected no progress under an even split, got {:?}",
+            swarm.finalized_blocks()
+        );
+    }
+}

--- a/monad-mock-swarm/src/sim_verify.rs
+++ b/monad-mock-swarm/src/sim_verify.rs
@@ -1,0 +1,412 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Assertions for swarms driven through the `monad-sim` harness.
+//!
+//! This is the new framework's self-contained replacement for the legacy
+//! `MockSwarmVerifier` / `swarm_ledger_verification`. It drives a [`SimSwarm`]
+//! purely through its public surface ([`SimSwarm::with_node`],
+//! [`SimSwarm::node_ids`], [`SimSwarm::current_tick`]) and depends on none of
+//! the legacy engine.
+//!
+//! Collect expectations on a [`SimVerifier`] and call [`SimVerifier::assert`]
+//! (or [`SimVerifier::check`] for the `Result`). Metric selectors are written
+//! with the [`sim_metric!`] macro, e.g.
+//! `verifier.metric_min(&ids, sim_metric!(consensus_events.created_vote), n)`.
+
+use std::collections::BTreeMap;
+
+use monad_consensus_types::metrics::Metrics;
+use monad_crypto::certificate_signature::CertificateSignaturePubKey;
+use monad_sim::Time;
+use monad_types::NodeId;
+use monad_updaters::ledger::MockableLedger;
+
+use crate::{sim::SimSwarm, swarm_relation::SwarmRelation};
+
+type Pk<S> = CertificateSignaturePubKey<<S as SwarmRelation>::SignatureType>;
+type MetricSelector = Box<dyn Fn(&Metrics) -> u64>;
+
+/// Builds a `(name, selector)` pair for a [`Metrics`] field, for the
+/// `metric_*` methods on [`SimVerifier`]. The path is the field access minus
+/// the trailing `.get()`, e.g. `sim_metric!(consensus_events.local_timeout)`.
+#[macro_export]
+macro_rules! sim_metric {
+    ( $( $k:ident ).+ ) => {
+        (stringify!($($k).+), |m| m.$($k).+.get())
+    };
+}
+
+enum ExpectedTick {
+    Exact(Time),
+    Range(Time, Time),
+}
+
+#[derive(Clone, Debug)]
+enum ExpectedMetric {
+    Exact(u64),
+    Range(u64, u64),
+    Minimum(u64),
+    Maximum(u64),
+}
+
+/// Accumulates tick / ledger / per-node-metric expectations, then checks them
+/// against a [`SimSwarm`].
+pub struct SimVerifier<S: SwarmRelation> {
+    tick: Option<ExpectedTick>,
+    min_ledger_len: Option<usize>,
+    metrics: BTreeMap<(NodeId<Pk<S>>, &'static str), (MetricSelector, ExpectedMetric)>,
+}
+
+impl<S: SwarmRelation> Default for SimVerifier<S> {
+    fn default() -> Self {
+        Self {
+            tick: None,
+            min_ledger_len: None,
+            metrics: BTreeMap::new(),
+        }
+    }
+}
+
+impl<S: SwarmRelation> SimVerifier<S> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Expect the final tick to equal `tick` exactly.
+    pub fn tick_exact(&mut self, tick: Time) -> &mut Self {
+        self.tick = Some(ExpectedTick::Exact(tick));
+        self
+    }
+
+    /// Expect the final tick to fall within `[lower, upper]`.
+    pub fn tick_range(&mut self, lower: Time, upper: Time) -> &mut Self {
+        self.tick = Some(ExpectedTick::Range(lower, upper));
+        self
+    }
+
+    /// Expect every node's ledger to hold at least `min` finalized blocks.
+    pub fn ledger_min_len(&mut self, min: usize) -> &mut Self {
+        self.min_ledger_len = Some(min);
+        self
+    }
+
+    pub fn metric_exact<F: Fn(&Metrics) -> u64 + Clone + 'static>(
+        &mut self,
+        node_ids: &[NodeId<Pk<S>>],
+        metric: (&'static str, F),
+        value: u64,
+    ) -> &mut Self {
+        self.insert(node_ids, metric, ExpectedMetric::Exact(value))
+    }
+
+    pub fn metric_range<F: Fn(&Metrics) -> u64 + Clone + 'static>(
+        &mut self,
+        node_ids: &[NodeId<Pk<S>>],
+        metric: (&'static str, F),
+        lower: u64,
+        upper: u64,
+    ) -> &mut Self {
+        self.insert(node_ids, metric, ExpectedMetric::Range(lower, upper))
+    }
+
+    pub fn metric_min<F: Fn(&Metrics) -> u64 + Clone + 'static>(
+        &mut self,
+        node_ids: &[NodeId<Pk<S>>],
+        metric: (&'static str, F),
+        minimum: u64,
+    ) -> &mut Self {
+        self.insert(node_ids, metric, ExpectedMetric::Minimum(minimum))
+    }
+
+    pub fn metric_max<F: Fn(&Metrics) -> u64 + Clone + 'static>(
+        &mut self,
+        node_ids: &[NodeId<Pk<S>>],
+        metric: (&'static str, F),
+        maximum: u64,
+    ) -> &mut Self {
+        self.insert(node_ids, metric, ExpectedMetric::Maximum(maximum))
+    }
+
+    fn insert<F: Fn(&Metrics) -> u64 + Clone + 'static>(
+        &mut self,
+        node_ids: &[NodeId<Pk<S>>],
+        metric: (&'static str, F),
+        expected: ExpectedMetric,
+    ) -> &mut Self {
+        let (name, selector) = metric;
+        // Last write for a given (id, name) wins, matching the legacy map.
+        for &id in node_ids {
+            self.metrics
+                .insert((id, name), (Box::new(selector.clone()), expected.clone()));
+        }
+        self
+    }
+
+    /// Check all expectations, collecting every failure.
+    pub fn check(&self, swarm: &SimSwarm<S>) -> Result<(), Vec<String>> {
+        let mut failures = Vec::new();
+
+        if let Some(expected) = &self.tick {
+            let actual = swarm.current_tick();
+            match expected {
+                ExpectedTick::Exact(t) => {
+                    if actual != *t {
+                        failures.push(format!("tick: expected {:?}, got {:?}", t, actual));
+                    }
+                }
+                ExpectedTick::Range(lower, upper) => {
+                    if actual < *lower || actual > *upper {
+                        failures.push(format!(
+                            "tick: expected [{:?}, {:?}], got {:?}",
+                            lower, upper, actual
+                        ));
+                    }
+                }
+            }
+        }
+
+        if let Some(min) = self.min_ledger_len {
+            for id in swarm.node_ids() {
+                let len = swarm.with_node(id, |node| node.ledger().get_finalized_blocks().len());
+                if len < min {
+                    failures.push(format!(
+                        "ledger: node {} has {} finalized blocks, expected >= {}",
+                        id, len, min
+                    ));
+                }
+            }
+        }
+
+        for ((id, name), (selector, expected)) in &self.metrics {
+            let actual = swarm.with_node(*id, |node| selector(node.metrics()));
+            let ok = match expected {
+                ExpectedMetric::Exact(v) => actual == *v,
+                ExpectedMetric::Range(l, u) => actual >= *l && actual <= *u,
+                ExpectedMetric::Minimum(v) => actual >= *v,
+                ExpectedMetric::Maximum(v) => actual <= *v,
+            };
+            if !ok {
+                failures.push(format!(
+                    "metric {} on node {}: expected {:?}, got {}",
+                    name, id, expected, actual
+                ));
+            }
+        }
+
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(failures)
+        }
+    }
+
+    /// Check all expectations, panicking with every failure if any fail.
+    pub fn assert(&self, swarm: &SimSwarm<S>) {
+        if let Err(failures) = self.check(swarm) {
+            panic!("SimVerifier failed:\n  {}", failures.join("\n  "));
+        }
+    }
+
+    /// Happy-path consensus/blocksync expectations for the given nodes,
+    /// independent of the path their peers take. Mirrors the legacy
+    /// `MockSwarmVerifier::metrics_happy_path`. Call after running the swarm
+    /// (it reads each node's ledger to derive the per-node bounds).
+    pub fn metrics_happy_path(
+        &mut self,
+        node_ids: &[NodeId<Pk<S>>],
+        swarm: &SimSwarm<S>,
+    ) -> &mut Self {
+        let num_nodes_total = swarm.node_ids().len() as u64;
+        // TODO: add stake awareness
+        let super_majority_nodes = num_nodes_total * 2 / 3 + 1;
+        let max_byzantine_nodes = num_nodes_total - super_majority_nodes;
+
+        // initial local timeout
+        self.metric_exact(node_ids, sim_metric!(consensus_events.local_timeout), 1)
+            .metric_exact(
+                node_ids,
+                sim_metric!(consensus_events.failed_txn_validation),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(consensus_events.invalid_proposal_round_leader),
+                0,
+            )
+            // should not miss a block in between
+            .metric_exact(
+                node_ids,
+                sim_metric!(consensus_events.out_of_order_proposals),
+                0,
+            )
+            // initial TC. In the happy path a node should never create a TC otherwise.
+            .metric_exact(node_ids, sim_metric!(consensus_events.created_tc), 1)
+            .metric_exact(
+                node_ids,
+                sim_metric!(consensus_events.rx_execution_lagging),
+                0,
+            )
+            // first proposal in Round 2 with TC
+            .metric_max(node_ids, sim_metric!(consensus_events.proposal_with_tc), 1)
+            .metric_exact(
+                node_ids,
+                sim_metric!(consensus_events.failed_verify_randao_reveal_sig),
+                0,
+            )
+            // blocksync metrics: should not request blocksync
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.self_headers_request),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.self_payload_request),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.headers_response_successful),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.headers_response_failed),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.headers_response_unexpected),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.headers_validation_failed),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.payload_response_successful),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.payload_response_failed),
+                0,
+            )
+            .metric_exact(
+                node_ids,
+                sim_metric!(blocksync_events.payload_response_unexpected),
+                0,
+            );
+
+        for &node_id in node_ids {
+            let (ledger_len, num_blocks_authored) = swarm.with_node(node_id, |node| {
+                let ledger = node.ledger().get_finalized_blocks();
+                let ledger_len = ledger.len() as u64;
+                // ledger should have genesis block
+                assert!(ledger_len > 0);
+                // number of blocks authored in the ledger <= number of rounds as
+                // leader. NOTE: '<=' since blocks can be rejected.
+                let authored = ledger
+                    .values()
+                    .filter(|b| b.get_author() == &node_id)
+                    .count() as u64;
+                (ledger_len, authored)
+            });
+
+            // should handle a proposal for all blocks in the ledger
+            self.metric_min(
+                &[node_id],
+                sim_metric!(consensus_events.handle_proposal),
+                ledger_len,
+            )
+            // should vote for every block in the ledger
+            .metric_min(
+                &[node_id],
+                sim_metric!(consensus_events.created_vote),
+                ledger_len,
+            )
+            // votes from f peers after receiving 2f+1 votes as a leader; 2x
+            // because votes are sent to the current and next leader
+            .metric_max(
+                &[node_id],
+                sim_metric!(consensus_events.old_vote_received),
+                2 * (num_blocks_authored + 1) * max_byzantine_nodes,
+            )
+            // votes from 2f+1 peers as a leader, except if the node is leader in
+            // round 2 when it receives timeouts instead
+            .metric_min(
+                &[node_id],
+                sim_metric!(consensus_events.vote_received),
+                num_blocks_authored.saturating_sub(1) * super_majority_nodes,
+            )
+            // should create a QC every time the node is a leader, except for the
+            // block produced in round 2 which uses the TC from round 1
+            .metric_min(
+                &[node_id],
+                sim_metric!(consensus_events.created_qc),
+                num_blocks_authored.saturating_sub(1),
+            )
+            // a node processes an old QC (generated by itself) when it receives
+            // it in the proposal for the next round
+            .metric_min(
+                &[node_id],
+                sim_metric!(consensus_events.process_old_qc),
+                num_blocks_authored,
+            )
+            // should create proposals for all blocks authored in the ledger
+            .metric_min(
+                &[node_id],
+                sim_metric!(consensus_events.creating_proposal),
+                num_blocks_authored,
+            );
+        }
+
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use monad_sim::{time::secs, Time};
+
+    use super::*;
+    use crate::sim::build_swarm;
+
+    #[test]
+    fn happy_path_verifier_passes() {
+        let mut swarm = build_swarm(4, 0);
+        assert!(swarm.run_until_blocks(20, Time(0) + secs(10)));
+        let ids = swarm.node_ids();
+
+        let mut verifier = SimVerifier::new();
+        verifier.ledger_min_len(1).metrics_happy_path(&ids, &swarm);
+        verifier.assert(&swarm);
+    }
+
+    #[test]
+    fn detects_metric_mismatch() {
+        let mut swarm = build_swarm(4, 0);
+        assert!(swarm.run_until_blocks(10, Time(0) + secs(10)));
+        let ids = swarm.node_ids();
+
+        // local_timeout is 1 on the happy path; expecting 999 must fail.
+        let mut verifier = SimVerifier::new();
+        verifier.metric_exact(&ids, sim_metric!(consensus_events.local_timeout), 999);
+        assert!(verifier.check(&swarm).is_err());
+    }
+}

--- a/monad-mock-swarm/src/swarm_relation.rs
+++ b/monad-mock-swarm/src/swarm_relation.rs
@@ -89,7 +89,7 @@ where
     type ChainConfigType: ChainConfig<Self::ChainRevisionType> + Send + Unpin;
     type ChainRevisionType: ChainRevision + Send + Unpin;
 
-    type TransportMessage: PartialEq + Eq + Send + Sync + Unpin;
+    type TransportMessage: PartialEq + Eq + Send + Sync + Unpin + Clone;
 
     type BlockValidator: BlockValidator<
             Self::SignatureType,

--- a/monad-mock-swarm/tests/eth_swarm_common/mod.rs
+++ b/monad-mock-swarm/tests/eth_swarm_common/mod.rs
@@ -39,6 +39,7 @@ use monad_mock_swarm::{
     mock::TimestamperConfig,
     mock_swarm::{Nodes, SwarmBuilder},
     node::NodeBuilder,
+    sim::{SimNodeBuilder, SimSwarm, DEFAULT_TIMESTAMP_PERIOD},
     swarm::make_state_configs,
     swarm_relation::SwarmRelation,
 };
@@ -134,12 +135,12 @@ pub static CHAIN_PARAMS: ChainParams = ChainParams {
     vote_pace: Duration::from_millis(0),
 };
 
-pub fn generate_eth_swarm_with_accounts(
+pub fn eth_swarm_config_with_accounts(
     num_nodes: u16,
     existing_accounts: BTreeMap<Address, AccountState>,
     txpool_byzantine_config: impl Fn(usize) -> ByzantineConfig,
     validate_reserve_balance: bool,
-) -> Nodes<EthSwarm> {
+) -> SwarmBuilder<EthSwarm> {
     let epoch_length = SeqNum(2000);
     let execution_delay = SeqNum(4);
 
@@ -172,7 +173,7 @@ pub fn generate_eth_swarm_with_accounts(
         .iter()
         .map(|state_config| NodeId::new(state_config.key.pubkey()))
         .collect();
-    let swarm_config = SwarmBuilder::<EthSwarm>(
+    SwarmBuilder::<EthSwarm>(
         state_configs
             .into_iter()
             .enumerate()
@@ -198,9 +199,98 @@ pub fn generate_eth_swarm_with_accounts(
                 )
             })
             .collect(),
-    );
+    )
+}
 
-    swarm_config.build()
+pub fn generate_eth_swarm_with_accounts(
+    num_nodes: u16,
+    existing_accounts: BTreeMap<Address, AccountState>,
+    txpool_byzantine_config: impl Fn(usize) -> ByzantineConfig,
+    validate_reserve_balance: bool,
+) -> Nodes<EthSwarm> {
+    eth_swarm_config_with_accounts(
+        num_nodes,
+        existing_accounts,
+        txpool_byzantine_config,
+        validate_reserve_balance,
+    )
+    .build()
+}
+
+/// The `monad-sim` counterpart of [`generate_eth_swarm`]: returns the node
+/// builders ready to feed into [`SimSwarm::from_builders`]. Constructed directly
+/// (no transformer pipelines) so the new framework stays independent of the
+/// legacy `SwarmBuilder` / `NodeBuilder` path.
+pub fn eth_swarm_config(
+    num_nodes: u16,
+    existing_accounts: impl IntoIterator<Item = Address>,
+    txpool_byzantine_config: impl Fn(usize) -> ByzantineConfig,
+) -> Vec<SimNodeBuilder<EthSwarm>> {
+    let existing_accounts: BTreeMap<Address, AccountState> = existing_accounts
+        .into_iter()
+        .map(|acc| (acc, AccountState::max_balance()))
+        .collect();
+    eth_sim_builders_with_accounts(num_nodes, existing_accounts, txpool_byzantine_config, false)
+}
+
+/// `monad-sim` builders mirroring [`eth_swarm_config_with_accounts`].
+pub fn eth_sim_builders_with_accounts(
+    num_nodes: u16,
+    existing_accounts: BTreeMap<Address, AccountState>,
+    txpool_byzantine_config: impl Fn(usize) -> ByzantineConfig,
+    validate_reserve_balance: bool,
+) -> Vec<SimNodeBuilder<EthSwarm>> {
+    let epoch_length = SeqNum(2000);
+    let execution_delay = SeqNum(4);
+    let chain_config = MockChainConfig::new(&CHAIN_PARAMS);
+    let create_block_policy = || EthBlockPolicy::new(GENESIS_SEQ_NUM, execution_delay.0);
+
+    let state_configs = make_state_configs::<EthSwarm>(
+        num_nodes,
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        EthBlockValidator::default,
+        create_block_policy,
+        || {
+            let state = InMemoryStateInner::new(
+                execution_delay,
+                InMemoryBlockState::genesis(existing_accounts.clone()),
+            );
+            if validate_reserve_balance {
+                state.lock().unwrap().validate_reserve_balance = true;
+            }
+            state
+        },
+        execution_delay,
+        CONSENSUS_DELTA,
+        chain_config,
+        SeqNum(100),
+    );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|state_config| NodeId::new(state_config.key.pubkey()))
+        .collect();
+
+    state_configs
+        .into_iter()
+        .enumerate()
+        .map(|(idx, state_builder)| {
+            let validators = state_builder.locked_epoch_validators[0].clone();
+            let state_read = state_builder.state_read.clone();
+            SimNodeBuilder {
+                id: NodeId::new(state_builder.key.pubkey()),
+                state_builder,
+                router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                val_set_updater: MockValSetUpdaterNop::new(validators.validators, epoch_length),
+                txpool_executor: MockTxPoolExecutor::new(create_block_policy(), state_read.clone())
+                    .with_chain_params(&CHAIN_PARAMS)
+                    .with_byzantine_config(txpool_byzantine_config(idx)),
+                ledger: MockEthLedger::new(state_read.clone()),
+                statesync_executor: MockStateSyncExecutor::new(state_read),
+                timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+            }
+        })
+        .collect()
 }
 
 pub fn generate_eth_swarm(
@@ -244,6 +334,36 @@ pub fn verify_transactions_in_ledger(
                 "Expected transactions don't exist. NodeID: {}, TxnHashes: {:?}",
                 node_id, txns_to_see
             );
+            return false;
+        }
+    }
+
+    true
+}
+
+/// [`verify_transactions_in_ledger`] for a swarm driven by the `monad-sim` harness.
+pub fn verify_transactions_in_sim(swarm: &SimSwarm<EthSwarm>, txns: Vec<TxEnvelope>) -> bool {
+    let txns: HashSet<_> = HashSet::from_iter(txns.iter().map(|t| *t.tx_hash()));
+    for node_id in swarm.node_ids() {
+        let mut txns_to_see = txns.clone();
+        let consistent = swarm.with_node(node_id, |node| {
+            for (round, block) in node.ledger().get_finalized_blocks() {
+                for txn in &block.body().execution_body.transactions {
+                    let txn_hash = txn.tx_hash();
+                    if txns_to_see.contains(txn_hash) {
+                        txns_to_see.remove(txn_hash);
+                    } else {
+                        println!(
+                            "Unexpected transaction in block round {}. SeqNum: {}, NodeID: {}, TxnHash: {}, Nonce: {}",
+                            round.0, block.get_seq_num().0, node_id, txn_hash, txn.nonce()
+                        );
+                        return false;
+                    }
+                }
+            }
+            txns_to_see.is_empty()
+        });
+        if !consistent {
             return false;
         }
     }

--- a/monad-mock-swarm/tests/sim_block_sync.rs
+++ b/monad-mock-swarm/tests/sim_block_sync.rs
@@ -1,0 +1,321 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Blocksync-recovery coverage, ported onto the `monad-sim` harness (mirrors
+//! the legacy `block_sync.rs`, which it does not replace).
+//!
+//! The legacy tests blackout nodes by mutating the transformer pipeline mid-run
+//! (`Partition + Periodic(from,to) + Drop`); the new framework expresses the
+//! same thing declaratively with a time-bounded `Network::partition(from..to,
+//! groups)` — no mid-run mutation. After the window the partition heals and the
+//! blacked-out nodes catch up via blocksync.
+//!
+//! Ported here: `black_out_recovery_with_block_sync` (6 cases),
+//! `lack_of_progress`, `extreme_delay_recovery_with_block_sync`,
+//! `bsync_timeout_recovery`.
+//!
+//! NOTE on `bsync_timeout_recovery`: the legacy test's middle phase (reconnected
+//! but blocksync still banned) was effectively a no-op — its `until_tick(5s)`
+//! fired immediately because the clock was already at 5s. The port here
+//! implements the *intended* scenario with real time windows, which is stronger
+//! coverage: blackout `[0,5s)`, then `[5s,10s)` reconnected but blocksync
+//! dropped (the node can follow new rounds but can't backfill the gap), then
+//! open — only then can it catch up.
+
+mod sim_common;
+
+#[cfg(test)]
+mod test {
+    use std::{collections::BTreeSet, time::Duration};
+
+    use monad_chain_config::{revision::ChainParams, MockChainConfig};
+    use monad_consensus_types::{block::PassthruBlockPolicy, block_validator::MockValidator};
+    use monad_crypto::{
+        certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey},
+        NopSignature,
+    };
+    use monad_execution_state_read::InMemoryStateInner;
+    use monad_mock_swarm::{
+        sim::{Network, SimNodeBuilder, SimSwarm, DEFAULT_TIMESTAMP_PERIOD},
+        sim_metric,
+        sim_verify::SimVerifier,
+        swarm::make_state_configs,
+        swarm_relation::MonadMessageNoSerSwarm,
+    };
+    use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+    use monad_sim::{time::secs, Time};
+    use monad_state::VerifiedMonadMessage;
+    use monad_types::{NodeId, SeqNum};
+    use monad_updaters::{
+        ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+        val_set::MockValSetUpdaterNop,
+    };
+    use monad_validator::{
+        simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory,
+    };
+    use test_case::test_case;
+
+    use crate::sim_common::{NoSerConfig, WindowedDelay};
+
+    static CHAIN_PARAMS: ChainParams = ChainParams {
+        tx_limit: 10_000,
+        proposal_gas_limit: 300_000_000,
+        proposal_byte_limit: 4_000_000,
+        max_reserve_balance: 1_000_000_000_000_000_000,
+        vote_pace: Duration::from_millis(5),
+    };
+
+    #[test_case(4, Duration::from_millis(100), Duration::from_millis(200), Duration::from_secs(4), 1; "test 1")]
+    #[test_case(50, Duration::from_secs(1), Duration::from_secs(2), Duration::from_secs(4), 10; "test 2")]
+    #[test_case(50, Duration::from_secs(1), Duration::from_secs(2), Duration::from_secs(4), 25; "test 3")]
+    #[test_case(50, Duration::from_secs(1), Duration::from_secs(2), Duration::from_secs(4), 50; "test 4")]
+    #[test_case(10, Duration::from_secs(0), Duration::from_secs(2), Duration::from_secs(4), 3; "test 5")]
+    #[test_case(10, Duration::from_secs(0), Duration::from_secs(10), Duration::from_secs(20), 3; "test 6")]
+    fn black_out_recovery_with_block_sync(
+        num_nodes: u16,
+        from: Duration,
+        to: Duration,
+        until: Duration,
+        black_out_cnt: usize,
+    ) {
+        let delta = Duration::from_millis(20);
+        assert!(
+            from < to
+                && to < until
+                && black_out_cnt <= (num_nodes as usize)
+                && black_out_cnt >= 1
+                && num_nodes >= 4
+        );
+
+        // high execution delay so the state root doesn't trigger
+        let mut swarm = NoSerConfig::new(num_nodes, delta, &CHAIN_PARAMS)
+            .execution_delay(SeqNum::MAX)
+            .genesis_seqnum(SeqNum::MAX)
+            .statesync_threshold(SeqNum(2000))
+            .swarm(|ids| {
+                // blackout the first `black_out_cnt` nodes (key-gen order, matching
+                // the legacy `state_configs.iter().take(black_out_cnt)`) by
+                // partitioning them off from the rest during [from, to).
+                let blacked: Vec<_> = ids[..black_out_cnt].to_vec();
+                Network::reliable(delta).partition((Time(0) + from)..(Time(0) + to), [blacked])
+            });
+
+        swarm.run_until(Time(0) + until);
+
+        let ids = swarm.node_ids();
+        let running: Vec<_> = ids[black_out_cnt..].to_vec();
+        let ledger_len = swarm.finalized_blocks().into_iter().max().unwrap_or(0) as u64;
+
+        let mut verifier = SimVerifier::new();
+        verifier
+            // every node (incl. recovered) commits at least 20 blocks
+            .ledger_min_len(20)
+            // the never-partitioned nodes never need blocksync
+            .metric_exact(
+                &running,
+                sim_metric!(blocksync_events.self_headers_request),
+                0,
+            )
+            .metric_exact(
+                &running,
+                sim_metric!(blocksync_events.self_payload_request),
+                0,
+            )
+            .metric_min(
+                &running,
+                sim_metric!(consensus_events.handle_proposal),
+                ledger_len,
+            )
+            .metric_min(
+                &running,
+                sim_metric!(consensus_events.created_vote),
+                ledger_len,
+            );
+        verifier.assert(&swarm);
+    }
+
+    #[test]
+    fn extreme_delay_recovery_with_block_sync() {
+        // A few messages to/from the first node are delayed ~800ms during the
+        // window [1s, 2s); the node recovers via blocksync afterwards.
+        let delta = Duration::from_millis(50);
+        let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+            .execution_delay(SeqNum::MAX)
+            .genesis_seqnum(SeqNum::MAX)
+            .swarm(|ids| {
+                Network::custom(WindowedDelay {
+                    slow: ids[0],
+                    delta,
+                    window: (Time(0) + secs(1))..(Time(0) + secs(2)),
+                    extra: Duration::from_millis(800),
+                })
+            });
+
+        swarm.run_until(Time(0) + secs(8));
+
+        let ids = swarm.node_ids();
+        let running: Vec<_> = ids[1..].to_vec();
+        let ledger_len = swarm.finalized_blocks().into_iter().max().unwrap_or(0) as u64;
+
+        let mut verifier = SimVerifier::new();
+        verifier
+            .ledger_min_len(20)
+            .metric_exact(
+                &running,
+                sim_metric!(blocksync_events.self_headers_request),
+                0,
+            )
+            .metric_exact(
+                &running,
+                sim_metric!(blocksync_events.self_payload_request),
+                0,
+            )
+            .metric_min(
+                &running,
+                sim_metric!(consensus_events.handle_proposal),
+                ledger_len,
+            )
+            .metric_min(
+                &running,
+                sim_metric!(consensus_events.created_vote),
+                ledger_len,
+            );
+        verifier.assert(&swarm);
+    }
+
+    #[test]
+    fn lack_of_progress() {
+        let delta = Duration::from_millis(50);
+        let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+            .execution_delay(SeqNum::MAX)
+            .genesis_seqnum(SeqNum::MAX)
+            .swarm(|ids| {
+                // the first node is partitioned off forever — it can never make
+                // progress (the legacy asserts this via a ProgressTerminator that
+                // times out; here we assert the stuck node stays at zero).
+                let stuck = vec![ids[0]];
+                Network::reliable(delta).partition(Time(0)..Time(i128::MAX), [stuck])
+            });
+
+        swarm.run_until(Time(0) + secs(3));
+
+        let ids = swarm.node_ids();
+        let stuck = swarm.with_node(ids[0], |n| n.finalized_blocks());
+        assert_eq!(stuck, 0, "partitioned node should make no progress");
+        // the remaining supermajority keeps committing
+        for &id in &ids[1..] {
+            assert!(
+                swarm.with_node(id, |n| n.finalized_blocks()) > 0,
+                "connected node {id} made no progress"
+            );
+        }
+    }
+
+    /// A 4-node `MonadMessageNoSerSwarm` (its transport is `VerifiedMonadMessage`,
+    /// so the network model can match on message type).
+    fn mm_swarm(
+        delta: Duration,
+        network: impl FnOnce(
+            &[NodeId<CertificateSignaturePubKey<NopSignature>>],
+        ) -> Network<MonadMessageNoSerSwarm>,
+    ) -> SimSwarm<MonadMessageNoSerSwarm> {
+        let state_configs = make_state_configs::<MonadMessageNoSerSwarm>(
+            4,
+            ValidatorSetFactory::default,
+            SimpleRoundRobin::default,
+            || MockValidator,
+            || PassthruBlockPolicy,
+            || InMemoryStateInner::genesis(SeqNum::MAX),
+            SeqNum::MAX,
+            delta,
+            MockChainConfig::new(&CHAIN_PARAMS),
+            SeqNum(1000),
+        );
+        let all_peers: BTreeSet<_> = state_configs
+            .iter()
+            .map(|config| NodeId::new(config.key.pubkey()))
+            .collect();
+        let builders: Vec<SimNodeBuilder<MonadMessageNoSerSwarm>> = state_configs
+            .into_iter()
+            .map(|config| {
+                let state_read = config.state_read.clone();
+                let validators = config.locked_epoch_validators[0].clone();
+                SimNodeBuilder {
+                    id: NodeId::new(config.key.pubkey()),
+                    state_builder: config,
+                    router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                    val_set_updater: MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
+                    txpool_executor: MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
+                    ledger: MockLedger::new(state_read.clone()),
+                    statesync_executor: MockStateSyncExecutor::new(state_read),
+                    timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+                }
+            })
+            .collect();
+        SimSwarm::from_builders(0, builders, network)
+    }
+
+    #[test]
+    fn bsync_timeout_recovery() {
+        let delta = Duration::from_millis(50);
+        let blackout_end = Time(0) + secs(5);
+        let blocksync_ban_end = Time(0) + secs(10);
+
+        let mut swarm = mm_swarm(delta, |ids| {
+            let first = ids[0];
+            Network::reliable(delta)
+                // phase 1: first node fully partitioned off
+                .partition(Time(0)..blackout_end, [vec![first]])
+                // phases 1+2: blocksync messages dropped everywhere, so even once
+                // reconnected the first node cannot backfill the gap
+                .drop_if(move |link, msg| {
+                    link.now < blocksync_ban_end
+                        && matches!(
+                            msg,
+                            VerifiedMonadMessage::BlockSyncRequest(_)
+                                | VerifiedMonadMessage::BlockSyncResponse(_)
+                        )
+                })
+        });
+
+        let ids = swarm.node_ids();
+        let first = ids[0];
+        let running: Vec<_> = ids[1..].to_vec();
+
+        // phase 1: others make progress, the partitioned node commits nothing
+        swarm.run_until(blackout_end);
+        assert_eq!(
+            swarm.with_node(first, |n| n.finalized_blocks()),
+            0,
+            "blacked-out node should commit nothing"
+        );
+        for &id in &running {
+            assert!(swarm.with_node(id, |n| n.finalized_blocks()) >= 10);
+        }
+
+        // phase 2: reconnected, but blocksync still banned — still can't backfill
+        swarm.run_until(blocksync_ban_end);
+        assert_eq!(
+            swarm.with_node(first, |n| n.finalized_blocks()),
+            0,
+            "node cannot backfill while blocksync is banned"
+        );
+
+        // phase 3: blocksync allowed — the node catches up
+        swarm.run_until(Time(0) + secs(30));
+        SimVerifier::new().ledger_min_len(10).assert(&swarm);
+        swarm.assert_agreement();
+    }
+}

--- a/monad-mock-swarm/tests/sim_common/mod.rs
+++ b/monad-mock-swarm/tests/sim_common/mod.rs
@@ -1,0 +1,286 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Shared `NoSerSwarm` test wiring for the `monad-sim` ports. Self-contained
+//! (no legacy engine): builds [`SimNodeBuilder`]s and custom [`NetworkModel`]s.
+
+#![allow(dead_code)]
+
+use std::{collections::BTreeSet, ops::Range, time::Duration};
+
+use monad_chain_config::{revision::ChainParams, MockChainConfig};
+use monad_consensus_types::{block::PassthruBlockPolicy, block_validator::MockValidator};
+use monad_crypto::certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey, PubKey};
+use monad_execution_state_read::InMemoryStateInner;
+use monad_mock_swarm::{
+    sim::{Link, Network, NetworkModel, SimNodeBuilder, SimSwarm, DEFAULT_TIMESTAMP_PERIOD},
+    swarm::make_state_configs,
+    swarm_relation::{NoSerSwarm, SwarmRelation},
+};
+use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+use monad_sim::Time;
+use monad_types::{NodeId, Round, SeqNum};
+use monad_updaters::{
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
+};
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaChaRng;
+
+pub type NoSerPk = CertificateSignaturePubKey<<NoSerSwarm as SwarmRelation>::SignatureType>;
+type NoSerTransport = <NoSerSwarm as SwarmRelation>::TransportMessage;
+
+/// A configurable `NoSerSwarm` builder for the sim ports. Construct with
+/// [`NoSerConfig::new`], override knobs fluently, then [`builders`] or [`swarm`].
+pub struct NoSerConfig {
+    pub num_nodes: u16,
+    pub delta: Duration,
+    pub chain_params: &'static ChainParams,
+    pub execution_delay: SeqNum,
+    pub genesis_seqnum: SeqNum,
+    pub statesync_threshold: SeqNum,
+    pub epoch_length: SeqNum,
+    /// When set, the chain config uses epoch params (epoch boundaries every
+    /// `epoch_length` blocks, new epoch starting `epoch_start_delay` rounds
+    /// after the boundary block).
+    pub epoch_start_delay: Option<Round>,
+    pub seed: u64,
+}
+
+impl NoSerConfig {
+    pub fn new(num_nodes: u16, delta: Duration, chain_params: &'static ChainParams) -> Self {
+        Self {
+            num_nodes,
+            delta,
+            chain_params,
+            execution_delay: SeqNum(4),
+            genesis_seqnum: SeqNum(4),
+            statesync_threshold: SeqNum(100),
+            epoch_length: SeqNum(2000),
+            epoch_start_delay: None,
+            seed: 0,
+        }
+    }
+
+    pub fn execution_delay(mut self, v: SeqNum) -> Self {
+        self.execution_delay = v;
+        self
+    }
+
+    pub fn genesis_seqnum(mut self, v: SeqNum) -> Self {
+        self.genesis_seqnum = v;
+        self
+    }
+
+    pub fn statesync_threshold(mut self, v: SeqNum) -> Self {
+        self.statesync_threshold = v;
+        self
+    }
+
+    pub fn epoch_length(mut self, v: SeqNum) -> Self {
+        self.epoch_length = v;
+        self
+    }
+
+    pub fn epoch_start_delay(mut self, v: Round) -> Self {
+        self.epoch_start_delay = Some(v);
+        self
+    }
+
+    pub fn seed(mut self, v: u64) -> Self {
+        self.seed = v;
+        self
+    }
+
+    pub fn builders(&self) -> Vec<SimNodeBuilder<NoSerSwarm>> {
+        let genesis = self.genesis_seqnum;
+        let chain_config = match self.epoch_start_delay {
+            Some(delay) => {
+                MockChainConfig::new_with_epoch_params(self.chain_params, self.epoch_length, delay)
+            }
+            None => MockChainConfig::new(self.chain_params),
+        };
+        let state_configs = make_state_configs::<NoSerSwarm>(
+            self.num_nodes,
+            ValidatorSetFactory::default,
+            SimpleRoundRobin::default,
+            || MockValidator,
+            || PassthruBlockPolicy,
+            move || InMemoryStateInner::genesis(genesis),
+            self.execution_delay,
+            self.delta,
+            chain_config,
+            self.statesync_threshold,
+        );
+        let all_peers: BTreeSet<_> = state_configs
+            .iter()
+            .map(|config| NodeId::new(config.key.pubkey()))
+            .collect();
+        let epoch_length = self.epoch_length;
+        let chain_params = self.chain_params;
+        state_configs
+            .into_iter()
+            .map(|config| {
+                let state_read = config.state_read.clone();
+                let validators = config.locked_epoch_validators[0].clone();
+                SimNodeBuilder {
+                    id: NodeId::new(config.key.pubkey()),
+                    state_builder: config,
+                    router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                    val_set_updater: MockValSetUpdaterNop::new(validators.validators, epoch_length),
+                    txpool_executor: MockTxPoolExecutor::default().with_chain_params(chain_params),
+                    ledger: MockLedger::new(state_read.clone()),
+                    statesync_executor: MockStateSyncExecutor::new(state_read),
+                    timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+                }
+            })
+            .collect()
+    }
+
+    pub fn swarm(
+        &self,
+        network: impl FnOnce(&[NodeId<NoSerPk>]) -> Network<NoSerSwarm>,
+    ) -> SimSwarm<NoSerSwarm> {
+        SimSwarm::from_builders(self.seed, self.builders(), network)
+    }
+}
+
+/// Deterministic per-link latency = `max * (xor_of_pubkey_bytes / 255)`,
+/// matching the legacy `XorLatencyTransformer`.
+pub struct XorLatency {
+    pub max: Duration,
+}
+
+impl NetworkModel<NodeId<NoSerPk>, NoSerTransport> for XorLatency {
+    fn deliveries(
+        &mut self,
+        link: &Link<NoSerSwarm>,
+        _message: &NoSerTransport,
+        _rng: &mut ChaChaRng,
+    ) -> Vec<Duration> {
+        let mut ck: u8 = 0;
+        for b in link.from.pubkey().bytes() {
+            ck ^= b;
+        }
+        for b in link.to.pubkey().bytes() {
+            ck ^= b;
+        }
+        vec![self.max.mul_f32(ck as f32 / u8::MAX as f32)]
+    }
+}
+
+/// Base `delta` latency, plus `extra` for messages crossing the `slow` node's
+/// boundary while `window` is active. Matches the legacy
+/// `Partition(slow) + Periodic(window) + Latency(extra)` pipeline.
+pub struct WindowedDelay {
+    pub slow: NodeId<NoSerPk>,
+    pub delta: Duration,
+    pub window: Range<Time>,
+    pub extra: Duration,
+}
+
+impl NetworkModel<NodeId<NoSerPk>, NoSerTransport> for WindowedDelay {
+    fn deliveries(
+        &mut self,
+        link: &Link<NoSerSwarm>,
+        _message: &NoSerTransport,
+        _rng: &mut ChaChaRng,
+    ) -> Vec<Duration> {
+        let crossing = (link.from == self.slow) != (link.to == self.slow);
+        let extra = if crossing && self.window.contains(&link.now) {
+            self.extra
+        } else {
+            Duration::ZERO
+        };
+        vec![self.delta + extra]
+    }
+}
+
+/// Order in which [`ReplayNetwork`] bursts held messages.
+#[derive(Clone, Copy)]
+pub enum ReplayOrder {
+    Forward,
+    Reverse,
+    Random(u64),
+}
+
+/// Isolates `node` by holding every message crossing its boundary until
+/// `release`, then delivering the held messages in a tight burst at `release`,
+/// ordered per [`ReplayOrder`]. Everything else gets the base `delta` latency.
+/// Models the legacy inbound `Partition(node) + Replay(release, order)`.
+pub struct ReplayNetwork {
+    node: NodeId<NoSerPk>,
+    release: Time,
+    delta: Duration,
+    order: ReplayOrder,
+    rng: ChaChaRng,
+    held: u64,
+}
+
+impl ReplayNetwork {
+    pub fn new(node: NodeId<NoSerPk>, release: Time, delta: Duration, order: ReplayOrder) -> Self {
+        let seed = match order {
+            ReplayOrder::Random(seed) => seed,
+            _ => 0,
+        };
+        Self {
+            node,
+            release,
+            delta,
+            order,
+            rng: ChaChaRng::seed_from_u64(seed),
+            held: 0,
+        }
+    }
+}
+
+impl NetworkModel<NodeId<NoSerPk>, NoSerTransport> for ReplayNetwork {
+    fn deliveries(
+        &mut self,
+        link: &Link<NoSerSwarm>,
+        _message: &NoSerTransport,
+        _rng: &mut ChaChaRng,
+    ) -> Vec<Duration> {
+        let crossing = (link.from == self.node) != (link.to == self.node);
+        if crossing && link.now < self.release {
+            // Held: deliver at `release`, with a sub-ms offset that orders the
+            // burst. (Same delivery instant, different offsets -> the scheduler
+            // processes them in offset order.)
+            let to_release = (self.release.0 - link.now.0) as u64;
+            let idx = self.held % 1_000_000;
+            self.held += 1;
+            let offset = match self.order {
+                ReplayOrder::Forward => idx,
+                ReplayOrder::Reverse => 999_999 - idx,
+                ReplayOrder::Random(_) => self.rng.gen_range(0..1_000_000),
+            };
+            vec![Duration::from_nanos(to_release + offset)]
+        } else {
+            vec![self.delta]
+        }
+    }
+}
+
+/// A [`Network`] that holds and replays one node's messages — see
+/// [`ReplayNetwork`].
+pub fn replay_network(
+    node: NodeId<NoSerPk>,
+    release: Time,
+    delta: Duration,
+    order: ReplayOrder,
+) -> Network<NoSerSwarm> {
+    Network::custom(ReplayNetwork::new(node, release, delta, order))
+}

--- a/monad-mock-swarm/tests/sim_epoch.rs
+++ b/monad-mock-swarm/tests/sim_epoch.rs
@@ -1,0 +1,497 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Epoch / validator-set-change coverage, ported onto the `monad-sim` harness
+//! (mirrors the legacy `epoch.rs`, which it does not replace). All four legacy
+//! tests are ported: `validator_switching`, `schedule_and_advance_epoch`,
+//! `verify_correct_leaders_in_epoch`, and `schedule_epoch_after_blocksync`.
+//!
+//! `schedule_epoch_after_blocksync` uses `SimSwarm::set_network` (mid-run
+//! reconfiguration) to blackout a node for exactly the few blocks around the
+//! epoch boundary — matching the legacy's event-triggered blackout, so the node
+//! recovers via blocksync rather than statesync (and avoids a production
+//! `todo!` reached only when a node falls many blocks behind across a boundary).
+
+mod sim_common;
+
+#[cfg(test)]
+mod test {
+    use std::{collections::BTreeSet, time::Duration};
+
+    use monad_chain_config::{
+        revision::{ChainParams, MockChainRevision},
+        MockChainConfig,
+    };
+    use monad_consensus_types::{
+        block::{MockExecutionProtocol, PassthruBlockPolicy},
+        block_validator::MockValidator,
+    };
+    use monad_crypto::{
+        certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey},
+        NopSignature,
+    };
+    use monad_execution_state_read::{InMemoryState, InMemoryStateInner};
+    use monad_mock_swarm::{
+        sim::{Network, SimNodeBuilder, SimSwarm, DEFAULT_TIMESTAMP_PERIOD},
+        sim_metric,
+        sim_verify::SimVerifier,
+        swarm::make_state_configs,
+        swarm_relation::SwarmRelation,
+    };
+    use monad_multi_sig::MultiSig;
+    use monad_router_scheduler::{NoSerRouterConfig, NoSerRouterScheduler, RouterSchedulerBuilder};
+    use monad_sim::{time::secs, Time};
+    use monad_state::{MonadMessage, Role, VerifiedMonadMessage};
+    use monad_transformer::GenericTransformerPipeline;
+    use monad_types::{Epoch, NodeId, Round, SeqNum};
+    use monad_updaters::{
+        ledger::{MockLedger, MockableLedger},
+        statesync::MockStateSyncExecutor,
+        txpool::MockTxPoolExecutor,
+        val_set::MockValSetUpdaterSwap,
+    };
+    use monad_validator::{
+        simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory,
+    };
+    use test_case::test_case;
+
+    use crate::sim_common::NoSerConfig;
+
+    type Pk<S> = CertificateSignaturePubKey<<S as SwarmRelation>::SignatureType>;
+
+    static EPOCH_LENGTH: SeqNum = SeqNum(1000);
+
+    struct ValidatorSwapSwarm;
+    impl SwarmRelation for ValidatorSwapSwarm {
+        type SignatureType = NopSignature;
+        type SignatureCollectionType = MultiSig<Self::SignatureType>;
+        type ExecutionProtocolType = MockExecutionProtocol;
+        type ExecutionStateReadType =
+            InMemoryState<Self::SignatureType, Self::SignatureCollectionType>;
+        type BlockPolicyType = PassthruBlockPolicy;
+        type ChainConfigType = MockChainConfig;
+        type ChainRevisionType = MockChainRevision;
+
+        type TransportMessage = VerifiedMonadMessage<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >;
+
+        type BlockValidator = MockValidator;
+        type ValidatorSetTypeFactory =
+            ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
+        type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
+        type Ledger = MockLedger<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >;
+
+        type RouterScheduler = NoSerRouterScheduler<
+            CertificateSignaturePubKey<Self::SignatureType>,
+            MonadMessage<
+                Self::SignatureType,
+                Self::SignatureCollectionType,
+                Self::ExecutionProtocolType,
+            >,
+            VerifiedMonadMessage<
+                Self::SignatureType,
+                Self::SignatureCollectionType,
+                Self::ExecutionProtocolType,
+            >,
+        >;
+        type Pipeline = GenericTransformerPipeline<
+            CertificateSignaturePubKey<Self::SignatureType>,
+            Self::TransportMessage,
+        >;
+
+        type ValSetUpdater = MockValSetUpdaterSwap<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >;
+        type TxPoolExecutor = MockTxPoolExecutor<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+            Self::BlockPolicyType,
+            Self::ExecutionStateReadType,
+            Self::ChainConfigType,
+            Self::ChainRevisionType,
+        >;
+        type StateSyncExecutor = MockStateSyncExecutor<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >;
+    }
+
+    static CHAIN_PARAMS: ChainParams = ChainParams {
+        tx_limit: 10_000,
+        proposal_gas_limit: 300_000_000,
+        proposal_byte_limit: 4_000_000,
+        max_reserve_balance: 1_000_000_000_000_000_000,
+        vote_pace: Duration::from_millis(0),
+    };
+
+    /// Build a 4-node `ValidatorSwapSwarm` (consensus `delta`, network
+    /// `latency`) and return it alongside the genesis validator order (which the
+    /// swap updater rotates through across epochs).
+    fn swap_swarm(
+        epoch_length: SeqNum,
+        epoch_start_delay: Round,
+        delta: Duration,
+        latency: Duration,
+    ) -> (
+        SimSwarm<ValidatorSwapSwarm>,
+        Vec<NodeId<Pk<ValidatorSwapSwarm>>>,
+    ) {
+        let state_configs = make_state_configs::<ValidatorSwapSwarm>(
+            4,
+            ValidatorSetFactory::default,
+            SimpleRoundRobin::default,
+            || MockValidator,
+            || PassthruBlockPolicy,
+            || InMemoryStateInner::genesis(SeqNum(4)),
+            SeqNum(4),
+            delta,
+            MockChainConfig::new_with_epoch_params(&CHAIN_PARAMS, epoch_length, epoch_start_delay),
+            SeqNum(100),
+        );
+        let all_peers: BTreeSet<_> = state_configs
+            .iter()
+            .map(|config| NodeId::new(config.key.pubkey()))
+            .collect();
+        let genesis_validators: Vec<NodeId<Pk<ValidatorSwapSwarm>>> = state_configs[0]
+            .locked_epoch_validators[0]
+            .validators
+            .0
+            .iter()
+            .map(|vdata| vdata.node_id)
+            .collect();
+
+        let builders: Vec<SimNodeBuilder<ValidatorSwapSwarm>> = state_configs
+            .into_iter()
+            .map(|config| {
+                let state_read = config.state_read.clone();
+                let validators = config.locked_epoch_validators[0].clone();
+                SimNodeBuilder {
+                    id: NodeId::new(config.key.pubkey()),
+                    state_builder: config,
+                    router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                    val_set_updater: MockValSetUpdaterSwap::new(
+                        validators.validators,
+                        epoch_length,
+                    ),
+                    txpool_executor: MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
+                    ledger: MockLedger::new(state_read.clone()),
+                    statesync_executor: MockStateSyncExecutor::new(state_read),
+                    timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+                }
+            })
+            .collect();
+
+        let swarm = SimSwarm::from_builders(0, builders, |_| Network::reliable(latency));
+        (swarm, genesis_validators)
+    }
+
+    #[test_case(SeqNum(100), Round(10), 1000; "update_interval: 100, epoch_start_delay: 10")]
+    #[test_case(SeqNum(500), Round(10), 5000; "update_interval: 500, epoch_start_delay: 10")]
+    #[test_case(SeqNum(2000), Round(50), 20000; "update_interval: 2000, epoch_start_delay: 50")]
+    fn validator_switching(epoch_length: SeqNum, epoch_start_delay: Round, until_block: usize) {
+        let delta = Duration::from_millis(20);
+        let (mut swarm, _) = swap_swarm(epoch_length, epoch_start_delay, delta, delta);
+
+        assert!(
+            swarm.run_until_blocks(until_block, Time(0) + secs(6000)),
+            "did not reach {until_block} blocks"
+        );
+
+        let ids = swarm.node_ids();
+        // NOTE (carried from the legacy test): validator switching is mimicked
+        // with unstaked validators that still send messages, so metrics aren't
+        // pure happy-path. Only the timeout counts are pinned.
+        SimVerifier::new()
+            .ledger_min_len(until_block)
+            .metric_exact(&ids, sim_metric!(consensus_events.local_timeout), 1)
+            .metric_exact(&ids, sim_metric!(consensus_events.remote_timeout_msg), 3)
+            .assert(&swarm);
+    }
+
+    /* ---- epoch-manager inspection helpers (over the SimSwarm view) ---- */
+
+    fn verify_nodes_in_epoch<S: SwarmRelation>(
+        swarm: &SimSwarm<S>,
+        ids: &[NodeId<Pk<S>>],
+        epoch: Epoch,
+    ) {
+        assert!(!ids.is_empty());
+        for &id in ids {
+            swarm.with_node(id, |node| {
+                let round = node
+                    .state()
+                    .consensus()
+                    .expect("consensus is live")
+                    .get_current_round();
+                let current = node
+                    .state()
+                    .epoch_manager()
+                    .get_epoch(round)
+                    .expect("epoch exists");
+                assert_eq!(current, epoch, "node {id} not in {epoch:?}");
+            });
+        }
+    }
+
+    /// Verify every node scheduled `expected` to start the right number of
+    /// rounds after the boundary block, and that they agree on that round.
+    fn verify_nodes_scheduled_epoch<S: SwarmRelation>(
+        swarm: &SimSwarm<S>,
+        ids: &[NodeId<Pk<S>>],
+        boundary_block_num: SeqNum,
+        expected: Epoch,
+    ) -> Round {
+        assert!(!ids.is_empty());
+        let mut rounds = Vec::new();
+        for &id in ids {
+            let esr = swarm.with_node(id, |node| {
+                let blocks = node.ledger().get_finalized_blocks();
+                let boundary = blocks
+                    .values()
+                    .find(|b| b.get_seq_num() == boundary_block_num)
+                    .expect("boundary block committed");
+                let em = node.state().epoch_manager();
+                let esr = boundary.get_block_round() + em.epoch_start_delay;
+                assert_ne!(
+                    em.get_epoch(esr - Round(1)).expect("epoch exists"),
+                    expected
+                );
+                assert_eq!(em.get_epoch(esr).expect("epoch exists"), expected);
+                esr
+            });
+            rounds.push(esr);
+        }
+        assert!(
+            rounds.iter().all(|r| *r == rounds[0]),
+            "nodes disagree on epoch start round: {rounds:?}"
+        );
+        rounds[0]
+    }
+
+    fn verify_nodes_not_schedule_epoch<S: SwarmRelation>(
+        swarm: &SimSwarm<S>,
+        ids: &[NodeId<Pk<S>>],
+        expected: Epoch,
+    ) {
+        for &id in ids {
+            swarm.with_node(id, |node| {
+                assert!(
+                    !node
+                        .state()
+                        .epoch_manager()
+                        .epoch_starts
+                        .contains_key(&expected),
+                    "node {id} unexpectedly scheduled {expected:?}"
+                );
+            });
+        }
+    }
+
+    #[test]
+    fn schedule_and_advance_epoch() {
+        let delta = Duration::from_millis(20);
+        let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+            .execution_delay(SeqNum::MAX)
+            .genesis_seqnum(SeqNum::MAX)
+            .epoch_length(EPOCH_LENGTH)
+            .epoch_start_delay(Round(20))
+            .swarm(|_| Network::reliable(delta));
+
+        let boundary = EPOCH_LENGTH - SeqNum(1); // 999, the block that schedules epoch 2
+        let ids = swarm.node_ids();
+
+        // before the boundary: still epoch 1, epoch 2 not yet scheduled (run with
+        // a margin so no node has committed the boundary block).
+        assert!(swarm.run_until_blocks(boundary.0 as usize - 5, Time(0) + secs(600)));
+        verify_nodes_in_epoch(&swarm, &ids, Epoch(1));
+        verify_nodes_not_schedule_epoch(&swarm, &ids, Epoch(2));
+
+        // every node commits the boundary block: still epoch 1, but epoch 2 scheduled
+        assert!(swarm.run_until_blocks(boundary.0 as usize + 1, Time(0) + secs(600)));
+        verify_nodes_in_epoch(&swarm, &ids, Epoch(1));
+        let epoch_start_round = verify_nodes_scheduled_epoch(&swarm, &ids, boundary, Epoch(2));
+
+        // advance into epoch 2 (a few rounds past the boundary so every node,
+        // not just the leader, has crossed it)
+        assert!(swarm.run_until_round(epoch_start_round + Round(5), Time(0) + secs(600)));
+        verify_nodes_in_epoch(&swarm, &ids, Epoch(2));
+    }
+
+    #[test]
+    fn verify_correct_leaders_in_epoch() {
+        let delta = Duration::from_millis(40);
+        let latency = Duration::from_millis(20);
+        let (mut swarm, genesis) = swap_swarm(EPOCH_LENGTH, Round(20), delta, latency);
+        let ids = swarm.node_ids();
+
+        // the swap updater uses genesis validators for epoch 1, the first half
+        // for epoch 2, the second half for epoch 3.
+        let (epoch_2_vals, epoch_3_vals) = genesis.split_at(2);
+        let epoch_2_vals = epoch_2_vals.to_vec();
+        let epoch_3_vals = epoch_3_vals.to_vec();
+
+        let boundary_1 = EPOCH_LENGTH - SeqNum(1); // 999
+        assert!(swarm.run_until_blocks(boundary_1.0 as usize + 1, Time(0) + secs(600)));
+        // epoch 1: all genesis validators are Validators
+        for &v in &genesis {
+            assert_eq!(
+                swarm.with_node_mut(v, |n| n.state_mut().get_role()),
+                Role::Validator
+            );
+        }
+        verify_nodes_in_epoch(&swarm, &ids, Epoch(1));
+        let epoch_2_start = verify_nodes_scheduled_epoch(&swarm, &ids, boundary_1, Epoch(2));
+
+        // epoch 2: first half are Validators, second half become FullNodes
+        assert!(swarm.run_until_round(epoch_2_start + Round(5), Time(0) + secs(600)));
+        verify_nodes_in_epoch(&swarm, &ids, Epoch(2));
+        for &v in &epoch_2_vals {
+            assert_eq!(
+                swarm.with_node_mut(v, |n| n.state_mut().get_role()),
+                Role::Validator
+            );
+        }
+        for &v in &epoch_3_vals {
+            assert_eq!(
+                swarm.with_node_mut(v, |n| n.state_mut().get_role()),
+                Role::FullNode
+            );
+        }
+
+        let boundary_2 = SeqNum(EPOCH_LENGTH.0 * 2) - SeqNum(1); // 1999
+        assert!(swarm.run_until_blocks(boundary_2.0 as usize + 1, Time(0) + secs(1200)));
+        verify_nodes_in_epoch(&swarm, &ids, Epoch(2));
+        let epoch_3_start = verify_nodes_scheduled_epoch(&swarm, &ids, boundary_2, Epoch(3));
+
+        // epoch 3: the second half are Validators, first half are FullNodes
+        assert!(swarm.run_until_round(epoch_3_start + Round(5), Time(0) + secs(1200)));
+        verify_nodes_in_epoch(&swarm, &ids, Epoch(3));
+        for &v in &epoch_3_vals {
+            assert_eq!(
+                swarm.with_node_mut(v, |n| n.state_mut().get_role()),
+                Role::Validator
+            );
+        }
+        for &v in &epoch_2_vals {
+            assert_eq!(
+                swarm.with_node_mut(v, |n| n.state_mut().get_role()),
+                Role::FullNode
+            );
+        }
+
+        // every committed block's author belongs to that round's validator set
+        for &id in &ids {
+            swarm.with_node(id, |node| {
+                for block in node.ledger().get_finalized_blocks().values() {
+                    let author = block.get_author();
+                    let round = block.get_block_round();
+                    let set = if round < epoch_2_start {
+                        &genesis
+                    } else if round < epoch_3_start {
+                        &epoch_2_vals
+                    } else {
+                        &epoch_3_vals
+                    };
+                    assert!(
+                        set.iter().any(|v| v == author),
+                        "block author {author} not in the active validator set"
+                    );
+                }
+            });
+        }
+
+        let max_ledger = swarm.finalized_blocks().into_iter().max().unwrap() as u64;
+        SimVerifier::new()
+            .metric_exact(&ids, sim_metric!(blocksync_events.self_headers_request), 0)
+            .metric_exact(&ids, sim_metric!(blocksync_events.self_payload_request), 0)
+            .metric_min(
+                &ids,
+                sim_metric!(consensus_events.handle_proposal),
+                max_ledger,
+            )
+            .metric_min(&ids, sim_metric!(consensus_events.created_vote), max_ledger)
+            .metric_max(&ids, sim_metric!(consensus_events.local_timeout), 4)
+            .assert(&swarm);
+    }
+
+    #[test]
+    fn schedule_epoch_after_blocksync() {
+        // A node blacked out across the epoch boundary defers scheduling the new
+        // epoch until it blocksyncs the boundary block. Uses a smaller
+        // epoch_length than the legacy (1000) so the boundary is reached in a few
+        // seconds, making the fixed blackout window tractable; the behavior under
+        // test is identical.
+        let epoch_length = SeqNum(100);
+        let delta = Duration::from_millis(20);
+        let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+            .execution_delay(SeqNum::MAX)
+            .genesis_seqnum(SeqNum::MAX)
+            .epoch_length(epoch_length)
+            .epoch_start_delay(Round(20))
+            .swarm(|_| Network::reliable(delta));
+        let ids = swarm.node_ids();
+        let blackout = ids[0];
+        let running: Vec<_> = ids[1..].to_vec();
+        let boundary = epoch_length - SeqNum(1); // 99
+
+        // run to just before the boundary (all connected): epoch 1, none scheduled
+        assert!(swarm.run_until_any_blocks(boundary.0 as usize - 2, Time(0) + secs(60)));
+        verify_nodes_in_epoch(&swarm, &ids, Epoch(1));
+        verify_nodes_not_schedule_epoch(&swarm, &ids, Epoch(2));
+
+        // blackout the first node via mid-run reconfiguration (as the legacy
+        // does): it misses only the few blocks around the boundary, so it later
+        // recovers via blocksync rather than statesync.
+        swarm.set_network(|ids| {
+            let first = ids[0];
+            Network::reliable(delta).partition(Time(0)..Time(i128::MAX), [vec![first]])
+        });
+        // running supermajority commits the boundary (run a little past so every
+        // running node has it); the blacked-out node is frozen just short of it
+        assert!(swarm.run_until_any_blocks(boundary.0 as usize + 3, Time(0) + secs(60)));
+        verify_nodes_scheduled_epoch(&swarm, &running, boundary, Epoch(2));
+        verify_nodes_not_schedule_epoch(&swarm, &[blackout], Epoch(2));
+
+        // restore connectivity; the node blocksyncs the boundary and schedules epoch 2
+        swarm.set_network(|_| Network::reliable(delta));
+        assert!(swarm.run_until_blocks(boundary.0 as usize + 10, Time(0) + secs(60)));
+        verify_nodes_scheduled_epoch(&swarm, &ids, boundary, Epoch(2));
+
+        // the never-partitioned nodes never needed blocksync
+        SimVerifier::new()
+            .metric_exact(
+                &running,
+                sim_metric!(blocksync_events.self_headers_request),
+                0,
+            )
+            .metric_exact(
+                &running,
+                sim_metric!(blocksync_events.self_payload_request),
+                0,
+            )
+            .assert(&swarm);
+    }
+}

--- a/monad-mock-swarm/tests/sim_epoch_missing_valset.rs
+++ b/monad-mock-swarm/tests/sim_epoch_missing_valset.rs
@@ -1,0 +1,112 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Regression gate for an open production `todo!()` in shared consensus code:
+//! a node computes upcoming leaders for an epoch whose validator set has not yet
+//! been delivered.
+//!
+//! Panic site: `monad-consensus-state/src/lib.rs`,
+//! `compute_upcoming_leader_round_pairs` — "handle non-existent validatorset for
+//! next k round epoch".
+//!
+//! Epoch E's validator set is delivered only once epoch (E-1)'s boundary block is
+//! *finalized*. But a node's leader look-ahead keys off `current_round`, which can
+//! outrun finalized height — rounds advance via timeouts (TCs) under a validator
+//! outage. When the look-ahead reaches E before E's set is delivered,
+//! `val_epoch_map` has no entry and the `todo!()` fires. `epoch_start_delay` is
+//! the buffer that normally hides this.
+//!
+//! The reproducing test is `#[should_panic]`: GREEN while the bug exists, RED
+//! once the case is handled. The epoch parameters are tiny for tractability, so
+//! this proves the path is *reachable*, not its production-scale frequency
+//! (production `epoch_start_delay` is 1k-5k, so the gap there needs a prolonged
+//! liveness disruption near a boundary, not the single-validator outage
+//! compressed here). The `healthy_baseline_crosses_boundaries` control confirms
+//! the trigger is the fault, not the small parameter alone.
+
+mod sim_common;
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use monad_chain_config::revision::ChainParams;
+    use monad_mock_swarm::sim::Network;
+    use monad_sim::{time::secs, Time};
+    use monad_types::{Round, SeqNum};
+
+    use crate::sim_common::NoSerConfig;
+
+    static CHAIN_PARAMS: ChainParams = ChainParams {
+        tx_limit: 10_000,
+        proposal_gas_limit: 300_000_000,
+        proposal_byte_limit: 4_000_000,
+        max_reserve_balance: 1_000_000_000_000_000_000,
+        vote_pace: Duration::from_millis(0),
+    };
+
+    // Tiny epoch params: an epoch boundary is reached in a few simulated seconds.
+    // (Production uses epoch_length 10k-50k, epoch_start_delay 1k-5k.)
+    const EPOCH_LENGTH: SeqNum = SeqNum(20);
+    const EPOCH_START_DELAY: Round = Round(5);
+
+    /// REPRO: with one validator partitioned off, the surviving supermajority's
+    /// rounds advance via timeouts faster than blocks finalize; approaching the
+    /// first epoch boundary, the leader look-ahead reaches epoch 2 before epoch
+    /// 2's validator set has been delivered -> production `todo!()` at
+    /// `monad-consensus-state/src/lib.rs:2023`.
+    ///
+    /// `#[should_panic]` so this is GREEN while the bug exists and turns RED when
+    /// the missing-validator-set case is handled (a built-in regression signal).
+    #[test]
+    #[should_panic(expected = "non-existent validatorset")]
+    fn epoch_boundary_missing_valset_under_outage() {
+        let delta = Duration::from_millis(20);
+        let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+            .execution_delay(SeqNum(4))
+            .genesis_seqnum(SeqNum(4))
+            .epoch_length(EPOCH_LENGTH)
+            .epoch_start_delay(EPOCH_START_DELAY)
+            // node 0 is a partitioned (down) validator for the whole run
+            .swarm(|ids| {
+                let down = ids[0];
+                Network::reliable(delta).partition(Time(0)..Time(i128::MAX), [vec![down]])
+            });
+
+        // drive the surviving supermajority forward. Epochs 1-2 are genesis-
+        // locked (their sets are present without any finalization), so the gap
+        // first bites at a later boundary, whose set must be delivered by
+        // finalizing the boundary block while rounds outrun finalization under the
+        // outage. It panics well before reaching this target.
+        swarm.run_until_any_blocks(EPOCH_LENGTH.0 as usize * 6, Time(0) + secs(300));
+    }
+
+    /// Baseline / control: with no fault, the same tiny `epoch_start_delay`
+    /// crosses several epoch boundaries cleanly. Confirms the panic above is
+    /// caused by the outage, not by the parameter value alone.
+    #[test]
+    fn healthy_baseline_crosses_boundaries() {
+        let delta = Duration::from_millis(20);
+        let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+            .execution_delay(SeqNum(4))
+            .genesis_seqnum(SeqNum(4))
+            .epoch_length(EPOCH_LENGTH)
+            .epoch_start_delay(EPOCH_START_DELAY)
+            .swarm(|_| Network::reliable(delta));
+
+        // crosses boundaries at blocks 19, 39, 59 with all four nodes healthy
+        assert!(swarm.run_until_blocks(70, Time(0) + secs(120)));
+    }
+}

--- a/monad-mock-swarm/tests/sim_eth.rs
+++ b/monad-mock-swarm/tests/sim_eth.rs
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The Eth execution relation (real transactions) driven through the `monad-sim`
+//! harness, mirroring the `nonces`/`reserve_balance` engine tests. This is the
+//! highest-coverage test category and the main thing the new engine must host
+//! before the legacy `Nodes` engine can be retired.
+
+mod eth_swarm_common;
+
+#[cfg(test)]
+mod test {
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::B256;
+    use monad_eth_testutil::{make_legacy_tx, secret_to_eth_address};
+    use monad_mock_swarm::sim::{Network, SimSwarm};
+    use monad_sim::{time::secs, Time};
+    use monad_updaters::txpool::ByzantineConfig;
+
+    use crate::eth_swarm_common::{
+        eth_swarm_config, verify_transactions_in_sim, BASE_FEE, GAS_LIMIT,
+    };
+
+    #[test]
+    fn eth_transactions_commit_through_monad_sim() {
+        let sender = B256::repeat_byte(15);
+        let config = eth_swarm_config(2, vec![secret_to_eth_address(sender)], |_| {
+            ByzantineConfig::default()
+        });
+        let mut swarm = SimSwarm::from_builders(0, config, |_| Network::default());
+        let node = swarm.node_ids()[0];
+
+        let deadline = Time(0) + secs(20);
+        // Step past initial sync until the nodes are committing blocks.
+        assert!(swarm.run_until_blocks(1, deadline), "no initial progress");
+
+        let mut expected = Vec::new();
+        for nonce in 0..5 {
+            let tx = make_legacy_tx(sender, BASE_FEE, GAS_LIMIT, nonce, 10);
+            swarm.send_transaction(node, tx.encoded_2718().into());
+            expected.push(tx);
+        }
+
+        assert!(
+            swarm.run_until_blocks(5, deadline),
+            "stalled before committing txns"
+        );
+        assert!(verify_transactions_in_sim(&swarm, expected));
+        swarm.assert_agreement();
+    }
+}

--- a/monad-mock-swarm/tests/sim_forkpoint.rs
+++ b/monad-mock-swarm/tests/sim_forkpoint.rs
@@ -1,0 +1,377 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Forkpoint restart / recovery, ported onto the `monad-sim` harness (mirrors
+//! the legacy `forkpoint.rs`). A node is removed mid-run and restarted from a
+//! reconstructed forkpoint (via `SimSwarm::remove_node` / `add_node` /
+//! `SimNode::get_forkpoint`), then must catch up to the rest of the swarm.
+//!
+//! The two `#[ignore]`'d exhaustive sweeps from the legacy
+//! (`test_forkpoint_restart_f`, `test_forkpoint_restart_below_all`, run over a
+//! rayon pool) are not ported; the focused configs below exercise the same
+//! restart paths (simple blocksync, statesync, delayed execution, target reset,
+//! epoch boundary).
+
+#[cfg(test)]
+mod test {
+    use std::{collections::BTreeSet, time::Duration};
+
+    use monad_chain_config::{
+        revision::{ChainParams, MockChainRevision},
+        MockChainConfig,
+    };
+    use monad_consensus_types::validator_data::ValidatorSetDataWithEpoch;
+    use monad_crypto::{
+        certificate_signature::{CertificateKeyPair, CertificateSignaturePubKey},
+        NopSignature,
+    };
+    use monad_eth_block_policy::EthBlockPolicy;
+    use monad_eth_block_validator::EthBlockValidator;
+    use monad_eth_types::EthExecutionProtocol;
+    use monad_execution_state_read::{InMemoryState, InMemoryStateInner};
+    use monad_mock_swarm::{
+        sim::{Network, SimNodeBuilder, SimSwarm, DEFAULT_TIMESTAMP_PERIOD},
+        swarm::make_state_configs,
+        swarm_relation::SwarmRelation,
+    };
+    use monad_multi_sig::MultiSig;
+    use monad_router_scheduler::{NoSerRouterConfig, NoSerRouterScheduler, RouterSchedulerBuilder};
+    use monad_sim::{time::secs, Time};
+    use monad_state::{MonadMessage, VerifiedMonadMessage};
+    use monad_transformer::GenericTransformerPipeline;
+    use monad_types::{NodeId, Round, SeqNum, GENESIS_SEQ_NUM};
+    use monad_updaters::{
+        ledger::{MockLedger, MockableLedger},
+        statesync::MockStateSyncExecutor,
+        txpool::MockTxPoolExecutor,
+        val_set::MockValSetUpdaterNop,
+    };
+    use monad_validator::{
+        simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory,
+    };
+
+    pub struct ForkpointSwarm;
+    impl SwarmRelation for ForkpointSwarm {
+        type SignatureType = NopSignature;
+        type SignatureCollectionType = MultiSig<Self::SignatureType>;
+        type ExecutionProtocolType = EthExecutionProtocol;
+        type ExecutionStateReadType =
+            InMemoryState<Self::SignatureType, Self::SignatureCollectionType>;
+        type BlockPolicyType = EthBlockPolicy<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ChainConfigType,
+            Self::ChainRevisionType,
+        >;
+        type ChainConfigType = MockChainConfig;
+        type ChainRevisionType = MockChainRevision;
+
+        type TransportMessage = VerifiedMonadMessage<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >;
+
+        type BlockValidator = EthBlockValidator<Self::SignatureType, Self::SignatureCollectionType>;
+        type ValidatorSetTypeFactory =
+            ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
+        type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
+        type Ledger = MockLedger<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >;
+
+        type RouterScheduler = NoSerRouterScheduler<
+            CertificateSignaturePubKey<Self::SignatureType>,
+            MonadMessage<
+                Self::SignatureType,
+                Self::SignatureCollectionType,
+                Self::ExecutionProtocolType,
+            >,
+            VerifiedMonadMessage<
+                Self::SignatureType,
+                Self::SignatureCollectionType,
+                Self::ExecutionProtocolType,
+            >,
+        >;
+        type Pipeline = GenericTransformerPipeline<
+            CertificateSignaturePubKey<Self::SignatureType>,
+            Self::TransportMessage,
+        >;
+
+        type ValSetUpdater = MockValSetUpdaterNop<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >;
+        type TxPoolExecutor = MockTxPoolExecutor<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+            Self::BlockPolicyType,
+            Self::ExecutionStateReadType,
+            Self::ChainConfigType,
+            Self::ChainRevisionType,
+        >;
+        type StateSyncExecutor = MockStateSyncExecutor<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >;
+    }
+
+    static CHAIN_PARAMS: ChainParams = ChainParams {
+        tx_limit: 10_000,
+        proposal_gas_limit: 300_000_000,
+        proposal_byte_limit: 4_000_000,
+        max_reserve_balance: 1_000_000_000_000_000_000,
+        vote_pace: Duration::from_millis(0),
+    };
+
+    const DELTA: Duration = Duration::from_millis(100);
+    const STATE_ROOT_DELAY: SeqNum = SeqNum(4);
+
+    fn forkpoint_restart_one(
+        num_nodes: u16,
+        blocks_before_failure: SeqNum,
+        time_before_new_forkpoint: SeqNum,
+        recovery_time: SeqNum,
+        epoch_length: SeqNum,
+        statesync_threshold: SeqNum,
+        statesync_service_window: SeqNum,
+        finalization_delay: SeqNum,
+    ) {
+        assert!(time_before_new_forkpoint <= recovery_time);
+        let chain_config =
+            MockChainConfig::new_with_epoch_params(&CHAIN_PARAMS, epoch_length, Round(50));
+        let create_block_policy = || EthBlockPolicy::new(GENESIS_SEQ_NUM, STATE_ROOT_DELAY.0);
+
+        // state configs are deterministic per call (keys aren't Clone), so we
+        // regenerate them where needed and match nodes by pubkey.
+        let configs = || {
+            make_state_configs::<ForkpointSwarm>(
+                num_nodes,
+                ValidatorSetFactory::default,
+                SimpleRoundRobin::default,
+                EthBlockValidator::default,
+                create_block_policy,
+                || InMemoryStateInner::genesis(STATE_ROOT_DELAY),
+                STATE_ROOT_DELAY,
+                DELTA,
+                chain_config,
+                statesync_threshold,
+            )
+        };
+
+        let restart_ids: Vec<NodeId<_>> = configs()
+            .iter()
+            .map(|c| NodeId::new(c.key.pubkey()))
+            .collect();
+
+        // enumerate the restarting node to cover the different leader cases
+        for restart_node_id in restart_ids {
+            let validators = configs()[0].locked_epoch_validators[0].validators.clone();
+            let mut restart_builder = configs()
+                .into_iter()
+                .find(|s| s.key.pubkey() == restart_node_id.pubkey())
+                .expect("restart node exists");
+
+            let state_configs = configs();
+            let all_peers: BTreeSet<_> = state_configs
+                .iter()
+                .map(|c| NodeId::new(c.key.pubkey()))
+                .collect();
+            let builders: Vec<SimNodeBuilder<ForkpointSwarm>> = state_configs
+                .into_iter()
+                .map(|state_builder| {
+                    let state_read = state_builder.state_read.clone();
+                    SimNodeBuilder {
+                        id: NodeId::new(state_builder.key.pubkey()),
+                        state_builder,
+                        router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                        val_set_updater: MockValSetUpdaterNop::new(
+                            validators.clone(),
+                            epoch_length,
+                        ),
+                        txpool_executor: MockTxPoolExecutor::new(
+                            create_block_policy(),
+                            state_read.clone(),
+                        )
+                        .with_chain_params(&CHAIN_PARAMS),
+                        ledger: MockLedger::new(state_read.clone())
+                            .with_finalization_delay(finalization_delay),
+                        statesync_executor: MockStateSyncExecutor::new(state_read)
+                            .with_max_service_window(statesync_service_window),
+                        timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+                    }
+                })
+                .collect();
+
+            let mut swarm = SimSwarm::from_builders(0, builders, |_| Network::reliable(DELTA));
+            let deadline = Time(0) + secs(6000);
+
+            assert!(swarm.run_until_blocks(blocks_before_failure.0 as usize, deadline));
+
+            // eject the failing node; read its forkpoint / ledger / state-backend
+            let failed_node = swarm.remove_node(restart_node_id);
+
+            let forkpoint = if time_before_new_forkpoint == SeqNum(0) {
+                failed_node.get_forkpoint()
+            } else {
+                let forkpoint_block = blocks_before_failure + time_before_new_forkpoint;
+                assert!(swarm.run_until_any_blocks(forkpoint_block.0 as usize, deadline));
+                let any = swarm.node_ids()[0];
+                swarm.with_node(any, |n| n.get_forkpoint())
+            };
+
+            let recover_block = blocks_before_failure + recovery_time;
+            assert!(swarm.run_until_any_blocks(recover_block.0 as usize, deadline));
+
+            // reconstruct the restart node from the forkpoint and re-add it
+            restart_builder.locked_epoch_validators = forkpoint
+                .validator_sets
+                .iter()
+                .map(|locked_epoch| ValidatorSetDataWithEpoch {
+                    epoch: locked_epoch.epoch,
+                    validators: validators.clone(),
+                })
+                .collect();
+            restart_builder.forkpoint = forkpoint.clone();
+            restart_builder.state_read = failed_node.state().state_read().clone();
+            let backend = restart_builder.state_read.clone();
+            swarm.add_node(SimNodeBuilder {
+                id: restart_node_id,
+                state_builder: restart_builder,
+                router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                val_set_updater: MockValSetUpdaterNop::new(validators.clone(), epoch_length),
+                txpool_executor: MockTxPoolExecutor::new(create_block_policy(), backend.clone()),
+                ledger: MockLedger::new(backend.clone())
+                    .with_finalization_delay(finalization_delay)
+                    .with_blocks(failed_node.ledger()),
+                statesync_executor: MockStateSyncExecutor::new(backend),
+                timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+            });
+
+            // run until 3 more epochs are produced so epoch switching exercises
+            let terminate_block = recover_block.0 as usize + epoch_length.0 as usize * 3;
+            assert!(swarm.run_until_any_blocks(terminate_block, deadline));
+
+            // the restarted node caught up and is voting
+            let metrics_voting = swarm.with_node(restart_node_id, |n| {
+                n.metrics().consensus_events.created_vote.get() > 0
+            });
+            let caught_up = swarm.with_node(restart_node_id, |n| {
+                n.ledger()
+                    .get_finalized_blocks()
+                    .values()
+                    .last()
+                    .map(|fb| fb.header().seq_num >= SeqNum(terminate_block as u64 - 2))
+                    .unwrap_or(false)
+            });
+            assert!(
+                caught_up && metrics_voting,
+                "restart {restart_node_id}: caught_up={caught_up} voting={metrics_voting}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_quick_restart() {
+        forkpoint_restart_one(
+            20,
+            SeqNum(10),
+            SeqNum(0),
+            SeqNum(0),
+            SeqNum(3),
+            SeqNum(5),
+            SeqNum::MAX,
+            SeqNum(0),
+        );
+    }
+
+    #[test]
+    fn test_forkpoint_restart_f_simple_blocksync() {
+        forkpoint_restart_one(
+            4,
+            SeqNum(10),
+            SeqNum(0),
+            SeqNum(50),
+            SeqNum(200),
+            SeqNum(100),
+            SeqNum::MAX,
+            SeqNum(0),
+        );
+    }
+
+    #[test]
+    fn test_forkpoint_restart_f_delayed_execution_no_statesync() {
+        forkpoint_restart_one(
+            4,
+            SeqNum(10),
+            SeqNum(0),
+            SeqNum(50),
+            SeqNum(200),
+            SeqNum(100),
+            SeqNum::MAX,
+            SeqNum(8),
+        );
+    }
+
+    #[test]
+    fn test_forkpoint_restart_f_simple_statesync() {
+        // restart from a fresh forkpoint 150 blocks in (statesync_threshold*3/2)
+        forkpoint_restart_one(
+            4,
+            SeqNum(10),
+            SeqNum(150),
+            SeqNum(150),
+            SeqNum(200),
+            SeqNum(100),
+            SeqNum::MAX,
+            SeqNum(0),
+        );
+    }
+
+    #[test]
+    fn test_forkpoint_restart_f_target_reset_statesync() {
+        // service window (50) < recovery (150): the statesync target must reset
+        forkpoint_restart_one(
+            4,
+            SeqNum(10),
+            SeqNum(10),
+            SeqNum(150),
+            SeqNum(200),
+            SeqNum(100),
+            SeqNum(50),
+            SeqNum(0),
+        );
+    }
+
+    #[test]
+    fn test_forkpoint_restart_f_epoch_boundary_statesync() {
+        // restart spans an epoch boundary (blocks_before_failure 275, epoch 200)
+        forkpoint_restart_one(
+            4,
+            SeqNum(275),
+            SeqNum(150),
+            SeqNum(150),
+            SeqNum(200),
+            SeqNum(100),
+            SeqNum::MAX,
+            SeqNum(0),
+        );
+    }
+}

--- a/monad-mock-swarm/tests/sim_many_nodes.rs
+++ b/monad-mock-swarm/tests/sim_many_nodes.rs
@@ -1,0 +1,99 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Larger swarms, ported onto the `monad-sim` harness (mirrors the legacy
+//! `many_nodes.rs`): a 40-node happy path, and a 10-node swarm with one node
+//! whose outbound messages are dropped (offline).
+
+mod sim_common;
+
+use std::time::Duration;
+
+use monad_chain_config::revision::ChainParams;
+use monad_mock_swarm::{sim::Network, sim_verify::SimVerifier};
+use monad_sim::{dist::uniform_duration, time::secs, Time};
+use monad_types::Round;
+
+use crate::sim_common::NoSerConfig;
+
+static CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(5),
+};
+
+#[test]
+fn many_nodes_noser() {
+    let delta = Duration::from_millis(20);
+    let mut swarm = NoSerConfig::new(40, delta, &CHAIN_PARAMS).swarm(|_| Network::reliable(delta));
+
+    assert!(
+        swarm.run_until_blocks(1024, Time(0) + secs(120)),
+        "did not reach 1024 blocks"
+    );
+
+    let ids = swarm.node_ids();
+    let mut verifier = SimVerifier::new();
+    verifier
+        // Deterministic exact tick (legacy ran to a fixed 47s window).
+        .tick_exact(Time(0) + Duration::from_millis(41_040))
+        .ledger_min_len(1024)
+        .metrics_happy_path(&ids, &swarm);
+    verifier.assert(&swarm);
+    swarm.assert_agreement();
+}
+
+#[test]
+fn many_nodes_noser_one_offline() {
+    let delta = Duration::from_millis(20);
+    let num_nodes = 10u16;
+    let num_offline_nodes = 1u64;
+    let num_rounds = 100u64;
+
+    // base 1ms + uniform [1, 20)ms, matching Latency(1ms) + RandLatency(0, 19ms).
+    let mut swarm = NoSerConfig::new(num_nodes, delta, &CHAIN_PARAMS).swarm(|ids| {
+        let offline = ids[0];
+        Network::with_latency(uniform_duration(
+            Duration::from_millis(2),
+            Duration::from_millis(20),
+        ))
+        .drop_if(move |link, _| link.from == offline)
+    });
+
+    assert!(
+        swarm.run_until_round(Round(num_rounds), Time(0) + secs(120)),
+        "did not reach round 100"
+    );
+
+    let max_observed_local_timeouts = swarm
+        .node_ids()
+        .iter()
+        .map(|&id| swarm.with_node(id, |node| node.metrics().consensus_events.local_timeout.get()))
+        .max()
+        .unwrap()
+        // subtract 1 for the initial timeout on startup
+        - 1;
+
+    let max_allowed_local_timeouts = (num_rounds * num_offline_nodes).div_ceil(num_nodes.into());
+
+    assert!(
+        max_observed_local_timeouts <= max_allowed_local_timeouts,
+        "max observed timeouts {} > allowed {}",
+        max_observed_local_timeouts,
+        max_allowed_local_timeouts
+    );
+}

--- a/monad-mock-swarm/tests/sim_msg_delays.rs
+++ b/monad-mock-swarm/tests/sim_msg_delays.rs
@@ -1,0 +1,60 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Per-link XOR latency, ported onto the `monad-sim` harness (mirrors the
+//! legacy `msg_delays.rs`). The deterministic XOR latency lets the final tick
+//! be asserted exactly (the legacy engine only bounded it below the max).
+
+mod sim_common;
+
+use std::time::Duration;
+
+use monad_chain_config::revision::ChainParams;
+use monad_mock_swarm::{sim::Network, sim_verify::SimVerifier};
+use monad_sim::{time::secs, Time};
+
+use crate::sim_common::{NoSerConfig, XorLatency};
+
+static CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(5),
+};
+
+#[test]
+fn xor_latency_four_nodes() {
+    let delta = Duration::from_millis(u8::MAX as u64);
+    let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+        .swarm(|_| Network::custom(XorLatency { max: delta }));
+
+    assert!(
+        swarm.run_until_blocks(100, Time(0) + secs(600)),
+        "did not reach 100 blocks"
+    );
+
+    let ids = swarm.node_ids();
+    let mut verifier = SimVerifier::new();
+    verifier
+        // Deterministic: exact tick (sub-ms tail comes from the float XOR
+        // latency). The legacy engine only bounded this below the theoretical
+        // max because its same-tick ordering was randomized.
+        .tick_exact(Time(8_954_000_078))
+        .ledger_min_len(98)
+        .metrics_happy_path(&ids, &swarm);
+    verifier.assert(&swarm);
+    swarm.assert_agreement();
+}

--- a/monad-mock-swarm/tests/sim_msg_delays.rs
+++ b/monad-mock-swarm/tests/sim_msg_delays.rs
@@ -1,0 +1,60 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Per-link XOR latency, ported onto the `monad-sim` harness (mirrors the
+//! legacy `msg_delays.rs`). The deterministic XOR latency lets the final tick
+//! be asserted exactly (the legacy engine only bounded it below the max).
+
+mod sim_common;
+
+use std::time::Duration;
+
+use monad_chain_config::revision::ChainParams;
+use monad_mock_swarm::{sim::Network, sim_verify::SimVerifier};
+use monad_sim::{time::secs, Time};
+
+use crate::sim_common::{NoSerConfig, XorLatency};
+
+static CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(5),
+};
+
+#[test]
+fn xor_latency_four_nodes() {
+    let delta = Duration::from_millis(u8::MAX as u64);
+    let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+        .swarm(|_| Network::custom(XorLatency { max: delta }));
+
+    assert!(
+        swarm.run_until_blocks(100, Time(0) + secs(600)),
+        "did not reach 100 blocks"
+    );
+
+    let ids = swarm.node_ids();
+    let mut verifier = SimVerifier::new();
+    verifier
+        // Deterministic: exact tick (sub-ms tail comes from the float XOR
+        // latency). The legacy engine only bounded this below the theoretical
+        // max because its same-tick ordering was randomized.
+        .tick_exact(Time(8_954_000_128))
+        .ledger_min_len(98)
+        .metrics_happy_path(&ids, &swarm);
+    verifier.assert(&swarm);
+    swarm.assert_agreement();
+}

--- a/monad-mock-swarm/tests/sim_nonces.rs
+++ b/monad-mock-swarm/tests/sim_nonces.rs
@@ -1,0 +1,445 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Nonce / transaction-commitment coverage, ported onto the `monad-sim`
+//! harness (mirrors the legacy `nonces.rs`, which it does not replace).
+//!
+//! NOT ported here (tracked for follow-up):
+//! - `test_forkpoint_serde_roundtrip`: per-step `high_certificate` RLP/JSON/TOML
+//!   round-trip — serialization coverage, independent of the engine; extract to
+//!   a standalone serialization test before the legacy engine is deleted.
+
+mod eth_swarm_common;
+
+#[cfg(test)]
+mod test {
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::B256;
+    use monad_eth_testutil::{
+        make_eip7702_tx, make_legacy_tx, make_signed_authorization, secret_to_eth_address,
+    };
+    use monad_mock_swarm::{
+        sim::{Network, SimNodeBuilder, SimSwarm},
+        sim_verify::SimVerifier,
+    };
+    use monad_sim::{time::secs, Time};
+    use monad_updaters::txpool::ByzantineConfig;
+    use rand::Rng;
+    use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
+    use seq_macro::seq;
+
+    use crate::eth_swarm_common::{
+        eth_swarm_config, verify_transactions_in_sim, EthSwarm, BASE_FEE, CONSENSUS_DELTA,
+        GAS_LIMIT,
+    };
+
+    fn deadline() -> Time {
+        Time(0) + secs(120)
+    }
+
+    /// Build an Eth `SimSwarm` over a reliable `CONSENSUS_DELTA` link and run it
+    /// past initial sync (block 1) so nodes are ready to receive transactions.
+    fn eth_sim(builders: Vec<SimNodeBuilder<EthSwarm>>) -> SimSwarm<EthSwarm> {
+        let mut swarm =
+            SimSwarm::from_builders(0, builders, |_| Network::reliable(CONSENSUS_DELTA));
+        assert!(swarm.run_until_blocks(1, deadline()), "no initial progress");
+        swarm
+    }
+
+    #[test]
+    fn non_sequential_nonces() {
+        let sender = B256::repeat_byte(15);
+        let builders = eth_swarm_config(2, vec![secret_to_eth_address(sender)], |_| {
+            ByzantineConfig::default()
+        });
+        let mut swarm = eth_sim(builders);
+        let node_1 = swarm.node_ids()[0];
+
+        let mut expected = Vec::new();
+        for nonce in 0..10 {
+            let tx = make_legacy_tx(sender, BASE_FEE, GAS_LIMIT, nonce, 10);
+            swarm.send_transaction(node_1, tx.encoded_2718().into());
+            expected.push(tx);
+        }
+        // a gap (20..30): these can never commit and must not appear
+        for nonce in 20..30 {
+            let tx = make_legacy_tx(sender, BASE_FEE, GAS_LIMIT, nonce, 10);
+            swarm.send_transaction(node_1, tx.encoded_2718().into());
+        }
+
+        assert!(
+            swarm.run_until_blocks(5, deadline()),
+            "stalled before block 5"
+        );
+
+        let ids = swarm.node_ids();
+        SimVerifier::new()
+            .ledger_min_len(2)
+            .metrics_happy_path(&ids, &swarm)
+            .assert(&swarm);
+        assert!(verify_transactions_in_sim(&swarm, expected));
+        swarm.assert_agreement();
+    }
+
+    #[test]
+    fn sanity_7702() {
+        let sender_1 = B256::repeat_byte(0xA);
+        let sender_2 = B256::repeat_byte(0xB);
+        let builders = eth_swarm_config(
+            2,
+            vec![
+                secret_to_eth_address(sender_1),
+                secret_to_eth_address(sender_2),
+            ],
+            |_| ByzantineConfig::default(),
+        );
+        let mut swarm = eth_sim(builders);
+        let node_1 = swarm.node_ids()[0];
+
+        let mut expected = Vec::new();
+        let txn1 = make_legacy_tx(sender_1, BASE_FEE, GAS_LIMIT, 0, 10);
+        swarm.send_transaction(node_1, txn1.encoded_2718().into());
+        expected.push(txn1);
+
+        let auth_list = vec![
+            make_signed_authorization(sender_2, secret_to_eth_address(B256::repeat_byte(0x1)), 0),
+            make_signed_authorization(sender_2, secret_to_eth_address(B256::repeat_byte(0x3)), 5),
+        ];
+        let txn2 = make_eip7702_tx(sender_1, BASE_FEE, 1, 1_000_000, 1, auth_list, 0);
+        swarm.send_transaction(node_1, txn2.encoded_2718().into());
+        expected.push(txn2);
+
+        let txn3 = make_legacy_tx(sender_2, BASE_FEE, GAS_LIMIT, 1, 10);
+        swarm.send_transaction(node_1, txn3.encoded_2718().into());
+        expected.push(txn3);
+
+        assert!(
+            swarm.run_until_blocks(10, deadline()),
+            "stalled before block 10"
+        );
+
+        let ids = swarm.node_ids();
+        SimVerifier::new()
+            .ledger_min_len(2)
+            .metrics_happy_path(&ids, &swarm)
+            .assert(&swarm);
+        assert!(verify_transactions_in_sim(&swarm, expected));
+        swarm.assert_agreement();
+    }
+
+    seq!(N in 0..512 {
+        #[test]
+        fn test_rand_nonces_7702_~N() {
+            rand_nonces_7702(N);
+        }
+    });
+
+    fn rand_nonces_7702(seed: u64) {
+        let test_sender = B256::repeat_byte(0xA);
+        let sender_7702 = B256::repeat_byte(0xB);
+        let builders = eth_swarm_config(
+            2,
+            vec![
+                secret_to_eth_address(test_sender),
+                secret_to_eth_address(sender_7702),
+            ],
+            |_| ByzantineConfig::default(),
+        );
+        let mut swarm = eth_sim(builders);
+        let node_1 = swarm.node_ids()[0];
+
+        let mut rng = ChaChaRng::seed_from_u64(seed);
+        let nonces: Vec<u64> = (0..10).map(|_| rng.gen_range(1..=10)).collect();
+        let mut auths = Vec::new();
+        for nonce in nonces {
+            if rng.gen_bool(0.5) {
+                // a legacy tx with a (likely non-sequential) nonce — dropped by
+                // the pool, exercises validation under random nonces
+                swarm.send_transaction(
+                    node_1,
+                    make_legacy_tx(test_sender, BASE_FEE, GAS_LIMIT, nonce, 10)
+                        .encoded_2718()
+                        .into(),
+                );
+            } else {
+                auths.push(make_signed_authorization(
+                    test_sender,
+                    secret_to_eth_address(B256::repeat_byte(0x1)),
+                    nonce,
+                ));
+            }
+        }
+
+        let txn1 = make_legacy_tx(test_sender, BASE_FEE, GAS_LIMIT, 0, 10);
+        swarm.send_transaction(node_1, txn1.encoded_2718().into());
+        let txn2 = make_eip7702_tx(sender_7702, BASE_FEE, 1, 1_000_000, 1, auths, 0);
+        swarm.send_transaction(node_1, txn2.encoded_2718().into());
+
+        assert!(
+            swarm.run_until_blocks(10, deadline()),
+            "seed {seed}: stalled"
+        );
+
+        let ids = swarm.node_ids();
+        SimVerifier::new()
+            .ledger_min_len(2)
+            .metrics_happy_path(&ids, &swarm)
+            .assert(&swarm);
+        swarm.assert_agreement();
+    }
+
+    #[test]
+    fn duplicate_nonces_multi_nodes() {
+        let sender = B256::repeat_byte(15);
+        let builders = eth_swarm_config(2, vec![secret_to_eth_address(sender)], |_| {
+            ByzantineConfig::default()
+        });
+        let mut swarm = eth_sim(builders);
+        let node_1 = swarm.node_ids()[0];
+        let node_2 = swarm.node_ids()[1];
+
+        let mut expected = Vec::new();
+        for nonce in 0..10 {
+            let tx = make_legacy_tx(sender, BASE_FEE, GAS_LIMIT, nonce, 10);
+            swarm.send_transaction(node_1, tx.encoded_2718().into());
+            expected.push(tx);
+        }
+        assert!(
+            swarm.run_until_blocks(5, deadline()),
+            "stalled before block 5"
+        );
+        assert!(verify_transactions_in_sim(&swarm, expected.clone()));
+
+        // duplicate nonces (different value) to node 2 — must not commit
+        for nonce in 0..10 {
+            let tx = make_legacy_tx(sender, BASE_FEE, GAS_LIMIT, nonce, 1000);
+            swarm.send_transaction(node_2, tx.encoded_2718().into());
+        }
+        assert!(
+            swarm.run_until_blocks(8, deadline()),
+            "stalled before block 8"
+        );
+
+        let ids = swarm.node_ids();
+        SimVerifier::new()
+            .ledger_min_len(8)
+            .metrics_happy_path(&ids, &swarm)
+            .assert(&swarm);
+        // still only the first 10
+        assert!(verify_transactions_in_sim(&swarm, expected));
+        swarm.assert_agreement();
+    }
+
+    #[test]
+    fn committed_nonces() {
+        let sender_1 = B256::repeat_byte(15);
+        let sender_2 = B256::repeat_byte(16);
+        let builders = eth_swarm_config(
+            2,
+            vec![
+                secret_to_eth_address(sender_1),
+                secret_to_eth_address(sender_2),
+            ],
+            |_| ByzantineConfig::default(),
+        );
+        let mut swarm = eth_sim(builders);
+        let node_1 = swarm.node_ids()[0];
+        let node_2 = swarm.node_ids()[1];
+
+        let mut expected = Vec::new();
+        for nonce in 0..10 {
+            let tx1 = make_legacy_tx(sender_1, BASE_FEE, GAS_LIMIT, nonce, 10);
+            let tx2 = make_legacy_tx(sender_2, BASE_FEE, GAS_LIMIT, nonce, 10);
+            swarm.send_transaction(node_1, tx1.encoded_2718().into());
+            swarm.send_transaction(node_1, tx2.encoded_2718().into());
+            expected.push(tx1);
+            expected.push(tx2);
+        }
+        assert!(
+            swarm.run_until_blocks(10, deadline()),
+            "stalled before block 10"
+        );
+
+        let ids = swarm.node_ids();
+        SimVerifier::new()
+            .ledger_min_len(8)
+            .metrics_happy_path(&ids, &swarm)
+            .assert(&swarm);
+        assert!(verify_transactions_in_sim(&swarm, expected.clone()));
+
+        // already-committed nonces (5..10) to node 2 must not re-commit
+        for nonce in 5..10 {
+            swarm.send_transaction(
+                node_2,
+                make_legacy_tx(sender_1, BASE_FEE, GAS_LIMIT, nonce, 10)
+                    .encoded_2718()
+                    .into(),
+            );
+            swarm.send_transaction(
+                node_2,
+                make_legacy_tx(sender_2, BASE_FEE, GAS_LIMIT, nonce, 10)
+                    .encoded_2718()
+                    .into(),
+            );
+        }
+        // fresh nonces (10..20) should commit
+        for nonce in 10..20 {
+            let tx1 = make_legacy_tx(sender_1, BASE_FEE, GAS_LIMIT, nonce, 10);
+            let tx2 = make_legacy_tx(sender_2, BASE_FEE, GAS_LIMIT, nonce, 10);
+            swarm.send_transaction(node_2, tx1.encoded_2718().into());
+            swarm.send_transaction(node_2, tx2.encoded_2718().into());
+            expected.push(tx1);
+            expected.push(tx2);
+        }
+        assert!(
+            swarm.run_until_blocks(20, deadline()),
+            "stalled before block 20"
+        );
+
+        SimVerifier::new()
+            .ledger_min_len(18)
+            .metrics_happy_path(&ids, &swarm)
+            .assert(&swarm);
+        assert!(verify_transactions_in_sim(&swarm, expected));
+        swarm.assert_agreement();
+    }
+
+    #[test]
+    fn test_nec() {
+        let sender = B256::repeat_byte(15);
+        let builders = eth_swarm_config(4, vec![secret_to_eth_address(sender)], |_| {
+            ByzantineConfig::default()
+        });
+        // The round-robin "second node" (2nd by sorted id) proposes in the first
+        // `delay` blocks; corrupt its state root so its block 4 fails validation
+        // (it produces an equivocating tip). `builders` is in key-gen order, so
+        // select by id to match the legacy `states().iter().nth(1)`.
+        let mut by_id: Vec<usize> = (0..builders.len()).collect();
+        by_id.sort_by_key(|&i| builders[i].id);
+        let bad_idx = by_id[1];
+        let bad_id = builders[bad_idx].id;
+        builders[bad_idx]
+            .state_builder
+            .state_read
+            .lock()
+            .unwrap()
+            .extra_data = 1;
+
+        let mut swarm =
+            SimSwarm::from_builders(0, builders, |_| Network::reliable(CONSENSUS_DELTA));
+        // Run the good nodes well past block 10 (leader/follower commit lag means
+        // stopping the instant one node hits 10 leaves laggards behind). The bad
+        // node is permanently stuck, so its ledger length and the NEC count don't
+        // grow while the good nodes keep progressing.
+        assert!(
+            swarm.run_until_any_blocks(15, deadline()),
+            "good nodes did not progress"
+        );
+
+        let ids = swarm.node_ids();
+        // exactly one NEC is constructed (for the first block the bad node makes)
+        let max_nec = ids
+            .iter()
+            .map(|&id| swarm.with_node(id, |n| n.metrics().consensus_events.created_nec.get()))
+            .max()
+            .unwrap();
+        assert_eq!(max_nec, 1, "expected exactly one NEC");
+
+        for &id in &ids {
+            let len = swarm.with_node(id, |n| n.finalized_blocks());
+            if id == bad_id {
+                // bad node can't validate block 4, so block 3 is never committed
+                assert_eq!(len, 2, "bad node ledger length");
+            } else {
+                assert!(len >= 10, "good node {id} only has {len} blocks");
+            }
+        }
+    }
+
+    #[test]
+    fn non_sequential_seqnum() {
+        for byz_idx in 0..4 {
+            let builders = eth_swarm_config(4, Vec::new(), move |idx| {
+                if idx == byz_idx {
+                    ByzantineConfig {
+                        no_increment_seq_num: true,
+                        ..Default::default()
+                    }
+                } else {
+                    ByzantineConfig::default()
+                }
+            });
+            let mut swarm =
+                SimSwarm::from_builders(0, builders, |_| Network::reliable(CONSENSUS_DELTA));
+
+            // some node reaches block 20; every node should be at >= 18
+            assert!(
+                swarm.run_until_any_blocks(20, deadline()),
+                "byz_idx {byz_idx}: did not reach block 20"
+            );
+            SimVerifier::new().ledger_min_len(18).assert(&swarm);
+        }
+    }
+
+    #[test]
+    fn blocksync_missing_nonces() {
+        let sender = B256::repeat_byte(15);
+        let builders = eth_swarm_config(4, vec![secret_to_eth_address(sender)], |_| {
+            ByzantineConfig::default()
+        });
+        // Blackout the first node during [2s, 7s): the window starts *after*
+        // every node is post-statesync, so the blacked-out node is initialized
+        // (and will hold txns it's sent), then can only catch up via blocksync
+        // once the partition heals.
+        let mut swarm = SimSwarm::from_builders(0, builders, move |peers| {
+            let first = peers[0];
+            Network::reliable(CONSENSUS_DELTA)
+                .partition((Time(0) + secs(2))..(Time(0) + secs(7)), [vec![first]])
+        });
+        let ids = swarm.node_ids();
+        let node_1 = ids[0];
+        let node_2 = ids[1];
+
+        // post-statesync: every node reaches block 1 before the blackout begins
+        swarm.run_until(Time(0) + secs(2));
+
+        // txns 0..10 to a connected node — the blacked-out node misses them
+        let mut expected = Vec::new();
+        for nonce in 0..10 {
+            let tx = make_legacy_tx(sender, BASE_FEE, GAS_LIMIT, nonce, 10);
+            swarm.send_transaction(node_2, tx.encoded_2718().into());
+            expected.push(tx);
+        }
+        swarm.run_until(Time(0) + secs(5));
+        // the blacked-out node has fallen behind the connected supermajority
+        assert!(
+            swarm.with_node(node_1, |n| n.finalized_blocks())
+                < swarm.with_node(node_2, |n| n.finalized_blocks()),
+            "blacked-out node should fall behind"
+        );
+
+        // txns 10..20 to the blacked-out node; it proposes them once it catches up
+        for nonce in 10..20 {
+            let tx = make_legacy_tx(sender, BASE_FEE, GAS_LIMIT, nonce, 10);
+            swarm.send_transaction(node_1, tx.encoded_2718().into());
+            expected.push(tx);
+        }
+        // partition heals at 7s; run well past it so the recovered node
+        // blocksyncs, becomes leader, and gets its own txns committed everywhere.
+        swarm.run_until(Time(0) + secs(30));
+        assert!(verify_transactions_in_sim(&swarm, expected));
+        swarm.assert_agreement();
+    }
+}

--- a/monad-mock-swarm/tests/sim_order.rs
+++ b/monad-mock-swarm/tests/sim_order.rs
@@ -1,0 +1,108 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Message-reordering recovery, ported onto the `monad-sim` harness (mirrors
+//! the legacy `order.rs`). One node is isolated for the first 500ms; its
+//! messages are then burst-delivered in Forward / Reverse / Random order, and
+//! it must catch up (via blocksync) regardless of the order.
+
+mod sim_common;
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use monad_chain_config::revision::ChainParams;
+    use monad_mock_swarm::{sim_metric, sim_verify::SimVerifier};
+    use monad_sim::{time::millis, Time};
+    use monad_types::SeqNum;
+    use test_case::test_case;
+
+    use crate::sim_common::{replay_network, NoSerConfig, ReplayOrder};
+
+    static CHAIN_PARAMS: ChainParams = ChainParams {
+        tx_limit: 10_000,
+        proposal_gas_limit: 300_000_000,
+        proposal_byte_limit: 4_000_000,
+        max_reserve_balance: 1_000_000_000_000_000_000,
+        vote_pace: Duration::from_millis(0),
+    };
+
+    #[test_case(ReplayOrder::Forward; "in order")]
+    #[test_case(ReplayOrder::Reverse; "reverse order")]
+    #[test_case(ReplayOrder::Random(1); "random seed 1")]
+    #[test_case(ReplayOrder::Random(2); "random seed 2")]
+    #[test_case(ReplayOrder::Random(3); "random seed 3")]
+    #[test_case(ReplayOrder::Random(4); "random seed 4")]
+    #[test_case(ReplayOrder::Random(5); "random seed 5")]
+    fn all_messages_delayed(order: ReplayOrder) {
+        let delta = Duration::from_millis(20);
+        let release = Time(0) + millis(500);
+
+        // execution_delay 1 so the replay-transformer burst can deliver within a
+        // single Duration without tripping the state-root check (as in legacy).
+        let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+            .execution_delay(SeqNum(1))
+            .genesis_seqnum(SeqNum(1))
+            .swarm(|ids| replay_network(ids[0], release, delta, order));
+        let ids = swarm.node_ids();
+        let running: Vec<_> = ids[1..].to_vec();
+
+        // run to just before the replay: the running nodes have progressed and
+        // never needed blocksync; the isolated node is behind.
+        swarm.run_until(Time(0) + millis(499));
+        let longest_before = swarm.finalized_blocks().into_iter().max().unwrap();
+        SimVerifier::new()
+            .metric_exact(
+                &running,
+                sim_metric!(blocksync_events.self_headers_request),
+                0,
+            )
+            .metric_exact(
+                &running,
+                sim_metric!(blocksync_events.self_payload_request),
+                0,
+            )
+            .metric_min(
+                &running,
+                sim_metric!(consensus_events.handle_proposal),
+                longest_before as u64,
+            )
+            .metric_min(
+                &running,
+                sim_metric!(consensus_events.created_vote),
+                longest_before as u64,
+            )
+            // enter rounds via QC, except round 2
+            .metric_min(
+                &running,
+                sim_metric!(consensus_events.enter_new_round_qc),
+                longest_before as u64 - 1,
+            )
+            .assert(&swarm);
+
+        // run past the replay: the isolated node receives the reordered burst and
+        // catches up, so every node reaches the same progress as a healthy swarm.
+        swarm.run_until(Time(0) + millis(1000));
+        // inverse of the happy-path block->tick formula over the 500ms / 20ms
+        // window, minus 3 (2 uncommitted blocks in the tree + the blackout node
+        // can't propose while it has unvalidated blocks): (500/20 - 1)/2 - 3 = 9.
+        let expected_blocks: usize = (500 / 20 - 1) / 2 - 3;
+        SimVerifier::new()
+            .ledger_min_len(longest_before + expected_blocks)
+            .assert(&swarm);
+        swarm.assert_agreement();
+    }
+}

--- a/monad-mock-swarm/tests/sim_rand_lat.rs
+++ b/monad-mock-swarm/tests/sim_rand_lat.rs
@@ -1,0 +1,108 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Four nodes under random per-message latency, ported onto the `monad-sim`
+//! harness (mirrors the legacy `rand_lat.rs`). The fuzzing seed parametrizes
+//! the simulation seed (which seeds the network latency RNG), so each case
+//! exercises a distinct latency schedule. Latency is non-deterministic across
+//! seeds, so the final tick is not asserted exactly; the metric bounds and
+//! ledger length carry the coverage.
+
+mod sim_common;
+
+use std::time::Duration;
+
+use monad_chain_config::revision::ChainParams;
+use monad_mock_swarm::{sim::Network, sim_metric, sim_verify::SimVerifier};
+use monad_sim::{dist::uniform_duration, time::secs, Time};
+use monad_types::SeqNum;
+use test_case::test_case;
+
+use crate::sim_common::NoSerConfig;
+
+static CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(10),
+};
+
+#[test_case(1; "seed1")]
+#[test_case(2; "seed2")]
+#[test_case(3; "seed3")]
+#[test_case(4; "seed4")]
+#[test_case(5; "seed5")]
+#[test_case(6; "seed6")]
+#[test_case(7; "seed7")]
+#[test_case(8; "seed8")]
+#[test_case(9; "seed9")]
+#[test_case(10; "seed10")]
+#[test_case(14710580201381303742; "seed11")]
+#[test_case(11282773634027867923; "seed12")]
+#[test_case(11868595526945931122; "seed13")]
+#[test_case(4712443726697299681; "seed14")]
+#[test_case(5153471631950140680; "seed15")]
+#[test_case(4180491672667595808; "seed16")]
+#[test_case(3250401801427586510; "seed17")]
+#[test_case(13102732628471206412; "seed18")]
+fn nodes_with_random_latency(latency_seed: u64) {
+    let delta = Duration::from_millis(200);
+    let last_block = 2000usize;
+    let min_ledger_len = last_block - 5;
+    let max_blocksync_requests = 55u64;
+
+    let mut swarm = NoSerConfig::new(4, delta, &CHAIN_PARAMS)
+        // avoid the state_root trigger in the random-latency setting
+        .execution_delay(SeqNum::MAX)
+        .genesis_seqnum(SeqNum::MAX)
+        .epoch_length(SeqNum(3000))
+        .seed(latency_seed)
+        .swarm(|_| Network::with_latency(uniform_duration(Duration::from_millis(1), delta)));
+
+    assert!(
+        swarm.run_until_blocks(last_block, Time(0) + secs(2000)),
+        "seed {}: did not reach {} blocks",
+        latency_seed,
+        last_block
+    );
+
+    let ids = swarm.node_ids();
+    let mut verifier = SimVerifier::new();
+    verifier
+        .ledger_min_len(min_ledger_len)
+        // nodes time out only on init
+        .metric_exact(&ids, sim_metric!(consensus_events.local_timeout), 1)
+        // last_block is committed by processing 2 QCs after it; no branching.
+        // the node with the most blocksync requests may have the fewest blocks.
+        .metric_range(
+            &ids,
+            sim_metric!(consensus_events.process_qc),
+            min_ledger_len as u64 - max_blocksync_requests,
+            last_block as u64 + 2,
+        )
+        .metric_max(
+            &ids,
+            sim_metric!(blocksync_events.self_headers_request),
+            max_blocksync_requests,
+        )
+        .metric_max(
+            &ids,
+            sim_metric!(blocksync_events.self_payload_request),
+            max_blocksync_requests,
+        );
+    verifier.assert(&swarm);
+    swarm.assert_agreement();
+}

--- a/monad-mock-swarm/tests/sim_raptorcast.rs
+++ b/monad-mock-swarm/tests/sim_raptorcast.rs
@@ -1,0 +1,100 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg(feature = "raptorcast")]
+
+//! RaptorCast-chunk transport over the `monad-sim` harness, ported from the
+//! legacy `raptorcast.rs` (which it does not replace). Drives the
+//! `RaptorcastSwarm` relation — whose `RouterScheduler` chunks outbound messages
+//! and reassembles inbound chunks — across several epoch boundaries, exercising
+//! the harness's forwarding of `AddEpochValidatorSet` / `UpdateCurrentRound`
+//! (which the chunk scheduler needs to resolve broadcast recipients).
+
+use std::time::Duration;
+
+use monad_chain_config::{revision::ChainParams, MockChainConfig};
+use monad_consensus_types::{block::PassthruBlockPolicy, block_validator::MockValidator};
+use monad_crypto::certificate_signature::CertificateKeyPair;
+use monad_execution_state_read::InMemoryStateInner;
+use monad_mock_swarm::{
+    raptorcast::{RaptorcastRouterConfig, RaptorcastSwarm},
+    sim::{Network, SimNodeBuilder, SimSwarm, DEFAULT_TIMESTAMP_PERIOD},
+    swarm::make_state_configs,
+};
+use monad_router_scheduler::RouterSchedulerBuilder;
+use monad_sim::{time::secs, Time};
+use monad_types::{Epoch, NodeId, Round, SeqNum};
+use monad_updaters::{
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
+};
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
+
+static CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(5),
+};
+
+#[test]
+fn raptorcast_smoke_four_nodes() {
+    let delta = Duration::from_millis(100);
+    let epoch_length = SeqNum(20);
+    let epoch_start_delay = Round(5);
+
+    let builders: Vec<SimNodeBuilder<RaptorcastSwarm>> = make_state_configs::<RaptorcastSwarm>(
+        4,
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        || MockValidator,
+        || PassthruBlockPolicy,
+        || InMemoryStateInner::genesis(SeqNum(4)),
+        SeqNum(4),
+        delta,
+        MockChainConfig::new_with_epoch_params(&CHAIN_PARAMS, epoch_length, epoch_start_delay),
+        SeqNum(100),
+    )
+    .into_iter()
+    .map(|state_builder| {
+        let state_read = state_builder.state_read.clone();
+        let validators = state_builder.locked_epoch_validators[0].clone();
+        let self_id = NodeId::new(state_builder.key.pubkey());
+        SimNodeBuilder {
+            id: self_id,
+            state_builder,
+            router_scheduler: RaptorcastRouterConfig::<_, _, _>::new(self_id).build(),
+            val_set_updater: MockValSetUpdaterNop::new(validators.validators, epoch_length),
+            txpool_executor: MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
+            ledger: MockLedger::new(state_read.clone()),
+            statesync_executor: MockStateSyncExecutor::new(state_read),
+            timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+        }
+    })
+    .collect();
+
+    let mut swarm =
+        SimSwarm::<RaptorcastSwarm>::from_builders(0, builders, |_| Network::reliable(delta));
+
+    // Run past epoch 4, i.e. (4 - 1) * epoch_length committed blocks — enough to
+    // cross several boundaries with the chunked transport.
+    let min_blocks = ((Epoch(4).0 - 1) * epoch_length.0) as usize;
+    assert!(
+        swarm.run_until_blocks(min_blocks, Time(0) + secs(120)),
+        "raptorcast swarm did not reach {min_blocks} blocks"
+    );
+    swarm.assert_agreement();
+}

--- a/monad-mock-swarm/tests/sim_reserve_balance.rs
+++ b/monad-mock-swarm/tests/sim_reserve_balance.rs
@@ -1,0 +1,179 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Reserve-balance coverage: random transactions (mixed types, including
+//! insufficient-balance cases) against accounts with bounded balances. With
+//! reserve-balance validation enabled, execution asserts the reserve-balance
+//! invariant as blocks commit, so the test checks that consensus makes progress
+//! and never violates it. Ported onto the `monad-sim` harness (mirrors the
+//! legacy `reserve_balance.rs`, which it does not replace).
+
+mod eth_swarm_common;
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeMap;
+
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::B256;
+    use monad_eth_testutil::{
+        make_eip1559_tx_with_value, make_eip7702_tx_with_value, make_legacy_tx_with_value,
+        make_signed_authorization, secret_to_eth_address,
+    };
+    use monad_execution_state_read::AccountState;
+    use monad_mock_swarm::{
+        sim::{Network, SimSwarm},
+        sim_verify::SimVerifier,
+    };
+    use monad_sim::{time::secs, Time};
+    use monad_types::Balance;
+    use monad_updaters::txpool::ByzantineConfig;
+    use rand::Rng;
+    use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
+    use seq_macro::seq;
+
+    use crate::eth_swarm_common::{
+        eth_sim_builders_with_accounts, BASE_FEE, CONSENSUS_DELTA, GAS_LIMIT,
+    };
+
+    const GAS_COST: u128 = BASE_FEE * GAS_LIMIT as u128;
+    const GAS_LIMIT_7702: u64 = 70_000;
+
+    fn deadline() -> Time {
+        Time(0) + secs(120)
+    }
+
+    seq!(N in 0..512 {
+        #[test]
+        fn test_rand_reserve_balance_~N() {
+            rand_reserve_balance(N);
+        }
+    });
+
+    fn rand_reserve_balance(seed: u64) {
+        let mut rng = ChaChaRng::seed_from_u64(seed);
+
+        // 2-4 senders, each with a random balance between 0 and 10 * GAS_COSTs
+        // (a multiplier of 0 exercises the insufficient-balance path).
+        let num_senders = rng.gen_range(2..=4u8);
+        let sender_keys: Vec<B256> = (0..num_senders)
+            .map(|i| B256::repeat_byte(0x40 + i))
+            .collect();
+        let existing_accounts: BTreeMap<_, _> = sender_keys
+            .iter()
+            .map(|key| {
+                let balance_multiplier = rng.gen_range(0..=10u128);
+                (
+                    secret_to_eth_address(*key),
+                    AccountState::new_with_balance(Balance::from(balance_multiplier * GAS_COST)),
+                )
+            })
+            .collect();
+
+        let builders = eth_sim_builders_with_accounts(
+            2,
+            existing_accounts,
+            |_| ByzantineConfig::default(),
+            true,
+        );
+        let mut swarm =
+            SimSwarm::from_builders(0, builders, |_| Network::reliable(CONSENSUS_DELTA));
+        // post-statesync: every node reaches block 1 before any transactions.
+        assert!(swarm.run_until_blocks(1, deadline()), "no initial progress");
+        let node_1_id = swarm.node_ids()[0];
+
+        let mut sender_nonces: Vec<u64> = vec![0; num_senders as usize];
+        let mut current_block: usize = 2;
+
+        for (sender_idx, sender_key) in sender_keys.iter().enumerate() {
+            let num_txns = rng.gen_range(1..=8u64);
+
+            for _ in 0..num_txns {
+                let nonce = sender_nonces[sender_idx];
+                let gas_price = BASE_FEE * rng.gen_range(1..=3u128);
+                let value = rng.gen_range(0..=2u128) * GAS_COST;
+                let tx_type = rng.gen_range(0..=2u8);
+
+                let txn = match tx_type {
+                    0 => make_legacy_tx_with_value(
+                        *sender_key,
+                        value,
+                        gas_price,
+                        GAS_LIMIT,
+                        nonce,
+                        10,
+                    ),
+                    1 => make_eip1559_tx_with_value(
+                        *sender_key,
+                        value,
+                        gas_price,
+                        0,
+                        GAS_LIMIT,
+                        nonce,
+                        10,
+                    ),
+                    _ => {
+                        let auth_target_idx = (sender_idx + 1) % num_senders as usize;
+                        let auth_key = sender_keys[auth_target_idx];
+                        let auth_nonce = sender_nonces[auth_target_idx];
+                        let auth_list = vec![make_signed_authorization(
+                            auth_key,
+                            alloy_primitives::Address::repeat_byte(0xDD),
+                            auth_nonce,
+                        )];
+                        sender_nonces[auth_target_idx] += 1;
+                        make_eip7702_tx_with_value(
+                            *sender_key,
+                            value,
+                            gas_price,
+                            0,
+                            GAS_LIMIT_7702,
+                            nonce,
+                            auth_list,
+                            10,
+                        )
+                    }
+                };
+
+                sender_nonces[sender_idx] += 1;
+                swarm.send_transaction(node_1_id, txn.encoded_2718().into());
+
+                // advance a block with 10% probability
+                if rng.gen_bool(0.1) {
+                    current_block += 1;
+                    assert!(
+                        swarm.run_until_blocks(current_block, deadline()),
+                        "stalled before block {current_block}"
+                    );
+                }
+            }
+        }
+
+        // run consensus block policy to filter invalid transactions; execution
+        // asserts the reserve-balance invariant as each block commits.
+        let total_blocks = current_block + 10;
+        assert!(
+            swarm.run_until_blocks(total_blocks, deadline()),
+            "stalled before block {total_blocks}"
+        );
+
+        let ids = swarm.node_ids();
+        SimVerifier::new()
+            .ledger_min_len(2)
+            .metrics_happy_path(&ids, &swarm)
+            .assert(&swarm);
+        swarm.assert_agreement();
+    }
+}

--- a/monad-mock-swarm/tests/sim_two_nodes.rs
+++ b/monad-mock-swarm/tests/sim_two_nodes.rs
@@ -1,0 +1,47 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Two-node happy-path coverage, ported onto the `monad-sim` harness (mirrors
+//! the legacy `two_nodes.rs`, which it does not replace). The deterministic
+//! scheduler lets the final tick be asserted exactly, with no tolerance window.
+
+use std::time::Duration;
+
+use monad_mock_swarm::{
+    sim::{build_swarm_with, Network},
+    sim_verify::SimVerifier,
+};
+use monad_sim::{time::secs, Time};
+
+#[test]
+fn two_nodes_noser() {
+    let delta = Duration::from_millis(100);
+    let mut swarm = build_swarm_with(2, 0, |_| Network::reliable(delta));
+
+    assert!(
+        swarm.run_until_blocks(1026, Time(0) + secs(600)),
+        "did not reach 1026 blocks"
+    );
+
+    let ids = swarm.node_ids();
+    let mut verifier = SimVerifier::new();
+    verifier
+        // The deterministic scheduler yields an exact tick (no tolerance window).
+        .tick_exact(Time(0) + Duration::from_millis(205_500))
+        .ledger_min_len(1024)
+        .metrics_happy_path(&ids, &swarm);
+    verifier.assert(&swarm);
+    swarm.assert_agreement();
+}

--- a/monad-mock-swarm/tests/sim_two_nodes_bls.rs
+++ b/monad-mock-swarm/tests/sim_two_nodes_bls.rs
@@ -1,0 +1,187 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Two-node consensus over a BLS signature collection, ported onto the
+//! `monad-sim` harness (mirrors the legacy `two_nodes_bls.rs`, which it does
+//! not replace).
+//!
+//! NOTE: the legacy test additionally round-trips every emitted `MonadEvent`
+//! through RLP and serde on each step. That is serialization coverage,
+//! independent of the simulation engine; the new harness drives events
+//! internally and has no per-event hook. The round-trip coverage stays in the
+//! (still-present) legacy test; it should be extracted into a standalone
+//! serialization test before the legacy engine is deleted.
+
+use std::{collections::BTreeSet, time::Duration};
+
+use monad_bls::BlsSignatureCollection;
+use monad_chain_config::{
+    revision::{ChainParams, MockChainRevision},
+    MockChainConfig,
+};
+use monad_consensus_types::{
+    block::{MockExecutionProtocol, PassthruBlockPolicy},
+    block_validator::MockValidator,
+};
+use monad_crypto::certificate_signature::CertificateSignaturePubKey;
+use monad_execution_state_read::{InMemoryState, InMemoryStateInner};
+use monad_mock_swarm::{
+    sim::{Network, SimNodeBuilder, SimSwarm, DEFAULT_TIMESTAMP_PERIOD},
+    sim_verify::SimVerifier,
+    swarm::make_state_configs,
+    swarm_relation::SwarmRelation,
+};
+use monad_router_scheduler::{NoSerRouterConfig, NoSerRouterScheduler, RouterSchedulerBuilder};
+use monad_secp::SecpSignature;
+use monad_sim::{time::secs, Time};
+use monad_state::{MonadMessage, VerifiedMonadMessage};
+use monad_transformer::GenericTransformerPipeline;
+use monad_types::{NodeId, SeqNum};
+use monad_updaters::{
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
+};
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
+
+struct BLSSwarm;
+impl SwarmRelation for BLSSwarm {
+    type SignatureType = SecpSignature;
+    type SignatureCollectionType =
+        BlsSignatureCollection<CertificateSignaturePubKey<Self::SignatureType>>;
+    type ExecutionProtocolType = MockExecutionProtocol;
+    type ExecutionStateReadType = InMemoryState<Self::SignatureType, Self::SignatureCollectionType>;
+    type BlockPolicyType = PassthruBlockPolicy;
+    type ChainConfigType = MockChainConfig;
+    type ChainRevisionType = MockChainRevision;
+
+    type TransportMessage = VerifiedMonadMessage<
+        Self::SignatureType,
+        Self::SignatureCollectionType,
+        Self::ExecutionProtocolType,
+    >;
+
+    type BlockValidator = MockValidator;
+    type ValidatorSetTypeFactory =
+        ValidatorSetFactory<CertificateSignaturePubKey<Self::SignatureType>>;
+    type LeaderElection = SimpleRoundRobin<CertificateSignaturePubKey<Self::SignatureType>>;
+    type Ledger =
+        MockLedger<Self::SignatureType, Self::SignatureCollectionType, Self::ExecutionProtocolType>;
+
+    type RouterScheduler = NoSerRouterScheduler<
+        CertificateSignaturePubKey<Self::SignatureType>,
+        MonadMessage<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >,
+        VerifiedMonadMessage<
+            Self::SignatureType,
+            Self::SignatureCollectionType,
+            Self::ExecutionProtocolType,
+        >,
+    >;
+
+    type Pipeline = GenericTransformerPipeline<
+        CertificateSignaturePubKey<Self::SignatureType>,
+        Self::TransportMessage,
+    >;
+
+    type ValSetUpdater = MockValSetUpdaterNop<
+        Self::SignatureType,
+        Self::SignatureCollectionType,
+        Self::ExecutionProtocolType,
+    >;
+    type TxPoolExecutor = MockTxPoolExecutor<
+        Self::SignatureType,
+        Self::SignatureCollectionType,
+        Self::ExecutionProtocolType,
+        Self::BlockPolicyType,
+        Self::ExecutionStateReadType,
+        Self::ChainConfigType,
+        Self::ChainRevisionType,
+    >;
+    type StateSyncExecutor = MockStateSyncExecutor<
+        Self::SignatureType,
+        Self::SignatureCollectionType,
+        Self::ExecutionProtocolType,
+    >;
+}
+
+static CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(5),
+};
+
+fn bls_sim(num_nodes: u16, delta: Duration) -> SimSwarm<BLSSwarm> {
+    let state_configs = make_state_configs::<BLSSwarm>(
+        num_nodes,
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        || MockValidator,
+        || PassthruBlockPolicy,
+        || InMemoryStateInner::genesis(SeqNum(4)),
+        SeqNum(4),
+        delta,
+        MockChainConfig::new(&CHAIN_PARAMS),
+        SeqNum(100),
+    );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|config| NodeId::new(config.key.pubkey()))
+        .collect();
+
+    let builders: Vec<SimNodeBuilder<BLSSwarm>> = state_configs
+        .into_iter()
+        .map(|config| {
+            let state_read = config.state_read.clone();
+            let validators = config.locked_epoch_validators[0].clone();
+            SimNodeBuilder {
+                id: NodeId::new(config.key.pubkey()),
+                state_builder: config,
+                router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                val_set_updater: MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
+                txpool_executor: MockTxPoolExecutor::default().with_chain_params(&CHAIN_PARAMS),
+                ledger: MockLedger::new(state_read.clone()),
+                statesync_executor: MockStateSyncExecutor::new(state_read),
+                timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+            }
+        })
+        .collect();
+
+    SimSwarm::from_builders(0, builders, |_| Network::reliable(delta))
+}
+
+#[test]
+fn two_nodes_bls() {
+    let delta = Duration::from_millis(20);
+    let mut swarm = bls_sim(2, delta);
+
+    assert!(
+        swarm.run_until_blocks(100, Time(0) + secs(60)),
+        "did not reach 100 blocks"
+    );
+
+    let ids = swarm.node_ids();
+    let mut verifier = SimVerifier::new();
+    verifier
+        .tick_exact(Time(0) + Duration::from_millis(4_060))
+        .ledger_min_len(98)
+        .metrics_happy_path(&ids, &swarm);
+    verifier.assert(&swarm);
+    swarm.assert_agreement();
+}

--- a/monad-mock-swarm/tests/sim_vote_delay_metrics.rs
+++ b/monad-mock-swarm/tests/sim_vote_delay_metrics.rs
@@ -1,0 +1,149 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Vote-delay metrics, ported onto the `monad-sim` harness. This mirrors the
+//! coverage of the legacy `vote_delay_metrics.rs` (which it does not replace)
+//! using the new framework's self-contained surface.
+
+use std::{collections::BTreeSet, time::Duration};
+
+use monad_chain_config::{revision::ChainParams, MockChainConfig};
+use monad_consensus_types::{block::PassthruBlockPolicy, block_validator::MockValidator};
+use monad_crypto::certificate_signature::CertificateKeyPair;
+use monad_execution_state_read::InMemoryStateInner;
+use monad_mock_swarm::{
+    sim::{Network, SimNodeBuilder, SimSwarm, DEFAULT_TIMESTAMP_PERIOD},
+    swarm::make_state_configs,
+    swarm_relation::NoSerSwarm,
+};
+use monad_router_scheduler::{NoSerRouterConfig, RouterSchedulerBuilder};
+use monad_sim::{time::secs, Time};
+use monad_types::{NodeId, SeqNum};
+use monad_updaters::{
+    ledger::MockLedger, statesync::MockStateSyncExecutor, txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
+};
+use monad_validator::{simple_round_robin::SimpleRoundRobin, validator_set::ValidatorSetFactory};
+
+static ON_TIME_CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(500),
+};
+
+static LATE_CHAIN_PARAMS: ChainParams = ChainParams {
+    tx_limit: 10_000,
+    proposal_gas_limit: 300_000_000,
+    proposal_byte_limit: 4_000_000,
+    max_reserve_balance: 1_000_000_000_000_000_000,
+    vote_pace: Duration::from_millis(5),
+};
+
+/// A two-node `NoSerSwarm` driven through the `monad-sim` harness, with link
+/// latency `delta`.
+fn two_node_sim(chain_params: &'static ChainParams, delta: Duration) -> SimSwarm<NoSerSwarm> {
+    let state_configs = make_state_configs::<NoSerSwarm>(
+        2,
+        ValidatorSetFactory::default,
+        SimpleRoundRobin::default,
+        || MockValidator,
+        || PassthruBlockPolicy,
+        || InMemoryStateInner::genesis(SeqNum(4)),
+        SeqNum(4),
+        delta,
+        MockChainConfig::new(chain_params),
+        SeqNum(100),
+    );
+    let all_peers: BTreeSet<_> = state_configs
+        .iter()
+        .map(|config| NodeId::new(config.key.pubkey()))
+        .collect();
+
+    let builders: Vec<SimNodeBuilder<NoSerSwarm>> = state_configs
+        .into_iter()
+        .map(|config| {
+            let state_read = config.state_read.clone();
+            let validators = config.locked_epoch_validators[0].clone();
+            SimNodeBuilder {
+                id: NodeId::new(config.key.pubkey()),
+                state_builder: config,
+                router_scheduler: NoSerRouterConfig::new(all_peers.clone()).build(),
+                val_set_updater: MockValSetUpdaterNop::new(validators.validators, SeqNum(2000)),
+                txpool_executor: MockTxPoolExecutor::default().with_chain_params(chain_params),
+                ledger: MockLedger::new(state_read.clone()),
+                statesync_executor: MockStateSyncExecutor::new(state_read),
+                timestamp_period: DEFAULT_TIMESTAMP_PERIOD,
+            }
+        })
+        .collect();
+
+    SimSwarm::from_builders(0, builders, |_| Network::reliable(delta))
+}
+
+#[test]
+fn vote_delay_metrics_record_ready_after_timer_start_on_happy_path() {
+    let delta = Duration::from_millis(100);
+    let mut swarm = two_node_sim(&ON_TIME_CHAIN_PARAMS, delta);
+
+    assert!(
+        swarm.run_until_blocks(64, Time(0) + secs(120)),
+        "did not reach 64 blocks"
+    );
+    assert!(swarm.finalized_blocks().iter().all(|&n| n >= 62));
+    swarm.assert_agreement();
+
+    for id in swarm.node_ids() {
+        swarm.with_node(id, |node| {
+            let metrics = node.metrics();
+            let p50 = metrics.vote_delay.ready_after_timer_start_p50_ms.get();
+            let p90 = metrics.vote_delay.ready_after_timer_start_p90_ms.get();
+            let p99 = metrics.vote_delay.ready_after_timer_start_p99_ms.get();
+
+            assert!(p50 > 0);
+            assert!(p50 <= p90);
+            assert!(p90 <= p99);
+            assert!(p99 < ON_TIME_CHAIN_PARAMS.vote_pace.as_millis() as u64);
+            assert!(metrics.consensus_events.local_timeout.get() <= 1);
+        });
+    }
+}
+
+#[test]
+fn vote_delay_metrics_record_large_ready_after_timer_start_when_vote_pace_is_too_small() {
+    let delta = Duration::from_millis(100);
+    let mut swarm = two_node_sim(&LATE_CHAIN_PARAMS, delta);
+
+    assert!(
+        swarm.run_until_blocks(64, Time(0) + secs(120)),
+        "did not reach 64 blocks"
+    );
+    assert!(swarm.finalized_blocks().iter().all(|&n| n >= 62));
+    swarm.assert_agreement();
+
+    for id in swarm.node_ids() {
+        swarm.with_node(id, |node| {
+            let metrics = node.metrics();
+            let p50 = metrics.vote_delay.ready_after_timer_start_p50_ms.get();
+            let p90 = metrics.vote_delay.ready_after_timer_start_p90_ms.get();
+            let p99 = metrics.vote_delay.ready_after_timer_start_p99_ms.get();
+
+            assert!(p50 > LATE_CHAIN_PARAMS.vote_pace.as_millis() as u64);
+            assert!(p50 <= p90);
+            assert!(p90 <= p99);
+        });
+    }
+}

--- a/monad-mock-swarm/tests/vote_delay_metrics.rs
+++ b/monad-mock-swarm/tests/vote_delay_metrics.rs
@@ -52,7 +52,10 @@ static LATE_CHAIN_PARAMS: ChainParams = ChainParams {
     vote_pace: Duration::from_millis(5),
 };
 
-fn build_two_node_swarm(chain_params: &'static ChainParams, delta: Duration) -> Nodes<NoSerSwarm> {
+fn build_two_node_config(
+    chain_params: &'static ChainParams,
+    delta: Duration,
+) -> SwarmBuilder<NoSerSwarm> {
     let chain_config = MockChainConfig::new(chain_params);
     let state_configs = make_state_configs::<NoSerSwarm>(
         2,
@@ -94,7 +97,10 @@ fn build_two_node_swarm(chain_params: &'static ChainParams, delta: Duration) -> 
             })
             .collect(),
     )
-    .build()
+}
+
+fn build_two_node_swarm(chain_params: &'static ChainParams, delta: Duration) -> Nodes<NoSerSwarm> {
+    build_two_node_config(chain_params, delta).build()
 }
 
 fn run_until_block(swarm: &mut Nodes<NoSerSwarm>, block: usize) {


### PR DESCRIPTION
Port the monad-mock-swarm tests to the new simulation framework in `monad-sim` and `monad-sim-swarm`.

* `monad-mock-swarm::sim`:
    - `SimNodBuilder`: a declarative builder for a consensus node in a swarm.
    - `SimNode`: a consensus node as a `monad-sim process`. Implements `SimClient` so that it can act as network client.
    - `Network`: a declarative network builder.
    - `SimSwarm`: a declarative swarm builder.
* `monad-mock-swarm::sim_verify`: assertions ford swarms running via `monad-sim`.
* The legacy test suite ported onto the new framework (`tests/sim_*.rs`).
* Benchmarks for the new framework.

No production-logic change (only + `Clone` on `SwarmRelation::TransportMessage`). The legacy engine stays in place for now and can be removed in a follow up PR.