### PR TITLE
Integrate the MVBA with Chorus

### DIFF
--- a/monad-mcp-chorus-sim/tests/cadence_conductor.rs
+++ b/monad-mcp-chorus-sim/tests/cadence_conductor.rs
@@ -138,6 +138,7 @@ fn full_window_rolls_over_with_chorus() {
             num_proposals: 1,
         };
         let context = ChorusContext {
+            node_id: id,
             key: Arc::new(id.keypair()),
             validator_data: val_data.clone(),
             da_handle: Arc::new(DAHandle),

--- a/monad-mcp-chorus-sim/tests/chorus.rs
+++ b/monad-mcp-chorus-sim/tests/chorus.rs
@@ -51,6 +51,7 @@ fn conductor() -> Conductor {
 fn add_node(builder: &mut CadenceSwarmBuilder<DummyMsg>, id: u64, val_data: &Arc<ValidatorData>) {
     let node_id = NodeId::dummy(id);
     let context = ChorusContext {
+        node_id,
         key: Arc::new(node_id.keypair()),
         validator_data: val_data.clone(),
         da_handle: Arc::new(DAHandle),

--- a/monad-mcp-chorus-sim/tests/fallback_mvba.rs
+++ b/monad-mcp-chorus-sim/tests/fallback_mvba.rs
@@ -387,7 +387,8 @@ fn agreement_survives_a_lossy_network() {
 }
 
 /// T5. A validator cut off for the first view's value-carrying rounds learns
-/// the verdict from an echoed commit certificate and the block from a peer
+/// the verdict from the deciders' one-shot commit certificate -- broadcast
+/// after the partition lifts -- and the block from a peer
 #[test]
 fn a_partitioned_validator_catches_up_through_block_sync() {
     let validator_data = fixtures::validator_data();
@@ -411,8 +412,9 @@ fn a_partitioned_validator_catches_up_through_block_sync() {
         .find(|node| **node != leader)
         .expect("four validators, one leader");
 
-    // the pre-prepare and prepare votes are sent inside the window and lost, the
-    // commit certificates echoed after it and kept: block sync, not slow recovery
+    // the pre-prepare and prepare votes are sent inside the window and lost; the
+    // commit certificates go out after it and are kept: block sync, not slow
+    // recovery
     let window = Time(0)..(Time(0) + 5 * LATENCY / 2);
     let network = Network::reliable(LATENCY).partition(window, [[laggard]]);
     let mut swarm = swarm(0, network, |node| inputs[&node].clone());
@@ -445,7 +447,7 @@ fn a_partitioned_validator_catches_up_through_block_sync() {
         "the partitioned validator decided without ever seeing the proposal"
     );
 
-    // then the laggard, off the echoed certificate plus a fetched block
+    // then the laggard, off the broadcast certificate plus a fetched block
     assert!(
         swarm.run_until_all_decided(views(3)),
         "the partitioned validator never caught up"
@@ -562,7 +564,7 @@ fn a_seed_reproduces_its_run() {
 }
 
 /// T7. Three validators hold a fallback input, the fourth none: it hears every
-/// message, echoed commit certificate included, and still never decides, since
+/// message, the commit certificate included, and still never decides, since
 /// participation is gated on the input. Three of four is exactly a supermajority
 #[test]
 fn a_validator_without_an_input_listens_without_deciding() {
@@ -597,8 +599,8 @@ fn a_validator_without_an_input_listens_without_deciding() {
     }
     let mut swarm = builder.build();
 
-    // long past the deciders' first echo of their commit certificate, one view
-    // timeout after they decide: whatever the listener learns, it stays out.
+    // long past the deciders' commit certificate, one view timeout after they
+    // decide: whatever the listener learns, it stays out.
     let deadline = views(3);
     let outcome = swarm.run_until_or(deadline, |_| false);
     assert_eq!(

--- a/monad-mcp-chorus/src/driver.rs
+++ b/monad-mcp-chorus/src/driver.rs
@@ -35,6 +35,7 @@ where
     fn schedule_slot_deadline(&mut self, slot: Slot, deadline: Timestamp);
     fn schedule_slot_timer(&mut self, delta: TimestampDelta, slot: Slot, timer: S::Timer);
     fn broadcast_slot(&mut self, slot: Slot, message: S::Message);
+    fn unicast_slot(&mut self, slot: Slot, to: NodeId, message: S::Message);
     fn broadcast_conductor(&mut self, message: C::Message);
     fn poll_node_event(&mut self) -> Option<NodeEvent<Self::WireMsg>>;
 
@@ -157,6 +158,13 @@ where
     fn broadcast_slot(&mut self, slot: Slot, message: S::Message) {
         self.outbox
             .push_back(NodeEvent::Broadcast(CadenceMessage::Slot(slot, message)));
+    }
+
+    fn unicast_slot(&mut self, slot: Slot, to: NodeId, message: S::Message) {
+        self.outbox.push_back(NodeEvent::Unicast {
+            to,
+            message: CadenceMessage::Slot(slot, message),
+        });
     }
 
     fn broadcast_conductor(&mut self, message: C::Message) {

--- a/monad-mcp-chorus/src/runtime.rs
+++ b/monad-mcp-chorus/src/runtime.rs
@@ -114,6 +114,9 @@ where
                 SlotOutput::Broadcast(message) => {
                     self.driver.broadcast_slot(slot, message);
                 }
+                SlotOutput::Unicast { to, message } => {
+                    self.driver.unicast_slot(slot, to, message);
+                }
                 SlotOutput::CommitOptimistic(data) => {
                     if let Some(observer) = &mut self.observer {
                         observer.handle_optimistic_commit(now, slot, &data);

--- a/monad-mcp-chorus/src/slot/chorus.rs
+++ b/monad-mcp-chorus/src/slot/chorus.rs
@@ -18,7 +18,10 @@ use std::{collections::VecDeque, sync::Arc};
 
 use super::{
     SlotConsensus, SlotOutput,
-    fallback::{FallbackPath, Metablock},
+    fallback::{
+        FallbackCommitQc, MVBAOutput, Metablock, Mvba as _,
+        monad_mvba::{self, MonadMvba, MvbaContext},
+    },
     fast::{
         BatchVoteMsg, CommitVoteDeadlineOutcome, EnterFallbackCert, FallbackVoteMsg, FastBlock,
         FastCommitQc, FastCommitVoteMsg, FastPath,
@@ -27,6 +30,11 @@ use super::{
         DAHandle, KeyPair, NodeId, ProposalIndex, ProposalMeta, Slot, TimestampDelta, ValidatorData,
     },
 };
+
+/// The fallback path's agreement protocol, at the instantiation Chorus runs it
+type FallbackState = MonadMvba<Metablock, EnterFallbackCert>;
+type FallbackMessage = monad_mvba::MvbaMessage<Metablock, EnterFallbackCert>;
+type FallbackTimer = monad_mvba::TimerEvent<Metablock>;
 
 // emitted from the DA layer upon validating a proposal
 // chunk. possibly only emitted after a significant fraction of
@@ -61,17 +69,20 @@ pub enum Message {
     // disseminate on entering fallback path
     #[from]
     EnterFallbackCert(EnterFallbackCert),
-    // messages for the fallback path (todo)
-    // ProposeBlock(Metablock),
-    // FallbackCommitQc(...)
+
+    // the fallback path's own protocol, dispatched into the MVBA
+    #[from]
+    Fallback(FallbackMessage),
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum TimerEvent {
     // emitted on D_s + Delta
     FallbackTransitionTimeout,
     // emitted on D_s + 2*Delta
     FallbackDecisionDelayElapsed,
+    // armed by the MVBA, fed straight back to it
+    Fallback(FallbackTimer),
 }
 
 /// Static per-slot configuration.
@@ -83,6 +94,7 @@ pub struct ChorusConfig {
 
 /// Shared resources needed to spawn a slot instance.
 pub struct ChorusContext {
+    pub node_id: NodeId,
     pub key: Arc<KeyPair>,
     pub validator_data: Arc<ValidatorData>,
     pub da_handle: Arc<DAHandle>,
@@ -92,27 +104,24 @@ pub struct ChorusContext {
 pub enum SlotFinalization {
     #[from]
     Fast(FastCommitQc),
-    // Fallback(FallbackCommitQc),
+    #[from]
+    Fallback(FallbackCommitQc<Metablock>),
 }
 
-#[derive(Clone)]
-struct FallbackMsgBuffer;
-
 /// The single-slot MCP consensus algorithm from the paper.
-#[derive(Clone)]
 pub struct Chorus {
     slot: Slot,
     key: Arc<KeyPair>,
 
     fast: FastPath,
-    fallback: Option<FallbackPath>,
+    /// memory is unbounded until this validator proposes into it: the MVBA
+    /// buffers what arrives without entering views or garbage-collecting. I
+    /// have a proposal to conditionally start fallback without self propose
+    fallback: FallbackState,
     outputs: VecDeque<SlotOutput<Chorus>>,
 
     // capital Delta from the paper
     delta: TimestampDelta,
-
-    // buffer messages for the fallback path until we enter it.
-    buffer: FallbackMsgBuffer,
 
     // Decided but slot not yet closed, ignore all subsequent messages
     // and timer events.
@@ -133,6 +142,7 @@ impl SlotConsensus for Chorus {
             num_proposals,
         } = config;
         let ChorusContext {
+            node_id,
             key,
             validator_data,
             da_handle,
@@ -146,13 +156,21 @@ impl SlotConsensus for Chorus {
             da_handle.clone(),
         );
 
+        let fallback = FallbackState::new(MvbaContext {
+            slot,
+            num_proposals: *num_proposals,
+            delta: *delta,
+            node_id: *node_id,
+            key: key.clone(),
+            validator_data: validator_data.clone(),
+        });
+
         Self {
             slot,
             delta: *delta,
             key: key.clone(),
             fast,
-            fallback: None,
-            buffer: FallbackMsgBuffer,
+            fallback,
             outputs: Default::default(),
             decided: false,
         }
@@ -215,6 +233,11 @@ impl SlotConsensus for Chorus {
                     self.enter_fallback(cert, block);
                 }
             }
+
+            Message::Fallback(message) => {
+                self.fallback.handle_message(author, message);
+                self.drain_fallback();
+            }
         }
     }
 
@@ -259,6 +282,10 @@ impl SlotConsensus for Chorus {
                     self.enter_fallback(cert, block);
                 }
             },
+            TimerEvent::Fallback(event) => {
+                self.fallback.handle_timer(event);
+                self.drain_fallback();
+            }
         }
     }
 }
@@ -268,30 +295,54 @@ impl Chorus {
     fn broadcast(&mut self, msg: impl Into<Message>) {
         self.push(SlotOutput::Broadcast(msg.into()));
     }
+
     fn schedule_timer(&mut self, delta: TimestampDelta, event: TimerEvent) {
         self.push(SlotOutput::ScheduleTimer(delta, event));
     }
+
     fn finalize(&mut self, cert: impl Into<SlotFinalization>) {
+        // TODO: introduce fast path handling of fallback commit
         if self.decided {
             // idempotent
             return;
         }
 
         self.decided = true;
+        self.fallback.abandon();
         self.push(SlotOutput::Finalize(cert.into()));
     }
+
+    /// `propose` is idempotent, so a second certificate changes nothing
     fn enter_fallback(&mut self, cert: EnterFallbackCert, block: Metablock) {
-        if self.fallback.is_some() {
-            // already in the fallback path.
-            return;
-        }
-        // the MVBA arms its own view timer and emits it as an
-        // MVBAOutput::ScheduleTimer; once messages are routed into the MVBA
-        // (see fallback/mod.rs), this layer only converts those outputs to
-        // SlotOutput::ScheduleTimer and feeds the events back -- it schedules
-        // nothing on the fallback's behalf.
-        self.fallback = Some(self.fast.spawn_fallback(cert, block));
+        self.fallback.propose(block, Some(cert));
+        self.drain_fallback();
     }
+
+    /// The MVBA arms its own timers and asks for its own sends; this layer only
+    /// converts them, and finalizes once a commit certificate is complete
+    fn drain_fallback(&mut self) {
+        // drained first: finalize -> abandon clears the MVBA's output queue,
+        // which holds the decide-broadcast certificate
+        while let Some(output) = self.fallback.poll() {
+            match output {
+                MVBAOutput::Broadcast(message) => self.broadcast(message),
+                MVBAOutput::Unicast { to, message } => self.push(SlotOutput::Unicast {
+                    to,
+                    message: message.into(),
+                }),
+                MVBAOutput::ScheduleTimer {
+                    duration,
+                    timer_event,
+                } => self.schedule_timer(duration, TimerEvent::Fallback(timer_event)),
+            }
+        }
+
+        if let Some(qc) = self.fallback.decision_proof() {
+            let qc = qc.clone();
+            self.finalize(qc);
+        }
+    }
+
     fn push(&mut self, out: SlotOutput<Chorus>) {
         self.outputs.push_back(out);
     }

--- a/monad-mcp-chorus/src/slot/fallback/mod.rs
+++ b/monad-mcp-chorus/src/slot/fallback/mod.rs
@@ -17,15 +17,14 @@
 //! proposer -- when the fast path cannot commit a slot. Votes and certificates
 //! range over `entries(x)`, never over the value that carried them
 
-// Not wired into `FallbackPath` yet; routing chorus messages in is a follow-up
-#[allow(dead_code)]
 pub mod monad_mvba;
 use std::{
     collections::{HashMap, VecDeque},
     fmt::Debug,
     hash::Hash,
-    sync::Arc,
 };
+
+pub use monad_mvba::FallbackCommitQc;
 
 /// MetaBlock components are exported
 pub use super::fast::{
@@ -36,16 +35,12 @@ use super::{
         driver::{NodeEvent, WakeId},
         runtime::Runtime,
     },
-    types::{
-        IsVote, KeyPair, NodeId, Slot, StrongQc, Timestamp, TimestampDelta, TotalProposalMap,
-        Validated, ValidatorData,
-    },
+    types::{IsVote, NodeId, StrongQc, Timestamp, TimestampDelta, TotalProposalMap, Validated},
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct FallbackView(u64);
 
-#[allow(dead_code)]
 impl FallbackView {
     /// Views are 1-indexed; view 0 is the not-yet-started state
     const GENESIS: Self = Self(0);
@@ -61,37 +56,6 @@ impl FallbackView {
 
     fn saturating_sub(self, views: u64) -> Self {
         Self(self.0.saturating_sub(views))
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct FallbackPath {
-    slot: Slot,
-    round: FallbackView,
-
-    cert: EnterFallbackCert,
-    block: Metablock,
-
-    key: Arc<KeyPair>,
-    validator_data: Arc<ValidatorData>,
-}
-
-impl FallbackPath {
-    pub(crate) fn new(
-        slot: Slot,
-        key: Arc<KeyPair>,
-        validator_data: Arc<ValidatorData>,
-        cert: EnterFallbackCert,
-        block: Metablock,
-    ) -> Self {
-        Self {
-            slot,
-            round: FallbackView(0),
-            key,
-            validator_data,
-            cert,
-            block,
-        }
     }
 }
 

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/certificates.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/certificates.rs
@@ -28,7 +28,7 @@ use crate::spec::{Stake as _, validator::ValidatorData as _, vote::SignatureColl
 pub(crate) type PrepareQc<V> = StrongQc<PrepareVote<V>>;
 
 /// `CommitQC`: 2f+1 commit votes on the same entries
-pub(crate) type FallbackCommitQc<V> = StrongQc<FallbackCommitVote<V>>;
+pub type FallbackCommitQc<V> = StrongQc<FallbackCommitVote<V>>;
 
 /// `TC_{slot, v}`: 2f+1 timeouts for view `v` from distinct senders
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/mod.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/mod.rs
@@ -36,7 +36,9 @@
 //!
 //! Agreement runs over `entries(x)`, so certificates arrive independently of
 //! the blocks behind them. [`MonadMvba::request_missing_blocks`] is the one
-//! place a fetch is asked for
+//! place a fetch is asked for. A decision is broadcast once and re-broadcast
+//! by whoever it reaches; being fetchable after that is the recovery layer's
+//! contract, not this instance's
 //!
 //! `v`, `lastVotedView`, `PrepQC` and `DecidedQC` must be durable before any
 //! message they enable is sent. There is no backend yet; the points are marked
@@ -59,7 +61,8 @@ use std::{
 };
 
 use block_store::{BlockRequestMsg, BlockResponseMsg, BlockStore};
-use certificates::{FallbackCommitQc, PrepareQc, TimeoutCertificate};
+pub use certificates::FallbackCommitQc;
+use certificates::{PrepareQc, TimeoutCertificate};
 use collectors::ViewCollectors;
 pub use messages::MvbaMessage;
 use messages::{
@@ -86,9 +89,6 @@ const LOOKBACK_VIEWS: u64 = 1;
 
 /// View timeout in multiples of Δ: proposal, prepare round, commit round
 const VIEW_TIMEOUT_DELTAS: u64 = 3;
-
-/// How often a decided instance re-broadcasts its commit certificate
-const DECIDED_ECHO_DELTAS: u64 = 3;
 
 pub struct MvbaContext {
     pub slot: Slot,
@@ -122,12 +122,6 @@ impl MvbaContext {
             .checked_mul(VIEW_TIMEOUT_DELTAS)
             .expect("view timeout overflows the timestamp range")
     }
-
-    fn decided_echo_timeout(&self) -> TimestampDelta {
-        self.delta
-            .checked_mul(DECIDED_ECHO_DELTAS)
-            .expect("echo timeout overflows the timestamp range")
-    }
 }
 
 /// Timers driven by the MVBA state machine
@@ -138,10 +132,6 @@ pub enum TimerEvent<V: Votable> {
     ViewTimeout(FallbackView),
     /// Retransmit the outstanding request for one block
     BlockRetransmit(V::Entries),
-    /// TODO: decide if fast or fallback path should guarantee eventual commit
-    ///
-    /// Retransmit decided commitQC
-    DecidedEcho,
 }
 
 /// Validation context for MetaBlock and FallbackCert
@@ -307,7 +297,6 @@ where
                         .extend(self.block_store.on_retransmit_timer(&entries));
                 }
             }
-            TimerEvent::DecidedEcho => self.echo_decision(),
         }
     }
 
@@ -745,31 +734,8 @@ where
 
         (
             Phase::Decided(Decided::new(commit_qc.clone(), block)),
-            vec![
-                MVBAOutput::Broadcast(MvbaMessage::CommitQc(commit_qc)),
-                MVBAOutput::ScheduleTimer {
-                    duration: self.context.decided_echo_timeout(),
-                    timer_event: TimerEvent::DecidedEcho,
-                },
-            ],
+            vec![MVBAOutput::Broadcast(MvbaMessage::CommitQc(commit_qc))],
         )
-    }
-
-    /// Runs outside `try_advance` because a decision ends the state machine,
-    /// not the obligation to be fetchable from
-    fn echo_decision(&mut self) {
-        let Some(decided) = self.phase.decided() else {
-            panic!("echo decision timer scheduled while not in decided state");
-        };
-
-        self.outputs
-            .push_back(MVBAOutput::Broadcast(MvbaMessage::CommitQc(
-                decided.commit_qc().clone(),
-            )));
-        self.outputs.push_back(MVBAOutput::ScheduleTimer {
-            duration: self.context.decided_echo_timeout(),
-            timer_event: TimerEvent::DecidedEcho,
-        });
     }
 
     /// `SyncView`

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/phases.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/phases.rs
@@ -64,11 +64,11 @@ pub(crate) struct Preparing<V: Votable> {
     entries: V::Entries,
 }
 
-/// Prepare certificate formed, commit vote sent
+/// Prepare certificate formed, commit vote sent. The certificate itself is the
+/// instance's lock, held in `high_prep_qc`
 #[derive(Clone)]
 pub(crate) struct Committing<V: Votable> {
     entries: V::Entries,
-    prepare_qc: PrepareQc<V>,
 }
 
 /// Decided, with the certificate that proves it and the block it settled
@@ -137,14 +137,6 @@ impl<V: Votable> Phase<V> {
         }
     }
 
-    pub(crate) fn prepare_qc(&self) -> Option<&PrepareQc<V>> {
-        match self {
-            Phase::Committing(p) => Some(&p.prepare_qc),
-            Phase::Poisoned => unreachable!("{POISON_OBSERVED}"),
-            _ => None,
-        }
-    }
-
     /// For assertion messages
     pub(crate) fn name(&self) -> &'static str {
         match self {
@@ -197,7 +189,6 @@ impl<V: Votable> Preparing<V> {
 
         Committing {
             entries: self.entries,
-            prepare_qc,
         }
     }
 }

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/tests.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/tests.rs
@@ -168,7 +168,7 @@ fn commit_votes_decide_once_the_block_is_fetched() {
     );
     assert!(
         decided_commit_qc(&outputs),
-        "the echo goes out with the decision, after retrieval"
+        "the certificate goes out with the decision, after retrieval"
     );
 }
 
@@ -1012,7 +1012,7 @@ fn a_received_certificate_decides_once_its_block_is_retrieved() {
     assert!(instance.decision().is_none());
     assert!(
         !decided_commit_qc(&outputs),
-        "a certificate this validator cannot complete is not echoed"
+        "a certificate this validator cannot complete is not passed on"
     );
 
     instance.handle_message(nodes()[2], block_response(block.clone()));
@@ -1408,8 +1408,8 @@ fn a_certificate_arriving_before_propose_is_fetched_once_it_does() {
     let mut instance = mvba(follower, &validator_data);
 
     // the certificate is recorded -- it is valid evidence whenever it arrives --
-    // but an instance with no input does not participate, so it sends nothing:
-    // not a request, and not the echo
+    // but an instance with no input does not participate, so it sends nothing,
+    // not even a block request
     instance.handle_message(
         nodes()[1],
         commit_qc_message(view(1), &block, &validator_data),
@@ -1648,100 +1648,32 @@ fn an_adopted_lock_over_a_held_block_requests_nothing() {
     );
 }
 
-// ---------------- the decided echo ----------------
+// ---------------- the decision, once broadcast ----------------
 
+/// The whole recovery loop: the one-shot broadcast on decide is the discovery
+/// step, and the block half stays pull-based behind it
 #[test]
-fn deciding_arms_the_decided_echo() {
-    let validator_data = validator_data();
-    let block = metablock(1, &validator_data);
-
-    let mut instance = decided(nodes()[0], &block, &validator_data);
-    let outputs = drain(&mut instance);
-
-    assert!(instance.decision().is_some());
-    assert!(decided_commit_qc(&outputs));
-    assert!(
-        scheduled_timers(&outputs).contains(&TimerEvent::DecidedEcho),
-        "one broadcast is not something a laggard can rely on having seen"
-    );
-}
-
-#[test]
-fn the_decided_echo_rebroadcasts_the_commit_certificate_and_re_arms() {
-    let validator_data = validator_data();
-    let block = metablock(1, &validator_data);
-
-    let mut instance = decided(nodes()[0], &block, &validator_data);
-    drain(&mut instance);
-
-    for _ in 0..2 {
-        instance.handle_timer(TimerEvent::DecidedEcho);
-        let outputs = drain(&mut instance);
-
-        assert!(decided_commit_qc(&outputs));
-        assert_eq!(scheduled_timers(&outputs), vec![TimerEvent::DecidedEcho]);
-    }
-}
-
-#[test]
-fn abandon_silences_the_decided_echo() {
-    let validator_data = validator_data();
-    let block = metablock(1, &validator_data);
-
-    let mut instance = decided(nodes()[0], &block, &validator_data);
-    drain(&mut instance);
-
-    instance.abandon();
-    instance.handle_timer(TimerEvent::DecidedEcho);
-
-    assert!(
-        drain(&mut instance).is_empty(),
-        "the fast path taking the slot over is what ends the obligation"
-    );
-}
-
-/// The echo timer is armed only at the moment of decision, so one firing
-/// earlier is a wiring bug, not a race to tolerate
-#[test]
-#[should_panic(expected = "echo decision timer scheduled while not in decided state")]
-fn a_decided_echo_before_any_decision_panics() {
-    let validator_data = validator_data();
-    let block = metablock(1, &validator_data);
-
-    let mut instance = started(nodes()[0], &block, &validator_data);
-    drain(&mut instance);
-
-    instance.handle_timer(TimerEvent::DecidedEcho);
-}
-
-/// The whole recovery loop: the echo is the discovery step, and the block half
-/// stays pull-based behind it
-#[test]
-fn a_laggard_catches_up_on_the_echo() {
+fn a_laggard_catches_up_on_the_decision_broadcast() {
     let validator_data = validator_data();
     let block = metablock(1, &validator_data);
     let own = metablock(2, &validator_data);
 
     let mut decider = decided(nodes()[0], &block, &validator_data);
-    drain(&mut decider);
+    let outputs = drain(&mut decider);
+    let decision = broadcasts(&outputs)
+        .into_iter()
+        .find(|message| matches!(message, Message::CommitQc(_)))
+        .expect("deciding broadcasts the certificate")
+        .clone();
 
-    // it holds a different input and never saw the proposal or the votes: the
-    // one-shot broadcast at decision time is gone, so nothing it holds says the
-    // slot was settled
+    // it holds a different input and never saw the proposal or the votes, so
+    // nothing it holds says the slot was settled
     let laggard_id = nodes()[2];
     let mut laggard = started(laggard_id, &own, &validator_data);
     drain(&mut laggard);
     assert!(laggard.decision().is_none());
 
-    decider.handle_timer(TimerEvent::DecidedEcho);
-    let outputs = drain(&mut decider);
-    let echo = broadcasts(&outputs)
-        .into_iter()
-        .find(|message| matches!(message, Message::CommitQc(_)))
-        .expect("the echo re-broadcasts the certificate")
-        .clone();
-
-    laggard.handle_message(nodes()[0], echo);
+    laggard.handle_message(nodes()[0], decision);
     let outputs = drain(&mut laggard);
     assert_eq!(
         requested_entries(&outputs),
@@ -1763,6 +1695,19 @@ fn a_laggard_catches_up_on_the_echo() {
 
     assert_eq!(laggard.decision(), Some(&block));
     assert!(laggard.decision_proof().is_some());
+}
+
+/// Abandoning is what ends the instance: the fast path taking the slot over
+/// silences everything the decision still had queued
+#[test]
+fn abandon_silences_a_decided_instance() {
+    let validator_data = validator_data();
+    let block = metablock(1, &validator_data);
+
+    let mut instance = decided(nodes()[0], &block, &validator_data);
+    instance.abandon();
+
+    assert!(drain(&mut instance).is_empty());
 }
 
 // ---------------- admission window ----------------

--- a/monad-mcp-chorus/src/slot/fast.rs
+++ b/monad-mcp-chorus/src/slot/fast.rs
@@ -19,7 +19,7 @@ use bytes::Bytes;
 use itertools::Either;
 
 use super::{
-    fallback::{FallbackPath, Metablock},
+    fallback::Metablock,
     types::{
         DAHandle, EquivCert, FetchProposalError, IsVote, KeyPair, MerkleRoot, NodeId,
         ProposalIndex, ProposalMap, ProposalMeta, Signature, Slot, StrongQc, TotalProposalMap,
@@ -99,16 +99,6 @@ impl FastPath {
     /// MVBA input, where admission used to be re-checked on every proposal.
     pub(crate) fn enter_fallback_cert_is_valid(&self, cert: &EnterFallbackCert) -> bool {
         cert.scope == self.slot && cert.verify(&self.validator_data)
-    }
-
-    pub(crate) fn spawn_fallback(&self, cert: EnterFallbackCert, block: Metablock) -> FallbackPath {
-        FallbackPath::new(
-            self.slot,
-            self.key.clone(),
-            self.validator_data.clone(),
-            cert,
-            block,
-        )
     }
 
     pub(crate) fn handle_batch_vote(

--- a/monad-mcp-chorus/src/slot/mod.rs
+++ b/monad-mcp-chorus/src/slot/mod.rs
@@ -57,6 +57,9 @@ pub enum SlotOutput<S: SlotConsensus> {
     /// SlotConsensusInput.
     Broadcast(S::Message),
 
+    /// Send a message to a single peer validator
+    Unicast { to: NodeId, message: S::Message },
+
     /// Signal execution for optimistic execution.  Q: maybe move this
     /// message into a Context handle method? CommitOptimistic is
     /// meaningless without the knowledge of execution.


### PR DESCRIPTION
The fallback path is the real MVBA instead of a placeholder. Chorus builds a MonadMvba<Metablock, EnterFallbackCert> at slot open and owns the dispatch: wrapped wire messages and timers route in through Message::Fallback and TimerEvent::Fallback, every touch is followed by a drain converting MVBA outputs into slot outputs, and the MVBA's CommitQC is the fallback finalization proof. SlotOutput::Unicast is new for the MVBA's block responses. Includes the MVBA cleanups this needed: the decided echo and the unread Committing::prepare_qc are gone, FallbackCommitQc is exported.

This code was generated using Claude Opus 5.