### PR TITLE
monad-dataplane: fall back on buffer ring setup failure

### DIFF
--- a/monad-dataplane/src/udp.rs
+++ b/monad-dataplane/src/udp.rs
@@ -312,15 +312,25 @@ async fn rx_multishot_socket(
             DEFAULT_RINGBUF_SIZE as usize,
             group_id,
         )
-        .expect("failed to create buffer ring")
     };
 
-    let mut ring = create_ring();
+    let mut ring = match create_ring() {
+        Ok(ring) => ring,
+        Err(err) => {
+            warn!(
+                ?err,
+                "failed to create multishot buffer ring, falling back to single-shot UDP receiver"
+            );
+            return rx_single_socket(socket, udp_ingress_tx, metrics).await;
+        }
+    };
 
     loop {
         match run_multishot_stream(&socket, &udp_ingress_tx, ring, &metrics).await {
             MultishotResult::ReuseRing(r) => ring = r,
-            MultishotResult::RecreateRing => ring = create_ring(),
+            MultishotResult::RecreateRing => {
+                ring = create_ring().expect("failed to recreate multishot buffer ring")
+            }
             MultishotResult::ChannelClosed => return,
         }
     }
@@ -581,5 +591,45 @@ mod tests {
             result.is_ok(),
             "main socket should still work after dup1 dropped"
         );
+    }
+
+    #[monoio::test(timer_enabled = true)]
+    async fn test_multishot_falls_back_when_ring_creation_fails() {
+        const GROUP_ID: u16 = 42;
+
+        let existing_ring = match UserRecvMsgRingBuf::<Ipv4RecvMsgParser>::new(
+            DEFAULT_RINGBUF_COUNT as u16,
+            DEFAULT_RINGBUF_SIZE as usize,
+            GROUP_ID,
+        ) {
+            Ok(ring) => Some(ring),
+            Err(err) if err.raw_os_error() == Some(libc::EINVAL) => None,
+            Err(err) => panic!("unexpected buffer ring creation error: {err}"),
+        };
+
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let rx_socket = UdpSocket::bind(addr).unwrap();
+        let rx_addr = rx_socket.local_addr().unwrap();
+        let tx_socket = UdpSocket::bind(addr).unwrap();
+        let (ingress_tx, mut ingress_rx) = mpsc::channel(1);
+
+        spawn(rx_multishot_socket(
+            rx_socket,
+            ingress_tx,
+            GROUP_ID,
+            DataplaneMetrics::new(),
+        ));
+
+        let payload = b"fallback";
+        let bytes_sent = tx_socket.send_to(payload, rx_addr).await.0.unwrap();
+        assert_eq!(bytes_sent, payload.len());
+
+        let msg = time::timeout(Duration::from_secs(1), ingress_rx.recv())
+            .await
+            .expect("timed out waiting for UDP message")
+            .expect("UDP ingress channel closed");
+        assert_eq!(msg.payload.as_ref(), payload);
+
+        drop(existing_ring);
     }
 }


### PR DESCRIPTION
Ubuntu 24.04 kernels 6.8.0-136 through 6.8.0-139 contain a faulty io_uring backport that causes provided buffer-ring registration to fail with EINVAL. Since UDP multishot is enabled by default, Monad nodes panic during startup on affected kernels.

This change handles initial buffer-ring registration failure by logging the error and falling back to the existing recv_from UDP reader. Multishot remains enabled when registration succeeds, and later ring recreation failures remain fatal. A regression test verifies UDP reception through the fallback path.