### PR TITLE
Add RLP serialization for Cadence protocol messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5697,6 +5697,7 @@ dependencies = [
 name = "monad-mcp-chorus"
 version = "0.1.0"
 dependencies = [
+ "alloy-rlp",
  "bytes",
  "derive_more",
  "itertools 0.13.0",

--- a/monad-mcp-chorus-sim/tests/fallback_mvba.rs
+++ b/monad-mcp-chorus-sim/tests/fallback_mvba.rs
@@ -36,8 +36,8 @@ mod fixtures {
             Mvba as _, monad_mvba::MvbaContext,
         },
         types::{
-            HeaderAuth, IsVote, MerkleRoot, NodeId, ProposalMap, Slot, Stake, StrongQc,
-            TimestampDelta, ValidatorData, VoteMsg, VotePool, WeakQc,
+            HeaderAuth, IsVote, MerkleRoot, NodeId, ProposalMap, ProposalScope, Slot, Stake,
+            StrongQc, TimestampDelta, ValidatorData, VoteMsg, VotePool, WeakQc,
         },
     };
     use monad_mcp_chorus::{spec::KeyPair as _, stub as chorus};
@@ -102,7 +102,12 @@ mod fixtures {
     pub fn fast_metablock(seed: u64, validator_data: &ValidatorData) -> Metablock {
         Metablock::new(ProposalMap::new(NUM_PROPOSALS, |j| {
             let entry = Entry::Positive(root(seed * 100 + j as u64));
-            CertifiedEntry::FastQc(strong_qc((SLOT, j), entry, &quorum(), validator_data))
+            CertifiedEntry::FastQc(strong_qc(
+                ProposalScope::new(SLOT, j),
+                entry,
+                &quorum(),
+                validator_data,
+            ))
         }))
     }
 
@@ -114,13 +119,18 @@ mod fixtures {
             let entry = Entry::Positive(root(seed * 100 + j as u64));
             if j == 0 {
                 CertifiedEntry::FallbackQc(weak_qc(
-                    (SLOT, j),
+                    ProposalScope::new(SLOT, j),
                     FallbackEntry(entry),
                     &quorum(),
                     validator_data,
                 ))
             } else {
-                CertifiedEntry::FastQc(strong_qc((SLOT, j), entry, &quorum(), validator_data))
+                CertifiedEntry::FastQc(strong_qc(
+                    ProposalScope::new(SLOT, j),
+                    entry,
+                    &quorum(),
+                    validator_data,
+                ))
             }
         }))
     }

--- a/monad-mcp-chorus/Cargo.toml
+++ b/monad-mcp-chorus/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 enable_stub = []
 
 [dependencies]
+alloy-rlp = { workspace = true, features = ["derive"] }
 bytes = { workspace = true }
 derive_more = { workspace = true, features = ["from", "sum", "add", "into"] }
 itertools = { workspace = true }

--- a/monad-mcp-chorus/src/conductor/acs/nop.rs
+++ b/monad-mcp-chorus/src/conductor/acs/nop.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use alloy_rlp::{Decodable, Encodable};
+
 use super::{Acs, AcsOutput, types::NodeId};
 
 /// An ACS that never communicates and immediately decides on its own
@@ -46,5 +48,21 @@ impl<V> Acs<V> for NopAcs<V> {
 
     fn poll(&mut self) -> Option<AcsOutput<Self::Message>> {
         None
+    }
+}
+
+impl Encodable for NoMessage {
+    fn encode(&self, _out: &mut dyn bytes::BufMut) {
+        panic!("NoMessage cannot be encoded");
+    }
+
+    fn length(&self) -> usize {
+        panic!("NoMessage has no encoded length");
+    }
+}
+
+impl Decodable for NoMessage {
+    fn decode(_buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Err(alloy_rlp::Error::Custom("NoMessage has no wire messages"))
     }
 }

