### PR TITLE
monad-node: expose triedb migration-phase as a Prometheus metric

### DIFF
--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -41,7 +41,7 @@ use monad_eth_block_validator::EthBlockValidator;
 use monad_eth_txpool_executor::{EthTxPoolExecutor, EthTxPoolIpcConfig};
 use monad_execution_state_read::ExecutionStateReadThreadClient;
 use monad_execution_state_read_cache::ExecutionStateReadCache;
-use monad_executor::{Executor, ExecutorMetricsChain};
+use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{LogFriendlyMonadEvent, Message, MonadEvent};
 use monad_ledger::MonadBlockFileLedger;
 use monad_node_config::{
@@ -85,7 +85,8 @@ use self::{
     cli::Cli,
     error::NodeSetupError,
     metrics::{
-        default_prometheus_labels, start_metrics_server, MetricsServerState, NodePrometheusMetrics,
+        default_prometheus_labels, init_triedb_phase_metrics, record_triedb_phase_metrics,
+        start_metrics_server, MetricsServerState, NodePrometheusMetrics,
     },
     state::NodeState,
 };
@@ -476,11 +477,25 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         }
     }
 
+    // Read the dual-DB migration phase once at startup and record it into a
+    // dedicated metrics set pushed alongside the executor's. The phase only
+    // changes via the offline monad-mpt tool, which requires a restart, so
+    // there is nothing to refresh. If triedb can't be opened, leave the metric
+    // unreported (empty set) rather than emitting a misleading default.
+    let mut triedb_phase_metrics = ExecutorMetrics::with_metric_defs(&[]);
+    match TriedbReader::try_new(node_state.triedb_path.as_path()) {
+        Some(reader) => {
+            triedb_phase_metrics = init_triedb_phase_metrics();
+            record_triedb_phase_metrics(&mut triedb_phase_metrics, reader.migration_phase());
+        }
+        None => warn!("triedb unavailable, migration-phase metric will not be reported"),
+    }
+
     let prometheus_metrics = Arc::new(
         NodePrometheusMetrics::new(
             prometheus_labels,
             state.metrics(),
-            executor.metrics(),
+            executor.metrics().push(&triedb_phase_metrics),
             process_start,
         )
         .map_err(|err| {
@@ -530,7 +545,7 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
                 None => futures_util::future::pending().boxed(),
             } => {
                 let otel_meter = maybe_otel_meter.as_ref().expect("otel_endpoint must have been set");
-                let executor_metrics = executor.metrics();
+                let executor_metrics = executor.metrics().push(&triedb_phase_metrics);
                 send_metrics(
                     otel_meter,
                     &mut gauge_cache,

--- a/monad-node/src/metrics.rs
+++ b/monad-node/src/metrics.rs
@@ -23,6 +23,7 @@ use actix_server::Server;
 use actix_web::{http::header, web, App, HttpRequest, HttpResponse, HttpServer};
 use monad_consensus_types::metrics::Metrics as StateMetrics;
 use monad_executor::{metric_consts, ExecutorMetrics, ExecutorMetricsChain, Gauge};
+use monad_triedb_utils::MigrationPhase;
 use prometheus::{Encoder, ProtobufEncoder, Registry, TextEncoder};
 
 pub fn default_prometheus_labels(
@@ -56,12 +57,35 @@ metric_consts! {
     }
 }
 
+metric_consts! {
+    pub GAUGE_TRIEDB_MIGRATION_PHASE {
+        name: "monad.triedb.migration_phase",
+        help: "Dual-DB migration phase: 0=legacy (not started), 1=dual-timeline (migrating), 2=page-encoded (complete)",
+    }
+}
+
 fn init_node_executor_metrics() -> ExecutorMetrics {
     ExecutorMetrics::with_metric_defs(&[
         GAUGE_TOTAL_UPTIME_US,
         GAUGE_STATE_TOTAL_UPDATE_US,
         GAUGE_NODE_INFO,
     ])
+}
+
+pub fn init_triedb_phase_metrics() -> ExecutorMetrics {
+    ExecutorMetrics::with_metric_defs(&[GAUGE_TRIEDB_MIGRATION_PHASE])
+}
+
+pub fn record_triedb_phase_metrics(metrics: &mut ExecutorMetrics, phase: MigrationPhase) {
+    // Map to the published 0/1/2 codes explicitly so the metric's wire contract
+    // stays fixed even if the MigrationPhase discriminants change upstream (the
+    // enum is defined in monad-triedb).
+    let code: u64 = match phase {
+        MigrationPhase::Legacy => 0,
+        MigrationPhase::DualTimeline => 1,
+        MigrationPhase::PageEncoded => 2,
+    };
+    metrics.gauge(GAUGE_TRIEDB_MIGRATION_PHASE).set(code);
 }
 
 fn duration_micros_u64(duration: &Duration) -> u64 {
@@ -217,4 +241,26 @@ pub fn start_metrics_server(addr: String, state: MetricsServerState) -> std::io:
     .bind(addr)?
     .workers(1)
     .run())
+}
+
+#[cfg(test)]
+mod migration_phase_tests {
+    use monad_triedb_utils::MigrationPhase;
+
+    use super::{
+        init_triedb_phase_metrics, record_triedb_phase_metrics, GAUGE_TRIEDB_MIGRATION_PHASE,
+    };
+
+    #[test]
+    fn records_phase_code() {
+        for (phase, code) in [
+            (MigrationPhase::Legacy, 0u64),
+            (MigrationPhase::DualTimeline, 1),
+            (MigrationPhase::PageEncoded, 2),
+        ] {
+            let mut metrics = init_triedb_phase_metrics();
+            record_triedb_phase_metrics(&mut metrics, phase);
+            assert_eq!(metrics.gauge(GAUGE_TRIEDB_MIGRATION_PHASE).get(), code);
+        }
+    }
 }

--- a/monad-triedb-utils/src/lib.rs
+++ b/monad-triedb-utils/src/lib.rs
@@ -32,6 +32,7 @@ use monad_crypto::certificate_signature::PubKey;
 use monad_eth_types::{EthAccount, EthHeader};
 use monad_execution_state_read::{ExecutionStateRead, ExecutionStateReadError};
 use monad_secp::SecpSignature;
+pub use monad_triedb::MigrationPhase;
 use monad_triedb::TriedbHandle;
 use monad_types::{BlockId, Epoch, Hash, SeqNum, Stake};
 use tracing::{debug, trace, warn};
@@ -68,6 +69,12 @@ impl TriedbReader {
             handle,
             state_read_total_lookups: Default::default(),
         })
+    }
+
+    /// The on-disk dual-DB migration phase. Cheap and safe to call while
+    /// execution is writing.
+    pub fn migration_phase(&self) -> MigrationPhase {
+        self.handle.migration_phase()
     }
 
     pub fn get_latest_voted_block(&self) -> Option<SeqNum> {


### PR DESCRIPTION
Read the triedb dual-DB migration phase (legacy/dual-timeline/page-encoded) once at startup and publish it as the gauge monad.triedb.migration_phase (0/1/2), so operators can monitor migration progress across the fleet without running the monad-mpt CLI on each node. Depends on the execution-side triedb_migration_phase FFI (submodule bump lands after that PR merges).

Depends on https://github.com/category-labs/monad/pull/2433