### PR TITLE
build: add debian package build to the repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,8 @@
 
 **/.git
 
+/dist
+
 **/target
 
 **/*.data

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+SHELL := /bin/sh
+
+ifeq ($(origin PACKAGE_VERSION),undefined)
+PACKAGE_VERSION := $(shell ./scripts/package-version)
+endif
+
+.PHONY: build
+
+build:
+	PACKAGE_VERSION=$(PACKAGE_VERSION) ./scripts/build-binaries

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ deb-container: builder
 		--build-arg GIT_BRANCH=$(GIT_BRANCH) \
 		--build-arg GIT_TAG=$(GIT_TAG) \
 		--build-arg GIT_MODIFIED=$(GIT_MODIFIED) \
+		--build-arg GIT_COMMIT_HASH=$(GIT_COMMIT) \
 		-t monad-bft-package:$(PACKAGE_VERSION) -f docker/debian-package/Dockerfile .
 	@mkdir -p $(DEB_OUTPUT_DIR); container_id=$$($(CONTAINER_ENGINE) create monad-bft-package:$(PACKAGE_VERSION) true); trap '$(CONTAINER_ENGINE) rm -f $$container_id >/dev/null' EXIT; $(CONTAINER_ENGINE) cp $$container_id:/out/. $(DEB_OUTPUT_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -13,19 +13,20 @@ GIT_BRANCH ?= $(shell git branch --show-current 2>/dev/null)
 GIT_TAG ?= $(shell git describe --tags --exact-match HEAD 2>/dev/null)
 GIT_MODIFIED ?= $(shell test -n "$$(git status --porcelain 2>/dev/null)" && echo true || echo false)
 
-.PHONY: build builder deb deb-container clean
+.PHONY: build builder deb deb-host clean
 
 build:
 	PACKAGE_VERSION=$(PACKAGE_VERSION) ./scripts/build-binaries
 
-deb:
+# Needs the docker/builder toolchain on the host; `make deb` needs only a container engine.
+deb-host:
 	PACKAGE_VERSION=$(PACKAGE_VERSION) DEB_OUTPUT_DIR=$(DEB_OUTPUT_DIR) ./scripts/build-deb
 
 builder:
 	@test -n "$(CONTAINER_ENGINE)" || { echo "Install Docker or Podman, or set CONTAINER_ENGINE."; exit 1; }
 	$(CONTAINER_ENGINE) build -t $(BUILDER_IMAGE) docker/builder
 
-deb-container: builder
+deb: builder
 	$(CONTAINER_ENGINE) build \
 		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
 		--build-arg PACKAGE_VERSION=$(PACKAGE_VERSION) \

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,10 @@ builder:
 	$(CONTAINER_ENGINE) build -t $(BUILDER_IMAGE) docker/builder
 
 deb: builder
+	@mkdir -p $(DEB_OUTPUT_DIR); iidfile=$$(mktemp); \
+	trap 'rm -f "$$iidfile"' EXIT; \
 	$(CONTAINER_ENGINE) build \
+		--iidfile "$$iidfile" \
 		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
 		--build-arg PACKAGE_VERSION=$(PACKAGE_VERSION) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
@@ -35,8 +38,10 @@ deb: builder
 		--build-arg GIT_TAG=$(GIT_TAG) \
 		--build-arg GIT_MODIFIED=$(GIT_MODIFIED) \
 		--build-arg GIT_COMMIT_HASH=$(GIT_COMMIT) \
-		-t monad-bft-package:$(PACKAGE_VERSION) -f docker/debian-package/Dockerfile .
-	@mkdir -p $(DEB_OUTPUT_DIR); container_id=$$($(CONTAINER_ENGINE) create monad-bft-package:$(PACKAGE_VERSION) true); trap '$(CONTAINER_ENGINE) rm -f $$container_id >/dev/null' EXIT; $(CONTAINER_ENGINE) cp $$container_id:/out/. $(DEB_OUTPUT_DIR)
+		-f docker/debian-package/Dockerfile . && \
+	container_id=$$($(CONTAINER_ENGINE) create "$$(cat "$$iidfile")" true) && \
+	trap '$(CONTAINER_ENGINE) rm -f $$container_id >/dev/null; rm -f "$$iidfile"' EXIT && \
+	$(CONTAINER_ENGINE) cp "$$container_id":/out/. $(DEB_OUTPUT_DIR)
 
 clean:
 	rm -rf $(DEB_OUTPUT_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,40 @@
 SHELL := /bin/sh
 
+CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 ifeq ($(origin PACKAGE_VERSION),undefined)
 PACKAGE_VERSION := $(shell ./scripts/package-version)
 endif
+DEB_OUTPUT_DIR ?= dist
+BUILDER_IMAGE ?= monad-bft-builder:local
 
-.PHONY: build
+# Passed into the container build, which has no .git to read them from.
+GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null)
+GIT_BRANCH ?= $(shell git branch --show-current 2>/dev/null)
+GIT_TAG ?= $(shell git describe --tags --exact-match HEAD 2>/dev/null)
+GIT_MODIFIED ?= $(shell test -n "$$(git status --porcelain 2>/dev/null)" && echo true || echo false)
+
+.PHONY: build builder deb deb-container clean
 
 build:
 	PACKAGE_VERSION=$(PACKAGE_VERSION) ./scripts/build-binaries
+
+deb:
+	PACKAGE_VERSION=$(PACKAGE_VERSION) DEB_OUTPUT_DIR=$(DEB_OUTPUT_DIR) ./scripts/build-deb
+
+builder:
+	@test -n "$(CONTAINER_ENGINE)" || { echo "Install Docker or Podman, or set CONTAINER_ENGINE."; exit 1; }
+	$(CONTAINER_ENGINE) build -t $(BUILDER_IMAGE) docker/builder
+
+deb-container: builder
+	$(CONTAINER_ENGINE) build \
+		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
+		--build-arg PACKAGE_VERSION=$(PACKAGE_VERSION) \
+		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
+		--build-arg GIT_BRANCH=$(GIT_BRANCH) \
+		--build-arg GIT_TAG=$(GIT_TAG) \
+		--build-arg GIT_MODIFIED=$(GIT_MODIFIED) \
+		-t monad-bft-package:$(PACKAGE_VERSION) -f docker/debian-package/Dockerfile .
+	@mkdir -p $(DEB_OUTPUT_DIR); container_id=$$($(CONTAINER_ENGINE) create monad-bft-package:$(PACKAGE_VERSION) true); trap '$(CONTAINER_ENGINE) rm -f $$container_id >/dev/null' EXIT; $(CONTAINER_ENGINE) cp $$container_id:/out/. $(DEB_OUTPUT_DIR)
+
+clean:
+	rm -rf $(DEB_OUTPUT_DIR)

--- a/debian/DEBIAN/control.in
+++ b/debian/DEBIAN/control.in
@@ -1,0 +1,10 @@
+Package: monad
+Version: @PACKAGE_VERSION@
+Section: net
+Priority: optional
+Architecture: amd64
+Maintainer: Category Labs <engineering@category.xyz>
+Depends: @DEPENDS@, libhugetlbfs-bin
+Description: Monad BFT stack
+ Consensus, execution, RPC, and archive binaries with their bundled native
+ libraries, systemd units, and operational scripts.

--- a/debian/DEBIAN/control.in
+++ b/debian/DEBIAN/control.in
@@ -4,7 +4,7 @@ Section: net
 Priority: optional
 Architecture: amd64
 Maintainer: Category Labs <engineering@category.xyz>
-Depends: @DEPENDS@, libhugetlbfs-bin
+Depends: @DEPENDS@, libhugetlbfs-bin, cron, whiptail
 Description: Monad BFT stack
  Consensus, execution, RPC, and archive binaries with their bundled native
  libraries, systemd units, and operational scripts.

--- a/debian/DEBIAN/postrm
+++ b/debian/DEBIAN/postrm
@@ -12,7 +12,11 @@ case "$1" in
     rm -f /etc/sysctl.d/90-monad-network-buffer.conf
     # NOTE: this leaves the backup keys folder
     USER="monad"
-    crontab -u "$USER" -l 2>/dev/null | grep -v -F -x -f /opt/monad/scripts/clear-old-artifacts.cron | crontab -u "$USER" -
+    # Depends: declares cron/whiptail now, but hosts that installed under an
+    # older control file may lack cron; guard so removal never fails on them.
+    if command -v crontab >/dev/null 2>&1; then
+      crontab -u "$USER" -l 2>/dev/null | grep -v -F -x -f /opt/monad/scripts/clear-old-artifacts.cron | crontab -u "$USER" -
+    fi
     rm -f /opt/monad/scripts/clear-old-artifacts.cron && rm -f /opt/monad/opt/monad/scripts/clear-old-artifacts.sh
     prefix="monad-"
     for svc in $(systemctl list-units --type=service --all --no-legend | awk '{print $1}' | grep "^${prefix}"); do

--- a/debian/DEBIAN/postrm
+++ b/debian/DEBIAN/postrm
@@ -12,8 +12,7 @@ case "$1" in
     rm -f /etc/sysctl.d/90-monad-network-buffer.conf
     # NOTE: this leaves the backup keys folder
     USER="monad"
-    # Depends: declares cron/whiptail now, but hosts that installed under an
-    # older control file may lack cron; guard so removal never fails on them.
+    # Older control files lack cron; guard so removal never fails.
     if command -v crontab >/dev/null 2>&1; then
       crontab -u "$USER" -l 2>/dev/null | grep -v -F -x -f /opt/monad/scripts/clear-old-artifacts.cron | crontab -u "$USER" -
     fi
@@ -34,3 +33,7 @@ case "$1" in
     fi
     ;;
 esac
+
+# Bundled /usr/local/lib libraries are gone; refresh the linker cache
+# (cf. postinst, Debian Policy 8.1.1).
+ldconfig

--- a/docker/debian-package/Dockerfile
+++ b/docker/debian-package/Dockerfile
@@ -1,0 +1,50 @@
+# syntax=docker/dockerfile:1
+
+# Toolchain comes from docker/builder/Dockerfile, the image Jenkins builds with.
+# `make deb-container` builds it locally; override to reuse a prebuilt copy.
+ARG BUILDER_IMAGE=monad-bft-builder:local
+FROM ${BUILDER_IMAGE} AS package
+
+ARG PACKAGE_VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    CARGO_NET_GIT_FETCH_WITH_CLI=true \
+    LIBCLANG_PATH=/usr/lib/llvm-19/lib
+
+# Only what docker/builder does not already carry: libclang for bindgen,
+# build-essential for the packaging tools (including dpkg-shlibdeps), and
+# patchelf to remove build-tree runpaths before dependency analysis.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential libclang-19-dev patchelf \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN test -n "$PACKAGE_VERSION"
+
+# monad-version resolves these from git, then falls back to the environment.
+# .dockerignore strips **/.git, so without them the binaries report no
+# provenance. Same contract as docker/rpc/Dockerfile.
+ARG GIT_COMMIT=""
+ARG GIT_BRANCH=""
+ARG GIT_TAG=""
+ARG GIT_MODIFIED="false"
+
+ENV GIT_COMMIT=$GIT_COMMIT \
+    GIT_BRANCH=$GIT_BRANCH \
+    GIT_TAG=$GIT_TAG \
+    GIT_MODIFIED=$GIT_MODIFIED
+
+WORKDIR /src
+COPY . .
+
+# A real release checkout must include the pinned execution repository.  This is
+# deliberately verified here instead of cloning an unpinned dependency at build time.
+RUN test -f monad-execution/CMakeLists.txt
+
+RUN --mount=type=cache,id=monad-bft-cargo-registry,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=monad-bft-cargo-git,target=/usr/local/cargo/git \
+    --mount=type=cache,id=monad-bft-target,target=/src/target \
+    --mount=type=cache,id=monad-bft-execution-build,target=/src/monad-execution/build \
+    PACKAGE_VERSION="${PACKAGE_VERSION}" DEB_OUTPUT_DIR=/out ./scripts/build-deb
+
+FROM scratch
+COPY --from=package /out /out

