### PR TITLE
Raptorcast: Publish AdvanceRound to full nodes using broadcast

### DIFF
--- a/monad-consensus-state/src/command.rs
+++ b/monad-consensus-state/src/command.rs
@@ -36,7 +36,9 @@ use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable,
 };
 use monad_execution_state_read::ExecutionStateRead;
-use monad_types::{Epoch, ExecutionProtocol, NodeId, Round, RouterTarget, SeqNum};
+use monad_types::{
+    Epoch, ExecutionProtocol, FullnodeBroadcastMode, NodeId, Round, RouterTarget, SeqNum,
+};
 use monad_validator::signature_collection::{SignatureCollection, SignatureCollectionKeyPairType};
 
 /// Command type that the consensus state-machine outputs
@@ -62,6 +64,7 @@ where
     PublishToFullNodes {
         epoch: Epoch,
         round: Round,
+        broadcast_mode: FullnodeBroadcastMode,
         message: Verified<ST, Validated<ConsensusMessage<ST, SCT, EPT>>>,
     },
     /// Schedule a timeout event for `round` to be emitted in `duration`
@@ -139,6 +142,7 @@ where
                 cmds.push(ConsensusCommand::PublishToFullNodes {
                     epoch,
                     round: high_certificate.round(),
+                    broadcast_mode: FullnodeBroadcastMode::Broadcast,
                     message: ConsensusMessage {
                         version,
                         message: ProtocolMessage::AdvanceRound(AdvanceRoundMessage {

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -50,8 +50,9 @@ use monad_crypto::certificate_signature::{
 };
 use monad_execution_state_read::ExecutionStateRead;
 use monad_types::{
-    deserialize_pubkey, serialize_pubkey, Epoch, ExecutionProtocol, LimitedVec, NodeId, Round,
-    RouterTarget, SeqNum, Stake, UdpPriority, MAX_FORWARDED_TXS_PER_MESSAGE,
+    deserialize_pubkey, serialize_pubkey, Epoch, ExecutionProtocol, FullnodeBroadcastMode,
+    LimitedVec, NodeId, Round, RouterTarget, SeqNum, Stake, UdpPriority,
+    MAX_FORWARDED_TXS_PER_MESSAGE,
 };
 use monad_validator::signature_collection::SignatureCollection;
 use serde::{Deserialize, Serialize};
@@ -81,6 +82,7 @@ pub enum RouterCommand<ST: CertificateSignatureRecoverable, OM> {
     PublishToFullNodes {
         epoch: Epoch,
         round: Round,
+        broadcast_mode: FullnodeBroadcastMode,
         message: OM,
     },
     AddEpochValidatorSet {
@@ -120,11 +122,13 @@ impl<ST: CertificateSignatureRecoverable, OM> Debug for RouterCommand<ST, OM> {
             Self::PublishToFullNodes {
                 epoch,
                 round,
+                broadcast_mode,
                 message: _,
             } => f
                 .debug_struct("PublishToFullNodes")
                 .field("epoch", epoch)
                 .field("round", round)
+                .field("broadcast_mode", broadcast_mode)
                 .finish(),
             Self::AddEpochValidatorSet {
                 epoch,

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -54,7 +54,10 @@ use monad_peer_discovery::{
     MonadNameRecord, NameRecord, PeerDiscoveryAlgo, PeerDiscoveryEvent,
 };
 use monad_peer_score::IdentityScore;
-use monad_types::{DropTimer, Epoch, ExecutionProtocol, NodeId, Round, RouterTarget, UdpPriority};
+use monad_types::{
+    DropTimer, Epoch, ExecutionProtocol, FullnodeBroadcastMode, NodeId, Round, RouterTarget,
+    UdpPriority,
+};
 use monad_validator::{
     proposer_schedule::BoxedProposerSchedule,
     signature_collection::SignatureCollection,
@@ -455,6 +458,7 @@ where
                 msg_bytes,
                 epoch,
                 round,
+                broadcast_mode,
                 group,
             } => {
                 // SAFETY: the SecondaryRaptorcast publisher instance
@@ -462,8 +466,14 @@ where
                 // consistent with the round.
                 let broadcast_group =
                     SecondaryBroadcastGroup::as_publisher(&self.self_id, round, &group);
-                let build_target =
-                    v1_rollout::secondary_build_target(self.v1_rollout, epoch, broadcast_group);
+                let build_target = match broadcast_mode {
+                    FullnodeBroadcastMode::SecondaryRaptorcast => {
+                        v1_rollout::secondary_build_target(self.v1_rollout, epoch, broadcast_group)
+                    }
+                    FullnodeBroadcastMode::Broadcast => {
+                        BuildTarget::FullNodeBroadcast(broadcast_group)
+                    }
+                };
                 builder
                     .build_into(&msg_bytes, &build_target, &mut sink)
                     .unwrap_log_on_error(&msg_bytes, &build_target)
@@ -1061,6 +1071,8 @@ where
                 RouterCommand::PublishToFullNodes {
                     epoch,
                     round: _,
+                    // we always broadcast to dedicated-fullnodes
+                    broadcast_mode: _,
                     message,
                 } => {
                     if self.is_dynamic_fullnode {

--- a/monad-raptorcast/src/packet/regular.rs
+++ b/monad-raptorcast/src/packet/regular.rs
@@ -633,6 +633,24 @@ fn generate_chunks<PT: PubKey>(
             chunks
         }
 
+        BuildTarget::FullNodeBroadcast(secondary_group) => {
+            let num_symbols = redundancy
+                .scale(num_base_symbols)
+                .ok_or(BuildError::TooManyChunks)?;
+            ensure!(num_symbols <= MAX_TRIPLES, BuildError::TooManyChunks);
+            let recipients: Vec<_> = secondary_group
+                .iter()
+                .filter(|node_id| *node_id != self_node_id)
+                .cloned()
+                .collect();
+            let mut chunks = Vec::with_capacity(num_symbols * recipients.len());
+            for recipient in &recipients {
+                let assignment = ChunkAssignment::unicast(*recipient, num_symbols);
+                chunks.extend(assignment.materialize(segment_len)?);
+            }
+            chunks
+        }
+
         BuildTarget::Raptorcast {
             group: primary_group,
             ..
@@ -666,6 +684,8 @@ fn broadcast_mode_from_build_target<PT: PubKey>(
     match build_target {
         BuildTarget::Raptorcast { .. } => BroadcastMode::Primary,
         BuildTarget::FullNodeRaptorCast { .. } => BroadcastMode::Secondary,
-        BuildTarget::Broadcast(_) | BuildTarget::PointToPoint { .. } => BroadcastMode::Unspecified,
+        BuildTarget::Broadcast(_)
+        | BuildTarget::FullNodeBroadcast(_)
+        | BuildTarget::PointToPoint { .. } => BroadcastMode::Unspecified,
     }
 }

--- a/monad-raptorcast/src/raptorcast_secondary/mod.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/mod.rs
@@ -35,7 +35,7 @@ use monad_crypto::certificate_signature::{
 use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::{Message, PeerEntry, RouterCommand};
 use monad_peer_discovery::{driver::PeerDiscoveryDriver, PeerDiscoveryAlgo, PeerDiscoveryEvent};
-use monad_types::{Epoch, NodeId, Round};
+use monad_types::{Epoch, FullnodeBroadcastMode, NodeId, Round};
 use publisher::Publisher;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -66,6 +66,7 @@ pub enum SecondaryOutboundMessage<PT: PubKey> {
         msg_bytes: bytes::Bytes,
         epoch: Epoch,
         round: Round,
+        broadcast_mode: FullnodeBroadcastMode,
         group: SecondaryGroup<PT>,
     },
 }
@@ -344,6 +345,7 @@ where
                 Self::Command::PublishToFullNodes {
                     epoch,
                     round,
+                    broadcast_mode,
                     message,
                 } => {
                     let group = match &mut self.role {
@@ -381,6 +383,7 @@ where
                         msg_bytes: outbound_message,
                         epoch,
                         round,
+                        broadcast_mode,
                         group,
                     };
                     if let Err(err) = self.channel_to_primary_outbound.send(outbound) {

--- a/monad-raptorcast/src/util.rs
+++ b/monad-raptorcast/src/util.rs
@@ -78,17 +78,20 @@ pub enum BuildTarget<'a, PT: PubKey> {
         group: PrimaryBroadcastGroup<'a, PT>,
         mode: RaptorcastMode,
     },
-    // unicast message as raptor-coded chunks to a single recipient
-    PointToPoint {
-        group_id: GroupId,
-        recipient: &'a NodeId<PT>,
-    },
+    // broadcast a message to a set of full nodes where each full node
+    // gets the full chunks of the raptor-coded message.
+    FullNodeBroadcast(SecondaryBroadcastGroup<'a, PT>),
     // raptorcast to a set of full nodes. In regular mode, chunks are
     // assigned round-robin; in deterministic mode, chunks are
     // assigned by the seeded shuffle of the full-node group.
     FullNodeRaptorCast {
         group: SecondaryBroadcastGroup<'a, PT>,
         mode: RaptorcastMode,
+    },
+    // unicast message as raptor-coded chunks to a single recipient
+    PointToPoint {
+        group_id: GroupId,
+        recipient: &'a NodeId<PT>,
     },
 }
 
@@ -139,7 +142,8 @@ impl<'a, PT: PubKey> BuildTarget<'a, PT> {
                 Box::new(group.iter().map(|(n, _)| n))
             }
             BuildTarget::PointToPoint { recipient, .. } => Box::new(std::iter::once(*recipient)),
-            BuildTarget::FullNodeRaptorCast { group, .. } => Box::new(group.iter()),
+            BuildTarget::FullNodeRaptorCast { group, .. }
+            | BuildTarget::FullNodeBroadcast(group) => Box::new(group.iter()),
         }
     }
 
@@ -148,7 +152,8 @@ impl<'a, PT: PubKey> BuildTarget<'a, PT> {
             BuildTarget::Broadcast(group) | BuildTarget::Raptorcast { group, .. } => {
                 group.group_id()
             }
-            BuildTarget::FullNodeRaptorCast { group, .. } => group.group_id(),
+            BuildTarget::FullNodeRaptorCast { group, .. }
+            | BuildTarget::FullNodeBroadcast(group) => group.group_id(),
             BuildTarget::PointToPoint { group_id, .. } => *group_id,
         }
     }

--- a/monad-raptorcast/tests/raptorcast_instance.rs
+++ b/monad-raptorcast/tests/raptorcast_instance.rs
@@ -654,6 +654,8 @@ async fn raptorcast_forwards_fullnodes_group_invite_at_cold_start() {
 #[cfg(test)]
 #[tokio::test]
 async fn publish_to_full_nodes() {
+    use monad_types::FullnodeBroadcastMode;
+
     ONCE_SETUP.call_once(|| {
         tracing_subscriber::fmt::fmt()
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
@@ -752,6 +754,7 @@ async fn publish_to_full_nodes() {
     let command = RouterCommand::PublishToFullNodes {
         epoch: Epoch(0),
         round: Round(0),
+        broadcast_mode: FullnodeBroadcastMode::SecondaryRaptorcast,
         message,
     };
     validator_rc.exec(vec![command]);

--- a/monad-router-multi/src/lib.rs
+++ b/monad-router-multi/src/lib.rs
@@ -375,11 +375,13 @@ where
                 RouterCommand::PublishToFullNodes {
                     epoch,
                     round,
+                    broadcast_mode,
                     ref message,
                 } => {
                     let cmd_cpy = RouterCommand::PublishToFullNodes {
                         epoch,
                         round,
+                        broadcast_mode,
                         message: message.clone(),
                     };
                     validator_cmds.push(cmd_cpy);

--- a/monad-state/src/consensus.rs
+++ b/monad-state/src/consensus.rs
@@ -44,7 +44,7 @@ use monad_executor_glue::{
     MempoolEvent, MonadEvent, RouterCommand, StateSyncEvent, TimeoutVariant, TimerCommand,
     TimestampCommand, TxPoolCommand, ValSetCommand,
 };
-use monad_types::{ExecutionProtocol, NodeId, Round, RouterTarget};
+use monad_types::{ExecutionProtocol, FullnodeBroadcastMode, NodeId, Round, RouterTarget};
 use monad_validator::{
     epoch_manager::EpochManager,
     leader_election::LeaderElection,
@@ -271,6 +271,7 @@ where
                                 proposal_cmds.push(ConsensusCommand::PublishToFullNodes {
                                     epoch: proposal_epoch,
                                     round: proposal_round,
+                                    broadcast_mode: FullnodeBroadcastMode::SecondaryRaptorcast,
                                     message: verified_message,
                                 });
                                 proposal_cmds
@@ -707,10 +708,12 @@ where
             ConsensusCommand::PublishToFullNodes {
                 epoch,
                 round,
+                broadcast_mode,
                 message,
             } => parent_cmds.push(Command::RouterCommand(RouterCommand::PublishToFullNodes {
                 epoch,
                 round,
+                broadcast_mode,
                 message: VerifiedMonadMessage::Consensus(message),
             })),
             ConsensusCommand::Schedule { round, duration } => {

--- a/monad-types/src/lib.rs
+++ b/monad-types/src/lib.rs
@@ -717,6 +717,15 @@ pub enum RouterTarget<P: PubKey> {
     },
 }
 
+/// How a validator disseminates a message to its full-node group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FullnodeBroadcastMode {
+    // use peer-to-peer two-hop raptorcast
+    SecondaryRaptorcast,
+    // broadcast to all full-nodes directly
+    Broadcast,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(usize)]
 pub enum UdpPriority {


### PR DESCRIPTION
Currently the `AdvanceRound` messages are published to full nodes through secondary raptorcast. In v1 determnistic rc in each round a node will commit to a singular secondary raptorcast message (merkle root) per (publisher, round), so this `AdvanceRound` message would conflict with the proposal message and get dropped.

Using raptorcast to publish `AdvanceRound` is not necessary because the message is fairly small, where we want to reserve raptorcast for proposals only.

Note: Publishing to dedicated full nodes are unaffected by the changes regardless of message types, all messages are sent to each of them via unicast.