### PR TITLE
monad-node: run consensus state on dedicated thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4996,6 +4996,7 @@ dependencies = [
  "monad-types",
  "monad-validator",
  "tempfile",
+ "tracing",
 ]
 
 [[package]]

--- a/monad-block-persist/Cargo.toml
+++ b/monad-block-persist/Cargo.toml
@@ -16,6 +16,7 @@ monad-validator = { workspace = true }
 
 alloy-rlp = { workspace = true }
 hex = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 inotify = { workspace = true }

--- a/monad-block-persist/src/lib.rs
+++ b/monad-block-persist/src/lib.rs
@@ -30,6 +30,7 @@ use monad_crypto::certificate_signature::{
 };
 use monad_types::{BlockId, ExecutionProtocol, Hash};
 use monad_validator::signature_collection::SignatureCollection;
+use tracing::instrument;
 
 pub const BLOCKDB_HEADERS_PATH: &str = "headers";
 const BLOCKDB_BODIES_PATH: &str = "bodies";
@@ -151,6 +152,7 @@ where
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
     EPT: ExecutionProtocol,
 {
+    #[instrument(name = "ledger_write_header", level = "debug", skip_all)]
     fn write_bft_header(&mut self, block: &ConsensusBlockHeader<ST, SCT, EPT>) -> io::Result<()> {
         let file_path = self.header_path(&block.get_id());
 
@@ -166,6 +168,7 @@ where
         Ok(())
     }
 
+    #[instrument(name = "ledger_write_body", level = "debug", skip_all)]
     fn write_bft_body(&mut self, body: &ConsensusBlockBody<EPT>) -> io::Result<()> {
         let file_path = self.body_path(&body.get_id());
 
@@ -181,14 +184,17 @@ where
         Ok(())
     }
 
+    #[instrument(name = "ledger_write_proposed_head", level = "debug", skip_all)]
     fn update_proposed_head(&mut self, block_id: &BlockId) -> io::Result<()> {
         atomic_symlink_update(&self.header_path(block_id), &self.proposed_head_path)
     }
 
+    #[instrument(name = "ledger_write_voted_head", level = "debug", skip_all)]
     fn update_voted_head(&mut self, block_id: &BlockId) -> io::Result<()> {
         atomic_symlink_update(&self.header_path(block_id), &self.voted_head_path)
     }
 
+    #[instrument(name = "ledger_write_finalized_head", level = "debug", skip_all)]
     fn update_finalized_head(&mut self, block_id: &BlockId) -> io::Result<()> {
         atomic_symlink_update(&self.header_path(block_id), &self.finalized_head_path)
     }

--- a/monad-eth-block-validator/src/lib.rs
+++ b/monad-eth-block-validator/src/lib.rs
@@ -58,7 +58,7 @@ use monad_system_calls::{validator::SystemTransactionValidator, SYSTEM_SENDER_ET
 use monad_types::Balance;
 use monad_validator::signature_collection::{SignatureCollection, SignatureCollectionPubKeyType};
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
-use tracing::{debug, trace, trace_span, warn};
+use tracing::{debug, instrument, trace, trace_span, warn};
 
 pub mod error;
 
@@ -96,7 +96,7 @@ where
 {
     type BlockValidationError = EthBlockValidationError;
 
-    #[tracing::instrument(
+    #[instrument(
         level = "debug",
         skip_all,
         fields(seq_num = header.seq_num.as_u64())
@@ -310,6 +310,24 @@ where
         Ok(())
     }
 
+    #[instrument(
+        level = "debug",
+        skip_all,
+        fields(transactions = transactions.len())
+    )]
+    fn recover_transaction_signers(
+        transactions: &[TxEnvelope],
+    ) -> Result<VecDeque<Recovered<TxEnvelope>>, monad_secp::Error> {
+        transactions
+            .par_iter()
+            .map(|tx| {
+                let _span = trace_span!("validator: recover signer").entered();
+                let signer = tx.secp256k1_recover()?;
+                Ok(Recovered::new_unchecked(tx.clone(), signer))
+            })
+            .collect()
+    }
+
     /// Validates the individual transactions in the block body, and block limits such as block gas limits and transaction limits
     /// For each transaction, validate that there is no nonce gap within this block
     /// Actual nonce and balance validation against account state and preceding blocks is done in check_coherency in monad-eth-block-policy
@@ -376,14 +394,7 @@ where
         }
 
         // recovering the signers verifies that these are valid signatures
-        let recovered_txns: VecDeque<Recovered<TxEnvelope>> = transactions
-            .par_iter()
-            .map(|tx| {
-                let _span = trace_span!("validator: recover signer").entered();
-                let signer = tx.secp256k1_recover()?;
-                Ok(Recovered::new_unchecked(tx.clone(), signer))
-            })
-            .collect::<Result<_, monad_secp::Error>>()
+        let recovered_txns = Self::recover_transaction_signers(transactions)
             .map_err(TxnError::SignerRecoveryError)?;
 
         let (system_txns, eth_txns) = match SystemTransactionValidator::extract_system_transactions(

--- a/monad-execution-state-read/src/thread.rs
+++ b/monad-execution-state-read/src/thread.rs
@@ -25,7 +25,7 @@ use monad_crypto::certificate_signature::{
 use monad_eth_types::{EthAccount, EthHeader};
 use monad_types::{BlockId, Epoch, SeqNum, Stake};
 use monad_validator::signature_collection::{SignatureCollection, SignatureCollectionPubKeyType};
-use tracing::warn;
+use tracing::{instrument, warn};
 
 use crate::{ExecutionStateRead, ExecutionStateReadError};
 
@@ -125,6 +125,12 @@ where
     ST: CertificateSignatureRecoverable,
     SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
 {
+    #[instrument(
+        name = "state_read_wait_account_statuses",
+        level = "debug",
+        skip_all,
+        fields(seq_num = seq_num.as_u64(), is_finalized = is_finalized)
+    )]
     fn get_account_statuses<'a>(
         &mut self,
         block_id: &BlockId,
@@ -141,6 +147,12 @@ where
         })
     }
 
+    #[instrument(
+        name = "state_read_wait_execution_result",
+        level = "debug",
+        skip_all,
+        fields(seq_num = seq_num.as_u64(), is_finalized = is_finalized)
+    )]
     fn get_execution_result(
         &mut self,
         block_id: &BlockId,

--- a/monad-executor/src/metrics.rs
+++ b/monad-executor/src/metrics.rs
@@ -186,6 +186,12 @@ impl ExecutorMetrics {
         }
     }
 
+    pub fn gauge_handle(&self, metric: &'static MetricDef) -> &Gauge {
+        self.gauges
+            .get(metric)
+            .expect("executor metric must be initialized before access")
+    }
+
     pub fn metric_handles(&self) -> Vec<(&'static str, Gauge, &'static str)> {
         self.gauges
             .iter()

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -629,8 +629,12 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
                     let _event_span = tracing::trace_span!("event_span", ?event).entered();
                     let start = Instant::now();
                     let cmds = state.update(event);
-                    total_state_update_elapsed += start.elapsed();
-                    prometheus_metrics.record_state_update_elapsed(&total_state_update_elapsed);
+                    let state_update_elapsed = start.elapsed();
+                    total_state_update_elapsed += state_update_elapsed;
+                    prometheus_metrics.record_state_update_elapsed(
+                        &state_update_elapsed,
+                        &total_state_update_elapsed,
+                    );
                     cmds
                 };
 

