### PR TITLE
Add concurrency limiter for fee history

### DIFF
--- a/monad-rpc/src/cli.rs
+++ b/monad-rpc/src/cli.rs
@@ -101,6 +101,10 @@ pub struct Cli {
     #[arg(long, default_value_t = 1000)]
     pub eth_call_max_concurrent_requests: u32,
 
+    /// Set the max concurrent requests for eth_feeHistory
+    #[arg(long, default_value_t = 100)]
+    pub feehistory_max_concurrent_requests: u32,
+
     /// Set the number of threads used for executing eth_call and eth_estimateGas
     #[arg(long, default_value_t = 2)]
     pub eth_call_executor_threads: u32,

--- a/monad-rpc/src/handlers/mod.rs
+++ b/monad-rpc/src/handlers/mod.rs
@@ -801,6 +801,9 @@ async fn eth_feeHistory(
 ) -> Result<Box<RawValue>, JsonRpcError> {
     let data_provider = app_state.data_provider.as_ref().method_not_supported()?;
     let params = serde_json::from_str(params.get()).invalid_params()?;
+    let _permit = app_state.feehistory_limiter.try_acquire().map_err(|_| {
+        JsonRpcError::internal_error("exceed feehistory max concurrent requests".into())
+    })?;
     monad_eth_feeHistory(data_provider, params)
         .await
         .map(serialize_result)?

--- a/monad-rpc/src/handlers/resources.rs
+++ b/monad-rpc/src/handlers/resources.rs
@@ -13,12 +13,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::sync::Arc;
+
 use actix::{Actor, Context};
 use actix_web::{
     dev::{ServiceRequest, ServiceResponse},
     Error,
 };
 use monad_triedb_utils::triedb_env::TriedbEnv;
+use tokio::sync::Semaphore;
 use tracing_actix_web::RootSpanBuilder;
 
 use crate::{
@@ -49,6 +52,7 @@ pub struct MonadRpcResources {
     pub enable_eth_simulate_v1: bool,
     pub metrics: Option<Metrics>,
     pub rpc_comparator: Option<RpcComparator>,
+    pub feehistory_limiter: Arc<Semaphore>,
 }
 
 impl MonadRpcResources {
@@ -72,6 +76,7 @@ impl MonadRpcResources {
         enable_eth_simulate_v1: bool,
         metrics: Option<Metrics>,
         rpc_comparator: Option<RpcComparator>,
+        feehistory_max_concurrent_requests: u32,
     ) -> Self {
         Self {
             txpool_bridge_client,
@@ -92,6 +97,9 @@ impl MonadRpcResources {
             enable_eth_simulate_v1,
             metrics,
             rpc_comparator,
+            feehistory_limiter: Arc::new(Semaphore::new(
+                feehistory_max_concurrent_requests as usize,
+            )),
         }
     }
 }

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -381,6 +381,7 @@ async fn main() -> std::io::Result<()> {
         args.enable_eth_simulate_v1,
         with_metrics.clone(),
         rpc_comparator.clone(),
+        args.feehistory_max_concurrent_requests,
     );
 
     // Configure the websocket server if enabled

--- a/monad-rpc/src/tests.rs
+++ b/monad-rpc/src/tests.rs
@@ -54,6 +54,7 @@ pub async fn init_server(
         enable_eth_simulate_v1: false,
         metrics: None,
         rpc_comparator: None,
+        feehistory_limiter: std::sync::Arc::new(tokio::sync::Semaphore::new(100)),
     };
 
     test::init_service(

--- a/monad-rpc/src/websocket/handler.rs
+++ b/monad-rpc/src/websocket/handler.rs
@@ -738,6 +738,7 @@ mod tests {
             enable_eth_simulate_v1: false,
             metrics: None,
             rpc_comparator: None,
+            feehistory_limiter: std::sync::Arc::new(tokio::sync::Semaphore::new(100)),
         };
         let conn_limit = ConnectionLimit::new(100);
         let sub_limit = SubscriptionLimit(100);


### PR DESCRIPTION
eth_feeHistory can scan large block ranges, adding a concurrency limiter to prevent requests accumulating in memory