### PR TITLE
Add BLS infinity aggregate regression test

### DIFF
--- a/monad-bls/src/aggregation_tree.rs
+++ b/monad-bls/src/aggregation_tree.rs
@@ -470,13 +470,14 @@ mod test {
         signature_collection::{
             SignatureCollection, SignatureCollectionError, SignatureCollectionKeyPairType,
         },
+        validator_mapping::ValidatorMapping,
         validator_set::ValidatorSetFactory,
     };
     use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
     use test_case::test_case;
 
     use super::{merge_nodes, AggregationTree, BlsSignatureCollection, SignerMap};
-    use crate::{BlsAggregateSignature, LazyBlsSignature};
+    use crate::{BlsAggregateSignature, BlsKeyPair, LazyBlsSignature};
 
     type SigningDomainType = signing_domain::Vote;
     type SignatureType = NopSignature;
@@ -577,6 +578,46 @@ mod test {
                 assert_eq!(expected_set, test_set);
             }
             _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn test_creation_rejects_infinity_aggregate_with_valid_leaf_signatures() {
+        let mut sk_one = [0_u8; 32];
+        sk_one[31] = 1;
+        let mut sk_minus_one = [
+            0x73, 0xed, 0xa7, 0x53, 0x29, 0x9d, 0x7d, 0x48, 0x33, 0x39, 0xd8, 0x08, 0x09, 0xa1,
+            0xd8, 0x05, 0x53, 0xbd, 0xa4, 0x02, 0xff, 0xfe, 0x5b, 0xfe, 0xff, 0xff, 0xff, 0xff,
+            0x00, 0x00, 0x00, 0x00,
+        ];
+
+        let keypair_one = BlsKeyPair::from_secret_key_bytes(&mut sk_one).unwrap();
+        let keypair_minus_one = BlsKeyPair::from_secret_key_bytes(&mut sk_minus_one).unwrap();
+
+        let node_id_one = NodeId::new(get_key::<SignatureType>(1).pubkey());
+        let node_id_minus_one = NodeId::new(get_key::<SignatureType>(2).pubkey());
+        let valmap = ValidatorMapping::new([
+            (node_id_one, keypair_one.pubkey()),
+            (node_id_minus_one, keypair_minus_one.pubkey()),
+        ]);
+
+        let msg = b"timeout infinity cancellation";
+        let sig_one = keypair_one.sign::<signing_domain::Timeout>(msg);
+        let sig_minus_one = keypair_minus_one.sign::<signing_domain::Timeout>(msg);
+        let sigs = vec![(node_id_one, sig_one), (node_id_minus_one, sig_minus_one)];
+
+        let sigcol_err =
+            SignatureCollectionType::new::<signing_domain::Timeout>(sigs.clone(), &valmap, msg)
+                .unwrap_err();
+
+        match sigcol_err {
+            SignatureCollectionError::InvalidSignaturesCreate(invalid_sigs) => {
+                let expected_set = sigs.into_iter().collect::<HashSet<_>>();
+                let actual_set = invalid_sigs.into_iter().collect::<HashSet<_>>();
+
+                assert_eq!(actual_set, expected_set);
+            }
+            err => panic!("expected InvalidSignaturesCreate, got {err:?}"),
         }
     }
 

--- a/monad-bls/src/bls.rs
+++ b/monad-bls/src/bls.rs
@@ -326,7 +326,9 @@ impl BlsKeyPair {
 
     /// Import an already-derived secret scalar bytes.
     #[cfg(test)]
-    fn from_secret_key_bytes(mut secret_key: impl AsMut<[u8]>) -> Result<Self, BlsError> {
+    pub(crate) fn from_secret_key_bytes(
+        mut secret_key: impl AsMut<[u8]>,
+    ) -> Result<Self, BlsError> {
         let b = secret_key.as_mut();
         // blst validates the scalar (non-zero, < r).
         let sk = BlsSecretKey(blst_core::SecretKey::from_bytes(b).map_err(BlsError)?);


### PR DESCRIPTION
- add a regression test covering cancellation of individually valid BLS signatures into the point at infinity
- assert signature collection creation rejects the aggregate and reports both leaf signatures as invalid
- expose the test-only secret-key constructor within the crate so the regression can construct the cancelling key pair
