### PR TITLE
monad-leanudp: isolate validator reassembly pools

### DIFF
--- a/monad-leanudp/benches/decoder.rs
+++ b/monad-leanudp/benches/decoder.rs
@@ -22,7 +22,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use monad_leanudp::{
     Clock, Config, Decoder, Encoder, FragmentPolicy, IdentityScore, PacketHeader,
-    MAX_CONCURRENT_MESSAGES_PER_IDENTITY,
+    MAX_CONCURRENT_MESSAGES_PER_DEDICATED_IDENTITY, MAX_CONCURRENT_MESSAGES_PER_IDENTITY,
 };
 
 #[derive(Clone, Copy)]
@@ -56,6 +56,7 @@ fn make_config(max_regular_messages: usize) -> Config {
         max_priority_messages: 100,
         max_regular_messages,
         max_messages_per_identity: MAX_CONCURRENT_MESSAGES_PER_IDENTITY,
+        max_messages_per_dedicated_identity: MAX_CONCURRENT_MESSAGES_PER_DEDICATED_IDENTITY,
         message_timeout: Duration::from_secs(60),
         max_fragment_payload: 1440,
     }

--- a/monad-leanudp/src/decoder.rs
+++ b/monad-leanudp/src/decoder.rs
@@ -13,7 +13,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{convert::Infallible, hash::Hash, time::Instant};
+use std::{
+    collections::{HashMap, HashSet},
+    convert::Infallible,
+    hash::Hash,
+    time::Instant,
+};
 
 use bytes::Bytes;
 use monad_executor::{ExecutorMetrics, MetricDef};
