### PR TITLE
Mock DA and swarm tests with DA

### DIFF
--- a/monad-mcp-chorus-sim/src/da.rs
+++ b/monad-mcp-chorus-sim/src/da.rs
@@ -1,0 +1,575 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! A simulated data-availability layer: chunks carry no payload, so a chunk is
+//! just "one validator's share of root r", and a proposal decodes once shares
+//! from f+1 distinct validators are in hand. Dissemination is driven by a
+//! [`DaDisseminator`] node that authors every proposal and follows a
+//! [`DisseminationPlan`] per (slot, proposer), which is what lets a test say
+//! "this proposal reached k of n validators". Validators relay their own share
+//! when they vote positive, and re-serve every validator its share when they
+//! cast a positive fallback entry.
+
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
+    sync::Arc,
+};
+
+use chorus::{
+    DAOutput, DASink, DataAvailability, NodeEvent, NodeMessage, Runtime, SlotLifecycle, WakeId,
+    slot::chorus::{Chorus, ChorusDACommand, ChorusDAEvent, ProposalDAEvent},
+    types::{
+        MerkleRoot, NodeId, OpaqueChunkHeader, ProposalIndex, ProposalMeta, ProposalSignature,
+        Slot, Timestamp, TimestampDelta, Validated, ValidatorData,
+    },
+};
+use monad_mcp_chorus::{
+    spec::{Stake as _, validator::ValidatorData as _},
+    stub as chorus,
+};
+
+/// One validator's share of a proposal. Who it came from is what matters here,
+/// not what it carries: from the author or a recaster it is the recipient's own
+/// share, from an owner it is the owner's
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum DaWire {
+    Chunk {
+        slot: Slot,
+        j: ProposalIndex,
+        meta: ProposalMeta,
+        upstream: Upstream,
+    },
+}
+
+/// Who handed us the chunk: the proposal's author, the validator whose own
+/// share it is relaying, or a fallback-yes voter that recovered the proposal and
+/// re-encoded our share
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum Upstream {
+    Author,
+    Owner(NodeId),
+    Recast(NodeId),
+}
+
+/// The root the author uses for proposer `j` in `slot`
+pub fn root_of(slot: Slot, j: ProposalIndex) -> MerkleRoot {
+    MerkleRoot(slot.get() * 1000 + j as u64)
+}
+
+/// The header the author signs for proposer `j` in `slot`
+pub fn meta_of(slot: Slot, j: ProposalIndex) -> ProposalMeta {
+    ProposalMeta {
+        root: root_of(slot, j),
+        sig: ProposalSignature,
+        opaque_header: OpaqueChunkHeader,
+    }
+}
+
+/// The author of every proposal: a swarm node outside the validator set
+pub fn disseminator_id() -> NodeId {
+    NodeId::dummy(u64::MAX)
+}
+
+/// One validator's view of the chunks in flight
+pub struct SimDA {
+    me: NodeId,
+    validator_data: Arc<ValidatorData>,
+    slots: BTreeMap<Slot, HashMap<(ProposalIndex, MerkleRoot), ChunkState>>,
+    outputs: VecDeque<DAOutput<ChorusDAEvent, DaWire>>,
+}
+
+struct ChunkState {
+    meta: ProposalMeta,
+    /// our own share arrived from the author
+    from_author: bool,
+    /// our own share arrived re-encoded from a fallback-yes voter
+    recast: bool,
+    /// validators that relayed their own share to us
+    owners: BTreeSet<NodeId>,
+    decoded: bool,
+}
+
+impl SimDA {
+    pub fn new(me: NodeId, validator_data: Arc<ValidatorData>) -> Self {
+        Self {
+            me,
+            validator_data,
+            slots: BTreeMap::new(),
+            outputs: VecDeque::new(),
+        }
+    }
+
+    fn emit(&mut self, slot: Slot, j: ProposalIndex, event: ProposalDAEvent) {
+        self.outputs
+            .push_back(DAOutput::Event(slot, ChorusDAEvent { j, event }));
+    }
+
+    fn state(&self, slot: Slot, j: ProposalIndex, root: MerkleRoot) -> Option<&ChunkState> {
+        self.slots.get(&slot)?.get(&(j, root))
+    }
+
+    /// Relay our own share of a root we were served, as the paper has positive
+    /// voters do
+    fn relay(&mut self, slot: Slot, j: ProposalIndex, root: MerkleRoot) {
+        let held = self
+            .state(slot, j, root)
+            .filter(|state| state.from_author)
+            .map(|state| state.meta.clone());
+
+        if let Some(meta) = held {
+            self.outputs.push_back(DAOutput::Broadcast(DaWire::Chunk {
+                slot,
+                j,
+                meta,
+                upstream: Upstream::Owner(self.me),
+            }));
+        }
+    }
+
+    /// Recover the proposal from the shares we hold, re-encode it and serve
+    /// every other validator its own share, as the paper has fallback-yes
+    /// voters do
+    fn recast(&mut self, slot: Slot, j: ProposalIndex, root: MerkleRoot) {
+        // consensus casts a positive fallback entry only for a root it saw
+        // decode, and decoding is what lets us re-encode every share
+        let Some(meta) = self
+            .state(slot, j, root)
+            .filter(|state| state.decoded)
+            .map(|state| state.meta.clone())
+        else {
+            return;
+        };
+
+        let validator_data = self.validator_data.clone();
+        for to in validator_data.nodes().copied().filter(|v| *v != self.me) {
+            self.outputs.push_back(DAOutput::Unicast {
+                to,
+                message: DaWire::Chunk {
+                    slot,
+                    j,
+                    meta: meta.clone(),
+                    upstream: Upstream::Recast(self.me),
+                },
+            });
+        }
+    }
+}
+
+/// The shares we hold are our own (when the author or a recaster served us)
+/// plus every relayed one; f+1 of them recover the proposal
+fn is_decodable(validator_data: &ValidatorData, me: &NodeId, state: &ChunkState) -> bool {
+    let holds_own = state.from_author || state.recast;
+    let holders = state.owners.iter().chain(holds_own.then_some(me));
+    let stake = validator_data.sum_stake(holders);
+
+    stake > validator_data.total_stake().honest_threshold()
+}
+
+impl DASink<ChorusDACommand> for SimDA {
+    fn handle_lifecycle(&mut self, slot: Slot, lifecycle: SlotLifecycle) {
+        match lifecycle {
+            SlotLifecycle::Opened => {}
+            SlotLifecycle::Completed => {
+                self.slots.remove(&slot);
+            }
+        }
+    }
+
+    fn handle_command(&mut self, slot: Slot, command: ChorusDACommand) {
+        match command {
+            ChorusDACommand::SlotVoted { positive } => {
+                for (j, root) in positive {
+                    self.relay(slot, j, root);
+                }
+            }
+            ChorusDACommand::FallbackEntryCast { j, root } => self.recast(slot, j, root),
+            // the header is already recorded by consensus itself; a real DA
+            // layer would pin the root here
+            ChorusDACommand::ObserveProposal { .. } => {}
+        }
+    }
+}
+
+impl DataAvailability<Chorus> for SimDA {
+    type WireMsg = DaWire;
+
+    fn handle_message(&mut self, _now: Timestamp, message: Validated<DaWire>) {
+        let (chunk, _from) = message.destructure();
+        let DaWire::Chunk {
+            slot,
+            j,
+            meta,
+            upstream,
+        } = chunk;
+
+        // our own relay comes back to us over the broadcast, carrying a share
+        // we already hold
+        if upstream == Upstream::Owner(self.me) {
+            return;
+        }
+
+        let root = meta.root;
+        let mut events = Vec::new();
+
+        let proposals = self.slots.entry(slot).or_default();
+        if !proposals.contains_key(&(j, root)) {
+            events.push(ProposalDAEvent::HeaderSeen(meta.clone()));
+        }
+
+        let state = proposals.entry((j, root)).or_insert_with(|| ChunkState {
+            meta,
+            from_author: false,
+            recast: false,
+            owners: BTreeSet::new(),
+            decoded: false,
+        });
+
+        match upstream {
+            Upstream::Author if !state.from_author => {
+                state.from_author = true;
+                events.push(ProposalDAEvent::ProposerObligationFulfilled(root));
+            }
+            // our own share, but not the author's doing: nothing to report
+            // beyond what it lets us decode
+            Upstream::Recast(_) => state.recast = true,
+            Upstream::Owner(owner) if state.owners.insert(owner) => {
+                events.push(ProposalDAEvent::OwnerObligationFulfilled { owner, root });
+            }
+            _ => {}
+        }
+
+        if !state.decoded && is_decodable(&self.validator_data, &self.me, state) {
+            state.decoded = true;
+            events.push(ProposalDAEvent::Decoded(root));
+        }
+
+        for event in events {
+            self.emit(slot, j, event);
+        }
+    }
+
+    fn wake(&mut self, _now: Timestamp, _wake: WakeId) {}
+
+    fn poll(&mut self) -> Option<DAOutput<ChorusDAEvent, DaWire>> {
+        self.outputs.pop_front()
+    }
+}
+
+/// What the author does with proposer `j`'s chunks in a slot
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum DisseminationPlan {
+    /// serve the first `k` validators in NodeId order
+    Reach(usize),
+    ReachSet(BTreeSet<NodeId>),
+    /// serve these validators `offset` late, i.e. at `D_s - Delta + offset`
+    Delay {
+        recipients: BTreeSet<NodeId>,
+        offset: TimestampDelta,
+    },
+    Silent,
+}
+
+/// The sole author of every proposal: a swarm node outside the validator set
+/// that serves each validator its own chunk at `D_s - Delta`, or does not.
+/// It ignores everything it receives, the validators' own relays included.
+pub struct DaDisseminator<CM> {
+    validators: Vec<NodeId>,
+    num_proposals: usize,
+    slots: std::ops::Range<u64>,
+    delta: TimestampDelta,
+    deadline_of: Box<dyn Fn(Slot) -> Timestamp>,
+    plans_of: Box<dyn Fn(Slot, ProposalIndex) -> Vec<DisseminationPlan>>,
+    pending: HashMap<WakeId, (Slot, ProposalIndex, Vec<NodeId>)>,
+    next_wake: WakeId,
+    outbox: VecDeque<NodeEvent<NodeMessage<CM, DaWire>>>,
+}
+
+impl<CM> DaDisseminator<CM> {
+    /// `plans_of` may return several plans for one (slot, j) so a proposal can
+    /// reach some validators on time and others late
+    pub fn new(
+        validators: Vec<NodeId>,
+        num_proposals: usize,
+        slots: std::ops::Range<u64>,
+        delta: TimestampDelta,
+        deadline_of: impl Fn(Slot) -> Timestamp + 'static,
+        plans_of: impl Fn(Slot, ProposalIndex) -> Vec<DisseminationPlan> + 'static,
+    ) -> Self {
+        let mut validators = validators;
+        validators.sort();
+
+        Self {
+            validators,
+            num_proposals,
+            slots,
+            delta,
+            deadline_of: Box::new(deadline_of),
+            plans_of: Box::new(plans_of),
+            pending: HashMap::new(),
+            next_wake: WakeId::FIRST,
+            outbox: VecDeque::new(),
+        }
+    }
+
+    fn recipients(&self, plan: &DisseminationPlan) -> (Vec<NodeId>, TimestampDelta) {
+        match plan {
+            DisseminationPlan::Reach(k) => (
+                self.validators.iter().copied().take(*k).collect(),
+                TimestampDelta::ZERO,
+            ),
+            DisseminationPlan::ReachSet(recipients) => {
+                (recipients.iter().copied().collect(), TimestampDelta::ZERO)
+            }
+            DisseminationPlan::Delay { recipients, offset } => {
+                (recipients.iter().copied().collect(), *offset)
+            }
+            DisseminationPlan::Silent => (Vec::new(), TimestampDelta::ZERO),
+        }
+    }
+}
+
+impl<CM> Runtime<NodeMessage<CM, DaWire>> for DaDisseminator<CM> {
+    fn init(&mut self) {
+        for s in self.slots.clone() {
+            let slot = Slot(s);
+            for j in 0..self.num_proposals {
+                for plan in (self.plans_of)(slot, j) {
+                    let (recipients, offset) = self.recipients(&plan);
+                    if recipients.is_empty() {
+                        continue;
+                    }
+
+                    let deadline = (self.deadline_of)(slot).as_nanos();
+                    let at = Timestamp::from_nanos(
+                        deadline.saturating_sub(u128::from(self.delta.as_nanos())),
+                    ) + offset;
+
+                    let id = self.next_wake.post_increment();
+                    self.pending.insert(id, (slot, j, recipients));
+                    self.outbox.push_back(NodeEvent::Wake(at, id));
+                }
+            }
+        }
+    }
+
+    fn wake(&mut self, _now: Timestamp, wake: WakeId) {
+        let Some((slot, j, recipients)) = self.pending.remove(&wake) else {
+            return;
+        };
+
+        for to in recipients {
+            let chunk = DaWire::Chunk {
+                slot,
+                j,
+                meta: meta_of(slot, j),
+                upstream: Upstream::Author,
+            };
+            self.outbox.push_back(NodeEvent::Unicast {
+                to,
+                message: NodeMessage::DA(chunk),
+            });
+        }
+    }
+
+    fn receive(&mut self, _now: Timestamp, _message: Validated<NodeMessage<CM, DaWire>>) {}
+
+    fn poll(&mut self) -> Option<NodeEvent<NodeMessage<CM, DaWire>>> {
+        self.outbox.pop_front()
+    }
+}
+
+/// Direct-drive tests: one `SimDA`, no network, no consensus. They check what
+/// a swarm cannot see -- the exact events reported and shares served
+#[cfg(test)]
+mod tests {
+    use monad_mcp_chorus::spec::KeyPair as _;
+
+    use super::{chorus::types::Stake, *};
+
+    const PROPOSER: ProposalIndex = 0;
+
+    /// The slot every test here drives
+    const SLOT: Slot = Slot(1);
+
+    /// n = 4, f = 1: a root decodes once two of the four shares are in hand
+    fn node(i: u64) -> SimDA {
+        let validators = (0..4).map(NodeId::dummy).collect::<Vec<_>>();
+        let valset = validators.iter().map(|id| (*id, Stake::from(1))).collect();
+        let mapping = validators
+            .iter()
+            .map(|id| (*id, id.keypair().pubkey()))
+            .collect();
+        SimDA::new(
+            NodeId::dummy(i),
+            Arc::new(ValidatorData::new(valset, mapping)),
+        )
+    }
+
+    /// A share of `PROPOSER`'s proposal in `SLOT`, handed to us by `upstream`
+    fn chunk(upstream: Upstream) -> DaWire {
+        DaWire::Chunk {
+            slot: SLOT,
+            j: PROPOSER,
+            meta: meta_of(SLOT, PROPOSER),
+            upstream,
+        }
+    }
+
+    fn ingest(da: &mut SimDA, upstream: Upstream, from: NodeId) {
+        da.handle_message(
+            Timestamp::GENESIS,
+            Validated::new_unchecked(chunk(upstream), from),
+        );
+    }
+
+    fn cast(da: &mut SimDA) {
+        da.handle_command(
+            SLOT,
+            ChorusDACommand::FallbackEntryCast {
+                j: PROPOSER,
+                root: root_of(SLOT, PROPOSER),
+            },
+        );
+    }
+
+    /// Everything the DA layer has queued, split by kind. `DAOutput` has no
+    /// `PartialEq`, so we take it apart here
+    fn drain(da: &mut SimDA) -> (Vec<ProposalDAEvent>, Vec<(NodeId, DaWire)>, Vec<DaWire>) {
+        let (mut events, mut unicasts, mut broadcasts) = (Vec::new(), Vec::new(), Vec::new());
+        while let Some(output) = da.poll() {
+            match output {
+                DAOutput::Event(_, ChorusDAEvent { event, .. }) => events.push(event),
+                DAOutput::Unicast { to, message } => unicasts.push((to, message)),
+                DAOutput::Broadcast(message) => broadcasts.push(message),
+                DAOutput::Schedule(..) => panic!("the sim DA schedules no wakes"),
+            }
+        }
+        (events, unicasts, broadcasts)
+    }
+
+    fn decoded() -> ProposalDAEvent {
+        ProposalDAEvent::Decoded(root_of(SLOT, PROPOSER))
+    }
+
+    /// A caster the author never served still owes every validator its share: the
+    /// shares it decoded from are enough to re-encode them all
+    #[test]
+    fn a_fallback_yes_voter_serves_every_other_validator_its_share() {
+        let mut da = node(2);
+        ingest(&mut da, Upstream::Owner(NodeId::dummy(0)), NodeId::dummy(0));
+        ingest(&mut da, Upstream::Owner(NodeId::dummy(1)), NodeId::dummy(1));
+
+        let (events, ..) = drain(&mut da);
+        assert_eq!(events.last(), Some(&decoded()));
+
+        cast(&mut da);
+        let (events, unicasts, broadcasts) = drain(&mut da);
+        assert!(events.is_empty(), "a recast reports nothing to consensus");
+        assert!(broadcasts.is_empty(), "a recast is unicast per assignee");
+        assert_eq!(
+            unicasts,
+            (0..4)
+                .filter(|i| *i != 2)
+                .map(|i| (NodeId::dummy(i), chunk(Upstream::Recast(NodeId::dummy(2)))))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// Consensus never casts a positive entry for a root it did not decode, and
+    /// without the shares to re-encode there is nothing to serve
+    #[test]
+    fn a_root_we_could_not_decode_is_not_recast() {
+        let mut da = node(0);
+        ingest(&mut da, Upstream::Author, disseminator_id());
+
+        let (events, ..) = drain(&mut da);
+        assert_eq!(
+            events,
+            vec![
+                ProposalDAEvent::HeaderSeen(meta_of(SLOT, PROPOSER)),
+                ProposalDAEvent::ProposerObligationFulfilled(root_of(SLOT, PROPOSER)),
+            ]
+        );
+
+        cast(&mut da);
+        let (events, unicasts, broadcasts) = drain(&mut da);
+        assert!(events.is_empty());
+        assert!(unicasts.is_empty());
+        assert!(broadcasts.is_empty());
+    }
+
+    /// A recaster hands us our own share, which is one holder toward decoding:
+    /// with one owner's relay already in hand, it is what tips the root over
+    #[test]
+    fn a_recast_share_counts_as_our_own_toward_decoding() {
+        let root = root_of(SLOT, PROPOSER);
+        let mut da = node(3);
+
+        ingest(&mut da, Upstream::Owner(NodeId::dummy(0)), NodeId::dummy(0));
+        let (events, ..) = drain(&mut da);
+        assert_eq!(
+            events,
+            vec![
+                ProposalDAEvent::HeaderSeen(meta_of(SLOT, PROPOSER)),
+                ProposalDAEvent::OwnerObligationFulfilled {
+                    owner: NodeId::dummy(0),
+                    root
+                },
+            ]
+        );
+
+        ingest(
+            &mut da,
+            Upstream::Recast(NodeId::dummy(1)),
+            NodeId::dummy(1),
+        );
+        let (events, ..) = drain(&mut da);
+        assert_eq!(events, vec![decoded()]);
+
+        // a slow author still fulfils its obligation, and decoding happens once
+        ingest(&mut da, Upstream::Author, disseminator_id());
+        let (events, ..) = drain(&mut da);
+        assert_eq!(
+            events,
+            vec![ProposalDAEvent::ProposerObligationFulfilled(root)]
+        );
+    }
+
+    /// Two recasters gave us one share -- ours -- not two: a recaster's own share
+    /// never reaches us, so it is not a holder we can count
+    #[test]
+    fn recasts_do_not_stand_in_for_the_casters_shares() {
+        let mut da = node(3);
+
+        ingest(
+            &mut da,
+            Upstream::Recast(NodeId::dummy(0)),
+            NodeId::dummy(0),
+        );
+        let (events, ..) = drain(&mut da);
+        assert_eq!(
+            events,
+            vec![ProposalDAEvent::HeaderSeen(meta_of(SLOT, PROPOSER))]
+        );
+
+        ingest(
+            &mut da,
+            Upstream::Recast(NodeId::dummy(1)),
+            NodeId::dummy(1),
+        );
+        let (events, ..) = drain(&mut da);
+        assert!(events.is_empty());
+    }
+}

--- a/monad-mcp-chorus-sim/src/lib.rs
+++ b/monad-mcp-chorus-sim/src/lib.rs
@@ -13,10 +13,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+mod da;
 mod mvba;
 mod node;
 mod swarm;
 
+pub use da::{
+    DaDisseminator, DaWire, DisseminationPlan, SimDA, Upstream, disseminator_id, meta_of, root_of,
+};
+pub use monad_sim_swarm::Network;
 pub use mvba::{Decision, Message, MonadMvba, MvbaSwarm, MvbaSwarmBuilder, at_millis};
 pub use node::SimNode;
-pub use swarm::{CadenceSwarm, CadenceSwarmBuilder, FinalizationLog};
+pub use swarm::{CadenceSwarm, CadenceSwarmBuilder, FinalizationLog, SlotLog};

--- a/monad-mcp-chorus-sim/src/swarm.rs
+++ b/monad-mcp-chorus-sim/src/swarm.rs
@@ -16,7 +16,8 @@
 use std::{cell::RefCell, collections::HashMap, rc::Rc, time::Duration};
 
 use chorus::{
-    CadenceRuntime, Conductor, FinalizationObserver, Runtime, SlotConsensus, SlotManager,
+    CadenceRuntime, Conductor, DataAvailability, FinalizationObserver, NodeRuntime, Runtime,
+    SlotConsensus, SlotManager,
     types::{NodeId, Slot, Timestamp},
 };
 use monad_mcp_chorus::stub as chorus;
@@ -48,6 +49,10 @@ impl<M> CadenceSwarmBuilder<M> {
         self.network = Network::reliable(latency);
     }
 
+    pub fn set_network(&mut self, network: Network<NodeId, M>) {
+        self.network = network;
+    }
+
     pub fn set_seed(&mut self, seed: u64) {
         self.seed = seed;
     }
@@ -76,6 +81,46 @@ impl<M> CadenceSwarmBuilder<M> {
         }
 
         self.add_generic_node(id, runtime);
+    }
+
+    /// A node whose data-availability layer is `da`. The returned log keeps
+    /// the certificate behind each finalization, which the swarm's own log
+    /// does not.
+    pub fn add_node_with_da<S, C, A>(
+        &mut self,
+        id: NodeId,
+        conductor: C,
+        slot_config: S::Config,
+        slot_context: S::Context,
+        da: A,
+    ) -> SlotLog<S::FinalizationData>
+    where
+        M: Clone + 'static,
+        S: SlotConsensus + 'static,
+        C: Conductor + 'static,
+        A: DataAvailability<S> + 'static,
+        NodeRuntime<S, C, A>: Runtime<M>,
+    {
+        let slot_manager = SlotManager::new(slot_config, slot_context);
+        let mut runtime = CadenceRuntime::<S, C>::new(slot_manager, conductor);
+
+        let mut shared = self.track_logs.then(|| {
+            self.log
+                .allocate::<S::OptimisticCommitData, S::FinalizationData>(id)
+        });
+        let log = SlotLog::default();
+        let recorder = log.clone();
+        runtime.on_finalization(
+            move |at: Timestamp, slot: Slot, data: &S::FinalizationData| {
+                if let Some(shared) = &mut shared {
+                    shared.handle_finalization(at, slot, data);
+                }
+                recorder.borrow_mut().push((at, slot, data.clone()));
+            },
+        );
+
+        self.add_generic_node(id, NodeRuntime::new(runtime, da));
+        log
     }
 
     pub fn add_generic_node(&mut self, id: NodeId, runtime: impl Runtime<M> + 'static)
@@ -160,6 +205,9 @@ where
         &mut self.swarm
     }
 }