--- a/docker/debian-package/Dockerfile
+++ b/docker/debian-package/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Toolchain comes from docker/builder/Dockerfile, the image Jenkins builds with.
-# `make deb-container` builds it locally; override to reuse a prebuilt copy.
+# `make deb` builds it locally; override to reuse a prebuilt copy.
 ARG BUILDER_IMAGE=monad-bft-builder:local
 FROM ${BUILDER_IMAGE} AS package
 

--- a/docker/debian-package/Dockerfile
+++ b/docker/debian-package/Dockerfile
@@ -27,11 +27,14 @@ ARG GIT_COMMIT=""
 ARG GIT_BRANCH=""
 ARG GIT_TAG=""
 ARG GIT_MODIFIED="false"
+# Stamps monad / monad-cli / monad-mpt via monad-execution's cmake.
+ARG GIT_COMMIT_HASH=""
 
 ENV GIT_COMMIT=$GIT_COMMIT \
     GIT_BRANCH=$GIT_BRANCH \
     GIT_TAG=$GIT_TAG \
-    GIT_MODIFIED=$GIT_MODIFIED
+    GIT_MODIFIED=$GIT_MODIFIED \
+    GIT_COMMIT_HASH=$GIT_COMMIT_HASH
 
 WORKDIR /src
 COPY . .
