### PR TITLE
debian: drop redundant sysctl -p from postinst

### DIFF
--- a/debian/DEBIAN/postinst
+++ b/debian/DEBIAN/postinst
@@ -11,7 +11,6 @@ case "$1" in
         systemctl enable set-hugepages.service
         systemctl enable monad-cruft.timer
         systemctl start monad-cruft.timer
-        sysctl -p
     else
       echo "Skipping systemd setup: systemd not found or not running as init"
     fi


### PR DESCRIPTION
`sysctl -p` only reads `/etc/sysctl.conf`, which Ubuntu 26.04 no longer ships, so it fails and aborts postinst under `set -e`. It's also redundant — the later `sysctl --system` call already loads `/etc/sysctl.conf` (when present) plus `/etc/sysctl.d/*`.