### PR TITLE
[rpc] Adopt new `monad_ethcall` Result-annotated interface

### DIFF
--- a/monad-rpc/src/handlers/debug_replay.rs
+++ b/monad-rpc/src/handlers/debug_replay.rs
@@ -15,7 +15,7 @@
 
 use std::num::TryFromIntError;
 
-use monad_ethcall::{CallResult, ChainId, MonadExecutor, MonadTracer};
+use monad_ethcall::{ChainId, MonadExecutor, MonadTracer};
 use monad_triedb_utils::triedb_env::{BlockKey, Triedb};
 use monad_types::SeqNum;
 use serde_json::value::RawValue;
@@ -249,11 +249,10 @@ pub async fn monad_debug_trace_replay<T: Triedb>(
         )
         .await;
     let raw_payload = match call_result {
-        CallResult::Success(monad_ethcall::SuccessCallResult { output_data, .. }) => output_data,
-        CallResult::Failure(error) => {
-            return Err(error.into());
+        Ok(result) => result.output_data.into_vec(),
+        Err(e) => {
+            return Err(e.into());
         }
-        CallResult::Revert(result) => result.trace,
     };
 
     // reject on the approximated encoded length before serialization

--- a/monad-rpc/src/handlers/eth/call.rs
+++ b/monad-rpc/src/handlers/eth/call.rs
@@ -24,8 +24,7 @@ use alloy_primitives::{Address, Bytes, Signature, TxKind, Uint, B256, U256, U64,
 use alloy_rpc_types::{AccessList, AccessListItem};
 use monad_chain_config::execution_revision::MonadExecutionRevision;
 use monad_ethcall::{
-    overrides::StateOverrideSet, CallResult, EthCallRequest, EthCallResult, FailureCallResult,
-    MonadExecutor, MonadTracer,
+    overrides::StateOverrideSet, EthCallRequest, EthCallResult, MonadExecutor, MonadTracer,
 };
 use monad_rpc_docs::rpc;
 use monad_triedb_utils::triedb_env::{
@@ -43,6 +42,7 @@ use crate::{
     },
     handlers::{
         debug::{decode_call_frame, TracerObject},
+        eth::{CallResult, FailureCallResult, SuccessCallResult},
         parse_ethcall_chain_id,
     },
     types::{
@@ -664,7 +664,7 @@ async fn prepare_eth_call_at_block<T: Triedb + TriedbPath>(
 
     let header_gas_limit = header.header.gas_limit;
 
-    match eth_call_executor
+    let call_result = match eth_call_executor
         .eth_call(EthCallRequest {
             chain_id: ethcall_chain_id,
             transaction: &txn,
@@ -678,9 +678,15 @@ async fn prepare_eth_call_at_block<T: Triedb + TriedbPath>(
         })
         .await
     {
-        CallResult::Failure(error) if matches!(error.error_code, EthCallResult::OutOfGas) => {
-            match out_of_gas_handling {
-                OutOfGasHandling::RpcError => Err(JsonRpcError::eth_call_error(
+        Ok(result) => result.into(),
+        Err(monad_ethcall::EthCallError::Failure {
+            error_code,
+            gas_used,
+            gas_refund,
+            ..
+        }) if matches!(error_code, EthCallResult::OutOfGas) => match out_of_gas_handling {
+            OutOfGasHandling::RpcError => {
+                return Err(JsonRpcError::eth_call_error(
                     if eth_call_provider_gas_limit < header_gas_limit
                         && U256::from(eth_call_provider_gas_limit) < original_tx_gas
                     {
@@ -689,21 +695,20 @@ async fn prepare_eth_call_at_block<T: Triedb + TriedbPath>(
                         "out of gas".to_string()
                     },
                     None,
-                )),
-                OutOfGasHandling::ReturnAsCallFailure => Ok((
-                    block_key,
-                    CallResult::Failure(FailureCallResult {
-                        error_code: error.error_code,
-                        gas_used: error.gas_used,
-                        gas_refund: error.gas_refund,
-                        message: "out of gas".to_string(),
-                        data: None,
-                    }),
-                )),
+                ));
             }
-        }
-        result => Ok((block_key, result)),
-    }
+            OutOfGasHandling::ReturnAsCallFailure => CallResult::Failure(FailureCallResult {
+                error_code,
+                gas_used,
+                gas_refund,
+                message: "out of gas".to_string(),
+                data: None,
+            }),
+        },
+        Err(error) => error.into(),
+    };
+
+    Ok((block_key, call_result))
 }
 
 /// Executes a new message call immediately without creating a transaction on the block chain.
@@ -733,7 +738,7 @@ pub async fn monad_eth_call<T: Triedb + TriedbPath>(
     )
     .await?;
     match result {
-        CallResult::Success(monad_ethcall::SuccessCallResult { output_data, .. }) => {
+        CallResult::Success(SuccessCallResult { output_data, .. }) => {
             Ok(ethhex::encode_bytes(&output_data))
         }
         CallResult::Failure(error) => Err(error.into()),
@@ -774,15 +779,15 @@ pub async fn monad_debug_traceCall<T: Triedb + TriedbPath>(
         OutOfGasHandling::RpcError,
     )
     .await?;
-    let raw_payload: Vec<u8> = match call_result {
-        CallResult::Success(monad_ethcall::SuccessCallResult { output_data, .. }) => output_data,
+    let raw_payload: Box<[u8]> = match call_result {
+        CallResult::Success(SuccessCallResult { output_data, .. }) => output_data,
         CallResult::Failure(error) => return Err(error.into()),
         CallResult::Revert(result) => result.trace,
     };
 
     match tracer {
         MonadTracer::CallTracer => {
-            let mut slice: &[u8] = raw_payload.as_slice();
+            let mut slice: &[u8] = raw_payload.as_ref();
             let frame = decode_call_frame(
                 &data_provider.triedb_env,
                 &mut slice,
@@ -890,7 +895,7 @@ fn decode_access_list_trace(raw_payload: &[u8]) -> Result<AccessList, JsonRpcErr
 
 fn access_list_from_trace_call_result(call_result: CallResult) -> Result<AccessList, JsonRpcError> {
     match call_result {
-        CallResult::Success(monad_ethcall::SuccessCallResult { output_data, .. }) => {
+        CallResult::Success(SuccessCallResult { output_data, .. }) => {
             decode_access_list_trace(&output_data)
         }
         CallResult::Failure(error) => Err(error.into()),
@@ -908,7 +913,7 @@ impl MonadCreateAccessListResult {
         call_result: CallResult,
     ) -> Result<Self, JsonRpcError> {
         match call_result {
-            CallResult::Success(monad_ethcall::SuccessCallResult { gas_used, .. }) => Ok(Self {
+            CallResult::Success(SuccessCallResult { gas_used, .. }) => Ok(Self {
                 access_list,
                 gas_used: U256::from(gas_used),
                 error: None,
@@ -1001,7 +1006,7 @@ mod tests {
     use monad_chain_config::execution_revision::MonadExecutionRevision;
     use monad_ethcall::{
         overrides::{StateOverrideObject, StateOverrideSet},
-        CallResult, EthCallResult, FailureCallResult, RevertCallResult, SuccessCallResult,
+        EthCallResult,
     };
     use monad_triedb_utils::{
         mock_triedb::MockTriedb,
@@ -1014,9 +1019,12 @@ mod tests {
     use crate::{
         handlers::{
             debug::Tracer,
-            eth::call::{
-                access_list_from_trace_call_result, decode_access_list_trace, sender_gas_allowance,
-                CallInput, MonadDebugTraceCallParams,
+            eth::{
+                call::{
+                    access_list_from_trace_call_result, decode_access_list_trace,
+                    sender_gas_allowance, CallInput, MonadDebugTraceCallParams,
+                },
+                CallResult, FailureCallResult, RevertCallResult, SuccessCallResult,
             },
         },
         types::{eth_json::MonadCreateAccessListResult, jsonrpc::JsonRpcError},
@@ -1066,7 +1074,7 @@ mod tests {
 
         let access_list =
             access_list_from_trace_call_result(CallResult::Success(SuccessCallResult {
-                output_data: payload,
+                output_data: payload.into_boxed_slice(),
                 ..Default::default()
             }))
             .expect("successful tracer result decodes");
@@ -1081,7 +1089,7 @@ mod tests {
 
         let access_list =
             access_list_from_trace_call_result(CallResult::Revert(RevertCallResult {
-                trace: payload,
+                trace: payload.into_boxed_slice(),
             }))
             .expect("reverted tracer result decodes");
 
@@ -1186,7 +1194,7 @@ mod tests {
 
         let access_list =
             access_list_from_trace_call_result(CallResult::Revert(RevertCallResult {
-                trace: trace_payload,
+                trace: trace_payload.into_boxed_slice(),
             }))
             .expect("reverted access-list trace still decodes");
 

--- a/monad-rpc/src/handlers/eth/gas.rs
+++ b/monad-rpc/src/handlers/eth/gas.rs
@@ -28,7 +28,7 @@ use futures::stream::StreamExt;
 use itertools::Itertools;
 use monad_ethcall::{
     overrides::{StateOverrideObject, StateOverrideSet},
-    CallResult, EthCallRequest, MonadExecutor, MonadTracer,
+    EthCallRequest, MonadExecutor, MonadTracer,
 };
 use monad_rpc_docs::rpc;
 use monad_triedb_utils::triedb_env::{BlockKey, Triedb};
@@ -41,7 +41,10 @@ use crate::{
         get_block_key_from_tag_or_hash, DataProvider,
     },
     handlers::{
-        eth::call::{check_contract_creation_size, fill_gas_params, CallRequest, GasPriceDetails},
+        eth::{
+            call::{check_contract_creation_size, fill_gas_params, CallRequest, GasPriceDetails},
+            CallResult, SuccessCallResult,
+        },
         parse_ethcall_chain_id,
     },
     types::{
@@ -55,6 +58,15 @@ use crate::{
 
 /// Additional gas added during a CALL.
 const CALL_STIPEND: u64 = 2_300;
+
+fn into_call_result(
+    result: Result<monad_ethcall::EthCallSuccess, monad_ethcall::EthCallError>,
+) -> CallResult {
+    match result {
+        Ok(success) => success.into(),
+        Err(error) => error.into(),
+    }
+}
 
 async fn estimate_gas(
     eth_call_fn: impl AsyncFn(&TxEnvelope) -> CallResult,
@@ -85,12 +97,12 @@ async fn estimate_gas_with_builder(
     let mut txn = build_tx(call_request)?;
 
     let (gas_used, gas_refund) = match eth_call_fn(&txn).await {
-        monad_ethcall::CallResult::Success(monad_ethcall::SuccessCallResult {
+        CallResult::Success(SuccessCallResult {
             gas_used,
             gas_refund,
             ..
         }) => (gas_used, gas_refund),
-        monad_ethcall::CallResult::Failure(error) => match error.error_code {
+        CallResult::Failure(error) => match error.error_code {
             monad_ethcall::EthCallResult::OutOfGas => {
                 if provider_gas_limit < protocol_gas_limit
                     && U256::from(provider_gas_limit) < original_tx_gas
@@ -122,11 +134,10 @@ async fn estimate_gas_with_builder(
     let (mut lower_bound_gas_limit, mut upper_bound_gas_limit) =
         if txn.gas_limit() < upper_bound_gas_limit {
             match eth_call_fn(&txn).await {
-                monad_ethcall::CallResult::Success(monad_ethcall::SuccessCallResult {
-                    gas_used,
-                    ..
-                }) => (gas_used.sub(1), txn.gas_limit()),
-                monad_ethcall::CallResult::Failure(_) => (txn.gas_limit(), upper_bound_gas_limit),
+                CallResult::Success(SuccessCallResult { gas_used, .. }) => {
+                    (gas_used.sub(1), txn.gas_limit())
+                }
+                CallResult::Failure(_) => (txn.gas_limit(), upper_bound_gas_limit),
                 _ => {
                     return Err(JsonRpcError::internal_error(
                         "Unexpected CallResult type".into(),
@@ -152,10 +163,10 @@ async fn estimate_gas_with_builder(
         txn = build_tx(call_request)?;
 
         match eth_call_fn(&txn).await {
-            monad_ethcall::CallResult::Success(monad_ethcall::SuccessCallResult { .. }) => {
+            CallResult::Success(SuccessCallResult { .. }) => {
                 upper_bound_gas_limit = mid;
             }
-            monad_ethcall::CallResult::Failure(_) => {
+            CallResult::Failure(_) => {
                 lower_bound_gas_limit = mid;
             }
             _ => {
@@ -355,19 +366,21 @@ pub async fn monad_eth_estimateGas<T: Triedb>(
     let (block_number, block_id) = block_key_to_parts(block_key);
 
     let eth_call_fn = async |transaction: &TxEnvelope| {
-        eth_call_executor
-            .eth_call(EthCallRequest {
-                chain_id: ethcall_chain_id,
-                transaction,
-                block_header: &header.header,
-                sender,
-                block_number,
-                block_id,
-                state_override_set: &state_override_set,
-                tracer: MonadTracer::NoopTracer,
-                gas_specified,
-            })
-            .await
+        into_call_result(
+            eth_call_executor
+                .eth_call(EthCallRequest {
+                    chain_id: ethcall_chain_id,
+                    transaction,
+                    block_header: &header.header,
+                    sender,
+                    block_number,
+                    block_id,
+                    state_override_set: &state_override_set,
+                    tracer: MonadTracer::NoopTracer,
+                    gas_specified,
+                })
+                .await,
+        )
     };
 
     // If the transaction is a regular value transfer, execute the transaction with a 21000 gas limit and return that gas limit if executes successfully.
@@ -385,10 +398,7 @@ pub async fn monad_eth_estimateGas<T: Triedb>(
             let txn: TxEnvelope = tx.clone().try_into()?;
             tx.gas = saved_gas;
 
-            if matches!(
-                eth_call_fn(&txn).await,
-                monad_ethcall::CallResult::Success(_)
-            ) {
+            if matches!(eth_call_fn(&txn).await, CallResult::Success(_)) {
                 return Ok(Quantity(21_000));
             }
         }
@@ -430,19 +440,21 @@ pub async fn monad_eth_fillTransaction<T: Triedb>(
     let eth_call_fn =
         async |header: &Header, from: Address, block_key: BlockKey, transaction: &TxEnvelope| {
             let (block_number, block_id) = block_key_to_parts(block_key);
-            eth_call_executor
-                .eth_call(EthCallRequest {
-                    chain_id: ethcall_chain_id,
-                    transaction,
-                    block_header: header,
-                    sender: from,
-                    block_number,
-                    block_id,
-                    state_override_set: &state_override,
-                    tracer: MonadTracer::NoopTracer,
-                    gas_specified: true,
-                })
-                .await
+            into_call_result(
+                eth_call_executor
+                    .eth_call(EthCallRequest {
+                        chain_id: ethcall_chain_id,
+                        transaction,
+                        block_header: header,
+                        sender: from,
+                        block_number,
+                        block_id,
+                        state_override_set: &state_override,
+                        tracer: MonadTracer::NoopTracer,
+                        gas_specified: true,
+                    })
+                    .await,
+            )
         };
 
     fill_transaction_with_provider(
@@ -1023,13 +1035,16 @@ mod tests {
     use alloy_signer_local::PrivateKeySigner;
     use monad_chain_config::execution_revision::MonadExecutionRevision;
     use monad_eth_types::{EthAccount, ReceiptWithLogIndex};
-    use monad_ethcall::{EthCallResult, FailureCallResult, SuccessCallResult};
+    use monad_ethcall::EthCallResult;
     use monad_triedb_utils::mock_triedb::MockTriedb;
 
     use super::*;
     use crate::{
         data::eth_call_handler::EthCallHandlerConfig,
-        handlers::eth::call::{CallInput, CallRequest, GasPriceDetails},
+        handlers::eth::{
+            call::{CallInput, CallRequest, GasPriceDetails},
+            FailureCallResult, SuccessCallResult,
+        },
     };
 
     #[derive(Clone, Copy)]

--- a/monad-rpc/src/handlers/eth/mod.rs
+++ b/monad-rpc/src/handlers/eth/mod.rs
@@ -13,9 +13,125 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use monad_ethcall::{EthCallError, EthCallResult, EthCallSuccess};
+
 pub mod account;
 pub mod block;
 pub mod call;
 pub mod gas;
 pub mod simulate;
 pub mod txn;
+
+#[derive(Clone, Debug)]
+pub enum CallResult {
+    Success(SuccessCallResult),
+    Failure(FailureCallResult),
+    Revert(RevertCallResult), // only used for trace
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SuccessCallResult {
+    pub gas_used: u64,
+    pub gas_refund: u64,
+    // We interpret this as rlp encoded CallFrames for debug_traceCall
+    pub output_data: Box<[u8]>,
+}
+
+impl From<EthCallSuccess> for SuccessCallResult {
+    fn from(result: EthCallSuccess) -> Self {
+        Self {
+            gas_used: result.gas_used,
+            gas_refund: result.gas_refund,
+            output_data: result.output_data,
+        }
+    }
+}
+
+impl From<SuccessCallResult> for CallResult {
+    fn from(result: SuccessCallResult) -> Self {
+        Self::Success(result)
+    }
+}
+
+impl From<EthCallSuccess> for CallResult {
+    fn from(result: EthCallSuccess) -> Self {
+        Self::Success(result.into())
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct FailureCallResult {
+    pub error_code: EthCallResult,
+    pub gas_used: u64,
+    pub gas_refund: u64,
+    pub message: String,
+    pub data: Option<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RevertCallResult {
+    pub trace: Box<[u8]>,
+}
+
+impl From<EthCallError> for CallResult {
+    fn from(error: EthCallError) -> Self {
+        match error {
+            EthCallError::Failure {
+                error_code,
+                gas_used,
+                gas_refund,
+                message,
+                data,
+            } => Self::Failure(FailureCallResult {
+                error_code,
+                gas_used,
+                gas_refund,
+                message,
+                data,
+            }),
+            EthCallError::GasLimitTooHigh => Self::Failure(FailureCallResult {
+                error_code: EthCallResult::OtherError,
+                gas_used: 0,
+                gas_refund: 0,
+                message: String::from("gas limit too high"),
+                data: None,
+            }),
+            EthCallError::InternalError => Self::Failure(FailureCallResult {
+                error_code: EthCallResult::OtherError,
+                gas_used: 0,
+                gas_refund: 0,
+                message: String::from("internal eth_call error"),
+                data: None,
+            }),
+            EthCallError::Other { message } => Self::Failure(FailureCallResult {
+                error_code: EthCallResult::OtherError,
+                gas_used: 0,
+                gas_refund: 0,
+                message,
+                data: None,
+            }),
+            EthCallError::ReserveBalanceViolation {
+                gas_used,
+                gas_refund,
+            } => Self::Failure(FailureCallResult {
+                error_code: EthCallResult::ReserveBalanceViolation,
+                gas_used,
+                gas_refund,
+                message: String::from("reserve balance violation"),
+                data: None,
+            }),
+            EthCallError::Trace { trace } => Self::Revert(RevertCallResult { trace }),
+        }
+    }
+}
+
+impl From<FailureCallResult> for crate::types::jsonrpc::JsonRpcError {
+    fn from(error: FailureCallResult) -> Self {
+        match error.error_code {
+            EthCallResult::ExecutionError => {
+                Self::eth_call_execution_revert(error.message, error.data)
+            }
+            _ => Self::eth_call_error(error.message, error.data),
+        }
+    }
+}

--- a/monad-rpc/src/handlers/eth/simulate.rs
+++ b/monad-rpc/src/handlers/eth/simulate.rs
@@ -19,7 +19,7 @@ use alloy_consensus::TxEnvelope;
 use alloy_primitives::{U256, U64};
 use monad_ethcall::{
     overrides::{BlockOverride, StateOverrideSet},
-    MonadExecutor, SimulateResult, SuccessSimulateResult,
+    MonadExecutor,
 };
 use monad_rpc_docs::rpc;
 use monad_triedb_utils::triedb_env::{Triedb, TriedbPath};
@@ -243,17 +243,15 @@ pub async fn monad_simulate_v1<T: Triedb + TriedbPath>(
         .await;
 
     match result {
-        SimulateResult::Success(SuccessSimulateResult { output_data, .. }) => {
+        Ok(result) => {
+            let output_data = result.output_data;
             let v: serde_cbor::Value = serde_cbor::from_slice(&output_data)
                 .map_err(|e| JsonRpcError::internal_error(format!("CBOR decode error: {}", e)))?;
             serde_json::value::to_raw_value(&v).map_err(|e| {
                 JsonRpcError::internal_error(format!("json serialization error: {}", e))
             })
         }
-
-        SimulateResult::Failure(error) => {
-            Err(JsonRpcError::eth_call_error(error.message, error.data))
-        }
+        Err(e) => Err(e.into()),
     }
 }
 

--- a/monad-rpc/src/types/jsonrpc.rs
+++ b/monad-rpc/src/types/jsonrpc.rs
@@ -550,14 +550,55 @@ impl From<monad_archive::prelude::Report> for JsonRpcError {
     }
 }
 
-impl From<monad_ethcall::FailureCallResult> for JsonRpcError {
-    fn from(error: monad_ethcall::FailureCallResult) -> Self {
-        match error.error_code {
-            monad_ethcall::EthCallResult::ExecutionError => {
-                Self::eth_call_execution_revert(error.message, error.data)
+impl From<monad_ethcall::EthCallError> for JsonRpcError {
+    fn from(error: monad_ethcall::EthCallError) -> Self {
+        use monad_ethcall::EthCallError::*;
+        match error {
+            Failure {
+                error_code,
+                message,
+                data,
+                ..
+            } => {
+                if matches!(error_code, monad_ethcall::EthCallResult::ExecutionError) {
+                    Self::eth_call_execution_revert(message, data)
+                } else {
+                    Self::eth_call_error(message, data)
+                }
             }
-            _ => Self::eth_call_error(error.message, error.data),
+            GasLimitTooHigh => Self::eth_call_error(String::from("gas limit too high"), None),
+            InternalError => Self::eth_call_error(String::from("internal eth_call error"), None),
+            Other { message } => Self::eth_call_error(message, None),
+            ReserveBalanceViolation { .. } => {
+                Self::eth_call_error(String::from("reserve balance violation"), None)
+            }
+            Trace { .. } => Self::eth_call_error(String::from("trace error"), None),
         }
+    }
+}
+
+impl From<monad_ethcall::EthTraceError> for JsonRpcError {
+    fn from(error: monad_ethcall::EthTraceError) -> Self {
+        use monad_ethcall::EthTraceError::*;
+        let message = match error {
+            InternalError => String::from("internal error"),
+            Other(message) => message,
+        };
+        Self::eth_call_error(message, None)
+    }
+}
+
+impl From<monad_ethcall::EthSimulateError> for JsonRpcError {
+    fn from(error: monad_ethcall::EthSimulateError) -> Self {
+        use monad_ethcall::EthSimulateError::*;
+        let message = match error {
+            BlockOverrideFailure => String::from("block override failure"),
+            InternalError => String::from("internal error"),
+            InputSizeMismatch => String::from("input size mismatch"),
+            StateOverrideFailure => String::from("state override failure"),
+            Other(message) => message,
+        };
+        Self::eth_call_error(message, None)
     }
 }
 


### PR DESCRIPTION
This patch adopts the new result-oriented interface of the upstream `monad_ethcall` crate along with the new error types.

Companion patch: https://github.com/category-labs/monad/pull/2381