### PR TITLE
monad-sim tests for MVBA protocol

### DIFF
--- a/monad-mcp-chorus-sim/src/lib.rs
+++ b/monad-mcp-chorus-sim/src/lib.rs
@@ -13,8 +13,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+mod mvba;
 mod node;
 mod swarm;
 
+pub use mvba::{Decision, Message, MonadMvba, MvbaSwarm, MvbaSwarmBuilder, at_millis};
 pub use node::SimNode;
 pub use swarm::{CadenceSwarm, CadenceSwarmBuilder, FinalizationLog};

--- a/monad-mcp-chorus-sim/src/mvba.rs
+++ b/monad-mcp-chorus-sim/src/mvba.rs
@@ -1,0 +1,263 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The fallback path's agreement protocol on a simulated network, with no
+//! Chorus around it. Each node is one [`MonadMvba`] whose fallback input is
+//! pre-formed -- or absent, for a validator the fast path left nothing for
+//!
+//! Broadcasts reach the sender too, which is what supplies a node its own vote:
+//! the state machine counts every vote off the wire, its own included
+
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, HashMap},
+    rc::Rc,
+    time::Duration,
+};
+
+use chorus::{
+    slot::fallback::{EnterFallbackCert, Metablock, MvbaRuntime, monad_mvba},
+    types::{NodeId, Timestamp},
+};
+use monad_mcp_chorus::stub as chorus;
+use monad_sim::{RunOutcome, Time};
+use monad_sim_swarm::{Network, Swarm};
+
+use crate::{
+    node::{SimNode, time_of, to_timestamp},
+    swarm::build_sim_swarm,
+};
+
+// the `V = Metablock` instantiation, the one the fallback path runs
+pub type MonadMvba = monad_mvba::MonadMvba<Metablock, EnterFallbackCert>;
+pub type Message = monad_mvba::MvbaMessage<Metablock, EnterFallbackCert>;
+
+type MvbaNodeRuntime = MvbaRuntime<MonadMvba, Metablock>;
+
+/// What one node decided, and when
+#[derive(Clone, Debug)]
+pub struct Decision {
+    pub at: Time,
+    pub block: Metablock,
+}
+
+/// What one node reported: its first decision, and whether a later report
+/// disagreed with it, which integrity forbids
+#[derive(Default)]
+struct DecisionState {
+    first: Option<Decision>,
+    conflict_decision: bool,
+}
+
+/// Per-node decisions, shared with the observers planted in the runtimes
+#[derive(Default)]
+struct DecisionLog(HashMap<NodeId, Rc<RefCell<DecisionState>>>);
+
+impl DecisionLog {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn record_decision(&mut self, node: NodeId) -> impl FnMut(Timestamp, &Metablock) + 'static {
+        let state = self.0.entry(node).or_default().clone();
+        move |at: Timestamp, block: &Metablock| {
+            let mut state = state.borrow_mut();
+            match &state.first {
+                None => {
+                    state.first = Some(Decision {
+                        at: time_of(at),
+                        block: block.clone(),
+                    })
+                }
+                Some(first) => {
+                    if first.block != *block {
+                        state.conflict_decision = true;
+                    }
+                }
+            }
+        }
+    }
+
+    fn decision_of(&self, node: &NodeId) -> Option<Decision> {
+        self.0.get(node)?.borrow().first.clone()
+    }
+
+    fn conflicted(&self, node: &NodeId) -> bool {
+        self.0
+            .get(node)
+            .is_some_and(|state| state.borrow().conflict_decision)
+    }
+}
+
+/// Assembles MVBA instances over one network, each with a start of its own:
+/// the four inputs can be handed over at four different times
+pub struct MvbaSwarmBuilder {
+    seed: u64,
+    network: Network<NodeId, Message>,
+    nodes: Vec<(NodeId, SimNode<Message>)>,
+    inputs: BTreeMap<NodeId, Metablock>,
+    log: DecisionLog,
+}
+
+impl MvbaSwarmBuilder {
+    pub fn new() -> Self {
+        Self {
+            seed: 0,
+            network: Network::default(),
+            nodes: Vec::new(),
+            inputs: BTreeMap::new(),
+            log: DecisionLog::new(),
+        }
+    }
+
+    pub fn set_seed(&mut self, seed: u64) -> &mut Self {
+        self.seed = seed;
+        self
+    }
+
+    pub fn set_network(&mut self, network: Network<NodeId, Message>) -> &mut Self {
+        self.network = network;
+        self
+    }
+
+    /// `start` is when this node hands its input to its state machine
+    pub fn add_node(
+        &mut self,
+        id: NodeId,
+        mvba: MonadMvba,
+        block: Metablock,
+        cert: Option<EnterFallbackCert>,
+        start: Time,
+    ) -> &mut Self {
+        self.inputs.insert(id, block.clone());
+        self.push(id, MvbaRuntime::new(mvba, block, cert), start)
+    }
+
+    /// Add a validator with no fallback input, which therefore only listens.
+    /// Having nothing to hand over, it needs no start
+    pub fn add_listener(&mut self, id: NodeId, mvba: MonadMvba) -> &mut Self {
+        self.push(id, MvbaRuntime::listening(mvba), Time(0))
+    }
+
+    fn push(&mut self, id: NodeId, mut runtime: MvbaNodeRuntime, start: Time) -> &mut Self {
+        runtime.set_start(to_timestamp(start));
+        runtime.on_decision(self.log.record_decision(id));
+        self.nodes.push((id, SimNode::new(id, runtime)));
+        self
+    }
+
+    pub fn build(self) -> MvbaSwarm {
+        MvbaSwarm {
+            swarm: build_sim_swarm(self.seed, self.network, self.nodes),
+            inputs: self.inputs,
+            log: self.log,
+        }
+    }
+}
+
+impl Default for MvbaSwarmBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A built swarm: run control, plus the decisions reached and inputs started from
+pub struct MvbaSwarm {
+    swarm: Swarm<SimNode<Message>>,
+    inputs: BTreeMap<NodeId, Metablock>,
+    log: DecisionLog,
+}
+
+impl MvbaSwarm {
+    pub fn swarm_mut(&mut self) -> &mut Swarm<SimNode<Message>> {
+        &mut self.swarm
+    }
+
+    /// Every node's input, including nodes since removed; listeners have none
+    pub fn inputs(&self) -> &BTreeMap<NodeId, Metablock> {
+        &self.inputs
+    }
+
+    /// What each node in the swarm has decided so far
+    pub fn decisions(&self) -> BTreeMap<NodeId, Decision> {
+        self.swarm
+            .node_ids()
+            .into_iter()
+            .filter_map(|id| self.log.decision_of(&id).map(|decision| (id, decision)))
+            .collect()
+    }
+
+    pub fn decision_of(&self, node: &NodeId) -> Option<Decision> {
+        self.log.decision_of(node)
+    }
+
+    /// Whether every node in the swarm has decided
+    pub fn all_decided(&self) -> bool {
+        self.swarm
+            .node_ids()
+            .iter()
+            .all(|id| self.log.decision_of(id).is_some())
+    }
+
+    /// Whether any node ever reported a second, different decision
+    pub fn any_conflicted(&self) -> bool {
+        self.swarm
+            .node_ids()
+            .iter()
+            .any(|id| self.log.conflicted(id))
+    }
+
+    /// Run until every node has decided or `deadline` passes; whether all did
+    pub fn run_until_all_decided(&mut self, deadline: Time) -> bool {
+        loop {
+            if self.all_decided() {
+                return true;
+            }
+            match self.swarm.simulation().peek_time() {
+                Some(at) if at <= deadline => {}
+                // nothing left to run, or nothing left before the deadline
+                _ => return self.all_decided(),
+            }
+            if self.swarm.sim().next_step().is_none() {
+                return self.all_decided();
+            }
+        }
+    }
+
+    /// Run until `done` holds, giving up at `deadline`
+    pub fn run_until_or(
+        &mut self,
+        deadline: Time,
+        mut done: impl FnMut(&Self) -> bool,
+    ) -> RunOutcome {
+        loop {
+            if done(self) {
+                return RunOutcome::Stopped;
+            }
+            match self.swarm.simulation().peek_time() {
+                Some(at) if at <= deadline => {}
+                _ => return RunOutcome::Drained,
+            }
+            if self.swarm.sim().next_step().is_none() {
+                return RunOutcome::Drained;
+            }
+        }
+    }
+}
+
+/// A time `millis` after the start of the simulation
+pub fn at_millis(millis: u64) -> Time {
+    Time(0) + Duration::from_millis(millis)
+}