@@ -43,7 +46,7 @@ RUN test -f monad-execution/CMakeLists.txt
 RUN --mount=type=cache,id=monad-bft-cargo-registry,target=/usr/local/cargo/registry \
     --mount=type=cache,id=monad-bft-cargo-git,target=/usr/local/cargo/git \
     --mount=type=cache,id=monad-bft-target,target=/src/target \
-    --mount=type=cache,id=monad-bft-execution-build,target=/src/monad-execution/build \
+    --mount=type=cache,id=monad-bft-execution-build,target=/src/monad-execution/build,sharing=locked \
     PACKAGE_VERSION="${PACKAGE_VERSION}" DEB_OUTPUT_DIR=/out ./scripts/build-deb
 
 FROM scratch

--- a/scripts/build-binaries
+++ b/scripts/build-binaries
@@ -12,11 +12,11 @@ fi
 # --- toolchain (matches .github/workflows/rust.yml and docker/builder) ---
 export CC="${CC:-gcc-15}"
 export CXX="${CXX:-g++-15}"
-export ASMFLAGS="${ASMFLAGS:--march=haswell}"
-export CFLAGS="${CFLAGS:--march=haswell}"
 export RUSTFLAGS="${RUSTFLAGS:--C force-frame-pointers=yes -C target-cpu=haswell}"
 export TRIEDB_TARGET="${TRIEDB_TARGET:-triedb_driver}"