--- a/monad-node/src/main.rs
+++ b/monad-node/src/main.rs
@@ -41,8 +41,8 @@ use monad_eth_block_validator::EthBlockValidator;
 use monad_eth_txpool_executor::{EthTxPoolExecutor, EthTxPoolIpcConfig};
 use monad_execution_state_read::ExecutionStateReadThreadClient;
 use monad_execution_state_read_cache::ExecutionStateReadCache;
-use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
-use monad_executor_glue::{LogFriendlyMonadEvent, Message, MonadEvent};
+use monad_executor::{Executor, ExecutorMetrics, Gauge as ExecutorGauge};
+use monad_executor_glue::{Command, LogFriendlyMonadEvent, Message, MonadEvent};
 use monad_ledger::MonadBlockFileLedger;
 use monad_node_config::{
     ExecutionProtocolType, FullNodeIdentityConfig, NodeBootstrapConfig, NodeBootstrapPeerConfig,
@@ -64,8 +64,12 @@ use monad_statesync_executor::StateSyncExecutor;
 use monad_triedb_utils::TriedbReader;
 use monad_types::{DropTimer, Epoch, NodeId, Round, SeqNum, GENESIS_SEQ_NUM};
 use monad_updaters::{
-    config_file::ConfigFile, config_loader::ConfigLoader, loopback::LoopbackExecutor,
-    parent::ParentExecutor, timer::TokioTimer, tokio_timestamp::TokioTimestamp,
+    config_file::ConfigFile,
+    config_loader::ConfigLoader,
+    loopback::LoopbackExecutor,
+    parent::{CoreExecutor, ExternalExecutor, ParentExecutor},
+    timer::TokioTimer,
+    tokio_timestamp::TokioTimestamp,
     triedb_val_set::ValSetUpdater,
 };
 use monad_validator::{
@@ -82,7 +86,7 @@ use tokio::{
     signal::unix::{signal, SignalKind},
     time::{interval, MissedTickBehavior},
 };
-use tracing::{error, event, info, warn, Instrument, Level};
+use tracing::{error, event, info, info_span, trace_span, warn, Level};
 
 use self::{
     cli::Cli,
@@ -113,6 +117,8 @@ const MONAD_NODE_VERSION: Option<&str> = option_env!("MONAD_VERSION");
 const STATESYNC_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 const EXECUTION_DELAY: u64 = 3;
+const CONSENSUS_EVENT_CHANNEL_CAPACITY: usize = 1024;
+const CONSENSUS_RESULT_CHANNEL_CAPACITY: usize = 1024;
 const WALTRACE_CHANNEL_CAPACITY: usize = 1024;
 const TRIEDB_STORAGE_METRICS_INTERVAL: Duration = Duration::from_secs(30);
 
@@ -157,7 +163,7 @@ fn main() {
     }
 
     if let Err(e) = runtime.block_on(run(node_state)) {
-        tracing::error!("monad consensus node crashed: {:?}", e);
+        error!("monad consensus node crashed: {:?}", e);
     }
 }
 
@@ -263,24 +269,26 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         }
     });
 