--- a/monad-mcp-chorus-sim/src/node.rs
+++ b/monad-mcp-chorus-sim/src/node.rs
@@ -107,6 +107,13 @@ where
                     net.broadcast(ctx, from, message)
                 });
             }
+            NodeEvent::Unicast { to, message } => {
+                let from = self.id;
+                let net = self.net.expect("node not wired");
+                ctx.schedule(net, now, StepLabel::source("unicast"), move |net, ctx| {
+                    net.send(ctx, from, to, message)
+                });
+            }
         }
     }
 }

--- a/monad-mcp-chorus-sim/src/swarm.rs
+++ b/monad-mcp-chorus-sim/src/swarm.rs
@@ -90,21 +90,30 @@ impl<M> CadenceSwarmBuilder<M> {
     where
         M: Clone + 'static,
     {
-        let mut swarm = Swarm::build(self.seed, self.network, self.nodes);
-        for id in swarm.node_ids() {
-            let handle = swarm.handle(&id).expect("node just built");
-            swarm.sim().schedule(
-                handle,
-                time_of(Timestamp::GENESIS),
-                StepLabel::source("init"),
-                |node, ctx| node.init(ctx),
-            );
-        }
         CadenceSwarm {
-            swarm,
+            swarm: build_sim_swarm(self.seed, self.network, self.nodes),
             log: self.log,
         }
     }
+}
+
+/// Wire nodes into a simulated network and schedule each node's init step
+pub(crate) fn build_sim_swarm<M: Clone + 'static>(
+    seed: u64,
+    network: Network<NodeId, M>,
+    nodes: Vec<(NodeId, SimNode<M>)>,
+) -> Swarm<SimNode<M>> {
+    let mut swarm = Swarm::build(seed, network, nodes);
+    for id in swarm.node_ids() {
+        let handle = swarm.handle(&id).expect("node just built");
+        swarm.sim().schedule(
+            handle,
+            time_of(Timestamp::GENESIS),
+            StepLabel::source("init"),
+            |node, ctx| node.init(ctx),
+        );
+    }
+    swarm
 }
 
 impl<M> Default for CadenceSwarmBuilder<M> {

--- a/monad-mcp-chorus-sim/tests/fallback_mvba.rs
+++ b/monad-mcp-chorus-sim/tests/fallback_mvba.rs
@@ -1,0 +1,673 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Four validators' MVBA instances on a simulated network, nothing else around
+//! them, run from inputs the fast path already formed. What is asserted is what
+//! the protocol promises: agreement, integrity, external validity, termination
+
+use std::{cell::Cell, collections::BTreeMap, rc::Rc, time::Duration};
+
+use chorus::{slot::fallback::Metablock, types::NodeId};
+use monad_mcp_chorus::stub as chorus;
+use monad_mcp_chorus_sim::{Message, MvbaSwarm, MvbaSwarmBuilder};
+use monad_sim::{RunOutcome, Time, dist::uniform_duration};
+use monad_sim_swarm::Network;
+
+/// The inputs the fast path would have formed
+mod fixtures {
+    use std::{collections::HashMap, sync::Arc};
+
+    use chorus::{
+        slot::fallback::{
+            CertifiedEntry, EnterFallbackCert, EnterFallbackVote, Entry, FallbackEntry, Metablock,
+            Mvba as _, monad_mvba::MvbaContext,
+        },
+        types::{
+            IsVote, MerkleRoot, NodeId, ProposalMap, Slot, Stake, StrongQc, TimestampDelta,
+            ValidatorData, VoteMsg, VotePool, WeakQc,
+        },
+    };
+    use monad_mcp_chorus::{spec::KeyPair as _, stub as chorus};
+    use monad_mcp_chorus_sim::MonadMvba;
+
+    const NUM_NODES: u64 = 4;
+    const NUM_PROPOSALS: usize = 2;
+    const SLOT: Slot = Slot(0);
+    pub const DELTA: TimestampDelta = TimestampDelta::from_millis(super::DELTA_MILLIS);
+
+    pub fn nodes() -> Vec<NodeId> {
+        (0..NUM_NODES).map(NodeId::dummy).collect()
+    }
+
+    /// A supermajority of the four: three signers
+    fn quorum() -> Vec<NodeId> {
+        nodes()[..3].to_vec()
+    }
+
+    pub fn validator_data() -> Arc<ValidatorData> {
+        let valset: HashMap<_, _> = nodes()
+            .into_iter()
+            .map(|node| (node, Stake::from(1u64)))
+            .collect();
+        let mapping = nodes()
+            .into_iter()
+            .map(|node| (node, node.keypair().pubkey()))
+            .collect();
+
+        Arc::new(ValidatorData::new(valset, mapping))
+    }
+
+    /// The same round-robin the implementation uses, restated so the tests do
+    /// not take their expectations from the code under test
+    /// TODO: wire up actual leader election
+    pub fn leader_of(view: u64) -> NodeId {
+        let index = (SLOT.get() + view) % NUM_NODES;
+        nodes()[index as usize]
+    }
+
+    pub fn mvba(node: NodeId, validator_data: &Arc<ValidatorData>) -> MonadMvba {
+        MonadMvba::new(MvbaContext {
+            slot: SLOT,
+            num_proposals: NUM_PROPOSALS,
+            node_id: node,
+            key: Arc::new(node.keypair()),
+            validator_data: validator_data.clone(),
+            delta: DELTA,
+        })
+    }
+
+    /// A valid metablock whose entries are determined by `seed`, so two seeds
+    /// give two metablocks that cannot be confused for one another
+    pub fn fast_metablock(seed: u64, validator_data: &ValidatorData) -> Metablock {
+        Metablock::new(ProposalMap::new(NUM_PROPOSALS, |j| {
+            let entry = Entry::Positive {
+                root: MerkleRoot(seed * 100 + j as u64),
+            };
+            CertifiedEntry::FastQc(strong_qc((SLOT, j), entry, &quorum(), validator_data))
+        }))
+    }
+
+    /// Valid but *not* a fast metablock: its first entry rests on a fallback
+    /// quorum. `entries()` matches [`metablock`] on the same seed, so the two
+    /// differ only in their evidence
+    pub fn mixed_evidence_metablock(seed: u64, validator_data: &ValidatorData) -> Metablock {
+        Metablock::new(ProposalMap::new(NUM_PROPOSALS, |j| {
+            let entry = Entry::Positive {
+                root: MerkleRoot(seed * 100 + j as u64),
+            };
+            if j == 0 {
+                CertifiedEntry::FallbackQc(weak_qc(
+                    (SLOT, j),
+                    FallbackEntry(entry),
+                    &quorum(),
+                    validator_data,
+                ))
+            } else {
+                CertifiedEntry::FastQc(strong_qc((SLOT, j), entry, &quorum(), validator_data))
+            }
+        }))
+    }
+
+    /// A genuine fallback certificate for this slot
+    pub fn enter_fallback_cert(validator_data: &ValidatorData) -> EnterFallbackCert {
+        strong_qc(SLOT, EnterFallbackVote, &quorum(), validator_data)
+    }
+
+    fn vote_pool<V: IsVote>(scope: V::Scope, vote: V, signers: &[NodeId]) -> VotePool<V> {
+        let mut pool = VotePool::new(scope.clone());
+        for node in signers {
+            pool.add_vote(
+                *node,
+                VoteMsg::new_signed(scope.clone(), vote.clone(), &node.keypair()),
+            );
+        }
+        pool
+    }
+
+    /// Aggregate a genuine supermajority certificate over `vote`
+    fn strong_qc<V: IsVote>(
+        scope: V::Scope,
+        vote: V,
+        signers: &[NodeId],
+        validator_data: &ValidatorData,
+    ) -> StrongQc<V> {
+        vote_pool(scope, vote, signers)
+            .try_form_strong_qc(validator_data)
+            .expect("the signers hold a supermajority of stake")
+    }
+
+    /// Aggregate a genuine `f+1` certificate over `vote`
+    fn weak_qc<V: IsVote>(
+        scope: V::Scope,
+        vote: V,
+        signers: &[NodeId],
+        validator_data: &ValidatorData,
+    ) -> WeakQc<V> {
+        vote_pool(scope, vote, signers)
+            .try_form_weak_qc(validator_data)
+            .expect("the signers hold more than an honest threshold of stake")
+            .left()
+            .expect("the signers all voted the same way")
+    }
+}
+
+/// The protocol's Δ: the assumed upper bound on one-way message latency
+const DELTA_MILLIS: u64 = 150;
+const DELTA: Duration = Duration::from_millis(DELTA_MILLIS);
+
+/// Every deadline below is a multiple of the state machine's own view timeout,
+/// so the tests hold whatever Δ and link are chosen, as long as the link keeps
+/// the assumption Δ rests on
+const LATENCY: Duration = Duration::from_millis(100);
+const _: () = assert!(LATENCY.as_millis() <= DELTA.as_millis());
+
+/// The view timeout the state machine derives from Δ: proposal, prepare, commit
+const VIEW_TIMEOUT: Duration = Duration::from_millis(3 * DELTA_MILLIS);
+
+/// One leg of the agreement: pre-prepare, prepare, commit
+fn rounds(n: u32) -> Time {
+    Time(0) + n * LATENCY
+}
+
+/// `n` view timeouts in
+fn views(n: u32) -> Time {
+    Time(0) + n * VIEW_TIMEOUT
+}
+
+/// Four validators, each with the fallback input `block_of` gives it
+fn swarm(
+    seed: u64,
+    network: Network<NodeId, Message>,
+    block_of: impl Fn(NodeId) -> Metablock,
+) -> MvbaSwarm {
+    let validator_data = fixtures::validator_data();
+    let mut builder = MvbaSwarmBuilder::new();
+    builder.set_seed(seed).set_network(network);
+
+    for node in fixtures::nodes() {
+        let mvba = fixtures::mvba(node, &validator_data);
+        let cert = fixtures::enter_fallback_cert(&validator_data);
+        builder.add_node(node, mvba, block_of(node), Some(cert), Time(0));
+    }
+
+    builder.build()
+}
+
+/// Agreement, integrity and external validity over every node that decided
+fn expect_agreement(swarm: &MvbaSwarm) -> Metablock {
+    let decisions = swarm.decisions();
+    assert!(!decisions.is_empty(), "nobody decided");
+    assert!(
+        !swarm.any_conflicted(),
+        "a node reported a second, different decision"
+    );
+
+    let (_, first) = decisions.iter().next().expect("just checked non-empty");
+    for (node, decision) in &decisions {
+        assert_eq!(
+            decision.block, first.block,
+            "{node:?} decided a different metablock"
+        );
+    }
+
+    // external validity: what was agreed is a metablock some validator held.
+    assert!(
+        swarm.inputs().values().any(|input| *input == first.block),
+        "the decided metablock was nobody's input"
+    );
+
+    first.block.clone()
+}
+
+fn expect_all_decided(swarm: &MvbaSwarm, expected: &[NodeId]) -> BTreeMap<NodeId, Time> {
+    let decisions = swarm.decisions();
+    for node in expected {
+        assert!(decisions.contains_key(node), "{node:?} did not decide");
+    }
+    assert_eq!(
+        decisions.len(),
+        expected.len(),
+        "unexpected set of deciding nodes"
+    );
+
+    decisions
+        .into_iter()
+        .map(|(node, decision)| (node, decision.at))
+        .collect()
+}
+
+/// T1. Same input everywhere on a reliable network: the first view's leader
+/// proposes and all four decide it three rounds later
+#[test]
+fn identical_inputs_decide_in_the_first_view() {
+    let validator_data = fixtures::validator_data();
+    let block = fixtures::fast_metablock(1, &validator_data);
+
+    let mut swarm = swarm(0, Network::reliable(LATENCY), |_| block.clone());
+    assert!(
+        swarm.run_until_all_decided(views(1)),
+        "not everyone decided: {:?}",
+        swarm.decisions().keys()
+    );
+
+    let decided = expect_agreement(&swarm);
+    assert_eq!(decided, block);
+
+    // pre-prepare, prepare, commit -- one link crossing each, the leader
+    // included, since it hears its own broadcast off the wire like anyone else.
+    for (node, at) in expect_all_decided(&swarm, &fixtures::nodes()) {
+        assert_eq!(at, rounds(3), "{node:?} decided late");
+    }
+}
+
+/// T2. Every validator holds a different, equally valid metablock, as partial
+/// dissemination leaves them. Nothing is locked, so the leader's input wins
+#[test]
+fn divergent_inputs_agree_on_the_leader_s_metablock() {
+    let validator_data = fixtures::validator_data();
+    let inputs: BTreeMap<NodeId, Metablock> = fixtures::nodes()
+        .into_iter()
+        .enumerate()
+        .map(|(i, node)| {
+            (
+                node,
+                fixtures::mixed_evidence_metablock(i as u64 + 1, &validator_data),
+            )
+        })
+        .collect();
+
+    // the inputs really do differ, or the test would prove nothing
+    let distinct: Vec<&Metablock> = inputs.values().collect();
+    for (i, block) in distinct.iter().enumerate() {
+        for other in &distinct[i + 1..] {
+            assert_ne!(block, other, "two validators were given the same input");
+        }
+    }
+
+    let mut swarm = swarm(0, Network::reliable(LATENCY), |node| inputs[&node].clone());
+    assert!(
+        swarm.run_until_all_decided(views(1)),
+        "not everyone decided: {:?}",
+        swarm.decisions().keys()
+    );
+
+    let decided = expect_agreement(&swarm);
+    let leader = fixtures::leader_of(1);
+    assert_eq!(decided, inputs[&leader], "the leader's input did not win");
+
+    for (node, at) in expect_all_decided(&swarm, &fixtures::nodes()) {
+        assert_eq!(at, rounds(3), "{node:?} decided late");
+    }
+}
+
+/// T3. The first view's leader never proposes. The rest time out and the second
+/// view's leader, locked by nothing, proposes its own input
+#[test]
+fn a_silent_first_leader_is_replaced_by_the_next_view() {
+    let validator_data = fixtures::validator_data();
+    let inputs: BTreeMap<NodeId, Metablock> = fixtures::nodes()
+        .into_iter()
+        .enumerate()
+        .map(|(i, node)| {
+            (
+                node,
+                fixtures::mixed_evidence_metablock(i as u64 + 1, &validator_data),
+            )
+        })
+        .collect();
+
+    let mut swarm = swarm(0, Network::reliable(LATENCY), |node| inputs[&node].clone());
+
+    // removed before the simulation runs, so it never even proposes: steps
+    // already scheduled for it are skipped, and messages to it are dropped.
+    let silent = fixtures::leader_of(1);
+    swarm.swarm_mut().remove_node(&silent);
+
+    let live: Vec<NodeId> = fixtures::nodes()
+        .into_iter()
+        .filter(|node| *node != silent)
+        .collect();
+
+    // after the view timeout the timeouts have to cross the network before the
+    // second view's three rounds can run.
+    let deadline = views(1) + 4 * LATENCY;
+    assert!(
+        swarm.run_until_all_decided(deadline),
+        "the survivors did not decide by {deadline:?}: {:?}",
+        swarm.decisions().keys()
+    );
+
+    let decided = expect_agreement(&swarm);
+    let second_leader = fixtures::leader_of(2);
+    assert_eq!(
+        decided, inputs[&second_leader],
+        "the second view's leader proposed something other than its own input"
+    );
+
+    let times = expect_all_decided(&swarm, &live);
+    for (node, at) in times {
+        assert!(at > views(1), "{node:?} decided before timing out");
+        assert!(at <= deadline, "{node:?} decided late: {at:?}");
+    }
+}
+
+/// T4. One message in eight is lost. No vote is ever retransmitted, so liveness
+/// rests on the view timeout; agreement must hold whatever the losses
+#[test]
+fn agreement_survives_a_lossy_network() {
+    let validator_data = fixtures::validator_data();
+    let block = fixtures::fast_metablock(1, &validator_data);
+
+    for seed in 0..8 {
+        let network = Network::reliable(LATENCY).loss(0.125);
+        let mut swarm = swarm(seed, network, |_| block.clone());
+
+        // room for a good many views
+        let decided = swarm.run_until_all_decided(views(100));
+        let block_decided = expect_agreement(&swarm);
+        assert_eq!(block_decided, block, "seed {seed} decided a foreign block");
+        assert!(
+            decided,
+            "seed {seed}: only {} of 4 decided in 100 views",
+            swarm.decisions().len()
+        );
+    }
+}
+
+/// T5. A validator cut off for the first view's value-carrying rounds learns
+/// the verdict from an echoed commit certificate and the block from a peer
+#[test]
+fn a_partitioned_validator_catches_up_through_block_sync() {
+    let validator_data = fixtures::validator_data();
+    // divergent, so the decided block is one the laggard never held: proposing
+    // remembers a validator's own input, leaving identical inputs nothing to fetch
+    let inputs: BTreeMap<NodeId, Metablock> = fixtures::nodes()
+        .into_iter()
+        .enumerate()
+        .map(|(i, node)| {
+            (
+                node,
+                fixtures::mixed_evidence_metablock(i as u64 + 1, &validator_data),
+            )
+        })
+        .collect();
+
+    let nodes = fixtures::nodes();
+    let leader = fixtures::leader_of(1);
+    let laggard = *nodes
+        .iter()
+        .find(|node| **node != leader)
+        .expect("four validators, one leader");
+
+    // the pre-prepare and prepare votes are sent inside the window and lost, the
+    // commit certificates echoed after it and kept: block sync, not slow recovery
+    let window = Time(0)..(Time(0) + 5 * LATENCY / 2);
+    let network = Network::reliable(LATENCY).partition(window, [[laggard]]);
+    let mut swarm = swarm(0, network, |node| inputs[&node].clone());
+
+    // a block response is the only unicast, so counting those steps separates
+    // catching up through block sync from merely hearing the round late
+    let responses = Rc::new(Cell::new(0usize));
+    let counter = responses.clone();
+    swarm.swarm_mut().sim().on_step(move |step| {
+        if step.label.source == Some("unicast") {
+            counter.set(counter.get() + 1);
+        }
+    });
+
+    let majority: Vec<NodeId> = nodes
+        .iter()
+        .copied()
+        .filter(|node| *node != laggard)
+        .collect();
+
+    // the majority decides on its own first
+    swarm.run_until_or(views(1), |swarm| {
+        majority
+            .iter()
+            .all(|node| swarm.decision_of(node).is_some())
+    });
+    let majority_at = expect_all_decided(&swarm, &majority);
+    assert!(
+        swarm.decision_of(&laggard).is_none(),
+        "the partitioned validator decided without ever seeing the proposal"
+    );
+
+    // then the laggard, off the echoed certificate plus a fetched block
+    assert!(
+        swarm.run_until_all_decided(views(3)),
+        "the partitioned validator never caught up"
+    );
+
+    let decided = expect_agreement(&swarm);
+    assert_eq!(decided, inputs[&leader]);
+    assert!(
+        responses.get() > 0,
+        "no block was ever fetched, so block sync was not what caught the laggard up"
+    );
+
+    let laggard_at = swarm
+        .decision_of(&laggard)
+        .expect("just asserted it decided")
+        .at;
+    for (node, at) in majority_at {
+        assert!(
+            laggard_at > at,
+            "the laggard decided no later than {node:?}, so it cannot have caught up"
+        );
+    }
+}
+
+/// T6. T1 and T2 again with the latency of every message sampled inside the Δ
+/// the protocol assumes: arrival order is no longer the send order. Three
+/// crossings still bound the first view, so the decision, its view and its
+/// timing all have to survive the jitter
+#[test]
+fn agreement_holds_under_randomized_latency() {
+    let validator_data = fixtures::validator_data();
+    let identical = fixtures::fast_metablock(1, &validator_data);
+    let divergent: BTreeMap<NodeId, Metablock> = fixtures::nodes()
+        .into_iter()
+        .enumerate()
+        .map(|(i, node)| {
+            (
+                node,
+                fixtures::mixed_evidence_metablock(i as u64 + 1, &validator_data),
+            )
+        })
+        .collect();
+    let leader = fixtures::leader_of(1);
+
+    for seed in 0..16 {
+        for divergent_inputs in [false, true] {
+            let validator_data = fixtures::validator_data();
+            let mut builder = MvbaSwarmBuilder::new();
+            // no sample exceeds Δ, so the three rounds fit the view timeout
+            // however they land
+            let latency = uniform_duration(LATENCY / 4, LATENCY);
+            builder
+                .set_seed(seed)
+                .set_network(Network::with_latency(latency));
+
+            for node in fixtures::nodes() {
+                let mvba = fixtures::mvba(node, &validator_data);
+                let cert = fixtures::enter_fallback_cert(&validator_data);
+                let block = if divergent_inputs {
+                    divergent[&node].clone()
+                } else {
+                    identical.clone()
+                };
+                builder.add_node(node, mvba, block, Some(cert), Time(0));
+            }
+
+            let mut swarm = builder.build();
+            let case = format!("seed {seed} (divergent: {divergent_inputs})");
+            assert!(
+                swarm.run_until_all_decided(views(1)),
+                "{case}: only {} of 4 decided",
+                swarm.decisions().len()
+            );
+
+            let decided = expect_agreement(&swarm);
+            let expected = if divergent_inputs {
+                &divergent[&leader]
+            } else {
+                &identical
+            };
+            assert_eq!(decided, *expected, "{case} agreed on the wrong metablock");
+
+            // no view change happened: every crossing costs at most one LATENCY,
+            // so three of them are the worst the first view can take
+            for (node, at) in expect_all_decided(&swarm, &fixtures::nodes()) {
+                assert!(at <= rounds(3), "{case}: {node:?} decided late: {at:?}");
+            }
+        }
+    }
+}
+
+/// Two runs of one seed decide at the same instants. Worth pinning because the
+/// state machine holds state in hash maps, whose order must not reach the wire
+#[test]
+fn a_seed_reproduces_its_run() {
+    let validator_data = fixtures::validator_data();
+    let block = fixtures::fast_metablock(1, &validator_data);
+
+    let decisions_of = || {
+        let network = Network::reliable(LATENCY).loss(0.125);
+        let mut swarm = swarm(4, network, |_| block.clone());
+        assert!(swarm.run_until_all_decided(views(100)));
+        swarm
+            .decisions()
+            .into_iter()
+            .map(|(node, decision)| (node, decision.at))
+            .collect::<BTreeMap<_, _>>()
+    };
+
+    let first = decisions_of();
+    // several views, or the run would be too short to tell anything apart
+    assert!(first.values().all(|at| *at > rounds(3)));
+    assert_eq!(first, decisions_of());
+}
+
+/// T7. Three validators hold a fallback input, the fourth none: it hears every
+/// message, echoed commit certificate included, and still never decides, since
+/// participation is gated on the input. Three of four is exactly a supermajority
+#[test]
+fn a_validator_without_an_input_listens_without_deciding() {
+    let validator_data = fixtures::validator_data();
+    let block = fixtures::fast_metablock(1, &validator_data);
+
+    let nodes = fixtures::nodes();
+    let leader = fixtures::leader_of(1);
+    // the leader must be one of the three that can propose, or the first view
+    // would time out and the test would be about view changes instead.
+    let listener = *nodes
+        .iter()
+        .rev()
+        .find(|node| **node != leader)
+        .expect("four validators, one leader");
+    let proposers: Vec<NodeId> = nodes
+        .iter()
+        .copied()
+        .filter(|node| *node != listener)
+        .collect();
+
+    let mut builder = MvbaSwarmBuilder::new();
+    builder.set_seed(0).set_network(Network::reliable(LATENCY));
+    for node in &nodes {
+        let mvba = fixtures::mvba(*node, &validator_data);
+        if *node == listener {
+            builder.add_listener(*node, mvba);
+        } else {
+            let cert = fixtures::enter_fallback_cert(&validator_data);
+            builder.add_node(*node, mvba, block.clone(), Some(cert), Time(0));
+        }
+    }
+    let mut swarm = builder.build();
+
+    // long past the deciders' first echo of their commit certificate, one view
+    // timeout after they decide: whatever the listener learns, it stays out.
+    let deadline = views(3);
+    let outcome = swarm.run_until_or(deadline, |_| false);
+    assert_eq!(
+        outcome,
+        RunOutcome::Drained,
+        "the run did not reach {deadline:?}"
+    );
+
+    let decided = expect_agreement(&swarm);
+    assert_eq!(decided, block);
+
+    // exactly the three proposers decided, and in the first view: three of four
+    // validators are a supermajority, so the missing input costs nothing here.
+    for (node, at) in expect_all_decided(&swarm, &proposers) {
+        assert_eq!(at, rounds(3), "{node:?} decided late");
+    }
+    assert!(
+        swarm.decision_of(&listener).is_none(),
+        "a validator with no fallback input reported a decision"
+    );
+}
+
+/// T8. The four inputs are handed over at four different times, the view-1
+/// leader's last: nothing can happen before the leader starts, and the three
+/// early starters have to sit on their inputs without timing their first view out
+#[test]
+fn staggered_starts_wait_on_the_leader_s_own_start() {
+    // timed off Δ rather than LATENCY, so the stagger and the three crossings
+    // both fit inside the first view whatever the link costs
+    const LINK: Duration = Duration::from_millis(DELTA_MILLIS / 4);
+
+    let validator_data = fixtures::validator_data();
+    let block = fixtures::fast_metablock(1, &validator_data);
+
+    let leader = fixtures::leader_of(1);
+    let base = views(1);
+    let leader_start = base + 3 * LINK;
+    // the followers go first, one link apart; the leader last
+    let mut starts: BTreeMap<NodeId, Time> = fixtures::nodes()
+        .into_iter()
+        .filter(|node| *node != leader)
+        .enumerate()
+        .map(|(i, node)| (node, base + i as u32 * LINK))
+        .collect();
+    starts.insert(leader, leader_start);
+
+    let mut builder = MvbaSwarmBuilder::new();
+    builder.set_network(Network::reliable(LINK));
+    for node in fixtures::nodes() {
+        let mvba = fixtures::mvba(node, &validator_data);
+        let cert = fixtures::enter_fallback_cert(&validator_data);
+        builder.add_node(node, mvba, block.clone(), Some(cert), starts[&node]);
+    }
+
+    let mut swarm = builder.build();
+    let deadline = leader_start + 4 * LINK;
+    assert!(
+        swarm.run_until_all_decided(deadline),
+        "not everyone decided by {deadline:?}: {:?}",
+        swarm.decisions().keys()
+    );
+    assert_eq!(expect_agreement(&swarm), block);
+
+    // the leader's start, not anyone else's, is what the run waited on
+    for (node, at) in expect_all_decided(&swarm, &fixtures::nodes()) {
+        assert_eq!(
+            at,
+            leader_start + 3 * LINK,
+            "{node:?} did not decide three crossings after the leader started"
+        );
+    }
+}

--- a/monad-mcp-chorus/src/driver.rs
+++ b/monad-mcp-chorus/src/driver.rs
@@ -18,7 +18,7 @@ use std::collections::{HashMap, VecDeque};
 use super::{
     conductor::Conductor,
     slot::SlotConsensus,
-    types::{Slot, Timestamp, TimestampDelta, Validated},
+    types::{NodeId, Slot, Timestamp, TimestampDelta, Validated},
 };
 
 // A driver translates consensus effects into concrete node effects
@@ -58,10 +58,21 @@ pub enum CadenceEvent<Timer, Alarm, SMessage, CMessage> {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct WakeId(u64);
 
+impl WakeId {
+    pub(crate) const FIRST: Self = Self(0);
+
+    pub(crate) fn post_increment(&mut self) -> Self {
+        let id = *self;
+        self.0 = self.0.wrapping_add(1);
+        id
+    }
+}
+
 pub enum NodeEvent<M> {
     Wake(Timestamp, WakeId),
     WakeAfter(TimestampDelta, WakeId),
     Broadcast(M),
+    Unicast { to: NodeId, message: M },
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -103,7 +114,7 @@ where
             inbox: VecDeque::new(),
             outbox: VecDeque::new(),
             wakes: HashMap::new(),
-            next_wake: WakeId(0),
+            next_wake: WakeId::FIRST,
         }
     }
 }
