### PR TITLE
ci(builder): publish builder image to ghcr.io

### DIFF
--- a/.github/workflows/build-builder.yml
+++ b/.github/workflows/build-builder.yml
@@ -14,8 +14,8 @@ name: Build and publish builder Docker image
       - 'docker/builder/**'
 
 env:
-  REGISTRY: peach10.devcore4.com
-  IMAGE_NAME: category-labs/builder
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/builder
 
 jobs:
   build-builder:
@@ -32,12 +32,12 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Log in to the Peach10 Container registry
+      - name: Log in to the GitHub Container registry
         uses: docker/login-action@v3.1.0
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.PRIVATE_REGISTRY_USERNAME }}
-          password: ${{ secrets.PRIVATE_REGISTRY_PASSWORD }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/build-builder.yml
+++ b/.github/workflows/build-builder.yml
@@ -15,7 +15,7 @@ name: Build and publish builder Docker image
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}/builder
+  IMAGE_NAME: category-labs/builder
 
 jobs:
   build-builder:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -35,13 +35,16 @@ env:
 jobs:
   fuzz:
     runs-on: ubuntu-24.04-32
+    permissions:
+      contents: read
+      packages: read
 
     container:
-      image: peach10.devcore4.com/category-labs/builder
+      image: ghcr.io/${{ github.repository }}/builder
       options: --privileged --security-opt seccomp=unconfined
       credentials:
-        username: ${{ secrets.PRIVATE_REGISTRY_USERNAME }}
-        password: ${{ secrets.PRIVATE_REGISTRY_PASSWORD }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -40,7 +40,7 @@ jobs:
       packages: read
 
     container:
-      image: ghcr.io/${{ github.repository }}/builder
+      image: ghcr.io/category-labs/builder:latest
       options: --privileged --security-opt seccomp=unconfined
       credentials:
         username: ${{ github.actor }}

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -16,6 +16,7 @@ env:
 
 permissions:
   contents: read
+  packages: read
   pull-requests: write
   issues: write
 
@@ -58,8 +59,11 @@ jobs:
     needs: check-command
     runs-on: self-hosted
     container:
-      image: peach10.devcore4.com/category-labs/builder
+      image: ghcr.io/${{ github.repository }}/builder
       options: --privileged -u 1000:1000
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Get PR info
         id: pr-info

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -59,7 +59,7 @@ jobs:
     needs: check-command
     runs-on: self-hosted
     container:
-      image: ghcr.io/${{ github.repository }}/builder
+      image: ghcr.io/category-labs/builder:latest
       options: --privileged -u 1000:1000
       credentials:
         username: ${{ github.actor }}


### PR DESCRIPTION
Push the builder image to ghcr.io using the built-in `GITHUB_TOKEN`. Merging this triggers the first build. Consumer workflows switch over in a follow-up.