### PR TITLE
feat(ledger-tail): log gas_used on proposed_block

### DIFF
--- a/monad-node/Cargo.toml
+++ b/monad-node/Cargo.toml
@@ -79,5 +79,6 @@ monad-version = { workspace = true }
 [dev-dependencies]
 monad-block-persist = { workspace = true }
 
+alloy-consensus = { workspace = true }
 inotify = { workspace = true }
 lru = { workspace = true }

--- a/monad-node/examples/ledger-tail.rs
+++ b/monad-node/examples/ledger-tail.rs
@@ -20,6 +20,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use alloy_consensus::Transaction;
 use clap::{CommandFactory, FromArgMatches, Parser};
 use futures_util::{Stream, StreamExt};
 use inotify::{Inotify, WatchMask};
@@ -209,6 +210,7 @@ async fn main() {
                 epoch =? block.header().epoch.0,
                 seq_num =? block.header().seq_num.0,
                 num_tx =? block.body().execution_body.transactions.len(),
+                gas_used =? block.body().execution_body.transactions.iter().map(|tx| tx.gas_limit()).sum::<u64>(),
                 author =? block.header().author,
                 block_ts_ms =? block.header().timestamp_ns / 1_000_000,
                 now_ts_ms =? now_ts.as_millis(),


### PR DESCRIPTION
This PR implements gas_used reporting in ledger-tail's proposed_block log event.

- Adds a `gas_used` field to the `proposed_block` tracing log line, alongside the existing `num_tx`
- Computed as the sum of each proposed transaction's `gas_limit`, since post-MONAD_ONE unused-gas refunds are hardcoded to 0, making gas_used == gas_limit exactly for every transaction
- Available synchronously from the proposal's own transaction list, with no need to wait on asynchronous execution output (delayed_execution_results / triedb)
- Adds `alloy-consensus` as a dev-dependency of `monad-node` to bring the `Transaction` trait (`.gas_limit()`) into scope for the example binary