### PR TITLE
Bump Rust toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,7 +79,7 @@ jobs:
             libsecp256k1-dev
 
       - run: rustup toolchain install nightly-2025-12-09 --profile minimal --component rustfmt
-      - run: rustup toolchain install 1.91.1-x86_64-unknown-linux-gnu --profile minimal --component clippy
+      - run: rustup toolchain install 1.97.1-x86_64-unknown-linux-gnu --profile minimal --component clippy
 
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@v1.15.7

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -81,7 +81,7 @@ jobs:
           submodules: recursive
 
       - run: rustup toolchain install nightly-2025-12-09 --profile minimal --component rustfmt
-      - run: rustup toolchain install 1.91.1-x86_64-unknown-linux-gnu --profile minimal --component clippy
+      - run: rustup toolchain install 1.97.1-x86_64-unknown-linux-gnu --profile minimal --component clippy
 
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@v1.15.7

--- a/docker/archive/Dockerfile
+++ b/docker/archive/Dockerfile
@@ -68,7 +68,7 @@ RUN apt update && apt install -y \
 ARG CARGO_ROOT="/root/.cargo"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 ENV PATH="${CARGO_ROOT}/bin:$PATH"
-RUN rustup toolchain install 1.91.1-x86_64-unknown-linux-gnu
+RUN rustup toolchain install 1.97.1-x86_64-unknown-linux-gnu
 ARG TRIEDB_TARGET=triedb_driver
 
 ARG GIT_COMMIT=""

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -73,6 +73,6 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
-RUN rustup toolchain install 1.91.1-x86_64-unknown-linux-gnu
+RUN rustup toolchain install 1.97.1-x86_64-unknown-linux-gnu
 
 RUN chmod -R a+rwX $RUSTUP_HOME $CARGO_HOME

--- a/docker/devnet/Dockerfile
+++ b/docker/devnet/Dockerfile
@@ -68,7 +68,7 @@ RUN apt update && apt install -y \
 ARG CARGO_ROOT="/root/.cargo"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 ENV PATH="${CARGO_ROOT}/bin:$PATH"
-RUN rustup toolchain install 1.91.1-x86_64-unknown-linux-gnu
+RUN rustup toolchain install 1.97.1-x86_64-unknown-linux-gnu
 ARG TRIEDB_TARGET=triedb_driver
 
 ARG GIT_TAG_VERSION

--- a/docker/rpc-request-gen/Dockerfile
+++ b/docker/rpc-request-gen/Dockerfile
@@ -68,7 +68,7 @@ RUN apt-get install -y \
 ARG CARGO_ROOT="/root/.cargo"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 ENV PATH="${CARGO_ROOT}/bin:$PATH"
-RUN rustup toolchain install 1.91.1-x86_64-unknown-linux-gnu
+RUN rustup toolchain install 1.97.1-x86_64-unknown-linux-gnu
 
 WORKDIR /usr/src/monad-bft
 

--- a/docker/rpc/Dockerfile
+++ b/docker/rpc/Dockerfile
@@ -66,7 +66,7 @@ RUN apt update && apt install -y \
 ARG CARGO_ROOT="/root/.cargo"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 ENV PATH="${CARGO_ROOT}/bin:$PATH"
-RUN rustup toolchain install 1.91.1-x86_64-unknown-linux-gnu
+RUN rustup toolchain install 1.97.1-x86_64-unknown-linux-gnu
 
 ENV TRIEDB_TARGET=triedb_driver
 

--- a/docker/txgen/Dockerfile
+++ b/docker/txgen/Dockerfile
@@ -68,7 +68,7 @@ RUN apt-get install -y \
 ARG CARGO_ROOT="/root/.cargo"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 ENV PATH="${CARGO_ROOT}/bin:$PATH"
-RUN rustup toolchain install 1.91.1-x86_64-unknown-linux-gnu
+RUN rustup toolchain install 1.97.1-x86_64-unknown-linux-gnu
 
 WORKDIR /usr/src/monad-bft
 

--- a/monad-archive/src/bin/monad-archiver/bft_archive_worker.rs
+++ b/monad-archive/src/bin/monad-archiver/bft_archive_worker.rs
@@ -140,7 +140,7 @@ async fn archive_bft_blocks(
     );
 
     // 3) Process files concurrently using streams