-# Not exported: each build below sets CXXFLAGS itself.
+# Arch flags reach the cargo build only; the cmake toolchain file owns its own.
+asmflags="${ASMFLAGS:--march=haswell}"
+cflags="${CFLAGS:--march=haswell}"
 cxxflags="${CXXFLAGS:--march=haswell}"
 
 # --- version stamping ---
@@ -28,6 +28,7 @@ fi
 cd "$root_dir"
 
 # --- rust binaries ---
+ASMFLAGS="$asmflags" CFLAGS="$cflags" \
 CXXFLAGS="$cxxflags -DQUILL_ACTIVE_LOG_LEVEL=QUILL_LOG_LEVEL_CRITICAL" \
 cargo build --locked --release \
   --bin monad-node \
@@ -45,7 +46,6 @@ cargo build --locked --release \
   --example txgen
 
 # --- standalone execution binaries (cmake) ---
-CXXFLAGS="$cxxflags" \
 cmake -S monad-execution -B monad-execution/build \
   -G "${CMAKE_GENERATOR:-Ninja}" \
   -DCMAKE_TOOLCHAIN_FILE:STRING="$root_dir/monad-execution/category/core/toolchains/gcc-avx2.cmake" \

--- a/scripts/build-binaries
+++ b/scripts/build-binaries
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+set -eu
+
+root_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+# --- pinned monad-execution submodule ---
+if [ ! -f "$root_dir/monad-execution/CMakeLists.txt" ]; then
+  echo "Initializing the pinned monad-execution submodule..." >&2
+  git -C "$root_dir" submodule update --init --recursive monad-execution
+fi
+
+# --- toolchain (matches .github/workflows/rust.yml and docker/builder) ---
+export CC="${CC:-gcc-15}"
+export CXX="${CXX:-g++-15}"
+export ASMFLAGS="${ASMFLAGS:--march=haswell}"
+export CFLAGS="${CFLAGS:--march=haswell}"
+export RUSTFLAGS="${RUSTFLAGS:--C force-frame-pointers=yes -C target-cpu=haswell}"
+export TRIEDB_TARGET="${TRIEDB_TARGET:-triedb_driver}"
+# Not exported: each build below sets CXXFLAGS itself.
+cxxflags="${CXXFLAGS:--march=haswell}"
+
+# --- version stamping ---
+# monad-node and monad-rpc read MONAD_VERSION at compile time via option_env!.
+if [ -z "${MONAD_VERSION:-}" ] && [ -n "${PACKAGE_VERSION:-}" ]; then
+  export MONAD_VERSION="$PACKAGE_VERSION"
+fi
+
+cd "$root_dir"
+
+# --- rust binaries ---
+CXXFLAGS="$cxxflags -DQUILL_ACTIVE_LOG_LEVEL=QUILL_LOG_LEVEL_CRITICAL" \
+cargo build --locked --release \
+  --bin monad-node \
+  --bin monad-keystore \
+  --bin monad-debug-node \
+  --bin monad-rpc \
+  --bin monad-archiver \
+  --bin monad-archive-checker \
+  --bin monad-indexer \
+  --bin monad-block-writer \
+  --example ledger-tail \
+  --example wal2json \
+  --example triedb-bench \
+  --example sign-name-record \
+  --example txgen
+
+# --- standalone execution binaries (cmake) ---
+CXXFLAGS="$cxxflags" \
+cmake -S monad-execution -B monad-execution/build \
+  -G "${CMAKE_GENERATOR:-Ninja}" \
+  -DCMAKE_TOOLCHAIN_FILE:STRING="$root_dir/monad-execution/category/core/toolchains/gcc-avx2.cmake" \
+  -DCMAKE_BUILD_TYPE:STRING="${CMAKE_BUILD_TYPE:-RelWithDebInfo}" \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE
+
+cmake --build monad-execution/build --target all

