### PR TITLE
statesync: negotiate v3 and relay page-encoded storage records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5616,6 +5616,7 @@ dependencies = [
  "monad-eth-types",
  "monad-execution-state-read",
  "monad-multi-sig",
+ "monad-statesync-version",
  "monad-types",
  "monad-validator",
  "monad-wal",
@@ -6259,6 +6260,13 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "monad-statesync-version"
+version = "0.1.0"
+dependencies = [
+ "monad-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ monad-ethcall = { path = "./monad-execution/rust/crates/monad-ethcall" }
 monad-event-ring = { path = "./monad-execution/rust/crates/monad-event-ring" }
 monad-exec-events = { path = "./monad-execution/rust/crates/monad-exec-events" }
 monad-statesync = { path = "./monad-execution/rust/crates/monad-statesync" }
+monad-statesync-version = { path = "./monad-execution/rust/crates/monad-statesync-version" }
 monad-triedb = { path = "./monad-execution/rust/crates/monad-triedb" }
 
 actix = "0.13"

--- a/monad-executor-glue/Cargo.toml
+++ b/monad-executor-glue/Cargo.toml
@@ -15,6 +15,7 @@ monad-consensus = { workspace = true }
 monad-consensus-types = { workspace = true }
 monad-crypto = { workspace = true }
 monad-execution-state-read = { workspace = true }
+monad-statesync-version = { workspace = true }
 monad-types = { workspace = true }
 monad-validator = { workspace = true }
 monad-wal = { workspace = true }

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -49,6 +49,7 @@ use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
 };
 use monad_execution_state_read::ExecutionStateRead;
+use monad_statesync_version::{MONAD_STATESYNC_MAJOR, MONAD_STATESYNC_MINOR_2};
 use monad_types::{
     deserialize_pubkey, serialize_pubkey, Epoch, ExecutionProtocol, FullnodeBroadcastMode,
     LimitedVec, NodeId, Round, RouterTarget, SeqNum, Stake, UdpPriority,
@@ -1486,12 +1487,14 @@ where
     }
 }
 