--- a/monad-mcp-chorus/src/conductor/deadline_agreement.rs
+++ b/monad-mcp-chorus/src/conductor/deadline_agreement.rs
@@ -13,13 +13,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+
 use super::{
     ConductorConfig, ConductorError, ConductorOutput, MonadConductor,
     acs::{Acs, AcsOutput},
     types::{NodeId, Slot, Timestamp, WindowId},
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 pub struct DeadlineAgreementMessage<M> {
     pub window: WindowId,
     pub acs_message: M,

--- a/monad-mcp-chorus/src/conductor/dummy.rs
+++ b/monad-mcp-chorus/src/conductor/dummy.rs
@@ -18,6 +18,8 @@ use std::{
     num::NonZeroU64,
 };
 
+use alloy_rlp::{Decodable, Encodable};
+
 use super::{
     Conductor, ConductorOutput,
     types::{NodeId, Slot, Timestamp, TimestampDelta},
@@ -62,6 +64,7 @@ impl DummyConductor {
         self.deadline_offset = offset;
         self
     }
+
     pub fn set_genesis(mut self, genesis: Timestamp) -> Self {
         self.genesis = genesis;
         self
@@ -122,5 +125,21 @@ impl Conductor for DummyConductor {
         ));
         self.outputs.push_back(ConductorOutput::OpenSlots(slots));
         self.outputs.push_back(ConductorOutput::CloseSlots { cap });
+    }
+}
+
+impl Encodable for Never {
+    fn encode(&self, _out: &mut dyn bytes::BufMut) {
+        panic!("Never cannot be encoded");
+    }
+
+    fn length(&self) -> usize {
+        panic!("Never has no encoded length");
+    }
+}
+
+impl Decodable for Never {
+    fn decode(_buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Err(alloy_rlp::Error::Custom("Never has no wire messages"))
     }
 }

--- a/monad-mcp-chorus/src/driver.rs
+++ b/monad-mcp-chorus/src/driver.rs
@@ -15,11 +15,15 @@
 
 use std::collections::{HashMap, VecDeque};
 
+use alloy_rlp::{Decodable, Encodable, Header, encode_list, list_length};
+use bytes::Bytes;
+
 use super::{
     conductor::Conductor,
     slot::SlotConsensus,
     types::{NodeId, Slot, Timestamp, TimestampDelta, Validated},
 };
+use crate::spec::{Deserializable, Serializable};
 
 // A driver translates consensus effects into concrete node effects
 // that are agnostic of the consensus protocol.
@@ -213,5 +217,251 @@ where
         &mut self,
     ) -> Option<CadenceEvent<S::Timer, C::Alarm, S::Message, C::Message>> {
         self.inbox.pop_front()
+    }
+}
+
+impl<SM, CM> Encodable for CadenceMessage<SM, CM>
+where
+    SM: Encodable,
+    CM: Encodable,
+{
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        match self {
+            Self::Slot(slot, message) => {
+                let fields: [&dyn Encodable; 3] = [&1u8, slot, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+            Self::Conductor(message) => {
+                let fields: [&dyn Encodable; 2] = [&2u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+        }
+    }
+
+    fn length(&self) -> usize {
+        match self {
+            Self::Slot(slot, message) => {
+                let fields: [&dyn Encodable; 3] = [&1u8, slot, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+            Self::Conductor(message) => {
+                let fields: [&dyn Encodable; 2] = [&2u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+        }
+    }
+}
+
+impl<SM, CM> Decodable for CadenceMessage<SM, CM>
+where
+    SM: Decodable,
+    CM: Decodable,
+{
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let mut payload = Header::decode_bytes(buf, true)?;
+        let result = match <u8 as Decodable>::decode(&mut payload)? {
+            1 => Self::Slot(
+                <Slot as Decodable>::decode(&mut payload)?,
+                <SM as Decodable>::decode(&mut payload)?,
+            ),
+            2 => Self::Conductor(<CM as Decodable>::decode(&mut payload)?),
+            _ => return Err(alloy_rlp::Error::Custom("unknown CadenceMessage tag")),
+        };
+        if !payload.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(result)
+    }
+}
+
+impl<SM: Encodable, CM: Encodable> Serializable<Bytes> for CadenceMessage<SM, CM> {
+    fn serialize(&self) -> Bytes {
+        alloy_rlp::encode(self).into()
+    }
+}
+
+impl<SM: Decodable, CM: Decodable> Deserializable<Bytes> for CadenceMessage<SM, CM> {
+    type ReadError = alloy_rlp::Error;
+
+    fn deserialize(message: &Bytes) -> Result<Self, Self::ReadError> {
+        alloy_rlp::decode_exact(message)
+    }
+}
+
+#[cfg(test)]
+mod rlp_tests {
+    use alloy_rlp::{Decodable, Encodable};
+
+    use super::{
+        super::{
+            conductor::deadline_agreement::DeadlineAgreementMessage,
+            test_utils::assert_roundtrip,
+            types::{Timestamp, WindowId},
+        },
+        *,
+    };
+
+    #[test]
+    fn cadence_wire_layout_and_byte_traits() {
+        type M = CadenceMessage<u64, DeadlineAgreementMessage<Timestamp>>;
+        let slot = M::Slot(Slot(7), 42);
+        assert_eq!(alloy_rlp::encode(&slot), [0xc3, 1, 7, 42]);
+        let conductor = M::Conductor(DeadlineAgreementMessage {
+            window: WindowId(3),
+            acs_message: Timestamp::from_nanos(42),
+        });
+        assert_eq!(alloy_rlp::encode(&conductor), [0xc4, 2, 0xc2, 3, 42]);
+        for message in [slot, conductor] {
+            assert_roundtrip(&message);
+            let bytes: bytes::Bytes = message.serialize();
+            assert_eq!(M::deserialize(&bytes).unwrap(), message);
+            let mut extra = bytes.to_vec();
+            extra.push(0);
+            assert!(M::deserialize(&bytes::Bytes::from(extra)).is_err());
+        }
+    }
+
+    fn chorus_message(slot: Slot) -> super::super::slot::chorus::ChorusMessage {
+        use super::super::{
+            slot::fallback::EnterFallbackVote,
+            types::{ValidatorData, VoteMsg, VotePool},
+        };
+        use crate::spec::KeyPair as _;
+
+        let nodes: Vec<_> = (0..4).map(NodeId::dummy).collect();
+        let validators = ValidatorData::new(
+            nodes.iter().map(|node| (*node, 1u64.into())).collect(),
+            nodes
+                .iter()
+                .map(|node| (*node, node.keypair().pubkey()))
+                .collect(),
+        );
+        let mut votes = VotePool::new(slot);
+        for node in &nodes[..3] {
+            votes.add_vote(
+                *node,
+                VoteMsg::new_signed(slot, EnterFallbackVote, &node.keypair()),
+            );
+        }
+        votes.try_form_strong_qc(&validators).unwrap().into()
+    }
+
+    #[test]
+    fn concrete_cadence_slot_and_conductor_byte_roundtrips() {
+        use super::super::{
+            conductor::{MonadConductor, acs::median::MedianAcs},
+            slot::chorus::Chorus,
+            test_utils::{assert_roundtrip, assert_serialization_roundtrip},
+            types::SlotDeadline,
+        };
+        type Wire = CadenceDriverMsg<Chorus, MonadConductor<MedianAcs<SlotDeadline>>>;
+
+        let slot = Slot(7);
+        let message = chorus_message(slot);
+        assert_roundtrip(&message);
+        assert_serialization_roundtrip(&Wire::Slot(slot, message));
+
+        for nanos in [0, 127, 128, u128::MAX] {
+            let message = DeadlineAgreementMessage {
+                window: WindowId(3),
+                acs_message: Timestamp::from_nanos(nanos),
+            };
+            assert_roundtrip(&message);
+            assert_serialization_roundtrip(&Wire::Conductor(message));
+        }
+    }
+
+    #[test]
+    fn nop_conductor_still_allows_slot_message_serialization() {
+        use super::super::{
+            conductor::{MonadConductor, acs::nop::NopAcs},
+            slot::chorus::Chorus,
+            types::SlotDeadline,
+        };
+        type Wire = CadenceDriverMsg<Chorus, MonadConductor<NopAcs<SlotDeadline>>>;
+
+        let slot = Slot(7);
+        let message = chorus_message(slot);
+        let wire = Wire::Slot(slot, message.clone());
+        let bytes = <Wire as Serializable<bytes::Bytes>>::serialize(&wire);
+        assert_eq!(bytes.len(), wire.length());
+        let Wire::Slot(decoded_slot, decoded_message) = Wire::deserialize(&bytes).unwrap();
+        assert_eq!(decoded_slot, slot);
+        assert_eq!(decoded_message, message);
+
+        for end in 0..bytes.len() {
+            assert!(Wire::deserialize(&bytes.slice(..end)).is_err());
+        }
+        let mut extra = bytes.to_vec();
+        extra.push(0x42);
+        assert!(Wire::deserialize(&bytes::Bytes::from(extra)).is_err());
+        // [Conductor, [window]] cannot supply a NoMessage value.
+        assert!(Wire::deserialize(&bytes::Bytes::from_static(&[0xc3, 2, 0xc1, 3])).is_err());
+    }
+
+    #[test]
+    fn dummy_conductor_still_allows_slot_message_serialization() {
+        use super::super::{
+            conductor::dummy::DummyConductor,
+            slot::dummy::{DummySlotConsensus, DummyVote},
+            test_utils::assert_roundtrip,
+            types::VoteMsg,
+        };
+        type Wire = CadenceDriverMsg<DummySlotConsensus, DummyConductor>;
+
+        let slot = Slot(7);
+        let message = VoteMsg::new_signed(slot, DummyVote, &NodeId::dummy(1).keypair());
+        assert_roundtrip(&message);
+        let wire = Wire::Slot(slot, message.clone());
+        let bytes = <Wire as Serializable<bytes::Bytes>>::serialize(&wire);
+        assert_eq!(bytes.len(), wire.length());
+        let Wire::Slot(decoded_slot, decoded_message) = Wire::deserialize(&bytes).unwrap();
+        assert_eq!(decoded_slot, slot);
+        assert_eq!(decoded_message, message);
+
+        for end in 0..bytes.len() {
+            assert!(Wire::deserialize(&bytes.slice(..end)).is_err());
+        }
+        let mut extra = bytes.to_vec();
+        extra.push(0x42);
+        assert!(Wire::deserialize(&bytes::Bytes::from(extra)).is_err());
+        // The conductor tag cannot be followed by a Never value.
+        assert!(Wire::deserialize(&bytes::Bytes::from_static(&[0xc2, 2, 0xc0])).is_err());
+    }
+
+    #[test]
+    fn rejects_bad_tags_and_list_framing() {
+        type M = CadenceMessage<u64, u64>;
+        for bad in [
+            vec![0xc0],
+            vec![0xc1, 3],
+            vec![0xc1, 0x80],
+            vec![0x80],
+            vec![0xc4, 1, 7, 42, 0],
+            vec![0xc2, 1, 7],
+            vec![0xc3, 2, 42, 0],
+            vec![0xc3, 0x81, 2, 42],
+        ] {
+            assert!(M::decode(&mut bad.as_slice()).is_err(), "accepted {bad:x?}");
+        }
+    }
+
+    #[test]
+    fn generic_directions_do_not_require_the_other_codec() {
+        struct Out;
+        impl Encodable for Out {
+            fn encode(&self, out: &mut dyn bytes::BufMut) {
+                1u8.encode(out);
+            }
+        }
+        struct In;
+        impl Decodable for In {
+            fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                u8::decode(buf)?;
+                Ok(Self)
+            }
+        }
+        let bytes = CadenceMessage::<Out, Out>::Slot(Slot(1), Out).serialize();
+        assert!(CadenceMessage::<In, In>::deserialize(&bytes).is_ok());
     }
 }

--- a/monad-mcp-chorus/src/env/stub.rs
+++ b/monad-mcp-chorus/src/env/stub.rs
@@ -18,13 +18,26 @@ pub use self::{proposal::*, validator::*, vote::*};
 mod validator {
     use std::collections::HashMap;
 
+    use alloy_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
     // Into implemented for testing purpose only.
     use derive_more::Into;
 
     use super::vote::{KeyPair, PubKey};
     use crate::spec::{self, validator::Stake as _};
 
-    #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Into)]
+    #[derive(
+        Clone,
+        Copy,
+        PartialEq,
+        Eq,
+        PartialOrd,
+        Ord,
+        Hash,
+        Debug,
+        Into,
+        RlpEncodableWrapper,
+        RlpDecodableWrapper,
+    )]
     pub struct NodeId(u64);
 
     impl spec::validator::NodeId for NodeId {}
@@ -191,21 +204,26 @@ mod validator {
 }
 
 mod proposal {
+    use alloy_rlp::{
+        Decodable, Encodable, Header, RlpDecodable, RlpDecodableWrapper, RlpEncodable,
+        RlpEncodableWrapper, encode_list, list_length,
+    };
+
     use super::NodeId;
     use crate::{
         spec,
         stub::types::{ProposalIndex, Slot},
     };
 
-    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, RlpEncodableWrapper, RlpDecodableWrapper)]
     pub struct MerkleHash(pub [u8; 20]);
 
-    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, RlpEncodableWrapper, RlpDecodableWrapper)]
     pub struct MerkleRoot(pub MerkleHash);
     impl spec::MerkleRoot for MerkleRoot {}
 
     // stub proposal signature, opaque to consensus
-    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
     pub struct ProposalSignature {
         pub signer: NodeId,
         pub checksum: u64,
@@ -217,7 +235,7 @@ mod proposal {
         D25(D25),
     }
 
-    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
     pub struct D25 {
         pub msg_len: u32,
         pub unix_ts: u64,
@@ -225,7 +243,41 @@ mod proposal {
         pub depth: u8,
     }
 
-    #[derive(Clone, PartialEq, Eq, Hash, Debug)]
+    impl Encodable for EncodingScheme {
+        fn encode(&self, out: &mut dyn bytes::BufMut) {
+            match self {
+                Self::D25(f0) => {
+                    let fields: [&dyn Encodable; 2] = [&1u8, f0];
+                    encode_list::<_, dyn Encodable>(&fields, out);
+                }
+            }
+        }
+
+        fn length(&self) -> usize {
+            match self {
+                Self::D25(f0) => {
+                    let fields: [&dyn Encodable; 2] = [&1u8, f0];
+                    list_length::<_, dyn Encodable>(&fields)
+                }
+            }
+        }
+    }
+
+    impl Decodable for EncodingScheme {
+        fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+            let mut payload = Header::decode_bytes(buf, true)?;
+            let result = match <u8 as Decodable>::decode(&mut payload)? {
+                1 => Self::D25(<D25 as Decodable>::decode(&mut payload)?),
+                _ => return Err(alloy_rlp::Error::Custom("unknown EncodingScheme tag")),
+            };
+            if !payload.is_empty() {
+                return Err(alloy_rlp::Error::UnexpectedLength);
+            }
+            Ok(result)
+        }
+    }
+
+    #[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
     pub struct ProposalHeader {
         pub slot: Slot,
         pub root: MerkleRoot,
@@ -285,6 +337,9 @@ mod proposal {
 mod vote {
     use std::collections::{BTreeMap, HashMap, HashSet};
 
+    use alloy_rlp::{
+        Decodable, Encodable, RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper,
+    };
     use bytes::Bytes;
     // Into implemented on these types for testing purpose only.
     use derive_more::Into;
@@ -297,10 +352,12 @@ mod vote {
     #[derive(PartialEq, Eq, Hash, Debug, Into)]
     pub struct KeyPair(u64);
 
-    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Into)]
+    #[derive(
+        Clone, Copy, PartialEq, Eq, Hash, Debug, Into, RlpEncodableWrapper, RlpDecodableWrapper,
+    )]
     pub struct PubKey(u64);
 
-    #[derive(Clone, PartialEq, Eq, Hash, Debug)]
+    #[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
     pub struct Signature {
         by: PubKey,
         data: Bytes,
@@ -325,6 +382,56 @@ mod vote {
         // BLS. keyed by index so duplicates cannot be represented,
         // like a bitmap.
         sigs: BTreeMap<usize, Signature>,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable)]
+    pub(super) struct IndexedSignature<S> {
+        pub(super) index: usize,
+        pub(super) signature: S,
+    }
+
+    impl Encodable for SignatureCollection {
+        fn encode(&self, out: &mut dyn bytes::BufMut) {
+            let pairs: Vec<_> = self
+                .sigs
+                .iter()
+                .map(|(index, sig)| IndexedSignature {
+                    index: *index,
+                    signature: sig,
+                })
+                .collect();
+            pairs.encode(out);
+        }
+
+        fn length(&self) -> usize {
+            let pairs: Vec<_> = self
+                .sigs
+                .iter()
+                .map(|(index, sig)| IndexedSignature {
+                    index: *index,
+                    signature: sig,
+                })
+                .collect();
+            pairs.length()
+        }
+    }
+
+    impl Decodable for SignatureCollection {
+        fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+            let pairs = Vec::<IndexedSignature<Signature>>::decode(buf)?;
+            let mut sigs = BTreeMap::new();
+            let mut previous = None;
+            for IndexedSignature { index, signature } in pairs {
+                if previous.is_some_and(|prev| index <= prev) {
+                    return Err(alloy_rlp::Error::Custom(
+                        "signature indices must be strictly increasing",
+                    ));
+                }
+                previous = Some(index);
+                sigs.insert(index, signature);
+            }
+            Ok(Self { sigs })
+        }
     }
 
     impl spec::vote::PubKey for PubKey {}
@@ -530,3 +637,46 @@ const _: () = crate::spec::assert_env::<
     ProposalHeader,
     HeaderAuth,
 >();
+
+#[cfg(test)]
+mod rlp_tests {
+    use super::{vote::IndexedSignature, *};
+    use crate::spec::vote::KeyPair as _;
+
+    #[test]
+    fn signature_maps_reject_duplicate_and_unordered_indices() {
+        let signature = KeyPair::dummy(1).sign(&bytes::Bytes::from_static(b"test"));
+        for indices in [[1usize, 1], [2, 1]] {
+            let encoded = alloy_rlp::encode(vec![
+                IndexedSignature {
+                    index: indices[0],
+                    signature: &signature,
+                },
+                IndexedSignature {
+                    index: indices[1],
+                    signature: &signature,
+                },
+            ]);
+            assert!(alloy_rlp::decode_exact::<SignatureCollection>(&encoded).is_err());
+        }
+        let encoded = alloy_rlp::encode(vec![
+            IndexedSignature {
+                index: 1usize,
+                signature: &signature,
+            },
+            IndexedSignature {
+                index: 2usize,
+                signature: &signature,
+            },
+        ]);
+        let collection: SignatureCollection = alloy_rlp::decode_exact(&encoded).unwrap();
+        assert_eq!(alloy_rlp::encode(&collection), encoded);
+
+        let mut malformed = signature;
+        malformed.make_malformed();
+        assert_eq!(
+            alloy_rlp::decode_exact::<Signature>(alloy_rlp::encode(&malformed)).unwrap(),
+            malformed
+        );
+    }
+}

--- a/monad-mcp-chorus/src/slot/chorus.rs
+++ b/monad-mcp-chorus/src/slot/chorus.rs
@@ -16,11 +16,13 @@
 /// Chorus module for managing single-slot consensus state and logic.
 use std::{collections::VecDeque, sync::Arc};
 
+use alloy_rlp::{Decodable, Encodable, Header, encode_list, list_length};
+
 use super::{
     SlotConsensus, SlotOutput,
     fallback::{
-        FallbackCommitQc, MVBAOutput, Metablock, Mvba as _,
-        monad_mvba::{self, MonadMvba, MvbaContext},
+        FallbackCommitQc, MVBAOutput, Metablock, Mvba as _, monad_mvba,
+        monad_mvba::{MonadMvba, MvbaContext},
     },
     fast::{
         BatchVoteMsg, CommitVoteDeadlineOutcome, EnterFallbackCert, FallbackVoteMsg, FastBlock,
@@ -39,7 +41,7 @@ type FallbackTimer = monad_mvba::TimerEvent<Metablock>;
 
 #[derive(derive_more::From, Clone, PartialEq, Eq, Hash, Debug)]
 #[non_exhaustive]
-pub enum Message {
+pub enum ChorusMessage {
     // vote on proposal deadline (D_s)
     #[from]
     BatchVote(BatchVoteMsg),
@@ -97,7 +99,7 @@ pub enum SlotFinalization {
     #[from]
     Fast(FastCommitQc),
     #[from]
-    Fallback(FallbackCommitQc<Metablock>),
+    Fallback(FallbackCommitQc<<Metablock as super::fallback::Votable>::Entries>),
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
@@ -187,7 +189,7 @@ pub struct Chorus {
 impl SlotConsensus for Chorus {
     type Config = ChorusConfig;
     type Context = ChorusContext;
-    type Message = Message;
+    type Message = ChorusMessage;
     type Timer = TimerEvent;
     type OptimisticCommitData = FastBlock;
     type FinalizationData = SlotFinalization;
@@ -258,34 +260,34 @@ impl SlotConsensus for Chorus {
         }
 
         match message {
-            Message::BatchVote(batch_vote_msg) => {
+            ChorusMessage::BatchVote(batch_vote_msg) => {
                 if let Some(fast_block) = self.fast.handle_batch_vote(author, batch_vote_msg) {
                     self.commit_fast_block(fast_block);
                 }
             }
-            Message::FastCommitVote(fast_commit_vote) => {
+            ChorusMessage::FastCommitVote(fast_commit_vote) => {
                 if let Some(fast_qc) = self.fast.handle_commit_vote(author, fast_commit_vote) {
                     self.finalize_fast(fast_qc);
                 }
             }
 
-            Message::FastBlock(fast_block) => {
+            ChorusMessage::FastBlock(fast_block) => {
                 if let Some(fast_block) = self.fast.handle_fast_block(fast_block) {
                     self.commit_fast_block(fast_block);
                 }
             }
 
-            Message::FallbackVote(fallback_vote_msg) => {
+            ChorusMessage::FallbackVote(fallback_vote_msg) => {
                 self.fast.handle_fallback_vote(author, fallback_vote_msg);
             }
-            Message::FastCommitQc(qc) => {
+            ChorusMessage::FastCommitQc(qc) => {
                 let scope_matches = qc.scope == self.slot;
                 if !scope_matches || !qc.verify(&self.validator_data) {
                     return;
                 }
                 self.finalize_fast(qc);
             }
-            Message::EnterFallbackCert(cert) => {
+            ChorusMessage::EnterFallbackCert(cert) => {
                 // a peer certified that 2f+1 validators entered
                 // fallback. enter too, building our block from local
                 // evidence. if we don't have enough evidence, we will
@@ -304,7 +306,7 @@ impl SlotConsensus for Chorus {
                 }
             }
 
-            Message::Fallback(message) => {
+            ChorusMessage::Fallback(message) => {
                 self.fallback.handle_message(author, message);
                 self.drain_fallback();
             }
@@ -392,7 +394,7 @@ impl Chorus {
     }
 
     // helpers mostly for documentation purpose
-    fn broadcast(&mut self, msg: impl Into<Message>) {
+    fn broadcast(&mut self, msg: impl Into<ChorusMessage>) {
         self.push(SlotOutput::Broadcast(msg.into()));
     }
 
@@ -445,6 +447,94 @@ impl Chorus {
 
     fn push(&mut self, out: SlotOutput<Chorus>) {
         self.outputs.push_back(out);
+    }
+}
+
+impl Encodable for ChorusMessage {
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        match self {
+            Self::BatchVote(message) => {
+                let fields: [&dyn Encodable; 2] = [&1u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+            Self::FastCommitVote(message) => {
+                let fields: [&dyn Encodable; 2] = [&2u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+            Self::FastBlock(message) => {
+                let fields: [&dyn Encodable; 2] = [&3u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+            Self::FallbackVote(message) => {
+                let fields: [&dyn Encodable; 2] = [&4u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+            Self::FastCommitQc(message) => {
+                let fields: [&dyn Encodable; 2] = [&5u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+            Self::EnterFallbackCert(message) => {
+                let fields: [&dyn Encodable; 2] = [&6u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+            Self::Fallback(message) => {
+                let fields: [&dyn Encodable; 2] = [&7u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+        }
+    }
+
+    fn length(&self) -> usize {
+        match self {
+            Self::BatchVote(message) => {
+                let fields: [&dyn Encodable; 2] = [&1u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+            Self::FastCommitVote(message) => {
+                let fields: [&dyn Encodable; 2] = [&2u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+            Self::FastBlock(message) => {
+                let fields: [&dyn Encodable; 2] = [&3u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+            Self::FallbackVote(message) => {
+                let fields: [&dyn Encodable; 2] = [&4u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+            Self::FastCommitQc(message) => {
+                let fields: [&dyn Encodable; 2] = [&5u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+            Self::EnterFallbackCert(message) => {
+                let fields: [&dyn Encodable; 2] = [&6u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+            Self::Fallback(message) => {
+                let fields: [&dyn Encodable; 2] = [&7u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+        }
+    }
+}
+
+impl Decodable for ChorusMessage {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let mut payload = Header::decode_bytes(buf, true)?;
+        let result = match <u8 as Decodable>::decode(&mut payload)? {
+            1 => Self::BatchVote(<BatchVoteMsg as Decodable>::decode(&mut payload)?),
+            2 => Self::FastCommitVote(<FastCommitVoteMsg as Decodable>::decode(&mut payload)?),
+            3 => Self::FastBlock(<FastBlock as Decodable>::decode(&mut payload)?),
+            4 => Self::FallbackVote(<FallbackVoteMsg as Decodable>::decode(&mut payload)?),
+            5 => Self::FastCommitQc(<FastCommitQc as Decodable>::decode(&mut payload)?),
+            6 => Self::EnterFallbackCert(<EnterFallbackCert as Decodable>::decode(&mut payload)?),
+            7 => Self::Fallback(<FallbackMessage as Decodable>::decode(&mut payload)?),
+            _ => return Err(alloy_rlp::Error::Custom("unknown Message tag")),
+        };
+        if !payload.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(result)
     }
 }
 
@@ -530,7 +620,7 @@ mod tests {
         let qc = pool
             .try_form_strong_qc(&context.validator_data)
             .expect("three of four votes form a commit qc");
-        chorus.handle_message(NodeId::dummy(0), Message::FastCommitQc(qc));
+        chorus.handle_message(NodeId::dummy(0), ChorusMessage::FastCommitQc(qc));
 
         // the pull is emitted before the finalization that closes the slot
         let mut order = Vec::new();

--- a/monad-mcp-chorus/src/slot/dummy.rs
+++ b/monad-mcp-chorus/src/slot/dummy.rs
@@ -15,6 +15,7 @@
 
 use std::{collections::VecDeque, sync::Arc};
 
+use alloy_rlp::{RlpDecodable, RlpEncodable};
 use bytes::Bytes;
 
 use super::{
@@ -45,7 +46,7 @@ impl Default for DummySlotConsensusConfig {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
 pub struct DummyVote;
 
 impl IsVote for DummyVote {

--- a/monad-mcp-chorus/src/slot/fallback/mod.rs
+++ b/monad-mcp-chorus/src/slot/fallback/mod.rs
@@ -24,22 +24,50 @@ use std::{
     hash::Hash,
 };
 
+use alloy_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
 pub use monad_mvba::FallbackCommitQc;
 
 /// MetaBlock components are exported
+pub use super::fast::CertifiedEntry;
 pub use super::fast::{
-    CertifiedEntry, EnterFallbackCert, EnterFallbackVote, Entry, FallbackEntry, FallbackQc, FastQc,
+    EnterFallbackCert, EnterFallbackVote, Entry, FallbackEntry, FallbackQc, FastQc,
 };
 use super::{
     super::{
         driver::{NodeEvent, WakeId},
         runtime::Runtime,
     },
-    types::{IsVote, NodeId, StrongQc, Timestamp, TimestampDelta, TotalProposalMap, Validated},
+    types::{
+        IsVote, NodeId, Slot, StrongQc, Timestamp, TimestampDelta, TotalProposalMap, Validated,
+    },
 };
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Debug,
+    RlpEncodableWrapper,
+    RlpDecodableWrapper,
+)]
 pub struct FallbackView(u64);
+
+/// The slot and view authenticated by an MVBA vote.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
+pub struct MvbaScope {
+    pub slot: Slot,
+    pub view: FallbackView,
+}
+
+impl MvbaScope {
+    pub const fn new(slot: Slot, view: FallbackView) -> Self {
+        Self { slot, view }
+    }
+}
 
 impl FallbackView {
     /// Views are 1-indexed; view 0 is the not-yet-started state
@@ -60,7 +88,7 @@ impl FallbackView {
 }
 
 /// The value the MVBA agrees on: one certified entry per proposer
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodableWrapper, RlpDecodableWrapper)]
 pub struct Metablock(TotalProposalMap<CertifiedEntry>);
 
 impl Metablock {

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/block_store.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/block_store.rs
@@ -15,6 +15,8 @@
 
 use std::collections::{HashMap, HashSet};
 
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+
 use super::{
     super::{
         super::types::{Slot, TimestampDelta},
@@ -27,13 +29,13 @@ use super::{
 /// request/response round trip
 const BLOCK_RETRANSMIT_DELTAS: u64 = 2;
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub(crate) struct BlockRequestMsg<V: Votable> {
+#[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
+pub(crate) struct BlockRequestMsg<E> {
     pub slot: Slot,
-    pub entries: V::Entries,
+    pub entries: E,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
 pub(crate) struct BlockResponseMsg<V> {
     pub slot: Slot,
     pub block: V,
@@ -83,7 +85,7 @@ impl<V: ValidateInput + Votable> BlockStore<V> {
         entries: &V::Entries,
     ) -> impl Iterator<Item = MVBAOutput<M, TimerEvent<V>>>
     where
-        M: From<BlockRequestMsg<V>>,
+        M: From<BlockRequestMsg<V::Entries>>,
     {
         let fresh = !self.known.contains_key(entries) && self.pending.insert(entries.clone());
         fresh.then(|| self.fetch(entries)).into_iter().flatten()
@@ -96,7 +98,7 @@ impl<V: ValidateInput + Votable> BlockStore<V> {
         entries: &V::Entries,
     ) -> impl Iterator<Item = MVBAOutput<M, TimerEvent<V>>>
     where
-        M: From<BlockRequestMsg<V>>,
+        M: From<BlockRequestMsg<V::Entries>>,
     {
         self.pending
             .contains(entries)
@@ -109,7 +111,7 @@ impl<V: ValidateInput + Votable> BlockStore<V> {
     /// live per pending entry: re-arming replaces, since the event is the key
     fn fetch<M>(&self, entries: &V::Entries) -> [MVBAOutput<M, TimerEvent<V>>; 2]
     where
-        M: From<BlockRequestMsg<V>>,
+        M: From<BlockRequestMsg<V::Entries>>,
     {
         [
             MVBAOutput::Broadcast(
@@ -128,7 +130,7 @@ impl<V: ValidateInput + Votable> BlockStore<V> {
 
     pub(crate) fn handle_request(
         &self,
-        request: &BlockRequestMsg<V>,
+        request: &BlockRequestMsg<V::Entries>,
     ) -> Option<BlockResponseMsg<V>> {
         if request.slot != self.slot {
             return None;

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/certificates.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/certificates.rs
@@ -13,39 +13,48 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashSet;
+use std::{collections::HashSet, fmt::Debug, hash::Hash};
+
+use alloy_rlp::{RlpDecodable, RlpEncodable};
 
 use super::{
     super::{
         super::types::{IsVote, SignatureCollection, Slot, StrongQc, ValidatorData},
-        FallbackView, Votable,
+        FallbackView, MvbaScope,
     },
     messages::{FallbackCommitVote, PrepareVote, TimeoutVote},
 };
 use crate::spec::{Stake as _, validator::ValidatorData as _, vote::SignatureCollection as _};
 
 /// `prepareQC_{slot, v}`: 2f+1 prepare votes on the same entries
-pub(crate) type PrepareQc<V> = StrongQc<PrepareVote<V>>;
+pub(crate) type PrepareQc<E> = StrongQc<PrepareVote<E>>;
 
 /// `CommitQC`: 2f+1 commit votes on the same entries
-pub type FallbackCommitQc<V> = StrongQc<FallbackCommitVote<V>>;
+pub type FallbackCommitQc<E> = StrongQc<FallbackCommitVote<E>>;
 
 /// `TC_{slot, v}`: 2f+1 timeouts for view `v` from distinct senders
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub(crate) struct TimeoutCertificate<V: Votable> {
+#[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
+#[rlp(trailing)]
+pub(crate) struct TimeoutCertificate<E: Clone + Eq + Hash + Debug> {
     pub slot: Slot,
     pub view: FallbackView,
     // exposing raw signature collection for BLS multisig optimization
-    pub groups: Vec<(TimeoutVote, SignatureCollection)>,
-    pub high_prep_qc: Option<PrepareQc<V>>,
+    pub groups: Vec<TimeoutGroup>,
+    pub high_prep_qc: Option<PrepareQc<E>>,
 }
 
-impl<V: Votable> TimeoutCertificate<V> {
+#[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
+pub(crate) struct TimeoutGroup {
+    pub vote: TimeoutVote,
+    pub sigcol: SignatureCollection,
+}
+
+impl<E: Clone + Eq + Hash + Debug> TimeoutCertificate<E> {
     pub(crate) fn verify(&self, validator_data: &ValidatorData) -> bool {
-        let scope = (self.slot, self.view);
+        let scope = MvbaScope::new(self.slot, self.view);
 
         let mut signers = HashSet::new();
-        for (vote, sigcol) in &self.groups {
+        for TimeoutGroup { vote, sigcol } in &self.groups {
             let data = vote.serialize(&scope);
             let Some(group_signers) = sigcol.verify(&data, validator_data) else {
                 return false;
@@ -66,7 +75,7 @@ impl<V: Votable> TimeoutCertificate<V> {
         let highest_claim = self
             .groups
             .iter()
-            .map(|(vote, _)| vote.high_prep_view)
+            .map(|group| group.vote.high_prep_view)
             .max()
             // view 0 is the "no lock" claim
             .filter(|view| *view != FallbackView::GENESIS);
@@ -74,7 +83,7 @@ impl<V: Votable> TimeoutCertificate<V> {
         match (highest_claim, &self.high_prep_qc) {
             (None, None) => true,
             (Some(claimed_view), Some(qc)) => {
-                qc.scope == (self.slot, claimed_view)
+                qc.scope == MvbaScope::new(self.slot, claimed_view)
                     // no validator can hold a prepare certificate from a view
                     // later than the one it is abandoning
                     && claimed_view <= self.view
@@ -85,7 +94,7 @@ impl<V: Votable> TimeoutCertificate<V> {
     }
 
     /// `lock(J) = entries(highPrepQC(J))`: what the next leader must extend
-    pub(crate) fn lock(&self) -> Option<&V::Entries> {
+    pub(crate) fn lock(&self) -> Option<&E> {
         self.high_prep_qc.as_ref().map(|qc| &qc.verdict.0)
     }
 }

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/collectors.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/collectors.rs
@@ -18,9 +18,9 @@ use std::{cell::OnceCell, collections::BTreeMap};
 use super::{
     super::{
         super::types::{IsVote, NodeId, Slot, StrongQc, ValidatorData, VoteMsg, VotePool},
-        FallbackView, ValidateCert, Votable,
+        FallbackView, MvbaScope, ValidateCert, Votable,
     },
-    certificates::{FallbackCommitQc, PrepareQc, TimeoutCertificate},
+    certificates::{FallbackCommitQc, PrepareQc, TimeoutCertificate, TimeoutGroup},
     messages::{
         CommitVoteMsg, FallbackCommitVote, PrePrepareMsg, PrepareVote, PrepareVoteMsg, TimeoutMsg,
         TimeoutVote,
@@ -75,15 +75,15 @@ pub(crate) struct ViewCollectors<V: Votable, C: ValidateCert> {
 
     /// The first pre-prepare seen for the view
     pre_prepare: Option<PrePrepareMsg<V, C>>,
-    prepare_votes: SealingVotePool<PrepareVote<V>>,
-    commit_votes: SealingVotePool<FallbackCommitVote<V>>,
+    prepare_votes: SealingVotePool<PrepareVote<V::Entries>>,
+    commit_votes: SealingVotePool<FallbackCommitVote<V::Entries>>,
     timeout_votes: VotePool<TimeoutVote>,
     /// Prepare certificates carried in by timeouts, keyed by their own view
-    prep_qcs: BTreeMap<FallbackView, PrepareQc<V>>,
+    prep_qcs: BTreeMap<FallbackView, PrepareQc<V::Entries>>,
 
     /// A timeout certificate for this view harvested from another message,
     /// kept even when that message is refused
-    harvested_tc: Option<TimeoutCertificate<V>>,
+    harvested_tc: Option<TimeoutCertificate<V::Entries>>,
 }
 
 impl<V: Votable, C: ValidateCert> ViewCollectors<V, C> {
@@ -92,9 +92,9 @@ impl<V: Votable, C: ValidateCert> ViewCollectors<V, C> {
             slot,
             view,
             pre_prepare: None,
-            prepare_votes: SealingVotePool::new((slot, view)),
-            commit_votes: SealingVotePool::new((slot, view)),
-            timeout_votes: VotePool::new((slot, view)),
+            prepare_votes: SealingVotePool::new(MvbaScope::new(slot, view)),
+            commit_votes: SealingVotePool::new(MvbaScope::new(slot, view)),
+            timeout_votes: VotePool::new(MvbaScope::new(slot, view)),
             prep_qcs: BTreeMap::new(),
             harvested_tc: None,
         }
@@ -111,11 +111,11 @@ impl<V: Votable, C: ValidateCert> ViewCollectors<V, C> {
         self.pre_prepare.as_ref()
     }
 
-    pub(crate) fn store_prepare_vote(&mut self, sender: NodeId, msg: PrepareVoteMsg<V>) {
+    pub(crate) fn store_prepare_vote(&mut self, sender: NodeId, msg: PrepareVoteMsg<V::Entries>) {
         self.prepare_votes.add_vote(sender, msg);
     }
 
-    pub(crate) fn store_commit_vote(&mut self, sender: NodeId, msg: CommitVoteMsg<V>) {
+    pub(crate) fn store_commit_vote(&mut self, sender: NodeId, msg: CommitVoteMsg<V::Entries>) {
         self.commit_votes.add_vote(sender, msg);
     }
 
@@ -124,7 +124,7 @@ impl<V: Votable, C: ValidateCert> ViewCollectors<V, C> {
     pub(crate) fn try_form_prepare_qc(
         &self,
         validator_data: &ValidatorData,
-    ) -> Option<PrepareQc<V>> {
+    ) -> Option<PrepareQc<V::Entries>> {
         self.prepare_votes
             .try_form_strong_qc(validator_data)
             .cloned()
@@ -134,17 +134,17 @@ impl<V: Votable, C: ValidateCert> ViewCollectors<V, C> {
     pub(crate) fn try_form_commit_qc(
         &self,
         validator_data: &ValidatorData,
-    ) -> Option<FallbackCommitQc<V>> {
+    ) -> Option<FallbackCommitQc<V::Entries>> {
         self.commit_votes
             .try_form_strong_qc(validator_data)
             .cloned()
     }
 
-    pub(crate) fn store_timeout(&mut self, sender: NodeId, msg: TimeoutMsg<V>) {
+    pub(crate) fn store_timeout(&mut self, sender: NodeId, msg: TimeoutMsg<V::Entries>) {
         debug_assert_eq!((msg.slot(), msg.view()), (self.slot, self.view));
 
         if let Some(qc) = msg.high_prep_qc {
-            self.prep_qcs.entry(qc.scope.1).or_insert(qc);
+            self.prep_qcs.entry(qc.scope.view).or_insert(qc);
         }
 
         // last write wins: sender may update its lock when periodically timing
@@ -160,13 +160,13 @@ impl<V: Votable, C: ValidateCert> ViewCollectors<V, C> {
 
     /// First write wins: every valid certificate for a view certifies the same
     /// thing
-    pub(crate) fn store_tc(&mut self, tc: TimeoutCertificate<V>) {
+    pub(crate) fn store_tc(&mut self, tc: TimeoutCertificate<V::Entries>) {
         debug_assert_eq!((tc.slot, tc.view), (self.slot, self.view));
 
         self.harvested_tc.get_or_insert(tc);
     }
 
-    pub(crate) fn harvested_tc(&self) -> Option<&TimeoutCertificate<V>> {
+    pub(crate) fn harvested_tc(&self) -> Option<&TimeoutCertificate<V::Entries>> {
         self.harvested_tc.as_ref()
     }
 
@@ -176,7 +176,7 @@ impl<V: Votable, C: ValidateCert> ViewCollectors<V, C> {
     pub(crate) fn try_form_tc(
         &self,
         validator_data: &ValidatorData,
-    ) -> Option<TimeoutCertificate<V>> {
+    ) -> Option<TimeoutCertificate<V::Entries>> {
         let target_stake = validator_data.total_stake().supermajority_threshold();
         let groups = self
             .timeout_votes
@@ -198,7 +198,10 @@ impl<V: Votable, C: ValidateCert> ViewCollectors<V, C> {
 
         let groups = groups
             .into_iter()
-            .map(|(vote, sigcol)| (vote.clone(), sigcol))
+            .map(|(vote, sigcol)| TimeoutGroup {
+                vote: vote.clone(),
+                sigcol,
+            })
             .collect();
 
         Some(TimeoutCertificate {

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/messages.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/messages.rs
@@ -16,6 +16,12 @@
 //! Wire messages of the MVBA. Every vote is a distinct type, so each gets its
 //! own signing domain, and every one is scoped by `(slot, view)`
 
+use std::{fmt::Debug, hash::Hash};
+
+use alloy_rlp::{
+    Decodable, Encodable, Header, RlpDecodable, RlpDecodableWrapper, RlpEncodable,
+    RlpEncodableWrapper, encode_list, list_length,
+};
 use bytes::Bytes;
 
 use super::{
@@ -23,7 +29,7 @@ use super::{
         super::types::{
             IsVote, KeyPair, PubKey, Signature, Slot, ValidatorData, VoteMsg, dummy_serialize,
         },
-        FallbackView, FromEntries, ValidateCert, Votable,
+        FallbackView, FromEntries, MvbaScope, ValidateCert, Votable,
     },
     block_store::{BlockRequestMsg, BlockResponseMsg},
     certificates::{FallbackCommitQc, PrepareQc, TimeoutCertificate},
@@ -35,59 +41,59 @@ pub enum MvbaMessage<V: Votable, C: ValidateCert> {
     #[from]
     PrePrepare(PrePrepareMsg<V, C>),
     #[from]
-    Prepare(PrepareVoteMsg<V>),
+    Prepare(PrepareVoteMsg<V::Entries>),
     #[from]
-    Commit(CommitVoteMsg<V>),
+    Commit(CommitVoteMsg<V::Entries>),
     #[from]
-    Timeout(TimeoutMsg<V>),
+    Timeout(TimeoutMsg<V::Entries>),
     /// So a validator that missed the votes it aggregates can still decide
     #[from]
-    CommitQc(FallbackCommitQc<V>),
+    CommitQc(FallbackCommitQc<V::Entries>),
     #[from]
-    BlockRequest(BlockRequestMsg<V>),
+    BlockRequest(BlockRequestMsg<V::Entries>),
     #[from]
     BlockResponse(BlockResponseMsg<V>),
 }
 
 /// `⟨Prepare, slot, v, entries(x)⟩`
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub(crate) struct PrepareVote<V: Votable>(pub V::Entries);
+#[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodableWrapper, RlpDecodableWrapper)]
+pub(crate) struct PrepareVote<E>(pub E);
 
-impl<V: Votable> FromEntries<V> for PrepareVote<V> {
+impl<V: Votable> FromEntries<V> for PrepareVote<V::Entries> {
     fn from_entries(entries: V::Entries) -> Self {
         Self(entries)
     }
 }
 
-impl<V: Votable> IsVote for PrepareVote<V> {
-    type Scope = (Slot, FallbackView);
+impl<E: Clone + Eq + Hash + Debug> IsVote for PrepareVote<E> {
+    type Scope = MvbaScope;
 
     fn serialize(&self, scope: &Self::Scope) -> Bytes {
         dummy_serialize(self, scope)
     }
 }
 
-pub(crate) type PrepareVoteMsg<V> = VoteMsg<PrepareVote<V>>;
+pub(crate) type PrepareVoteMsg<E> = VoteMsg<PrepareVote<E>>;
 
 /// `⟨Commit, slot, v, entries(x)⟩`
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub struct FallbackCommitVote<V: Votable>(pub(crate) V::Entries);
+#[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodableWrapper, RlpDecodableWrapper)]
+pub struct FallbackCommitVote<E>(pub(crate) E);
 
-impl<V: Votable> FromEntries<V> for FallbackCommitVote<V> {
+impl<V: Votable> FromEntries<V> for FallbackCommitVote<V::Entries> {
     fn from_entries(entries: V::Entries) -> Self {
         Self(entries)
     }
 }
 
-impl<V: Votable> IsVote for FallbackCommitVote<V> {
-    type Scope = (Slot, FallbackView);
+impl<E: Clone + Eq + Hash + Debug> IsVote for FallbackCommitVote<E> {
+    type Scope = MvbaScope;
 
     fn serialize(&self, scope: &Self::Scope) -> Bytes {
         dummy_serialize(self, scope)
     }
 }
 
-pub(crate) type CommitVoteMsg<V> = VoteMsg<FallbackCommitVote<V>>;
+pub(crate) type CommitVoteMsg<E> = VoteMsg<FallbackCommitVote<E>>;
 
 /// The signed part of a timeout: the *view* of the prepare certificate the
 /// sender carries, not the certificate, so timeouts holding the same lock sign
@@ -99,7 +105,7 @@ pub(crate) struct TimeoutVote {
 }
 
 impl IsVote for TimeoutVote {
-    type Scope = (Slot, FallbackView);
+    type Scope = MvbaScope;
 
     fn serialize(&self, scope: &Self::Scope) -> Bytes {
         dummy_serialize(self, scope)
@@ -107,37 +113,38 @@ impl IsVote for TimeoutVote {
 }
 
 /// `⟨Timeout, slot, v, PrepQC_i, σ_i⟩`
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub(crate) struct TimeoutMsg<V: Votable> {
+#[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
+#[rlp(trailing)]
+pub(crate) struct TimeoutMsg<E: Clone + Eq + Hash + Debug> {
     pub vote: VoteMsg<TimeoutVote>,
-    pub high_prep_qc: Option<PrepareQc<V>>,
+    pub high_prep_qc: Option<PrepareQc<E>>,
 }
 
-impl<V: Votable> TimeoutMsg<V> {
+impl<E: Clone + Eq + Hash + Debug> TimeoutMsg<E> {
     pub(crate) fn new_signed(
         slot: Slot,
         view: FallbackView,
-        high_prep_qc: Option<PrepareQc<V>>,
+        high_prep_qc: Option<PrepareQc<E>>,
         key: &KeyPair,
     ) -> Self {
         let vote = TimeoutVote {
             high_prep_view: high_prep_qc
                 .as_ref()
-                .map_or(FallbackView::GENESIS, |qc| qc.scope.1),
+                .map_or(FallbackView::GENESIS, |qc| qc.scope.view),
         };
 
         Self {
-            vote: VoteMsg::new_signed((slot, view), vote, key),
+            vote: VoteMsg::new_signed(MvbaScope::new(slot, view), vote, key),
             high_prep_qc,
         }
     }
 
     pub(crate) fn slot(&self) -> Slot {
-        self.vote.scope.0
+        self.vote.scope.slot
     }
 
     pub(crate) fn view(&self) -> FallbackView {
-        self.vote.scope.1
+        self.vote.scope.view
     }
 
     /// Whether the claim in the signed digest is backed by what rides along
@@ -147,7 +154,10 @@ impl<V: Votable> TimeoutMsg<V> {
         match &self.high_prep_qc {
             None => high_prep_view == FallbackView::GENESIS,
             Some(qc) => {
-                let (qc_slot, qc_view) = qc.scope;
+                let MvbaScope {
+                    slot: qc_slot,
+                    view: qc_view,
+                } = qc.scope;
                 qc_slot == self.slot()
                     // view 0 has no certificate, so this also rejects one
                     // carried unclaimed
@@ -178,12 +188,12 @@ pub(crate) struct PrePrepareMsg<V: Votable, C: ValidateCert> {
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub(crate) enum Justification<V: Votable, C: ValidateCert> {
     FallbackCert(Option<C>),
-    Tc(TimeoutCertificate<V>),
+    Tc(TimeoutCertificate<V::Entries>),
 }
 
 impl<V: Votable, C: ValidateCert> Justification<V, C> {
     /// The part of `J` the leader's signature covers
-    fn signed_part(&self) -> Option<&TimeoutCertificate<V>> {
+    fn signed_part(&self) -> Option<&TimeoutCertificate<V::Entries>> {
         match self {
             Justification::FallbackCert(_) => None,
             Justification::Tc(tc) => Some(tc),
@@ -226,6 +236,365 @@ fn signed_bytes<V: Votable, C: ValidateCert>(
 ) -> Bytes {
     dummy_serialize(
         &(value.entries(), justification.signed_part()),
-        &(slot, view),
+        &MvbaScope::new(slot, view),
     )
+}
+
+impl<V: Votable, C: ValidateCert> Encodable for MvbaMessage<V, C>
+where
+    V: Encodable,
+    V::Entries: Encodable,
+    C: Encodable,
+{
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        match self {
+            Self::PrePrepare(message) => {
+                let fields: [&dyn Encodable; 2] = [&1u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+            Self::Prepare(message) => {
+                let fields: [&dyn Encodable; 2] = [&2u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+            Self::Commit(message) => {
+                let fields: [&dyn Encodable; 2] = [&3u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+            Self::Timeout(message) => {
+                let fields: [&dyn Encodable; 2] = [&4u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+            Self::CommitQc(message) => {
+                let fields: [&dyn Encodable; 2] = [&5u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+            Self::BlockRequest(message) => {
+                let fields: [&dyn Encodable; 2] = [&6u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+            Self::BlockResponse(message) => {
+                let fields: [&dyn Encodable; 2] = [&7u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+        }
+    }
+
+    fn length(&self) -> usize {
+        match self {
+            Self::PrePrepare(message) => {
+                let fields: [&dyn Encodable; 2] = [&1u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+            Self::Prepare(message) => {
+                let fields: [&dyn Encodable; 2] = [&2u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+            Self::Commit(message) => {
+                let fields: [&dyn Encodable; 2] = [&3u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+            Self::Timeout(message) => {
+                let fields: [&dyn Encodable; 2] = [&4u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+            Self::CommitQc(message) => {
+                let fields: [&dyn Encodable; 2] = [&5u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+            Self::BlockRequest(message) => {
+                let fields: [&dyn Encodable; 2] = [&6u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+            Self::BlockResponse(message) => {
+                let fields: [&dyn Encodable; 2] = [&7u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+        }
+    }
+}
+
+impl<V: Votable, C: ValidateCert> Decodable for MvbaMessage<V, C>
+where
+    V: Decodable,
+    V::Entries: Decodable,
+    C: Decodable,
+{
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let mut payload = Header::decode_bytes(buf, true)?;
+        let result = match <u8 as Decodable>::decode(&mut payload)? {
+            1 => Self::PrePrepare(<PrePrepareMsg<V, C> as Decodable>::decode(&mut payload)?),
+            2 => Self::Prepare(<PrepareVoteMsg<V::Entries> as Decodable>::decode(
+                &mut payload,
+            )?),
+            3 => Self::Commit(<CommitVoteMsg<V::Entries> as Decodable>::decode(
+                &mut payload,
+            )?),
+            4 => Self::Timeout(<TimeoutMsg<V::Entries> as Decodable>::decode(&mut payload)?),
+            5 => Self::CommitQc(<FallbackCommitQc<V::Entries> as Decodable>::decode(
+                &mut payload,
+            )?),
+            6 => Self::BlockRequest(<BlockRequestMsg<V::Entries> as Decodable>::decode(
+                &mut payload,
+            )?),
+            7 => Self::BlockResponse(<BlockResponseMsg<V> as Decodable>::decode(&mut payload)?),
+            _ => return Err(alloy_rlp::Error::Custom("unknown MvbaMessage tag")),
+        };
+        if !payload.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(result)
+    }
+}
+
+// Alloy's derives add codec bounds on V and C, but Justification<V, C> also
+// needs a codec for V::Entries. A codec bound on V does not imply one on its
+// associated entries type, so these manual implementations supply that bound
+// without requiring it on the struct definition.
+impl<V: Votable, C: ValidateCert> Encodable for PrePrepareMsg<V, C>
+where
+    V: Encodable,
+    V::Entries: Encodable,
+    C: Encodable,
+{
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        let fields: [&dyn Encodable; 5] = [
+            &self.slot,
+            &self.view,
+            &self.value,
+            &self.justification,
+            &self.signature,
+        ];
+        encode_list::<_, dyn Encodable>(&fields, out);
+    }
+
+    fn length(&self) -> usize {
+        let fields: [&dyn Encodable; 5] = [
+            &self.slot,
+            &self.view,
+            &self.value,
+            &self.justification,
+            &self.signature,
+        ];
+        list_length::<_, dyn Encodable>(&fields)
+    }
+}
+
+impl<V: Votable, C: ValidateCert> Decodable for PrePrepareMsg<V, C>
+where
+    V: Decodable,
+    V::Entries: Decodable,
+    C: Decodable,
+{
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let mut payload = Header::decode_bytes(buf, true)?;
+        let result = Self {
+            slot: <Slot as Decodable>::decode(&mut payload)?,
+            view: <FallbackView as Decodable>::decode(&mut payload)?,
+            value: <V as Decodable>::decode(&mut payload)?,
+            justification: <Justification<V, C> as Decodable>::decode(&mut payload)?,
+            signature: <Signature as Decodable>::decode(&mut payload)?,
+        };
+        if !payload.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(result)
+    }
+}
+
+impl<V: Votable, C: ValidateCert + Encodable> Encodable for Justification<V, C>
+where
+    V::Entries: Encodable,
+{
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        match self {
+            Self::FallbackCert(None) => encode_list(&[1u8], out),
+            Self::FallbackCert(Some(cert)) => {
+                encode_list::<_, dyn Encodable>(&[&1u8 as &dyn Encodable, cert], out)
+            }
+            Self::Tc(tc) => encode_list::<_, dyn Encodable>(&[&2u8 as &dyn Encodable, tc], out),
+        }
+    }
+
+    fn length(&self) -> usize {
+        match self {
+            Self::FallbackCert(None) => list_length(&[1u8]),
+            Self::FallbackCert(Some(cert)) => {
+                list_length::<_, dyn Encodable>(&[&1u8 as &dyn Encodable, cert])
+            }
+            Self::Tc(tc) => list_length::<_, dyn Encodable>(&[&2u8 as &dyn Encodable, tc]),
+        }
+    }
+}
+
+impl<V: Votable, C: ValidateCert + Decodable> Decodable for Justification<V, C>
+where
+    V::Entries: Decodable,
+{
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let mut payload = Header::decode_bytes(buf, true)?;
+        let result = match u8::decode(&mut payload)? {
+            1 => Self::FallbackCert(if payload.is_empty() {
+                None
+            } else {
+                Some(C::decode(&mut payload)?)
+            }),
+            2 => Self::Tc(TimeoutCertificate::decode(&mut payload)?),
+            _ => return Err(alloy_rlp::Error::Custom("unknown Justification tag")),
+        };
+        if !payload.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(result)
+    }
+}
+
+// Alloy 0.3.12's wrapper decoder derive only constructs tuple newtypes.
+// Keep both wrapper codecs manual for this named-field struct.
+impl Encodable for TimeoutVote {
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        self.high_prep_view.encode(out);
+    }
+
+    fn length(&self) -> usize {
+        self.high_prep_view.length()
+    }
+}
+
+impl Decodable for TimeoutVote {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Ok(Self {
+            high_prep_view: <FallbackView as Decodable>::decode(buf)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod rlp_tests {
+    use super::{
+        super::{
+            super::{
+                super::{
+                    super::{
+                        conductor::{MonadConductor, acs::median::MedianAcs},
+                        driver::CadenceDriverMsg,
+                        test_utils::{assert_roundtrip, assert_serialization_roundtrip},
+                        types::SlotDeadline,
+                    },
+                    chorus,
+                    types::ProposalMap,
+                },
+                EnterFallbackCert, Entry, Metablock,
+            },
+            test_helpers as h,
+        },
+        *,
+    };
+    type Wire = CadenceDriverMsg<chorus::Chorus, MonadConductor<MedianAcs<SlotDeadline>>>;
+
+    #[test]
+    fn every_mvba_variant_and_optional_certificate_roundtrips() {
+        type M = MvbaMessage<Metablock, EnterFallbackCert>;
+        let validators = h::validator_data();
+        let block = h::mixed_evidence_metablock(7, &validators);
+        let entries = block.entries();
+        let key = h::nodes()[0].keypair();
+        let qc = h::prepare_qc(h::view(1), &entries, &validators);
+        // Cover proposals with and without a fallback certificate, votes, and block exchange.
+        let mut messages = vec![
+            h::pre_prepare_with_cert(h::view(1), &block, None).1,
+            h::pre_prepare_with_cert(
+                h::view(1),
+                &block,
+                Some(h::enter_fallback_cert(&validators)),
+            )
+            .1,
+            M::Prepare(VoteMsg::new_signed(
+                MvbaScope::new(h::SLOT, h::view(1)),
+                PrepareVote(entries.clone()),
+                &key,
+            )),
+            M::Commit(VoteMsg::new_signed(
+                MvbaScope::new(h::SLOT, h::view(1)),
+                FallbackCommitVote(entries.clone()),
+                &key,
+            )),
+            M::CommitQc(h::strong_qc(
+                MvbaScope::new(h::SLOT, h::view(1)),
+                FallbackCommitVote(entries.clone()),
+                &h::quorum(),
+                &validators,
+            )),
+            h::block_request(&entries),
+            h::block_response(block.clone()),
+        ];
+        // Exercise absent/present prepare QCs in timeouts and timeout certificates.
+        for lock in [None, Some(qc)] {
+            let tc = h::timeout_certificate(h::view(1), lock.clone(), &validators);
+            assert!(assert_roundtrip(&tc).verify(&validators));
+            messages.push(h::pre_prepare(h::view(2), &block, Some(tc)).1);
+            messages.push(M::Timeout(TimeoutMsg::new_signed(
+                h::SLOT,
+                h::view(1),
+                lock,
+                &key,
+            )));
+        }
+        // Check every variant's round trip and that signed evidence still verifies.
+        for message in messages {
+            let decoded = assert_roundtrip(&message);
+            match decoded {
+                M::PrePrepare(p) => {
+                    assert!(p.verify_signature(&h::leader_of(p.view).keypair().pubkey()))
+                }
+                M::Timeout(t) => assert!(t.is_valid(&validators)),
+                M::CommitQc(qc) => assert!(qc.verify(&validators)),
+                _ => {}
+            }
+            // The outer Chorus and Cadence framing also wraps the MVBA arm.
+            assert_serialization_roundtrip(&Wire::Slot(
+                h::SLOT,
+                chorus::ChorusMessage::Fallback(message),
+            ));
+        }
+    }
+
+    #[test]
+    fn mvba_wrappers_and_unknown_tags() {
+        let scope = MvbaScope::new(Slot(7), h::view(1));
+        assert_eq!(alloy_rlp::encode(scope), [0xc2, 7, 1]);
+        assert_roundtrip(&scope);
+        let entries = ProposalMap::new(0, |_| Entry::Negative);
+        assert_eq!(
+            alloy_rlp::encode(PrepareVote::<<Metablock as Votable>::Entries>(
+                entries.clone()
+            )),
+            [0xc0]
+        );
+        assert_eq!(
+            alloy_rlp::encode(FallbackCommitVote::<<Metablock as Votable>::Entries>(
+                entries
+            )),
+            [0xc0]
+        );
+        assert_eq!(
+            alloy_rlp::encode(TimeoutVote {
+                high_prep_view: h::view(1)
+            }),
+            [1]
+        );
+        assert_eq!(
+            alloy_rlp::encode(Justification::<Metablock, EnterFallbackCert>::FallbackCert(
+                None
+            )),
+            [0xc1, 1]
+        );
+        assert!(
+            alloy_rlp::decode_exact::<MvbaMessage<Metablock, EnterFallbackCert>>(&[0xc1, 8])
+                .is_err()
+        );
+        assert!(
+            alloy_rlp::decode_exact::<Justification<Metablock, EnterFallbackCert>>(&[0xc1, 3])
+                .is_err()
+        );
+    }
 }

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/metablock.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/metablock.rs
@@ -17,7 +17,7 @@ use super::{
     super::{
         super::{
             fast::{CertifiedEntry, Entry},
-            types::{HeaderAuth, ProposalIndex, ProposalMap, Slot, ValidatorData},
+            types::{HeaderAuth, ProposalMap, ProposalScope, Slot, ValidatorData},
         },
         Metablock, ValidateInput, Votable,
     },
@@ -38,11 +38,14 @@ impl Metablock {
             return false;
         }
 
-        self.0
-            .as_ref()
-            .into_iter()
-            .enumerate()
-            .all(|(j, cert)| certified_entry_is_valid(cert, slot, j, header_auth, validator_data))
+        self.0.as_ref().into_iter().enumerate().all(|(j, cert)| {
+            certified_entry_is_valid(
+                cert,
+                ProposalScope::new(slot, j),
+                header_auth,
+                validator_data,
+            )
+        })
     }
 
     /// The paper's *fast metablock*: every entry a `FastQc`
@@ -87,18 +90,17 @@ impl Votable for Metablock {
 /// `CE.verify(slot, j)`
 fn certified_entry_is_valid(
     cert: &CertifiedEntry,
-    slot: Slot,
-    j: ProposalIndex,
+    scope: ProposalScope,
     header_auth: &HeaderAuth,
     validator_data: &ValidatorData,
 ) -> bool {
     let bound_to_proposer = match cert {
-        CertifiedEntry::FastQc(qc) => qc.scope == (slot, j),
-        CertifiedEntry::FallbackQc(qc) => qc.scope == (slot, j),
+        CertifiedEntry::FastQc(qc) => qc.scope == scope,
+        CertifiedEntry::FallbackQc(qc) => qc.scope == scope,
         // an EquivCert's binding to (slot, j) is checked by `verify`, which
         // authenticates both headers against the scope
         CertifiedEntry::EquivCert(_) => true,
     };
 
-    bound_to_proposer && cert.verify((slot, j), header_auth, validator_data)
+    bound_to_proposer && cert.verify(scope, header_auth, validator_data)
 }

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/mod.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/mod.rs
@@ -78,7 +78,7 @@ use super::{
             HeaderAuth, IsVote, KeyPair, NodeId, Slot, TimestampDelta, ValidatorData, VoteMsg,
         },
     },
-    FallbackView, MVBAOutput, Metablock, Mvba, ValidateCert, ValidateInput, Votable,
+    FallbackView, MVBAOutput, Metablock, Mvba, MvbaScope, ValidateCert, ValidateInput, Votable,
 };
 use crate::spec::validator::ValidatorData as _;
 
@@ -190,16 +190,16 @@ pub struct MonadMvba<V: ValidateInput + Votable, C: ValidateCert> {
     last_voted_view: FallbackView,
     /// `PrepQC_i`: the highest prepare certificate seen; the entries this
     /// validator is locked on
-    high_prep_qc: Option<PrepareQc<V>>,
+    high_prep_qc: Option<PrepareQc<V::Entries>>,
     /// `DecidedQC_i`: recorded before the block it settles is necessarily held
-    decided_qc: Option<FallbackCommitQc<V>>,
+    decided_qc: Option<FallbackCommitQc<V::Entries>>,
 
     /// Message buffer and storage
     collectors: BTreeMap<FallbackView, ViewCollectors<V, C>>,
     block_store: BlockStore<V>,
 
     /// `J` for the current view, which also fixes it -- see [`MonadMvba::view`]
-    entry_tc: Option<TimeoutCertificate<V>>,
+    entry_tc: Option<TimeoutCertificate<V::Entries>>,
     /// Whether the timer for the *current* view has fired; cleared on entering
     /// a view and timer fire
     timer_fired: bool,
@@ -218,7 +218,7 @@ where
     type Context = MvbaContext;
     type TimerEvent = TimerEvent<V>;
     type FallbackCert = C;
-    type CommitVote = FallbackCommitVote<V>;
+    type CommitVote = FallbackCommitVote<V::Entries>;
 
     fn new(context: MvbaContext) -> Self {
         let slot = context.slot;
@@ -314,7 +314,7 @@ where
         self.decided().map(Decided::block)
     }
 
-    fn decision_proof(&self) -> Option<&FallbackCommitQc<V>> {
+    fn decision_proof(&self) -> Option<&FallbackCommitQc<V::Entries>> {
         // an instance with no input, an abandoned one, or still fetching
         // decided block may hold a certificate it never acted on
         self.decided().map(Decided::commit_qc)
@@ -391,8 +391,8 @@ where
         self.collectors_mut(view).store_pre_prepare(msg);
     }
 
-    fn handle_prepare_vote(&mut self, sender: NodeId, msg: PrepareVoteMsg<V>) {
-        let (slot, view) = msg.scope;
+    fn handle_prepare_vote(&mut self, sender: NodeId, msg: PrepareVoteMsg<V::Entries>) {
+        let MvbaScope { slot, view } = msg.scope;
         if slot != self.context.slot || !self.in_window(view) {
             return;
         }
@@ -400,8 +400,8 @@ where
         self.collectors_mut(view).store_prepare_vote(sender, msg);
     }
 
-    fn handle_commit_vote(&mut self, sender: NodeId, msg: CommitVoteMsg<V>) {
-        let (slot, view) = msg.scope;
+    fn handle_commit_vote(&mut self, sender: NodeId, msg: CommitVoteMsg<V::Entries>) {
+        let MvbaScope { slot, view } = msg.scope;
         if slot != self.context.slot || !self.in_window(view) {
             return;
         }
@@ -409,7 +409,7 @@ where
         self.collectors_mut(view).store_commit_vote(sender, msg);
     }
 
-    fn handle_timeout(&mut self, sender: NodeId, msg: TimeoutMsg<V>) {
+    fn handle_timeout(&mut self, sender: NodeId, msg: TimeoutMsg<V::Entries>) {
         let view = msg.view();
         if msg.slot() != self.context.slot || !self.in_window(view) {
             return;
@@ -430,8 +430,8 @@ where
         self.collectors_mut(view).store_timeout(sender, msg);
     }
 
-    fn handle_commit_qc(&mut self, qc: FallbackCommitQc<V>) {
-        if qc.scope.0 != self.context.slot || !qc.verify(&self.context.validator_data) {
+    fn handle_commit_qc(&mut self, qc: FallbackCommitQc<V::Entries>) {
+        if qc.scope.slot != self.context.slot || !qc.verify(&self.context.validator_data) {
             return;
         }
 
@@ -441,7 +441,7 @@ where
         }
     }
 
-    fn answer_block_request(&mut self, sender: NodeId, request: &BlockRequestMsg<V>) {
+    fn answer_block_request(&mut self, sender: NodeId, request: &BlockRequestMsg<V::Entries>) {
         if let Some(response) = self.block_store.handle_request(request) {
             self.outputs.push_back(MVBAOutput::Unicast {
                 to: sender,
@@ -586,7 +586,7 @@ where
 
     /// `TryFormCommitQC`. Whether the decision can be *reported* is
     /// [`MonadMvba::pending_decide`]
-    fn known_commit_qc(&self) -> Option<FallbackCommitQc<V>> {
+    fn known_commit_qc(&self) -> Option<FallbackCommitQc<V::Entries>> {
         if let Some(qc) = &self.decided_qc {
             return Some(qc.clone());
         }
@@ -599,7 +599,7 @@ where
 
     /// `TryDecide`: a commit certificate together with the block it settled
     /// Waiting for the block is safe -- the certificate is already recorded
-    fn pending_decide(&self) -> Option<(FallbackCommitQc<V>, V)> {
+    fn pending_decide(&self) -> Option<(FallbackCommitQc<V::Entries>, V)> {
         let qc = self.known_commit_qc()?;
         let block = self.block_store.get(&qc.verdict.0)?.clone();
 
@@ -607,7 +607,7 @@ where
     }
 
     /// `TryFormPrepQC`
-    fn pending_prepare_qc(&self) -> Option<PrepareQc<V>> {
+    fn pending_prepare_qc(&self) -> Option<PrepareQc<V::Entries>> {
         let entries = self.phase.preparing_entries()?;
         let qc = self
             .current_view_collectors()?
@@ -619,7 +619,7 @@ where
 
     /// `SyncView`: the highest timeout certificate for this view or later,
     /// which lets a validator that fell behind rejoin in one step
-    fn pending_tc(&self) -> Option<TimeoutCertificate<V>> {
+    fn pending_tc(&self) -> Option<TimeoutCertificate<V::Entries>> {
         let organic = self
             .current_view_collectors()
             .and_then(|collectors| collectors.try_form_tc(&self.context.validator_data));
@@ -688,7 +688,7 @@ where
         // persist-before-send: lastVotedView
         self.last_voted_view = self.view();
 
-        let vote = self.sign_vote(PrepareVote::<V>(preparing.entries().clone()));
+        let vote = self.sign_vote(PrepareVote::<V::Entries>(preparing.entries().clone()));
         (
             Phase::Preparing(preparing),
             vec![MVBAOutput::Broadcast(MvbaMessage::Prepare(vote))],
@@ -700,7 +700,7 @@ where
     fn apply_prepare_qc(
         &mut self,
         phase: Phase<V>,
-        qc: PrepareQc<V>,
+        qc: PrepareQc<V::Entries>,
     ) -> (Phase<V>, Vec<MVBAOutput<MvbaMessage<V, C>, TimerEvent<V>>>) {
         let committing = match phase {
             Phase::Preparing(p) => p.commit(qc.clone()),
@@ -714,7 +714,9 @@ where
         // persist-before-send: PrepQC
         self.update_prep_qc(qc);
 
-        let vote = self.sign_vote(FallbackCommitVote::<V>(committing.entries().clone()));
+        let vote = self.sign_vote(FallbackCommitVote::<V::Entries>(
+            committing.entries().clone(),
+        ));
 
         (
             Phase::Committing(committing),
@@ -726,7 +728,7 @@ where
     fn decide(
         &mut self,
         phase: Phase<V>,
-        commit_qc: FallbackCommitQc<V>,
+        commit_qc: FallbackCommitQc<V::Entries>,
         block: V,
     ) -> (Phase<V>, Vec<MVBAOutput<MvbaMessage<V, C>, TimerEvent<V>>>) {
         // `pending_decide` fetched the block by the certificate's entries
@@ -746,7 +748,7 @@ where
     /// `SyncView`
     fn advance_view(
         &mut self,
-        tc: TimeoutCertificate<V>,
+        tc: TimeoutCertificate<V::Entries>,
     ) -> (Phase<V>, Vec<MVBAOutput<MvbaMessage<V, C>, TimerEvent<V>>>) {
         debug_assert!(tc.view >= self.view());
 
@@ -806,7 +808,7 @@ where
     #[must_use]
     fn enter_view(
         &mut self,
-        justification: Option<TimeoutCertificate<V>>,
+        justification: Option<TimeoutCertificate<V::Entries>>,
     ) -> Vec<MVBAOutput<MvbaMessage<V, C>, TimerEvent<V>>> {
         self.timer_fired = false;
         self.entry_tc = justification;
@@ -952,11 +954,11 @@ where
     }
 
     /// Understating the lock would be a safety bug
-    fn update_prep_qc(&mut self, qc: PrepareQc<V>) {
+    fn update_prep_qc(&mut self, qc: PrepareQc<V::Entries>) {
         let is_higher = self
             .high_prep_qc
             .as_ref()
-            .is_none_or(|held| held.scope.1 < qc.scope.1);
+            .is_none_or(|held| held.scope.view < qc.scope.view);
 
         if is_higher {
             self.high_prep_qc = Some(qc);
@@ -969,8 +971,12 @@ where
 
     fn sign_vote<T>(&self, vote: T) -> VoteMsg<T>
     where
-        T: IsVote<Scope = (Slot, FallbackView)>,
+        T: IsVote<Scope = MvbaScope>,
     {
-        VoteMsg::new_signed((self.context.slot, self.view()), vote, &self.context.key)
+        VoteMsg::new_signed(
+            MvbaScope::new(self.context.slot, self.view()),
+            vote,
+            &self.context.key,
+        )
     }
 }

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/phases.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/phases.rs
@@ -74,7 +74,7 @@ pub(crate) struct Committing<V: Votable> {
 /// Decided, with the certificate that proves it and the block it settled
 #[derive(Clone)]
 pub(crate) struct Decided<V: Votable> {
-    commit_qc: FallbackCommitQc<V>,
+    commit_qc: FallbackCommitQc<V::Entries>,
     block: V,
 }
 
@@ -184,7 +184,7 @@ impl<V: Votable> Preparing<V> {
         &self.entries
     }
 
-    pub(crate) fn commit(self, prepare_qc: PrepareQc<V>) -> Committing<V> {
+    pub(crate) fn commit(self, prepare_qc: PrepareQc<V::Entries>) -> Committing<V> {
         debug_assert_eq!(prepare_qc.verdict.0, self.entries);
 
         Committing {
@@ -204,7 +204,7 @@ impl<V: Votable> Decided<V> {
         &self.commit_qc.verdict.0
     }
 
-    pub(crate) fn commit_qc(&self) -> &FallbackCommitQc<V> {
+    pub(crate) fn commit_qc(&self) -> &FallbackCommitQc<V::Entries> {
         &self.commit_qc
     }
 
@@ -214,7 +214,7 @@ impl<V: Votable> Decided<V> {
 
     /// A supermajority commit certificate together with its block decides from
     /// any phase: the certificate is the evidence, the local phase adds none
-    pub(crate) fn new(commit_qc: FallbackCommitQc<V>, block: V) -> Self {
+    pub(crate) fn new(commit_qc: FallbackCommitQc<V::Entries>, block: V) -> Self {
         Decided { commit_qc, block }
     }
 }
@@ -223,14 +223,14 @@ impl<V: Votable> Decided<V> {
 /// `find_pending_transition` constructs these, so applying one cannot fail
 pub(crate) enum Transition<V: Votable, C: ValidateCert> {
     Proposal(PrePrepareMsg<V, C>),
-    PrepareQc(PrepareQc<V>),
+    PrepareQc(PrepareQc<V::Entries>),
     Decide {
-        qc: FallbackCommitQc<V>,
+        qc: FallbackCommitQc<V::Entries>,
         block: V,
     },
     OwnProposalReady(PrePrepareMsg<V, C>),
     AwaitProposal,
-    Tc(TimeoutCertificate<V>),
+    Tc(TimeoutCertificate<V::Entries>),
     /// Timer fired, or f+1 stake already timed out. Repeats in a timed-out view
     /// per retransmission
     Timeout,

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/test_helpers.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/test_helpers.rs
@@ -27,17 +27,17 @@ use super::{
         super::{
             fast::{CertifiedEntry, EnterFallbackCert, EnterFallbackVote, Entry, FallbackEntry},
             types::{
-                HeaderAuth, IsVote, MerkleRoot, NodeId, ProposalMap, Slot, StrongQc,
+                HeaderAuth, IsVote, MerkleRoot, NodeId, ProposalMap, ProposalScope, Slot, StrongQc,
                 TimestampDelta, ValidatorData, VoteMsg, VotePool, WeakQc,
             },
         },
-        FallbackView, MVBAOutput, Metablock, Mvba,
+        FallbackView, MVBAOutput, Metablock, Mvba, MvbaScope, Votable,
     },
     MvbaContext,
     block_store::{BlockRequestMsg, BlockResponseMsg},
     messages::{FallbackCommitVote, PrepareVote},
 };
-use crate::env::stub::MerkleHash;
+use crate::{env::stub::MerkleHash, spec::vote::KeyPair as _};
 
 /// A root whose hash spells out `n`, so distinct seeds give distinct roots
 fn root(n: u64) -> MerkleRoot {
@@ -52,9 +52,10 @@ pub(super) type MonadMvba = super::MonadMvba<Metablock, EnterFallbackCert>;
 pub(super) type Message = super::messages::MvbaMessage<Metablock, EnterFallbackCert>;
 pub(super) type PrePrepareMsg = super::messages::PrePrepareMsg<Metablock, EnterFallbackCert>;
 pub(super) type Justification = super::messages::Justification<Metablock, EnterFallbackCert>;
-pub(super) type TimeoutMsg = super::messages::TimeoutMsg<Metablock>;
-pub(super) type PrepareQc = super::certificates::PrepareQc<Metablock>;
-pub(super) type TimeoutCertificate = super::certificates::TimeoutCertificate<Metablock>;
+pub(super) type TimeoutMsg = super::messages::TimeoutMsg<<Metablock as Votable>::Entries>;
+pub(super) type PrepareQc = super::certificates::PrepareQc<<Metablock as Votable>::Entries>;
+pub(super) type TimeoutCertificate =
+    super::certificates::TimeoutCertificate<<Metablock as Votable>::Entries>;
 pub(super) type ViewCollectors = super::collectors::ViewCollectors<Metablock, EnterFallbackCert>;
 pub(super) type TimerEvent = super::TimerEvent<Metablock>;
 
@@ -87,7 +88,7 @@ pub(super) fn validator_data() -> Arc<ValidatorData> {
     let mapping: HashMap<_, _> = nodes()
         .into_iter()
         .map(|node| {
-            let pubkey = crate::spec::vote::KeyPair::pubkey(&node.keypair());
+            let pubkey = node.keypair().pubkey();
             (node, pubkey)
         })
         .collect();
@@ -119,7 +120,12 @@ pub(super) fn mvba(node: NodeId, validator_data: &Arc<ValidatorData>) -> MonadMv
 pub(super) fn metablock(seed: u64, validator_data: &ValidatorData) -> Metablock {
     Metablock::new(ProposalMap::new(NUM_PROPOSALS, |j| {
         let entry = Entry::Positive(root(seed * 100 + j as u64));
-        let fast_qc = strong_qc((SLOT, j), entry, &quorum(), validator_data);
+        let fast_qc = strong_qc(
+            ProposalScope::new(SLOT, j),
+            entry,
+            &quorum(),
+            validator_data,
+        );
         CertifiedEntry::FastQc(fast_qc)
     }))
 }
@@ -131,10 +137,20 @@ pub(super) fn mixed_evidence_metablock(seed: u64, validator_data: &ValidatorData
     Metablock::new(ProposalMap::new(NUM_PROPOSALS, |j| {
         let entry = Entry::Positive(root(seed * 100 + j as u64));
         if j == 0 {
-            let qc = weak_qc((SLOT, j), FallbackEntry(entry), &quorum(), validator_data);
+            let qc = weak_qc(
+                ProposalScope::new(SLOT, j),
+                FallbackEntry(entry),
+                &quorum(),
+                validator_data,
+            );
             CertifiedEntry::FallbackQc(qc)
         } else {
-            CertifiedEntry::FastQc(strong_qc((SLOT, j), entry, &quorum(), validator_data))
+            CertifiedEntry::FastQc(strong_qc(
+                ProposalScope::new(SLOT, j),
+                entry,
+                &quorum(),
+                validator_data,
+            ))
         }
     }))
 }
@@ -186,7 +202,7 @@ pub(super) fn prepare_qc(
     validator_data: &ValidatorData,
 ) -> PrepareQc {
     strong_qc(
-        (SLOT, v),
+        MvbaScope::new(SLOT, v),
         PrepareVote(entries.clone()),
         &quorum(),
         validator_data,
@@ -269,7 +285,11 @@ pub(super) fn feed_prepare_votes(
     signers: &[NodeId],
 ) {
     for node in signers {
-        let msg = VoteMsg::new_signed((SLOT, v), PrepareVote(entries.clone()), &node.keypair());
+        let msg = VoteMsg::new_signed(
+            MvbaScope::new(SLOT, v),
+            PrepareVote(entries.clone()),
+            &node.keypair(),
+        );
         instance.handle_message(*node, Message::Prepare(msg));
     }
 }
@@ -284,7 +304,7 @@ pub(super) fn feed_commit_votes(
 ) {
     for node in signers {
         let msg = VoteMsg::new_signed(
-            (SLOT, v),
+            MvbaScope::new(SLOT, v),
             FallbackCommitVote(block.entries()),
             &node.keypair(),
         );
@@ -300,7 +320,7 @@ pub(super) fn commit_qc_message(
     validator_data: &ValidatorData,
 ) -> Message {
     let qc = strong_qc(
-        (SLOT, v),
+        MvbaScope::new(SLOT, v),
         FallbackCommitVote(block.entries()),
         &quorum(),
         validator_data,

--- a/monad-mcp-chorus/src/slot/fallback/monad_mvba/tests.rs
+++ b/monad-mcp-chorus/src/slot/fallback/monad_mvba/tests.rs
@@ -17,9 +17,9 @@ use super::{
     super::{
         super::{
             fast::{CertifiedEntry, EnterFallbackVote},
-            types::{ProposalMap, Slot, VoteMsg},
+            types::{ProposalMap, ProposalScope, Slot, VoteMsg},
         },
-        FallbackView, Metablock, Mvba,
+        FallbackView, Metablock, Mvba, MvbaScope,
     },
     messages::FallbackCommitVote,
     test_helpers::*,
@@ -514,7 +514,7 @@ fn a_formed_commit_certificate_is_final_against_later_votes() {
     let mut collectors = ViewCollectors::new(SLOT, view(1));
     for node in quorum() {
         let msg = VoteMsg::new_signed(
-            (SLOT, view(1)),
+            MvbaScope::new(SLOT, view(1)),
             FallbackCommitVote(block.entries()),
             &node.keypair(),
         );
@@ -528,7 +528,7 @@ fn a_formed_commit_certificate_is_final_against_later_votes() {
     // sealed by the first quorum
     let late = nodes()[3];
     let msg = VoteMsg::new_signed(
-        (SLOT, view(1)),
+        MvbaScope::new(SLOT, view(1)),
         FallbackCommitVote(other.entries()),
         &late.keypair(),
     );
@@ -1054,7 +1054,7 @@ fn a_bogus_block_response_is_ignored() {
     let forged = Metablock::new(ProposalMap::new(NUM_PROPOSALS, |j| {
         let entry = block_entries[j].clone();
         CertifiedEntry::FastQc(strong_qc(
-            (Slot(SLOT.get() + 1), j),
+            ProposalScope::new(Slot(SLOT.get() + 1), j),
             entry,
             &quorum(),
             &validator_data,
@@ -1900,16 +1900,21 @@ fn a_signer_in_two_groups_invalidates_the_certificate() {
 mod toy_value {
     use std::sync::Arc;
 
-    use super::super::{
+    use super::{
         super::{
-            super::types::{HeaderAuth, NodeId, ValidatorData, VoteMsg},
-            MVBAOutput, Mvba, ValidateCert, ValidateInput, Votable,
+            super::{
+                super::types::{HeaderAuth, NodeId, ValidatorData, VoteMsg},
+                MVBAOutput, Mvba, ValidateCert, ValidateInput, Votable,
+            },
+            MakesValidationContext, MonadMvba, MvbaContext, TimerEvent,
+            messages::{
+                FallbackCommitVote, Justification, MvbaMessage, PrePrepareMsg, PrepareVote,
+            },
+            test_helpers::{
+                DELTA, NUM_PROPOSALS, SLOT, leader_of, nodes, quorum, validator_data, view,
+            },
         },
-        MakesValidationContext, MonadMvba, MvbaContext, TimerEvent,
-        messages::{FallbackCommitVote, Justification, MvbaMessage, PrePrepareMsg, PrepareVote},
-        test_helpers::{
-            DELTA, NUM_PROPOSALS, SLOT, leader_of, nodes, quorum, validator_data, view,
-        },
+        MvbaScope,
     };
 
     #[derive(Clone, PartialEq, Eq, Hash, Debug)]
@@ -2002,8 +2007,8 @@ mod toy_value {
 
         for node in quorum() {
             let msg = VoteMsg::new_signed(
-                (SLOT, view(1)),
-                PrepareVote::<TestValue>(value.entries()),
+                MvbaScope::new(SLOT, view(1)),
+                PrepareVote::<<TestValue as Votable>::Entries>(value.entries()),
                 &node.keypair(),
             );
             instance.handle_message(node, MvbaMessage::Prepare(msg));
@@ -2017,8 +2022,8 @@ mod toy_value {
 
         for node in quorum() {
             let msg = VoteMsg::new_signed(
-                (SLOT, view(1)),
-                FallbackCommitVote::<TestValue>(value.entries()),
+                MvbaScope::new(SLOT, view(1)),
+                FallbackCommitVote::<<TestValue as Votable>::Entries>(value.entries()),
                 &node.keypair(),
             );
             instance.handle_message(node, MvbaMessage::Commit(msg));

--- a/monad-mcp-chorus/src/slot/fast.rs
+++ b/monad-mcp-chorus/src/slot/fast.rs
@@ -18,6 +18,10 @@ use std::{
     sync::Arc,
 };
 
+use alloy_rlp::{
+    Decodable, Encodable, Header, RlpDecodable, RlpDecodableWrapper, RlpEncodable,
+    RlpEncodableWrapper, encode_list, list_length,
+};
 use bytes::Bytes;
 use itertools::Either;
 
@@ -27,8 +31,8 @@ use super::{
     fallback::Metablock,
     types::{
         Admission, EquivCert, GatedVotePool, GatingRoot, HeaderAuth, IsVote, KeyPair, MerkleRoot,
-        NodeId, ProposalHeader, ProposalIndex, ProposalMap, Signature, Slot, StrongQc,
-        TotalProposalMap, ValidatorData, VoteMsg, VotePool, WeakQc, dummy_serialize,
+        NodeId, ProposalHeader, ProposalIndex, ProposalMap, ProposalScope, Signature, Slot,
+        StrongQc, TotalProposalMap, ValidatorData, VoteMsg, VotePool, WeakQc, dummy_serialize,
     },
 };
 use crate::spec::{
@@ -89,13 +93,15 @@ impl FastPath {
         Self {
             slot: s,
 
-            votes: ProposalMap::new(num_proposals, |j| GatedVotePool::new(VotePool::new((s, j)))),
+            votes: ProposalMap::new(num_proposals, |j| {
+                GatedVotePool::new(VotePool::new(ProposalScope::new(s, j)))
+            }),
             certs: ProposalMap::new_default(num_proposals),
             commit_votes: VotePool::new(s),
 
             enter_fallback_votes: VotePool::new(s),
             fallback_entry_votes: ProposalMap::new(num_proposals, |j| {
-                GatedVotePool::new(VotePool::new((s, j)))
+                GatedVotePool::new(VotePool::new(ProposalScope::new(s, j)))
             }),
 
             phase: Phase::Propose,
@@ -176,7 +182,7 @@ impl FastPath {
     fn handle_vote(&mut self, node_id: NodeId, vote_msg: VoteMsg<Entry>) {
         debug_assert!(self.validator_data.contains(&node_id));
 
-        let (_s, j) = vote_msg.scope;
+        let j = vote_msg.scope.index;
         self.votes[j].add_vote(node_id, vote_msg);
         self.try_form_fast_qc(j);
     }
@@ -321,9 +327,11 @@ impl FastPath {
                 };
                 entry.well_formed() && header_valid
             }
-            ProposalEvidence::Certified(cert) => {
-                cert.verify((self.slot, j), &self.header_auth, &self.validator_data)
-            }
+            ProposalEvidence::Certified(cert) => cert.verify(
+                ProposalScope::new(self.slot, j),
+                &self.header_auth,
+                &self.validator_data,
+            ),
         }
     }
 
@@ -342,11 +350,15 @@ impl FastPath {
                 None => Entry::Negative,
             };
 
-            let vote_msg = VoteMsg::new_signed((self.slot, *j), entry.clone(), &self.key);
-            (entry, vote_msg.signature)
+            let vote_msg =
+                VoteMsg::new_signed(ProposalScope::new(self.slot, *j), entry.clone(), &self.key);
+            SignedEntry {
+                entry,
+                signature: vote_msg.signature,
+            }
         });
 
-        for (j, (entry, _)) in votes.as_ref().into_indexed_iter() {
+        for (j, SignedEntry { entry, .. }) in votes.as_ref().into_indexed_iter() {
             if let Entry::Positive(root) = entry {
                 self.emit(ChorusDACommand::PinRoot { j, root: *root });
             }
@@ -442,7 +454,7 @@ impl FastPath {
             return cert.clone().into();
         }
 
-        let scope = (self.slot, j);
+        let scope = ProposalScope::new(self.slot, j);
 
         // if there are f+1 positive votes on a root and it's decoded,
         // vote positive.
@@ -634,7 +646,7 @@ pub enum Entry {
 }
 
 impl IsVote for Entry {
-    type Scope = (Slot, ProposalIndex);
+    type Scope = ProposalScope;
 
     fn serialize(&self, scope: &Self::Scope) -> Bytes {
         dummy_serialize(self, scope)
@@ -652,19 +664,27 @@ impl GatingRoot for Entry {
 
 pub type FastQc = StrongQc<Entry>;
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
 pub(crate) struct BatchVoteMsg {
     slot: Slot,
-    votes: ProposalMap<(Entry, Signature)>,
+    votes: ProposalMap<SignedEntry>,
     // vote only. fields for chunks & decryption share may be added by
     // other components.
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
+struct SignedEntry {
+    entry: Entry,
+    signature: Signature,
 }
 
 impl BatchVoteMsg {
     pub fn split(self) -> Vec<VoteMsg<Entry>> {
         self.votes
             .into_indexed_iter()
-            .map(|(j, (entry, sig))| VoteMsg::new((self.slot, j), entry, sig))
+            .map(|(j, SignedEntry { entry, signature })| {
+                VoteMsg::new(ProposalScope::new(self.slot, j), entry, signature)
+            })
             .collect()
     }
 }
@@ -676,7 +696,7 @@ pub(crate) struct FastCommitVote {
 
 pub(crate) type FastCommitVoteMsg = VoteMsg<FastCommitVote>;
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodableWrapper, RlpDecodableWrapper)]
 pub struct FastBlock(TotalProposalMap<FastQc>);
 
 impl FastBlock {
@@ -706,11 +726,11 @@ pub(crate) type FastCommitQc = StrongQc<FastCommitVote>;
 // ============ Fallback ===============
 
 // same as Entry, but signed under a distinct signing domain
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodableWrapper, RlpDecodableWrapper)]
 pub struct FallbackEntry(pub Entry);
 
 impl IsVote for FallbackEntry {
-    type Scope = (Slot, ProposalIndex);
+    type Scope = ProposalScope;
 
     fn serialize(&self, scope: &Self::Scope) -> Bytes {
         dummy_serialize(self, scope)
@@ -781,7 +801,7 @@ impl CertifiedEntry {
     /// boundary explicit and catch protocol-logic bugs.
     pub(crate) fn verify(
         &self,
-        scope: (Slot, ProposalIndex),
+        scope: ProposalScope,
         header_auth: &HeaderAuth,
         validator_data: &ValidatorData,
     ) -> bool {
@@ -789,7 +809,7 @@ impl CertifiedEntry {
             CertifiedEntry::FastQc(qc) => qc.verify(validator_data),
             CertifiedEntry::FallbackQc(qc) => qc.verify(validator_data),
             CertifiedEntry::EquivCert(EquivCert(a, b)) => {
-                let (s, j) = scope;
+                let ProposalScope { slot: s, index: j } = scope;
                 a.root != b.root
                     && header_auth.validate(a, s.get(), j)
                     && header_auth.validate(b, s.get(), j)
@@ -798,7 +818,8 @@ impl CertifiedEntry {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
+#[rlp(trailing)]
 struct FallbackSignedEntry {
     entry: FallbackEntry,
     // over (slot, j, self.entry)
@@ -810,7 +831,7 @@ struct FallbackSignedEntry {
 
 impl FallbackSignedEntry {
     fn new_signed_positive(
-        scope: (Slot, ProposalIndex),
+        scope: ProposalScope,
         root: MerkleRoot,
         key: &KeyPair,
         header: ProposalHeader,
@@ -824,7 +845,7 @@ impl FallbackSignedEntry {
         }
     }
 
-    fn new_signed_negative(scope: (Slot, ProposalIndex), key: &KeyPair) -> Self {
+    fn new_signed_negative(scope: ProposalScope, key: &KeyPair) -> Self {
         let entry = FallbackEntry(Entry::Negative);
         let signature = VoteMsg::new_signed(scope, entry.clone(), key).signature;
         Self {
@@ -849,7 +870,7 @@ impl FallbackSignedEntry {
     }
 
     fn into_vote_msg(self, slot: Slot, j: ProposalIndex) -> VoteMsg<FallbackEntry> {
-        VoteMsg::new((slot, j), self.entry, self.signature)
+        VoteMsg::new(ProposalScope::new(slot, j), self.entry, self.signature)
     }
 }
 
@@ -907,7 +928,7 @@ impl LocalCertifiedEntry {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
 pub struct EnterFallbackVote;
 
 impl IsVote for EnterFallbackVote {
@@ -918,7 +939,7 @@ impl IsVote for EnterFallbackVote {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
 pub(crate) struct FallbackVoteMsg {
     enter_fallback_vote: VoteMsg<EnterFallbackVote>,
     evidences: ProposalMap<ProposalEvidence>,
@@ -926,6 +947,166 @@ pub(crate) struct FallbackVoteMsg {
 
 // A fallback cert certifies 2f+1 validators agree to enter fallback path
 pub type EnterFallbackCert = StrongQc<EnterFallbackVote>;
+
+impl Encodable for Entry {
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        match self {
+            Self::Positive(message) => {
+                let fields: [&dyn Encodable; 2] = [&1u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+            Self::Negative => {
+                let fields: [&dyn Encodable; 1] = [&2u8];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+        }
+    }
+
+    fn length(&self) -> usize {
+        match self {
+            Self::Positive(message) => {
+                let fields: [&dyn Encodable; 2] = [&1u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+            Self::Negative => {
+                let fields: [&dyn Encodable; 1] = [&2u8];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+        }
+    }
+}
+
+impl Decodable for Entry {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let mut payload = Header::decode_bytes(buf, true)?;
+        let result = match <u8 as Decodable>::decode(&mut payload)? {
+            1 => Self::Positive(<MerkleRoot as Decodable>::decode(&mut payload)?),
+            2 => Self::Negative,
+            _ => return Err(alloy_rlp::Error::Custom("unknown Entry tag")),
+        };
+        if !payload.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(result)
+    }
+}
+
+impl Encodable for CertifiedEntry {
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        match self {
+            Self::FastQc(message) => {
+                let fields: [&dyn Encodable; 2] = [&1u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+            Self::EquivCert(message) => {
+                let fields: [&dyn Encodable; 2] = [&2u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+            Self::FallbackQc(message) => {
+                let fields: [&dyn Encodable; 2] = [&3u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+        }
+    }
+
+    fn length(&self) -> usize {
+        match self {
+            Self::FastQc(message) => {
+                let fields: [&dyn Encodable; 2] = [&1u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+            Self::EquivCert(message) => {
+                let fields: [&dyn Encodable; 2] = [&2u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+            Self::FallbackQc(message) => {
+                let fields: [&dyn Encodable; 2] = [&3u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+        }
+    }
+}
+
+impl Decodable for CertifiedEntry {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let mut payload = Header::decode_bytes(buf, true)?;
+        let result = match <u8 as Decodable>::decode(&mut payload)? {
+            1 => Self::FastQc(<FastQc as Decodable>::decode(&mut payload)?),
+            2 => Self::EquivCert(<EquivCert as Decodable>::decode(&mut payload)?),
+            3 => Self::FallbackQc(<FallbackQc as Decodable>::decode(&mut payload)?),
+            _ => return Err(alloy_rlp::Error::Custom("unknown CertifiedEntry tag")),
+        };
+        if !payload.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(result)
+    }
+}
+
+impl Encodable for ProposalEvidence {
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        match self {
+            Self::Certified(message) => {
+                let fields: [&dyn Encodable; 2] = [&1u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+            Self::FallbackSignedEntry(message) => {
+                let fields: [&dyn Encodable; 2] = [&2u8, message];
+                encode_list::<_, dyn Encodable>(&fields, out);
+            }
+        }
+    }
+
+    fn length(&self) -> usize {
+        match self {
+            Self::Certified(message) => {
+                let fields: [&dyn Encodable; 2] = [&1u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+            Self::FallbackSignedEntry(message) => {
+                let fields: [&dyn Encodable; 2] = [&2u8, message];
+                list_length::<_, dyn Encodable>(&fields)
+            }
+        }
+    }
+}
+
+impl Decodable for ProposalEvidence {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let mut payload = Header::decode_bytes(buf, true)?;
+        let result = match <u8 as Decodable>::decode(&mut payload)? {
+            1 => Self::Certified(<CertifiedEntry as Decodable>::decode(&mut payload)?),
+            2 => {
+                Self::FallbackSignedEntry(<FallbackSignedEntry as Decodable>::decode(&mut payload)?)
+            }
+            _ => return Err(alloy_rlp::Error::Custom("unknown ProposalEvidence tag")),
+        };
+        if !payload.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(result)
+    }
+}
+
+// Alloy 0.3.12's wrapper decoder derive only constructs tuple newtypes.
+// Keep both wrapper codecs manual for this named-field struct.
+impl Encodable for FastCommitVote {
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        self.entries.encode(out);
+    }
+
+    fn length(&self) -> usize {
+        self.entries.length()
+    }
+}
+
+impl Decodable for FastCommitVote {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Ok(Self {
+            entries: <ProposalMap<Entry> as Decodable>::decode(buf)?,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -1007,8 +1188,12 @@ mod tests {
     fn positive_fallback_vote(voter: u64, byte: u8) -> (NodeId, FallbackVoteMsg) {
         let voter = NodeId::dummy(voter);
         let key = voter.keypair();
-        let entry =
-            FallbackSignedEntry::new_signed_positive((SLOT, 0), root(byte), &key, header(byte));
+        let entry = FallbackSignedEntry::new_signed_positive(
+            ProposalScope::new(SLOT, 0),
+            root(byte),
+            &key,
+            header(byte),
+        );
         let msg = FallbackVoteMsg {
             enter_fallback_vote: VoteMsg::new_signed(SLOT, EnterFallbackVote, &key),
             evidences: ProposalMap::new(1, |_| {
@@ -1020,10 +1205,14 @@ mod tests {
 
     // a fast qc on root(byte) signed by validators 0, 2 and 3
     fn fast_block(byte: u8) -> FastBlock {
-        let mut pool = VotePool::new((SLOT, 0));
+        let mut pool = VotePool::new(ProposalScope::new(SLOT, 0));
         for id in [0, 2, 3] {
             let voter = NodeId::dummy(id);
-            let msg = VoteMsg::new_signed((SLOT, 0), Entry::Positive(root(byte)), &voter.keypair());
+            let msg = VoteMsg::new_signed(
+                ProposalScope::new(SLOT, 0),
+                Entry::Positive(root(byte)),
+                &voter.keypair(),
+            );
             pool.add_vote(voter, msg);
         }
         let qc = pool
@@ -1111,8 +1300,12 @@ mod tests {
         let voter = NodeId::dummy(voter);
         let key = voter.keypair();
         let votes = ProposalMap::new(1, |j| {
-            let signature = VoteMsg::new_signed((SLOT, j), entry.clone(), &key).signature;
-            (entry.clone(), signature)
+            let signature =
+                VoteMsg::new_signed(ProposalScope::new(SLOT, j), entry.clone(), &key).signature;
+            SignedEntry {
+                entry: entry.clone(),
+                signature,
+            }
         });
         (voter, BatchVoteMsg { slot: SLOT, votes })
     }
@@ -1226,5 +1419,155 @@ mod tests {
         });
         fast.recover_committed(&fast_commit_qc(1));
         assert!(drain_requests(&mut fast).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod rlp_tests {
+    use super::{
+        super::{
+            super::{
+                conductor::{MonadConductor, acs::median::MedianAcs},
+                driver::CadenceDriverMsg,
+                test_utils::{assert_roundtrip, assert_serialization_roundtrip},
+                types::SlotDeadline,
+            },
+            chorus::{Chorus, ChorusMessage},
+        },
+        *,
+    };
+    use crate::{
+        env::stub::{D25, EncodingScheme, MerkleHash, ProposalSignature},
+        spec::vote::KeyPair as _,
+    };
+
+    #[test]
+    fn chorus_variants_and_nested_evidence_roundtrip() {
+        let slot = Slot(9);
+        let key = NodeId::dummy(1).keypair();
+        let root = MerkleRoot(MerkleHash([7; 20]));
+        let positive = Entry::Positive(root);
+        let signature = key.sign(&Bytes::from_static(b"test"));
+        // Empty collections suffice for wire tests; validation remains separate.
+        let sigcol = alloy_rlp::decode_exact([0xc0]).unwrap();
+        let fast_qc = StrongQc {
+            scope: ProposalScope::new(slot, 0usize),
+            verdict: positive.clone(),
+            sigcol,
+        };
+        let weak_qc = WeakQc {
+            scope: ProposalScope::new(slot, 0usize),
+            verdict: FallbackEntry(Entry::Negative),
+            sigcol: fast_qc.sigcol.clone(),
+        };
+        let h = ProposalHeader {
+            slot: crate::stub::types::Slot(9),
+            root,
+            sig: ProposalSignature {
+                signer: NodeId::dummy(1),
+                checksum: 12,
+            },
+            scheme: EncodingScheme::D25(D25 {
+                msg_len: 1000,
+                unix_ts: 12345,
+                depth: 4,
+            }),
+        };
+        let mut h2 = h.clone();
+        h2.root = MerkleRoot(MerkleHash([8; 20]));
+        // Cover every certificate variant and signed fallback entries with/without a header.
+        let evidence = vec![
+            ProposalEvidence::Certified(CertifiedEntry::FastQc(fast_qc.clone())),
+            ProposalEvidence::Certified(CertifiedEntry::FallbackQc(weak_qc)),
+            ProposalEvidence::Certified(CertifiedEntry::EquivCert(EquivCert(h.clone(), h2))),
+            ProposalEvidence::FallbackSignedEntry(FallbackSignedEntry::new_signed_positive(
+                ProposalScope::new(slot, 0),
+                root,
+                &key,
+                h,
+            )),
+            ProposalEvidence::FallbackSignedEntry(FallbackSignedEntry::new_signed_negative(
+                ProposalScope::new(slot, 1),
+                &key,
+            )),
+        ];
+        for value in &evidence {
+            assert_roundtrip(value);
+        }
+        let enter = StrongQc {
+            scope: slot,
+            verdict: EnterFallbackVote,
+            sigcol: fast_qc.sigcol.clone(),
+        };
+        let fast_commit_vote = FastCommitVote {
+            entries: ProposalMap::new(2, |i| {
+                if i == 0 {
+                    positive.clone()
+                } else {
+                    Entry::Negative
+                }
+            }),
+        };
+        // Cover all six non-MVBA Chorus variants; MVBA messages have their own round-trip test.
+        let messages = vec![
+            ChorusMessage::BatchVote(BatchVoteMsg {
+                slot,
+                votes: ProposalMap::new(2, |i| SignedEntry {
+                    entry: if i == 0 {
+                        positive.clone()
+                    } else {
+                        Entry::Negative
+                    },
+                    signature: signature.clone(),
+                }),
+            }),
+            ChorusMessage::FastCommitVote(VoteMsg::new_signed(
+                slot,
+                fast_commit_vote.clone(),
+                &key,
+            )),
+            ChorusMessage::FastBlock(FastBlock(ProposalMap::new(2, |_| fast_qc.clone()))),
+            ChorusMessage::FallbackVote(FallbackVoteMsg {
+                enter_fallback_vote: VoteMsg::new_signed(slot, EnterFallbackVote, &key),
+                evidences: ProposalMap::new(evidence.len(), |i| evidence[i].clone()),
+            }),
+            ChorusMessage::FastCommitQc(StrongQc {
+                scope: slot,
+                verdict: fast_commit_vote,
+                sigcol: fast_qc.sigcol,
+            }),
+            ChorusMessage::EnterFallbackCert(enter),
+        ];
+        type Wire = CadenceDriverMsg<Chorus, MonadConductor<MedianAcs<SlotDeadline>>>;
+        // Check both the Chorus RLP payload and its enclosing Cadence byte serialization.
+        for message in messages {
+            assert_roundtrip(&message);
+            assert_serialization_roundtrip(&Wire::Slot(slot, message));
+        }
+    }
+
+    #[test]
+    fn transparent_wrappers_and_unit_votes_have_no_extra_list() {
+        fn encode_scope<V: IsVote>(scope: &V::Scope) -> Vec<u8> {
+            alloy_rlp::encode(scope)
+        }
+        let scope = ProposalScope::new(Slot(7), 3);
+        assert_eq!(encode_scope::<Entry>(&scope), [0xc2, 7, 3]);
+        assert_roundtrip(&scope);
+        let root = MerkleRoot(MerkleHash([7; 20]));
+        assert_eq!(alloy_rlp::encode(root), alloy_rlp::encode([7u8; 20]));
+        let entry = Entry::Negative;
+        assert_eq!(alloy_rlp::encode(&entry), [0xc1, 2]);
+        assert_eq!(alloy_rlp::encode(FallbackEntry(entry)), [0xc1, 2]);
+        assert_eq!(alloy_rlp::encode(EnterFallbackVote), [0xc0]);
+        assert_roundtrip(&EnterFallbackVote);
+        let entries = ProposalMap::new(0, |_| Entry::Negative);
+        assert_eq!(alloy_rlp::encode(FastCommitVote { entries }), [0xc0]);
+        let block = FastBlock(ProposalMap::new(0, |_| unreachable!()));
+        assert_eq!(alloy_rlp::encode(&block), [0xc0]);
+        assert_roundtrip(&block);
+        for bad in [&[0xc1, 3][..], &[0xc2, 2, 0][..], &[0x80][..]] {
+            assert!(alloy_rlp::decode_exact::<Entry>(bad).is_err());
+        }
     }
 }

--- a/monad-mcp-chorus/src/spec.rs
+++ b/monad-mcp-chorus/src/spec.rs
@@ -17,6 +17,34 @@ pub use proposal::{MerkleRoot, ProposalHeader};
 pub use validator::{NodeId, Stake};
 pub use vote::{KeyPair, PubKey, Signature, SignatureCollection};
 
+/// Serialize to S, usually bytes.
+pub trait Serializable<S> {
+    fn serialize(&self) -> S;
+}
+
+/// All types can trivially serialize to itself
+impl<S: Clone> Serializable<S> for S {
+    fn serialize(&self) -> S {
+        self.clone()
+    }
+}
+
+/// Deserialize from S, usually bytes
+pub trait Deserializable<S: ?Sized>: Sized {
+    type ReadError: std::error::Error + Send + Sync + 'static;
+
+    fn deserialize(message: &S) -> Result<Self, Self::ReadError>;
+}
+
+/// All types can trivially deserialize to itself
+impl<S: Clone> Deserializable<S> for S {
+    type ReadError = std::io::Error;
+
+    fn deserialize(message: &S) -> Result<Self, Self::ReadError> {
+        Ok(message.clone())
+    }
+}
+
 pub mod validator {
     use std::{iter::Sum, ops::Add};
 

--- a/monad-mcp-chorus/src/test_utils.rs
+++ b/monad-mcp-chorus/src/test_utils.rs
@@ -1,0 +1,66 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use alloy_rlp::{Decodable, Encodable};
+use bytes::Bytes;
+
+use crate::spec::{Deserializable, Serializable};
+
+pub(crate) fn assert_roundtrip<T>(value: &T) -> T
+where
+    T: Encodable + Decodable + std::fmt::Debug + PartialEq,
+{
+    let encoded = alloy_rlp::encode(value);
+    assert_eq!(value.length(), encoded.len());
+    let decoded: T = alloy_rlp::decode_exact(&encoded).unwrap();
+    assert_eq!(&decoded, value);
+    for end in 0..encoded.len() {
+        assert!(
+            alloy_rlp::decode_exact::<T>(&encoded[..end]).is_err(),
+            "accepted truncated input at {end}"
+        );
+    }
+    let mut stream = encoded;
+    stream.push(0x42);
+    let mut remaining = stream.as_slice();
+    assert_eq!(&T::decode(&mut remaining).unwrap(), value);
+    assert_eq!(remaining, &[0x42]);
+    assert!(alloy_rlp::decode_exact::<T>(&stream).is_err());
+    decoded
+}
+
+/// Check the network byte traits as well as the underlying streaming RLP codecs.
+pub(crate) fn assert_serialization_roundtrip<T>(value: &T) -> T
+where
+    T: Encodable
+        + Decodable
+        + Serializable<Bytes>
+        + Deserializable<Bytes, ReadError = alloy_rlp::Error>
+        + std::fmt::Debug
+        + PartialEq,
+{
+    assert_roundtrip(value);
+    let bytes = value.serialize();
+    assert_eq!(bytes.as_ref(), alloy_rlp::encode(value));
+    let decoded = T::deserialize(&bytes).unwrap();
+    assert_eq!(&decoded, value);
+    for end in 0..bytes.len() {
+        assert!(T::deserialize(&bytes.slice(..end)).is_err());
+    }
+    let mut extra = bytes.to_vec();
+    extra.push(0x42);
+    assert!(T::deserialize(&Bytes::from(extra)).is_err());
+    decoded
+}

--- a/monad-mcp-chorus/src/top_level.rs
+++ b/monad-mcp-chorus/src/top_level.rs
@@ -24,6 +24,8 @@ pub mod driver;
 pub mod runtime;
 pub mod slot;
 pub mod slot_manager;
+#[cfg(test)]
+pub(crate) mod test_utils;
 pub mod types;
 
 pub use conductor::{Conductor, ConductorOutput};

--- a/monad-mcp-chorus/src/types.rs
+++ b/monad-mcp-chorus/src/types.rs
@@ -20,6 +20,10 @@ use std::{
     time::Duration,
 };
 
+use alloy_rlp::{
+    Decodable, Encodable, Header, RlpDecodable, RlpDecodableWrapper, RlpEncodable,
+    RlpEncodableWrapper, encode_list, list_length,
+};
 use bytes::Bytes;
 use itertools::Either;
 
@@ -35,7 +39,18 @@ use crate::spec::{
 };
 
 // Slot number, starting from 0.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Debug,
+    RlpEncodableWrapper,
+    RlpDecodableWrapper,
+)]
 pub struct Slot(pub u64);
 
 impl Slot {
@@ -77,7 +92,18 @@ impl Slot {
 }
 
 /// An absolute point on the timeline, stored in nanoseconds.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Debug,
+    RlpEncodableWrapper,
+    RlpDecodableWrapper,
+)]
 pub struct Timestamp(u128);
 
 impl Timestamp {
@@ -120,7 +146,18 @@ impl Timestamp {
 }
 
 #[derive(
-    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, derive_more::Add, derive_more::Sum,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Debug,
+    derive_more::Add,
+    derive_more::Sum,
+    RlpEncodableWrapper,
+    RlpDecodableWrapper,
 )]
 pub struct TimestampDelta(u64);
 
@@ -175,7 +212,9 @@ impl TimestampDelta {
 pub type SlotDeadline = Timestamp;
 
 // Identifies a window of contiguous slots, starting from 0.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, RlpEncodableWrapper, RlpDecodableWrapper,
+)]
 pub struct WindowId(pub(crate) u64);
 
 impl WindowId {
@@ -251,7 +290,7 @@ impl<T> Validated<T> {
 }
 
 pub trait IsVote: Clone + Hash + Eq {
-    type Scope: Clone + Hash + Eq + std::fmt::Debug;
+    type Scope: Clone + Hash + Eq + std::fmt::Debug + Encodable + Decodable;
 
     // type SigningDomain;
     fn serialize(&self, scope: &Self::Scope) -> Bytes;
@@ -678,7 +717,123 @@ where
     }
 }
 
+// The scope is `V::Scope`, which Alloy's derives cannot bound, so the vote
+// containers encode their three fields as a list by hand.
+impl<V> Encodable for VoteMsg<V>
+where
+    V: IsVote + Encodable,
+{
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        let fields: [&dyn Encodable; 3] = [&self.scope, &self.vote, &self.signature];
+        encode_list::<_, dyn Encodable>(&fields, out);
+    }
+
+    fn length(&self) -> usize {
+        let fields: [&dyn Encodable; 3] = [&self.scope, &self.vote, &self.signature];
+        list_length::<_, dyn Encodable>(&fields)
+    }
+}
+
+impl<V> Decodable for VoteMsg<V>
+where
+    V: IsVote + Decodable,
+{
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let mut payload = Header::decode_bytes(buf, true)?;
+        let scope = <V::Scope as Decodable>::decode(&mut payload)?;
+        let vote = <V as Decodable>::decode(&mut payload)?;
+        let signature = <Signature as Decodable>::decode(&mut payload)?;
+        if !payload.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(Self::new(scope, vote, signature))
+    }
+}
+
+impl<V> Encodable for StrongQc<V>
+where
+    V: IsVote + Encodable,
+{
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        let fields: [&dyn Encodable; 3] = [&self.scope, &self.verdict, &self.sigcol];
+        encode_list::<_, dyn Encodable>(&fields, out);
+    }
+
+    fn length(&self) -> usize {
+        let fields: [&dyn Encodable; 3] = [&self.scope, &self.verdict, &self.sigcol];
+        list_length::<_, dyn Encodable>(&fields)
+    }
+}
+
+impl<V> Decodable for StrongQc<V>
+where
+    V: IsVote + Decodable,
+{
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let mut payload = Header::decode_bytes(buf, true)?;
+        let scope = <V::Scope as Decodable>::decode(&mut payload)?;
+        let verdict = <V as Decodable>::decode(&mut payload)?;
+        let sigcol = <SignatureCollection as Decodable>::decode(&mut payload)?;
+        if !payload.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(Self {
+            scope,
+            verdict,
+            sigcol,
+        })
+    }
+}
+
+impl<V> Encodable for WeakQc<V>
+where
+    V: IsVote + Encodable,
+{
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        let fields: [&dyn Encodable; 3] = [&self.scope, &self.verdict, &self.sigcol];
+        encode_list::<_, dyn Encodable>(&fields, out);
+    }
+
+    fn length(&self) -> usize {
+        let fields: [&dyn Encodable; 3] = [&self.scope, &self.verdict, &self.sigcol];
+        list_length::<_, dyn Encodable>(&fields)
+    }
+}
+
+impl<V> Decodable for WeakQc<V>
+where
+    V: IsVote + Decodable,
+{
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let mut payload = Header::decode_bytes(buf, true)?;
+        let scope = <V::Scope as Decodable>::decode(&mut payload)?;
+        let verdict = <V as Decodable>::decode(&mut payload)?;
+        let sigcol = <SignatureCollection as Decodable>::decode(&mut payload)?;
+        if !payload.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(Self {
+            scope,
+            verdict,
+            sigcol,
+        })
+    }
+}
+
 pub type ProposalIndex = usize;
+
+/// The slot and proposal index authenticated by a per-proposal vote.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
+pub struct ProposalScope {
+    pub slot: Slot,
+    pub index: ProposalIndex,
+}
+
+impl ProposalScope {
+    pub const fn new(slot: Slot, index: ProposalIndex) -> Self {
+        Self { slot, index }
+    }
+}
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct ProposalMap<T> {
@@ -814,12 +969,38 @@ impl<T> std::ops::IndexMut<ProposalIndex> for ProposalMap<T> {
 pub struct Erased<T>(pub T);
 
 // invariant: .0.root != .1.root and both properly signed.
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, RlpEncodable, RlpDecodable)]
 pub struct EquivCert(pub ProposalHeader, pub ProposalHeader);
+
+impl<T> Encodable for ProposalMap<T>
+where
+    T: Encodable,
+{
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        encode_list(&self.values, out);
+    }
+
+    fn length(&self) -> usize {
+        list_length(&self.values)
+    }
+}
+
+impl<T> Decodable for ProposalMap<T>
+where
+    T: Decodable,
+{
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let result = Self {
+            values: Vec::<T>::decode(buf)?.into_boxed_slice(),
+        };
+        Ok(result)
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::env::stub::MerkleHash;
 
     #[test]
     fn timestamp_arithmetic_is_checked() {
@@ -1114,7 +1295,7 @@ mod tests {
     }
 
     fn root(byte: u8) -> MerkleRoot {
-        crate::env::stub::MerkleRoot(crate::env::stub::MerkleHash([byte; 20]))
+        MerkleRoot(MerkleHash([byte; 20]))
     }
 
     fn signed(id: u64, vote: ClaimVote) -> (NodeId, VoteMsg<ClaimVote>) {


### PR DESCRIPTION
Implement Alloy RLP encoding and decoding for CadenceMessage and its Chorus, Conductor, and MVBA payloads. Use tagged lists for enums and transparent encoding for wrappers, rejecting unknown tags and extra data.

Define Serializable and Deserializable in the Chorus spec and implement the byte interface for CadenceMessage without a monad-types dependency.

Parameterize MVBA votes, certificates, and block requests directly by entries rather than by the votable value, and replace tuple scopes with ProposalScope and MvbaScope so codecs bind the actual wire fields.

Cover concrete Cadence envelopes, message variants, optional certificates, wrapper layouts, and malformed input with round-trip tests.

This code was generated using Codex (GPT-6) and Claude Fable 5.1.