### PR TITLE
Fix error code for insufficient balance

### DIFF
--- a/monad-rpc/src/handlers/eth/call.rs
+++ b/monad-rpc/src/handlers/eth/call.rs
@@ -932,9 +932,7 @@ impl MonadCreateAccessListResult {
                         error: Some(message),
                     })
                 }
-                EthCallResult::OtherError => {
-                    Err(JsonRpcError::eth_call_error(error.message, error.data))
-                }
+                EthCallResult::OtherError => Err(error.into()),
                 EthCallResult::Success => Err(JsonRpcError::internal_error(
                     "unexpected successful eth_call failure".into(),
                 )),

--- a/monad-rpc/src/types/jsonrpc.rs
+++ b/monad-rpc/src/types/jsonrpc.rs
@@ -489,8 +489,8 @@ impl JsonRpcError {
 
     pub fn insufficient_funds() -> Self {
         Self {
-            code: -32003,
-            message: "Insufficient funds for gas * price + value".into(),
+            code: -32000,
+            message: "insufficient funds for gas * price + value".into(),
             data: None,
         }
     }
@@ -555,6 +555,14 @@ impl From<monad_ethcall::FailureCallResult> for JsonRpcError {
         match error.error_code {
             monad_ethcall::EthCallResult::ExecutionError => {
                 Self::eth_call_execution_revert(error.message, error.data)
+            }
+            monad_ethcall::EthCallResult::OtherError
+                if matches!(
+                    error.message.as_str(),
+                    "insufficient balance" | "insufficient balance for fee"
+                ) =>
+            {
+                Self::insufficient_funds()
             }
             _ => Self::eth_call_error(error.message, error.data),
         }


### PR DESCRIPTION
Previously we would return an internal error code for errors that were related to eth_call insufficient balance. 

This is an immediate fix, but the ideal fix is to build off of https://github.com/category-labs/monad-bft/pull/3214 and pass insufficient balance error reason as an enum variant through the FFI boundary.  

flexnet: https://github.com/category-labs/monad-integration/pull/460