+
+/// One node's finalizations with the data behind them
+pub type SlotLog<FD> = Rc<RefCell<Vec<(Timestamp, Slot, FD)>>>;
 
 // Per-node finalization histories, shared with the observers planted in
 // the runtimes.

--- a/monad-mcp-chorus-sim/tests/cadence_conductor.rs
+++ b/monad-mcp-chorus-sim/tests/cadence_conductor.rs
@@ -29,7 +29,7 @@ use chorus::{
         chorus::{Chorus, ChorusConfig, ChorusContext},
         dummy::{DummySlotConsensus, DummySlotConsensusConfig},
     },
-    types::{DAHandle, NodeId, SlotDeadline, Stake, Timestamp, TimestampDelta, ValidatorData},
+    types::{NodeId, SlotDeadline, Stake, Timestamp, TimestampDelta, ValidatorData},
 };
 use helper::{expect_finalized, expect_finalized_at};
 use monad_mcp_chorus::{spec::KeyPair as _, stub as chorus};
@@ -141,7 +141,6 @@ fn full_window_rolls_over_with_chorus() {
             node_id: id,
             key: Arc::new(id.keypair()),
             validator_data: val_data.clone(),
-            da_handle: Arc::new(DAHandle),
         };
         builder.add_node::<Chorus, _>(id, conductor(), slot_config, context);
     }