--- a/scripts/build-binaries
+++ b/scripts/build-binaries
@@ -9,7 +9,7 @@ if [ ! -f "$root_dir/monad-execution/CMakeLists.txt" ]; then
   git -C "$root_dir" submodule update --init --recursive monad-execution
 fi
 
-# --- toolchain (matches .github/workflows/rust.yml and docker/builder) ---
+# --- toolchain (matches the Jenkins release build, in the docker/builder image) ---
 export CC="${CC:-gcc-15}"
 export CXX="${CXX:-g++-15}"
 export RUSTFLAGS="${RUSTFLAGS:--C force-frame-pointers=yes -C target-cpu=haswell}"

--- a/scripts/build-deb
+++ b/scripts/build-deb
@@ -1,0 +1,95 @@
+#!/usr/bin/env sh
+set -eu
+
+root_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+output_dir=${DEB_OUTPUT_DIR:-"$root_dir/dist"}
+strip_symbols=${STRIP_SYMBOLS:-0}
+stage_dir="$root_dir/target/debian/monad"
+
+# --- version ---
+version=${PACKAGE_VERSION:-$("$root_dir/scripts/package-version")}
+case "$version" in
+  *[!0-9A-Za-z.+:~\-]*) echo "Invalid Debian version: $version" >&2; exit 2 ;;
+esac
+
+cd "$root_dir"
+
+# --- build ---
+PACKAGE_VERSION="$version" "$root_dir/scripts/build-binaries"
+
+# --- stage binaries ---
+rm -rf "$stage_dir"
+mkdir -p "$stage_dir/DEBIAN" "$stage_dir/usr/local/bin" "$stage_dir/usr/local/lib"
+
+# Install binaries under the names the fleet expects: the ledger-tail,
+# sign-name-record, and txgen examples gain a monad- prefix.
+while read -r source name; do
+  install -m 0755 "$source" "$stage_dir/usr/local/bin/$name"
+done <<EOF
+target/release/monad-node monad-node
+target/release/monad-keystore monad-keystore
+target/release/monad-debug-node monad-debug-node
+target/release/monad-rpc monad-rpc
+target/release/monad-archiver monad-archiver
+target/release/monad-archive-checker monad-archive-checker
+target/release/monad-indexer monad-indexer
+target/release/monad-block-writer monad-block-writer
+target/release/examples/ledger-tail monad-ledger-tail
+target/release/examples/sign-name-record monad-sign-name-record
+target/release/examples/txgen monad-txgen
+target/release/examples/wal2json wal2json
+target/release/examples/triedb-bench triedb-bench
+monad-execution/build/category/mpt/monad-mpt monad-mpt
+monad-execution/build/cmd/monad monad
+monad-execution/build/cmd/monad-cli monad-cli
+EOF
+
+# --- stage libraries ---
+# Bundle libtriedb_driver.so, which is loaded with dlopen at runtime and so
+# never appears as a declared dependency, plus every library that the staged
+# binaries or the driver resolve from inside this source tree. Those are
+# build products the target host does not have. ldd lists dependencies
+# transitively, so one pass is enough, and dpkg-shlibdeps below fails the
+# build if anything is missed here.
+triedb=$(find target/release -name 'libtriedb_driver.so' -exec ls -Lt {} + | head -n 1)
+test -n "$triedb" || { echo "libtriedb_driver.so not found under target/release" >&2; exit 2; }
+cp "$triedb" "$stage_dir/usr/local/lib/"
+ldd "$stage_dir"/usr/local/bin/* "$triedb" \
+  | awk -v root="$root_dir/" '$2 == "=>" && index($3, root) == 1 { print $3 }' \
+  | sort -u | xargs -I {} cp {} "$stage_dir/usr/local/lib/"
+
+if [ "$strip_symbols" = 1 ]; then
+  find "$stage_dir/usr/local/bin" -type f -exec strip --strip-all {} \;
+  find "$stage_dir/usr/local/lib" -type f -name '*.so*' -exec strip --strip-unneeded {} \;
+fi
+
+# --- check linkage & compute library dependencies ---
+# Strip build-tree runpaths, then run dpkg-shlibdeps to generate Depends.
+#
+# For every library our binaries need, dpkg-shlibdeps locates the file and
+# maps it to a package: our own libraries (such as libtriedb_driver.so)
+# resolve inside the debian/monad staging tree and need no Depends entry;
+# system libraries become versioned Depends. Anything it can't attribute to
+# a package fails the build.
+#
+# Runpaths into the build tree have to go first, or a library that's absent
+# on the target host still resolves here and the check passes wrongly.
+# Installed binaries find their libraries through ldconfig instead.
+find "$stage_dir/usr/local/bin" "$stage_dir/usr/local/lib" -type f \
+  -exec patchelf --remove-rpath {} \;
+printf 'Source: monad\n\nPackage: monad\nArchitecture: amd64\nDescription: stub\n' \
+  > "$root_dir/target/debian/control"
+lib_deps=$(cd "$root_dir/target" && dpkg-shlibdeps -O \
+  debian/monad/usr/local/bin/* debian/monad/usr/local/lib/*.so*)
+rm "$root_dir/target/debian/control"
+lib_deps=${lib_deps#shlibs:Depends=}
+
+# --- debian metadata ---
+cp -a debian/. "$stage_dir/"
+sed -e "s/@PACKAGE_VERSION@/$version/" -e "s%@DEPENDS@%$lib_deps%" \
+  debian/DEBIAN/control.in > "$stage_dir/DEBIAN/control"
+rm "$stage_dir/DEBIAN/control.in"
+
+# --- package ---
+mkdir -p "$output_dir"
+dpkg-deb --root-owner-group --build "$stage_dir" "$output_dir/monad_${version}_amd64.deb"

--- a/scripts/build-deb
+++ b/scripts/build-deb
@@ -4,7 +4,10 @@ set -eu
 root_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 output_dir=${DEB_OUTPUT_DIR:-"$root_dir/dist"}
 strip_symbols=${STRIP_SYMBOLS:-0}
-stage_dir="$root_dir/target/debian/monad"
+# Stage outside target/, which is a shared cache mount in container builds.
+stage_root=$(mktemp -d)
+trap 'rm -rf "$stage_root"' EXIT
+stage_dir="$stage_root/debian/monad"
 
 # --- version ---
 version=${PACKAGE_VERSION:-$("$root_dir/scripts/package-version")}
@@ -18,7 +21,6 @@ cd "$root_dir"
 PACKAGE_VERSION="$version" "$root_dir/scripts/build-binaries"
 
 # --- stage binaries ---
-rm -rf "$stage_dir"
 mkdir -p "$stage_dir/DEBIAN" "$stage_dir/usr/local/bin" "$stage_dir/usr/local/lib"
 
 # Install binaries under the names the fleet expects: the ledger-tail,
@@ -54,9 +56,30 @@ EOF
 triedb=$(find target/release -name 'libtriedb_driver.so' -exec ls -Lt {} + | head -n 1)
 test -n "$triedb" || { echo "libtriedb_driver.so not found under target/release" >&2; exit 2; }
 cp "$triedb" "$stage_dir/usr/local/lib/"
-ldd "$stage_dir"/usr/local/bin/* "$triedb" \
+libs=$(ldd "$stage_dir"/usr/local/bin/* "$triedb" \
   | awk -v root="$root_dir/" '$2 == "=>" && index($3, root) == 1 { print $3 }' \
-  | sort -u | xargs -I {} cp {} "$stage_dir/usr/local/lib/"
+  | sort -u)
+seen=" "
+for lib in $libs; do
+  base=${lib##*/}
+  case $seen in
+    *" $base "*)
+      # libkeccak.so is built identically by both cargo-driven cmake trees.
+      if [ "$base" != "libkeccak.so" ]; then
+        echo "Bundled library basename collision: $base ($lib)" >&2
+        exit 2
+      fi
+      ;;
+  esac
+  seen="$seen$base "
+  cp "$lib" "$stage_dir/usr/local/lib/"
+done
+
+# The 26.04 builder's libsecp256k1 soname exists on no fleet host; bundle it like Jenkins.
+secp=/usr/lib/x86_64-linux-gnu/libsecp256k1.so.6
+if [ -e "$secp" ]; then
+  cp -L "$secp" "$stage_dir/usr/local/lib/"
+fi
 
 if [ "$strip_symbols" = 1 ]; then
   find "$stage_dir/usr/local/bin" -type f -exec strip --strip-all {} \;
