### PR TITLE
MCP: Data availability framework & raptorcast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5717,6 +5717,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-mcp-da"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "monad-mcp-chorus",
+]
+
+[[package]]
 name = "monad-merkle"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5720,8 +5720,13 @@ dependencies = [
 name = "monad-mcp-da"
 version = "0.1.0"
 dependencies = [
+ "bitvec",
  "bytes",
+ "derive_more",
+ "monad-crypto",
  "monad-mcp-chorus",
+ "monad-merkle",
+ "tracing",
 ]
 
 [[package]]

--- a/docs/0004_data_availability.md
+++ b/docs/0004_data_availability.md
@@ -1,0 +1,190 @@
+# Data Availability (monad-mcp-da)
+
+This document describes the architecture of the data availability (DA)
+module in `monad-mcp-da`.
+
+DA owns everything about chunks: receiving, checking, forwarding,
+decoding, serving them on request, and telling consensus what it has
+learned. It decides nothing about voting. Chorus (consensus) tells DA
+what it needs through three commands.
+
+## 1. Inputs and outputs
+
+DA is a state machine with no clock, no sockets and no threads. The
+surrounding runtime feeds it and drains it.
+
+```
+   wire                    conductor              chorus
+    |   ^                      |                  |     ^
+    |   |                      |                  |     |
+    v   |                      v                  v     |
+  +-----------------------------------------------------------+
+  |                        DARuntime                          |
+  +-----------------------------------------------------------+
+                               |
+                               v
+                     decoded proposal (translation/execution)
+```
+
+**In:**
+
+- from the wire: a proposal envelope, that is one header plus any
+  subset of its chunks (a chunk is `header + chunk id + merkle proof +
+  symbol`); or a chunk request from a peer.
+- from the conductor: slot `Opened` and slot `Completed`.
+- from chorus: `ReleaseChunks`, `PinRoot { j, root }`,
+  `RecoverChunks { j, root, MyChunks | YourChunks, voters }`.
+
+**Out:**
+
+- to chorus, per `(slot, j)`: `HeaderSeen(header)`,
+  `ProposerObligationFulfilled(root)`,
+  `OwnerObligationFulfilled { owner, root }`, `Decoded(root)`,
+  `DecodingFailed(root)`.
+- to translation/execution: the decoded proposal bytes under
+  `(slot, j, root)`.
+- to the wire: envelopes to send (second hop, answers to requests) and
+  chunk requests to send.
+
+What the events mean to chorus:
+
+- `HeaderSeen`: once per distinct signed root of a proposer. Two of
+  them for one `(slot, j)` are an equivocation certificate.
+- `ProposerObligationFulfilled`: all of our own chunks arrived from the
+  author. This is what we vote positively on at the deadline.
+- `OwnerObligationFulfilled { owner }`: that owner finished its second
+  hop to us. Chorus then admits the owner's positive vote, so that a
+  counted vote always means "we hold the chunks it vouches for".
+- `Decoded` satisfies every gate at once. `DecodingFailed` marks the
+  root invalid. Either one is "resolved".
+
+What the commands mean:
+
+- `PinRoot`: chunks of this root are to be admitted. Chorus pins a
+  root when it expects to decode it (it voted for it, or holds a
+  certificate for it).
+- `ReleaseChunks`: let the slot's chunks leave DA: rebroadcast our
+  owned chunks and answer requests. Sent at the deadline `D_s`.
+- `RecoverChunks`: pull chunks from these peers, following ChunkSync.
+  Chorus sends it on a certificate for an unresolved root (P1), with
+  `MyChunks` towards positive fallback signers (P2), and at the fallback
+  transition for blocked roots (P3, P4).
+
+## 2. The raptorcast layering
+
+DA is a tower of nested scopes. Each layer certifies one fact about
+everything below it, so the layers below never re-check it.
+
+```
+DARuntime                                      node
+  SlotRaptorcast                               slot
+    ProposerRaptorcast                         (slot, j)
+      RaptorcastInstance                       (slot, j, root)
+```
+
+| layer | certifies | holds |
+|---|---|---|
+| runtime | - | the live slots, following the conductor's slot lifecycle |
+| slot | the slot is alive | the epoch context, and one proposer per proposal index of the slot |
+| proposer | the proposer is legitimate for `(slot, j)` | the roots it has announced, one instance per admitted root |
+| instance | the proposal is known: a header signed by the proposer | the chunk store, the decoding state, and the per-proposal trackers |
+
+- **Runtime**: opens a slot when the conductor opens it, drops it some
+  slots after completion.
+- **Slot**: authenticates incoming headers. Signature plus election
+  gives the proposer index `j`, and the envelope goes to that proposer.
+- **Proposer**: validates the author's chunks and decides which of its
+  roots get an instance. Every new root is reported as `HeaderSeen`
+  once. Pinned roots are always admitted.
+- **Instance**: stores and disseminates the chunks of one proposal.
+
+## 3. The raptorcast instance
+
+The instance's job is to hold chunks and decode. Ingesting a chunk is:
+verify it against the root, store it, rebroadcast it if we own it, and
+decode once enough chunks are held.
+
+Two more duties fall to the instance because of what it holds:
+
+- **Recovery.** It serves chunk requests because it holds the chunks,
+  and it knows exactly which chunks to ask a peer for because it knows
+  which ones it is missing.
+- **Obligations.** It knows, for every chunk, who should have sent it,
+  so it can tell chorus when the author or an owner has delivered
+  everything it owed.
+
+## 4. Assignment, upstream, obligation
+
+The **assignment** is a table from chunk id to owner, determined by
+the encoding scheme, the author and the validator set. Every validator
+computes the same table. Owners get chunks in proportion to stake; the
+author owns nothing.
+
+The assignment implies, for each chunk and each receiver, an
+**upstream**: who should deliver the chunk to that receiver. A chunk's
+owner gets it from the author (first hop). Everyone else gets it from
+the owner (second hop).
+
+An **obligation** is the set of chunks one upstream owes a receiver.
+
+- When the author has delivered all of our own chunks, its obligation
+  is fulfilled, and chorus votes positively.
+- When an owner has delivered all of its chunks to us, its obligation
+  is fulfilled, and chorus admits that owner's positive vote.
+
+## 5. The proposal header and the encoding scheme
+
+The proposal header is the tuple (encoding scheme, merkle root,
+signature), scoped to a slot. It is the minimal data that can be
+validated on its own given the validator set, the slot and the proposer
+election: the signature names the proposer, the election confirms it
+proposes in this slot. That is why an equivocation certificate is
+simply two headers of the same proposer with different roots.
+
+To DA the scheme fixes three things:
+
+1. the **packet layout**: segment size, tree depth, symbol size;
+2. the **chunk assignment**: the set of valid chunk ids, and who owns
+   which chunk;
+3. the **codec**: how a message becomes symbols and vice versa.
+
+```rust
+trait DAEncodingScheme {
+    type Encoder: SymbolEncoder;
+    type Decoder: SymbolDecoder;
+
+    fn packet_layout(&self, num_validators: usize) -> Option<PacketLayout>;
+    fn chunk_assignment(&self, layout: &PacketLayout, author: &NodeId,
+                        validator_data: &ValidatorData) -> ChunkAssignment;
+    fn encoder(&self, layout: PacketLayout, num_chunks: usize) -> Self::Encoder;
+    fn decoder(&self, layout: PacketLayout, num_chunks: usize) -> Self::Decoder;
+}
+
+// sizes only: how the 1440-byte segment splits into header, proof,
+// chunk header and symbol, given the tree depth
+struct PacketLayout { .. }
+impl PacketLayout {
+    fn symbol_len(&self) -> usize;
+    fn merkle_leaf_hash(&self, chunk_id: WireChunkId, symbol: &[u8]) -> Hash;
+}
+
+// a frozen table, identical on every validator
+struct ChunkAssignment {
+  nodes: Vec<NodeId>,
+  targets: Vec<NodeIndex> // targets.len() is num_chunks
+}
+impl ChunkAssignment {
+    fn resolve_chunk_id(&self, chunk_id: u16) -> Option<(ChunkId, Owner)>;
+    fn owned_chunks(&self, node: NodeIndex) -> impl Iterator<Item = ChunkId>;
+}
+
+trait SymbolEncoder {
+    // outputs one symbol per chunk, in chunk id order
+    fn encode(&self, message: &[u8]) -> Vec<Bytes>;
+}
+
+trait SymbolDecoder {
+    fn ingest(&mut self, chunk_id: ChunkId, symbol: &Bytes);
+    fn try_decode(&mut self) -> Option<Bytes>;
+}
+```

--- a/monad-mcp-chorus-sim/tests/cadence_conductor.rs
+++ b/monad-mcp-chorus-sim/tests/cadence_conductor.rs
@@ -29,7 +29,7 @@ use chorus::{
         chorus::{Chorus, ChorusConfig, ChorusContext},
         dummy::{DummySlotConsensus, DummySlotConsensusConfig},
     },
-    types::{DAHandle, NodeId, SlotDeadline, Stake, Timestamp, TimestampDelta, ValidatorData},
+    types::{HeaderAuth, NodeId, SlotDeadline, Stake, Timestamp, TimestampDelta, ValidatorData},
 };
 use helper::{expect_finalized, expect_finalized_at};
 use monad_mcp_chorus::{spec::KeyPair as _, stub as chorus};
@@ -141,7 +141,7 @@ fn full_window_rolls_over_with_chorus() {
             node_id: id,
             key: Arc::new(id.keypair()),
             validator_data: val_data.clone(),
-            da_handle: Arc::new(DAHandle),
+            header_auth: Arc::new(HeaderAuth::new(|_, _| None)),
         };
         builder.add_node::<Chorus, _>(id, conductor(), slot_config, context);
     }

--- a/monad-mcp-chorus-sim/tests/chorus.rs
+++ b/monad-mcp-chorus-sim/tests/chorus.rs
@@ -21,7 +21,7 @@ use chorus::{
     CadenceDriverMsg,
     conductor::{ConductorConfig, MonadConductor, acs::nop::NopAcs},
     slot::chorus::{Chorus, ChorusConfig, ChorusContext},
-    types::{DAHandle, NodeId, SlotDeadline, Stake, TimestampDelta, ValidatorData},
+    types::{HeaderAuth, NodeId, SlotDeadline, Stake, TimestampDelta, ValidatorData},
 };
 use helper::expect_finalized_at;
 use monad_mcp_chorus::{spec::KeyPair as _, stub as chorus};
