### PR TITLE
monad-node: export triedb disk capacity/usage as Prometheus gauges

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,6 +68,7 @@ jobs:
             libcli11-dev \
             libcrypto++-dev \
             libgmp-dev \
+            libsecp256k1-dev \
             libzstd-dev \
             clang-19 \
             libclang-19-dev \

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -78,15 +78,19 @@ use monad_wal::wal::{WALLog, WALoggerConfig};
 use opentelemetry::metrics::{Gauge, Meter, MeterProvider};
 use opentelemetry_otlp::{MetricExporter, WithExportConfig};
 use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
-use tokio::signal::unix::{signal, SignalKind};
+use tokio::{
+    signal::unix::{signal, SignalKind},
+    time::{interval, MissedTickBehavior},
+};
 use tracing::{error, event, info, warn, Instrument, Level};
 
 use self::{
     cli::Cli,
     error::NodeSetupError,
     metrics::{
-        default_prometheus_labels, init_triedb_phase_metrics, record_triedb_phase_metrics,
-        start_metrics_server, MetricsServerState, NodePrometheusMetrics,
+        default_prometheus_labels, init_triedb_phase_metrics, init_triedb_storage_metrics,
+        record_triedb_phase_metrics, record_triedb_storage_metrics, start_metrics_server,
+        MetricsServerState, NodePrometheusMetrics,
     },
     state::NodeState,
 };
@@ -110,6 +114,7 @@ const STATESYNC_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 const EXECUTION_DELAY: u64 = 3;
 const WALTRACE_CHANNEL_CAPACITY: usize = 1024;
+const TRIEDB_STORAGE_METRICS_INTERVAL: Duration = Duration::from_secs(30);
 
 fn main() {
     let mut cmd = Cli::command();
@@ -443,8 +448,8 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
             )
             .expect("failed to build otel monad-node");
 
-            let mut timer = tokio::time::interval(record_metrics_interval);
-            timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            let mut timer = interval(record_metrics_interval);
+            timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
             (provider, timer)
         })
@@ -477,25 +482,35 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         }
     }
 
-    // Read the dual-DB migration phase once at startup and record it into a
-    // dedicated metrics set pushed alongside the executor's. The phase only
-    // changes via the offline monad-mpt tool, which requires a restart, so
-    // there is nothing to refresh. If triedb can't be opened, leave the metric
-    // unreported (empty set) rather than emitting a misleading default.
+    // Migration phase is read once (it only changes via the offline monad-mpt
+    // tool, which requires a restart). Disk usage is dynamic, so we keep a
+    // long-lived read-only reader on this task (TriedbReader is !Send) and
+    // refresh it on a ticker in the loop below. If triedb can't be opened,
+    // leave both metrics unreported (empty sets) rather than emitting a
+    // misleading default.
     let mut triedb_phase_metrics = ExecutorMetrics::with_metric_defs(&[]);
