### PR TITLE
Raptorcast: Canonicalize depth and reserved fields

### DIFF
--- a/monad-raptorcast/src/decoding.rs
+++ b/monad-raptorcast/src/decoding.rs
@@ -35,8 +35,11 @@ use monad_validator::validator_set::{ValidatorSet, ValidatorSetType as _};
 use rand::Rng as _;
 
 use crate::{
+    packet::deterministic,
     udp::ValidatedChunk,
-    util::{compute_hash, AppMessageHash, BroadcastMode, GlobalMerkleRoot, NodeIdHash},
+    util::{
+        compute_hash, AppMessageHash, BroadcastMode, EncodingScheme, GlobalMerkleRoot, NodeIdHash,
+    },
 };
 
 pub const DECODING_CACHE_METRIC_PREFIX: &str = "monad.raptorcast.decoding_cache";
@@ -214,7 +217,7 @@ where
 
             None => {
                 // the decoder state is not in cache, try create a new one
-                let decoder_state = DecoderState::from_initial_message(message)
+                let decoder_state = DecoderState::from_initial_message(message, context)
                     .map_err(TryDecodeError::InvalidSymbol)?;
 
                 let Some(decoder_state) =
@@ -1455,6 +1458,47 @@ pub(crate) enum InvalidSymbol {
     DuplicateSymbol { encoding_symbol_id: usize },
     /// Error when creating a `ManagedDecoder` with invalid parameters (e.g., too many source symbols).
     InvalidDecoderParameter(std::io::Error),
+    /// The symbol length is not that of the canonical layout for the
+    /// message and its group
+    NonCanonical {
+        symbol_len: usize,
+        // None if there is no possible canonical symbol len
+        canonical_symbol_len: Option<usize>,
+    },
+}
+
+fn canonical_symbol_len<PT: PubKey>(
+    symbol_len: usize,
+    message: &ValidatedChunk<PT>,
+    context: &DecodingContext<'_, PT>,
+) -> Result<usize, InvalidSymbol> {
+    if !matches!(message.encoding_scheme, EncodingScheme::Deterministic25(_)) {
+        // non-deterministic (i.e. v0)
+        return Ok(symbol_len);
+    }
+
+    let app_message_len = message.app_message_len as usize;
+    let canonical_symbol_len = match message.broadcast_mode {
+        BroadcastMode::Primary => context.validator_set_size().and_then(|group_size| {
+            deterministic::canonical_symbol_len(
+                message.encoding_scheme,
+                app_message_len,
+                group_size,
+            )
+        }),
+        BroadcastMode::Secondary => {
+            deterministic::canonical_symbol_len_secondary(message.encoding_scheme, app_message_len)
+        }
+        BroadcastMode::Unspecified => None,
+    };
+
+    if canonical_symbol_len != Some(symbol_len) {
+        return Err(InvalidSymbol::NonCanonical {
+            symbol_len,
+            canonical_symbol_len,
+        });
+    }
+    Ok(symbol_len)
 }
 
 impl InvalidSymbol {
@@ -1529,6 +1573,23 @@ impl InvalidSymbol {
                     "invalid parameter for ManagedDecoder::new"
                 );
             }
+
+            InvalidSymbol::NonCanonical {
+                symbol_len,
+                canonical_symbol_len,
+            } => {
+                tracing::warn!(
+                    ?self_id,
+                    author =? symbol.author,
+                    unix_ts_ms = symbol.unix_ts_ms,
+                    merkle_root =? symbol.merkle_root,
+                    broadcast_mode =? symbol.broadcast_mode,
+                    app_message_len = symbol.app_message_len,
+                    symbol_len,
+                    ?canonical_symbol_len,
+                    "received non-canonical symbol length"
+                );
+            }
         }
     }
 }