@@ -54,7 +54,7 @@ fn add_node(builder: &mut CadenceSwarmBuilder<DummyMsg>, id: u64, val_data: &Arc
         node_id,
         key: Arc::new(node_id.keypair()),
         validator_data: val_data.clone(),
-        da_handle: Arc::new(DAHandle),
+        header_auth: Arc::new(HeaderAuth::new(|_, _| None)),
     };
     let config = ChorusConfig {
         delta: DELTA,

--- a/monad-mcp-chorus-sim/tests/fallback_mvba.rs
+++ b/monad-mcp-chorus-sim/tests/fallback_mvba.rs
@@ -92,9 +92,7 @@ mod fixtures {
     /// give two metablocks that cannot be confused for one another
     pub fn fast_metablock(seed: u64, validator_data: &ValidatorData) -> Metablock {
         Metablock::new(ProposalMap::new(NUM_PROPOSALS, |j| {
-            let entry = Entry::Positive {
-                root: MerkleRoot(seed * 100 + j as u64),
-            };
+            let entry = Entry::Positive(MerkleRoot(seed * 100 + j as u64));
             CertifiedEntry::FastQc(strong_qc((SLOT, j), entry, &quorum(), validator_data))
         }))
     }
@@ -104,9 +102,7 @@ mod fixtures {
     /// differ only in their evidence
     pub fn mixed_evidence_metablock(seed: u64, validator_data: &ValidatorData) -> Metablock {
         Metablock::new(ProposalMap::new(NUM_PROPOSALS, |j| {
-            let entry = Entry::Positive {
-                root: MerkleRoot(seed * 100 + j as u64),
-            };
+            let entry = Entry::Positive(MerkleRoot(seed * 100 + j as u64));
             if j == 0 {
                 CertifiedEntry::FallbackQc(weak_qc(
                     (SLOT, j),

--- a/monad-mcp-chorus-sim/tests/fallback_mvba.rs
+++ b/monad-mcp-chorus-sim/tests/fallback_mvba.rs
@@ -30,19 +30,27 @@ mod fixtures {
     use std::{collections::HashMap, sync::Arc};
 
     use chorus::{
+        env::MerkleHash,
         slot::fallback::{
             CertifiedEntry, EnterFallbackCert, EnterFallbackVote, Entry, FallbackEntry, Metablock,
             Mvba as _, monad_mvba::MvbaContext,
         },
         types::{
-            IsVote, MerkleRoot, NodeId, ProposalMap, Slot, Stake, StrongQc, TimestampDelta,
-            ValidatorData, VoteMsg, VotePool, WeakQc,
+            HeaderAuth, IsVote, MerkleRoot, NodeId, ProposalMap, Slot, Stake, StrongQc,
+            TimestampDelta, ValidatorData, VoteMsg, VotePool, WeakQc,
         },
     };
     use monad_mcp_chorus::{spec::KeyPair as _, stub as chorus};
     use monad_mcp_chorus_sim::MonadMvba;
 
     const NUM_NODES: u64 = 4;
+
+    /// A root whose hash spells out `n`, so distinct seeds give distinct roots
+    fn root(n: u64) -> MerkleRoot {
+        let mut hash = [0u8; 20];
+        hash[..8].copy_from_slice(&n.to_le_bytes());
+        MerkleRoot(MerkleHash(hash))
+    }
     const NUM_PROPOSALS: usize = 2;
     const SLOT: Slot = Slot(0);
     pub const DELTA: TimestampDelta = TimestampDelta::from_millis(super::DELTA_MILLIS);
@@ -84,6 +92,7 @@ mod fixtures {
             node_id: node,
             key: Arc::new(node.keypair()),
             validator_data: validator_data.clone(),
+            header_auth: Arc::new(HeaderAuth::new(|_, _| None)),
             delta: DELTA,
         })
     }
@@ -92,7 +101,7 @@ mod fixtures {
     /// give two metablocks that cannot be confused for one another
     pub fn fast_metablock(seed: u64, validator_data: &ValidatorData) -> Metablock {
         Metablock::new(ProposalMap::new(NUM_PROPOSALS, |j| {
-            let entry = Entry::Positive(MerkleRoot(seed * 100 + j as u64));
+            let entry = Entry::Positive(root(seed * 100 + j as u64));
             CertifiedEntry::FastQc(strong_qc((SLOT, j), entry, &quorum(), validator_data))
         }))
     }
@@ -102,7 +111,7 @@ mod fixtures {
     /// differ only in their evidence
     pub fn mixed_evidence_metablock(seed: u64, validator_data: &ValidatorData) -> Metablock {
         Metablock::new(ProposalMap::new(NUM_PROPOSALS, |j| {
-            let entry = Entry::Positive(MerkleRoot(seed * 100 + j as u64));
+            let entry = Entry::Positive(root(seed * 100 + j as u64));
             if j == 0 {
                 CertifiedEntry::FallbackQc(weak_qc(
                     (SLOT, j),

--- a/monad-mcp-chorus/src/conductor/mod.rs
+++ b/monad-mcp-chorus/src/conductor/mod.rs
@@ -156,7 +156,7 @@ impl ConductorConfig {
         }
 
         let offset = slot
-            .checked_sub(slot_start)
+            .slots_since(slot_start)
             .ok_or(ConductorError::ArithmeticOverflow)?;
         first_deadline
             .checked_add_deltas(self.slot_interval, offset)
@@ -201,7 +201,7 @@ impl CompletionTracker {
     // Number of slots in `[cap, open_slot_cap)` not yet completed.
     fn open_slot_count(&self, open_slot_cap: Slot) -> Result<u64, ConductorError> {
         open_slot_cap
-            .checked_sub(self.cap)
+            .slots_since(self.cap)
             .and_then(|tracked| tracked.checked_sub(self.completed.len() as u64))
             .ok_or(ConductorError::ArithmeticOverflow)
     }

--- a/monad-mcp-chorus/src/env/stub.rs
+++ b/monad-mcp-chorus/src/env/stub.rs
@@ -116,11 +116,11 @@ mod validator {
             }
         }
 
-        pub(super) fn indices(&self) -> &HashMap<NodeId, usize> {
+        pub(crate) fn indices(&self) -> &HashMap<NodeId, usize> {
             &self.indices
         }
 
-        pub(super) fn get_node(&self, index: usize) -> Option<&NodeId> {
+        pub(crate) fn get_node(&self, index: usize) -> Option<&NodeId> {
             self.sorted.get(index)
         }
     }

--- a/monad-mcp-chorus/src/env/stub.rs
+++ b/monad-mcp-chorus/src/env/stub.rs
@@ -181,28 +181,87 @@ mod validator {
 }
 
 mod proposal {
-    use crate::spec;
+    use super::NodeId;
+    use crate::{
+        spec,
+        stub::types::{ProposalIndex, Slot},
+    };
 
     #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-    pub struct MerkleRoot(pub u64);
+    pub struct MerkleHash(pub [u8; 20]);
 
-    impl spec::proposal::MerkleRoot for MerkleRoot {}
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+    pub struct MerkleRoot(pub MerkleHash);
+    impl spec::MerkleRoot for MerkleRoot {}
+
+    // stub proposal signature, opaque to consensus
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+    pub struct ProposalSignature(pub u64);
+
+    // the encoding scheme descriptor used by DA. opaque to consensus.
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+    pub enum EncodingScheme {
+        D25(D25),
+    }
+
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+    pub struct D25 {
+        pub msg_len: usize,
+        pub unix_ts: u64,
+    }
 
     #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-    pub struct ProposalSignature;
+    pub struct ProposalHeader {
+        pub slot: Slot,
+        pub root: MerkleRoot,
 
-    impl spec::proposal::ProposalSignature for ProposalSignature {}
+        // DA-owned fields. defined here rather than in DA because we
+        // don't want chorus to depend on DA.
+        // todo: we may extract a monad-mcp-da-types crate and depend
+        // on it from monad-mcp-chorus and monad-mcp-da.
+        pub sig: ProposalSignature,
+        pub scheme: EncodingScheme,
+    }
 
-    #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-    pub struct OpaqueChunkHeader;
-
-    impl spec::proposal::ChunkHeader for OpaqueChunkHeader {
+    impl spec::ProposalHeader for ProposalHeader {
         type Root = MerkleRoot;
-        type Sig = ProposalSignature;
 
-        fn validate(&self, _root: &MerkleRoot, _sig: &ProposalSignature) -> bool {
-            // stubbed to always return true for testing purpose
-            true
+        fn slot(&self) -> u64 {
+            self.slot.0
+        }
+
+        fn root(&self) -> &MerkleRoot {
+            &self.root
+        }
+    }
+
+    type ProposerElection = dyn Fn(u64, &NodeId) -> Option<ProposalIndex> + Send + Sync;
+
+    pub struct HeaderAuth {
+        // todo: change to Box<dyn ProposerElection> after moving this to shared types crate.
+        proposer_election: Box<ProposerElection>,
+    }
+
+    impl HeaderAuth {
+        pub fn new<F>(proposer_index: F) -> Self
+        where
+            F: Fn(u64, &NodeId) -> Option<ProposalIndex> + Send + Sync + 'static,
+        {
+            Self {
+                proposer_election: Box::new(proposer_index),
+            }
+        }
+    }
+
+    impl spec::proposal::HeaderAuth for HeaderAuth {
+        type Header = ProposalHeader;
+
+        fn authenticate(&self, header: &ProposalHeader, slot: u64) -> Option<ProposalIndex> {
+            if header.slot.get() != slot {
+                return None;
+            }
+            let signer = NodeId::dummy(header.sig.0);
+            (self.proposer_election)(slot, &signer)
         }
     }
 }
@@ -452,6 +511,6 @@ const _: () = crate::spec::assert_env::<
     SignatureCollection,
     VoteAggregation<'_>,
     MerkleRoot,
-    ProposalSignature,
-    OpaqueChunkHeader,
+    ProposalHeader,
+    HeaderAuth,
 >();

--- a/monad-mcp-chorus/src/env/stub.rs
+++ b/monad-mcp-chorus/src/env/stub.rs
@@ -66,6 +66,12 @@ mod validator {
         fn honest_threshold(&self) -> Self {
             Self(self.0 / 3)
         }
+
+        fn obligation(&self, total: &Self, shares: usize) -> (usize, usize) {
+            let prod = self.0 as u128 * shares as u128;
+            let total = total.0 as u128;
+            ((prod / total) as usize, (prod % total) as usize)
+        }
     }
 
     // invariant: valset/mapping have exactly the same key set, and
@@ -132,6 +138,10 @@ mod validator {
 
         fn nodes(&self) -> impl Iterator<Item = &NodeId> {
             self.sorted.iter()
+        }
+
+        fn len(&self) -> usize {
+            self.sorted.len()
         }
 
         fn contains(&self, node_id: &NodeId) -> bool {

--- a/monad-mcp-chorus/src/runtime.rs
+++ b/monad-mcp-chorus/src/runtime.rs
@@ -42,12 +42,15 @@ where
     conductor: C,
     driver: D,
     observer: Option<Box<ObserverOf<S>>>,
+    da_sink: Option<Box<DASinkOf<S>>>,
 }
 
 type ObserverOf<S> = dyn FinalizationObserver<
         <S as SlotConsensus>::OptimisticCommitData,
         <S as SlotConsensus>::FinalizationData,
     >;
+
+type DASinkOf<S> = dyn DASink<<S as SlotConsensus>::DACommand>;
 
 impl<S, C> CadenceRuntime<S, C>
 where
@@ -61,6 +64,7 @@ where
             conductor,
             driver: CadenceDriver::default(),
             observer: None,
+            da_sink: None,
         }
     }
 
@@ -73,6 +77,7 @@ where
             slot_manager: self.slot_manager,
             conductor: self.conductor,
             observer: self.observer,
+            da_sink: self.da_sink,
             driver,
         }
     }
@@ -91,10 +96,28 @@ where
         self.observer = Some(Box::new(observer));
     }
 
+    pub fn on_da(&mut self, sink: impl DASink<S::DACommand> + 'static) {
+        self.da_sink = Some(Box::new(sink));
+    }
+
     // in actual runtime this can be controlled by the system clock.
     pub fn advance_clock(&mut self, now: Timestamp) {
         assert!(now >= self.clock);
         self.clock = now;
+    }
+
+    // Inject a data-availability event into the slot's consensus
+    // instance. DA events are local and trusted by construction.
+    pub fn handle_da_event(&mut self, now: Timestamp, slot: Slot, event: S::DAEvent) {
+        self.advance_clock(now);
+
+        if let Some(instance) = self.slot_manager.slot_instance(slot) {
+            // q: do we need to buffer the da events? da begins to
+            // accept chunk ingestion at the same time as slot
+            // consensus, which normally is already conservative.
+            instance.handle_da_event(event);
+        }
+        self.step();
     }
 
     fn step(&mut self) {
@@ -117,6 +140,11 @@ where
                 SlotOutput::Unicast { to, message } => {
                     self.driver.unicast_slot(slot, to, message);
                 }
+                SlotOutput::DA(action) => {
+                    if let Some(sink) = &mut self.da_sink {
+                        sink.handle_command(slot, action);
+                    }
+                }
                 SlotOutput::CommitOptimistic(data) => {
                     if let Some(observer) = &mut self.observer {
                         observer.handle_optimistic_commit(now, slot, &data);
@@ -126,11 +154,17 @@ where
                     if let Some(observer) = &mut self.observer {
                         observer.handle_finalization(now, slot, &data);
                     }
+                    if let Some(sink) = &mut self.da_sink {
+                        sink.handle_lifecycle(slot, SlotLifecycle::Completed);
+                    }
                     self.conductor.handle_slot_finalization(now, slot);
                     self.slot_manager.close(slot);
                 }
                 SlotOutput::Fault { reason } => {
                     tracing::warn!(?slot, reason = %reason, "slot faulted");
+                    if let Some(sink) = &mut self.da_sink {
+                        sink.handle_lifecycle(slot, SlotLifecycle::Completed);
+                    }
                     self.slot_manager.close(slot);
                 }
             }
@@ -152,6 +186,9 @@ where
                     for (slot, deadline) in slots {
                         self.slot_manager.open(slot);
                         self.driver.schedule_slot_deadline(slot, deadline);
+                        if let Some(sink) = &mut self.da_sink {
+                            sink.handle_lifecycle(slot, SlotLifecycle::Opened);
+                        }
                     }
                 }
             }
@@ -216,6 +253,17 @@ where
         self.driver.handle_message(message);
         self.step();
     }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SlotLifecycle {
+    Opened,
+    Completed,
+}
+
+pub trait DASink<A> {
+    fn handle_lifecycle(&mut self, slot: Slot, event: SlotLifecycle);
+    fn handle_command(&mut self, slot: Slot, action: A);
 }
 
 pub trait FinalizationObserver<OD, FD> {

--- a/monad-mcp-chorus/src/slot/availability.rs
+++ b/monad-mcp-chorus/src/slot/availability.rs
@@ -1,0 +1,205 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::{HashMap, HashSet};
+
+use super::{
+    chorus::ProposalDAEvent,
+    types::{EquivCert, MerkleRoot, ProposalHeader},
+};
+
+// (slot, j)-scoped proposal availability state, built from DA events.
+#[derive(Clone, Default)]
+pub(crate) struct ProposalAvailability {
+    // seen signed headers
+    headers: HashMap<MerkleRoot, ProposalHeader>,
+
+    // proposals for which all our own chunks have been received from
+    // the author.
+    author_fulfilled: Vec<MerkleRoot>,
+
+    // proposals that have been successfully decoded.
+    decoded: HashSet<MerkleRoot>,
+
+    // proposals whose decoding or re-encoding failed.
+    invalid: HashSet<MerkleRoot>,
+}
+
+impl ProposalAvailability {
+    // the equivocation certificate a newly seen header forms, if any
+    pub fn ingest(&mut self, event: ProposalDAEvent) -> Option<EquivCert> {
+        match event {
+            ProposalDAEvent::HeaderSeen(header) => return self.record_header(header),
+            ProposalDAEvent::ProposerObligationFulfilled(root) => {
+                if !self.author_fulfilled.contains(&root) {
+                    self.author_fulfilled.push(root);
+                }
+            }
+            ProposalDAEvent::Decoded(root) => {
+                self.decoded.insert(root);
+                // decoding implies possession of every chunk, our own
+                // author-assigned ones included
+                if !self.author_fulfilled.contains(&root) {
+                    self.author_fulfilled.push(root);
+                }
+            }
+            ProposalDAEvent::OwnerObligationFulfilled { .. } => {
+                // handled in GatedVotePool
+            }
+            ProposalDAEvent::DecodingFailed(root) => {
+                self.invalid.insert(root);
+            }
+        }
+        None
+    }
+
+    // invariant: every recorded header is authenticated, so any two
+    // with distinct roots form an equivocation certificate. The
+    // certificate is formed once, by the second distinct root.
+    pub fn record_header(&mut self, header: ProposalHeader) -> Option<EquivCert> {
+        if self.headers.contains_key(&header.root) {
+            return None;
+        }
+        let rival = match self.headers.len() {
+            1 => self.headers.values().next().cloned(),
+            _ => None,
+        };
+        self.headers.insert(header.root, header.clone());
+        Some(EquivCert(rival?, header))
+    }
+
+    // The proposal to vote positively on at D_s: the first root
+    // whose author obligation was fulfilled.
+    pub fn fetch_proposal(&self) -> Option<&ProposalHeader> {
+        let root = self.author_fulfilled.first()?;
+        self.headers.get(root)
+    }
+
+    pub fn decoded(&self, root: &MerkleRoot) -> bool {
+        self.decoded.contains(root)
+    }
+
+    // whether all our own chunks under root arrived
+    pub fn author_fulfilled(&self, root: &MerkleRoot) -> bool {
+        self.author_fulfilled.contains(root)
+    }
+
+    pub fn is_resolved(&self, root: &MerkleRoot) -> bool {
+        self.decoded.contains(root) || self.invalid.contains(root)
+    }
+
+    pub fn header_for(&self, root: &MerkleRoot) -> Option<&ProposalHeader> {
+        self.headers.get(root)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::env::stub::{D25, EncodingScheme, MerkleHash, ProposalSignature};
+
+    fn root(byte: u8) -> MerkleRoot {
+        MerkleRoot(MerkleHash([byte; 20]))
+    }
+
+    fn header(byte: u8) -> ProposalHeader {
+        ProposalHeader {
+            slot: crate::stub::types::Slot(1),
+            root: root(byte),
+            sig: ProposalSignature(0),
+            scheme: EncodingScheme::D25(D25 {
+                msg_len: 0,
+                unix_ts: 0,
+            }),
+        }
+    }
+
+    #[test]
+    fn fetch_proposal_returns_first_fulfilled_root() {
+        let mut avail = ProposalAvailability::default();
+
+        assert!(avail.fetch_proposal().is_none());
+        avail.ingest(ProposalDAEvent::HeaderSeen(header(1)));
+        // header alone is not enough to vote positively
+        assert!(avail.fetch_proposal().is_none());
+
+        avail.ingest(ProposalDAEvent::ProposerObligationFulfilled(root(1)));
+        assert_eq!(avail.fetch_proposal(), Some(&header(1)));
+
+        // a later fulfillment does not displace the vote target
+        avail.ingest(ProposalDAEvent::HeaderSeen(header(2)));
+        avail.ingest(ProposalDAEvent::ProposerObligationFulfilled(root(2)));
+        assert_eq!(avail.fetch_proposal(), Some(&header(1)));
+    }
+
+    #[test]
+    fn conflicting_headers_form_equivocation_cert() {
+        let mut avail = ProposalAvailability::default();
+
+        assert!(
+            avail
+                .ingest(ProposalDAEvent::HeaderSeen(header(1)))
+                .is_none()
+        );
+        // repeated root is not a conflict
+        assert!(avail.record_header(header(1)).is_none());
+
+        let cert = avail.record_header(header(2));
+        let EquivCert(a, b) = cert.expect("distinct roots conflict");
+        assert!(a.root != b.root);
+
+        // a third root adds no evidence
+        assert!(avail.record_header(header(3)).is_none());
+
+        // both headers remain queryable
+        assert_eq!(avail.header_for(&root(1)), Some(&header(1)));
+        assert_eq!(avail.header_for(&root(2)), Some(&header(2)));
+    }
+
+    #[test]
+    fn decoded_implies_positive_vote_target() {
+        let mut avail = ProposalAvailability::default();
+
+        avail.ingest(ProposalDAEvent::HeaderSeen(header(1)));
+        avail.ingest(ProposalDAEvent::Decoded(root(1)));
+
+        assert_eq!(avail.fetch_proposal(), Some(&header(1)));
+    }
+
+    #[test]
+    fn resolved_by_decode_or_failure() {
+        let mut avail = ProposalAvailability::default();
+
+        assert!(!avail.is_resolved(&root(1)));
+        avail.ingest(ProposalDAEvent::Decoded(root(1)));
+        avail.ingest(ProposalDAEvent::DecodingFailed(root(2)));
+
+        assert!(avail.is_resolved(&root(1)));
+        assert!(avail.is_resolved(&root(2)));
+        assert!(!avail.decoded(&root(2)));
+        assert!(!avail.is_resolved(&root(3)));
+    }
+
+    #[test]
+    fn decoded_is_root_scoped() {
+        let mut avail = ProposalAvailability::default();
+
+        assert!(!avail.decoded(&root(1)));
+        avail.ingest(ProposalDAEvent::Decoded(root(1)));
+
+        assert!(avail.decoded(&root(1)));
+        assert!(!avail.decoded(&root(2)));
+    }
+}

--- a/monad-mcp-chorus/src/slot/chorus.rs
+++ b/monad-mcp-chorus/src/slot/chorus.rs
@@ -27,7 +27,8 @@ use super::{
         FastCommitQc, FastCommitVoteMsg, FastPath,
     },
     types::{
-        DAHandle, KeyPair, NodeId, ProposalIndex, ProposalMeta, Slot, TimestampDelta, ValidatorData,
+        HeaderAuth, KeyPair, MerkleRoot, NodeId, ProposalHeader, ProposalIndex, Slot,
+        TimestampDelta, ValidatorData,
     },
 };
 
@@ -35,15 +36,6 @@ use super::{
 type FallbackState = MonadMvba<Metablock, EnterFallbackCert>;
 type FallbackMessage = monad_mvba::MvbaMessage<Metablock, EnterFallbackCert>;
 type FallbackTimer = monad_mvba::TimerEvent<Metablock>;
-
-// emitted from the DA layer upon validating a proposal
-// chunk. possibly only emitted after a significant fraction of
-// the chunks for first-hop-recipient is available.
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub struct Proposal {
-    pub j: ProposalIndex,
-    pub meta: ProposalMeta,
-}
 
 #[derive(derive_more::From, Clone, PartialEq, Eq, Hash, Debug)]
 #[non_exhaustive]
@@ -97,7 +89,7 @@ pub struct ChorusContext {
     pub node_id: NodeId,
     pub key: Arc<KeyPair>,
     pub validator_data: Arc<ValidatorData>,
-    pub da_handle: Arc<DAHandle>,
+    pub header_auth: Arc<HeaderAuth>,
 }
 
 #[derive(derive_more::From, Clone, PartialEq, Eq, Hash, Debug)]
@@ -108,10 +100,74 @@ pub enum SlotFinalization {
     Fallback(FallbackCommitQc<Metablock>),
 }
 
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct ChorusDAEvent {
+    pub j: ProposalIndex,
+    pub event: ProposalDAEvent,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum ProposalDAEvent {
+    // a validated proposer-signed header observed (once per root)
+    HeaderSeen(ProposalHeader),
+
+    // all our own assigned chunks under the root have arrived
+    ProposerObligationFulfilled(MerkleRoot),
+
+    // the owner's rebroadcast obligation to us fulfilled under the root
+    OwnerObligationFulfilled { owner: NodeId, root: MerkleRoot },
+
+    // decode-then-re-encode verified. implies all chunks recoverable
+    // from DA.
+    Decoded(MerkleRoot),
+    DecodingFailed(MerkleRoot),
+}
+
+// An effect directed at the DA layer. Roots named here are pinned by DA.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum ChorusDACommand {
+    // release the slot's chunks to peers: rebroadcast our owned
+    // chunks, held and arriving, and serve chunk recovery requests.
+    ReleaseChunks,
+
+    // keep the root's chunks admitted
+    PinRoot {
+        j: ProposalIndex,
+        root: MerkleRoot,
+    },
+
+    // request chunks of the type under (j, root) from its voters:
+    // their own chunks to decode the proposal, or our own chunks from
+    // positive fallback signers, who hold the decoded proposal.
+    RecoverChunks {
+        j: ProposalIndex,
+        root: MerkleRoot,
+        request_type: ChunkRequestType,
+        voters: Vec<NodeId>,
+    },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum ChunkRequestType {
+    MyChunks,
+    YourChunks,
+}
+
+impl ChunkRequestType {
+    // whose chunks the request names, seen from the requester
+    pub fn owner<T: Copy>(self, requester: T, peer: T) -> T {
+        match self {
+            Self::MyChunks => requester,
+            Self::YourChunks => peer,
+        }
+    }
+}
+
 /// The single-slot MCP consensus algorithm from the paper.
 pub struct Chorus {
     slot: Slot,
     key: Arc<KeyPair>,
+    validator_data: Arc<ValidatorData>,
 
     fast: FastPath,
     /// memory is unbounded until this validator proposes into it: the MVBA
@@ -135,6 +191,8 @@ impl SlotConsensus for Chorus {
     type Timer = TimerEvent;
     type OptimisticCommitData = FastBlock;
     type FinalizationData = SlotFinalization;
+    type DAEvent = ChorusDAEvent;
+    type DACommand = ChorusDACommand;
 
     fn new(slot: Slot, config: &Self::Config, context: &Self::Context) -> Self {
         let ChorusConfig {
@@ -145,7 +203,7 @@ impl SlotConsensus for Chorus {
             node_id,
             key,
             validator_data,
-            da_handle,
+            header_auth,
         } = context;
 
         let fast = FastPath::new(
@@ -153,7 +211,7 @@ impl SlotConsensus for Chorus {
             *num_proposals,
             key.clone(),
             validator_data.clone(),
-            da_handle.clone(),
+            header_auth.clone(),
         );
 
         let fallback = FallbackState::new(MvbaContext {
@@ -163,12 +221,14 @@ impl SlotConsensus for Chorus {
             node_id: *node_id,
             key: key.clone(),
             validator_data: validator_data.clone(),
+            header_auth: header_auth.clone(),
         });
 
         Self {
             slot,
             delta: *delta,
             key: key.clone(),
+            validator_data: validator_data.clone(),
             fast,
             fallback,
             outputs: Default::default(),
@@ -180,6 +240,18 @@ impl SlotConsensus for Chorus {
         self.outputs.pop_front()
     }
 
+    fn handle_da_event(&mut self, event: ChorusDAEvent) {
+        if self.decided {
+            return;
+        }
+
+        if let Some(fast_block) = self.fast.handle_da_event(event) {
+            self.commit_fast_block(fast_block);
+        }
+
+        self.drain_da_commands();
+    }
+
     fn handle_message(&mut self, author: NodeId, message: Self::Message) {
         if self.decided {
             return;
@@ -188,24 +260,18 @@ impl SlotConsensus for Chorus {
         match message {
             Message::BatchVote(batch_vote_msg) => {
                 if let Some(fast_block) = self.fast.handle_batch_vote(author, batch_vote_msg) {
-                    let commit_vote = fast_block.commit_vote(self.slot, &self.key);
-                    self.push(SlotOutput::CommitOptimistic(fast_block.clone()));
-                    self.broadcast(commit_vote);
-                    self.broadcast(fast_block);
+                    self.commit_fast_block(fast_block);
                 }
             }
             Message::FastCommitVote(fast_commit_vote) => {
                 if let Some(fast_qc) = self.fast.handle_commit_vote(author, fast_commit_vote) {
-                    self.broadcast(fast_qc.clone());
-                    self.finalize(fast_qc);
+                    self.finalize_fast(fast_qc);
                 }
             }
 
             Message::FastBlock(fast_block) => {
                 if let Some(fast_block) = self.fast.handle_fast_block(fast_block) {
-                    let commit_vote = fast_block.commit_vote(self.slot, &self.key);
-                    self.push(SlotOutput::CommitOptimistic(fast_block));
-                    self.broadcast(commit_vote);
+                    self.commit_fast_block(fast_block);
                 }
             }
 
@@ -213,7 +279,11 @@ impl SlotConsensus for Chorus {
                 self.fast.handle_fallback_vote(author, fallback_vote_msg);
             }
             Message::FastCommitQc(qc) => {
-                self.finalize(qc);
+                let scope_matches = qc.scope == self.slot;
+                if !scope_matches || !qc.verify(&self.validator_data) {
+                    return;
+                }
+                self.finalize_fast(qc);
             }
             Message::EnterFallbackCert(cert) => {
                 // a peer certified that 2f+1 validators entered
@@ -239,6 +309,8 @@ impl SlotConsensus for Chorus {
                 self.drain_fallback();
             }
         }
+
+        self.drain_da_commands();
     }
 
     fn handle_deadline(&mut self) {
@@ -248,9 +320,11 @@ impl SlotConsensus for Chorus {
 
         self.schedule_timer(self.delta, TimerEvent::FallbackTransitionTimeout);
 
-        if let Some(batch_vote) = self.fast.on_propose_deadline() {
+        if let Some(batch_vote) = self.fast.on_deadline() {
             self.broadcast(batch_vote);
         }
+
+        self.drain_da_commands();
     }
 
     fn handle_timer(&mut self, event: Self::Timer) {
@@ -287,10 +361,33 @@ impl SlotConsensus for Chorus {
                 self.drain_fallback();
             }
         }
+
+        self.drain_da_commands();
     }
 }
 
 impl Chorus {
+    // speculatively commit a newly completed fast block, cast our
+    // commit vote, and disseminate the block for peers to adopt
+    fn commit_fast_block(&mut self, fast_block: FastBlock) {
+        let commit_vote = fast_block.commit_vote(self.slot, &self.key);
+        self.push(SlotOutput::CommitOptimistic(fast_block.clone()));
+        self.broadcast(commit_vote);
+        self.broadcast(fast_block);
+    }
+
+    // finalize on a fast commit certificate
+    fn finalize_fast(&mut self, qc: FastCommitQc) {
+        self.broadcast(qc.clone());
+        self.finalize(qc);
+    }
+
+    fn drain_da_commands(&mut self) {
+        while let Some(command) = self.fast.next_da_command() {
+            self.push(SlotOutput::DA(command));
+        }
+    }
+
     // helpers mostly for documentation purpose
     fn broadcast(&mut self, msg: impl Into<Message>) {
         self.push(SlotOutput::Broadcast(msg.into()));
@@ -345,5 +442,54 @@ impl Chorus {
 
     fn push(&mut self, out: SlotOutput<Chorus>) {
         self.outputs.push_back(out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::{
+        super::types::{HeaderAuth, NodeId, Slot, Stake, TimestampDelta, ValidatorData},
+        *,
+    };
+    use crate::spec::vote::KeyPair as _;
+
+    fn validator_data(n: u64) -> ValidatorData {
+        let validators = (0..n).map(NodeId::dummy).collect::<Vec<_>>();
+        let valset = validators.iter().map(|id| (*id, Stake::from(1))).collect();
+        let mapping = validators
+            .iter()
+            .map(|id| (*id, id.keypair().pubkey()))
+            .collect();
+
+        ValidatorData::new(valset, mapping)
+    }
+
+    #[test]
+    fn deadline_releases_chunks() {
+        let config = ChorusConfig {
+            delta: TimestampDelta::from_millis(100),
+            num_proposals: 2,
+        };
+        let context = ChorusContext {
+            node_id: NodeId::dummy(0),
+            key: Arc::new(NodeId::dummy(0).keypair()),
+            validator_data: Arc::new(validator_data(4)),
+            header_auth: Arc::new(HeaderAuth::new(|_, _| None)),
+        };
+        let mut chorus = Chorus::new(Slot(1), &config, &context);
+
+        chorus.handle_deadline();
+
+        let mut commands = Vec::new();
+        while let Some(output) = chorus.poll() {
+            if let SlotOutput::DA(command) = output {
+                commands.push(command);
+            }
+        }
+
+        // nothing is available, so the all-negative vote pins no root
+        assert_eq!(commands, vec![ChorusDACommand::ReleaseChunks]);
     }
 }

--- a/monad-mcp-chorus/src/slot/chorus.rs
+++ b/monad-mcp-chorus/src/slot/chorus.rs
@@ -376,9 +376,12 @@ impl Chorus {
         self.broadcast(fast_block);
     }
 
-    // finalize on a fast commit certificate
+    // finalize on a fast commit certificate. the slot closes on
+    // finalization, so committed roots are pulled first.
     fn finalize_fast(&mut self, qc: FastCommitQc) {
         self.broadcast(qc.clone());
+        self.fast.recover_committed(&qc);
+        self.drain_da_commands();
         self.finalize(qc);
     }
 
@@ -491,5 +494,53 @@ mod tests {
 
         // nothing is available, so the all-negative vote pins no root
         assert_eq!(commands, vec![ChorusDACommand::ReleaseChunks]);
+    }
+
+    #[test]
+    fn commit_certificate_pulls_before_finalizing() {
+        use super::super::{
+            fast::{Entry, FastCommitVote},
+            types::{MerkleRoot, ProposalMap, VoteMsg, VotePool},
+        };
+        use crate::env::stub::MerkleHash;
+
+        let config = ChorusConfig {
+            delta: TimestampDelta::from_millis(100),
+            num_proposals: 1,
+        };
+        let context = ChorusContext {
+            node_id: NodeId::dummy(1),
+            key: Arc::new(NodeId::dummy(1).keypair()),
+            validator_data: Arc::new(validator_data(4)),
+            header_auth: Arc::new(HeaderAuth::new(|_, _| None)),
+        };
+        let mut chorus = Chorus::new(Slot(1), &config, &context);
+
+        // a commit qc on an undecoded root, signed by validators 0, 2, 3
+        let root = MerkleRoot(MerkleHash([1; 20]));
+        let entries = ProposalMap::new(1, |_| Entry::Positive(root));
+        let mut pool = VotePool::new(Slot(1));
+        for id in [0, 2, 3] {
+            let voter = NodeId::dummy(id);
+            let vote = FastCommitVote {
+                entries: entries.clone(),
+            };
+            pool.add_vote(voter, VoteMsg::new_signed(Slot(1), vote, &voter.keypair()));
+        }
+        let qc = pool
+            .try_form_strong_qc(&context.validator_data)
+            .expect("three of four votes form a commit qc");
+        chorus.handle_message(NodeId::dummy(0), Message::FastCommitQc(qc));
+
+        // the pull is emitted before the finalization that closes the slot
+        let mut order = Vec::new();
+        while let Some(output) = chorus.poll() {
+            match output {
+                SlotOutput::DA(ChorusDACommand::RecoverChunks { .. }) => order.push("pull"),
+                SlotOutput::Finalize(_) => order.push("finalize"),
+                _ => {}
+            }
+        }
+        assert_eq!(order, ["pull", "finalize"]);
     }
 }

--- a/monad-mcp-chorus/src/slot/dummy.rs
+++ b/monad-mcp-chorus/src/slot/dummy.rs
@@ -64,6 +64,8 @@ impl SlotConsensus for DummySlotConsensus {
     type Timer = ();
     type OptimisticCommitData = ();
     type FinalizationData = ();
+    type DAEvent = ();
+    type DACommand = ();
 
     fn new(slot: Slot, config: &Self::Config, key: &Arc<KeyPair>) -> Self {
         Self {

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/metablock.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/metablock.rs
@@ -17,7 +17,7 @@ use super::{
     super::{
         super::{
             fast::{CertifiedEntry, Entry},
-            types::{ProposalIndex, ProposalMap, Slot, ValidatorData},
+            types::{HeaderAuth, ProposalIndex, ProposalMap, Slot, ValidatorData},
         },
         Metablock, ValidateInput, Votable,
     },
@@ -31,6 +31,7 @@ impl Metablock {
         &self,
         slot: Slot,
         num_proposals: usize,
+        header_auth: &HeaderAuth,
         validator_data: &ValidatorData,
     ) -> bool {
         if self.0.size() != num_proposals {
@@ -41,7 +42,7 @@ impl Metablock {
             .as_ref()
             .into_iter()
             .enumerate()
-            .all(|(j, cert)| certified_entry_is_valid(cert, slot, j, validator_data))
+            .all(|(j, cert)| certified_entry_is_valid(cert, slot, j, header_auth, validator_data))
     }
 
     /// The paper's *fast metablock*: every entry a `FastQc`
@@ -62,7 +63,12 @@ impl ValidateInput for Metablock {
     type Context = ValidationContext;
 
     fn validate(&self, context: &Self::Context) -> bool {
-        self.is_valid(context.slot, context.num_proposals, &context.validator_data)
+        self.is_valid(
+            context.slot,
+            context.num_proposals,
+            &context.header_auth,
+            &context.validator_data,
+        )
     }
 
     fn fbcert_optional(&self) -> bool {
@@ -83,15 +89,16 @@ fn certified_entry_is_valid(
     cert: &CertifiedEntry,
     slot: Slot,
     j: ProposalIndex,
+    header_auth: &HeaderAuth,
     validator_data: &ValidatorData,
 ) -> bool {
     let bound_to_proposer = match cert {
         CertifiedEntry::FastQc(qc) => qc.scope == (slot, j),
         CertifiedEntry::FallbackQc(qc) => qc.scope == (slot, j),
-        // an EquivCert's binding to (slot, j) sits inside the opaque chunk
-        // header, which only `CertifiedEntry::verify` can check
+        // an EquivCert's binding to (slot, j) is checked by `verify`, which
+        // authenticates both headers against the scope
         CertifiedEntry::EquivCert(_) => true,
     };
 
-    bound_to_proposer && cert.verify(validator_data)
+    bound_to_proposer && cert.verify((slot, j), header_auth, validator_data)
 }

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/mod.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/mod.rs
@@ -74,7 +74,9 @@ use phases::{Decided, Phase, Transition};
 use super::{
     super::{
         fast::EnterFallbackCert,
-        types::{IsVote, KeyPair, NodeId, Slot, TimestampDelta, ValidatorData, VoteMsg},
+        types::{
+            HeaderAuth, IsVote, KeyPair, NodeId, Slot, TimestampDelta, ValidatorData, VoteMsg,
+        },
     },
     FallbackView, MVBAOutput, Metablock, Mvba, ValidateCert, ValidateInput, Votable,
 };
@@ -98,6 +100,7 @@ pub struct MvbaContext {
     pub node_id: NodeId,
     pub key: Arc<KeyPair>,
     pub validator_data: Arc<ValidatorData>,
+    pub header_auth: Arc<HeaderAuth>,
 }
 
 impl MvbaContext {
@@ -139,6 +142,7 @@ pub struct ValidationContext {
     pub slot: Slot,
     pub num_proposals: usize,
     pub validator_data: Arc<ValidatorData>,
+    pub header_auth: Arc<HeaderAuth>,
 }
 
 /// Transforms protocol context to Input/Cert validation context
@@ -152,6 +156,7 @@ impl MakesValidationContext<Metablock> for MvbaContext {
             slot: self.slot,
             num_proposals: self.num_proposals,
             validator_data: self.validator_data.clone(),
+            header_auth: self.header_auth.clone(),
         }
     }
 }

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/test_helpers.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/test_helpers.rs
@@ -109,9 +109,7 @@ pub(super) fn mvba(node: NodeId, validator_data: &Arc<ValidatorData>) -> MonadMv
 /// two metablocks that cannot be confused for one another
 pub(super) fn metablock(seed: u64, validator_data: &ValidatorData) -> Metablock {
     Metablock::new(ProposalMap::new(NUM_PROPOSALS, |j| {
-        let entry = Entry::Positive {
-            root: MerkleRoot(seed * 100 + j as u64),
-        };
+        let entry = Entry::Positive(MerkleRoot(seed * 100 + j as u64));
         let fast_qc = strong_qc((SLOT, j), entry, &quorum(), validator_data);
         CertifiedEntry::FastQc(fast_qc)
     }))
@@ -122,9 +120,7 @@ pub(super) fn metablock(seed: u64, validator_data: &ValidatorData) -> Metablock 
 /// differ only in their evidence
 pub(super) fn mixed_evidence_metablock(seed: u64, validator_data: &ValidatorData) -> Metablock {
     Metablock::new(ProposalMap::new(NUM_PROPOSALS, |j| {
-        let entry = Entry::Positive {
-            root: MerkleRoot(seed * 100 + j as u64),
-        };
+        let entry = Entry::Positive(MerkleRoot(seed * 100 + j as u64));
         if j == 0 {
             let qc = weak_qc((SLOT, j), FallbackEntry(entry), &quorum(), validator_data);
             CertifiedEntry::FallbackQc(qc)

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/test_helpers.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/test_helpers.rs
@@ -27,8 +27,8 @@ use super::{
         super::{
             fast::{CertifiedEntry, EnterFallbackCert, EnterFallbackVote, Entry, FallbackEntry},
             types::{
-                IsVote, MerkleRoot, NodeId, ProposalMap, Slot, StrongQc, TimestampDelta,
-                ValidatorData, VoteMsg, VotePool, WeakQc,
+                HeaderAuth, IsVote, MerkleRoot, NodeId, ProposalMap, Slot, StrongQc,
+                TimestampDelta, ValidatorData, VoteMsg, VotePool, WeakQc,
             },
         },
         FallbackView, MVBAOutput, Metablock, Mvba,
@@ -37,6 +37,14 @@ use super::{
     block_store::{BlockRequestMsg, BlockResponseMsg},
     messages::{FallbackCommitVote, PrepareVote},
 };
+use crate::env::stub::MerkleHash;
+
+/// A root whose hash spells out `n`, so distinct seeds give distinct roots
+fn root(n: u64) -> MerkleRoot {
+    let mut hash = [0u8; 20];
+    hash[..8].copy_from_slice(&n.to_le_bytes());
+    MerkleRoot(MerkleHash(hash))
+}
 
 // The `V = Metablock` instantiation the existing suite runs on; the toy-value
 // test in `tests` is what pins genericity
@@ -101,6 +109,7 @@ pub(super) fn mvba(node: NodeId, validator_data: &Arc<ValidatorData>) -> MonadMv
         node_id: node,
         key: Arc::new(node.keypair()),
         validator_data: validator_data.clone(),
+        header_auth: Arc::new(HeaderAuth::new(|_, _| None)),
         delta: DELTA,
     })
 }
@@ -109,7 +118,7 @@ pub(super) fn mvba(node: NodeId, validator_data: &Arc<ValidatorData>) -> MonadMv
 /// two metablocks that cannot be confused for one another
 pub(super) fn metablock(seed: u64, validator_data: &ValidatorData) -> Metablock {
     Metablock::new(ProposalMap::new(NUM_PROPOSALS, |j| {
-        let entry = Entry::Positive(MerkleRoot(seed * 100 + j as u64));
+        let entry = Entry::Positive(root(seed * 100 + j as u64));
         let fast_qc = strong_qc((SLOT, j), entry, &quorum(), validator_data);
         CertifiedEntry::FastQc(fast_qc)
     }))
@@ -120,7 +129,7 @@ pub(super) fn metablock(seed: u64, validator_data: &ValidatorData) -> Metablock 
 /// differ only in their evidence
 pub(super) fn mixed_evidence_metablock(seed: u64, validator_data: &ValidatorData) -> Metablock {
     Metablock::new(ProposalMap::new(NUM_PROPOSALS, |j| {
-        let entry = Entry::Positive(MerkleRoot(seed * 100 + j as u64));
+        let entry = Entry::Positive(root(seed * 100 + j as u64));
         if j == 0 {
             let qc = weak_qc((SLOT, j), FallbackEntry(entry), &quorum(), validator_data);
             CertifiedEntry::FallbackQc(qc)

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/tests.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/tests.rs
@@ -1902,7 +1902,7 @@ mod toy_value {
 
     use super::super::{
         super::{
-            super::types::{NodeId, ValidatorData, VoteMsg},
+            super::types::{HeaderAuth, NodeId, ValidatorData, VoteMsg},
             MVBAOutput, Mvba, ValidateCert, ValidateInput, Votable,
         },
         MakesValidationContext, MonadMvba, MvbaContext, TimerEvent,
@@ -1963,6 +1963,7 @@ mod toy_value {
             node_id: node,
             key: Arc::new(node.keypair()),
             validator_data: validator_data.clone(),
+            header_auth: Arc::new(HeaderAuth::new(|_, _| None)),
             delta: DELTA,
         })
     }

--- a/monad-mcp-chorus/src/slot/fast.rs
+++ b/monad-mcp-chorus/src/slot/fast.rs
@@ -20,12 +20,12 @@ use itertools::Either;
 
 use super::{
     availability::ProposalAvailability,
-    chorus::{ChorusDACommand, ChorusDAEvent},
+    chorus::{ChorusDACommand, ChorusDAEvent, ProposalDAEvent},
     fallback::Metablock,
     types::{
-        EquivCert, HeaderAuth, IsVote, KeyPair, MerkleRoot, NodeId, ProposalHeader, ProposalIndex,
-        ProposalMap, Signature, Slot, StrongQc, TotalProposalMap, ValidatorData, VoteMsg, VotePool,
-        WeakQc, dummy_serialize,
+        EquivCert, GatedVotePool, GatingRoot, HeaderAuth, IsVote, KeyPair, MerkleRoot, NodeId,
+        ProposalHeader, ProposalIndex, ProposalMap, Signature, Slot, StrongQc, TotalProposalMap,
+        ValidatorData, VoteMsg, VotePool, WeakQc, dummy_serialize,
     },
 };
 use crate::spec::{Stake as _, proposal::HeaderAuth as _, validator::ValidatorData as _};
@@ -51,11 +51,11 @@ pub struct FastPath {
     certs: ProposalMap<LocalCertifiedEntry>,
     phase: Phase,
 
-    votes: ProposalMap<VotePool<Entry>>,
+    votes: ProposalMap<GatedVotePool<Entry>>,
     commit_votes: VotePool<FastCommitVote>,
 
     enter_fallback_votes: VotePool<EnterFallbackVote>,
-    fallback_entry_votes: ProposalMap<VotePool<FallbackEntry>>,
+    fallback_entry_votes: ProposalMap<GatedVotePool<FallbackEntry>>,
 
     // helper field to construct per-proposal values
     proposals: ProposalMap<ProposalIndex>,
@@ -83,12 +83,14 @@ impl FastPath {
         Self {
             slot: s,
 
-            votes: ProposalMap::new(num_proposals, |j| VotePool::new((s, j))),
+            votes: ProposalMap::new(num_proposals, |j| GatedVotePool::new(VotePool::new((s, j)))),
             certs: ProposalMap::new_default(num_proposals),
             commit_votes: VotePool::new(s),
 
             enter_fallback_votes: VotePool::new(s),
-            fallback_entry_votes: ProposalMap::new(num_proposals, |j| VotePool::new((s, j))),
+            fallback_entry_votes: ProposalMap::new(num_proposals, |j| {
+                GatedVotePool::new(VotePool::new((s, j)))
+            }),
 
             phase: Phase::Propose,
             proposals: ProposalMap::new(num_proposals, |j| j),
@@ -109,15 +111,33 @@ impl FastPath {
         self.commands.push_back(command);
     }
 
-    // an equivocation certificate can complete the fast block
+    // admission of gated votes can complete the fast block
     #[must_use]
     pub(crate) fn handle_da_event(&mut self, event: ChorusDAEvent) -> Option<FastBlock> {
         let ChorusDAEvent { j, event } = event;
+
+        match &event {
+            ProposalDAEvent::OwnerObligationFulfilled { owner, root } => {
+                self.votes[j].open(*owner, *root);
+            }
+            ProposalDAEvent::Decoded(root) => {
+                // decode implies possession of every chunk, so it
+                // satisfies both admission gates
+                self.votes[j].open_all(*root);
+                self.fallback_entry_votes[j].open_all(*root);
+            }
+            ProposalDAEvent::ProposerObligationFulfilled(root) => {
+                self.fallback_entry_votes[j].open_all(*root);
+            }
+            _ => {}
+        }
 
         if let Some(cert) = self.availability[j].ingest(event) {
             self.certs[j].try_upgrade(cert);
         }
 
+        self.try_form_fast_qc(j);
+        self.try_form_fallback_qc(j);
         self.try_cast_fast_commit_vote()
     }
 
@@ -292,8 +312,8 @@ impl FastPath {
         // do we have at least 2f+1 valid vote messages?
         //
         // todo: handle invalid signatures
-        let has_enough_votes = self.votes.as_ref().into_iter().all(|pool| {
-            let voter_stake = self.validator_data.sum_stake(pool.all_voters());
+        let has_enough_votes = self.votes.as_ref().into_iter().all(|votes| {
+            let voter_stake = self.validator_data.sum_stake(votes.pool().all_voters());
             voter_stake > self.validator_data.total_stake().supermajority_threshold()
         });
         if !has_enough_votes {
@@ -384,7 +404,10 @@ impl FastPath {
     // find a merkle root for proposer j with f+1 positive votes that is
     // locally decoded, so we can cast a positive fallback entry
     fn weak_available_root(&self, j: ProposalIndex) -> Option<MerkleRoot> {
-        let candidates = match self.votes[j].try_form_weak_qc(&self.validator_data)? {
+        let candidates = match self.votes[j]
+            .pool()
+            .try_form_weak_qc(&self.validator_data)?
+        {
             Either::Left(qc) => [Some(qc), None],
             Either::Right((qc1, qc2)) => [Some(qc1), Some(qc2)],
         };
@@ -405,7 +428,10 @@ impl FastPath {
             return;
         }
 
-        let weak_qc = match self.fallback_entry_votes[j].try_form_weak_qc(&self.validator_data) {
+        let weak_qc = match self.fallback_entry_votes[j]
+            .pool()
+            .try_form_weak_qc(&self.validator_data)
+        {
             None => return,
             Some(Either::Left(qc)) => qc,
             Some(Either::Right((qc1, qc2))) => {
@@ -449,7 +475,10 @@ impl FastPath {
             return;
         }
 
-        if let Some(fast_qc) = self.votes[j].try_form_strong_qc(&self.validator_data) {
+        if let Some(fast_qc) = self.votes[j]
+            .pool()
+            .try_form_strong_qc(&self.validator_data)
+        {
             self.certs[j].try_upgrade(fast_qc);
         }
     }
@@ -466,6 +495,15 @@ impl IsVote for Entry {
 
     fn serialize(&self, scope: &Self::Scope) -> Bytes {
         dummy_serialize(self, scope)
+    }
+}
+
+impl GatingRoot for Entry {
+    fn gating_root(&self) -> Option<MerkleRoot> {
+        match self {
+            Entry::Positive(root) => Some(*root),
+            Entry::Negative => None,
+        }
     }
 }
 
@@ -533,6 +571,12 @@ impl IsVote for FallbackEntry {
 
     fn serialize(&self, scope: &Self::Scope) -> Bytes {
         dummy_serialize(self, scope)
+    }
+}
+
+impl GatingRoot for FallbackEntry {
+    fn gating_root(&self) -> Option<MerkleRoot> {
+        self.0.gating_root()
     }
 }
 
@@ -726,10 +770,7 @@ pub type EnterFallbackCert = StrongQc<EnterFallbackVote>;
 #[cfg(test)]
 mod tests {
     use super::{
-        super::{
-            chorus::ProposalDAEvent,
-            types::{Stake, ValidatorData},
-        },
+        super::types::{Stake, ValidatorData},
         *,
     };
     use crate::{

--- a/monad-mcp-chorus/src/slot/fast.rs
+++ b/monad-mcp-chorus/src/slot/fast.rs
@@ -13,20 +13,22 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::Arc;
+use std::{collections::VecDeque, sync::Arc};
 
 use bytes::Bytes;
 use itertools::Either;
 
 use super::{
+    availability::ProposalAvailability,
+    chorus::{ChorusDACommand, ChorusDAEvent},
     fallback::Metablock,
     types::{
-        DAHandle, EquivCert, FetchProposalError, IsVote, KeyPair, MerkleRoot, NodeId,
-        ProposalIndex, ProposalMap, ProposalMeta, Signature, Slot, StrongQc, TotalProposalMap,
-        ValidatorData, VoteMsg, VotePool, WeakQc, dummy_serialize,
+        EquivCert, HeaderAuth, IsVote, KeyPair, MerkleRoot, NodeId, ProposalHeader, ProposalIndex,
+        ProposalMap, Signature, Slot, StrongQc, TotalProposalMap, ValidatorData, VoteMsg, VotePool,
+        WeakQc, dummy_serialize,
     },
 };
-use crate::spec::{Stake as _, proposal::ChunkHeader as _, validator::ValidatorData as _};
+use crate::spec::{Stake as _, proposal::HeaderAuth as _, validator::ValidatorData as _};
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 enum Phase {
@@ -58,12 +60,16 @@ pub struct FastPath {
     // helper field to construct per-proposal values
     proposals: ProposalMap<ProposalIndex>,
 
+    // what we know about each proposal's DA
+    availability: ProposalMap<ProposalAvailability>,
+
+    // effects for the DA layer, drained by the slot consensus wrapper
+    commands: VecDeque<ChorusDACommand>,
+
     // using Arc to avoid lifetime issues.
     key: Arc<KeyPair>,
     validator_data: Arc<ValidatorData>,
-
-    // data availability layer handle
-    da: Arc<DAHandle>,
+    header_auth: Arc<HeaderAuth>,
 }
 
 impl FastPath {
@@ -72,7 +78,7 @@ impl FastPath {
         num_proposals: usize,
         key: Arc<KeyPair>,
         validator_data: Arc<ValidatorData>,
-        da_handle: Arc<DAHandle>,
+        header_auth: Arc<HeaderAuth>,
     ) -> Self {
         Self {
             slot: s,
@@ -86,11 +92,33 @@ impl FastPath {
 
             phase: Phase::Propose,
             proposals: ProposalMap::new(num_proposals, |j| j),
+            availability: ProposalMap::new_default(num_proposals),
+            commands: VecDeque::new(),
 
             key,
             validator_data,
-            da: da_handle,
+            header_auth,
         }
+    }
+
+    pub(crate) fn next_da_command(&mut self) -> Option<ChorusDACommand> {
+        self.commands.pop_front()
+    }
+
+    fn emit(&mut self, command: ChorusDACommand) {
+        self.commands.push_back(command);
+    }
+
+    // an equivocation certificate can complete the fast block
+    #[must_use]
+    pub(crate) fn handle_da_event(&mut self, event: ChorusDAEvent) -> Option<FastBlock> {
+        let ChorusDAEvent { j, event } = event;
+
+        if let Some(cert) = self.availability[j].ingest(event) {
+            self.certs[j].try_upgrade(cert);
+        }
+
+        self.try_cast_fast_commit_vote()
     }
 
     /// Whether a fallback certificate received from a peer admits this slot
@@ -106,6 +134,12 @@ impl FastPath {
         node_id: NodeId,
         vote_msg: BatchVoteMsg,
     ) -> Option<FastBlock> {
+        let shape_valid =
+            vote_msg.slot == self.slot && vote_msg.votes.size() == self.proposals.size();
+        if !shape_valid {
+            return None;
+        }
+
         for vote_msg in vote_msg.split() {
             self.handle_vote(node_id, vote_msg);
         }
@@ -129,14 +163,26 @@ impl FastPath {
     ) -> Option<FastCommitQc> {
         debug_assert!(self.validator_data.contains(&node_id));
 
+        if vote_msg.scope != self.slot {
+            return None;
+        }
+
         // no phase guard on purpose
         self.commit_votes.add_vote(node_id, vote_msg);
         self.commit_votes.try_form_strong_qc(&self.validator_data)
     }
 
     pub(crate) fn handle_fast_block(&mut self, fast_block: FastBlock) -> Option<FastBlock> {
+        let all_qcs_valid = fast_block
+            .0
+            .as_ref()
+            .into_iter()
+            .all(|qc| qc.verify(&self.validator_data));
+        if !all_qcs_valid {
+            return None;
+        }
+
         for (j, qc) in fast_block.0.into_indexed_iter() {
-            debug_assert!(qc.verify(&self.validator_data));
             self.certs[j].try_upgrade(qc);
         }
 
@@ -146,32 +192,67 @@ impl FastPath {
     pub(crate) fn handle_fallback_vote(&mut self, node_id: NodeId, vote_msg: FallbackVoteMsg) {
         debug_assert!(self.validator_data.contains(&node_id));
 
+        let shape_valid = vote_msg.enter_fallback_vote.scope == self.slot
+            && vote_msg.evidences.size() == self.proposals.size();
+        if !shape_valid {
+            return;
+        }
+
+        // admission is all-or-nothing: any invalid evidence rejects the
+        // whole vote, including its enter-fallback part.
+        let all_evidences_valid = vote_msg
+            .evidences
+            .as_ref()
+            .into_indexed_iter()
+            .all(|(j, evidence)| self.evidence_valid(j, evidence));
+        if !all_evidences_valid {
+            return;
+        }
+
         self.enter_fallback_votes
             .add_vote(node_id, vote_msg.enter_fallback_vote);
 
         for (j, evidence) in vote_msg.evidences.into_indexed_iter() {
             match evidence {
                 ProposalEvidence::FallbackSignedEntry(entry) => {
-                    debug_assert!(entry.well_formed());
-                    if let Some(meta) = entry.meta() {
-                        self.da.observe_proposal(self.slot, j, meta.clone());
+                    if let Some(header) = entry.header() {
+                        // positive fallback entry
+                        let avail = &mut self.availability[j];
+                        if let Some(equiv_cert) = avail.record_header(header.clone()) {
+                            self.certs[j].try_upgrade(equiv_cert);
+                        }
                     }
+
                     let vote = entry.into_vote_msg(self.slot, j);
                     self.fallback_entry_votes[j].add_vote(node_id, vote);
                     self.try_form_fallback_qc(j);
                 }
 
                 ProposalEvidence::Certified(cert) => {
-                    debug_assert!(cert.verify(&self.validator_data));
                     self.certs[j].try_upgrade(cert);
                 }
             }
         }
     }
 
+    fn evidence_valid(&self, j: ProposalIndex, evidence: &ProposalEvidence) -> bool {
+        match evidence {
+            ProposalEvidence::FallbackSignedEntry(entry) => {
+                let header_valid = match entry.header() {
+                    Some(header) => self.header_auth.validate(header, self.slot.get(), j),
+                    None => true,
+                };
+                entry.well_formed() && header_valid
+            }
+            ProposalEvidence::Certified(cert) => {
+                cert.verify((self.slot, j), &self.header_auth, &self.validator_data)
+            }
+        }
+    }
+
     // D_s
     #[must_use]
-    pub(crate) fn on_propose_deadline(&mut self) -> Option<BatchVoteMsg> {
+    pub(crate) fn on_deadline(&mut self) -> Option<BatchVoteMsg> {
         if self.phase != Phase::Propose {
             return None; // already voted; no-op
         }
@@ -179,19 +260,21 @@ impl FastPath {
         self.phase = Phase::Vote;
 
         let votes = self.proposals.as_ref().map(|j| {
-            let entry = match self.da.fetch_proposal(self.slot, *j) {
-                Ok(proposal) => Entry::Positive(proposal.root),
-                Err(FetchProposalError::Absent) => Entry::Negative,
-                Err(FetchProposalError::Equivocation(equiv_cert)) => {
-                    self.certs[*j].try_upgrade(equiv_cert);
-                    // upgrade on the equivocation certificate?
-                    todo!()
-                }
+            let entry = match self.availability[*j].fetch_proposal() {
+                Some(proposal) => Entry::Positive(proposal.root),
+                None => Entry::Negative,
             };
 
             let vote_msg = VoteMsg::new_signed((self.slot, *j), entry.clone(), &self.key);
             (entry, vote_msg.signature)
         });
+
+        for (j, (entry, _)) in votes.as_ref().into_indexed_iter() {
+            if let Entry::Positive(root) = entry {
+                self.emit(ChorusDACommand::PinRoot { j, root: *root });
+            }
+        }
+        self.emit(ChorusDACommand::ReleaseChunks);
 
         Some(BatchVoteMsg {
             slot: self.slot,
@@ -223,6 +306,18 @@ impl FastPath {
         let enter_fallback_vote = VoteMsg::new_signed(self.slot, EnterFallbackVote, &self.key);
 
         let evidences = self.proposals.as_ref().map(|j| self.proposal_evidence(*j));
+
+        // the roots our positive fallback entries vouch for
+        for (j, evidence) in evidences.as_ref().into_indexed_iter() {
+            if let ProposalEvidence::FallbackSignedEntry(entry) = evidence
+                && let Some(header) = entry.header()
+            {
+                self.emit(ChorusDACommand::PinRoot {
+                    j,
+                    root: header.root,
+                });
+            }
+        }
 
         let fallback_vote = FallbackVoteMsg {
             enter_fallback_vote,
@@ -274,10 +369,10 @@ impl FastPath {
         // if there are f+1 positive votes on a root and it's decoded,
         // vote positive.
         if let Some(root) = self.weak_available_root(j)
-            && let Ok(meta) = self.da.fetch_proposal(self.slot, j)
-            && meta.root == root
+            && let Some(header) = self.availability[j].header_for(&root)
         {
-            let fse = FallbackSignedEntry::new_signed_positive(scope, root, &self.key, meta);
+            let fse =
+                FallbackSignedEntry::new_signed_positive(scope, root, &self.key, header.clone());
             return ProposalEvidence::FallbackSignedEntry(fse);
         }
 
@@ -301,7 +396,7 @@ impl FastPath {
                 Entry::Positive(root) => Some(root),
                 Entry::Negative => None,
             })
-            .find(|root| self.da.proposal_decoded(self.slot, j, root))
+            .find(|root| self.availability[j].decoded(root))
     }
 
     fn try_form_fallback_qc(&mut self, j: ProposalIndex) {
@@ -314,9 +409,9 @@ impl FastPath {
             None => return,
             Some(Either::Left(qc)) => qc,
             Some(Either::Right((qc1, qc2))) => {
-                // we already handled equivocation from distinct
-                // positive weak qc from observe_proposal that
-                // should preceed this call
+                // at most one is positive: two positive entries carry
+                // rival headers, whose EquivCert outranks a FallbackQc
+                // and returned above
                 match (&qc1.verdict.0, &qc2.verdict.0) {
                     (Entry::Positive { .. }, _) => qc1,
                     (_, Entry::Positive { .. }) => qc2,
@@ -483,14 +578,20 @@ impl CertifiedEntry {
     /// signatures. Authenticity is enforced at message ingress (see the
     /// crate header); we restate it at adoption points to make the trust
     /// boundary explicit and catch protocol-logic bugs.
-    pub(crate) fn verify(&self, validator_data: &ValidatorData) -> bool {
+    pub(crate) fn verify(
+        &self,
+        scope: (Slot, ProposalIndex),
+        header_auth: &HeaderAuth,
+        validator_data: &ValidatorData,
+    ) -> bool {
         match self {
             CertifiedEntry::FastQc(qc) => qc.verify(validator_data),
             CertifiedEntry::FallbackQc(qc) => qc.verify(validator_data),
             CertifiedEntry::EquivCert(EquivCert(a, b)) => {
+                let (s, j) = scope;
                 a.root != b.root
-                    && a.opaque_header.validate(&a.root, &a.sig)
-                    && b.opaque_header.validate(&b.root, &b.sig)
+                    && header_auth.validate(a, s.get(), j)
+                    && header_auth.validate(b, s.get(), j)
             }
         }
     }
@@ -501,9 +602,9 @@ struct FallbackSignedEntry {
     entry: FallbackEntry,
     // over (slot, j, self.entry)
     signature: Signature,
-    // invariant: meta.is_some() iff entry is positive
-    // invariant: meta.root == entry.root
-    meta: Option<ProposalMeta>,
+    // invariant: header.is_some() iff entry is positive
+    // invariant: header.root == entry.root
+    header: Option<ProposalHeader>,
 }
 
 impl FallbackSignedEntry {
@@ -511,14 +612,14 @@ impl FallbackSignedEntry {
         scope: (Slot, ProposalIndex),
         root: MerkleRoot,
         key: &KeyPair,
-        meta: ProposalMeta,
+        header: ProposalHeader,
     ) -> Self {
         let entry = FallbackEntry(Entry::Positive(root));
         let signature = VoteMsg::new_signed(scope, entry.clone(), key).signature;
         Self {
             entry,
             signature,
-            meta: Some(meta),
+            header: Some(header),
         }
     }
 
@@ -528,21 +629,22 @@ impl FallbackSignedEntry {
         Self {
             entry,
             signature,
-            meta: None,
+            header: None,
         }
     }
 
     fn well_formed(&self) -> bool {
         match &self.entry.0 {
-            Entry::Positive(root) => self.meta.as_ref().is_some_and(|meta| {
-                meta.root == *root && meta.opaque_header.validate(&meta.root, &meta.sig)
-            }),
-            Entry::Negative => self.meta.is_none(),
+            Entry::Positive(root) => self
+                .header
+                .as_ref()
+                .is_some_and(|header| header.root == *root),
+            Entry::Negative => self.header.is_none(),
         }
     }
 
-    fn meta(&self) -> Option<&ProposalMeta> {
-        self.meta.as_ref()
+    fn header(&self) -> Option<&ProposalHeader> {
+        self.header.as_ref()
     }
 
     fn into_vote_msg(self, slot: Slot, j: ProposalIndex) -> VoteMsg<FallbackEntry> {
@@ -620,3 +722,85 @@ pub(crate) struct FallbackVoteMsg {
 
 // A fallback cert certifies 2f+1 validators agree to enter fallback path
 pub type EnterFallbackCert = StrongQc<EnterFallbackVote>;
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::{
+            chorus::ProposalDAEvent,
+            types::{Stake, ValidatorData},
+        },
+        *,
+    };
+    use crate::{
+        env::stub::{D25, EncodingScheme, MerkleHash, ProposalSignature},
+        spec::vote::KeyPair as _,
+    };
+
+    const SLOT: Slot = Slot(1);
+
+    fn validator_data(n: u64) -> ValidatorData {
+        let validators = (0..n).map(NodeId::dummy).collect::<Vec<_>>();
+        let valset = validators.iter().map(|id| (*id, Stake::from(1))).collect();
+        let mapping = validators
+            .iter()
+            .map(|id| (*id, id.keypair().pubkey()))
+            .collect();
+
+        ValidatorData::new(valset, mapping)
+    }
+
+    fn root(byte: u8) -> MerkleRoot {
+        MerkleRoot(MerkleHash([byte; 20]))
+    }
+
+    // signed by validator 0, the only proposer
+    fn header(byte: u8) -> ProposalHeader {
+        ProposalHeader {
+            slot: crate::stub::types::Slot(SLOT.get()),
+            root: root(byte),
+            sig: ProposalSignature(0),
+            scheme: EncodingScheme::D25(D25 {
+                msg_len: 0,
+                unix_ts: 0,
+            }),
+        }
+    }
+
+    // the local node is validator 1 among 4, one proposal per slot
+    fn fast_path() -> FastPath {
+        let header_auth = HeaderAuth::new(|_, signer| (*signer == NodeId::dummy(0)).then_some(0));
+        FastPath::new(
+            SLOT,
+            1,
+            Arc::new(NodeId::dummy(1).keypair()),
+            Arc::new(validator_data(4)),
+            Arc::new(header_auth),
+        )
+    }
+
+    #[test]
+    fn deadline_pins_positive_roots_before_releasing_chunks() {
+        let mut fast = fast_path();
+
+        let _ = fast.handle_da_event(ChorusDAEvent {
+            j: 0,
+            event: ProposalDAEvent::HeaderSeen(header(1)),
+        });
+        let _ = fast.handle_da_event(ChorusDAEvent {
+            j: 0,
+            event: ProposalDAEvent::ProposerObligationFulfilled(root(1)),
+        });
+        let _ = fast.on_deadline();
+
+        let mut commands = Vec::new();
+        while let Some(command) = fast.next_da_command() {
+            commands.push(command);
+        }
+        let pin = ChorusDACommand::PinRoot {
+            j: 0,
+            root: root(1),
+        };
+        assert_eq!(commands, vec![pin, ChorusDACommand::ReleaseChunks]);
+    }
+}

--- a/monad-mcp-chorus/src/slot/fast.rs
+++ b/monad-mcp-chorus/src/slot/fast.rs
@@ -180,9 +180,7 @@ impl FastPath {
 
         let votes = self.proposals.as_ref().map(|j| {
             let entry = match self.da.fetch_proposal(self.slot, *j) {
-                Ok(proposal) => Entry::Positive {
-                    root: proposal.root,
-                },
+                Ok(proposal) => Entry::Positive(proposal.root),
                 Err(FetchProposalError::Absent) => Entry::Negative,
                 Err(FetchProposalError::Equivocation(equiv_cert)) => {
                     self.certs[*j].try_upgrade(equiv_cert);
@@ -300,7 +298,7 @@ impl FastPath {
             .into_iter()
             .flatten()
             .filter_map(|qc| match qc.verdict {
-                Entry::Positive { root } => Some(root),
+                Entry::Positive(root) => Some(root),
                 Entry::Negative => None,
             })
             .find(|root| self.da.proposal_decoded(self.slot, j, root))
@@ -364,7 +362,7 @@ impl FastPath {
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum Entry {
-    Positive { root: MerkleRoot },
+    Positive(MerkleRoot),
     Negative,
 }
 
@@ -515,7 +513,7 @@ impl FallbackSignedEntry {
         key: &KeyPair,
         meta: ProposalMeta,
     ) -> Self {
-        let entry = FallbackEntry(Entry::Positive { root });
+        let entry = FallbackEntry(Entry::Positive(root));
         let signature = VoteMsg::new_signed(scope, entry.clone(), key).signature;
         Self {
             entry,
@@ -536,7 +534,7 @@ impl FallbackSignedEntry {
 
     fn well_formed(&self) -> bool {
         match &self.entry.0 {
-            Entry::Positive { root } => self.meta.as_ref().is_some_and(|meta| {
+            Entry::Positive(root) => self.meta.as_ref().is_some_and(|meta| {
                 meta.root == *root && meta.opaque_header.validate(&meta.root, &meta.sig)
             }),
             Entry::Negative => self.meta.is_none(),

--- a/monad-mcp-chorus/src/slot/fast.rs
+++ b/monad-mcp-chorus/src/slot/fast.rs
@@ -13,22 +13,28 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{collections::VecDeque, sync::Arc};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+};
 
 use bytes::Bytes;
 use itertools::Either;
 
 use super::{
     availability::ProposalAvailability,
-    chorus::{ChorusDACommand, ChorusDAEvent, ProposalDAEvent},
+    chorus::{ChorusDACommand, ChorusDAEvent, ChunkRequestType, ProposalDAEvent},
     fallback::Metablock,
     types::{
-        EquivCert, GatedVotePool, GatingRoot, HeaderAuth, IsVote, KeyPair, MerkleRoot, NodeId,
-        ProposalHeader, ProposalIndex, ProposalMap, Signature, Slot, StrongQc, TotalProposalMap,
-        ValidatorData, VoteMsg, VotePool, WeakQc, dummy_serialize,
+        Admission, EquivCert, GatedVotePool, GatingRoot, HeaderAuth, IsVote, KeyPair, MerkleRoot,
+        NodeId, ProposalHeader, ProposalIndex, ProposalMap, Signature, Slot, StrongQc,
+        TotalProposalMap, ValidatorData, VoteMsg, VotePool, WeakQc, dummy_serialize,
     },
 };
-use crate::spec::{Stake as _, proposal::HeaderAuth as _, validator::ValidatorData as _};
+use crate::spec::{
+    Stake as _, proposal::HeaderAuth as _, validator::ValidatorData as _,
+    vote::SignatureCollection as _,
+};
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 enum Phase {
@@ -203,7 +209,9 @@ impl FastPath {
         }
 
         for (j, qc) in fast_block.0.into_indexed_iter() {
-            self.certs[j].try_upgrade(qc);
+            if self.certs[j].try_upgrade(qc) {
+                self.recover_certified(j);
+            }
         }
 
         self.try_cast_fast_commit_vote()
@@ -243,16 +251,65 @@ impl FastPath {
                         }
                     }
 
+                    let positive_root = entry.header().map(|header| header.root);
                     let vote = entry.into_vote_msg(self.slot, j);
-                    self.fallback_entry_votes[j].add_vote(node_id, vote);
+                    let admission = self.fallback_entry_votes[j].add_vote(node_id, vote);
+                    if admission == Admission::Held
+                        && let Some(root) = positive_root
+                    {
+                        // P2: the signer holds the decoded proposal,
+                        // so it can serve our own chunks under the root
+                        self.request_chunks(ChunkRequestType::MyChunks, j, root, vec![node_id]);
+                    }
                     self.try_form_fallback_qc(j);
                 }
 
                 ProposalEvidence::Certified(cert) => {
-                    self.certs[j].try_upgrade(cert);
+                    if self.certs[j].try_upgrade(cert) {
+                        self.recover_certified(j);
+                    }
                 }
             }
         }
+    }
+
+    // P1: pull a newly certified root from the certificate's signers.
+    // A positive FallbackQc's signers also hold the decoded proposal,
+    // so they can serve our own chunks.
+    fn recover_certified(&mut self, j: ProposalIndex) {
+        let LocalCertifiedEntry::Certified(cert) = &self.certs[j] else {
+            return;
+        };
+        let Entry::Positive(root) = cert.entry() else {
+            return;
+        };
+        if self.availability[j].is_resolved(&root) {
+            return;
+        }
+        let signers = cert.signers(&self.validator_data);
+        let signers_decoded = matches!(cert, CertifiedEntry::FallbackQc(_));
+
+        if signers_decoded && !self.availability[j].author_fulfilled(&root) {
+            self.request_chunks(ChunkRequestType::MyChunks, j, root, signers.clone());
+        }
+        self.request_chunks(ChunkRequestType::YourChunks, j, root, signers);
+    }
+
+    fn request_chunks(
+        &mut self,
+        request_type: ChunkRequestType,
+        j: ProposalIndex,
+        root: MerkleRoot,
+        mut voters: Vec<NodeId>,
+    ) {
+        // stable request order across runs
+        voters.sort();
+        self.emit(ChorusDACommand::RecoverChunks {
+            j,
+            root,
+            request_type,
+            voters,
+        });
     }
 
     fn evidence_valid(&self, j: ProposalIndex, evidence: &ProposalEvidence) -> bool {
@@ -338,6 +395,7 @@ impl FastPath {
                 });
             }
         }
+        self.recover_at_transition();
 
         let fallback_vote = FallbackVoteMsg {
             enter_fallback_vote,
@@ -401,25 +459,107 @@ impl FastPath {
         ProposalEvidence::FallbackSignedEntry(fse)
     }
 
-    // find a merkle root for proposer j with f+1 positive votes that is
-    // locally decoded, so we can cast a positive fallback entry
-    fn weak_available_root(&self, j: ProposalIndex) -> Option<MerkleRoot> {
-        let candidates = match self.votes[j]
-            .pool()
-            .try_form_weak_qc(&self.validator_data)?
-        {
+    // the weak qcs for proposer j on a positive entry, as (root, qc)
+    fn positive_weak_qcs(&self, j: ProposalIndex) -> Vec<(MerkleRoot, WeakQc<Entry>)> {
+        let Some(weak_qc) = self.votes[j].pool().try_form_weak_qc(&self.validator_data) else {
+            return vec![];
+        };
+        let candidates = match weak_qc {
             Either::Left(qc) => [Some(qc), None],
             Either::Right((qc1, qc2)) => [Some(qc1), Some(qc2)],
         };
 
-        candidates
+        let mut positive = Vec::new();
+        for qc in candidates.into_iter().flatten() {
+            let Entry::Positive(root) = qc.verdict else {
+                continue;
+            };
+            positive.push((root, qc));
+        }
+        positive
+    }
+
+    fn weak_available_root(&self, j: ProposalIndex) -> Option<MerkleRoot> {
+        self.positive_weak_qcs(j)
             .into_iter()
-            .flatten()
-            .filter_map(|qc| match qc.verdict {
-                Entry::Positive(root) => Some(root),
-                Entry::Negative => None,
-            })
+            .map(|(root, _)| root)
             .find(|root| self.availability[j].decoded(root))
+    }
+
+    // P3 and P4: at the fallback transition, pull the roots that block
+    // picking a fallback entry for each proposer without a certificate
+    fn recover_at_transition(&mut self) {
+        for j in 0..self.proposals.size() {
+            if matches!(self.certs[j], LocalCertifiedEntry::Certified(_)) {
+                // picked by certificate. P1 pulls it.
+                continue;
+            }
+            for (root, voters) in self.blocking_roots(j) {
+                self.request_chunks(ChunkRequestType::YourChunks, j, root, voters);
+            }
+        }
+    }
+
+    // the roots of proposer j that block picking its fallback entry,
+    // each with its positive voters: an unresolved root with f+1
+    // positive votes (P3), or a root of a claimed equivocation that no
+    // held chunk witnesses (P4)
+    fn blocking_roots(&self, j: ProposalIndex) -> Vec<(MerkleRoot, Vec<NodeId>)> {
+        let avail = &self.availability[j];
+        let positive_voters = self.positive_voters(j);
+        let equivocation_claimed = positive_voters.len() >= 2;
+
+        let mut weak_roots = Vec::new();
+        for (root, _) in self.positive_weak_qcs(j) {
+            weak_roots.push(root);
+        }
+
+        let mut blocking = Vec::new();
+        for (root, voters) in positive_voters {
+            let unresolved_weak = weak_roots.contains(&root) && !avail.is_resolved(&root);
+            let unwitnessed_claim = equivocation_claimed && avail.header_for(&root).is_none();
+            if unresolved_weak || unwitnessed_claim {
+                blocking.push((root, voters));
+            }
+        }
+        blocking
+    }
+
+    // the voters of every positive root of proposer j, admitted or held
+    fn positive_voters(&self, j: ProposalIndex) -> HashMap<MerkleRoot, Vec<NodeId>> {
+        let mut positive_voters: HashMap<MerkleRoot, Vec<NodeId>> = HashMap::new();
+        for (entry, voters) in self.votes[j].pool().buckets() {
+            let Entry::Positive(root) = entry else {
+                continue;
+            };
+            positive_voters
+                .entry(*root)
+                .or_default()
+                .extend(voters.iter().copied());
+        }
+        for (voter, root) in self.votes[j].held() {
+            positive_voters.entry(root).or_default().push(voter);
+        }
+        positive_voters
+    }
+
+    // P1 for a committed slot: pull every committed root we have not
+    // resolved from the commit certificate's signers
+    pub(crate) fn recover_committed(&mut self, qc: &FastCommitQc) {
+        let Some(signers) = qc.sigcol.signers(&self.validator_data) else {
+            return;
+        };
+        let signers: Vec<NodeId> = signers.into_iter().copied().collect();
+
+        for (j, entry) in qc.verdict.entries.as_ref().into_indexed_iter() {
+            let Entry::Positive(root) = entry else {
+                continue;
+            };
+            if self.availability[j].is_resolved(root) {
+                continue;
+            }
+            self.request_chunks(ChunkRequestType::YourChunks, j, *root, signers.clone());
+        }
     }
 
     fn try_form_fallback_qc(&mut self, j: ProposalIndex) {
@@ -446,7 +586,9 @@ impl FastPath {
             }
         };
 
-        self.certs[j].try_upgrade(weak_qc);
+        if self.certs[j].try_upgrade(weak_qc) {
+            self.recover_certified(j);
+        }
     }
 
     fn try_cast_fast_commit_vote(&mut self) -> Option<FastBlock> {
@@ -478,8 +620,9 @@ impl FastPath {
         if let Some(fast_qc) = self.votes[j]
             .pool()
             .try_form_strong_qc(&self.validator_data)
+            && self.certs[j].try_upgrade(fast_qc)
         {
-            self.certs[j].try_upgrade(fast_qc);
+            self.recover_certified(j);
         }
     }
 }
@@ -618,6 +761,20 @@ impl CertifiedEntry {
         }
     }
 
+    // the validators whose votes form the certificate. none for an
+    // equivocation certificate.
+    fn signers(&self, validator_data: &ValidatorData) -> Vec<NodeId> {
+        let sigcol = match self {
+            CertifiedEntry::FastQc(qc) => &qc.sigcol,
+            CertifiedEntry::FallbackQc(qc) => &qc.sigcol,
+            CertifiedEntry::EquivCert(_) => return vec![],
+        };
+        let Some(signers) = sigcol.signers(validator_data) else {
+            return vec![];
+        };
+        signers.into_iter().copied().collect()
+    }
+
     /// Whether this certificate is well-formed and carries valid
     /// signatures. Authenticity is enforced at message ingress (see the
     /// crate header); we restate it at adoption points to make the trust
@@ -732,17 +889,20 @@ impl LocalCertifiedEntry {
         }
     }
 
-    fn try_upgrade(&mut self, new_ev: impl Into<CertifiedEntry>) {
+    // whether the evidence was adopted
+    fn try_upgrade(&mut self, new_ev: impl Into<CertifiedEntry>) -> bool {
         let new_ev = new_ev.into();
 
         match self {
             LocalCertifiedEntry::Absent => {
                 *self = LocalCertifiedEntry::Certified(new_ev);
+                true
             }
             LocalCertifiedEntry::Certified(ev) if new_ev.strength() > ev.strength() => {
                 *ev = new_ev;
+                true
             }
-            _ => {}
+            _ => false,
         }
     }
 }
@@ -820,6 +980,103 @@ mod tests {
         )
     }
 
+    // the chunk requests among the drained commands, for proposal 0
+    fn drain_requests(fast: &mut FastPath) -> Vec<(ChunkRequestType, MerkleRoot, Vec<NodeId>)> {
+        let mut requests = Vec::new();
+        while let Some(command) = fast.next_da_command() {
+            let ChorusDACommand::RecoverChunks {
+                j,
+                root,
+                request_type,
+                voters,
+            } = command
+            else {
+                continue;
+            };
+            assert_eq!(j, 0);
+            requests.push((request_type, root, voters));
+        }
+        requests
+    }
+
+    fn positive_fallback_vote(voter: u64, byte: u8) -> (NodeId, FallbackVoteMsg) {
+        let voter = NodeId::dummy(voter);
+        let key = voter.keypair();
+        let entry =
+            FallbackSignedEntry::new_signed_positive((SLOT, 0), root(byte), &key, header(byte));
+        let msg = FallbackVoteMsg {
+            enter_fallback_vote: VoteMsg::new_signed(SLOT, EnterFallbackVote, &key),
+            evidences: ProposalMap::new(1, |_| {
+                ProposalEvidence::FallbackSignedEntry(entry.clone())
+            }),
+        };
+        (voter, msg)
+    }
+
+    // a fast qc on root(byte) signed by validators 0, 2 and 3
+    fn fast_block(byte: u8) -> FastBlock {
+        let mut pool = VotePool::new((SLOT, 0));
+        for id in [0, 2, 3] {
+            let voter = NodeId::dummy(id);
+            let msg = VoteMsg::new_signed((SLOT, 0), Entry::Positive(root(byte)), &voter.keypair());
+            pool.add_vote(voter, msg);
+        }
+        let qc = pool
+            .try_form_strong_qc(&validator_data(4))
+            .expect("three of four votes form a fast qc");
+        FastBlock(ProposalMap::new(1, |_| qc.clone()))
+    }
+
+    #[test]
+    fn suspended_fallback_entry_pulls_own_chunks_from_its_signer() {
+        let mut fast = fast_path();
+
+        let (voter, msg) = positive_fallback_vote(2, 1);
+        fast.handle_fallback_vote(voter, msg);
+        let expected = (ChunkRequestType::MyChunks, root(1), vec![voter]);
+        assert_eq!(drain_requests(&mut fast), vec![expected]);
+
+        // once our own chunks arrived, positive entries are admitted.
+        // the FallbackQc they form pulls the root from its signers (P1),
+        // but not our own chunks, which we hold
+        let arrived = ProposalDAEvent::ProposerObligationFulfilled(root(1));
+        let _ = fast.handle_da_event(ChorusDAEvent {
+            j: 0,
+            event: arrived,
+        });
+        let (voter, msg) = positive_fallback_vote(3, 1);
+        fast.handle_fallback_vote(voter, msg);
+        let signers = vec![NodeId::dummy(2), NodeId::dummy(3)];
+        let expected = (ChunkRequestType::YourChunks, root(1), signers);
+        assert_eq!(drain_requests(&mut fast), vec![expected]);
+    }
+
+    #[test]
+    fn certified_root_is_pulled_from_its_signers() {
+        let mut fast = fast_path();
+
+        fast.handle_fast_block(fast_block(1));
+        let signers = vec![NodeId::dummy(0), NodeId::dummy(2), NodeId::dummy(3)];
+        let expected = (ChunkRequestType::YourChunks, root(1), signers);
+        assert_eq!(drain_requests(&mut fast), vec![expected]);
+
+        // the same certificate again is no news
+        fast.handle_fast_block(fast_block(1));
+        assert!(drain_requests(&mut fast).is_empty());
+    }
+
+    #[test]
+    fn resolved_root_is_not_pulled() {
+        let mut fast = fast_path();
+
+        let _ = fast.handle_da_event(ChorusDAEvent {
+            j: 0,
+            event: ProposalDAEvent::Decoded(root(1)),
+        });
+        fast.handle_fast_block(fast_block(1));
+        assert!(drain_requests(&mut fast).is_empty());
+    }
+
     #[test]
     fn deadline_pins_positive_roots_before_releasing_chunks() {
         let mut fast = fast_path();
@@ -843,5 +1100,126 @@ mod tests {
             root: root(1),
         };
         assert_eq!(commands, vec![pin, ChorusDACommand::ReleaseChunks]);
+    }
+
+    fn batch_vote(voter: u64, entry: Entry) -> (NodeId, BatchVoteMsg) {
+        let voter = NodeId::dummy(voter);
+        let key = voter.keypair();
+        let votes = ProposalMap::new(1, |j| {
+            let signature = VoteMsg::new_signed((SLOT, j), entry.clone(), &key).signature;
+            (entry.clone(), signature)
+        });
+        (voter, BatchVoteMsg { slot: SLOT, votes })
+    }
+
+    // the chunks of the voter under the root arrived, admitting its
+    // positive vote
+    fn owner_fulfilled(fast: &mut FastPath, voter: u64, byte: u8) {
+        let event = ProposalDAEvent::OwnerObligationFulfilled {
+            owner: NodeId::dummy(voter),
+            root: root(byte),
+        };
+        let _ = fast.handle_da_event(ChorusDAEvent { j: 0, event });
+    }
+
+    // cast the votes and pass both deadlines into the fallback transition
+    fn transition(fast: &mut FastPath, votes: Vec<(NodeId, BatchVoteMsg)>) {
+        let _ = fast.on_deadline();
+        for (voter, msg) in votes {
+            let _ = fast.handle_batch_vote(voter, msg);
+        }
+        let outcome = fast.on_commit_vote_deadline();
+        assert!(matches!(
+            outcome,
+            CommitVoteDeadlineOutcome::FallbackVote(_)
+        ));
+    }
+
+    #[test]
+    fn transition_pulls_an_unresolved_weak_root_from_its_voters() {
+        let mut fast = fast_path();
+
+        // validators 0 and 3 vote positive on root(1), which we have not
+        // decoded. their chunks arrived, so the votes are admitted and
+        // form a weak qc
+        let _ = fast.handle_da_event(ChorusDAEvent {
+            j: 0,
+            event: ProposalDAEvent::HeaderSeen(header(1)),
+        });
+        owner_fulfilled(&mut fast, 0, 1);
+        owner_fulfilled(&mut fast, 3, 1);
+        let votes = vec![
+            batch_vote(0, Entry::Positive(root(1))),
+            batch_vote(3, Entry::Positive(root(1))),
+            batch_vote(2, Entry::Negative),
+            batch_vote(1, Entry::Negative),
+        ];
+        transition(&mut fast, votes);
+
+        let voters = vec![NodeId::dummy(0), NodeId::dummy(3)];
+        let expected = (ChunkRequestType::YourChunks, root(1), voters);
+        assert_eq!(drain_requests(&mut fast), vec![expected]);
+    }
+
+    #[test]
+    fn transition_pulls_the_unwitnessed_root_of_a_claimed_equivocation() {
+        let mut fast = fast_path();
+
+        // validator 0 votes positive on root(1), whose header and chunks
+        // we hold. validator 2 votes positive on root(2), of which we
+        // hold nothing: its vote is held and its claim is unwitnessed
+        let _ = fast.handle_da_event(ChorusDAEvent {
+            j: 0,
+            event: ProposalDAEvent::HeaderSeen(header(1)),
+        });
+        owner_fulfilled(&mut fast, 0, 1);
+        let votes = vec![
+            batch_vote(0, Entry::Positive(root(1))),
+            batch_vote(2, Entry::Positive(root(2))),
+            batch_vote(3, Entry::Negative),
+            batch_vote(1, Entry::Negative),
+        ];
+        transition(&mut fast, votes);
+
+        let expected = (
+            ChunkRequestType::YourChunks,
+            root(2),
+            vec![NodeId::dummy(2)],
+        );
+        assert_eq!(drain_requests(&mut fast), vec![expected]);
+    }
+
+    // a fast commit qc on the entries [root(byte)] signed by validators
+    // 0, 2 and 3
+    fn fast_commit_qc(byte: u8) -> FastCommitQc {
+        let entries = ProposalMap::new(1, |_| Entry::Positive(root(byte)));
+        let mut pool = VotePool::new(SLOT);
+        for id in [0, 2, 3] {
+            let voter = NodeId::dummy(id);
+            let vote = FastCommitVote {
+                entries: entries.clone(),
+            };
+            pool.add_vote(voter, VoteMsg::new_signed(SLOT, vote, &voter.keypair()));
+        }
+        pool.try_form_strong_qc(&validator_data(4))
+            .expect("three of four votes form a commit qc")
+    }
+
+    #[test]
+    fn committed_roots_are_pulled_from_the_commit_signers() {
+        let mut fast = fast_path();
+
+        fast.recover_committed(&fast_commit_qc(1));
+        let signers = vec![NodeId::dummy(0), NodeId::dummy(2), NodeId::dummy(3)];
+        let expected = (ChunkRequestType::YourChunks, root(1), signers);
+        assert_eq!(drain_requests(&mut fast), vec![expected]);
+
+        // a resolved root is not pulled
+        let _ = fast.handle_da_event(ChorusDAEvent {
+            j: 0,
+            event: ProposalDAEvent::Decoded(root(1)),
+        });
+        fast.recover_committed(&fast_commit_qc(1));
+        assert!(drain_requests(&mut fast).is_empty());
     }
 }

--- a/monad-mcp-chorus/src/slot/mod.rs
+++ b/monad-mcp-chorus/src/slot/mod.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+mod availability;
 pub mod chorus;
 pub mod dummy;
 pub mod fallback;
@@ -30,6 +31,11 @@ pub trait SlotConsensus: Sized {
     type OptimisticCommitData: Clone;
     type FinalizationData: Clone;
 
+    /// Notification from the data-availability layer
+    type DAEvent;
+    /// Effect directed at the data-availability layer
+    type DACommand: Clone;
+
     fn new(slot: Slot, config: &Self::Config, context: &Self::Context) -> Self;
 
     /// Called on the deadline of the slot
@@ -40,6 +46,10 @@ pub trait SlotConsensus: Sized {
 
     /// Handle a timer event.
     fn handle_timer(&mut self, timer: Self::Timer);
+
+    /// Handle a data-availability event. Consensus without a DA layer
+    /// ignores these.
+    fn handle_da_event(&mut self, _event: Self::DAEvent) {}
 
     /// Poll for output actions to be taken by the conductor.
     fn poll(&mut self) -> Option<SlotOutput<Self>>;
@@ -59,6 +69,10 @@ pub enum SlotOutput<S: SlotConsensus> {
 
     /// Send a message to a single peer validator
     Unicast { to: NodeId, message: S::Message },
+
+    /// Effect directed at the data-availability layer, routed by the
+    /// runtime to the DA sink under this slot.
+    DA(S::DACommand),
 
     /// Signal execution for optimistic execution.  Q: maybe move this
     /// message into a Context handle method? CommitOptimistic is

--- a/monad-mcp-chorus/src/spec.rs
+++ b/monad-mcp-chorus/src/spec.rs
@@ -42,10 +42,10 @@ pub mod validator {
         fn nodes(&self) -> impl Iterator<Item = &Self::NodeId>;
         fn contains(&self, node_id: &Self::NodeId) -> bool;
 
-        // the caller must gurantee that the node_id is in the valset.
+        // the caller must guarantee that the node_id is in the valset.
         fn get_pubkey(&self, node_id: &Self::NodeId) -> &Self::PubKey;
 
-        // the caller must gurantee that the node_id is in the valset.
+        // the caller must guarantee that the node_id is in the valset.
         fn get_stake(&self, node_id: &Self::NodeId) -> &Self::Stake;
 
         // the caller must guarantee that the nodes are all in the valset.

--- a/monad-mcp-chorus/src/spec.rs
+++ b/monad-mcp-chorus/src/spec.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pub use proposal::{ChunkHeader, MerkleRoot, ProposalSignature};
+pub use proposal::{MerkleRoot, ProposalHeader};
 pub use validator::{NodeId, Stake};
 pub use vote::{KeyPair, PubKey, Signature, SignatureCollection};
 
@@ -200,19 +200,32 @@ pub mod vote {
 }
 
 pub mod proposal {
+    use crate::prod::types::ProposalIndex;
+
     // A commitment to a proposal's payload.
     pub trait MerkleRoot: Copy + Eq + std::hash::Hash + std::fmt::Debug {}
 
-    // not the same as vote signature. at least ProposalSignature is not
-    // supposed to be aggregatable.
-    pub trait ProposalSignature: Clone + Eq + std::hash::Hash + std::fmt::Debug {}
-
-    // The DA chunk header, opaque to consensus except for validation
-    // against the proposal commitment and signature.
-    pub trait ChunkHeader: Clone + Eq + std::hash::Hash + std::fmt::Debug {
+    pub trait ProposalHeader: Clone + Eq + std::hash::Hash + std::fmt::Debug {
         type Root: MerkleRoot;
-        type Sig: ProposalSignature;
-        fn validate(&self, root: &Self::Root, sig: &Self::Sig) -> bool;
+
+        // todo: change to Slot when we move it to a shared mcp-types
+        // crate.
+        fn slot(&self) -> u64;
+
+        fn root(&self) -> &Self::Root;
+    }
+
+    pub trait HeaderAuth {
+        type Header: ProposalHeader;
+
+        fn authenticate(&self, header: &Self::Header, slot: u64) -> Option<ProposalIndex>;
+
+        // returns true when:
+        // - header is scoped to the slot
+        // - header is signed by the legitimate proposer of the slot
+        fn validate(&self, header: &Self::Header, slot: u64, j: ProposalIndex) -> bool {
+            self.authenticate(header, slot) == Some(j)
+        }
     }
 }
 
@@ -228,8 +241,8 @@ pub const fn assert_env<
     SignatureCollection,
     VoteAggregation,
     MerkleRoot,
-    ProposalSignature,
-    ChunkHeader,
+    ProposalHeader,
+    HeaderAuth,
 >()
 where
     NodeId: validator::NodeId,
@@ -242,7 +255,7 @@ where
         vote::SignatureCollection<Signature = Signature, ValidatorData = ValidatorData>,
     VoteAggregation: vote::VoteAggregation<'a, Stake, SignatureCollection = SignatureCollection>,
     MerkleRoot: proposal::MerkleRoot,
-    ProposalSignature: proposal::ProposalSignature,
-    ChunkHeader: proposal::ChunkHeader<Root = MerkleRoot, Sig = ProposalSignature>,
+    ProposalHeader: proposal::ProposalHeader,
+    HeaderAuth: proposal::HeaderAuth<Header = ProposalHeader>,
 {
 }

--- a/monad-mcp-chorus/src/spec.rs
+++ b/monad-mcp-chorus/src/spec.rs
@@ -32,14 +32,23 @@ pub mod validator {
 
         // floor(1/3 * self)
         fn honest_threshold(&self) -> Self;
+
+        // Proportional claim on shares discrete shares, as the
+        // quotient and remainder of shares * (self / total). The
+        // caller must guarantee that total is non-zero.
+        fn obligation(&self, total: &Self, shares: usize) -> (usize, usize);
     }
 
+    #[expect(clippy::len_without_is_empty)]
     pub trait ValidatorData {
         type NodeId: NodeId;
         type PubKey: super::vote::PubKey;
         type Stake: Stake;
 
+        // iterate through the validators in a stable order across
+        // all nodes.
         fn nodes(&self) -> impl Iterator<Item = &Self::NodeId>;
+        fn len(&self) -> usize;
         fn contains(&self, node_id: &Self::NodeId) -> bool;
 
         // the caller must guarantee that the node_id is in the valset.

--- a/monad-mcp-chorus/src/top_level.rs
+++ b/monad-mcp-chorus/src/top_level.rs
@@ -28,6 +28,6 @@ pub mod types;
 
 pub use conductor::{Conductor, ConductorOutput};
 pub use driver::{CadenceDriver, CadenceDriverMsg, CadenceMessage, Driver, NodeEvent, WakeId};
-pub use runtime::{CadenceRuntime, FinalizationObserver, Runtime};
+pub use runtime::{CadenceRuntime, DASink, FinalizationObserver, Runtime, SlotLifecycle};
 pub use slot::{SlotConsensus, SlotOutput};
 pub use slot_manager::SlotManager;

--- a/monad-mcp-chorus/src/types.rs
+++ b/monad-mcp-chorus/src/types.rs
@@ -55,8 +55,8 @@ impl Slot {
         self.checked_add(1)
     }
 
-    pub fn checked_sub(self, other: Self) -> Option<u64> {
-        self.0.checked_sub(other.0)
+    pub fn slots_since(self, earlier: Self) -> Option<u64> {
+        self.0.checked_sub(earlier.0)
     }
 }
 
@@ -555,7 +555,7 @@ impl<T> ProposalMap<T> {
         }
     }
 
-    pub(crate) fn new_default(size: usize) -> Self
+    pub fn new_default(size: usize) -> Self
     where
         T: Default,
     {
@@ -568,12 +568,12 @@ impl<T> ProposalMap<T> {
         self.values.len()
     }
 
-    pub(crate) fn as_ref(&self) -> ProposalMap<&T> {
+    pub fn as_ref(&self) -> ProposalMap<&T> {
         let values = self.values.iter().collect();
         ProposalMap { values }
     }
 
-    pub(crate) fn map<F, U>(self, f: F) -> ProposalMap<U>
+    pub fn map<F, U>(self, f: F) -> ProposalMap<U>
     where
         F: FnMut(T) -> U,
     {
@@ -581,7 +581,7 @@ impl<T> ProposalMap<T> {
         ProposalMap { values }
     }
 
-    pub(crate) fn map_indexed<F, U>(self, mut f: F) -> ProposalMap<U>
+    pub fn map_indexed<F, U>(self, mut f: F) -> ProposalMap<U>
     where
         F: FnMut(ProposalIndex, T) -> U,
     {
@@ -610,11 +610,11 @@ impl<T> IntoIterator for ProposalMap<T> {
 
 impl<T> ProposalMap<Option<T>> {
     /// Panics if index out of bounds. The caller must ensure the index is valid.
-    fn set(&mut self, index: ProposalIndex, value: T) {
+    pub fn set(&mut self, index: ProposalIndex, value: T) {
         self.values[index] = Some(value);
     }
 
-    pub(crate) fn try_into_total<S>(self) -> Option<TotalProposalMap<S>>
+    pub fn try_into_total<S>(self) -> Option<TotalProposalMap<S>>
     where
         S: From<T>,
     {
@@ -633,7 +633,7 @@ impl<T> ProposalMap<Option<T>> {
         Some(ProposalMap { values })
     }
 
-    fn into_total<S>(self) -> TotalProposalMap<S>
+    pub fn into_total<S>(self) -> TotalProposalMap<S>
     where
         S: From<Option<T>>,
     {
@@ -642,7 +642,7 @@ impl<T> ProposalMap<Option<T>> {
 }
 
 impl<T> ProposalMap<&T> {
-    pub(crate) fn into_owned(self) -> ProposalMap<T>
+    pub fn into_owned(self) -> ProposalMap<T>
     where
         T: Clone,
     {

--- a/monad-mcp-chorus/src/types.rs
+++ b/monad-mcp-chorus/src/types.rs
@@ -458,6 +458,133 @@ where
     }
 }
 
+pub trait GatingRoot {
+    fn gating_root(&self) -> Option<MerkleRoot>;
+}
+
+// Admission state for one voter
+#[derive(Clone)]
+struct Gate<V>
+where
+    V: IsVote,
+{
+    open_roots: HashSet<MerkleRoot>,
+    held: Option<VoteMsg<V>>,
+}
+
+impl<V> Default for Gate<V>
+where
+    V: IsVote,
+{
+    fn default() -> Self {
+        Self {
+            open_roots: HashSet::new(),
+            held: None,
+        }
+    }
+}
+
+impl<V> Gate<V>
+where
+    V: IsVote + GatingRoot,
+{
+    fn release(&mut self, root: MerkleRoot) -> Option<VoteMsg<V>> {
+        let claim_open = self
+            .held
+            .as_ref()
+            .is_some_and(|msg| msg.vote.gating_root() == Some(root));
+        if !claim_open {
+            return None;
+        }
+        self.held.take()
+    }
+}
+
+// the fate of a vote added to a GatedVotePool
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Admission {
+    Admitted,
+    // suspended until its root opens for the voter
+    Held,
+    // the voter already has a vote suspended
+    Dropped,
+}
+
+// VotePool with admission control
+#[derive(Clone)]
+pub struct GatedVotePool<V>
+where
+    V: IsVote + GatingRoot,
+{
+    pool: VotePool<V>,
+    gates: HashMap<NodeId, Gate<V>>,
+    open_roots: HashSet<MerkleRoot>,
+}
+
+impl<V> GatedVotePool<V>
+where
+    V: IsVote + GatingRoot,
+{
+    pub fn new(pool: VotePool<V>) -> Self {
+        Self {
+            pool,
+            gates: HashMap::new(),
+            open_roots: HashSet::new(),
+        }
+    }
+
+    pub fn add_vote(&mut self, node_id: NodeId, msg: VoteMsg<V>) -> Admission {
+        let gate = self.gates.entry(node_id).or_default();
+        if gate.held.is_some() {
+            // already holding a vote, ignore new ones
+            return Admission::Dropped;
+        }
+
+        let admissible = match msg.vote.gating_root() {
+            None => true, // e.g. negative vote; always admitted
+            Some(root) => self.open_roots.contains(&root) || gate.open_roots.contains(&root),
+        };
+
+        if !admissible {
+            gate.held = Some(msg);
+            return Admission::Held;
+        }
+        self.pool.add_vote(node_id, msg);
+        Admission::Admitted
+    }
+
+    pub fn open(&mut self, node_id: NodeId, root: MerkleRoot) {
+        let gate = self.gates.entry(node_id).or_default();
+        gate.open_roots.insert(root);
+
+        if let Some(msg) = gate.release(root) {
+            self.pool.add_vote(node_id, msg);
+        }
+    }
+
+    pub fn open_all(&mut self, root: MerkleRoot) {
+        self.open_roots.insert(root);
+
+        for (node_id, gate) in &mut self.gates {
+            if let Some(msg) = gate.release(root) {
+                self.pool.add_vote(*node_id, msg);
+            }
+        }
+    }
+
+    pub fn pool(&self) -> &VotePool<V> {
+        &self.pool
+    }
+
+    // the suspended votes, as (voter, root claimed)
+    pub fn held(&self) -> impl Iterator<Item = (NodeId, MerkleRoot)> + '_ {
+        self.gates.iter().filter_map(|(node_id, gate)| {
+            let root = gate.held.as_ref()?.vote.gating_root()?;
+            Some((*node_id, root))
+        })
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct VoteMsg<V>
 where
@@ -945,5 +1072,118 @@ mod tests {
         assert_eq!(WindowId::FIRST, WindowId(0));
         assert_eq!(WindowId::default(), WindowId(0));
         assert_eq!(WindowId(0).to_index(), Some(0));
+    }
+
+    #[derive(Clone, PartialEq, Eq, Hash, Debug)]
+    enum ClaimVote {
+        Claiming(MerkleRoot),
+        Free,
+    }
+
+    impl IsVote for ClaimVote {
+        type Scope = Slot;
+
+        fn serialize(&self, scope: &Self::Scope) -> bytes::Bytes {
+            dummy_serialize(self, scope)
+        }
+    }
+
+    impl GatingRoot for ClaimVote {
+        fn gating_root(&self) -> Option<MerkleRoot> {
+            match self {
+                ClaimVote::Claiming(root) => Some(*root),
+                ClaimVote::Free => None,
+            }
+        }
+    }
+
+    fn gated_pool() -> GatedVotePool<ClaimVote> {
+        GatedVotePool::new(VotePool::new(Slot(1)))
+    }
+
+    fn root(byte: u8) -> MerkleRoot {
+        crate::env::stub::MerkleRoot(crate::env::stub::MerkleHash([byte; 20]))
+    }
+
+    fn signed(id: u64, vote: ClaimVote) -> (NodeId, VoteMsg<ClaimVote>) {
+        let node = crate::env::stub::NodeId::dummy(id);
+        let msg = VoteMsg::new_signed(Slot(1), vote, &node.keypair());
+        (node, msg)
+    }
+
+    fn admitted(pool: &GatedVotePool<ClaimVote>) -> usize {
+        pool.pool().all_voters().count()
+    }
+
+    #[test]
+    fn free_votes_admit_immediately() {
+        let mut pool = gated_pool();
+        let (node, msg) = signed(1, ClaimVote::Free);
+
+        pool.add_vote(node, msg);
+        assert_eq!(admitted(&pool), 1);
+    }
+
+    #[test]
+    fn claiming_vote_suspends_until_matching_evidence() {
+        let mut pool = gated_pool();
+        let (node, msg) = signed(1, ClaimVote::Claiming(root(1)));
+
+        pool.add_vote(node, msg);
+        assert_eq!(admitted(&pool), 0);
+
+        // evidence for a different root does not release the vote
+        pool.open(node, root(2));
+        assert_eq!(admitted(&pool), 0);
+
+        pool.open(node, root(1));
+        assert_eq!(admitted(&pool), 1);
+    }
+
+    #[test]
+    fn evidence_before_vote_admits_on_arrival() {
+        let mut pool = gated_pool();
+        let (node, msg) = signed(1, ClaimVote::Claiming(root(1)));
+
+        pool.open(node, root(1));
+        pool.add_vote(node, msg);
+        assert_eq!(admitted(&pool), 1);
+    }
+
+    #[test]
+    fn open_all_is_pool_wide_and_root_scoped() {
+        let mut pool = gated_pool();
+        let (n1, m1) = signed(1, ClaimVote::Claiming(root(1)));
+        let (n2, m2) = signed(2, ClaimVote::Claiming(root(1)));
+        let (n3, m3) = signed(3, ClaimVote::Claiming(root(2)));
+
+        pool.add_vote(n1, m1);
+        pool.add_vote(n2, m2);
+        pool.add_vote(n3, m3);
+        assert_eq!(admitted(&pool), 0);
+
+        pool.open_all(root(1));
+        assert_eq!(admitted(&pool), 2);
+
+        // future votes on the opened root admit immediately
+        let (n4, m4) = signed(4, ClaimVote::Claiming(root(1)));
+        pool.add_vote(n4, m4);
+        assert_eq!(admitted(&pool), 3);
+    }
+
+    #[test]
+    fn first_held_vote_wins() {
+        let mut pool = gated_pool();
+        let (node, held) = signed(1, ClaimVote::Claiming(root(1)));
+        pool.add_vote(node, held);
+
+        // a later vote is dropped while one is suspended, even an
+        // immediately admissible one
+        let (_, second) = signed(1, ClaimVote::Free);
+        pool.add_vote(node, second);
+        assert_eq!(admitted(&pool), 0);
+
+        pool.open(node, root(1));
+        assert_eq!(admitted(&pool), 1);
     }
 }

--- a/monad-mcp-chorus/src/types.rs
+++ b/monad-mcp-chorus/src/types.rs
@@ -331,6 +331,11 @@ where
         self.votes.keys()
     }
 
+    // the distinct votes cast, each with its voters
+    pub fn buckets(&self) -> impl Iterator<Item = (&V, &HashSet<NodeId>)> {
+        self.buckets.iter()
+    }
+
     pub fn try_aggregate(
         &self,
         target_stake: Stake,

--- a/monad-mcp-chorus/src/types.rs
+++ b/monad-mcp-chorus/src/types.rs
@@ -25,7 +25,7 @@ use itertools::Either;
 
 // the environment this module subtree is instantiated.
 pub use super::env::{
-    KeyPair, MerkleRoot, NodeId, OpaqueChunkHeader, ProposalSignature, PubKey, Signature,
+    HeaderAuth, KeyPair, MerkleRoot, NodeId, ProposalHeader, PubKey, Signature,
     SignatureCollection, Stake, ValidatorData, VoteAggregation,
 };
 use crate::spec::{
@@ -40,8 +40,13 @@ pub struct Slot(pub u64);
 
 impl Slot {
     pub const FIRST: Self = Slot(0);
-    // the first meaningful slot number
+
+    // the first and last meaningful slot numbers
     pub const MIN: Self = Self::FIRST;
+    pub const MAX: Self = Slot(u64::MAX - 1);
+
+    // the max meaningful slot number used as cap
+    pub const MAX_CAP: Self = Slot(u64::MAX);
 
     pub const fn get(self) -> u64 {
         self.0
@@ -49,6 +54,10 @@ impl Slot {
 
     pub fn checked_add(self, slots: u64) -> Option<Self> {
         self.0.checked_add(slots).map(Self)
+    }
+
+    pub fn checked_sub(self, slots: u64) -> Option<Self> {
+        self.0.checked_sub(slots).map(Self)
     }
 
     pub fn checked_next(self) -> Option<Self> {
@@ -192,13 +201,6 @@ impl Default for WindowId {
     fn default() -> Self {
         Self::FIRST
     }
-}
-
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub struct ProposalMeta {
-    pub root: MerkleRoot,
-    pub sig: ProposalSignature,
-    pub opaque_header: OpaqueChunkHeader,
 }
 
 // A message with author signature validated.
@@ -573,6 +575,10 @@ impl<T> ProposalMap<T> {
         ProposalMap { values }
     }
 
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
+        self.values.iter_mut()
+    }
+
     pub fn map<F, U>(self, f: F) -> ProposalMap<U>
     where
         F: FnMut(T) -> U,
@@ -668,46 +674,9 @@ impl<T> std::ops::IndexMut<ProposalIndex> for ProposalMap<T> {
 // A helper wrapper type for a type-erased implementation of a trait
 pub struct Erased<T>(pub T);
 
-// A stub implementation of DAHandle that never returns any
-// proposal. used for testing purposes.
-pub struct DAHandle;
-
 // invariant: .0.root != .1.root and both properly signed.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub struct EquivCert(pub ProposalMeta, pub ProposalMeta);
-
-pub enum FetchProposalError {
-    Absent,
-    Equivocation(EquivCert),
-}
-
-impl DAHandle {
-    pub fn proposal_decoded(&self, _s: Slot, _j: ProposalIndex, _root: &MerkleRoot) -> bool {
-        false
-    }
-
-    /// Info DA about proposals we received through consensus messages (e.g. FallbackSignedEntry)
-    pub fn observe_proposal(&self, _s: Slot, _j: ProposalIndex, _meta: ProposalMeta) {
-        // do nothing
-    }
-
-    pub fn fetch_proposal(
-        &self,
-        _s: Slot,
-        _j: ProposalIndex,
-    ) -> Result<ProposalMeta, FetchProposalError> {
-        // Please do note that there is an potential to have more than
-        // one proposal meta for the same root. This can occur if the
-        // proposer sign the same root with different chunk header
-        // fields (e.g. varying unix_ts_ms).
-        //
-        // Q: How should we deal with this situation? Should we count
-        // it as equivocation? Or should we simply ignore that? Our
-        // current implementation follows the paper which doesn't
-        // currently consider this case as equivocation.
-        Err(FetchProposalError::Absent)
-    }
-}
+pub struct EquivCert(pub ProposalHeader, pub ProposalHeader);
 
 #[cfg(test)]
 mod tests {

--- a/monad-mcp-da/Cargo.toml
+++ b/monad-mcp-da/Cargo.toml
@@ -7,6 +7,11 @@ edition = "2024"
 enable_stub = ["monad-mcp-chorus/enable_stub"]
 
 [dependencies]
+bitvec = { workspace = true }
 bytes = { workspace = true }
+derive_more = { workspace = true, features = ["into"] }
+tracing = { workspace = true }
 
+monad-crypto = { workspace = true }
 monad-mcp-chorus = { workspace = true }
+monad-merkle = { workspace = true }

--- a/monad-mcp-da/Cargo.toml
+++ b/monad-mcp-da/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "monad-mcp-da"
+version = "0.1.0"
+edition = "2024"
+
+[features]
+enable_stub = ["monad-mcp-chorus/enable_stub"]
+
+[dependencies]
+bytes = { workspace = true }
+
+monad-mcp-chorus = { workspace = true }

--- a/monad-mcp-da/src/assignment.rs
+++ b/monad-mcp-da/src/assignment.rs
@@ -1,0 +1,341 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+
+use monad_mcp_chorus::spec::Stake as _;
+
+use super::{
+    chunk::WireChunkId,
+    types::{NodeId, Stake},
+};
+
+// a verified chunk id associated to a chunk assignment. always in
+// range.
+#[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd, Debug, Hash, derive_more::Into)]
+#[into(usize)]
+pub struct ChunkId(u16);
+
+impl ChunkId {
+    pub fn to_wire(self) -> WireChunkId {
+        self.0
+    }
+
+    #[cfg(test)]
+    pub(crate) fn unchecked(wire: WireChunkId) -> Self {
+        Self(wire)
+    }
+}
+
+// a verified index of a node in a chunk assignment. only meaningful with the
+// assignment that produced it.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, derive_more::Into)]
+pub(crate) struct NodeIndex(usize);
+
+// Resolved routing for a single chunk: the dissemination path author
+// -> owner -> rebroadcast targets. The author is never a target.
+pub struct ChunkRouting<'a> {
+    chunk_id: ChunkId,
+    target: &'a ChunkTarget,
+    assignment: &'a ChunkAssignment,
+}
+
+impl<'a> ChunkRouting<'a> {
+    pub fn chunk_id(&self) -> ChunkId {
+        self.chunk_id
+    }
+
+    pub(crate) fn owner_index(&self) -> NodeIndex {
+        self.target.owner_node_index
+    }
+
+    // rounding chunks in stake-proportional multicast
+    pub fn partial_rebroadcast_targets(&self) -> Option<HashSet<NodeId>> {
+        let indices = self.target.rebroadcast_targets.as_ref()?;
+        let nodes = indices
+            .iter()
+            .filter(|idx| self.is_rebroadcast_target(**idx))
+            .map(|idx| *self.assignment.nodes.get(*idx))
+            .collect();
+        Some(nodes)
+    }
+
+    // whether the node receives this chunk via rebroadcast
+    fn is_rebroadcast_target(&self, node: NodeIndex) -> bool {
+        if node == self.owner_index() || node == self.assignment.author {
+            return false;
+        }
+        let Some(indices) = &self.target.rebroadcast_targets else {
+            // rebroadcast to all other nodes
+            return true;
+        };
+        indices.contains(&node)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ChunkTarget {
+    // the first-hop recipient
+    owner_node_index: NodeIndex,
+
+    // if None, rebroadcast to all other recipients. reserved for
+    // stake-proportional multicast rounding chunks.
+    rebroadcast_targets: Option<Vec<NodeIndex>>,
+}
+
+// A frozen ordered list of nodes, indexable by NodeIndex. Captures
+// the concept of "the owner table for a ChunkAssignment".
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OrderedNodes(Box<[NodeId]>);
+
+impl OrderedNodes {
+    fn get(&self, index: NodeIndex) -> &NodeId {
+        &self.0[index.0]
+    }
+
+    // Note: O(N)
+    fn index_of(&self, node: &NodeId) -> Option<NodeIndex> {
+        let index = self.0.iter().position(|n| n == node)?;
+        Some(NodeIndex(index))
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (NodeIndex, &NodeId)> + '_ {
+        self.0.iter().enumerate().map(|(i, n)| (NodeIndex(i), n))
+    }
+}
+
+// A frozen assignment of chunks to nodes, identical on every
+// validator.
+//
+// NodeIndex and ChunkId are considered validated against the
+// assignment.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ChunkAssignment {
+    // mapping from NodeIndex to NodeId. The ordering is frozen on
+    // assignment.
+    //
+    // Invariant: every target's node indices are < nodes.len().
+    nodes: OrderedNodes,
+
+    // the source of every chunk
+    author: NodeIndex,
+
+    // mapping from chunk_id to the target node.
+    targets: Vec<ChunkTarget>,
+}
+
+impl ChunkAssignment {
+    pub fn num_chunks(&self) -> usize {
+        self.targets.len()
+    }
+
+    pub(crate) fn num_nodes(&self) -> usize {
+        self.nodes.0.len()
+    }
+
+    pub(crate) fn node(&self, index: NodeIndex) -> &NodeId {
+        self.nodes.get(index)
+    }
+
+    // Note: O(N). None if node is not in the assignment.
+    pub(crate) fn index_of(&self, node: &NodeId) -> Option<NodeIndex> {
+        self.nodes.index_of(node)
+    }
+
+    pub(crate) fn nodes(&self) -> impl Iterator<Item = (NodeIndex, &NodeId)> {
+        self.nodes.iter()
+    }
+
+    // Resolve the target information for a given chunk_id. Returns
+    // None if chunk_id is out of range.
+    pub fn resolve_chunk_id(&self, chunk_id: WireChunkId) -> Option<ChunkRouting<'_>> {
+        if usize::from(chunk_id) >= self.num_chunks() {
+            return None;
+        }
+        Some(self.routing(ChunkId(chunk_id)))
+    }
+
+    pub fn routing(&self, chunk_id: ChunkId) -> ChunkRouting<'_> {
+        ChunkRouting {
+            chunk_id,
+            target: &self.targets[usize::from(chunk_id)],
+            assignment: self,
+        }
+    }
+
+    fn routings(&self) -> impl Iterator<Item = ChunkRouting<'_>> {
+        self.chunk_ids().map(|chunk_id| self.routing(chunk_id))
+    }
+
+    pub(crate) fn chunk_ids(&self) -> impl Iterator<Item = ChunkId> {
+        (0..self.num_chunks() as u16).map(ChunkId)
+    }
+
+    pub(crate) fn owned_chunks(&self, node: NodeIndex) -> impl Iterator<Item = ChunkRouting<'_>> {
+        self.routings()
+            .filter(move |routing| routing.owner_index() == node)
+    }
+
+    pub(crate) fn full_rebroadcast_targets(&self, owner: NodeIndex) -> HashSet<NodeId> {
+        let mut targets = HashSet::with_capacity(self.num_nodes());
+        for (index, node) in self.nodes() {
+            if index == owner || index == self.author {
+                continue;
+            }
+            targets.insert(*node);
+        }
+        targets
+    }
+}
+
+// assign each node to chunks according to their stake, rounded up.
+pub struct StakePartition {
+    nodes: OrderedNodes,
+    // the stake of each node, by NodeIndex
+    weights: Vec<Stake>,
+}
+
+impl StakePartition {
+    pub fn new(weights: impl IntoIterator<Item = (NodeId, Stake)>) -> Self {
+        let mut nodes = Vec::new();
+        let mut stakes = Vec::new();
+        for (node, stake) in weights {
+            nodes.push(node);
+            stakes.push(stake);
+        }
+        Self {
+            nodes: OrderedNodes(nodes.into_boxed_slice()),
+            weights: stakes,
+        }
+    }
+
+    // the author must be one of the weighted nodes.
+    pub fn assign(
+        self,
+        author: &NodeId,
+        num_source_chunks: usize,
+        // todo: use raptorcast's fixed point redundancy type
+        redundancy: f32,
+    ) -> ChunkAssignment {
+        let scaled_num_source_chunks = (num_source_chunks as f32 * redundancy).ceil() as usize;
+        let mut remaining = self.obligations(scaled_num_source_chunks);
+
+        // chunk ids are dealt round-robin across nodes
+        let mut targets = Vec::new();
+        while !remaining.is_empty() {
+            for (node_index, obligation) in &mut remaining {
+                targets.push(ChunkTarget {
+                    owner_node_index: *node_index,
+                    // every chunk (including rounding) is currently
+                    // rebroadcast to the whole group. todo: stake
+                    // proportional rebroadcast for rounding chunks.
+                    rebroadcast_targets: None,
+                });
+                *obligation -= 1;
+            }
+            remaining.retain(|(_, obligation)| *obligation > 0);
+        }
+
+        let author = self
+            .nodes
+            .index_of(author)
+            .expect("author is a weighted node");
+        ChunkAssignment {
+            nodes: self.nodes,
+            author,
+            targets,
+        }
+    }
+
+    fn obligations(&self, shares: usize) -> Vec<(NodeIndex, usize)> {
+        let total = self.weights.iter().copied().sum::<Stake>();
+
+        let mut obligations = Vec::with_capacity(self.weights.len());
+        for (index, stake) in self.weights.iter().enumerate() {
+            let (whole, remainder) = stake.obligation(&total, shares);
+            let rounding_chunk = if remainder > 0 { 1 } else { 0 };
+            let obligation = whole + rounding_chunk;
+            if obligation > 0 {
+                obligations.push((NodeIndex(index), obligation));
+            }
+        }
+        obligations
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use monad_mcp_chorus::spec::Stake as _;
+
+    use super::*;
+
+    fn node(id: u64) -> NodeId {
+        NodeId::dummy(id)
+    }
+
+    // author 0 with no stake, then stakes 1, 1 and 2, over 10 chunks
+    fn assignment() -> ChunkAssignment {
+        let weights = [
+            (node(0), Stake::ZERO),
+            (node(1), Stake::from(1)),
+            (node(2), Stake::from(1)),
+            (node(3), Stake::from(2)),
+        ];
+        StakePartition::new(weights).assign(&node(0), 10, 1.0)
+    }
+
+    fn owned(assignment: &ChunkAssignment, id: u64) -> Vec<WireChunkId> {
+        let index = assignment.index_of(&node(id)).expect("in the assignment");
+        let mut owned = Vec::new();
+        for routing in assignment.owned_chunks(index) {
+            owned.push(routing.chunk_id().to_wire());
+        }
+        owned
+    }
+
+    #[test]
+    fn chunks_follow_stake_with_a_rounding_chunk_each() {
+        let assignment = assignment();
+
+        // 10 * 1/4 = 2 rem 2 -> 3; 10 * 2/4 = 5; the author owns nothing.
+        // ids are dealt round-robin among the owners
+        assert_eq!(assignment.num_chunks(), 11);
+        assert!(owned(&assignment, 0).is_empty());
+        assert_eq!(owned(&assignment, 1), [0, 3, 6]);
+        assert_eq!(owned(&assignment, 2), [1, 4, 7]);
+        assert_eq!(owned(&assignment, 3), [2, 5, 8, 9, 10]);
+    }
+
+    #[test]
+    fn redundancy_scales_the_source_count_rounding_up() {
+        // ceil(3 * 2.5) = 8 shares over 3 equal nodes: 2 rem 2 -> 3 each
+        let weights = (0..3).map(|id| (node(id), Stake::from(1)));
+        let assignment = StakePartition::new(weights).assign(&node(0), 3, 2.5);
+        assert_eq!(assignment.num_chunks(), 9);
+    }
+
+    #[test]
+    fn ids_and_nodes_are_checked_against_the_assignment() {
+        let assignment = assignment();
+        assert!(assignment.resolve_chunk_id(10).is_some());
+        assert!(assignment.resolve_chunk_id(11).is_none());
+        assert!(assignment.index_of(&node(9)).is_none());
+    }
+
+    #[test]
+    fn the_same_weights_give_the_same_assignment() {
+        assert_eq!(assignment(), assignment());
+    }
+}

--- a/monad-mcp-da/src/assignment.rs
+++ b/monad-mcp-da/src/assignment.rs
@@ -83,6 +83,21 @@ impl<'a> ChunkRouting<'a> {
         };
         indices.contains(&node)
     }
+
+    // from whom should the receiver get this chunk? none if unrouted
+    pub(crate) fn upstream(&self, receiver: NodeIndex) -> Option<Upstream> {
+        if receiver == self.assignment.author {
+            // the source holds every chunk
+            return None;
+        }
+        if self.owner_index() == receiver {
+            return Some(Upstream::Author);
+        }
+        if self.is_rebroadcast_target(receiver) {
+            return Some(Upstream::Owner(self.owner_index()));
+        }
+        None
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -188,6 +203,12 @@ impl ChunkAssignment {
             .filter(move |routing| routing.owner_index() == node)
     }
 
+    // the upstream of every chunk routed to the receiver
+    pub(crate) fn upstreams(&self, receiver: NodeIndex) -> impl Iterator<Item = Upstream> + '_ {
+        self.routings()
+            .filter_map(move |routing| routing.upstream(receiver))
+    }
+
     pub(crate) fn full_rebroadcast_targets(&self, owner: NodeIndex) -> HashSet<NodeId> {
         let mut targets = HashSet::with_capacity(self.num_nodes());
         for (index, node) in self.nodes() {
@@ -198,6 +219,19 @@ impl ChunkAssignment {
         }
         targets
     }
+}
+
+// upstream(c, R) = bottom    if R == author
+//                  author    if R == owner(c)
+//                  owner(c)  if R is a rebroadcast target of c
+//                  bottom    if c is unrouted to R
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub(crate) enum Upstream {
+    // the chunk is routed to the receiver in first-hop
+    Author,
+    // the chunk is routed to the receiver through rebroadcast via
+    // this node.
+    Owner(NodeIndex),
 }
 
 // assign each node to chunks according to their stake, rounded up.
@@ -324,6 +358,28 @@ mod tests {
         let weights = (0..3).map(|id| (node(id), Stake::from(1)));
         let assignment = StakePartition::new(weights).assign(&node(0), 3, 2.5);
         assert_eq!(assignment.num_chunks(), 9);
+    }
+
+    #[test]
+    fn upstream_follows_the_dissemination_tree() {
+        let assignment = assignment();
+        let author = assignment.index_of(&node(0)).unwrap();
+        let owner = assignment.index_of(&node(1)).unwrap();
+        let other = assignment.index_of(&node(2)).unwrap();
+
+        // chunk 0 is owned by node 1
+        let routing = assignment.routing(ChunkId(0));
+        assert_eq!(routing.owner_index(), owner);
+        assert_eq!(routing.upstream(author), None);
+        assert_eq!(routing.upstream(owner), Some(Upstream::Author));
+        assert_eq!(routing.upstream(other), Some(Upstream::Owner(owner)));
+
+        // the full rebroadcast reaches everyone but the owner and the author
+        assert_eq!(routing.partial_rebroadcast_targets(), None);
+        assert_eq!(
+            assignment.full_rebroadcast_targets(owner),
+            HashSet::from([node(2), node(3)])
+        );
     }
 
     #[test]

--- a/monad-mcp-da/src/chunk.rs
+++ b/monad-mcp-da/src/chunk.rs
@@ -1,0 +1,125 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::{BTreeMap, HashMap};
+
+use bytes::Bytes;
+
+use super::types::{MerkleHash, ProposalHeader};
+
+// a chunk id as carried on the wire, not yet checked against an
+// assignment.
+pub type WireChunkId = u16;
+
+// the chunk-specific half of a chunk: what remains after the shared
+// proposal header and the chunk id are factored out.
+#[derive(Clone)]
+pub struct ChunkData {
+    pub(crate) symbol: Bytes,
+    pub(crate) proof: Box<[MerkleHash]>,
+}
+
+// a chunk is exactly a well-formed (proposal header, chunk id, merkle
+// proof, symbol). todo: enforce proof validity at parse time, so a
+// Chunk always holds a valid merkle proof.
+#[derive(Clone)]
+pub struct Chunk {
+    header: ProposalHeader,
+    chunk_id: WireChunkId,
+    data: ChunkData,
+}
+
+impl Chunk {
+    pub(crate) fn new(header: ProposalHeader, chunk_id: WireChunkId, data: ChunkData) -> Self {
+        Self {
+            header,
+            chunk_id,
+            data,
+        }
+    }
+
+    pub fn proposal_header(&self) -> &ProposalHeader {
+        &self.header
+    }
+
+    pub fn chunk_id(&self) -> WireChunkId {
+        self.chunk_id
+    }
+
+    pub fn proof(&self) -> &[MerkleHash] {
+        &self.data.proof
+    }
+
+    pub fn symbol(&self) -> &Bytes {
+        &self.data.symbol
+    }
+
+    pub(crate) fn into_parts(self) -> (ProposalHeader, WireChunkId, ChunkData) {
+        (self.header, self.chunk_id, self.data)
+    }
+}
+
+// a partial view of one proposal: its header plus any subset of its
+// chunks. the unit of both dissemination and ingestion.
+#[derive(Clone)]
+pub struct ProposalEnvelope {
+    header: ProposalHeader,
+    chunks: BTreeMap<WireChunkId, ChunkData>,
+}
+
+impl ProposalEnvelope {
+    pub(crate) fn new(header: ProposalHeader, chunks: BTreeMap<WireChunkId, ChunkData>) -> Self {
+        Self { header, chunks }
+    }
+
+    pub fn from_chunk(chunk: Chunk) -> Self {
+        let (header, chunk_id, data) = chunk.into_parts();
+        let mut chunks = BTreeMap::new();
+        chunks.insert(chunk_id, data);
+        Self::new(header, chunks)
+    }
+
+    pub fn from_header(header: ProposalHeader) -> Self {
+        Self::new(header, BTreeMap::new())
+    }
+
+    // group chunks by header. each header appears once.
+    pub fn group(
+        chunks: impl IntoIterator<Item = Chunk>,
+    ) -> impl Iterator<Item = (ProposalHeader, BTreeMap<WireChunkId, ChunkData>)> {
+        let mut groups: HashMap<ProposalHeader, BTreeMap<WireChunkId, ChunkData>> = HashMap::new();
+        for chunk in chunks {
+            let (header, chunk_id, data) = chunk.into_parts();
+            groups.entry(header).or_default().insert(chunk_id, data);
+        }
+        groups.into_iter()
+    }
+
+    pub fn header(&self) -> &ProposalHeader {
+        &self.header
+    }
+
+    pub fn chunks(&self) -> &BTreeMap<WireChunkId, ChunkData> {
+        &self.chunks
+    }
+
+    pub(crate) fn insert(&mut self, chunk_id: WireChunkId, data: ChunkData) {
+        self.chunks.insert(chunk_id, data);
+    }
+
+    pub(crate) fn into_parts(self) -> (ProposalHeader, BTreeMap<WireChunkId, ChunkData>) {
+        (self.header, self.chunks)
+    }
+}

--- a/monad-mcp-da/src/chunk.rs
+++ b/monad-mcp-da/src/chunk.rs
@@ -123,3 +123,24 @@ impl ProposalEnvelope {
         (self.header, self.chunks)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::test_util::{epoch_handle, proposal_chunks},
+        *,
+    };
+
+    #[test]
+    fn grouping_collects_each_proposal_once() {
+        let epoch_handle = epoch_handle();
+        let (header_a, a) = proposal_chunks(&epoch_handle, 1);
+        let (header_b, b) = proposal_chunks(&epoch_handle, 2);
+
+        let mixed = [a[0].clone(), b[0].clone(), a[1].clone()];
+        let groups: HashMap<_, _> = ProposalEnvelope::group(mixed).collect();
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[&header_a].len(), 2);
+        assert_eq!(groups[&header_b].len(), 1);
+    }
+}

--- a/monad-mcp-da/src/chunk.rs
+++ b/monad-mcp-da/src/chunk.rs
@@ -13,15 +13,62 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use bytes::Bytes;
 
-use super::types::{MerkleHash, ProposalHeader};
+use super::{
+    assignment::ChunkId,
+    types::{ChunkRequestType, MerkleHash, ProposalHeader},
+};
 
 // a chunk id as carried on the wire, not yet checked against an
 // assignment.
 pub type WireChunkId = u16;
+
+// the chunks of the type (your-chunks/my-chunks)
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ChunksSubset {
+    All,
+    // non-empty. todo: allow empty to request the header alone.
+    Narrowed(BTreeSet<WireChunkId>),
+}
+
+impl ChunksSubset {
+    // the caller must ensure chunk_ids is not empty.
+    pub fn narrowed(chunk_ids: impl IntoIterator<Item = ChunkId>) -> Self {
+        let chunk_ids: BTreeSet<_> = chunk_ids.into_iter().map(ChunkId::to_wire).collect();
+        assert!(!chunk_ids.is_empty());
+        Self::Narrowed(chunk_ids)
+    }
+
+    pub fn restrict<'a>(
+        &'a self,
+        chunk_ids: impl IntoIterator<Item = ChunkId> + 'a,
+    ) -> impl Iterator<Item = ChunkId> + 'a {
+        chunk_ids.into_iter().filter(move |id| match self {
+            Self::All => true,
+            Self::Narrowed(named) => named.contains(&id.to_wire()),
+        })
+    }
+}
+
+// the chunks of one owner, the requester's or the peer's
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct ChunkRequest {
+    pub(crate) kind: ChunkRequestType,
+    pub(crate) subset: ChunksSubset,
+}
+
+impl ChunkRequest {
+    // the full set of chunks of the kind
+    pub(crate) fn all(kind: ChunkRequestType) -> Self {
+        Self {
+            kind,
+            subset: ChunksSubset::All,
+        }
+    }
+}
 
 // the chunk-specific half of a chunk: what remains after the shared
 // proposal header and the chunk id are factored out.
@@ -142,5 +189,21 @@ mod tests {
         assert_eq!(groups.len(), 2);
         assert_eq!(groups[&header_a].len(), 2);
         assert_eq!(groups[&header_b].len(), 1);
+    }
+
+    #[test]
+    fn restrict_keeps_the_named_ids() {
+        let ids = [
+            ChunkId::unchecked(1),
+            ChunkId::unchecked(2),
+            ChunkId::unchecked(3),
+        ];
+
+        let all: Vec<_> = ChunksSubset::All.restrict(ids).collect();
+        assert_eq!(all, ids);
+
+        let narrowed = ChunksSubset::narrowed([ChunkId::unchecked(2), ChunkId::unchecked(9)]);
+        let kept: Vec<_> = narrowed.restrict(ids).collect();
+        assert_eq!(kept, [ChunkId::unchecked(2)]);
     }
 }

--- a/monad-mcp-da/src/chunk_tree.rs
+++ b/monad-mcp-da/src/chunk_tree.rs
@@ -1,0 +1,211 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::BTreeMap;
+
+use bytes::Bytes;
+use monad_merkle::{MerkleProof, MerkleTree};
+
+use super::{
+    assignment::ChunkId,
+    chunk::{ChunkData, WireChunkId},
+    layout::PacketLayout,
+    types::{MerkleHash, MerkleRoot},
+};
+
+// the chunks of one proposal under its merkle root. Partial while
+// chunks arrive with their wire proofs. Complete once every symbol is
+// known, when any chunk is derivable.
+pub(crate) enum ChunkTree {
+    Partial {
+        root: MerkleRoot,
+        chunks: BTreeMap<ChunkId, ChunkData>,
+    },
+    Complete {
+        root: MerkleRoot,
+        // in chunk id order
+        symbols: Vec<Bytes>,
+        tree: MerkleTree,
+    },
+}
+
+impl ChunkTree {
+    pub(crate) fn partial(root: MerkleRoot) -> Self {
+        Self::Partial {
+            root,
+            chunks: BTreeMap::new(),
+        }
+    }
+
+    // commit to the symbols in chunk id order. None if they do not fit
+    // the layout's tree depth.
+    pub(crate) fn complete(layout: &PacketLayout, symbols: Vec<Bytes>) -> Option<Self> {
+        let depth = layout.merkle_tree_depth();
+        if symbols.is_empty() || depth == 0 || depth > MerkleTree::MAX_DEPTH {
+            return None;
+        }
+        if symbols.len() > 1usize << (depth - 1) {
+            return None;
+        }
+
+        let mut leaves = Vec::with_capacity(symbols.len());
+        for (leaf_idx, symbol) in symbols.iter().enumerate() {
+            let hash = layout.merkle_leaf_hash(leaf_idx as WireChunkId, symbol);
+            leaves.push(hash);
+        }
+        let tree = MerkleTree::new_with_depth(&leaves, depth);
+        let root = MerkleRoot(MerkleHash(*tree.root()));
+
+        Some(Self::Complete {
+            root,
+            symbols,
+            tree,
+        })
+    }
+
+    pub(crate) fn root(&self) -> MerkleRoot {
+        match self {
+            Self::Partial { root, .. } | Self::Complete { root, .. } => *root,
+        }
+    }
+
+    // whether the chunk's proof binds it to our root
+    pub(crate) fn verify(
+        &self,
+        layout: &PacketLayout,
+        chunk_id: ChunkId,
+        data: &ChunkData,
+    ) -> bool {
+        let leaf_idx = chunk_id.to_wire();
+        let leaf = layout.merkle_leaf_hash(leaf_idx, &data.symbol);
+        let siblings = data.proof.iter().map(|hash| hash.0).collect();
+        let Some(proof) = MerkleProof::new_from_leaf_idx(siblings, leaf_idx) else {
+            return false;
+        };
+        let Some(computed) = proof.compute_root(&leaf) else {
+            return false;
+        };
+        MerkleRoot(MerkleHash(computed)) == self.root()
+    }
+
+    // record a received chunk. nothing to record once complete.
+    pub(crate) fn insert(&mut self, chunk_id: ChunkId, data: ChunkData) {
+        let Self::Partial { chunks, .. } = self else {
+            return;
+        };
+        chunks.entry(chunk_id).or_insert(data);
+    }
+
+    pub(crate) fn contains(&self, chunk_id: ChunkId) -> bool {
+        match self {
+            Self::Partial { chunks, .. } => chunks.contains_key(&chunk_id),
+            Self::Complete { .. } => true,
+        }
+    }
+
+    // None if the chunk has not arrived
+    pub(crate) fn chunk_data(&self, chunk_id: ChunkId) -> Option<ChunkData> {
+        match self {
+            Self::Partial { chunks, .. } => chunks.get(&chunk_id).cloned(),
+            Self::Complete { symbols, tree, .. } => {
+                let symbol = symbols[usize::from(chunk_id)].clone();
+                let proof = tree.proof(chunk_id.to_wire());
+                let siblings = proof.siblings().iter().map(|hash| MerkleHash(*hash));
+                Some(ChunkData {
+                    symbol,
+                    proof: siblings.collect(),
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn symbols(n: usize) -> Vec<Bytes> {
+        (0..n).map(|i| Bytes::from(vec![i as u8; 8])).collect()
+    }
+
+    fn id(wire: WireChunkId) -> ChunkId {
+        ChunkId::unchecked(wire)
+    }
+
+    // depth 3: four leaves
+    fn layout() -> PacketLayout {
+        PacketLayout::new(32, 3)
+    }
+
+    #[test]
+    fn derived_chunks_verify_under_the_root() {
+        let complete = ChunkTree::complete(&layout(), symbols(4)).expect("fits depth 3");
+        let partial = ChunkTree::partial(complete.root());
+
+        for wire in 0..4 {
+            let data = complete.chunk_data(id(wire)).expect("derivable");
+            assert!(partial.verify(&layout(), id(wire), &data));
+            assert!(complete.contains(id(wire)));
+        }
+    }
+
+    #[test]
+    fn verification_binds_symbol_index_and_root() {
+        let complete = ChunkTree::complete(&layout(), symbols(4)).unwrap();
+        let data = complete.chunk_data(id(0)).unwrap();
+        let tree = ChunkTree::partial(complete.root());
+
+        // wrong index
+        assert!(!tree.verify(&layout(), id(1), &data));
+
+        // tampered symbol
+        let tampered = ChunkData {
+            symbol: Bytes::from_static(b"tampered"),
+            proof: data.proof.clone(),
+        };
+        assert!(!tree.verify(&layout(), id(0), &tampered));
+
+        // another proposal's root
+        let other = ChunkTree::complete(&layout(), symbols(3)).unwrap();
+        assert!(!ChunkTree::partial(other.root()).verify(&layout(), id(0), &data));
+    }
+
+    #[test]
+    fn completion_needs_symbols_that_fit_the_depth() {
+        assert!(ChunkTree::complete(&layout(), vec![]).is_none());
+        assert!(ChunkTree::complete(&layout(), symbols(5)).is_none());
+        assert!(ChunkTree::complete(&PacketLayout::new(32, 0), symbols(1)).is_none());
+        let too_deep = PacketLayout::new(32, MerkleTree::MAX_DEPTH + 1);
+        assert!(ChunkTree::complete(&too_deep, symbols(1)).is_none());
+        assert!(ChunkTree::complete(&layout(), symbols(4)).is_some());
+    }
+
+    #[test]
+    fn a_partial_tree_records_chunks_and_a_complete_one_ignores_them() {
+        let mut complete = ChunkTree::complete(&layout(), symbols(4)).unwrap();
+        let data = complete.chunk_data(id(0)).unwrap();
+
+        let mut partial = ChunkTree::partial(complete.root());
+        assert!(!partial.contains(id(0)));
+        assert!(partial.chunk_data(id(0)).is_none());
+        partial.insert(id(0), data.clone());
+        assert!(partial.contains(id(0)));
+        assert!(partial.chunk_data(id(0)).is_some());
+        assert!(!partial.contains(id(1)));
+
+        complete.insert(id(0), data);
+        assert!(complete.contains(id(3)));
+    }
+}

--- a/monad-mcp-da/src/egress.rs
+++ b/monad-mcp-da/src/egress.rs
@@ -1,0 +1,155 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::{BTreeMap, HashSet};
+
+use super::{
+    chunk::{ChunkData, ProposalEnvelope, WireChunkId},
+    types::{NodeId, ProposalHeader},
+};
+
+pub struct Dissemination {
+    pub to: HashSet<NodeId>,
+    pub envelope: ProposalEnvelope,
+}
+
+pub(crate) struct ChunkEgress {
+    released: bool,
+    pending: Vec<Dissemination>,
+}
+
+impl ChunkEgress {
+    pub(crate) fn new() -> Self {
+        Self {
+            // todo: flip to true to rebroadcast immediately as in
+            // ChunkSync proposal.
+            released: false,
+            pending: Vec::new(),
+        }
+    }
+
+    // todo: bound the pending buffer
+    pub(crate) fn enqueue(
+        &mut self,
+        recipients: &HashSet<NodeId>,
+        header: &ProposalHeader,
+        chunk_id: WireChunkId,
+        data: ChunkData,
+    ) {
+        if let Some(last) = self.pending.last_mut()
+            && last.to == *recipients
+            && last.envelope.header() == header
+        {
+            // merge with existing envelop
+            last.envelope.insert(chunk_id, data);
+            return;
+        }
+
+        let chunks = BTreeMap::from([(chunk_id, data)]);
+        let envelope = ProposalEnvelope::new(header.clone(), chunks);
+        self.pending.push(Dissemination {
+            to: recipients.clone(),
+            envelope,
+        });
+    }
+
+    pub(crate) fn release(&mut self) {
+        self.released = true;
+    }
+
+    pub(crate) fn drain(&mut self) -> Vec<Dissemination> {
+        if !self.released {
+            return vec![];
+        }
+        std::mem::take(&mut self.pending)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::{
+            chunk::Chunk,
+            test_util::{epoch_handle, proposal_chunks},
+        },
+        *,
+    };
+
+    fn parts(chunk: &Chunk) -> (ProposalHeader, WireChunkId, ChunkData) {
+        chunk.clone().into_parts()
+    }
+
+    fn to(ids: impl IntoIterator<Item = u64>) -> HashSet<NodeId> {
+        ids.into_iter().map(NodeId::dummy).collect()
+    }
+
+    fn released() -> ChunkEgress {
+        let mut egress = ChunkEgress::new();
+        egress.release();
+        egress
+    }
+
+    fn enqueue(egress: &mut ChunkEgress, chunk: &Chunk, recipients: &HashSet<NodeId>) {
+        let (header, chunk_id, data) = parts(chunk);
+        egress.enqueue(recipients, &header, chunk_id, data);
+    }
+
+    #[test]
+    fn consecutive_chunks_to_the_same_recipients_share_an_envelope() {
+        let (_, chunks) = proposal_chunks(&epoch_handle(), 1);
+        let mut egress = released();
+
+        enqueue(&mut egress, &chunks[0], &to([2, 3]));
+        enqueue(&mut egress, &chunks[1], &to([2, 3]));
+
+        let messages = egress.drain();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].to, to([2, 3]));
+        assert_eq!(messages[0].envelope.chunks().len(), 2);
+        assert!(egress.drain().is_empty());
+    }
+
+    #[test]
+    fn a_new_message_starts_on_other_recipients_or_another_header() {
+        let epoch_handle = epoch_handle();
+        let (_, a) = proposal_chunks(&epoch_handle, 1);
+        let (_, b) = proposal_chunks(&epoch_handle, 2);
+        let mut egress = released();
+
+        enqueue(&mut egress, &a[0], &to([2, 3]));
+        enqueue(&mut egress, &a[1], &to([3]));
+        enqueue(&mut egress, &b[0], &to([3]));
+        // a repeat of an earlier key is not merged backwards
+        enqueue(&mut egress, &a[2], &to([3]));
+
+        let messages = egress.drain();
+        assert_eq!(messages.len(), 4);
+        for message in &messages {
+            assert_eq!(message.envelope.chunks().len(), 1);
+        }
+    }
+
+    #[test]
+    fn nothing_drains_before_release() {
+        let (_, chunks) = proposal_chunks(&epoch_handle(), 1);
+        let mut egress = ChunkEgress::new();
+
+        enqueue(&mut egress, &chunks[0], &to([2, 3]));
+        assert!(egress.drain().is_empty());
+
+        egress.release();
+        assert_eq!(egress.drain().len(), 1);
+    }
+}

--- a/monad-mcp-da/src/election.rs
+++ b/monad-mcp-da/src/election.rs
@@ -13,16 +13,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// re-export chorus types
-pub use super::{
-    chorus::{
-        SlotLifecycle,
-        env::MerkleHash,
-        slot::chorus::{ChorusDACommand, ChorusDAEvent, ProposalDAEvent},
-        types::{
-            HeaderAuth, MerkleRoot, NodeId, ProposalHeader, ProposalIndex, ProposalMap, Slot,
-            Stake, ValidatorData,
-        },
-    },
-    env::ProposalKeyPair,
-};
+use super::types::{NodeId, ProposalIndex, Slot};
+
+pub trait ProposerElection {
+    // invariant: get_proposer(s, i) == Some(n) iff get_index(s, n) == Some(i)
+    // corollary: for each slot, a node can occupy at most one index
+
+    // returns None if index has no proposer
+    fn get_proposer(&self, slot: Slot, index: ProposalIndex) -> Option<&NodeId>;
+
+    // returns None if node is not a valid proposer for the slot
+    fn get_index(&self, slot: Slot, node: &NodeId) -> Option<ProposalIndex>;
+}

--- a/monad-mcp-da/src/encoding_scheme/d25.rs
+++ b/monad-mcp-da/src/encoding_scheme/d25.rs
@@ -1,0 +1,165 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use monad_mcp_chorus::spec::{Stake as _, validator::ValidatorData as _};
+use monad_merkle::MerkleTree;
+
+use super::{
+    super::{
+        assignment::{ChunkAssignment, StakePartition},
+        chorus::env::D25,
+        layout::PacketLayout,
+        types::{NodeId, Stake, ValidatorData},
+    },
+    DAEncodingScheme,
+    stub::{StubSymbolDecoder, StubSymbolEncoder},
+};
+
+const REDUNDANCY: f32 = 2.5;
+
+// the encoding scheme of deterministic raptorcast for the current
+// monad-bft. This encoding scheme is not going to be used by mcp. I'm
+// re-implementing it here to mainly serve as a reference to ensure
+// the da implementation is versatile enough to support other encoding
+// schemes.
+//
+// D25 encoding scheme:
+// - 2.5x redundancy
+// - author owns no chunks, and is the last node of the table
+// - stake partition with round up chunks
+// - todo: valset pre-shuffled based on (slot, ...)
+// - assigned round-robin
+// - todo: symbols encoded using raptor code
+impl DAEncodingScheme for D25 {
+    type Encoder = StubSymbolEncoder;
+    type Decoder = StubSymbolDecoder;
+
+    // the smallest merkle tree depth whose leaves fit the assignment's
+    // chunk count (bounded by one rounding chunk per owner)
+    fn packet_layout(&self, num_validators: usize) -> Option<PacketLayout> {
+        let num_owners = num_validators.saturating_sub(1);
+        for depth in 2..=MerkleTree::MAX_DEPTH {
+            let layout = PacketLayout::new(self.msg_len, depth);
+            let scaled_source_chunks =
+                (layout.num_source_chunks() as f32 * REDUNDANCY).ceil() as usize;
+            let chunk_bound = scaled_source_chunks + num_owners;
+            if chunk_bound <= 1usize << (depth - 1) {
+                return Some(layout);
+            }
+        }
+        None
+    }
+
+    fn chunk_assignment(
+        &self,
+        layout: &PacketLayout,
+        author: &NodeId,
+        validator_data: &ValidatorData,
+    ) -> ChunkAssignment {
+        let mut weights = vec![];
+        for node_id in validator_data.nodes() {
+            if node_id == author {
+                continue;
+            }
+            let stake = validator_data.get_stake(node_id);
+            weights.push((*node_id, *stake));
+        }
+        weights.push((*author, Stake::ZERO));
+
+        let partition = StakePartition::new(weights);
+        let num_source_chunks = layout.num_source_chunks();
+        partition.assign(author, num_source_chunks, REDUNDANCY)
+    }
+
+    fn encoder(&self, _layout: PacketLayout, num_chunks: usize) -> StubSymbolEncoder {
+        StubSymbolEncoder::new(num_chunks)
+    }
+
+    fn decoder(&self, layout: PacketLayout, _num_chunks: usize) -> StubSymbolDecoder {
+        StubSymbolDecoder::new(layout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::{
+        super::{
+            super::{
+                assignment::ChunkId,
+                test_util::{MESSAGE_LEN, author, epoch_handle},
+            },
+            SymbolDecoder as _, SymbolEncoder as _,
+        },
+        *,
+    };
+
+    fn scheme() -> D25 {
+        D25 {
+            msg_len: MESSAGE_LEN,
+            unix_ts: 0,
+        }
+    }
+
+    #[test]
+    fn packet_layout_is_the_smallest_depth_that_fits() {
+        // 2 source chunks at 2.5x is 5, plus one rounding chunk per
+        // owner: 8 leaves for 3 owners (depth 4), 16 for 11 (depth 5)
+        let layout = scheme().packet_layout(4).expect("fits");
+        assert_eq!(layout.merkle_tree_depth(), 4);
+        assert_eq!(layout.num_source_chunks(), 2);
+        assert_eq!(scheme().packet_layout(12).unwrap().merkle_tree_depth(), 5);
+
+        let oversized = D25 {
+            msg_len: 1 << 40,
+            unix_ts: 0,
+        };
+        assert!(oversized.packet_layout(4).is_none());
+    }
+
+    #[test]
+    fn the_author_comes_last_and_owns_nothing() {
+        let epoch_handle = epoch_handle();
+        let layout = scheme().packet_layout(4).unwrap();
+        let assignment =
+            scheme().chunk_assignment(&layout, &author(), &epoch_handle.validator_data);
+
+        let author_index = assignment.index_of(&author()).expect("in the table");
+        assert_eq!(usize::from(author_index), 3);
+        assert_eq!(assignment.owned_chunks(author_index).count(), 0);
+
+        assert_eq!(assignment.num_chunks(), 6);
+        for id in 1..=3 {
+            let index = assignment.index_of(&NodeId::dummy(id)).unwrap();
+            assert_eq!(assignment.owned_chunks(index).count(), 2);
+        }
+    }
+
+    #[test]
+    fn decoding_needs_one_more_symbol_than_the_source_count() {
+        let layout = scheme().packet_layout(4).unwrap();
+        let message = vec![7u8; MESSAGE_LEN];
+        let symbols = scheme().encoder(layout, 6).encode(&message);
+        assert_eq!(symbols.len(), 6);
+
+        let mut decoder = scheme().decoder(layout, 6);
+        decoder.ingest(ChunkId::unchecked(0), &symbols[0]);
+        decoder.ingest(ChunkId::unchecked(1), &symbols[1]);
+        assert!(decoder.try_decode().is_none());
+        decoder.ingest(ChunkId::unchecked(2), &symbols[2]);
+        assert_eq!(decoder.try_decode(), Some(Bytes::from(message)));
+    }
+}

--- a/monad-mcp-da/src/encoding_scheme/mod.rs
+++ b/monad-mcp-da/src/encoding_scheme/mod.rs
@@ -1,0 +1,125 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+mod d25;
+mod stub;
+
+use bytes::Bytes;
+
+use super::{
+    assignment::{ChunkAssignment, ChunkId},
+    chorus::env::EncodingScheme,
+    chunk_tree::ChunkTree,
+    layout::PacketLayout,
+    types::{NodeId, ValidatorData},
+};
+
+// the DA-side capabilities of an encoding scheme: it fixes the packet
+// layout, the chunk assignment and the symbol code.
+//
+// Note: packet_layout & chunk_assignment can be expensive to
+// calculate. Avoid recomputing them where possible.
+pub(crate) trait DAEncodingScheme {
+    type Encoder: SymbolEncoder;
+    type Decoder: SymbolDecoder;
+
+    // None if the scheme fits no packet layout (e.g. an oversized
+    // msg_len)
+    fn packet_layout(&self, num_validators: usize) -> Option<PacketLayout>;
+
+    fn chunk_assignment(
+        &self,
+        layout: &PacketLayout,
+        author: &NodeId,
+        validator_data: &ValidatorData,
+    ) -> ChunkAssignment;
+
+    fn encoder(&self, layout: PacketLayout, num_chunks: usize) -> Self::Encoder;
+
+    fn decoder(&self, layout: PacketLayout, num_chunks: usize) -> Self::Decoder;
+
+    // encode a proposal into its chunk tree. None if the message does
+    // not fit the layout.
+    fn encode(&self, message: &[u8], layout: PacketLayout, num_chunks: usize) -> Option<ChunkTree> {
+        if message.is_empty() {
+            return None;
+        }
+        let symbols = self.encoder(layout, num_chunks).encode(message);
+        ChunkTree::complete(&layout, symbols)
+    }
+}
+
+pub(crate) trait SymbolEncoder {
+    // one symbol per chunk, in chunk id order
+    fn encode(&self, message: &[u8]) -> Vec<Bytes>;
+}
+
+// the decoding state of one proposal.
+pub(crate) trait SymbolDecoder {
+    fn ingest(&mut self, chunk_id: ChunkId, symbol: &Bytes);
+
+    // the message, once enough symbols arrived
+    fn try_decode(&mut self) -> Option<Bytes>;
+}
+
+impl DAEncodingScheme for EncodingScheme {
+    type Encoder = Box<dyn SymbolEncoder>;
+    type Decoder = Box<dyn SymbolDecoder>;
+
+    fn packet_layout(&self, num_validators: usize) -> Option<PacketLayout> {
+        match self {
+            EncodingScheme::D25(d25) => d25.packet_layout(num_validators),
+        }
+    }
+
+    fn chunk_assignment(
+        &self,
+        layout: &PacketLayout,
+        author: &NodeId,
+        validator_data: &ValidatorData,
+    ) -> ChunkAssignment {
+        match self {
+            EncodingScheme::D25(d25) => d25.chunk_assignment(layout, author, validator_data),
+        }
+    }
+
+    fn encoder(&self, layout: PacketLayout, num_chunks: usize) -> Self::Encoder {
+        match self {
+            EncodingScheme::D25(d25) => Box::new(d25.encoder(layout, num_chunks)),
+        }
+    }
+
+    fn decoder(&self, layout: PacketLayout, num_chunks: usize) -> Self::Decoder {
+        match self {
+            EncodingScheme::D25(d25) => Box::new(d25.decoder(layout, num_chunks)),
+        }
+    }
+}
+
+impl SymbolEncoder for Box<dyn SymbolEncoder> {
+    fn encode(&self, message: &[u8]) -> Vec<Bytes> {
+        (**self).encode(message)
+    }
+}
+
+impl SymbolDecoder for Box<dyn SymbolDecoder> {
+    fn ingest(&mut self, chunk_id: ChunkId, symbol: &Bytes) {
+        (**self).ingest(chunk_id, symbol)
+    }
+
+    fn try_decode(&mut self) -> Option<Bytes> {
+        (**self).try_decode()
+    }
+}

--- a/monad-mcp-da/src/encoding_scheme/stub.rs
+++ b/monad-mcp-da/src/encoding_scheme/stub.rs
@@ -1,0 +1,69 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use bytes::Bytes;
+
+use super::{
+    super::{assignment::ChunkId, layout::PacketLayout},
+    SymbolDecoder, SymbolEncoder,
+};
+
+// the stub symbol code: every symbol is the whole message
+pub(crate) struct StubSymbolEncoder {
+    num_chunks: usize,
+}
+
+impl StubSymbolEncoder {
+    pub(crate) fn new(num_chunks: usize) -> Self {
+        Self { num_chunks }
+    }
+}
+
+impl SymbolEncoder for StubSymbolEncoder {
+    fn encode(&self, message: &[u8]) -> Vec<Bytes> {
+        vec![Bytes::copy_from_slice(message); self.num_chunks]
+    }
+}
+
+// decodes once more than num_source_chunks symbols arrived
+pub(crate) struct StubSymbolDecoder {
+    threshold: usize,
+    received: usize,
+    message: Option<Bytes>,
+}
+
+impl StubSymbolDecoder {
+    pub(crate) fn new(layout: PacketLayout) -> Self {
+        Self {
+            threshold: layout.num_source_chunks() + 1,
+            received: 0,
+            message: None,
+        }
+    }
+}
+
+impl SymbolDecoder for StubSymbolDecoder {
+    fn ingest(&mut self, _chunk_id: ChunkId, symbol: &Bytes) {
+        self.received += 1;
+        self.message = Some(symbol.clone());
+    }
+
+    fn try_decode(&mut self) -> Option<Bytes> {
+        if self.received < self.threshold {
+            return None;
+        }
+        self.message.clone()
+    }
+}

--- a/monad-mcp-da/src/env/mod.rs
+++ b/monad-mcp-da/src/env/mod.rs
@@ -13,23 +13,5 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pub use crate::env::stub::{
-    HeaderAuth, KeyPair, MerkleRoot, NodeId, ProposalHeader, PubKey, Signature,
-    SignatureCollection, Stake, ValidatorData, VoteAggregation,
-};
-
-// TODO: fill in the actual production implementation for above types
-
-const _: () = crate::spec::assert_env::<
-    NodeId,
-    Stake,
-    PubKey,
-    KeyPair,
-    Signature,
-    ValidatorData,
-    SignatureCollection,
-    VoteAggregation<'_>,
-    MerkleRoot,
-    ProposalHeader,
-    HeaderAuth,
->();
+#[cfg(feature = "enable_stub")]
+pub(crate) mod stub;

--- a/monad-mcp-da/src/env/stub.rs
+++ b/monad-mcp-da/src/env/stub.rs
@@ -13,23 +13,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pub use crate::env::stub::{
-    HeaderAuth, KeyPair, MerkleRoot, NodeId, ProposalHeader, PubKey, Signature,
-    SignatureCollection, Stake, ValidatorData, VoteAggregation,
-};
+pub(crate) use chorus::types::NodeId;
+pub(crate) use monad_mcp_chorus::stub as chorus;
 
-// TODO: fill in the actual production implementation for above types
+// The keypair used to sign/verify proposal. Not used for aggregation.
+pub struct ProposalKeyPair(NodeId);
 
-const _: () = crate::spec::assert_env::<
-    NodeId,
-    Stake,
-    PubKey,
-    KeyPair,
-    Signature,
-    ValidatorData,
-    SignatureCollection,
-    VoteAggregation<'_>,
-    MerkleRoot,
-    ProposalHeader,
-    HeaderAuth,
->();
+impl ProposalKeyPair {
+    pub fn dummy(node_id: NodeId) -> Self {
+        Self(node_id)
+    }
+}

--- a/monad-mcp-da/src/header.rs
+++ b/monad-mcp-da/src/header.rs
@@ -13,23 +13,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pub use crate::env::stub::{
-    HeaderAuth, KeyPair, MerkleRoot, NodeId, ProposalHeader, PubKey, Signature,
-    SignatureCollection, Stake, ValidatorData, VoteAggregation,
-};
-
-// TODO: fill in the actual production implementation for above types
-
-const _: () = crate::spec::assert_env::<
-    NodeId,
-    Stake,
-    PubKey,
-    KeyPair,
-    Signature,
-    ValidatorData,
-    SignatureCollection,
-    VoteAggregation<'_>,
-    MerkleRoot,
-    ProposalHeader,
-    HeaderAuth,
->();
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InvalidProposalHeader {
+    SlotOutOfRange,
+    // not signed by a proposer of the slot
+    Unauthenticated,
+}

--- a/monad-mcp-da/src/header.rs
+++ b/monad-mcp-da/src/header.rs
@@ -13,9 +13,25 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use super::{chorus::env::EncodingScheme, types::ProposalHeader};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InvalidProposalHeader {
     SlotOutOfRange,
     // not signed by a proposer of the slot
     Unauthenticated,
+    // the scheme fits no packet layout
+    NoPacketLayout,
+}
+
+pub trait DAProposalHeader: monad_mcp_chorus::spec::ProposalHeader {
+    // the encoding scheme determines the packet layout, the chunk
+    // assignment and the symbol code.
+    fn encoding_scheme(&self) -> EncodingScheme;
+}
+
+impl DAProposalHeader for ProposalHeader {
+    fn encoding_scheme(&self) -> EncodingScheme {
+        self.scheme
+    }
 }

--- a/monad-mcp-da/src/instance_rc/decoding_tracker.rs
+++ b/monad-mcp-da/src/instance_rc/decoding_tracker.rs
@@ -1,0 +1,77 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use bitvec::{bitbox, boxed::BitBox};
+
+use super::super::assignment::ChunkId;
+
+// track the received chunk ids and report once more than `threshold`
+// chunks have arrived.
+pub(crate) struct DecodingTracker {
+    chunks: BitBox,
+    count: usize,
+    threshold: usize,
+}
+
+impl DecodingTracker {
+    pub(crate) fn new(num_chunks: usize, threshold: usize) -> Self {
+        assert!(0 < threshold && threshold < num_chunks);
+        Self {
+            chunks: bitbox![0; num_chunks],
+            count: 0,
+            threshold,
+        }
+    }
+
+    pub(crate) fn already_received(&self, chunk_id: ChunkId) -> bool {
+        self.chunks[usize::from(chunk_id)]
+    }
+
+    pub(crate) fn mark(&mut self, chunk_id: ChunkId) {
+        self.chunks.set(usize::from(chunk_id), true);
+        self.count += 1;
+    }
+
+    pub(crate) fn mark_all(&mut self) {
+        self.chunks.fill(true);
+        self.count = self.chunks.len();
+    }
+
+    pub(crate) fn ready(&self) -> bool {
+        self.count > self.threshold
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ready_once_more_than_the_threshold_arrived() {
+        let mut tracker = DecodingTracker::new(6, 2);
+
+        tracker.mark(ChunkId::unchecked(0));
+        tracker.mark(ChunkId::unchecked(1));
+        assert!(!tracker.ready());
+        assert!(tracker.already_received(ChunkId::unchecked(1)));
+        assert!(!tracker.already_received(ChunkId::unchecked(2)));
+
+        tracker.mark(ChunkId::unchecked(2));
+        assert!(tracker.ready());
+
+        tracker.mark_all();
+        assert!(tracker.already_received(ChunkId::unchecked(5)));
+    }
+}

--- a/monad-mcp-da/src/instance_rc/mod.rs
+++ b/monad-mcp-da/src/instance_rc/mod.rs
@@ -15,23 +15,25 @@
 
 mod decoding_tracker;
 mod obligation_tracker;
+mod recovery_tracker;
 
 use std::collections::HashSet;
 
 use bytes::Bytes;
 use decoding_tracker::DecodingTracker;
 use obligation_tracker::ObligationTracker;
+use recovery_tracker::ChunkRecoveryTracker;
 
 use super::{
     assignment::{ChunkAssignment, ChunkId, ChunkRouting, NodeIndex, Upstream},
-    chunk::{ChunkData, WireChunkId},
+    chunk::{ChunkData, ChunkRequest, ChunksSubset, WireChunkId},
     chunk_tree::ChunkTree,
     egress::ChunkEgress,
     encoding_scheme::{DAEncodingScheme as _, SymbolDecoder},
     header::DAProposalHeader as _,
     layout::PacketLayout,
     runtime::EpochHandle,
-    types::{NodeId, ProposalDAEvent, ProposalHeader},
+    types::{ChunkRequestType, NodeId, ProposalDAEvent, ProposalHeader},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -61,6 +63,7 @@ pub(crate) struct RaptorcastInstance {
     decoder: Box<dyn SymbolDecoder>,
     decoding_tracker: DecodingTracker,
     obligation_tracker: ObligationTracker,
+    recovery_tracker: ChunkRecoveryTracker,
 }
 
 impl RaptorcastInstance {
@@ -82,12 +85,14 @@ impl RaptorcastInstance {
         let decoding_tracker = DecodingTracker::new(num_chunks, decoding_threshold);
 
         let obligation_tracker = ObligationTracker::new(&assignment, self_index);
+        let recovery_tracker = ChunkRecoveryTracker::new(num_chunks);
 
         Self {
             decoding_outcome,
             decoder,
             decoding_tracker,
             obligation_tracker,
+            recovery_tracker,
 
             layout,
             assignment,
@@ -178,6 +183,64 @@ impl RaptorcastInstance {
         Ok(event)
     }
 
+    // serve the requester the requested chunks we hold, once each
+    pub(crate) fn handle_chunk_request(
+        &mut self,
+        requester: &NodeId,
+        request: ChunkRequest,
+        egress: &mut ChunkEgress,
+    ) {
+        let Some(requester_index) = self.assignment.index_of(requester) else {
+            // requester not in chunk assignment, not responding
+            return;
+        };
+        let requested =
+            Self::requested_chunks(&self.assignment, self.self_index, requester_index, request);
+
+        for chunk_id in requested {
+            if !self.chunk_tree.contains(chunk_id) {
+                continue;
+            }
+            if !self.recovery_tracker.try_serve(requester, chunk_id) {
+                continue;
+            }
+            self.enqueue(chunk_id, &HashSet::from([*requester]), egress);
+        }
+    }
+
+    // the request to peers for chunks of the type
+    pub(crate) fn chunk_request(
+        &self,
+        request_type: ChunkRequestType,
+        peer: &NodeId,
+    ) -> Option<ChunkRequest> {
+        if !self.accepting_chunks() {
+            // already decoded/failed, not requesting more chunks.
+            return None;
+        }
+
+        // outside the assignment we own nothing to ask for
+        let owner = request_type.owner(self.self_index, self.assignment.index_of(peer))?;
+
+        let mut missing = vec![];
+        for routing in self.assignment.owned_chunks(owner) {
+            let chunk_id = routing.chunk_id();
+            if !self.chunk_tree.contains(chunk_id) {
+                missing.push(chunk_id);
+            }
+        }
+
+        if missing.is_empty() {
+            // no chunk is missing, so no request is needed.
+            return None;
+        }
+
+        Some(ChunkRequest {
+            kind: request_type,
+            subset: ChunksSubset::narrowed(missing),
+        })
+    }
+
     fn try_decode(&mut self) -> Option<ProposalDAEvent> {
         if !self.decoding_tracker.ready() {
             return None;
@@ -250,6 +313,26 @@ impl RaptorcastInstance {
             .expect("caller ensures the chunk is held");
         egress.enqueue(to, &self.header, chunk_id.to_wire(), data);
     }
+
+    // the chunks a recovery request resolves to. Out-of-range ids are
+    // dropped.
+    fn requested_chunks(
+        assignment: &ChunkAssignment,
+        server: Option<NodeIndex>,
+        requester: NodeIndex,
+        request: ChunkRequest,
+    ) -> Vec<ChunkId> {
+        let ChunkRequest { kind, subset } = request;
+        // outside the assignment we own nothing
+        let Some(owner) = kind.owner(Some(requester), server) else {
+            return vec![];
+        };
+
+        let owned = assignment
+            .owned_chunks(owner)
+            .map(|routing| routing.chunk_id());
+        subset.restrict(owned).collect()
+    }
 }
 
 #[cfg(test)]
@@ -260,7 +343,8 @@ mod tests {
         super::{
             chunk::Chunk,
             test_util::{
-                MESSAGE_LEN, author, epoch_handle, inconsistent_proposal_chunks, proposal_chunks,
+                MESSAGE_LEN, author, epoch_handle, epoch_handle_for, inconsistent_proposal_chunks,
+                proposal_chunks,
             },
         },
         *,
@@ -297,6 +381,10 @@ mod tests {
         }
         ids.sort();
         ids
+    }
+
+    fn all(kind: ChunkRequestType) -> ChunkRequest {
+        ChunkRequest::all(kind)
     }
 
     #[test]
@@ -365,6 +453,10 @@ mod tests {
 
         assert!(!instance.accepting_chunks());
         assert!(instance.decoded_message().is_none());
+        assert_eq!(
+            instance.chunk_request(ChunkRequestType::YourChunks, &NodeId::dummy(2)),
+            None
+        );
         // later chunks are ignored
         assert_eq!(ingest(&mut instance, &chunks[4], &mut egress), Ok(None));
 
@@ -402,6 +494,41 @@ mod tests {
         // node 2 owns 1 and 4: one of them settles nothing
         ingest(&mut instance, &chunks[1], &mut egress).expect("valid");
         assert!(instance.drain_obligation_events().is_empty());
+    }
+
+    #[test]
+    fn outside_the_assignment_decodes_without_owning_anything() {
+        // validator 9 is not in the validator set
+        let epoch_handle = epoch_handle_for(NodeId::dummy(9), 4, vec![author()]);
+        let (header, chunks) = proposal_chunks(&epoch_handle, 1);
+        let mut instance = instance(&epoch_handle, &header);
+        let mut egress = released();
+        let peer = NodeId::dummy(2);
+
+        // nothing of ours to ask for, but theirs can be asked
+        assert_eq!(
+            instance.chunk_request(ChunkRequestType::MyChunks, &peer),
+            None
+        );
+        assert!(
+            instance
+                .chunk_request(ChunkRequestType::YourChunks, &peer)
+                .is_some()
+        );
+
+        for chunk in &chunks[..3] {
+            ingest(&mut instance, chunk, &mut egress).expect("valid");
+        }
+        assert!(instance.decoded_message().is_some());
+        // nothing owned, nothing forwarded
+        assert!(sent(&mut egress).is_empty());
+
+        // nothing of ours to serve, but once decoded theirs is derivable
+        let requester = NodeId::dummy(3);
+        instance.handle_chunk_request(&requester, all(ChunkRequestType::YourChunks), &mut egress);
+        assert!(sent(&mut egress).is_empty());
+        instance.handle_chunk_request(&requester, all(ChunkRequestType::MyChunks), &mut egress);
+        assert_eq!(sent(&mut egress), [2, 5]);
     }
 
     #[test]

--- a/monad-mcp-da/src/instance_rc/mod.rs
+++ b/monad-mcp-da/src/instance_rc/mod.rs
@@ -14,14 +14,16 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 mod decoding_tracker;
+mod obligation_tracker;
 
 use std::collections::HashSet;
 
 use bytes::Bytes;
 use decoding_tracker::DecodingTracker;
+use obligation_tracker::ObligationTracker;
 
 use super::{
-    assignment::{ChunkAssignment, ChunkId, ChunkRouting, NodeIndex},
+    assignment::{ChunkAssignment, ChunkId, ChunkRouting, NodeIndex, Upstream},
     chunk::{ChunkData, WireChunkId},
     chunk_tree::ChunkTree,
     egress::ChunkEgress,
@@ -58,6 +60,7 @@ pub(crate) struct RaptorcastInstance {
     decoding_outcome: DecodingOutcome,
     decoder: Box<dyn SymbolDecoder>,
     decoding_tracker: DecodingTracker,
+    obligation_tracker: ObligationTracker,
 }
 
 impl RaptorcastInstance {
@@ -78,10 +81,13 @@ impl RaptorcastInstance {
         let decoding_threshold = layout.num_source_chunks();
         let decoding_tracker = DecodingTracker::new(num_chunks, decoding_threshold);
 
+        let obligation_tracker = ObligationTracker::new(&assignment, self_index);
+
         Self {
             decoding_outcome,
             decoder,
             decoding_tracker,
+            obligation_tracker,
 
             layout,
             assignment,
@@ -102,6 +108,22 @@ impl RaptorcastInstance {
         Some(message)
     }
 
+    pub(crate) fn drain_obligation_events(&mut self) -> Vec<ProposalDAEvent> {
+        let root = self.header.root;
+        let mut events = Vec::new();
+        for upstream in self.obligation_tracker.drain_fulfilled() {
+            let event = match upstream {
+                Upstream::Author => ProposalDAEvent::ProposerObligationFulfilled(root),
+                Upstream::Owner(owner) => ProposalDAEvent::OwnerObligationFulfilled {
+                    owner: *self.assignment.node(owner),
+                    root,
+                },
+            };
+            events.push(event);
+        }
+        events
+    }
+
     pub(crate) fn ingest_chunk(
         &mut self,
         chunk_id: WireChunkId,
@@ -117,6 +139,12 @@ impl RaptorcastInstance {
             // chunk id is out of range
             return Err(InvalidChunk::InvalidChunkId);
         };
+
+        // None if the chunk is not routed to us: accepted, but credited
+        // to no obligation.
+        let upstream = self
+            .self_index
+            .and_then(|receiver| routing.upstream(receiver));
 
         let chunk_id = routing.chunk_id();
         if self.decoding_tracker.already_received(chunk_id) {
@@ -136,7 +164,8 @@ impl RaptorcastInstance {
         self.decoder.ingest(chunk_id, &data.symbol);
         self.chunk_tree.insert(chunk_id, data);
 
-        // track decoding
+        // track decoding & obligation
+        self.obligation_tracker.mark(upstream);
         self.decoding_tracker.mark(chunk_id);
 
         // try rebroadcast & decode
@@ -342,6 +371,37 @@ mod tests {
         // our chunk 0 went out on arrival; nothing is derivable from an
         // invalid proposal
         assert_eq!(sent(&mut egress), [0]);
+    }
+
+    #[test]
+    fn our_obligation_from_the_author_completes_with_our_last_chunk() {
+        let epoch_handle = epoch_handle();
+        let (header, chunks) = proposal_chunks(&epoch_handle, 1);
+        let mut instance = instance(&epoch_handle, &header);
+        let mut egress = released();
+
+        // the chunkless author owes nothing from the start
+        let author_owes_nothing = ProposalDAEvent::OwnerObligationFulfilled {
+            owner: author(),
+            root: header.root,
+        };
+        assert_eq!(
+            instance.drain_obligation_events(),
+            vec![author_owes_nothing]
+        );
+
+        // we own 0 and 3
+        ingest(&mut instance, &chunks[0], &mut egress).expect("valid");
+        assert!(instance.drain_obligation_events().is_empty());
+        ingest(&mut instance, &chunks[3], &mut egress).expect("valid");
+        assert_eq!(
+            instance.drain_obligation_events(),
+            vec![ProposalDAEvent::ProposerObligationFulfilled(header.root)]
+        );
+
+        // node 2 owns 1 and 4: one of them settles nothing
+        ingest(&mut instance, &chunks[1], &mut egress).expect("valid");
+        assert!(instance.drain_obligation_events().is_empty());
     }
 
     #[test]

--- a/monad-mcp-da/src/instance_rc/mod.rs
+++ b/monad-mcp-da/src/instance_rc/mod.rs
@@ -1,0 +1,361 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+mod decoding_tracker;
+
+use std::collections::HashSet;
+
+use bytes::Bytes;
+use decoding_tracker::DecodingTracker;
+
+use super::{
+    assignment::{ChunkAssignment, ChunkId, ChunkRouting, NodeIndex},
+    chunk::{ChunkData, WireChunkId},
+    chunk_tree::ChunkTree,
+    egress::ChunkEgress,
+    encoding_scheme::{DAEncodingScheme as _, SymbolDecoder},
+    header::DAProposalHeader as _,
+    layout::PacketLayout,
+    runtime::EpochHandle,
+    types::{NodeId, ProposalDAEvent, ProposalHeader},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InvalidChunk {
+    InvalidChunkId,
+    BadProof,
+}
+
+pub enum DecodingOutcome {
+    Pending,
+    Decoded(Bytes),
+    // merkle root doesn't match the decoded-then-re-encoded message
+    BadEncoding,
+}
+
+// per-(slot, proposal) raptorcast committed to single root
+pub(crate) struct RaptorcastInstance {
+    header: ProposalHeader,
+    // None when this node is outside the assignment (e.g. a full node)
+    self_index: Option<NodeIndex>,
+
+    layout: PacketLayout,
+    assignment: ChunkAssignment,
+    chunk_tree: ChunkTree,
+
+    decoding_outcome: DecodingOutcome,
+    decoder: Box<dyn SymbolDecoder>,
+    decoding_tracker: DecodingTracker,
+}
+
+impl RaptorcastInstance {
+    pub(crate) fn new(
+        epoch_handle: &EpochHandle,
+        header: ProposalHeader,
+        layout: PacketLayout,
+        author: &NodeId,
+    ) -> Self {
+        let scheme = header.encoding_scheme();
+        let assignment = scheme.chunk_assignment(&layout, author, &epoch_handle.validator_data);
+        let self_index = assignment.index_of(&epoch_handle.self_id);
+
+        let num_chunks = assignment.num_chunks();
+        let decoder = scheme.decoder(layout, num_chunks);
+        let decoding_outcome = DecodingOutcome::Pending;
+
+        let decoding_threshold = layout.num_source_chunks();
+        let decoding_tracker = DecodingTracker::new(num_chunks, decoding_threshold);
+
+        Self {
+            decoding_outcome,
+            decoder,
+            decoding_tracker,
+
+            layout,
+            assignment,
+            chunk_tree: ChunkTree::partial(header.root),
+            header,
+            self_index,
+        }
+    }
+
+    pub(crate) fn accepting_chunks(&self) -> bool {
+        matches!(self.decoding_outcome, DecodingOutcome::Pending)
+    }
+
+    pub(crate) fn decoded_message(&self) -> Option<&Bytes> {
+        let DecodingOutcome::Decoded(message) = &self.decoding_outcome else {
+            return None;
+        };
+        Some(message)
+    }
+
+    pub(crate) fn ingest_chunk(
+        &mut self,
+        chunk_id: WireChunkId,
+        data: ChunkData,
+        egress: &mut ChunkEgress,
+    ) -> Result<Option<ProposalDAEvent>, InvalidChunk> {
+        if !self.accepting_chunks() {
+            // root already decoded (or failed), refusing further chunks.
+            return Ok(None);
+        }
+
+        let Some(routing) = self.assignment.resolve_chunk_id(chunk_id) else {
+            // chunk id is out of range
+            return Err(InvalidChunk::InvalidChunkId);
+        };
+
+        let chunk_id = routing.chunk_id();
+        if self.decoding_tracker.already_received(chunk_id) {
+            // chunk already ingested previously, skip ingestion.
+            return Ok(None);
+        }
+
+        // todo: check the proof in chunk parsing, so a Chunk always
+        // holds a valid merkle proof.
+        if !self.chunk_tree.verify(&self.layout, chunk_id, &data) {
+            return Err(InvalidChunk::BadProof);
+        }
+
+        // ingestion is infallible from here on.
+
+        // store & update decoder state
+        self.decoder.ingest(chunk_id, &data.symbol);
+        self.chunk_tree.insert(chunk_id, data);
+
+        // track decoding
+        self.decoding_tracker.mark(chunk_id);
+
+        // try rebroadcast & decode
+        self.try_rebroadcast(routing, egress);
+        let event = self.try_decode();
+        if matches!(event, Some(ProposalDAEvent::Decoded(_))) {
+            self.rebroadcast_remaining(egress);
+            self.decoding_tracker.mark_all();
+        }
+        Ok(event)
+    }
+
+    fn try_decode(&mut self) -> Option<ProposalDAEvent> {
+        if !self.decoding_tracker.ready() {
+            return None;
+        }
+        let Some(message) = self.decoder.try_decode() else {
+            // todo: decoder still not ready after ingesting enough
+            // chunks. this means the codec doesn't guarantee
+            // decodability (e.g. r10).
+            return None;
+        };
+
+        let root = self.header.root;
+        if !self.reencodes_to_root(&message) {
+            self.decoding_outcome = DecodingOutcome::BadEncoding;
+            return Some(ProposalDAEvent::DecodingFailed(root));
+        }
+        self.decoding_outcome = DecodingOutcome::Decoded(message);
+        Some(ProposalDAEvent::Decoded(root))
+    }
+
+    fn reencodes_to_root(&mut self, message: &[u8]) -> bool {
+        let scheme = self.header.encoding_scheme();
+        let num_chunks = self.assignment.num_chunks();
+        let Some(tree) = scheme.encode(message, self.layout, num_chunks) else {
+            return false;
+        };
+        if tree.root() != self.header.root {
+            return false;
+        }
+        self.chunk_tree = tree;
+
+        true
+    }
+
+    fn try_rebroadcast(&self, routing: ChunkRouting<'_>, egress: &mut ChunkEgress) {
+        if self.self_index != Some(routing.owner_index()) {
+            // it's not our responsibility to rebroadcast this chunk
+            return;
+        }
+
+        let to = match routing.partial_rebroadcast_targets() {
+            Some(targets) => targets,
+            None => self
+                .assignment
+                .full_rebroadcast_targets(routing.owner_index()),
+        };
+        let chunk_id = routing.chunk_id();
+        self.enqueue(chunk_id, &to, egress);
+    }
+
+    // rebroadcast all remaining owned chunks (after decoding).
+    fn rebroadcast_remaining(&self, egress: &mut ChunkEgress) {
+        let Some(self_index) = self.self_index else {
+            return;
+        };
+        for routing in self.assignment.owned_chunks(self_index) {
+            let chunk_id = routing.chunk_id();
+            if self.decoding_tracker.already_received(chunk_id) {
+                continue;
+            }
+            self.try_rebroadcast(routing, egress);
+        }
+    }
+
+    // the caller must ensure the chunk exists in chunk tree.
+    fn enqueue(&self, chunk_id: ChunkId, to: &HashSet<NodeId>, egress: &mut ChunkEgress) {
+        let data = self
+            .chunk_tree
+            .chunk_data(chunk_id)
+            .expect("caller ensures the chunk is held");
+        egress.enqueue(to, &self.header, chunk_id.to_wire(), data);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use monad_mcp_chorus::spec::validator::ValidatorData as _;
+
+    use super::{
+        super::{
+            chunk::Chunk,
+            test_util::{
+                MESSAGE_LEN, author, epoch_handle, inconsistent_proposal_chunks, proposal_chunks,
+            },
+        },
+        *,
+    };
+
+    fn instance(epoch_handle: &EpochHandle, header: &ProposalHeader) -> RaptorcastInstance {
+        let layout = header
+            .encoding_scheme()
+            .packet_layout(epoch_handle.validator_data.len())
+            .expect("fits a layout");
+        RaptorcastInstance::new(epoch_handle, header.clone(), layout, &author())
+    }
+
+    fn released() -> ChunkEgress {
+        let mut egress = ChunkEgress::new();
+        egress.release();
+        egress
+    }
+
+    fn ingest(
+        instance: &mut RaptorcastInstance,
+        chunk: &Chunk,
+        egress: &mut ChunkEgress,
+    ) -> Result<Option<ProposalDAEvent>, InvalidChunk> {
+        let (_, chunk_id, data) = chunk.clone().into_parts();
+        instance.ingest_chunk(chunk_id, data, egress)
+    }
+
+    // the wire ids in the drained messages, sorted
+    fn sent(egress: &mut ChunkEgress) -> Vec<WireChunkId> {
+        let mut ids = Vec::new();
+        for message in egress.drain() {
+            ids.extend(message.envelope.chunks().keys().copied());
+        }
+        ids.sort();
+        ids
+    }
+
+    #[test]
+    fn malformed_chunks_are_rejected() {
+        let epoch_handle = epoch_handle();
+        let (header, chunks) = proposal_chunks(&epoch_handle, 1);
+        let mut instance = instance(&epoch_handle, &header);
+        let mut egress = released();
+        let (_, _, data) = chunks[0].clone().into_parts();
+
+        let out_of_range = instance.ingest_chunk(99, data.clone(), &mut egress);
+        assert_eq!(out_of_range, Err(InvalidChunk::InvalidChunkId));
+
+        let tampered = ChunkData {
+            symbol: Bytes::from_static(b"tampered"),
+            proof: data.proof.clone(),
+        };
+        let tampered = instance.ingest_chunk(0, tampered, &mut egress);
+        assert_eq!(tampered, Err(InvalidChunk::BadProof));
+
+        // a good chunk under the wrong id fails its proof
+        let misplaced = instance.ingest_chunk(1, data, &mut egress);
+        assert_eq!(misplaced, Err(InvalidChunk::BadProof));
+
+        assert!(sent(&mut egress).is_empty());
+    }
+
+    #[test]
+    fn a_repeated_chunk_counts_and_forwards_once() {
+        let epoch_handle = epoch_handle();
+        let (header, chunks) = proposal_chunks(&epoch_handle, 1);
+        let mut instance = instance(&epoch_handle, &header);
+        let mut egress = released();
+
+        // chunk 0 is ours: forwarded on arrival, not on the repeat
+        assert_eq!(ingest(&mut instance, &chunks[0], &mut egress), Ok(None));
+        assert_eq!(sent(&mut egress), [0]);
+        assert_eq!(ingest(&mut instance, &chunks[0], &mut egress), Ok(None));
+        assert!(sent(&mut egress).is_empty());
+
+        // the repeat did not count towards decoding: one more distinct
+        // chunk is short, the next one decodes
+        assert_eq!(ingest(&mut instance, &chunks[1], &mut egress), Ok(None));
+        let event = ingest(&mut instance, &chunks[2], &mut egress);
+        assert_eq!(event, Ok(Some(ProposalDAEvent::Decoded(header.root))));
+        assert_eq!(
+            instance.decoded_message(),
+            Some(&Bytes::from(vec![1u8; MESSAGE_LEN]))
+        );
+    }
+
+    #[test]
+    fn inconsistent_chunks_resolve_invalid() {
+        let epoch_handle = epoch_handle();
+        let (header, chunks) = inconsistent_proposal_chunks(&epoch_handle);
+        let mut instance = instance(&epoch_handle, &header);
+        let mut egress = released();
+
+        assert_eq!(ingest(&mut instance, &chunks[0], &mut egress), Ok(None));
+        assert_eq!(ingest(&mut instance, &chunks[1], &mut egress), Ok(None));
+        let event = ingest(&mut instance, &chunks[2], &mut egress);
+        assert_eq!(
+            event,
+            Ok(Some(ProposalDAEvent::DecodingFailed(header.root)))
+        );
+
+        assert!(!instance.accepting_chunks());
+        assert!(instance.decoded_message().is_none());
+        // later chunks are ignored
+        assert_eq!(ingest(&mut instance, &chunks[4], &mut egress), Ok(None));
+
+        // our chunk 0 went out on arrival; nothing is derivable from an
+        // invalid proposal
+        assert_eq!(sent(&mut egress), [0]);
+    }
+
+    #[test]
+    fn decoding_needs_more_chunks_than_the_source_count() {
+        let epoch_handle = epoch_handle();
+        let (header, chunks) = proposal_chunks(&epoch_handle, 1);
+        let mut instance = instance(&epoch_handle, &header);
+        let mut egress = released();
+
+        // two source chunks: two received is not enough
+        assert_eq!(ingest(&mut instance, &chunks[1], &mut egress), Ok(None));
+        assert_eq!(ingest(&mut instance, &chunks[2], &mut egress), Ok(None));
+        assert!(instance.decoded_message().is_none());
+        let event = ingest(&mut instance, &chunks[4], &mut egress);
+        assert_eq!(event, Ok(Some(ProposalDAEvent::Decoded(header.root))));
+    }
+}

--- a/monad-mcp-da/src/instance_rc/obligation_tracker.rs
+++ b/monad-mcp-da/src/instance_rc/obligation_tracker.rs
@@ -1,0 +1,177 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::super::assignment::{ChunkAssignment, NodeIndex, Upstream};
+
+pub(crate) struct ObligationTracker {
+    // the number of chunks remaining to be received from each
+    // rebroadcast owner, by NodeIndex
+    remaining_owner_obligation: Box<[usize]>,
+
+    // the number of chunks remaining to be received from the author
+    remaining_author_obligation: usize,
+
+    // an outbox of upstreams whose obligations have been fulfilled
+    // since the last drain.
+    fulfilled: Vec<Upstream>,
+}
+
+impl ObligationTracker {
+    // a receiver outside the assignment (None) is routed nothing.
+    pub(crate) fn new(assignment: &ChunkAssignment, receiver: Option<NodeIndex>) -> Self {
+        let mut remaining_owner_obligation = vec![0; assignment.num_nodes()].into_boxed_slice();
+        let mut remaining_author_obligation = 0;
+
+        if let Some(receiver) = receiver {
+            for upstream in assignment.upstreams(receiver) {
+                match upstream {
+                    Upstream::Author => {
+                        remaining_author_obligation += 1;
+                    }
+                    Upstream::Owner(owner) => {
+                        remaining_owner_obligation[usize::from(owner)] += 1;
+                    }
+                }
+            }
+        }
+
+        // todo: reduce obligations by a small fraction to account for
+        // network packet loss. q: should we reduce obligation from
+        // author as well?
+
+        let mut fulfilled = Vec::new();
+        if remaining_author_obligation == 0 {
+            // vacuously fulfilled from the start.
+            fulfilled.push(Upstream::Author);
+        }
+        for (owner, _) in assignment.nodes() {
+            if Some(owner) == receiver {
+                continue;
+            }
+            if remaining_owner_obligation[usize::from(owner)] == 0 {
+                // vacuously fulfilled from the start.
+                fulfilled.push(Upstream::Owner(owner));
+            }
+        }
+
+        Self {
+            remaining_author_obligation,
+            remaining_owner_obligation,
+            fulfilled,
+        }
+    }
+
+    pub(crate) fn drain_fulfilled(&mut self) -> Vec<Upstream> {
+        std::mem::take(&mut self.fulfilled)
+    }
+
+    // the caller must ensure each chunk is recorded at most once, with
+    // the upstream given by the assignment this tracker was built from.
+    pub(crate) fn mark(&mut self, upstream: Option<Upstream>) {
+        let Some(upstream) = upstream else {
+            // chunk not routed to us, no obligation to record
+            return;
+        };
+        let counter: &mut usize = match upstream {
+            Upstream::Author => &mut self.remaining_author_obligation,
+            Upstream::Owner(owner) => &mut self.remaining_owner_obligation[usize::from(owner)],
+        };
+
+        if *counter == 0 {
+            return;
+        }
+
+        *counter -= 1;
+        if *counter == 0 {
+            self.fulfilled.push(upstream);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use monad_mcp_chorus::spec::Stake as _;
+
+    use super::{
+        super::super::{
+            assignment::StakePartition,
+            types::{NodeId, Stake},
+        },
+        *,
+    };
+
+    // author 0 owning nothing, then 3 nodes with equal stake over 30
+    // source chunks at 2.5x redundancy: 75 chunks, 25 owned by each
+    fn assignment() -> ChunkAssignment {
+        let author = NodeId::dummy(0);
+        let mut weights = vec![(author, Stake::ZERO)];
+        weights.extend((1..=3).map(|id| (NodeId::dummy(id), Stake::from(1))));
+        StakePartition::new(weights).assign(&author, 30, 2.5)
+    }
+
+    #[test]
+    fn zero_obligations_are_vacuously_fulfilled() {
+        let assignment = assignment();
+        let author = assignment
+            .index_of(&NodeId::dummy(0))
+            .expect("author in assignment");
+
+        // the author is owed nothing: everything but itself is vacuous
+        // from the start, and drained once
+        let mut tracker = ObligationTracker::new(&assignment, Some(author));
+        let fulfilled = tracker.drain_fulfilled();
+        assert!(fulfilled.contains(&Upstream::Author));
+        assert!(!fulfilled.contains(&Upstream::Owner(author)));
+        assert_eq!(fulfilled.len(), assignment.num_nodes());
+        assert!(tracker.drain_fulfilled().is_empty());
+
+        // a member is owed nothing only by the chunkless author
+        let member = assignment.index_of(&NodeId::dummy(1));
+        let mut tracker = ObligationTracker::new(&assignment, member);
+        assert_eq!(tracker.drain_fulfilled(), vec![Upstream::Owner(author)]);
+
+        // a node outside the assignment is owed nothing by anyone
+        let mut tracker = ObligationTracker::new(&assignment, None);
+        assert_eq!(tracker.drain_fulfilled().len(), 1 + assignment.num_nodes());
+    }
+
+    #[test]
+    fn an_obligation_is_fulfilled_once_by_its_last_chunk() {
+        let assignment = assignment();
+        let member = assignment.index_of(&NodeId::dummy(1));
+        let owner = assignment
+            .index_of(&NodeId::dummy(2))
+            .expect("in the assignment");
+        let mut tracker = ObligationTracker::new(&assignment, member);
+        tracker.drain_fulfilled();
+
+        // 25 chunks are owed by the author and 25 by each owner
+        for _ in 0..24 {
+            tracker.mark(Some(Upstream::Author));
+            tracker.mark(Some(Upstream::Owner(owner)));
+        }
+        assert!(tracker.drain_fulfilled().is_empty());
+
+        tracker.mark(Some(Upstream::Author));
+        assert_eq!(tracker.drain_fulfilled(), vec![Upstream::Author]);
+        tracker.mark(Some(Upstream::Owner(owner)));
+        assert_eq!(tracker.drain_fulfilled(), vec![Upstream::Owner(owner)]);
+
+        // fulfilled once; unrouted chunks credit nothing
+        tracker.mark(Some(Upstream::Author));
+        tracker.mark(None);
+        assert!(tracker.drain_fulfilled().is_empty());
+    }
+}

--- a/monad-mcp-da/src/instance_rc/recovery_tracker.rs
+++ b/monad-mcp-da/src/instance_rc/recovery_tracker.rs
@@ -1,0 +1,89 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+
+use bitvec::{bitbox, boxed::BitBox};
+
+use super::super::{assignment::ChunkId, types::NodeId};
+
+// each chunk is served to a requester at most once
+pub(crate) struct ChunkRecoveryTracker {
+    num_chunks: usize,
+
+    // the chunks served to each requester
+    served_chunks: HashMap<NodeId, BitBox>,
+}
+
+impl ChunkRecoveryTracker {
+    pub(crate) fn new(num_chunks: usize) -> Self {
+        Self {
+            num_chunks,
+            served_chunks: HashMap::new(),
+        }
+    }
+
+    // returns whether to serve the chunk to the requester, recording it as
+    // served if true.
+    pub(crate) fn try_serve(&mut self, requester: &NodeId, chunk_id: ChunkId) -> bool {
+        let num_chunks = self.num_chunks;
+        let served = self
+            .served_chunks
+            .entry(*requester)
+            .or_insert_with(|| bitbox![0; num_chunks]);
+
+        if served[usize::from(chunk_id)] {
+            return false;
+        }
+        served.set(usize::from(chunk_id), true);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use monad_mcp_chorus::spec::Stake as _;
+
+    use super::{
+        super::super::{
+            assignment::{ChunkAssignment, StakePartition},
+            types::Stake,
+        },
+        *,
+    };
+
+    // author 0 owning nothing, then 3 nodes with equal stake over 30
+    // source chunks at 2.5x redundancy: 75 chunks
+    fn assignment() -> ChunkAssignment {
+        let author = NodeId::dummy(0);
+        let mut weights = vec![(author, Stake::ZERO)];
+        weights.extend((1..=3).map(|id| (NodeId::dummy(id), Stake::from(1))));
+        StakePartition::new(weights).assign(&author, 30, 2.5)
+    }
+
+    #[test]
+    fn served_chunks_are_not_served_twice() {
+        let assignment = assignment();
+        let mut tracker = ChunkRecoveryTracker::new(assignment.num_chunks());
+        let requester = NodeId::dummy(2);
+        let chunk_id = assignment.chunk_ids().next().unwrap();
+
+        assert!(tracker.try_serve(&requester, chunk_id));
+        assert!(!tracker.try_serve(&requester, chunk_id));
+
+        // per requester
+        assert!(tracker.try_serve(&NodeId::dummy(3), chunk_id));
+    }
+}

--- a/monad-mcp-da/src/layout.rs
+++ b/monad-mcp-da/src/layout.rs
@@ -1,0 +1,111 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use monad_crypto::hasher::{Hash, Hasher as _, HasherType};
+
+use super::chunk::WireChunkId;
+
+#[derive(Debug, Clone, Copy)]
+pub struct PacketLayout {
+    app_message_len: usize,
+    merkle_tree_depth: u8,
+}
+
+impl PacketLayout {
+    // prod v1 wire constants
+    const SEGMENT_LEN: usize = 1440;
+    const HEADER_LEN: usize = 117;
+    const CHUNK_HEADER_LEN: usize = 4;
+    const MERKLE_HASH_LEN: usize = 20;
+
+    pub(crate) fn new(app_message_len: usize, merkle_tree_depth: u8) -> Self {
+        Self {
+            app_message_len,
+            merkle_tree_depth,
+        }
+    }
+
+    pub fn num_source_chunks(&self) -> usize {
+        self.app_message_len.div_ceil(self.symbol_len())
+    }
+
+    pub fn symbol_len(&self) -> usize {
+        Self::SEGMENT_LEN - Self::HEADER_LEN - self.merkle_proof_len() - Self::CHUNK_HEADER_LEN
+    }
+
+    pub fn merkle_proof_len(&self) -> usize {
+        Self::MERKLE_HASH_LEN * (self.merkle_tree_depth as usize - 1)
+    }
+
+    pub fn merkle_tree_depth(&self) -> u8 {
+        self.merkle_tree_depth
+    }
+
+    // the v1 chunk header
+    pub(crate) fn chunk_header(&self, chunk_id: WireChunkId) -> [u8; Self::CHUNK_HEADER_LEN] {
+        let [lo, hi] = chunk_id.to_le_bytes();
+        [0, 0, lo, hi]
+    }
+
+    pub(crate) fn merkle_leaf_hash(&self, chunk_id: WireChunkId, symbol: &[u8]) -> Hash {
+        let mut hasher = HasherType::new();
+        hasher.update(self.chunk_header(chunk_id));
+        hasher.update(symbol);
+        hasher.hash()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn symbol_len_leaves_room_for_headers_and_proof() {
+        assert_eq!(PacketLayout::new(0, 2).symbol_len(), 1440 - 117 - 4 - 20);
+        assert_eq!(PacketLayout::new(0, 5).symbol_len(), 1440 - 117 - 4 - 80);
+    }
+
+    #[test]
+    fn source_chunks_round_up() {
+        let symbol_len = PacketLayout::new(0, 2).symbol_len();
+        assert_eq!(PacketLayout::new(symbol_len, 2).num_source_chunks(), 1);
+        assert_eq!(PacketLayout::new(symbol_len + 1, 2).num_source_chunks(), 2);
+    }
+
+    #[test]
+    fn chunk_header_is_the_little_endian_id_after_two_zero_bytes() {
+        assert_eq!(
+            PacketLayout::new(0, 2).chunk_header(0x0201),
+            [0, 0, 0x01, 0x02]
+        );
+    }
+
+    #[test]
+    fn leaf_hash_covers_the_chunk_id() {
+        let layout = PacketLayout::new(0, 2);
+        assert_eq!(
+            layout.merkle_leaf_hash(1, b"x"),
+            layout.merkle_leaf_hash(1, b"x")
+        );
+        assert_ne!(
+            layout.merkle_leaf_hash(1, b"x"),
+            layout.merkle_leaf_hash(2, b"x")
+        );
+        assert_ne!(
+            layout.merkle_leaf_hash(1, b"x"),
+            layout.merkle_leaf_hash(1, b"y")
+        );
+    }
+}

--- a/monad-mcp-da/src/lib.rs
+++ b/monad-mcp-da/src/lib.rs
@@ -13,23 +13,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pub use crate::env::stub::{
-    HeaderAuth, KeyPair, MerkleRoot, NodeId, ProposalHeader, PubKey, Signature,
-    SignatureCollection, Stake, ValidatorData, VoteAggregation,
-};
+mod env;
 
-// TODO: fill in the actual production implementation for above types
+#[cfg(feature = "enable_stub")]
+#[path = ""]
+pub mod stub {
+    use crate::env::stub as env;
 
-const _: () = crate::spec::assert_env::<
-    NodeId,
-    Stake,
-    PubKey,
-    KeyPair,
-    Signature,
-    ValidatorData,
-    SignatureCollection,
-    VoteAggregation<'_>,
-    MerkleRoot,
-    ProposalHeader,
-    HeaderAuth,
->();
+    #[path = "top_level.rs"]
+    mod top_level;
+    pub use top_level::*;
+}

--- a/monad-mcp-da/src/proposer_rc.rs
+++ b/monad-mcp-da/src/proposer_rc.rs
@@ -19,13 +19,13 @@ use bytes::Bytes;
 use monad_mcp_chorus::spec::validator::ValidatorData as _;
 
 use super::{
-    chunk::ProposalEnvelope,
+    chunk::{ChunkRequest, ProposalEnvelope},
     egress::ChunkEgress,
     encoding_scheme::DAEncodingScheme as _,
     header::{DAProposalHeader as _, InvalidProposalHeader},
     instance_rc::RaptorcastInstance,
     runtime::EpochHandle,
-    types::{MerkleRoot, NodeId, ProposalDAEvent, ProposalHeader},
+    types::{ChunkRequestType, MerkleRoot, NodeId, ProposalDAEvent, ProposalHeader},
 };
 
 // per-(slot, proposer) raptorcast: root-keyed
@@ -142,12 +142,42 @@ impl ProposerRaptorcast {
     fn can_admit_unpinned(&self) -> bool {
         self.instances.keys().all(|root| self.pinned.contains(root))
     }
+
+    pub(crate) fn handle_chunk_request(
+        &mut self,
+        requester: &NodeId,
+        root: &MerkleRoot,
+        request: ChunkRequest,
+        egress: &mut ChunkEgress,
+    ) {
+        let Some(instance) = self.instances.get_mut(root) else {
+            return;
+        };
+        instance.handle_chunk_request(requester, request, egress);
+    }
+
+    pub(crate) fn chunk_request(
+        &self,
+        root: &MerkleRoot,
+        request_type: ChunkRequestType,
+        peer: &NodeId,
+    ) -> Option<ChunkRequest> {
+        let Some(instance) = self.instances.get(root) else {
+            // without the header there is no assignment to narrow by
+            return Some(ChunkRequest::all(request_type));
+        };
+        instance.chunk_request(request_type, peer)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        super::test_util::{epoch_handle, group, proposal_chunks},
+        super::{
+            chunk::ChunksSubset,
+            egress::Dissemination,
+            test_util::{chunk_id, epoch_handle, group, proposal_chunks},
+        },
         *,
     };
 
@@ -356,5 +386,115 @@ mod tests {
             .expect("well-formed header");
         let events = instance.drain_events();
         assert!(events.contains(&ProposalDAEvent::Decoded(header_b.root)));
+    }
+
+    #[test]
+    fn own_chunk_recovery_serves_the_requesters_chunks() {
+        let epoch_handle = epoch_handle();
+        let mut egress = released_egress();
+        let (header, chunks) = proposal_chunks(&epoch_handle, 1);
+
+        let mut instance = ProposerRaptorcast::new(NodeId::dummy(0));
+        instance
+            .ingest(group(&chunks[..3]), &epoch_handle, &mut egress)
+            .expect("well-formed header");
+        // discard the rebroadcast of our own chunks
+        egress.drain();
+
+        // node 3 asks without naming ids; it owns 2 of the 6 chunks
+        let requester = NodeId::dummy(3);
+        let my_chunks = || ChunkRequest::all(ChunkRequestType::MyChunks);
+        instance.handle_chunk_request(&requester, &header.root, my_chunks(), &mut egress);
+        let recovered = egress.drain();
+        let [Dissemination { to, envelope }] = &recovered[..] else {
+            panic!("recovery unicasts to the requester");
+        };
+        assert_eq!(*to, HashSet::from([requester]));
+        assert_eq!(envelope.chunks().len(), 2);
+
+        // served once
+        instance.handle_chunk_request(&requester, &header.root, my_chunks(), &mut egress);
+        assert!(egress.drain().is_empty());
+    }
+
+    #[test]
+    fn your_chunk_recovery_serves_what_we_hold_before_decoding() {
+        let epoch_handle = epoch_handle();
+        let mut egress = released_egress();
+        let (header, chunks) = proposal_chunks(&epoch_handle, 1);
+
+        // chunk ids 0 and 3 are ours (validator 1); ingesting ids 0
+        // and 1 is short of the decoding threshold
+        let mut instance = ProposerRaptorcast::new(NodeId::dummy(0));
+        instance
+            .ingest(group(&chunks[..2]), &epoch_handle, &mut egress)
+            .expect("well-formed header");
+        assert!(instance.decoded_message(&header.root).is_none());
+        // discard the rebroadcast of our own chunk
+        egress.drain();
+
+        let requester = NodeId::dummy(3);
+        let your_chunks = ChunkRequest::all(ChunkRequestType::YourChunks);
+        instance.handle_chunk_request(&requester, &header.root, your_chunks, &mut egress);
+        let recovered = egress.drain();
+        let [Dissemination { to, envelope }] = &recovered[..] else {
+            panic!("recovery unicasts to the requester");
+        };
+        assert_eq!(*to, HashSet::from([requester]));
+        assert_eq!(envelope.chunks().keys().copied().collect::<Vec<_>>(), [0]);
+
+        // the requester's own chunks (ids 2 and 5) are not held yet
+        let my_chunks = ChunkRequest::all(ChunkRequestType::MyChunks);
+        instance.handle_chunk_request(&requester, &header.root, my_chunks, &mut egress);
+        assert!(egress.drain().is_empty());
+    }
+
+    #[test]
+    fn requests_narrow_to_the_missing_chunks_once_the_assignment_is_known() {
+        let epoch_handle = epoch_handle();
+        let mut egress = released_egress();
+        let (header, chunks) = proposal_chunks(&epoch_handle, 1);
+        let mut instance = ProposerRaptorcast::new(NodeId::dummy(0));
+
+        // without the header every request is for the full set
+        let peer = NodeId::dummy(2);
+        let request = instance.chunk_request(&header.root, ChunkRequestType::YourChunks, &peer);
+        assert_eq!(
+            request,
+            Some(ChunkRequest::all(ChunkRequestType::YourChunks))
+        );
+
+        // holding ids 0 and 1: node 2 still owes id 4, we still miss
+        // our own id 3
+        instance
+            .ingest(group(&chunks[..2]), &epoch_handle, &mut egress)
+            .expect("well-formed header");
+        let request = instance.chunk_request(&header.root, ChunkRequestType::YourChunks, &peer);
+        let expected = ChunksSubset::narrowed([chunk_id(&epoch_handle, &header, 4)]);
+        assert_eq!(
+            request,
+            Some(ChunkRequest {
+                kind: ChunkRequestType::YourChunks,
+                subset: expected
+            })
+        );
+
+        let request = instance.chunk_request(&header.root, ChunkRequestType::MyChunks, &peer);
+        let expected = ChunksSubset::narrowed([chunk_id(&epoch_handle, &header, 3)]);
+        assert_eq!(
+            request,
+            Some(ChunkRequest {
+                kind: ChunkRequestType::MyChunks,
+                subset: expected
+            })
+        );
+
+        // decoded: nothing left to ask for
+        instance
+            .ingest(group(&chunks[2..3]), &epoch_handle, &mut egress)
+            .expect("well-formed header");
+        assert!(instance.decoded_message(&header.root).is_some());
+        let request = instance.chunk_request(&header.root, ChunkRequestType::YourChunks, &peer);
+        assert_eq!(request, None);
     }
 }

--- a/monad-mcp-da/src/proposer_rc.rs
+++ b/monad-mcp-da/src/proposer_rc.rs
@@ -1,0 +1,342 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::{HashMap, HashSet};
+
+use bytes::Bytes;
+use monad_mcp_chorus::spec::validator::ValidatorData as _;
+
+use super::{
+    chunk::ProposalEnvelope,
+    egress::ChunkEgress,
+    encoding_scheme::DAEncodingScheme as _,
+    header::{DAProposalHeader as _, InvalidProposalHeader},
+    instance_rc::RaptorcastInstance,
+    runtime::EpochHandle,
+    types::{MerkleRoot, NodeId, ProposalDAEvent, ProposalHeader},
+};
+
+// per-(slot, proposer) raptorcast: root-keyed
+pub struct ProposerRaptorcast {
+    proposer: NodeId,
+
+    // admitted roots. todo: make the chorus commitment to a digest of
+    // the whole signed header.
+    instances: HashMap<MerkleRoot, RaptorcastInstance>,
+
+    // roots received from consensus. chunks from pinned roots are
+    // always admitted.
+    pinned: HashSet<MerkleRoot>,
+
+    // roots whose header has been reported to consensus.
+    // invariant: every instance's root is seen
+    seen: HashSet<MerkleRoot>,
+
+    // events pending delivery since the last drain
+    out_events: Vec<ProposalDAEvent>,
+}
+
+impl ProposerRaptorcast {
+    pub(crate) fn new(proposer: NodeId) -> Self {
+        Self {
+            proposer,
+            instances: HashMap::new(),
+            pinned: HashSet::new(),
+            seen: HashSet::new(),
+            out_events: Vec::new(),
+        }
+    }
+
+    pub(crate) fn drain_events(&mut self) -> Vec<ProposalDAEvent> {
+        std::mem::take(&mut self.out_events)
+    }
+
+    // the decoded message under root, once decoding succeeded
+    pub(crate) fn decoded_message(&self, root: &MerkleRoot) -> Option<&Bytes> {
+        let instance = self.instances.get(root)?;
+        instance.decoded_message()
+    }
+
+    pub(crate) fn ingest(
+        &mut self,
+        envelope: ProposalEnvelope,
+        epoch_handle: &EpochHandle,
+        egress: &mut ChunkEgress,
+    ) -> Result<(), InvalidProposalHeader> {
+        let (header, chunks) = envelope.into_parts();
+        let root = header.root;
+        self.admit(header, epoch_handle)?;
+
+        let Some(instance) = self.instances.get_mut(&root) else {
+            // dismissed root: its chunks are dropped
+            return Ok(());
+        };
+
+        for (chunk_id, data) in chunks {
+            let event = match instance.ingest_chunk(chunk_id, data, egress) {
+                Ok(event) => event,
+                Err(err) => {
+                    tracing::debug!(?root, chunk_id, ?err, "dropping invalid chunk");
+                    continue;
+                }
+            };
+
+            self.out_events.extend(event);
+        }
+        Ok(())
+    }
+
+    // admission & instance creation. no-op for known roots.
+    fn admit(
+        &mut self,
+        header: ProposalHeader,
+        epoch_handle: &EpochHandle,
+    ) -> Result<(), InvalidProposalHeader> {
+        if self.instances.contains_key(&header.root) {
+            return Ok(());
+        }
+
+        if self.seen.insert(header.root) {
+            // fresh header, report for equivocation evidence.
+            self.out_events
+                .push(ProposalDAEvent::HeaderSeen(header.clone()));
+        }
+
+        let admissible = self.pinned.contains(&header.root) || self.can_admit_unpinned();
+        if !admissible {
+            return Ok(());
+        }
+
+        let num_validators = epoch_handle.validator_data.len();
+        let layout = header
+            .encoding_scheme()
+            .packet_layout(num_validators)
+            .ok_or(InvalidProposalHeader::NoPacketLayout)?;
+
+        let root = header.root;
+        let instance = RaptorcastInstance::new(epoch_handle, header, layout, &self.proposer);
+        self.instances.insert(root, instance);
+        Ok(())
+    }
+
+    // pin a root to ensure its chunks are always admitted.
+    pub(crate) fn pin(&mut self, root: &MerkleRoot) {
+        self.pinned.insert(*root);
+    }
+
+    // Invariant: we only keep at most one unpinned instance to ensure
+    // constant memory.
+    fn can_admit_unpinned(&self) -> bool {
+        self.instances.keys().all(|root| self.pinned.contains(root))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::test_util::{epoch_handle, group, proposal_chunks},
+        *,
+    };
+
+    fn released_egress() -> ChunkEgress {
+        let mut egress = ChunkEgress::new();
+        egress.release();
+        egress
+    }
+
+    #[test]
+    fn first_unpinned_root_is_admitted() {
+        let epoch_handle = epoch_handle();
+        let mut egress = released_egress();
+        let (header, _) = proposal_chunks(&epoch_handle, 1);
+
+        let mut instance = ProposerRaptorcast::new(NodeId::dummy(0));
+        instance
+            .ingest(
+                ProposalEnvelope::from_header(header.clone()),
+                &epoch_handle,
+                &mut egress,
+            )
+            .expect("well-formed header");
+        let events = instance.drain_events();
+
+        assert!(events.contains(&ProposalDAEvent::HeaderSeen(header)));
+    }
+
+    #[test]
+    fn header_alone_creates_the_instance() {
+        let epoch_handle = epoch_handle();
+        let mut egress = released_egress();
+        let (header, chunks) = proposal_chunks(&epoch_handle, 1);
+
+        let mut instance = ProposerRaptorcast::new(NodeId::dummy(0));
+        instance
+            .ingest(
+                ProposalEnvelope::from_header(header.clone()),
+                &epoch_handle,
+                &mut egress,
+            )
+            .expect("well-formed header");
+        let events = instance.drain_events();
+        assert_eq!(events, vec![ProposalDAEvent::HeaderSeen(header.clone())]);
+
+        // the instance exists: later chunks decode it
+        instance
+            .ingest(group(&chunks[..3]), &epoch_handle, &mut egress)
+            .expect("well-formed header");
+        let events = instance.drain_events();
+        assert!(events.contains(&ProposalDAEvent::Decoded(header.root)));
+    }
+
+    #[test]
+    fn second_unpinned_root_announces_its_header_once() {
+        let epoch_handle = epoch_handle();
+        let mut egress = released_egress();
+        let (header_a, _) = proposal_chunks(&epoch_handle, 1);
+        let (header_b, chunks_b) = proposal_chunks(&epoch_handle, 2);
+
+        let mut instance = ProposerRaptorcast::new(NodeId::dummy(0));
+        instance
+            .ingest(
+                ProposalEnvelope::from_header(header_a),
+                &epoch_handle,
+                &mut egress,
+            )
+            .expect("well-formed header");
+        instance.drain_events();
+
+        instance
+            .ingest(
+                ProposalEnvelope::from_header(header_b.clone()),
+                &epoch_handle,
+                &mut egress,
+            )
+            .expect("well-formed header");
+        let events = instance.drain_events();
+        assert_eq!(events, vec![ProposalDAEvent::HeaderSeen(header_b.clone())]);
+        instance
+            .ingest(
+                ProposalEnvelope::from_header(header_b.clone()),
+                &epoch_handle,
+                &mut egress,
+            )
+            .expect("well-formed header");
+        let events = instance.drain_events();
+        assert!(events.is_empty());
+
+        // announced once; the rival is not assembled, so its chunks
+        // are dropped silently and it never decodes
+        instance
+            .ingest(group(&chunks_b), &epoch_handle, &mut egress)
+            .expect("well-formed header");
+        assert!(instance.drain_events().is_empty());
+        assert!(instance.decoded_message(&header_b.root).is_none());
+    }
+
+    #[test]
+    fn pinned_roots_are_always_admitted() {
+        let epoch_handle = epoch_handle();
+        let mut egress = released_egress();
+        let (header_a, _) = proposal_chunks(&epoch_handle, 1);
+        let (header_b, _) = proposal_chunks(&epoch_handle, 2);
+
+        let mut instance = ProposerRaptorcast::new(NodeId::dummy(0));
+        instance
+            .ingest(
+                ProposalEnvelope::from_header(header_a),
+                &epoch_handle,
+                &mut egress,
+            )
+            .expect("well-formed header");
+        instance.drain_events();
+
+        instance.pin(&header_b.root);
+        instance
+            .ingest(
+                ProposalEnvelope::from_header(header_b.clone()),
+                &epoch_handle,
+                &mut egress,
+            )
+            .expect("well-formed header");
+        let events = instance.drain_events();
+        assert!(events.contains(&ProposalDAEvent::HeaderSeen(header_b)));
+
+        // still at most one unpinned instance: a third root is announced
+        // but not assembled
+        let (header_c, chunks_c) = proposal_chunks(&epoch_handle, 3);
+        instance
+            .ingest(
+                ProposalEnvelope::from_header(header_c.clone()),
+                &epoch_handle,
+                &mut egress,
+            )
+            .expect("well-formed header");
+        let events = instance.drain_events();
+        assert_eq!(events, vec![ProposalDAEvent::HeaderSeen(header_c)]);
+        instance
+            .ingest(group(&chunks_c[..1]), &epoch_handle, &mut egress)
+            .expect("well-formed header");
+        let events = instance.drain_events();
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn pinning_a_seen_root_admits_without_reannouncing() {
+        let epoch_handle = epoch_handle();
+        let mut egress = released_egress();
+        let (header_a, _) = proposal_chunks(&epoch_handle, 1);
+        let (header_b, chunks_b) = proposal_chunks(&epoch_handle, 2);
+
+        let mut instance = ProposerRaptorcast::new(NodeId::dummy(0));
+        instance
+            .ingest(
+                ProposalEnvelope::from_header(header_a),
+                &epoch_handle,
+                &mut egress,
+            )
+            .expect("well-formed header");
+        instance.drain_events();
+
+        // rejected rival: header reported once
+        instance
+            .ingest(
+                ProposalEnvelope::from_header(header_b.clone()),
+                &epoch_handle,
+                &mut egress,
+            )
+            .expect("well-formed header");
+        let events = instance.drain_events();
+        assert_eq!(events, vec![ProposalDAEvent::HeaderSeen(header_b.clone())]);
+
+        instance.pin(&header_b.root);
+
+        // admitted now, without a second announcement
+        instance
+            .ingest(
+                ProposalEnvelope::from_header(header_b.clone()),
+                &epoch_handle,
+                &mut egress,
+            )
+            .expect("well-formed header");
+        assert!(instance.drain_events().is_empty());
+
+        // and genuinely assembled: enough chunks decode it
+        instance
+            .ingest(group(&chunks_b[..3]), &epoch_handle, &mut egress)
+            .expect("well-formed header");
+        let events = instance.drain_events();
+        assert!(events.contains(&ProposalDAEvent::Decoded(header_b.root)));
+    }
+}

--- a/monad-mcp-da/src/proposer_rc.rs
+++ b/monad-mcp-da/src/proposer_rc.rs
@@ -95,6 +95,7 @@ impl ProposerRaptorcast {
 
             self.out_events.extend(event);
         }
+        self.out_events.extend(instance.drain_obligation_events());
         Ok(())
     }
 
@@ -190,7 +191,18 @@ mod tests {
             )
             .expect("well-formed header");
         let events = instance.drain_events();
-        assert_eq!(events, vec![ProposalDAEvent::HeaderSeen(header.clone())]);
+        // the chunkless author owes nothing from the start
+        let author_owes_nothing = ProposalDAEvent::OwnerObligationFulfilled {
+            owner: NodeId::dummy(0),
+            root: header.root,
+        };
+        assert_eq!(
+            events,
+            vec![
+                ProposalDAEvent::HeaderSeen(header.clone()),
+                author_owes_nothing
+            ]
+        );
 
         // the instance exists: later chunks decode it
         instance
@@ -322,7 +334,8 @@ mod tests {
 
         instance.pin(&header_b.root);
 
-        // admitted now, without a second announcement
+        // admitted now, without a second announcement: only the
+        // chunkless author's vacuous obligation
         instance
             .ingest(
                 ProposalEnvelope::from_header(header_b.clone()),
@@ -330,7 +343,12 @@ mod tests {
                 &mut egress,
             )
             .expect("well-formed header");
-        assert!(instance.drain_events().is_empty());
+        let events = instance.drain_events();
+        let author_owes_nothing = ProposalDAEvent::OwnerObligationFulfilled {
+            owner: NodeId::dummy(0),
+            root: header_b.root,
+        };
+        assert_eq!(events, vec![author_owes_nothing]);
 
         // and genuinely assembled: enough chunks decode it
         instance

--- a/monad-mcp-da/src/runtime.rs
+++ b/monad-mcp-da/src/runtime.rs
@@ -1,0 +1,167 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    collections::{BTreeMap, VecDeque},
+    ops::Range,
+    sync::Arc,
+};
+
+use super::{
+    chunk::{Chunk, ProposalEnvelope},
+    header::InvalidProposalHeader,
+    slot_rc::SlotRaptorcast,
+    types::{
+        ChorusDACommand, ChorusDAEvent, HeaderAuth, NodeId, ProposalKeyPair, Slot, SlotLifecycle,
+        ValidatorData,
+    },
+    util::SlotCompletion,
+};
+
+// todo: give this type a more proper name. it encodes the concept of
+// slot-scoped config, the identity and validator set. think about if
+// we can further refine this concept to have a clearer boundary. note
+// this is almost the same shape as ChorusContext, so maybe we can
+// just share the type.
+#[derive(Clone)]
+pub struct EpochHandle {
+    pub self_id: NodeId,
+    pub num_proposals: usize,
+    pub key_pair: Arc<ProposalKeyPair>,
+    pub header_auth: Arc<HeaderAuth>,
+    // todo: only this field is slot-scoped, should we isolate it out?
+    pub validator_data: Arc<ValidatorData>,
+}
+
+pub struct DAConfig {
+    // keep completed slots for additional time (measured in slots),
+    // still ingesting chunks and serving peer chunk recovery requests.
+    pub completed_slot_retention: u64,
+}
+
+pub struct DARuntime {
+    config: DAConfig,
+    // todo: make epoch_handle slot dependent
+    epoch_handle: EpochHandle,
+    raptorcast_map: BTreeMap<Slot, SlotRaptorcast>,
+
+    // inclusive start, exclusive end
+    ingestion_window: Range<Slot>,
+    slot_completion: SlotCompletion,
+
+    outbox: VecDeque<DAOutput>,
+}
+
+impl DARuntime {
+    pub fn new(config: DAConfig, epoch_handle: EpochHandle) -> Self {
+        Self {
+            config,
+            epoch_handle,
+            raptorcast_map: Default::default(),
+            // todo: set the lower bound with finalization certificate
+            ingestion_window: Slot::MIN..Slot::MIN,
+            slot_completion: SlotCompletion::new(),
+            outbox: Default::default(),
+        }
+    }
+
+    pub fn ingest_chunk(&mut self, chunk: Chunk) -> Result<(), InvalidProposalHeader> {
+        let envelope = ProposalEnvelope::from_chunk(chunk);
+        self.ingest(envelope)
+    }
+
+    pub fn ingest(&mut self, envelope: ProposalEnvelope) -> Result<(), InvalidProposalHeader> {
+        let slot = envelope.header().slot;
+        let Some(slot_raptorcast) = self.open_slot_raptorcast(slot) else {
+            return Err(InvalidProposalHeader::SlotOutOfRange);
+        };
+
+        slot_raptorcast.ingest(envelope)?;
+        self.collect(slot);
+        Ok(())
+    }
+
+    // move the slot's pending events to the outbox
+    fn collect(&mut self, slot: Slot) {
+        let Some(slot_raptorcast) = self.raptorcast_map.get_mut(&slot) else {
+            return;
+        };
+
+        for event in slot_raptorcast.drain_events() {
+            self.outbox.push_back(DAOutput::Consensus(slot, event));
+        }
+    }
+
+    // the slot's raptorcast, created on first use. None once the slot
+    // is outside the ingestion window.
+    fn open_slot_raptorcast(&mut self, slot: Slot) -> Option<&mut SlotRaptorcast> {
+        if !self.ingestion_window.contains(&slot) {
+            return None;
+        }
+
+        let slot_raptorcast = self
+            .raptorcast_map
+            .entry(slot)
+            .or_insert_with(|| SlotRaptorcast::new(&self.epoch_handle, slot));
+        Some(slot_raptorcast)
+    }
+
+    pub fn handle_slot_event(&mut self, slot: Slot, event: SlotLifecycle) {
+        match event {
+            SlotLifecycle::Opened => {
+                let open_ingestion_slot = slot
+                    .checked_next()
+                    .unwrap_or(Slot::MAX_CAP)
+                    .max(self.ingestion_window.end);
+                self.ingestion_window.end = open_ingestion_slot;
+            }
+            SlotLifecycle::Completed => {
+                self.slot_completion.mark_completed(slot);
+                self.close_slots();
+            }
+        }
+    }
+
+    pub fn handle_command(&mut self, slot: Slot, command: ChorusDACommand) {
+        let Some(slot_raptorcast) = self.open_slot_raptorcast(slot) else {
+            return;
+        };
+        let outputs = slot_raptorcast.handle_command(command);
+        self.outbox.extend(outputs);
+        self.collect(slot);
+    }
+
+    pub fn poll(&mut self) -> Option<DAOutput> {
+        self.outbox.pop_front()
+    }
+
+    // drop the completed slots past retention and stop ingesting for
+    // them
+    fn close_slots(&mut self) {
+        let kept_slot_cap = self
+            .slot_completion
+            .cap()
+            .checked_sub(self.config.completed_slot_retention)
+            .unwrap_or(Slot::MIN);
+
+        self.ingestion_window.start = kept_slot_cap;
+        self.raptorcast_map.retain(|&slot, _| slot >= kept_slot_cap);
+    }
+}
+
+pub enum DAOutput {
+    // notification for the consensus layer's slot instance
+    Consensus(Slot, ChorusDAEvent),
+}

--- a/monad-mcp-da/src/runtime.rs
+++ b/monad-mcp-da/src/runtime.rs
@@ -19,13 +19,17 @@ use std::{
     sync::Arc,
 };
 
+use bytes::Bytes;
+
 use super::{
     chunk::{Chunk, ProposalEnvelope},
+    egress::Dissemination,
+    election::ProposerElection,
     header::InvalidProposalHeader,
     slot_rc::SlotRaptorcast,
     types::{
-        ChorusDACommand, ChorusDAEvent, HeaderAuth, NodeId, ProposalKeyPair, Slot, SlotLifecycle,
-        ValidatorData,
+        ChorusDACommand, ChorusDAEvent, HeaderAuth, MerkleRoot, NodeId, ProposalDAEvent,
+        ProposalIndex, ProposalKeyPair, Slot, SlotLifecycle, ValidatorData,
     },
     util::SlotCompletion,
 };
@@ -51,11 +55,13 @@ pub struct DAConfig {
     pub completed_slot_retention: u64,
 }
 
-pub struct DARuntime {
+pub struct DARuntime<E> {
     config: DAConfig,
     // todo: make epoch_handle slot dependent
     epoch_handle: EpochHandle,
     raptorcast_map: BTreeMap<Slot, SlotRaptorcast>,
+
+    election: Arc<E>,
 
     // inclusive start, exclusive end
     ingestion_window: Range<Slot>,
@@ -64,10 +70,14 @@ pub struct DARuntime {
     outbox: VecDeque<DAOutput>,
 }
 
-impl DARuntime {
-    pub fn new(config: DAConfig, epoch_handle: EpochHandle) -> Self {
+impl<E> DARuntime<E>
+where
+    E: ProposerElection,
+{
+    pub fn new(config: DAConfig, epoch_handle: EpochHandle, election: Arc<E>) -> Self {
         Self {
             config,
+            election,
             epoch_handle,
             raptorcast_map: Default::default(),
             // todo: set the lower bound with finalization certificate
@@ -93,15 +103,33 @@ impl DARuntime {
         Ok(())
     }
 
-    // move the slot's pending events to the outbox
+    // move the slot's pending events and messages to the outbox
     fn collect(&mut self, slot: Slot) {
         let Some(slot_raptorcast) = self.raptorcast_map.get_mut(&slot) else {
             return;
         };
 
+        let mut outputs = Vec::new();
         for event in slot_raptorcast.drain_events() {
-            self.outbox.push_back(DAOutput::Consensus(slot, event));
+            if let ProposalDAEvent::Decoded(root) = &event.event {
+                let message = slot_raptorcast
+                    .decoded_message(event.j, root)
+                    .expect("decoded event implies a decoded message")
+                    .clone();
+                outputs.push(DAOutput::Decoded {
+                    slot,
+                    proposal_index: event.j,
+                    root: *root,
+                    message,
+                });
+            }
+
+            outputs.push(DAOutput::Consensus(slot, event));
         }
+        for message in slot_raptorcast.drain_messages() {
+            outputs.push(DAOutput::Disseminate(message));
+        }
+        self.outbox.extend(outputs);
     }
 
     // the slot's raptorcast, created on first use. None once the slot
@@ -114,7 +142,7 @@ impl DARuntime {
         let slot_raptorcast = self
             .raptorcast_map
             .entry(slot)
-            .or_insert_with(|| SlotRaptorcast::new(&self.epoch_handle, slot));
+            .or_insert_with(|| SlotRaptorcast::new(&self.epoch_handle, slot, &*self.election));
         Some(slot_raptorcast)
     }
 
@@ -164,4 +192,132 @@ impl DARuntime {
 pub enum DAOutput {
     // notification for the consensus layer's slot instance
     Consensus(Slot, ChorusDAEvent),
+
+    // the message decoded under (slot, proposal_index, root), for the
+    // layer that recovers proposals
+    Decoded {
+        slot: Slot,
+        proposal_index: ProposalIndex,
+        root: MerkleRoot,
+        message: Bytes,
+    },
+
+    // deliver a proposal's chunks (possibly only its header) to peers
+    Disseminate(Dissemination),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::test_util::{
+            MESSAGE_LEN, Proposers, SLOT, author, epoch_handle, group, proposal_chunks,
+            proposal_chunks_from,
+        },
+        *,
+    };
+
+    fn runtime(retention: u64) -> DARuntime<Proposers> {
+        let config = DAConfig {
+            completed_slot_retention: retention,
+        };
+        let election = Arc::new(Proposers::new(vec![author()]));
+        DARuntime::new(config, epoch_handle(), election)
+    }
+
+    fn open(runtime: &mut DARuntime<Proposers>, slots: impl IntoIterator<Item = u64>) {
+        for slot in slots {
+            runtime.handle_slot_event(Slot(slot), SlotLifecycle::Opened);
+        }
+    }
+
+    fn outputs(runtime: &mut DARuntime<Proposers>) -> Vec<DAOutput> {
+        let mut outputs = Vec::new();
+        while let Some(output) = runtime.poll() {
+            outputs.push(output);
+        }
+        outputs
+    }
+
+    #[test]
+    fn ingestion_is_bounded_by_the_opened_slots() {
+        let mut runtime = runtime(1);
+        let epoch_handle = epoch_handle();
+        let (_, chunks) = proposal_chunks(&epoch_handle, 1);
+
+        let closed = runtime.ingest(group(&chunks[..1]));
+        assert_eq!(closed, Err(InvalidProposalHeader::SlotOutOfRange));
+
+        open(&mut runtime, [0, 1]);
+        assert_eq!(runtime.ingest(group(&chunks[..1])), Ok(()));
+
+        let (_, later) = proposal_chunks_from(&epoch_handle, 0, Slot(5), 1);
+        let beyond = runtime.ingest(group(&later[..1]));
+        assert_eq!(beyond, Err(InvalidProposalHeader::SlotOutOfRange));
+    }
+
+    #[test]
+    fn completed_slots_are_kept_for_the_retention_then_dropped() {
+        let mut runtime = runtime(1);
+        let epoch_handle = epoch_handle();
+        open(&mut runtime, [0, 1, 2]);
+        let (_, slot0) = proposal_chunks_from(&epoch_handle, 0, Slot(0), 1);
+        let (_, slot1) = proposal_chunks_from(&epoch_handle, 0, Slot(1), 1);
+        assert_eq!(runtime.ingest(group(&slot0[..1])), Ok(()));
+        assert_eq!(runtime.ingest(group(&slot1[..1])), Ok(()));
+
+        // completing 1 before 0 retires nothing
+        runtime.handle_slot_event(Slot(1), SlotLifecycle::Completed);
+        assert_eq!(runtime.ingest(group(&slot0[1..2])), Ok(()));
+
+        // the cap reaches 2: slot 0 leaves the retention window, slot 1 stays
+        runtime.handle_slot_event(Slot(0), SlotLifecycle::Completed);
+        let retired = runtime.ingest(group(&slot0[2..3]));
+        assert_eq!(retired, Err(InvalidProposalHeader::SlotOutOfRange));
+        assert_eq!(runtime.ingest(group(&slot1[1..2])), Ok(()));
+    }
+
+    #[test]
+    fn a_decode_reaches_execution_then_consensus_then_the_wire() {
+        let mut runtime = runtime(1);
+        let epoch_handle = epoch_handle();
+        open(&mut runtime, [0, 1]);
+        runtime.handle_command(SLOT, ChorusDACommand::ReleaseChunks);
+        let (header, chunks) = proposal_chunks(&epoch_handle, 1);
+        runtime.ingest(group(&chunks[..3])).expect("valid");
+
+        let mut decoded_at = None;
+        let mut consensus_decoded_at = None;
+        let mut disseminated_at = Vec::new();
+        for (i, output) in outputs(&mut runtime).iter().enumerate() {
+            match output {
+                DAOutput::Decoded {
+                    slot,
+                    proposal_index,
+                    root,
+                    message,
+                } => {
+                    assert_eq!((*slot, *proposal_index, *root), (SLOT, 0, header.root));
+                    assert_eq!(message, &Bytes::from(vec![1u8; MESSAGE_LEN]));
+                    decoded_at = Some(i);
+                }
+                DAOutput::Consensus(slot, event) => {
+                    assert_eq!(*slot, SLOT);
+                    if event.event == ProposalDAEvent::Decoded(header.root) {
+                        consensus_decoded_at = Some(i);
+                    }
+                }
+                DAOutput::Disseminate(dissemination) => {
+                    // our chunk 0 on arrival and 3 once derivable, one message
+                    let ids: Vec<_> = dissemination.envelope.chunks().keys().copied().collect();
+                    assert_eq!(ids, [0, 3]);
+                    disseminated_at.push(i);
+                }
+            }
+        }
+
+        let decoded_at = decoded_at.expect("the message is delivered");
+        assert_eq!(consensus_decoded_at, Some(decoded_at + 1));
+        assert_eq!(disseminated_at.len(), 1);
+        assert!(disseminated_at[0] > decoded_at);
+    }
 }

--- a/monad-mcp-da/src/runtime.rs
+++ b/monad-mcp-da/src/runtime.rs
@@ -22,7 +22,7 @@ use std::{
 use bytes::Bytes;
 
 use super::{
-    chunk::{Chunk, ProposalEnvelope},
+    chunk::{Chunk, ChunkRequest, ProposalEnvelope},
     egress::Dissemination,
     election::ProposerElection,
     header::InvalidProposalHeader,
@@ -68,6 +68,14 @@ pub struct DARuntime<E> {
     slot_completion: SlotCompletion,
 
     outbox: VecDeque<DAOutput>,
+}
+
+pub struct ChunkRecoveryRequest {
+    pub slot: Slot,
+    pub proposal_index: ProposalIndex,
+    pub root: MerkleRoot,
+
+    pub request: ChunkRequest,
 }
 
 impl<E> DARuntime<E>
@@ -146,6 +154,22 @@ where
         Some(slot_raptorcast)
     }
 
+    pub fn handle_chunk_request(&mut self, from: &NodeId, req: ChunkRecoveryRequest) {
+        let ChunkRecoveryRequest {
+            slot,
+            proposal_index,
+            root,
+            request,
+        } = req;
+
+        let Some(slot_raptorcast) = self.raptorcast_map.get_mut(&slot) else {
+            return;
+        };
+
+        slot_raptorcast.handle_chunk_request(from, proposal_index, root, request);
+        self.collect(slot);
+    }
+
     pub fn handle_slot_event(&mut self, slot: Slot, event: SlotLifecycle) {
         match event {
             SlotLifecycle::Opened => {
@@ -204,14 +228,23 @@ pub enum DAOutput {
 
     // deliver a proposal's chunks (possibly only its header) to peers
     Disseminate(Dissemination),
+
+    // request chunks from a peer
+    RecoveryRequest {
+        to: NodeId,
+        request: ChunkRecoveryRequest,
+    },
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        super::test_util::{
-            MESSAGE_LEN, Proposers, SLOT, author, epoch_handle, group, proposal_chunks,
-            proposal_chunks_from,
+        super::{
+            test_util::{
+                MESSAGE_LEN, Proposers, SLOT, author, epoch_handle, group, proposal_chunks,
+                proposal_chunks_from,
+            },
+            types::ChunkRequestType,
         },
         *,
     };
@@ -312,6 +345,7 @@ mod tests {
                     assert_eq!(ids, [0, 3]);
                     disseminated_at.push(i);
                 }
+                DAOutput::RecoveryRequest { .. } => panic!("nothing to recover"),
             }
         }
 
@@ -319,5 +353,46 @@ mod tests {
         assert_eq!(consensus_decoded_at, Some(decoded_at + 1));
         assert_eq!(disseminated_at.len(), 1);
         assert!(disseminated_at[0] > decoded_at);
+    }
+
+    #[test]
+    fn recovery_requests_skip_ourselves_and_unknown_slots_are_ignored() {
+        let mut runtime = runtime(1);
+        let epoch_handle = epoch_handle();
+        open(&mut runtime, [0, 1]);
+        let (header, _) = proposal_chunks(&epoch_handle, 1);
+
+        let voters = vec![NodeId::dummy(1), NodeId::dummy(2), NodeId::dummy(3)];
+        let command = ChorusDACommand::RecoverChunks {
+            j: 0,
+            root: header.root,
+            request_type: ChunkRequestType::YourChunks,
+            voters,
+        };
+        runtime.handle_command(SLOT, command);
+
+        let mut peers = Vec::new();
+        for output in outputs(&mut runtime) {
+            let DAOutput::RecoveryRequest { to, request } = output else {
+                panic!("only requests are produced");
+            };
+            assert_eq!((request.slot, request.proposal_index), (SLOT, 0));
+            assert_eq!(request.root, header.root);
+            assert_eq!(
+                request.request,
+                ChunkRequest::all(ChunkRequestType::YourChunks)
+            );
+            peers.push(to);
+        }
+        assert_eq!(peers, [NodeId::dummy(2), NodeId::dummy(3)]);
+
+        let unknown_slot = ChunkRecoveryRequest {
+            slot: Slot(7),
+            proposal_index: 0,
+            root: header.root,
+            request: ChunkRequest::all(ChunkRequestType::YourChunks),
+        };
+        runtime.handle_chunk_request(&NodeId::dummy(2), unknown_slot);
+        assert!(outputs(&mut runtime).is_empty());
     }
 }

--- a/monad-mcp-da/src/slot_rc.rs
+++ b/monad-mcp-da/src/slot_rc.rs
@@ -1,0 +1,81 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+
+use monad_mcp_chorus::spec::proposal::HeaderAuth as _;
+
+use super::{
+    chunk::ProposalEnvelope,
+    header::InvalidProposalHeader,
+    runtime::{DAOutput, EpochHandle},
+    types::{ChorusDACommand, ChorusDAEvent, ProposalHeader, ProposalIndex, Slot},
+};
+
+// per-slot raptorcast tracking. mainly handles proposer-related
+// validation.
+pub struct SlotRaptorcast {
+    epoch_handle: EpochHandle,
+    slot: Slot,
+
+    // memoize the proposal index of headers that authenticated. todo:
+    // bound per proposer.
+    authenticated_headers: HashMap<ProposalHeader, ProposalIndex>,
+
+    // events pending delivery since the last drain
+    out_events: Vec<ChorusDAEvent>,
+}
+
+impl SlotRaptorcast {
+    pub fn new(epoch_handle: &EpochHandle, slot: Slot) -> Self {
+        Self {
+            epoch_handle: epoch_handle.clone(),
+            slot,
+            authenticated_headers: HashMap::new(),
+            out_events: Vec::new(),
+        }
+    }
+
+    pub fn drain_events(&mut self) -> Vec<ChorusDAEvent> {
+        std::mem::take(&mut self.out_events)
+    }
+
+    pub fn ingest(&mut self, envelope: ProposalEnvelope) -> Result<(), InvalidProposalHeader> {
+        debug_assert!(envelope.header().slot == self.slot);
+
+        self.authenticate(envelope.header())
+            .ok_or(InvalidProposalHeader::Unauthenticated)?;
+        Ok(())
+    }
+
+    // the proposal index of a proposer-signed header for this slot
+    fn authenticate(&mut self, header: &ProposalHeader) -> Option<ProposalIndex> {
+        if let Some(j) = self.authenticated_headers.get(header) {
+            return Some(*j);
+        }
+
+        let j = self
+            .epoch_handle
+            .header_auth
+            .authenticate(header, self.slot.get())?;
+        self.authenticated_headers.insert(header.clone(), j);
+        Some(j)
+    }
+
+    // no command has an effect on an authenticated header alone
+    pub(crate) fn handle_command(&mut self, _command: ChorusDACommand) -> Vec<DAOutput> {
+        vec![]
+    }
+}

--- a/monad-mcp-da/src/slot_rc.rs
+++ b/monad-mcp-da/src/slot_rc.rs
@@ -19,15 +19,15 @@ use bytes::Bytes;
 use monad_mcp_chorus::spec::proposal::HeaderAuth as _;
 
 use super::{
-    chunk::ProposalEnvelope,
+    chunk::{ChunkRequest, ProposalEnvelope},
     egress::{ChunkEgress, Dissemination},
     election::ProposerElection,
     header::InvalidProposalHeader,
     proposer_rc::ProposerRaptorcast,
-    runtime::{DAOutput, EpochHandle},
+    runtime::{ChunkRecoveryRequest, DAOutput, EpochHandle},
     types::{
-        ChorusDACommand, ChorusDAEvent, MerkleRoot, ProposalHeader, ProposalIndex, ProposalMap,
-        Slot,
+        ChorusDACommand, ChorusDAEvent, ChunkRequestType, MerkleRoot, NodeId, ProposalHeader,
+        ProposalIndex, ProposalMap, Slot,
     },
 };
 
@@ -143,13 +143,69 @@ impl SlotRaptorcast {
                 }
                 vec![]
             }
-            ChorusDACommand::RecoverChunks { j, root, .. } => {
-                if let Some(raptorcast) = self.raptorcast_mut(j) {
-                    raptorcast.pin(&root);
-                }
-                vec![]
+            ChorusDACommand::RecoverChunks {
+                j,
+                root,
+                request_type,
+                voters,
+            } => {
+                let Some(raptorcast) = self.raptorcast_mut(j) else {
+                    return vec![];
+                };
+                raptorcast.pin(&root);
+                self.recover_chunks(j, root, request_type, &voters)
             }
         }
+    }
+
+    // ask each peer for the chunks of the type under (j, root) that we
+    // still miss
+    fn recover_chunks(
+        &self,
+        j: ProposalIndex,
+        root: MerkleRoot,
+        request_type: ChunkRequestType,
+        peers: &[NodeId],
+    ) -> Vec<DAOutput> {
+        let self_id = &self.epoch_handle.self_id;
+        let Some(raptorcast) = self.raptorcast(j) else {
+            return vec![];
+        };
+
+        let mut outputs = Vec::new();
+        for peer in peers {
+            if peer == self_id {
+                continue;
+            }
+            let Some(request) = raptorcast.chunk_request(&root, request_type, peer) else {
+                continue;
+            };
+            let request = ChunkRecoveryRequest {
+                slot: self.slot,
+                proposal_index: j,
+                root,
+                request,
+            };
+            outputs.push(DAOutput::RecoveryRequest { to: *peer, request });
+        }
+        outputs
+    }
+
+    // serve a peer chunks under (j, root)
+    pub(crate) fn handle_chunk_request(
+        &mut self,
+        requester: &NodeId,
+        proposal_index: ProposalIndex,
+        root: MerkleRoot,
+        request: ChunkRequest,
+    ) {
+        if proposal_index >= self.raptorcasts.size() {
+            return;
+        }
+        let Some(raptorcast) = self.raptorcasts[proposal_index].as_mut() else {
+            return;
+        };
+        raptorcast.handle_chunk_request(requester, &root, request, &mut self.egress);
     }
 }
 
@@ -165,12 +221,12 @@ mod tests {
 
     use super::{
         super::{
-            chunk::WireChunkId,
+            chunk::{ChunksSubset, WireChunkId},
             test_util::{
-                Proposers, SLOT, author, epoch_handle, epoch_handle_for, group, proposal_chunks,
-                proposal_chunks_from, validator_data,
+                MESSAGE_LEN, Proposers, SLOT, author, chunk_id, epoch_handle, epoch_handle_for,
+                group, proposal_chunks, proposal_chunks_from, validator_data,
             },
-            types::{HeaderAuth, NodeId, ProposalDAEvent, ProposalKeyPair},
+            types::{HeaderAuth, ProposalDAEvent, ProposalKeyPair},
         },
         *,
     };
@@ -200,6 +256,34 @@ mod tests {
     fn ingest(raptorcast: &mut SlotRaptorcast, envelope: ProposalEnvelope) -> Vec<Dissemination> {
         raptorcast.ingest(envelope).expect("well-formed header");
         raptorcast.drain_messages()
+    }
+
+    // node 3 asks for our chunks, returning the messages it caused
+    fn your_chunks(raptorcast: &mut SlotRaptorcast, root: MerkleRoot) -> Vec<Dissemination> {
+        let request = ChunkRequest::all(ChunkRequestType::YourChunks);
+        raptorcast.handle_chunk_request(&NodeId::dummy(3), 0, root, request);
+        raptorcast.drain_messages()
+    }
+
+    #[test]
+    fn chunks_are_held_until_released() {
+        let (epoch_handle, mut raptorcast) = slot_raptorcast();
+        let (header, chunks) = proposal_chunks(&epoch_handle, 1);
+
+        // our chunk 0 arrives and node 3 asks for it: nothing leaves
+        assert!(ingest(&mut raptorcast, group(&chunks[..1])).is_empty());
+        assert!(your_chunks(&mut raptorcast, header.root).is_empty());
+
+        // released: the second hop to the other owners, and the answer
+        // to node 3, both pending until now
+        raptorcast.handle_command(ChorusDACommand::ReleaseChunks);
+        let messages = raptorcast.drain_messages();
+        assert_eq!(chunk_ids(&messages), [0, 0]);
+        assert_eq!(messages[0].to, nodes([2, 3]));
+        assert_eq!(messages[1].to, nodes([3]));
+
+        // served once
+        assert!(your_chunks(&mut raptorcast, header.root).is_empty());
     }
 
     #[test]
@@ -284,6 +368,63 @@ mod tests {
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
+    // the (peer, request) pairs among the outputs
+    fn requests(outputs: Vec<DAOutput>) -> Vec<(NodeId, ChunkRequest)> {
+        let mut requests = Vec::new();
+        for output in outputs {
+            let DAOutput::RecoveryRequest { to, request } = output else {
+                panic!("only requests are produced");
+            };
+            requests.push((to, request.request));
+        }
+        requests
+    }
+
+    #[test]
+    fn recovery_requests_narrow_once_chunks_are_held_and_pin_the_root() {
+        let (epoch_handle, mut raptorcast) = slot_raptorcast();
+        let (header_a, _) = proposal_chunks(&epoch_handle, 1);
+        let (header_b, chunks_b) = proposal_chunks(&epoch_handle, 2);
+        let voters = vec![NodeId::dummy(1), NodeId::dummy(2), NodeId::dummy(3)];
+        let recover = |root| ChorusDACommand::RecoverChunks {
+            j: 0,
+            root,
+            request_type: ChunkRequestType::YourChunks,
+            voters: voters.clone(),
+        };
+
+        // the scratch instance is taken by root a
+        raptorcast
+            .ingest(ProposalEnvelope::from_header(header_a))
+            .expect("valid");
+
+        // nothing is known about b: ask every voter but us for everything
+        let all = ChunkRequest::all(ChunkRequestType::YourChunks);
+        let outputs = raptorcast.handle_command(recover(header_b.root));
+        assert_eq!(
+            requests(outputs),
+            [(NodeId::dummy(2), all.clone()), (NodeId::dummy(3), all)]
+        );
+
+        // the command pinned b, so it is assembled beside the scratch
+        // root; holding 0 and 1 narrows the asks to what is missing
+        raptorcast.ingest(group(&chunks_b[..2])).expect("valid");
+        let outputs = raptorcast.handle_command(recover(header_b.root));
+        let narrowed = |ids: &[WireChunkId]| ChunkRequest {
+            kind: ChunkRequestType::YourChunks,
+            subset: ChunksSubset::narrowed(
+                ids.iter().map(|id| chunk_id(&epoch_handle, &header_b, *id)),
+            ),
+        };
+        assert_eq!(
+            requests(outputs),
+            [
+                (NodeId::dummy(2), narrowed(&[4])),
+                (NodeId::dummy(3), narrowed(&[2, 5])),
+            ]
+        );
+    }
+
     #[test]
     fn a_second_proposers_events_carry_its_index() {
         let proposers = vec![author(), NodeId::dummy(2)];
@@ -299,5 +440,99 @@ mod tests {
             event: ProposalDAEvent::HeaderSeen(header),
         }));
         assert!(events.iter().all(|event| event.j == 1));
+    }
+
+    // deliver messages to their recipients among `nodes`, dropping
+    // those `lost` names
+    fn deliver(
+        nodes: &mut [(EpochHandle, SlotRaptorcast)],
+        messages: Vec<Dissemination>,
+        lost: &HashSet<NodeId>,
+    ) {
+        for message in messages {
+            for to in &message.to {
+                if lost.contains(to) {
+                    continue;
+                }
+                let Some((_, node)) = nodes.iter_mut().find(|(handle, _)| handle.self_id == *to)
+                else {
+                    continue;
+                };
+                node.ingest(message.envelope.clone()).expect("valid");
+            }
+        }
+    }
+
+    fn drain_all(nodes: &mut [(EpochHandle, SlotRaptorcast)]) -> Vec<Dissemination> {
+        let mut messages = Vec::new();
+        for (_, node) in nodes {
+            messages.extend(node.drain_messages());
+        }
+        messages
+    }
+
+    #[test]
+    fn chunks_reach_everyone_through_the_second_hop_and_recovery() {
+        // validators 1, 2 and 3 own two chunks each of validator 0's proposal
+        let mut nodes = Vec::new();
+        for id in 1..=3 {
+            let epoch_handle = epoch_handle_for(NodeId::dummy(id), 4, vec![author()]);
+            let election = Proposers::new(vec![author()]);
+            let mut node = SlotRaptorcast::new(&epoch_handle, SLOT, &election);
+            node.handle_command(ChorusDACommand::ReleaseChunks);
+            nodes.push((epoch_handle, node));
+        }
+        let (header, chunks) = proposal_chunks(&nodes[0].0, 1);
+        let decoded = |node: &SlotRaptorcast| node.decoded_message(0, &header.root).is_some();
+
+        // the author's first hop reaches 1 and 2; 3 is cut off entirely
+        let cut_off = HashSet::from([NodeId::dummy(3)]);
+        nodes[0]
+            .1
+            .ingest(group(&[chunks[0].clone(), chunks[3].clone()]))
+            .expect("valid");
+        nodes[1]
+            .1
+            .ingest(group(&[chunks[1].clone(), chunks[4].clone()]))
+            .expect("valid");
+        let second_hop = drain_all(&mut nodes);
+        deliver(&mut nodes, second_hop, &cut_off);
+        assert!(decoded(&nodes[0].1));
+        assert!(decoded(&nodes[1].1));
+        assert!(!decoded(&nodes[2].1));
+
+        // 3 pulls its own chunks from a decoded peer, then everyone's
+        let ask = |kind, voters: Vec<u64>| ChorusDACommand::RecoverChunks {
+            j: 0,
+            root: header.root,
+            request_type: kind,
+            voters: voters.into_iter().map(NodeId::dummy).collect(),
+        };
+        let mut outputs = nodes[2]
+            .1
+            .handle_command(ask(ChunkRequestType::MyChunks, vec![1]));
+        outputs.extend(
+            nodes[2]
+                .1
+                .handle_command(ask(ChunkRequestType::YourChunks, vec![1, 2])),
+        );
+        for (peer, request) in requests(outputs) {
+            let (_, server) = nodes
+                .iter_mut()
+                .find(|(handle, _)| handle.self_id == peer)
+                .unwrap();
+            server.handle_chunk_request(&NodeId::dummy(3), 0, header.root, request);
+        }
+        // 1 answers both asks in one message, 2 in another; together
+        // they carry every chunk
+        let responses = drain_all(&mut nodes);
+        assert_eq!(responses.len(), 2);
+        assert_eq!(chunk_ids(&responses), [0, 1, 2, 3, 4, 5]);
+        deliver(&mut nodes, responses, &HashSet::new());
+        assert!(decoded(&nodes[2].1));
+        assert_eq!(
+            nodes[2].1.decoded_message(0, &header.root),
+            Some(&Bytes::from(vec![1u8; MESSAGE_LEN]))
+        );
     }
 }

--- a/monad-mcp-da/src/slot_rc.rs
+++ b/monad-mcp-da/src/slot_rc.rs
@@ -15,13 +15,20 @@
 
 use std::collections::HashMap;
 
+use bytes::Bytes;
 use monad_mcp_chorus::spec::proposal::HeaderAuth as _;
 
 use super::{
     chunk::ProposalEnvelope,
+    egress::{ChunkEgress, Dissemination},
+    election::ProposerElection,
     header::InvalidProposalHeader,
+    proposer_rc::ProposerRaptorcast,
     runtime::{DAOutput, EpochHandle},
-    types::{ChorusDACommand, ChorusDAEvent, ProposalHeader, ProposalIndex, Slot},
+    types::{
+        ChorusDACommand, ChorusDAEvent, MerkleRoot, ProposalHeader, ProposalIndex, ProposalMap,
+        Slot,
+    },
 };
 
 // per-slot raptorcast tracking. mainly handles proposer-related
@@ -30,20 +37,35 @@ pub struct SlotRaptorcast {
     epoch_handle: EpochHandle,
     slot: Slot,
 
+    // None if the index has no proposer
+    raptorcasts: ProposalMap<Option<ProposerRaptorcast>>,
+
     // memoize the proposal index of headers that authenticated. todo:
     // bound per proposer.
     authenticated_headers: HashMap<ProposalHeader, ProposalIndex>,
+
+    egress: ChunkEgress,
 
     // events pending delivery since the last drain
     out_events: Vec<ChorusDAEvent>,
 }
 
 impl SlotRaptorcast {
-    pub fn new(epoch_handle: &EpochHandle, slot: Slot) -> Self {
+    pub fn new<E>(epoch_handle: &EpochHandle, slot: Slot, election: &E) -> Self
+    where
+        E: ProposerElection,
+    {
+        let raptorcasts = ProposalMap::new(epoch_handle.num_proposals, |j| {
+            let proposer = election.get_proposer(slot, j)?;
+            Some(ProposerRaptorcast::new(*proposer))
+        });
+
         Self {
             epoch_handle: epoch_handle.clone(),
             slot,
+            raptorcasts,
             authenticated_headers: HashMap::new(),
+            egress: ChunkEgress::new(),
             out_events: Vec::new(),
         }
     }
@@ -52,12 +74,33 @@ impl SlotRaptorcast {
         std::mem::take(&mut self.out_events)
     }
 
+    pub fn drain_messages(&mut self) -> Vec<Dissemination> {
+        self.egress.drain()
+    }
+
     pub fn ingest(&mut self, envelope: ProposalEnvelope) -> Result<(), InvalidProposalHeader> {
         debug_assert!(envelope.header().slot == self.slot);
 
-        self.authenticate(envelope.header())
+        let j = self
+            .authenticate(envelope.header())
             .ok_or(InvalidProposalHeader::Unauthenticated)?;
+
+        let raptorcast = self.raptorcasts[j]
+            .as_mut()
+            .expect("authenticated indices have proposers");
+        raptorcast.ingest(envelope, &self.epoch_handle, &mut self.egress)?;
+
+        for event in raptorcast.drain_events() {
+            self.out_events.push(ChorusDAEvent { j, event });
+        }
+
         Ok(())
+    }
+
+    // the decoded message under (j, root), once decoding succeeded
+    pub(crate) fn decoded_message(&self, j: ProposalIndex, root: &MerkleRoot) -> Option<&Bytes> {
+        let raptorcast = self.raptorcast(j)?;
+        raptorcast.decoded_message(root)
     }
 
     // the proposal index of a proposer-signed header for this slot
@@ -74,8 +117,187 @@ impl SlotRaptorcast {
         Some(j)
     }
 
-    // no command has an effect on an authenticated header alone
-    pub(crate) fn handle_command(&mut self, _command: ChorusDACommand) -> Vec<DAOutput> {
-        vec![]
+    fn raptorcast(&self, j: ProposalIndex) -> Option<&ProposerRaptorcast> {
+        if j >= self.raptorcasts.size() {
+            return None;
+        }
+        self.raptorcasts[j].as_ref()
+    }
+
+    fn raptorcast_mut(&mut self, j: ProposalIndex) -> Option<&mut ProposerRaptorcast> {
+        if j >= self.raptorcasts.size() {
+            return None;
+        }
+        self.raptorcasts[j].as_mut()
+    }
+
+    pub(crate) fn handle_command(&mut self, command: ChorusDACommand) -> Vec<DAOutput> {
+        match command {
+            ChorusDACommand::ReleaseChunks => {
+                self.egress.release();
+                vec![]
+            }
+            ChorusDACommand::PinRoot { j, root } => {
+                if let Some(raptorcast) = self.raptorcast_mut(j) {
+                    raptorcast.pin(&root);
+                }
+                vec![]
+            }
+            ChorusDACommand::RecoverChunks { j, root, .. } => {
+                if let Some(raptorcast) = self.raptorcast_mut(j) {
+                    raptorcast.pin(&root);
+                }
+                vec![]
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashSet,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
+    use super::{
+        super::{
+            chunk::WireChunkId,
+            test_util::{
+                Proposers, SLOT, author, epoch_handle, epoch_handle_for, group, proposal_chunks,
+                proposal_chunks_from, validator_data,
+            },
+            types::{HeaderAuth, NodeId, ProposalDAEvent, ProposalKeyPair},
+        },
+        *,
+    };
+
+    fn slot_raptorcast() -> (EpochHandle, SlotRaptorcast) {
+        let epoch_handle = epoch_handle();
+        let election = Proposers::new(vec![author()]);
+        let raptorcast = SlotRaptorcast::new(&epoch_handle, SLOT, &election);
+        (epoch_handle, raptorcast)
+    }
+
+    fn nodes(ids: impl IntoIterator<Item = u64>) -> HashSet<NodeId> {
+        ids.into_iter().map(NodeId::dummy).collect()
+    }
+
+    // the wire ids carried by the messages, sorted
+    fn chunk_ids(messages: &[Dissemination]) -> Vec<WireChunkId> {
+        let mut ids = Vec::new();
+        for message in messages {
+            ids.extend(message.envelope.chunks().keys().copied());
+        }
+        ids.sort();
+        ids
+    }
+
+    // ingest, returning the messages it caused
+    fn ingest(raptorcast: &mut SlotRaptorcast, envelope: ProposalEnvelope) -> Vec<Dissemination> {
+        raptorcast.ingest(envelope).expect("well-formed header");
+        raptorcast.drain_messages()
+    }
+
+    #[test]
+    fn own_chunks_are_forwarded_once_on_arrival() {
+        let (epoch_handle, mut raptorcast) = slot_raptorcast();
+        let (_, chunks) = proposal_chunks(&epoch_handle, 1);
+        raptorcast.handle_command(ChorusDACommand::ReleaseChunks);
+
+        // our chunk 3 is forwarded on arrival, a repeat is not
+        let messages = ingest(&mut raptorcast, group(&chunks[3..4]));
+        assert_eq!(chunk_ids(&messages), [3]);
+        assert_eq!(messages[0].to, nodes([2, 3]));
+        assert!(ingest(&mut raptorcast, group(&chunks[3..4])).is_empty());
+
+        // a chunk we do not own is not ours to forward
+        assert!(ingest(&mut raptorcast, group(&chunks[1..2])).is_empty());
+    }
+
+    #[test]
+    fn own_chunks_in_one_envelope_leave_in_one_message() {
+        let (epoch_handle, mut raptorcast) = slot_raptorcast();
+        let (_, chunks) = proposal_chunks(&epoch_handle, 1);
+        raptorcast.handle_command(ChorusDACommand::ReleaseChunks);
+
+        // chunks 0 and 3 are ours, 1 is not
+        let messages = ingest(&mut raptorcast, group(&chunks[..4]));
+        assert_eq!(messages.len(), 1);
+        assert_eq!(chunk_ids(&messages), [0, 3]);
+    }
+
+    #[test]
+    fn decoding_forwards_the_derivable_own_chunks() {
+        let (epoch_handle, mut raptorcast) = slot_raptorcast();
+        let (header, chunks) = proposal_chunks(&epoch_handle, 1);
+        raptorcast.handle_command(ChorusDACommand::ReleaseChunks);
+
+        // chunks 1, 2 and 4 belong to others; the third one decodes
+        assert!(ingest(&mut raptorcast, group(&chunks[1..3])).is_empty());
+        let messages = ingest(&mut raptorcast, group(&chunks[4..5]));
+
+        let decoded = ChorusDAEvent {
+            j: 0,
+            event: ProposalDAEvent::Decoded(header.root),
+        };
+        assert!(raptorcast.drain_events().contains(&decoded));
+        // our chunks 0 and 3 never arrived, but re-encoding derives them
+        assert_eq!(chunk_ids(&messages), [0, 3]);
+    }
+
+    #[test]
+    fn unauthenticated_headers_are_rejected() {
+        let (epoch_handle, mut raptorcast) = slot_raptorcast();
+        // signed by validator 2, who proposes nothing
+        let (_, chunks) = proposal_chunks_from(&epoch_handle, 2, SLOT, 1);
+
+        let rejected = raptorcast.ingest(group(&chunks[..1]));
+        assert_eq!(rejected, Err(InvalidProposalHeader::Unauthenticated));
+        assert!(raptorcast.drain_events().is_empty());
+        assert!(raptorcast.drain_messages().is_empty());
+    }
+
+    #[test]
+    fn authentication_is_memoized_per_header() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let counted = calls.clone();
+        let epoch_handle = EpochHandle {
+            self_id: NodeId::dummy(1),
+            num_proposals: 1,
+            key_pair: Arc::new(ProposalKeyPair::dummy(NodeId::dummy(1))),
+            header_auth: Arc::new(HeaderAuth::new(move |_slot, signer| {
+                counted.fetch_add(1, Ordering::SeqCst);
+                (*signer == author()).then_some(0)
+            })),
+            validator_data: Arc::new(validator_data(4)),
+        };
+        let election = Proposers::new(vec![author()]);
+        let mut raptorcast = SlotRaptorcast::new(&epoch_handle, SLOT, &election);
+        let (_, chunks) = proposal_chunks(&epoch_handle, 1);
+
+        raptorcast.ingest(group(&chunks[..1])).expect("valid");
+        raptorcast.ingest(group(&chunks[1..2])).expect("valid");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn a_second_proposers_events_carry_its_index() {
+        let proposers = vec![author(), NodeId::dummy(2)];
+        let epoch_handle = epoch_handle_for(NodeId::dummy(1), 4, proposers.clone());
+        let election = Proposers::new(proposers);
+        let mut raptorcast = SlotRaptorcast::new(&epoch_handle, SLOT, &election);
+        let (header, chunks) = proposal_chunks_from(&epoch_handle, 2, SLOT, 1);
+
+        raptorcast.ingest(group(&chunks[..1])).expect("valid");
+        let events = raptorcast.drain_events();
+        assert!(events.contains(&ChorusDAEvent {
+            j: 1,
+            event: ProposalDAEvent::HeaderSeen(header),
+        }));
+        assert!(events.iter().all(|event| event.j == 1));
     }
 }

--- a/monad-mcp-da/src/test_util.rs
+++ b/monad-mcp-da/src/test_util.rs
@@ -23,12 +23,13 @@ use bytes::Bytes;
 use monad_mcp_chorus::spec::{validator::ValidatorData as _, vote::KeyPair as _};
 
 use super::{
-    assignment::ChunkAssignment,
+    assignment::{ChunkAssignment, ChunkId},
     chorus::env::{D25, EncodingScheme, ProposalSignature},
-    chunk::{Chunk, ProposalEnvelope},
+    chunk::{Chunk, ProposalEnvelope, WireChunkId},
     chunk_tree::ChunkTree,
     election::ProposerElection,
     encoding_scheme::DAEncodingScheme as _,
+    header::DAProposalHeader as _,
     layout::PacketLayout,
     runtime::EpochHandle,
     types::{
@@ -181,6 +182,24 @@ pub(crate) fn inconsistent_proposal_chunks(
     }
     let tree = ChunkTree::complete(&layout, symbols).expect("fits the layout");
     chunks_of(&tree, &assignment, SLOT, 0)
+}
+
+// the verified id of a wire chunk id under the header's assignment
+pub(crate) fn chunk_id(
+    epoch_handle: &EpochHandle,
+    header: &ProposalHeader,
+    wire: WireChunkId,
+) -> ChunkId {
+    let validator_data = &epoch_handle.validator_data;
+    let scheme = header.encoding_scheme();
+    let layout = scheme
+        .packet_layout(validator_data.len())
+        .expect("fits a layout");
+    let assignment = scheme.chunk_assignment(&layout, &author(), validator_data);
+    assignment
+        .resolve_chunk_id(wire)
+        .expect("in range")
+        .chunk_id()
 }
 
 pub(crate) fn group(chunks: &[Chunk]) -> ProposalEnvelope {

--- a/monad-mcp-da/src/test_util.rs
+++ b/monad-mcp-da/src/test_util.rs
@@ -1,0 +1,191 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Shared test fixtures. By default: four equal-stake validators,
+// validator 0 authoring proposals at index 0, the local node being
+// validator 1.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use monad_mcp_chorus::spec::{validator::ValidatorData as _, vote::KeyPair as _};
+
+use super::{
+    assignment::ChunkAssignment,
+    chorus::env::{D25, EncodingScheme, ProposalSignature},
+    chunk::{Chunk, ProposalEnvelope},
+    chunk_tree::ChunkTree,
+    election::ProposerElection,
+    encoding_scheme::DAEncodingScheme as _,
+    layout::PacketLayout,
+    runtime::EpochHandle,
+    types::{
+        HeaderAuth, NodeId, ProposalHeader, ProposalIndex, ProposalKeyPair, Slot, Stake,
+        ValidatorData,
+    },
+};
+
+pub(crate) const SLOT: Slot = Slot(1);
+pub(crate) const MESSAGE_LEN: usize = 1500;
+
+pub(crate) fn author() -> NodeId {
+    NodeId::dummy(0)
+}
+
+pub(crate) fn validator_data(n: u64) -> ValidatorData {
+    let validators = (0..n).map(NodeId::dummy).collect::<Vec<_>>();
+    let valset = validators.iter().map(|id| (*id, Stake::from(1))).collect();
+    let mapping = validators
+        .iter()
+        .map(|id| (*id, id.keypair().pubkey()))
+        .collect();
+
+    ValidatorData::new(valset, mapping)
+}
+
+// the node's view of `num_validators` equal-stake validators, where
+// `proposers` propose at their position in every slot
+pub(crate) fn epoch_handle_for(
+    self_id: NodeId,
+    num_validators: u64,
+    proposers: Vec<NodeId>,
+) -> EpochHandle {
+    let num_proposals = proposers.len();
+    let proposer_index =
+        move |_slot: u64, signer: &NodeId| proposers.iter().position(|p| p == signer);
+    EpochHandle {
+        self_id,
+        num_proposals,
+        key_pair: Arc::new(ProposalKeyPair::dummy(self_id)),
+        header_auth: Arc::new(HeaderAuth::new(proposer_index)),
+        validator_data: Arc::new(validator_data(num_validators)),
+    }
+}
+
+pub(crate) fn epoch_handle() -> EpochHandle {
+    epoch_handle_for(NodeId::dummy(1), 4, vec![author()])
+}
+
+// the listed nodes propose at their position, in every slot
+pub(crate) struct Proposers(Vec<NodeId>);
+
+impl Proposers {
+    pub(crate) fn new(proposers: Vec<NodeId>) -> Self {
+        Self(proposers)
+    }
+}
+
+impl ProposerElection for Proposers {
+    fn get_proposer(&self, _slot: Slot, index: ProposalIndex) -> Option<&NodeId> {
+        self.0.get(index)
+    }
+
+    fn get_index(&self, _slot: Slot, node: &NodeId) -> Option<ProposalIndex> {
+        self.0.iter().position(|p| p == node)
+    }
+}
+
+fn scheme() -> EncodingScheme {
+    EncodingScheme::D25(D25 {
+        msg_len: MESSAGE_LEN,
+        unix_ts: 0,
+    })
+}
+
+fn layout_and_assignment(
+    epoch_handle: &EpochHandle,
+    author: &NodeId,
+) -> (PacketLayout, ChunkAssignment) {
+    let validator_data = &epoch_handle.validator_data;
+    let layout = scheme()
+        .packet_layout(validator_data.len())
+        .expect("fits a layout");
+    let assignment = scheme().chunk_assignment(&layout, author, validator_data);
+    (layout, assignment)
+}
+
+// the header and every chunk of a complete tree, in wire id order
+fn chunks_of(
+    tree: &ChunkTree,
+    assignment: &ChunkAssignment,
+    slot: Slot,
+    author_id: u64,
+) -> (ProposalHeader, Vec<Chunk>) {
+    let header = ProposalHeader {
+        slot,
+        root: tree.root(),
+        sig: ProposalSignature(author_id),
+        scheme: scheme(),
+    };
+
+    let mut chunks = Vec::new();
+    for chunk_id in assignment.chunk_ids() {
+        let data = tree.chunk_data(chunk_id).expect("complete tree");
+        chunks.push(Chunk::new(header.clone(), chunk_id.to_wire(), data));
+    }
+    (header, chunks)
+}
+
+// encode a distinct proposal per payload byte, authored by validator
+// `author_id` for `slot`. Under the default fixture: 2 source chunks
+// over 3 non-author validators at 2.5x redundancy = 6 chunks, 2 owned
+// by each: ids 0 and 3 by validator 1, 1 and 4 by validator 2, 2 and 5
+// by validator 3.
+pub(crate) fn proposal_chunks_from(
+    epoch_handle: &EpochHandle,
+    author_id: u64,
+    slot: Slot,
+    payload: u8,
+) -> (ProposalHeader, Vec<Chunk>) {
+    let author = NodeId::dummy(author_id);
+    let (layout, assignment) = layout_and_assignment(epoch_handle, &author);
+    let message = vec![payload; MESSAGE_LEN];
+    let tree = scheme()
+        .encode(&message, layout, assignment.num_chunks())
+        .expect("valid encoding parameters");
+    chunks_of(&tree, &assignment, slot, author_id)
+}
+
+pub(crate) fn proposal_chunks(
+    epoch_handle: &EpochHandle,
+    payload: u8,
+) -> (ProposalHeader, Vec<Chunk>) {
+    proposal_chunks_from(epoch_handle, 0, SLOT, payload)
+}
+
+// a proposal whose chunks all verify under its root but do not decode
+// to a message that re-encodes to it: the first half of the symbols
+// carry one payload, the second half another
+pub(crate) fn inconsistent_proposal_chunks(
+    epoch_handle: &EpochHandle,
+) -> (ProposalHeader, Vec<Chunk>) {
+    let (layout, assignment) = layout_and_assignment(epoch_handle, &author());
+    let num_chunks = assignment.num_chunks();
+
+    let mut symbols = Vec::with_capacity(num_chunks);
+    for i in 0..num_chunks {
+        let payload = if i < num_chunks / 2 { 1 } else { 2 };
+        symbols.push(Bytes::from(vec![payload; MESSAGE_LEN]));
+    }
+    let tree = ChunkTree::complete(&layout, symbols).expect("fits the layout");
+    chunks_of(&tree, &assignment, SLOT, 0)
+}
+
+pub(crate) fn group(chunks: &[Chunk]) -> ProposalEnvelope {
+    let mut groups = ProposalEnvelope::group(chunks.iter().cloned());
+    let (header, chunks) = groups.next().expect("nonempty chunks");
+    assert!(groups.next().is_none(), "chunks share a header");
+    ProposalEnvelope::new(header, chunks)
+}

--- a/monad-mcp-da/src/top_level.rs
+++ b/monad-mcp-da/src/top_level.rs
@@ -32,6 +32,6 @@ mod test_util;
 mod types;
 mod util;
 
-pub use chunk::{Chunk, ProposalEnvelope};
+pub use chunk::{Chunk, ChunkRequest, ProposalEnvelope};
 pub use egress::Dissemination;
-pub use runtime::{DAConfig, DAOutput, DARuntime, EpochHandle};
+pub use runtime::{ChunkRecoveryRequest, DAConfig, DAOutput, DARuntime, EpochHandle};

--- a/monad-mcp-da/src/top_level.rs
+++ b/monad-mcp-da/src/top_level.rs
@@ -15,12 +15,23 @@
 
 use super::{env, env::chorus};
 
+mod assignment;
 mod chunk;
+mod chunk_tree;
+mod egress;
+mod election;
+mod encoding_scheme;
 mod header;
+mod instance_rc;
+mod layout;
+mod proposer_rc;
 mod runtime;
 mod slot_rc;
+#[cfg(test)]
+mod test_util;
 mod types;
 mod util;
 
 pub use chunk::{Chunk, ProposalEnvelope};
+pub use egress::Dissemination;
 pub use runtime::{DAConfig, DAOutput, DARuntime, EpochHandle};

--- a/monad-mcp-da/src/top_level.rs
+++ b/monad-mcp-da/src/top_level.rs
@@ -13,23 +13,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pub use crate::env::stub::{
-    HeaderAuth, KeyPair, MerkleRoot, NodeId, ProposalHeader, PubKey, Signature,
-    SignatureCollection, Stake, ValidatorData, VoteAggregation,
-};
+use super::{env, env::chorus};
 
-// TODO: fill in the actual production implementation for above types
+mod chunk;
+mod header;
+mod runtime;
+mod slot_rc;
+mod types;
+mod util;
 
-const _: () = crate::spec::assert_env::<
-    NodeId,
-    Stake,
-    PubKey,
-    KeyPair,
-    Signature,
-    ValidatorData,
-    SignatureCollection,
-    VoteAggregation<'_>,
-    MerkleRoot,
-    ProposalHeader,
-    HeaderAuth,
->();
+pub use chunk::{Chunk, ProposalEnvelope};
+pub use runtime::{DAConfig, DAOutput, DARuntime, EpochHandle};

--- a/monad-mcp-da/src/types.rs
+++ b/monad-mcp-da/src/types.rs
@@ -18,7 +18,7 @@ pub use super::{
     chorus::{
         SlotLifecycle,
         env::MerkleHash,
-        slot::chorus::{ChorusDACommand, ChorusDAEvent, ProposalDAEvent},
+        slot::chorus::{ChorusDACommand, ChorusDAEvent, ChunkRequestType, ProposalDAEvent},
         types::{
             HeaderAuth, MerkleRoot, NodeId, ProposalHeader, ProposalIndex, ProposalMap, Slot,
             Stake, ValidatorData,

--- a/monad-mcp-da/src/types.rs
+++ b/monad-mcp-da/src/types.rs
@@ -13,23 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pub use crate::env::stub::{
-    HeaderAuth, KeyPair, MerkleRoot, NodeId, ProposalHeader, PubKey, Signature,
-    SignatureCollection, Stake, ValidatorData, VoteAggregation,
+// re-export chorus types
+pub use super::{
+    chorus::{
+        SlotLifecycle,
+        env::MerkleHash,
+        slot::chorus::{ChorusDACommand, ChorusDAEvent},
+        types::{HeaderAuth, NodeId, ProposalHeader, ProposalIndex, Slot, ValidatorData},
+    },
+    env::ProposalKeyPair,
 };
-
-// TODO: fill in the actual production implementation for above types
-
-const _: () = crate::spec::assert_env::<
-    NodeId,
-    Stake,
-    PubKey,
-    KeyPair,
-    Signature,
-    ValidatorData,
-    SignatureCollection,
-    VoteAggregation<'_>,
-    MerkleRoot,
-    ProposalHeader,
-    HeaderAuth,
->();

--- a/monad-mcp-da/src/util.rs
+++ b/monad-mcp-da/src/util.rs
@@ -1,0 +1,71 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::BTreeSet;
+
+use super::types::Slot;
+
+// todo: share with conductor's CompletionTracker
+pub struct SlotCompletion {
+    cap: Slot,
+    completed_slots: BTreeSet<Slot>,
+}
+
+impl SlotCompletion {
+    pub fn new() -> Self {
+        Self {
+            cap: Slot::MIN,
+            completed_slots: BTreeSet::new(),
+        }
+    }
+
+    pub fn mark_completed(&mut self, slot: Slot) {
+        if slot < self.cap {
+            return;
+        }
+
+        self.completed_slots.insert(slot);
+
+        while self.completed_slots.contains(&self.cap) {
+            self.completed_slots.remove(&self.cap);
+            self.cap = self.cap.checked_next().expect("slot cap overflow");
+        }
+    }
+
+    pub fn cap(&self) -> Slot {
+        self.cap
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_cap_advances_through_contiguous_completions_only() {
+        let mut completion = SlotCompletion::new();
+
+        completion.mark_completed(Slot(2));
+        assert_eq!(completion.cap(), Slot(0));
+        completion.mark_completed(Slot(0));
+        assert_eq!(completion.cap(), Slot(1));
+        completion.mark_completed(Slot(1));
+        assert_eq!(completion.cap(), Slot(3));
+
+        // below the cap is already accounted for
+        completion.mark_completed(Slot(0));
+        assert_eq!(completion.cap(), Slot(3));
+    }
+}


### PR DESCRIPTION
This PR contains the implementation of the Data Availability (DA) framework for Cadence. This PR has been split into smaller logical commits for the ease of review; I recommend reviewing the individual commits in order.

----

Here's an overview of the core concepts:

**DA Runtime**

The entry point of DA is the `DARuntime` type, a pure state machine that exchanges data with wire and chorus.

- Chunks: the runtime expects the ingested chunks to be parsed and extracted into the format of a `ProposalEnvelope`. It consists of a `ProposalHeader` (contains signature, merkle root, etc), and a set of chunk-specific data (chunk id, merkle proof, symbol). A single chunk is isomorphic to a single-chunk `ProposalEnvelope`. The disseminated chunks from the DA runtime is also in the format of `ProposalEnvelope`.
  + the design of `ProposalEnvelope` type naturally encodes the fact that the header is per-proposal, shared by all chunks. Practically, this can allow us to process the header without recomputation. Also, it allows the expression of header-only dissemination, which is useful for certain chunk assignment algorithms where some validators could have no assigned chunks.
- ChunkRequest: the runtime expects chunk requests from peers and can emit chunk requests.
- Command inputs:
  + chorus command (slot,j)-scoped: `PinRoot`, `ReleaseChunks`, `RecoverChunks` (grep for `ChorusDACommand`)
  + conductor slot lifecycle commands: `SlotOpen`, `SlotCompleted` (grep for `DASink`/`SlotLifecycle`)
- DA event outputs (slot-scoped): `HeaderSeen`, `ProposerObligationFulfilled`, `OwnerObligationFulfilled`, `Decoded`, `DecodingFailed` (grep for `ProposalDAEvent`)
- Decoded app message output: feed to downstream consumer - eg decryption, translation, execution

**Layers of Raptorcast**

At its core, raptorcast is a protocol for chunk assignment, dissemination, as well as encoding/decoding. In the implementation, the smallest unit of the raptorcast state machine is the `RaptorcastInstance` type. A `RaptorcastInstance` runs the protocol for a *single* proposal. The `RaptorcastInstance` is agnostic of the conepts of slot, proposer, authentication, equivocation, etc. At it's core, `RaptorcastInstance` just tracks the chunks, serve them under different commands, and decode the message when ready.

There is a layer of hierarchy before a Raptorcast instance is reached on chunk ingestion:

- DARuntime: (handles slot lifecycle) sends chunk to the correct `SlotRaptorcast`
- (per-)`SlotRaptorcast`: (handles proposer election) sends chunk to the correct proposer-indexed `ProposerRaptorcast`
- (per-)`ProposerRaptorcast`: (handles proposal equivocation) sends chunk to the correct root-indexed `RaptorcastInstance`

At each layer, only the property that is pertinent to that layer is checked. For example, slot is checked at the outermost layer; the next layer authenticates the author; the next layer decides whether or not to admit the root; only when reaching the innermost layer, we do other types of checks.

**RaptorcastInstance**

`RaptorcastInstance` hold onto a single `ProposalHeader`. The header specifies a `EncodingScheme`, which specifies the encoding parameters: packet layout, chunk assignment, symbol codec. Internally, `RaptorcastInstance` holds the following components:

- `EncodingScheme` derivatives: packet layout, chunk assignment
- `ChunkTree`: the chunk store
- `Decoder`: the internal state of a symbol decoder
- various trackers for chunk reception, obligation fulfillment, etc

**EncodingScheme**

An `EncodingScheme` contains all the information needed to derive a packet layout, a chunk assignment, and the codec given the proper context (proposer, validator set, etc). This is most cleanly seen from the shape of the trait:

```rust
pub(crate) trait DAEncodingScheme {
    type Encoder: SymbolEncoder;
    type Decoder: SymbolDecoder;

    fn packet_layout(&self, num_validators: usize) -> Option<PacketLayout>;
    fn chunk_assignment(&self, layout: &PacketLayout, author: &NodeId, validator_data: &ValidatorData) -> ChunkAssignment;

    fn encoder(&self, layout: PacketLayout, num_chunks: usize) -> Self::Encoder;
    fn decoder(&self, layout: PacketLayout, num_chunks: usize) -> Self::Decoder;
}

pub(crate) trait SymbolEncoder {
    // one symbol per chunk, in chunk id order
    fn encode(&self, message: &[u8]) -> Vec<Bytes>;
}

pub(crate) trait SymbolDecoder {
    fn ingest(&mut self, chunk_id: ChunkId, symbol: &Bytes);
    fn try_decode(&mut self) -> Option<Bytes>;
}
```

---------

For more details of the design, refer to docs/0004_data_availability.md.

The scope of the implementation in this PR includes the complete DA state machine, including chunk recover, pull-based chunk sync, as well as DA-related bridging with Chorus/Conductor. A reference encoding scheme implementation `D25` in the same shape as current v1 raptorcast is included with stub symbol encoding/decoding.

What's purposely left out from this PR:
- conversion of `ProposalEnvelope` and Wire format (i.e. packet parsing/generation)
- networking
- MCP-ready encoding scheme, including its symbol decoder/encoder