### PR TITLE
Use InvalidParams for wrong eth filter

### DIFF
--- a/monad-rpc/src/handlers/eth/txn.rs
+++ b/monad-rpc/src/handlers/eth/txn.rs
@@ -48,10 +48,10 @@ impl From<FilterError> for JsonRpcError {
     fn from(e: FilterError) -> Self {
         match e {
             FilterError::InvalidBlockRange => {
-                JsonRpcError::with_message(ErrorCode::ServerError, "invalid block range")
+                JsonRpcError::with_message(ErrorCode::InvalidParams, "invalid block range")
             }
             FilterError::RangeTooLarge => {
-                JsonRpcError::with_message(ErrorCode::ServerError, "block range too large")
+                JsonRpcError::with_message(ErrorCode::InvalidParams, "block range too large")
             }
         }
     }


### PR DESCRIPTION
When a user submits an invalid filter to rpc, we should return the invalidparams error code instead of the generic server error.