-    stream::iter(local.into_iter())
+    stream::iter(local)
         .map(|(key, path)| {
             let store = store.clone();
             let metrics = metrics.clone();

--- a/monad-archive/src/bin/monad-archiver/generic_folder_archiver.rs
+++ b/monad-archive/src/bin/monad-archiver/generic_folder_archiver.rs
@@ -277,7 +277,7 @@ async fn archive_dir(
     local.retain(|k, _| !known_in_s3.contains(k));
 
     // Process concurrently
-    stream::iter(local.into_iter())
+    stream::iter(local)
         .map(|(key, path)| {
             let store = store.clone();
             let metrics = metrics.clone();

--- a/monad-blocksync/src/blocksync.rs
+++ b/monad-blocksync/src/blocksync.rs
@@ -543,7 +543,7 @@ where
             return Some(payload);
         }
 
-        for (_, completed_header) in self.block_sync.self_completed_headers_requests.iter() {
+        for completed_header in self.block_sync.self_completed_headers_requests.values() {
             if let Some(payload) = completed_header.payload_cache.get(&payload_id) {
                 return Some(payload.clone());
             }
@@ -590,8 +590,7 @@ where
                     }
                 }
 
-                for (_, completed_header) in
-                    self.block_sync.self_completed_headers_requests.iter_mut()
+                for completed_header in self.block_sync.self_completed_headers_requests.values_mut()
                 {
                     for (block, maybe_payload) in &mut completed_header.blocks {
                         if block.block_body_id == payload_id && maybe_payload.is_none() {
@@ -868,8 +867,7 @@ where
                 // remove entry and update existing requests
                 entry.remove();
 
-                for (_, completed_header) in
-                    self.block_sync.self_completed_headers_requests.iter_mut()
+                for completed_header in self.block_sync.self_completed_headers_requests.values_mut()
                 {
                     for (block, maybe_payload) in &mut completed_header.blocks {
                         if block.block_body_id == payload_id && maybe_payload.is_none() {

--- a/monad-raptorcast/src/decoding.rs
+++ b/monad-raptorcast/src/decoding.rs
@@ -848,8 +848,8 @@ impl<PT: PubKey> SoftQuotaCache<PT> {
         let key_set_2 = self
             .author_index
             .per_author_index
-            .iter()
-            .flat_map(|(_, index)| index.reverse_index.keys().cloned())
+            .values()
+            .flat_map(|index| index.reverse_index.keys().cloned())
             .collect::<HashSet<_>>();
 
         if key_set_1 != key_set_2 {

--- a/monad-raptorcast/src/raptorcast_secondary/publisher.rs
+++ b/monad-raptorcast/src/raptorcast_secondary/publisher.rs
@@ -415,7 +415,7 @@ where
         trace!(?time_point, ?schedule_end, "RaptorCastSecondary step_until");
 
         // Check if scheduled groups need servicing: time-outs, invites, confirm
-        for (_, group) in self.group_schedule.iter_mut() {
+        for group in self.group_schedule.values_mut() {
             if let Some(out_msg) =
                 group.advance_invites(time_point, &self.scheduling_cfg, self.validator_node_id)
             {

--- a/monad-rpc/monad-rpc-docs/monad-rpc-docs-derive/src/lib.rs
+++ b/monad-rpc/monad-rpc-docs/monad-rpc-docs-derive/src/lib.rs
@@ -180,10 +180,8 @@ fn extract_attrs(attrs: &[NestedMeta]) -> Args {
                     }
                 }
             }
-            NestedMeta::Meta(Meta::Path(path)) => {
-                if path.is_ident("experimental") {
-                    args.experimental = true;
-                }
+            NestedMeta::Meta(Meta::Path(path)) if path.is_ident("experimental") => {
+                args.experimental = true;
             }
             _ => {}
         }
@@ -239,10 +237,7 @@ fn extract_output_info(output: ReturnType) -> Option<(String, Type, TokenStream2
 
                 match args.next() {
                     Some(GenericArgument::Type(inner_ty)) => {
-                        let type_ident = match &type_path.path.segments.last() {
-                            Some(segment) => &segment.ident,
-                            None => return None,
-                        };
+                        let type_ident = &type_path.path.segments.last()?.ident;
 
                         let name = type_ident.to_string();
 

--- a/monad-rpc/src/docs.rs
+++ b/monad-rpc/src/docs.rs
@@ -25,7 +25,7 @@ pub fn as_openrpc() -> OpenRpc {
     };
 
     // Register components from all RPC methods
-    for (_, info) in method_map.iter() {
+    for info in method_map.values() {
         (info.register_components)(&mut components);
     }
 

--- a/monad-rpc/src/main.rs
+++ b/monad-rpc/src/main.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#![recursion_limit = "256"]
+
 use std::{sync::Arc, time::Duration};
 
 use actix_web::{web, App, HttpServer};

--- a/monad-sim/src/dist.rs
+++ b/monad-sim/src/dist.rs
@@ -19,16 +19,12 @@
 //! [`crate::Simulation::sample`] or [`crate::Ctx::sample`] so that all randomness
 //! is driven by the simulation's seeded generator.
 
-// See `crate::time::DurationFromNanosU128`: local shim for the 1.93-only
-// `Duration::from_nanos_u128` while the workspace builds on 1.91.1.
-#![allow(unstable_name_collisions)]
-
 use std::time::Duration;
 
 use rand::{distributions::Distribution, Rng};
 use rand_distr::{LogNormal, Normal};
 
-use crate::time::{ClockDiff, DurationFromNanosU128};
+use crate::time::ClockDiff;
 
 /// The pair of two independent distributions, sampled jointly.
 #[derive(Clone)]

--- a/monad-sim/src/time.rs
+++ b/monad-sim/src/time.rs
@@ -15,41 +15,10 @@
 
 //! Simulation time and clock differences.
 
-// `Duration::from_nanos_u128` is stable only since Rust 1.93, but this workspace
-// builds on 1.91.1, so it is provided locally by the `DurationFromNanosU128`
-// extension trait below. This `allow` silences the future-ambiguity lint raised by
-// calling it through the trait while std's (still-unstable) inherent method
-// already exists. Remove the trait and this `allow` once the toolchain reaches 1.93.
-#![allow(unstable_name_collisions)]
-
 use std::{
     ops::{Add, AddAssign, Sub, SubAssign},
     time::Duration,
 };
-
-/// Local stand-in for [`Duration::from_nanos_u128`] (stable since Rust 1.93; the
-/// workspace toolchain is 1.91.1). Behaviour matches std, including the panic
-/// when the nanosecond count exceeds [`Duration::MAX`].
-///
-/// Remove once the toolchain reaches 1.93: std's inherent method then shadows
-/// this, and the `use crate::time::DurationFromNanosU128;` imports in sibling
-/// modules surface as `unused_imports` warnings pointing back here.
-pub(crate) trait DurationFromNanosU128 {
-    fn from_nanos_u128(nanos: u128) -> Duration;
-}
-
-impl DurationFromNanosU128 for Duration {
-    #[inline]
-    #[track_caller]
-    fn from_nanos_u128(nanos: u128) -> Duration {
-        const NANOS_PER_SEC: u128 = 1_000_000_000;
-        let secs =
-            u64::try_from(nanos / NANOS_PER_SEC).expect("overflow in `Duration::from_nanos_u128`");
-        // `nanos % NANOS_PER_SEC < 1_000_000_000`, so `Duration::new` takes its
-        // no-carry fast path and the result equals std's `new_unchecked` form.
-        Duration::new(secs, (nanos % NANOS_PER_SEC) as u32)
-    }
-}
 
 /// Discrete simulation time: the affine line over clock differences measured in
 /// nanoseconds. It has no defined epoch; time `0` is the conventional origin of

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.97.1"
 components = ["clippy"]
 profile = "minimal"


### PR DESCRIPTION
Update rust-toolchain.toml, both CI workflows, and the six Dockerfiles from 1.91.1 to 1.97.1, and fix the lints the newer clippy adds to the CI gate.

Nightly toolchain remain unchanged. The updated toolchain introduces ugly indentation formatting changes