@@ -1540,11 +1601,15 @@ struct DecoderState {
 }
 
 impl DecoderState {
-    pub fn from_initial_message<PT>(message: &ValidatedChunk<PT>) -> Result<Self, InvalidSymbol>
+    pub fn from_initial_message<PT>(
+        message: &ValidatedChunk<PT>,
+        context: &DecodingContext<'_, PT>,
+    ) -> Result<Self, InvalidSymbol>
     where
         PT: PubKey,
     {
-        let symbol_len = message.chunk.len();
+        let symbol_len = canonical_symbol_len(message.chunk.len(), message, context)?;
+
         let app_message_len: usize = message
             .app_message_len
             .try_into()
@@ -1721,7 +1786,7 @@ mod test {
 
     use bytes::BytesMut;
     use itertools::Itertools;
-    use monad_types::{Epoch, Stake};
+    use monad_types::{Epoch, Round, Stake};
     use rand::seq::SliceRandom as _;
 
     use super::*;
@@ -1765,6 +1830,104 @@ mod test {
         config.validator_tier.total_slots = validator_tier_cache_size;
         config.p2p_tier.total_slots = p2p_tier_cache_size;
         DecoderCache::new(config)
+    }
+
+    fn deterministic_chunk(
+        broadcast_mode: BroadcastMode,
+        depth: u8,
+        app_message_len: usize,
+    ) -> ValidatedChunk<PT> {
+        let layout = deterministic::PacketLayout::new(deterministic::DEFAULT_SEGMENT_LEN, depth);
+        let num_source_symbols = app_message_len.div_ceil(layout.symbol_len());
+        let group_id = match broadcast_mode {
+            BroadcastMode::Secondary => GroupId::Secondary(Round(1)),
+            _ => GroupId::Primary(EPOCH),
+        };
+        ValidatedChunk {
+            chunk: Bytes::from(vec![0_u8; layout.symbol_len()]),
+            message: Bytes::new(),
+            signature: Bytes::new(),
+            author: node_id(1),
+            group_id,
+            unix_ts_ms: UNIX_TS_MS,
+            app_message_hash: None,
+            merkle_root: HexBytes([depth; 20]),
+            app_message_len: app_message_len as u32,
+            version: ChunkVersion::V1,
+            encoding_scheme: EncodingScheme::Deterministic25(Round(1)),
+            broadcast_mode,
+            recipient_hash: None,
+            chunk_id: 0,
+            num_source_symbols,
+            encoded_symbol_capacity: num_source_symbols * 3,
+        }
+    }
+
+    // The layout rule is enforced on the symbol that opens a decoder;
+    // a non-canonical one never gets a decoder.
+    #[test]
+    fn test_non_canonical_symbol_len_opens_no_decoder() {
+        let app_message_len = 200 * 1024;
+        let scheme = EncodingScheme::Deterministic25(Round(1));
+        let validator_set = make_validator_set(&[(1, 1), (2, 1), (3, 1)]);
+        let primary = DecodingContext::new(Some(&validator_set), UNIX_TS_MS);
+        let secondary = DecodingContext::new(None, UNIX_TS_MS);
+        let mut cache = make_cache(1, 1, 1);
+
+        let depth =
+            deterministic::canonical_tree_depth(scheme, app_message_len, validator_set.len())
+                .unwrap();
+        let canonical = deterministic_chunk(BroadcastMode::Primary, depth, app_message_len);
+        // No validator set, or no mode, gives no canonical layout.
+        assert!(matches!(
+            cache.try_decode(&canonical, &secondary),
+            Err(TryDecodeError::InvalidSymbol(InvalidSymbol::NonCanonical {
+                canonical_symbol_len: None,
+                ..
+            }))
+        ));
+        let modeless = deterministic_chunk(BroadcastMode::Unspecified, depth, app_message_len);
+        assert!(matches!(
+            cache.try_decode(&modeless, &primary),
+            Err(TryDecodeError::InvalidSymbol(InvalidSymbol::NonCanonical {
+                canonical_symbol_len: None,
+                ..
+            }))
+        ));
+        assert!(matches!(
+            cache.try_decode(&canonical, &primary),
+            Ok(TryDecodeStatus::NeedsMoreSymbols)
+        ));
+        let deeper = deterministic_chunk(BroadcastMode::Primary, depth + 1, app_message_len);
+        for _ in 0..2 {
+            assert!(matches!(
+                cache.try_decode(&deeper, &primary),
+                Err(TryDecodeError::InvalidSymbol(InvalidSymbol::NonCanonical {
+                    symbol_len,
+                    canonical_symbol_len,
+                })) if symbol_len == deeper.chunk.len()
+                    && canonical_symbol_len == Some(canonical.chunk.len())
+            ));
+        }
+
+        // Primary and secondary chunks share the broadcast tier, whose
+        // single slot the primary entry above holds.
+        let mut cache = make_cache(1, 1, 1);
+        let depth = deterministic::canonical_tree_depth_secondary(scheme, app_message_len).unwrap();
+        let canonical = deterministic_chunk(BroadcastMode::Secondary, depth, app_message_len);
+        assert!(matches!(
+            cache.try_decode(&canonical, &secondary),
+            Ok(TryDecodeStatus::NeedsMoreSymbols)
+        ));
+        let deeper = deterministic_chunk(BroadcastMode::Secondary, depth + 1, app_message_len);
+        assert!(matches!(
+            cache.try_decode(&deeper, &secondary),
+            Err(TryDecodeError::InvalidSymbol(InvalidSymbol::NonCanonical {
+                symbol_len,
+                canonical_symbol_len,
+            })) if symbol_len == deeper.chunk.len()
+                && canonical_symbol_len == Some(canonical.chunk.len())
+        ));
     }
 
     fn make_symbols(

--- a/monad-raptorcast/src/packet/deterministic.rs
+++ b/monad-raptorcast/src/packet/deterministic.rs
@@ -458,7 +458,7 @@ impl<PT: PubKey> SecondaryEncoding<PT> {
     }
 }
 
-pub fn calc_tree_depth(
+pub fn canonical_tree_depth(
     encoding_scheme: EncodingScheme,
     app_message_len: usize,
     validator_set_size: usize,
@@ -480,7 +480,7 @@ pub fn calc_tree_depth(
     Some(depth)
 }
 
-pub fn calc_tree_depth_secondary(
+pub fn canonical_tree_depth_secondary(
     encoding_scheme: EncodingScheme,
     app_message_len: usize,
 ) -> Option<u8> {
@@ -498,6 +498,23 @@ pub fn calc_tree_depth_secondary(
         let num_base_symbols = layout.num_base_symbols(app_message_len);
         even_partition_num_chunks(num_base_symbols, redundancy)
     })
+}
+
+pub fn canonical_symbol_len(
+    encoding_scheme: EncodingScheme,
+    app_message_len: usize,
+    validator_set_size: usize,
+) -> Option<usize> {
+    let depth = canonical_tree_depth(encoding_scheme, app_message_len, validator_set_size)?;
+    Some(PacketLayout::new(DEFAULT_SEGMENT_LEN, depth).symbol_len())
+}
+
+pub fn canonical_symbol_len_secondary(
+    encoding_scheme: EncodingScheme,
+    app_message_len: usize,
+) -> Option<usize> {
+    let depth = canonical_tree_depth_secondary(encoding_scheme, app_message_len)?;
+    Some(PacketLayout::new(DEFAULT_SEGMENT_LEN, depth).symbol_len())
 }
 
 #[cfg(test)]
@@ -681,8 +698,8 @@ mod tests {
     use zerocopy::Ref;
 
     use super::{
-        build_header, build_secondary, calc_global_merkle_root_secondary, calc_tree_depth,
-        calc_tree_depth_secondary, PacketLayout, DEFAULT_REDUNDANCY, DEFAULT_SEGMENT_LEN,
+        build_header, build_secondary, calc_global_merkle_root_secondary, canonical_tree_depth,
+        canonical_tree_depth_secondary, PacketLayout, DEFAULT_REDUNDANCY, DEFAULT_SEGMENT_LEN,
         MAX_MERKLE_TREE_DEPTH, MAX_SYMBOL_LEN, MIN_MERKLE_TREE_DEPTH, MIN_SYMBOL_LEN,
     };
     use crate::{
@@ -727,7 +744,7 @@ mod tests {
     const _: () = assert!(MAX_SYMBOL_LEN == 1279);
 
     fn validate_d25_layout(app_msg_len: usize, val_set_size: usize) {
-        let depth = calc_tree_depth(
+        let depth = canonical_tree_depth(
             super::EncodingScheme::Deterministic25(super::Round(0)),
             app_msg_len,
             val_set_size,
@@ -957,11 +974,13 @@ mod tests {
     }
 
     #[test]
-    fn test_calc_tree_depth_secondary_in_range() {
+    fn test_canonical_tree_depth_secondary_in_range() {
         for app_msg_len in [1_usize, 1024, 64 * 1024, MAX_MESSAGE_SIZE] {
-            let depth =
-                calc_tree_depth_secondary(EncodingScheme::Deterministic25(Round(0)), app_msg_len)
-                    .expect("should find a valid depth");
+            let depth = canonical_tree_depth_secondary(
+                EncodingScheme::Deterministic25(Round(0)),
+                app_msg_len,
+            )
+            .expect("should find a valid depth");
             assert!((MIN_MERKLE_TREE_DEPTH..=MAX_MERKLE_TREE_DEPTH).contains(&depth));
         }
     }

--- a/monad-raptorcast/src/parser/packet_parser.rs
+++ b/monad-raptorcast/src/parser/packet_parser.rs
@@ -70,6 +70,8 @@ pub enum MalformedPacket {
     TooLong,
     InvalidTreeDepth(u8),
     InvalidBroadcastBits(u8),
+    InvalidMode(u8),
+    InvalidChunkHeader,
     InvalidEncodingScheme(u8),
     UnknownVersion(u16),
 }
@@ -201,7 +203,7 @@ impl RaptorcastChunkHeaderV0 {
 
 /// Raptorcast packet V1 versioned header layout (follows common header):
 /// - 2 bits => broadcast mode
-/// - 2 bits => unused
+/// - 2 bits => reserved, must be zero
 /// - 4 bits => Merkle tree depth
 /// - 1 byte (u8) => encoding scheme variant
 /// - 8 bytes (u64) => Round #
@@ -212,7 +214,7 @@ impl RaptorcastChunkHeaderV0 {
 #[repr(C, packed)]
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Clone, Copy)]
 pub struct RaptorcastHeaderV1 {
-    broadcast_tree_depth: u8,
+    mode_depth: u8,
     encoding_scheme_variant: u8,
     round: U64<LE>,
     epoch: U64<LE>,
@@ -228,11 +230,20 @@ impl RaptorcastHeaderV1 {
     const SIZE: usize = 1 + 1 + 8 + 8 + 8 + MERKLE_HASH_SIZE + 4;
 
     pub fn broadcast_mode(&self) -> Result<BroadcastMode, MalformedPacket> {
-        match (self.broadcast_tree_depth & 0b1100_0000) >> 6 {
+        match (self.mode_depth & 0b1100_0000) >> 6 {
             0b10 => Ok(BroadcastMode::Primary),
             0b01 => Ok(BroadcastMode::Secondary),
             bits => Err(MalformedPacket::InvalidBroadcastBits(bits)),
         }
+    }
+
+    fn validate_reserved(&self) -> Result<(), MalformedPacket> {
+        let mode_bits = self.mode_depth >> 4;
+        ensure!(
+            mode_bits & 0b0011 == 0,
+            MalformedPacket::InvalidMode(mode_bits)
+        );
+        Ok(())
     }
 
     pub fn encoding_scheme(&self) -> Result<EncodingScheme, MalformedPacket> {
@@ -245,7 +256,7 @@ impl RaptorcastHeaderV1 {
 
     #[allow(clippy::manual_range_contains)]
     pub fn tree_depth(&self) -> Result<u8, MalformedPacket> {
-        let depth = self.broadcast_tree_depth & 0b0000_1111;
+        let depth = self.mode_depth & 0b0000_1111;
         ensure!(
             (deterministic::MIN_MERKLE_TREE_DEPTH..=deterministic::MAX_MERKLE_TREE_DEPTH)
                 .contains(&depth),
@@ -294,6 +305,14 @@ pub struct RaptorcastChunkHeaderV1 {
 
 impl RaptorcastChunkHeaderV1 {
     const SIZE: usize = 2 + 2;
+
+    fn validate_reserved(&self) -> Result<(), MalformedPacket> {
+        ensure!(
+            self.reserved.get() == 0,
+            MalformedPacket::InvalidChunkHeader
+        );
+        Ok(())
+    }
 
     fn merkle_leaf_index(&self) -> u16 {
         self.chunk_id.get()
@@ -563,6 +582,8 @@ impl<'a> RaptorcastPacketV1<'a> {
             Ref::from_bytes(header_bytes).map_err(|_| MalformedPacket::TooShort)?;
 
         let tree_depth = header.tree_depth()?;
+        header.validate_reserved()?;
+
         let merkle_proof_len = MERKLE_HASH_SIZE * (tree_depth - 1) as usize;
         ensure!(rest.len() > merkle_proof_len, MalformedPacket::TooShort);
 
@@ -578,6 +599,7 @@ impl<'a> RaptorcastPacketV1<'a> {
             chunk_header_and_payload.split_at(RaptorcastChunkHeaderV1::SIZE);
         let chunk_header: Ref<&[u8], RaptorcastChunkHeaderV1> =
             Ref::from_bytes(chunk_header_bytes).map_err(|_| MalformedPacket::TooShort)?;
+        chunk_header.validate_reserved()?;
 
         ensure!(!payload.is_empty(), MalformedPacket::TooShort);
 

--- a/monad-raptorcast/src/udp.rs
+++ b/monad-raptorcast/src/udp.rs
@@ -1491,7 +1491,7 @@ mod tests_deterministic {
             MessageBuilder,
         },
         parser::{
-            packet_parser::{ChunkValidationEnv, RaptorcastPacket},
+            packet_parser::{ChunkValidationEnv, MalformedPacket, RaptorcastPacket},
             signature_verifier::SignatureVerifier,
         },
         udp::SIGNATURE_CACHE_SIZE,
@@ -1501,6 +1501,7 @@ mod tests_deterministic {
             ValidatorGroupMap,
         },
         v1_rollout::DeterministicProtocolRolloutStage,
+        SIGNATURE_SIZE,
     };
 
     type SignatureType = SecpSignature;
@@ -2148,6 +2149,128 @@ mod tests_deterministic {
             Err(InvalidChunk::InvalidChunkId)
         ));
         assert!(matches!(forge(u16::MAX), Err(InvalidChunk::InvalidChunkId)));
+    }
+
+    #[test]
+    fn test_v1_reserved_fields_must_be_zero() {
+        let app_message: Bytes = vec![0x5A_u8; 64 * 1024].into();
+        let (key, validators, _) = validator_set();
+        let self_id = NodeId::new(key.pubkey());
+        let group_map = make_group_map(&validators);
+        let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &self_id, &group_map).unwrap();
+        let packets = build_packets(&key, &app_message, group);
+
+        ChunkParser::new()
+            .parse(&packets[0].payload)
+            .expect("valid packet");
+        let depth = deterministic::canonical_tree_depth(
+            EncodingScheme::Deterministic25(ROUND),
+            app_message.len(),
+            validators.len(),
+        )
+        .unwrap();
+        let layout = deterministic::PacketLayout::new(deterministic::DEFAULT_SEGMENT_LEN, depth);
+
+        let forge = |mutate: &dyn Fn(&mut [u8])| {
+            let mut payload = BytesMut::from(&packets[0].payload[..]);
+            mutate(&mut payload[..]);
+            ChunkParser::new().parse(&payload.freeze()).err()
+        };
+
+        // The broadcast-mode/depth byte follows the signature and version.
+        const MODE_DEPTH_BYTE: usize = SIGNATURE_SIZE + 2;
+        // Each nonzero reserved pair; the error reports the mode nibble.
+        for bits in 1_u8..=0b11 {
+            let malformed = forge(&|payload| payload[MODE_DEPTH_BYTE] |= bits << 4);
+            let mode_bits = (packets[0].payload[MODE_DEPTH_BYTE] | bits << 4) >> 4;
+            assert_eq!(
+                malformed,
+                Some(InvalidChunk::Malformed(MalformedPacket::InvalidMode(
+                    mode_bits
+                )))
+            );
+        }
+
+        let malformed = forge(&|payload| {
+            let chunk_header = &mut payload[layout.chunk_header_range()];
+            chunk_header[..2].copy_from_slice(&0x0102_u16.to_le_bytes());
+        });
+        assert_eq!(
+            malformed,
+            Some(InvalidChunk::Malformed(MalformedPacket::InvalidChunkHeader))
+        );
+    }
+
+    // A chunk whose depth differs from the one derived for the
+    // receiver's group opens no decoder, so it is never rebroadcast.
+    #[test]
+    fn test_deterministic_primary_rejects_non_canonical_depth() {
+        // Small enough that the |V| term moves the depth: 100
+        // validators need depth 9, 10 validators depth 7.
+        let app_message: Bytes = vec![0x5A_u8; 16 * 1024].into();
+        let scheme = EncodingScheme::Deterministic25(ROUND);
+        let (sender_key, validators, _) = validator_set();
+        let sender_id = NodeId::new(sender_key.pubkey());
+        let group_map = make_group_map(&validators);
+        let group = PrimaryBroadcastGroup::of_epoch(EPOCH, &sender_id, &group_map).unwrap();
+        let packets = build_packets(&sender_key, &app_message, group);
+
+        // The receiver knows a smaller validator set for the epoch.
+        let mut members = BTreeMap::new();
+        members.insert(sender_id, Stake::ONE);
+        for (id, stake) in validators.get_members() {
+            if members.len() == 10 {
+                break;
+            }
+            members.insert(*id, *stake);
+        }
+        let small_validators = ValidatorSet::new_unchecked(members);
+        let sender_depth =
+            deterministic::canonical_tree_depth(scheme, app_message.len(), validators.len());
+        let receiver_depth =
+            deterministic::canonical_tree_depth(scheme, app_message.len(), small_validators.len());
+        assert_ne!(sender_depth, receiver_depth);
+
+        // Receive as the first hop of chunk 0 under the receiver-side
+        // assignment, so that a missing check would rebroadcast.
+        let small_group_map = make_group_map(&small_validators);
+        let small_group =
+            PrimaryBroadcastGroup::of_epoch(EPOCH, &sender_id, &small_group_map).unwrap();
+        let encoding = deterministic::PrimaryEncoding::new(
+            scheme,
+            &small_group,
+            app_message.len(),
+            UNIX_TS_MS,
+        )
+        .unwrap();
+        let assignment = encoding.make_assignment().unwrap();
+        let receiver_id = *assignment.resolve_chunk_id(0).unwrap().recipient();
+
+        let epoch_validators: BTreeMap<_, _> = [(EPOCH, small_validators)].into();
+        let full_node_groups = FullNodeGroupMap::default();
+        let mut udp_state = UdpState::<SignatureType>::new(receiver_id, u64::MAX, 10_000);
+        udp_state.set_v1_rollout(DeterministicProtocolRolloutStage::AlwaysV1);
+
+        let mut rebroadcasts = 0;
+        let mut decoded = Vec::new();
+        for packet in &packets {
+            let recv_msg = AuthRecvMsg {
+                src_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8000),
+                payload: packet.payload.clone(),
+                stride: deterministic::DEFAULT_SEGMENT_LEN as u16,
+                sender: None,
+            };
+            decoded.extend(udp_state.handle_message(
+                &epoch_validators,
+                &full_node_groups,
+                &StubProposerSchedule::VALID,
+                |_, _, _| rebroadcasts += 1,
+                recv_msg,
+            ));
+        }
+
+        assert_eq!(rebroadcasts, 0);
+        assert!(decoded.is_empty());
     }
 
     #[rstest]


### PR DESCRIPTION
This PR enforces v1 packet rules the receiver was not previously checking.

- Reject nonzero reserved bits in `mode` field
  + Previously we do not validate on the reserved bits.
- Reject nonzero reserved u16 in chunk header
  + Previously such nonzero bytes on chunk header gets rejected during merkle proof check.
  + This PR rejects the values earlier to be consistent with the other reserved bits check.
- Reject non-canonical merkle tree depth/symbol length
  + An invalid merkle depth is already rejected early in packet parsing. However, valid but non-canonical depth were previously accepted in chunk ingestion path.
  + Messages of non-canonical depth were previously only detected and rejected during re-encoding.
  + This PR rejects non-canonical merkle tree depth early in decoder initialization indirectly through canonical symbol length check.

These changes are made to align with the MIP specification.