@@ -114,9 +125,7 @@ where
     C: Conductor,
 {
     fn fresh_wake(&mut self) -> WakeId {
-        let id = self.next_wake;
-        self.next_wake.0 += 1;
-        id
+        self.next_wake.post_increment()
     }
 }
 

--- a/monad-mcp-chorus/src/slot/fallback/mod.rs
+++ b/monad-mcp-chorus/src/slot/fallback/mod.rs
@@ -19,18 +19,31 @@
 
 // Not wired into `FallbackPath` yet; routing chorus messages in is a follow-up
 #[allow(dead_code)]
-mod monad_mvba;
-use std::{fmt::Debug, hash::Hash, sync::Arc};
+pub mod monad_mvba;
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt::Debug,
+    hash::Hash,
+    sync::Arc,
+};
 
+/// MetaBlock components are exported
+pub use super::fast::{
+    CertifiedEntry, EnterFallbackCert, EnterFallbackVote, Entry, FallbackEntry, FallbackQc, FastQc,
+};
 use super::{
-    fast::{CertifiedEntry, EnterFallbackCert},
+    super::{
+        driver::{NodeEvent, WakeId},
+        runtime::Runtime,
+    },
     types::{
-        IsVote, KeyPair, NodeId, Slot, StrongQc, TimestampDelta, TotalProposalMap, ValidatorData,
+        IsVote, KeyPair, NodeId, Slot, StrongQc, Timestamp, TimestampDelta, TotalProposalMap,
+        Validated, ValidatorData,
     },
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub(crate) struct FallbackView(u64);
+pub struct FallbackView(u64);
 
 #[allow(dead_code)]
 impl FallbackView {
@@ -84,10 +97,10 @@ impl FallbackPath {
 
 /// The value the MVBA agrees on: one certified entry per proposer
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub(crate) struct Metablock(TotalProposalMap<CertifiedEntry>);
+pub struct Metablock(TotalProposalMap<CertifiedEntry>);
 
 impl Metablock {
-    pub(crate) fn new(entries: TotalProposalMap<CertifiedEntry>) -> Self {
+    pub fn new(entries: TotalProposalMap<CertifiedEntry>) -> Self {
         Self(entries)
     }
 }
@@ -170,4 +183,148 @@ pub enum MVBAOutput<M, T> {
         duration: TimestampDelta,
         timer_event: T,
     },
+}
+
+pub struct MvbaRuntime<M, V>
+where
+    M: Mvba<V>,
+    V: ValidateInput + Votable,
+{
+    mvba: M,
+    /// Held until the start wake fires; `None` is a listener, which never proposes
+    input: Option<(V, Option<M::FallbackCert>)>,
+
+    // Deferred start mechanism
+    start_at: Timestamp,
+    start_wake: Option<WakeId>,
+
+    outbox: VecDeque<NodeEvent<M::Message>>,
+    /// Pending timers; the last arm of the same event wins, so a superseded
+    /// wake misses the map
+    armed: HashMap<WakeId, M::TimerEvent>,
+    next_wake: WakeId,
+
+    observer: Option<Box<dyn FnMut(Timestamp, &V)>>,
+    reported: Option<V>,
+}
+
+impl<A, V> MvbaRuntime<A, V>
+where
+    A: Mvba<V>,
+    V: ValidateInput + Votable,
+    A::TimerEvent: Eq,
+{
+    pub fn new(mvba: A, input: V, cert: Option<A::FallbackCert>) -> Self {
+        Self::with_input(mvba, Some((input, cert)))
+    }
+
+    /// A validator with no fallback input: its state machine gates
+    /// participation on that input, so it listens without voting or deciding
+    pub fn listening(mvba: A) -> Self {
+        Self::with_input(mvba, None)
+    }
+
+    fn with_input(mvba: A, input: Option<(V, Option<A::FallbackCert>)>) -> Self {
+        Self {
+            mvba,
+            input,
+            start_at: Timestamp::GENESIS,
+            start_wake: None,
+            outbox: VecDeque::new(),
+            armed: HashMap::new(),
+            next_wake: WakeId::FIRST,
+            observer: None,
+            reported: None,
+        }
+    }
+
+    /// When the state machine is handed its input
+    pub fn set_start(&mut self, at: Timestamp) {
+        self.start_at = at;
+    }
+
+    /// Reports the first decision, and any later one that differs from it
+    pub fn on_decision(&mut self, observer: impl FnMut(Timestamp, &V) + 'static) {
+        self.observer = Some(Box::new(observer));
+    }
+
+    fn drain(&mut self, now: Timestamp) {
+        while let Some(output) = self.mvba.poll() {
+            match output {
+                MVBAOutput::Broadcast(message) => {
+                    self.outbox.push_back(NodeEvent::Broadcast(message));
+                }
+                MVBAOutput::Unicast { to, message } => {
+                    self.outbox.push_back(NodeEvent::Unicast { to, message });
+                }
+                MVBAOutput::ScheduleTimer {
+                    duration,
+                    timer_event,
+                } => {
+                    // evicting the previous arm is what makes its wake stale
+                    self.armed.retain(|_, armed| *armed != timer_event);
+                    let id = self.next_wake.post_increment();
+                    self.armed.insert(id, timer_event);
+                    self.outbox.push_back(NodeEvent::WakeAfter(duration, id));
+                }
+            }
+        }
+        self.report_decision(now);
+    }
+
+    fn report_decision(&mut self, now: Timestamp) {
+        if self.observer.is_none() {
+            return;
+        }
+        let Some(decision) = self.mvba.decision() else {
+            return;
+        };
+        if self.reported.as_ref() == Some(decision) {
+            return;
+        }
+        let decision = decision.clone();
+        let observer = self.observer.as_mut().expect("just checked");
+        observer(now, &decision);
+        self.reported = Some(decision);
+    }
+}
+
+impl<A, V> Runtime<A::Message> for MvbaRuntime<A, V>
+where
+    A: Mvba<V>,
+    V: ValidateInput + Votable,
+    A::TimerEvent: Eq,
+{
+    fn init(&mut self) {
+        if self.input.is_none() {
+            return;
+        }
+        let id = self.next_wake.post_increment();
+        self.start_wake = Some(id);
+        self.outbox.push_back(NodeEvent::Wake(self.start_at, id));
+    }
+
+    fn wake(&mut self, now: Timestamp, wake: WakeId) {
+        if self.start_wake == Some(wake) {
+            self.start_wake = None;
+            let (input, cert) = self.input.take().expect("start wake armed with an input");
+            self.mvba.propose(input, cert);
+        } else if let Some(timer_event) = self.armed.remove(&wake) {
+            self.mvba.handle_timer(timer_event);
+        } else {
+            // canceled: the event was re-armed after this wake was scheduled
+            return;
+        }
+        self.drain(now);
+    }
+
+    fn receive(&mut self, now: Timestamp, message: Validated<A::Message>) {
+        let (message, author) = message.destructure();
+        self.mvba.handle_message(author, message);
+        self.drain(now);
+    }
+
+    fn poll(&mut self) -> Option<NodeEvent<A::Message>> {
+        self.outbox.pop_front()
+    }
 }

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/messages.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/messages.rs
@@ -31,7 +31,7 @@ use super::{
 use crate::spec::vote::{KeyPair as _, Signature as _};
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, derive_more::From)]
-pub(crate) enum Message<V: Votable, C: ValidateCert> {
+pub enum MvbaMessage<V: Votable, C: ValidateCert> {
     #[from]
     PrePrepare(PrePrepareMsg<V, C>),
     #[from]
@@ -71,7 +71,7 @@ pub(crate) type PrepareVoteMsg<V> = VoteMsg<PrepareVote<V>>;
 
 /// `⟨Commit, slot, v, entries(x)⟩`
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub(crate) struct FallbackCommitVote<V: Votable>(pub V::Entries);
+pub struct FallbackCommitVote<V: Votable>(pub(crate) V::Entries);
 
 impl<V: Votable> FromEntries<V> for FallbackCommitVote<V> {
     fn from_entries(entries: V::Entries) -> Self {

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/mod.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/mod.rs
@@ -104,6 +104,7 @@ impl MvbaContext {
     /// Placeholder leader election
     ///
     /// `Leader(slot, view)`: placeholder round-robin, ignoring stake
+    /// TODO: replace with prod leader election
     pub(crate) fn leader(&self, view: FallbackView) -> NodeId {
         let num_nodes = self.validator_data.nodes().count() as u64;
         assert!(num_nodes > 0);

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/mod.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/mod.rs
@@ -61,9 +61,10 @@ use std::{
 use block_store::{BlockRequestMsg, BlockResponseMsg, BlockStore};
 use certificates::{FallbackCommitQc, PrepareQc, TimeoutCertificate};
 use collectors::ViewCollectors;
+pub use messages::MvbaMessage;
 use messages::{
-    CommitVoteMsg, FallbackCommitVote, Justification, Message, PrePrepareMsg, PrepareVote,
-    PrepareVoteMsg, TimeoutMsg,
+    CommitVoteMsg, FallbackCommitVote, Justification, PrePrepareMsg, PrepareVote, PrepareVoteMsg,
+    TimeoutMsg,
 };
 use phases::{Decided, Phase, Transition};
 
@@ -89,7 +90,7 @@ const VIEW_TIMEOUT_DELTAS: u64 = 3;
 /// How often a decided instance re-broadcasts its commit certificate
 const DECIDED_ECHO_DELTAS: u64 = 3;
 
-pub(crate) struct Context {
+pub struct MvbaContext {
     pub slot: Slot,
     pub num_proposals: usize,
     pub delta: TimestampDelta,
@@ -99,7 +100,7 @@ pub(crate) struct Context {
     pub validator_data: Arc<ValidatorData>,
 }
 
-impl Context {
+impl MvbaContext {
     /// Placeholder leader election
     ///
     /// `Leader(slot, view)`: placeholder round-robin, ignoring stake
@@ -130,7 +131,7 @@ impl Context {
 
 /// Timers driven by the MVBA state machine
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub(crate) enum TimerEvent<V: Votable> {
+pub enum TimerEvent<V: Votable> {
     /// View change timeout. Timeouts are periodically re-sent every view change
     /// timeout
     ViewTimeout(FallbackView),
@@ -143,18 +144,18 @@ pub(crate) enum TimerEvent<V: Votable> {
 }
 
 /// Validation context for MetaBlock and FallbackCert
-pub(crate) struct ValidationContext {
+pub struct ValidationContext {
     pub slot: Slot,
     pub num_proposals: usize,
     pub validator_data: Arc<ValidatorData>,
 }
 
 /// Transforms protocol context to Input/Cert validation context
-pub(crate) trait MakesValidationContext<V: ValidateInput> {
+pub trait MakesValidationContext<V: ValidateInput> {
     fn make_validation_context(&self) -> V::Context;
 }
 
-impl MakesValidationContext<Metablock> for Context {
+impl MakesValidationContext<Metablock> for MvbaContext {
     fn make_validation_context(&self) -> ValidationContext {
         ValidationContext {
             slot: self.slot,
@@ -180,8 +181,8 @@ struct ProposedInput<V, C> {
     fbcert: Option<C>,
 }
 
-pub(crate) struct MonadMvba<V: ValidateInput + Votable, C: ValidateCert> {
-    context: Context,
+pub struct MonadMvba<V: ValidateInput + Votable, C: ValidateCert> {
+    context: MvbaContext,
     validation_context: V::Context,
     input: Option<ProposedInput<V, C>>,
 
@@ -207,7 +208,7 @@ pub(crate) struct MonadMvba<V: ValidateInput + Votable, C: ValidateCert> {
     /// a view and timer fire
     timer_fired: bool,
 
-    outputs: VecDeque<MVBAOutput<Message<V, C>, TimerEvent<V>>>,
+    outputs: VecDeque<MVBAOutput<MvbaMessage<V, C>, TimerEvent<V>>>,
     abandoned: bool,
 }
 
@@ -215,15 +216,15 @@ impl<V, C> Mvba<V> for MonadMvba<V, C>
 where
     V: ValidateInput + Votable,
     C: ValidateCert<Context = V::Context>,
-    Context: MakesValidationContext<V>,
+    MvbaContext: MakesValidationContext<V>,
 {
-    type Message = Message<V, C>;
-    type Context = Context;
+    type Message = MvbaMessage<V, C>;
+    type Context = MvbaContext;
     type TimerEvent = TimerEvent<V>;
     type FallbackCert = C;
     type CommitVote = FallbackCommitVote<V>;
 
-    fn new(context: Context) -> Self {
+    fn new(context: MvbaContext) -> Self {
         let slot = context.slot;
         let validation_context = context.make_validation_context();
         let delta = context.delta;
@@ -271,13 +272,13 @@ where
         assert!(self.context.validator_data.contains(&sender));
 
         match message {
-            Message::PrePrepare(msg) => self.handle_pre_prepare(sender, msg),
-            Message::Prepare(msg) => self.handle_prepare_vote(sender, msg),
-            Message::Commit(msg) => self.handle_commit_vote(sender, msg),
-            Message::Timeout(msg) => self.handle_timeout(sender, msg),
-            Message::CommitQc(qc) => self.handle_commit_qc(qc),
-            Message::BlockRequest(msg) => self.answer_block_request(sender, &msg),
-            Message::BlockResponse(msg) => self.handle_block_response(msg),
+            MvbaMessage::PrePrepare(msg) => self.handle_pre_prepare(sender, msg),
+            MvbaMessage::Prepare(msg) => self.handle_prepare_vote(sender, msg),
+            MvbaMessage::Commit(msg) => self.handle_commit_vote(sender, msg),
+            MvbaMessage::Timeout(msg) => self.handle_timeout(sender, msg),
+            MvbaMessage::CommitQc(qc) => self.handle_commit_qc(qc),
+            MvbaMessage::BlockRequest(msg) => self.answer_block_request(sender, &msg),
+            MvbaMessage::BlockResponse(msg) => self.handle_block_response(msg),
         }
 
         self.try_advance();
@@ -335,7 +336,7 @@ impl<V, C> MonadMvba<V, C>
 where
     V: ValidateInput + Votable,
     C: ValidateCert<Context = V::Context>,
-    Context: MakesValidationContext<V>,
+    MvbaContext: MakesValidationContext<V>,
 {
     fn handle_pre_prepare(&mut self, sender: NodeId, msg: PrePrepareMsg<V, C>) {
         // catching up is allowed past the window: only the TC arm below can
@@ -449,7 +450,7 @@ where
         if let Some(response) = self.block_store.handle_request(request) {
             self.outputs.push_back(MVBAOutput::Unicast {
                 to: sender,
-                message: Message::BlockResponse(response),
+                message: MvbaMessage::BlockResponse(response),
             });
         }
     }
@@ -495,7 +496,7 @@ impl<V, C> MonadMvba<V, C>
 where
     V: ValidateInput + Votable,
     C: ValidateCert<Context = V::Context>,
-    Context: MakesValidationContext<V>,
+    MvbaContext: MakesValidationContext<V>,
 {
     fn is_running(&self) -> bool {
         self.input.is_some() && !self.abandoned && !self.phase.is_decided()
@@ -663,7 +664,7 @@ where
         &mut self,
         phase: Phase<V>,
         transition: Transition<V, C>,
-    ) -> (Phase<V>, Vec<MVBAOutput<Message<V, C>, TimerEvent<V>>>) {
+    ) -> (Phase<V>, Vec<MVBAOutput<MvbaMessage<V, C>, TimerEvent<V>>>) {
         match transition {
             Transition::Proposal(pre_prepare) => self.accept_proposal(phase, pre_prepare),
             Transition::OwnProposalReady(pre_prepare) => self.propose_as_leader(phase, pre_prepare),
@@ -680,7 +681,7 @@ where
         &mut self,
         phase: Phase<V>,
         msg: PrePrepareMsg<V, C>,
-    ) -> (Phase<V>, Vec<MVBAOutput<Message<V, C>, TimerEvent<V>>>) {
+    ) -> (Phase<V>, Vec<MVBAOutput<MvbaMessage<V, C>, TimerEvent<V>>>) {
         let Phase::AwaitingProposal(awaiting) = phase else {
             unreachable!("a proposal transition is only found while awaiting one");
         };
@@ -695,7 +696,7 @@ where
         let vote = self.sign_vote(PrepareVote::<V>(preparing.entries().clone()));
         (
             Phase::Preparing(preparing),
-            vec![MVBAOutput::Broadcast(Message::Prepare(vote))],
+            vec![MVBAOutput::Broadcast(MvbaMessage::Prepare(vote))],
         )
     }
 
@@ -705,7 +706,7 @@ where
         &mut self,
         phase: Phase<V>,
         qc: PrepareQc<V>,
-    ) -> (Phase<V>, Vec<MVBAOutput<Message<V, C>, TimerEvent<V>>>) {
+    ) -> (Phase<V>, Vec<MVBAOutput<MvbaMessage<V, C>, TimerEvent<V>>>) {
         let committing = match phase {
             Phase::Preparing(p) => p.commit(qc.clone()),
             // `preparing_entries` stops looking once the timeout is sent
@@ -722,7 +723,7 @@ where
 
         (
             Phase::Committing(committing),
-            vec![MVBAOutput::Broadcast(Message::Commit(vote))],
+            vec![MVBAOutput::Broadcast(MvbaMessage::Commit(vote))],
         )
     }
 
@@ -732,7 +733,7 @@ where
         phase: Phase<V>,
         commit_qc: FallbackCommitQc<V>,
         block: V,
-    ) -> (Phase<V>, Vec<MVBAOutput<Message<V, C>, TimerEvent<V>>>) {
+    ) -> (Phase<V>, Vec<MVBAOutput<MvbaMessage<V, C>, TimerEvent<V>>>) {
         // `pending_decide` fetched the block by the certificate's entries
         debug_assert_eq!(block.entries(), commit_qc.verdict.0);
         // a decided instance finds no further transitions
@@ -744,7 +745,7 @@ where
         (
             Phase::Decided(Decided::new(commit_qc.clone(), block)),
             vec![
-                MVBAOutput::Broadcast(Message::CommitQc(commit_qc)),
+                MVBAOutput::Broadcast(MvbaMessage::CommitQc(commit_qc)),
                 MVBAOutput::ScheduleTimer {
                     duration: self.context.decided_echo_timeout(),
                     timer_event: TimerEvent::DecidedEcho,
@@ -761,7 +762,7 @@ where
         };
 
         self.outputs
-            .push_back(MVBAOutput::Broadcast(Message::CommitQc(
+            .push_back(MVBAOutput::Broadcast(MvbaMessage::CommitQc(
                 decided.commit_qc().clone(),
             )));
         self.outputs.push_back(MVBAOutput::ScheduleTimer {
@@ -774,7 +775,7 @@ where
     fn advance_view(
         &mut self,
         tc: TimeoutCertificate<V>,
-    ) -> (Phase<V>, Vec<MVBAOutput<Message<V, C>, TimerEvent<V>>>) {
+    ) -> (Phase<V>, Vec<MVBAOutput<MvbaMessage<V, C>, TimerEvent<V>>>) {
         debug_assert!(tc.view >= self.view());
 
         if let Some(qc) = &tc.high_prep_qc {
@@ -793,7 +794,7 @@ where
     fn local_time_out(
         &mut self,
         phase: Phase<V>,
-    ) -> (Phase<V>, Vec<MVBAOutput<Message<V, C>, TimerEvent<V>>>) {
+    ) -> (Phase<V>, Vec<MVBAOutput<MvbaMessage<V, C>, TimerEvent<V>>>) {
         self.timer_fired = false;
         let view = self.view();
 
@@ -821,7 +822,7 @@ where
                 duration: self.context.view_timeout(),
                 timer_event: TimerEvent::ViewTimeout(view),
             },
-            MVBAOutput::Broadcast(Message::Timeout(timeout)),
+            MVBAOutput::Broadcast(MvbaMessage::Timeout(timeout)),
         ];
 
         (phase, outputs)
@@ -834,7 +835,7 @@ where
     fn enter_view(
         &mut self,
         justification: Option<TimeoutCertificate<V>>,
-    ) -> Vec<MVBAOutput<Message<V, C>, TimerEvent<V>>> {
+    ) -> Vec<MVBAOutput<MvbaMessage<V, C>, TimerEvent<V>>> {
         self.timer_fired = false;
         self.entry_tc = justification;
 
@@ -879,10 +880,10 @@ where
         &mut self,
         phase: Phase<V>,
         pre_prepare: PrePrepareMsg<V, C>,
-    ) -> (Phase<V>, Vec<MVBAOutput<Message<V, C>, TimerEvent<V>>>) {
+    ) -> (Phase<V>, Vec<MVBAOutput<MvbaMessage<V, C>, TimerEvent<V>>>) {
         (
             Self::leave_new_view(phase),
-            vec![MVBAOutput::Broadcast(Message::PrePrepare(pre_prepare))],
+            vec![MVBAOutput::Broadcast(MvbaMessage::PrePrepare(pre_prepare))],
         )
     }
 

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/test_helpers.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/test_helpers.rs
@@ -33,7 +33,7 @@ use super::{
         },
         FallbackView, MVBAOutput, Metablock, Mvba,
     },
-    Context,
+    MvbaContext,
     block_store::{BlockRequestMsg, BlockResponseMsg},
     messages::{FallbackCommitVote, PrepareVote},
 };
@@ -41,7 +41,7 @@ use super::{
 // The `V = Metablock` instantiation the existing suite runs on; the toy-value
 // test in `tests` is what pins genericity
 pub(super) type MonadMvba = super::MonadMvba<Metablock, EnterFallbackCert>;
-pub(super) type Message = super::messages::Message<Metablock, EnterFallbackCert>;
+pub(super) type Message = super::messages::MvbaMessage<Metablock, EnterFallbackCert>;
 pub(super) type PrePrepareMsg = super::messages::PrePrepareMsg<Metablock, EnterFallbackCert>;
 pub(super) type Justification = super::messages::Justification<Metablock, EnterFallbackCert>;
 pub(super) type TimeoutMsg = super::messages::TimeoutMsg<Metablock>;
@@ -95,7 +95,7 @@ pub(super) fn leader_of(v: FallbackView) -> NodeId {
 }
 
 pub(super) fn mvba(node: NodeId, validator_data: &Arc<ValidatorData>) -> MonadMvba {
-    MonadMvba::new(Context {
+    MonadMvba::new(MvbaContext {
         slot: SLOT,
         num_proposals: NUM_PROPOSALS,
         node_id: node,

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/tests.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/tests.rs
@@ -1960,8 +1960,8 @@ mod toy_value {
             super::types::{NodeId, ValidatorData, VoteMsg},
             MVBAOutput, Mvba, ValidateCert, ValidateInput, Votable,
         },
-        Context, MakesValidationContext, MonadMvba, TimerEvent,
-        messages::{FallbackCommitVote, Justification, Message, PrePrepareMsg, PrepareVote},
+        MakesValidationContext, MonadMvba, MvbaContext, TimerEvent,
+        messages::{FallbackCommitVote, Justification, MvbaMessage, PrePrepareMsg, PrepareVote},
         test_helpers::{
             DELTA, NUM_PROPOSALS, SLOT, leader_of, nodes, quorum, validator_data, view,
         },
@@ -1992,7 +1992,7 @@ mod toy_value {
         }
     }
 
-    impl MakesValidationContext<TestValue> for Context {
+    impl MakesValidationContext<TestValue> for MvbaContext {
         fn make_validation_context(&self) {}
     }
 
@@ -2012,7 +2012,7 @@ mod toy_value {
         node: NodeId,
         validator_data: &Arc<ValidatorData>,
     ) -> MonadMvba<TestValue, TestCert> {
-        MonadMvba::new(Context {
+        MonadMvba::new(MvbaContext {
             slot: SLOT,
             num_proposals: NUM_PROPOSALS,
             node_id: node,
@@ -2046,11 +2046,11 @@ mod toy_value {
             Justification::FallbackCert(Some(TestCert)),
             &leader.keypair(),
         );
-        instance.handle_message(leader, Message::PrePrepare(proposal));
+        instance.handle_message(leader, MvbaMessage::PrePrepare(proposal));
         assert!(
             drain(&mut instance)
                 .into_iter()
-                .any(|output| matches!(output, MVBAOutput::Broadcast(Message::Prepare(_)))),
+                .any(|output| matches!(output, MVBAOutput::Broadcast(MvbaMessage::Prepare(_)))),
             "an accepted proposal is voted to prepare"
         );
 
@@ -2060,12 +2060,12 @@ mod toy_value {
                 PrepareVote::<TestValue>(value.entries()),
                 &node.keypair(),
             );
-            instance.handle_message(node, Message::Prepare(msg));
+            instance.handle_message(node, MvbaMessage::Prepare(msg));
         }
         assert!(
             drain(&mut instance)
                 .into_iter()
-                .any(|output| matches!(output, MVBAOutput::Broadcast(Message::Commit(_)))),
+                .any(|output| matches!(output, MVBAOutput::Broadcast(MvbaMessage::Commit(_)))),
             "a prepare certificate over the projection is voted to commit"
         );
 
@@ -2075,7 +2075,7 @@ mod toy_value {
                 FallbackCommitVote::<TestValue>(value.entries()),
                 &node.keypair(),
             );
-            instance.handle_message(node, Message::Commit(msg));
+            instance.handle_message(node, MvbaMessage::Commit(msg));
         }
 
         assert_eq!(
@@ -2090,7 +2090,7 @@ mod toy_value {
     /// `V = Metablock`
     fn drain(
         instance: &mut MonadMvba<TestValue, TestCert>,
-    ) -> Vec<MVBAOutput<Message<TestValue, TestCert>, TimerEvent<TestValue>>> {
+    ) -> Vec<MVBAOutput<MvbaMessage<TestValue, TestCert>, TimerEvent<TestValue>>> {
         std::iter::from_fn(|| instance.poll()).collect()
     }
 }

--- a/monad-mcp-chorus/src/slot/fast.rs
+++ b/monad-mcp-chorus/src/slot/fast.rs
@@ -373,7 +373,7 @@ impl FastPath {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub(crate) enum Entry {
+pub enum Entry {
     Positive { root: MerkleRoot },
     Negative,
 }
@@ -386,7 +386,7 @@ impl IsVote for Entry {
     }
 }
 
-pub(crate) type FastQc = StrongQc<Entry>;
+pub type FastQc = StrongQc<Entry>;
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub(crate) struct BatchVoteMsg {
@@ -443,7 +443,7 @@ pub(crate) type FastCommitQc = StrongQc<FastCommitVote>;
 
 // same as Entry, but signed under a distinct signing domain
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub(crate) struct FallbackEntry(pub Entry);
+pub struct FallbackEntry(pub Entry);
 
 impl IsVote for FallbackEntry {
     type Scope = (Slot, ProposalIndex);
@@ -453,7 +453,7 @@ impl IsVote for FallbackEntry {
     }
 }
 
-pub(crate) type FallbackQc = WeakQc<FallbackEntry>;
+pub type FallbackQc = WeakQc<FallbackEntry>;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum EvidenceStrength {
@@ -465,7 +465,7 @@ enum EvidenceStrength {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, derive_more::From, Debug)]
-pub(crate) enum CertifiedEntry {
+pub enum CertifiedEntry {
     #[from]
     FastQc(FastQc),
     #[from]
@@ -614,7 +614,7 @@ impl LocalCertifiedEntry {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub(crate) struct EnterFallbackVote;
+pub struct EnterFallbackVote;
 
 impl IsVote for EnterFallbackVote {
     type Scope = Slot;
@@ -631,4 +631,4 @@ pub(crate) struct FallbackVoteMsg {
 }
 
 // A fallback cert certifies 2f+1 validators agree to enter fallback path
-pub(crate) type EnterFallbackCert = StrongQc<EnterFallbackVote>;
+pub type EnterFallbackCert = StrongQc<EnterFallbackVote>;

--- a/monad-mcp-chorus/src/slot/mod.rs
+++ b/monad-mcp-chorus/src/slot/mod.rs
@@ -15,7 +15,7 @@
 
 pub mod chorus;
 pub mod dummy;
-mod fallback;
+pub mod fallback;
 mod fast;
 
 use super::types::{self, NodeId, Slot, TimestampDelta};


### PR DESCRIPTION
monad-sim test harness and tests for MVBA protocol. MVBARuntime is introduced to fit MVBA to the test framework, not intended to be run independently