--- a/monad-mcp-chorus-sim/tests/chorus.rs
+++ b/monad-mcp-chorus-sim/tests/chorus.rs
@@ -21,7 +21,7 @@ use chorus::{
     CadenceDriverMsg,
     conductor::{ConductorConfig, MonadConductor, acs::nop::NopAcs},
     slot::chorus::{Chorus, ChorusConfig, ChorusContext},
-    types::{DAHandle, NodeId, SlotDeadline, Stake, TimestampDelta, ValidatorData},
+    types::{NodeId, SlotDeadline, Stake, TimestampDelta, ValidatorData},
 };
 use helper::expect_finalized_at;
 use monad_mcp_chorus::{spec::KeyPair as _, stub as chorus};
@@ -48,20 +48,26 @@ fn conductor() -> Conductor {
     MonadConductor::genesis(config, ()).unwrap()
 }
 
-fn add_node(builder: &mut CadenceSwarmBuilder<DummyMsg>, id: u64, val_data: &Arc<ValidatorData>) {
-    let node_id = NodeId::dummy(id);
-    let context = ChorusContext {
+fn chorus_context(node_id: NodeId, val_data: &Arc<ValidatorData>) -> ChorusContext {
+    ChorusContext {
         node_id,
         key: Arc::new(node_id.keypair()),
         validator_data: val_data.clone(),
-        da_handle: Arc::new(DAHandle),
-    };
-    let config = ChorusConfig {
+    }
+}
+
+fn chorus_config() -> ChorusConfig {
+    ChorusConfig {
         delta: DELTA,
         num_proposals: 1,
-    };
+    }
+}
 
-    builder.add_node::<Chorus, _>(node_id, conductor(), config, context);
+fn add_node(builder: &mut CadenceSwarmBuilder<DummyMsg>, id: u64, val_data: &Arc<ValidatorData>) {
+    let node_id = NodeId::dummy(id);
+    let context = chorus_context(node_id, val_data);
+
+    builder.add_node::<Chorus, _>(node_id, conductor(), chorus_config(), context);
 }
 
 fn gen_validator_data(n: u64) -> ValidatorData {

--- a/monad-mcp-chorus-sim/tests/da_dissemination.rs
+++ b/monad-mcp-chorus-sim/tests/da_dissemination.rs
@@ -1,0 +1,349 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Which path a slot takes is decided by how far its proposal got: the
+//! disseminator serves k of the n validators, and with n = 3f+1,
+//!   k >= 2f+1     every validator votes positive, the fast path commits;
+//!   k <= f        no root ever decodes, the fast path commits it absent;
+//!   f < k < 2f+1  neither verdict has a supermajority, so the fast path
+//!                 cannot commit and the fallback path decides the slot --
+//!                 positively, because the k holders relay in time for
+//!                 everyone to decode before the fallback vote -- or
+//!                 negatively, when those relays are lost and no one decodes.
+//!
+//! What a single `SimDA` sends and reports is unit-tested in the crate itself.
+
+use std::{collections::BTreeSet, num::NonZeroU64, ops::Range, sync::Arc};
+
+use chorus::{
+    CadenceNodeMsg, NodeMessage,
+    conductor::{ConductorConfig, MonadConductor, acs::nop::NopAcs},
+    slot::{
+        chorus::{Chorus, ChorusConfig, ChorusContext, SlotFinalization},
+        fallback::Entry,
+    },
+    types::{NodeId, Slot, SlotDeadline, Stake, Timestamp, TimestampDelta, ValidatorData},
+};
+use monad_mcp_chorus::{spec::KeyPair as _, stub as chorus};
+use monad_mcp_chorus_sim::{
+    CadenceSwarmBuilder, DaDisseminator, DaWire, DisseminationPlan, Network, SimDA, SlotLog,
+    Upstream, disseminator_id, root_of,
+};
+
+const SLOTS_PER_WINDOW: NonZeroU64 = NonZeroU64::new(10).unwrap();
+const SYNC_BOUNDARY_SLOTS: NonZeroU64 = NonZeroU64::new(8).unwrap();
+const SLOT_INTERVAL: TimestampDelta = TimestampDelta::from_millis(100);
+const GENESIS_DEADLINE: SlotDeadline = SlotDeadline::from_millis(100);
+const LATENCY: TimestampDelta = TimestampDelta::from_millis(50);
+const DELTA: TimestampDelta = TimestampDelta::from_millis(100);
+
+const NUM_PROPOSALS: usize = 1;
+const PROPOSER: usize = 0;
+
+type Conductor = MonadConductor<NopAcs<SlotDeadline>>;
+type NodeMsg = CadenceNodeMsg<Chorus, Conductor, SimDA>;
+type Logs = Vec<SlotLog<SlotFinalization>>;
+
+fn conductor() -> Conductor {
+    let config = ConductorConfig::new(
+        SLOTS_PER_WINDOW,
+        SYNC_BOUNDARY_SLOTS,
+        SLOT_INTERVAL,
+        GENESIS_DEADLINE,
+    )
+    .unwrap();
+    MonadConductor::genesis(config, ()).unwrap()
+}
+
+fn deadline_of(slot: Slot) -> Timestamp {
+    GENESIS_DEADLINE
+        .checked_add_deltas(SLOT_INTERVAL, slot.get())
+        .unwrap()
+}
+
+fn gen_validator_data(n: u64) -> ValidatorData {
+    let validators = (0..n).map(NodeId::dummy).collect::<Vec<_>>();
+    let valset = validators.iter().map(|id| (*id, Stake::from(1))).collect();
+    let mapping = validators
+        .iter()
+        .map(|id| (*id, id.keypair().pubkey()))
+        .collect();
+
+    ValidatorData::new(valset, mapping)
+}
+
+/// n validators plus the disseminator authoring every proposal under `plans`
+fn run(
+    n: u64,
+    slots: Range<u64>,
+    plans: impl Fn(Slot, usize) -> Vec<DisseminationPlan> + 'static,
+) -> Logs {
+    run_on(reliable(), n, slots, plans)
+}
+
+/// `run` over a network of the caller's choosing, so faults can be layered on
+fn run_on(
+    network: Network<NodeId, NodeMsg>,
+    n: u64,
+    slots: Range<u64>,
+    plans: impl Fn(Slot, usize) -> Vec<DisseminationPlan> + 'static,
+) -> Logs {
+    let mut builder = CadenceSwarmBuilder::<NodeMsg>::new();
+    builder.set_network(network);
+
+    let val_data = Arc::new(gen_validator_data(n));
+    let config = ChorusConfig {
+        delta: DELTA,
+        num_proposals: NUM_PROPOSALS,
+    };
+
+    let logs: Logs = (0..n)
+        .map(|i| {
+            let node_id = NodeId::dummy(i);
+            let context = ChorusContext {
+                node_id,
+                key: Arc::new(node_id.keypair()),
+                validator_data: val_data.clone(),
+            };
+            builder.add_node_with_da::<Chorus, _, _>(
+                node_id,
+                conductor(),
+                config.clone(),
+                context,
+                SimDA::new(node_id, val_data.clone()),
+            )
+        })
+        .collect();
+
+    let last = Slot(slots.end - 1);
+    let disseminator = DaDisseminator::new(
+        (0..n).map(NodeId::dummy).collect(),
+        NUM_PROPOSALS,
+        slots,
+        DELTA,
+        deadline_of,
+        plans,
+    );
+    builder.add_generic_node(disseminator_id(), disseminator);
+
+    let mut swarm = builder.build();
+    swarm.run_until(deadline_of(last) + fallback_latency());
+    logs
+}
+
+fn reliable() -> Network<NodeId, NodeMsg> {
+    Network::reliable(LATENCY.as_duration())
+}
+
+/// D_s + 2 latencies: batch votes form the fast block, commit votes the QC
+fn fast_latency() -> TimestampDelta {
+    LATENCY.checked_mul(2).unwrap()
+}
+
+/// D_s + 2Δ to enter the fallback path, then the MVBA's first view:
+/// pre-prepare, prepare, commit, one crossing each
+fn fallback_latency() -> TimestampDelta {
+    DELTA.checked_mul(2).unwrap() + LATENCY.checked_mul(3).unwrap()
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+enum Path {
+    Fast,
+    Fallback,
+}
+
+fn path_of(finalization: &SlotFinalization) -> Path {
+    match finalization {
+        SlotFinalization::Fallback(_) => Path::Fallback,
+        // the fast commit certificate's vote type is crate-private
+        _ => Path::Fast,
+    }
+}
+
+/// Every validator finalized `slot` the same way, on time, with the same
+/// verdict for the proposal
+fn assert_agreed(logs: &Logs, slot: u64, path: Path, entry: Entry) {
+    let slot = Slot(slot);
+    let at = deadline_of(slot)
+        + match path {
+            Path::Fast => fast_latency(),
+            Path::Fallback => fallback_latency(),
+        };
+
+    let mut agreed: Option<SlotFinalization> = None;
+    for (i, log) in logs.iter().enumerate() {
+        let node = NodeId::dummy(i as u64);
+        let finalized = log.borrow();
+        let (finalized_at, _, data) = finalized
+            .iter()
+            .find(|(_, finalized_slot, _)| *finalized_slot == slot)
+            .unwrap_or_else(|| panic!("{node:?} did not finalize {slot:?}"));
+
+        assert_eq!(
+            path_of(data),
+            path,
+            "{node:?} finalized {slot:?} on the wrong path"
+        );
+        assert_eq!(
+            data.entries()[PROPOSER],
+            entry,
+            "{node:?} committed the wrong verdict for {slot:?}"
+        );
+        assert_eq!(
+            *finalized_at, at,
+            "{node:?} finalized {slot:?} off schedule"
+        );
+
+        match &agreed {
+            None => agreed = Some(data.clone()),
+            Some(agreed) => assert_eq!(data, agreed, "{node:?} finalized {slot:?} differently"),
+        }
+    }
+}
+
+fn positive(slot: u64) -> Entry {
+    Entry::Positive {
+        root: root_of(Slot(slot), PROPOSER),
+    }
+}
+
+/// Slot s is reached by exactly s validators, so one run walks the whole
+/// range from "nobody has it" to "everybody has it"
+#[test]
+fn sweep_k_over_four_validators() {
+    // n = 4, f = 1
+    let logs = run(4, 0..5, |slot, _j| {
+        vec![DisseminationPlan::Reach(slot.get() as usize)]
+    });
+
+    assert_agreed(&logs, 0, Path::Fast, Entry::Negative);
+    assert_agreed(&logs, 1, Path::Fast, Entry::Negative);
+    assert_agreed(&logs, 2, Path::Fallback, positive(2));
+    assert_agreed(&logs, 3, Path::Fast, positive(3));
+    assert_agreed(&logs, 4, Path::Fast, positive(4));
+}
+
+/// The same walk with f = 2, so the split band f < k < 2f+1 is two slots wide
+#[test]
+fn sweep_k_over_seven_validators() {
+    // n = 7, f = 2
+    let logs = run(7, 0..8, |slot, _j| {
+        vec![DisseminationPlan::Reach(slot.get() as usize)]
+    });
+
+    for slot in 0..=2 {
+        assert_agreed(&logs, slot, Path::Fast, Entry::Negative);
+    }
+    for slot in 3..=4 {
+        assert_agreed(&logs, slot, Path::Fallback, positive(slot));
+    }
+    for slot in 5..=7 {
+        assert_agreed(&logs, slot, Path::Fast, positive(slot));
+    }
+}
+
+/// A proposal that reaches everyone, but only after the deadline it had to
+/// beat, is committed absent by the fast path
+#[test]
+fn late_delivery_is_voted_absent() {
+    let logs = run(4, 0..3, |_slot, _j| {
+        vec![DisseminationPlan::Delay {
+            recipients: (0..4).map(NodeId::dummy).collect(),
+            offset: DELTA,
+        }]
+    });
+
+    for slot in 0..=2 {
+        assert_agreed(&logs, slot, Path::Fast, Entry::Negative);
+    }
+}
+
+/// The same delayed delivery, offset little enough to still land before the
+/// deadline (at `D_s - Delta + 25ms + latency`): it is voted present, so what
+/// makes the late one absent is the offset, not the plan dropping chunks
+#[test]
+fn delivery_before_the_deadline_is_voted_present() {
+    let logs = run(4, 0..3, |_slot, _j| {
+        vec![DisseminationPlan::Delay {
+            recipients: (0..4).map(NodeId::dummy).collect(),
+            offset: TimestampDelta::from_millis(25),
+        }]
+    });
+
+    for slot in 0..=2 {
+        assert_agreed(&logs, slot, Path::Fast, positive(slot));
+    }
+}
+
+/// The fast path cannot commit a slot its validators disagree about, and only
+/// the DA layer can make them disagree: two of the four hold the proposal and
+/// vote it positive, two hold nothing and vote it absent. Neither verdict is a
+/// supermajority, so no fast QC forms and every validator enters the MVBA
+#[test]
+fn a_slot_the_fast_path_cannot_commit_finalizes_through_the_fallback() {
+    let logs = run(4, 0..3, |_slot, _j| vec![DisseminationPlan::Reach(2)]);
+
+    for slot in 0..=2 {
+        assert_agreed(&logs, slot, Path::Fallback, positive(slot));
+    }
+}
+
+/// f+1 validators are served in time and the rest too late to vote on it. The
+/// on-time holders relay at D_s, so everyone decodes well before the fallback
+/// vote and the fallback path commits it positive
+#[test]
+fn late_delivery_splits_the_vote_into_a_positive_fallback() {
+    let on_time: BTreeSet<NodeId> = (0..2).map(NodeId::dummy).collect();
+    let late: BTreeSet<NodeId> = (2..4).map(NodeId::dummy).collect();
+
+    let logs = run(4, 0..3, move |_slot, _j| {
+        vec![
+            DisseminationPlan::ReachSet(on_time.clone()),
+            DisseminationPlan::Delay {
+                recipients: late.clone(),
+                offset: DELTA,
+            },
+        ]
+    });
+
+    for slot in 0..=2 {
+        assert_agreed(&logs, slot, Path::Fallback, positive(slot));
+    }
+}
+
+/// Two of the four are served, so the fast path splits, and every relay is
+/// lost, so no one ever holds more than its own share. The positive weak QC
+/// exists but no root decodes, so all four cast a negative fallback entry and
+/// the fallback path commits the slot absent
+#[test]
+fn lost_relays_turn_a_split_vote_into_a_negative_fallback() {
+    let network = reliable().drop_if(|_link, msg: &NodeMsg| {
+        matches!(
+            msg,
+            NodeMessage::DA(DaWire::Chunk {
+                upstream: Upstream::Owner(_),
+                ..
+            })
+        )
+    });
+
+    let logs = run_on(network, 4, 0..3, |_slot, _j| {
+        vec![DisseminationPlan::Reach(2)]
+    });
+
+    for slot in 0..=2 {
+        assert_agreed(&logs, slot, Path::Fallback, Entry::Negative);
+    }
+}

--- a/monad-mcp-chorus/src/driver.rs
+++ b/monad-mcp-chorus/src/driver.rs
@@ -60,9 +60,9 @@ pub enum CadenceEvent<Timer, Alarm, SMessage, CMessage> {
 pub struct WakeId(u64);
 
 impl WakeId {
-    pub(crate) const FIRST: Self = Self(0);
+    pub const FIRST: Self = Self(0);
 
-    pub(crate) fn post_increment(&mut self) -> Self {
+    pub fn post_increment(&mut self) -> Self {
         let id = *self;
         self.0 = self.0.wrapping_add(1);
         id
@@ -74,6 +74,21 @@ pub enum NodeEvent<M> {
     WakeAfter(TimestampDelta, WakeId),
     Broadcast(M),
     Unicast { to: NodeId, message: M },
+}
+
+impl<M> NodeEvent<M> {
+    /// Re-tag the payload of a send, e.g. into a node-level wire type
+    pub fn map_message<M2>(self, f: impl FnOnce(M) -> M2) -> NodeEvent<M2> {
+        match self {
+            NodeEvent::Wake(at, id) => NodeEvent::Wake(at, id),
+            NodeEvent::WakeAfter(delta, id) => NodeEvent::WakeAfter(delta, id),
+            NodeEvent::Broadcast(message) => NodeEvent::Broadcast(f(message)),
+            NodeEvent::Unicast { to, message } => NodeEvent::Unicast {
+                to,
+                message: f(message),
+            },
+        }
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]

--- a/monad-mcp-chorus/src/node.rs
+++ b/monad-mcp-chorus/src/node.rs
@@ -1,0 +1,199 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::{HashMap, VecDeque};
+
+use super::{
+    conductor::Conductor,
+    driver::{CadenceDriverMsg, NodeEvent, WakeId},
+    runtime::{CadenceRuntime, DAQueue, DASink, Runtime},
+    slot::SlotConsensus,
+    types::{NodeId, Slot, Timestamp, TimestampDelta, Validated},
+};
+
+/// The DA layer as a node runs it: consumes what consensus sinks plus its own
+/// wire traffic, reports back slot-scoped events.
+pub trait DataAvailability<S: SlotConsensus>: DASink<S::DACommand> {
+    /// Chunk traffic, distinct from the consensus wire
+    type WireMsg;
+
+    fn handle_message(&mut self, now: Timestamp, message: Validated<Self::WireMsg>);
+    fn wake(&mut self, now: Timestamp, wake: WakeId);
+    fn poll(&mut self) -> Option<DAOutput<S::DAEvent, Self::WireMsg>>;
+}
+
+pub enum DAOutput<E, M> {
+    Event(Slot, E),
+    Broadcast(M),
+    Unicast { to: NodeId, message: M },
+    Schedule(TimestampDelta, WakeId),
+}
+
+/// The node's wire type, muxing consensus traffic and the DA layer's own
+pub type CadenceNodeMsg<S, C, A> =
+    NodeMessage<CadenceDriverMsg<S, C>, <A as DataAvailability<S>>::WireMsg>;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum NodeMessage<CM, DM> {
+    Cadence(CM),
+    DA(DM),
+}
+
+/// A cadence runtime composed with a data-availability layer. Each side
+/// numbers its own wakes, so pending wakes are re-keyed at the node level.
+pub struct NodeRuntime<S, C, A>
+where
+    S: SlotConsensus,
+    C: Conductor,
+    A: DataAvailability<S>,
+{
+    cadence: CadenceRuntime<S, C>,
+
+    clock: Timestamp,
+    wakes: HashMap<WakeId, Side>,
+    next_wake: WakeId,
+
+    da: A,
+    da_inbox: DAQueue<S::DACommand>,
+    da_outbox: VecDeque<NodeEvent<A::WireMsg>>,
+}
+
+enum Side {
+    Cadence(WakeId),
+    DA(WakeId),
+}
+
+impl<S, C, A> NodeRuntime<S, C, A>
+where
+    S: SlotConsensus + 'static,
+    C: Conductor,
+    A: DataAvailability<S>,
+{
+    pub fn new(mut cadence: CadenceRuntime<S, C>, da: A) -> Self {
+        let da_inbox = DAQueue::default();
+        cadence.on_da(da_inbox.clone());
+
+        Self {
+            clock: Timestamp::GENESIS,
+            cadence,
+            da_inbox,
+            da,
+            wakes: HashMap::new(),
+            next_wake: WakeId::FIRST,
+            da_outbox: VecDeque::new(),
+        }
+    }
+
+    fn advance_clock(&mut self, now: Timestamp) {
+        assert!(now >= self.clock);
+        self.clock = now;
+    }
+
+    fn register_wake(&mut self, side: Side) -> WakeId {
+        let id = self.next_wake.post_increment();
+        self.wakes.insert(id, side);
+        id
+    }
+
+    fn step(&mut self) {
+        while self.step_once() {}
+    }
+
+    // returns true if any progress was made
+    fn step_once(&mut self) -> bool {
+        if self.da_inbox.pop_into(&mut self.da) {
+            return true;
+        }
+
+        if let Some(output) = self.da.poll() {
+            match output {
+                DAOutput::Event(slot, event) => {
+                    self.cadence.handle_da_event(self.clock, slot, event);
+                }
+                DAOutput::Broadcast(message) => {
+                    self.da_outbox.push_back(NodeEvent::Broadcast(message));
+                }
+                DAOutput::Unicast { to, message } => {
+                    self.da_outbox.push_back(NodeEvent::Unicast { to, message });
+                }
+                DAOutput::Schedule(delta, wake) => {
+                    let id = self.register_wake(Side::DA(wake));
+                    self.da_outbox.push_back(NodeEvent::WakeAfter(delta, id));
+                }
+            }
+            return true;
+        }
+
+        false
+    }
+}
+
+impl<S, C, A> Runtime<CadenceNodeMsg<S, C, A>> for NodeRuntime<S, C, A>
+where
+    S: SlotConsensus + 'static,
+    C: Conductor,
+    A: DataAvailability<S>,
+{
+    fn init(&mut self) {
+        self.cadence.init();
+        self.step();
+    }
+
+    fn wake(&mut self, now: Timestamp, wake: WakeId) {
+        self.advance_clock(now);
+        match self.wakes.remove(&wake) {
+            Some(Side::Cadence(wake)) => self.cadence.wake(now, wake),
+            Some(Side::DA(wake)) => self.da.wake(now, wake),
+            None => {}
+        }
+        self.step();
+    }
+
+    fn receive(&mut self, now: Timestamp, message: Validated<CadenceNodeMsg<S, C, A>>) {
+        self.advance_clock(now);
+
+        // safety: message is already validated.
+        let (message, author) = message.destructure();
+        match message {
+            NodeMessage::Cadence(message) => self
+                .cadence
+                .receive(now, Validated::new_unchecked(message, author)),
+            NodeMessage::DA(message) => self
+                .da
+                .handle_message(now, Validated::new_unchecked(message, author)),
+        }
+
+        self.step();
+    }
+
+    fn poll(&mut self) -> Option<NodeEvent<CadenceNodeMsg<S, C, A>>> {
+        if let Some(event) = self.cadence.poll() {
+            let event = match event {
+                NodeEvent::Wake(at, wake) => {
+                    NodeEvent::Wake(at, self.register_wake(Side::Cadence(wake)))
+                }
+                NodeEvent::WakeAfter(delta, wake) => {
+                    NodeEvent::WakeAfter(delta, self.register_wake(Side::Cadence(wake)))
+                }
+                event => event,
+            };
+            return Some(event.map_message(NodeMessage::Cadence));
+        }
+
+        self.da_outbox
+            .pop_front()
+            .map(|event| event.map_message(NodeMessage::DA))
+    }
+}

--- a/monad-mcp-chorus/src/runtime.rs
+++ b/monad-mcp-chorus/src/runtime.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
+
 use super::{
     conductor::{Conductor, ConductorOutput},
     driver::{CadenceDriver, CadenceEvent, Driver, NodeEvent, WakeId},
@@ -42,12 +44,15 @@ where
     conductor: C,
     driver: D,
     observer: Option<Box<ObserverOf<S>>>,
+    da_sink: Option<Box<DASinkOf<S>>>,
 }
 
 type ObserverOf<S> = dyn FinalizationObserver<
         <S as SlotConsensus>::OptimisticCommitData,
         <S as SlotConsensus>::FinalizationData,
     >;
+
+type DASinkOf<S> = dyn DASink<<S as SlotConsensus>::DACommand>;
 
 impl<S, C> CadenceRuntime<S, C>
 where
@@ -61,6 +66,7 @@ where
             conductor,
             driver: CadenceDriver::default(),
             observer: None,
+            da_sink: None,
         }
     }
 
@@ -73,6 +79,7 @@ where
             slot_manager: self.slot_manager,
             conductor: self.conductor,
             observer: self.observer,
+            da_sink: self.da_sink,
             driver,
         }
     }
@@ -91,10 +98,28 @@ where
         self.observer = Some(Box::new(observer));
     }
 
+    pub fn on_da(&mut self, sink: impl DASink<S::DACommand> + 'static) {
+        self.da_sink = Some(Box::new(sink));
+    }
+
     // in actual runtime this can be controlled by the system clock.
     pub fn advance_clock(&mut self, now: Timestamp) {
         assert!(now >= self.clock);
         self.clock = now;
+    }
+
+    // Inject a data-availability event into the slot's consensus
+    // instance. DA events are local and trusted by construction.
+    pub fn handle_da_event(&mut self, now: Timestamp, slot: Slot, event: S::DAEvent) {
+        self.advance_clock(now);
+
+        if let Some(instance) = self.slot_manager.slot_instance(slot) {
+            // q: do we need to buffer the da events? da begins to
+            // accept chunk ingestion at the same time as slot
+            // consensus, which normally is already conservative.
+            instance.handle_da_event(event);
+        }
+        self.step();
     }
 
     fn step(&mut self) {
@@ -117,6 +142,11 @@ where
                 SlotOutput::Unicast { to, message } => {
                     self.driver.unicast_slot(slot, to, message);
                 }
+                SlotOutput::DA(action) => {
+                    if let Some(sink) = &mut self.da_sink {
+                        sink.handle_command(slot, action);
+                    }
+                }
                 SlotOutput::CommitOptimistic(data) => {
                     if let Some(observer) = &mut self.observer {
                         observer.handle_optimistic_commit(now, slot, &data);
@@ -126,11 +156,17 @@ where
                     if let Some(observer) = &mut self.observer {
                         observer.handle_finalization(now, slot, &data);
                     }
+                    if let Some(sink) = &mut self.da_sink {
+                        sink.handle_lifecycle(slot, SlotLifecycle::Completed);
+                    }
                     self.conductor.handle_slot_finalization(now, slot);
                     self.slot_manager.close(slot);
                 }
                 SlotOutput::Fault { reason } => {
                     tracing::warn!(?slot, reason = %reason, "slot faulted");
+                    if let Some(sink) = &mut self.da_sink {
+                        sink.handle_lifecycle(slot, SlotLifecycle::Completed);
+                    }
                     self.slot_manager.close(slot);
                 }
             }
@@ -152,6 +188,9 @@ where
                     for (slot, deadline) in slots {
                         self.slot_manager.open(slot);
                         self.driver.schedule_slot_deadline(slot, deadline);
+                        if let Some(sink) = &mut self.da_sink {
+                            sink.handle_lifecycle(slot, SlotLifecycle::Opened);
+                        }
                     }
                 }
             }
@@ -218,6 +257,89 @@ where
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SlotLifecycle {
+    Opened,
+    Completed,
+}
+
+/// What consensus hands the DA layer, in the order it happens: a slot's
+/// commands fall strictly between its `Opened` and `Completed`
+pub trait DASink<A> {
+    fn handle_lifecycle(&mut self, slot: Slot, event: SlotLifecycle);
+    fn handle_command(&mut self, slot: Slot, action: A);
+}
+
+/// One deferred sink call; a single queue of these keeps the two methods'
+/// relative order
+enum Queued<A> {
+    Lifecycle(SlotLifecycle),
+    Command(A),
+}
+
+type SinkQueue<A> = VecDeque<(Slot, Queued<A>)>;
+
+impl<A> DASink<A> for SinkQueue<A> {
+    fn handle_lifecycle(&mut self, slot: Slot, event: SlotLifecycle) {
+        self.push_back((slot, Queued::Lifecycle(event)));
+    }
+
+    fn handle_command(&mut self, slot: Slot, action: A) {
+        self.push_back((slot, Queued::Command(action)));
+    }
+}
+
+impl<A, T: DASink<A>> DASink<A> for Rc<RefCell<T>> {
+    fn handle_lifecycle(&mut self, slot: Slot, event: SlotLifecycle) {
+        self.borrow_mut().handle_lifecycle(slot, event);
+    }
+
+    fn handle_command(&mut self, slot: Slot, action: A) {
+        self.borrow_mut().handle_command(slot, action);
+    }
+}
+
+/// A shared sink queue: one clone is boxed into [`CadenceRuntime::on_da`],
+/// the other is replayed into the DA layer by whoever runs it.
+pub struct DAQueue<A>(Rc<RefCell<SinkQueue<A>>>);
+
+impl<A> DAQueue<A> {
+    /// Replays the oldest deferred call into `sink`; false when there is none
+    pub fn pop_into(&self, sink: &mut impl DASink<A>) -> bool {
+        // the borrow ends with the let-else statement, before the sink call
+        let Some((slot, queued)) = self.0.borrow_mut().pop_front() else {
+            return false;
+        };
+        match queued {
+            Queued::Lifecycle(event) => sink.handle_lifecycle(slot, event),
+            Queued::Command(action) => sink.handle_command(slot, action),
+        }
+        true
+    }
+}
+
+impl<A> Clone for DAQueue<A> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<A> Default for DAQueue<A> {
+    fn default() -> Self {
+        Self(Rc::default())
+    }
+}
+
+impl<A> DASink<A> for DAQueue<A> {
+    fn handle_lifecycle(&mut self, slot: Slot, event: SlotLifecycle) {
+        self.0.handle_lifecycle(slot, event);
+    }
+
+    fn handle_command(&mut self, slot: Slot, action: A) {
+        self.0.handle_command(slot, action);
+    }
+}
+
 pub trait FinalizationObserver<OD, FD> {
     fn handle_optimistic_commit(&mut self, _now: Timestamp, _slot: Slot, _data: &OD) {}
     fn handle_finalization(&mut self, now: Timestamp, slot: Slot, data: &FD);
@@ -235,5 +357,57 @@ where
 impl<OD, FD> FinalizationObserver<OD, FD> for Vec<(Timestamp, Slot)> {
     fn handle_finalization(&mut self, now: Timestamp, slot: Slot, _data: &FD) {
         self.push((now, slot));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(PartialEq, Eq, Debug)]
+    enum Seen {
+        Lifecycle(Slot, SlotLifecycle),
+        Command(Slot, u8),
+    }
+
+    impl DASink<u8> for Vec<Seen> {
+        fn handle_lifecycle(&mut self, slot: Slot, event: SlotLifecycle) {
+            self.push(Seen::Lifecycle(slot, event));
+        }
+
+        fn handle_command(&mut self, slot: Slot, action: u8) {
+            self.push(Seen::Command(slot, action));
+        }
+    }
+
+    /// A slot's commands replay between its Opened and Completed even when
+    /// other slots interleave
+    #[test]
+    fn da_queue_replays_in_sink_order() {
+        let queue = DAQueue::<u8>::default();
+        let mut producer = queue.clone();
+        producer.handle_lifecycle(Slot(1), SlotLifecycle::Opened);
+        producer.handle_command(Slot(1), 7);
+        producer.handle_lifecycle(Slot(2), SlotLifecycle::Opened);
+        producer.handle_command(Slot(1), 8);
+        producer.handle_lifecycle(Slot(1), SlotLifecycle::Completed);
+
+        let mut seen = Vec::new();
+        while queue.pop_into(&mut seen) {}
+
+        assert_eq!(
+            seen,
+            vec![
+                Seen::Lifecycle(Slot(1), SlotLifecycle::Opened),
+                Seen::Command(Slot(1), 7),
+                Seen::Lifecycle(Slot(2), SlotLifecycle::Opened),
+                Seen::Command(Slot(1), 8),
+                Seen::Lifecycle(Slot(1), SlotLifecycle::Completed),
+            ]
+        );
+        assert!(
+            !queue.pop_into(&mut seen),
+            "an empty queue reports no progress"
+        );
     }
 }

--- a/monad-mcp-chorus/src/slot/availability.rs
+++ b/monad-mcp-chorus/src/slot/availability.rs
@@ -1,0 +1,191 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::{HashMap, HashSet};
+
+use super::{
+    chorus::ProposalDAEvent,
+    types::{EquivCert, MerkleRoot, ProposalMeta},
+};
+
+// (slot, j)-scoped proposal availability state, built from DA events.
+#[derive(Clone, Default)]
+pub(crate) struct ProposalAvailability {
+    // seen signed headers
+    headers: HashMap<MerkleRoot, ProposalMeta>,
+
+    // proposals that all our own chunks have been fully received from the
+    // author.
+    author_fulfilled: Vec<MerkleRoot>,
+
+    // proposals that have been successfully decoded.
+    decoded: HashSet<MerkleRoot>,
+}
+
+impl ProposalAvailability {
+    pub fn ingest(&mut self, event: ProposalDAEvent) {
+        match event {
+            ProposalDAEvent::HeaderSeen(meta) => self.record_header(meta),
+            ProposalDAEvent::ProposerObligationFulfilled(root) => {
+                if !self.author_fulfilled.contains(&root) {
+                    self.author_fulfilled.push(root);
+                }
+            }
+            ProposalDAEvent::Decoded(root) => {
+                self.decoded.insert(root);
+                // decoding implies possession of every chunk, our own
+                // author-assigned ones included
+                if !self.author_fulfilled.contains(&root) {
+                    self.author_fulfilled.push(root);
+                }
+            }
+            ProposalDAEvent::Equivocation(cert) => {
+                let EquivCert(a, b) = cert;
+                self.record_header(a);
+                self.record_header(b);
+            }
+            ProposalDAEvent::OwnerObligationFulfilled { .. } => {
+                // relay obligations gate vote admission, which is not
+                // part of this seam yet
+            }
+            ProposalDAEvent::DecodingFailed(_root) => todo!(),
+        }
+    }
+
+    pub fn equiv_cert(&self) -> Option<EquivCert> {
+        if self.headers.len() < 2 {
+            return None;
+        }
+
+        let mut iter = self.headers.values().cloned();
+        let a = iter.next().expect("at least two");
+        let b = iter.next().expect("at least two");
+        Some(EquivCert(a, b))
+    }
+
+    // invariant: every recorded header is authenticated, so any two
+    // with distinct roots form an equivocation certificate.
+    pub fn record_header(&mut self, meta: ProposalMeta) {
+        if self.headers.contains_key(&meta.root) {
+            return;
+        }
+        self.headers.insert(meta.root, meta);
+    }
+
+    // The proposal to vote positively on at D_s: the first root
+    // whose author obligation was fulfilled.
+    pub fn fetch_proposal(&self) -> Option<&ProposalMeta> {
+        let root = self.author_fulfilled.first()?;
+        self.headers.get(root)
+    }
+
+    pub fn decoded(&self, root: &MerkleRoot) -> bool {
+        self.decoded.contains(root)
+    }
+
+    pub fn header_for(&self, root: &MerkleRoot) -> Option<&ProposalMeta> {
+        self.headers.get(root)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::types::{OpaqueChunkHeader, ProposalSignature},
+        *,
+    };
+
+    fn root(byte: u8) -> MerkleRoot {
+        MerkleRoot(byte as u64)
+    }
+
+    fn meta(byte: u8) -> ProposalMeta {
+        ProposalMeta {
+            root: root(byte),
+            sig: ProposalSignature,
+            opaque_header: OpaqueChunkHeader,
+        }
+    }
+
+    #[test]
+    fn fetch_proposal_returns_first_fulfilled_root() {
+        let mut avail = ProposalAvailability::default();
+
+        assert!(avail.fetch_proposal().is_none());
+        avail.ingest(ProposalDAEvent::HeaderSeen(meta(1)));
+        // header alone is not enough to vote positively
+        assert!(avail.fetch_proposal().is_none());
+
+        avail.ingest(ProposalDAEvent::ProposerObligationFulfilled(root(1)));
+        assert_eq!(avail.fetch_proposal(), Some(&meta(1)));
+
+        // a later fulfillment does not displace the vote target
+        avail.ingest(ProposalDAEvent::HeaderSeen(meta(2)));
+        avail.ingest(ProposalDAEvent::ProposerObligationFulfilled(root(2)));
+        assert_eq!(avail.fetch_proposal(), Some(&meta(1)));
+    }
+
+    #[test]
+    fn conflicting_headers_form_equivocation_cert() {
+        let mut avail = ProposalAvailability::default();
+
+        avail.ingest(ProposalDAEvent::HeaderSeen(meta(1)));
+        assert!(avail.equiv_cert().is_none());
+        // repeated root is not a conflict
+        avail.record_header(meta(1));
+        assert!(avail.equiv_cert().is_none());
+
+        avail.record_header(meta(2));
+        let EquivCert(a, b) = avail.equiv_cert().expect("distinct roots conflict");
+        assert!(a.root != b.root);
+
+        // both headers remain queryable
+        assert_eq!(avail.header_for(&root(1)), Some(&meta(1)));
+        assert_eq!(avail.header_for(&root(2)), Some(&meta(2)));
+    }
+
+    #[test]
+    fn equivocation_event_records_both_headers() {
+        let mut avail = ProposalAvailability::default();
+
+        let cert = EquivCert(meta(1), meta(2));
+        avail.ingest(ProposalDAEvent::Equivocation(cert));
+
+        assert!(avail.equiv_cert().is_some());
+        assert_eq!(avail.header_for(&root(1)), Some(&meta(1)));
+        assert_eq!(avail.header_for(&root(2)), Some(&meta(2)));
+    }
+
+    #[test]
+    fn decoded_implies_positive_vote_target() {
+        let mut avail = ProposalAvailability::default();
+
+        avail.ingest(ProposalDAEvent::HeaderSeen(meta(1)));
+        avail.ingest(ProposalDAEvent::Decoded(root(1)));
+
+        assert_eq!(avail.fetch_proposal(), Some(&meta(1)));
+    }
+
+    #[test]
+    fn decoded_is_root_scoped() {
+        let mut avail = ProposalAvailability::default();
+
+        assert!(!avail.decoded(&root(1)));
+        avail.ingest(ProposalDAEvent::Decoded(root(1)));
+
+        assert!(avail.decoded(&root(1)));
+        assert!(!avail.decoded(&root(2)));
+    }
+}

--- a/monad-mcp-chorus/src/slot/chorus.rs
+++ b/monad-mcp-chorus/src/slot/chorus.rs
@@ -23,11 +23,12 @@ use super::{
         monad_mvba::{self, MonadMvba, MvbaContext},
     },
     fast::{
-        BatchVoteMsg, CommitVoteDeadlineOutcome, EnterFallbackCert, FallbackVoteMsg, FastBlock,
-        FastCommitQc, FastCommitVoteMsg, FastPath,
+        BatchVoteMsg, CommitVoteDeadlineOutcome, EnterFallbackCert, Entry, FallbackVoteMsg,
+        FastBlock, FastCommitQc, FastCommitVoteMsg, FastPath,
     },
     types::{
-        DAHandle, KeyPair, NodeId, ProposalIndex, ProposalMeta, Slot, TimestampDelta, ValidatorData,
+        EquivCert, KeyPair, MerkleRoot, NodeId, ProposalIndex, ProposalMap, ProposalMeta, Slot,
+        TimestampDelta, ValidatorData,
     },
 };
 
@@ -35,15 +36,6 @@ use super::{
 type FallbackState = MonadMvba<Metablock, EnterFallbackCert>;
 type FallbackMessage = monad_mvba::MvbaMessage<Metablock, EnterFallbackCert>;
 type FallbackTimer = monad_mvba::TimerEvent<Metablock>;
-
-// emitted from the DA layer upon validating a proposal
-// chunk. possibly only emitted after a significant fraction of
-// the chunks for first-hop-recipient is available.
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub struct Proposal {
-    pub j: ProposalIndex,
-    pub meta: ProposalMeta,
-}
 
 #[derive(derive_more::From, Clone, PartialEq, Eq, Hash, Debug)]
 #[non_exhaustive]
@@ -97,7 +89,6 @@ pub struct ChorusContext {
     pub node_id: NodeId,
     pub key: Arc<KeyPair>,
     pub validator_data: Arc<ValidatorData>,
-    pub da_handle: Arc<DAHandle>,
 }
 
 #[derive(derive_more::From, Clone, PartialEq, Eq, Hash, Debug)]
@@ -106,6 +97,65 @@ pub enum SlotFinalization {
     Fast(FastCommitQc),
     #[from]
     Fallback(FallbackCommitQc<Metablock>),
+}
+
+impl SlotFinalization {
+    /// The verdict committed for each proposer, whichever path decided
+    pub fn entries(&self) -> ProposalMap<Entry> {
+        match self {
+            SlotFinalization::Fast(qc) => qc.verdict.entries.clone(),
+            SlotFinalization::Fallback(qc) => qc.verdict.0.clone(),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct ChorusDAEvent {
+    pub j: ProposalIndex,
+    pub event: ProposalDAEvent,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum ProposalDAEvent {
+    // a validated proposer-signed header observed (once per root)
+    HeaderSeen(ProposalMeta),
+
+    // all our own assigned chunks under the root have arrived
+    ProposerObligationFulfilled(MerkleRoot),
+
+    // the owner's rebroadcast obligation to us fulfilled under the root
+    OwnerObligationFulfilled { owner: NodeId, root: MerkleRoot },
+
+    // decode-then-re-encode verified. implies all chunks recoverable
+    // from DA.
+    Decoded(MerkleRoot),
+    DecodingFailed(MerkleRoot),
+
+    // two validly signed conflicting headers observed by DA
+    Equivocation(EquivCert),
+}
+
+// An effect directed at the DA layer. Roots named here are pinned by DA.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum ChorusDACommand {
+    // batch vote cast; rebroadcast our obliged chunks for roots we
+    // voted positive.
+    SlotVoted {
+        positive: Vec<(ProposalIndex, MerkleRoot)>,
+    },
+
+    // positive fallback entry cast; re-encode and send every validator
+    // its assigned chunks
+    FallbackEntryCast {
+        j: ProposalIndex,
+        root: MerkleRoot,
+    },
+
+    // report header learned from consensus evidence
+    ObserveProposal {
+        j: ProposalIndex,
+        meta: ProposalMeta,
+    },
 }
 
 /// The single-slot MCP consensus algorithm from the paper.
@@ -135,6 +185,8 @@ impl SlotConsensus for Chorus {
     type Timer = TimerEvent;
     type OptimisticCommitData = FastBlock;
     type FinalizationData = SlotFinalization;
+    type DAEvent = ChorusDAEvent;
+    type DACommand = ChorusDACommand;
 
     fn new(slot: Slot, config: &Self::Config, context: &Self::Context) -> Self {
         let ChorusConfig {
@@ -145,16 +197,9 @@ impl SlotConsensus for Chorus {
             node_id,
             key,
             validator_data,
-            da_handle,
         } = context;
 
-        let fast = FastPath::new(
-            slot,
-            *num_proposals,
-            key.clone(),
-            validator_data.clone(),
-            da_handle.clone(),
-        );
+        let fast = FastPath::new(slot, *num_proposals, key.clone(), validator_data.clone());
 
         let fallback = FallbackState::new(MvbaContext {
             slot,
@@ -180,6 +225,18 @@ impl SlotConsensus for Chorus {
         self.outputs.pop_front()
     }
 
+    fn handle_da_event(&mut self, event: ChorusDAEvent) {
+        if self.decided {
+            return;
+        }
+
+        if let Some(fast_block) = self.fast.handle_da_event(event) {
+            self.vote_fast_block(fast_block);
+        }
+
+        self.drain_da_commands();
+    }
+
     fn handle_message(&mut self, author: NodeId, message: Self::Message) {
         if self.decided {
             return;
@@ -188,10 +245,7 @@ impl SlotConsensus for Chorus {
         match message {
             Message::BatchVote(batch_vote_msg) => {
                 if let Some(fast_block) = self.fast.handle_batch_vote(author, batch_vote_msg) {
-                    let commit_vote = fast_block.commit_vote(self.slot, &self.key);
-                    self.push(SlotOutput::CommitOptimistic(fast_block.clone()));
-                    self.broadcast(commit_vote);
-                    self.broadcast(fast_block);
+                    self.vote_fast_block(fast_block);
                 }
             }
             Message::FastCommitVote(fast_commit_vote) => {
@@ -203,9 +257,7 @@ impl SlotConsensus for Chorus {
 
             Message::FastBlock(fast_block) => {
                 if let Some(fast_block) = self.fast.handle_fast_block(fast_block) {
-                    let commit_vote = fast_block.commit_vote(self.slot, &self.key);
-                    self.push(SlotOutput::CommitOptimistic(fast_block));
-                    self.broadcast(commit_vote);
+                    self.vote_fast_block(fast_block);
                 }
             }
 
@@ -239,6 +291,8 @@ impl SlotConsensus for Chorus {
                 self.drain_fallback();
             }
         }
+
+        self.drain_da_commands();
     }
 
     fn handle_deadline(&mut self) {
@@ -251,6 +305,8 @@ impl SlotConsensus for Chorus {
         if let Some(batch_vote) = self.fast.on_propose_deadline() {
             self.broadcast(batch_vote);
         }
+
+        self.drain_da_commands();
     }
 
     fn handle_timer(&mut self, event: Self::Timer) {
@@ -287,10 +343,27 @@ impl SlotConsensus for Chorus {
                 self.drain_fallback();
             }
         }
+
+        self.drain_da_commands();
     }
 }
 
 impl Chorus {
+    /// speculatively commit a newly completed fast block, cast our commit
+    /// vote, and disseminate the block for peers to adopt
+    fn vote_fast_block(&mut self, fast_block: FastBlock) {
+        let commit_vote = fast_block.commit_vote(self.slot, &self.key);
+        self.push(SlotOutput::CommitOptimistic(fast_block.clone()));
+        self.broadcast(commit_vote);
+        self.broadcast(fast_block);
+    }
+
+    fn drain_da_commands(&mut self) {
+        while let Some(command) = self.fast.next_da_command() {
+            self.push(SlotOutput::DA(command));
+        }
+    }
+
     // helpers mostly for documentation purpose
     fn broadcast(&mut self, msg: impl Into<Message>) {
         self.push(SlotOutput::Broadcast(msg.into()));

--- a/monad-mcp-chorus/src/slot/dummy.rs
+++ b/monad-mcp-chorus/src/slot/dummy.rs
@@ -64,6 +64,8 @@ impl SlotConsensus for DummySlotConsensus {
     type Timer = ();
     type OptimisticCommitData = ();
     type FinalizationData = ();
+    type DAEvent = ();
+    type DACommand = ();
 
     fn new(slot: Slot, config: &Self::Config, key: &Arc<KeyPair>) -> Self {
         Self {

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/metablock.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/metablock.rs
@@ -53,7 +53,7 @@ impl Metablock {
     }
 
     /// `entries(B)`, in increasing order of proposer index
-    pub(crate) fn entries(&self) -> ProposalMap<Entry> {
+    pub fn entries(&self) -> ProposalMap<Entry> {
         self.0.as_ref().map(CertifiedEntry::entry)
     }
 }

--- a/monad-mcp-chorus/src/slot/fast.rs
+++ b/monad-mcp-chorus/src/slot/fast.rs
@@ -13,17 +13,19 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::Arc;
+use std::{collections::VecDeque, sync::Arc};
 
 use bytes::Bytes;
 use itertools::Either;
 
 use super::{
+    availability::ProposalAvailability,
+    chorus::{ChorusDACommand, ChorusDAEvent},
     fallback::Metablock,
     types::{
-        DAHandle, EquivCert, FetchProposalError, IsVote, KeyPair, MerkleRoot, NodeId,
-        ProposalIndex, ProposalMap, ProposalMeta, Signature, Slot, StrongQc, TotalProposalMap,
-        ValidatorData, VoteMsg, VotePool, WeakQc, dummy_serialize,
+        EquivCert, IsVote, KeyPair, MerkleRoot, NodeId, ProposalIndex, ProposalMap, ProposalMeta,
+        Signature, Slot, StrongQc, TotalProposalMap, ValidatorData, VoteMsg, VotePool, WeakQc,
+        dummy_serialize,
     },
 };
 use crate::spec::{Stake as _, proposal::ChunkHeader as _, validator::ValidatorData as _};
@@ -58,12 +60,15 @@ pub struct FastPath {
     // helper field to construct per-proposal values
     proposals: ProposalMap<ProposalIndex>,
 
+    // what we know about each proposal's availability
+    availability: ProposalMap<ProposalAvailability>,
+
+    // effects for the DA layer, drained by the slot consensus wrapper
+    commands: VecDeque<ChorusDACommand>,
+
     // using Arc to avoid lifetime issues.
     key: Arc<KeyPair>,
     validator_data: Arc<ValidatorData>,
-
-    // data availability layer handle
-    da: Arc<DAHandle>,
 }
 
 impl FastPath {
@@ -72,7 +77,6 @@ impl FastPath {
         num_proposals: usize,
         key: Arc<KeyPair>,
         validator_data: Arc<ValidatorData>,
-        da_handle: Arc<DAHandle>,
     ) -> Self {
         Self {
             slot: s,
@@ -86,11 +90,35 @@ impl FastPath {
 
             phase: Phase::Propose,
             proposals: ProposalMap::new(num_proposals, |j| j),
+            availability: ProposalMap::new_default(num_proposals),
+            commands: VecDeque::new(),
 
             key,
             validator_data,
-            da: da_handle,
         }
+    }
+
+    pub(crate) fn next_da_command(&mut self) -> Option<ChorusDACommand> {
+        self.commands.pop_front()
+    }
+
+    fn emit(&mut self, command: ChorusDACommand) {
+        self.commands.push_back(command);
+    }
+
+    /// Ingest what the DA layer learned, and retry whatever it unblocks
+    #[must_use]
+    pub(crate) fn handle_da_event(&mut self, event: ChorusDAEvent) -> Option<FastBlock> {
+        let ChorusDAEvent { j, event } = event;
+
+        self.availability[j].ingest(event);
+        if let Some(cert) = self.availability[j].equiv_cert() {
+            self.certs[j].try_upgrade(cert);
+        }
+
+        self.try_form_fast_qc(j);
+        self.try_form_fallback_qc(j);
+        self.try_cast_fast_commit_vote()
     }
 
     /// Whether a fallback certificate received from a peer admits this slot
@@ -154,8 +182,20 @@ impl FastPath {
                 ProposalEvidence::FallbackSignedEntry(entry) => {
                     debug_assert!(entry.well_formed());
                     if let Some(meta) = entry.meta() {
-                        self.da.observe_proposal(self.slot, j, meta.clone());
+                        if self.availability[j].header_for(&meta.root).is_none() {
+                            // a header consensus learned of before DA did
+                            self.emit(ChorusDACommand::ObserveProposal {
+                                j,
+                                meta: meta.clone(),
+                            });
+                        }
+
+                        self.availability[j].record_header(meta.clone());
+                        if let Some(equiv_cert) = self.availability[j].equiv_cert() {
+                            self.certs[j].try_upgrade(equiv_cert);
+                        }
                     }
+
                     let vote = entry.into_vote_msg(self.slot, j);
                     self.fallback_entry_votes[j].add_vote(node_id, vote);
                     self.try_form_fallback_qc(j);
@@ -178,22 +218,23 @@ impl FastPath {
 
         self.phase = Phase::Vote;
 
+        let mut positive = Vec::new();
         let votes = self.proposals.as_ref().map(|j| {
-            let entry = match self.da.fetch_proposal(self.slot, *j) {
-                Ok(proposal) => Entry::Positive {
-                    root: proposal.root,
-                },
-                Err(FetchProposalError::Absent) => Entry::Negative,
-                Err(FetchProposalError::Equivocation(equiv_cert)) => {
-                    self.certs[*j].try_upgrade(equiv_cert);
-                    // upgrade on the equivocation certificate?
-                    todo!()
+            let entry = match self.availability[*j].fetch_proposal() {
+                Some(proposal) => {
+                    positive.push((*j, proposal.root));
+                    Entry::Positive {
+                        root: proposal.root,
+                    }
                 }
+                None => Entry::Negative,
             };
 
             let vote_msg = VoteMsg::new_signed((self.slot, *j), entry.clone(), &self.key);
             (entry, vote_msg.signature)
         });
+
+        self.emit(ChorusDACommand::SlotVoted { positive });
 
         Some(BatchVoteMsg {
             slot: self.slot,
@@ -225,6 +266,17 @@ impl FastPath {
         let enter_fallback_vote = VoteMsg::new_signed(self.slot, EnterFallbackVote, &self.key);
 
         let evidences = self.proposals.as_ref().map(|j| self.proposal_evidence(*j));
+
+        // a fresh positive fallback entry obliges us to re-disseminate the
+        // proposal we hold
+        for (j, evidence) in evidences.as_ref().into_indexed_iter() {
+            if let ProposalEvidence::FallbackSignedEntry(entry) = evidence
+                && let Some(meta) = entry.meta()
+            {
+                let root = meta.root;
+                self.emit(ChorusDACommand::FallbackEntryCast { j, root });
+            }
+        }
 
         let fallback_vote = FallbackVoteMsg {
             enter_fallback_vote,
@@ -276,10 +328,10 @@ impl FastPath {
         // if there are f+1 positive votes on a root and it's decoded,
         // vote positive.
         if let Some(root) = self.weak_available_root(j)
-            && let Ok(meta) = self.da.fetch_proposal(self.slot, j)
-            && meta.root == root
+            && let Some(meta) = self.availability[j].header_for(&root)
         {
-            let fse = FallbackSignedEntry::new_signed_positive(scope, root, &self.key, meta);
+            let fse =
+                FallbackSignedEntry::new_signed_positive(scope, root, &self.key, meta.clone());
             return ProposalEvidence::FallbackSignedEntry(fse);
         }
 
@@ -303,7 +355,7 @@ impl FastPath {
                 Entry::Positive { root } => Some(root),
                 Entry::Negative => None,
             })
-            .find(|root| self.da.proposal_decoded(self.slot, j, root))
+            .find(|root| self.availability[j].decoded(root))
     }
 
     fn try_form_fallback_qc(&mut self, j: ProposalIndex) {

--- a/monad-mcp-chorus/src/slot/mod.rs
+++ b/monad-mcp-chorus/src/slot/mod.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+mod availability;
 pub mod chorus;
 pub mod dummy;
 pub mod fallback;
@@ -30,6 +31,11 @@ pub trait SlotConsensus: Sized {
     type OptimisticCommitData: Clone;
     type FinalizationData: Clone;
 
+    /// Notification from the data-availability layer
+    type DAEvent;
+    /// Effect directed at the data-availability layer
+    type DACommand: Clone;
+
     fn new(slot: Slot, config: &Self::Config, context: &Self::Context) -> Self;
 
     /// Called on the deadline of the slot
@@ -40,6 +46,10 @@ pub trait SlotConsensus: Sized {
 
     /// Handle a timer event.
     fn handle_timer(&mut self, timer: Self::Timer);
+
+    /// Handle a data-availability event. Consensus without a DA layer
+    /// ignores these.
+    fn handle_da_event(&mut self, _event: Self::DAEvent) {}
 
     /// Poll for output actions to be taken by the conductor.
     fn poll(&mut self) -> Option<SlotOutput<Self>>;
@@ -59,6 +69,10 @@ pub enum SlotOutput<S: SlotConsensus> {
 
     /// Send a message to a single peer validator
     Unicast { to: NodeId, message: S::Message },
+
+    /// Effect directed at the data-availability layer, routed by the
+    /// runtime to the DA component under this slot.
+    DA(S::DACommand),
 
     /// Signal execution for optimistic execution.  Q: maybe move this
     /// message into a Context handle method? CommitOptimistic is

--- a/monad-mcp-chorus/src/top_level.rs
+++ b/monad-mcp-chorus/src/top_level.rs
@@ -21,6 +21,7 @@ use super::env;
 
 pub mod conductor;
 pub mod driver;
+pub mod node;
 pub mod runtime;
 pub mod slot;
 pub mod slot_manager;
@@ -28,6 +29,7 @@ pub mod types;
 
 pub use conductor::{Conductor, ConductorOutput};
 pub use driver::{CadenceDriver, CadenceDriverMsg, CadenceMessage, Driver, NodeEvent, WakeId};
-pub use runtime::{CadenceRuntime, FinalizationObserver, Runtime};
+pub use node::{CadenceNodeMsg, DAOutput, DataAvailability, NodeMessage, NodeRuntime};
+pub use runtime::{CadenceRuntime, DAQueue, DASink, FinalizationObserver, Runtime, SlotLifecycle};
 pub use slot::{SlotConsensus, SlotOutput};
 pub use slot_manager::SlotManager;

--- a/monad-mcp-chorus/src/types.rs
+++ b/monad-mcp-chorus/src/types.rs
@@ -668,46 +668,9 @@ impl<T> std::ops::IndexMut<ProposalIndex> for ProposalMap<T> {
 // A helper wrapper type for a type-erased implementation of a trait
 pub struct Erased<T>(pub T);
 
-// A stub implementation of DAHandle that never returns any
-// proposal. used for testing purposes.
-pub struct DAHandle;
-
 // invariant: .0.root != .1.root and both properly signed.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct EquivCert(pub ProposalMeta, pub ProposalMeta);
-
-pub enum FetchProposalError {
-    Absent,
-    Equivocation(EquivCert),
-}
-
-impl DAHandle {
-    pub fn proposal_decoded(&self, _s: Slot, _j: ProposalIndex, _root: &MerkleRoot) -> bool {
-        false
-    }
-
-    /// Info DA about proposals we received through consensus messages (e.g. FallbackSignedEntry)
-    pub fn observe_proposal(&self, _s: Slot, _j: ProposalIndex, _meta: ProposalMeta) {
-        // do nothing
-    }
-
-    pub fn fetch_proposal(
-        &self,
-        _s: Slot,
-        _j: ProposalIndex,
-    ) -> Result<ProposalMeta, FetchProposalError> {
-        // Please do note that there is an potential to have more than
-        // one proposal meta for the same root. This can occur if the
-        // proposer sign the same root with different chunk header
-        // fields (e.g. varying unix_ts_ms).
-        //
-        // Q: How should we deal with this situation? Should we count
-        // it as equivocation? Or should we simply ignore that? Our
-        // current implementation follows the paper which doesn't
-        // currently consider this case as equivocation.
-        Err(FetchProposalError::Absent)
-    }
-}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
A DataAvailability layer composed with the cadence runtime (NodeRuntime), with the sink split into lifecycle and command calls, and a SimDA that models who sends which share to whom: authors serve, positive voters relay, fallback-yes voters recast every share. Swarm tests drive dissemination plans through the fast and fallback paths, including a negative fallback when every relay is lost; SimDA's own behaviour is unit-tested in da.rs.

This code was generated using Claude Fable 5.1.