### PR TITLE
monad-raptorcast: avoid redundant wireauth lookups

### DIFF
--- a/monad-raptorcast/src/auth/socket.rs
+++ b/monad-raptorcast/src/auth/socket.rs
@@ -201,11 +201,14 @@ where
                 }
 
                 let msg_len = msg.len() as u64;
-                if self
-                    .authenticated
-                    .write_with_buffering(public_key, msg, stride, priority)
-                    .is_err()
-                {
+                let result = if has_authenticated_socket {
+                    self.authenticated
+                        .write_connected_socket_with_priority(auth_addr, msg, stride, priority)
+                } else {
+                    self.authenticated
+                        .write_with_buffering(public_key, msg, stride, priority)
+                };
+                if result.is_err() {
                     warn!(
                         ?public_key,
                         "failed to write or buffer authenticated UDP packet"
@@ -357,22 +360,34 @@ where
     }
 
     pub fn write_unicast_with_priority(&mut self, msg: UnicastMsg, priority: UdpPriority) {
-        let stride = msg.stride as usize;
-        for (addr, mut chunk) in msg.msgs {
-            while !chunk.is_empty() {
-                let piece = chunk.split_to(chunk.len().min(stride));
-                let piece_len = piece.len() as u16;
-                if let Some(encrypted) = self.encrypt_packet(addr, piece) {
-                    self.socket.write_unicast_with_priority(
-                        UnicastMsg {
-                            msgs: vec![encrypted],
-                            stride: piece_len + AP::HEADER_SIZE,
-                        },
-                        priority,
-                    );
-                }
-            }
+        for (addr, chunk) in msg.msgs {
+            let _ = self.write_connected_socket_with_priority(addr, chunk, msg.stride, priority);
         }
+    }
+
+    fn write_connected_socket_with_priority(
+        &mut self,
+        addr: SocketAddr,
+        mut plaintext: Bytes,
+        stride: u16,
+        priority: UdpPriority,
+    ) -> Result<(), ()> {
+        let stride = usize::from(stride);
+        while !plaintext.is_empty() {
+            let piece = plaintext.split_to(plaintext.len().min(stride));
+            let piece_len = piece.len() as u16;
+            let Some(encrypted) = self.encrypt_packet(addr, piece) else {
+                return Err(());
+            };
+            self.socket.write_unicast_with_priority(
+                UnicastMsg {
+                    msgs: vec![encrypted],
+                    stride: piece_len + AP::HEADER_SIZE,
+                },
+                priority,
+            );
+        }
+        Ok(())
     }
 
     /// Returns `Err(())` if the message was not written.
@@ -387,6 +402,15 @@ where
             return Err(());
         }
 
+        self.write_by_connected_public_key_with_priority(public_key, plaintext, priority)
+    }
+
+    fn write_by_connected_public_key_with_priority(
+        &mut self,
+        public_key: &AP::PublicKey,
+        plaintext: Bytes,
+        priority: UdpPriority,
+    ) -> Result<(), ()> {
         let Some(addr) = self.auth_protocol.get_socket_by_public_key(public_key) else {
             warn!("failed to find socket for connected public key");
             return Err(());
@@ -425,11 +449,11 @@ where
         priority: UdpPriority,
     ) -> Result<(), ()> {
         let has_authenticated_socket = self.auth_protocol.is_connected_public_key(public_key);
-        let has_initiator_session = self
-            .auth_protocol
-            .has_initiator_session_by_public_key(public_key);
-
-        if !has_authenticated_socket && !has_initiator_session {
+        if !has_authenticated_socket
+            && !self
+                .auth_protocol
+                .has_initiator_session_by_public_key(public_key)
+        {
             return Err(());
         }
 
@@ -442,7 +466,7 @@ where
             let piece = plaintext.split_to(plaintext.len().min(stride));
 
             if has_authenticated_socket {
-                self.write_by_public_key_with_priority(public_key, piece, priority)?;
+                self.write_by_connected_public_key_with_priority(public_key, piece, priority)?;
                 continue;
             }
 


### PR DESCRIPTION
perf profiling of the raptorcast service thread under a 64-target load showed repeated public-key hashing and wireauth session lookup in the authenticated send path.

reuse the authenticated socket address after validating that its active session belongs to the target public key. also avoid rechecking connected and initiating sessions for each piece of a buffered message.

in the throughput stress test with 2 udp tx workers, a 25.625 gbps offer, a 25 gbps global limit, and a 1 gbps per-peer limit, raptorcast throughput increased from 15,796 to 18,427 chunks/s (+16.7%). authenticated dataplane handoff increased from 11.646 to 13.586 gbps (+16.7%), while udp tx remained saturated at about 3.5 gbps.