### PR TITLE
fix(debian): don't abort install on imperfect hosts

### DIFF
--- a/debian/DEBIAN/postinst
+++ b/debian/DEBIAN/postinst
@@ -5,9 +5,12 @@ case "$1" in
     ldconfig
     if command -v systemctl >/dev/null 2>&1 && [ "$(ps -p 1 -o comm=)" = "systemd" ]; then
         echo "Detected systemd, enabling service..."
-        systemctl daemon-reexec
         systemctl daemon-reload
-        systemctl start set-hugepages.service
+        # Hugepage allocation can fail on fragmented or unsupported hosts;
+        # warn instead of leaving the package half-configured.
+        if ! systemctl start set-hugepages.service; then
+            echo "WARN: set-hugepages.service failed to start; check hugepage support and start it manually." >&2
+        fi
         systemctl enable set-hugepages.service
         systemctl enable monad-cruft.timer
         systemctl start monad-cruft.timer

--- a/debian/DEBIAN/preinst
+++ b/debian/DEBIAN/preinst
@@ -35,7 +35,10 @@ case "$1" in
 
     CORES_PER_SOCKET=$(lscpu | awk '/Core\(s\) per socket:/ { print $4 }')
 
-    if [ "$CORES_PER_SOCKET" -lt 16 ]; then
+    # Informational only — never abort the install if lscpu output is unexpected
+    if ! [ "$CORES_PER_SOCKET" -ge 0 ] 2>/dev/null; then
+        echo "WARN: Could not determine cores per socket from lscpu."
+    elif [ "$CORES_PER_SOCKET" -lt 16 ]; then
         echo "WARN: System has only $CORES_PER_SOCKET cores per socket. Minimum required: 16."
     else
         echo "System has $CORES_PER_SOCKET cores per socket."


### PR DESCRIPTION
Installs previously failed on hosts where lscpu doesn't report cores per socket or where hugepage allocation fails, leaving the package half-configured in dpkg. preinst now warns instead of aborting, postinst warns when set-hugepages.service can't start, and the unnecessary daemon-reexec is dropped.