-    let mut executor = ParentExecutor {
-        metrics: Default::default(),
-        router,
-        timer: TokioTimer::default(),
-        ledger: MonadBlockFileLedger::new(node_state.ledger_path),
-        config_file: ConfigFile::new(
+    let core_executor = CoreExecutor::new(
+        TokioTimer::default(),
+        MonadBlockFileLedger::new(node_state.ledger_path),
+        ConfigFile::new(
             node_state.forkpoint_path,
             node_state.validators_path.clone(),
             node_state.chain_config,
         ),
-        val_set: ValSetUpdater::new(
+        ValSetUpdater::new(
             node_state.validators_path,
             node_state.chain_config.get_epoch_length(),
             node_state.chain_config.get_staking_activation(),
             state_read.clone(),
         ),
-        timestamp: TokioTimestamp::new(Duration::from_millis(5), 100, 10001),
-        txpool: EthTxPoolExecutor::start(
+        TokioTimestamp::new(Duration::from_millis(5), 100, 10001),
+        LoopbackExecutor::default(),
+    );
+    let external_executor = ExternalExecutor::new(
+        router,
+        EthTxPoolExecutor::start(
             create_block_policy(),
             state_read.clone(),
             EthTxPoolIpcConfig {
@@ -305,14 +313,13 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
             score_reader,
         )
         .expect("txpool ipc succeeds"),
-        control_panel: ControlPanelIpcReceiver::new(
+        ControlPanelIpcReceiver::new(
             node_state.control_panel_ipc_path,
             node_state.reload_handle,
             1000,
         )
         .expect("uds bind failed"),
-        loopback: LoopbackExecutor::default(),
-        state_sync: StateSyncExecutor::<SignatureType, SignatureCollectionType>::new(
+        StateSyncExecutor::<SignatureType, SignatureCollectionType>::new(
             node_state.chain_config.chain_id(),
             vec![statesync_triedb_path.to_string_lossy().to_string()],
             node_state.statesync_sq_thread_cpu,
@@ -329,8 +336,9 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
                 .expect("invalid file name")
                 .to_owned(),
         ),
-        config_loader: ConfigLoader::new(node_state.node_config_path),
-    };
+        ConfigLoader::new(node_state.node_config_path),
+    );
+    let executor = ParentExecutor::new(core_executor, external_executor);
 
     let waltrace_tx = if node_state.wal_chunks == 0 {
         info!("wal is disabled");
@@ -356,7 +364,7 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
                     }
                 };
                 while let Ok(event) = waltrace_rx.recv() {
-                    let _wal_event_span = tracing::trace_span!("wal_event_span").entered();
+                    let _wal_event_span = trace_span!("wal_event_span").entered();
                     if let Err(err) = wal.push(&event) {
                         event!(Level::ERROR, ?err, "failed to push to wal");
                         return;
@@ -392,8 +400,6 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         )
         .collect();
 
-    let mut last_ledger_tip: Option<SeqNum> = None;
-
     let builder = MonadStateBuilder {
         validator_set_factory: ValidatorSetFactory::default(),
         leader_election,
@@ -426,13 +432,7 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         _phantom: PhantomData,
     };
 
-    let (mut state, init_commands) = builder.build();
-    executor.exec(init_commands);
-
-    let mut ledger_span = tracing::info_span!(
-        "ledger_span",
-        last_ledger_tip = last_ledger_tip.map(|s| s.as_u64())
-    );
+    let (state, init_commands) = builder.build();
 
     let (maybe_otel_meter_provider, mut maybe_metrics_ticker) = node_state
         .otel_endpoint_interval
@@ -460,7 +460,6 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         .map(|provider| provider.meter("opentelemetry"));
     let mut gauge_cache = HashMap::new();
     let process_start = Instant::now();
-    let mut total_state_update_elapsed = Duration::ZERO;
 
     let mut prometheus_labels = default_prometheus_labels(
         format!(
@@ -504,6 +503,11 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         }
     }
 
+    let executor_metric_handles = executor
+        .metrics()
+        .push(&triedb_phase_metrics)
+        .push(&triedb_storage_metrics)
+        .metric_handles();
     let prometheus_metrics = Arc::new(
         NodePrometheusMetrics::new(
             prometheus_labels,
@@ -541,38 +545,188 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
         });
     }
 
+    let ParentExecutor {
+        core: mut core_executor,
+        external: mut external_executor,
+    } = executor;
+    let (consensus_event_tx, mut consensus_event_rx) = tokio::sync::mpsc::channel::<
+        MonadEvent<SignatureType, SignatureCollectionType, ExecutionProtocolType>,
+    >(CONSENSUS_EVENT_CHANNEL_CAPACITY);
+    let (consensus_result_tx, mut consensus_result_rx) =
+        tokio::sync::mpsc::channel(CONSENSUS_RESULT_CHANNEL_CAPACITY);
+    let (consensus_shutdown_tx, mut consensus_shutdown_rx) = tokio::sync::oneshot::channel();
+    let consensus_prometheus_metrics = Arc::clone(&prometheus_metrics);
+    let consensus_thread = std::thread::Builder::new()
+        .name("monad-consensus".to_string())
+        .spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_time()
+                .build()
+                .expect("failed to build consensus runtime");
+            runtime.block_on(async move {
+                let mut state = state;
+                let mut total_state_update_elapsed = Duration::ZERO;
+                let mut last_ledger_tip: Option<SeqNum> = None;
+                let mut ledger_span = info_span!(
+                    "ledger_span",
+                    last_ledger_tip = last_ledger_tip.map(|s| s.as_u64())
+                );
+                let mut commands = Some(init_commands);
+
+                loop {
+                    let commands = match commands.take() {
+                        Some(commands) => commands,
+                        None => {
+                            let event = tokio::select! {
+                                biased;
+
+                                _ = &mut consensus_shutdown_rx => {
+                                    return;
+                                }
+                                event = core_executor.next() => {
+                                    let Some(event) = event else {
+                                        event!(Level::ERROR, "core executor stopped");
+                                        return;
+                                    };
+                                    event
+                                }
+                                event = consensus_event_rx.recv() => {
+                                    let Some(event) = event else {
+                                        return;
+                                    };
+                                    event
+                                }
+                            };
+                            if event.is_wal_logged() {
+                                if let Some(waltrace_tx) = waltrace_tx.as_ref() {
+                                    let wal_event = LogFriendlyMonadEvent {
+                                        timestamp: Utc::now(),
+                                        event: event.lossy_clone(),
+                                    };
+                                    match waltrace_tx.try_send(wal_event) {
+                                        Ok(()) => {}
+                                        Err(TrySendError::Full(_)) => {
+                                            warn!("waltrace is lagging; dropping wal event");
+                                        }
+                                        Err(TrySendError::Disconnected(_)) => {
+                                            event!(Level::ERROR, "waltrace thread stopped");
+                                        }
+                                    }
+                                }
+                            }
+                            let event_debug = {
+                                let _timer =
+                                    DropTimer::start(Duration::from_millis(1), |elapsed| {
+                                        warn!(?elapsed, ?event, "long time to format event")
+                                    });
+                                format!("{:?}", event)
+                            };
+                            let commands = {
+                                let _timer =
+                                    DropTimer::start(Duration::from_millis(50), |elapsed| {
+                                        warn!(
+                                            ?elapsed,
+                                            event =? event_debug,
+                                            "long time to update event"
+                                        )
+                                    });
+                                let _ledger_span = ledger_span.enter();
+                                let _event_span = trace_span!("event_span", ?event).entered();
+                                let start = Instant::now();
+                                let commands = state.update(event);
+                                let state_update_elapsed = start.elapsed();
+                                total_state_update_elapsed += state_update_elapsed;
+                                consensus_prometheus_metrics.record_state_update_elapsed(
+                                    &state_update_elapsed,
+                                    &total_state_update_elapsed,
+                                );
+                                commands
+                            };
+                            commands
+                        }
+                    };
+
+                    let num_commands = commands.len();
+                    let (
+                        router,
+                        timer,
+                        ledger,
+                        config_file,
+                        val_set,
+                        timestamp,
+                        txpool,
+                        control_panel,
+                        loopback,
+                        state_sync,
+                        config_reload,
+                    ) = Command::split_commands(commands);
+                    let num_external_commands = router.len()
+                        + txpool.len()
+                        + control_panel.len()
+                        + state_sync.len()
+                        + config_reload.len();
+                    if num_external_commands != 0
+                        && consensus_result_tx
+                            .send((router, txpool, control_panel, state_sync, config_reload))
+                            .await
+                            .is_err()
+                    {
+                        return;
+                    }
+
+                    let num_core_commands = num_commands - num_external_commands;
+                    let _exec_span =
+                        trace_span!("core_exec_span", num_commands = num_core_commands).entered();
+                    core_executor.exec(timer, ledger, config_file, val_set, timestamp, loopback);
+                    if let Some(ledger_tip) = core_executor.ledger().last_commit() {
+                        if last_ledger_tip.is_none_or(|last_tip| ledger_tip > last_tip) {
+                            last_ledger_tip = Some(ledger_tip);
+                            ledger_span = info_span!(
+                                "ledger_span",
+                                last_ledger_tip = last_ledger_tip.map(|s| s.as_u64())
+                            );
+                        }
+                    }
+                }
+            });
+        })
+        .expect("failed to spawn consensus thread");
+
     let mut sigterm = signal(SignalKind::terminate()).expect("in tokio rt");
     let mut sigint = signal(SignalKind::interrupt()).expect("in tokio rt");
 
     let mut triedb_storage_ticker = interval(TRIEDB_STORAGE_METRICS_INTERVAL);
     triedb_storage_ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
+    let mut consensus_shutdown_tx = Some(consensus_shutdown_tx);
+    let mut shutting_down = false;
     loop {
         tokio::select! {
             biased; // events are in order of priority
 
-            result = sigterm.recv() => {
+            result = sigterm.recv(), if !shutting_down => {
                 info!(?result, "received SIGTERM, exiting...");
-                break;
+                shutting_down = true;
+                let _ = consensus_shutdown_tx.take().unwrap().send(());
             }
-            result = sigint.recv() => {
+            result = sigint.recv(), if !shutting_down => {
                 info!(?result, "received SIGINT, exiting...");
-                break;
+                shutting_down = true;
+                let _ = consensus_shutdown_tx.take().unwrap().send(());
             }
             _ = match &mut maybe_metrics_ticker {
                 Some(ticker) => ticker.tick().boxed(),
                 None => futures_util::future::pending().boxed(),
-            } => {
+            }, if !shutting_down => {
                 let otel_meter = maybe_otel_meter.as_ref().expect("otel_endpoint must have been set");
-                let executor_metrics = executor.metrics().push(&triedb_phase_metrics).push(&triedb_storage_metrics);
                 send_metrics(
                     otel_meter,
                     &mut gauge_cache,
                     prometheus_metrics.as_ref(),
-                    executor_metrics,
+                    &executor_metric_handles,
                 );
             }
-            _ = triedb_storage_ticker.tick() => {
+            _ = triedb_storage_ticker.tick(), if !shutting_down => {
                 if let Some(reader) = &triedb_metrics_reader {
                     record_triedb_storage_metrics(
                         &mut triedb_storage_metrics,
@@ -580,87 +734,55 @@ async fn run(node_state: NodeState) -> Result<(), ()> {
                     );
                 }
             }
-            event = executor.next().instrument(ledger_span.clone()) => {
-                let Some(event) = event else {
-                    event!(Level::ERROR, "parent executor returned none!");
+            result = consensus_result_rx.recv() => {
+                let Some(commands) = result else {
+                    if shutting_down {
+                        break;
+                    }
+                    event!(Level::ERROR, "consensus thread stopped");
                     return Err(());
                 };
-                let event_debug = {
-                    let _timer = DropTimer::start(Duration::from_millis(1), |elapsed| {
-                        warn!(
-                            ?elapsed,
-                            ?event,
-                            "long time to format event"
-                        )
-                    });
-                    format!("{:?}", event)
+                let (router, txpool, control_panel, state_sync, config_reload) = commands;
+                let num_commands = router.len()
+                    + txpool.len()
+                    + control_panel.len()
+                    + state_sync.len()
+                    + config_reload.len();
+                let _timer = DropTimer::start(Duration::from_millis(50), |elapsed| {
+                    warn!(
+                        ?elapsed,
+                        num_commands,
+                        "long time to execute commands"
+                    )
+                });
+                let _exec_span = trace_span!("external_exec_span", num_commands).entered();
+                external_executor.exec(
+                    router,
+                    txpool,
+                    control_panel,
+                    state_sync,
+                    config_reload,
+                );
+            }
+            result = async {
+                // reserve capacity before polling an executor so an event is never pulled without room to retain it.
+                let permit = consensus_event_tx.clone().reserve_owned().await;
+                let event = external_executor.next().await;
+                (permit, event)
+            }, if !shutting_down => {
+                let (Ok(permit), Some(event)) = result else {
+                    event!(Level::ERROR, "parent executor or consensus thread stopped");
+                    return Err(());
                 };
 
-                {
-                    let _ledger_span = ledger_span.enter();
-                    if event.is_wal_logged() {
-                        if let Some(waltrace_tx) = waltrace_tx.as_ref() {
-                            let wal_event = LogFriendlyMonadEvent {
-                                timestamp: Utc::now(),
-                                event: event.lossy_clone(),
-                            };
-                            match waltrace_tx.try_send(wal_event) {
-                                Ok(()) => {}
-                                Err(TrySendError::Full(_)) => {
-                                    warn!("waltrace is lagging; dropping wal event");
-                                }
-                                Err(TrySendError::Disconnected(_)) => {
-                                    event!(Level::ERROR, "waltrace thread stopped");
-                                }
-                            }
-                        }
-                    }
-                }
-
-                let commands = {
-                    let _timer = DropTimer::start(Duration::from_millis(50), |elapsed| {
-                        warn!(
-                            ?elapsed,
-                            event =? event_debug,
-                            "long time to update event"
-                        )
-                    });
-                    let _ledger_span = ledger_span.enter();
-                    let _event_span = tracing::trace_span!("event_span", ?event).entered();
-                    let start = Instant::now();
-                    let cmds = state.update(event);
-                    let state_update_elapsed = start.elapsed();
-                    total_state_update_elapsed += state_update_elapsed;
-                    prometheus_metrics.record_state_update_elapsed(
-                        &state_update_elapsed,
-                        &total_state_update_elapsed,
-                    );
-                    cmds
-                };
-
-                if !commands.is_empty() {
-                    let num_commands = commands.len();
-                    let _timer = DropTimer::start(Duration::from_millis(50), |elapsed| {
-                        warn!(
-                            ?elapsed,
-                            event =? event_debug,
-                            num_commands,
-                            "long time to execute commands"
-                        )
-                    });
-                    let _ledger_span = ledger_span.enter();
-                    let _exec_span = tracing::trace_span!("exec_span", num_commands).entered();
-                    executor.exec(commands);
-                }
-
-                if let Some(ledger_tip) = executor.ledger.last_commit() {
-                    if last_ledger_tip.is_none_or(|last_ledger_tip| ledger_tip > last_ledger_tip) {
-                        last_ledger_tip = Some(ledger_tip);
-                        ledger_span = tracing::info_span!("ledger_span", last_ledger_tip = last_ledger_tip.map(|s| s.as_u64()));
-                    }
-                }
+                permit.send(event);
             }
         }
+    }
+
+    if consensus_thread.join().is_err() {
+        event!(Level::ERROR, "consensus thread panicked during shutdown");
+        return Err(());
     }
 
     Ok(())
@@ -996,7 +1118,7 @@ fn send_metrics(
     meter: &Meter,
     gauge_cache: &mut HashMap<&'static str, Gauge<u64>>,
     node_metrics: &NodePrometheusMetrics,
-    executor_metrics: ExecutorMetricsChain,
+    executor_metrics: &[(&'static str, ExecutorGauge, &'static str)],
 ) {
     node_metrics.refresh_dynamic_metrics();
 
@@ -1004,7 +1126,11 @@ fn send_metrics(
         .metric_handles()
         .into_iter()
         .map(|(name, gauge, help)| (name, gauge.get(), help))
-        .chain(executor_metrics.into_inner())
+        .chain(
+            executor_metrics
+                .iter()
+                .map(|(name, gauge, help)| (*name, gauge.get(), *help)),
+        )
     {
         let gauge = gauge_cache.entry(k).or_insert_with(|| {
             if desc.is_empty() {

--- a/monad-node/src/metrics.rs
+++ b/monad-node/src/metrics.rs
@@ -50,6 +50,18 @@ metric_consts! {
         name: "monad.state.total_update_us",
         help: "Total time spent updating state in microseconds",
     }
+    pub GAUGE_STATE_LAST_UPDATE_US {
+        name: "monad.state.last_update_us",
+        help: "Time spent on the most recent state update in microseconds",
+    }
+    pub GAUGE_STATE_MAX_UPDATE_US {
+        name: "monad.state.max_update_us",
+        help: "Maximum time spent on a single state update in microseconds",
+    }
+    pub GAUGE_STATE_UPDATE_COUNT {
+        name: "monad.state.update_count",
+        help: "Number of state updates",
+    }
     // Keep this already sanitized so Prometheus and OTel export the same info metric name.
     pub GAUGE_NODE_INFO {
         name: "monad_node_info",
@@ -68,6 +80,9 @@ fn init_node_executor_metrics() -> ExecutorMetrics {
     ExecutorMetrics::with_metric_defs(&[
         GAUGE_TOTAL_UPTIME_US,
         GAUGE_STATE_TOTAL_UPDATE_US,
+        GAUGE_STATE_LAST_UPDATE_US,
+        GAUGE_STATE_MAX_UPDATE_US,
+        GAUGE_STATE_UPDATE_COUNT,
         GAUGE_NODE_INFO,
     ])
 }
@@ -122,9 +137,7 @@ fn duration_micros_u64(duration: &Duration) -> u64 {
 pub struct NodePrometheusMetrics {
     registry: Registry,
     state_metrics: Vec<(&'static str, Gauge, &'static str)>,
-    total_uptime: Gauge,
-    total_state_update: Gauge,
-    node_info: Gauge,
+    node_metrics: ExecutorMetrics,
     process_start: Instant,
 }
 
@@ -145,22 +158,14 @@ impl NodePrometheusMetrics {
             registry.register(Box::new(gauge))?;
         }
 
-        let mut node_executor_metrics = init_node_executor_metrics();
-        node_executor_metrics.gauge(GAUGE_NODE_INFO).set(1);
-        node_executor_metrics.gauge(GAUGE_TOTAL_UPTIME_US).set(0);
-        node_executor_metrics
-            .gauge(GAUGE_STATE_TOTAL_UPDATE_US)
-            .set(0);
-        node_executor_metrics.register(&registry)?;
+        let mut node_metrics = init_node_executor_metrics();
+        node_metrics.gauge(GAUGE_NODE_INFO).set(1);
+        node_metrics.register(&registry)?;
 
         Ok(Self {
             registry,
             state_metrics: state_metric_handles,
-            total_uptime: node_executor_metrics.gauge(GAUGE_TOTAL_UPTIME_US).clone(),
-            total_state_update: node_executor_metrics
-                .gauge(GAUGE_STATE_TOTAL_UPDATE_US)
-                .clone(),
-            node_info: node_executor_metrics.gauge(GAUGE_NODE_INFO).clone(),
+            node_metrics,
             process_start,
         })
     }
@@ -173,33 +178,32 @@ impl NodePrometheusMetrics {
         self.state_metrics
             .iter()
             .map(|(name, gauge, help)| (*name, gauge.clone(), *help))
-            .chain([
-                (
-                    GAUGE_TOTAL_UPTIME_US.name,
-                    self.total_uptime.clone(),
-                    GAUGE_TOTAL_UPTIME_US.help,
-                ),
-                (
-                    GAUGE_STATE_TOTAL_UPDATE_US.name,
-                    self.total_state_update.clone(),
-                    GAUGE_STATE_TOTAL_UPDATE_US.help,
-                ),
-                (
-                    GAUGE_NODE_INFO.name,
-                    self.node_info.clone(),
-                    GAUGE_NODE_INFO.help,
-                ),
-            ])
+            .chain(self.node_metrics.metric_handles())
             .collect()
     }
 
-    pub fn record_state_update_elapsed(&self, total_state_update_elapsed: &Duration) {
-        self.total_state_update
+    pub fn record_state_update_elapsed(
+        &self,
+        state_update_elapsed: &Duration,
+        total_state_update_elapsed: &Duration,
+    ) {
+        let elapsed_us = duration_micros_u64(state_update_elapsed);
+        self.node_metrics
+            .gauge_handle(GAUGE_STATE_LAST_UPDATE_US)
+            .set(elapsed_us);
+        let max_state_update = self.node_metrics.gauge_handle(GAUGE_STATE_MAX_UPDATE_US);
+        max_state_update.set(max_state_update.get().max(elapsed_us));
+        self.node_metrics
+            .gauge_handle(GAUGE_STATE_UPDATE_COUNT)
+            .inc();
+        self.node_metrics
+            .gauge_handle(GAUGE_STATE_TOTAL_UPDATE_US)
             .set(duration_micros_u64(total_state_update_elapsed));
     }
 
     pub fn refresh_dynamic_metrics(&self) {
-        self.total_uptime
+        self.node_metrics
+            .gauge_handle(GAUGE_TOTAL_UPTIME_US)
             .set(duration_micros_u64(&self.process_start.elapsed()));
     }
 }

--- a/monad-testground/src/executor.rs
+++ b/monad-testground/src/executor.rs
@@ -48,10 +48,18 @@ use monad_raptorcast::{
 use monad_state::{Forkpoint, MonadMessage, MonadState, MonadStateBuilder, VerifiedMonadMessage};
 use monad_types::{Epoch, ExecutionProtocol, NodeId, Round, SeqNum};
 use monad_updaters::{
-    config_file::MockConfigFile, config_loader::MockConfigLoader, ledger::MockLedger,
-    local_router::LocalPeerRouter, loopback::LoopbackExecutor, parent::ParentExecutor,
-    statesync::MockStateSyncExecutor, timer::TokioTimer, tokio_timestamp::TokioTimestamp,
-    txpool::MockTxPoolExecutor, val_set::MockValSetUpdaterNop, BoxUpdater, Updater,
+    config_file::MockConfigFile,
+    config_loader::MockConfigLoader,
+    ledger::MockLedger,
+    local_router::LocalPeerRouter,
+    loopback::LoopbackExecutor,
+    parent::{CoreExecutor, ExternalExecutor, ParentExecutor},
+    statesync::MockStateSyncExecutor,
+    timer::TokioTimer,
+    tokio_timestamp::TokioTimestamp,
+    txpool::MockTxPoolExecutor,
+    val_set::MockValSetUpdaterNop,
+    BoxUpdater, Updater,
 };
 use monad_validator::{
     signature_collection::SignatureCollection, simple_round_robin::SimpleRoundRobin,
@@ -148,72 +156,71 @@ where
         ..Default::default()
     };
 
-    ParentExecutor {
-        metrics: Default::default(),
-        router: match config.router_config {
-            RouterConfig::Local(router) => Updater::boxed(router),
+    let router = match config.router_config {
+        RouterConfig::Local(router) => Updater::boxed(router),
 
-            RouterConfig::RaptorCast(cfg) => {
-                let pdd = PeerDiscoveryDriver::new(peer_discovery_builder);
-                let shared_peer_discovery_driver = Arc::new(Mutex::new(pdd));
+        RouterConfig::RaptorCast(cfg) => {
+            let pdd = PeerDiscoveryDriver::new(peer_discovery_builder);
+            let shared_peer_discovery_driver = Arc::new(Mutex::new(pdd));
 
-                let auth_socket_addr =
-                    SocketAddr::new(config.local_addr.ip(), config.local_addr.port() + 1);
-                let dataplane_builder = DataplaneBuilder::new(1_000)
-                    .with_udp_buffer_size(62_500_000)
-                    .with_udp_sockets([
-                        (UdpSocketId::Raptorcast, config.local_addr),
-                        (UdpSocketId::AuthenticatedRaptorcast, auth_socket_addr),
-                    ])
-                    .with_tcp_sockets([(TcpSocketId::Raptorcast, config.local_addr)]);
+            let auth_socket_addr =
+                SocketAddr::new(config.local_addr.ip(), config.local_addr.port() + 1);
+            let dataplane_builder = DataplaneBuilder::new(1_000)
+                .with_udp_buffer_size(62_500_000)
+                .with_udp_sockets([
+                    (UdpSocketId::Raptorcast, config.local_addr),
+                    (UdpSocketId::AuthenticatedRaptorcast, auth_socket_addr),
+                ])
+                .with_tcp_sockets([(TcpSocketId::Raptorcast, config.local_addr)]);
 
-                let mut dp = dataplane_builder.build();
-                assert!(dp.block_until_ready(Duration::from_secs(1)));
+            let mut dp = dataplane_builder.build();
+            assert!(dp.block_until_ready(Duration::from_secs(1)));
 
-                let tcp_socket = dp
-                    .tcp_sockets
-                    .take(TcpSocketId::Raptorcast)
-                    .expect("tcp raptorcast socket");
-                let authenticated_socket = dp
-                    .udp_sockets
-                    .take(UdpSocketId::AuthenticatedRaptorcast)
-                    .expect("authenticated raptorcast socket");
-                let non_authenticated_socket = dp
-                    .udp_sockets
-                    .take(UdpSocketId::Raptorcast)
-                    .expect("raptorcast socket");
-                let control = dp.control;
+            let tcp_socket = dp
+                .tcp_sockets
+                .take(TcpSocketId::Raptorcast)
+                .expect("tcp raptorcast socket");
+            let authenticated_socket = dp
+                .udp_sockets
+                .take(UdpSocketId::AuthenticatedRaptorcast)
+                .expect("authenticated raptorcast socket");
+            let non_authenticated_socket = dp
+                .udp_sockets
+                .take(UdpSocketId::Raptorcast)
+                .expect("raptorcast socket");
+            let control = dp.control;
 
-                let authenticated = (authenticated_socket, NoopAuthProtocol::new());
-                Updater::boxed(RaptorCast::<
-                    ST,
-                    MonadMessage<ST, SCT, MockExecutionProtocol>,
-                    VerifiedMonadMessage<ST, SCT, MockExecutionProtocol>,
-                    MonadEvent<ST, SCT, MockExecutionProtocol>,
-                    NopDiscovery<ST>,
-                    NoopAuthProtocol<CertificateSignaturePubKey<ST>>,
-                    NopScore<NodeId<CertificateSignaturePubKey<ST>>>,
-                >::new(
-                    cfg,
-                    SecondaryRaptorCastModeConfig::None,
-                    tcp_socket,
-                    authenticated,
-                    None,
-                    Some(non_authenticated_socket),
-                    control,
-                    shared_peer_discovery_driver,
-                    Epoch(0),
-                    monad_raptorcast::dummy_proposer_schedule(),
-                ))
-            }
-        },
+            let authenticated = (authenticated_socket, NoopAuthProtocol::new());
+            Updater::boxed(RaptorCast::<
+                ST,
+                MonadMessage<ST, SCT, MockExecutionProtocol>,
+                VerifiedMonadMessage<ST, SCT, MockExecutionProtocol>,
+                MonadEvent<ST, SCT, MockExecutionProtocol>,
+                NopDiscovery<ST>,
+                NoopAuthProtocol<CertificateSignaturePubKey<ST>>,
+                NopScore<NodeId<CertificateSignaturePubKey<ST>>>,
+            >::new(
+                cfg,
+                SecondaryRaptorCastModeConfig::None,
+                tcp_socket,
+                authenticated,
+                None,
+                Some(non_authenticated_socket),
+                control,
+                shared_peer_discovery_driver,
+                Epoch(0),
+                monad_raptorcast::dummy_proposer_schedule(),
+            ))
+        }
+    };
 
-        timer: TokioTimer::default(),
-        ledger: match config.ledger_config {
+    let core = CoreExecutor::new(
+        TokioTimer::default(),
+        match config.ledger_config {
             LedgerConfig::Mock => MockLedger::new(state_read.clone()),
         },
-        config_file: MockConfigFile::default(),
-        val_set: match config.val_set_config {
+        MockConfigFile::default(),
+        match config.val_set_config {
             ValSetConfig::Mock {
                 genesis_validator_data,
                 epoch_length,
@@ -222,18 +229,22 @@ where
                 epoch_length,
             )),
         },
-        timestamp: TokioTimestamp::new(Duration::from_millis(5), 100, 10001),
-        txpool: MockTxPoolExecutor::default(),
-        control_panel: ControlPanelIpcReceiver::new(
+        TokioTimestamp::new(Duration::from_millis(5), 100, 10001),
+        LoopbackExecutor::default(),
+    );
+    let external = ExternalExecutor::new(
+        router,
+        MockTxPoolExecutor::default(),
+        ControlPanelIpcReceiver::new(
             format!("./monad_controlpanel_{}.sock", index).into(),
             Box::new(reload_handle),
             1000,
         )
         .expect("uds bind failed"),
-        loopback: LoopbackExecutor::default(),
-        state_sync: MockStateSyncExecutor::new(state_read),
-        config_loader: MockConfigLoader::default(),
-    }
+        MockStateSyncExecutor::new(state_read),
+        MockConfigLoader::default(),
+    );
+    ParentExecutor::new(core, external)
 }
 
 type MonadStateType<ST, SCT> = MonadState<

--- a/monad-updaters/src/config_file.rs
+++ b/monad-updaters/src/config_file.rs
@@ -30,7 +30,7 @@ use monad_executor::{Executor, ExecutorMetrics, ExecutorMetricsChain};
 use monad_executor_glue::ConfigFileCommand;
 use monad_types::{Epoch, ExecutionProtocol, Round, SeqNum};
 use monad_validator::signature_collection::SignatureCollection;
-use tracing::warn;
+use tracing::{instrument, warn};
 
 pub struct MockConfigFile<ST, SCT, EPT>
 where
@@ -125,6 +125,12 @@ where
         }
     }
 
+    #[instrument(
+        name = "config_write_checkpoint",
+        level = "debug",
+        skip_all,
+        fields(root_seq_num = root_seq_num.as_u64())
+    )]
     fn write_checkpoint(&self, root_seq_num: SeqNum, checkpoint: Checkpoint<ST, SCT, EPT>) {
         // write forkpoint.rlp or panic
         Self::write_checkpoint_bytes_to_path(
@@ -180,6 +186,12 @@ where
         std::fs::rename(&temp_path, path).expect("failed to rename checkpoint");
     }
 
+    #[instrument(
+        name = "config_write_validator_set",
+        level = "debug",
+        skip_all,
+        fields(epoch = new_validator_set.epoch.0)
+    )]
     fn write_validator_set(&mut self, new_validator_set: ValidatorSetDataWithEpoch<SCT>) {
         let epoch = new_validator_set.epoch;
         let validator_sets = if let Some(last_validator_set) =

--- a/monad-updaters/src/parent.rs
+++ b/monad-updaters/src/parent.rs
@@ -100,24 +100,158 @@ fn init_executor_metrics() -> ExecutorMetrics {
     ])
 }
 
-/// Single top-level executor for all other required by a node.
-/// This executor will distribute commands to the appropriate sub-executor
-/// and will poll them for events
-pub struct ParentExecutor<R, T, L, C, V, TS, TP, CP, LO, SS, CL> {
-    pub metrics: ParentExecutorMetrics,
-
-    pub router: R,
+pub struct CoreExecutor<T, L, C, V, TS, LO> {
+    metrics: ParentExecutorMetrics,
     pub timer: T,
     pub ledger: L,
     pub config_file: C,
     pub val_set: V,
     pub timestamp: TS,
+    pub loopback: LO,
+}
+
+impl<T, L, C, V, TS, LO> CoreExecutor<T, L, C, V, TS, LO> {
+    pub fn new(
+        timer: T,
+        ledger: L,
+        config_file: C,
+        val_set: V,
+        timestamp: TS,
+        loopback: LO,
+    ) -> Self {
+        Self {
+            metrics: Default::default(),
+            timer,
+            ledger,
+            config_file,
+            val_set,
+            timestamp,
+            loopback,
+        }
+    }
+
+    pub fn exec<E, ST, SCT, EPT>(
+        &mut self,
+        timer: Vec<TimerCommand<E>>,
+        ledger: Vec<LedgerCommand<ST, SCT, EPT>>,
+        config_file: Vec<ConfigFileCommand<ST, SCT, EPT>>,
+        val_set: Vec<ValSetCommand>,
+        timestamp: Vec<TimestampCommand>,
+        loopback: Vec<LoopbackCommand<E>>,
+    ) where
+        T: Executor<Command = TimerCommand<E>>,
+        L: Executor<Command = LedgerCommand<ST, SCT, EPT>>,
+        C: Executor<Command = ConfigFileCommand<ST, SCT, EPT>>,
+        V: Executor<Command = ValSetCommand>,
+        TS: Executor<Command = TimestampCommand>,
+        LO: Executor<Command = LoopbackCommand<E>>,
+        ST: CertificateSignatureRecoverable,
+        SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+        EPT: ExecutionProtocol,
+    {
+        let guard = ParentExecutorMetricsGuard::new(&mut self.metrics, GAUGE_PARENT_TOTAL_EXEC_US);
+        self.timer.exec(timer);
+        guard
+            .metrics
+            .record(GAUGE_LEDGER_TOTAL_EXEC_US, || self.ledger.exec(ledger));
+        guard.metrics.record(GAUGE_CONFIG_FILE_TOTAL_EXEC_US, || {
+            self.config_file.exec(config_file)
+        });
+        self.val_set.exec(val_set);
+        self.timestamp.exec(timestamp);
+        self.loopback.exec(loopback);
+    }
+
+    pub fn ledger(&self) -> &L {
+        &self.ledger
+    }
+}
+
+pub struct ExternalExecutor<R, TP, CP, SS, CL> {
+    metrics: ParentExecutorMetrics,
+    pub router: R,
     pub txpool: TP,
     pub control_panel: CP,
-    pub loopback: LO,
     pub state_sync: SS,
     pub config_loader: CL,
-    // if you add an executor here, you must add it to BOTH exec AND poll_next !
+}
+
+impl<R, TP, CP, SS, CL> ExternalExecutor<R, TP, CP, SS, CL> {
+    pub fn new(
+        router: R,
+        txpool: TP,
+        control_panel: CP,
+        state_sync: SS,
+        config_loader: CL,
+    ) -> Self {
+        Self {
+            metrics: Default::default(),
+            router,
+            txpool,
+            control_panel,
+            state_sync,
+            config_loader,
+        }
+    }
+
+    pub fn exec<OM, ST, SCT, EPT, BPT, ESRT, CCT, CRT>(
+        &mut self,
+        router: Vec<RouterCommand<ST, OM>>,
+        txpool: Vec<TxPoolCommand<ST, SCT, EPT, BPT, ESRT, CCT, CRT>>,
+        control_panel: Vec<ControlPanelCommand<ST>>,
+        state_sync: Vec<StateSyncCommand<ST, EPT>>,
+        config_reload: Vec<ConfigReloadCommand>,
+    ) where
+        R: Executor<Command = RouterCommand<ST, OM>>,
+        TP: Executor<Command = TxPoolCommand<ST, SCT, EPT, BPT, ESRT, CCT, CRT>>,
+        CP: Executor<Command = ControlPanelCommand<ST>>,
+        SS: Executor<Command = StateSyncCommand<ST, EPT>>,
+        CL: Executor<Command = ConfigReloadCommand>,
+        ST: CertificateSignatureRecoverable,
+        SCT: SignatureCollection<NodeIdPubKey = CertificateSignaturePubKey<ST>>,
+        EPT: ExecutionProtocol,
+        BPT: BlockPolicy<ST, SCT, EPT, ESRT, CCT, CRT>,
+        ESRT: ExecutionStateRead<ST, SCT>,
+        CCT: ChainConfig<CRT>,
+        CRT: ChainRevision,
+    {
+        let guard = ParentExecutorMetricsGuard::new(&mut self.metrics, GAUGE_PARENT_TOTAL_EXEC_US);
+        guard
+            .metrics
+            .record(GAUGE_ROUTER_TOTAL_EXEC_US, || self.router.exec(router));
+        guard
+            .metrics
+            .record(GAUGE_TXPOOL_TOTAL_EXEC_US, || self.txpool.exec(txpool));
+        self.control_panel.exec(control_panel);
+        guard.metrics.record(GAUGE_STATESYNC_TOTAL_EXEC_US, || {
+            self.state_sync.exec(state_sync)
+        });
+        self.config_loader.exec(config_reload);
+    }
+}
+
+/// Single top-level executor for all other required by a node.
+/// This executor will distribute commands to the appropriate sub-executor
+/// and will poll them for events
+pub struct ParentExecutor<R, T, L, C, V, TS, TP, CP, LO, SS, CL> {
+    pub core: CoreExecutor<T, L, C, V, TS, LO>,
+    pub external: ExternalExecutor<R, TP, CP, SS, CL>,
+}
+
+impl<R, T, L, C, V, TS, TP, CP, LO, SS, CL> ParentExecutor<R, T, L, C, V, TS, TP, CP, LO, SS, CL> {
+    pub fn new(
+        mut core: CoreExecutor<T, L, C, V, TS, LO>,
+        mut external: ExternalExecutor<R, TP, CP, SS, CL>,
+    ) -> Self {
+        let metrics = ParentExecutorMetrics::default();
+        core.metrics = metrics.clone();
+        external.metrics = metrics;
+        Self { core, external }
+    }
+
+    pub fn ledger(&self) -> &L {
+        self.core.ledger()
+    }
 }
 
 impl<
@@ -168,58 +302,59 @@ where
 
     fn exec(&mut self, commands: Vec<Command<E, OM, ST, SCT, EPT, BPT, ESRT, CCT, CRT>>) {
         let _exec_span = tracing::trace_span!("exec_span", num_cmds = commands.len()).entered();
-        let guard = ParentExecutorMetricsGuard::new(&mut self.metrics, GAUGE_PARENT_TOTAL_EXEC_US);
         let (
-            router_cmds,
-            timer_cmds,
-            ledger_cmds,
-            config_file_cmds,
-            val_set_cmds,
-            timestamp_cmds,
-            txpool_cmds,
-            control_panel_cmds,
-            loopback_cmds,
-            state_sync_cmds,
-            config_reload_cmds,
+            router,
+            timer,
+            ledger,
+            config_file,
+            val_set,
+            timestamp,
+            txpool,
+            control_panel,
+            loopback,
+            state_sync,
+            config_reload,
         ) = Command::split_commands(commands);
+        let guard =
+            ParentExecutorMetricsGuard::new(&mut self.core.metrics, GAUGE_PARENT_TOTAL_EXEC_US);
 
+        guard.metrics.record(GAUGE_ROUTER_TOTAL_EXEC_US, || {
+            self.external.router.exec(router)
+        });
+        self.core.timer.exec(timer);
         guard
             .metrics
-            .record(GAUGE_ROUTER_TOTAL_EXEC_US, || self.router.exec(router_cmds));
-        self.timer.exec(timer_cmds);
-        guard
-            .metrics
-            .record(GAUGE_LEDGER_TOTAL_EXEC_US, || self.ledger.exec(ledger_cmds));
+            .record(GAUGE_LEDGER_TOTAL_EXEC_US, || self.core.ledger.exec(ledger));
         guard.metrics.record(GAUGE_CONFIG_FILE_TOTAL_EXEC_US, || {
-            self.config_file.exec(config_file_cmds)
+            self.core.config_file.exec(config_file)
         });
-        self.val_set.exec(val_set_cmds);
-        self.timestamp.exec(timestamp_cmds);
-        guard
-            .metrics
-            .record(GAUGE_TXPOOL_TOTAL_EXEC_US, || self.txpool.exec(txpool_cmds));
-        self.control_panel.exec(control_panel_cmds);
-        self.loopback.exec(loopback_cmds);
+        self.core.val_set.exec(val_set);
+        self.core.timestamp.exec(timestamp);
+        guard.metrics.record(GAUGE_TXPOOL_TOTAL_EXEC_US, || {
+            self.external.txpool.exec(txpool)
+        });
+        self.external.control_panel.exec(control_panel);
+        self.core.loopback.exec(loopback);
         guard.metrics.record(GAUGE_STATESYNC_TOTAL_EXEC_US, || {
-            self.state_sync.exec(state_sync_cmds)
+            self.external.state_sync.exec(state_sync)
         });
-        self.config_loader.exec(config_reload_cmds);
+        self.external.config_loader.exec(config_reload);
     }
 
     fn metrics(&self) -> ExecutorMetricsChain<'_> {
         ExecutorMetricsChain::default()
-            .push(&self.metrics.0)
-            .chain(self.router.metrics())
-            .chain(self.timer.metrics())
-            .chain(self.ledger.metrics())
-            .chain(self.config_file.metrics())
-            .chain(self.val_set.metrics())
-            .chain(self.timestamp.metrics())
-            .chain(self.txpool.metrics())
-            .chain(self.control_panel.metrics())
-            .chain(self.loopback.metrics())
-            .chain(self.state_sync.metrics())
-            .chain(self.config_loader.metrics())
+            .push(&self.core.metrics.0)
+            .chain(self.external.router.metrics())
+            .chain(self.core.timer.metrics())
+            .chain(self.core.ledger.metrics())
+            .chain(self.core.config_file.metrics())
+            .chain(self.core.val_set.metrics())
+            .chain(self.core.timestamp.metrics())
+            .chain(self.external.txpool.metrics())
+            .chain(self.external.control_panel.metrics())
+            .chain(self.core.loopback.metrics())
+            .chain(self.external.state_sync.metrics())
+            .chain(self.external.config_loader.metrics())
     }
 }
 
@@ -245,22 +380,75 @@ where
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.deref_mut();
-        let guard = ParentExecutorMetricsGuard::new(&mut this.metrics, GAUGE_PARENT_TOTAL_POLL_US);
+        let guard =
+            ParentExecutorMetricsGuard::new(&mut this.core.metrics, GAUGE_PARENT_TOTAL_POLL_US);
 
-        if let Poll::Ready(Some(e)) = this.timer.next().poll_unpin(cx) {
+        if let Poll::Ready(Some(e)) = this.core.timer.next().poll_unpin(cx) {
             return Poll::Ready(Some(e));
         }
-        if let Poll::Ready(Some(e)) = this.control_panel.next().poll_unpin(cx) {
+        if let Poll::Ready(Some(e)) = this.external.control_panel.next().poll_unpin(cx) {
             return Poll::Ready(Some(e));
         }
         if let Poll::Ready(Some(e)) = guard.metrics.record(GAUGE_LEDGER_TOTAL_POLL_US, || {
-            this.ledger.next().poll_unpin(cx)
+            this.core.ledger.next().poll_unpin(cx)
         }) {
             return Poll::Ready(Some(e));
         }
         // TODO: ingesting txs should be deprioritized
         if let Poll::Ready(Some(e)) = guard.metrics.record(GAUGE_TXPOOL_TOTAL_POLL_US, || {
-            this.txpool.next().poll_unpin(cx)
+            this.external.txpool.next().poll_unpin(cx)
+        }) {
+            return Poll::Ready(Some(e));
+        }
+        if let Poll::Ready(Some(e)) = this.core.val_set.next().poll_unpin(cx) {
+            return Poll::Ready(Some(e));
+        }
+        if let Poll::Ready(Some(e)) = this.core.timestamp.next().poll_unpin(cx) {
+            return Poll::Ready(Some(e));
+        }
+        if let Poll::Ready(Some(e)) = this.core.loopback.next().poll_unpin(cx) {
+            return Poll::Ready(Some(e));
+        }
+        // TODO: consensus msgs should be prioritized
+        if let Poll::Ready(Some(e)) = guard.metrics.record(GAUGE_ROUTER_TOTAL_POLL_US, || {
+            this.external.router.next().poll_unpin(cx)
+        }) {
+            return Poll::Ready(Some(e));
+        }
+        if let Poll::Ready(Some(e)) = guard.metrics.record(GAUGE_STATESYNC_TOTAL_POLL_US, || {
+            this.external.state_sync.next().poll_unpin(cx)
+        }) {
+            return Poll::Ready(Some(e));
+        }
+        if let Poll::Ready(Some(e)) = this.external.config_loader.next().poll_unpin(cx) {
+            return Poll::Ready(Some(e));
+        }
+
+        Poll::Pending
+    }
+}
+
+impl<E, T, L, C, V, TS, LO> Stream for CoreExecutor<T, L, C, V, TS, LO>
+where
+    T: Stream<Item = E> + Unpin,
+    L: Stream<Item = E> + Unpin,
+    V: Stream<Item = E> + Unpin,
+    TS: Stream<Item = E> + Unpin,
+    LO: Stream<Item = E> + Unpin,
+    E: Debug,
+    Self: Unpin,
+{
+    type Item = E;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.deref_mut();
+        let guard = ParentExecutorMetricsGuard::new(&mut this.metrics, GAUGE_PARENT_TOTAL_POLL_US);
+
+        if let Poll::Ready(Some(e)) = this.timer.next().poll_unpin(cx) {
+            return Poll::Ready(Some(e));
+        }
+        if let Poll::Ready(Some(e)) = guard.metrics.record(GAUGE_LEDGER_TOTAL_POLL_US, || {
+            this.ledger.next().poll_unpin(cx)
         }) {
             return Poll::Ready(Some(e));
         }
@@ -271,6 +459,36 @@ where
             return Poll::Ready(Some(e));
         }
         if let Poll::Ready(Some(e)) = this.loopback.next().poll_unpin(cx) {
+            return Poll::Ready(Some(e));
+        }
+
+        Poll::Pending
+    }
+}
+
+impl<E, R, TP, CP, SS, CL> Stream for ExternalExecutor<R, TP, CP, SS, CL>
+where
+    R: Stream<Item = E> + Unpin,
+    TP: Stream<Item = E> + Unpin,
+    CP: Stream<Item = E> + Unpin,
+    SS: Stream<Item = E> + Unpin,
+    CL: Stream<Item = E> + Unpin,
+    E: Debug,
+    Self: Unpin,
+{
+    type Item = E;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.deref_mut();
+        let guard = ParentExecutorMetricsGuard::new(&mut this.metrics, GAUGE_PARENT_TOTAL_POLL_US);
+
+        if let Poll::Ready(Some(e)) = this.control_panel.next().poll_unpin(cx) {
+            return Poll::Ready(Some(e));
+        }
+        // TODO: ingesting txs should be deprioritized
+        if let Poll::Ready(Some(e)) = guard.metrics.record(GAUGE_TXPOOL_TOTAL_POLL_US, || {
+            this.txpool.next().poll_unpin(cx)
+        }) {
             return Poll::Ready(Some(e));
         }
         // TODO: consensus msgs should be prioritized
@@ -292,12 +510,7 @@ where
     }
 }
 
-impl<R, T, L, C, S, TS, TP, CP, LO, SS, CL> ParentExecutor<R, T, L, C, S, TS, TP, CP, LO, SS, CL> {
-    pub fn ledger(&self) -> &L {
-        &self.ledger
-    }
-}
-
+#[derive(Clone)]
 pub struct ParentExecutorMetrics(ExecutorMetrics);
 
 impl Default for ParentExecutorMetrics {


### PR DESCRIPTION
full proposals contain 3,750 transactions. across 86 full proposals matched by round between original and
modified clients, proposal handling on the original averaged 72.4 ms, with 71.3 ms p50, 84.2 ms p95, and
90.0 ms max. at the target 3.3 full blocks per second, the mean corresponds to about 239 ms of blocked
main-thread time per second.

while state.update runs inline, main cannot poll raptorcast or the txpool client. bft cannot rebroadcast, service
wireauth requests, receive network transactions into mempool processing, or consume mempool events until the
update returns.

move consensus state, consensus-local executors, and ledger commits to monad-consensus. keep raptorcast, txpool
access, discovery, state sync, control-panel work, and router publication on main. bound both cross-thread channels
at 1,024 items.

instrument state updates, signer recovery, ledger persistence, configuration writes, and execution-state-read
waits so blocking and io remain observable.