### PR TITLE
monad-wireauth: preserve buffered message metadata

### DIFF
--- a/monad-wireauth/src/api.rs
+++ b/monad-wireauth/src/api.rs
@@ -41,10 +41,10 @@ use crate::{
     state::State,
 };
 
-pub struct API<C: Context, K: AsRef<monad_secp::KeyPair> = monad_secp::KeyPair> {
-    state: State,
+pub struct API<C: Context, K: AsRef<monad_secp::KeyPair> = monad_secp::KeyPair, M = ()> {
+    state: State<M>,
     timers: BTreeSet<(Duration, SessionIndex)>,
-    packet_queue: VecDeque<(SocketAddr, Bytes)>,
+    packet_queue: VecDeque<(SocketAddr, Bytes, Option<M>)>,
     config: Config,
     local_static_key: K,
     // Cached compressed public key to avoid recomputing when logging
@@ -59,9 +59,9 @@ pub struct API<C: Context, K: AsRef<monad_secp::KeyPair> = monad_secp::KeyPair> 
     connect_rate_last_reset: Duration,
 }
 
-impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
+impl<C: Context, K: AsRef<monad_secp::KeyPair>, M> API<C, K, M> {
     /// Creates a new API instance, it should be created for an individual socket.
-    pub fn new(
+    pub fn new_with_metadata(
         metric_names: &'static MetricNames,
         config: Config,
         local_static_key: K,
@@ -88,7 +88,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         let local_serialized_public = CompressedPublicKey::from(&local_static_public);
         debug!(local_public_key=?local_serialized_public, "initialized manager");
         Self {
-            state: State::new(metric_names),
+            state: State::new_with_metadata(metric_names),
             timers: BTreeSet::new(),
             packet_queue: VecDeque::new(),
             config,
@@ -117,7 +117,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
     /// Note: There are no limits for the internal queue, so it is better to use a separate
     /// queue for pacing.
     #[instrument(level = Level::TRACE, skip(self), fields(local_public_key = ?self.local_serialized_public))]
-    pub fn next_packet(&mut self) -> Option<(SocketAddr, Bytes)> {
+    pub fn next_packet_with_metadata(&mut self) -> Option<(SocketAddr, Bytes, Option<M>)> {
         self.metrics.gauge(self.metric_names.api_next_packet).inc();
         let result = self.packet_queue.pop_front();
         self.metrics
@@ -126,8 +126,8 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         result
     }
 
-    fn enqueue_packet(&mut self, addr: SocketAddr, pkt: impl Into<Bytes>) {
-        self.packet_queue.push_back((addr, pkt.into()));
+    fn enqueue_packet(&mut self, addr: SocketAddr, pkt: impl Into<Bytes>, metadata: Option<M>) {
+        self.packet_queue.push_back((addr, pkt.into(), metadata));
         self.metrics
             .gauge(self.metric_names.state_packet_queue_size)
             .set(self.packet_queue.len() as u64);
@@ -253,7 +253,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
                 self.metrics
                     .gauge(self.metric_names.enqueued_keepalive)
                     .inc();
-                self.enqueue_packet(message.remote_addr, message.header);
+                self.enqueue_packet(message.remote_addr, message.header, None);
             }
 
             if let Some(rekey) = rekey {
@@ -266,7 +266,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
                     self.metrics
                         .gauge(self.metric_names.enqueued_handshake_init)
                         .inc();
-                    self.enqueue_packet(rekey.remote_addr, message);
+                    self.enqueue_packet(rekey.remote_addr, message, None);
                     self.insert_timer(timer, new_session_index);
                 }
             }
@@ -331,7 +331,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         self.metrics
             .gauge(self.metric_names.enqueued_handshake_init)
             .inc();
-        self.enqueue_packet(remote_addr, message);
+        self.enqueue_packet(remote_addr, message, None);
         self.insert_timer(timer, local_index);
 
         Ok(())
@@ -429,7 +429,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
                 self.metrics
                     .gauge(self.metric_names.enqueued_cookie_reply)
                     .inc();
-                self.enqueue_packet(remote_addr, reply);
+                self.enqueue_packet(remote_addr, reply, None);
                 false
             }
             FilterAction::Drop => {
@@ -518,7 +518,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         self.metrics
             .gauge(self.metric_names.enqueued_handshake_response)
             .inc();
-        self.enqueue_packet(remote_addr, message);
+        self.enqueue_packet(remote_addr, message, None);
         self.insert_timer(timer, local_index);
 
         Ok(())
@@ -732,7 +732,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
         self.state
             .insert_transport(receiver_session_index, transport);
 
-        for msg in messages {
+        for (msg, metadata) in messages {
             let mut packet = BytesMut::with_capacity(DataPacketHeader::SIZE + msg.len());
             packet.resize(DataPacketHeader::SIZE, 0);
             packet.extend_from_slice(&msg);
@@ -750,7 +750,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
             packet[..DataPacketHeader::SIZE].copy_from_slice(header.as_bytes());
 
             self.replace_timer(timer, receiver_session_index);
-            self.enqueue_packet(remote_addr, packet.freeze());
+            self.enqueue_packet(remote_addr, packet.freeze(), metadata);
             if is_buffered {
                 self.metrics
                     .gauge(self.metric_names.initiator_messages_sent_from_buffer)
@@ -829,11 +829,12 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
     /// Buffers a message for a peer that has an initiator session (handshake in progress).
     /// Returns Ok(()) if the message was buffered, or Err if no initiator session exists
     /// or the buffer limit would be exceeded.
-    #[instrument(level = Level::TRACE, skip(self, public_key, message), fields(local_public_key = ?self.local_serialized_public))]
-    pub fn buffer_message(
+    #[instrument(level = Level::TRACE, skip(self, public_key, message, metadata), fields(local_public_key = ?self.local_serialized_public))]
+    pub fn buffer_message_with_metadata(
         &mut self,
         public_key: &monad_secp::PubKey,
         message: Bytes,
+        metadata: M,
     ) -> Result<()> {
         let initiator = self
             .state
@@ -852,7 +853,7 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
                 limit: self.config.max_buffered_bytes_per_session,
             });
         }
-        initiator.buffer_message(message);
+        initiator.buffer_message(message, metadata);
         self.metrics
             .gauge(self.metric_names.initiator_buffered_messages)
             .inc();
@@ -916,6 +917,30 @@ impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
     /// Returns the socket address of the latest initiated session with the given public key.
     pub fn get_socket_by_public_key(&self, public_key: &monad_secp::PubKey) -> Option<SocketAddr> {
         self.state.get_socket_by_public_key(public_key)
+    }
+}
+
+impl<C: Context, K: AsRef<monad_secp::KeyPair>> API<C, K> {
+    pub fn new(
+        metric_names: &'static MetricNames,
+        config: Config,
+        local_static_key: K,
+        context: C,
+    ) -> Self {
+        Self::new_with_metadata(metric_names, config, local_static_key, context)
+    }
+
+    pub fn next_packet(&mut self) -> Option<(SocketAddr, Bytes)> {
+        self.next_packet_with_metadata()
+            .map(|(addr, packet, _)| (addr, packet))
+    }
+
+    pub fn buffer_message(
+        &mut self,
+        public_key: &monad_secp::PubKey,
+        message: Bytes,
+    ) -> Result<()> {
+        self.buffer_message_with_metadata(public_key, message, ())
     }
 }
 

--- a/monad-wireauth/src/filter.rs
+++ b/monad-wireauth/src/filter.rs
@@ -116,9 +116,9 @@ impl Filter {
         self.last_reset + self.handshake_rate_reset_interval
     }
 
-    pub fn apply(
+    pub fn apply<M>(
         &mut self,
-        state: &State,
+        state: &State<M>,
         remote_addr: SocketAddr,
         duration_since_start: Duration,
         cookie_valid: bool,
@@ -235,7 +235,7 @@ impl Filter {
         }
     }
 
-    fn check_max_sessions_per_ip(&self, state: &State, ip: IpAddr) -> Option<FilterAction> {
+    fn check_max_sessions_per_ip<M>(&self, state: &State<M>, ip: IpAddr) -> Option<FilterAction> {
         (state.ip_session_count(&ip) >= self.max_sessions_per_ip).then(|| {
             debug!(
                 ip = %ip,

--- a/monad-wireauth/src/session/initiator.rs
+++ b/monad-wireauth/src/session/initiator.rs
@@ -41,14 +41,14 @@ pub struct ValidatedHandshakeResponse {
     remote_index: SessionIndex,
 }
 
-pub struct InitiatorState {
+pub struct InitiatorState<M = ()> {
     handshake_state: handshake::HandshakeState,
     common: SessionState,
-    buffered_messages: VecDeque<Bytes>,
+    buffered_messages: VecDeque<(Bytes, M)>,
     buffered_bytes: usize,
 }
 
-impl InitiatorState {
+impl<M> InitiatorState<M> {
     #[allow(clippy::too_many_arguments)]
     pub fn new<R: secp256k1::rand::Rng + secp256k1::rand::CryptoRng>(
         rng: &mut R,
@@ -138,7 +138,7 @@ impl InitiatorState {
         config: &Config,
         duration_since_start: Duration,
         validated_response: ValidatedHandshakeResponse,
-    ) -> (TransportState, MessagesToSend) {
+    ) -> (TransportState, MessagesToSend<M>) {
         self.common.reset_session_timeout(
             duration_since_start,
             add_jitter(rng, config.session_timeout, config.session_timeout_jitter),
@@ -185,9 +185,9 @@ impl InitiatorState {
         Some((timer, SessionTimeoutResult { terminated, rekey }))
     }
 
-    pub fn buffer_message(&mut self, message: Bytes) {
+    pub fn buffer_message(&mut self, message: Bytes, metadata: M) {
         self.buffered_bytes = self.buffered_bytes.saturating_add(message.len());
-        self.buffered_messages.push_back(message);
+        self.buffered_messages.push_back((message, metadata));
     }
 
     pub fn buffered_message_count(&self) -> usize {
@@ -199,17 +199,17 @@ impl InitiatorState {
     }
 }
 
-pub struct MessagesToSend {
-    inner: MessagesToSendInner,
+pub struct MessagesToSend<M> {
+    inner: MessagesToSendInner<M>,
 }
 
-enum MessagesToSendInner {
-    Buffered(vec_deque::IntoIter<Bytes>),
+enum MessagesToSendInner<M> {
+    Buffered(vec_deque::IntoIter<(Bytes, M)>),
     Keepalive(iter::Once<Bytes>),
 }
 
-impl MessagesToSend {
-    fn new(messages: VecDeque<Bytes>) -> Self {
+impl<M> MessagesToSend<M> {
+    fn new(messages: VecDeque<(Bytes, M)>) -> Self {
         let inner = if messages.is_empty() {
             MessagesToSendInner::Keepalive(iter::once(Bytes::new()))
         } else {
@@ -223,13 +223,15 @@ impl MessagesToSend {
     }
 }
 
-impl Iterator for MessagesToSend {
-    type Item = Bytes;
+impl<M> Iterator for MessagesToSend<M> {
+    type Item = (Bytes, Option<M>);
 
     fn next(&mut self) -> Option<Self::Item> {
         match &mut self.inner {
-            MessagesToSendInner::Buffered(iter) => iter.next(),
-            MessagesToSendInner::Keepalive(iter) => iter.next(),
+            MessagesToSendInner::Buffered(iter) => iter
+                .next()
+                .map(|(message, metadata)| (message, Some(metadata))),
+            MessagesToSendInner::Keepalive(iter) => iter.next().map(|message| (message, None)),
         }
     }
 
@@ -241,7 +243,7 @@ impl Iterator for MessagesToSend {
     }
 }
 
-impl ExactSizeIterator for MessagesToSend {
+impl<M> ExactSizeIterator for MessagesToSend<M> {
     fn len(&self) -> usize {
         match &self.inner {
             MessagesToSendInner::Buffered(iter) => iter.len(),
@@ -250,7 +252,7 @@ impl ExactSizeIterator for MessagesToSend {
     }
 }
 
-impl Deref for InitiatorState {
+impl<M> Deref for InitiatorState<M> {
     type Target = SessionState;
 
     fn deref(&self) -> &Self::Target {
@@ -258,7 +260,7 @@ impl Deref for InitiatorState {
     }
 }
 
-impl DerefMut for InitiatorState {
+impl<M> DerefMut for InitiatorState<M> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.common
     }

--- a/monad-wireauth/src/state.rs
+++ b/monad-wireauth/src/state.rs
@@ -91,12 +91,12 @@ impl EstablishedSessions {
     }
 }
 
-pub(crate) struct SessionIndexReservation<'a> {
-    state: &'a mut State,
+pub(crate) struct SessionIndexReservation<'a, M> {
+    state: &'a mut State<M>,
     index: SessionIndex,
 }
 
-impl<'a> SessionIndexReservation<'a> {
+impl<M> SessionIndexReservation<'_, M> {
     pub(crate) fn index(&self) -> SessionIndex {
         self.index
     }
@@ -112,8 +112,8 @@ impl<'a> SessionIndexReservation<'a> {
     }
 }
 
-pub struct State {
-    initiating_sessions: HashMap<SessionIndex, InitiatorState>,
+pub struct State<M = ()> {
+    initiating_sessions: HashMap<SessionIndex, InitiatorState<M>>,
     responding_sessions: HashMap<SessionIndex, ResponderState>,
     transport_sessions: HashMap<SessionIndex, TransportState>,
     last_established_session_by_public_key: HashMap<monad_secp::PubKey, EstablishedSessions>,
@@ -128,8 +128,8 @@ pub struct State {
     metric_names: &'static MetricNames,
 }
 
-impl State {
-    pub fn new(metric_names: &'static MetricNames) -> Self {
+impl<M> State<M> {
+    pub fn new_with_metadata(metric_names: &'static MetricNames) -> Self {
         Self {
             initiating_sessions: HashMap::new(),
             responding_sessions: HashMap::new(),
@@ -255,7 +255,7 @@ impl State {
         self.transport_sessions.get_mut(&session_id)
     }
 
-    pub(crate) fn reserve_session_index(&mut self) -> Option<SessionIndexReservation<'_>> {
+    pub(crate) fn reserve_session_index(&mut self) -> Option<SessionIndexReservation<'_, M>> {
         let start_index = self.next_session_index;
         let mut candidate = self.next_session_index;
 
@@ -451,21 +451,21 @@ impl State {
     }
 
     #[cfg(test)]
-    pub fn get_initiator(&self, session_index: &SessionIndex) -> Option<&InitiatorState> {
+    pub fn get_initiator(&self, session_index: &SessionIndex) -> Option<&InitiatorState<M>> {
         self.initiating_sessions.get(session_index)
     }
 
     pub fn get_initiator_mut(
         &mut self,
         session_index: &SessionIndex,
-    ) -> Option<&mut InitiatorState> {
+    ) -> Option<&mut InitiatorState<M>> {
         self.initiating_sessions.get_mut(session_index)
     }
 
     pub fn get_initiator_by_public_key_mut(
         &mut self,
         public_key: &monad_secp::PubKey,
-    ) -> Option<&mut InitiatorState> {
+    ) -> Option<&mut InitiatorState<M>> {
         let session_id = self.initiated_session_by_peer.get(public_key)?;
         self.initiating_sessions.get_mut(session_id)
     }
@@ -482,7 +482,7 @@ impl State {
         self.responding_sessions.get_mut(session_index)
     }
 
-    pub fn remove_initiator(&mut self, session_index: &SessionIndex) -> Option<InitiatorState> {
+    pub fn remove_initiator(&mut self, session_index: &SessionIndex) -> Option<InitiatorState<M>> {
         let session = self.initiating_sessions.remove(session_index)?;
         self.metrics
             .gauge(self.metric_names.state_initiating_sessions)
@@ -517,7 +517,7 @@ impl State {
     pub fn insert_initiator(
         &mut self,
         session_index: SessionIndex,
-        session: InitiatorState,
+        session: InitiatorState<M>,
         remote_key: monad_secp::PubKey,
     ) {
         let remote_addr = session.remote_addr;
@@ -681,6 +681,13 @@ impl State {
 
     pub fn initiated_sessions_count(&self) -> usize {
         self.initiating_sessions.len()
+    }
+}
+
+#[cfg(test)]
+impl State {
+    pub fn new(metric_names: &'static MetricNames) -> Self {
+        Self::new_with_metadata(metric_names)
     }
 }
 

--- a/monad-wireauth/tests/tests.rs
+++ b/monad-wireauth/tests/tests.rs
@@ -825,6 +825,44 @@ fn test_message_buffering_during_handshake() {
 }
 
 #[test]
+fn test_buffered_message_metadata() {
+    init_tracing();
+    let mut rng = rng();
+    let keypair = monad_secp::KeyPair::generate(&mut rng);
+    let mut peer1: API<TestContext, _, u8> = API::new_with_metadata(
+        DEFAULT_METRICS,
+        Config::default(),
+        keypair,
+        TestContext::new(),
+    );
+    let (mut peer2, peer2_pubkey, _, _) = create_manager();
+    let peer1_addr: SocketAddr = "127.0.0.1:8001".parse().unwrap();
+    let peer2_addr: SocketAddr = "127.0.0.1:8002".parse().unwrap();
+
+    peer1
+        .connect(peer2_pubkey, peer2_addr, DEFAULT_RETRY_ATTEMPTS)
+        .unwrap();
+    peer1
+        .buffer_message_with_metadata(&peer2_pubkey, bytes::Bytes::from_static(b"buffered"), 7)
+        .unwrap();
+
+    let (_, init, metadata) = peer1.next_packet_with_metadata().unwrap();
+    assert_eq!(metadata, None);
+    dispatch(&mut peer2, &init, peer1_addr);
+
+    let response = collect::<HandshakeResponse>(&mut peer2);
+    let mut response = response;
+    let Packet::Control(response) = Packet::try_from(response.as_mut_slice()).unwrap() else {
+        panic!("expected handshake response");
+    };
+    peer1.dispatch_control(response, peer2_addr).unwrap();
+
+    let (_, packet, metadata) = peer1.next_packet_with_metadata().unwrap();
+    assert_eq!(metadata, Some(7));
+    assert_eq!(decrypt(&mut peer2, &packet, peer1_addr), b"buffered");
+}
+
+#[test]
 fn test_handshake_response_address_mismatch_rejected() {
     init_tracing();
     let (mut peer1, _, _, _) = create_manager();


### PR DESCRIPTION
will be used to preserve statesync completions