### PR TITLE
Add slot number and BAL-hash header fields gated on V_NEXT

### DIFF
--- a/monad-chain-config/src/execution_revision.rs
+++ b/monad-chain-config/src/execution_revision.rs
@@ -20,10 +20,11 @@ pub enum MonadExecutionRevision {
     V_ONE,
     V_TWO,
     V_FOUR,
+    V_NEXT,
 }
 
 impl MonadExecutionRevision {
-    pub const LATEST: Self = Self::V_FOUR;
+    pub const LATEST: Self = Self::V_NEXT;
 }
 
 impl MonadExecutionRevision {
@@ -33,6 +34,7 @@ impl MonadExecutionRevision {
             Self::V_ONE => &EXECUTION_CHAIN_PARAMS_V_ONE,
             Self::V_TWO => &EXECUTION_CHAIN_PARAMS_V_TWO,
             Self::V_FOUR => &EXECUTION_CHAIN_PARAMS_V_FOUR,
+            Self::V_NEXT => &EXECUTION_CHAIN_PARAMS_V_NEXT,
         }
     }
 }
@@ -41,29 +43,41 @@ impl MonadExecutionRevision {
 pub struct ExecutionChainParams {
     pub max_code_size: usize,
     pub prague_enabled: bool,
+    pub amsterdam_enabled: bool,
     pub validate_system_txs: bool,
 }
 
 const EXECUTION_CHAIN_PARAMS_V_ZERO: ExecutionChainParams = ExecutionChainParams {
     max_code_size: 24 * 1024,
     prague_enabled: false,
+    amsterdam_enabled: false,
     validate_system_txs: false,
 };
 
 const EXECUTION_CHAIN_PARAMS_V_ONE: ExecutionChainParams = ExecutionChainParams {
     max_code_size: 24 * 1024,
     prague_enabled: false,
+    amsterdam_enabled: false,
     validate_system_txs: false,
 };
 
 const EXECUTION_CHAIN_PARAMS_V_TWO: ExecutionChainParams = ExecutionChainParams {
     max_code_size: 128 * 1024,
     prague_enabled: false,
+    amsterdam_enabled: false,
     validate_system_txs: false,
 };
 
 const EXECUTION_CHAIN_PARAMS_V_FOUR: ExecutionChainParams = ExecutionChainParams {
     max_code_size: 128 * 1024,
     prague_enabled: true,
+    amsterdam_enabled: false,
+    validate_system_txs: true,
+};
+
+const EXECUTION_CHAIN_PARAMS_V_NEXT: ExecutionChainParams = ExecutionChainParams {
+    max_code_size: 128 * 1024,
+    prague_enabled: true,
+    amsterdam_enabled: true,
     validate_system_txs: true,
 };

--- a/monad-chain-config/src/lib.rs
+++ b/monad-chain-config/src/lib.rs
@@ -66,6 +66,7 @@ pub struct MonadChainConfig {
     pub execution_v_one_activation: u64,
     pub execution_v_two_activation: u64,
     pub execution_v_four_activation: u64,
+    pub execution_v_next_activation: u64,
 }
 
 #[derive(Debug, Error)]
@@ -159,7 +160,9 @@ impl ChainConfig<MonadChainRevision> for MonadChainConfig {
     }
 
     fn get_execution_chain_revision(&self, execution_timestamp_s: u64) -> MonadExecutionRevision {
-        if execution_timestamp_s >= self.execution_v_four_activation {
+        if execution_timestamp_s >= self.execution_v_next_activation {
+            MonadExecutionRevision::V_NEXT
+        } else if execution_timestamp_s >= self.execution_v_four_activation {
             MonadExecutionRevision::V_FOUR
         } else if execution_timestamp_s >= self.execution_v_two_activation {
             MonadExecutionRevision::V_TWO
@@ -187,6 +190,7 @@ const MONAD_DEVNET_CHAIN_CONFIG: MonadChainConfig = MonadChainConfig {
     execution_v_one_activation: 0,
     execution_v_two_activation: 0,
     execution_v_four_activation: 0,
+    execution_v_next_activation: 0,
 };
 
 const MONAD_HIVE_CHAIN_CONFIG: MonadChainConfig = MonadChainConfig {
@@ -210,6 +214,8 @@ const MONAD_TESTNET_CHAIN_CONFIG: MonadChainConfig = MonadChainConfig {
     execution_v_one_activation: 0,
     execution_v_two_activation: 0,
     execution_v_four_activation: 0,
+    // amsterdam not yet on testnet
+    execution_v_next_activation: u64::MAX,
 };
 
 // Mainnet uses latest version of testnet from genesis
@@ -229,6 +235,8 @@ const MONAD_MAINNET_CHAIN_CONFIG: MonadChainConfig = MonadChainConfig {
     execution_v_one_activation: 0,
     execution_v_two_activation: 0,
     execution_v_four_activation: 1762266600, // 2025-11-04T14:30:00.000Z
+    // amsterdam not yet on mainnet
+    execution_v_next_activation: u64::MAX,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/monad-consensus-state/src/lib.rs
+++ b/monad-consensus-state/src/lib.rs
@@ -2409,23 +2409,27 @@ mod test {
                 &self.epoch_manager,
                 &self.val_epoch_map,
                 &self.election,
-                |seq_num, timestamp_ns, round_signature: RoundSignature<_>| ProposedEthHeader {
-                    transactions_root: *EMPTY_TRANSACTIONS,
-                    ommers_hash: *EMPTY_OMMER_ROOT_HASH,
-                    withdrawals_root: *EMPTY_WITHDRAWALS,
-                    beneficiary: Default::default(),
-                    difficulty: 0,
-                    number: seq_num.0,
-                    gas_limit: CHAIN_PARAMS.proposal_gas_limit,
-                    timestamp: (timestamp_ns / 1_000_000_000) as u64,
-                    mix_hash: round_signature.get_hash().0,
-                    nonce: [0_u8; 8],
-                    extra_data: [0_u8; 32],
-                    base_fee_per_gas: BASE_FEE,
-                    blob_gas_used: 0,
-                    excess_blob_gas: 0,
-                    parent_beacon_block_root: [0_u8; 32],
-                    requests_hash: Some([0_u8; 32]),
+                |seq_num, timestamp_ns, round, round_signature: RoundSignature<_>| {
+                    ProposedEthHeader {
+                        transactions_root: *EMPTY_TRANSACTIONS,
+                        ommers_hash: *EMPTY_OMMER_ROOT_HASH,
+                        withdrawals_root: *EMPTY_WITHDRAWALS,
+                        beneficiary: Default::default(),
+                        difficulty: 0,
+                        number: seq_num.0,
+                        gas_limit: CHAIN_PARAMS.proposal_gas_limit,
+                        timestamp: (timestamp_ns / 1_000_000_000) as u64,
+                        mix_hash: round_signature.get_hash().0,
+                        nonce: [0_u8; 8],
+                        extra_data: [0_u8; 32],
+                        base_fee_per_gas: BASE_FEE,
+                        blob_gas_used: 0,
+                        excess_blob_gas: 0,
+                        parent_beacon_block_root: [0_u8; 32],
+                        requests_hash: Some([0_u8; 32]),
+                        block_access_list_hash: Some([0_u8; 32]),
+                        slot_number: Some(round.as_u64()),
+                    }
                 },
                 Vec::new(),
             )
@@ -2441,7 +2445,7 @@ mod test {
                 &self.epoch_manager,
                 &self.val_epoch_map,
                 &self.election,
-                |seq_num, timestamp_ns, round_signature| ProposedEthHeader {
+                |seq_num, timestamp_ns, round, round_signature| ProposedEthHeader {
                     transactions_root: *EMPTY_TRANSACTIONS,
                     ommers_hash: *EMPTY_OMMER_ROOT_HASH,
                     withdrawals_root: *EMPTY_WITHDRAWALS,
@@ -2458,6 +2462,8 @@ mod test {
                     excess_blob_gas: 0,
                     parent_beacon_block_root: [0_u8; 32],
                     requests_hash: Some([0_u8; 32]),
+                    block_access_list_hash: Some([0_u8; 32]),
+                    slot_number: Some(round.as_u64()),
                 },
                 delayed_execution_results,
             )
@@ -2474,7 +2480,7 @@ mod test {
                 &self.epoch_manager,
                 &self.val_epoch_map,
                 &self.election,
-                |seq_num, timestamp_ns, round_signature| ProposedEthHeader {
+                |seq_num, timestamp_ns, round, round_signature| ProposedEthHeader {
                     transactions_root: *EMPTY_TRANSACTIONS,
                     ommers_hash: *EMPTY_OMMER_ROOT_HASH,
                     withdrawals_root: *EMPTY_WITHDRAWALS,
@@ -2491,6 +2497,8 @@ mod test {
                     excess_blob_gas: 0,
                     parent_beacon_block_root: [0_u8; 32],
                     requests_hash: Some([0_u8; 32]),
+                    block_access_list_hash: Some([0_u8; 32]),
+                    slot_number: Some(round.as_u64()),
                 },
                 delayed_execution_results,
             )

--- a/monad-eth-block-validator/src/error.rs
+++ b/monad-eth-block-validator/src/error.rs
@@ -70,6 +70,14 @@ pub enum HeaderError {
         expected: Option<[u8; 32]>,
         actual: Option<[u8; 32]>,
     },
+    InvalidBlockAccessListHash {
+        expected: Option<[u8; 32]>,
+        actual: Option<[u8; 32]>,
+    },
+    InvalidSlotNumber {
+        expected: Option<u64>,
+        actual: Option<u64>,
+    },
 }
 
 impl From<HeaderError> for EthBlockValidationError {

--- a/monad-eth-block-validator/src/lib.rs
+++ b/monad-eth-block-validator/src/lib.rs
@@ -227,6 +227,8 @@ where
             excess_blob_gas,
             parent_beacon_block_root,
             requests_hash,
+            block_access_list_hash,
+            slot_number,
         } = &header.execution_inputs;
 
         if ommers_hash != EMPTY_OMMER_ROOT_HASH {
@@ -304,6 +306,28 @@ where
             return Err(HeaderError::InvalidRequestsHash {
                 expected: expected_requests_hash,
                 actual: *requests_hash,
+            });
+        }
+
+        // Monad does not use block access list hashes yet
+        // It is set to zero hash for amsterdam compatibility
+        let expected_block_access_list_hash = execution_chain_params
+            .amsterdam_enabled
+            .then_some([0_u8; 32]);
+        if block_access_list_hash != &expected_block_access_list_hash {
+            return Err(HeaderError::InvalidBlockAccessListHash {
+                expected: expected_block_access_list_hash,
+                actual: *block_access_list_hash,
+            });
+        }
+
+        let expected_slot_number = execution_chain_params
+            .amsterdam_enabled
+            .then_some(header.block_round.as_u64());
+        if slot_number != &expected_slot_number {
+            return Err(HeaderError::InvalidSlotNumber {
+                expected: expected_slot_number,
+                actual: *slot_number,
             });
         }
 
@@ -1421,6 +1445,8 @@ mod test {
                 excess_blob_gas: 0,
                 parent_beacon_block_root: [0_u8; 32],
                 requests_hash: Some([0_u8; 32]),
+                block_access_list_hash: Some([0_u8; 32]),
+                slot_number: Some(1),
                 ..ProposedEthHeader::default()
             },
             payload.get_id(),

--- a/monad-eth-block-validator/tests/coherency_test.rs
+++ b/monad-eth-block-validator/tests/coherency_test.rs
@@ -681,6 +681,8 @@ fn create_block_header_helper(
             base_fee_per_gas: base_fee,
             withdrawals_root: EMPTY_WITHDRAWALS.0,
             requests_hash: Some([0_u8; 32]),
+            block_access_list_hash: Some([0_u8; 32]),
+            slot_number: Some(round.as_u64()),
             ..Default::default()
         },
         body_id,

--- a/monad-eth-testutil/src/lib.rs
+++ b/monad-eth-testutil/src/lib.rs
@@ -401,6 +401,8 @@ pub fn generate_consensus_test_block(
             base_fee_per_gas: base_fee,
             withdrawals_root: EMPTY_WITHDRAWALS.0,
             requests_hash: Some([0_u8; 32]),
+            block_access_list_hash: Some([0_u8; 32]),
+            slot_number: Some(round.as_u64()),
             ..Default::default()
         },
         body.get_id(),

--- a/monad-eth-txpool/src/pool/mod.rs
+++ b/monad-eth-txpool/src/pool/mod.rs
@@ -389,6 +389,18 @@ where
             None
         };
 
+        // Monad does not use block access list hashes
+        // It is hardcoded to zero hash for amsterdam compatibility
+        let (maybe_block_access_list_hash, maybe_slot_number) = if self
+            .execution_revision
+            .execution_chain_params()
+            .amsterdam_enabled
+        {
+            (Some([0_u8; 32]), Some(round.as_u64()))
+        } else {
+            (None, None)
+        };
+
         let header = ProposedEthHeader {
             transactions_root: *alloy_consensus::proofs::calculate_transaction_root(
                 &body.transactions,
@@ -415,6 +427,8 @@ where
             excess_blob_gas: 0,
             parent_beacon_block_root: [0_u8; 32],
             requests_hash: maybe_request_hash,
+            block_access_list_hash: maybe_block_access_list_hash,
+            slot_number: maybe_slot_number,
         };
 
         self.update_aggregate_metrics(event_tracker);

--- a/monad-eth-types/src/lib.rs
+++ b/monad-eth-types/src/lib.rs
@@ -96,6 +96,12 @@ pub struct ProposedEthHeader {
     // eip-7685
     #[serde_as(as = "Option<serde_with::hex::Hex>")]
     pub requests_hash: Option<[u8; 32]>,
+    // eip-7928
+    #[serde_as(as = "Option<serde_with::hex::Hex>")]
+    pub block_access_list_hash: Option<[u8; 32]>,
+    // eip-7843
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub slot_number: Option<u64>,
 }
 
 impl ProposedEthHeader {
@@ -119,6 +125,14 @@ impl ProposedEthHeader {
 
         if let Some(requests_hash) = &self.requests_hash {
             length += requests_hash.length();
+        }
+
+        if let Some(block_access_list_hash) = &self.block_access_list_hash {
+            length += block_access_list_hash.length();
+        }
+
+        if let Some(slot_number) = &self.slot_number {
+            length += slot_number.length();
         }
 
         length
@@ -158,6 +172,17 @@ impl Encodable for ProposedEthHeader {
         if let Some(requests_hash) = &self.requests_hash {
             requests_hash.encode(out);
         }
+
+        if let Some(block_access_list_hash) = &self.block_access_list_hash {
+            debug_assert!(self.requests_hash.is_some());
+            debug_assert!(self.slot_number.is_some());
+            block_access_list_hash.encode(out);
+        }
+
+        if let Some(slot_number) = &self.slot_number {
+            debug_assert!(self.block_access_list_hash.is_some());
+            slot_number.encode(out);
+        }
     }
 }
 
@@ -185,10 +210,20 @@ impl Decodable for ProposedEthHeader {
             excess_blob_gas: Decodable::decode(buf)?,
             parent_beacon_block_root: Decodable::decode(buf)?,
             requests_hash: None,
+            block_access_list_hash: None,
+            slot_number: None,
         };
 
         if starting_len - buf.len() < rlp_header.payload_length {
             this.requests_hash = Some(Decodable::decode(buf)?);
+        }
+
+        if starting_len - buf.len() < rlp_header.payload_length {
+            this.block_access_list_hash = Some(Decodable::decode(buf)?);
+        }
+
+        if starting_len - buf.len() < rlp_header.payload_length {
+            this.slot_number = Some(Decodable::decode(buf)?);
         }
 
         let consumed = starting_len - buf.len();
@@ -421,8 +456,10 @@ mod test {
             old_header.parent_beacon_block_root
         );
         assert_eq!(new_header.requests_hash, None);
+        assert_eq!(new_header.block_access_list_hash, None);
+        assert_eq!(new_header.slot_number, None);
 
-        // new encoding with requests_hash == None can be decoded as old header
+        // new encoding with empty trailing optional fields can be decoded as old header
 
         let new_header = ProposedEthHeader {
             ommers_hash: *EMPTY_OMMER_ROOT_HASH,
@@ -441,6 +478,8 @@ mod test {
             excess_blob_gas: 0,
             parent_beacon_block_root: [0_u8; 32],
             requests_hash: None,
+            block_access_list_hash: None,
+            slot_number: None,
         };
 
         let encoded = alloy_rlp::encode(&new_header);
@@ -467,6 +506,34 @@ mod test {
     }
 
     #[test]
+    fn test_proposed_eth_header_amsterdam_roundtrip() {
+        let amsterdam_header = ProposedEthHeader {
+            ommers_hash: *EMPTY_OMMER_ROOT_HASH,
+            beneficiary: Address::new([0xff_u8; 20]),
+            transactions_root: *EMPTY_TRANSACTIONS,
+            difficulty: 0,
+            number: 72,
+            gas_limit: 150_000_000,
+            timestamp: 1756656000,
+            extra_data: [0_u8; 32],
+            mix_hash: [0xff_u8; 32],
+            nonce: [0_u8; 8],
+            base_fee_per_gas: 100_000_000_000,
+            withdrawals_root: *EMPTY_WITHDRAWALS,
+            blob_gas_used: 0,
+            excess_blob_gas: 0,
+            parent_beacon_block_root: [0_u8; 32],
+            requests_hash: Some([0_u8; 32]),
+            block_access_list_hash: Some([0_u8; 32]),
+            slot_number: Some(1234),
+        };
+
+        let encoded = alloy_rlp::encode(&amsterdam_header);
+        let decoded: ProposedEthHeader = alloy_rlp::decode_exact(&encoded).unwrap();
+        assert_eq!(decoded, amsterdam_header);
+    }
+
+    #[test]
     fn test_proposed_eth_header_toml_roundtrip_u64_max() {
         let header = ProposedEthHeader {
             ommers_hash: *EMPTY_OMMER_ROOT_HASH,
@@ -485,6 +552,8 @@ mod test {
             excess_blob_gas: u64::MAX,
             parent_beacon_block_root: [0_u8; 32],
             requests_hash: None,
+            block_access_list_hash: None,
+            slot_number: None,
         };
 
         let encoded = toml::to_string_pretty(&header).unwrap();

--- a/monad-testutil/src/proposal.rs
+++ b/monad-testutil/src/proposal.rs
@@ -119,6 +119,7 @@ where
         create_execution_inputs: impl FnOnce(
             SeqNum,
             u128,
+            Round,
             RoundSignature<SCT::SignatureType>,
         ) -> EPT::ProposedHeader,
         delayed_execution_results: Vec<EPT::FinalizedHeader>,
@@ -188,7 +189,7 @@ where
             self.epoch,
             self.round,
             delayed_execution_results,
-            create_execution_inputs(seq_num, self.timestamp, round_signature.clone()),
+            create_execution_inputs(seq_num, self.timestamp, self.round, round_signature.clone()),
             block_body.get_id(),
             qc.clone(),
             seq_num,


### PR DESCRIPTION
Adds `MonadExecutionRevision::V_NEXT` with `amsterdam_enabled: true` gating two new `ProposedEthHeader` fields:

- `block_access_list_hash` (EIP-7928), always zeroed, as monad doesn't implement block access lists. Like `requests_hash`, it's required to be populated for RLP encoding/decoding of `slot_number`
- `slot_number` (EIP-7843), set to the consensus block round

`V_NEXT` is activated at 0 on devnet and left as `u64::MAX` on testnet and mainnet.

Will bump `monad-execution` submodule on submit, changes are in PR here: https://github.com/category-labs/monad/pull/2439