@@ -148,6 +153,7 @@ impl From<(PacketHeader, Bytes)> for Packet {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PoolSelection {
+    Dedicated,
     Priority,
     Regular,
 }
@@ -164,6 +170,7 @@ impl From<FragmentPolicy> for PoolSelection {
 impl PoolSelection {
     fn fragments_counter(self) -> &'static MetricDef {
         match self {
+            PoolSelection::Dedicated => COUNTER_LEANUDP_DECODE_FRAGMENTS_DEDICATED,
             PoolSelection::Priority => COUNTER_LEANUDP_DECODE_FRAGMENTS_PRIORITY,
             PoolSelection::Regular => COUNTER_LEANUDP_DECODE_FRAGMENTS_REGULAR,
         }
@@ -171,6 +178,7 @@ impl PoolSelection {
 
     fn bytes_counter(self) -> &'static MetricDef {
         match self {
+            PoolSelection::Dedicated => COUNTER_LEANUDP_DECODE_BYTES_DEDICATED,
             PoolSelection::Priority => COUNTER_LEANUDP_DECODE_BYTES_PRIORITY,
             PoolSelection::Regular => COUNTER_LEANUDP_DECODE_BYTES_REGULAR,
         }
@@ -183,6 +191,10 @@ where
     P: IdentityScore<Identity = I>,
     C: Clock,
 {
+    dedicated_pools: HashMap<I, MessagePool<I, StdRng>>,
+    dedicated_pool_config: PoolConfig,
+    max_messages_per_dedicated_identity: usize,
+    dedicated_pool_rng: StdRng,
     priority_pool: MessagePool<I, StdRng>,
     regular_pool: MessagePool<I, StdRng>,
     identity_score: P,
@@ -217,44 +229,94 @@ where
             StdRng::from_rng(&mut pool_rng).expect("failed to seed priority pool rng");
         let regular_pool_rng =
             StdRng::from_rng(&mut pool_rng).expect("failed to seed regular pool rng");
+        let dedicated_pool_rng =
+            StdRng::from_rng(&mut pool_rng).expect("failed to seed dedicated pool rng");
+        let mut metrics = init_decoder_metrics();
+        let priority_messages_gauge = metrics.gauge(GAUGE_LEANUDP_POOL_PRIORITY_MESSAGES).clone();
+        let regular_messages_gauge = metrics.gauge(GAUGE_LEANUDP_POOL_REGULAR_MESSAGES).clone();
         Self {
+            dedicated_pools: HashMap::new(),
+            dedicated_pool_config: PoolConfig::from_config(
+                config,
+                config.max_messages_per_dedicated_identity,
+            ),
+            max_messages_per_dedicated_identity: config.max_messages_per_dedicated_identity,
+            dedicated_pool_rng,
             priority_pool: MessagePool::new(
                 PoolConfig::from_config(config, config.max_priority_messages),
                 priority_pool_rng,
                 IdentityUsage::new(config),
+                priority_messages_gauge,
             ),
             regular_pool: MessagePool::new(
                 PoolConfig::from_config(config, config.max_regular_messages),
                 regular_pool_rng,
                 IdentityUsage::new(config),
+                regular_messages_gauge,
             ),
             identity_score,
             clock,
-            metrics: init_decoder_metrics(),
+            metrics,
         }
     }
 
     fn select_pool(&mut self, identity: &I, key: &(I, u16), now: Instant) -> PoolSelection {
+        // an identity's pool classification may change while a message is being reassembled.
+        // search all pools first so later fragments reach the pool containing the pending message.
+        let is_dedicated = if let Some(pool) = self.dedicated_pools.get_mut(identity) {
+            match pool.message_status(key, now) {
+                MessageStatus::Active => return PoolSelection::Dedicated,
+                MessageStatus::Stale => {
+                    self.metrics
+                        .gauge(EvictionKind::Timeout.metric_name())
+                        .inc();
+                }
+                MessageStatus::Missing => {}
+            }
+            true
+        } else {
+            false
+        };
+
         match self.priority_pool.message_status(key, now) {
             MessageStatus::Active => return PoolSelection::Priority,
             MessageStatus::Stale => {
                 self.metrics
                     .gauge(EvictionKind::Timeout.metric_name())
                     .inc();
-                return self.identity_score.score(identity).into();
             }
             MessageStatus::Missing => {}
         }
 
         match self.regular_pool.message_status(key, now) {
-            MessageStatus::Active => PoolSelection::Regular,
+            MessageStatus::Active => return PoolSelection::Regular,
             MessageStatus::Stale => {
                 self.metrics
                     .gauge(EvictionKind::Timeout.metric_name())
                     .inc();
-                self.identity_score.score(identity).into()
             }
-            MessageStatus::Missing => self.identity_score.score(identity).into(),
+            MessageStatus::Missing => {}
+        }
+
+        if is_dedicated {
+            PoolSelection::Dedicated
+        } else {
+            self.identity_score.score(identity).into()
+        }
+    }
+
+    fn pool_mut(
+        &mut self,
+        selected_pool: PoolSelection,
+        identity: &I,
+    ) -> &mut MessagePool<I, StdRng> {
+        match selected_pool {
+            PoolSelection::Dedicated => self
+                .dedicated_pools
+                .get_mut(identity)
+                .expect("dedicated pool must exist for selected identity"),
+            PoolSelection::Priority => &mut self.priority_pool,
+            PoolSelection::Regular => &mut self.regular_pool,
         }
     }
 
@@ -265,40 +327,23 @@ where
         key: &(I, u16),
         input: FragmentInput<I>,
     ) -> Result<DecodeOutcome, DecodeError> {
-        let is_new_message = match selected_pool {
-            PoolSelection::Priority => !self.priority_pool.has_message(key),
-            PoolSelection::Regular => !self.regular_pool.has_message(key),
+        let input_identity = input.identity.clone();
+        let mut identity_timeout_evicted = false;
+        let (result, pool_evicted) = {
+            let pool = self.pool_mut(selected_pool, &input_identity);
+            if !pool.has_message(key) {
+                identity_timeout_evicted =
+                    pool.evict_one_stale_for_identity_if_limited(&input_identity, now);
+                pool.ensure_identity_capacity(&input_identity)?;
+            }
+            pool.decode_with_admission(now, key, input)
         };
 
-        if is_new_message {
-            let evicted = match selected_pool {
-                PoolSelection::Priority => self
-                    .priority_pool
-                    .evict_one_stale_for_identity_if_limited(&input.identity, now),
-                PoolSelection::Regular => self
-                    .regular_pool
-                    .evict_one_stale_for_identity_if_limited(&input.identity, now),
-            };
-            if evicted {
-                self.metrics
-                    .gauge(EvictionKind::Timeout.metric_name())
-                    .inc();
-            }
-            match selected_pool {
-                PoolSelection::Priority => self
-                    .priority_pool
-                    .ensure_identity_capacity(&input.identity)?,
-                PoolSelection::Regular => self
-                    .regular_pool
-                    .ensure_identity_capacity(&input.identity)?,
-            }
+        if identity_timeout_evicted {
+            self.metrics
+                .gauge(EvictionKind::Timeout.metric_name())
+                .inc();
         }
-
-        let (result, pool_evicted) = match selected_pool {
-            PoolSelection::Priority => self.priority_pool.decode_with_admission(now, key, input),
-            PoolSelection::Regular => self.regular_pool.decode_with_admission(now, key, input),
-        };
-
         if let Some(kind) = pool_evicted {
             self.metrics.gauge(kind.metric_name()).inc();
         }
@@ -335,18 +380,8 @@ where
         }
     }
 
-    fn update_pool_gauges(&mut self) {
-        self.metrics
-            .gauge(GAUGE_LEANUDP_POOL_PRIORITY_MESSAGES)
-            .set(self.priority_pool.message_count() as u64);
-        self.metrics
-            .gauge(GAUGE_LEANUDP_POOL_REGULAR_MESSAGES)
-            .set(self.regular_pool.message_count() as u64);
-    }
-
     fn reject_decode(&mut self, error: DecodeError) -> DecodeError {
         self.metrics.gauge(error.metric_name()).inc();
-        self.update_pool_gauges();
         error
     }
 
@@ -393,9 +428,39 @@ where
 
         let result = self.decode_in_pool(now, selected_pool, &key, input);
         self.record_decode_metrics(selected_pool, payload_bytes, &result);
-        self.update_pool_gauges();
 
         result
+    }
+
+    /// Replaces the identities that receive isolated reassembly pools.
+    ///
+    /// Existing messages for identities that remain dedicated are preserved.
+    /// Pools for removed identities, including incomplete messages, are dropped.
+    pub fn set_dedicated_identities(&mut self, identities: impl IntoIterator<Item = I>) {
+        let identities = identities.into_iter().collect::<HashSet<_>>();
+        self.dedicated_pools
+            .retain(|identity, _| identities.contains(identity));
+        let dedicated_messages_gauge = self
+            .metrics
+            .gauge(GAUGE_LEANUDP_POOL_DEDICATED_MESSAGES)
+            .clone();
+
+        for identity in identities {
+            if self.dedicated_pools.contains_key(&identity) {
+                continue;
+            }
+            let rng = StdRng::from_rng(&mut self.dedicated_pool_rng)
+                .expect("failed to seed dedicated identity pool rng");
+            self.dedicated_pools.insert(
+                identity,
+                MessagePool::new(
+                    self.dedicated_pool_config.clone(),
+                    rng,
+                    IdentityUsage::with_limit(self.max_messages_per_dedicated_identity),
+                    dedicated_messages_gauge.clone(),
+                ),
+            );
+        }
     }
 
     pub fn executor_metrics(&self) -> &ExecutorMetrics {

--- a/monad-leanudp/src/lib.rs
+++ b/monad-leanudp/src/lib.rs
@@ -28,6 +28,8 @@ pub const LEANUDP_HEADER_SIZE: usize = PacketHeader::SIZE;
 pub(crate) const LEANUDP_PROTOCOL_VERSION: u8 = 1;
 /// Default in-flight messages per identity.
 pub const MAX_CONCURRENT_MESSAGES_PER_IDENTITY: usize = 100;
+/// Default in-flight messages reserved for each dedicated identity.
+pub const MAX_CONCURRENT_MESSAGES_PER_DEDICATED_IDENTITY: usize = 10;
 
 const DEFAULT_MESSAGE_TIMEOUT: Duration = Duration::from_millis(100);
 
@@ -111,6 +113,7 @@ pub struct Config {
     pub max_priority_messages: usize,
     pub max_regular_messages: usize,
     pub max_messages_per_identity: usize,
+    pub max_messages_per_dedicated_identity: usize,
     pub message_timeout: Duration,
     /// Max fragment size on wire (including LeanUDP header). Defaults to 1440.
     pub max_fragment_payload: usize,
@@ -122,6 +125,10 @@ impl Config {
         assert!(
             self.max_messages_per_identity > 0,
             "max_messages_per_identity must be > 0"
+        );
+        assert!(
+            self.max_messages_per_dedicated_identity > 0,
+            "max_messages_per_dedicated_identity must be > 0"
         );
         assert!(
             !self.message_timeout.is_zero(),
@@ -166,6 +173,7 @@ impl Default for Config {
             max_priority_messages: 2_048,
             max_regular_messages: 1_024,
             max_messages_per_identity: MAX_CONCURRENT_MESSAGES_PER_IDENTITY,
+            max_messages_per_dedicated_identity: MAX_CONCURRENT_MESSAGES_PER_DEDICATED_IDENTITY,
             message_timeout: DEFAULT_MESSAGE_TIMEOUT,
             max_fragment_payload: 1440, // MTU(1500) - IP(20) - UDP(8) - WireAuth(32)
         }

--- a/monad-leanudp/src/metrics.rs
+++ b/monad-leanudp/src/metrics.rs
@@ -24,6 +24,10 @@ monad_executor::metric_consts! {
         name: "monad.leanudp.pool.regular_messages",
         help: "Regular pool in-flight message count",
     }
+    pub GAUGE_LEANUDP_POOL_DEDICATED_MESSAGES {
+        name: "monad.leanudp.pool.dedicated_messages",
+        help: "Dedicated per-identity pools in-flight message count",
+    }
     pub COUNTER_LEANUDP_DECODE_FRAGMENTS_RECEIVED {
         name: "monad.leanudp.decode.fragments_received",
         help: "Total LeanUDP fragments received",
@@ -47,6 +51,14 @@ monad_executor::metric_consts! {
     pub COUNTER_LEANUDP_DECODE_BYTES_REGULAR {
         name: "monad.leanudp.decode.bytes_regular",
         help: "Total fragment payload bytes routed to the regular pool, excluding LeanUDP headers",
+    }
+    pub COUNTER_LEANUDP_DECODE_FRAGMENTS_DEDICATED {
+        name: "monad.leanudp.decode.fragments_dedicated",
+        help: "Total fragments routed to dedicated per-identity pools",
+    }
+    pub COUNTER_LEANUDP_DECODE_BYTES_DEDICATED {
+        name: "monad.leanudp.decode.bytes_dedicated",
+        help: "Total fragment payload bytes routed to dedicated per-identity pools, excluding LeanUDP headers",
     }
     pub COUNTER_LEANUDP_DECODE_MESSAGES_COMPLETED {
         name: "monad.leanudp.decode.messages_completed",
@@ -127,12 +139,15 @@ pub fn init_decoder_metrics() -> ExecutorMetrics {
     ExecutorMetrics::with_metric_defs(&[
         GAUGE_LEANUDP_POOL_PRIORITY_MESSAGES,
         GAUGE_LEANUDP_POOL_REGULAR_MESSAGES,
+        GAUGE_LEANUDP_POOL_DEDICATED_MESSAGES,
         COUNTER_LEANUDP_DECODE_FRAGMENTS_RECEIVED,
         COUNTER_LEANUDP_DECODE_BYTES_RECEIVED,
         COUNTER_LEANUDP_DECODE_FRAGMENTS_PRIORITY,
         COUNTER_LEANUDP_DECODE_BYTES_PRIORITY,
         COUNTER_LEANUDP_DECODE_FRAGMENTS_REGULAR,
         COUNTER_LEANUDP_DECODE_BYTES_REGULAR,
+        COUNTER_LEANUDP_DECODE_FRAGMENTS_DEDICATED,
+        COUNTER_LEANUDP_DECODE_BYTES_DEDICATED,
         COUNTER_LEANUDP_DECODE_MESSAGES_COMPLETED,
         COUNTER_LEANUDP_DECODE_BYTES_COMPLETED,
         COUNTER_LEANUDP_DECODE_EVICTED_TIMEOUT,

--- a/monad-leanudp/src/pool.rs
+++ b/monad-leanudp/src/pool.rs
@@ -21,7 +21,7 @@ use std::{
 
 use bytes::{Bytes, BytesMut};
 use indexmap::IndexMap;
-use monad_executor::MetricDef;
+use monad_executor::{Gauge, MetricDef};
 use rand::{CryptoRng, Rng as _, RngCore};
 
 use crate::{
@@ -79,6 +79,7 @@ impl MessageState {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct PoolConfig {
     max_messages: usize,
     max_message_size: usize,
@@ -130,9 +131,13 @@ where
     I: Eq + Hash + Clone + Ord,
 {
     pub(crate) fn new(config: &Config) -> Self {
+        Self::with_limit(config.max_messages_per_identity)
+    }
+
+    pub(crate) fn with_limit(max_messages_per_identity: usize) -> Self {
         Self {
             message_counts: HashMap::new(),
-            max_messages_per_identity: config.max_messages_per_identity,
+            max_messages_per_identity,
         }
     }
 
@@ -186,10 +191,16 @@ where
     cfg: PoolConfig,
     rng: R,
     identity_usage: IdentityUsage<I>,
+    messages_gauge: Gauge,
 }
 
 impl<I: Eq + Hash + Clone + Ord, R: CryptoRng + RngCore> MessagePool<I, R> {
-    pub(crate) fn new(cfg: PoolConfig, rng: R, identity_usage: IdentityUsage<I>) -> Self {
+    pub(crate) fn new(
+        cfg: PoolConfig,
+        rng: R,
+        identity_usage: IdentityUsage<I>,
+        messages_gauge: Gauge,
+    ) -> Self {
         Self {
             messages: IndexMap::new(),
             eviction_index: BTreeSet::new(),
@@ -197,6 +208,7 @@ impl<I: Eq + Hash + Clone + Ord, R: CryptoRng + RngCore> MessagePool<I, R> {
             cfg,
             rng,
             identity_usage,
+            messages_gauge,
         }
     }
 
@@ -262,6 +274,7 @@ impl<I: Eq + Hash + Clone + Ord, R: CryptoRng + RngCore> MessagePool<I, R> {
         let deadline = now + self.cfg.message_timeout;
         self.messages
             .insert(key.clone(), MessageState::new(deadline));
+        self.messages_gauge.inc();
         self.eviction_index.insert((deadline, key.clone()));
         self.eviction_index_by_identity
             .entry(key.0.clone())
@@ -409,6 +422,7 @@ impl<I: Eq + Hash + Clone + Ord, R: CryptoRng + RngCore> MessagePool<I, R> {
 
     fn remove_message(&mut self, key: &(I, u16)) -> Option<MessageState> {
         let state = self.messages.swap_remove(key)?;
+        self.messages_gauge.dec();
         let deadline = state.eviction_deadline;
         let _ = self.eviction_index.remove(&(deadline, key.clone()));
         let mut should_remove_identity = false;
@@ -424,9 +438,15 @@ impl<I: Eq + Hash + Clone + Ord, R: CryptoRng + RngCore> MessagePool<I, R> {
         self.identity_usage.decrement_identity_count(&key.0);
         Some(state)
     }
+}
 
-    pub(crate) fn message_count(&self) -> usize {
-        self.messages.len()
+impl<I, R> Drop for MessagePool<I, R>
+where
+    I: Eq + Hash + Clone + Ord,
+    R: CryptoRng + RngCore,
+{
+    fn drop(&mut self) {
+        self.messages_gauge.sub(self.messages.len() as u64);
     }
 }
 
@@ -443,6 +463,9 @@ mod tests {
             PoolConfig::from_config(&config, config.max_regular_messages),
             StdRng::seed_from_u64(1),
             IdentityUsage::new(&config),
+            init_decoder_metrics()
+                .gauge(GAUGE_LEANUDP_POOL_REGULAR_MESSAGES)
+                .clone(),
         );
         let identity = 7u64;
         let msg_id = 11u16;

--- a/monad-leanudp/tests/tests.rs
+++ b/monad-leanudp/tests/tests.rs
@@ -23,8 +23,9 @@ use bytes::{BufMut, Bytes, BytesMut};
 use monad_leanudp::{
     metrics::{
         COUNTER_LEANUDP_DECODE_EVICTED_RANDOM, COUNTER_LEANUDP_DECODE_EVICTED_TIMEOUT,
-        COUNTER_LEANUDP_DECODE_FRAGMENTS_PRIORITY, COUNTER_LEANUDP_DECODE_FRAGMENTS_REGULAR,
-        COUNTER_LEANUDP_ERROR_INVALID_HEADER, COUNTER_LEANUDP_ERROR_UNSUPPORTED_VERSION,
+        COUNTER_LEANUDP_DECODE_FRAGMENTS_DEDICATED, COUNTER_LEANUDP_DECODE_FRAGMENTS_PRIORITY,
+        COUNTER_LEANUDP_DECODE_FRAGMENTS_REGULAR, COUNTER_LEANUDP_ERROR_INVALID_HEADER,
+        COUNTER_LEANUDP_ERROR_UNSUPPORTED_VERSION, GAUGE_LEANUDP_POOL_DEDICATED_MESSAGES,
         GAUGE_LEANUDP_POOL_PRIORITY_MESSAGES, GAUGE_LEANUDP_POOL_REGULAR_MESSAGES,
     },
     Clock, Config, DecodeError, DecodeOutcome, Decoder, EncodeError, Encoder, FragmentPolicy,
@@ -165,6 +166,13 @@ fn test_invalid_config_panics() {
                 ..Config::default()
             },
             "max_messages_per_identity must be > 0",
+        ),
+        (
+            Config {
+                max_messages_per_dedicated_identity: 0,
+                ..Config::default()
+            },
+            "max_messages_per_dedicated_identity must be > 0",
         ),
         (
             Config {
@@ -466,6 +474,94 @@ fn test_identity_limit_is_independent_per_pool() {
             .gauge(COUNTER_LEANUDP_DECODE_FRAGMENTS_REGULAR)
             .get(),
         2
+    );
+}
+
+#[test]
+fn test_dedicated_identity_limits_are_independent() {
+    let config = Config {
+        max_messages_per_dedicated_identity: 1,
+        ..Config::default()
+    };
+    let (mut encoder, mut decoder, _clock) = build_regular(config);
+    decoder.set_dedicated_identities([1000, 2000]);
+
+    let first = first_packet(&mut encoder, Bytes::from(vec![1u8; 3000]));
+    let over_limit = first_packet(&mut encoder, Bytes::from(vec![2u8; 3000]));
+    let other_identity = first_packet(&mut encoder, Bytes::from(vec![3u8; 3000]));
+
+    assert_pending!(decoder, 1000, first);
+    assert_eq!(
+        decoder.decode(1000, over_limit),
+        Err(DecodeError::IdentityLimitExceeded { max: 1 })
+    );
+    assert_pending!(decoder, 2000, other_identity);
+
+    assert_eq!(
+        decoder
+            .metrics()
+            .gauge(GAUGE_LEANUDP_POOL_DEDICATED_MESSAGES)
+            .get(),
+        2
+    );
+    assert_eq!(
+        decoder
+            .metrics()
+            .gauge(COUNTER_LEANUDP_DECODE_FRAGMENTS_DEDICATED)
+            .get(),
+        3
+    );
+    assert_eq!(
+        decoder
+            .metrics()
+            .gauge(GAUGE_LEANUDP_POOL_REGULAR_MESSAGES)
+            .get(),
+        0
+    );
+}
+
+#[test]
+fn test_dedicated_message_gauge_tracks_pool_mutations() {
+    let config = Config {
+        message_timeout: Duration::from_millis(100),
+        ..Config::default()
+    };
+    let (mut encoder, mut decoder, clock) = build_regular(config);
+    decoder.set_dedicated_identities([1000, 2000]);
+
+    let stale = fragment_packets(&mut encoder, Bytes::from(vec![1u8; 3000]));
+    assert_pending!(decoder, 1000, stale[0].clone());
+    clock.advance_ms(200);
+    assert_pending!(decoder, 1000, stale[1].clone());
+
+    let complete = fragment_packets(&mut encoder, Bytes::from(vec![2u8; 3000]));
+    assert_pending!(decoder, 2000, complete[0].clone());
+    assert_eq!(
+        decoder
+            .metrics()
+            .gauge(GAUGE_LEANUDP_POOL_DEDICATED_MESSAGES)
+            .get(),
+        2
+    );
+
+    decoder.set_dedicated_identities([2000]);
+    assert_eq!(
+        decoder
+            .metrics()
+            .gauge(GAUGE_LEANUDP_POOL_DEDICATED_MESSAGES)
+            .get(),
+        1
+    );
+
+    for packet in complete.into_iter().skip(1) {
+        let _ = decoder.decode(2000, packet).unwrap();
+    }
+    assert_eq!(
+        decoder
+            .metrics()
+            .gauge(GAUGE_LEANUDP_POOL_DEDICATED_MESSAGES)
+            .get(),
+        0
     );
 }
 

--- a/monad-raptorcast/src/auth/framing.rs
+++ b/monad-raptorcast/src/auth/framing.rs
@@ -123,6 +123,10 @@ where
         &self.config
     }
 
+    pub fn set_dedicated_identities(&mut self, identities: impl IntoIterator<Item = N>) {
+        self.decoder.set_dedicated_identities(identities);
+    }
+
     pub fn metrics(&self) -> ExecutorMetricsChain<'_> {
         ExecutorMetricsChain::default()
             .push(self.encoder.executor_metrics())
@@ -164,5 +168,133 @@ where
 
     fn metrics(&self) -> ExecutorMetricsChain<'_> {
         LeanUdpFramer::metrics(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use monad_leanudp::{
+        metrics::{
+            COUNTER_LEANUDP_DECODE_FRAGMENTS_DEDICATED, COUNTER_LEANUDP_DECODE_FRAGMENTS_PRIORITY,
+            COUNTER_LEANUDP_DECODE_FRAGMENTS_REGULAR, GAUGE_LEANUDP_POOL_DEDICATED_MESSAGES,
+            GAUGE_LEANUDP_POOL_PRIORITY_MESSAGES, GAUGE_LEANUDP_POOL_REGULAR_MESSAGES,
+        },
+        DecodeError,
+    };
+    use monad_peer_score::{PeerStatus, Score};
+
+    use super::*;
+
+    struct TestScore {
+        promoted: BTreeSet<u64>,
+    }
+
+    impl monad_peer_score::IdentityScore for TestScore {
+        type Identity = u64;
+
+        fn score(&self, identity: &Self::Identity) -> PeerStatus {
+            if self.promoted.contains(identity) {
+                PeerStatus::Promoted(Score::ONE)
+            } else {
+                PeerStatus::Unknown
+            }
+        }
+    }
+
+    fn fragmented_message(framer: &mut LeanUdpFramer<u64, TestScore>, fill: u8) -> Vec<Bytes> {
+        let payload = Bytes::from(vec![fill; framer.config().max_fragment_payload]);
+        <LeanUdpFramer<u64, TestScore> as AuthPacketFramer<u64>>::frame(framer, payload)
+            .unwrap()
+            .collect()
+    }
+
+    #[test]
+    fn validator_traffic_uses_dedicated_pools() {
+        let config = Config {
+            max_priority_messages: 1,
+            max_regular_messages: 1,
+            max_messages_per_identity: 1,
+            max_messages_per_dedicated_identity: 1,
+            max_fragment_payload: 64,
+            ..Config::default()
+        };
+        let mut framer = LeanUdpFramer::new(
+            TestScore {
+                promoted: [2].into(),
+            },
+            config,
+        );
+        framer.set_dedicated_identities([3, 4]);
+
+        let regular = fragmented_message(&mut framer, b'R');
+        let priority = fragmented_message(&mut framer, b'P');
+        assert_eq!(
+            framer.deframe(1u64, regular[0].clone()).unwrap(),
+            None,
+            "regular pool should contain an incomplete message",
+        );
+        assert_eq!(
+            framer.deframe(2u64, priority[0].clone()).unwrap(),
+            None,
+            "priority pool should contain an incomplete message",
+        );
+
+        let validator = fragmented_message(&mut framer, b'V');
+        assert_eq!(framer.deframe(3u64, validator[0].clone()).unwrap(), None);
+
+        let same_validator = fragmented_message(&mut framer, b'X');
+        assert!(matches!(
+            framer.deframe(3u64, same_validator[0].clone()),
+            Err(LeanUdpFramingError::Decode(
+                DecodeError::IdentityLimitExceeded { max: 1 }
+            ))
+        ));
+
+        let other_validator = fragmented_message(&mut framer, b'W');
+        assert_eq!(
+            framer.deframe(4u64, other_validator[0].clone()).unwrap(),
+            None,
+            "each validator should have an independent allowance",
+        );
+
+        let mut outcome = None;
+        for fragment in validator.into_iter().skip(1) {
+            outcome = framer.deframe(3u64, fragment).unwrap();
+        }
+        assert_eq!(
+            outcome,
+            Some(Bytes::from(vec![
+                b'V';
+                framer.config().max_fragment_payload
+            ]))
+        );
+
+        let metrics = framer.decoder.metrics();
+        assert_eq!(metrics.gauge(GAUGE_LEANUDP_POOL_REGULAR_MESSAGES).get(), 1);
+        assert_eq!(metrics.gauge(GAUGE_LEANUDP_POOL_PRIORITY_MESSAGES).get(), 1);
+        assert_eq!(
+            metrics.gauge(GAUGE_LEANUDP_POOL_DEDICATED_MESSAGES).get(),
+            1
+        );
+        assert_eq!(
+            metrics
+                .gauge(COUNTER_LEANUDP_DECODE_FRAGMENTS_REGULAR)
+                .get(),
+            1
+        );
+        assert_eq!(
+            metrics
+                .gauge(COUNTER_LEANUDP_DECODE_FRAGMENTS_PRIORITY)
+                .get(),
+            1
+        );
+        assert!(
+            metrics
+                .gauge(COUNTER_LEANUDP_DECODE_FRAGMENTS_DEDICATED)
+                .get()
+                > 2
+        );
     }
 }

--- a/monad-raptorcast/src/auth/socket.rs
+++ b/monad-raptorcast/src/auth/socket.rs
@@ -26,6 +26,7 @@ use monad_crypto::certificate_signature::PubKey;
 use monad_dataplane::{UdpSocketHandle, UnicastMsg};
 use monad_executor::{ExecutorMetrics, ExecutorMetricsChain};
 use monad_peer_discovery::NameRecord;
+use monad_peer_score::IdentityScore;
 use monad_types::{NodeId, UdpPriority};
 use thiserror::Error;
 use tokio::time::Sleep;
@@ -33,7 +34,7 @@ use tracing::{debug, trace, warn};
 use zerocopy::IntoBytes;
 
 use super::{
-    framing::AuthPacketFramer,
+    framing::{AuthPacketFramer, LeanUdpFramer},
     metrics::{
         init_socket_executor_metrics, GAUGE_RAPTORCAST_AUTH_AUTHENTICATED_UDP_BYTES_READ,
         GAUGE_RAPTORCAST_AUTH_AUTHENTICATED_UDP_BYTES_WRITTEN,
@@ -715,6 +716,19 @@ where
 
     pub fn metrics(&self) -> ExecutorMetricsChain<'_> {
         self.socket.metrics().chain(self.framer.metrics())
+    }
+}
+
+impl<AP, S> FramedAuthenticatedSocketHandle<AP, LeanUdpFramer<NodeId<AP::PublicKey>, S>>
+where
+    AP: AuthenticationProtocol,
+    S: IdentityScore<Identity = NodeId<AP::PublicKey>>,
+{
+    pub fn set_dedicated_identities(
+        &mut self,
+        identities: impl IntoIterator<Item = NodeId<AP::PublicKey>>,
+    ) {
+        self.framer.set_dedicated_identities(identities);
     }
 }
 

--- a/monad-raptorcast/src/lib.rs
+++ b/monad-raptorcast/src/lib.rs
@@ -370,6 +370,17 @@ where
         self.dedicated_full_nodes = nodes;
     }
 
+    fn update_direct_udp_validator_pools(&mut self) {
+        let validators = [self.current_epoch, self.current_epoch + Epoch(1)]
+            .into_iter()
+            .filter_map(|epoch| self.epoch_validators.get(&epoch))
+            .flat_map(|validator_set| validator_set.get_members().keys().copied());
+
+        if let Some(transport) = self.direct_udp_transport.as_mut() {
+            transport.set_dedicated_identities(validators);
+        }
+    }
+
     // Used only in tests
     pub fn get_full_node_groups(&self) -> &FullNodeGroupMap<CertificateSignaturePubKey<ST>> {
         &self.full_node_groups
@@ -1011,6 +1022,7 @@ where
                         self.current_epoch = epoch;
 
                         self.epoch_validators.retain(|e, _| *e + Epoch(1) >= epoch);
+                        self.update_direct_udp_validator_pools();
                     }
 
                     self.udp_state.update_current_round(round);
@@ -1055,6 +1067,7 @@ where
                         let removed = self.epoch_validators.insert(epoch, validators.clone());
                         assert!(removed.is_none());
                     }
+                    self.update_direct_udp_validator_pools();
 
                     self.proposer_schedule
                         .insert_epoch(epoch, epoch_start, validators);


### PR DESCRIPTION
dedicated leanudp decoding pools for validators.
each validator in current and next epochs will be able to concurrently send and decode 10 messages using direct udp.