-const STATESYNC_VERSION_V0: StateSyncVersion = StateSyncVersion { major: 1, minor: 0 };
-const STATESYNC_VERSION_V1: StateSyncVersion = StateSyncVersion { major: 1, minor: 1 };
-// Client is required to send completions since this version
-pub const STATESYNC_VERSION_V2: StateSyncVersion = StateSyncVersion { major: 1, minor: 2 };
-pub const SELF_STATESYNC_VERSION: StateSyncVersion = STATESYNC_VERSION_V2;
-pub const STATESYNC_VERSION_MIN: StateSyncVersion = STATESYNC_VERSION_V0;
+// Client is required to send completions since this version. Minors 0 and 1
+// predate that and are no longer spoken; nothing deployed still runs them.
+pub const STATESYNC_VERSION_1_2: StateSyncVersion = StateSyncVersion {
+    major: MONAD_STATESYNC_MAJOR,
+    minor: MONAD_STATESYNC_MINOR_2,
+};
+pub const SELF_STATESYNC_VERSION: StateSyncVersion = STATESYNC_VERSION_1_2;
+pub const STATESYNC_VERSION_MIN: StateSyncVersion = STATESYNC_VERSION_1_2;
 
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, RlpEncodable, RlpDecodable, Serialize,
@@ -1583,39 +1586,15 @@ pub enum StateSyncUpsertType {
 
 #[serde_as]
 #[derive(Clone, PartialEq, Eq, RlpEncodable, RlpDecodable, Serialize)]
-pub struct StateSyncUpsertV0 {
-    pub upsert_type: StateSyncUpsertType,
-    #[serde_as(as = "serde_with::hex::Hex")]
-    pub data: Vec<u8>,
-}
-
-#[serde_as]
-#[derive(Clone, PartialEq, Eq, RlpEncodable, RlpDecodable, Serialize)]
 pub struct StateSyncUpsertV1 {
     pub upsert_type: StateSyncUpsertType,
     #[serde_as(as = "serde_with::hex::Hex")]
     pub data: Bytes,
 }
 
-impl StateSyncUpsertV0 {
-    fn as_v1(&self) -> StateSyncUpsertV1 {
-        StateSyncUpsertV1 {
-            upsert_type: self.upsert_type,
-            data: Bytes::copy_from_slice(&self.data),
-        }
-    }
-}
-
 impl StateSyncUpsertV1 {
     pub fn new(upsert_type: StateSyncUpsertType, data: Bytes) -> Self {
         Self { upsert_type, data }
-    }
-
-    fn as_v0(&self) -> StateSyncUpsertV0 {
-        StateSyncUpsertV0 {
-            upsert_type: self.upsert_type,
-            data: self.data.to_vec(),
-        }
     }
 }
 
@@ -1701,57 +1680,27 @@ pub struct StateSyncResponse {
 
 impl Encodable for StateSyncResponse {
     fn encode(&self, out: &mut dyn BufMut) {
-        // check if client version is past V1: upsert fork
-        if self.request.version >= STATESYNC_VERSION_V1 {
-            let enc: [&dyn Encodable; 6] = [
-                &self.version,
-                &self.nonce,
-                &self.response_index,
-                &self.request,
-                &self.response,
-                &self.response_n,
-            ];
-            encode_list::<_, dyn Encodable>(&enc, out);
-        } else {
-            let v0_response: Vec<StateSyncUpsertV0> =
-                self.response.iter().map(StateSyncUpsertV1::as_v0).collect();
-            let enc: [&dyn Encodable; 6] = [
-                &self.version,
-                &self.nonce,
-                &self.response_index,
-                &self.request,
-                &v0_response,
-                &self.response_n,
-            ];
-            encode_list::<_, dyn Encodable>(&enc, out);
-        }
+        let enc: [&dyn Encodable; 6] = [
+            &self.version,
+            &self.nonce,
+            &self.response_index,
+            &self.request,
+            &self.response,
+            &self.response_n,
+        ];
+        encode_list::<_, dyn Encodable>(&enc, out);
     }
 
     fn length(&self) -> usize {
-        // check if client version is past V1: upsert fork
-        if self.request.version >= STATESYNC_VERSION_V1 {
-            let enc: Vec<&dyn Encodable> = vec![
-                &self.version,
-                &self.nonce,
-                &self.response_index,
-                &self.request,
-                &self.response,
-                &self.response_n,
-            ];
-            Encodable::length(&enc)
-        } else {
-            let v0_response: Vec<StateSyncUpsertV0> =
-                self.response.iter().map(StateSyncUpsertV1::as_v0).collect();
-            let enc: Vec<&dyn Encodable> = vec![
-                &self.version,
-                &self.nonce,
-                &self.response_index,
-                &self.request,
-                &v0_response,
-                &self.response_n,
-            ];
-            Encodable::length(&enc)
-        }
+        let enc: Vec<&dyn Encodable> = vec![
+            &self.version,
+            &self.nonce,
+            &self.response_index,
+            &self.request,
+            &self.response,
+            &self.response_n,
+        ];
+        Encodable::length(&enc)
     }
 }
 
@@ -1763,16 +1712,9 @@ impl Decodable for StateSyncResponse {
         let nonce = u64::decode(&mut payload)?;
         let response_index = u32::decode(&mut payload)?;
         let request = StateSyncRequest::decode(&mut payload)?;
-        // check if server version is past V1: upsert fork
-        let response: Vec<StateSyncUpsertV1> = if version >= STATESYNC_VERSION_V1 {
+        let response =
             LimitedVec::<StateSyncUpsertV1, MAX_UPSERTS_PER_RESPONSE>::decode(&mut payload)?
-                .into_inner()
-        } else {
-            let v0_response =
-                LimitedVec::<StateSyncUpsertV0, MAX_UPSERTS_PER_RESPONSE>::decode(&mut payload)?
-                    .into_inner();
-            v0_response.iter().map(StateSyncUpsertV0::as_v1).collect()
-        };
+                .into_inner();
         let response_n = u64::decode(&mut payload)?;
 
         if !payload.is_empty() {
@@ -2519,8 +2461,8 @@ mod tests {
     use crate::{
         BlockSyncEvent, MempoolEvent, MonadEvent, PeerEntry, PeerEntryAddress, StateSyncEvent,
         StateSyncNetworkMessage, StateSyncRequest, StateSyncResponse, StateSyncUpsertType,
-        StateSyncUpsertV1, StateSyncVersion, SELF_STATESYNC_VERSION, STATESYNC_VERSION_V0,
-        STATESYNC_VERSION_V1,
+        StateSyncUpsertV1, StateSyncVersion, SELF_STATESYNC_VERSION, STATESYNC_VERSION_1_2,
+        STATESYNC_VERSION_MIN,
     };
 
     type TestSignature = NopSignature;
@@ -2551,13 +2493,29 @@ mod tests {
 
     #[test]
     fn statesync_version_is_compatible() {
-        assert!(STATESYNC_VERSION_V0.is_compatible());
-        assert!(STATESYNC_VERSION_V1.is_compatible());
+        assert!(STATESYNC_VERSION_1_2.is_compatible());
+        assert!(SELF_STATESYNC_VERSION.is_compatible());
+        assert!(STATESYNC_VERSION_MIN == STATESYNC_VERSION_1_2);
+        // Retired: a peer still speaking either one gets BadVersion.
+        assert!(!StateSyncVersion { major: 1, minor: 0 }.is_compatible());
+        assert!(!StateSyncVersion { major: 1, minor: 1 }.is_compatible());
+    }
+
+    /// The rung values come from execution's statesync_version.h, but which rung
+    /// is current and which is the floor is picked independently on each side,
+    /// so a bump here has to be matched there.
+    #[test]
+    fn statesync_version_aliases_match_execution() {
+        use monad_statesync_version::{MONAD_STATESYNC_VERSION, MONAD_STATESYNC_VERSION_MIN};
+
+        assert_eq!(SELF_STATESYNC_VERSION.to_u32(), MONAD_STATESYNC_VERSION);
+        assert_eq!(STATESYNC_VERSION_MIN.to_u32(), MONAD_STATESYNC_VERSION_MIN);
     }
 
     #[test]
     fn statesync_version_ord() {
-        assert!(STATESYNC_VERSION_V0 < STATESYNC_VERSION_V1);
+        assert!(StateSyncVersion { major: 1, minor: 1 } < STATESYNC_VERSION_1_2);
+        assert!(STATESYNC_VERSION_1_2 < StateSyncVersion { major: 2, minor: 0 });
     }
 
     fn make_response(
@@ -2586,53 +2544,14 @@ mod tests {
     }
 
     #[test]
-    fn statesync_version_v0_roundtrip() {
-        let response = make_response(STATESYNC_VERSION_V0, STATESYNC_VERSION_V0);
+    fn statesync_response_roundtrip() {
+        let response = make_response(STATESYNC_VERSION_1_2, STATESYNC_VERSION_1_2);
         let serialized_response = alloy_rlp::encode(&response);
+        assert_eq!(serialized_response.len(), Encodable::length(&response));
         let deserialized_response = alloy_rlp::decode_exact(&serialized_response).unwrap();
         if response != deserialized_response {
-            panic!("failed to roundtrip v0 statesync response")
+            panic!("failed to roundtrip statesync response")
         }
-    }
-
-    #[test]
-    fn statesync_version_v1_roundtrip() {
-        let response = make_response(STATESYNC_VERSION_V1, STATESYNC_VERSION_V1);
-        let serialized_response = alloy_rlp::encode(&response);
-        let deserialized_response = alloy_rlp::decode_exact(&serialized_response).unwrap();
-        if response != deserialized_response {
-            panic!("failed to roundtrip v1 statesync response")
-        }
-    }
-
-    #[test]
-    fn statesync_version_v1_to_v0() {
-        // v0 client, v1 server
-        let response = alloy_rlp::encode(make_response(STATESYNC_VERSION_V0, STATESYNC_VERSION_V1));
-
-        // v0 format
-        let v0_response =
-            alloy_rlp::encode(make_response(STATESYNC_VERSION_V0, STATESYNC_VERSION_V0));
-        // v1 format
-        let v1_response =
-            alloy_rlp::encode(make_response(STATESYNC_VERSION_V1, STATESYNC_VERSION_V1));
-        assert!(
-            v0_response.len() > v1_response.len(),
-            "v1 serializes smaller messages"
-        );
-
-        // use len as a proxy for format
-        // can't check pure equality, because the versions won't match in the serialized messages
-        assert_eq!(
-            response.len(),
-            v0_response.len(),
-            "v0 client can't understand v1 server"
-        );
-        assert_ne!(
-            response.len(),
-            v1_response.len(),
-            "v1 server sent v1 response to v0 client"
-        );
     }
 
     #[test]

--- a/monad-executor-glue/src/lib.rs
+++ b/monad-executor-glue/src/lib.rs
@@ -49,7 +49,9 @@ use monad_crypto::certificate_signature::{
     CertificateSignaturePubKey, CertificateSignatureRecoverable, PubKey,
 };
 use monad_execution_state_read::ExecutionStateRead;
-use monad_statesync_version::{MONAD_STATESYNC_MAJOR, MONAD_STATESYNC_MINOR_2};
+use monad_statesync_version::{
+    MONAD_STATESYNC_MAJOR, MONAD_STATESYNC_MINOR_2, MONAD_STATESYNC_MINOR_3,
+};
 use monad_types::{
     deserialize_pubkey, serialize_pubkey, Epoch, ExecutionProtocol, FullnodeBroadcastMode,
     LimitedVec, NodeId, Round, RouterTarget, SeqNum, Stake, UdpPriority,
@@ -1493,7 +1495,12 @@ pub const STATESYNC_VERSION_1_2: StateSyncVersion = StateSyncVersion {
     major: MONAD_STATESYNC_MAJOR,
     minor: MONAD_STATESYNC_MINOR_2,
 };
-pub const SELF_STATESYNC_VERSION: StateSyncVersion = STATESYNC_VERSION_1_2;
+// Server sends page-encoded storage leaves verbatim since this version
+pub const STATESYNC_VERSION_1_3: StateSyncVersion = StateSyncVersion {
+    major: MONAD_STATESYNC_MAJOR,
+    minor: MONAD_STATESYNC_MINOR_3,
+};
+pub const SELF_STATESYNC_VERSION: StateSyncVersion = STATESYNC_VERSION_1_3;
 pub const STATESYNC_VERSION_MIN: StateSyncVersion = STATESYNC_VERSION_1_2;
 
 #[derive(
@@ -1582,6 +1589,7 @@ pub enum StateSyncUpsertType {
     AccountDelete,
     StorageDelete,
     Header,
+    StoragePage,
 }
 
 #[serde_as]
@@ -1625,6 +1633,10 @@ impl Encodable for StateSyncUpsertType {
                 let enc: [&dyn Encodable; 1] = [&6u8];
                 encode_list::<_, dyn Encodable>(&enc, out);
             }
+            Self::StoragePage => {
+                let enc: [&dyn Encodable; 1] = [&7u8];
+                encode_list::<_, dyn Encodable>(&enc, out);
+            }
         }
     }
 
@@ -1647,6 +1659,7 @@ impl Decodable for StateSyncUpsertType {
             4 => Self::AccountDelete,
             5 => Self::StorageDelete,
             6 => Self::Header,
+            7 => Self::StoragePage,
             _ => {
                 return Err(alloy_rlp::Error::Custom(
                     "failed to decode unknown StateSyncUpsertType",
@@ -2443,7 +2456,7 @@ where
 mod tests {
     use std::{net::Ipv4Addr, num::NonZeroU16};
 
-    use alloy_rlp::{encode_list, Encodable};
+    use alloy_rlp::{encode_list, Decodable, Encodable};
     use bytes::Bytes;
     use monad_blocksync::messages::message::BlockSyncRequestMessage;
     use monad_consensus_types::block::BlockRange;
@@ -2462,7 +2475,7 @@ mod tests {
         BlockSyncEvent, MempoolEvent, MonadEvent, PeerEntry, PeerEntryAddress, StateSyncEvent,
         StateSyncNetworkMessage, StateSyncRequest, StateSyncResponse, StateSyncUpsertType,
         StateSyncUpsertV1, StateSyncVersion, SELF_STATESYNC_VERSION, STATESYNC_VERSION_1_2,
-        STATESYNC_VERSION_MIN,
+        STATESYNC_VERSION_1_3, STATESYNC_VERSION_MIN,
     };
 
     type TestSignature = NopSignature;
@@ -2516,6 +2529,22 @@ mod tests {
     fn statesync_version_ord() {
         assert!(StateSyncVersion { major: 1, minor: 1 } < STATESYNC_VERSION_1_2);
         assert!(STATESYNC_VERSION_1_2 < StateSyncVersion { major: 2, minor: 0 });
+    }
+
+    #[test]
+    fn storage_page_upsert_type_roundtrips() {
+        let encoded = alloy_rlp::encode(StateSyncUpsertType::StoragePage);
+        let decoded = StateSyncUpsertType::decode(&mut encoded.as_slice()).unwrap();
+        assert!(decoded == StateSyncUpsertType::StoragePage);
+    }
+
+    #[test]
+    fn page_passthrough_version_is_self() {
+        assert!(STATESYNC_VERSION_1_2 < STATESYNC_VERSION_1_3);
+        assert!(SELF_STATESYNC_VERSION == STATESYNC_VERSION_1_3);
+        assert!(STATESYNC_VERSION_1_3.is_compatible());
+        // Adding v3 must not raise MIN: deployed peers still speak v2.
+        assert!(STATESYNC_VERSION_MIN == STATESYNC_VERSION_1_2);
     }
 
     fn make_response(

--- a/monad-statesync-executor/src/client/mod.rs
+++ b/monad-statesync-executor/src/client/mod.rs
@@ -198,6 +198,9 @@ impl<PT: PubKey> StateSyncClient<PT> {
                                             StateSyncUpsertType::Header => {
                                                 ffi::monad_sync_type_SYNC_TYPE_UPSERT_HEADER
                                             }
+                                            StateSyncUpsertType::StoragePage => {
+                                                ffi::monad_sync_type_SYNC_TYPE_UPSERT_STORAGE_PAGE
+                                            }
                                         },
                                         upsert.data.as_ptr(),
                                         upsert.data.len() as u64,

--- a/monad-statesync-executor/src/ipc.rs
+++ b/monad-statesync-executor/src/ipc.rs
@@ -31,7 +31,7 @@ use monad_crypto::certificate_signature::PubKey;
 use monad_executor_glue::{
     SessionId, StateSyncBadVersion, StateSyncNetworkMessage, StateSyncRequest, StateSyncResponse,
     StateSyncUpsertType, StateSyncUpsertV1, MAX_UPSERTS_PER_RESPONSE, SELF_STATESYNC_VERSION,
-    STATESYNC_VERSION_MIN, STATESYNC_VERSION_V2,
+    STATESYNC_VERSION_MIN,
 };
 use monad_statesync::ffi;
 use monad_types::NodeId;
@@ -282,8 +282,7 @@ impl<PT: PubKey> WipResponse<PT> {
     pub fn can_send(&self) -> bool {
         self.pending_response_completions.as_ref().is_none_or(|r| {
             r.len() < MAX_PENDING_RESPONSES
-                && (self.response.version < STATESYNC_VERSION_V2
-                    || self.unacknowledged_responses < MAX_UNACKNOWLEDGED_RESPONSES)
+                && self.unacknowledged_responses < MAX_UNACKNOWLEDGED_RESPONSES
         })
     }
 
@@ -361,10 +360,9 @@ impl<'a, PT: PubKey> StreamState<'a, PT> {
                 futures.push(fut.boxed());
             }
 
-            // If we have a pending response, schedule a timeout for the client that supports completions
+            // If we have a pending response, schedule a timeout for the client
             if wip_response.unacknowledged_responses > 0
                 && wip_response.pending_response_completions.is_some()
-                && wip_response.response.version >= STATESYNC_VERSION_V2
             {
                 let fut = async {
                     tokio::time::sleep_until(

--- a/monad-statesync-executor/src/ipc.rs
+++ b/monad-statesync-executor/src/ipc.rs
@@ -724,6 +724,7 @@ impl<'a, PT: PubKey> StreamState<'a, PT> {
             from: request.request.from,
             until: request.request.until,
             old_target: request.request.old_target,
+            version: request.request.version.to_u32(),
         })
         .await?;
 
@@ -765,6 +766,10 @@ impl<'a, PT: PubKey> StreamState<'a, PT> {
             }
             ffi::monad_sync_type_SYNC_TYPE_UPSERT_HEADER => {
                 self.read_sync_upsert(StateSyncUpsertType::Header).await?
+            }
+            ffi::monad_sync_type_SYNC_TYPE_UPSERT_STORAGE_PAGE => {
+                self.read_sync_upsert(StateSyncUpsertType::StoragePage)
+                    .await?
             }
             ffi::monad_sync_type_SYNC_TYPE_DONE => {
                 let mut buf = [0_u8; std::mem::size_of::<ffi::monad_sync_done>()];


### PR DESCRIPTION
Stacked on #3211 — that lands first; this PR's own change is the second commit.
Also needs category-labs/monad#2483 merged, for the submodule bump.

Protocol 1.3 adds a storage-page upsert record: one record per storage page
leaf, carrying the page exactly as the server holds it. Route it through
`StateSyncUpsertType` and the ffi mapping, raise `SELF_STATESYNC_VERSION` to v3,
and pass the requesting peer's negotiated version down to the C++ server, which
previously dropped it — without that the server cannot tell which wire a peer
speaks, so it cannot choose to send page records at all.

`STATESYNC_VERSION_1_3` is built from execution's `MONAD_STATESYNC_MINOR_3`, the
same way #3211 does it for v2, so the rung is defined once.

### Testing

- `storage_page_upsert_type_roundtrips` — the new
  `StateSyncUpsertType::StoragePage` survives RLP encode/decode at discriminant
  7, which is what keeps the wire tag stable.
- `page_passthrough_version_is_self` — v3 orders above v2, is what
  `SELF_STATESYNC_VERSION` reports, and is compatible; the part that matters is
  the last assertion, that adding v3 does **not** raise
  `STATESYNC_VERSION_MIN`, which would cut off every deployed v2 peer.