@@ -69,19 +92,27 @@ fi
 # For every library our binaries need, dpkg-shlibdeps locates the file and
 # maps it to a package: our own libraries (such as libtriedb_driver.so)
 # resolve inside the debian/monad staging tree and need no Depends entry;
-# system libraries become versioned Depends. Anything it can't attribute to
-# a package fails the build.
+# system libraries become versioned Depends.
 #
 # Runpaths into the build tree have to go first, or a library that's absent
 # on the target host still resolves here and the check passes wrongly.
 # Installed binaries find their libraries through ldconfig instead.
 find "$stage_dir/usr/local/bin" "$stage_dir/usr/local/lib" -type f \
   -exec patchelf --remove-rpath {} \;
+
+# dpkg-shlibdeps only warns about libraries it cannot find, so fail on them here.
+unresolved=$(LD_LIBRARY_PATH="$stage_dir/usr/local/lib" \
+  ldd "$stage_dir"/usr/local/bin/* "$stage_dir"/usr/local/lib/*.so* 2>/dev/null \
+  | grep 'not found' || true)
+if [ -n "$unresolved" ]; then
+  printf 'Unresolved shared libraries after staging:\n%s\n' "$unresolved" >&2
+  exit 2
+fi
+
 printf 'Source: monad\n\nPackage: monad\nArchitecture: amd64\nDescription: stub\n' \
-  > "$root_dir/target/debian/control"
-lib_deps=$(cd "$root_dir/target" && dpkg-shlibdeps -O \
+  > "$stage_root/debian/control"
+lib_deps=$(cd "$stage_root" && dpkg-shlibdeps -O \
   debian/monad/usr/local/bin/* debian/monad/usr/local/lib/*.so*)
-rm "$root_dir/target/debian/control"
 lib_deps=${lib_deps#shlibs:Depends=}
 
 # --- debian metadata ---

--- a/scripts/build-deb
+++ b/scripts/build-deb
@@ -79,6 +79,9 @@ done
 secp=/usr/lib/x86_64-linux-gnu/libsecp256k1.so.6
 if [ -e "$secp" ]; then
   cp -L "$secp" "$stage_dir/usr/local/lib/"
+else
+  echo "libsecp256k1.so.6 not found - soname bumped in the builder image?" >&2
+  exit 2
 fi
 
 if [ "$strip_symbols" = 1 ]; then

--- a/scripts/package-version
+++ b/scripts/package-version
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+# Single source of truth for the Debian package version, used by the Makefile
+# and as scripts/build-deb's fallback. Requires a git checkout; container
+# builds have no .git and must receive PACKAGE_VERSION explicitly.
+set -eu
+
+root_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+timestamp=$(git -C "$root_dir" log -1 --format=%cd --date=format:%Y%m%d-%H%M)
+sha=$(git -C "$root_dir" rev-parse --short=7 HEAD)
+printf '0.0-%s-%s\n' "$timestamp" "$sha"


### PR DESCRIPTION
Adds a Makefile and scripts to build the monad .deb from this repo: `make deb` builds in the `docker/builder` image, bundles in-tree libraries via `ldd`, and derives `Depends` with `dpkg-shlibdeps` instead of hand-maintained lists in the Jenkins shared library. Inert on merge — nothing calls it yet.