### PR TITLE
Allow nodes to opt out from serving statesync requests

### DIFF
--- a/docker/devnet/monad/config/node.toml
+++ b/docker/devnet/monad/config/node.toml
@@ -63,6 +63,7 @@ peers = []
 
 [statesync]
 expand_to_group = true
+serve_statesync = true
 init_peers = []
 # [[statesync.init_peers]]
 # secp256k1_pubkey = "..."

--- a/monad-mock-swarm/src/node.rs
+++ b/monad-mock-swarm/src/node.rs
@@ -143,6 +143,7 @@ impl<S: SwarmRelation> NodeBuilder<S> {
                 consensus_config: self.state_builder.consensus_config,
                 whitelisted_statesync_nodes: self.state_builder.whitelisted_statesync_nodes,
                 statesync_expand_to_group: self.state_builder.statesync_expand_to_group,
+                serve_statesync: self.state_builder.serve_statesync,
 
                 _phantom: PhantomData,
             },

--- a/monad-mock-swarm/src/swarm.rs
+++ b/monad-mock-swarm/src/swarm.rs
@@ -123,6 +123,7 @@ pub fn make_state_configs<S: SwarmRelation>(
 
             whitelisted_statesync_nodes: Default::default(),
             statesync_expand_to_group: true,
+            serve_statesync: true,
 
             _phantom: PhantomData,
         })

--- a/monad-node-config/src/sync_peers.rs
+++ b/monad-node-config/src/sync_peers.rs
@@ -28,8 +28,15 @@ pub struct BlockSyncPeersConfig<P: PubKey> {
 #[serde(deny_unknown_fields)]
 pub struct StateSyncPeersConfig<P: PubKey> {
     pub expand_to_group: bool,
+    /// When false, all inbound statesync requests are refused
+    #[serde(default = "default_serve_statesync")]
+    pub serve_statesync: bool,
     #[serde(bound = "P:PubKey")]
     pub init_peers: Vec<SyncPeerIdentityConfig<P>>,
+}
+
+fn default_serve_statesync() -> bool {
+    true
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -422,6 +422,7 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         },
         whitelisted_statesync_nodes,
         statesync_expand_to_group: node_state.node_config.statesync.expand_to_group,
+        serve_statesync: node_state.node_config.statesync.serve_statesync,
         _phantom: PhantomData,
     };
 

--- a/monad-state/src/lib.rs
+++ b/monad-state/src/lib.rs
@@ -439,6 +439,7 @@ where
     // - For validators, this means all validators
     // - For full nodes, this means all secondary raptorcast peers
     statesync_expand_to_group: bool,
+    serve_statesync: bool,
 }
 
 impl<ST, SCT, EPT, BPT, ESRT, VTF, LT, BVT, CCT, CRT>
@@ -528,6 +529,7 @@ where
     /// Check if a statesync request from the given sender should be serviced.
     ///
     /// Service rules:
+    /// - If serve_statesync is disabled: service no requests
     /// - If self is a validator: only service requests from validators or whitelisted full nodes
     /// - If self is a full node: service all requests
     fn should_service_statesync_request(
@@ -535,6 +537,10 @@ where
         sender: &NodeId<CertificateSignaturePubKey<ST>>,
         _request: &StateSyncRequest,
     ) -> bool {
+        if !self.serve_statesync {
+            return false;
+        }
+
         // Check if self is a validator
         let self_role = self.get_role();
 
@@ -856,6 +862,7 @@ where
     pub maybe_blocksync_rng_seed: Option<u64>,
     pub whitelisted_statesync_nodes: HashSet<NodeId<SCT::NodeIdPubKey>>,
     pub statesync_expand_to_group: bool,
+    pub serve_statesync: bool,
 
     pub consensus_config: ConsensusConfig<CCT, CRT>,
 
@@ -955,6 +962,7 @@ where
 
             whitelisted_statesync_nodes: self.whitelisted_statesync_nodes,
             statesync_expand_to_group: self.statesync_expand_to_group,
+            serve_statesync: self.serve_statesync,
         };
 
         let mut init_cmds = Vec::new();

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -313,6 +313,7 @@ where
         consensus_config: config.consensus_config,
         whitelisted_statesync_nodes: Default::default(),
         statesync_expand_to_group: true,
+        serve_statesync: true,
 
         _phantom: PhantomData,
     }

--- a/monad-twins/utils/src/twin_reader.rs
+++ b/monad-twins/utils/src/twin_reader.rs
@@ -152,6 +152,7 @@ where
 
                 whitelisted_statesync_nodes: Default::default(),
                 statesync_expand_to_group: true,
+                serve_statesync: true,
 
                 _phantom: PhantomData,
             },
@@ -403,6 +404,7 @@ where
 
             whitelisted_statesync_nodes: Default::default(),
             statesync_expand_to_group: true,
+            serve_statesync: true,
 
             _phantom: PhantomData,
         })


### PR DESCRIPTION
Allow nodes to opt out from serving statesync requests when needed. Default to allowing serving statesync requests, no config changes needed if using default setting

Closes https://github.com/category-labs/monad-bft/issues/2703