### PR TITLE
Support page-encoded and dual-db modes in reset-workspace.sh

### DIFF
--- a/debian/opt/monad/scripts/reset-workspace.sh
+++ b/debian/opt/monad/scripts/reset-workspace.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+systemctl stop monad-bft monad-execution monad-rpc monad-mpt monad-execution-genesis || true
+
 DB_MODE="slot"
 MPT_OUTPUT=$(monad-mpt --storage /dev/triedb 2>/dev/null || true)
 if echo "$MPT_OUTPUT" | grep -q "Secondary:"; then
@@ -10,8 +12,6 @@ elif echo "$MPT_OUTPUT" | grep -q "State machine kind: monad"; then
   DB_MODE="page"
 fi
 echo "Detected DB mode: $DB_MODE"
-
-systemctl stop monad-bft monad-execution monad-rpc monad-mpt monad-execution-genesis || true
 mkdir /home/monad/monad-bft/empty-dir
 rsync -r --delete /home/monad/monad-bft/empty-dir/ /home/monad/monad-bft/ledger/
 rsync -r --delete /home/monad/monad-bft/empty-dir/ /home/monad/monad-bft/config/forkpoint/

--- a/debian/opt/monad/scripts/reset-workspace.sh
+++ b/debian/opt/monad/scripts/reset-workspace.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 
 set -ex
+
+DB_MODE="slot"
+MPT_OUTPUT=$(monad-mpt --storage /dev/triedb 2>/dev/null || true)
+if echo "$MPT_OUTPUT" | grep -q "Secondary:"; then
+  DB_MODE="dual"
+elif echo "$MPT_OUTPUT" | grep -q "State machine kind: monad"; then
+  DB_MODE="page"
+fi
+echo "Detected DB mode: $DB_MODE"
+
 systemctl stop monad-bft monad-execution monad-rpc monad-mpt monad-execution-genesis || true
 mkdir /home/monad/monad-bft/empty-dir
 rsync -r --delete /home/monad/monad-bft/empty-dir/ /home/monad/monad-bft/ledger/
@@ -15,7 +25,19 @@ rm -f /home/monad/monad-bft/wal_*
 rm -f /home/monad/monad-bft/config/peers.toml
 rm -rf /home/monad/monad-bft/blockdb
 source /home/monad/.env
-monad-mpt --storage /dev/triedb --truncate --yes
+case "$DB_MODE" in
+  dual)
+    monad-mpt --storage /dev/triedb --truncate --yes
+    monad-mpt --storage /dev/triedb --activate-secondary --state-machine monad
+    ;;
+  page)
+    monad-mpt --storage /dev/triedb --truncate --state-machine monad --yes
+    ;;
+  *)
+    monad-mpt --storage /dev/triedb --truncate --yes
+    ;;
+esac
+
 if [ -f "/home/monad/.config/forkpoint.genesis.toml" ]; then
   yes | cp -rf /home/monad/.config/forkpoint.genesis.toml /home/monad/monad-bft/config/forkpoint/forkpoint.toml
 fi

--- a/debian/opt/monad/scripts/reset-workspace.sh
+++ b/debian/opt/monad/scripts/reset-workspace.sh
@@ -6,7 +6,9 @@ systemctl stop monad-bft monad-execution monad-rpc monad-mpt monad-execution-gen
 
 DB_MODE="slot"
 MPT_OUTPUT=$(monad-mpt --storage /dev/triedb 2>/dev/null || true)
-if echo "$MPT_OUTPUT" | grep -q "Secondary:"; then
+if [ -z "$MPT_OUTPUT" ]; then
+  echo "WARNING: monad-mpt returned no output; defaulting to slot mode"
+elif echo "$MPT_OUTPUT" | grep -q "Secondary:"; then
   DB_MODE="dual"
 elif echo "$MPT_OUTPUT" | grep -q "State machine kind: monad"; then
   DB_MODE="page"


### PR DESCRIPTION
## Summary

- Detect the current TrieDB mode (slot/dual/page) before truncation and restore it after reset
- Previously the script only handled slot-encoded databases — nodes in dual-db or page-only mode would lose their timeline configuration after a reset

### Detection logic
- `Secondary:` present in `monad-mpt` output → **dual**
- Primary is `State machine kind: monad` with no secondary → **page**
- Otherwise → **slot** (default/legacy)

### Truncation behavior
- **slot**: `monad-mpt --truncate --yes` (unchanged from before)
- **dual**: `monad-mpt --truncate --yes` then `--activate-secondary --state-machine monad`
- **page**: `monad-mpt --truncate --state-machine monad --yes` (single command, matches `restore_from_snapshot.sh`)

## Test plan

- [x] Tested on perfnet `tyo-001` (page-only mode, v0.16.0)
- [x] Script correctly detected `DB_MODE=page`
- [x] Truncation + page-only restore completed successfully
- [x] Snapshot restore and service restart confirmed working after reset
- [x] Test on a dual-db node
- [x] Test on a slot-only node (legacy behavior, should be unchanged)