-    match TriedbReader::try_new(node_state.triedb_path.as_path()) {
+    let mut triedb_storage_metrics = ExecutorMetrics::with_metric_defs(&[]);
+    let triedb_metrics_reader = TriedbReader::try_new(node_state.triedb_path.as_path());
+    match &triedb_metrics_reader {
         Some(reader) => {
             triedb_phase_metrics = init_triedb_phase_metrics();
             record_triedb_phase_metrics(&mut triedb_phase_metrics, reader.migration_phase());
+            triedb_storage_metrics = init_triedb_storage_metrics();
+            record_triedb_storage_metrics(&mut triedb_storage_metrics, reader.storage_stats());
         }
-        None => warn!("triedb unavailable, migration-phase metric will not be reported"),
+        None => {
+            warn!("triedb unavailable, migration-phase and disk-usage metrics will not be reported")
+        }
     }
 
     let prometheus_metrics = Arc::new(
         NodePrometheusMetrics::new(
             prometheus_labels,
             state.metrics(),
-            executor.metrics().push(&triedb_phase_metrics),
+            executor
+                .metrics()
+                .push(&triedb_phase_metrics)
+                .push(&triedb_storage_metrics),
             process_start,
         )
         .map_err(|err| {
@@ -528,6 +543,9 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
     let mut sigterm = signal(SignalKind::terminate()).expect("in tokio rt");
     let mut sigint = signal(SignalKind::interrupt()).expect("in tokio rt");
 
+    let mut triedb_storage_ticker = interval(TRIEDB_STORAGE_METRICS_INTERVAL);
+    triedb_storage_ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
     loop {
         tokio::select! {
             biased; // events are in order of priority
@@ -545,13 +563,21 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
                 None => futures_util::future::pending().boxed(),
             } => {
                 let otel_meter = maybe_otel_meter.as_ref().expect("otel_endpoint must have been set");
-                let executor_metrics = executor.metrics().push(&triedb_phase_metrics);
+                let executor_metrics = executor.metrics().push(&triedb_phase_metrics).push(&triedb_storage_metrics);
                 send_metrics(
                     otel_meter,
                     &mut gauge_cache,
                     prometheus_metrics.as_ref(),
                     executor_metrics,
                 );
+            }
+            _ = triedb_storage_ticker.tick() => {
+                if let Some(reader) = &triedb_metrics_reader {
+                    record_triedb_storage_metrics(
+                        &mut triedb_storage_metrics,
+                        reader.storage_stats(),
+                    );
+                }
             }
             event = executor.next().instrument(ledger_span.clone()) => {
                 let Some(event) = event else {

--- a/monad-node/src/metrics.rs
+++ b/monad-node/src/metrics.rs
@@ -23,7 +23,7 @@ use actix_server::Server;
 use actix_web::{http::header, web, App, HttpRequest, HttpResponse, HttpServer};
 use monad_consensus_types::metrics::Metrics as StateMetrics;
 use monad_executor::{metric_consts, ExecutorMetrics, ExecutorMetricsChain, Gauge};
-use monad_triedb_utils::MigrationPhase;
+use monad_triedb_utils::{MigrationPhase, StorageStats};
 use prometheus::{Encoder, ProtobufEncoder, Registry, TextEncoder};
 
 pub fn default_prometheus_labels(
@@ -86,6 +86,33 @@ pub fn record_triedb_phase_metrics(metrics: &mut ExecutorMetrics, phase: Migrati
         MigrationPhase::PageEncoded => 2,
     };
     metrics.gauge(GAUGE_TRIEDB_MIGRATION_PHASE).set(code);
+}
+
+metric_consts! {
+    pub GAUGE_TRIEDB_DISK_CAPACITY_BYTES {
+        name: "monad.triedb.disk_capacity_bytes",
+        help: "Total triedb storage-pool capacity in bytes: sum of file sizes (file pools) or raw device sizes (block-device pools).",
+    }
+    pub GAUGE_TRIEDB_DISK_USED_BYTES {
+        name: "monad.triedb.disk_used_bytes",
+        help: "triedb storage-pool bytes in use. Block-device pools sum appended bytes per chunk and under-report pool overhead by a few hundred MiB per device; file pools report filesystem-allocated blocks, a high-water mark that does not shrink as chunks are recycled. Treat the trend as the signal, not the absolute value.",
+    }
+}
+
+pub fn init_triedb_storage_metrics() -> ExecutorMetrics {
+    ExecutorMetrics::with_metric_defs(&[
+        GAUGE_TRIEDB_DISK_CAPACITY_BYTES,
+        GAUGE_TRIEDB_DISK_USED_BYTES,
+    ])
+}
+
+pub fn record_triedb_storage_metrics(metrics: &mut ExecutorMetrics, stats: StorageStats) {
+    metrics
+        .gauge(GAUGE_TRIEDB_DISK_CAPACITY_BYTES)
+        .set(stats.disk_capacity_bytes);
+    metrics
+        .gauge(GAUGE_TRIEDB_DISK_USED_BYTES)
+        .set(stats.disk_used_bytes);
 }
 
 fn duration_micros_u64(duration: &Duration) -> u64 {
@@ -262,5 +289,64 @@ mod migration_phase_tests {
             record_triedb_phase_metrics(&mut metrics, phase);
             assert_eq!(metrics.gauge(GAUGE_TRIEDB_MIGRATION_PHASE).get(), code);
         }
+    }
+}
+
+#[cfg(test)]
+mod storage_metrics_tests {
+    use monad_triedb_utils::StorageStats;
+    use prometheus::{Encoder, Registry, TextEncoder};
+
+    use super::{
+        init_triedb_storage_metrics, record_triedb_storage_metrics,
+        GAUGE_TRIEDB_DISK_CAPACITY_BYTES, GAUGE_TRIEDB_DISK_USED_BYTES,
+    };
+
+    #[test]
+    fn records_capacity_and_used() {
+        let mut metrics = init_triedb_storage_metrics();
+        record_triedb_storage_metrics(
+            &mut metrics,
+            StorageStats {
+                disk_capacity_bytes: 1_000,
+                disk_used_bytes: 600,
+            },
+        );
+        assert_eq!(metrics.gauge(GAUGE_TRIEDB_DISK_CAPACITY_BYTES).get(), 1_000);
+        assert_eq!(metrics.gauge(GAUGE_TRIEDB_DISK_USED_BYTES).get(), 600);
+    }
+
+    // A refresh reaches the scrape only if it writes the same gauges the
+    // registry holds, so assert through the encoded output rather than through
+    // the ExecutorMetrics the ticker writes to.
+    #[test]
+    fn refresh_after_registration_reaches_the_scrape() {
+        let mut metrics = init_triedb_storage_metrics();
+        let registry = Registry::new();
+        metrics.register(&registry).expect("gauges registered");
+
+        for used in [600, 700] {
+            record_triedb_storage_metrics(
+                &mut metrics,
+                StorageStats {
+                    disk_capacity_bytes: 1_000,
+                    disk_used_bytes: used,
+                },
+            );
+        }
+
+        let mut buffer = Vec::new();
+        TextEncoder::new()
+            .encode(&registry.gather(), &mut buffer)
+            .expect("encoded");
+        let scraped = String::from_utf8(buffer).expect("utf-8");
+        assert!(
+            scraped.contains("monad_triedb_disk_capacity_bytes 1000"),
+            "{scraped}"
+        );
+        assert!(
+            scraped.contains("monad_triedb_disk_used_bytes 700"),
+            "{scraped}"
+        );
     }
 }

--- a/monad-triedb-utils/src/lib.rs
+++ b/monad-triedb-utils/src/lib.rs
@@ -32,8 +32,8 @@ use monad_crypto::certificate_signature::PubKey;
 use monad_eth_types::{EthAccount, EthHeader};
 use monad_execution_state_read::{ExecutionStateRead, ExecutionStateReadError};
 use monad_secp::SecpSignature;
-pub use monad_triedb::MigrationPhase;
 use monad_triedb::TriedbHandle;
+pub use monad_triedb::{MigrationPhase, StorageStats};
 use monad_types::{BlockId, Epoch, Hash, SeqNum, Stake};
 use tracing::{debug, trace, warn};
 
@@ -75,6 +75,12 @@ impl TriedbReader {
     /// execution is writing.
     pub fn migration_phase(&self) -> MigrationPhase {
         self.handle.migration_phase()
+    }
+
+    /// Storage-pool disk capacity and usage in bytes. Safe on a read-only
+    /// handle while execution writes.
+    pub fn storage_stats(&self) -> StorageStats {
+        self.handle.storage_stats()
     }
 
     pub fn get_latest_voted_block(&self) -> Option<SeqNum> {


### PR DESCRIPTION
Add monad.triedb.disk_capacity_bytes and monad.triedb.disk_used_bytes, sourced from the storage pool via the new TriedbReader::storage_stats(). Unlike the read-once migration-phase metric, disk usage is dynamic, so a long-lived read-only TriedbReader is kept on the main task (it is !Send) and both gauges are refreshed on a 30s ticker.

Bumps the monad-execution submodule to pick up the storage_stats FFI.